### PR TITLE
examples: add tetris

### DIFF
--- a/examples/tetris/AUTHORS
+++ b/examples/tetris/AUTHORS
@@ -1,0 +1,14 @@
+Initiator:
+	Freek Wiedijk <freek@cs.ru.nl>
+
+Original Author:
+	John Tromp <john.tromp@gmail.com>
+
+Current maintainer:
+	Joachim Nilsson <troglobit@gmail.com>
+
+Contributors:
+	Mattias Walstrom <lazzer@gmail.com>
+
+RIOT port:
+	Kaspar Schleiser <kaspar@schleiser.de>

--- a/examples/tetris/LICENSE
+++ b/examples/tetris/LICENSE
@@ -1,0 +1,38 @@
+Micro Tetris, based on an obfuscated tetris, 1989 IOCCC Best Game
+
+Copyright (c) 1989, John Tromp <john.tromp@gmail.com>
+Copyright (c) 2009, Joachim Nilsson <troglobit@gmail.com>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+See the following URLs for more information, first John Tromp's page about
+the game http://homepages.cwi.nl/~tromp/tetris.html then there's the entry
+page at IOCCC http://www.ioccc.org/1989/tromp.hint
+
+See the Git repository, http://git.vmlinux.org/tetris.git, for details on
+the historical ancestry.
+
+The email conversation with John about the license, slightly paraphrased.
+
+On Mon, June 8, 2009, Joachim Nilsson wrote:
+> Hi John, what's the license, can I redistribute it as part of a commercial
+> (binary only) application, and/or change the source and publish it further?
+> Personally I usually prefer the ISC Licence, it's brief and to the point.
+> 
+>    http://en.wikipedia.org/wiki/ISC_license
+
+There is no license. Use as you see fit.
+You're welcome to slap the ISC license on there.
+
+regards,
+-John

