### PR TITLE
cpu/saml21: Conditionally define LITTLE_ENDIAN

### DIFF
--- a/cpu/saml21/include/atmel/saml21e15a.h
+++ b/cpu/saml21/include/atmel/saml21e15a.h
@@ -231,7 +231,9 @@ void PICOP_Handler               ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#ifndef LITTLE_ENDIAN
+#   define LITTLE_ENDIAN       1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/cpu/saml21/include/atmel/saml21e16a.h
+++ b/cpu/saml21/include/atmel/saml21e16a.h
@@ -231,7 +231,9 @@ void PICOP_Handler               ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#ifndef LITTLE_ENDIAN
+#   define LITTLE_ENDIAN       1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/cpu/saml21/include/atmel/saml21e17a.h
+++ b/cpu/saml21/include/atmel/saml21e17a.h
@@ -231,7 +231,9 @@ void PICOP_Handler               ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#ifndef LITTLE_ENDIAN
+#   define LITTLE_ENDIAN       1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/cpu/saml21/include/atmel/saml21g16a.h
+++ b/cpu/saml21/include/atmel/saml21g16a.h
@@ -235,7 +235,9 @@ void PICOP_Handler               ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#ifndef LITTLE_ENDIAN
+#   define LITTLE_ENDIAN       1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/cpu/saml21/include/atmel/saml21g17a.h
+++ b/cpu/saml21/include/atmel/saml21g17a.h
@@ -235,7 +235,9 @@ void PICOP_Handler               ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#ifndef LITTLE_ENDIAN
+#   define LITTLE_ENDIAN       1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/cpu/saml21/include/atmel/saml21g18a.h
+++ b/cpu/saml21/include/atmel/saml21g18a.h
@@ -235,7 +235,9 @@ void PICOP_Handler               ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#ifndef LITTLE_ENDIAN
+#   define LITTLE_ENDIAN       1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/cpu/saml21/include/atmel/saml21j16a.h
+++ b/cpu/saml21/include/atmel/saml21j16a.h
@@ -239,7 +239,9 @@ void PICOP_Handler               ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#ifndef LITTLE_ENDIAN
+#   define LITTLE_ENDIAN       1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/cpu/saml21/include/atmel/saml21j17a.h
+++ b/cpu/saml21/include/atmel/saml21j17a.h
@@ -239,7 +239,9 @@ void PICOP_Handler               ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#ifndef LITTLE_ENDIAN
+#   define LITTLE_ENDIAN       1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */

--- a/cpu/saml21/include/atmel/saml21j18a.h
+++ b/cpu/saml21/include/atmel/saml21j18a.h
@@ -239,7 +239,9 @@ void PICOP_Handler               ( void );
  * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
  */
 
-#define LITTLE_ENDIAN          1
+#ifndef LITTLE_ENDIAN
+#   define LITTLE_ENDIAN       1
+#endif
 #define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
 #define __MPU_PRESENT          0         /*!< MPU present or not */
 #define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */


### PR DESCRIPTION
Caused problems with redefined macros when building with a recent newlib.

Follow up to #5600 