### PR TITLE
genconfigheader.sh: Fix for for building on OSX

### DIFF
--- a/dist/tools/genconfigheader/genconfigheader.sh
+++ b/dist/tools/genconfigheader/genconfigheader.sh
@@ -23,7 +23,7 @@ shift
 
 MD5SUM=md5sum
 if [ "$(uname -s)" = "Darwin" ]; then
-  MD5SUM=md5 -r
+  MD5SUM="md5 -r"
 fi
 
 # atomically update the file


### PR DESCRIPTION
make -C examples/default fails with 
dist/tools/genconfigheader/genconfigheader.sh: line 26: -r: command not found

PR solves this issue introduced in https://github.com/RIOT-OS/RIOT/commit/77a15e7886c978161fb1bf442cc5a82226571cd2
