### PR TITLE
saul: add a self test function in saul driver

### DIFF
--- a/drivers/dht/dht_saul.c
+++ b/drivers/dht/dht_saul.c
@@ -70,11 +70,13 @@ static int read_hum(void *dev, phydat_t *res)
 const saul_driver_t dht_temp_saul_driver = {
     .read = read_temp,
     .write = saul_notsup,
+    .test = saul_test_notsup,
     .type = SAUL_SENSE_TEMP
 };
 
 const saul_driver_t dht_hum_saul_driver = {
     .read = read_hum,
     .write = saul_notsup,
+    .test = saul_test_notsup,
     .type = SAUL_SENSE_HUM
 };

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2016 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -37,6 +38,7 @@
  * @brief       Definition of the generic [S]ensor [A]ctuator [U]ber [L]ayer
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Vincent Dupont <vincent@otakeys.com>
  */
 
 #ifndef SAUL_H

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -131,11 +131,23 @@ typedef int(*saul_read_t)(void *dev, phydat_t *res);
 typedef int(*saul_write_t)(void *dev, phydat_t *data);
 
 /**
+ * @brief   Test a device
+ *
+ * @param[in] dev       device descriptor of the target device
+ *
+ * @return a non negative value if the device test is OK
+ * @return -ENOTSUP if the device does not support this operation
+ * @return any other negative value on error
+ */
+typedef int(*saul_test_t)(void *dev);
+
+/**
  * @brief   Definition of the RIOT actuator/sensor interface
  */
 typedef struct {
     saul_read_t read;       /**< read function pointer */
     saul_write_t write;     /**< write function pointer */
+    saul_test_t test;       /**< test function pointer */
     uint8_t type;           /**< device class the device belongs to */
 } saul_driver_t;
 
