### PR TITLE
cortexm_common: Fix isr_stack usage count

### DIFF
--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -257,10 +257,14 @@ void thread_arch_stack_print(void)
 /* This function returns the number of bytes used on the ISR stack */
 int thread_arch_isr_stack_usage(void)
 {
-    uint32_t  *ptr = &_sstack;
+    uint32_t *ptr = &_sstack;
 
-    while (*(ptr++) == STACK_CANARY_WORD) {}
-    return (ISR_STACKSIZE - (ptr - &_sstack));
+    while(((*ptr) == STACK_CANARY_WORD) && (ptr < &_estack)) {
+        ++ptr;
+    }
+
+    ptrdiff_t num_used_words = &_estack - ptr;
+    return num_used_words * sizeof(*ptr);
 }
 
 __attribute__((naked)) void NORETURN thread_arch_start_threading(void)


### PR DESCRIPTION
Refactor and add multiply by word size to get the usage in number of bytes instead of in number of words.

Verified implementation by manual memory inspection in GDB.

(I remarked on this error in the original pr #4201, but the comment got lost somehow and then I forgot about it.)