### PR TITLE
cpu/cc2538: add GPIO_PIN() macro to periph_conf.h.

### DIFF
--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 
 #include "cc2538_ssi.h"
+#include "cc2538_gpio.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,6 +39,8 @@ extern "C" {
  */
 #define HAVE_GPIO_T
 typedef uint32_t gpio_t;
+
+#define GPIO_PIN(port_num, bit_num) GPIO_PXX_TO_NUM(port_num, bit_num)
 /** @} */
 
 /**


### PR DESCRIPTION
Implement the specific `GPIO_PIN()` macro for *cc2538* cpu. Some new code, using this macro is not working as expected without a cpu-specific implementation.
Uses a already existing macro (`GPIO_PXX_TO_NUM()`) from *cc2538_gpio.h* which has exactly the same function.
Other possible ways to implement it:
0. Define `GPIO_PIN()` with the same "body" as `GPIO_PXX_TO_NUM()`.
0. Rename  `GPIO_PXX_TO_NUM()` to `GPIO_PIN()` in *cc2538_gpio.h*.

I implemented what I assume the most obvious solution. If there is a different (and better) approach, make your proposals.