### PR TITLE
drivers/dht: fix fake parsing error with DHT22

### DIFF
--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -152,6 +152,7 @@ int dht_read(dht_t *dev, int16_t *temp, int16_t *hum)
             else {
                 *temp = (int16_t)raw_temp;
             }
+            break;
         default:
             return -2;
     }


### PR DESCRIPTION
The switch-case in [dht.c](https://github.com/RIOT-OS/RIOT/blob/master/drivers/dht/dht.c#L146) that interprets which sensor type is in use lacks a **break;** statement at the end of the DHT22 case. This leads to a fall through to the default case which then always returns -2 (parsing error) to the caller of the function. 
@PeterKietzmann we talked about this bug some time ago. Since it's obvious what needs to be fixed and it's only one line I created a PR right away instead of raising an issue to keep it simple.