### PR TITLE
gnrc: use gnrc_netapi_dispatch_send() instead of manual iteration

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -57,7 +57,6 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
 {
     gnrc_pktsnip_t *icmpv6, *ipv6;
     icmpv6_hdr_t *hdr;
-    gnrc_netreg_entry_t *sendto;
 
     icmpv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_ICMPV6);
 
@@ -127,24 +126,9 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
 
     /* ICMPv6-all will be send in gnrc_ipv6.c so only dispatch of subtypes is
      * needed */
-
-    sendto = gnrc_netreg_lookup(GNRC_NETTYPE_ICMPV6, hdr->type);
-
-    if (sendto == NULL) {
-        DEBUG("icmpv6: no receivers for ICMPv6 type %u\n", hdr->type);
-        /* don't release: IPv6 does this */
-        return;
-    }
-
-    /* IPv6 might still do stuff to the packet, so no `- 1` */
-    gnrc_pktbuf_hold(pkt, gnrc_netreg_num(GNRC_NETTYPE_ICMPV6, hdr->type));
-
-    while (sendto != NULL) {
-        if (gnrc_netapi_receive(sendto->pid, pkt) < 1) {
-            DEBUG("icmpv6: unable to deliver packet\n");
-            gnrc_pktbuf_release(pkt);
-        }
-        sendto = gnrc_netreg_getnext(sendto);
+    if (!gnrc_netapi_dispatch_receive(GNRC_NETTYPE_ICMPV6, hdr->type, pkt)) {
+        DEBUG("icmpv6: no one interested in type %d\n", hdr->type);
+        gnrc_pktbuf_release(pkt);
     }
 }
 

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -168,7 +168,6 @@ void gnrc_ipv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *current, gnrc_pktsnip_t
         case PROTNUM_ICMPV6:
             DEBUG("ipv6: handle ICMPv6 packet (nh = %u)\n", nh);
             gnrc_icmpv6_demux(iface, pkt);
-            gnrc_pktbuf_release(pkt);
             return;
 #endif
 #ifdef MODULE_GNRC_IPV6_EXT

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -117,13 +117,13 @@ void gnrc_ndp_nbr_sol_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
         (ipv6_addr_is_unspecified(&ipv6->src) &&
          ipv6_addr_is_solicited_node(&ipv6->dst))) {
         DEBUG("ndp: neighbor solicitation was invalid.\n");
-        /* ipv6 releases */
+        /* icmpv6 releases */
         return;
     }
     if ((tgt = gnrc_ipv6_netif_find_addr(iface, &nbr_sol->tgt)) == NULL) {
         DEBUG("ndp: Target address is not to interface %" PRIkernel_pid "\n",
               iface);
-        /* ipv6 releases */
+        /* icmpv6 releases */
         return;
     }
     sicmpv6_size -= sizeof(ndp_nbr_sol_t);
@@ -228,14 +228,14 @@ void gnrc_ndp_nbr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt,
         (icmpv6_size < sizeof(ndp_nbr_adv_t)) ||
         ipv6_addr_is_multicast(&nbr_adv->tgt)) {
         DEBUG("ndp: neighbor advertisement was invalid.\n");
-        /* ipv6 releases */
+        /* icmpv6 releases */
         return;
     }
 
     if (nc_entry == NULL) {
         /* see https://tools.ietf.org/html/rfc4861#section-7.2.5 */
         DEBUG("ndp: no neighbor cache entry found for advertisement's target\n");
-        /* ipv6 releases */
+        /* icmpv6 releases */
         return;
     }
 
@@ -507,7 +507,7 @@ void gnrc_ndp_rtr_adv_handle(kernel_pid_t iface, gnrc_pktsnip_t *pkt, ipv6_hdr_t
         (ipv6->hl != 255) || (rtr_adv->code != 0) ||
         (icmpv6_size < sizeof(ndp_rtr_adv_t))) {
         DEBUG("ndp: router advertisement was invalid\n");
-        /* ipv6 releases */
+        /* icmpv6 releases */
         return;
     }
     /* get source from default router list */

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -153,8 +153,7 @@ int _icmpv6_ping(int argc, char **argv)
     ipv6_addr_t addr;
     kernel_pid_t src_iface;
     msg_t msg;
-    gnrc_netreg_entry_t *ipv6_entry, my_entry = { NULL, ICMPV6_ECHO_REP,
-                                                  thread_getpid() };
+    gnrc_netreg_entry_t my_entry = { NULL, ICMPV6_ECHO_REP, thread_getpid() };
     uint32_t min_rtt = UINT32_MAX, max_rtt = 0;
     uint64_t sum_rtt = 0;
     uint64_t ping_start;
@@ -231,13 +230,6 @@ int _icmpv6_ping(int argc, char **argv)
         return 1;
     }
 
-    ipv6_entry = gnrc_netreg_lookup(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL);
-
-    if (ipv6_entry == NULL) {
-        puts("error: ipv6 thread missing");
-        return 1;
-    }
-
     remaining = count;
 
     ping_start = xtimer_now64();
@@ -277,7 +269,7 @@ int _icmpv6_ping(int argc, char **argv)
         }
 
         start = xtimer_now();
-        if (gnrc_netapi_send(ipv6_entry->pid, pkt) < 1) {
+        if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {
             puts("error: unable to send ICMPv6 echo request\n");
             gnrc_pktbuf_release(pkt);
             continue;


### PR DESCRIPTION
There were still some occurrences of manual lookup in `gnrc_netreg` inside and in the usage of GNRC, that need not to be. This PR fixes that (and is also, like #5524 a preperation step for `gnrc_netreg` with `mbox`es)