### PR TITLE
tests/drivers_*: use bus parameters from board or driver

### DIFF
--- a/drivers/include/tmp006.h
+++ b/drivers/include/tmp006.h
@@ -84,8 +84,8 @@ extern "C"
 {
 #endif
 
-#ifndef TMP006_I2C_ADDRESS
-#define TMP006_I2C_ADDRESS         0x41 /**< TMP006 Sensor Default Address */
+#ifndef TMP006_ADDR
+#define TMP006_ADDR                0x40 /**< TMP006 Sensor Default Address */
 #endif
 
 #ifndef TMP006_CONVERSION_TIME

--- a/tests/driver_tmp006/Makefile
+++ b/tests/driver_tmp006/Makefile
@@ -6,14 +6,4 @@ FEATURES_REQUIRED = periph_i2c
 USEMODULE += tmp006
 USEMODULE += xtimer
 
-# set default device parameters in case they are undefined
-TEST_TMP006_I2C       ?= I2C_0
-TEST_TMP006_ADDR      ?= 0x41
-TEST_TMP006_CONFIG_CR ?= TMP006_CONFIG_CR_DEF
-
-# export parameters
-CFLAGS += -DTEST_TMP006_I2C=$(TEST_TMP006_I2C)
-CFLAGS += -DTEST_TMP006_ADDR=$(TEST_TMP006_ADDR)
-CFLAGS += -DTEST_TMP006_CONFIG_CR=$(TEST_TMP006_CONFIG_CR)
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tmp006/main.c
+++ b/tests/driver_tmp006/main.c
@@ -20,20 +20,23 @@
  * @}
  */
 
-#ifndef TEST_TMP006_I2C
-#error "TEST_TMP006_I2C not defined"
-#endif
-#ifndef TEST_TMP006_ADDR
-#error "TEST_TMP006_ADDR not defined"
-#endif
-#ifndef TEST_TMP006_CONFIG_CR
-#error "TEST_TMP006_ADDR not defined"
-#endif
-
 #include <stdio.h>
 
 #include "xtimer.h"
 #include "tmp006.h"
+
+#ifdef TMP006_I2C
+#define TEST_TMP006_I2C TMP006_I2C
+#else
+#define TEST_TMP006_I2C I2C_0
+#endif
+#ifdef TMP006_ADDR
+#define TEST_TMP006_ADDR TMP006_ADDR
+#else
+#define TEST_TMP006_ADDR 0x40
+#endif
+
+#define TEST_TMP006_CONFIG_CR       TMP006_CONFIG_CR_DEF /**< Default for Testing */
 
 int main(void)
 {


### PR DESCRIPTION
Some sensors define default parameters in their drivers, especially I'm talking about the bus- and/or bus-addresses. Sensors are permanently mounted on a board or externally connected via cables. In the first case, the default parameters are also defined in the board.h which makes sense. Most of the sensor tests define these parameters by itself which may lead to configuration errors. In addition to that, some I2C devices have address pins to set up a different bus address. That shows the need of separation between (i) board-default and (ii) sensor **or** personal configuration. 

Question 1:
What do you think about it and my proposal for the `tmp006` in this PR? 

Question 2:
Do you think the driver itself should define a default value (which may change according to address pins) or should we rather define the default in the test application and leave it to the user in case there isn't a default configuration e.g. from the board.h?
