### PR TITLE
netdev2: some parameter type changes

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -35,8 +35,8 @@
 
 static int  _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len);
 static int  _set(netdev2_t *dev, netopt_t opt, void *value, size_t value_len);
-static int  _send(netdev2_t *netdev, const struct iovec *vector, int count);
-static int  _recv(netdev2_t *netdev, char *buf, int len, void *info);
+static int  _send(netdev2_t *netdev, const struct iovec *vector, unsigned count);
+static int  _recv(netdev2_t *netdev, void *buf, size_t len, void *info);
 static void _isr(netdev2_t *netdev);
 static int  _init(netdev2_t *dev);
 
@@ -253,7 +253,7 @@ static int _set(netdev2_t *netdev, netopt_t opt, void *value, size_t value_len)
     return res;
 }
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 {
     int pkt_len = 0;
 
@@ -268,7 +268,7 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
        start of the FIFO, so we can come back and update it later */
     rfcore_write_byte(0);
 
-    for (int i = 0; i < count; i++) {
+    for (unsigned i = 0; i < count; i++) {
         pkt_len += vector[i].iov_len;
 
         if (pkt_len > CC2538_RF_MAX_DATA_LEN) {
@@ -289,7 +289,7 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
     return pkt_len;
 }
 
-static int _recv(netdev2_t *netdev, char *buf, int len, void *info)
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
 {
     cc2538_rf_t *dev = (cc2538_rf_t *) netdev;
     size_t pkt_len;

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -67,8 +67,8 @@ netdev2_tap_t netdev2_tap;
 
 /* netdev2 interface */
 static int _init(netdev2_t *netdev);
-static int _send(netdev2_t *netdev, const struct iovec *vector, int n);
-static int _recv(netdev2_t *netdev, char* buf, int n, void *info);
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned n);
+static int _recv(netdev2_t *netdev, void *buf, size_t n, void *info);
 
 static inline void _get_mac_addr(netdev2_t *netdev, uint8_t *dst)
 {
@@ -211,7 +211,7 @@ static void _continue_reading(netdev2_tap_t *dev)
     _native_in_syscall--;
 }
 
-static int _recv(netdev2_t *netdev2, char *buf, int len, void *info)
+static int _recv(netdev2_t *netdev2, void *buf, size_t len, void *info)
 {
     netdev2_tap_t *dev = (netdev2_tap_t*)netdev2;
     (void)info;
@@ -284,13 +284,13 @@ static int _recv(netdev2_t *netdev2, char *buf, int len, void *info)
     return -1;
 }
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int n)
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned n)
 {
     netdev2_tap_t *dev = (netdev2_tap_t*)netdev;
     int res = _native_writev(dev->tap_fd, vector, n);
 #ifdef MODULE_NETSTATS_L2
     size_t bytes = 0;
-    for (int i = 0; i < n; i++) {
+    for (unsigned i = 0; i < n; i++) {
         bytes += vector->iov_len;
         vector++;
     }

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -40,8 +40,8 @@
 
 #define _MAX_MHR_OVERHEAD   (25)
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count);
-static int _recv(netdev2_t *netdev, char *buf, int len, void *info);
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count);
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev2_t *netdev);
 static void _isr(netdev2_t *netdev);
 static int _get(netdev2_t *netdev, netopt_t opt, void *val, size_t max_len);