@@ -143,6 +155,11 @@ typedef struct {
  * @brief   Default not supported function
  */
 int saul_notsup(void *dev, phydat_t *dat);
+
+/**
+ * @brief   Default test not supported function
+ */
+int saul_test_notsup(void *dev);
 
 /**
  * @brief   Helper function converts a class ID to a string

--- a/drivers/isl29020/isl29020_saul.c
+++ b/drivers/isl29020/isl29020_saul.c
@@ -41,5 +41,6 @@ static int write(void *dev, phydat_t *state)
 const saul_driver_t isl29020_saul_driver = {
     .read = read,
     .write = write,
+    .test = saul_test_notsup,
     .type = SAUL_SENSE_LIGHT,
 };

--- a/drivers/l3g4200d/l3g4200d_saul.c
+++ b/drivers/l3g4200d/l3g4200d_saul.c
@@ -40,5 +40,6 @@ static int write(void *dev, phydat_t *state)
 const saul_driver_t l3g4200d_saul_driver = {
     .read = read,
     .write = write,
+    .test = saul_test_notsup,
     .type = SAUL_SENSE_GYRO,
 };

--- a/drivers/lis3dh/lis3dh_saul.c
+++ b/drivers/lis3dh/lis3dh_saul.c
@@ -55,5 +55,6 @@ static int write(void *dev, phydat_t *state)
 const saul_driver_t lis3dh_saul_driver = {
     .read = read_acc,
     .write = write,
+    .test = saul_test_notsup,
     .type = SAUL_SENSE_ACCEL,
 };

--- a/drivers/lps331ap/lps331ap_saul.c
+++ b/drivers/lps331ap/lps331ap_saul.c
@@ -41,5 +41,6 @@ static int write(void *dev, phydat_t *state)
 const saul_driver_t lps331ap_saul_driver = {
     .read = read,
     .write = write,
+    .test = saul_test_notsup,
     .type = SAUL_SENSE_PRESS,
 };

--- a/drivers/lsm303dlhc/lsm303dlhc_saul.c
+++ b/drivers/lsm303dlhc/lsm303dlhc_saul.c
@@ -75,11 +75,13 @@ static int write(void *dev, phydat_t *state)
 const saul_driver_t lsm303dlhc_saul_acc_driver = {
     .read = read_acc,
     .write = write,
+    .test = saul_test_notsup,
     .type = SAUL_SENSE_ACCEL,
 };
 
 const saul_driver_t lsm303dlhc_saul_mag_driver = {
     .read = read_mag,
     .write = write,
+    .test = saul_test_notsup,
     .type = SAUL_SENSE_MAG,
 };

--- a/drivers/mma8652/mma8652_saul.c
+++ b/drivers/mma8652/mma8652_saul.c
@@ -48,8 +48,16 @@ static int write(void *dev, phydat_t *state)
     return -ENOTSUP;
 }
 
+static int test(void *dev)
+{
+    mma8652_t *d = (mma8652_t *)dev;
+
+    return mma8652_test(d);
+}
+
 const saul_driver_t mma8652_saul_driver = {
     .read = read_acc,
     .write = write,
+    .test = test,
     .type = SAUL_SENSE_ACCEL,
 };

--- a/drivers/saul/gpio_saul.c
+++ b/drivers/saul/gpio_saul.c
@@ -45,5 +45,6 @@ static int write(void *dev, phydat_t *state)
 const saul_driver_t gpio_saul_driver = {
     .read = read,
     .write = write,
+    .test = saul_test_notsup,
     .type = SAUL_ACT_SWITCH,
 };

--- a/drivers/saul/saul.c
+++ b/drivers/saul/saul.c
@@ -28,3 +28,9 @@ int saul_notsup(void *dev, phydat_t *dat)
     (void)dat;
     return -ENOTSUP;
 }
+
+int saul_test_notsup(void *dev)
+{
+    (void)dev;
+    return -ENOTSUP;
+}

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2016 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -17,6 +18,7 @@
  * @brief       SAUL registry interface definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Vincent Dupont <vincent@otakeys.com>
  */
 
 #ifndef SAUL_REG_H
@@ -132,6 +134,17 @@ int saul_reg_read(saul_reg_t *dev, phydat_t *res);
  * @return      -ECANCELED on device errors
  */
 int saul_reg_write(saul_reg_t *dev, phydat_t *data);
+
+/**
+ * @brief   Test the given device
+ *
+ * @param[in] dev       device to test
+ *
+ * @return      0 if test pass successfully
+ * @return      -ENODEV if given device is invalid
+ * @return      -ENOTSUP if test operation is not supported by the device
+ */
+int saul_reg_test(saul_reg_t *dev);
 
 #ifdef __cplusplus
 }

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -128,9 +128,9 @@ int saul_reg_read(saul_reg_t *dev, phydat_t *res);
  * @param[in] dev       device to write to
  * @param[in] data      data to write to the device
  *
- * @return      the number of data elements read to @p res [1-3]
+ * @return      the number of data elements actually written into @p dev [1-3]
  * @return      -ENODEV if given device is invalid
- * @return      -ENOTSUP if read operation is not supported by the device
+ * @return      -ENOTSUP if write operation is not supported by the device
  * @return      -ECANCELED on device errors
  */
 int saul_reg_write(saul_reg_t *dev, phydat_t *data);

--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2016 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       SAUL registry implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Vincent Dupont <vincent@otakeys.com>
  *
  * @}
  */
@@ -125,4 +127,13 @@ int saul_reg_write(saul_reg_t *dev, phydat_t *data)
         return -ENODEV;
     }
     return dev->driver->write(dev->dev, data);
+}
+
+int saul_reg_test(saul_reg_t *dev)
+{
+
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+    return dev->driver->test(dev->dev);
 }


### PR DESCRIPTION
Hi,

I would like to have your feedback on this.
I'm currently working on implementing some hardware tests on our board and having such a functionality for the saul interface could be interesting.
This PR just adds a test function to the saul interface which can be used to test the device. It's implemented on the mma8652 driver.
