### PR TITLE
cpu/stellaris: revise header include guards.

### DIFF
--- a/cpu/stellaris_common/include/cortex-m4-def.h
+++ b/cpu/stellaris_common/include/cortex-m4-def.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef CORTEX_M4_DEF_H_
-#define CORTEX_M4_DEF_H_
+#ifndef STELLARIS_CORTEX_M4_DEF_H_
+#define STELLARIS_CORTEX_M4_DEF_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -10062,4 +10062,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CORTEX_M4_DEF_H_ */
+#endif /* STELLARIS_CORTEX_M4_DEF_H_ */

--- a/cpu/stellaris_common/include/hw_adc.h
+++ b/cpu/stellaris_common/include/hw_adc.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_ADC_H_
-#define HW_ADC_H_
+#ifndef STELLARIS_HW_ADC_H_
+#define STELLARIS_HW_ADC_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -1357,4 +1357,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_ADC_H_ */
+#endif /* STELLARIS_HW_ADC_H_ */

--- a/cpu/stellaris_common/include/hw_gpio.h
+++ b/cpu/stellaris_common/include/hw_gpio.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_GPIO_H_
-#define HW_GPIO_H_
+#ifndef STELLARIS_HW_GPIO_H_
+#define STELLARIS_HW_GPIO_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -197,4 +197,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_GPIO_H_ */
+#endif /* STELLARIS_HW_GPIO_H_ */

--- a/cpu/stellaris_common/include/hw_hibernate.h
+++ b/cpu/stellaris_common/include/hw_hibernate.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_HIBERNATE_H_
-#define HW_HIBERNATE_H_
+#ifndef STELLARIS_HW_HIBERNATE_H_
+#define STELLARIS_HW_HIBERNATE_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -291,4 +291,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_HIBERNATE_H_ */
+#endif /* STELLARIS_HW_HIBERNATE_H_ */

--- a/cpu/stellaris_common/include/hw_i2c.h
+++ b/cpu/stellaris_common/include/hw_i2c.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_I2C_H_
-#define HW_I2C_H_
+#ifndef STELLARIS_HW_I2C_H_
+#define STELLARIS_HW_I2C_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -494,4 +494,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_I2C_H_ */
+#endif /* STELLARIS_HW_I2C_H_ */

--- a/cpu/stellaris_common/include/hw_ints.h
+++ b/cpu/stellaris_common/include/hw_ints.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_INTS_H_
-#define HW_INTS_H_
+#ifndef STELLARIS_HW_INTS_H_
+#define STELLARIS_HW_INTS_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -222,4 +222,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_INTS_H_ */
+#endif /* STELLARIS_HW_INTS_H_ */

--- a/cpu/stellaris_common/include/hw_memmap.h
+++ b/cpu/stellaris_common/include/hw_memmap.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_MEMMAP_H_
-#define HW_MEMMAP_H_
+#ifndef STELLARIS_HW_MEMMAP_H_
+#define STELLARIS_HW_MEMMAP_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -169,4 +169,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_MEMMAP_H_ */
+#endif /* STELLARIS_HW_MEMMAP_H_ */

--- a/cpu/stellaris_common/include/hw_nvic.h
+++ b/cpu/stellaris_common/include/hw_nvic.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_NVIC_H_
-#define HW_NVIC_H_
+#ifndef STELLARIS_HW_NVIC_H_
+#define STELLARIS_HW_NVIC_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -1722,4 +1722,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_NVIC_H_ */
+#endif /* STELLARIS_HW_NVIC_H_ */

--- a/cpu/stellaris_common/include/hw_pwm.h
+++ b/cpu/stellaris_common/include/hw_pwm.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_PWM_H_
-#define HW_PWM_H_
+#ifndef STELLARIS_HW_PWM_H_
+#define STELLARIS_HW_PWM_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -2025,4 +2025,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_PWM_H_ */
+#endif /* STELLARIS_HW_PWM_H_ */

--- a/cpu/stellaris_common/include/hw_ssi.h
+++ b/cpu/stellaris_common/include/hw_ssi.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_SSI_H_
-#define HW_SSI_H_
+#ifndef STELLARIS_HW_SSI_H_
+#define STELLARIS_HW_SSI_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -249,4 +249,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_SSI_H_ */
+#endif /* STELLARIS_HW_SSI_H_ */

--- a/cpu/stellaris_common/include/hw_sysctl.h
+++ b/cpu/stellaris_common/include/hw_sysctl.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_SYSCTL_H_
-#define HW_SYSCTL_H_
+#ifndef STELLARIS_HW_SYSCTL_H_
+#define STELLARIS_HW_SYSCTL_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -3681,4 +3681,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_SYSCTL_H_ */
+#endif /* STELLARIS_HW_SYSCTL_H_ */

--- a/cpu/stellaris_common/include/hw_sysexc.h
+++ b/cpu/stellaris_common/include/hw_sysexc.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_SYSEXC_H_
-#define HW_SYSEXC_H_
+#ifndef STELLARIS_HW_SYSEXC_H_
+#define STELLARIS_HW_SYSEXC_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -136,4 +136,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_SYSEXC_H_ */
+#endif /* STELLARIS_HW_SYSEXC_H_ */

