### PR TITLE
examples: add xbee example for gnrc_minimal

### DIFF
--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -9,6 +9,21 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h
 
+## Uncomment to support the XBee module and nomac
+#USEMODULE += xbee
+#USEMODULE += gnrc_nomac
+
+## set default UART to use in case none was defined
+#XBEE_UART ?= "UART_NUMOF-1"
+
+## export UART to params file
+#CFLAGS += -DXBEE_UART=$(XBEE_UART)
+
+## add current directory to the include path. Putting it in CFLAGS will make
+## it go to the beginning, before the standard includes.
+## That way xbee_params.h get's included and auto configuration can pick it up.
+#CFLAGS += -I$(CURDIR)
+
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default

--- a/examples/gnrc_minimal/README.md
+++ b/examples/gnrc_minimal/README.md
@@ -29,3 +29,7 @@ is achieved by:
  * Reducing the maximum neighbor cache size from 8 to 1.
 
 Please take a look at the Makefile to see how the configuration is done.
+
+## Support for XBee
+Please uncomment the lines in the Makefile in order to support the XBee into
+this example.

--- a/examples/gnrc_minimal/xbee_params.h
+++ b/examples/gnrc_minimal/xbee_params.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   xbee driver parameters example, used by auto_init_gnrc_netif
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef XBEE_PARAMS_H
+#define XBEE_PARAMS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static xbee_params_t xbee_params[] = {
+    { .uart = XBEE_UART,
+      .baudrate = 9600U,
+      .sleep_pin = GPIO_UNDEF,
+      .reset_pin = GPIO_UNDEF
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* XBEE_PARAMS_H */
+/** @} */


### PR DESCRIPTION
Adding support for XBee with gnrc_minimal.

I don't know how useful can be this in the examples folder, but I used it on small platforms like arduino-mega2560 and waspmote.

If you don't think it worths to have its own example we can close it.