### PR TITLE
boards/remote: adds RF 2.4GHz support

### DIFF
--- a/boards/remote-common/Makefile.dep
+++ b/boards/remote-common/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+    USEMODULE += netif
+    USEMODULE += cc2538_rf
+    USEMODULE += gnrc_netdev2
+endif

--- a/boards/remote-common/Makefile.include
+++ b/boards/remote-common/Makefile.include
@@ -33,3 +33,6 @@ export INCLUDES += -I$(RIOTBOARD)/remote-common/include
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
+
+# Include board dependencies
+include $(RIOTBOARD)/remote-common/Makefile.dep

--- a/boards/remote-common/include/periph_common.h
+++ b/boards/remote-common/include/periph_common.h
@@ -84,6 +84,13 @@
 #define TIMER_3_ISR_2       isr_timer3_chan1
 /** @} */
 
+/**
+ * @name Radio peripheral configuration
+ * @{
+ */
+#define RADIO_IRQ_PRIO      1
+/** @} */
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/remote-pa/README.md
+++ b/boards/remote-pa/README.md
@@ -34,11 +34,11 @@ In terms of hardware support, the following drivers have been implemented:
     * ADC
     * LEDs
     * Buttons
-    * Internal/external 2.4GHz antenna switch controllable by SW.
+    * Internal/external 2.4GHz antenna switch controllable by SW
+    * RF 2.4GHz built-in in CC2538
 
 And under work or pending at cc2538 base cpu:
 
-    * RF 2.4GHz built-in in CC2538 (PR #2198)
     * Built-in core temperature and battery sensor.
     * TMP102 temperature sensor driver.
     * CC1120 sub-1GHz radio interface.

--- a/boards/remote-reva/README.md
+++ b/boards/remote-reva/README.md
@@ -28,10 +28,10 @@ In terms of hardware support, the following drivers have been implemented:
     * LEDs
     * Buttons
     * RF switch to programatically drive either 2.4GHz or sub-1GHz to a single RP-SMA
+    * RF 2.4GHz built-in in CC2538
 
 And under work or pending at cc2538 base cpu:
 
-    * RF 2.4GHz built-in in CC2538
     * Built-in core temperature and battery sensor.
     * CC1200 sub-1GHz radio interface.
     * Micro-SD external storage.


### PR DESCRIPTION
Depends on https://github.com/RIOT-OS/RIOT/pull/5291