### PR TITLE
Adjust find-tty.sh to return all matches, then use it in boards/cc2538dk

### DIFF
--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -2,8 +2,12 @@
 export CPU        = cc2538
 export CPU_MODEL ?= cc2538nf53
 
+# the SmartRF06 Evaluation Board serial numbers all begin with "06EB":
+export PROGRAMMER_SERIAL ?= 06EB
+
 # setup serial terminal
-PORT_LINUX ?= $(firstword $(wildcard /dev/serial/by-id/*XDS100v3*if01* /dev/ttyUSB1))
+# the debug UART is always the second tty with the matching serial number:
+PORT_LINUX ?= $(word 2,$(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh '^$(PROGRAMMER_SERIAL)'))
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 include $(RIOTBOARD)/Makefile.include.serial
 

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -76,10 +76,10 @@ ifeq ($(PORT),)
   # try to find tty name by serial number, only works on Linux currently.
   ifeq ($(OS),Linux)
     ifneq ($(PROGRAMMER_SERIAL),)
-      PORT := $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh '^$(PROGRAMMER_SERIAL)$$')
+      PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh '^$(PROGRAMMER_SERIAL)$$'))
     else
       # find-tty.sh will return the first USB tty if no serial is given.
-      PORT := $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh)
+      PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh))
   endif
   else ifeq ($(OS),Darwin)
     ifneq ($(PROGRAMMER_SERIAL),)

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -34,7 +34,7 @@ include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 #   Usage: SERIAL="0200..." BOARD="pba-d-01-kw2x" make flash
 ifneq (,$(SERIAL))
     export OPENOCD_EXTRA_INIT += "-c cmsis_dap_serial $(SERIAL)"
-    SERIAL_TTY = $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL))
+    SERIAL_TTY = $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL)))
     ifeq (,$(SERIAL_TTY))
         $(error Did not find a device with serial $(SERIAL))
     endif

--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -17,7 +17,7 @@ include $(RIOTBOARD)/Makefile.include.serial
 #   Usage: SERIAL="ATML..." BOARD="samr21-xpro" make flash
 ifneq (,$(SERIAL))
     export OPENOCD_EXTRA_INIT += "-c cmsis_dap_serial $(SERIAL)"
-    SERIAL_TTY = $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL))
+    SERIAL_TTY = $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL)))
     ifeq (,$(SERIAL_TTY))
         $(error Did not find a device with serial $(SERIAL))
     endif

--- a/dist/tools/usb-serial/README.md
+++ b/dist/tools/usb-serial/README.md
@@ -13,15 +13,15 @@ List all currently connected USB to serial adapters by searching through
 
     ./find-tty.sh [serial_regex1] [serial_regex2] ... [serial_regexZ]
 
-Write to `stdout` the first tty connected to the chosen programmer.
+Write to `stdout` all ttys connected to the chosen programmer.
 `serial_regexN` are extended regular expressions (as understood by `egrep`)
 containing a pattern matched against the USB device serial number. Each of the
-given expressions are tested, against each serial number until a match has been
-found.
+given expressions are tested, against each serial number, and matching ttys are
+output (one tty per line).
 
 In order to search for an exact match against the device serial, use
 '^serialnumber$' as the pattern. If no pattern is given, `find-tty.sh` returns
-the first found USB tty (in an arbitrary order, this is not guaranteed to be
+all found USB ttys (in an arbitrary order, this is not guaranteed to be
 the `/dev/ttyUSBX` with the lowest number).
 
 Serial strings from all connected USB ttys can be found from the list generated
@@ -45,7 +45,7 @@ solution):
       ifeq ($(PORT),)
         # try to find tty name by serial number, only works on Linux currently.
         ifeq ($(OS),Linux)
-          PORT := $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh "^$(PROGRAMMER_SERIAL)$$")
+          PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh "^$(PROGRAMMER_SERIAL)$$"))
         endif
       endif
     endif
@@ -53,7 +53,7 @@ solution):
     # Fallback PORT if no serial was specified or if the specified serial was not found
     ifeq ($(PORT),)
         ifeq ($(OS),Linux)
-          PORT := $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh)
+          PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh))
         else ifeq ($(OS),Darwin)
           PORT := $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
         endif

--- a/dist/tools/usb-serial/find-tty.sh
+++ b/dist/tools/usb-serial/find-tty.sh
@@ -9,35 +9,38 @@
 #
 
 # Find all USB to serial devices
+
+# default error status code
+status=1
+
 # iterate over usb-tty devices:
 for basedev in $(find /sys/bus/usb/devices/ -regex "/sys/bus/usb/devices/[0-9]+[^:/]*" -maxdepth 2 -follow 2>/dev/null); do
     ttydirs=$(find ${basedev} -regex "${basedev}/[^/]*:.*" -mindepth 2 -maxdepth 3 -name tty -follow 2>/dev/null)
     if [ -z "${ttydirs}" ]; then
         continue
     fi
-    # See if the device has any tty devices assigned to it, get the first match
-    tty=$(find ${ttydirs} -maxdepth 1 -mindepth 1 -printf '%f\n' | head -n 1 2>/dev/null)
-    if [ -z "${tty}" ]; then
-        continue
-    fi
-    parent=$(echo ${basedev} | sed -e 's%\(/sys/bus/usb/devices/[^/]*\)/.*%\1%')
-    serial=$(cat "${parent}/serial" 2>/dev/null)
-    # split results into array
+    # See if the device has any tty devices assigned to it
+    for tty in $(find ${ttydirs} -maxdepth 1 -mindepth 1 -printf '%f\n' 2>/dev/null); do
+        parent=$(echo ${basedev} | sed -e 's%\(/sys/bus/usb/devices/[^/]*\)/.*%\1%')
+        serial=$(cat "${parent}/serial" 2>/dev/null)
+        # split results into array
 
-    if [ $# -lt 1 ]; then
-        # No arguments given, return first found tty
-        echo "/dev/${tty}"
-        exit 0
-    fi
-    # else: Match any of the given serials
-    for s in "${@}"; do
-        echo "${serial}" | egrep -e "${s}" -q
-        if [ $? -eq 0 ]; then
-            # return first tty
+        if [ $# -lt 1 ]; then
+            # No arguments given, return all ttys
             echo "/dev/${tty}"
-            exit 0
+            status=0
+            continue
         fi
+        # else: Match any of the given serials
+        for s in "${@}"; do
+            echo "${serial}" | egrep -e "${s}" -q
+            if [ $? -eq 0 ]; then
+                # return tty
+                echo "/dev/${tty}"
+                status=0
+            fi
+        done
     done
 done
-# not found
-exit 1;
+
+exit $status;


### PR DESCRIPTION
This is an improvement upon merged PR #4877. `find-tty.sh` now returns all matches, not just the first match. This allows the board-specific `Makefile.include` to select the `firstword` or second word as needed. It's necessary for `boards/cc2538dk`, but may also appeal to other/future boards.