### PR TITLE
dist/tools/jlink: remove jlink prompt

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -152,6 +152,7 @@ do_flash() {
                     -device '${JLINK_DEVICE}' \
                     -speed '${JLINK_SPEED}' \
                     -if '${JLINK_IF}' \
+                    -jtagconf -1,-1 \
                     -commandfile '${BINDIR}/burn.seg'"
 }
 
@@ -197,6 +198,7 @@ do_reset() {
                     -device '${JLINK_DEVICE}' \
                     -speed '${JLINK_SPEED}' \
                     -if '${JLINK_IF}' \
+                    -jtagconf -1,-1 \
                     -commandfile '${RIOTBASE}/dist/tools/jlink/reset.seg'"
 }
 


### PR DESCRIPTION
When flashing over JTAG, the prompt "J-Link> " appears, and the user needs to press enter to continue with a flash. Segger removed this at one point, but they seem to have brought it back for legacy users...
