### PR TITLE
pkg/oonf_api: fix cflags for osx

### DIFF
--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -7,6 +7,8 @@ INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
 			-I$(RIOTBASE)/sys/posix/include
 endif
 
+CFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+
 MODULE:=$(PKG_NAME)
 
 .PHONY: all


### PR DESCRIPTION
This PR sets some CFLAGS to make the package compile on latest OSX
