### PR TITLE
cpu/cc2538: Remove union names from structs

### DIFF
--- a/cpu/cc2538/include/cc2538_rfcore.h
+++ b/cpu/cc2538/include/cc2538_rfcore.h
@@ -136,7 +136,7 @@ typedef struct {
             cc2538_reg_t RSSI_VALID :  1; /**< RSSI value is valid */
             cc2538_reg_t RESERVED   : 31; /**< Reserved bits */
         } XREG_RSSISTATbits;
-    } cc2538_rfcore_xreg_rssistat;
+    };
 
     cc2538_reg_t XREG_RXFIRST;            /**< RF First byte in RX FIFO */
     cc2538_reg_t XREG_RXFIFOCNT;          /**< RF Number of bytes in RX FIFO */
@@ -162,7 +162,7 @@ typedef struct {
             cc2538_reg_t QRND       :  1; /**< Random bit from the Q channel of the receiver */
             cc2538_reg_t RESERVED   : 30; /**< Reserved bits */
         } XREG_RFRNDbits;
-    } cc2538_rfcore_xreg_rfrnd;
+    };
 
     cc2538_reg_t XREG_MDMCTRL0;           /**< RF Controls modem */
     cc2538_reg_t XREG_MDMCTRL1;           /**< RF Controls modem */

--- a/cpu/cc2538/periph/hwrng.c
+++ b/cpu/cc2538/periph/hwrng.c
@@ -48,7 +48,7 @@ void hwrng_init(void)
      * have died out. A convenient way to do this is to wait for the RSSI-valid
      * signal to go high."
      */
-    while (!RFCORE->cc2538_rfcore_xreg_rssistat.XREG_RSSISTATbits.RSSI_VALID);
+    while (!RFCORE->XREG_RSSISTATbits.RSSI_VALID);
 
     /*
      * Form the seed by concatenating bits from IF_ADC in the RF receive path.
@@ -58,7 +58,7 @@ void hwrng_init(void)
      */
     for (i = 0; (i < 8) || (seed == 0) || (seed == 0x8003); i++) {
         seed <<= 2;
-        seed ^= RFCORE->cc2538_rfcore_xreg_rfrnd.XREG_RFRND;
+        seed ^= RFCORE->XREG_RFRND;
     }
 
     /* Seed the high byte first: */

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -65,13 +65,13 @@ bool cc2538_channel_clear(void)
     if (RFCORE->XREG_FSMSTAT0bits.FSM_FFCTRL_STATE == FSM_STATE_IDLE) {
         bool result;
         cc2538_on();
-        RFCORE_WAIT_UNTIL(RFCORE->cc2538_rfcore_xreg_rssistat.XREG_RSSISTATbits.RSSI_VALID);
+        RFCORE_WAIT_UNTIL(RFCORE->XREG_RSSISTATbits.RSSI_VALID);
         result = BOOLEAN(RFCORE->XREG_FSMSTAT1bits.CCA);
         cc2538_off();
         return result;
     }
     else {
-        RFCORE_WAIT_UNTIL(RFCORE->cc2538_rfcore_xreg_rssistat.XREG_RSSISTATbits.RSSI_VALID);
+        RFCORE_WAIT_UNTIL(RFCORE->XREG_RSSISTATbits.RSSI_VALID);
         return BOOLEAN(RFCORE->XREG_FSMSTAT1bits.CCA);
     }
 }


### PR DESCRIPTION
Make the unions anonymous, since this makes referencing their bytes much simpler.