### PR TITLE
cpu/atmega_common: improve to add smaller atmega MCUs.

### DIFF
--- a/boards/arduino-mega2560/include/periph_conf.h
+++ b/boards/arduino-mega2560/include/periph_conf.h
@@ -97,6 +97,7 @@ extern "C" {
  */
 #define SPI_NUMOF           1           /* set to 0 to disable SPI */
 #define SPI_0_EN            1           /* remove once SPI rework is done */
+#define MEGA_PRR            PRR0        /* Power Reduction Register is PRR0 */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/waspmote-pro/include/periph_conf.h
+++ b/boards/waspmote-pro/include/periph_conf.h
@@ -104,6 +104,7 @@ extern "C" {
  */
 #define SPI_NUMOF           1           /* set to 0 to disable SPI */
 #define SPI_0_EN            1           /* remove once SPI rework is done */
+#define MEGA_PRR            PRR0        /* Power Reduction Resgister */
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -133,7 +133,9 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     uint8_t pin_num = _pin_num(pin);
 
     if ((_port_num(pin) == PORT_D && pin_num > 3)
+#if defined (PORTE)
          || (_port_num(pin) == PORT_E && pin_num < 4)
+#endif
          || ((mode != GPIO_IN) && (mode != GPIO_IN_PU))) {
         return -1;
     }

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -17,6 +17,7 @@
  *
  * @author      René Herthel <rene-herthel@outlook.de>
  * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ * @author      Laurent Navet <laurent.navet@gmail.com>
  *
  * @}
  */
@@ -84,10 +85,11 @@ static inline uint16_t _port_addr(gpio_t pin)
     port_addr += GPIO_BASE_PORT_A;
     port_addr += GPIO_OFFSET_PIN_PORT;
 
+#if defined (PORTG)
     if (port_num > PORT_G) {
         port_addr += GPIO_OFFSET_PORT_H;
     }
-
+#endif
     return port_addr;
 }
 
@@ -153,25 +155,31 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
             if (pin_num < 4) {
                 EICRA |= (3 << pin_num * 2);
             }
+#if defined(EICRB)
             else {
                 EICRB |= (3 << (pin_num * 2) % 4);
             }
+#endif
             break;
         case GPIO_FALLING:
             if (pin_num < 4) {
                 EICRA |= (2 << pin_num * 2);
             }
+#if defined(EICRB)
             else {
                 EICRB |= (2 << (pin_num * 2) % 4);
             }
+#endif
             break;
         case GPIO_BOTH:
             if (pin_num < 4) {
                 EICRA |= (1 << pin_num * 2);
             }
+#if defined(EICRB)
             else {
                 EICRB |= (1 << (pin_num * 2) % 4);
             }
+#endif
             break;
         default:
             return -1;

--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -61,7 +61,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     DDRB |= ((1 << DDB2) | (1 << DDB1) | (1 << DDB0));
 
     /* make sure the SPI is not powered off */
-    PRR0 &= ~(1 << PRSPI);
+    MEGA_PRR &= ~(1 << PRSPI);
 
     /* configure as master, with given mode and clock */
     SPSR = (speed >> S2X_SHIFT);

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -208,10 +208,12 @@ ISR(TIMER_0_ISRB, ISR_BLOCK)
     _isr(0, 1);
 }
 
+#ifdef TIMER_0_ISRC
 ISR(TIMER_0_ISRC, ISR_BLOCK)
 {
     _isr(0, 2);
 }
+#endif /* TIMER_0_ISRC */
 #endif /* TIMER_0 */
 
 #ifdef TIMER_1


### PR DESCRIPTION
Prepare atmega_common for atmega328p inclusion.
- abstract PRR
- add # !defined(__AVR_ATmega328P__) where needed
- some typo fix / improve documentation