### PR TITLE
cpu/cortexm_common: Remove register keyword from variables

### DIFF
--- a/cpu/cortexm_common/include/cmsis_gcc.h
+++ b/cpu/cortexm_common/include/cmsis_gcc.h
@@ -151,7 +151,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
   return(result);
@@ -176,7 +176,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PSP(uint32_t topOf
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
   return(result);

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -63,7 +63,7 @@ void cortexm_init(void);
  */
 static inline void cpu_print_last_instruction(void)
 {
-    register uint32_t *lr_ptr;
+    uint32_t *lr_ptr;
     __asm__ __volatile__("mov %0, lr" : "=r"(lr_ptr));
     printf("%p\n", (void*) lr_ptr);
 }


### PR DESCRIPTION
`register` is deprecated when building C++11 code and removed in C++17, using it causes build failures with C++11 and -Werror (Clang 3.8.0). 

The register hint keyword is likely ignored in GCC anyway.