### PR TITLE
boards/arduino-zero: add initial support

### DIFF
--- a/boards/arduino-zero/Makefile
+++ b/boards/arduino-zero/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-zero/Makefile.dep
+++ b/boards/arduino-zero/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/arduino-zero/Makefile.features
+++ b/boards/arduino-zero/Makefile.features
@@ -1,0 +1,17 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += arduino
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/arduino-zero/Makefile.include
+++ b/boards/arduino-zero/Makefile.include
@@ -1,0 +1,29 @@
+# define the cpu used by Arduino/Genuino Zero board
+export CPU = samd21
+export CPU_MODEL = samd21g18a
+export CFLAGS += -D__SAMD21G18A__
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup the boards dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
+# setup serial terminal
+include $(RIOTBOARD)/Makefile.include.serial
+
+# Add board selector (USB serial) to OpenOCD options if specified.
+# Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
+#   Usage: SERIAL="<SERIAL>" BOARD="arduino-zero" make flash
+ifneq (,$(SERIAL))
+    export OPENOCD_EXTRA_INIT += "-c cmsis_dap_serial $(SERIAL)"
+    SERIAL_TTY = $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL))
+    ifeq (,$(SERIAL_TTY))
+        $(error Did not find a device with serial $(SERIAL))
+    endif
+    PORT_LINUX := $(SERIAL_TTY)
+endif
+
+# this board uses openocd
+include $(RIOTBOARD)/Makefile.include.openocd

--- a/boards/arduino-zero/board.c
+++ b/boards/arduino-zero/board.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-zero
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Arduino Zero board
+ *
+ * @author      Hauke Pertersen  <hauke.pertersen@fu-berlin.de>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+    /* initialize the on-board Amber "L" LED on pin PA17 */
+    gpio_init(LED0_PIN, GPIO_OUT);
+}

--- a/boards/arduino-zero/dist/openocd.cfg
+++ b/boards/arduino-zero/dist/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/cmsis-dap.cfg]
+
+set CHIPNAME at91samd21g18
+set ENDIAN little
+set telnet_port 0
+
+source [find target/at91samdXX.cfg]

--- a/boards/arduino-zero/include/arduino_board.h
+++ b/boards/arduino-zero/include/arduino_board.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-zero
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Hauke Petersen  <hauke.petersen@fu-berlin.de>
+ * @author      Alexandre Abadie  <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 13 on this board
+ */
+#define ARDUINO_LED         (13)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/arduino-zero/include/arduino_pinmap.h
+++ b/boards/arduino-zero/include/arduino_pinmap.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C)  2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-zero
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PA, 11)
+#define ARDUINO_PIN_1           GPIO_PIN(PA, 10)
+#define ARDUINO_PIN_2           GPIO_PIN(PA, 14)
+#define ARDUINO_PIN_3           GPIO_PIN(PA, 9)
+#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)
+#define ARDUINO_PIN_5           GPIO_PIN(PA, 15)
+#define ARDUINO_PIN_6           GPIO_PIN(PA, 20)
+#define ARDUINO_PIN_7           GPIO_PIN(PA, 21)
+
+#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)
+#define ARDUINO_PIN_9           GPIO_PIN(PA, 7)
+#define ARDUINO_PIN_10          GPIO_PIN(PA, 18)
+#define ARDUINO_PIN_11          GPIO_PIN(PA, 16)
+#define ARDUINO_PIN_12          GPIO_PIN(PA, 19)
+#define ARDUINO_PIN_13          GPIO_PIN(PA, 17) /* on-board LED */
+
+#define ARDUINO_PIN_A0          GPIO_PIN(PA, 2)
+#define ARDUINO_PIN_A1          GPIO_PIN(PB, 8)
+#define ARDUINO_PIN_A2          GPIO_PIN(PB, 9)
+#define ARDUINO_PIN_A3          GPIO_PIN(PA, 4)
+#define ARDUINO_PIN_A4          GPIO_PIN(PA, 5)
+#define ARDUINO_PIN_A5          GPIO_PIN(PB, 2)
+/** @ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/arduino-zero/include/board.h
+++ b/boards/arduino-zero/include/board.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_arduino-zero Arduino Zero
+ * @ingroup     boards
+ * @brief       Support for the Arduino Zero board.
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Arduino Zero
+ *              board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph_cpu.h"
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   xtimer configuration
+ * @{
+ */
+#define XTIMER              TIMER_0
+#define XTIMER_CHAN         (0)
+/** @} */
+
+/**
+ * @brief   LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 17)
+
+#define LED_PORT            PORT->Group[PA]
+#define LED0_MASK           (1 << 17)
+
+#define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H_ */
+/** @} */

