### PR TITLE
gnrc_ipv6: copy user flags from old netif headers

### DIFF
--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
@@ -25,6 +25,22 @@ void gnrc_netif_hdr_print(gnrc_netif_hdr_t *hdr)
     printf("if_pid: %" PRIkernel_pid "  ", hdr->if_pid);
     printf("rssi: %" PRIu8 "  ", hdr->rssi);
     printf("lqi: %" PRIu8 "\n", hdr->lqi);
+    printf("flags: ");
+
+    if (hdr->flags) {
+        if (hdr->flags & GNRC_NETIF_HDR_FLAGS_BROADCAST) {
+            printf("BROADCAST ");
+        }
+
+        if (hdr->flags & GNRC_NETIF_HDR_FLAGS_MULTICAST) {
+            printf("MULTICAST ");
+        }
+        puts("");
+    }
+    else {
+        puts("0x0");
+    }
+
 
     if (hdr->src_l2addr_len > 0) {
         printf("src_l2addr: %s\n",


### PR DESCRIPTION
Upper layers might want to utilize the flags (e.g. to tell 6LoWPAN to elide UDP checksums, as @ReneHerthel is currently working on). This change allows for this by copying non-addressing related flags to the address resolution generated netif header from the user generated netif header.