### PR TITLE
cortexm_common: point VTOR to the actual vector table instead of CPU_FLASH_BASE

### DIFF
--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <stdint.h>
+
 #include "cpu.h"
 
 /**
@@ -25,6 +27,8 @@
  *         allow full FPU access
  */
 #define FULL_FPU_ACCESS         (0x00f00000)
+
+extern const void *interrupt_vector[];
 
 void cortexm_init(void)
 {
@@ -37,7 +41,7 @@ void cortexm_init(void)
     /* configure the vector table location to internal flash */
 #if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
     defined(CPU_ARCH_CORTEX_M4F)
-    SCB->VTOR = CPU_FLASH_BASE;
+    SCB->VTOR = (uintptr_t)interrupt_vector;
 #endif
 
     /* initialize the interrupt priorities */


### PR DESCRIPTION
Currently RIOT assumes that the vector table is stored at the bottom of flash memory. It usually is, but under more complex configurations it might not be. This change allows a custom linker script to locate the vector table anywhere in flash, which is important if you want to have, for example, multiple OS images on the same MCU, a separate bootloader, or over-the-air software updates.
