### PR TITLE
sys/shell: adding definition for deactiving prompt and/or echo in shell

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -234,8 +234,10 @@ static int readline(char *buf, size_t size)
         /* DOS newlines are handled like hitting enter twice, but empty lines are ignored. */
         if (c == '\r' || c == '\n') {
             *line_buf_ptr = '\0';
+#ifndef SHELL_NO_ECHO
             _putchar('\r');
             _putchar('\n');
+#endif
 
             /* return 1 if line is empty, 0 otherwise */
             return line_buf_ptr == buf;
@@ -249,21 +251,27 @@ static int readline(char *buf, size_t size)
 
             *--line_buf_ptr = '\0';
             /* white-tape the character */
+#ifndef SHELL_NO_ECHO
             _putchar('\b');
             _putchar(' ');
             _putchar('\b');
+#endif
         }
         else {
             *line_buf_ptr++ = c;
+#ifndef SHELL_NO_ECHO
             _putchar(c);
+#endif
         }
     }
 }
 
 static inline void print_prompt(void)
 {
+#ifndef SHELL_NO_PROMPT
     _putchar('>');
     _putchar(' ');
+#endif
 
 #ifdef MODULE_NEWLIB
     fflush(stdout);


### PR DESCRIPTION
The goal of this PR is to provide a way to configure the shell so that RIOT can be used for testing firmwares on the iotlab open nodes. I wrote some test firmwares using the shell of RIOT.

Given some inputs on the serial port of the board, the firmware tests on iotlab are expecting output strings without the command issued and no prompt. That's why I added those options. 
Then, in your application `Makefile`, simply add :
```
CFLAGS += -DSHELL_NO_PROMPT -DSHELL_NO_ECHO
```
Maybe someone has a better idea.