### PR TITLE
conn: rename connection to connectivity

### DIFF
--- a/pkg/emb6/include/emb6/conn/udp.h
+++ b/pkg/emb6/include/emb6/conn/udp.h
@@ -11,7 +11,7 @@
  * @ingroup     emb6
  * @brief       UDP conn for emb6
  *
- * For this implementation to receive with an open connection only with one
+ * For this implementation to receive with an open connectivity only with one
  * thread at once. If you use @ref conn_udp_recvfrom() with more than one thread
  * simultaneously, it will return `-EALREADY`.
  *
@@ -43,9 +43,9 @@ extern "C" {
  */
 struct conn_udp {
     struct udp_socket sock;         /**< emb6 internal socket */
-    mutex_t mutex;                  /**< mutex for the connection */
+    mutex_t mutex;                  /**< mutex for the connectivity object */
     kernel_pid_t waiting_thread;    /**< thread waiting for an incoming packet
-                                     *   on this connection */
+                                     *   on this connectivity object */
     struct {
         uint16_t src_port;          /**< source port */
         const ipv6_addr_t *src;     /**< source address */

--- a/pkg/lwip/include/lwip/conn.h
+++ b/pkg/lwip/include/lwip/conn.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    pkg_lwip_conn   Connection type definitions for lwIP
+ * @defgroup    pkg_lwip_conn   Connectivity type definitions for lwIP
  * @ingroup     pkg_lwip
  * @{
  *
@@ -28,21 +28,21 @@ extern "C" {
  * @brief   Generic @ref net_conn object for lwIP (used internally)
  */
 struct conn {
-    struct netconn *lwip_conn;  /**< stack-internal connection object */
+    struct netconn *lwip_conn;  /**< stack-internal connectivity object */
 };
 
 /**
  * @brief   @ref net_conn_ip definition for lwIP
  */
 struct conn_ip {
-    struct netconn *lwip_conn;  /**< stack-internal connection object */
+    struct netconn *lwip_conn;  /**< stack-internal connectivity object */
 };
 
 /**
  * @brief   @ref net_conn_udp definition for lwIP
  */
 struct conn_udp {
-    struct netconn *lwip_conn;  /**< stack-internal connection object */
+    struct netconn *lwip_conn;  /**< stack-internal connectivity object */
 };
 
 /**

--- a/sys/include/net/conn.h
+++ b/sys/include/net/conn.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_conn    Application connection API
+ * @defgroup    net_conn    Application connectivity API
  * @ingroup     net
  * @brief       Provides a minimal common API for applications to connect to the
  *              different network stacks.
@@ -29,42 +29,44 @@
  *    | Network Stack |
  *    +---------------+
  *
- * This module provides a minimal set of functions to establish a connection using
- * different types of connections. Together, they serve as a common API
- * that connects application- and network stack code.
+ * This module provides a minimal set of functions to establish connectivity or
+ * send and receives datagrams using different types of connectivity. Together,
+ * they serve as a common API that connects application- and network stack code.
  *
- * Currently the following connection types are defined:
+ * Currently the following connectivity types are defined:
  *
- * * @ref conn_ip_t (net/conn/ip.h): raw IP connections
- * * @ref conn_tcp_t (net/conn/tcp.h): TCP connections
- * * @ref conn_udp_t (net/conn/udp.h): UDP connections
+ * * @ref conn_ip_t (net/conn/ip.h): raw IP connectivity
+ * * @ref conn_tcp_t (net/conn/tcp.h): TCP connectivity
+ * * @ref conn_udp_t (net/conn/udp.h): UDP connectivity
  *
- * Each network stack must implement at least one connection type.
+ * Each network stack must implement at least one connectivity type.
  *
- * Note that there might be no relation between the different connection types.
- * For simplicity and modularity this API doesn't put any restriction of the actual
- * implementation of the type. For example, one implementation might choose
- * to have all connection types have a common base class or use the raw IPv6
- * connection type to send e.g. UDP packets, while others will keep them
+ * Note that there might be no relation between the different connectivity
+ * types.
+ * For simplicity and modularity this API doesn't put any restriction of the
+ * actual implementation of the type. For example, one implementation might
+ * choose to have all connectivity types have a common base class or use the raw
+ * IPv6 connectivity type to send e.g. UDP packets, while others will keep them
  * completely separate from each other.
  *
  * How To Use
  * ==========
  *
- * A RIOT application uses the functions provided by one or more of the connection types
- * headers (for example @ref conn_udp_t), regardless of the network stack it uses.
- * The network stack used under the bonnet is specified by including the appropriate
- * module (for example USEMODULE += gnrc_conn_udp)
+ * A RIOT application uses the functions provided by one or more of the
+ * connectivity type headers (for example @ref conn_udp), regardless of the
+ * network stack it uses.
+ * The network stack used under the bonnet is specified by including the
+ * appropriate module (for example USEMODULE += gnrc_conn_udp)
  *
  * This allows for network stack agnostic code on the application layer.
- * The application code to establish a connection is always the same, allowing
- * the network stack underneath to be switched simply by changing the USEMODULE
- * definition in the application's Makefile.
+ * The application code to establish connectivity is always the same, allowing
+ * the network stack underneath to be switched simply by changing the
+ * `USEMODULE` definitions in the application's Makefile.
  *
  * @{
  *
  * @file
- * @brief   Application connection API definitions
+ * @brief   Application connectivity API definitions
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>

--- a/sys/include/net/conn/ip.h
+++ b/sys/include/net/conn/ip.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @defgroup    net_conn_ip     Raw IPv4/IPv6 connections
+ * @defgroup    net_conn_ip     Raw IPv4/IPv6 connectivity
  * @ingroup     net_conn
- * @brief       Connection submodule for raw IPv4/IPv6 connections
+ * @brief       Connectivity submodule for raw IPv4/IPv6 connectivity
  * @{
  *
  * @file
- * @brief   Raw IPv4/IPv6 connection definitions
+ * @brief   Raw IPv4/IPv6 connectivity definitions
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
@@ -41,15 +41,15 @@ extern "C" {
 struct conn_ip;
 
 /**
- * @brief   Implementation-specific type of a raw IPv4/IPv6 connection object
+ * @brief   Implementation-specific type of a raw IPv4/IPv6 connectivity object
  */
 typedef struct conn_ip conn_ip_t;
 
 /**
- * @brief   Creates a new raw IPv4/IPv6 connection object
+ * @brief   Creates a new raw IPv4/IPv6 connectivity object
  *
- * @param[out] conn     Preallocated connection object. Must fill the size of the stack-specific
- *                      connection desriptor.
+ * @param[out] conn     Preallocated connectivity object. Must fill the size of the
+ *                      stack-specific connectivity desriptor.
  * @param[in] addr      The local IP address for @p conn.
  * @param[in] addr_len  Length of @p addr. Must be fitting for the @p family.
  * @param[in] family    The family of @p addr (see @ref net_af).
@@ -62,16 +62,16 @@ typedef struct conn_ip conn_ip_t;
 int conn_ip_create(conn_ip_t *conn, const void *addr, size_t addr_len, int family, int proto);
 
 /**
- * @brief   Closes a raw IPv4/IPv6 connection
+ * @brief   Closes a raw IPv4/IPv6 connectivity
  *
- * @param[in,out] conn  A raw IPv4/IPv6 connection object.
+ * @param[in,out] conn  A raw IPv4/IPv6 connectivity object.
  */
 void conn_ip_close(conn_ip_t *conn);
 
 /**
- * @brief   Gets the local address of a raw IPv4/IPv6 connection
+ * @brief   Gets the local end point of a raw IPv4/IPv6 connectivity
  *
- * @param[in] conn  A raw IPv4/IPv6 connection object.
+ * @param[in] conn  A raw IPv4/IPv6 connectivity object.
  * @param[out] addr The local IP address. Must have space for any address of the connection's
  *                  family.
  *
@@ -85,7 +85,7 @@ int conn_ip_getlocaladdr(conn_ip_t *conn, void *addr);
 /**
  * @brief   Receives a message over IPv4/IPv6
  *
- * @param[in] conn      A raw IPv4/IPv6 connection object.
+ * @param[in] conn      A raw IPv4/IPv6 connectivity object.
  * @param[out] data     Pointer where the received data should be stored.
  * @param[in] max_len   Maximum space available at @p data.
  * @param[out] addr     NULL pointer or the sender's IP address. Must have space for any address

--- a/sys/include/net/conn/tcp.h
+++ b/sys/include/net/conn/tcp.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @defgroup    net_conn_tcp    TCP connections
+ * @defgroup    net_conn_tcp    TCP connectivity
  * @ingroup     net_conn
- * @brief       Connection submodule for TCP connections
+ * @brief       Connectivity submodule for TCP connectivity
  * @{
  *
  * @file
- * @brief   TCP connection definitions
+ * @brief   TCP connectivity definitions
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
@@ -37,15 +37,15 @@ extern "C" {
 struct conn_tcp;
 
 /**
- * @brief   Implementation-specific type of a TCP connection object
+ * @brief   Implementation-specific type of a TCP connectivity object
  */
 typedef struct conn_tcp conn_tcp_t;
 
 /**
- * @brief   Creates a new TCP connection object
+ * @brief   Creates a new TCP connectivity object
  *
- * @param[out] conn     Preallocated connection object. Must fill the size of the stack-specific
- *                      connection desriptor.
+ * @param[out] conn     Preallocated connectivity object. Must fill the size of the stack-specific
+ *                      connectivity desriptor.
  * @param[in] addr      The local network layer address for @p conn.
  * @param[in] addr_len  The length of @p addr. Must be fitting for the @p family.
  * @param[in] family    The family of @p addr (see @ref net_af).
@@ -61,16 +61,16 @@ int conn_tcp_create(conn_tcp_t *conn, const void *addr, size_t addr_len, int fam
 /**
  * @brief   Closes a TCP connection
  *
- * @param[in,out] conn  A TCP connection object.
+ * @param[in,out] conn  A TCP connectivity object.
  */
 void conn_tcp_close(conn_tcp_t *conn);
 
 /**
  * @brief   Gets the local address of a TCP connection
  *
- * @param[in] conn  A TCP connection object.
+ * @param[in] conn  A TCP connectivity object.
  * @param[out] addr The local network layer address. Must have space for any address of
- *                  the connection's family.
+ *                  the connectivity's family.
  * @param[out] port The local TCP port.
  *
  * @return  length of @p addr on success.
@@ -83,9 +83,9 @@ int conn_tcp_getlocaladdr(conn_tcp_t *conn, void *addr, uint16_t *port);
 /**
  * @brief   Gets the address of the connected peer of a TCP connection
  *
- * @param[in] conn  A TCP connection object.
+ * @param[in] conn  A TCP connectivity object.
  * @param[out] addr The network layer address of the connected peer. Must have space for any
- *                  address of the connection's family.
+ *                  address of the connectivity's family.
  * @param[out] port The TCP port of the connected peer.
  *
  * @return  length of @p addr on success.
@@ -98,7 +98,7 @@ int conn_tcp_getpeeraddr(conn_tcp_t *conn, void *addr, uint16_t *port);
 /**
  * @brief   Connects to a remote TCP peer
  *
- * @param[in] conn      A TCP connection object.
+ * @param[in] conn      A TCP connectivity object.
  * @param[in] addr      The remote network layer address for @p conn.
  * @param[in] addr_len  Length of @p addr.
  * @param[in] port      The remote TCP port for @p conn.
@@ -110,10 +110,10 @@ int conn_tcp_getpeeraddr(conn_tcp_t *conn, void *addr, uint16_t *port);
 int conn_tcp_connect(conn_tcp_t *conn, const void *addr, size_t addr_len, uint16_t port);
 
 /**
- * @brief   Marks connection to listen for a connection request by a remote TCP peer
+ * @brief   Marks connectivity to listen for a connection request by a remote TCP peer
  *
- * @param[in] conn      A TCP connection object.
- * @param[in] queue_len Maximum length of the queue for connection requests.
+ * @param[in] conn      A TCP connectivity object.
+ * @param[in] queue_len Maximum length of the queue for connectivity requests.
  *                      An implementation may choose to silently adapt this value to its needs
  *                      (setting it to a minimum or maximum value). Any negative number must be
  *                      set at least to 0.
@@ -127,8 +127,8 @@ int conn_tcp_listen(conn_tcp_t *conn, int queue_len);
 /**
  * @brief   Receives and handles TCP connection requests from other peers
  *
- * @param[in] conn      A TCP connection object.
- * @param[out] out_conn A new TCP connection object for the established connection.
+ * @param[in] conn      A TCP connectivity object.
+ * @param[out] out_conn A new TCP connectivity object for the established connectivity.
  *
  * @return  0 on success.
  * @return  any other negative number in case of an error. For portability implementations should
@@ -139,7 +139,7 @@ int conn_tcp_accept(conn_tcp_t *conn, conn_tcp_t *out_conn);
 /**
  * @brief   Receives a TCP message
  *
- * @param[in] conn      A TCP connection object.
+ * @param[in] conn      A TCP connectivity object.
  * @param[out] data     Pointer where the received data should be stored.
  * @param[in] max_len   Maximum space available at @p data.
  *
@@ -156,7 +156,7 @@ int conn_tcp_recv(conn_tcp_t *conn, void *data, size_t max_len);
 /**
  * @brief   Sends a TCP message
  *
- * @param[in] conn  A TCP connection object.
+ * @param[in] conn  A TCP connectivity object.
  * @param[in] data  Pointer where the received data should be stored.
  * @param[in] len   Maximum space available at @p data.
  *

--- a/sys/include/net/conn/udp.h
+++ b/sys/include/net/conn/udp.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @defgroup    net_conn_udp    UDP connections
+ * @defgroup    net_conn_udp    UDP connectivity
  * @ingroup     net_conn
- * @brief       Connection submodule for UDP connections
+ * @brief       Connectivity submodule for UDP connectivity
  * @{
  *
  * @file
- * @brief   UDP connection definitions
+ * @brief   UDP connectivity definitions
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
@@ -45,15 +45,15 @@ extern "C" {
 struct conn_udp;
 
 /**
- * @brief   Implementation-specific type of a UDP connection object
+ * @brief   Implementation-specific type of a UDP connectivity object
  */
 typedef struct conn_udp conn_udp_t;
 
 /**
- * @brief   Creates a new UDP connection object
+ * @brief   Creates a new UDP connectivity object
  *
- * @param[out] conn     Preallocated connection object. Must fill the size of the stack-specific
- *                      connection desriptor.
+ * @param[out] conn     Preallocated connectivity object. Must fill the size of the stack-specific
+ *                      connectivity desriptor.
  * @param[in] addr      The local network layer address for @p conn.
  * @param[in] addr_len  The length of @p addr. Must be fitting for the @p family.
  * @param[in] family    The family of @p addr (see @ref net_af).
@@ -71,18 +71,18 @@ int conn_udp_create(conn_udp_t *conn, const void *addr, size_t addr_len, int fam
                     uint16_t port);
 
 /**
- * @brief   Closes a UDP connection
+ * @brief   Closes a UDP connectivity
  *
- * @param[in,out] conn  A UDP connection object.
+ * @param[in,out] conn  A UDP connectivity object.
  */
 void conn_udp_close(conn_udp_t *conn);
 
 /**
- * @brief   Gets the local address of a UDP connection
+ * @brief   Gets the local address of a UDP connectivity
  *
- * @param[in] conn  A UDP connection object.
+ * @param[in] conn  A UDP connectivity object.
  * @param[out] addr The local network layer address. Must have space for any address of
- *                  the connection's family.
+ *                  the connectivity object's family.
  * @param[out] port The local UDP port.
  *
  * @return  length of @p addr on success.
@@ -95,11 +95,11 @@ int conn_udp_getlocaladdr(conn_udp_t *conn, void *addr, uint16_t *port);
 /**
  * @brief   Receives a UDP message
  *
- * @param[in] conn      A UDP connection object.
+ * @param[in] conn      A UDP connectivity object.
  * @param[out] data     Pointer where the received data should be stored.
  * @param[in] max_len   Maximum space available at @p data.
  * @param[out] addr     NULL pointer or the sender's network layer address. Must have space
- *                      for any address of the connection's family.
+ *                      for any address of the connectivity object's family.
  * @param[out] addr_len Length of @p addr. Can be NULL if @p addr is NULL.
  * @param[out] port     NULL pointer or the sender's UDP port.
  *

--- a/sys/include/net/gnrc/conn.h
+++ b/sys/include/net/gnrc/conn.h
@@ -7,7 +7,8 @@
  */
 
 /**
- * @defgroup    net_gnrc_conn   GNRC-specific implementation of the connection API
+ * @defgroup    net_gnrc_conn   GNRC-specific implementation of the connectivity
+ *                              API
  * @ingroup     net_gnrc
  * @brief       Provides an implementation of the @ref net_conn by the
  *              @ref net_gnrc
@@ -33,52 +34,52 @@ extern "C" {
 #endif
 
 /**
- * @brief   Connection base class
+ * @brief   Connectivity base class
  * @internal
  */
 typedef struct {
-    gnrc_nettype_t l3_type;                     /**< Network layer type of the connection */
-    gnrc_nettype_t l4_type;                     /**< Transport layer type of the connection */
-    gnrc_netreg_entry_t netreg_entry;           /**< @p net_ng_netreg entry for the connection */
+    gnrc_nettype_t l3_type;                     /**< Network layer type of the connectivity */
+    gnrc_nettype_t l4_type;                     /**< Transport layer type of the connectivity */
+    gnrc_netreg_entry_t netreg_entry;           /**< @p net_ng_netreg entry for the connectivity */
 } conn_t;
 
 /**
- * @brief   Raw connection type
+ * @brief   Raw connectivity type
  * @internal
  * @extends conn_t
  */
 struct conn_ip {
-    gnrc_nettype_t l3_type;                     /**< Network layer type of the connection. */
-    gnrc_nettype_t l4_type;                     /**< Transport layer type of the connection.
+    gnrc_nettype_t l3_type;                     /**< Network layer type of the connectivity. */
+    gnrc_nettype_t l4_type;                     /**< Transport layer type of the connectivity.
                                                  *   Always GNRC_NETTYPE_UNDEF */
-    gnrc_netreg_entry_t netreg_entry;           /**< @p net_ng_netreg entry for the connection */
+    gnrc_netreg_entry_t netreg_entry;           /**< @p net_ng_netreg entry for the connectivity */
     uint8_t local_addr[sizeof(ipv6_addr_t)];    /**< local IP address */
     size_t local_addr_len;                      /**< length of struct conn_ip::local_addr */
 };
 
 /**
- * @brief   UDP connection type
+ * @brief   UDP connectivity type
  * @internal
  * @extends conn_t
  */
 struct conn_udp {
-    gnrc_nettype_t l3_type;                     /**< Network layer type of the connection.
+    gnrc_nettype_t l3_type;                     /**< Network layer type of the connectivity.
                                                  *   Always GNRC_NETTYPE_IPV6 */
-    gnrc_nettype_t l4_type;                     /**< Transport layer type of the connection.
+    gnrc_nettype_t l4_type;                     /**< Transport layer type of the connectivity.
                                                  *   Always GNRC_NETTYPE_UDP */
-    gnrc_netreg_entry_t netreg_entry;           /**< @p net_ng_netreg entry for the connection */
+    gnrc_netreg_entry_t netreg_entry;           /**< @p net_ng_netreg entry for the connectivity */
     uint8_t local_addr[sizeof(ipv6_addr_t)];    /**< local IP address */
     size_t local_addr_len;                      /**< length of struct conn_ip::local_addr */
 };
 
 /**
- * @brief  Bind connection to demux context
+ * @brief  Bind connectivity to demux context
  *
  * @internal
  *
  * @param[out] entry    @ref net_ng_netreg entry.
  * @param[in] type      @ref net_ng_nettype.
- * @param[in] demux_ctx demux context (port or proto) for the connection.
+ * @param[in] demux_ctx demux context (port or proto) for the connectivity.
  */
 static inline void gnrc_conn_reg(gnrc_netreg_entry_t *entry, gnrc_nettype_t type,
                                  uint32_t demux_ctx)
@@ -89,16 +90,16 @@ static inline void gnrc_conn_reg(gnrc_netreg_entry_t *entry, gnrc_nettype_t type
 }
 
 /**
- * @brief   Sets local address for a connection
+ * @brief   Sets local address for a connectivity
  *
  * @internal
  *
- * @param[out] conn_addr    Pointer to the local address on the connection.
+ * @param[out] conn_addr    Pointer to the local address on the connectivity.
  * @param[in] addr          An IPv6 address.
  *
  * @return  true, if @p addr was a legal address (`::`, `::1` or an address assigned to any
- *          interface of this node) for the connection.
- * @return  false if @p addr was not a legal address for the connection.
+ *          interface of this node) for the connectivity.
+ * @return  false if @p addr was not a legal address for the connectivity.
  */
 bool gnrc_conn6_set_local_addr(uint8_t *conn_addr, const ipv6_addr_t *addr);
 
@@ -107,11 +108,11 @@ bool gnrc_conn6_set_local_addr(uint8_t *conn_addr, const ipv6_addr_t *addr);
  *
  * @internal
  *
- * @param[in] conn      Connection object.
+ * @param[in] conn      Connectivity object.
  * @param[out] data     Pointer where the received data should be stored.
  * @param[in] max_len   Maximum space available at @p data.
- * @param[out] addr     NULL pointer or the sender's IP address. Must fit address of connection's
- *                      family if not NULL.
+ * @param[out] addr     NULL pointer or the sender's IP address. Must fit address of
+ *                      the connectivity object's family if not NULL.
  * @param[out] addr_len Length of @p addr. May be NULL if @p addr is NULL.
  * @param[out] port     NULL pointer or the sender's port.
  *

--- a/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
+++ b/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
@@ -104,7 +104,7 @@ int conn_ip_sendto(const void *data, size_t len, const void *src, size_t src_len
                 gnrc_pktbuf_release(pkt);
                 return -ENOMEM;
             }
-            /* set next header to connection's proto */
+            /* set next header to connectivity object's proto */
             ipv6_hdr_t *ipv6_hdr = hdr->data;
             ipv6_hdr->nh = (uint8_t)proto;
             pkt = hdr;


### PR DESCRIPTION
In the paper about RIOT [1] we used the wording “connectivity” for `conn` to
differentiate the terminology from the fact that `conn` supports both
connection-less and connection-oriented transport types.

This change applies the same wording to the documentation.

[1] O. Hahm, K. Schleiser, H. Petersen, M. Lenders, P. Kietzmann, E. Baccelli,
T.C. Schmidt, and M. Wählisch. RIOT: Reconsidering Operating Systems for Low-End
IoT Devices. May 2016.