### PR TITLE
WIP cpu/native: allow for multiple netdev2_tap devices

### DIFF
--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -69,11 +69,12 @@ void native_async_read_setup(void) {
 void native_async_read_cleanup(void) {
     unregister_interrupt(SIGIO);
 
-#ifdef __MACH__
     for (int i = 0; i < _next_index; i++) {
+#ifdef __MACH__
         kill(_sigio_child_pids[i], SIGKILL);
-    }
 #endif
+        real_close(_fds[i]);
+    }
 }
 
 void native_async_read_continue(int fd) {

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -32,7 +32,7 @@ extern "C" {
 /**
  * @brief   asynchronus read callback type
  */
-typedef void (*native_async_read_callback_t)(int fd);
+typedef void (*native_async_read_callback_t)(int fd, void *arg);
 
 /**
  * @brief   initialize asynchronus read system
@@ -61,10 +61,11 @@ void native_async_read_continue(int fd);
  * @brief   start monitoring of file descriptor
  *
  * @param[in] fd       The file descriptor to monitor
+ * @param[in] arg      Pointer to be passed as arguments to the callback
  * @param[in] handler  The callback function to be called when the file
  *                     descriptor is ready to read.
  */
-void native_async_read_add_handler(int fd, native_async_read_callback_t handler);
+void native_async_read_add_handler(int fd, void *arg, native_async_read_callback_t handler);
 
 #ifdef __cplusplus
 }

--- a/cpu/native/include/netdev2_tap.h
+++ b/cpu/native/include/netdev2_tap.h
@@ -55,24 +55,12 @@ typedef struct {
 } netdev2_tap_params_t;
 
 /**
- * @brief global device struct. driver only supports one tap device as of now.
- */
-extern netdev2_tap_t netdev2_tap;
-
-/**
  * @brief Setup netdev2_tap_t structure.
  *
  * @param dev       the preallocated netdev2_tap device handle to setup
  * @param params    initialization parameters
  */
 void netdev2_tap_setup(netdev2_tap_t *dev, const netdev2_tap_params_t *params);
-
-/**
- * @brief Cleanup tap resources
- *
- * @param dev  the netdev2_tap device handle to cleanup
- */
-void netdev2_tap_cleanup(netdev2_tap_t *dev);
 
 #ifdef __cplusplus
 }

