### PR TITLE
boards: arduino-mega2560, waspmote-pro: garbage collect dead code

### DIFF
--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -41,6 +41,6 @@ export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -e reset_handler
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc -e reset_handler
 export OFLAGS += -j .text -j .data -O ihex
 export FFLAGS += -p m2560 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -D -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -55,6 +55,6 @@ export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -e reset_handler
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc -e reset_handler
 export OFLAGS += -j .text -j .data -O ihex
 export FFLAGS += -p m1281 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex


### PR DESCRIPTION
In PR #5549 I noticed that the simple test case exceeded flash size by a lot, for AVR platforms. Since the basis is an Arduino library, that seemed weird. Adding `-Wl,--gc-sections` to the linker options fixes it, and results in a test case of 20KB instead of >1MB, because the fonts that were not referenced were not stripped..

I don't have Arduino platforms here to test it with, I can only rely on Murdock. However, the Arduino IDE also enforces this option, so I think it will work just fine :-)

P.s. I suspect a similar problem and fix for MSP-430 boards, but I cannot get a working compiler under OS X. Any hints?