### PR TITLE
pkg ccn-lite: callbacks for on-the-fly content creation

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=ccn-lite
 PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
-PKG_VERSION=9e48d328e162e97f091d913ada0bf50f58d1d3d7
+PKG_VERSION=1ae5bddc68334bc062c148b877894ba8155112c4
 
 .PHONY: all
 

--- a/pkg/ccn-lite/ccn-lite-riot.h
+++ b/pkg/ccn-lite/ccn-lite-riot.h
@@ -137,6 +137,12 @@ extern "C" {
 extern struct ccnl_relay_s ccnl_relay;
 
 /**
+ * @brief Function pointer type for local producer function
+ */
+typedef int (*ccnl_producer_func)(struct ccnl_relay_s *relay, struct
+                                  ccnl_face_s *from, struct ccnl_pkt_s *pkt);
+
+/**
  * @brief   Start the main CCN-Lite event-loop
  *
  * @return  The PID of the event-loop's thread
@@ -207,6 +213,16 @@ int ccnl_fib_rem_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx, st
  * @par[in] relay   Local relay struct
  */
 void ccnl_fib_show(struct ccnl_relay_s *relay);
+
+/**
+ * @brief Set a local producer function
+ *
+ * Setting a local producer function allows to generate content on the fly or
+ * react otherwise on any kind of incoming interest.
+ *
+ * @param[in] func  The function to be called first for any incoming interest
+ */
+void ccnl_set_local_producer(ccnl_producer_func func);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR does:
 * update the CCN-lite package to the latest upstream revision
 * adds prototypes to register callbacks that allows for on-the-fly content creation (useful for e.g. sensors)