### PR TITLE
gnrc_ipv6: fix UDP issue when a packet passes through another node

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -852,7 +852,6 @@ static void _receive(gnrc_pktsnip_t *pkt)
         ipv6 = gnrc_pktbuf_mark(pkt, sizeof(ipv6_hdr_t), GNRC_NETTYPE_IPV6);
 
         first_ext = pkt;
-        pkt->type = GNRC_NETTYPE_UNDEF; /* snip is no longer IPv6 */
 
         if (ipv6 == NULL) {
             DEBUG("ipv6: error marking IPv6 header, dropping packet\n");
@@ -886,10 +885,10 @@ static void _receive(gnrc_pktsnip_t *pkt)
         gnrc_pktbuf_realloc_data(pkt, byteorder_ntohs(hdr->len));
     }
     else if (byteorder_ntohs(hdr->len) >
-             (gnrc_pkt_len_upto(pkt, GNRC_NETTYPE_IPV6) - sizeof(ipv6_hdr_t))) {
+             gnrc_pkt_len_upto(pkt, GNRC_NETTYPE_IPV6)) {
         DEBUG("ipv6: invalid payload length: %d, actual: %d, dropping packet\n",
               (int) byteorder_ntohs(hdr->len),
-              (int) (gnrc_pkt_len_upto(pkt, GNRC_NETTYPE_IPV6) - sizeof(ipv6_hdr_t)));
+              (int) gnrc_pkt_len_upto(pkt, GNRC_NETTYPE_IPV6));
         gnrc_pktbuf_release(pkt);
         return;
     }


### PR DESCRIPTION
The issue was related to the marking of non-valid IPv6 pck and to payload length. The IPv6 Payload length contains just the length of the payload (eg. UDP header+UDP Payload) without the (fixed) ipv6 header length.