### PR TITLE
xtimer: allow initialisation of XTIMER to any ticks value

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -43,6 +43,13 @@
 #include "xtimer_trace.h"
 #endif
 
+/**
+ * @brief Define default ticks initialisation if none is defined
+ */
+#ifndef XTIMER_TICKS_INIT
+#define XTIMER_TICKS_INIT       1000000ul
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -57,7 +57,7 @@ static inline int _is_set(xtimer_t *timer)
 void xtimer_init(void)
 {
     /* initialize low-level timer */
-    timer_init(XTIMER, XTIMER_USEC_TO_TICKS(1000000ul), _periph_timer_callback, NULL);
+    timer_init(XTIMER, XTIMER_USEC_TO_TICKS(XTIMER_TICKS_INIT), _periph_timer_callback, NULL);
 
     /* register initial overflow tick */
     _lltimer_set(0xFFFFFFFF);


### PR DESCRIPTION
This PR allows to the user to initialise the XTIMER to any ticks value. This is useful when on-board clocks are not compatible with the previous initialisation value (1000000).