### PR TITLE
examples/microcoap_server: fix .well-known/core endpoint

### DIFF
--- a/examples/microcoap_server/coap.c
+++ b/examples/microcoap_server/coap.c
@@ -43,6 +43,8 @@ static int handle_get_well_known_core(coap_rw_buffer_t *scratch,
         uint8_t id_hi, uint8_t id_lo)
 {
     char *rsp = (char *)response;
+    /* resetting the content of response message */
+    memset(response, 0, sizeof(response));
     int len = sizeof(response);
     const coap_endpoint_t *ep = endpoints;
     int i;


### PR DESCRIPTION
While playing with the microcoap_server example, I noticed that results of queries on the .well-know/core endpoint path where appended until the node crashes.
This is a simple fix that ensure the response buffer is correctly reset before one starts writing in it.