--- a/boards/arduino-zero/include/gpio_params.h
+++ b/boards/arduino-zero/include/gpio_params.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_arduino-zero
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author    Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(orange)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-zero
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for Arduino Zero board
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H_
+#define PERIPH_CONF_H_
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   External oscillator and clock configuration
+ *
+ * For selection of the used CORECLOCK, we have implemented two choices:
+ *
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why we use this option as default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL       (1)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+/* generate the actual used core clock frequency */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+#define TIMER_NUMOF         (2U)
+#define TIMER_0_EN          1
+#define TIMER_1_EN          1
+
+/* Timer 0 configuration */
+#define TIMER_0_DEV         TC3->COUNT16
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_MAX_VALUE   (0xffff)
+#define TIMER_0_ISR         isr_tc3
+
+/* Timer 1 configuration */
+#define TIMER_1_DEV         TC4->COUNT32
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_MAX_VALUE   (0xffffffff)
+#define TIMER_1_ISR         isr_tc4
+
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    /* device, RX pin, TX pin, mux, RX pad, TX pad */
+    {&SERCOM5->USART, GPIO_PIN(PB,23), GPIO_PIN(PB,22), GPIO_MUX_D, SERCOM_RX_PAD_3, UART_TX_PAD_2},
+    {&SERCOM0->USART, GPIO_PIN(PA,11), GPIO_PIN(PA,10), GPIO_MUX_C, SERCOM_RX_PAD_3, UART_TX_PAD_2},
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom5
+#define UART_1_ISR          isr_sercom0
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_0_EN            1
+#define PWM_1_EN            1
+#define PWM_MAX_CHANNELS    2
+/* for compatibility with test application */
+#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
+#define PWM_1_CHANNELS      PWM_MAX_CHANNELS
+
+/* PWM device configuration */
+static const pwm_conf_t pwm_config[] = {
+#if PWM_0_EN
+    {TCC0, {
+        /* GPIO pin, MUX value, TCC channel */
+        { GPIO_PIN(PA, 8), GPIO_MUX_E,  0 },
+        { GPIO_PIN(PA, 9), GPIO_MUX_E,  1 },
+    }},
+#endif
+#if PWM_1_EN
+    {TCC1, {
+        /* GPIO pin, MUX value, TCC channel */
+        { GPIO_PIN(PA, 6), GPIO_MUX_E, 0 },
+        { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 },
+    }},
+#endif
+};
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           (2U)
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_CONFIG {            \
+    { GPIO_PIN(PA, 2), 0, 0  }, \
+    { GPIO_PIN(PB, 8), 0, 2  }, \
+    { GPIO_PIN(PB, 9), 0, 3  }, \
+    { GPIO_PIN(PA, 4), 0, 4  }, \
+    { GPIO_PIN(PA, 5), 0, 5  }, \
+    { GPIO_PIN(PB, 2), 0, 10 }}
+
+#define ADC_NUMOF           (6)
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+#define SPI_NUMOF          (1)
+#define SPI_0_EN           1
+
+/*      SPI0             */
+#define SPI_0_DEV          SERCOM4->SPI
+#define SPI_IRQ_0          SERCOM4_IRQn
+#define SPI_0_GCLK_ID      SERCOM4_GCLK_ID_CORE
+/* SPI 0 pin configuration */
+#define SPI_0_SCLK         GPIO_PIN(PB, 11)
+#define SPI_0_SCLK_MUX     GPIO_MUX_D
+#define SPI_0_MISO         GPIO_PIN(PA, 12)
+#define SPI_0_MISO_MUX     GPIO_MUX_D
+#define SPI_0_MISO_PAD     SERCOM_RX_PAD_0
+#define SPI_0_MOSI         GPIO_PIN(PB, 10)
+#define SPI_0_MOSI_MUX     GPIO_MUX_D
+#define SPI_0_MOSI_PAD     SPI_PAD_2_SCK_3
+
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF          (1U)
+#define I2C_0_EN            1
+#define I2C_1_EN            0
+#define I2C_2_EN            0
+#define I2C_3_EN            0
+#define I2C_IRQ_PRIO        1
+
+#define I2C_0_DEV           SERCOM3->I2CM
+#define I2C_0_IRQ           SERCOM3_IRQn
+#define I2C_0_ISR           isr_sercom3
+/* I2C 0 GCLK */
+#define I2C_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
+#define I2C_0_GCLK_ID_SLOW  SERCOM3_GCLK_ID_SLOW
+/* I2C 0 pin configuration */
+#define I2C_0_SDA           GPIO_PIN(PA, 22)
+#define I2C_0_SCL           GPIO_PIN(PA, 23)
+#define I2C_0_MUX           GPIO_MUX_C
+
+/**
+ * @name RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1U)
+#define RTC_DEV             RTC->MODE2
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             RTC->MODE0
+#define RTT_IRQ             RTC_IRQn
+#define RTT_IRQ_PRIO        10
+#define RTT_ISR             isr_rtc
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
+#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H_ */
+/** @} */

