### PR TITLE
sys: ps: display waiting for flags

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -39,7 +39,9 @@ const char *state_names[] = {
     [STATUS_MUTEX_BLOCKED] = "bl mutex",
     [STATUS_RECEIVE_BLOCKED] = "bl rx",
     [STATUS_SEND_BLOCKED] = "bl send",
-    [STATUS_REPLY_BLOCKED] = "bl reply"
+    [STATUS_REPLY_BLOCKED] = "bl reply",
+    [STATUS_FLAG_BLOCKED_ANY] = "bl anyfl",
+    [STATUS_FLAG_BLOCKED_ALL] = "bl allfl"
 };
 
 /**


### PR DESCRIPTION
This adds support for the recently introduced thread flags mechanism to
the `ps` module; while previously it would show a thread in state
"(null)" when it is blocked on thread_flags_wait_any or
thread_flags_wait_all, it now shoes the state "bl anyfl" or "bl allfl",
respectively. The labels are kept that short to not mess with the
fixed-width layout.