### PR TITLE
cpu/x86: fix header include guard.

### DIFF
--- a/cpu/x86/include/x86_pci_init.h
+++ b/cpu/x86/include/x86_pci_init.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef __X86__PCI_INIT__H
-#define __X86__PCI_INIT__H
+#ifndef X86_PCI_INIT_H
+#define X86_PCI_INIT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,4 +31,4 @@ void x86_init_pci_devices(void);
 }
 #endif
 
-#endif
+#endif /* X86_PCI_INIT_H */


### PR DESCRIPTION
Pull request created as per the issue  [#2623](https://github.com/RIOT-OS/RIOT/issues/2623#)