### PR TITLE
native: add timeout for select. Fixes #5442

### DIFF
--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -42,6 +42,8 @@ static void _async_io_isr(void) {
 
     int max_fd = 0;
 
+    struct timeval timeout = { .tv_usec = 0 };
+
     for (int i = 0; i < _next_index; i++) {
         FD_SET(_fds[i], &rfds);
 
@@ -50,7 +52,7 @@ static void _async_io_isr(void) {
         }
     }
 
-    if (real_select(max_fd + 1, &rfds, NULL, NULL, NULL) > 0) {
+    if (real_select(max_fd + 1, &rfds, NULL, NULL, &timeout) > 0) {
         for (int i = 0; i < _next_index; i++) {
             if (FD_ISSET(_fds[i], &rfds)) {
                 _native_async_read_callbacks[i](_fds[i]);


### PR DESCRIPTION
It may be locked in the following scenario theoretically:

1. new data arrives
2. `SIGIO`
3. new data arrives
4. `select` in `_async_io_isr`, processing all data
5. `SIGIO`
6. `select` in `_async_io_isr` but no data available