--- a/examples/tetris/Makefile
+++ b/examples/tetris/Makefile
@@ -1,0 +1,22 @@
+# name of your application
+APPLICATION = tetris
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+USEMODULE += xtimer
+USEMODULE += core_thread_flags
+USEMODULE += tsrb
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/tetris/README
+++ b/examples/tetris/README
@@ -1,0 +1,85 @@
+README                                          -*-text-*-
+
+Welcome to Micro Tetris, based on an original implementation by John Tromp,
+initiated by Freek Wiedijk.  Currently maintained by Joachim Nilsson.
+
+I decided to call this game Micro Tetris because it is very small and only
+utilizes ANSI escape sequences to draw the board. Hence it is very suitable
+for todays small embedded devices.
+
+The game is available from as a Git source control archive from GitHub:
+
+	http://github.com/troglobit/tetris
+
+See the file AUTHORS for contact information.
+
+                       -- Joachim Nilsson <troglobit@gmail.com>
+
+Keyboard Control
+----------------
+
+    j         - Left
+    k         - Rotate
+    l         - Right
+    <SPACE>   - Drop
+    p         - Pause
+    q         - Quit
+
+
+Background
+----------
+The following game description is from the original IOCCC entry, taken from
+John's home page at http://homepages.cwi.nl/~tromp/tetris.html
+
+An ofbuscated tetris, 1989 IOCCC Best Game
+
+This program plays the familiar game of `TETRIS' with the following features:
+
+   * outputs vt100-like escape-sequences for:
+      o cursor positioning
+      o normal/reverse video 
+     in curses like fashion (minimal output for screen updates)
+   * continuously increasing speed (except in pause)
+   * start speed selectable by giving n as first argument, where n is the
+     number of drops per second (default=2).
+   * controls also selectable by giving as the second argument a string
+     consisting of the following 6 charachters: left, rotate, right,drop, 
+     pause, quit (default="jkl pq")
+   * the screen is blanked during the pause and the score is shown
+   * finally, the program maintains a high-score table. giving a full path
+     name for the table will result in a system-wide hiscore allowing a
+     competition between users. 
+
+Obfuscation has been achieved by:
+
+   * making effects of signals hard to trace
+   * implicit flushing by getchar()
+   * tricky cursor-parking
+   * minimizing code length
+   * hard coding include-file constants
+   * faking include-file structures
+   * throwing portability out of the window 
+
+For more on the 1989 IOCCC entry, see http://www.ioccc.org/1989/tromp.hint
+
+long h[4];t(){h[3]-=h[3]/3000;setitimer(0,h,0);}c,d,l,v[]={(int)t,0,2},w,s,I,K
+=0,i=276,j,k,q[276],Q[276],*n=q,*m,x=17,f[]={7,-13,-12,1,8,-11,-12,-1,9,-1,1,
+12,3,-13,-12,-1,12,-1,11,1,15,-1,13,1,18,-1,1,2,0,-12,-1,11,1,-12,1,13,10,-12,
+1,12,11,-12,-1,1,2,-12,-1,12,13,-12,12,13,14,-11,-1,1,4,-13,-12,12,16,-11,-12,
+12,17,-13,1,-1,5,-12,12,11,6,-12,12,24};u(){for(i=11;++i<264;)if((k=q[i])-Q[i]
+){Q[i]=k;if(i-++I||i%12<1)printf("\033[%d;%dH",(I=i)/12,i%12*2+28);printf(
+"\033[%dm  "+(K-k?0:5),k);K=k;}Q[263]=c=getchar();}G(b){for(i=4;i--;)if(q[i?b+
+n[i]:b])return 0;return 1;}g(b){for(i=4;i--;q[i?x+n[i]:x]=b);}main(C,V,a)char*
+*V,*a;{h[3]=1000000/(l=C>1?atoi(V[1]):2);for(a=C>2?V[2]:"jkl pq";i;i--)*n++=i<
+25||i%12<2?7:0;srand(getpid());system("stty cbreak -echo stop u");sigvec(14,v,
+0);t();puts("\033[H\033[J");for(n=f+rand()%7*4;;g(7),u(),g(0)){if(c<0){if(G(x+
+12))x+=12;else{g(7);++w;for(j=0;j<252;j=12*(j/12+1))for(;q[++j];)if(j%12==10){
+for(;j%12;q[j--]=0);u();for(;--j;q[j+12]=q[j]);u();}n=f+rand()%7*4;G(x=17)||(c
+=a[5]);}}if(c==*a)G(--x)||++x;if(c==a[1])n=f+4**(m=n),G(x)||(n=m);if(c==a[2])G
+(++x)||--x;if(c==a[3])for(;G(x+12);++w)x+=12;if(c==a[4]||c==a[5]){s=sigblock(
+8192);printf("\033[H\033[J\033[0m%d\n",w);if(c==a[5])break;for(j=264;j--;Q[j]=
+0);while(getchar()-a[4]);puts("\033[H\033[J\033[7m");sigsetmask(s);}}d=popen(
+"stty -cbreak echo stop \023;sort -mnr -o HI - HI;cat HI","w");fprintf(d,
+"%4d from level %1d by %s\n",w,l,getlogin());pclose(d);}
+
+                       -- John Tromp <tromp@cwi.nl>

--- a/examples/tetris/README-RIOT.md
+++ b/examples/tetris/README-RIOT.md
@@ -1,0 +1,18 @@
+# RIOT Tetris
+
+This is a quick and dirty port of micro tetris to RIOT.
+It has only been tested on samr21-xpro.
+
+You need a terminal which passes all key presses directly, without waiting for
+a full line.  I use picocom:
+
+    sudo picocom -b 115200 /dev/ttyACM3 --imap lfcrlf
+
+Have fun!
+
+Kaspar
+
+# known issues
+
+- the native uart somehow doesn't work
+- to turn off echo and break for native, try "stty cbreak -echo ; path-to/tetris.elf ; stty sane"

--- a/examples/tetris/TODO
+++ b/examples/tetris/TODO
@@ -1,0 +1,7 @@
+TODO
+====
+
+   * Make sure new stuff is optional in the build, to be able to keep it small.
+   * Clarify scoring/points/levels, see, e.g., http://tetris.wikia.com/wiki/Scoring
+   * Award more points for clearing multiple lines at the same time.
+

--- a/examples/tetris/conio.h
+++ b/examples/tetris/conio.h
@@ -1,0 +1,81 @@
+/* A conio.h like implementation for VTANSI displays.
+ *
+ * Copyright (c) 2009  Joachim Nilsson <troglobit@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef __CONIO_H__
+#define __CONIO_H__
+
+#include <stdio.h>
+
+/* Attributes */
+#define RESETATTR    0
+#define BRIGHT       1
+#define DIM          2
+#define UNDERSCORE   4
+#define BLINK        5           /* May not work on all displays. */
+#define REVERSE      7
+#define HIDDEN       8
+
+/* Colors for text and background */
+#define BLACK        0x0
+#define RED          0x1
+#define GREEN        0x2
+#define BROWN        0x3
+#define BLUE         0x4
+#define MAGENTA      0x5
+#define CYAN         0x6
+#define LIGHTGREY    0x7
+
+#define DARKGREY     0x10
+#define LIGHTRED     0x11
+#define LIGHTGREEN   0x12
+#define YELLOW       0x13
+#define LIGHTBLUE    0x14
+#define LIGHTMAGENTA 0x15
+#define LIGHTCYAN    0x16
+#define WHITE        0x17
+
+/* Esc[2JEsc[1;1H             - Clear screen and move cursor to 1,1 (upper left) pos. */
+#define clrscr()              puts ("\033[2J\033[1;1H")
+/* Esc[K                      - Erases from the current cursor position to the end of the current line. */
+#define clreol()              puts ("\033[K")
+/* Esc[2K                     - Erases the entire current line. */
+#define delline()             puts ("\033[2K")
+/* Esc[Line;ColumnH           - Moves the cursor to the specified position (coordinates) */
+#define gotoxy(x,y)           printf("\033[%d;%dH", y, x)
+/* Esc[?25l (lower case L)    - Hide Cursor */
+#define hidecursor()          puts ("\033[?25l")
+/* Esc[?25h (lower case H)    - Show Cursor */
+#define showcursor()          puts ("\033[?25h")
+
+/* Esc[Value;...;Valuem       - Set Graphics Mode */
+#define __set_gm(attr,color,val)                                        \
+        if (!color)                                                     \
+                printf("\033[%dm", attr);                                 \
+        else                                                            \
+                printf("\033[%d;%dm", color & 0x10 ? 1 : 0, (color & 0xF) + val)
+#define textattr(attr)        __set_gm(attr, 0, 0)
+#define textcolor(color)      __set_gm(RESETATTR, color, 30)
+#define textbackground(color) __set_gm(RESETATTR, color, 40)
+
+#endif /* __CONIO_H__ */
+
+/**
+ * Local Variables:
+ *  version-control: t
+ *  c-file-style: "ellemtel"
+ * End:
+ */

--- a/examples/tetris/tetris.c
+++ b/examples/tetris/tetris.c
@@ -1,0 +1,387 @@
+/* Micro Tetris, based on an obfuscated tetris, 1989 IOCCC Best Game
+ *
+ * Copyright (c) 1989  John Tromp <john.tromp@gmail.com>
+ * Copyright (c) 2009, 2010 Joachim Nilsson <troglobit@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * See the following URLs for more information, first John Tromp's page about
+ * the game http://homepages.cwi.nl/~tromp/tetris.html then there's the entry
+ * page at IOCCC http://www.ioccc.org/1989/tromp.hint
+ */
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "conio.h"
+#include "tetris.h"
+
+#include "thread_flags.h"
+#include "tsrb.h"
+#include "xtimer.h"
+#include "periph/uart.h"
+#include "uart_stdio.h"
+
+int _getchar(void);
+static thread_t *tetris_thread;
+
+#define      TL     -B_COLS - 1     /* top left */
+#define      TC     -B_COLS         /* top center */
+#define      TR     -B_COLS + 1     /* top right */
+#define      ML     -1              /* middle left */
+#define      MR     1               /* middle right */
+#define      BL     B_COLS - 1      /* bottom left */
+#define      BC     B_COLS          /* bottom center */
+#define      BR     B_COLS + 1      /* bottom right */
+
+/* These can be overridden by the user. */
+#define DEFAULT_KEYS "jkl pq"
+#define KEY_LEFT   0
+#define KEY_RIGHT  2
+#define KEY_ROTATE 1
+#define KEY_DROP   3
+#define KEY_PAUSE  4
+#define KEY_QUIT   5
+
+#define HIGH_SCORE_FILE "/var/games/tetris.scores"
+#define TEMP_SCORE_FILE "/tmp/tetris-tmp.scores"
+
+char *keys = DEFAULT_KEYS;
+int level = 1;
+int points = 0;
+int lines_cleared = 0;
+int board[B_SIZE], shadow[B_SIZE];
+
+int *peek_shape;                /* peek preview of next shape */
+int *shape;
+int shapes[] = {
+    7,  TL,  TC,  MR,
+    8,  TR,  TC,  ML,
+    9,  ML,  MR,  BC,
+    3,  TL,  TC,  ML,
+    12,  ML,  BL,  MR,
+    15,  ML,  BR,  MR,
+    18,  ML,  MR,   2,          /* sticks out */
+    0,  TC,  ML,  BL,
+    1,  TC,  MR,  BR,
+    10,  TC,  MR,  BC,
+    11,  TC,  ML,  MR,
+    2,  TC,  ML,  BC,
+    13,  TC,  BC,  BR,
+    14,  TR,  ML,  MR,
+    4,  TL,  TC,  BC,
+    16,  TR,  TC,  BC,
+    17,  TL,  MR,  ML,
+    5,  TC,  BC,  BL,
+    6,  TC,  BC,  2 * B_COLS,   /* sticks out */
+};
+
+static void timer(void *arg);
+static xtimer_t xtimer = { .callback = timer };
+
+static void timer(void *arg)
+{
+    (void)arg;
+    uint32_t interval = 500000;
+
+    interval -= interval / (3000 - 10 * level);
+    xtimer_set(&xtimer, interval);
+    thread_flags_set(tetris_thread, 0x2);
+}
+
+int update(void)
+{
+    int x, y;
+
+#ifdef ENABLE_PREVIEW
+    const int start = 5;
+    int preview[B_COLS * 10];
+    int shadow_preview[B_COLS * 10];
+
+    /* Display piece preview. */
+    memset(preview, 0, sizeof(preview));
+    preview[2 * B_COLS + 1] = 7;
+    preview[2 * B_COLS + 1 + peek_shape[1]] = 7;
+    preview[2 * B_COLS + 1 + peek_shape[2]] = 7;
+    preview[2 * B_COLS + 1 + peek_shape[3]] = 7;
+
+    for (y = 0; y < 4; y++) {
+        for (x = 0; x < B_COLS; x++) {
+            if (preview[y * B_COLS + x] - shadow_preview[y * B_COLS + x]) {
+                shadow_preview[y * B_COLS + x] = preview[y * B_COLS + x];
+                gotoxy(x * 2 + 26 + 28, start + y);
+                printf("\033[%dm  ", preview[y * B_COLS + x]);
+            }
+        }
+    }
+#endif
+
+    /* Display board. */
+    for (y = 1; y < B_ROWS - 1; y++) {
+        for (x = 0; x < B_COLS; x++) {
+            if (board[y * B_COLS + x] - shadow[y * B_COLS + x]) {
+                shadow[y * B_COLS + x] = board[y * B_COLS + x];
+                gotoxy(x * 2 + 28, y);
+                printf("\033[%dm  ", board[y * B_COLS + x]);
+            }
+        }
+    }
+
+    /* Update points and level*/
+    while (lines_cleared >= 10) {
+        lines_cleared -= 10;
+        level++;
+    }
+
+#ifdef ENABLE_SCORE
+    /* Display current level and points */
+    textattr(RESETATTR);
+    gotoxy(26 + 28, 2);
+    printf("Level  : %d", level);
+    gotoxy(26 + 28, 3);
+    printf("Points : %d", points);
+#endif
+#ifdef ENABLE_PREVIEW
+    gotoxy(26 + 28, 5);
+    printf("Preview:");
+#endif
+    gotoxy(26 + 28, 10);
+    printf("Keys:");
+
+    fflush(stdout);
+
+    return _getchar();
+}
+
+int fits_in(int *shape, int pos)
+{
+    if (board[pos] || board[pos + shape[1]] ||
+        board[pos + shape[2]]  || board[pos + shape[3]]) {
+        return 0;
+    }
+
+    return 1;
+}
+
+void place(int *shape, int pos, int b)
+{
+    board[pos] = b;
+    board[pos + shape[1]] = b;
+    board[pos + shape[2]] = b;
+    board[pos + shape[3]] = b;
+}
+
+int *next_shape(void)
+{
+    int *next = peek_shape;
+
+    peek_shape = &shapes[rand() % 7 * 4];
+    if (!next) {
+        return next_shape();
+    }
+
+    return next;
+}
+
+void show_high_score(void)
+{
+#ifdef ENABLE_HIGH_SCORE
+    FILE *tmpscore;
+
+    if ((tmpscore = fopen(HIGH_SCORE_FILE, "a"))) {
+        char *name = getenv("LOGNAME");
+
+        if (!name) {
+            name = "anonymous";
+        }
+
+        fprintf(tmpscore, "%7d\t %5d\t  %3d\t%s\n", points * level, points, level, name);
+        fclose(tmpscore);
+
+        system("cat " HIGH_SCORE_FILE "| sort -rn | head -10 >" TEMP_SCORE_FILE
+               "&& cp " TEMP_SCORE_FILE " " HIGH_SCORE_FILE);
+        remove(TEMP_SCORE_FILE);
+    }
+// puts ("\nHit RETURN to see high scores, ^C to skip.");
+    fprintf(stderr, "  Score\tPoints\tLevel\tName\n");
+    system("cat " HIGH_SCORE_FILE);
+#endif /* ENABLE_HIGH_SCORE */
+}
+
+void show_online_help(void)
+{
+    const int start = 11;
+
+    textattr(RESETATTR);
+    gotoxy(26 + 28, start);
+    puts("j     - left");
+    gotoxy(26 + 28, start + 1);
+    puts("k     - rotate");
+    gotoxy(26 + 28, start + 2);
+    puts("l     - right");
+    gotoxy(26 + 28, start + 3);
+    puts("space - drop");
+    gotoxy(26 + 28, start + 4);
+    puts("p     - pause");
+    gotoxy(26 + 28, start + 5);
+    puts("q     - quit");
+}
+
+/* Code stolen from http://c-faq.com/osdep/cbreak.html */
+void tty_break(void)
+{
+    hidecursor();
+}
+
+void tty_fix(void)
+{
+    showcursor();
+}
+
+static char _rx_buf_mem[UART_STDIO_RX_BUFSIZE];
+static tsrb_t _rx_buf = TSRB_INIT(_rx_buf_mem);
+
+/**
+ * @brief Receive a new character from the UART and put it into the receive buffer
+ */
+static void _uart_stdio_rx_cb(void *arg, uint8_t data)
+{
+    (void)arg;
+    tsrb_add_one(&_rx_buf, (uint8_t)data);
+    thread_flags_set(tetris_thread, 0x1);
+}
+
+int _getchar(void)
+{
+    if (!tsrb_avail(&_rx_buf)) {
+        thread_flags_wait_any(0x3);
+    }
+    return tsrb_get_one(&_rx_buf);
+}
+
+int main(void)
+{
+    int c = 0, i, j, *ptr;
+    int pos = 17;
+    int *backup;
+
+    /* Initialize board */
+    ptr = board;
+    for (i = B_SIZE; i; i--) {
+        *ptr++ = i < 25 || i % B_COLS < 2 ? 7 : 0;
+    }
+
+    srand(xtimer_now());
+
+    tetris_thread = (thread_t *)sched_active_thread;
+
+    /* set up uart */
+    uart_init(UART_STDIO_DEV, UART_STDIO_BAUDRATE, _uart_stdio_rx_cb, NULL);
+
+    /* set up terminal */
+    tty_break();
+
+    timer(NULL);
+
+    clrscr();
+    show_online_help();
+
+    shape = next_shape();
+    while (1) {
+        if (c < 0) {
+            if (fits_in(shape, pos + B_COLS)) {
+                pos += B_COLS;
+            }
+            else {
+                place(shape, pos, 7);
+                ++points;
+                for (j = 0; j < 252; j = B_COLS * (j / B_COLS + 1)) {
+                    for (; board[++j]; ) {
+                        if (j % B_COLS == 10) {
+                            lines_cleared++;
+
+                            for (; j % B_COLS; board[j--] = 0) ;
+                            c = update();
+                            for (; --j; board[j + B_COLS] = board[j]) ;
+                            c = update();
+                        }
+                    }
+                }
+                shape = next_shape();
+                if (!fits_in(shape, pos = 17)) {
+                    c = keys[KEY_QUIT];
+                }
+            }
+        }
+        if (c == keys[KEY_LEFT]) {
+            if (!fits_in(shape, --pos)) {
+                ++pos;
+            }
+        }
+        if (c == keys[KEY_ROTATE]) {
+            backup = shape;
+            shape = &shapes[4 * *shape]; /* Rotate */
+            /* Check if it fits, if not restore shape from backup */
+            if (!fits_in(shape, pos)) {
+                shape = backup;
+            }
+        }
+
+        if (c == keys[KEY_RIGHT]) {
+            if (!fits_in(shape, ++pos)) {
+                --pos;
+            }
+        }
+        if (c == keys[KEY_DROP]) {
+            for (; fits_in(shape, pos + B_COLS); ++points) {
+                pos += B_COLS;
+            }
+        }
+        if (c == keys[KEY_PAUSE] || c == keys[KEY_QUIT]) {
+            // stop timer
+
+            if (c == keys[KEY_QUIT]) {
+                clrscr();
+                gotoxy(0, 0);
+                textattr(RESETATTR);
+
+                printf("Your score: %d points x level %d = %d\n\n", points, level, points * level);
+                show_high_score();
+                break;
+            }
+
+            for (j = B_SIZE; j--; shadow[j] = 0) ;
+
+            while (_getchar() - keys[KEY_PAUSE]) ;
+
+            // restart timer
+        }
+
+        place(shape, pos, 7);
+        c = update();
+        place(shape, pos, 0);
+    }
+
+    tty_fix();
+
+    return 0;
+}
+
+/**
+ * Local Variables:
+ *  version-control: t
+ *  c-file-style: "ellemtel"
+ * End:
+ */

--- a/examples/tetris/tetris.h
+++ b/examples/tetris/tetris.h
@@ -1,0 +1,34 @@
+/* Micro Tetris, based on an obfuscated tetris, 1989 IOCCC Best Game
+ *
+ * Copyright (c) 1989, John Tromp <john.tromp@gmail.com>
+ * Copyright (c) 2009, Joachim Nilsson <troglobit@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef __TETRIS_H__
+#define __TETRIS_H__
+
+        /* the board */
+#define      B_COLS 12
+#define      B_ROWS 23
+#define      B_SIZE (B_ROWS * B_COLS)
+
+#endif  /* __TETRIS_H__ */
+
+/**
+ * Local Variables:
+ *  version-control: t
+ *  c-file-style: "ellemtel"
+ * End:
+ */


### PR DESCRIPTION
This is a quick and dirty port of micro tetris to RIOT.
It has only been tested on samr21-xpro.

You need a terminal which passes all key presses directly, without waiting for
a full line.  I use picocom:

```
sudo picocom -b 115200 /dev/ttyACM3 --imap lfcrlf
```

Have fun!