--- a/cpu/stellaris_common/include/hw_timer.h
+++ b/cpu/stellaris_common/include/hw_timer.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_TIMER_H_
-#define HW_TIMER_H_
+#ifndef STELLARIS_HW_TIMER_H_
+#define STELLARIS_HW_TIMER_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -764,4 +764,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_TIMER_H_ */
+#endif /* STELLARIS_HW_TIMER_H_ */

--- a/cpu/stellaris_common/include/hw_types.h
+++ b/cpu/stellaris_common/include/hw_types.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_TYPES_H_
-#define HW_TYPES_H_
+#ifndef STELLARIS_HW_TYPES_H_
+#define STELLARIS_HW_TYPES_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -223,4 +223,4 @@ typedef unsigned char tBoolean;
 }
 #endif
 
-#endif /* HW_TYPES_H_ */
+#endif /* STELLARIS_HW_TYPES_H_ */

--- a/cpu/stellaris_common/include/hw_uart.h
+++ b/cpu/stellaris_common/include/hw_uart.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_UART_H_
-#define HW_UART_H_
+#ifndef STELLARIS_HW_UART_H_
+#define STELLARIS_HW_UART_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -527,4 +527,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_UART_H_ */
+#endif /* STELLARIS_HW_UART_H_ */

--- a/cpu/stellaris_common/include/hw_watchdog.h
+++ b/cpu/stellaris_common/include/hw_watchdog.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HW_WATCHDOG_H_
-#define HW_WATCHDOG_H_
+#ifndef STELLARIS_HW_WATCHDOG_H_
+#define STELLARIS_HW_WATCHDOG_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -196,4 +196,4 @@ extern "C" {
 }
 #endif
 
-#endif /* HW_WATCHDOG_H_ */
+#endif /* STELLARIS_HW_WATCHDOG_H_ */

--- a/cpu/stellaris_common/include/stellaris_periph/adc.h
+++ b/cpu/stellaris_common/include/stellaris_periph/adc.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef ADC_H_
-#define ADC_H_
+#ifndef STELLARIS_ADC_H_
+#define STELLARIS_ADC_H_
 
 //*****************************************************************************
 //
@@ -308,4 +308,4 @@ extern unsigned long ADCPhaseDelayGet(unsigned long ulBase);
 }
 #endif
 
-#endif /* ADC_H_ */
+#endif /* STELLARIS_ADC_H_ */

--- a/cpu/stellaris_common/include/stellaris_periph/comp.h
+++ b/cpu/stellaris_common/include/stellaris_periph/comp.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef COMP_H_
-#define COMP_H_
+#ifndef STELLARIS_COMP_H_
+#define STELLARIS_COMP_H_
 
 //*****************************************************************************
 //
@@ -142,4 +142,4 @@ extern void ComparatorIntClear(unsigned long ulBase, unsigned long ulComp);
 }
 #endif
 
-#endif /* COMP_H_ */
+#endif /* STELLARIS_COMP_H_ */

--- a/cpu/stellaris_common/include/stellaris_periph/fpu.h
+++ b/cpu/stellaris_common/include/stellaris_periph/fpu.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef FPU_H_
-#define FPU_H_
+#ifndef STELLARIS_FPU_H_
+#define STELLARIS_FPU_H_
 
 //*****************************************************************************
 //
@@ -109,4 +109,4 @@ extern void FPURoundingModeSet(unsigned long ulMode);
 }
 #endif
 
-#endif /* FPU_H_ */
+#endif /* STELLARIS_FPU_H_ */

--- a/cpu/stellaris_common/include/stellaris_periph/gpio.h
+++ b/cpu/stellaris_common/include/stellaris_periph/gpio.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef GPIO_H_
-#define GPIO_H_
+#ifndef STELLARIS_GPIO_H_
+#define STELLARIS_GPIO_H_
 
 //*****************************************************************************
 //
@@ -196,4 +196,4 @@ extern void GPIOADCTriggerDisable(unsigned long ulPort, unsigned char ucPins);
 }
 #endif
 
-#endif /* GPIO_H_ */
+#endif /* STELLARIS_GPIO_H_ */

--- a/cpu/stellaris_common/include/stellaris_periph/hibernate.h
+++ b/cpu/stellaris_common/include/stellaris_periph/hibernate.h
@@ -37,8 +37,8 @@
 //
 //*****************************************************************************
 
-#ifndef HIBERNATE_H_
-#define HIBERNATE_H_
+#ifndef STELLARIS_HIBERNATE_H_
+#define STELLARIS_HIBERNATE_H_
 
 //*****************************************************************************
 //
@@ -164,4 +164,4 @@ extern unsigned long HibernateBatCheckDone(void);
 }
 #endif
 
-#endif  /* HIBERNATE_H_ */
+#endif  /* STELLARIS_HIBERNATE_H_ */


### PR DESCRIPTION
Revised cpu\stellaris header include gurads, just to be consistent with the revisions in  [#5571](https://github.com/RIOT-OS/RIOT/pull/5571#).

See the comments in PR [#5571](https://github.com/RIOT-OS/RIOT/pull/5571#).