### PR TITLE
unittests: Add cpp_ctors test for C++ constructors

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -27,7 +27,7 @@ else
 endif
 
 ARM7_BOARDS := msba2 avrextrem
-DISABLE_TEST_FOR_ARM7 := tests-relic
+DISABLE_TEST_FOR_ARM7 := tests-relic tests-cpp_%
 
 ARM_CORTEX_M_BOARDS := airfy-beacon arduino-due arduino-zero cc2538dk ek-lm4f120xl \
                        f4vi1 fox frdm-k64f iotlab-m3 limifrog-v1 mbed_lpc1768 msbiot \
@@ -43,10 +43,10 @@ ARM_CORTEX_M_BOARDS := airfy-beacon arduino-due arduino-zero cc2538dk ek-lm4f120
 DISABLE_TEST_FOR_ARM_CORTEX_M := tests-relic
 
 AVR_BOARDS := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove
-DISABLE_TEST_FOR_AVR := tests-relic
+DISABLE_TEST_FOR_AVR := tests-relic tests-cpp_%
 
 MSP430_BOARDS :=  chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
-DISABLE_TEST_FOR_MSP430 := tests-relic tests-spiffs
+DISABLE_TEST_FOR_MSP430 := tests-relic tests-spiffs tests-cpp_%
 
 ifneq (, $(filter $(ARM7_BOARDS), $(BOARD)))
 UNIT_TESTS := $(filter-out $(DISABLE_TEST_FOR_ARM7), $(UNIT_TESTS))
@@ -62,6 +62,12 @@ endif
 
 ifneq (, $(filter $(MSP430_BOARDS), $(BOARD)))
 UNIT_TESTS := $(filter-out $(DISABLE_TEST_FOR_MSP430), $(UNIT_TESTS))
+endif
+
+ifneq (,$(filter tests-cpp_%, $(UNIT_TESTS)))
+    # We need to tell the build system to use the C++ compiler for linking
+    export FEATURES_REQUIRED += cpp
+    export CPPMIX := 1
 endif
 
 DISABLE_MODULE += auto_init

--- a/tests/unittests/tests-cpp_ctors/Makefile
+++ b/tests/unittests/tests-cpp_ctors/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-cpp_ctors/Makefile.include
+++ b/tests/unittests/tests-cpp_ctors/Makefile.include
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += cpp

--- a/tests/unittests/tests-cpp_ctors/README.md
+++ b/tests/unittests/tests-cpp_ctors/README.md
@@ -1,0 +1,18 @@
+The purpose of this test is to ensure that C++ constructors are executed
+properly during the startup of RIOT. This requires that the port calls
+constructors somewhere during C-library initialization. On newlib ports this is
+done by __libc_init_array(), other ports may need to manually iterate through
+the list of initializer functions (usually .init_array), and call each one in
+order.
+
+There are three tests:
+ - Global constructor
+ - Static constructor
+ - Local constructor
+
+The global constructor test checks to see if the constructor of a global object
+has been run during the boot process. The static constructor test does the
+same, but for static object inside a function. The local constructor test checks
+that a locally created object does have its constructor run.
+The local constructor test will only fail if there is a significant problem with
+the C++ tool chain, since it does not rely on any external C++ support code.

--- a/tests/unittests/tests-cpp_ctors/tests-cpp_ctors-class.cpp
+++ b/tests/unittests/tests-cpp_ctors/tests-cpp_ctors-class.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016-2017 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "tests-cpp_ctors.h"
+
+volatile long tests_cpp_ctors_magic1 = 12345;
+volatile long tests_cpp_ctors_magic2 = 11111111;
+void *tests_cpp_ctors_order[8];
+
+namespace RIOTTestCPP {
+
+MyClass::MyClass()
+{
+    var = tests_cpp_ctors_magic1;
+}
+
+MyClass::MyClass(long value) : var(value)
+{
+}
+
+long MyClass::value()
+{
+    return var;
+}
+
+void MyClass::inc()
+{
+    ++var;
+}
+
+} /* namespace RIOTTestCPP */