--- a/cpu/native/include/tty_uart.h
+++ b/cpu/native/include/tty_uart.h
@@ -33,11 +33,6 @@ extern "C" {
  */
 void tty_uart_setup(uart_t uart, const char *name);
 
-/**
- * @brief   closes files opened
- */
-void uart_cleanup(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -307,8 +307,9 @@ void netdev2_tap_setup(netdev2_tap_t *dev, const netdev2_tap_params_t *params) {
     strncpy(dev->tap_name, *(params->tap_name), IFNAMSIZ);
 }
 
-static void _tap_isr(int fd) {
+static void _tap_isr(int fd, void *arg) {
     (void) fd;
+    (void) arg;
 
     netdev2_t *netdev = (netdev2_t *)&netdev2_tap;
 
@@ -393,7 +394,7 @@ static int _init(netdev2_t *netdev)
 
     /* configure signal handler for fds */
     native_async_read_setup();
-    native_async_read_add_handler(dev->tap_fd, _tap_isr);
+    native_async_read_add_handler(dev->tap_fd, NULL, _tap_isr);
 
 #ifdef MODULE_NETSTATS_L2
     memset(&netdev->stats, 0, sizeof(netstats_t));

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -390,16 +390,3 @@ static int _init(netdev2_t *netdev)
     return 0;
 }
 
-void netdev2_tap_cleanup(netdev2_tap_t *dev)
-{
-    /* Do we have a device */
-    if (!dev) {
-        return;
-    }
-
-    /* cleanup signal handling */
-    native_async_read_cleanup();
-
-    /* close the tap device */
-    real_close(dev->tap_fd);
-}

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -62,9 +62,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/* support one tap interface for now */
-netdev2_tap_t netdev2_tap;
-
 /* netdev2 interface */
 static int _init(netdev2_t *netdev);
 static int _send(netdev2_t *netdev, const struct iovec *vector, int n);
@@ -109,10 +106,6 @@ static inline void _isr(netdev2_t *netdev)
 
 static int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
 {
-    if (dev != (netdev2_t *)&netdev2_tap) {
-        return -ENODEV;
-    }
-
     int res = 0;
 
     switch (opt) {
@@ -140,11 +133,6 @@ static int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
 static int _set(netdev2_t *dev, netopt_t opt, void *value, size_t value_len)
 {
     (void)value_len;
-
-    if (dev != (netdev2_t *)&netdev2_tap) {
-        return -ENODEV;
-    }
-
     int res = 0;
 
     switch (opt) {
@@ -309,9 +297,8 @@ void netdev2_tap_setup(netdev2_tap_t *dev, const netdev2_tap_params_t *params) {
 
 static void _tap_isr(int fd, void *arg) {
     (void) fd;
-    (void) arg;
 
-    netdev2_t *netdev = (netdev2_t *)&netdev2_tap;
+    netdev2_t *netdev = (netdev2_t *)arg;
 
     if (netdev->event_callback) {
         netdev->event_callback(netdev, NETDEV2_EVENT_ISR);
@@ -394,7 +381,7 @@ static int _init(netdev2_t *netdev)
 
     /* configure signal handler for fds */
     native_async_read_setup();
-    native_async_read_add_handler(dev->tap_fd, NULL, _tap_isr);
+    native_async_read_add_handler(dev->tap_fd, netdev, _tap_isr);
 
 #ifdef MODULE_NETSTATS_L2
     memset(&netdev->stats, 0, sizeof(netstats_t));

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -175,14 +175,4 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     _native_write(tty_fds[uart], data, len);
 }
 
-void uart_cleanup(void) {
-    native_async_read_cleanup();
-
-    for (uart_t uart = 0; uart < UART_NUMOF; uart++) {
-        if (uart_config[uart].rx_cb != NULL) {
-            real_close(tty_fds[uart]);
-        }
-    }
-}
-
 /** @} */

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -51,9 +51,10 @@ void tty_uart_setup(uart_t uart, const char *filename)
     tty_device_filenames[uart] = strndup(filename, PATH_MAX - 1);
 }
 
-static void io_signal_handler(int fd)
+static void io_signal_handler(int fd, void *arg)
 {
     uart_t uart;
+    (void) arg;
 
     for (uart = 0; uart < UART_NUMOF; uart++) {
         if (tty_fds[uart] == fd) {
@@ -151,7 +152,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     uart_config[uart].arg = arg;
 
     native_async_read_setup();
-    native_async_read_add_handler(tty_fds[uart], io_signal_handler);
+    native_async_read_add_handler(tty_fds[uart], NULL, io_signal_handler);
 
     return 0;
 }

--- a/cpu/native/reboot.c
+++ b/cpu/native/reboot.c
@@ -19,18 +19,14 @@
 #include <stdlib.h>
 
 #include "native_internal.h"
-#include "netdev2_tap.h"
+#include "async_read.h"
 #include "tty_uart.h"
 
 void reboot(void)
 {
     printf("\n\n\t\t!! REBOOT !!\n\n");
 
-#ifdef MODULE_NETDEV2_TAP
-    netdev2_tap_cleanup(&netdev2_tap);
-#endif
-
-    uart_cleanup();
+    native_async_read_cleanup();
 
     if (real_execve(_native_argv[0], _native_argv, NULL) == -1) {
         err(EXIT_FAILURE, "reboot: execve");

--- a/sys/auto_init/netif/auto_init_netdev2_tap.c
+++ b/sys/auto_init/netif/auto_init_netdev2_tap.c
@@ -25,7 +25,7 @@
 #include "netdev2_tap.h"
 #include "net/gnrc/netdev2/eth.h"
 
-extern netdev2_tap_t netdev2_tap;
+static netdev2_tap_t netdev2_tap;
 
 /**
  * @brief   Define stack parameters for the MAC layer thread


### PR DESCRIPTION
While implementing some changes in #5613, I saw that the netdev2_tap driver could make use of this change to allow multiple tap devices. 
TODO: find some way to have a pointer to the right netdev2_tap device in startup.c

I'm not sure if this makes sense to go through with this, so comments very welcome.
