### PR TITLE
doc: eliminate clutter in adc and gpio periph docs

### DIFF
--- a/cpu/cc26x0/include/periph_cpu.h
+++ b/cpu/cc26x0/include/periph_cpu.h
@@ -30,6 +30,7 @@ extern "C" {
  */
 #define CPUID_LEN           (16U)
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO mode values
  */
@@ -52,6 +53,7 @@ typedef enum {
     GPIO_RISING = IOCFG_EDGEDET_RISING,
     GPIO_BOTH = IOCFG_EDGEDET_BOTH
 } gpio_flank_t;
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Timer configuration options

--- a/cpu/ezr32wg/include/periph_cpu.h
+++ b/cpu/ezr32wg/include/periph_cpu.h
@@ -88,6 +88,7 @@ enum {
     PF = 5                  /**< port F */
 };
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
  * @{
@@ -114,6 +115,7 @@ typedef enum {
     GPIO_BOTH = 3           /**< emit interrupt on both flanks */
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   UART device configuration

--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -61,6 +61,7 @@ typedef uint16_t gpio_t;
  */
 #define GPIO_MODE(pu, pe, od, out)   (pu | (pe << 1) | (od << 5) | (out << 7))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
  * @{
@@ -75,6 +76,7 @@ typedef enum {
     GPIO_OD_PU = GPIO_MODE(1, 1, 1, 1),     /**< OD with pull-up */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Define a condensed set of PORT PCR values
@@ -95,6 +97,7 @@ enum {
     GPIO_PCR_PU    = (PORT_PCR_PE_MASK | PORT_PCR_PS_MASK)  /**< enable PU */
 };
 
+#ifndef DOXYGEN
 /**
  * @brief   Override flank configuration values
  * @{
@@ -106,6 +109,7 @@ typedef enum {
     GPIO_BOTH    = PORT_PCR_IRQC(0xb),  /**< emit interrupt on both flanks */
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Available ports on the Kinetis family
@@ -123,6 +127,7 @@ enum {
     GPIO_PORTS_NUMOF        /**< overall number of available ports */
 };
 
+#ifndef DOXYGEN
 /**
  * @brief   Override default ADC resolution values
  * @{
@@ -137,6 +142,7 @@ typedef enum {
     ADC_RES_16BIT = ADC_CFG1_MODE(3)    /**< ADC resolution: 16 bit */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   CPU specific ADC configuration

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -40,6 +40,7 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x,y) ((gpio_t)((x<<4) | y))
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
  * @{
@@ -54,6 +55,7 @@ typedef enum {
     GPIO_OD_PU = (GPIO_DIR_MODE_OUT | (GPIO_PIN_TYPE_OD_WPU << 4)), /**< OD with pull-up */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Override values for pull register configuration
@@ -78,6 +80,7 @@ typedef enum {
 } gpio_dir_t;
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override active flank configuration values
  * @{
@@ -89,6 +92,7 @@ typedef enum {
     GPIO_BOTH = GPIO_BOTH_EDGES          /**< emit interrupt on both flanks */
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Available ports on the LM4F120
@@ -105,6 +109,7 @@ enum {
 /**
  * @brief   Override resolution options
  */
+#ifndef DOXYGEN
 #define HAVE_ADC_RES_T
 typedef enum {
     ADC_RES_6BIT  = 0xa00,            /**< not supported by hardware */
@@ -114,6 +119,7 @@ typedef enum {
     ADC_RES_14BIT = 0xc00,            /**< not supported by hardware */
     ADC_RES_16BIT = 0xd00,            /**< not supported by hardware */
 } adc_res_t;
+#endif /* ndef DOXYGEN */
 
 #ifdef __cplusplus
 }

--- a/cpu/lpc11u34/include/periph_cpu.h
+++ b/cpu/lpc11u34/include/periph_cpu.h
@@ -47,6 +47,7 @@ extern "C" {
  */
 #define ADC_NUMOF           (10U)
 
+#ifndef DOXYGEN
 /**
  * @brief   Override the ADC resolution settings
  * @{
@@ -61,6 +62,7 @@ typedef enum {
     ADC_RES_16BIT,          /**< ADC resolution: 16 bit */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 #ifdef __cplusplus
 }

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -56,12 +56,14 @@ void gpio_init_states(void);
 
 #define GPIO_PIN(port, pin) (port*32 + pin)
 
+#ifndef DOXYGEN
 #define HAVE_GPIO_FLANK_T
 typedef enum {
     GPIO_FALLING = 1,       /**< emit interrupt on falling flank */
     GPIO_RISING = 2,        /**< emit interrupt on rising flank */
     GPIO_BOTH = 3           /**< emit interrupt on both flanks */
 } gpio_flank_t;
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Number of available timer channels

--- a/cpu/msp430fxyz/include/periph_cpu.h
+++ b/cpu/msp430fxyz/include/periph_cpu.h
@@ -45,6 +45,7 @@ typedef uint16_t gpio_t;
  */
 #define GPIO_PIN(x, y)      ((gpio_t)(((x & 0xff) << 8) | (1 << (y & 0xff))))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override flank selection values
  * @{
@@ -56,6 +57,7 @@ typedef enum {
     GPIO_BOTH    = 0xab         /**< not supported -> random value*/
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Available ports on MSP430 platforms

--- a/cpu/nrf5x_common/include/periph_cpu.h
+++ b/cpu/nrf5x_common/include/periph_cpu.h
@@ -63,6 +63,7 @@ extern "C" {
  */
 #define GPIO_MODE(oe, ic, pr)   (oe | (ic << 1) | (pr << 2))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
  *
@@ -109,6 +110,7 @@ typedef enum {
     ADC_RES_16BIT = 0xf3    /**< ADC resolution: 16 bit */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Timer configuration options

--- a/cpu/sam21_common/include/periph_cpu_common.h
+++ b/cpu/sam21_common/include/periph_cpu_common.h
@@ -58,6 +58,7 @@ typedef uint32_t gpio_t;
  */
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
 
+#ifndef DOXYGEN
 /**
  * @brief   Override active flank configuration values
  * @{
@@ -69,6 +70,7 @@ typedef enum {
     GPIO_BOTH = 3           /**< emit interrupt on both flanks */
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Available MUX values for configuring a pin's alternate function

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -80,6 +80,7 @@ typedef uint32_t gpio_t;
  */
 #define GPIO_MODE(io, pu, od)   (io | (pu << 1) | (od << 2))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
  * @{
@@ -106,6 +107,7 @@ typedef enum {
     GPIO_BOTH = 3           /**< emit interrupt on both flanks */
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief Available ports on the SAM3X8E

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -44,6 +44,7 @@ enum {
  */
 #define GPIO_MODE(pr, ie, pe)   (pr | (ie << 1) | (pe << 2))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
  * @{
@@ -58,6 +59,7 @@ typedef enum {
     GPIO_OD_PU = 0xff                   /**< not supported by HW */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   PWM channel configuration data structure

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -43,6 +43,7 @@ enum {
  */
 #define GPIO_MODE(pr, ie, pe)   (pr | (ie << 1) | (pe << 2))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
  * @{
@@ -57,6 +58,7 @@ typedef enum {
     GPIO_OD_PU = 0xff                   /**< not supported by HW */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32f0/include/periph_cpu.h
+++ b/cpu/stm32f0/include/periph_cpu.h
@@ -35,6 +35,7 @@ extern "C" {
  */
 #define GPIO_MODE(io, pr, ot)   ((io << 0) | (pr << 2) | (ot << 4))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO mode options
  * @{
@@ -61,6 +62,7 @@ typedef enum {
     GPIO_BOTH = 3           /**< emit interrupt on both flanks */
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Available ports on the STM32F4 family
@@ -83,6 +85,7 @@ typedef enum {
     GPIO_AF3,               /**< use alternate function 3 */
 } gpio_af_t;
 
+#ifndef DOXYGEN
 /**
  * @brief   Override ADC resolution values
  * @{
@@ -97,6 +100,7 @@ typedef enum {
     ADC_RES_16BIT = (0xff)          /**< not applicable */
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   ADC line configuration values

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -51,6 +51,7 @@ extern "C" {
  */
 #define GPIO_MODE(mode, cnf, odr)       (mode | (cnf << 2) | (odr << 4))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO mode options
  *
@@ -67,6 +68,7 @@ typedef enum {
     GPIO_OD_PU = (0xff)                 /**< not supported by HW */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Override values for pull register configuration
@@ -80,6 +82,7 @@ typedef enum {
 } gpio_pp_t;
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override flank configuration values
  * @{
@@ -91,6 +94,7 @@ typedef enum {
     GPIO_BOTH = 3           /**< emit interrupt on both flanks */
 } gpio_flank_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Available ports on the STM32F1 family

--- a/cpu/stm32f3/include/periph_cpu.h
+++ b/cpu/stm32f3/include/periph_cpu.h
@@ -35,6 +35,7 @@ extern "C" {
  */
 #define GPIO_MODE(io, pr, ot)   ((io << 0) | (pr << 2) | (ot << 4))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO mode options
  * @{
@@ -49,6 +50,7 @@ typedef enum {
     GPIO_OD_PU = GPIO_MODE(1, 1, 1)     /**< open-drain with pull-up */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Available ports on the STM32F3 family

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -43,6 +43,7 @@ extern "C" {
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */
 
+#ifndef DOXYGEN
 /**
  * @brief   Override the ADC resolution configuration
  * @{
@@ -57,6 +58,7 @@ typedef enum {
     ADC_RES_16BIT = 2            /**< ADC resolution: 16 bit (not supported)*/
 } adc_res_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Generate GPIO mode bitfields
@@ -68,6 +70,7 @@ typedef enum {
  */
 #define GPIO_MODE(io, pr, ot)   ((io << 0) | (pr << 2) | (ot << 4))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO mode options
  * @{
@@ -82,6 +85,7 @@ typedef enum {
     GPIO_OD_PU = GPIO_MODE(1, 1, 1)     /**< open-drain with pull-up */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Available ports on the STM32F4 family

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -37,6 +37,7 @@ extern "C" {
  */
 #define GPIO_MODE(io, pr, ot)   ((io << 0) | (pr << 2) | (ot << 4))
 
+#ifndef DOXYGEN
 /**
  * @brief   Override GPIO mode options
  * @{
@@ -51,6 +52,7 @@ typedef enum {
     GPIO_OD_PU = GPIO_MODE(1, 1, 1)     /**< open-drain with pull-up */
 } gpio_mode_t;
 /** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   Available ports on the STM32L1 family


### PR DESCRIPTION
Fixes issue #5391. Thanks @gebart for the suggestion.