### PR TITLE
gnrc_netreg: mbox and arbitrary callback support

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -57,6 +57,10 @@ ifneq (,$(filter gnrc_conn_udp,$(USEMODULE)))
   USEMODULE += gnrc_udp
 endif
 
+ifneq (,$(filter gnrc_netapi_mbox,$(USEMODULE)))
+  USEMODULE += core_mbox
+endif
+
 ifneq (,$(filter netdev2_tap,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += netdev2_eth

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -12,6 +12,7 @@ PSEUDOMODULES += gnrc_ipv6_router
 PSEUDOMODULES += gnrc_ipv6_router_default
 PSEUDOMODULES += gnrc_netdev_default
 PSEUDOMODULES += gnrc_neterr
+PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_pktbuf
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default

--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -12,6 +12,7 @@ PSEUDOMODULES += gnrc_ipv6_router
 PSEUDOMODULES += gnrc_ipv6_router_default
 PSEUDOMODULES += gnrc_netdev_default
 PSEUDOMODULES += gnrc_neterr
+PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_pktbuf
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -94,7 +94,7 @@ static void start_server(char *port_str)
     uint16_t port;
 
     /* check if server is already running */
-    if (server.pid != KERNEL_PID_UNDEF) {
+    if (server.target.pid != KERNEL_PID_UNDEF) {
         printf("Error: server already running on port %" PRIu32 "\n",
                server.demux_ctx);
         return;
@@ -106,7 +106,7 @@ static void start_server(char *port_str)
         return;
     }
     /* start server (which means registering pktdump for the chosen port) */
-    server.pid = gnrc_pktdump_pid;
+    server.target.pid = gnrc_pktdump_pid;
     server.demux_ctx = (uint32_t)port;
     gnrc_netreg_register(GNRC_NETTYPE_UDP, &server);
     printf("Success: started UDP server on port %" PRIu16 "\n", port);
@@ -115,13 +115,13 @@ static void start_server(char *port_str)
 static void stop_server(void)
 {
     /* check if server is running at all */
-    if (server.pid == KERNEL_PID_UNDEF) {
+    if (server.target.pid == KERNEL_PID_UNDEF) {
         printf("Error: server was not running\n");
         return;
     }
     /* stop server */
     gnrc_netreg_unregister(GNRC_NETTYPE_UDP, &server);
-    server.pid = KERNEL_PID_UNDEF;
+    server.target.pid = KERNEL_PID_UNDEF;
     puts("Success: stopped UDP server");
 }
 

--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -21,6 +21,21 @@
  * @file
  * @brief       Generic interface to communicate with GNRC modules
  *
+ * @defgroup    net_gnrc_netapi_mbox   Mailbox IPC extension
+ * @ingroup     net_gnrc_netapi
+ * @brief       @ref core_mbox "Mailbox IPC" extension for @ref net_gnrc_netapi
+ * @{
+ *
+ * @details The submodule `gnrc_netapi_mbox` provides an extension for
+ *          @ref core_mbox "Mailbox IPC".
+ *
+ * To use, add the module `gnrc_netapi_mbox` to the `USEMODULE` macro in your
+ * application's Makefile:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ * USEMODULE += gnrc_netapi_mbox
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * @}
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */

--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -36,6 +36,21 @@
  * USEMODULE += gnrc_netapi_mbox
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * @}
+ *
+ * @defgroup    net_gnrc_netapi_callbacks   Callback extension
+ * @ingroup     net_gnrc_netapi
+ * @brief       Callback extension for @ref net_gnrc_netapi
+ * @{
+ * @details The submodule `gnrc_netapi_callbacks` provides an extension for
+ *          callbacks to run GNRC thread-less.
+ *
+ * To use, add the module `gnrc_netapi_callbacks` to the `USEMODULE` macro in
+ * your application's Makefile:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ * USEMODULE += gnrc_netapi_callbacks
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * @}
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */

--- a/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
+++ b/sys/net/gnrc/conn/ip/gnrc_conn_ip.c
@@ -52,7 +52,7 @@ int conn_ip_create(conn_ip_t *conn, const void *addr, size_t addr_len, int famil
 void conn_ip_close(conn_ip_t *conn)
 {
     assert(conn->l4_type == GNRC_NETTYPE_UNDEF);
-    if (conn->netreg_entry.pid != KERNEL_PID_UNDEF) {
+    if (conn->netreg_entry.target.pid != KERNEL_PID_UNDEF) {
         gnrc_netreg_unregister(conn->l3_type, &conn->netreg_entry);
     }
 }

--- a/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
+++ b/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
@@ -56,9 +56,9 @@ int conn_udp_create(conn_udp_t *conn, const void *addr, size_t addr_len,
 void conn_udp_close(conn_udp_t *conn)
 {
     assert(conn->l4_type == GNRC_NETTYPE_UDP);
-    if (conn->netreg_entry.pid != KERNEL_PID_UNDEF) {
+    if (conn->netreg_entry.target.pid != KERNEL_PID_UNDEF) {
         gnrc_netreg_unregister(GNRC_NETTYPE_UDP, &conn->netreg_entry);
-        conn->netreg_entry.pid = KERNEL_PID_UNDEF;
+        conn->netreg_entry.target.pid = KERNEL_PID_UNDEF;
     }
 }
 

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -37,8 +37,16 @@ void gnrc_netreg_init(void)
 
 int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
 {
+#if defined(MODULE_GNRC_NETAPI_MBOX) || defined(MODULE_GNRC_NETAPI_CALLBACKS)
+#ifdef DEVELHELP
     /* only threads with a message queue are allowed to register at gnrc */
-    assert(sched_threads[entry->pid]->msg_array);
+    assert((entry->type != GNRC_NETREG_TYPE_DEFAULT) ||
+           sched_threads[entry->target.pid]->msg_array);
+#endif
+#else
+    /* only threads with a message queue are allowed to register at gnrc */
+    assert(sched_threads[entry->target.pid]->msg_array);
+#endif
 
     if (_INVALID_TYPE(type)) {
         return -EINVAL;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -68,7 +68,7 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid)
         }
 
         _me_reg.demux_ctx = ICMPV6_RPL_CTRL;
-        _me_reg.pid = gnrc_rpl_pid;
+        _me_reg.target.pid = gnrc_rpl_pid;
         /* register interest in all ICMPv6 packets */
         gnrc_netreg_register(GNRC_NETTYPE_ICMPV6, &_me_reg);
 

--- a/tests/slip/main.c
+++ b/tests/slip/main.c
@@ -36,7 +36,7 @@ int main(void)
     puts("SLIP test");
 
     /* register pktdump */
-    if (dump.pid <= KERNEL_PID_UNDEF) {
+    if (dump.target.pid <= KERNEL_PID_UNDEF) {
         puts("Error starting pktdump thread");
         return -1;
     }

--- a/tests/unittests/tests-netreg/tests-netreg.c
+++ b/tests/unittests/tests-netreg/tests-netreg.c
@@ -45,7 +45,7 @@ static void test_netreg_register__success(void)
     TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_register(GNRC_NETTYPE_TEST, &entries[0]));
     TEST_ASSERT_NOT_NULL((res = gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16)));
     TEST_ASSERT_EQUAL_INT(TEST_UINT16, res->demux_ctx);
-    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res->pid);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res->target.pid);
     TEST_ASSERT_NULL((gnrc_netreg_getnext(res)));
 }
 
@@ -66,7 +66,7 @@ void test_netreg_unregister__success2(void)
     gnrc_netreg_unregister(GNRC_NETTYPE_TEST, &entries[0]);
     TEST_ASSERT_NOT_NULL((res = gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16)));
     TEST_ASSERT_EQUAL_INT(TEST_UINT16, res->demux_ctx);
-    TEST_ASSERT_EQUAL_INT(TEST_UINT8 + 1, res->pid);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 + 1, res->target.pid);
     gnrc_netreg_unregister(GNRC_NETTYPE_TEST, &entries[1]);
     TEST_ASSERT_NULL(gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16));
 }
@@ -80,7 +80,7 @@ void test_netreg_unregister__success3(void)
     gnrc_netreg_unregister(GNRC_NETTYPE_TEST, &entries[1]);
     TEST_ASSERT_NOT_NULL((res = gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16)));
     TEST_ASSERT_EQUAL_INT(TEST_UINT16, res->demux_ctx);
-    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res->pid);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8, res->target.pid);
     gnrc_netreg_unregister(GNRC_NETTYPE_TEST, &entries[0]);
     TEST_ASSERT_NULL(gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16));
 }


### PR DESCRIPTION
Adds dispatch capabilities to `gnrc_netapi`/`gnrc_netreg` other than target threads. This is optional behavior. The new target types introduced are:

* `mbox` (see #4919)
* arbitrary callbacks providing both `TYPE` and `pkt`

Depends on ~~#5524~~ (merged), ~~#5525~~ (merged), and ~~#4919~~ (merged)