### PR TITLE
boards/samr21-xpro:fix SPI_1 DIPO config

### DIFF
--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -178,7 +178,7 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_1_DEV          SERCOM5->SPI
 #define SPI_IRQ_1          SERCOM5_IRQn
 #define SPI_1_DOPO         (1)
-#define SPI_1_DIPO         (2)
+#define SPI_1_DIPO         (0)
 
 #define SPI_1_SCLK_DEV     PORT->Group[1]
 #define SPI_1_SCLK_PIN     (23)


### PR DESCRIPTION
Tested some transmissions with *tests/periph_spi* on `SPI_1`. Looks fine