### PR TITLE
native: add 802.15.4 raw driver

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -51,6 +51,15 @@ ifneq (,$(filter netdev2_tap,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter netdev2_raw802154,$(USEMODULE)))
+  USEMODULE += netif
+  USEMODULE += ieee802154
+  USEMODULE += netdev2_ieee802154
+  ifneq (,$(filter gnrc_%,$(USEMODULE)))
+    USEMODULE += gnrc_netdev2
+  endif
+endif
+
 ifneq (,$(filter gnrc_zep,$(USEMODULE)))
   USEMODULE += hashes
   USEMODULE += ieee802154

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -1,3 +1,7 @@
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += netdev2_tap
 endif
+
+ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+    USEMODULE += netdev2_raw802154
+endif

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -6,6 +6,10 @@ ifneq (,$(filter netdev2_tap,$(USEMODULE)))
 	DIRS += netdev2_tap
 endif
 
+ifneq (,$(filter netdev2_raw802154,$(USEMODULE)))
+	DIRS += netdev2_raw802154
+endif
+
 include $(RIOTBASE)/Makefile.base
 
 INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -58,6 +58,15 @@ void native_async_read_cleanup(void);
 void native_async_read_continue(int fd);
 
 /**
+ * @brief   helper for read continue with select
+ *
+ * Call this function after reading file descriptors.
+ *
+ * @param[in] fd  The file descriptor to monitor
+ */
+void native_async_continue_reading(int fd);
+
+/**
  * @brief   start monitoring of file descriptor
  *
  * @param[in] fd       The file descriptor to monitor

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -117,6 +117,7 @@ extern int (*real_setitimer)(int which, const struct itimerval
 extern int (*real_setsid)(void);
 extern int (*real_setsockopt)(int socket, ...);
 extern int (*real_socket)(int domain, int type, int protocol);
+extern int (*real_shutdown)(int sockfd, int how);
 extern int (*real_printf)(const char *format, ...);
 extern int (*real_unlink)(const char *);
 extern long int (*real_random)(void);

--- a/cpu/native/include/netdev2_raw802154.h
+++ b/cpu/native/include/netdev2_raw802154.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @ingroup     netdev2
+ * @brief       Low-level ethernet driver for native tap interfaces
+ * @{
+ *
+ * @file
+ * @brief       Definitions for @ref netdev2 ethernet driver for host system's
+ *              TAP interfaces
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+#ifndef NETDEV2_RAW802154_H
+#define NETDEV2_RAW802154_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "net/netdev2.h"
+#include "net/netdev2/ieee802154.h"
+
+#ifdef __MACH__
+#include "net/if_var.h"
+#else
+#include "net/if.h"
+#endif
+
+/**
+ * @brief tap interface state
+ */
+typedef struct netdev2_raw802154 {
+    netdev2_ieee802154_t netdev;
+    char ifname[IFNAMSIZ + 1];
+    int fd;
+    int rand_addr;
+    uint8_t page;
+} netdev2_raw802154_t;
+
+/**
+ * @brief global device struct. driver only supports one tap device as of now.
+ */
+extern netdev2_raw802154_t netdev2_raw802154;
+
+/**
+ * @brief Setup netdev2_tap_t structure.
+ *
+ * @param dev       the preallocated netdev2_tap device handle to setup
+ */
+void netdev2_raw802154_setup(netdev2_raw802154_t *dev, const char *ifname, int rand_addr);
+
+/**
+ * @brief Cleanup tap resources
+ *
+ * @param dev  the netdev2_tap device handle to cleanup
+ */
+void netdev2_raw802154_cleanup(netdev2_raw802154_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* NETDEV2_RAW802154_H */

--- a/cpu/native/netdev2_raw802154/Makefile
+++ b/cpu/native/netdev2_raw802154/Makefile
@@ -1,0 +1,3 @@
+include $(RIOTBASE)/Makefile.base
+
+INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/netdev2_raw802154/netdev2_raw802154.c
+++ b/cpu/native/netdev2_raw802154/netdev2_raw802154.c
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2016 Alexander Aring <aar@pengutronix.de>
+ * Copyright (C) 2015 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>,
+ *                    Martine Lenders <mlenders@inf.fu-berlin.de>
+ *                    Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Ell-i open source co-operative
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#ifdef __MACH__
+#define _POSIX_C_SOURCE
+#include <net/if.h>
+#undef _POSIX_C_SOURCE
+#include <sys/types.h>
+#include <ifaddrs.h>
+#include <net/if_dl.h>
+#elif defined(__FreeBSD__)
+#include <sys/socket.h>
+#include <net/if.h>
+#include <ifaddrs.h>
+#include <net/if_dl.h>
+#else
+#include <net/if.h>
+#include <linux/if_tun.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#endif
+
+#include "native_internal.h"
+
+#include "net/eui64.h"
+#include "net/netdev2.h"
+#include "net/netdev2/eth.h"
+#include "net/ethernet.h"
+#include "net/ethernet/hdr.h"
+#include "netdev2_raw802154.h"
+#include "net/netopt.h"
+#include "net/eui64.h"
+
+#include "periph/hwrng.h"
+
+#include "async_read.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifndef ETH_P_IEEE802154
+#define ETH_P_IEEE802154 0x00F6
+#endif
+
+#define RAW802154_DEFAULT_ADDR_PAN      (0x0023)
+#define RAW802154_DEFAULT_ADDR_SHORT    (0xfffe)
+#define RAW802154_DEFAULT_ADDR_LONG     (0x1222334455667788)
+
+/* support one raw802154 interface for now */
+netdev2_raw802154_t netdev2_raw802154;
+
+void _set_page(netdev2_raw802154_t *dev, uint8_t page)
+{
+    dev->page = page;
+}
+
+static uint8_t _get_page(netdev2_raw802154_t *dev)
+{
+    return dev->page;
+}
+
+static void _set_chan(netdev2_raw802154_t *dev, uint8_t channel)
+{
+    dev->netdev.chan = channel;
+}
+
+static inline void _isr(netdev2_t *netdev)
+{
+    if (netdev->event_callback)
+        netdev->event_callback(netdev, NETDEV2_EVENT_RX_COMPLETE);
+}
+
+static void _raw802154_isr(int fd) {
+    (void) fd;
+    netdev2_t *netdev = (netdev2_t *)&netdev2_raw802154;
+
+    if (netdev->event_callback)
+        netdev->event_callback(netdev, NETDEV2_EVENT_ISR);
+}
+
+static void _set_addr_short(netdev2_raw802154_t *dev, uint16_t addr)
+{
+    dev->netdev.short_addr[0] = (uint8_t)(addr);
+    dev->netdev.short_addr[1] = (uint8_t)(addr >> 8);
+}
+
+static void _set_addr_long(netdev2_raw802154_t *dev, uint64_t addr)
+{
+    for (int i = 0; i < 8; i++)
+        dev->netdev.long_addr[i] = (uint8_t)(addr >> (i * 8));
+}
+
+static void _set_pan(netdev2_raw802154_t *dev, uint16_t pan)
+{
+    dev->netdev.pan = pan;
+}
+
+static int16_t _get_txpower(netdev2_raw802154_t *dev)
+{
+    (void)dev;
+    return 0;
+}
+
+static uint8_t _get_max_retries(netdev2_raw802154_t *dev)
+{
+    (void)dev;
+    return 0;
+}
+
+#define _MAX_MHR_OVERHEAD   (25)
+static int _get(netdev2_t *netdev, netopt_t opt, void *val, size_t max_len)
+{
+    netdev2_raw802154_t *dev = (netdev2_raw802154_t *)netdev;
+
+    switch (opt) {
+        case NETOPT_STATE:
+            if (max_len < sizeof(netopt_state_t)) {
+                return -EOVERFLOW;
+            }
+            *((netopt_state_t *)val) = NETOPT_STATE_RX;
+            return sizeof(netopt_state_t);
+        case NETOPT_CHANNEL_PAGE:
+            if (max_len < sizeof(int16_t)) {
+                return -EOVERFLOW;
+            }
+            ((uint8_t *)val)[1] = 0;
+            ((uint8_t *)val)[0] = _get_page(dev);
+            return sizeof(uint16_t);
+        case NETOPT_MAX_PACKET_SIZE:
+            if (max_len < sizeof(int16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)val) = 127 - _MAX_MHR_OVERHEAD;
+            return sizeof(uint16_t);
+        case NETOPT_TX_POWER:
+            if (max_len < sizeof(int16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)val) = _get_txpower(dev);
+            return sizeof(uint16_t);
+            break;
+        case NETOPT_CSMA:
+            if (max_len < sizeof(netopt_enable_t)) {
+                return -EOVERFLOW;
+            }
+            *((netopt_enable_t *)val) = NETOPT_DISABLE;
+            return sizeof(netopt_enable_t);
+        case NETOPT_AUTOCCA:
+            if (max_len < sizeof(netopt_enable_t)) {
+                return -EOVERFLOW;
+            }
+            *((netopt_enable_t *)val) = NETOPT_DISABLE;
+            return sizeof(netopt_enable_t);
+        case NETOPT_RETRANS:
+            if (max_len < sizeof(uint8_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint8_t *)val) = _get_max_retries(dev);
+            return sizeof(uint8_t);
+            break;
+        default:
+            break;
+    }
+    int res;
+    if (((res = netdev2_ieee802154_get((netdev2_ieee802154_t *)netdev, opt, val,
+                                       max_len)) >= 0) || (res != -ENOTSUP)) {
+        return res;
+    }
+    return 0;
+}
+
+static int _set(netdev2_t *netdev, netopt_t opt, void *val, size_t len)
+{
+    return netdev2_ieee802154_set((netdev2_ieee802154_t *)netdev, opt,
+                                  val, len);
+}
+
+static int _recv(netdev2_t *netdev, char *buf, int len, void *info)
+{
+    netdev2_raw802154_t *dev = (netdev2_raw802154_t *)netdev;
+    (void)info;
+    int nread;
+
+    if (!buf) {
+        if (len > 0)
+            native_async_continue_reading(dev->fd);
+        else
+            return 127;
+    }
+
+    nread = real_read(dev->fd, buf, len) - 2;
+    if (nread > 0) {
+        native_async_continue_reading(dev->fd);
+
+#ifdef MODULE_NETSTATS_L2
+        netdev->stats.rx_count++;
+        netdev->stats.rx_bytes += nread;
+#endif
+    }
+
+    return nread;
+}
+
+static int _send(netdev2_t *netdev, const struct iovec *vector, int n)
+{
+    netdev2_raw802154_t *dev = (netdev2_raw802154_t *)netdev;
+    int res = _native_writev(dev->fd, vector, n);
+#ifdef MODULE_NETSTATS_L2
+    size_t bytes = 0;
+
+    for (int i = 0; i < n; i++) {
+        bytes += vector->iov_len;
+        vector++;
+    }
+    netdev->stats.tx_bytes += bytes;
+#endif
+    if (netdev->event_callback)
+        netdev->event_callback(netdev, NETDEV2_EVENT_TX_COMPLETE);
+
+    return res;
+}
+
+static int _init(netdev2_t *netdev)
+{
+    netdev2_raw802154_t *dev = (netdev2_raw802154_t *)netdev;
+    uint64_t extended_rand_addr;
+    struct sockaddr_ll sll;
+    struct ifreq ifr;
+    int ret;
+
+#ifdef MODULE_NETSTATS_L2
+    memset(&netdev->stats, 0, sizeof(netstats_t));
+#endif
+
+    /* reset options and sequence number */
+    dev->netdev.seq = 0;
+
+    _set_page(dev, 0);
+    _set_chan(dev, 11);
+
+    if (dev->rand_addr) {
+        hwrng_init();
+        hwrng_read((uint8_t *)&extended_rand_addr, sizeof(extended_rand_addr));
+        /* make sure we mark the address as non-multicast and not globally unique */
+        ((uint8_t *)&extended_rand_addr)[0] &= ~(0x01);
+        ((uint8_t *)&extended_rand_addr)[0] |= 0x02;
+        _set_addr_long(dev, extended_rand_addr);
+    } else {
+        _set_addr_long(dev, RAW802154_DEFAULT_ADDR_LONG);
+    }
+    _set_addr_short(dev, RAW802154_DEFAULT_ADDR_SHORT);
+    _set_pan(dev, RAW802154_DEFAULT_ADDR_PAN);
+
+#ifdef MODULE_GNRC_SIXLOWPAN
+    dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;
+#elif MODULE_GNRC
+    dev->netdev.proto = GNRC_NETTYPE_UNDEF;
+#endif
+
+    dev->fd = real_socket(AF_PACKET, SOCK_RAW, htons(ETH_P_IEEE802154));
+    if (dev->fd == -1) {
+        err(EXIT_FAILURE, "Couldn't create a raw 802154 socket\n");
+    }
+
+    strncpy(ifr.ifr_name, dev->ifname, IFNAMSIZ);
+    ret = real_ioctl(dev->fd, SIOCGIFINDEX, &ifr);
+    if (ret < 0) {
+        real_close(dev->fd);
+        err(EXIT_FAILURE, "Failed SIOCGIFINDEX on interface %s", dev->ifname);
+    }
+
+    sll.sll_family = AF_PACKET;
+    sll.sll_ifindex = ifr.ifr_ifindex;
+    sll.sll_protocol = htons(ETH_P_IEEE802154);
+    ret = real_bind(dev->fd, (struct sockaddr *)&sll, sizeof(sll));
+    if (ret == -1) {
+        real_close(dev->fd);
+        err(EXIT_FAILURE, "Failed to bind interface");
+    }
+
+    /* configure signal handler for fds */
+    native_async_read_add_handler(dev->fd, _raw802154_isr);
+
+    return 0;
+}
+
+void netdev2_raw802154_cleanup(netdev2_raw802154_t *dev)
+{
+    /* Do we have a device */
+    if (!dev) {
+        return;
+    }
+
+    /* cleanup signal handling */
+    native_async_read_cleanup();
+
+    /* close the raw802154 device */
+    real_shutdown(dev->fd, SHUT_RDWR);
+    real_close(dev->fd);
+}
+
+static netdev2_driver_t netdev2_driver_raw802154 = {
+    .send = _send,
+    .recv = _recv,
+    .init = _init,
+    .isr = _isr,
+    .get = _get,
+    .set = _set,
+};
+
+void netdev2_raw802154_setup(netdev2_raw802154_t *dev, const char *ifname, int rand_addr) {
+    dev->netdev.netdev.driver = &netdev2_driver_raw802154;
+    strncpy(dev->ifname, ifname, IFNAMSIZ);
+    dev->rand_addr = rand_addr;
+}

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -365,7 +365,6 @@ static int _init(netdev2_t *netdev)
             dev->addr[3], dev->addr[4], dev->addr[5]);
 
     /* configure signal handler for fds */
