### PR TITLE
gnrc_sixlowpan_iphc: propagate UDP decode error

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -499,7 +499,12 @@ size_t gnrc_sixlowpan_iphc_decode(gnrc_pktsnip_t **dec_hdr, gnrc_pktsnip_t *pkt,
         switch (iphc_hdr[payload_offset] & NHC_ID_MASK) {
             case NHC_UDP_ID:
                 payload_offset = iphc_nhc_udp_decode(pkt, dec_hdr, datagram_size,
-                                                     payload_offset + offset) - offset;
+                                                     payload_offset + offset);
+
+                if (payload_offset != 0) {
+                    payload_offset -= offset;
+                }
+
                 *nh_len += sizeof(udp_hdr_t);
                 break;
 


### PR DESCRIPTION
`gnrc_sixlowpan_iphc_decode` and its helper functions return 0 to indicate errors. This patch makes `gnrc_sixlowpan_iphc_decode` to propagate errors from `iphc_nhc_udp_decode` to the caller.