### PR TITLE
drivers: sensor doxygen group

### DIFF
--- a/drivers/include/lis3mdl.h
+++ b/drivers/include/lis3mdl.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    driver_LIS3MDL LIS3MDL 3-axis magnetometer
- * @ingroup     drivers
+ * @ingroup     drivers_sensors
  * @brief       Device driver for the LIS3MDL 3-axis magnetometer
  * @{
  *

--- a/drivers/include/si70xx.h
+++ b/drivers/include/si70xx.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    driver_si70xx Si70xx
- * @ingroup     drivers
+ * @ingroup     drivers_sensors
  * @brief       Driver for the Si7006/13/20/21 temperature and humidity sensor.
  * @{
  *


### PR DESCRIPTION
Two sensors were found at the top level of the drivers documentation tree at http://riot-os.org/api/