### PR TITLE
native: let valgrind print the leak summary at the end

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -85,6 +85,7 @@ export TERMFLAGS := $(PORT) $(TERMFLAGS)
 export ASFLAGS =
 export DEBUGGER_FLAGS = -q --args $(ELF) $(TERMFLAGS)
 term-valgrind: export VALGRIND_FLAGS ?= \
+	--leak-check=full \
 	--track-origins=yes \
 	--fullpath-after=$(RIOTBASE)/ \
 	--read-var-info=yes


### PR DESCRIPTION
~~Basically the same as #5387, but for valgrind.~~

*Edit* Show a summary about the detected memory leaks at process termination.