### PR TITLE
cpu/native: add args to async_read callback

### DIFF
--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -32,7 +32,7 @@ extern "C" {
 /**
  * @brief   asynchronus read callback type
  */
-typedef void (*native_async_read_callback_t)(int fd);
+typedef void (*native_async_read_callback_t)(int fd, void *arg);
 
 /**
  * @brief   initialize asynchronus read system
@@ -61,10 +61,11 @@ void native_async_read_continue(int fd);
  * @brief   start monitoring of file descriptor
  *
  * @param[in] fd       The file descriptor to monitor
+ * @param[in] arg      Pointer to be passed as arguments to the callback
  * @param[in] handler  The callback function to be called when the file
  *                     descriptor is ready to read.
  */
-void native_async_read_add_handler(int fd, native_async_read_callback_t handler);
+void native_async_read_add_handler(int fd, void *arg, native_async_read_callback_t handler);
 
 #ifdef __cplusplus
 }

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -307,8 +307,9 @@ void netdev2_tap_setup(netdev2_tap_t *dev, const netdev2_tap_params_t *params) {
     strncpy(dev->tap_name, *(params->tap_name), IFNAMSIZ);
 }
 
-static void _tap_isr(int fd) {
+static void _tap_isr(int fd, void *arg) {
     (void) fd;
+    (void) arg;
 
     netdev2_t *netdev = (netdev2_t *)&netdev2_tap;
 
@@ -393,7 +394,7 @@ static int _init(netdev2_t *netdev)
 
     /* configure signal handler for fds */
     native_async_read_setup();
-    native_async_read_add_handler(dev->tap_fd, _tap_isr);
+    native_async_read_add_handler(dev->tap_fd, NULL, _tap_isr);
 
 #ifdef MODULE_NETSTATS_L2
     memset(&netdev->stats, 0, sizeof(netstats_t));

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -51,9 +51,10 @@ void tty_uart_setup(uart_t uart, const char *filename)
     tty_device_filenames[uart] = strndup(filename, PATH_MAX - 1);
 }
 
-static void io_signal_handler(int fd)
+static void io_signal_handler(int fd, void *arg)
 {
     uart_t uart;
+    (void) arg;
 
     for (uart = 0; uart < UART_NUMOF; uart++) {
         if (tty_fds[uart] == fd) {
@@ -151,7 +152,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     uart_config[uart].arg = arg;
 
     native_async_read_setup();
-    native_async_read_add_handler(tty_fds[uart], io_signal_handler);
+    native_async_read_add_handler(tty_fds[uart], NULL, io_signal_handler);
 
     return 0;
 }


### PR DESCRIPTION
this makes it possible to pass some generic pointer that's given back as an argument when the callback is called.