### PR TITLE
cpu/atmega_common: generalize register/peripheral definitions

### DIFF
--- a/cpu/atmega_common/include/atmega_regs_common.h
+++ b/cpu/atmega_common/include/atmega_regs_common.h
@@ -61,56 +61,60 @@ typedef struct {
 } mega_uart_t;
 
 /**
- * @brief    Base register address definitions
+ * @brief    Timer register definitions and instances
  * @{
  */
+#if defined(TCCR1A)
 #define MEGA_TIMER1_BASE        (uint16_t *)(&TCCR1A)
-#if defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1281__)
-#define MEGA_TIMER3_BASE        (uint16_t *)(&TCCR3A)
-#define MEGA_TIMER4_BASE        (uint16_t *)(&TCCR4A)
-#define MEGA_TIMER5_BASE        (uint16_t *)(&TCCR5A)
-#endif
-/** @} */
-
-/**
- * @brief    Base register address definitions
- * @{
- */
-#define MEGA_UART0_BASE         ((uint16_t *)(&UCSR0A))
-#if defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1281__)
-#define MEGA_UART1_BASE         ((uint16_t *)(&UCSR1A))
-#define MEGA_UART2_BASE         ((uint16_t *)(&UCSR2A))
-#define MEGA_UART3_BASE         ((uint16_t *)(&UCSR3A))
-#endif
-/** @} */
-
-/**
- * @brief    Peripheral instances
- * @{
- */
 #define MEGA_TIMER1             ((mega_timer_t *)MEGA_TIMER1_BASE)
-#if defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1281__)
+#endif
+
+#if defined(TCCR3A)
+#define MEGA_TIMER3_BASE        (uint16_t *)(&TCCR3A)
 #define MEGA_TIMER3             ((mega_timer_t *)MEGA_TIMER3_BASE)
+#endif
+
+#if defined(TCCR4A)
+#define MEGA_TIMER4_BASE        (uint16_t *)(&TCCR4A)
 #define MEGA_TIMER4             ((mega_timer_t *)MEGA_TIMER4_BASE)
+#endif
+
+#if defined(TCCR5A)
+#define MEGA_TIMER5_BASE        (uint16_t *)(&TCCR5A)
 #define MEGA_TIMER5             ((mega_timer_t *)MEGA_TIMER5_BASE)
 #endif
 /** @} */
 
+
 /**
- * @brief    Peripheral instances
+ * @brief    Peripheral register definitions and instances
  * @{
  */
+#if defined(UCSR0A)
+#define MEGA_UART0_BASE         ((uint16_t *)(&UCSR0A))
 #define MEGA_UART0              ((mega_uart_t *)MEGA_UART0_BASE)
-#if defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1281__)
+#endif
+
+#if defined(UCSR1A)
+#define MEGA_UART1_BASE         ((uint16_t *)(&UCSR1A))
 #define MEGA_UART1              ((mega_uart_t *)MEGA_UART1_BASE)
+#endif
+
+#if defined(UCSR2A)
+#define MEGA_UART2_BASE         ((uint16_t *)(&UCSR2A))
 #define MEGA_UART2              ((mega_uart_t *)MEGA_UART2_BASE)
+#endif
+
+#if defined(UCSR3A)
+#define MEGA_UART3_BASE         ((uint16_t *)(&UCSR3A))
 #define MEGA_UART3              ((mega_uart_t *)MEGA_UART3_BASE)
 #endif
 /** @} */
+
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* ATMEGA2560_REGS_H */
+#endif /* ATMEGA_REGS_COMMON_H */
 /** @} */

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -39,8 +39,18 @@
  * @brief     Define GPIO interruptions for an specific atmega CPU, by default
  *            2 (for small atmega CPUs)
  */
-#if defined(__AVR_ATmega2560__)
-#define GPIO_EXT_INT_NUMOF      (8U)
+#if defined(INT2_vect)
+#define GPIO_EXT_INT_NUMOF      (3U)
+#elif defined(INT3_vect)
+#define GPIO_EXT_INT_NUMOF      (4U)
+#elif defined(INT4_vect)
+#define GPIO_EXT_INT_NUMOF      (4U)
+#elif defined(INT5_vect)
+#define GPIO_EXT_INT_NUMOF      (4U)
+#elif defined(INT6_vect)
+#define GPIO_EXT_INT_NUMOF      (4U)
+#elif defined(INT7_vect)
+#define GPIO_EXT_INT_NUMOF      (4U)
 #else
 #define GPIO_EXT_INT_NUMOF      (2U)
 #endif
@@ -237,32 +247,42 @@ ISR(INT1_vect, ISR_BLOCK)
     irq_handler(1); /**< predefined interrupt pin */
 }
 
-#if defined(__AVR_ATmega2560__)
+#if defined(INT2_vect)
 ISR(INT2_vect, ISR_BLOCK)
 {
     irq_handler(2); /**< predefined interrupt pin */
 }
+#endif
 
+#if defined(INT3_vect)
 ISR(INT3_vect, ISR_BLOCK)
 {
     irq_handler(3); /**< predefined interrupt pin */
 }
+#endif
 
+#if defined(INT4_vect)
 ISR(INT4_vect, ISR_BLOCK)
 {
     irq_handler(4); /**< predefined interrupt pin */
 }
+#endif
 
+#if defined(INT5_vect)
 ISR(INT5_vect, ISR_BLOCK)
 {
     irq_handler(5); /**< predefined interrupt pin */
 }
+#endif
 
+#if defined(INT6_vect)
 ISR(INT6_vect, ISR_BLOCK)
 {
     irq_handler(6); /**< predefined interrupt pin */
 }
+#endif
 
+#if defined(INT7_vect)
 ISR(INT7_vect, ISR_BLOCK)
 {
     irq_handler(7); /**< predefined interrupt pin */

--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -8,11 +8,11 @@
  */
 
 /**
- * @ingroup     cpu_atmega2560
+ * @ingroup     driver_periph
  * @{
  *
  * @file
- * @brief       Low-level SPI driver implementation
+ * @brief       Low-level SPI driver implementation for ATmega family
  *
  * @author      Daniel Amkaer Sorensen <daniel.amkaer@gmail.com>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Low-level timer driver implementation for the ATmega2560 CPU
+ * @brief       Low-level timer driver implementation for the ATmega family
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>


### PR DESCRIPTION
Makes AVR register definitions dependent on what avr-libc defines for a given MCU, rather then duplicating that effort here.
Definitions done in this way are based on functionality provided, rather than a specific MCU device name.