@@ -97,7 +97,7 @@ static int _init(netdev2_t *netdev)
     return 0;
 }
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 {
     at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
     const struct iovec *ptr = vector;
@@ -106,7 +106,7 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
     at86rf2xx_tx_prepare(dev);
 
     /* load packet data into FIFO */
-    for (int i = 0; i < count; i++, ptr++) {
+    for (unsigned i = 0; i < count; i++, ptr++) {
         /* current packet data + FCS too long */
         if ((len + ptr->iov_len + 2) > AT86RF2XX_MAX_PKT_LENGTH) {
             DEBUG("[at86rf2xx] error: packet too large (%u byte) to be send\n",
@@ -127,7 +127,7 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
     return (int)len;
 }
 
-static int _recv(netdev2_t *netdev, char *buf, int len, void *info)
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
 {
     at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
     uint8_t phr;

--- a/drivers/cc110x/cc110x-netdev2.c
+++ b/drivers/cc110x/cc110x-netdev2.c
@@ -37,7 +37,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static int _send(netdev2_t *dev, const struct iovec *vector, int count)
+static int _send(netdev2_t *dev, const struct iovec *vector, unsigned count)
 {
     DEBUG("%s:%u\n", __func__, __LINE__);
 
@@ -47,7 +47,7 @@ static int _send(netdev2_t *dev, const struct iovec *vector, int count)
     return cc110x_send(&netdev2_cc110x->cc110x, cc110x_pkt);
 }
 
-static int _recv(netdev2_t *dev, char* buf, int len, void *info)
+static int _recv(netdev2_t *dev, void *buf, size_t len, void *info)
 {
     DEBUG("%s:%u\n", __func__, __LINE__);
 

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -143,7 +143,7 @@ bool cc2420_cca(cc2420_t *dev)
     return gpio_read(dev->params.pin_cca);
 }
 
-size_t cc2420_send(cc2420_t *dev, const struct iovec *data, int count)
+size_t cc2420_send(cc2420_t *dev, const struct iovec *data, unsigned count)
 {
     size_t n = cc2420_tx_prepare(dev, data, count);
 
@@ -154,7 +154,7 @@ size_t cc2420_send(cc2420_t *dev, const struct iovec *data, int count)
     return n;
 }
 
-size_t cc2420_tx_prepare(cc2420_t *dev, const struct iovec *data, int count)
+size_t cc2420_tx_prepare(cc2420_t *dev, const struct iovec *data, unsigned count)
 {
     size_t pkt_len = 2;     /* include the FCS (frame check sequence) */
 
@@ -162,7 +162,7 @@ size_t cc2420_tx_prepare(cc2420_t *dev, const struct iovec *data, int count)
     while (cc2420_get_state(dev) & NETOPT_STATE_TX) {}
 
     /* get and check the length of the packet */
-    for (int i = 0; i < count; i++) {
+    for (unsigned i = 0; i < count; i++) {
         pkt_len += data[i].iov_len;
     }
     if (pkt_len >= CC2420_PKT_MAXLEN) {

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -39,8 +39,8 @@
 #include "debug.h"
 
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count);
-static int _recv(netdev2_t *netdev, char *buf, int len, void *info);
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count);
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev2_t *netdev);
 static void _isr(netdev2_t *netdev);
 static int _get(netdev2_t *netdev, netopt_t opt, void *val, size_t max_len);
@@ -151,16 +151,16 @@ static void _isr(netdev2_t *netdev)
     netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE);
 }
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 {
     cc2420_t *dev = (cc2420_t *)netdev;
     return (int)cc2420_send(dev, vector, count);
 }
 
-static int _recv(netdev2_t *netdev, char *buf, int len, void *info)
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
 {
     cc2420_t *dev = (cc2420_t *)netdev;
-    return (int)cc2420_rx(dev, (uint8_t *)buf, len, info);
+    return (int)cc2420_rx(dev, buf, len, info);
 }
 
 static int _get(netdev2_t *netdev, netopt_t opt, void *val, size_t max_len)

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -219,7 +219,7 @@ static void on_int(void *arg)
     netdev->event_callback(arg, NETDEV2_EVENT_ISR);
 }
 
-static int nd_send(netdev2_t *netdev, const struct iovec *data, int count)
+static int nd_send(netdev2_t *netdev, const struct iovec *data, unsigned count)
 {
     enc28j60_t *dev = (enc28j60_t *)netdev;
     uint8_t ctrl = 0;
@@ -248,7 +248,7 @@ static int nd_send(netdev2_t *netdev, const struct iovec *data, int count)
     return c;
 }
 
-static int nd_recv(netdev2_t *netdev, char *buf, int max_len, void *info)
+static int nd_recv(netdev2_t *netdev, void *buf, size_t max_len, void *info)
 {
     enc28j60_t *dev = (enc28j60_t *)netdev;
     uint8_t head[6];

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -59,8 +59,8 @@ static inline int _packets_available(encx24j600_t *dev);
 static void _get_mac_addr(netdev2_t *dev, uint8_t* buf);
 
 /* netdev2 interface */
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count);
-static int _recv(netdev2_t *netdev, char* buf, int len, void *info);
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count);
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev2_t *dev);
 static void _isr(netdev2_t *dev);
 static int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len);
@@ -303,7 +303,7 @@ static int _init(netdev2_t *encdev)
     return 0;
 }
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count) {
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count) {
     encx24j600_t * dev = (encx24j600_t *) netdev;
     lock(dev);
 
@@ -358,7 +358,7 @@ static void _get_mac_addr(netdev2_t *encdev, uint8_t* buf)
     unlock(dev);
 }
 
-static int _recv(netdev2_t *netdev, char* buf, int len, void *info)
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
 {
     encx24j600_t * dev = (encx24j600_t *) netdev;
     encx24j600_frame_hdr_t hdr;

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -254,7 +254,7 @@ void ethos_send_frame(ethos_t *dev, const uint8_t *data, size_t len, unsigned fr
     }
 }
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 {
     ethos_t * dev = (ethos_t *) netdev;
     (void)dev;
@@ -292,7 +292,7 @@ static void _get_mac_addr(netdev2_t *encdev, uint8_t* buf)
     memcpy(buf, dev->mac_addr, 6);
 }
 
