### PR TITLE
core/kernel_macros: Fix typo/coding convention in Doxygen for container_of macro

### DIFF
--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -31,8 +31,8 @@
  * @details     For a struct `TYPE` with a member `MEMBER`,
  *              given a pointer `PTR` to `TYPE::MEMBER` this function returns a pointer
  *              to the instance of `TYPE`.
- * @details     E.g. for `struct my_struct_t { ...; something_t n; ... } my_struct;`,
- *              `&my_struct == container_of(&my_struct.n, struct my_struct_t, n)`.
+ * @details     E.g. for `struct my_struct { ...; something_t n; ... } my_struct_t;`,
+ *              `&my_struct == container_of(&my_struct.n, my_struct_t, n)`.
  * @param[in]   PTR      pointer to a member
  * @param[in]   TYPE     a type name (a struct or union), container of PTR
  * @param[in]   MEMBER   name of the member of TYPE which PTR points to


### PR DESCRIPTION
Small typo in the Doxygen docs for the container_of macro declared a `struct my_struct_t` and typedefed it to `my_struct` (instead of the reverse which is what the rest of the RIOT code base does)