### PR TITLE
cpu: add capability to show stack usage of ISR

### DIFF
--- a/boards/qemu-i386/include/cpu_conf.h
+++ b/boards/qemu-i386/include/cpu_conf.h
@@ -30,6 +30,7 @@ extern "C" {
 #define THREAD_EXTRA_STACKSIZE_PRINTF            (8192)
 #define THREAD_EXTRA_STACKSIZE_PRINTF_FLOAT      (8192)
 #define THREAD_STACKSIZE_MINIMUM                 (8192)
+#define ISR_STACKSIZE                            (0)
 
 #ifdef __cplusplus
 }

--- a/core/include/arch/thread_arch.h
+++ b/core/include/arch/thread_arch.h
@@ -59,6 +59,11 @@ typedef void *(*thread_task_func_t)(void *arg);
 char *thread_arch_stack_init(thread_task_func_t task_func, void *arg, void *stack_start, int stack_size);
 
 /**
+ * @brief   Get the number of bytes used on the ISR stack
+ */
+int thread_arch_isr_stack_usage(void);
+
+/**
  * @brief Print the current stack to stdout
  */
 void thread_arch_stack_print(void);

--- a/cpu/arm7_common/arm_cpu.c
+++ b/cpu/arm7_common/arm_cpu.c
@@ -28,6 +28,13 @@ void thread_yield_higher(void)
     __asm__("svc 0\n");
 }
 
