### PR TITLE
docker: allow make unittest goals to pass on to container

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -7,6 +7,7 @@ export DOCKER_MAKECMDGOALS_POSSIBLE = \
   buildtest \
   scan-build \
   scan-build-analyze \
+  tests-% \
   #
 export DOCKER_MAKECMDGOALS = $(filter $(DOCKER_MAKECMDGOALS_POSSIBLE),$(MAKECMDGOALS))
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -8,7 +8,7 @@ export DOCKER_MAKECMDGOALS_POSSIBLE = \
   scan-build \
   scan-build-analyze \
   #
-export DOCKER_MAKECMDGOALS = $(filter $(MAKECMDGOALS),$(DOCKER_MAKECMDGOALS_POSSIBLE))
+export DOCKER_MAKECMDGOALS = $(filter $(DOCKER_MAKECMDGOALS_POSSIBLE),$(MAKECMDGOALS))
 
 # Docker creates the files .dockerinit and .dockerenv in the root directory of
 # the container, we check for the files to determine if we are inside a container.


### PR DESCRIPTION
Otherwise `make tests-(anything) BUILD_IN_DOCKER=1` builds all tests instead of only the selected groups.