### PR TITLE
makefiles: expose a single DEFAULT_CHANNEL variable

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -58,7 +58,12 @@ extern "C" {
 #define CC2538_MAX_FREQ             (2507)
 
 #define CC2538_RF_POWER_DEFAULT     (3)    /**< Default output power in dBm */
+#ifdef DEFAULT_CHANNEL
+#define CC2538_RF_CHANNEL_DEFAULT   (DEFAULT_CHANNEL)
+#endif
+#ifndef CC2538_RF_CHANNEL_DEFAULT
 #define CC2538_RF_CHANNEL_DEFAULT   (26U)
+#endif
 #define CC2538_RF_PANID_DEFAULT     (0x0023)
 
 #define OUTPUT_POWER_MIN            (-24)  /**< Min output power in dBm */

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -63,12 +63,18 @@ extern "C" {
 /* the AT86RF212B has a sub-1GHz radio */
 #define AT86RF2XX_MIN_CHANNEL           (0)
 #define AT86RF2XX_MAX_CHANNEL           (10)
+#ifdef DEFAULT_CHANNEL
+#define AT86RF2XX_DEFAULT_CHANNEL (DEFAULT_CHANNEL)
+#endif
 #ifndef AT86RF2XX_DEFAULT_CHANNEL
 #define AT86RF2XX_DEFAULT_CHANNEL       (5)
 #endif
 #else
 #define AT86RF2XX_MIN_CHANNEL           (11U)
 #define AT86RF2XX_MAX_CHANNEL           (26U)
+#ifdef DEFAULT_CHANNEL
+#define AT86RF2XX_DEFAULT_CHANNEL (DEFAULT_CHANNEL)
+#endif
 #ifndef AT86RF2XX_DEFAULT_CHANNEL
 #define AT86RF2XX_DEFAULT_CHANNEL       (26U)
 #endif

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -57,7 +57,12 @@ extern "C" {
   */
 #define CC2420_CHAN_MIN         (11U)
 #define CC2420_CHAN_MAX         (26U)
+#ifdef DEFAULT_CHANNEL
+#define CC2420_CHAN_DEFAULT     (DEFAULT_CHANNEL)
+#endif
+#ifndef CC2420_CHAN_DEFAULT
 #define CC2420_CHAN_DEFAULT     (26U)
+#endif
 /** @} */
 
 /**

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -65,6 +65,9 @@ extern "C" {
 /**
  * @brief   Default channel used after initialization
  */
+#ifdef DEFAULT_CHANNEL
+#define KW2XRF_DEFAULT_CHANNEL (DEFAULT_CHANNEL)
+#endif
 #ifndef KW2XRF_DEFAULT_CHANNEL
 #define KW2XRF_DEFAULT_CHANNEL        (26U)
 #endif

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -72,6 +72,9 @@ extern "C" {
 /**
  * @brief   Default channel used after initialization
  */
+#ifdef DEFAULT_CHANNEL
+#define XBEE_DEFAULT_CHANNEL (DEFAULT_CHANNEL)
+#endif
 #ifndef XBEE_DEFAULT_CHANNEL
 #define XBEE_DEFAULT_CHANNEL        (23U)
 #endif

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -70,4 +70,8 @@ ifneq (,$(filter msba2,$(BOARD)))
   USEMODULE += random
 endif
 
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
 include $(RIOTBASE)/Makefile.include

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -42,6 +42,10 @@ USEMODULE += ps
 # include UHCP client
 USEMODULE += gnrc_uhcpc
 
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -36,6 +36,10 @@ USEMODULE += gnrc_icmpv6_echo
 # Use minimal standard PRNG
 USEMODULE += prng_minstd
 
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
 CFLAGS += -DGNRC_PKTBUF_SIZE=512 -DGNRC_IPV6_NETIF_ADDR_NUMOF=4 -DGNRC_IPV6_NC_SIZE=1
 
 # Change this to 0 show compiler invocation lines by default:

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -33,6 +33,10 @@ USEMODULE += ps
 USEMODULE += netstats_l2
 USEMODULE += netstats_ipv6
 
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/examples/microcoap_server/Makefile
+++ b/examples/microcoap_server/Makefile
@@ -33,6 +33,10 @@ CFLAGS += -DMICROCOAP_DEBUG
 # include this for printing IP addresses
 USEMODULE += shell_commands
 
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:


### PR DESCRIPTION
The idea of this PR is to use a single variable for setting the default channel when building a firmware. It can be use like this:
```
$ make BOARD=samr21-xpro DEFAULT_CHANNEL=23 flash term
```