### PR TITLE
auto_init: initialize gnrc_rpl

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -1,3 +1,4 @@
+PSEUDOMODULES += auto_init_gnrc_rpl
 PSEUDOMODULES += conn
 PSEUDOMODULES += conn_ip
 PSEUDOMODULES += conn_tcp

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -21,6 +21,7 @@ USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_udp
 # Add a routing protocol
 USEMODULE += gnrc_rpl
+USEMODULE += auto_init_gnrc_rpl
 # This application dumps received packets to STDIO using the pktdump module
 USEMODULE += gnrc_pktdump
 # Additional networking modules that can be dropped if not needed

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -256,4 +256,13 @@ void auto_init(void)
 #endif
 
 #endif /* MODULE_AUTO_INIT_SAUL */
+
+#ifdef MODULE_AUTO_INIT_GNRC_RPL
+
+#ifdef MODULE_GNRC_RPL
+    extern void auto_init_gnrc_rpl(void);
+    auto_init_gnrc_rpl();
+#endif
+
+#endif /* MODULE_AUTO_INIT_GNRC_RPL */
 }

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -24,6 +24,25 @@
  *   USEMODULE += gnrc_rpl
  *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
+ * - RPL auto-initialization on interface
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ *   USEMODULE += auto_init_gnrc_rpl
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * Auto-Initialization
+ * -------------------
+ *
+ * If the application defines only one interface (`GNRC_NETIF_NUMOF == 1`),
+ * then RPL will be initialized on this interface.
+ *
+ * If the application defines several interfaces (`GNRC_NETIF_NUMOF > 1`),
+ * then RPL will be initialized on the interface `GNRC_RPL_DEFAULT_NETIF`.
+ * Your application is responsible for setting `GNRC_RPL_DEFAULT_NETIF` to a
+ * valid interface PID, e.g. via `CFLAGS`.
+ *
+ * Initializing RPL on multiple interfaces automatically is currently not supported.
+ * Call `gnrc_rpl_init()` manually from your application for the desired interfaces in this case.
+ *
  * CFLAGS
  * ------
  *
@@ -47,6 +66,12 @@
  *   only a DODAG once a DODAG_CONF is received.
  *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
  *   CFLAGS += -DGNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * - Set interface for auto-initialization if more than one
+ *   interface exists (`GNRC_NETIF_NUMOF > 1`)
+ *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ *   CFLAGS += -DGNRC_RPL_DEFAULT_NETIF=6
  *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * @{

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_auto_init.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2016 Cenk Gündoğan <mail@cgundogan.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup gnrc_rpl
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for gnrc_rpl
+ *
+ * @author  Cenk Gündoğan <mail@cgundogan.de>
+ */
+
+#ifdef MODULE_AUTO_INIT_GNRC_RPL
+
+#include "net/gnrc.h"
+#include "net/gnrc/rpl.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+void auto_init_gnrc_rpl(void)
+{
+#if (GNRC_NETIF_NUMOF == 1)
+    kernel_pid_t ifs[GNRC_NETIF_NUMOF];
+    gnrc_netif_get(ifs);
+    DEBUG("auto_init_gnrc_rpl: initializing RPL on interface %" PRIkernel_pid "\n", ifs[0]);
+    gnrc_rpl_init(ifs[0]);
+    return;
+#elif defined(GNRC_RPL_DEFAULT_NETIF)
+    if (gnrc_netif_exist(GNRC_RPL_DEFAULT_NETIF)) {
+        DEBUG("auto_init_gnrc_rpl: initializing RPL on interface %" PRIkernel_pid "\n",
+              GNRC_RPL_DEFAULT_NETIF);
+        gnrc_rpl_init(GNRC_RPL_DEFAULT_NETIF);
+        return;
+    }
+    DEBUG("auto_init_gnrc_rpl: could not initialize RPL on interface %" PRIkernel_pid" - "
+          "interface does not exist\n", GNRC_RPL_DEFAULT_NETIF);
+    return;
+#else
+    DEBUG("auto_init_gnrc_rpl: please specify an interface by setting GNRC_RPL_DEFAULT_NETIF\n");
+#endif
+}
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_AUTO_INIT_GNRC_RPL */
+
+/** @} */


### PR DESCRIPTION
Initializes rpl automatically and enables this feature for `gnrc_networking`.

If one interface exists: rpl will be initialized on this interface.
If several interfaces exist, `GNRC_RPL_DEFAULT_NETIF` will be used to initialize rpl.

Initializing rpl on multiple interfaces automatically is not supported for now, but can be achieved from within the application by calling `gnrc_rpl_init()` manually for the desired interfaces.