### PR TITLE
netif: initial import of a common network interface API

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -34,7 +34,6 @@ PSEUDOMODULES += lwip_tcp
 PSEUDOMODULES += lwip_udp
 PSEUDOMODULES += lwip_udplite
 PSEUDOMODULES += netdev_default
-PSEUDOMODULES += netif
 PSEUDOMODULES += netstats
 PSEUDOMODULES += netstats_l2
 PSEUDOMODULES += netstats_ipv6

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -10,6 +10,9 @@ endif
 ifneq (,$(filter shell_commands,$(USEMODULE)))
     DIRS += shell/commands
 endif
+ifneq (,$(filter netif,$(USEMODULE)))
+    DIRS += net/crosslayer/netif
+endif
 ifneq (,$(filter net_help,$(USEMODULE)))
     DIRS += net/crosslayer/net_help
 endif

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -27,6 +27,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Special identifier for "any interface" e.g. for usage with socks
+ *
+ * @todo    Add reference to sock module when #5758 was merged.
+ */
+#define NETIF_ANY       (0)
+
+/**
  * @brief   Maximum length of the optional interface names
  */
 #define NETIF_NAME_LEN  (4U)
@@ -86,9 +93,6 @@ int netif_add(netif_t *netif);
  * @brief   Get ID (position in @ref netifs, with 1 being the first) of
  *          interface
  *
- * @note    The ID starts with 1 so 0 can be a special value (e.g. "any interface"
- *          when using with @ref net_conn "conn")
- *
  * @param[in] netif An interface.
  *
  * @return  The ID of @p netif.
@@ -99,9 +103,6 @@ int netif_get_id(netif_t *netif);
 /**
  * @brief   Get ID (position in @ref netifs, with 1 being the first) of
  *          interface
- *
- * @note    The ID starts with 1 so 0 can be a special value (e.g. "any interface"
- *          when using with @ref net_conn "conn")
  *
  * @param[in] id    An ID for an interface. This parameter is of type `int`,
  *                  so it is easily usable with the result from

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup net_netif  Network interfaces
+ * @ingroup  net
+ * @brief   Common network interface API
+ * @{
+ *
+ * @file
+ * @brief   Network interface API definition
+ *
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef NETIF_H_
+#define NETIF_H_
+
+#include "net/netdev2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Maximum length of the optional interface names
+ */
+#define NETIF_NAME_LEN  (4U)
+
+#ifndef NETIF_NAMED
+#if defined(DEVELHELP) || defined(DOXYGEN)
+/**
+ * @brief   Switch to have named interfaces or not
+ *
+ * This macro is 1 by default if `DEVELHELP` is defined, otherwise it is
+ * undefined.
+ */
+#define NETIF_NAMED     (1)
+#endif
+#endif
+
+/**
+ * @brief   Representation of an interface
+ *
+ * @note    Don't change any of these fields externally unless you are 100% sure
+ *          what you are doing.
+ */
+typedef struct netif {
+    struct netif *next; /**< pointer to next interface */
+    netdev2_t *dev;     /**< pointer to handling network device */
+    void *internal;     /**< pointer to stack-internal representation */
+#if NETIF_NAMED
+    /**
+     * @brief   name of the interface
+     *
+     * @note    To use maximum space this will not be NULL terminated.
+     */
+    char name[NETIF_NAME_LEN];
+#endif
+} netif_t;
+
+/**
+ * @brief   The global list of interfaces
+ */
+extern netif_t *netifs;
+
+/**
+ * @brief   Add a new interface
+ *
+ * @pre `netif != NULL && netif->next == NULL` (@p netif is not already in
+ *      @ref netifs).
+ *
+ * @param[in] netif An interface.
+ *
+ * @return  0 on success
+ * @return  -EEXIST, if @ref NETIF_NAMED is set and netif_t::name of
+ *          @p netif already exists in @ref netifs.
+ */
+int netif_add(netif_t *netif);
+
+/**
+ * @brief   Get ID (position in @ref netifs, with 1 being the first) of
+ *          interface
+ *
+ * @note    The ID starts with 1 so 0 can be a special value (e.g. "any interface"
+ *          when using with @ref net_conn "conn")
+ *
+ * @param[in] netif An interface.
+ *
+ * @return  The ID of @p netif.
+ * @return  -ENOENT, if @p netif is not a valid interface
+ */
+int netif_get_id(netif_t *netif);
+
+/**
+ * @brief   Get ID (position in @ref netifs, with 1 being the first) of
+ *          interface
+ *
+ * @note    The ID starts with 1 so 0 can be a special value (e.g. "any interface"
+ *          when using with @ref net_conn "conn")
+ *
+ * @param[in] id    An ID for an interface. This parameter is of type `int`,
+ *                  so it is easily usable with the result from
+ *                  `netif_get_id()`.
+ *
+ * @return  The ID of @p netif.
+ * @return  NULL, if there is no interface with ID @p id
+ */
+netif_t *netif_by_id(int id);
+
+#if NETIF_NAMED || defined(DOXYGEN)
+/**
+ * @brief   Get interface by name
+ *
+ * @pre `name != NULL`
+ *
+ * @note    Only available when @ref NETIF_NAMED "NETIF_NAMED != 0"
+ *
+ * If @p name is longer than @ref NETIF_NAME_LEN characters, it will be
+ * truncated.
+ *
+ * @param[in] name  A name for an interface.
+ *
+ * @return  The interface named @p name.
+ * @return  NULL, if there is no interface named @p name
+ */
+netif_t *netif_by_name(char *name);
+
+/**
+ * @brief   Set a new name for an interface
+ *
+ * @pre `netif != NULL && name != NULL`
+ *
+ * @note    Only available when @ref NETIF_NAMED "NETIF_NAMED != 0"
+ *
+ * If @p name is longer than @ref NETIF_NAME_LEN characters, it will be
+ * truncated.
+ *
+ * @param[in] netif The interface that should be named.
+ * @param[in] name  A name for an interface.
+ *
+ * @return  0 on success
+ * @return  -EEXIST, if there is already an interface != @p netif named this way
+ * @return  -ENOENT, if @p netif is not a valid interface
+ */
+int netif_set_name(netif_t *netif, char *name);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NETIF_H_ */
+/** @} */

