### PR TITLE
drivers: added driver for ina226 current monitor

### DIFF
--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -43,6 +43,9 @@ endif
 ifneq (,$(filter ina220,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ina220/include
 endif
+ifneq (,$(filter ina226,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ina226/include
+endif
 ifneq (,$(filter pcd8544,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/pcd8544/include
 endif

--- a/drivers/ina226/Makefile
+++ b/drivers/ina226/Makefile
@@ -1,0 +1,3 @@
+MODULE = ina226
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ina226/ina226.c
+++ b/drivers/ina226/ina226.c
@@ -26,8 +26,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/** @brief Read one 16 bit register from a INA226 device and swap byte order, if necessary. */
-static int ina226_read_reg(ina226_t *dev, uint8_t reg, uint16_t *out)
+
+int ina226_read_reg(ina226_t *dev, uint8_t reg, uint16_t *out)
 {
     union {
         char c[2];
@@ -45,8 +45,7 @@ static int ina226_read_reg(ina226_t *dev, uint8_t reg, uint16_t *out)
     return 0;
 }
 
-/** @brief Write one 16 bit register to a INA226 device and swap byte order, if necessary. */
-static int ina226_write_reg(ina226_t *dev, uint8_t reg, uint16_t in)
+int ina226_write_reg(ina226_t *dev, uint8_t reg, uint16_t in)
 {
     union {
         char c[2];
@@ -71,76 +70,6 @@ int ina226_init(ina226_t *dev, i2c_t i2c, uint8_t address)
     dev->i2c = i2c;
     dev->addr = address;
     return 0;
-}
-
-int ina226_read_calibration(ina226_t *dev, uint16_t *calibration)
-{
-    return ina226_read_reg(dev, INA226_REG_CALIBRATION, calibration);
-}
-
-int ina226_write_calibration(ina226_t *dev, uint16_t calibration)
-{
-    return ina226_write_reg(dev, INA226_REG_CALIBRATION, calibration);
-}
-
-int ina226_read_config(ina226_t *dev, uint16_t *config)
-{
-    return ina226_read_reg(dev, INA226_REG_CONFIGURATION, config);   
-}
-
-int ina226_write_config(ina226_t *dev, uint16_t config)
-{
-    return ina226_write_reg(dev, INA226_REG_CONFIGURATION, config);
-}
-
-int ina226_read_shunt(ina226_t *dev, int16_t *voltage)
-{
-    return ina226_read_reg(dev, INA226_REG_SHUNT_VOLTAGE, (uint16_t *)voltage);
-}
-
-int ina226_read_bus(ina226_t *dev, int16_t *voltage)
-{
-    return ina226_read_reg(dev, INA226_REG_BUS_VOLTAGE, (uint16_t *)voltage);
-}
-
-int ina226_read_current(ina226_t *dev, int16_t *current)
-{
-    return ina226_read_reg(dev, INA226_REG_CURRENT, (uint16_t *)current);
-}
-
-int ina226_read_power(ina226_t *dev, int16_t *power)
-{
-    return ina226_read_reg(dev, INA226_REG_POWER, (uint16_t *)power);
-}
-
-int ina226_read_die_id(ina226_t *dev, uint16_t *id)
-{
-    return ina226_read_reg(dev, INA226_REG_DIE_ID, id);
-}
-
-int ina226_read_manufacturer_id(ina226_t *dev, uint16_t *id)
-{
-    return ina226_read_reg(dev, INA226_REG_MANUFACTURER_ID, id);
-}
-
-int ina226_read_mask_enable(ina226_t *dev, uint16_t *me_val)
-{
-    return ina226_read_reg(dev, INA226_REG_MASK_ENABLE, me_val);
-}
-
-int ina226_write_mask_enable(ina226_t *dev, uint16_t me_val)
-{
-    return ina226_write_reg(dev, INA226_REG_MASK_ENABLE, me_val);
-}
-
-int ina226_read_alert_limit(ina226_t *dev, uint16_t *alert_limit)
-{
-    return ina226_read_reg(dev, INA226_REG_ALERT_LIMIT, alert_limit);
-}
-
-int ina226_write_alert_limit(ina226_t *dev, uint16_t alert_limit)
-{
-    return ina226_write_reg(dev, INA226_REG_ALERT_LIMIT, alert_limit);
 }
 
 int ina226_activate_int(ina226_t *dev, uint16_t me_config, gpio_t pin, gpio_cb_t callback)

--- a/drivers/ina226/ina226.c
+++ b/drivers/ina226/ina226.c
@@ -1,0 +1,155 @@
+/*/*
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_sensors
+ * @{
+ * @file
+ * @brief       Device driver for Texas Instruments INA226 High-Side or Low-Side Measurement,
+ * 				Bi-Directional Current and Power Monitor with I2C Compatible Interface
+ *
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ * @}
+ */
+
+#include <stdint.h>
+
+#include "ina226.h"
+#include "ina226-regs.h"
+#include "periph/gpio.h"
+#include "periph/i2c.h"
+#include "byteorder.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/** @brief Read one 16 bit register from a INA226 device and swap byte order, if necessary. */
+static int ina226_read_reg(ina226_t *dev, uint8_t reg, uint16_t *out)
+{
+    union {
+        char c[2];
+        uint16_t u16;
+    } tmp = { .u16 = 0 };
+    int status = 0;
+
+    status = i2c_read_regs(dev->i2c, dev->addr, reg, &tmp.c[0], 2);
+
+    if (status != 2) {
+        return -1;
+    }
+
+    *out = NTOHS(tmp.u16);
+    return 0;
+}
+
+/** @brief Write one 16 bit register to a INA226 device and swap byte order, if necessary. */
+static int ina226_write_reg(ina226_t *dev, uint8_t reg, uint16_t in)
+{
+    union {
+        char c[2];
+        uint16_t u16;
+    } tmp = { .u16 = 0 };
+    int status = 0;
+
+    tmp.u16 = HTONS(in);
+
+    status = i2c_write_regs(dev->i2c, dev->addr, reg, &tmp.c[0], 2);
+
+    if (status != 2) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int ina226_init(ina226_t *dev, i2c_t i2c, uint8_t address)
+{
+    /* write device descriptor */
+    dev->i2c = i2c;
+    dev->addr = address;
+    return 0;
+}
+
+int ina226_read_calibration(ina226_t *dev, uint16_t *calibration)
+{
+    return ina226_read_reg(dev, INA226_REG_CALIBRATION, calibration);
+}
+
+int ina226_write_calibration(ina226_t *dev, uint16_t calibration)
+{
+    return ina226_write_reg(dev, INA226_REG_CALIBRATION, calibration);
+}
+
+int ina226_read_config(ina226_t *dev, uint16_t *config)
+{
+    return ina226_read_reg(dev, INA226_REG_CONFIGURATION, config);   
+}
+
+int ina226_write_config(ina226_t *dev, uint16_t config)
+{
+    return ina226_write_reg(dev, INA226_REG_CONFIGURATION, config);
+}
+
+int ina226_read_shunt(ina226_t *dev, int16_t *voltage)
+{
+    return ina226_read_reg(dev, INA226_REG_SHUNT_VOLTAGE, (uint16_t *)voltage);
+}
+
+int ina226_read_bus(ina226_t *dev, int16_t *voltage)
+{
+    return ina226_read_reg(dev, INA226_REG_BUS_VOLTAGE, (uint16_t *)voltage);
+}
+
+int ina226_read_current(ina226_t *dev, int16_t *current)
+{
+    return ina226_read_reg(dev, INA226_REG_CURRENT, (uint16_t *)current);
+}
+
+int ina226_read_power(ina226_t *dev, int16_t *power)
+{
+    return ina226_read_reg(dev, INA226_REG_POWER, (uint16_t *)power);
+}
+
+int ina226_read_die_id(ina226_t *dev, uint16_t *id)
+{
+	return ina226_read_reg(dev, INA226_REG_DIE_ID, id);
+}
+
+int ina226_read_manufacturer_id(ina226_t *dev, uint16_t *id)
+{
+	return ina226_read_reg(dev, INA226_REG_MANUFACTURER_ID, id);
+}
+
+int ina226_read_mask_enable(ina226_t *dev, uint16_t *me_val)
+{
+	return ina226_read_reg(dev, INA226_REG_MASK_ENABLE, me_val);
+}
+
+int ina226_write_mask_enable(ina226_t *dev, uint16_t me_val)
+{
+	return ina226_write_reg(dev, INA226_REG_MASK_ENABLE, me_val);
+}
+
+int ina226_read_alert_limit(ina226_t *dev, uint16_t *alert_limit)
+{
+    return ina226_read_reg(dev, INA226_REG_ALERT_LIMIT, alert_limit);
+}
+
+int ina226_write_alert_limit(ina226_t *dev, uint16_t alert_limit)
+{
+    return ina226_write_reg(dev, INA226_REG_ALERT_LIMIT, alert_limit);
+}
+
+int ina226_activate_int(ina226_t *dev, uint16_t me_config, gpio_t pin, gpio_cb_t callback)
+{
+    if (ina226_write_reg(dev, INA226_REG_MASK_ENABLE, me_config) == 0 ) {
+    	return gpio_init_int(pin, GPIO_IN_PU, GPIO_FALLING, callback, dev);
+    }
+    else {
+    	return -1;
+    }
+}

--- a/drivers/ina226/ina226.c
+++ b/drivers/ina226/ina226.c
@@ -1,5 +1,4 @@
-/*/*
- *
+/*
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
@@ -10,7 +9,7 @@
  * @{
  * @file
  * @brief       Device driver for Texas Instruments INA226 High-Side or Low-Side Measurement,
- * 				Bi-Directional Current and Power Monitor with I2C Compatible Interface
+ *              Bi-Directional Current and Power Monitor with I2C Compatible Interface
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  * @}
@@ -116,22 +115,22 @@ int ina226_read_power(ina226_t *dev, int16_t *power)
 
 int ina226_read_die_id(ina226_t *dev, uint16_t *id)
 {
-	return ina226_read_reg(dev, INA226_REG_DIE_ID, id);
+    return ina226_read_reg(dev, INA226_REG_DIE_ID, id);
 }
 
 int ina226_read_manufacturer_id(ina226_t *dev, uint16_t *id)
 {
-	return ina226_read_reg(dev, INA226_REG_MANUFACTURER_ID, id);
+    return ina226_read_reg(dev, INA226_REG_MANUFACTURER_ID, id);
 }
 
 int ina226_read_mask_enable(ina226_t *dev, uint16_t *me_val)
 {
-	return ina226_read_reg(dev, INA226_REG_MASK_ENABLE, me_val);
+    return ina226_read_reg(dev, INA226_REG_MASK_ENABLE, me_val);
 }
 
 int ina226_write_mask_enable(ina226_t *dev, uint16_t me_val)
 {
-	return ina226_write_reg(dev, INA226_REG_MASK_ENABLE, me_val);
+    return ina226_write_reg(dev, INA226_REG_MASK_ENABLE, me_val);
 }
 
 int ina226_read_alert_limit(ina226_t *dev, uint16_t *alert_limit)
@@ -147,9 +146,9 @@ int ina226_write_alert_limit(ina226_t *dev, uint16_t alert_limit)
 int ina226_activate_int(ina226_t *dev, uint16_t me_config, gpio_t pin, gpio_cb_t callback)
 {
     if (ina226_write_reg(dev, INA226_REG_MASK_ENABLE, me_config) == 0 ) {
-    	return gpio_init_int(pin, GPIO_IN_PU, GPIO_FALLING, callback, dev);
+        return gpio_init_int(pin, GPIO_IN_PU, GPIO_FALLING, callback, dev);
     }
     else {
-    	return -1;
+        return -1;
     }
 }

--- a/drivers/ina226/include/ina226-regs.h
+++ b/drivers/ina226/include/ina226-regs.h
@@ -1,0 +1,74 @@
+/*
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_ina226
+ * @{
+ *
+ * @file
+ * @brief       Register definitions for Texas Instruments INA226 High-Side or Low-Side Measurement,
+ * 				Bi-Directional Current and Power Monitor with I2C Compatible Interface
+ *
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ */
+
+
+#ifndef INA226_REGS_H
+#define INA226_REGS_H
+
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+
+/**
+ * @brief INA226 register addresses
+ *
+ * All registers in the INA226 are 16 bit wide and transmitted MSB first.
+ */
+typedef enum ina226_reg {
+    INA226_REG_CONFIGURATION   = 0x00, /**< Configuration register (read/write) */
+    INA226_REG_SHUNT_VOLTAGE   = 0x01, /**< Shunt voltage register (read only) */
+    INA226_REG_BUS_VOLTAGE     = 0x02, /**< Bus voltage register (read only) */
+    INA226_REG_POWER           = 0x03, /**< Power register (read only) */
+    INA226_REG_CURRENT         = 0x04, /**< Current register (read only) */
+    INA226_REG_CALIBRATION     = 0x05, /**< Calibration register (read/write) */
+	INA226_REG_MASK_ENABLE     = 0x06, /**< Mask/Enable register (read/write) */
+	INA226_REG_ALERT_LIMIT     = 0x07, /**< Alert Limit register (read/write) */
+	INA226_REG_MANUFACTURER_ID = 0xFE, /**< Manufacturer ID register (read only) */
+	INA226_REG_DIE_ID          = 0xFF, /**< Die ID register (read only) */
+
+} ina226_reg_t;
+
+/**
+ * @brief INA226 mask/enable register bits
+ * @see Table 15 in INA226 data sheet
+ */
+typedef enum ina226_mask_enable_reg_bit {
+    INA226_MASK_ENABLE_LEN     = 0x0001, /**< Alert Latch Enable */
+	INA226_MASK_ENABLE_APOL    = 0x0002, /**< Alert Polarity bit */
+	INA226_MASK_ENABLE_OVF     = 0x0004, /**< Math Overflow Flag */
+	INA226_MASK_ENABLE_CVRF    = 0x0008, /**< Conversion Ready Flag */
+	INA226_MASK_ENABLE_AFF     = 0x0010, /**< Alert Function Flag */
+	INA226_MASK_ENABLE_CNVR    = 0x0400, /**< Conversion Ready */
+	INA226_MASK_ENABLE_POL     = 0x0800, /**< Power Over-Limit */
+	INA226_MASK_ENABLE_BUL     = 0x1000, /**< Bus Voltage Under-Voltage */
+	INA226_MASK_ENABLE_BOL     = 0x2000, /**< Bus Voltage Over-Voltage */
+	INA226_MASK_ENABLE_SUL     = 0x4000, /**< Shunt Voltage Under-Voltage */
+	INA226_MASK_ENABLE_SOL     = 0x8000, /**< Shunt Voltage Over-Voltage */
+} ina226_mask_enable_reg_bit_t;
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INA226_REGS_H */
+/** @} */

--- a/drivers/ina226/include/ina226-regs.h
+++ b/drivers/ina226/include/ina226-regs.h
@@ -11,7 +11,7 @@
  *
  * @file
  * @brief       Register definitions for Texas Instruments INA226 High-Side or Low-Side Measurement,
- * 				Bi-Directional Current and Power Monitor with I2C Compatible Interface
+ *                 Bi-Directional Current and Power Monitor with I2C Compatible Interface
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */
@@ -38,10 +38,10 @@ typedef enum ina226_reg {
     INA226_REG_POWER           = 0x03, /**< Power register (read only) */
     INA226_REG_CURRENT         = 0x04, /**< Current register (read only) */
     INA226_REG_CALIBRATION     = 0x05, /**< Calibration register (read/write) */
-	INA226_REG_MASK_ENABLE     = 0x06, /**< Mask/Enable register (read/write) */
-	INA226_REG_ALERT_LIMIT     = 0x07, /**< Alert Limit register (read/write) */
-	INA226_REG_MANUFACTURER_ID = 0xFE, /**< Manufacturer ID register (read only) */
-	INA226_REG_DIE_ID          = 0xFF, /**< Die ID register (read only) */
+    INA226_REG_MASK_ENABLE     = 0x06, /**< Mask/Enable register (read/write) */
+    INA226_REG_ALERT_LIMIT     = 0x07, /**< Alert Limit register (read/write) */
+    INA226_REG_MANUFACTURER_ID = 0xFE, /**< Manufacturer ID register (read only) */
+    INA226_REG_DIE_ID          = 0xFF, /**< Die ID register (read only) */
 
 } ina226_reg_t;
 
@@ -51,16 +51,16 @@ typedef enum ina226_reg {
  */
 typedef enum ina226_mask_enable_reg_bit {
     INA226_MASK_ENABLE_LEN     = 0x0001, /**< Alert Latch Enable */
-	INA226_MASK_ENABLE_APOL    = 0x0002, /**< Alert Polarity bit */
-	INA226_MASK_ENABLE_OVF     = 0x0004, /**< Math Overflow Flag */
-	INA226_MASK_ENABLE_CVRF    = 0x0008, /**< Conversion Ready Flag */
-	INA226_MASK_ENABLE_AFF     = 0x0010, /**< Alert Function Flag */
-	INA226_MASK_ENABLE_CNVR    = 0x0400, /**< Conversion Ready */
-	INA226_MASK_ENABLE_POL     = 0x0800, /**< Power Over-Limit */
-	INA226_MASK_ENABLE_BUL     = 0x1000, /**< Bus Voltage Under-Voltage */
-	INA226_MASK_ENABLE_BOL     = 0x2000, /**< Bus Voltage Over-Voltage */
-	INA226_MASK_ENABLE_SUL     = 0x4000, /**< Shunt Voltage Under-Voltage */
-	INA226_MASK_ENABLE_SOL     = 0x8000, /**< Shunt Voltage Over-Voltage */
+    INA226_MASK_ENABLE_APOL    = 0x0002, /**< Alert Polarity bit */
+    INA226_MASK_ENABLE_OVF     = 0x0004, /**< Math Overflow Flag */
+    INA226_MASK_ENABLE_CVRF    = 0x0008, /**< Conversion Ready Flag */
+    INA226_MASK_ENABLE_AFF     = 0x0010, /**< Alert Function Flag */
+    INA226_MASK_ENABLE_CNVR    = 0x0400, /**< Conversion Ready */
+    INA226_MASK_ENABLE_POL     = 0x0800, /**< Power Over-Limit */
+    INA226_MASK_ENABLE_BUL     = 0x1000, /**< Bus Voltage Under-Voltage */
+    INA226_MASK_ENABLE_BOL     = 0x2000, /**< Bus Voltage Over-Voltage */
+    INA226_MASK_ENABLE_SUL     = 0x4000, /**< Shunt Voltage Under-Voltage */
+    INA226_MASK_ENABLE_SOL     = 0x8000, /**< Shunt Voltage Over-Voltage */
 } ina226_mask_enable_reg_bit_t;
 
 

--- a/drivers/ina226/include/ina226-regs.h
+++ b/drivers/ina226/include/ina226-regs.h
@@ -11,7 +11,7 @@
  *
  * @file
  * @brief       Register definitions for Texas Instruments INA226 High-Side or Low-Side Measurement,
- *                 Bi-Directional Current and Power Monitor with I2C Compatible Interface
+ *              Bi-Directional Current and Power Monitor with I2C Compatible Interface
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */
@@ -24,7 +24,6 @@
 #ifdef __cplusplus
  extern "C" {
 #endif
-
 
 /**
  * @brief INA226 register addresses
@@ -42,7 +41,6 @@ typedef enum ina226_reg {
     INA226_REG_ALERT_LIMIT     = 0x07, /**< Alert Limit register (read/write) */
     INA226_REG_MANUFACTURER_ID = 0xFE, /**< Manufacturer ID register (read only) */
     INA226_REG_DIE_ID          = 0xFF, /**< Die ID register (read only) */
-
 } ina226_reg_t;
 
 /**
@@ -62,8 +60,6 @@ typedef enum ina226_mask_enable_reg_bit {
     INA226_MASK_ENABLE_SUL     = 0x4000, /**< Shunt Voltage Under-Voltage */
     INA226_MASK_ENABLE_SOL     = 0x8000, /**< Shunt Voltage Over-Voltage */
 } ina226_mask_enable_reg_bit_t;
-
-
 
 
 #ifdef __cplusplus

--- a/drivers/include/ina226.h
+++ b/drivers/include/ina226.h
@@ -1,0 +1,318 @@
+/*
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_ina226 INA226 current/power monitor
+ * @ingroup     drivers_sensors
+ * @brief		Device driver for Texas Instruments INA226 High-Side or Low-Side Measurement,
+ * 				Bi-Directional Current and Power Monitor with I2C Compatible Interface
+ * @{
+ *
+ * @file
+ * @brief       Device driver interface for Texas Instruments INA226 High-Side or Low-Side Measurement,
+ * 				Bi-Directional Current and Power Monitor with I2C Compatible Interface
+ * 				All references to the INA226 data sheet are related to the document revision SBOS547A
+ *
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ */
+
+#ifndef INA226_H
+#define INA226_H
+
+#include <stdint.h>
+
+#include "periph/gpio.h"
+#include "periph/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Device descriptor for INA226 sensors
+ */
+typedef struct {
+    i2c_t i2c;              /**< I2C device the sensor is connected to */
+    uint8_t addr;           /**< the slave address of the sensor on the I2C bus */
+} ina226_t;
+
+/** INA226 reset command bit in configuration register (setting this bit to '1' generates a system reset) */
+#define INA226_RESET_BIT (0x8000)
+
+/** INA226 full scale (max. value) of the bus voltage register. Equivalent to 40.96 V (LSB = 1.25 mV)*/
+#define INA226_FULL_VOLTAGE_SCALE (0x7FFF)
+
+/** INA226 bus voltage LSB in microvolts = 1.25 mV*/
+#define INA226_BUS_VOLTAGE_LSB_UV (1250)
+
+/** INA226 shunt voltage LSB in nanovolts = 2.5 uV*/
+#define INA226_SHUNT_VOLTAGE_LSB_NV (2500)
+
+/** INA226 maximum voltage drop over shunt-resistor see "Shunt voltage input range" in data sheet section 6.5*/
+#define INA226_MAX_SHUNT_VOLTAGE_UV (81920)
+
+/** INA226 power register value LSB is based on the programmed current register LSB. For the ina226 this fixed ratio is 25. => 25 * CurrentLSB = PowerLSB */
+#define INA226_POWER_LSB_CURRENT_LSB_RATIO (25)
+
+/** INA226 Current_LSB = MAX_EXPECTED_CURRENT / 2^15 (see ina226 datasheet section 7.5)*/
+#define INA226_MAX_CURRENT_TO_LSB_RATIO (32768)
+
+
+/**
+ * @brief Determines the number of samples that are collected and averaged. (Bits 9–11 in configuration register)
+ * @see Table 6 in INA226 data sheet
+ */
+typedef enum ina226_avg {
+    INA226_AVG_1     = 0x0000, /**no averaging, default */
+	INA226_AVG_4     = 0x0200, /**averaging 4 measurements */
+	INA226_AVG_16    = 0x0400, /**averaging 16 measurements */
+	INA226_AVG_64    = 0x0600, /**averaging 64 measurements */
+	INA226_AVG_128   = 0x0800, /**averaging 128 measurements */
+	INA226_AVG_256   = 0x0A00, /**averaging 256 measurements */
+	INA226_AVG_512   = 0x0C00, /**averaging 512 measurements */
+	INA226_AVG_1024  = 0x0E00, /**averaging 1024 measurements */
+} ina226_avg_t;
+
+/**
+ * @brief Determines the bus voltage measurement conversion time. (Bits 6–8 in configuration register)
+ * @see Table 7 in INA226 data sheet
+ */
+typedef enum ina226_vbusct {
+    INA226_VBUSCT_140_US   = 0x0000, /**conversion time 140 us */
+	INA226_VBUSCT_204_US   = 0x0040, /**conversion time 204 us */
+	INA226_VBUSCT_332_US   = 0x0080, /**conversion time 332 us */
+	INA226_VBUSCT_588_US   = 0x00C0, /**conversion time 588 us */
+	INA226_VBUSCT_1_1_MS   = 0x0100, /**conversion time 1.1 ms, default */
+	INA226_VBUSCT_2_116_MS = 0x0140, /**conversion time 2.116 ms */
+	INA226_VBUSCT_4_156_MS = 0x0180, /**conversion time 4.156 ms */
+	INA226_VBUSCT_8_244_MS = 0x01C0, /**conversion time 8.244 ms */
+} ina226_vbusct_t;
+
+/**
+ * @brief Determines the shunt voltage measurement conversion time. (Bits 3–5 in configuration register)
+ * @see Table 8 in INA226 data sheet
+ */
+typedef enum ina226_vshct {
+    INA226_VSHCT_140_US   = 0x0000, /**conversion time 140 us */
+	INA226_VSHCT_204_US   = 0x0008, /**conversion time 204 us */
+	INA226_VSHCT_332_US   = 0x0010, /**conversion time 332 us */
+	INA226_VSHCT_588_US   = 0x0018, /**conversion time 588 us */
+	INA226_VSHCT_1_1_MS   = 0x0020, /**conversion time 1.1 ms, default */
+	INA226_VSHCT_2_116_MS = 0x0028, /**conversion time 2.116 ms */
+	INA226_VSHCT_4_156_MS = 0x0030, /**conversion time 4.156 ms */
+	INA226_VSHCT_8_244_MS = 0x0038, /**conversion time 8.244 ms */
+} ina226_vshct_t;
+
+/**
+ * @brief INA226 possible mode settings. (Bits 0-2 in configuration register)
+ * @see Table 9 in INA226 data sheet
+ */
+typedef enum ina226_operating_mode {
+    INA226_OPERATING_MODE_POWERDOWN                = 0x0000, /**< Power-Down (or Shutdown) */
+    INA226_OPERATING_MODE_TRIGGER_SHUNT_ONLY       = 0x0001, /**< Shunt Voltage, Triggered */
+    INA226_OPERATING_MODE_TRIGGER_BUS_ONLY         = 0x0002, /**< Bus Voltage, Triggered */
+    INA226_OPERATING_MODE_TRIGGER_SHUNT_AND_BUS    = 0x0003, /**< Shunt and Bus, Triggered */
+	INA226_OPERATING_MODE_POWERDOWN_2              = 0x0004, /**< Power-Down (or Shutdown) */
+    INA226_OPERATING_MODE_CONTINUOUS_SHUNT_ONLY    = 0x0005, /**< Shunt Voltage, Continuous */
+    INA226_OPERATING_MODE_CONTINUOUS_BUS_ONLY      = 0x0006, /**< Bus Voltage, Continuous */
+    INA226_OPERATING_MODE_CONTINUOUS_SHUNT_AND_BUS = 0x0007, /**< Shunt and Bus, Continuous, default */
+} ina226_mode_t;
+
+/**
+ * @brief Initialize a current sensor
+ *
+ * @param[out] dev          device descriptor of sensor to initialize
+ * @param[in]  i2c          I2C bus the sensor is connected to
+ * @param[in]  address      I2C slave address of the sensor
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_init(ina226_t *dev, i2c_t i2c, uint8_t address);
+
+/**
+ * @brief Read calibration register
+ *
+ * @param[in]   dev          device descriptor of sensor to configure
+ * @param[out]  calibration  calibration register settings, see data sheet
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_calibration(ina226_t *dev, uint16_t *calibration);
+
+/**
+ * @brief Write to calibration register
+ *
+ * @param[in]  dev          device descriptor of sensor to configure
+ * @param[in]  calibration  calibration register settings, see data sheet
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_write_calibration(ina226_t *dev, uint16_t calibration);
+
+/**
+ * @brief Read configuration register
+ *
+ * @param[in]   dev          device descriptor of sensor to configure
+ * @param[out]  config       configuration register settings, see data sheet
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_config(ina226_t *dev, uint16_t *config);
+
+/**
+ * @brief Write to configuration register
+ *
+ * @param[in]  dev          device descriptor of sensor to configure
+ * @param[in]  config       configuration register settings, see data sheet
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_write_config(ina226_t *dev, uint16_t config);
+
+/**
+ * @brief Read shunt voltage
+ *
+ * The Shunt Voltage Register stores the current shunt voltage reading. Negative numbers are represented in two's complement format.
+ * If averaging is enabled, this register displays the averaged value. Full-scale range = 81.92 mV (decimal = 7FFF); LSB: 2.5 uV
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] voltage      measured voltage across shunt resistor
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_shunt(ina226_t *dev, int16_t *voltage);
+
+/**
+ * @brief Read bus voltage register
+ *
+ * The Bus Voltage Register stores the most recent bus voltage reading, VBUS.
+ * If averaging is enabled, this register displays the averaged value.
+ * Full-scale range = 40.96 V (decimal = 7FFF); LSB = 1.25 mV.
+ *
+ * See the device data sheet for details.
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] voltage      measured bus voltage
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_bus(ina226_t *dev, int16_t *voltage);
+
+/**
+ * @brief Read shunt current
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] current      measured current through shunt resistor
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_current(ina226_t *dev, int16_t *current);
+
+/**
+ * @brief Read power consumption
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] power        measured power consumption
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_power(ina226_t *dev, int16_t *power);
+
+/**
+ * @brief read die ID Register
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] id           the unique identification number and the revision ID for the die
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_die_id(ina226_t *dev, uint16_t *id);
+
+/**
+ * @brief read manufacturer ID Register
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] id           the manufacturer ID (if the INA226 is set up correctly this value should be 0x5449)
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_manufacturer_id(ina226_t *dev, uint16_t *id);
+
+/**
+ * @brief read the mask/enable register
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] val          the value of the mask/enable register
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_mask_enable(ina226_t *dev, uint16_t *val);
+
+/**
+ * @brief write the mask/enable register
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[in]  val          the value of the mask/enable register
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_write_mask_enable(ina226_t *dev, uint16_t val);
+
+/**
+ * @brief read alert limit register
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] val          the value of the alert limit register
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_alert_limit(ina226_t *dev, uint16_t *val);
+
+/**
+ * @brief write alert limit register
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[in]  val          the value of the alert limit register
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_write_alert_limit(ina226_t *dev, uint16_t val);
+
+/**
+ * @brief enable interrupt for the alert pin
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[in]  me_config    the configuration of the mask/enable register (specifies which condition triggers the interrupt)
+ * @param[in]  pin 	        the gpio pin that is connected to the alert pin of the ina226 device
+ * @param[in]  callback     function pointer to the function that is called when an interrupt occurs
+ *
+ * @return 					0 on success
+ * 							<0 on error
+ */
+int ina226_activate_int(ina226_t *dev, uint16_t me_config, gpio_t pin, gpio_cb_t callback);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INA226_H */
+/** @} */

--- a/drivers/include/ina226.h
+++ b/drivers/include/ina226.h
@@ -27,6 +27,7 @@
 
 #include "periph/gpio.h"
 #include "periph/i2c.h"
+#include "ina226-regs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -132,6 +133,30 @@ typedef enum ina226_OP_mode {
 } ina226_mode_t;
 
 /**
+ * @brief Read one 16 bit register of INA226 device
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[in]  reg          register to read
+ * @param[out] out          pointer to where the register value will be stored
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_read_reg(ina226_t *dev, uint8_t reg, uint16_t *out);
+
+/**
+ * @brief Write one 16 bit register of INA226 device
+ *
+ * @param[in] dev           device descriptor of sensor
+ * @param[in] reg           register to write
+ * @param[in] in            value to write to register
+ *
+ * @return                  0 on success
+ * @return                  <0 on error
+ */
+int ina226_write_reg(ina226_t *dev, uint8_t reg, uint16_t in);
+
+/**
  * @brief Initialize a current sensor
  *
  * @param[out] dev          device descriptor of sensor to initialize
@@ -144,6 +169,21 @@ typedef enum ina226_OP_mode {
 int ina226_init(ina226_t *dev, i2c_t i2c, uint8_t address);
 
 /**
+ * @brief enable interrupt for the alert pin
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[in]  me_config    the configuration of the mask/enable register (specifies 
+                            which condition triggers the interrupt)
+ * @param[in]  pin          the gpio pin that is connected to the alert pin 
+                            of the ina226 device
+ * @param[in]  callback     function that is called when an interrupt occurs
+ *
+ * @return                     0 on success
+ *                             <0 on error
+ */
+int ina226_activate_int(ina226_t *dev, uint16_t me_config, gpio_t pin, gpio_cb_t callback);
+
+/**
  * @brief Read calibration register
  *
  * @param[in]   dev          device descriptor of sensor to configure
@@ -152,7 +192,10 @@ int ina226_init(ina226_t *dev, i2c_t i2c, uint8_t address);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_read_calibration(ina226_t *dev, uint16_t *calibration);
+inline int ina226_read_calibration(ina226_t *dev, uint16_t *calibration)
+{
+    return ina226_read_reg(dev, INA226_REG_CALIBRATION, calibration);
+}
 
 /**
  * @brief Write to calibration register
@@ -163,7 +206,10 @@ int ina226_read_calibration(ina226_t *dev, uint16_t *calibration);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_write_calibration(ina226_t *dev, uint16_t calibration);
+inline int ina226_write_calibration(ina226_t *dev, uint16_t calibration)
+{
+    return ina226_write_reg(dev, INA226_REG_CALIBRATION, calibration);
+}
 
 /**
  * @brief Read configuration register
@@ -174,7 +220,10 @@ int ina226_write_calibration(ina226_t *dev, uint16_t calibration);
  * @return                   0 on success
  * @return                   <0 on error
  */
-int ina226_read_config(ina226_t *dev, uint16_t *config);
+inline int ina226_read_config(ina226_t *dev, uint16_t *config)
+{
+    return ina226_read_reg(dev, INA226_REG_CONFIGURATION, config);   
+}
 
 /**
  * @brief Write to configuration register
@@ -185,7 +234,10 @@ int ina226_read_config(ina226_t *dev, uint16_t *config);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_write_config(ina226_t *dev, uint16_t config);
+inline int ina226_write_config(ina226_t *dev, uint16_t config)
+{
+    return ina226_write_reg(dev, INA226_REG_CONFIGURATION, config);
+}
 
 /**
  * @brief Read shunt voltage
@@ -201,7 +253,10 @@ int ina226_write_config(ina226_t *dev, uint16_t config);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_read_shunt(ina226_t *dev, int16_t *voltage);
+inline int ina226_read_shunt(ina226_t *dev, int16_t *voltage)
+{
+    return ina226_read_reg(dev, INA226_REG_SHUNT_VOLTAGE, (uint16_t *)voltage);
+}
 
 /**
  * @brief Read bus voltage register
@@ -218,7 +273,10 @@ int ina226_read_shunt(ina226_t *dev, int16_t *voltage);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_read_bus(ina226_t *dev, int16_t *voltage);
+inline int ina226_read_bus(ina226_t *dev, int16_t *voltage)
+{
+    return ina226_read_reg(dev, INA226_REG_BUS_VOLTAGE, (uint16_t *)voltage);
+}
 
 /**
  * @brief Read shunt current
@@ -229,7 +287,10 @@ int ina226_read_bus(ina226_t *dev, int16_t *voltage);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_read_current(ina226_t *dev, int16_t *current);
+inline int ina226_read_current(ina226_t *dev, int16_t *current)
+{
+    return ina226_read_reg(dev, INA226_REG_CURRENT, (uint16_t *)current);
+}
 
 /**
  * @brief Read power consumption
@@ -240,7 +301,10 @@ int ina226_read_current(ina226_t *dev, int16_t *current);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_read_power(ina226_t *dev, int16_t *power);
+inline int ina226_read_power(ina226_t *dev, int16_t *power)
+{
+    return ina226_read_reg(dev, INA226_REG_POWER, (uint16_t *)power);
+}
 
 /**
  * @brief read die ID Register
@@ -251,7 +315,10 @@ int ina226_read_power(ina226_t *dev, int16_t *power);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_read_die_id(ina226_t *dev, uint16_t *id);
+inline int ina226_read_die_id(ina226_t *dev, uint16_t *id)
+{
+    return ina226_read_reg(dev, INA226_REG_DIE_ID, id);
+}
 
 /**
  * @brief read manufacturer ID Register
@@ -263,7 +330,10 @@ int ina226_read_die_id(ina226_t *dev, uint16_t *id);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_read_manufacturer_id(ina226_t *dev, uint16_t *id);
+inline int ina226_read_manufacturer_id(ina226_t *dev, uint16_t *id)
+{
+    return ina226_read_reg(dev, INA226_REG_MANUFACTURER_ID, id);
+}
 
 /**
  * @brief read the mask/enable register
@@ -274,7 +344,10 @@ int ina226_read_manufacturer_id(ina226_t *dev, uint16_t *id);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_read_mask_enable(ina226_t *dev, uint16_t *val);
+inline int ina226_read_mask_enable(ina226_t *dev, uint16_t *val)
+{
+    return ina226_read_reg(dev, INA226_REG_MASK_ENABLE, val);
+}
 
 /**
  * @brief write the mask/enable register
@@ -285,7 +358,10 @@ int ina226_read_mask_enable(ina226_t *dev, uint16_t *val);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_write_mask_enable(ina226_t *dev, uint16_t val);
+inline int ina226_write_mask_enable(ina226_t *dev, uint16_t val)
+{
+    return ina226_write_reg(dev, INA226_REG_MASK_ENABLE, val);
+}
 
 /**
  * @brief read alert limit register
@@ -296,7 +372,10 @@ int ina226_write_mask_enable(ina226_t *dev, uint16_t val);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_read_alert_limit(ina226_t *dev, uint16_t *val);
+inline int ina226_read_alert_limit(ina226_t *dev, uint16_t *val)
+{
+    return ina226_read_reg(dev, INA226_REG_ALERT_LIMIT, val);
+}
 
 /**
  * @brief write alert limit register
@@ -307,22 +386,10 @@ int ina226_read_alert_limit(ina226_t *dev, uint16_t *val);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina226_write_alert_limit(ina226_t *dev, uint16_t val);
-
-/**
- * @brief enable interrupt for the alert pin
- *
- * @param[in]  dev          device descriptor of sensor
- * @param[in]  me_config    the configuration of the mask/enable register (specifies 
-                            which condition triggers the interrupt)
- * @param[in]  pin          the gpio pin that is connected to the alert pin 
-                            of the ina226 device
- * @param[in]  callback     function that is called when an interrupt occurs
- *
- * @return                     0 on success
- *                             <0 on error
- */
-int ina226_activate_int(ina226_t *dev, uint16_t me_config, gpio_t pin, gpio_cb_t callback);
+inline int ina226_write_alert_limit(ina226_t *dev, uint16_t val)
+{
+    return ina226_write_reg(dev, INA226_REG_ALERT_LIMIT, val);
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/include/ina226.h
+++ b/drivers/include/ina226.h
@@ -8,14 +8,14 @@
 /**
  * @defgroup    drivers_ina226 INA226 current/power monitor
  * @ingroup     drivers_sensors
- * @brief		Device driver for Texas Instruments INA226 High-Side or Low-Side Measurement,
- * 				Bi-Directional Current and Power Monitor with I2C Compatible Interface
+ * @brief       Device driver for Texas Instruments INA226 High-Side or Low-Side Measurement,
+ *              Bi-Directional Current and Power Monitor with I2C Compatible Interface
  * @{
  *
  * @file
  * @brief       Device driver interface for Texas Instruments INA226 High-Side or Low-Side Measurement,
- * 				Bi-Directional Current and Power Monitor with I2C Compatible Interface
- * 				All references to the INA226 data sheet are related to the document revision SBOS547A
+ *              Bi-Directional Current and Power Monitor with I2C Compatible Interface.
+ *              All references to the INA226 data sheet are related to the document revision SBOS547A
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */
@@ -55,11 +55,20 @@ typedef struct {
 /** INA226 maximum voltage drop over shunt-resistor see "Shunt voltage input range" in data sheet section 6.5*/
 #define INA226_MAX_SHUNT_VOLTAGE_UV (81920)
 
-/** INA226 power register value LSB is based on the programmed current register LSB. For the ina226 this fixed ratio is 25. => 25 * CurrentLSB = PowerLSB */
+/** 
+ * INA226 power register value LSB is based on the programmed current register LSB. 
+ * For the ina226 this fixed ratio is 25. => 25 * CurrentLSB = PowerLSB */
 #define INA226_POWER_LSB_CURRENT_LSB_RATIO (25)
 
 /** INA226 Current_LSB = MAX_EXPECTED_CURRENT / 2^15 (see ina226 datasheet section 7.5)*/
 #define INA226_MAX_CURRENT_TO_LSB_RATIO (32768)
+
+/** 
+ * INA226 CAL = 0.00512 / Current_LSB * R_shunt (see ina226 datasheet section 7.5) 
+ * this value equals 1,000,000,000,000 * 0.00512. This value is scaled up to ensure 
+ * maximum accuracy for macro-based calculation of CAL value without using floating point.
+ * For proper calculation of CAL value based on this define use [nA] for Current_LSB and [mOhm] for R_shunt*/
+#define INA226_CAL_SCALE_FACTOR_INT (5120000000LL)
 
 
 /**
@@ -68,13 +77,13 @@ typedef struct {
  */
 typedef enum ina226_avg {
     INA226_AVG_1     = 0x0000, /**no averaging, default */
-	INA226_AVG_4     = 0x0200, /**averaging 4 measurements */
-	INA226_AVG_16    = 0x0400, /**averaging 16 measurements */
-	INA226_AVG_64    = 0x0600, /**averaging 64 measurements */
-	INA226_AVG_128   = 0x0800, /**averaging 128 measurements */
-	INA226_AVG_256   = 0x0A00, /**averaging 256 measurements */
-	INA226_AVG_512   = 0x0C00, /**averaging 512 measurements */
-	INA226_AVG_1024  = 0x0E00, /**averaging 1024 measurements */
+    INA226_AVG_4     = 0x0200, /**averaging 4 measurements */
+    INA226_AVG_16    = 0x0400, /**averaging 16 measurements */
+    INA226_AVG_64    = 0x0600, /**averaging 64 measurements */
+    INA226_AVG_128   = 0x0800, /**averaging 128 measurements */
+    INA226_AVG_256   = 0x0A00, /**averaging 256 measurements */
+    INA226_AVG_512   = 0x0C00, /**averaging 512 measurements */
+    INA226_AVG_1024  = 0x0E00, /**averaging 1024 measurements */
 } ina226_avg_t;
 
 /**
@@ -83,13 +92,13 @@ typedef enum ina226_avg {
  */
 typedef enum ina226_vbusct {
     INA226_VBUSCT_140_US   = 0x0000, /**conversion time 140 us */
-	INA226_VBUSCT_204_US   = 0x0040, /**conversion time 204 us */
-	INA226_VBUSCT_332_US   = 0x0080, /**conversion time 332 us */
-	INA226_VBUSCT_588_US   = 0x00C0, /**conversion time 588 us */
-	INA226_VBUSCT_1_1_MS   = 0x0100, /**conversion time 1.1 ms, default */
-	INA226_VBUSCT_2_116_MS = 0x0140, /**conversion time 2.116 ms */
-	INA226_VBUSCT_4_156_MS = 0x0180, /**conversion time 4.156 ms */
-	INA226_VBUSCT_8_244_MS = 0x01C0, /**conversion time 8.244 ms */
+    INA226_VBUSCT_204_US   = 0x0040, /**conversion time 204 us */
+    INA226_VBUSCT_332_US   = 0x0080, /**conversion time 332 us */
+    INA226_VBUSCT_588_US   = 0x00C0, /**conversion time 588 us */
+    INA226_VBUSCT_1_1_MS   = 0x0100, /**conversion time 1.1 ms, default */
+    INA226_VBUSCT_2_116_MS = 0x0140, /**conversion time 2.116 ms */
+    INA226_VBUSCT_4_156_MS = 0x0180, /**conversion time 4.156 ms */
+    INA226_VBUSCT_8_244_MS = 0x01C0, /**conversion time 8.244 ms */
 } ina226_vbusct_t;
 
 /**
@@ -98,28 +107,28 @@ typedef enum ina226_vbusct {
  */
 typedef enum ina226_vshct {
     INA226_VSHCT_140_US   = 0x0000, /**conversion time 140 us */
-	INA226_VSHCT_204_US   = 0x0008, /**conversion time 204 us */
-	INA226_VSHCT_332_US   = 0x0010, /**conversion time 332 us */
-	INA226_VSHCT_588_US   = 0x0018, /**conversion time 588 us */
-	INA226_VSHCT_1_1_MS   = 0x0020, /**conversion time 1.1 ms, default */
-	INA226_VSHCT_2_116_MS = 0x0028, /**conversion time 2.116 ms */
-	INA226_VSHCT_4_156_MS = 0x0030, /**conversion time 4.156 ms */
-	INA226_VSHCT_8_244_MS = 0x0038, /**conversion time 8.244 ms */
+    INA226_VSHCT_204_US   = 0x0008, /**conversion time 204 us */
+    INA226_VSHCT_332_US   = 0x0010, /**conversion time 332 us */
+    INA226_VSHCT_588_US   = 0x0018, /**conversion time 588 us */
+    INA226_VSHCT_1_1_MS   = 0x0020, /**conversion time 1.1 ms, default */
+    INA226_VSHCT_2_116_MS = 0x0028, /**conversion time 2.116 ms */
+    INA226_VSHCT_4_156_MS = 0x0030, /**conversion time 4.156 ms */
+    INA226_VSHCT_8_244_MS = 0x0038, /**conversion time 8.244 ms */
 } ina226_vshct_t;
 
 /**
  * @brief INA226 possible mode settings. (Bits 0-2 in configuration register)
  * @see Table 9 in INA226 data sheet
  */
-typedef enum ina226_operating_mode {
-    INA226_OPERATING_MODE_POWERDOWN                = 0x0000, /**< Power-Down (or Shutdown) */
-    INA226_OPERATING_MODE_TRIGGER_SHUNT_ONLY       = 0x0001, /**< Shunt Voltage, Triggered */
-    INA226_OPERATING_MODE_TRIGGER_BUS_ONLY         = 0x0002, /**< Bus Voltage, Triggered */
-    INA226_OPERATING_MODE_TRIGGER_SHUNT_AND_BUS    = 0x0003, /**< Shunt and Bus, Triggered */
-	INA226_OPERATING_MODE_POWERDOWN_2              = 0x0004, /**< Power-Down (or Shutdown) */
-    INA226_OPERATING_MODE_CONTINUOUS_SHUNT_ONLY    = 0x0005, /**< Shunt Voltage, Continuous */
-    INA226_OPERATING_MODE_CONTINUOUS_BUS_ONLY      = 0x0006, /**< Bus Voltage, Continuous */
-    INA226_OPERATING_MODE_CONTINUOUS_SHUNT_AND_BUS = 0x0007, /**< Shunt and Bus, Continuous, default */
+typedef enum ina226_OP_mode {
+    INA226_OP_MODE_POWERDOWN                = 0x0000, /**< Power-Down (or Shutdown) */
+    INA226_OP_MODE_TRIGGER_SHUNT_ONLY       = 0x0001, /**< Shunt Voltage, Triggered */
+    INA226_OP_MODE_TRIGGER_BUS_ONLY         = 0x0002, /**< Bus Voltage, Triggered */
+    INA226_OP_MODE_TRIGGER_SHUNT_AND_BUS    = 0x0003, /**< Shunt and Bus, Triggered */
+    INA226_OP_MODE_POWERDOWN_2              = 0x0004, /**< Power-Down (or Shutdown) */
+    INA226_OP_MODE_CONTINUOUS_SHUNT_ONLY    = 0x0005, /**< Shunt Voltage, Continuous */
+    INA226_OP_MODE_CONTINUOUS_BUS_ONLY      = 0x0006, /**< Bus Voltage, Continuous */
+    INA226_OP_MODE_CONTINUOUS_SHUNT_AND_BUS = 0x0007, /**< Shunt and Bus, Continuous, default */
 } ina226_mode_t;
 
 /**
@@ -162,8 +171,8 @@ int ina226_write_calibration(ina226_t *dev, uint16_t calibration);
  * @param[in]   dev          device descriptor of sensor to configure
  * @param[out]  config       configuration register settings, see data sheet
  *
- * @return                  0 on success
- * @return                  <0 on error
+ * @return                   0 on success
+ * @return                   <0 on error
  */
 int ina226_read_config(ina226_t *dev, uint16_t *config);
 
@@ -181,8 +190,10 @@ int ina226_write_config(ina226_t *dev, uint16_t config);
 /**
  * @brief Read shunt voltage
  *
- * The Shunt Voltage Register stores the current shunt voltage reading. Negative numbers are represented in two's complement format.
- * If averaging is enabled, this register displays the averaged value. Full-scale range = 81.92 mV (decimal = 7FFF); LSB: 2.5 uV
+ * The Shunt Voltage Register stores the current shunt voltage reading. 
+ * Negative numbers are represented in two's complement format.
+ * If averaging is enabled, this register displays the averaged value. 
+ * Full-scale range = 81.92 mV (decimal = 7FFF); LSB: 2.5 uV
  *
  * @param[in]  dev          device descriptor of sensor
  * @param[out] voltage      measured voltage across shunt resistor
@@ -246,7 +257,8 @@ int ina226_read_die_id(ina226_t *dev, uint16_t *id);
  * @brief read manufacturer ID Register
  *
  * @param[in]  dev          device descriptor of sensor
- * @param[out] id           the manufacturer ID (if the INA226 is set up correctly this value should be 0x5449)
+ * @param[out] id           the manufacturer ID (if the INA226 is set up correctly 
+                            this value should be 0x5449)
  *
  * @return                  0 on success
  * @return                  <0 on error
@@ -301,12 +313,14 @@ int ina226_write_alert_limit(ina226_t *dev, uint16_t val);
  * @brief enable interrupt for the alert pin
  *
  * @param[in]  dev          device descriptor of sensor
- * @param[in]  me_config    the configuration of the mask/enable register (specifies which condition triggers the interrupt)
- * @param[in]  pin 	        the gpio pin that is connected to the alert pin of the ina226 device
- * @param[in]  callback     function pointer to the function that is called when an interrupt occurs
+ * @param[in]  me_config    the configuration of the mask/enable register (specifies 
+                            which condition triggers the interrupt)
+ * @param[in]  pin          the gpio pin that is connected to the alert pin 
+                            of the ina226 device
+ * @param[in]  callback     function that is called when an interrupt occurs
  *
- * @return 					0 on success
- * 							<0 on error
+ * @return                     0 on success
+ *                             <0 on error
  */
 int ina226_activate_int(ina226_t *dev, uint16_t me_config, gpio_t pin, gpio_cb_t callback);
 

--- a/tests/driver_ina226/Makefile
+++ b/tests/driver_ina226/Makefile
@@ -1,0 +1,9 @@
+APPLICATION = driver_ina226
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_i2c
+
+USEMODULE += ina226
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ina226/Makefile
+++ b/tests/driver_ina226/Makefile
@@ -1,7 +1,8 @@
 APPLICATION = driver_ina226
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_i2c
 
 USEMODULE += ina226
 USEMODULE += xtimer

--- a/tests/driver_ina226/README.md
+++ b/tests/driver_ina226/README.md
@@ -2,12 +2,27 @@
 This is a manual test application for the INA226 current and power monitor driver.
 
 # Usage
-This test application initializes the sensor with continous measuring mode for bus voltage and shunt voltage.
-Both adc conversion times are set to 1.1 ms which are then averaged over 256 Samples by the INA226 averaging mechanism.
+This test application initializes the sensor with continuous measuring mode for bus voltage and shunt voltage.
+Both ADC conversion times are set to 1.1 ms which are then averaged over 256 Samples by the INA226 averaging mechanism.
 This configuration leads to updated values ~two times per second (every 563.2 ms). 
 To print new measurements this example takes advantage of the INA226 alert pin to fire an interrupt 
-whenever a new measuremt value is available (see test_ina226_callback definition for reference).
+whenever a new measurement value is available (see test_ina226_callback definition for reference).
 To change this default configuration make use of the defines under "GENERAL CONFIGURATION PARAMETERS" in main.c
-The value for the calibration register is set acording to the datasheet including an example on how to 
+The value for the calibration register is set according to the data sheet including an example on how to 
 calculate a corrected calibration register value to compensate hardware related variations eg. shunt resistor 
 tolerance (see "REFERENCE MEASUREMENT CALIBRATION PARAMETERS" in main.c).
+
+To run the test with your specific hardware setup and get correct measurements following steps are needed:
+
+1) in main.c under 'GENERAL CONFIGURATION PARAMETERS' section adjust the following defines according to your platform:
+    TEST_INA226_I2C: I2C bus that is connected to the ina226 device (eg. I2C_0)
+    TEST_INA226_ADDR: I2C address of the ina226 that is set by external pin configuration of A0 and A1 pin
+    TEST_INA226_ALERT_PIN: GPIO pin that is connected to the ina226 alert pin (eg. GPIO_PIN(0,6))
+    TEST_INA226_SHUNT_RESISTOR_MILLI_OHM: value of the used shunt resistor in milliohm
+2) connect a static load to the ina226 circuit, build and run the test application
+3) read the reported measurements of the test application from the console
+4) perform a reference measurement with an external ampere meter 
+5) if values of 3) and 4) don't differ to much for your application you are done. Otherwise continue with 6)
+6) set 'TEST_INA226_CAL_REPORTED_CURRENT' in main.c to the value from step 3
+7) set 'TEST_INA226_CAL_AMM_MEAS_CURRENT' in main.c to the value from step 4
+8) uncomment the line '#define TEST_INA226_REF_MEASUREMENTS_DONE' in main.c to use the corrected calibration value

--- a/tests/driver_ina226/README.md
+++ b/tests/driver_ina226/README.md
@@ -1,0 +1,13 @@
+# About
+This is a manual test application for the INA226 current and power monitor driver.
+
+# Usage
+This test application initializes the sensor with continous measuring mode for bus voltage and shunt voltage.
+Both adc conversion times are set to 1.1 ms which are then averaged over 256 Samples by the INA226 averaging mechanism.
+This configuration leads to updated values ~two times per second (every 563.2 ms). 
+To print new measurements this example takes advantage of the INA226 alert pin to fire an interrupt 
+whenever a new measuremt value is available (see test_ina226_callback definition for reference).
+To change this default configuration make use of the defines under "GENERAL CONFIGURATION PARAMETERS" in main.c
+The value for the calibration register is set acording to the datasheet including an example on how to 
+calculate a corrected calibration register value to compensate hardware related variations eg. shunt resistor 
+tolerance (see "REFERENCE MEASUREMENT CALIBRATION PARAMETERS" in main.c).

--- a/tests/driver_ina226/main.c
+++ b/tests/driver_ina226/main.c
@@ -35,44 +35,55 @@
 #define NANOS_PER_MILLI  (1000 * NANOS_PER_MICRO)
 
 //--------------------------------- GENERAL CONFIGURATION PARAMETERS -----vvvvv
-#ifndef TEST_INA226_I2C
+/* I2C bus that is connected to the ina226 device */
 #define TEST_INA226_I2C (I2C_0)
-#endif
-#ifndef TEST_INA226_ADDR
-#define TEST_INA226_ADDR (0b1000000) //slave address of INA226 for A0 = A1 = GND --> 0b1000000 = 0x40
-#endif
-#ifndef TEST_INA226_ALERT_PIN
+
+/* Slave address of INA226. For A0 = A1 = GND --> 0b1000000 = 0x40 */
+#define TEST_INA226_ADDR (0b1000000)
+
+/* GPIO pin that is connected to the ina226 alert pin */
 #define TEST_INA226_ALERT_PIN (GPIO_PIN(0,6)) //PIN PA06
-#endif
 
-/**
- * This configuration enables continuous measurement of both shunt and bus voltage.
+/* This configuration enables continuous measurement of both shunt and bus voltage.
  * The adc conversion time for both is set to be 1.1 ms and the measurements are averaged over 256 individual samples -> so the interrupt will fire ~twice per second*/
-#define TEST_INA226_CONFIG (INA226_OPERATING_MODE_CONTINUOUS_SHUNT_AND_BUS | INA226_VBUSCT_1_1_MS | INA226_VSHCT_1_1_MS | INA226_AVG_256)
+#define TEST_INA226_CONFIG (INA226_OP_MODE_CONTINUOUS_SHUNT_AND_BUS | INA226_VBUSCT_1_1_MS | INA226_VSHCT_1_1_MS | INA226_AVG_256)
 
+/* Value of the used shunt resistor in milli ohm */
 #define TEST_INA226_SHUNT_RESISTOR_MILLI_OHM (750)
 
-/** Calculated value for the calibration register for use with a 0.75 Ohm shunt resistor. See section 7.5 in INA226 data sheet */
-#define TEST_INA226_CALIBRATION_VALUE (2048)
-
-/** The maximum current that is expected to flow through the shunt resistor in microampere. See section 7.5 in INA226 data sheet */
+/* The maximum current that is expected to flow through the shunt resistor in microampere. See section 7.5 in INA226 data sheet */
 #define TEST_INA226_MAX_EXPECTED_CURRENT_UA ((INA226_MAX_SHUNT_VOLTAGE_UV * MICROS_PER_MILLI) / TEST_INA226_SHUNT_RESISTOR_MILLI_OHM)
 
-/** The value of one LSB of the current register in nanoampere. See section 7.5 in INA226 data sheet */
+/* The value of one LSB of the current register in nanoampere. See section 7.5 in INA226 data sheet */
 #define TEST_INA226_CURRENT_LSB_NA ((TEST_INA226_MAX_EXPECTED_CURRENT_UA * NANOS_PER_MICRO) / INA226_MAX_CURRENT_TO_LSB_RATIO)
+
+/* Calculated value for the calibration register for use with a 0.75 Ohm shunt resistor. See section 7.5 in INA226 data sheet */
+#define TEST_INA226_CALIBRATION_VALUE ((uint16_t)(INA226_CAL_SCALE_FACTOR_INT / (TEST_INA226_CURRENT_LSB_NA * TEST_INA226_SHUNT_RESISTOR_MILLI_OHM)))
 //--------------------------------- GENERAL CONFIGURATION PARAMETERS -----^^^^^
 
 
 //--------------------- REFERENCE MEASUREMENT CALIBRATION PARAMETERS -----vvvvv
-/** Current [uA] that was measured with external ampere meter. This value was measured under the same conditions as when the INA226
- *  (configured with the original calculated TEST_INA226_CALIBRATION_VALUE) reported TEST_INA226_CAL_REPORTED_CURRENT*/
+/* Current [uA] that was measured with external ampere meter. This value was measured under the same conditions as when the INA226
+ * (configured with the original calculated TEST_INA226_CALIBRATION_VALUE) reported TEST_INA226_CAL_REPORTED_CURRENT*/
 #define TEST_INA226_CAL_AMM_MEAS_CURRENT (6593)
 
-/** Current [uA] that was reported by INA226 corresponding to the value of TEST_INA226_CAL_AMM_MEAS_CURRENT above. */
+/* Current [uA] that was reported by INA226 corresponding to the value of TEST_INA226_CAL_AMM_MEAS_CURRENT above. */
 #define TEST_INA226_CAL_REPORTED_CURRENT (7002)
 
-/** This value is derived by the Equation shown in INA226 datasheet section 7.5.2 */
-#define TEST_CORRECTED_FULL_SCALE_CAL ((TEST_INA226_CALIBRATION_VALUE * TEST_INA226_CAL_AMM_MEAS_CURRENT) / TEST_INA226_CAL_REPORTED_CURRENT)
+/* This value is derived by the equation shown in INA226 datasheet section 7.5.2 
+ * Write this value to the calibration register when the above reference measurement values ('TEST_INA226_CAL_AMM_MEAS_CURRENT' and
+ * 'TEST_INA226_CAL_REPORTED_CURRENT') are set to values that were measured in your specific setup. */
+#define TEST_INA226_CORRECTED_FULL_SCALE_CAL ((uint16_t)((TEST_INA226_CALIBRATION_VALUE * TEST_INA226_CAL_AMM_MEAS_CURRENT) / TEST_INA226_CAL_REPORTED_CURRENT))
+
+/* Uncomment this line if after performing reference measurements with your hardware setup 
+ * and updating 'TEST_INA226_CAL_AMM_MEAS_CURRENT' 'TEST_INA226_CAL_REPORTED_CURRENT' accordingly. */
+//#define TEST_INA226_REF_MEASUREMENTS_DONE
+
+#ifndef TEST_INA226_REF_MEASUREMENTS_DONE
+#define TEST_INA226_CALIBRATION_VALUE_TO_USE TEST_INA226_CALIBRATION_VALUE
+#else
+#define TEST_INA226_CALIBRATION_VALUE_TO_USE TEST_INA226_CORRECTED_FULL_SCALE_CAL
+#endif
 //--------------------- REFERENCE MEASUREMENT CALIBRATION PARAMETERS -----^^^^^
 
 /** callback that gets fired whenever a new measurement is available (the alert pin of the INA226 gets triggered). */
@@ -80,90 +91,89 @@ static void test_ina226_callback(void *arg);
 
 int main(void)
 {
-	ina226_t ina226_dev;
-	uint16_t ina_226_die_id;
-	uint16_t ina_226_manufac_id;
+    ina226_t ina226_dev;
+    uint16_t ina_226_die_id;
+    uint16_t ina_226_manufac_id;
 
-	xtimer_init();
+    xtimer_init();
 
-	printf("--- RIOT: INA226 test application ---\n");	
+    printf("--- RIOT: INA226 test application ---\n");    
 
-	printf("initializing I2C... ");
-	if (i2c_init_master(TEST_INA226_I2C, I2C_SPEED_FAST) == 0) {
-		printf("i2c_init_master [OK]\n");
-	}
-	else {
-		printf("i2c_init_master [FAILED]\n");
-		return -1;
-	}
+    printf("initializing I2C... ");
+    if (i2c_init_master(TEST_INA226_I2C, I2C_SPEED_FAST) == 0) {
+        printf("i2c_init_master [OK]\n");
+    }
+    else {
+        printf("i2c_init_master [FAILED]\n");
+        return -1;
+    }
 
-	printf("Initializing INA226 sensor at I2C_%" PRIu16 ", address 0x%02" PRIx16 "... ",TEST_INA226_I2C, TEST_INA226_ADDR);
-	if (ina226_init(&ina226_dev, TEST_INA226_I2C, TEST_INA226_ADDR) == 0) {
-		printf("ina226_init [OK]\n");
-	}
-	else {
-		printf("ina226_init [FAILED]\n");
-		return -1;
-	}
+    printf("Initializing INA226 sensor at I2C_%" PRIu16 ", address 0x%02" PRIx16 "... ",TEST_INA226_I2C, TEST_INA226_ADDR);
+    if (ina226_init(&ina226_dev, TEST_INA226_I2C, TEST_INA226_ADDR) == 0) {
+        printf("ina226_init [OK]\n");
+    }
+    else {
+        printf("ina226_init [FAILED]\n");
+        return -1;
+    }
 
-	printf("reading die-id of INA226 sensor... ");
-	if (ina226_read_die_id(&ina226_dev, &ina_226_die_id) == 0) {
-		printf("ina226_read_die_id [OK]: ina_226_die_id = 0x%0" PRIx16 "\n", ina_226_die_id);
-	}
-	else {
-		printf("ina226_read_die_id [FAILED]\n");
-		return -1;
-	}
+    printf("reading die-id of INA226 sensor... ");
+    if (ina226_read_die_id(&ina226_dev, &ina_226_die_id) == 0) {
+        printf("ina226_read_die_id [OK]: ina_226_die_id = 0x%0" PRIx16 "\n", ina_226_die_id);
+    }
+    else {
+        printf("ina226_read_die_id [FAILED]\n");
+        return -1;
+    }
 
-	printf("reading manufacturer-id of INA226 sensor... ");
-	if (ina226_read_manufacturer_id(&ina226_dev, &ina_226_manufac_id) == 0) {
-		printf("ina226_read_manufacturer_id [OK]: ina_226_manufac_id = 0x%0" PRIx16 "\n", ina_226_manufac_id);
-	}
-	else {
-		printf("ina226_read_manufacturer_id [FAILED]\n");
-		return -1;
-	}
+    printf("reading manufacturer-id of INA226 sensor... ");
+    if (ina226_read_manufacturer_id(&ina226_dev, &ina_226_manufac_id) == 0) {
+        printf("ina226_read_manufacturer_id [OK]: ina_226_manufac_id = 0x%0" PRIx16 "\n", ina_226_manufac_id);
+    }
+    else {
+        printf("ina226_read_manufacturer_id [FAILED]\n");
+        return -1;
+    }
 
-	printf("setting configuration register of INA226 sensor... ");
-	if (ina226_write_config(&ina226_dev, TEST_INA226_CONFIG) == 0) {
-		printf("ina226_set_config [OK]\n");
-	}
-	else {
-		printf("ina226_set_config [FAILED]\n");
-		return -1;
-	}
+    printf("setting configuration register of INA226 sensor... ");
+    if (ina226_write_config(&ina226_dev, TEST_INA226_CONFIG) == 0) {
+        printf("ina226_set_config [OK]\n");
+    }
+    else {
+        printf("ina226_set_config [FAILED]\n");
+        return -1;
+    }
 
-	printf("setting calibration register to %" PRIu16 "... ", TEST_CORRECTED_FULL_SCALE_CAL);
-	if (ina226_write_calibration(&ina226_dev, TEST_CORRECTED_FULL_SCALE_CAL) == 0) {
-		printf("ina226_set_calibration [OK]\n");
-	}
-	else {
-		printf("ina226_set_calibration [FAILED!]\n");
-		return -1;
-	}
+    printf("setting calibration register to %" PRIu16 "... ", TEST_INA226_CALIBRATION_VALUE_TO_USE);
+    if (ina226_write_calibration(&ina226_dev, TEST_INA226_CALIBRATION_VALUE_TO_USE) == 0) {
+        printf("ina226_set_calibration [OK]\n");
+    }
+    else {
+        printf("ina226_set_calibration [FAILED!]\n");
+        return -1;
+    }
 
-	printf("enabling interrupt by alert pin... ");
-	if (ina226_activate_int(&ina226_dev, INA226_MASK_ENABLE_CNVR, TEST_INA226_ALERT_PIN,test_ina226_callback) == 0) {
-		printf("ina226_activate_int [OK]\n");
-	}
-	else {
-		printf("ina226_activate_int [FAILED]\n");
-		return -1;
-	}
+    printf("enabling interrupt by alert pin... ");
+    if (ina226_activate_int(&ina226_dev, INA226_MASK_ENABLE_CNVR, TEST_INA226_ALERT_PIN, test_ina226_callback ) == 0) {
+        printf("ina226_activate_int [OK]\n");
+    }
+    else {
+        printf("ina226_activate_int [FAILED]\n");
+        return -1;
+    }
 
-	printf("INA226 initialized successfully -> now waiting for interrupts...\n");
+    printf("INA226 initialized successfully -> now waiting for interrupts...\n");
 
-	while(true){
-		xtimer_usleep(3000000);
-
-	}
+    while(true){
+        xtimer_sleep(10);
+    }
 }
 
 static void test_ina226_callback(void *arg)
 {
-	DEBUG("test_ina226_callback called\n");
+    DEBUG("test_ina226_callback called\n");
 
-	ina226_t *dev = (ina226_t*) arg;
+    ina226_t *dev = (ina226_t*) arg;
 
     //--- raw values of INA226 registers ---vvv
     uint16_t mask_enable_reg;
@@ -192,67 +202,67 @@ static void test_ina226_callback(void *arg)
 
     //reading the mask enable register is needed to re-enable interrupt generation by ina226
     if (ina226_read_mask_enable(dev, &mask_enable_reg) == 0) {
-    	DEBUG("ina226_read_mask_enable [OK]\n");
+        DEBUG("ina226_read_mask_enable [OK]\n");
     }
     else {
-    	DEBUG("ina226_read_mask_enable [FAILED]\n");
+        DEBUG("ina226_read_mask_enable [FAILED]\n");
     }
 
-	if (ina226_read_bus(dev, &bus_voltage_reg) == 0) {
-		DEBUG("ina226_read_bus [OK]: bus_voltage_reg = %"PRIu16"\n", bus_voltage_reg);
-		bus_voltage_int_v  = (bus_voltage_reg * INA226_BUS_VOLTAGE_LSB_UV) / MICROS_PER_INT;
-		bus_voltage_frac_mv = ( (bus_voltage_reg * INA226_BUS_VOLTAGE_LSB_UV) / MICROS_PER_MILLI) % MILLIS_PER_INT;
-	}
-	else {
-		DEBUG("ina226_read_bus [FAILED]\n");
-		return;
-	}
-
-	if (ina226_read_shunt(dev, &shunt_voltage_reg) == 0) {
-		DEBUG("ina226_read_shunt [OK]: shunt_voltage_reg = %"PRIi16"\n", shunt_voltage_reg);
-		shunt_voltage_int_mv  = (shunt_voltage_reg * INA226_SHUNT_VOLTAGE_LSB_NV) / NANOS_PER_MILLI;
-	    if (shunt_voltage_reg < 0) {
-			shunt_voltage_frac_uv = ( (-1 * shunt_voltage_reg * INA226_SHUNT_VOLTAGE_LSB_NV) / NANOS_PER_MICRO ) % MICROS_PER_MILLI;
-		}
-		else {
-			shunt_voltage_frac_uv = ( (shunt_voltage_reg* INA226_SHUNT_VOLTAGE_LSB_NV) / NANOS_PER_MICRO ) % MICROS_PER_MILLI;
-		}
-	}
-	else {
-		DEBUG("ina226_read_shunt [FAILED]\n");
-		return;
-	}
-
-	if (ina226_read_current(dev, &current_reg) == 0) {
-		DEBUG("ina226_read_current [OK]: current_reg = %"PRIi16"\n", current_reg);
-		current_ua = (current_reg * TEST_INA226_CURRENT_LSB_NA) / NANOS_PER_MICRO;
-		current_int_ma = current_ua / MICROS_PER_MILLI;
-
-	    if (current_ua < 0) {
-			current_frac_ua = (-1 * current_ua) % MICROS_PER_MILLI;
-		}
-		else{
-			current_frac_ua = current_ua % MICROS_PER_MILLI;
-		}
+    if (ina226_read_bus(dev, &bus_voltage_reg) == 0) {
+        DEBUG("ina226_read_bus [OK]: bus_voltage_reg = %"PRIu16"\n", bus_voltage_reg);
+        bus_voltage_int_v  = (bus_voltage_reg * INA226_BUS_VOLTAGE_LSB_UV) / MICROS_PER_INT;
+        bus_voltage_frac_mv = ( (bus_voltage_reg * INA226_BUS_VOLTAGE_LSB_UV) / MICROS_PER_MILLI) % MILLIS_PER_INT;
     }
-	else {
-		DEBUG("ina226_read_current [FAILED]\n");
-		return;
-	}
+    else {
+        DEBUG("ina226_read_bus [FAILED]\n");
+        return;
+    }
 
-	if (ina226_read_power(dev,&power_reg) == 0) {
-		DEBUG("ina226_read_power [OK]: power_reg = %"PRIi16"\n", power_reg);
-		power_uw = (INA226_POWER_LSB_CURRENT_LSB_RATIO * TEST_INA226_CURRENT_LSB_NA * power_reg) / NANOS_PER_MICRO;
-		power_int_mw = power_uw / MICROS_PER_MILLI;
-		power_frac_uw = power_uw % MICROS_PER_MILLI;
-	}
-	else {
-		DEBUG("ina226_read_power [FAILED]\n");
-		return;
-	}
+    if (ina226_read_shunt(dev, &shunt_voltage_reg) == 0) {
+        DEBUG("ina226_read_shunt [OK]: shunt_voltage_reg = %"PRIi16"\n", shunt_voltage_reg);
+        shunt_voltage_int_mv  = (shunt_voltage_reg * INA226_SHUNT_VOLTAGE_LSB_NV) / NANOS_PER_MILLI;
+        if (shunt_voltage_reg < 0) {
+            shunt_voltage_frac_uv = ( (-1 * shunt_voltage_reg * INA226_SHUNT_VOLTAGE_LSB_NV) / NANOS_PER_MICRO ) % MICROS_PER_MILLI;
+        }
+        else {
+            shunt_voltage_frac_uv = ( (shunt_voltage_reg* INA226_SHUNT_VOLTAGE_LSB_NV) / NANOS_PER_MICRO ) % MICROS_PER_MILLI;
+        }
+    }
+    else {
+        DEBUG("ina226_read_shunt [FAILED]\n");
+        return;
+    }
 
-	printf("| bus: %c%" PRIu32 ",%03" PRIu32 " V ", ((bus_voltage_int_v == 0 && bus_voltage_reg < 0) ? '-' : ' '), bus_voltage_int_v, bus_voltage_frac_mv);
-	printf("| shunt: %c%" PRId32 ",%03" PRId32 " mV ", ((shunt_voltage_int_mv == 0 && shunt_voltage_reg < 0) ? '-' : ' '), shunt_voltage_int_mv, shunt_voltage_frac_uv);
-	printf("| current: %c%" PRId32 ",%03" PRId32 " mA ", ((current_int_ma == 0 && current_ua < 0) ? '-' : ' '), current_int_ma, current_frac_ua);
-	printf("| power:  %" PRId32 ",%03" PRId32 " mW |\n", power_int_mw, power_frac_uw);
+    if (ina226_read_current(dev, &current_reg) == 0) {
+        DEBUG("ina226_read_current [OK]: current_reg = %"PRIi16"\n", current_reg);
+        current_ua = (current_reg * TEST_INA226_CURRENT_LSB_NA) / NANOS_PER_MICRO;
+        current_int_ma = current_ua / MICROS_PER_MILLI;
+
+        if (current_ua < 0) {
+            current_frac_ua = (-1 * current_ua) % MICROS_PER_MILLI;
+        }
+        else{
+            current_frac_ua = current_ua % MICROS_PER_MILLI;
+        }
+    }
+    else {
+        DEBUG("ina226_read_current [FAILED]\n");
+        return;
+    }
+
+    if (ina226_read_power(dev,&power_reg) == 0) {
+        DEBUG("ina226_read_power [OK]: power_reg = %"PRIi16"\n", power_reg);
+        power_uw = (INA226_POWER_LSB_CURRENT_LSB_RATIO * TEST_INA226_CURRENT_LSB_NA * power_reg) / NANOS_PER_MICRO;
+        power_int_mw = power_uw / MICROS_PER_MILLI;
+        power_frac_uw = power_uw % MICROS_PER_MILLI;
+    }
+    else {
+        DEBUG("ina226_read_power [FAILED]\n");
+        return;
+    }
+
+    printf("| bus: %c%" PRIu32 ",%03" PRIu32 " V ", ((bus_voltage_int_v == 0 && bus_voltage_reg < 0) ? '-' : ' '), bus_voltage_int_v, bus_voltage_frac_mv);
+    printf("| shunt: %c%" PRId32 ",%03" PRId32 " mV ", ((shunt_voltage_int_mv == 0 && shunt_voltage_reg < 0) ? '-' : ' '), shunt_voltage_int_mv, shunt_voltage_frac_uv);
+    printf("| current: %c%" PRId32 ",%03" PRId32 " mA ", ((current_int_ma == 0 && current_ua < 0) ? '-' : ' '), current_int_ma, current_frac_ua);
+    printf("| power:  %" PRId32 ",%03" PRId32 " mW |\n", power_int_mw, power_frac_uw);
 }

--- a/tests/driver_ina226/main.c
+++ b/tests/driver_ina226/main.c
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2016
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the INA226 sensor driver
+ *              All references to the INA226 data sheet are related to the document revision SBOS547A
+ *
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ *
+ * @}
+ */
+#include <stdio.h>
+
+#include "xtimer.h"
+#include "ina226.h"
+#include "ina226-regs.h"
+#include "phydat.h"
+#include "debug.h"
+
+#define ENABLE_DEBUG (0)
+
+#define MILLIS_PER_INT   (1000)
+#define MICROS_PER_INT   (1000 * MILLIS_PER_INT)
+#define MICROS_PER_MILLI (1000)
+#define NANOS_PER_MICRO  (1000)
+#define NANOS_PER_MILLI  (1000 * NANOS_PER_MICRO)
+
+//--------------------------------- GENERAL CONFIGURATION PARAMETERS -----vvvvv
+#ifndef TEST_INA226_I2C
+#define TEST_INA226_I2C (I2C_0)
+#endif
+#ifndef TEST_INA226_ADDR
+#define TEST_INA226_ADDR (0b1000000) //slave address of INA226 for A0 = A1 = GND --> 0b1000000 = 0x40
+#endif
+#ifndef TEST_INA226_ALERT_PIN
+#define TEST_INA226_ALERT_PIN (GPIO_PIN(0,6)) //PIN PA06
+#endif
+
+/**
+ * This configuration enables continuous measurement of both shunt and bus voltage.
+ * The adc conversion time for both is set to be 1.1 ms and the measurements are averaged over 256 individual samples -> so the interrupt will fire ~twice per second*/
+#define TEST_INA226_CONFIG (INA226_OPERATING_MODE_CONTINUOUS_SHUNT_AND_BUS | INA226_VBUSCT_1_1_MS | INA226_VSHCT_1_1_MS | INA226_AVG_256)
+
+#define TEST_INA226_SHUNT_RESISTOR_MILLI_OHM (750)
+
+/** Calculated value for the calibration register for use with a 0.75 Ohm shunt resistor. See section 7.5 in INA226 data sheet */
+#define TEST_INA226_CALIBRATION_VALUE (2048)
+
+/** The maximum current that is expected to flow through the shunt resistor in microampere. See section 7.5 in INA226 data sheet */
+#define TEST_INA226_MAX_EXPECTED_CURRENT_UA ((INA226_MAX_SHUNT_VOLTAGE_UV * MICROS_PER_MILLI) / TEST_INA226_SHUNT_RESISTOR_MILLI_OHM)
+
+/** The value of one LSB of the current register in nanoampere. See section 7.5 in INA226 data sheet */
+#define TEST_INA226_CURRENT_LSB_NA ((TEST_INA226_MAX_EXPECTED_CURRENT_UA * NANOS_PER_MICRO) / INA226_MAX_CURRENT_TO_LSB_RATIO)
+//--------------------------------- GENERAL CONFIGURATION PARAMETERS -----^^^^^
+
+
+//--------------------- REFERENCE MEASUREMENT CALIBRATION PARAMETERS -----vvvvv
+/** Current [uA] that was measured with external ampere meter. This value was measured under the same conditions as when the INA226
+ *  (configured with the original calculated TEST_INA226_CALIBRATION_VALUE) reported TEST_INA226_CAL_REPORTED_CURRENT*/
+#define TEST_INA226_CAL_AMM_MEAS_CURRENT (6593)
+
+/** Current [uA] that was reported by INA226 corresponding to the value of TEST_INA226_CAL_AMM_MEAS_CURRENT above. */
+#define TEST_INA226_CAL_REPORTED_CURRENT (7002)
+
+/** This value is derived by the Equation shown in INA226 datasheet section 7.5.2 */
+#define TEST_CORRECTED_FULL_SCALE_CAL ((TEST_INA226_CALIBRATION_VALUE * TEST_INA226_CAL_AMM_MEAS_CURRENT) / TEST_INA226_CAL_REPORTED_CURRENT)
+//--------------------- REFERENCE MEASUREMENT CALIBRATION PARAMETERS -----^^^^^
+
+/** callback that gets fired whenever a new measurement is available (the alert pin of the INA226 gets triggered). */
+static void test_ina226_callback(void *arg);
+
+int main(void)
+{
+	ina226_t ina226_dev;
+	uint16_t ina_226_die_id;
+	uint16_t ina_226_manufac_id;
+
+	xtimer_init();
+
+	printf("--- RIOT: INA226 test application ---\n");	
+
+	printf("initializing I2C... ");
+	if (i2c_init_master(TEST_INA226_I2C, I2C_SPEED_FAST) == 0) {
+		printf("i2c_init_master [OK]\n");
+	}
+	else {
+		printf("i2c_init_master [FAILED]\n");
+		return -1;
+	}
+
+	printf("Initializing INA226 sensor at I2C_%" PRIu16 ", address 0x%02" PRIx16 "... ",TEST_INA226_I2C, TEST_INA226_ADDR);
+	if (ina226_init(&ina226_dev, TEST_INA226_I2C, TEST_INA226_ADDR) == 0) {
+		printf("ina226_init [OK]\n");
+	}
+	else {
+		printf("ina226_init [FAILED]\n");
+		return -1;
+	}
+
+	printf("reading die-id of INA226 sensor... ");
+	if (ina226_read_die_id(&ina226_dev, &ina_226_die_id) == 0) {
+		printf("ina226_read_die_id [OK]: ina_226_die_id = 0x%0" PRIx16 "\n", ina_226_die_id);
+	}
+	else {
+		printf("ina226_read_die_id [FAILED]\n");
+		return -1;
+	}
+
+	printf("reading manufacturer-id of INA226 sensor... ");
+	if (ina226_read_manufacturer_id(&ina226_dev, &ina_226_manufac_id) == 0) {
+		printf("ina226_read_manufacturer_id [OK]: ina_226_manufac_id = 0x%0" PRIx16 "\n", ina_226_manufac_id);
+	}
+	else {
+		printf("ina226_read_manufacturer_id [FAILED]\n");
+		return -1;
+	}
+
+	printf("setting configuration register of INA226 sensor... ");
+	if (ina226_write_config(&ina226_dev, TEST_INA226_CONFIG) == 0) {
+		printf("ina226_set_config [OK]\n");
+	}
+	else {
+		printf("ina226_set_config [FAILED]\n");
+		return -1;
+	}
+
+	printf("setting calibration register to %" PRIu16 "... ", TEST_CORRECTED_FULL_SCALE_CAL);
+	if (ina226_write_calibration(&ina226_dev, TEST_CORRECTED_FULL_SCALE_CAL) == 0) {
+		printf("ina226_set_calibration [OK]\n");
+	}
+	else {
+		printf("ina226_set_calibration [FAILED!]\n");
+		return -1;
+	}
+
+	printf("enabling interrupt by alert pin... ");
+	if (ina226_activate_int(&ina226_dev, INA226_MASK_ENABLE_CNVR, TEST_INA226_ALERT_PIN,test_ina226_callback) == 0) {
+		printf("ina226_activate_int [OK]\n");
+	}
+	else {
+		printf("ina226_activate_int [FAILED]\n");
+		return -1;
+	}
+
+	printf("INA226 initialized successfully -> now waiting for interrupts...\n");
+
+	while(true){
+		xtimer_usleep(3000000);
+
+	}
+}
+
+static void test_ina226_callback(void *arg)
+{
+	DEBUG("test_ina226_callback called\n");
+
+	ina226_t *dev = (ina226_t*) arg;
+
+    //--- raw values of INA226 registers ---vvv
+    uint16_t mask_enable_reg;
+    int16_t bus_voltage_reg;
+    int16_t  shunt_voltage_reg;
+    int16_t  current_reg;
+    int16_t  power_reg;
+    //--- raw values of INA226 registers ---^^^
+
+    //--- derived values for pretty printing afterwards ---vvv
+    int32_t current_ua;
+    int32_t power_uw;
+
+    uint32_t bus_voltage_int_v;   //integer part of bus voltage [V]
+    uint32_t bus_voltage_frac_mv; //fractional part of bus voltage [mV]
+
+    int32_t shunt_voltage_int_mv;  //integer part of shunt voltage [mV]
+    int32_t shunt_voltage_frac_uv; //fractional part of shunt voltage [uV]
+
+    int32_t current_int_ma;  //integer part of current [mA]
+    int32_t current_frac_ua; //fractional part of current [uA]
+
+    int32_t power_int_mw;  //integer part of power [mW]
+    int32_t power_frac_uw; //fractional part of power [uW]
+    //--- derived values for pretty printing afterwards ---^^^
+
+    //reading the mask enable register is needed to re-enable interrupt generation by ina226
+    if (ina226_read_mask_enable(dev, &mask_enable_reg) == 0) {
+    	DEBUG("ina226_read_mask_enable [OK]\n");
+    }
+    else {
+    	DEBUG("ina226_read_mask_enable [FAILED]\n");
+    }
+
+	if (ina226_read_bus(dev, &bus_voltage_reg) == 0) {
+		DEBUG("ina226_read_bus [OK]: bus_voltage_reg = %"PRIu16"\n", bus_voltage_reg);
+		bus_voltage_int_v  = (bus_voltage_reg * INA226_BUS_VOLTAGE_LSB_UV) / MICROS_PER_INT;
+		bus_voltage_frac_mv = ( (bus_voltage_reg * INA226_BUS_VOLTAGE_LSB_UV) / MICROS_PER_MILLI) % MILLIS_PER_INT;
+	}
+	else {
+		DEBUG("ina226_read_bus [FAILED]\n");
+		return;
+	}
+
+	if (ina226_read_shunt(dev, &shunt_voltage_reg) == 0) {
+		DEBUG("ina226_read_shunt [OK]: shunt_voltage_reg = %"PRIi16"\n", shunt_voltage_reg);
+		shunt_voltage_int_mv  = (shunt_voltage_reg * INA226_SHUNT_VOLTAGE_LSB_NV) / NANOS_PER_MILLI;
+	    if (shunt_voltage_reg < 0) {
+			shunt_voltage_frac_uv = ( (-1 * shunt_voltage_reg * INA226_SHUNT_VOLTAGE_LSB_NV) / NANOS_PER_MICRO ) % MICROS_PER_MILLI;
+		}
+		else {
+			shunt_voltage_frac_uv = ( (shunt_voltage_reg* INA226_SHUNT_VOLTAGE_LSB_NV) / NANOS_PER_MICRO ) % MICROS_PER_MILLI;
+		}
+	}
+	else {
+		DEBUG("ina226_read_shunt [FAILED]\n");
+		return;
+	}
+
+	if (ina226_read_current(dev, &current_reg) == 0) {
+		DEBUG("ina226_read_current [OK]: current_reg = %"PRIi16"\n", current_reg);
+		current_ua = (current_reg * TEST_INA226_CURRENT_LSB_NA) / NANOS_PER_MICRO;
+		current_int_ma = current_ua / MICROS_PER_MILLI;
+
+	    if (current_ua < 0) {
+			current_frac_ua = (-1 * current_ua) % MICROS_PER_MILLI;
+		}
+		else{
+			current_frac_ua = current_ua % MICROS_PER_MILLI;
+		}
+    }
+	else {
+		DEBUG("ina226_read_current [FAILED]\n");
+		return;
+	}
+
+	if (ina226_read_power(dev,&power_reg) == 0) {
+		DEBUG("ina226_read_power [OK]: power_reg = %"PRIi16"\n", power_reg);
+		power_uw = (INA226_POWER_LSB_CURRENT_LSB_RATIO * TEST_INA226_CURRENT_LSB_NA * power_reg) / NANOS_PER_MICRO;
+		power_int_mw = power_uw / MICROS_PER_MILLI;
+		power_frac_uw = power_uw % MICROS_PER_MILLI;
+	}
+	else {
+		DEBUG("ina226_read_power [FAILED]\n");
+		return;
+	}
+
+	printf("| bus: %c%" PRIu32 ",%03" PRIu32 " V ", ((bus_voltage_int_v == 0 && bus_voltage_reg < 0) ? '-' : ' '), bus_voltage_int_v, bus_voltage_frac_mv);
+	printf("| shunt: %c%" PRId32 ",%03" PRId32 " mV ", ((shunt_voltage_int_mv == 0 && shunt_voltage_reg < 0) ? '-' : ' '), shunt_voltage_int_mv, shunt_voltage_frac_uv);
+	printf("| current: %c%" PRId32 ",%03" PRId32 " mA ", ((current_int_ma == 0 && current_ua < 0) ? '-' : ' '), current_int_ma, current_frac_ua);
+	printf("| power:  %" PRId32 ",%03" PRId32 " mW |\n", power_int_mw, power_frac_uw);
+}


### PR DESCRIPTION
This is a simple device driver for the ina226 current and power monitor using I2C. The code structure is based on the existing driver for ina220. The included test application was tested on samR21-xpro. Instructions on how to use this driver can be found in tests/driver_ina226/README.md.