-    native_async_read_setup();
     native_async_read_add_handler(dev->tap_fd, _tap_isr);
 
 #ifdef MODULE_NETSTATS_L2

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -184,33 +184,6 @@ static inline bool _is_addr_multicast(uint8_t *addr)
     return (addr[0] & 0x01);
 }
 
-static void _continue_reading(netdev2_tap_t *dev)
-{
-    /* work around lost signals */
-    fd_set rfds;
-    struct timeval t;
-    memset(&t, 0, sizeof(t));
-    FD_ZERO(&rfds);
-    FD_SET(dev->tap_fd, &rfds);
-
-    _native_in_syscall++; /* no switching here */
-
-    if (real_select(dev->tap_fd + 1, &rfds, NULL, NULL, &t) == 1) {
-        int sig = SIGIO;
-        extern int _sig_pipefd[2];
-        extern ssize_t (*real_write)(int fd, const void * buf, size_t count);
-        real_write(_sig_pipefd[1], &sig, sizeof(int));
-        _native_sigpend++;
-        DEBUG("netdev2_tap: sigpend++\n");
-    }
-    else {
-        DEBUG("netdev2_tap: native_async_read_continue\n");
-        native_async_read_continue(dev->tap_fd);
-    }
-
-    _native_in_syscall--;
-}
-
 static int _recv(netdev2_t *netdev2, char *buf, int len, void *info)
 {
     netdev2_tap_t *dev = (netdev2_tap_t*)netdev2;
@@ -233,7 +206,7 @@ static int _recv(netdev2_t *netdev2, char *buf, int len, void *info)
 
             real_read(dev->tap_fd, buf, sizeof(buf));
 
-            _continue_reading(dev);
+            native_async_continue_reading(dev->tap_fd);
         }
 
         /* no way of figuring out packet size without racey buffering,
@@ -259,7 +232,7 @@ static int _recv(netdev2_t *netdev2, char *buf, int len, void *info)
             return 0;
         }
 
-        _continue_reading(dev);
+        native_async_continue_reading(dev->tap_fd);
 
 #ifdef MODULE_NETSTATS_L2
         netdev2->stats.rx_count++;

--- a/cpu/native/periph/hwrng.c
+++ b/cpu/native/periph/hwrng.c
@@ -54,6 +54,10 @@ unsigned _native_rng_read_hq(uint8_t *buf, unsigned num);
 void hwrng_init(void)
 {
     DEBUG("hwrng_init: initializing\n");
+
+    if (initialized)
+        return;
+
     switch (_native_rng_mode) {
         case 0:
             _native_rng_init_hq();

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -30,6 +30,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include "async_read.h"
+
 #include "kernel_init.h"
 #include "cpu.h"
 
@@ -326,6 +328,9 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
     native_cpu_init();
     native_interrupt_init();
 #ifdef MODULE_NETDEV2_TAP
+    /* configure signal handler for fds */
+    native_async_read_setup();
+
     if (tap_dev) {
         netdev2_tap_params_t p;
         p.tap_name = &(argv[1]);

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -85,6 +85,7 @@ int (*real_setitimer)(int which, const struct itimerval
 int (*real_setsid)(void);
 int (*real_setsockopt)(int socket, ...);
 int (*real_socket)(int domain, int type, int protocol);
+int (*real_shutdown)(int sockfd, int how);
 int (*real_unlink)(const char *);
 long int (*real_random)(void);
 const char* (*real_gai_strerror)(int errcode);
@@ -459,6 +460,7 @@ void _native_init_syscalls(void)
     *(void **)(&real_setsid) = dlsym(RTLD_NEXT, "setsid");
     *(void **)(&real_setsockopt) = dlsym(RTLD_NEXT, "setsockopt");
     *(void **)(&real_socket) = dlsym(RTLD_NEXT, "socket");
+    *(void **)(&real_shutdown) = dlsym(RTLD_NEXT, "shutdown");
     *(void **)(&real_unlink) = dlsym(RTLD_NEXT, "unlink");
     *(void **)(&real_random) = dlsym(RTLD_NEXT, "random");
     *(void **)(&real_execve) = dlsym(RTLD_NEXT, "execve");

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -215,6 +215,11 @@ void auto_init(void)
     auto_init_netdev2_tap();
 #endif
 
+#ifdef MODULE_NETDEV2_RAW802154
+    extern void auto_init_netdev2_raw802154(void);
+    auto_init_netdev2_raw802154();
+#endif
+
 #endif /* MODULE_AUTO_INIT_GNRC_NETIF */
 
 #ifdef MODULE_GNRC_IPV6_NETIF

--- a/sys/auto_init/netif/auto_init_netdev2_raw802154.c
+++ b/sys/auto_init/netif/auto_init_netdev2_raw802154.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup auto_init_ng_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for ethernet devices
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifdef MODULE_NETDEV2_RAW802154
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#include "netdev2_raw802154.h"
+#include "net/gnrc/netdev2/ieee802154.h"
+
+extern netdev2_raw802154_t netdev2_raw802154;
+extern char *raw802154_ifname;
+
+/**
+ * @brief   Define stack parameters for the MAC layer thread
+ * @{
+ */
+#define RAW802154_MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#define RAW802154_MAC_PRIO                (THREAD_PRIORITY_MAIN - 3)
+
+/**
+ * @brief   Stacks for the MAC layer threads
+ */
+static char _netdev2_raw802154_stack[RAW802154_MAC_STACKSIZE + DEBUG_EXTRA_STACKSIZE];
+static gnrc_netdev2_t _gnrc_netdev2_raw802154;
+
+void auto_init_netdev2_raw802154(void)
+{
+	int res;
+
+    if (!raw802154_ifname) {
+        return;
+    }
+
+	res = gnrc_netdev2_ieee802154_init(&_gnrc_netdev2_raw802154,
+					   (netdev2_ieee802154_t *)&netdev2_raw802154);
+	if (res < 0)
+		DEBUG("Error initializing raw802154 virtual device!\n");
+	else
+		gnrc_netdev2_init(_netdev2_raw802154_stack, RAW802154_MAC_STACKSIZE,
+				  RAW802154_MAC_PRIO, "gnrc_netdev2_raw802154",
+				  &_gnrc_netdev2_raw802154);
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_NETDEV2_RAW802154 */
+/** @} */

--- a/sys/auto_init/netif/auto_init_netdev2_tap.c
+++ b/sys/auto_init/netif/auto_init_netdev2_tap.c
@@ -26,6 +26,7 @@
 #include "net/gnrc/netdev2/eth.h"
 
 extern netdev2_tap_t netdev2_tap;
+extern char *tap_dev;
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
@@ -42,6 +43,10 @@ static gnrc_netdev2_t _gnrc_netdev2_tap;
 
 void auto_init_netdev2_tap(void)
 {
+    if (!tap_dev) {
+        return;
+    }
+
     gnrc_netdev2_eth_init(&_gnrc_netdev2_tap, (netdev2_t*)&netdev2_tap);
 
     gnrc_netdev2_init(_netdev2_eth_stack, TAP_MAC_STACKSIZE,


### PR DESCRIPTION
This pull-request adds a raw802154 driver to native board functionality.

With this driver you can run the RIOT stack on 802.15.4 Linux interfaces.
In general the basic idea is to run on monitor interfaces to test Linux 802.15.4 stack with RIOT and have some way to easily reproduce issues by running RIOT in userspace. For this use-case the Linux kernel has a virtual phy driver named "fakelb".

Furthermore it could be possible to run on normal wpan "node" interfaces as well. It should be possible if mac address settings are equal with the RIOT mac address settings. Nevertheless this needs more logic with netlink nl802154 interface and it will not work right now, because receiving expects FCS which is not available on node interfaces (again needs additional nl802154 handling).

Note: because other issues wireshark expects a FCS while sending on monitor interfaces, but there is none. Frames will be marked as corrupted but they are still correct.
To sniff the traffic, create one "wpan phy" interface more and run them as monitor (without running RIOT-OS stack on it.)

Please note also, that you can't run multiple RIOT-OS instances on one interface, it need always a separate phy. This is because we don't send frames back on a phy which actually transmit them.

At least, you need 1-2 patches which are currently on linux-wpan mailinglist http://www.spinics.net/lists/linux-wpan to make the full stuff working with fakelb driver, on other driver with monitor interface (e.g. at86rf230) it should be possible. I didn't test it with real hardware because I saw other issues to cross compile native board and when I had a cross compiled version for my arm device it didn't work because some not working assembler code. :-)

Here are the steps how to use it (with monitor interface for sniffing):

modprobe fakelb numlbs=3

ip link add link wpan0 name lowpan0 type lowpan
iwpan dev wpan0 set pan_id 0x23
ip link set wpan0 up
ip link set lowpan0 up

iwpan dev wpan1 del
iwpan phy1 interface add riot0 type monitor
ip link set riot0 up

iwpan dev wpan2 del
iwpan phy2 interface add monitor0 type monitor
ip link set monitor0 up

Starting native gnrc_networking example:

gnrc_networking.elf -r riot0 -ra

Sniffing example:

run wireshark on monitor0 interface.