--- a/sys/net/crosslayer/netif/Makefile
+++ b/sys/net/crosslayer/netif/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/crosslayer/netif/netif.c
+++ b/sys/net/crosslayer/netif/netif.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+
+#include "utlist.h"
+
+#include "net/netif.h"
+
+#define _NETIF_MIN_ID   (1)
+
+netif_t *netifs = NULL;
+
+int netif_add(netif_t *netif)
+{
+    assert((netif != NULL) && (netif->next != NULL));
+    if (netifs != NULL) {
+        netif_t *ptr;
+        for (ptr = netifs; ptr->next != NULL; ptr = ptr->next) {
+#if NETIF_NAMED
+            if (strncmp(ptr->name, netif->name, NETIF_NAME_LEN) == 0) {
+                return -EEXIST;
+            }
+#endif
+        }
+#if NETIF_NAMED
+        /* last element was skipped in loop, so check it here */
+        if (strncmp(ptr->name, netif->name, NETIF_NAME_LEN) == 0) {
+            return -EEXIST;
+        }
+#endif
+        /* already inserted, but is last (not recognized by assert above, but
+         * not critical so we don't have to abort) */
+        if (ptr == netif) {
+            return 0;
+        }
+        ptr->next = netif;
+    }
+    else {
+        netifs = netif;
+    }
+    return 0;
+}
+
+int netif_get_id(netif_t *netif)
+{
+    int id;
+    netif_t *ptr;
+
+    for (id = _NETIF_MIN_ID, ptr = netifs; ptr != NULL; id++, ptr = ptr->next) {
+        if (ptr == netif) {
+            return id;
+        }
+    }
+    return -ENOENT;
+}
+
+netif_t *netif_by_id(int id)
+{
+    netif_t *ptr = NULL;
+
+    if (id > 0) {
+        /* We can use id as temporary variable to find the interface if we count
+         * down, so */
+        /* cppcheck-suppress uselessAssignmentArg */
+        for (ptr = netifs; (ptr != NULL) && (id > _NETIF_MIN_ID); id--,
+             ptr = ptr->next) {}
+    }
+    return ptr;
+}
+
+#if NETIF_NAMED || defined(DOXYGEN)
+netif_t *netif_by_name(char *name)
+{
+    netif_t *ptr;
+
+    assert(name != NULL);
+    for (ptr = netifs; ptr != NULL; ptr = ptr->next) {
+        if (strncmp(ptr->name, name, NETIF_NAME_LEN) == 0) {
+            break;
+        }
+    }
+    return ptr;
+}
+
+int netif_set_name(netif_t *netif, char *name)
+{
+    netif_t *ptr;
+    int res = -ENOENT;
+
+    assert((netif != NULL) && (name != NULL));
+    for (ptr = netifs; ptr != NULL; ptr = ptr->next) {
+        if (ptr == netif) {
+            res = 0;
+        }
+        else if (strncmp(ptr->name, name, NETIF_NAME_LEN) == 0) {
+            return -EEXIST;
+        }
+    }
+    if (res == 0) {
+        strncpy(netif->name, name, NETIF_NAME_LEN);
+    }
+    return res;
+}
+
+#endif
+
+/** @} */

--- a/tests/unittests/tests-netif/Makefile
+++ b/tests/unittests/tests-netif/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-netif/Makefile.include
+++ b/tests/unittests/tests-netif/Makefile.include
@@ -1,0 +1,3 @@
+USEMODULE += netif
+
+CFLAGS += -DNETIF_NAMED=1

