### PR TITLE
gnrc_border_router: use start_network.sh script as for term target

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -53,5 +53,15 @@ CFLAGS += -DDEVELHELP
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
+TAP ?= tap0
+IPV6_PREFIX ?= 2001:db8::/64
 
 include $(RIOTBASE)/Makefile.include
+
+.PHONY: host-tools
+
+term: host-tools
+	$(AD)sudo sh $(RIOTBASE)/dist/tools/ethos/start_network.sh $(PORT) $(TAP) $(IPV6_PREFIX)
+
+host-tools:
+	$(AD)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools


### PR DESCRIPTION
Simplifies the border router even more, by allowing a user just to type `make term` to start up `uhcpd` and `ethos`. Caveat: `sudo` in a Makefile. Some people in the security communtity might give us a fowl eye for that.