-static int _recv(netdev2_t *netdev, char* buf, int len, void* info)
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void* info)
 {
     (void) info;
     ethos_t * dev = (ethos_t *) netdev;
@@ -303,7 +303,7 @@ static int _recv(netdev2_t *netdev, char* buf, int len, void* info)
             return -1;
         }
 
-        len = (int)dev->last_framesize;
+        len = dev->last_framesize;
         dev->last_framesize = 0;
 
         if ((tsrb_get(&dev->inbuf, buf, len) != len)) {
@@ -311,7 +311,7 @@ static int _recv(netdev2_t *netdev, char* buf, int len, void* info)
             return -1;
         }
 
-        return len;
+        return (int)len;
     }
     else {
         return dev->last_framesize;

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -281,7 +281,7 @@ netopt_state_t cc2420_get_state(cc2420_t *dev);
  * @return                  number of bytes that were actually send
  * @return                  0 on error
  */
-size_t cc2420_send(cc2420_t *dev, const struct iovec *data, int count);
+size_t cc2420_send(cc2420_t *dev, const struct iovec *data, unsigned count);
 
 /**
  * @brief   Prepare for sending of data
@@ -293,7 +293,7 @@ size_t cc2420_send(cc2420_t *dev, const struct iovec *data, int count);
  * @param[in] data          data to prepare (must include IEEE802.15.4 header)
  * @param[in] count         length of @p data
  */
-size_t cc2420_tx_prepare(cc2420_t *dev, const struct iovec *data, int count);
+size_t cc2420_tx_prepare(cc2420_t *dev, const struct iovec *data, unsigned count);
 
 /**
  * @brief   Trigger sending of data previously loaded into transmit buffer

--- a/drivers/include/net/netdev2.h
+++ b/drivers/include/net/netdev2.h
@@ -137,7 +137,7 @@ typedef struct netdev2_driver {
      *
      * @return nr of bytes sent, or <=0 on error
      */
-    int (*send)(netdev2_t *dev, const struct iovec *vector, int count);
+    int (*send)(netdev2_t *dev, const struct iovec *vector, unsigned count);
 
     /**
      * @brief Get a received frame
@@ -158,7 +158,7 @@ typedef struct netdev2_driver {
      * @return nr of bytes read if buf != NULL
      * @return packet size if buf == NULL
      */
-    int (*recv)(netdev2_t *dev, char *buf, int len, void *info);
+    int (*recv)(netdev2_t *dev, void *buf, size_t len, void *info);
 
     /**
      * @brief the driver's initialization function

--- a/sys/net/netdev2_test/netdev2_test.c
+++ b/sys/net/netdev2_test/netdev2_test.c
@@ -19,8 +19,8 @@
 
 #include "net/netdev2_test.h"
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count);
-static int _recv(netdev2_t *netdev, char *buf, int len, void *info);
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count);
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev2_t *dev);
 static void _isr(netdev2_t *dev);
 static int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len);
@@ -57,10 +57,10 @@ void netdev2_test_reset(netdev2_test_t *dev)
     mutex_unlock(&dev->mutex);
 }
 
-static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
+static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 {
     netdev2_test_t *dev = (netdev2_test_t *)netdev;
-    int res = count;    /* assume everything would be fine */
+    int res = (int)count;   /* assume everything would be fine */
 
     mutex_lock(&dev->mutex);
     if (dev->send_cb != NULL) {
@@ -70,7 +70,7 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, int count)
     return res;
 }
 
-static int _recv(netdev2_t *netdev, char *buf, int len, void *info)
+static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
 {
     netdev2_test_t *dev = (netdev2_test_t *)netdev;
     int res = (buf == NULL) ? 0 : len;  /* assume everything would be fine */

--- a/tests/driver_at86rf2xx/recv.c
+++ b/tests/driver_at86rf2xx/recv.c
@@ -34,7 +34,7 @@ void recv(netdev2_t *dev)
     le_uint16_t src_pan, dst_pan;
 
     putchar('\n');
-    data_len = dev->driver->recv(dev, (char *)buffer, sizeof(buffer), &rx_info);
+    data_len = dev->driver->recv(dev, buffer, sizeof(buffer), &rx_info);
     mhr_len = ieee802154_get_frame_hdr_len(buffer);
     if (mhr_len == 0) {
         puts("Unexpected MHR for incoming packet");


### PR DESCRIPTION
`recv`'s `len` parameter and `send`'s `count` parameter are currently `int`, though it wouldn't make any sense to have them `< 0`. We could add an assert every time this function is implemented, but I would rather vote to change the type.

As a bonus I made the type of `recv`'s `buf` parameter generic - no reason for it to be a `char` and it might lead to unnecessary static casting requirements (already happening in https://github.com/RIOT-OS/RIOT/blob/master/tests/driver_at86rf2xx/recv.c#L37).