### PR TITLE
samd21/i2c: wait for bus idle after stop condition

### DIFF
--- a/cpu/samd21/periph/i2c.c
+++ b/cpu/samd21/periph/i2c.c
@@ -489,6 +489,8 @@ static inline void _stop(SercomI2cm *dev)
     while(dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
     /* Stop command */
     dev->CTRLB.reg |= SERCOM_I2CM_CTRLB_CMD(3);
+    /* Wait for bus to be idle again */
+    while(dev->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE(1)) {}
     DEBUG("Stop sent\n");
 }
 


### PR DESCRIPTION
Follow discussion in #5460. @smlng please verify before merging.