### PR TITLE
Unified interface of hashing functions

### DIFF
--- a/sys/hashes/md5.c
+++ b/sys/hashes/md5.c
@@ -97,10 +97,10 @@ static const uint32_t T[4][16] = {
  * All of these operations are bitwise, and so not impacted by endian-ness.
  * @{
  */
-#define md5F( X, Y, Z ) ( ((X) & (Y)) | ((~(X)) & (Z)) )
-#define md5G( X, Y, Z ) ( ((X) & (Z)) | ((Y) & (~(Z))) )
-#define md5H( X, Y, Z ) ( (X) ^ (Y) ^ (Z) )
-#define md5I( X, Y, Z ) ( (Y) ^ ((X) | (~(Z))) )
+#define md5F( X, Y, Z ) (((X) &(Y)) | ((~(X)) & (Z)))
+#define md5G( X, Y, Z ) (((X) &(Z)) | ((Y) &(~(Z))))
+#define md5H( X, Y, Z ) ((X) ^ (Y) ^ (Z))
+#define md5I( X, Y, Z ) ((Y) ^ ((X) | (~(Z))))
 /** @} */
 
 /**
@@ -109,7 +109,7 @@ static const uint32_t T[4][16] = {
  * A value of 0 for <idx> indicates the lowest order byte, while 3 indicates
  * the highest order byte.
  */
-#define GETBYTE(L, idx) ((uint8_t)(( L >> (((idx) & 0x03) << 3) ) & 0xFF))
+#define GETBYTE(L, idx) ((uint8_t)((L >> (((idx) & 0x03) << 3)) & 0xFF))
 
 /**
  * @brief   Permute the ABCD "registers" using the 64-byte <block> as a driver
@@ -144,14 +144,14 @@ static void permute(uint32_t abcd[4], const uint8_t block[64] )
     uint32_t x[16];
 
     /* Store the current ABCD values for later re-use */
-    for(int i = 0; i < 4; i++ ) {
+    for (int i = 0; i < 4; i++) {
         keep_abcd[i] = abcd[i];
     }
 
     /* Convert the input block into an array of unsigned longs, taking care
      * to read the block in Little Endian order (the algorithm assumes this).
      * The uint32_t values are then handled in host order. */
-    for(int i = 0, j = 0; i < 16; i++ ) {
+    for (int i = 0, j = 0; i < 16; i++) {
         x[i]  =  (uint32_t)block[j++];
         x[i] |= ((uint32_t)block[j++] << 8);
         x[i] |= ((uint32_t)block[j++] << 16);
@@ -171,23 +171,23 @@ static void permute(uint32_t abcd[4], const uint8_t block[64] )
      *
      * (My implementation appears to be a poor compromise between speed, size,
      * and clarity.  Ugh.  [crh]) */
-    for(int round = 0; round < 4; round++) {
-        for(int i = 0; i < 16; i++) {
+    for (int round = 0; round < 4; round++) {
+        for (int i = 0; i < 16; i++) {
             /* <j> handles the rotation of ABCD */
             int j = (4 - (i % 4)) & 0x3;
             /* <s> is the bit shift for this iteration */
-            s = S[round][i%4];
+            s = S[round][i % 4];
 
             /* Copy the b,c,d values per ABCD rotation. This isn't really
              * necessary, it just looks clean & will hopefully be optimized
              * away. */
-            b = abcd[(j+1) & 0x3];
-            c = abcd[(j+2) & 0x3];
-            d = abcd[(j+3) & 0x3];
+            b = abcd[(j + 1) & 0x3];
+            c = abcd[(j + 2) & 0x3];
+            d = abcd[(j + 3) & 0x3];
 
             /* The actual perumation function.
              * This is broken out to minimize the code within the switch(). */
-            switch( round ) {
+            switch (round) {
                 case 0:         /* round 1 */
                     a = md5F( b, c, d ) + x[i];
                     break;
@@ -201,14 +201,14 @@ static void permute(uint32_t abcd[4], const uint8_t block[64] )
                     a = md5I( b, c, d ) + x[ K[2][i] ];
                     break;
             }
-            a = 0xFFFFFFFF & ( abcd[j] + a + T[round][i] );
-            abcd[j] = b + (0xFFFFFFFF & (( a << s ) | ( a >> (32 - s) )));
-      }
+            a = 0xFFFFFFFF & (abcd[j] + a + T[round][i]);
+            abcd[j] = b + (0xFFFFFFFF & ((a << s) | (a >> (32 - s))));
+        }
     }
 
     /* Use the stored original A, B, C, D values to perform
      * one last convolution. */
-    for(int i = 0; i < 4; i++) {
+    for (int i = 0; i < 4; i++) {
         abcd[i] = (abcd[i] + keep_abcd[i]);
     }
 }
@@ -239,10 +239,10 @@ void md5_update(md5_ctx_t *ctx, const uint8_t *data, size_t len)
 
     /* Copy the new block's data into the context block.
      * Call the permute() function whenever the context block is full. */
-    for(size_t i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         ctx->block[ctx->b_used] = data[i];
         (ctx->b_used)++;
-        if(64 == ctx->b_used) {
+        if (64 == ctx->b_used) {
             permute(ctx->abcd, ctx->block);
             ctx->b_used = 0;
         }
@@ -263,15 +263,15 @@ void md5_final(md5_ctx_t *ctx, uint8_t *dst)
     (ctx->b_used)++;
 
     /* Zero out any remaining free bytes in the context block. */
-    for(int i = ctx->b_used; i < 64; i++) {
+    for (int i = ctx->b_used; i < 64; i++) {
         ctx->block[i] = 0;
     }
 
     /* We need 8 bytes to store the length field.
      * If we don't have 8, call permute() and reset the context block. */
-    if(56 < ctx->b_used) {
+    if (56 < ctx->b_used) {
         permute(ctx->abcd, ctx->block);
-        for(int i = 0; i < 64; i++) {
+        for (int i = 0; i < 64; i++) {
             ctx->block[i] = 0;
         }
     }
@@ -281,18 +281,18 @@ void md5_final(md5_ctx_t *ctx, uint8_t *dst)
      *        and shifted to the correct position.  This neatly avoids
      *        any MAXINT numeric overflow issues. */
     l = ctx->len << 3;
-    for(int i = 0; i < 4; i++) {
-        ctx->block[56+i] |= GETBYTE(l, i);
+    for (int i = 0; i < 4; i++) {
+        ctx->block[56 + i] |= GETBYTE(l, i);
     }
     ctx->block[60] = ((GETBYTE(ctx->len, 3) & 0xE0) >> 5);  /* See Above! */
     permute(ctx->abcd, ctx->block);
 
     /* Now copy the result into the output buffer and we're done */
-    for(int i = 0; i < 4; i++) {
-        dst[ 0+i] = GETBYTE(ctx->abcd[0], i);
-        dst[ 4+i] = GETBYTE(ctx->abcd[1], i);
-        dst[ 8+i] = GETBYTE(ctx->abcd[2], i);
-        dst[12+i] = GETBYTE(ctx->abcd[3], i);
+    for (int i = 0; i < 4; i++) {
+        dst[ 0 + i] = GETBYTE(ctx->abcd[0], i);
+        dst[ 4 + i] = GETBYTE(ctx->abcd[1], i);
+        dst[ 8 + i] = GETBYTE(ctx->abcd[2], i);
+        dst[12 + i] = GETBYTE(ctx->abcd[3], i);
     }
 }
 

--- a/sys/hashes/sha1.c
+++ b/sys/hashes/sha1.c
@@ -111,7 +111,7 @@ static void sha1_add_uncounted(sha1_context *s, uint8_t data)
 static void sha1_update_byte(sha1_context *ctx, uint8_t data)
 {
     ++ctx->byte_count;
-    sha1_add_uncounted(ctx, data++);
+    sha1_add_uncounted(ctx, data);
 }
 
 void sha1_update(sha1_context *ctx, const uint8_t *data, size_t len)

--- a/sys/hashes/sha1.c
+++ b/sys/hashes/sha1.c
@@ -180,7 +180,7 @@ void sha1_init_hmac(sha1_context *ctx, const uint8_t *key, size_t key_length)
     if (key_length > SHA1_BLOCK_LENGTH) {
         /* Hash long keys */
         sha1_init(ctx);
-        while(key_length--) {
+        while (key_length--) {
             sha1_update_byte(ctx, *key++);
         }
         sha1_final(ctx, ctx->key_buffer);

--- a/sys/hashes/sha1.c
+++ b/sys/hashes/sha1.c
@@ -34,15 +34,15 @@
 #define SHA1_K40 0x8f1bbcdc
 #define SHA1_K60 0xca62c1d6
 
-void sha1_init(sha1_context *s)
+void sha1_init(sha1_context *ctx)
 {
-    s->state[0] = 0x67452301;
-    s->state[1] = 0xefcdab89;
-    s->state[2] = 0x98badcfe;
-    s->state[3] = 0x10325476;
-    s->state[4] = 0xc3d2e1f0;
-    s->byte_count = 0;
-    s->buffer_offset = 0;
+    ctx->state[0] = 0x67452301;
+    ctx->state[1] = 0xefcdab89;
+    ctx->state[2] = 0x98badcfe;
+    ctx->state[3] = 0x10325476;
+    ctx->state[4] = 0xc3d2e1f0;
+    ctx->byte_count = 0;
+    ctx->buffer_offset = 0;
 }
 
 static uint32_t sha1_rol32(uint32_t number, uint8_t bits)
@@ -108,16 +108,16 @@ static void sha1_add_uncounted(sha1_context *s, uint8_t data)
     }
 }
 
-static void sha1_update_byte(sha1_context *s, unsigned char data)
+static void sha1_update_byte(sha1_context *ctx, uint8_t data)
 {
-    ++s->byte_count;
-    sha1_add_uncounted(s, data++);
+    ++ctx->byte_count;
+    sha1_add_uncounted(ctx, data++);
 }
 
-void sha1_update(sha1_context *s, const unsigned char *data, size_t len)
+void sha1_update(sha1_context *ctx, const uint8_t *data, size_t len)
 {
     while (len--) {
-        sha1_update_byte(s, *(data++));
+        sha1_update_byte(ctx, *(data++));
     }
 }
 
@@ -142,22 +142,22 @@ static void sha1_pad(sha1_context *s)
     sha1_add_uncounted(s, s->byte_count << 3);
 }
 
-uint8_t *sha1_final(sha1_context *s)
+void sha1_final(sha1_context *ctx, uint8_t *dst)
 {
     /* Pad to complete the last block */
-    sha1_pad(s);
+    sha1_pad(ctx);
 
     /* Swap byte order back */
     for (int i = 0; i < 5; i++) {
-        s->state[i] =
-            (((s->state[i]) << 24) & 0xff000000)
-            | (((s->state[i]) << 8) & 0x00ff0000)
-            | (((s->state[i]) >> 8) & 0x0000ff00)
-            | (((s->state[i]) >> 24) & 0x000000ff);
+        ctx->state[i] =
+            (((ctx->state[i]) << 24) & 0xff000000)
+            | (((ctx->state[i]) << 8) & 0x00ff0000)
+            | (((ctx->state[i]) >> 8) & 0x0000ff00)
+            | (((ctx->state[i]) >> 24) & 0x000000ff);
     }
 
-    /* Return pointer to hash (20 characters) */
-    return (uint8_t *) s->state;
+    /* Copy the content of the hash (20 characters) */
+    memcpy(dst, ctx->state, 20);
 }
 
 void sha1(uint8_t *dst, const uint8_t *src, size_t len)
@@ -166,49 +166,50 @@ void sha1(uint8_t *dst, const uint8_t *src, size_t len)
 
     sha1_init(&ctx);
     sha1_update(&ctx, (unsigned char *) src, len);
-    memcpy(dst, sha1_final(&ctx), SHA1_DIGEST_LENGTH);
+    sha1_final(&ctx, dst);
 }
 
 #define HMAC_IPAD 0x36
 #define HMAC_OPAD 0x5c
 
-void sha1_init_hmac(sha1_context *s, const unsigned char *key, size_t key_length)
+void sha1_init_hmac(sha1_context *ctx, const uint8_t *key, size_t key_length)
 {
     uint8_t i;
 
-    memset(s->key_buffer, 0, SHA1_BLOCK_LENGTH);
+    memset(ctx->key_buffer, 0, SHA1_BLOCK_LENGTH);
     if (key_length > SHA1_BLOCK_LENGTH) {
         /* Hash long keys */
-        sha1_init(s);
+        sha1_init(ctx);
         while(key_length--) {
-            sha1_update_byte(s, (unsigned char) *key++);
+            sha1_update_byte(ctx, *key++);
         }
-        memcpy(s->key_buffer, sha1_final(s), SHA1_DIGEST_LENGTH);
+        sha1_final(ctx, ctx->key_buffer);
     }
     else {
         /* Block length keys are used as is */
-        memcpy(s->key_buffer, key, key_length);
+        memcpy(ctx->key_buffer, key, key_length);
     }
     /* Start inner hash */
-    sha1_init(s);
+    sha1_init(ctx);
     for (i = 0; i < SHA1_BLOCK_LENGTH; i++) {
-        sha1_update_byte(s, s->key_buffer[i] ^ HMAC_IPAD);
+        sha1_update_byte(ctx, ctx->key_buffer[i] ^ HMAC_IPAD);
     }
 }
 
-uint8_t *sha1_final_hmac(sha1_context *s)
+void sha1_final_hmac(sha1_context *ctx, uint8_t *dst)
 {
     uint8_t i;
 
     /* Complete inner hash */
-    memcpy(s->inner_hash, sha1_final(s), SHA1_DIGEST_LENGTH);
+    sha1_final(ctx, ctx->inner_hash);
     /* Calculate outer hash */
-    sha1_init(s);
+    sha1_init(ctx);
     for (i = 0; i < SHA1_BLOCK_LENGTH; i++) {
-        sha1_update_byte(s, s->key_buffer[i] ^ HMAC_OPAD);
+        sha1_update_byte(ctx, ctx->key_buffer[i] ^ HMAC_OPAD);
     }
     for (i = 0; i < SHA1_DIGEST_LENGTH; i++) {
-        sha1_update_byte(s, s->inner_hash[i]);
+        sha1_update_byte(ctx, ctx->inner_hash[i]);
     }
-    return sha1_final(s);
+
+    sha1_final(ctx, dst);
 }

--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -66,6 +66,7 @@ static void be32enc_vect(void *dst_, const void *src_, size_t len)
 {
     uint32_t *dst = dst_;
     const uint32_t *src = src_;
+
     for (size_t i = 0; i < len / 4; i++) {
         dst[i] = __builtin_bswap32(src[i]);
     }
@@ -161,6 +162,7 @@ static void sha256_pad(sha256_context_t *ctx)
      * than later because the length will change after we pad.
      */
     unsigned char len[8];
+
     be32enc_vect(len, ctx->count, 8);
 
     /* Add 1--64 bytes so that the resulting length is 56 mod 64 */
@@ -270,13 +272,14 @@ const unsigned char *hmac_sha256(const unsigned char *key,
                                  unsigned char *result)
 {
     unsigned char k[SHA256_INTERNAL_BLOCK_SIZE];
+
     memset((void *)k, 0x00, SHA256_INTERNAL_BLOCK_SIZE);
 
     if (key_length > SHA256_INTERNAL_BLOCK_SIZE) {
         sha256(key, key_length, k);
     }
     else {
-        memcpy((void*)k, key, key_length);
+        memcpy((void *)k, key, key_length);
     }
 
     /*
@@ -288,8 +291,8 @@ const unsigned char *hmac_sha256(const unsigned char *key,
     unsigned char i_key_pad[SHA256_INTERNAL_BLOCK_SIZE];
 
     for (size_t i = 0; i < SHA256_INTERNAL_BLOCK_SIZE; ++i) {
-        o_key_pad[i] = 0x5c^k[i];
-        i_key_pad[i] = 0x36^k[i];
+        o_key_pad[i] = 0x5c ^ k[i];
+        i_key_pad[i] = 0x36 ^ k[i];
     }
 
     /*
@@ -331,6 +334,7 @@ const unsigned char *hmac_sha256(const unsigned char *key,
 static inline void sha256_inplace(unsigned char element[SHA256_DIGEST_LENGTH])
 {
     sha256_context_t ctx;
+
     sha256_init(&ctx);
     sha256_update(&ctx, element, SHA256_DIGEST_LENGTH);
     sha256_final(&ctx, element);
@@ -402,7 +406,7 @@ unsigned char *sha256_chain_with_waypoints(const unsigned char *seed,
         /* 1st waypoint iteration */
         sha256(seed, seed_length, tmp_element);
         for (size_t i = 1; i < waypoint_streak; ++i) {
-                sha256_inplace(tmp_element);
+            sha256_inplace(tmp_element);
         }
         memcpy(waypoints[0].element, tmp_element, SHA256_DIGEST_LENGTH);
         waypoints[0].index = (waypoint_streak - 1);
@@ -437,9 +441,9 @@ unsigned char *sha256_chain_with_waypoints(const unsigned char *seed,
 }
 
 int sha256_chain_verify_element(unsigned char *element,
-                                 size_t element_index,
-                                 unsigned char *tail_element,
-                                 size_t chain_length)
+                                size_t element_index,
+                                unsigned char *tail_element,
+                                size_t chain_length)
 {
     unsigned char tmp_element[SHA256_DIGEST_LENGTH];
 
@@ -448,7 +452,7 @@ int sha256_chain_verify_element(unsigned char *element,
     /* assert if we have an index mismatch */
     assert(delta_count >= 1);
 
-    memcpy((void*)tmp_element, (void*)element, SHA256_DIGEST_LENGTH);
+    memcpy((void *)tmp_element, (void *)element, SHA256_DIGEST_LENGTH);
 
     /* perform all consecutive iterations down to tail_element */
     for (int i = 0; i < (delta_count - 1); ++i) {

--- a/sys/include/hashes/md5.h
+++ b/sys/include/hashes/md5.h
@@ -69,8 +69,7 @@ extern "C" {
 /**
  * @brief   MD5 calculation context
  */
-typedef struct
-{
+typedef struct {
     uint32_t len;       /**< overall number of bytes processed */
     uint32_t abcd[4];   /**< virtual registers for hash calculation */
     int b_used;         /**< number of bytes used in the current block */

--- a/sys/include/hashes/sha1.h
+++ b/sys/include/hashes/sha1.h
@@ -66,27 +66,27 @@ typedef struct {
 /**
  * @brief Initialize SHA-1 message digest context
  *
- * @param[in] s     Pointer to the SHA-1 context to initialize
+ * @param[in] ctx     Pointer to the SHA-1 context to initialize
  */
-void sha1_init(sha1_context *s);
+void sha1_init(sha1_context *ctx);
 
 /**
  * @brief Update the SHA-1 context with a portion of the message being hashed
  *
- * @param[in] s     Pointer to the SHA-1 context to update
- * @param[in] data  Pointer to the buffer to be hashed
- * @param[in] len   Length of the buffer
+ * @param[in] ctx       Pointer to the SHA-1 context to update
+ * @param[in] data      Input data
+ * @param[in] len       Length of @p data
  */
-void sha1_update(sha1_context *s, const unsigned char *data, size_t len);
+void sha1_update(sha1_context *ctx, const uint8_t *data, size_t len);
 
 /**
  * @brief Finalizes the SHA-1 message digest
  *
- * @param[in] s     Pointer to the SHA-1 context
+ * @param[in] ctx     Pointer to the SHA-1 context
+ * @param[out] dst    Result location, must be 20 byte
  *
- * @return Calculated digest
  */
-uint8_t *sha1_final(sha1_context *s);
+void sha1_final(sha1_context *ctx, uint8_t *dst);
 
 /**
  * @brief   Calculate a SHA1 hash from the given data
@@ -100,20 +100,20 @@ void sha1(uint8_t *dst, const uint8_t *src, size_t len);
 /**
  * @brief Initialize SHA-1 message digest context with MAC
  *
- * @param[in] s             Pointer to the SHA-1 context to initialize
+ * @param[in] ctx           Pointer to the SHA-1 context to initialize
  * @param[in] key           Key used in the HMAC-SHA1 computation
  * @param[in] key_length    The size in bytes of @p key
  */
-void sha1_init_hmac(sha1_context *s, const unsigned char *key, size_t key_length);
+void sha1_init_hmac(sha1_context *ctx, const uint8_t *key, size_t key_length);
 
 /**
  * @brief Finalizes the SHA-1 message digest with MAC
  *
  * @param[in] s     Pointer to the SHA-1 context
- *
+ * @param[out] dst      Result location, must be 20 byte
  * @return Calculated digest
  */
-uint8_t* sha1_final_hmac(sha1_context *s);
+void sha1_final_hmac(sha1_context *ctx, uint8_t *dst);
 
 #ifdef __cplusplus
 }

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -90,10 +90,10 @@ void sha256_init(sha256_context_t *ctx);
  * @brief Add bytes into the hash
  *
  * @param ctx  sha256_context_t handle to use
- * @param in   pointer to the input buffer
- * @param len  length of the buffer
+ * @param[in] data      Input data
+ * @param[in] len       Length of @p data
  */
-void sha256_update(sha256_context_t *ctx, const void *in, size_t len);
+void sha256_update(sha256_context_t *ctx, const uint8_t *data, size_t len);
 
 /**
  * @brief SHA-256 finalization.  Pads the input data, exports the hash value,
@@ -102,7 +102,7 @@ void sha256_update(sha256_context_t *ctx, const void *in, size_t len);
  * @param digest resulting digest, this is the hash of all the bytes
  * @param ctx    sha256_context_t handle to use
  */
-void sha256_final(unsigned char digest[32], sha256_context_t *ctx);
+void sha256_final(sha256_context_t *ctx, uint8_t *dst);
 
 /**
  * @brief A wrapper function to simplify the generation of a hash, this is

--- a/tests/unittests/tests-hashes/tests-hashes-sha1.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha1.c
@@ -112,7 +112,7 @@ static int calc_and_compare_hash(const char *str, const char *expected,
 {
     sha1_context ctx;
 
-    uint8_t *hash;
+    uint8_t hash[SHA1_DIGEST_LENGTH];
     char tmp[(3 * SHA1_DIGEST_LENGTH) + 1];
 
     /* calculate hash */
@@ -120,7 +120,7 @@ static int calc_and_compare_hash(const char *str, const char *expected,
     for (long int i = 0; i < repeatcount; ++i) {
         sha1_update(&ctx, (unsigned char*) str, strlen(str));
     }
-    hash = sha1_final(&ctx);
+    sha1_final(&ctx, hash);
     /* copy hash to string */
     for (size_t i = 0; i < SHA1_DIGEST_LENGTH; i++) {
         sprintf(&(tmp[i * 3]), "%02X ", (unsigned) hash[i]);
@@ -150,19 +150,20 @@ static int calc_and_compare_hash_hmac(const char *str, const char *expected,
 {
     sha1_context ctx;
 
-    uint8_t *hash;
+    uint8_t hash[SHA1_DIGEST_LENGTH];
     char tmp[(3 * SHA1_DIGEST_LENGTH) + 1];
 
     /* calculate hash */
     sha1_init_hmac(&ctx, key, key_len);
     sha1_update(&ctx, (unsigned char*) str, strlen(str));
 
-    hash = sha1_final_hmac(&ctx);
+    sha1_final_hmac(&ctx, hash);
     /* copy hash to string */
     for (size_t i = 0; i < SHA1_DIGEST_LENGTH; i++) {
         sprintf(&(tmp[i * 3]), "%02X ", (unsigned) hash[i]);
     }
     tmp[SHA1_DIGEST_LENGTH* 2] = '\0';
+
     /* compare with result string */
     return strncmp(tmp, expected, strlen((char*) tmp));
 }

--- a/tests/unittests/tests-hashes/tests-hashes-sha256-chain.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha256-chain.c
@@ -60,7 +60,7 @@ static void test_sha256_hash_chain(void)
         sha256_context_t ctx;
         sha256_init(&ctx);
         sha256_update(&ctx, tmp_element, SHA256_DIGEST_LENGTH);
-        sha256_final(tmp_element, &ctx);
+        sha256_final(&ctx, tmp_element);
 
         TEST_ASSERT(sha256_chain_verify_element(tmp_element, i,
                                                 tail_hash_chain_element, elements) == 0);

--- a/tests/unittests/tests-hashes/tests-hashes-sha256-hmac.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha256-hmac.c
@@ -18,7 +18,7 @@
 #include "tests-hashes.h"
 
 static int compare_str_vs_digest(const char *str,
-                                 const unsigned char hash[SHA256_DIGEST_LENGTH])
+                                 const uint8_t hash[SHA256_DIGEST_LENGTH])
 {
     char ch[3] = { 0, 0, 0 };
     size_t iter_hash = 0;
@@ -39,7 +39,7 @@ static void test_hashes_hmac_sha256_hash_sequence(void)
     unsigned char key[64];
     /* prepare an empty key */
     memset((void*)key, 0x0, 64);
-    static unsigned char hmac[SHA256_DIGEST_LENGTH];
+    static uint8_t hmac[SHA256_DIGEST_LENGTH];
 
     /* use an empty message */
     const unsigned *m = NULL;

--- a/tests/unittests/tests-hashes/tests-hashes-sha256.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha256.c
@@ -140,8 +140,8 @@ static int calc_and_compare_hash(const char *str, const unsigned char *expected)
     sha256_context_t sha256;
 
     sha256_init(&sha256);
-    sha256_update(&sha256, str, strlen(str));
-    sha256_final(hash, &sha256);
+    sha256_update(&sha256, (uint8_t*)str, strlen(str));
+    sha256_final(&sha256, hash);
 
     return (memcmp(expected, hash, SHA256_DIGEST_LENGTH) == 0);
 }


### PR DESCRIPTION
The signatures of the functions used to access the cryptographic hash functions sha1, sha256 and md5 have been pretty inconsistent.
With this patch, the functions XXX_init, XXX_update and XXX_final use the same parameters.