### PR TITLE
Makefile.include: Move USEMODULE CFLAGS expansion last

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -176,8 +176,14 @@ export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
 # Import all toolchain settings
 include $(RIOTCPU)/Makefile.include.$(TOOLCHAIN)
 
+# Add standard include directories
+INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
+INCLUDES += -I$(RIOTCPU)/$(CPU)/include
+INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+
 # mandatory includes!
-include $(RIOTBASE)/Makefile.modules
+include $(RIOTBASE)/Makefile.pseudomodules
+include $(RIOTBASE)/Makefile.defaultmodules
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
@@ -491,6 +497,9 @@ include $(RIOTBASE)/dist/tools/desvirt/Makefile.desvirt
 
 # include bindist target
 include $(RIOTBASE)/Makefile.bindist
+
+# Add all USEMODULE modules to CFLAGS
+include $(RIOTBASE)/Makefile.modules
 
 # Build a header file with all common macro definitions and undefinitions
 # make it phony to force re-run of the script every time even if the file exists

--- a/Makefile.modules
+++ b/Makefile.modules
@@ -1,11 +1,5 @@
-include $(RIOTBASE)/Makefile.pseudomodules
-include $(RIOTBASE)/Makefile.defaultmodules
-
 USEMODULE := $(filter-out $(filter-out $(FEATURES_PROVIDED), $(FEATURES_OPTIONAL)), $(sort $(USEMODULE)))
 
-INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
-INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
 ED = $(addprefix FEATURE_,$(sort $(filter $(FEATURES_PROVIDED), $(FEATURES_REQUIRED))))
 ED += $(addprefix MODULE_,$(sort $(USEMODULE) $(USEPKG)))
 EXTDEFINES = $(addprefix -D,$(shell echo '$(ED)' | tr 'a-z-' 'A-Z_'))


### PR DESCRIPTION
Some `USEMODULE` parts (e.g. defined in `${BOARD}/Makefile.dep`) were not being properly exported to CFLAGS `-DMODULE_xxx` options because of the order of the Makefile inclusion.

IMHO, this should go in the release because it can break external code relying on `#if MODULE_xxx`

What I did was move the CFLAGS expansion to the end of `/Makefile.include`, but keep the default and pseudo module includes at the top.