### PR TITLE
cpu: Cast to unsigned int for argument bounds checks

### DIFF
--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -55,7 +55,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 {
     cc2538_ssi_t* ssi = spi_config[dev].dev;
 
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 
@@ -160,7 +160,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
 
 int spi_conf_pins(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 
@@ -197,7 +197,7 @@ int spi_conf_pins(spi_t dev)
 
 int spi_acquire(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_lock(&locks[dev]);
@@ -206,7 +206,7 @@ int spi_acquire(spi_t dev)
 
 int spi_release(spi_t dev)
 {
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
     mutex_unlock(&locks[dev]);
@@ -251,7 +251,7 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     cc2538_ssi_t* ssi = spi_config[dev].dev;
     typeof(length) tx_n = 0, rx_n = 0;
 
-    if (dev >= SPI_NUMOF) {
+    if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -34,7 +34,7 @@ static gpio_isr_ctx_t gpio_chan[GPIO_ISR_CHAN_NUMOF];
 
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
-    if ((pin < 0) || (pin > 31))
+    if ((unsigned int)pin > 31)
         return -1;
 
     /* enable GPIO clock */


### PR DESCRIPTION
Same as #4916
Fixes warning errors when building with Clang.