### PR TITLE
net/gnrc,auto_init: Add prerequisites for NDN-RIOT module

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -557,3 +557,16 @@ ifneq (,$(filter random,$(USEMODULE)))
         USEMODULE += tinymt32
     endif
 endif
+
+ifneq (,$(filter ndn-riot,$(USEMODULE)))
+    USEMODULE += ndn-encoding
+    USEMODULE += gnrc
+    USEMODULE += xtimer
+endif
+
+ifneq (,$(filter ndn-encoding,$(USEMODULE)))
+    USEMODULE += gnrc_pktbuf
+    USEMODULE += random
+    USEMODULE += hashes
+    USEPKG += micro-ecc
+endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -92,6 +92,10 @@
 #include "random.h"
 #endif
 
+#ifdef MODULE_NDN_RIOT
+#include "ndn-riot/ndn.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -234,6 +238,12 @@ void auto_init(void)
 #ifdef MODULE_GNRC_UHCPC
     extern void auto_init_gnrc_uhcpc(void);
     auto_init_gnrc_uhcpc();
+#endif
+
+/* initialize NDN module after the network devices are initialized */
+#ifdef MODULE_NDN_RIOT
+    DEBUG("Auto init NDN module.\n");
+    ndn_init();
 #endif
 
 /* initialize sensors and actuators */

--- a/sys/include/net/ethertype.h
+++ b/sys/include/net/ethertype.h
@@ -34,7 +34,8 @@ extern "C" {
 #define ETHERTYPE_RESERVED      (0x0000)    /**< Reserved */
 #define ETHERTYPE_IPV4          (0x0800)    /**< Internet protocol version 4 */
 #define ETHERTYPE_ARP           (0x0806)    /**< Address resolution protocol */
-#define ETHERTYPE_NDN           (0x0801)    /**< Parc CCNX */
+#define ETHERTYPE_CCNX          (0x0801)    /**< Parc CCNX */
+#define ETHERTYPE_NDN           (0x8624)    /**< NDN Protocol (http://named-data.net/) */
 #define ETHERTYPE_IPV6          (0x86dd)    /**< Internet protocol version 6 */
 #define ETHERTYPE_UNKNOWN       (0xffff)    /**< Reserved (no protocol specified) */
 

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -93,6 +93,10 @@ typedef enum {
                                      chunk */
 #endif
 
+#ifdef MODULE_NDN_RIOT
+    GNRC_NETTYPE_NDN,           /**< Protocol is NDN */
+#endif
+
     /**
      * @{
      * @name Testing
@@ -126,8 +130,12 @@ static inline gnrc_nettype_t gnrc_nettype_from_ethertype(uint16_t type)
             return GNRC_NETTYPE_IPV6;
 #endif
 #ifdef MODULE_CCN_LITE
-        case ETHERTYPE_NDN:
+        case ETHERTYPE_CCNX:
             return GNRC_NETTYPE_CCN;
+#endif
+#ifdef MODULE_NDN_RIOT
+        case ETHERTYPE_NDN:
+            return GNRC_NETTYPE_NDN;
 #endif
         default:
             return GNRC_NETTYPE_UNDEF;
@@ -154,6 +162,10 @@ static inline uint16_t gnrc_nettype_to_ethertype(gnrc_nettype_t type)
 #endif
 #ifdef MODULE_CCN_LITE
         case GNRC_NETTYPE_CCN:
+            return ETHERTYPE_CCNX;
+#endif
+#ifdef MODULE_NDN_RIOT
+        case GNRC_NETTYPE_NDN:
             return ETHERTYPE_NDN;
 #endif
         default:

--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -84,6 +84,12 @@ static void _dump_snip(gnrc_pktsnip_t *pkt)
             udp_hdr_print(pkt->data);
             break;
 #endif
+#ifdef MODULE_NDN
+    case GNRC_NETTYPE_NDN:
+            printf("NETTYPE_NDN (%i)\n", pkt->type);
+            od_hex_dump(pkt->data, pkt->size, OD_WIDTH_DEFAULT);
+        break;
+#endif
 #ifdef TEST_SUITES
         case GNRC_NETTYPE_TEST:
             printf("NETTYPE_TEST (%i)\n", pkt->type);


### PR DESCRIPTION
Necessary hooks to enable [NDN-RIOT module](https://github.com/named-data-iot/ndn-riot)
