### PR TITLE
cpu: Fix array-bounds errors with GCC 6

### DIFF
--- a/cpu/nrf51/periph/adc.c
+++ b/cpu/nrf51/periph/adc.c
@@ -25,15 +25,11 @@
 #include "periph/adc.h"
 #include "periph_conf.h"
 
+#ifdef ADC_CONFIG
 /**
  * @brief   Load the ADC configuration
- * @{
  */
-#ifdef ADC_CONFIG
 static const uint8_t adc_config[] = ADC_CONFIG;
-#else
-static const uint8_t adc_config[] = {};
-#endif
 
 /**
  * @brief   Lock to prevent concurrency issues when used from different threads
@@ -91,3 +87,7 @@ int adc_sample(adc_t line, adc_res_t res)
 
     return val;
 }
+
+#else
+typedef int dont_be_pedantic;
+#endif /* ADC_CONFIG */

--- a/cpu/stm32_common/periph/dac.c
+++ b/cpu/stm32_common/periph/dac.c
@@ -25,7 +25,7 @@
 #include "periph_conf.h"
 
 /* only compile this, if the CPU has a DAC */
-#if defined(DAC) || defined(DAC1)
+#if (defined(DAC) || defined(DAC1)) && defined(DAC_CONFIG)
 
 #ifdef DAC2
 #define _DAC(line)          (dac_config[line].dac ? DAC2 : DAC1)
@@ -34,15 +34,9 @@
 #endif
 
 /**
- * @brief   Get the DAC configuration from the board (if configured)
- * @{
+ * @brief   Get the DAC configuration from the board config
  */
-#ifdef DAC_CONFIG
 static const dac_conf_t dac_config[] = DAC_CONFIG;
-#else
-static const dac_conf_t dac_config[] = {};
-#endif
-/** @} */
 
 int8_t dac_init(dac_t line)
 {
@@ -96,4 +90,6 @@ void dac_poweroff(dac_t line)
     DAC->CR &= ~(1 << (16 * dac_config[line].chan));
 }
 
+#else
+typedef int dont_be_pedantic;
 #endif /* DAC */

--- a/cpu/stm32f0/periph/adc.c
+++ b/cpu/stm32f0/periph/adc.c
@@ -22,6 +22,8 @@
 #include "mutex.h"
 #include "periph/adc.h"
 
+#ifdef ADC_CONFIG
+
 /**
  * @brief   Maximum allowed ADC clock speed
  */
@@ -29,13 +31,8 @@
 
 /**
  * @brief   Load the ADC configuration
- * @{
  */
-#ifdef ADC_CONFIG
 static const adc_conf_t adc_config[] = ADC_CONFIG;
-#else
-static const adc_conf_t adc_config[] = {};
-#endif
 
 /**
  * @brief   Allocate locks for all three available ADC device
@@ -105,3 +102,7 @@ int adc_sample(adc_t line,  adc_res_t res)
 
     return sample;
 }
+
+#else
+typedef int dont_be_pedantic;
+#endif /* ADC_CONFIG */

--- a/cpu/stm32f1/periph/adc.c
+++ b/cpu/stm32f1/periph/adc.c
@@ -24,6 +24,8 @@
 #include "periph/adc.h"
 #include "periph_conf.h"
 
+#ifdef ADC_CONFIG
+
 /**
  * @brief   Maximum allowed ADC clock speed
  */
@@ -31,13 +33,8 @@
 
 /**
  * @brief   Load the ADC configuration
- * @{
  */
-#ifdef ADC_CONFIG
 static const adc_conf_t adc_config[] = ADC_CONFIG;
-#else
-static const adc_conf_t adc_config[] = {};
-#endif
 
 /**
  * @brief   Allocate locks for all three available ADC devices
@@ -159,3 +156,7 @@ int adc_sample(adc_t line, adc_res_t res)
 
     return sample;
 }
+
+#else
+typedef int dont_be_pedantic;
+#endif /* ADC_CONFIG */

--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -23,6 +23,8 @@
 #include "periph/adc.h"
 #include "periph_conf.h"
 
+#ifdef ADC_CONFIG
+
 /**
  * @brief   Maximum allowed ADC clock speed
  */
@@ -30,13 +32,8 @@
 
 /**
  * @brief   Load the ADC configuration
- * @{
  */
-#ifdef ADC_CONFIG
 static const adc_conf_t adc_config[] = ADC_CONFIG;
-#else
-static const adc_conf_t adc_config[] = {};
-#endif
 
 /**
  * @brief   Allocate locks for all three available ADC devices
@@ -124,3 +121,7 @@ int adc_sample(adc_t line, adc_res_t res)
 
     return sample;
 }
+
+#else
+typedef int dont_be_pedantic;
+#endif /* ADC_CONFIG */


### PR DESCRIPTION
Fixes
```
error: array subscript is above array bounds [-Werror=array-bounds]
```
which shows up when building with GCC-6 and the peripheral is implemented but not configured in the periph_conf header for the given board.

I have successfully run make buildtest with GCC 6 (`arm-none-eabi-gcc-6.1.0 (Gentoo 6.1.0 p1.1) 6.1.0`) on my machine for `tests/thread_basic` and `examples/gnrc_networking`.

~~Based on #5601~~
Fixes #5519 