--- a/tests/unittests/tests-netif/tests-netif.c
+++ b/tests/unittests/tests-netif/tests-netif.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "embUnit.h"
+
+#include "net/netif.h"
+
+#include "unittests-constants.h"
+#include "tests-netif.h"
+
+#define NETIFS  (3U)
+
+static netif_t test_netifs[NETIFS];
+static unsigned int netif = 0;
+
+static void check_netif(void)
+{
+    TEST_ASSERT(netif <= NETIFS);
+}
+
+static void test_netif_add__success(void)
+{
+    strncpy(test_netifs[netif].name, TEST_STRING4, NETIF_NAME_LEN);
+    TEST_ASSERT_EQUAL_INT(0, netif_add(&test_netifs[netif]));
+    netif++;
+}
+
+static void test_netif_add__duplicate(void)
+{
+    strncpy(test_netifs[netif].name, TEST_STRING4, NETIF_NAME_LEN);
+    TEST_ASSERT_MESSAGE(netif_add(&test_netifs[netif]) == -EEXIST,
+                        "res != -EEXIST");
+}
+
+static void test_netif_add__non_duplicate(void)
+{
+    strncpy(test_netifs[netif].name, TEST_STRING8, NETIF_NAME_LEN);
+    TEST_ASSERT_EQUAL_INT(0, netif_add(&test_netifs[netif]));
+    netif++;
+}
+
+static void test_netif_get_id(void)
+{
+    TEST_ASSERT(netif > 0);
+    TEST_ASSERT_EQUAL_INT(netif, netif_get_id(&test_netifs[netif - 1]));
+}
+
+static void test_netif_get_id__ENOENT(void)
+{
+    TEST_ASSERT_MESSAGE(netif_get_id(&test_netifs[netif + 1]) == -ENOENT,
+                        "res != -ENOENT");
+}
+
+static void test_netif_get_id__NULL(void)
+{
+    TEST_ASSERT_MESSAGE(netif_get_id(NULL) == -ENOENT,
+                        "res != -ENOENT");
+}
+
+static void test_netif_by_id(void)
+{
+    for (unsigned int i = 1; i <= netif; i++) {
+        TEST_ASSERT(netif_by_id(i) == &test_netifs[i - 1]);
+    }
+    TEST_ASSERT_NULL(netif_by_id(netif + 1));
+}
+
+static void test_netif_by_name(void)
+{
+    for (unsigned int i = 0; i < netif; i++) {
+        TEST_ASSERT(netif_by_name(test_netifs[i].name) == &test_netifs[i]);
+    }
+    TEST_ASSERT_NULL(netif_by_name(TEST_STRING64));
+}
+
+static void test_netif_set_name(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, netif_set_name(&test_netifs[0],
+                                            test_netifs[0].name));
+    TEST_ASSERT_EQUAL_INT(0, netif_set_name(&test_netifs[0], TEST_STRING64));
+}
+
+static void test_netif_set_name__duplicate(void)
+{
+    TEST_ASSERT(netif >= 1);
+    TEST_ASSERT_MESSAGE(netif_set_name(&test_netifs[0],
+                                       test_netifs[1].name) == -EEXIST,
+                        "res != -EEXIST");
+    TEST_ASSERT_MESSAGE(netif_set_name(&test_netifs[1],
+                                       test_netifs[0].name) == -EEXIST,
+                        "res != -EEXIST");
+}
+
+Test *tests_netif_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_netif_add__success),
+        new_TestFixture(test_netif_add__duplicate),
+        new_TestFixture(test_netif_add__non_duplicate),
+        new_TestFixture(test_netif_get_id),
+        new_TestFixture(test_netif_get_id__ENOENT),
+        new_TestFixture(test_netif_get_id__NULL),
+        new_TestFixture(test_netif_by_id),
+        new_TestFixture(test_netif_by_name),
+        new_TestFixture(test_netif_set_name),
+        new_TestFixture(test_netif_set_name__duplicate),
+    };
+
+    EMB_UNIT_TESTCALLER(netif_tests, NULL, check_netif, fixtures);
+
+    return (Test *)&netif_tests;
+}
+
+void tests_netif(void)
+{
+    TESTS_RUN(tests_netif_tests());
+}
+/** @} */

--- a/tests/unittests/tests-netif/tests-netif.h
+++ b/tests/unittests/tests-netif/tests-netif.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 Martin Lenders
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``netif`` module
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+#ifndef TESTS_NETIF_H_
+#define TESTS_NETIF_H_
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_netif(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_NETIF_H_ */
+/** @} */


### PR DESCRIPTION
This PR introduces a new common network interface API. Interfaces are identified by a unique ID. Currently this ID is their position in a global list, that is why interfaces can't be deleted. Alternatively we could add the ID as a field to `netif_t`, but I don't think that deleting an interface is a use-case we need.

Things to do as a follow-up PR:
- add option handling
- implement for existing network stacks
- port `ifconfig` to this API

~~Depends on #5510.~~ (merged)
