### PR TITLE
cortexm_common: move the stack to the bottom of RAM

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -101,6 +101,16 @@ SECTIONS
     . = ALIGN(4);
     _etext = .;
 
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        KEEP (*(.isr_stack))
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
     .relocate : AT (_etext)
     {
         . = ALIGN(4);
@@ -122,16 +132,6 @@ SECTIONS
         . = ALIGN(4);
         _ebss = . ;
         _ezero = .;
-    } > ram
-
-    /* stack section */
-    .stack (NOLOAD):
-    {
-        . = ALIGN(8);
-        _sstack = .;
-        KEEP (*(.isr_stack))
-        . = ALIGN(8);
-        _estack = .;
     } > ram
 
     /* heap section */


### PR DESCRIPTION
`cortexm_base.ld` currently places the `relocate` section at the bottom of RAM, followed by the `stack` section. Since the stack grows downward on ARM platforms, it will silently overwrite parts of the relocated data if it overflows. Moving the stack to the bottom of RAM will prevent this from happening and will also trigger an exception immediately when an overflow occurs. I see two benefits and don't know of any downsides.