--- a/tests/unittests/tests-cpp_ctors/tests-cpp_ctors-trampoline.c
+++ b/tests/unittests/tests-cpp_ctors/tests-cpp_ctors-trampoline.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016-2017 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "embUnit.h"
+#include "embUnit/embUnit.h"
+#include "tests-cpp_ctors.h"
+#include "thread.h" /* For thread_getpid() */
+
+long tests_cpp_ctors_global_value(void);
+long tests_cpp_ctors_static_value(void);
+long tests_cpp_ctors_local_value(long number);
+
+extern volatile long tests_cpp_ctors_magic1;
+extern volatile long tests_cpp_ctors_magic2;
+extern void *tests_cpp_ctors_order[8];
+
+static void tests_cpp_global_ctors(void)
+{
+    long expected = tests_cpp_ctors_magic1;
+    long actual = tests_cpp_ctors_global_value();
+    /* Test to ensure that global constructors have executed */
+    TEST_ASSERT_EQUAL_INT(expected, actual);
+}
+
+static void tests_cpp_static_ctors(void)
+{
+    for (long i = 1; i < 10; ++i) {
+        long expected = tests_cpp_ctors_magic2 + i;
+        long actual = tests_cpp_ctors_static_value();
+        TEST_ASSERT_EQUAL_INT(expected, actual);
+    }
+}
+
+static void tests_cpp_local_ctors(void)
+{
+    /* Test to ensure that local constructors are executed properly */
+    long expected = thread_getpid() + 1;
+    long actual = tests_cpp_ctors_local_value(thread_getpid());
+    TEST_ASSERT_EQUAL_INT(expected, actual);
+}
+
+Test *tests_cpp_ctors_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(tests_cpp_local_ctors),
+        new_TestFixture(tests_cpp_global_ctors),
+        new_TestFixture(tests_cpp_static_ctors),
+    };
+
+    EMB_UNIT_TESTCALLER(cpp_tests, NULL, NULL, fixtures);
+
+    return (Test *)&cpp_tests;
+}
+
+void tests_cpp_ctors(void)
+{
+    TESTS_RUN(tests_cpp_ctors_tests());
+}

--- a/tests/unittests/tests-cpp_ctors/tests-cpp_ctors.cpp
+++ b/tests/unittests/tests-cpp_ctors/tests-cpp_ctors.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016-2017 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "tests-cpp_ctors.h"
+
+using RIOTTestCPP::MyClass;
+
+MyClass global_obj;
+
+extern "C" {
+long tests_cpp_ctors_global_value(void);
+long tests_cpp_ctors_static_value(void);
+long tests_cpp_ctors_local_value(long);
+}
+extern volatile long tests_cpp_ctors_magic2;
+
+long tests_cpp_ctors_local_value(long number) {
+    MyClass local_obj(number);
+    local_obj.inc();
+    return local_obj.value();
+}
+
+long tests_cpp_ctors_static_value() {
+    static MyClass static_obj(tests_cpp_ctors_magic2);
+    static_obj.inc();
+
+    return static_obj.value();
+}
+
+long tests_cpp_ctors_global_value() {
+    return global_obj.value();
+}

--- a/tests/unittests/tests-cpp_ctors/tests-cpp_ctors.h
+++ b/tests/unittests/tests-cpp_ctors/tests-cpp_ctors.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016-2017 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for C++ constructors
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+#ifndef TESTS_CPP_CTORS_H
+#define TESTS_CPP_CTORS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_cpp(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+namespace RIOTTestCPP {
+    /**
+     * @brief Simple class used for testing constructor calls
+     */
+    class MyClass {
+    private:
+        volatile long var;
+
+    public:
+        MyClass();
+
+        explicit MyClass(long value);
+
+        long value();
+
+        void inc();
+    };
+}
+#endif
+
+#endif /* TESTS_CPP_CTORS_H */
+/** @} */


### PR DESCRIPTION
~~Small test program to assist in debugging missing constructor calls.~~

Add a unit test for checking that global and static constructors are being called during the system start up.
