### PR TITLE
sys: newlib: check if toolchain is compiled with -fshort-wchar, set CFLAGS accordingly

### DIFF
--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -4,6 +4,9 @@ ifneq (,$(filter newlib_nano,$(USEMODULE)))
   # Test if nano.specs is available
   ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
     USE_NEWLIB_NANO = 1
+    ifeq ($(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(CC) -xc - -o /dev/null -lc -specs=nano.specs -Wall -Wextra -pedantic 2>&1 | grep -q "use of wchar_t values across objects may fail" ; echo $$?),0)
+        CFLAGS += -fshort-wchar
+    endif
   endif
 endif
 


### PR DESCRIPTION
I just tried to use the gnu-arm-none-eabi toolchain shipped with Ubuntu 16.04.

It compiles fine apart from this:
```
/usr/lib/gcc/arm-none-eabi/4.9.3/../../../arm-none-eabi/bin/ld: warning: /usr/lib/gcc/arm-none-eabi/4.9.3/../../../arm-none-eabi/lib/armv7e-m/libc_nano.a(lib_a-nano-msizer.o) uses 2-byte wchar_t yet the output is to use 4-byte wchar_t; use of wchar_t values across objects may fail
```
(linker warning for all .a files)

This PR adds a check to newlib's Makefile, setting the option if the compile would lead to the warning without.