### PR TITLE
cpu/samd21: remove include instance_sercom3.h

### DIFF
--- a/cpu/samd21/periph/i2c.c
+++ b/cpu/samd21/periph/i2c.c
@@ -23,7 +23,6 @@
 #include "mutex.h"
 #include "periph_conf.h"
 #include "periph/i2c.h"
-#include "instance/instance_sercom3.h"
 
 #include "sched.h"
 #include "thread.h"


### PR DESCRIPTION
That include will be already picked up by cpu.h -> cpu_conf.h -> samd21.h