### PR TITLE
make: distclean pkg sources on clean-intermediates target

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -312,7 +312,7 @@ clean:
 
 # Remove intermediates, but keep the .elf, .hex and .map etc.
 clean-intermediates:
-	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i clean ; done
+	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i distclean ; done
 	-@rm -rf $(BINDIR)/*.a $(BINDIR)/*/
 
 clean-pkg:


### PR DESCRIPTION
Previously, "make clean-intermediates" ran "make clean" for each used package. That kept all the sources around. That breaks murdock with a full ramdisk, as each package source is kept around ~40 times, and our packages have ~40mb sources, leading to up to 1.6gb unused leftovers in the build ramdisk.

This PR makes "clean-intermediates" run "make distclean" for each used package.

I can't think of anything that would break, but please @all, take a thorough but quick look, so we can get murdock running again.