--- a/cpu/sam21_common/include/sam0.h
+++ b/cpu/sam21_common/include/sam0.h
@@ -29,6 +29,8 @@ extern "C" {
 #include "cmsis/samr21/include/samr21e18a.h"
 #elif defined(__SAMD21J18A__) || defined(__ATSAMD21J18A__)
 #include "cmsis/samd21/include/samd21j18a.h"
+#elif defined(__SAMD21G18A__) || defined(__ATSAMD21G18A__)
+#include "cmsis/samd21/include/samd21g18a.h"
 #else
   #error "Unsupported SAM0 variant."
 #endif

--- a/cpu/samd21/ldscripts/samd21g18a.ld
+++ b/cpu/samd21/ldscripts/samd21g18a.ld
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015, 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_samd21
+ * @{
+ *
+ * @file
+ * @brief           Memory definitions for the SAMD21DG18A
+ *
+ * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+MEMORY
+{
+    rom (rx)    : ORIGIN = 0x00000000, LENGTH = 256K
+    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 32K
+}
+
+INCLUDE cortexm_base.ld

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -7,7 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon cc2650stk chronos msb-430 msb-430h pca
                           nucleo-f334 yunjia-nrf51822 samr21-xpro \
                           arduino-mega2560 airfy-beacon nrf51dongle nrf6310 \
                           weio waspmote-pro nucleo-f072 arduino-uno \
-                          arduino-duemilanove sodaq-autonomo
+                          arduino-duemilanove sodaq-autonomo arduino-zero
 
 USEMODULE += embunit
 
@@ -25,7 +25,8 @@ ARM_CORTEX_M_BOARDS := airfy-beacon arduino-due cc2538dk ek-lm4f120xl f4vi1 fox 
                        nucleo-f091 nucleo-f303 nucleo-f334 nucleo-f401 nucleo-l1 openmote-cc2538 \
                        pba-d-01-kw2x pca10000 pca10005 remote saml21-xpro samr21-xpro slwstk6220a \
                        spark-core stm32f0discovery stm32f3discovery stm32f4discovery udoo weio \
-                       yunjia-nrf51822 sodaq-autonomo
+                       yunjia-nrf51822 sodaq-autonomo arduino-zero
+
 DISABLE_TEST_FOR_ARM_CORTEX_M := tests-relic
 
 AVR_BOARDS := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove


### PR DESCRIPTION
This PR is a first try to port RIOT on [arduino-zero](https://www.arduino.cc/en/Main/ArduinoBoardZero) board. The schematics are [here](https://www.arduino.cc/en/uploads/Main/ArduinoZero-schematic.pdf).

I took inspiration from the implementation of the samr21-xpro board as they share the same MCU and also the Arduino-due board for the arduino pin mapping.

The actual status is:
* it can be build
* it can be flashed on the board
* the timer doesn't not work
* the serial port is not working

Looking at the schematics, it seems that external oscillator is connected to the timer TC2 which is not available in the MCU implementation but maybe I'm wrong. Could this be the cause of problem with the serial port not working ?
I couldn't go further than this and I need a bit of help from more experienced RIOT devs.