### PR TITLE
sixlowpan_print: fix dump for elided source/destination address

### DIFF
--- a/sys/net/network_layer/sixlowpan/sixlowpan_print.c
+++ b/sys/net/network_layer/sixlowpan/sixlowpan_print.c
@@ -127,7 +127,7 @@ void sixlowpan_print(uint8_t *data, size_t size)
                     puts("16 bits inline");
                     break;
 
-                case 0x40:
+                case 0x30:
                     puts("elided (use L2 address)");
                     break;
             }
@@ -148,7 +148,7 @@ void sixlowpan_print(uint8_t *data, size_t size)
                     puts("16 bits inline");
                     break;
 
-                case 0x40:
+                case 0x30:
                     puts("elided (use L2 address)");
                     break;
             }
@@ -209,7 +209,7 @@ void sixlowpan_print(uint8_t *data, size_t size)
                         puts("16 bits inline");
                         break;
 
-                    case 0x40:
+                    case 0x30:
                         puts("elided (use L2 address)");
                         break;
                 }
@@ -230,7 +230,7 @@ void sixlowpan_print(uint8_t *data, size_t size)
                         puts("16 bits inline");
                         break;
 
-                    case 0x40:
+                    case 0x30:
                         puts("elided (use L2 address)");
                         break;
                 }


### PR DESCRIPTION
RFC 6282 Section 3.1.1:
```
   SAM: Source Address Mode:

      If SAC=0:

         00:  128 bits.  The full address is carried in-line.

         01:  64 bits.  The first 64-bits of the address are elided.
            The value of those bits is the link-local prefix padded with
            zeros.  The remaining 64 bits are carried in-line.

         10:  16 bits.  The first 112 bits of the address are elided.
            The value of the first 64 bits is the link-local prefix
            padded with zeros.  The following 64 bits are 0000:00ff:
            fe00:XXXX, where XXXX are the 16 bits carried in-line.

         11:  0 bits.  The address is fully elided.  The first 64 bits
            of the address are the link-local prefix padded with zeros.
            The remaining 64 bits are computed from the encapsulating
            header (e.g., 802.15.4 or IPv6 source address) as specified
            in Section 3.2.2.
```