### PR TITLE
cpu/stm32: fix header include guards

### DIFF
--- a/cpu/stm32f0/include/cpu_conf.h
+++ b/cpu/stm32f0/include/cpu_conf.h
@@ -18,8 +18,8 @@
  * @author          Hauke Petersen <hauke.peterse@fu-berlin.de>
  */
 
-#ifndef __CPU_CONF_H
-#define __CPU_CONF_H
+#ifndef STM32F0_CPU_CONF_H
+#define STM32F0_CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -49,5 +49,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __CPU_CONF_H */
+#endif /* STM32F0_CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f0/include/stm32f051x8.h
+++ b/cpu/stm32f0/include/stm32f051x8.h
@@ -50,8 +50,8 @@
   * @{
   */
 
-#ifndef __STM32F051x8_H
-#define __STM32F051x8_H
+#ifndef STM32F051x8_H
+#define STM32F051x8_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -3781,7 +3781,7 @@ typedef struct
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F051x8_H */
+#endif /* STM32F051x8_H */
 
 /**
   * @}

--- a/cpu/stm32f0/include/stm32f072xb.h
+++ b/cpu/stm32f0/include/stm32f072xb.h
@@ -51,8 +51,8 @@
   * @{
   */
 
-#ifndef __STM32F072xB_H
-#define __STM32F072xB_H
+#ifndef STM32F072xB_H
+#define STM32F072xB_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -5977,7 +5977,7 @@ typedef struct
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F072xB_H */
+#endif /* STM32F072xB_H */
 
 /**
   * @}

--- a/cpu/stm32f0/include/stm32f091xc.h
+++ b/cpu/stm32f0/include/stm32f091xc.h
@@ -49,8 +49,8 @@
   * @{
   */
 
-#ifndef __STM32F091xC_H
-#define __STM32F091xC_H
+#ifndef STM32F091xC_H
+#define STM32F091xC_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -5765,7 +5765,7 @@ typedef struct
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F091xC_H */
+#endif /* STM32F091xC_H */
 
 /**
   * @}

--- a/cpu/stm32f1/include/stm32f103xb.h
+++ b/cpu/stm32f1/include/stm32f103xb.h
@@ -52,8 +52,8 @@
   * @{
   */
 
-#ifndef __STM32F103xB_H
-#define __STM32F103xB_H
+#ifndef STM32F103xB_H
+#define STM32F103xB_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -6037,7 +6037,7 @@ typedef struct
   }
 #endif /* __cplusplus */
 
-#endif /* __STM32F103xB_H */
+#endif /* STM32F103xB_H */
 
 
 

--- a/cpu/stm32f1/include/stm32f103xe.h
+++ b/cpu/stm32f1/include/stm32f103xe.h
@@ -52,8 +52,8 @@
   * @{
   */
 
-#ifndef __STM32F103xE_H
-#define __STM32F103xE_H
+#ifndef STM32F103xE_H
+#define STM32F103xE_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -6839,7 +6839,7 @@ typedef struct
   }
 #endif /* __cplusplus */
 
-#endif /* __STM32F103xE_H */
+#endif /* STM32F103xE_H */
 
 
 

--- a/cpu/stm32f3/include/cpu_conf.h
+++ b/cpu/stm32f3/include/cpu_conf.h
@@ -19,8 +19,8 @@
  * @author          Katja Kirstein <katja.kirstein@haw-hamburg.de>
  */
 
-#ifndef __CPU_CONF_H
-#define __CPU_CONF_H
+#ifndef STM32F3_CPU_CONF_H
+#define STM32F3_CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -52,5 +52,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __CPU_CONF_H */
+#endif /* STM32F3_CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f3/include/stm32f303xc.h
+++ b/cpu/stm32f3/include/stm32f303xc.h
@@ -49,8 +49,8 @@
   * @{
   */
 
-#ifndef __STM32F303xC_H
-#define __STM32F303xC_H
+#ifndef STM32F303xC_H
+#define STM32F303xC_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -6977,7 +6977,7 @@ typedef struct
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F303xC_H */
+#endif /* STM32F303xC_H */
 
 /**
   * @}

--- a/cpu/stm32f3/include/stm32f303xe.h
+++ b/cpu/stm32f3/include/stm32f303xe.h
@@ -49,8 +49,8 @@
   * @{
   */
 
-#ifndef __STM32F303xE_H
-#define __STM32F303xE_H
+#ifndef STM32F303xE_H
+#define STM32F303xE_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -8198,7 +8198,7 @@ typedef struct
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F303xE_H */
+#endif /* STM32F303xE_H */
 
 /**
   * @}

--- a/cpu/stm32f3/include/stm32f334x8.h
+++ b/cpu/stm32f3/include/stm32f334x8.h
@@ -49,8 +49,8 @@
   * @{
   */
 
-#ifndef __STM32F334x8_H
-#define __STM32F334x8_H
+#ifndef STM32F334x8_H
+#define STM32F334x8_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -7590,7 +7590,7 @@ typedef struct
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F334x8_H */
+#endif /* STM32F334x8_H */
 
 /**
  * @}

--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -18,8 +18,8 @@
  * @author          Hauke Petersen <hauke.peterse@fu-berlin.de>
  */
 
-#ifndef __CPU_CONF_H
-#define __CPU_CONF_H
+#ifndef STM32F4_CPU_CONF_H
+#define STM32F4_CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -48,5 +48,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __CPU_CONF_H */
+#endif /* STM32F4_CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f4/include/stm32f401xe.h
+++ b/cpu/stm32f4/include/stm32f401xe.h
@@ -49,8 +49,8 @@
   * @{
   */
 
-#ifndef __STM32F401xE_H
-#define __STM32F401xE_H
+#ifndef STM32F401xE_H
+#define STM32F401xE_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -4764,7 +4764,7 @@ USB_OTG_HostChannelTypeDef;
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F401xE_H */
+#endif /* STM32F401xE_H */
 
 
 

--- a/cpu/stm32f4/include/stm32f407xx.h
+++ b/cpu/stm32f4/include/stm32f407xx.h
@@ -49,8 +49,8 @@
   * @{
   */
 
-#ifndef __STM32F407xx_H
-#define __STM32F407xx_H
+#ifndef STM32F407xx_H
+#define STM32F407xx_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -7943,7 +7943,7 @@ USB_OTG_HostChannelTypeDef;
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F407xx_H */
+#endif /* STM32F407xx_H */
 
 
 

--- a/cpu/stm32f4/include/stm32f415xx.h
+++ b/cpu/stm32f4/include/stm32f415xx.h
@@ -49,8 +49,8 @@
   * @{
   */
 
-#ifndef __STM32F415xx_H
-#define __STM32F415xx_H
+#ifndef STM32F415xx_H
+#define STM32F415xx_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -7518,7 +7518,7 @@ USB_OTG_HostChannelTypeDef;
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F415xx_H */
+#endif /* STM32F415xx_H */
 
 
 

--- a/cpu/stm32l1/include/stm32l1xx.h
+++ b/cpu/stm32l1/include/stm32l1xx.h
@@ -51,8 +51,8 @@
   * @{
   */
 
-#ifndef __STM32L1XX_H
-#define __STM32L1XX_H
+#ifndef STM32L1XX_H
+#define STM32L1XX_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -6661,7 +6661,7 @@ typedef struct
 }
 #endif
 
-#endif /* __STM32L1XX_H */
+#endif /* STM32L1XX_H */
 
 /**
   * @}


### PR DESCRIPTION
Pull request created as per the issue  [#2623](https://github.com/RIOT-OS/RIOT/issues/2623#)