### PR TITLE
shell: set NULL pointer for data pakets with zero-length payload

### DIFF
--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -1041,7 +1041,7 @@ int _netif_send(int argc, char **argv)
 {
     kernel_pid_t dev;
     uint8_t addr[MAX_ADDR_LEN];
-    size_t addr_len;
+    size_t addr_len, data_len;
     gnrc_pktsnip_t *pkt, *hdr;
     gnrc_netif_hdr_t *nethdr;
     uint8_t flags = 0x00;
@@ -1073,10 +1073,16 @@ int _netif_send(int argc, char **argv)
     }
 
     /* put packet together */
-    pkt = gnrc_pktbuf_add(NULL, argv[3], strlen(argv[3]), GNRC_NETTYPE_UNDEF);
-    if (pkt == NULL) {
-        puts("error: packet buffer full");
-        return 1;
+    data_len = strlen(argv[3]);
+    if (data_len == 0) {
+        pkt = NULL;
+    }
+    else {
+        pkt = gnrc_pktbuf_add(NULL, argv[3], data_len, GNRC_NETTYPE_UNDEF);
+        if (pkt == NULL) {
+            puts("error: packet buffer full");
+            return 1;
+        }
     }
     hdr = gnrc_netif_hdr_build(NULL, 0, addr, addr_len);
     if (hdr == NULL) {


### PR DESCRIPTION
This PR makes it possible to send empty packets using `txtsnd` at the shell, e.g.:

`txtsnd 4 bcast ""`

Previously `_netif_send()` would attempt to create an empty packet for the NETIF header to point to, however `gnrc_pktbuf_add()` won't allow snips with zero length. Now, the NETIF header pointer is set to NULL for zero-length snips instead.

Fixes #5530.