### PR TITLE
gnrc_netreg: introduce helper macro/function for entry init

### DIFF
--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -53,10 +53,8 @@ int main(void)
 #endif
 
 #ifdef MODULE_NETIF
-    gnrc_netreg_entry_t dump;
-
-    dump.pid = gnrc_pktdump_pid;
-    dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
+    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                          gnrc_pktdump_pid);
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 #endif
 

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -28,7 +28,8 @@
 #include "timex.h"
 #include "xtimer.h"
 
-static gnrc_netreg_entry_t server = { NULL, GNRC_NETREG_DEMUX_CTX_ALL, KERNEL_PID_UNDEF };
+static gnrc_netreg_entry_t server = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                               KERNEL_PID_UNDEF);
 
 
 static void send(char *addr_str, char *port_str, char *data, unsigned int num,

--- a/pkg/ccn-lite/patches/0001-RIOT-adapter-port-to-new-netreg-struct.patch
+++ b/pkg/ccn-lite/patches/0001-RIOT-adapter-port-to-new-netreg-struct.patch
@@ -1,0 +1,27 @@
+From 3f675f891794b3655c06b721c7f34c462233e7a5 Mon Sep 17 00:00:00 2001
+From: Martine Lenders <mail@martine-lenders.eu>
+Date: Fri, 26 Aug 2016 11:48:26 +0200
+Subject: [PATCH] RIOT adapter: port to new netreg struct
+
+---
+ src/ccn-lite-riot.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/ccn-lite-riot.c b/src/ccn-lite-riot.c
+index b5e7660..ba0a2cc 100644
+--- a/src/ccn-lite-riot.c
++++ b/src/ccn-lite-riot.c
+@@ -229,8 +229,8 @@ ccnl_open_netif(kernel_pid_t if_pid, gnrc_nettype_t netreg_type)
+     /* configure the interface to use the specified nettype protocol */
+     gnrc_netapi_set(if_pid, NETOPT_PROTO, 0, &netreg_type, sizeof(gnrc_nettype_t));
+     /* register for this nettype */
+-    _ccnl_ne.demux_ctx =  GNRC_NETREG_DEMUX_CTX_ALL;
+-    _ccnl_ne.pid = _ccnl_event_loop_pid;
++    gnrc_netreg_entry_init_pid(&_ccnl_ne, GNRC_NETREG_DEMUX_CTX_ALL,
++                               _ccnl_event_loop_pid);
+     return gnrc_netreg_register(netreg_type, &_ccnl_ne);
+ }
+ 
+-- 
+2.7.4
+

--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -66,10 +66,9 @@
  *     static msg_t _msg_q[Q_SZ];
  *     (void)arg;
  *     msg_init_queue(_msg_q, Q_SZ);
