### PR TITLE
sys/ps: Add current stack pointer to DEVELHELP output

### DIFF
--- a/core/include/arch/thread_arch.h
+++ b/core/include/arch/thread_arch.h
@@ -64,6 +64,16 @@ char *thread_arch_stack_init(thread_task_func_t task_func, void *arg, void *stac
 int thread_arch_isr_stack_usage(void);
 
 /**
+ * @brief   Get the current ISR stack pointer
+ */
+void *thread_arch_isr_stack_pointer(void);
+
+/**
+ * @brief   Get the start of the ISR stack
+ */
+void *thread_arch_isr_stack_start(void);
+
+/**
  * @brief Print the current stack to stdout
  */
 void thread_arch_stack_print(void);

--- a/cpu/arm7_common/arm_cpu.c
+++ b/cpu/arm7_common/arm_cpu.c
@@ -35,6 +35,18 @@ int thread_arch_isr_stack_usage(void)
     return -1;
 }
 
+void *thread_arch_isr_stack_pointer(void)
+{
+    /* TODO */
+    return (void *)-1;
+}
+
+void *thread_arch_isr_stack_start(void)
+{
+    /* TODO */
+    return (void *)-1;
+}
+
 /*----------------------------------------------------------------------------
  * Processor specific routine - here for ARM7
  * sizeof(void*) = sizeof(int)

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -205,6 +205,18 @@ int thread_arch_isr_stack_usage(void)
     return -1;
 }
 
+void *thread_arch_isr_stack_pointer(void)
+{
+    /* TODO */
+    return (void *)-1;
+}
+
+void *thread_arch_isr_stack_start(void)
+{
+    /* TODO */
+    return (void *)-1;
+}
+
 void thread_arch_start_threading(void) __attribute__((naked));
 void thread_arch_start_threading(void)
 {

--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -267,6 +267,17 @@ int thread_arch_isr_stack_usage(void)
     return num_used_words * sizeof(*ptr);
 }
 
+void *thread_arch_isr_stack_pointer(void)
+{
+    void *msp = (void *)__get_MSP();
+    return msp;
+}
+
+void *thread_arch_isr_stack_start(void)
+{
+    return (void *)&_sstack;
+}
+
 __attribute__((naked)) void NORETURN thread_arch_start_threading(void)
 {
     __asm__ volatile (

--- a/cpu/msp430-common/cpu.c
+++ b/cpu/msp430-common/cpu.c
@@ -40,6 +40,18 @@ int thread_arch_isr_stack_usage(void)
     return -1;
 }
 
+void *thread_arch_isr_stack_pointer(void)
+{
+    /* TODO */
+    return (void *)-1;
+}
+
+void *thread_arch_isr_stack_start(void)
+{
+    /* TODO */
+    return (void *)-1;
+}
+
 NORETURN void cpu_switch_context_exit(void)
 {
     sched_active_thread = sched_threads[0];

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -62,6 +62,16 @@ int _sig_pipefd[2];
 static _native_callback_t native_irq_handlers[255];
 char sigalt_stk[SIGSTKSZ];
 
+void *thread_arch_isr_stack_pointer(void)
+{
+    return native_isr_context.uc_stack.ss_sp;
+}
+
+void *thread_arch_isr_stack_start(void)
+{
+    return __isr_stack;
+}
+
 void print_thread_sigmask(ucontext_t *cp)
 {
     sigset_t *p = &cp->uc_sigmask;

--- a/cpu/x86/x86_threading.c
+++ b/cpu/x86/x86_threading.c
@@ -117,6 +117,16 @@ void thread_yield_higher(void)
     irq_restore(old_intr);
 }
 
+void *thread_arch_isr_stack_pointer(void)
+{
+    return isr_context.uc_stack.ss_sp;
+}
+
+void *thread_arch_isr_stack_start(void)
+{
+    return isr_stack;
+}
+
 void isr_cpu_switch_context_exit(void)
 {
     DEBUG("XXX: cpu_switch_context_exit(), num_tasks = %d\n", sched_num_threads);

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -72,9 +72,11 @@ void ps(void)
            "state");
 
 #ifdef DEVELHELP
-    int isr_usage = thread_arch_isr_stack_usage();                                 /* ISR stack usage */
+    int isr_usage = thread_arch_isr_stack_usage();
+    void *isr_start = thread_arch_isr_stack_start();
+    void *isr_sp = thread_arch_isr_stack_pointer();
     printf("\t  - | isr_stack            | -        - |"
-           "   - | %5i (%5i) | -\n", ISR_STACKSIZE, isr_usage);
+           "   - | %5i (%5i) | %10p | %10p\n", ISR_STACKSIZE, isr_usage, isr_start, isr_sp);
     overall_stacksz += ISR_STACKSIZE;
     if (isr_usage > 0) {
         overall_used += isr_usage;

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -60,7 +60,7 @@ void ps(void)
 #endif
             "%-9sQ | pri "
 #ifdef DEVELHELP
-           "| stack ( used) | location   "
+           "| stack ( used) | base       | current    "
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
            "| runtime | switches"
@@ -104,7 +104,7 @@ void ps(void)
 #endif
                    " | %-8s %.1s | %3i"
 #ifdef DEVELHELP
-                   " | %5i (%5i) | %p "
+                   " | %5i (%5i) | %10p | %10p "
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
                    " | %6.3f%% |  %8d"
@@ -116,7 +116,7 @@ void ps(void)
 #endif
                    sname, queued, p->priority
 #ifdef DEVELHELP
-                   , p->stack_size, stacksz, (void *)p->stack_start
+                   , p->stack_size, stacksz, (void *)p->stack_start, (void *)p->sp
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
                    , runtime_ticks, switches


### PR DESCRIPTION
~~Depends on #5558.~~

This PR adds an extra column to the `ps` shell command output which shows the current value of the stack pointer for each thread. This may or may not be equal to the address found by adding stack usage to the stack start address, since the usage column specifies the greatest stack usage since the system was started.

Also added the stack start and stack pointer outputs to the `isr_stack` line.

I only implemented the isr_stack changes for cortexm_common, x86 and native. The other platforms are stubs. All platforms should have the thread stack pointers though.