+/* This function calculates the ISR_usage */
+int thread_arch_isr_stack_usage(void)
+{
+    /* TODO */
+    return -1;
+}
+
 /*----------------------------------------------------------------------------
  * Processor specific routine - here for ARM7
  * sizeof(void*) = sizeof(int)

--- a/cpu/atmega2560/include/cpu_conf.h
+++ b/cpu/atmega2560/include/cpu_conf.h
@@ -40,6 +40,7 @@ extern "C" {
 #endif
 
 #define THREAD_STACKSIZE_IDLE      (128)
+#define ISR_STACKSIZE              (0)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -198,6 +198,13 @@ void thread_arch_stack_print(void)
     printf("stack size: %u bytes\n", size);
 }
 
+/* This function calculates the ISR_usage */
+int thread_arch_isr_stack_usage(void)
+{
+    /* TODO */
+    return -1;
+}
+
 void thread_arch_start_threading(void) __attribute__((naked));
 void thread_arch_start_threading(void)
 {

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -49,6 +49,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief Interrupt stack canary value
+ *
+ * @note 0xe7fe is the ARM Thumb machine code equivalent of asm("bl #-2\n") or
+ * 'while (1);', i.e. an infinite loop.
+ * @internal
+ */
+#define STACK_CANARY_WORD   (0xE7FEE7FEu)
+
+/**
  * @brief   Initialization of the CPU
  */
 void cpu_init(void);

--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -100,6 +100,9 @@
 #include "irq.h"
 #include "cpu.h"
 
+extern uint32_t _estack;
+extern uint32_t _sstack;
+
 /**
  * @brief   Noticeable marker marking the beginning of a stack segment
  *
@@ -249,6 +252,15 @@ void thread_arch_stack_print(void)
     } while (*sp != STACK_MARKER);
 
     printf("current stack size: %i byte\n", count);
+}
+
+/* This function returns the number of bytes used on the ISR stack */
+int thread_arch_isr_stack_usage(void)
+{
+    uint32_t  *ptr = &_sstack;
+
+    while (*(ptr++) == STACK_CANARY_WORD) {}
+    return (ISR_STACKSIZE - (ptr - &_sstack));
 }
 
 __attribute__((naked)) void NORETURN thread_arch_start_threading(void)

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -32,14 +32,6 @@
 #include "vectors_cortexm.h"
 
 /**
- * @brief Interrupt stack canary value
- *
- * @note 0xe7fe is the ARM Thumb machine code equivalent of __asm__("bl #-2\n") or
- * 'while (1);', i.e. an infinite loop.
- */
-#define STACK_CANARY_WORD 0xE7FEE7FEu
-
-/**
  * @brief   Memory markers, defined in the linker script
  * @{
  */

--- a/cpu/lpc2387/include/cpu_conf.h
+++ b/cpu/lpc2387/include/cpu_conf.h
@@ -51,6 +51,8 @@ extern "C" {
 #endif
 
 #define THREAD_STACKSIZE_IDLE      (160)
+
+#define ISR_STACKSIZE              (0)
 /** @} */
 
 /**

--- a/cpu/msp430-common/cpu.c
+++ b/cpu/msp430-common/cpu.c
@@ -33,6 +33,13 @@ __attribute__((naked)) void thread_yield_higher(void)
     UNREACHABLE();
 }
 
+/* This function calculates the ISR_usage */
+int thread_arch_isr_stack_usage(void)
+{
+    /* TODO */
+    return -1;
+}
+
 NORETURN void cpu_switch_context_exit(void)
 {
     sched_active_thread = sched_threads[0];

--- a/cpu/msp430-common/include/cpu.h
+++ b/cpu/msp430-common/include/cpu.h
@@ -75,7 +75,7 @@ extern volatile int __irq_is_in;
 /**
  * @brief   Memory used as stack for the interrupt context
  */
-extern char __isr_stack[MSP430_ISR_STACK_SIZE];
+extern char __isr_stack[ISR_STACKSIZE];
 
 /**
  * @brief   Save the current thread context from inside an ISR
@@ -126,7 +126,7 @@ static inline void __attribute__((always_inline)) __restore_context(void)
 static inline void __attribute__((always_inline)) __enter_isr(void)
 {
     __save_context();
-    __asm__("mov.w %0,r1" : : "i"(__isr_stack + MSP430_ISR_STACK_SIZE));
+    __asm__("mov.w %0,r1" : : "i"(__isr_stack + ISR_STACKSIZE));
     __irq_is_in = 1;
 }
 

--- a/cpu/msp430-common/include/cpu_conf.h
+++ b/cpu/msp430-common/include/cpu_conf.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 #define THREAD_STACKSIZE_IDLE      (96)
-#define MSP430_ISR_STACK_SIZE           (256)
+#define ISR_STACKSIZE              (256)
 
 #ifndef GNRC_PKTBUF_SIZE
 #define GNRC_PKTBUF_SIZE                (2560)    /* TODO: Make this value

--- a/cpu/msp430-common/irq.c
+++ b/cpu/msp430-common/irq.c
@@ -24,7 +24,7 @@
 
 volatile int __irq_is_in = 0;
 
-char __isr_stack[MSP430_ISR_STACK_SIZE];
+char __isr_stack[ISR_STACKSIZE];
 
 unsigned int irq_disable(void)
 {

--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -36,7 +36,7 @@ extern "C" {
 #define THREAD_STACKSIZE_MINIMUM            (163840)
 /* native internal */
 #define THREAD_STACKSIZE_MINIMUM            (163840)
-#define NATIVE_ISR_STACKSIZE                (163840)
+#define ISR_STACKSIZE                       (163840)
 
 #else /* Linux etc. */
 #define THREAD_STACKSIZE_DEFAULT            (8192)
@@ -46,7 +46,7 @@ extern "C" {
 /* for core/include/thread.h */
 #define THREAD_STACKSIZE_MINIMUM            (8192)
 /* native internal */
-#define NATIVE_ISR_STACKSIZE                (8192)
+#define ISR_STACKSIZE                       (8192)
 #endif /* OS */
 /** @} */
 

--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -74,6 +74,13 @@ void thread_print_stack(void)
     return;
 }
 
+/* This function calculates the ISR_usage */
+int thread_arch_isr_stack_usage(void)
+{
+    /* TODO */
+    return -1;
+}
+
 char *thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_start, int stacksize)
 {
     char *stk;

--- a/cpu/x86/x86_thread_arch.c
+++ b/cpu/x86/x86_thread_arch.c
@@ -13,7 +13,7 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#include "thread_arch.h"
+#include "arch/thread_arch.h"
 
 /* This function calculates the ISR_usage */
 int thread_arch_isr_stack_usage(void)

--- a/cpu/x86/x86_thread_arch.c
+++ b/cpu/x86/x86_thread_arch.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include "thread_arch.h"
+
+/* This function calculates the ISR_usage */
+int thread_arch_isr_stack_usage(void)
+{
+    /* TODO */
+    return -1;
+}
+
+/** @} */

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -71,6 +71,16 @@ void ps(void)
 #endif
            "state");
 
+#ifdef DEVELHELP
+    int isr_usage = thread_arch_isr_stack_usage();                                 /* ISR stack usage */
+    printf("\t  - | isr_stack            | -        - |"
+           "   - | %5i (%5i) | -\n", ISR_STACKSIZE, isr_usage);
+    overall_stacksz += ISR_STACKSIZE;
+    if (isr_usage > 0) {
+        overall_used += isr_usage;
+    }
+#endif
+
     for (kernel_pid_t i = KERNEL_PID_FIRST; i <= KERNEL_PID_LAST; i++) {
         thread_t *p = (thread_t *)sched_threads[i];
 


### PR DESCRIPTION
replacement of PR #4201 where its history got missed up, and i couldn't fix.
Tested on Native and Arduino-due boards, Hack and Ack for the rest of the boards.

If the board is not a Cortex based board, the output when running the 'ps' command should contain a line like this
`	       - | isr_stack            | -        - |  -  |  xxx (   -1) |   ` 
xxx could be any number depending on the cpu,
CPUs that doesn't contain an explicit 'isr_stack' , the xxx which is the isr_stacksize is set to Zero.  