- *     gnrc_netreg_entry me_reg = {
- *             .demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL,
- *             .pid = thread_getpid()
- *         };
+ *     gnrc_netreg_entry me_reg = GNRC_NETREG_ENTRY_INIT_PID(
+ *                                      GNRC_NETREG_DEMUX_CTX_ALL,
+ *                                      sched_active_pid);
  *     gnrc_netreg_register(GNRC_NETTYPE_IPV6, &me_reg);
  *     while (1) {
  *         msg_receive(&msg);

--- a/sys/include/net/gnrc/conn.h
+++ b/sys/include/net/gnrc/conn.h
@@ -83,8 +83,7 @@ struct conn_udp {
 static inline void gnrc_conn_reg(gnrc_netreg_entry_t *entry, gnrc_nettype_t type,
                                  uint32_t demux_ctx)
 {
-    entry->pid = sched_active_pid;
-    entry->demux_ctx = demux_ctx;
+    gnrc_netreg_entry_init_pid(entry, demux_ctx, sched_active_pid);
     gnrc_netreg_register(type, entry);
 }
 

--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -39,6 +39,17 @@ extern "C" {
 #define GNRC_NETREG_DEMUX_CTX_ALL   (0xffff0000)
 
 /**
+ * @brief   Initializes a netreg entry statically with PID
+ *
+ * @param[in] demux_ctx The @ref gnrc_netreg_entry_t::demux_ctx "demux context"
+ *                      for the netreg entry
+ * @param[in] pid       The PID of the registering thread
+ *
+ * @return  An initialized netreg entry
+ */
+#define GNRC_NETREG_ENTRY_INIT_PID(demux_ctx, pid)  { NULL, demux_ctx, pid }
+
+/**
  * @brief   Entry to the @ref net_gnrc_netreg
  */
 typedef struct gnrc_netreg_entry {
@@ -64,6 +75,24 @@ typedef struct gnrc_netreg_entry {
  * @brief   Initializes module.
  */
 void gnrc_netreg_init(void);
+
+/**
+ * @brief   Initializes a netreg entry statically with PID
+ *
+ * @param[out] entry    A netreg entry
+ * @param[in] demux_ctx The @ref gnrc_netreg_entry_t::demux_ctx "demux context"
+ *                      for the netreg entry
+ * @param[in] pid       The PID of the registering thread
+ *
+ */
+static inline void gnrc_netreg_entry_init_pid(gnrc_netreg_entry_t *entry,
+                                              uint32_t demux_ctx,
+                                              kernel_pid_t pid)
+{
+    entry->next = NULL;
+    entry->demux_ctx = demux_ctx;
+    entry->pid = pid;
+}
 
 /**
  * @brief   Registers a thread to the registry.

--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -77,7 +77,7 @@ typedef struct gnrc_netreg_entry {
 void gnrc_netreg_init(void);
 
 /**
- * @brief   Initializes a netreg entry statically with PID
+ * @brief   Initializes a netreg entry dynamically with PID
  *
  * @param[out] entry    A netreg entry
  * @param[in] demux_ctx The @ref gnrc_netreg_entry_t::demux_ctx "demux context"

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -454,8 +454,8 @@ int _tftp_server(tftp_context_t *ctxt)
 {
     msg_t msg;
     bool active = true;
-    gnrc_netreg_entry_t entry = { NULL, GNRC_TFTP_DEFAULT_DST_PORT,
-                                  thread_getpid() };
+    gnrc_netreg_entry_t entry = GNRC_NETREG_ENTRY_INIT_PID(GNRC_TFTP_DEFAULT_DST_PORT,
+                                                           sched_active_pid);
 
     while (active) {
         int ret = TS_BUSY;
@@ -520,7 +520,8 @@ int _tftp_do_client_transfer(tftp_context_t *ctxt)
     tftp_state ret = TS_BUSY;
 
     /* register our DNS response listener */
-    gnrc_netreg_entry_t entry = { NULL, ctxt->src_port, thread_getpid() };
+    gnrc_netreg_entry_t entry = GNRC_NETREG_ENTRY_INIT_PID(ctxt->src_port,
+                                                           sched_active_pid);
 
     if (gnrc_netreg_register(GNRC_NETTYPE_UDP, &entry)) {
         DEBUG("tftp: error starting server.");
@@ -636,9 +637,8 @@ tftp_state _tftp_state_processes(tftp_context_t *ctxt, msg_t *m)
             }
 
             /* register a listener for the UDP port */
-            ctxt->entry.next = NULL;
-            ctxt->entry.demux_ctx = ctxt->src_port;
-            ctxt->entry.pid = thread_getpid();
+            gnrc_netreg_entry_init_pid(&(ctxt->entry), ctxt->src_port,
+                                       sched_active_pid);
             gnrc_netreg_register(GNRC_NETTYPE_UDP, &(ctxt->entry));
 
             /* try to decode the options */

--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -557,13 +557,10 @@ void *_event_loop(void *args)
     msg_t msg, ack, msg_q[GNRC_ZEP_MSG_QUEUE_SIZE];
     gnrc_netdev_t *dev = (gnrc_netdev_t *)args;
     gnrc_netapi_opt_t *opt;
-    gnrc_netreg_entry_t my_reg = { NULL, ((gnrc_zep_t *)args)->src_port,
-                                   KERNEL_PID_UNDEF
-                                 };
+    gnrc_netreg_entry_t my_reg = GNRC_NETREG_ENTRY_INIT_PID(((gnrc_zep_t *)args)->src_port,
+                                                            sched_active_pid);
 
     msg_init_queue(msg_q, GNRC_ZEP_MSG_QUEUE_SIZE);
-
-    my_reg.pid = thread_getpid();
 
     gnrc_netreg_register(GNRC_NETTYPE_UDP, &my_reg);
 

--- a/sys/net/gnrc/nettest/gnrc_nettest.c
+++ b/sys/net/gnrc/nettest/gnrc_nettest.c
@@ -111,7 +111,8 @@ gnrc_nettest_res_t gnrc_nettest_send(kernel_pid_t pid, gnrc_pktsnip_t *in,
                                      const gnrc_pktsnip_t **exp_out,
                                      gnrc_nettype_t exp_type, uint32_t exp_demux_ctx)
 {
-    gnrc_netreg_entry_t reg_entry = { NULL, exp_demux_ctx, thread_getpid() };
+    gnrc_netreg_entry_t reg_entry = GNRC_NETREG_ENTRY_INIT_PID(exp_demux_ctx,
+                                                               sched_active_pid);
     gnrc_nettest_res_t res;
 
     gnrc_netreg_register(exp_type, &reg_entry);
@@ -147,7 +148,8 @@ gnrc_nettest_res_t gnrc_nettest_receive(kernel_pid_t pid, gnrc_pktsnip_t *in,
                                         const gnrc_pktsnip_t **exp_out,
                                         gnrc_nettype_t exp_type, uint32_t exp_demux_ctx)
 {
-    gnrc_netreg_entry_t reg_entry = { NULL, exp_demux_ctx, thread_getpid() };
+    gnrc_netreg_entry_t reg_entry = GNRC_NETREG_ENTRY_INIT_PID(exp_demux_ctx,
+                                                               sched_active_pid);
     gnrc_nettest_res_t res;
 
     gnrc_netreg_register(exp_type, &reg_entry);

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -251,13 +251,11 @@ static void _dispatch_next_header(gnrc_pktsnip_t *current, gnrc_pktsnip_t *pkt,
 static void *_event_loop(void *args)
 {
     msg_t msg, reply, msg_q[GNRC_IPV6_MSG_QUEUE_SIZE];
-    gnrc_netreg_entry_t me_reg;
+    gnrc_netreg_entry_t me_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                            sched_active_pid);
 
     (void)args;
     msg_init_queue(msg_q, GNRC_IPV6_MSG_QUEUE_SIZE);
-
-    me_reg.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
-    me_reg.pid = thread_getpid();
 
     /* register interest in all IPv6 packets */
     gnrc_netreg_register(GNRC_NETTYPE_IPV6, &me_reg);

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -310,13 +310,11 @@ static void _send(gnrc_pktsnip_t *pkt)
 static void *_event_loop(void *args)
 {
     msg_t msg, reply, msg_q[GNRC_SIXLOWPAN_MSG_QUEUE_SIZE];
-    gnrc_netreg_entry_t me_reg;
+    gnrc_netreg_entry_t me_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                            sched_active_pid);
 
     (void)args;
     msg_init_queue(msg_q, GNRC_SIXLOWPAN_MSG_QUEUE_SIZE);
-
-    me_reg.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
-    me_reg.pid = thread_getpid();
 
     /* register interest in all 6LoWPAN packets */
     gnrc_netreg_register(GNRC_NETTYPE_SIXLOWPAN, &me_reg);

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -222,16 +222,14 @@ static void *_event_loop(void *arg)
     (void)arg;
     msg_t msg, reply;
     msg_t msg_queue[GNRC_UDP_MSG_QUEUE_SIZE];
-    gnrc_netreg_entry_t netreg;
-
+    gnrc_netreg_entry_t netreg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                            sched_active_pid);
     /* preset reply message */
     reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
     reply.content.value = (uint32_t)-ENOTSUP;
     /* initialize message queue */
     msg_init_queue(msg_queue, GNRC_UDP_MSG_QUEUE_SIZE);
     /* register UPD at netreg */
-    netreg.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
-    netreg.pid = thread_getpid();
     gnrc_netreg_register(GNRC_NETTYPE_UDP, &netreg);
 
     /* dispatch NETAPI messages */

--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -211,10 +211,10 @@ int _ccnl_interest(int argc, char **argv)
     memset(_int_buf, '\0', BUF_SIZE);
     memset(_cont_buf, '\0', BUF_SIZE);
     for (int cnt = 0; cnt < CCNL_INTEREST_RETRIES; cnt++) {
-        gnrc_netreg_entry_t _ne;
+        gnrc_netreg_entry_t _ne =
+            GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                       sched_active_pid);
         /* register for content chunks */
-        _ne.demux_ctx =  GNRC_NETREG_DEMUX_CTX_ALL;
-        _ne.pid = sched_active_pid;
         gnrc_netreg_register(GNRC_NETTYPE_CCN_CHUNK, &_ne);
 
         struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(argv[1], CCNL_SUITE_NDNTLV, NULL, 0);

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -153,7 +153,8 @@ int _icmpv6_ping(int argc, char **argv)
     ipv6_addr_t addr;
     kernel_pid_t src_iface;
     msg_t msg;
-    gnrc_netreg_entry_t my_entry = { NULL, ICMPV6_ECHO_REP, thread_getpid() };
+    gnrc_netreg_entry_t my_entry = GNRC_NETREG_ENTRY_INIT_PID(ICMPV6_ECHO_REP,
+                                                              sched_active_pid);
     uint32_t min_rtt = UINT32_MAX, max_rtt = 0;
     uint64_t sum_rtt = 0;
     uint64_t ping_start;

--- a/tests/driver_kw2xrf/main.c
+++ b/tests/driver_kw2xrf/main.c
@@ -26,14 +26,13 @@
 
 int main(void)
 {
-    gnrc_netreg_entry_t dump;
+    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                          gnrc_pktdump_pid);
 
     puts("KW2XRF device driver test");
 
     /* register the pktdump thread */
     puts("Register the packet dump thread for GNRC_NETTYPE_UNDEF packets");
-    dump.pid = gnrc_pktdump_pid;
-    dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 
     /* start the shell */

--- a/tests/driver_nrfmin/main.c
+++ b/tests/driver_nrfmin/main.c
@@ -31,7 +31,8 @@ static char nomac_stack[THREAD_STACKSIZE_DEFAULT];
 int main(void)
 {
     gnrc_netdev_t dev;
-    gnrc_netreg_entry_t netobj;
+    gnrc_netreg_entry_t netobj = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                            gnrc_pktdump_pid);
 
     puts("\nManual test for the minimal NRF51822 radio driver\n");
     puts("Use the 'ifconfig' and 'txtsnd' shell commands to verify the driver");
@@ -41,8 +42,6 @@ int main(void)
     gnrc_nomac_init(nomac_stack, sizeof(nomac_stack), 5, "nomac", &dev);
 
     /* initialize packet dumper */
-    netobj.pid = gnrc_pktdump_pid;
-    netobj.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &netobj);
 
     /* initialize and run the shell */

--- a/tests/driver_xbee/main.c
+++ b/tests/driver_xbee/main.c
@@ -30,17 +30,16 @@
  */
 int main(void)
 {
-    gnrc_netreg_entry_t dump;
+    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                          gnrc_pktdump_pid);
 
     puts("Xbee S1 device driver test");
 
     /* initialize and register pktdump */
-    dump.pid = gnrc_pktdump_pid;
-    if (dump.pid <= KERNEL_PID_UNDEF) {
+    if (gnrc_pktdump_pid <= KERNEL_PID_UNDEF) {
         puts("Error starting pktdump thread");
         return -1;
     }
-    dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 
     /* start the shell */

--- a/tests/gnrc_sixlowpan/main.c
+++ b/tests/gnrc_sixlowpan/main.c
@@ -123,10 +123,10 @@ static void _send_packet(void)
         0x00, 0x00, 0x00, 0x00,
     };
 
-    gnrc_netreg_entry_t dump_6lowpan = { NULL, GNRC_NETREG_DEMUX_CTX_ALL, gnrc_pktdump_pid };
-    gnrc_netreg_entry_t dump_ipv6 = { NULL, GNRC_NETREG_DEMUX_CTX_ALL, gnrc_pktdump_pid };
-    gnrc_netreg_entry_t dump_udp = { NULL, GNRC_NETREG_DEMUX_CTX_ALL, gnrc_pktdump_pid };
-    gnrc_netreg_entry_t dump_udp_61616 = { NULL, 61616, gnrc_pktdump_pid };
+    gnrc_netreg_entry_t dump_6lowpan = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL, gnrc_pktdump_pid);
+    gnrc_netreg_entry_t dump_ipv6 = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL, gnrc_pktdump_pid);
+    gnrc_netreg_entry_t dump_udp = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL, gnrc_pktdump_pid);
+    gnrc_netreg_entry_t dump_udp_61616 = GNRC_NETREG_ENTRY_INIT_PID(61616, gnrc_pktdump_pid);
 
     gnrc_netreg_register(GNRC_NETTYPE_SIXLOWPAN, &dump_6lowpan);
     gnrc_netreg_register(GNRC_NETTYPE_IPV6, &dump_ipv6);

--- a/tests/netdev2_test/main.c
+++ b/tests/netdev2_test/main.c
@@ -133,8 +133,8 @@ static int test_receive(void)
     ethernet_hdr_t *rcv_mac = (ethernet_hdr_t *)_tmp;
     uint8_t *rcv_payload = _tmp + sizeof(ethernet_hdr_t);
     gnrc_pktsnip_t *pkt, *hdr;
-    gnrc_netreg_entry_t me = { NULL, GNRC_NETREG_DEMUX_CTX_ALL,
-                               thread_getpid() };
+    gnrc_netreg_entry_t me = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                        sched_active_pid);
     msg_t msg;
 
     if (_dev.netdev.event_callback == NULL) {

--- a/tests/slip/main.c
+++ b/tests/slip/main.c
@@ -30,14 +30,12 @@
  */
 int main(void)
 {
-    gnrc_netreg_entry_t dump;
+    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                          gnrc_pktdump_pid);
 
     puts("SLIP test");
 
-    /* initialize and register pktdump */
-    dump.pid = gnrc_pktdump_pid;
-    dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
-
+    /* register pktdump */
     if (dump.pid <= KERNEL_PID_UNDEF) {
         puts("Error starting pktdump thread");
         return -1;

--- a/tests/unittests/tests-netreg/tests-netreg.c
+++ b/tests/unittests/tests-netreg/tests-netreg.c
@@ -22,8 +22,8 @@
 #include "tests-netreg.h"
 
 static gnrc_netreg_entry_t entries[] = {
-    { NULL, TEST_UINT16, TEST_UINT8 },
-    { NULL, TEST_UINT16, TEST_UINT8 + 1 }
+    GNRC_NETREG_ENTRY_INIT_PID(TEST_UINT16, TEST_UINT8),
+    GNRC_NETREG_ENTRY_INIT_PID(TEST_UINT16, TEST_UINT8 + 1)
 };
 
 static void set_up(void)

--- a/tests/zep/main.c
+++ b/tests/zep/main.c
@@ -30,19 +30,17 @@
  */
 int main(void)
 {
-    gnrc_netreg_entry_t dump;
+    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                          gnrc_pktdump_pid);
 
     puts("ZEP module test");
 
     /* initialize and register pktdump */
-    dump.pid = gnrc_pktdump_pid;
-
-    if (dump.pid <= KERNEL_PID_UNDEF) {
+    if (gnrc_pktdump_pid <= KERNEL_PID_UNDEF) {
         puts("Error starting pktdump thread");
         return -1;
     }
 
-    dump.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
     gnrc_netreg_register(GNRC_NETTYPE_NETIF, &dump);
 
     /* start the shell */


### PR DESCRIPTION
This introduces a helper macro/function for `gnrc_netreg_entry_t` initialization, similar like the ones in `mutex.h`.

This is a preparation step for `mbox` (see #4919) integration into GNRC