### PR TITLE
boards/wsn430-v1_*: use USART1 for serial communication

### DIFF
--- a/boards/wsn430-common/include/periph_conf.h
+++ b/boards/wsn430-common/include/periph_conf.h
@@ -16,6 +16,7 @@
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  *              Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *              Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
 
 #ifndef PERIPH_CONF_H
@@ -53,18 +54,18 @@ extern "C" {
 #define UART_NUMOF          (1U)
 #define UART_0_EN           (1U)
 
-#define UART_BASE           (USART_0)
-#define UART_IE             (SFR->IE1)
-#define UART_IF             (SFR->IFG1)
+#define UART_BASE           (USART_1)
+#define UART_IE             (SFR->IE2)
+#define UART_IF             (SFR->IFG2)
 #define UART_IE_RX_BIT      (1 << 6)
 #define UART_IE_TX_BIT      (1 << 7)
-#define UART_ME             (SFR->ME1)
-#define UART_ME_BITS        (0xc0)
+#define UART_ME             (SFR->ME2)
+#define UART_ME_BITS        (0x30)
 #define UART_PORT           (PORT_3)
-#define UART_RX_PIN         (1 << 4)
-#define UART_TX_PIN         (1 << 5)
-#define UART_RX_ISR         (USART0RX_VECTOR)
-#define UART_TX_ISR         (USART0TX_VECTOR)
+#define UART_RX_PIN         (1 << 6)
+#define UART_TX_PIN         (1 << 7)
+#define UART_RX_ISR         (USART1RX_VECTOR)
+#define UART_TX_ISR         (USART1TX_VECTOR)
 /** @} */
 
 /**


### PR DESCRIPTION
The intention of this change is to enable wsn430-v1.3b and wsn430-v1.4
boards to use the radio and serial communication at the same time.
Thus USART0 is dedicated to the radio now to be used as SPI module,
while USART1 acts as a serial module for serial I/O.

Fixes #5599 
