### PR TITLE
Adapt Si70xx temperature/humidity sensor for SAUL

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -111,6 +111,11 @@ ifneq (,$(filter sht11,$(USEMODULE)))
     USEMODULE += xtimer
 endif
 
+ifneq (,$(filter si70xx,$(USEMODULE)))
+    USEMODULE += xtimer
+    FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter srf02,$(USEMODULE)))
   USEMODULE += xtimer
 endif

--- a/drivers/include/si70xx.h
+++ b/drivers/include/si70xx.h
@@ -21,8 +21,6 @@
 #ifndef SI70XX_H_
 #define SI70XX_H_
 
-#include <stdint.h>
-
 #include "periph/i2c.h"
 
 #ifdef __cplusplus
@@ -39,7 +37,7 @@ extern "C" {
 #define SI70XX_ADDRESS_SI7021       (0x80)
 
 /**
- * @name Si70xx device commands
+ * @name Si70xx device commands.
  * @{
  */
 #define SI70XX_MEASURE_RH_HOLD      (0xE5)
@@ -61,7 +59,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name Si70xx register values
+ * @name Si70xx register values.
  * @{
  */
 #define SI70XX_ID_SI7006            (0x06)
@@ -74,12 +72,20 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Si70xx device descriptor
+ * @brief Si70xx device descriptor.
  */
 typedef struct {
     i2c_t i2c_dev;              /**< I2C bus the sensors is connected to */
     uint8_t address;            /**< sensor address */
 } si70xx_t;
+
+/**
+ * @brief Device initialization parameters.
+ */
+typedef struct {
+    i2c_t i2c_dev;              /**< I2C bus the sensor is connected to */
+    uint8_t address;            /**< sensor address */
+} si70xx_params_t;
 
 /**
  * @brief   Test if the device id and revision number are as expected.

--- a/drivers/si70xx/si70xx.c
+++ b/drivers/si70xx/si70xx.c
@@ -19,12 +19,12 @@
  */
 
 
-#include "si70xx.h"
-
 #include "xtimer.h"
 
+#include "si70xx.h"
+
 /**
- * @brief       Utility method to perform and reconstruct a measurement.
+ * @brief   Utility method to perform and reconstruct a measurement.
  */
 static uint32_t si70xx_measure(si70xx_t *dev, uint8_t command)
 {

--- a/drivers/si70xx/si70xx_saul.c
+++ b/drivers/si70xx/si70xx_saul.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_si70xx
+ * @{
+ *
+ * @file
+ * @brief       SAUL adoption for Si7006/13/20/21 sensor.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include "saul.h"
+
+#include "si70xx.h"
+
+static int read_temperature(void *dev, phydat_t *res)
+{
+    si70xx_t *d = (si70xx_t *)dev;
+
+    res->val[0] = (int32_t) si70xx_get_temperature(d);
+    res->unit = UNIT_TEMP_C;
+    res->scale = -2;
+
+    return 1;
+}
+
+static int read_relative_humidity(void *dev, phydat_t *res)
+{
+    si70xx_t *d = (si70xx_t *)dev;
+
+    res->val[0] = (int32_t) si70xx_get_relative_humidity(d);
+    res->unit = UNIT_PERCENT;
+    res->scale = -2;
+
+    return 1;
+}
+
+const saul_driver_t si70xx_temperature_saul_driver = {
+    .read = read_temperature,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TEMP
+};
+
+const saul_driver_t si70xx_relative_humidity_saul_driver = {
+    .read = read_relative_humidity,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_HUM
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -277,6 +277,10 @@ void auto_init(void)
     extern void auto_init_mma8652(void);
     auto_init_mma8652();
 #endif
+#ifdef MODULE_SI70XX
+    extern void auto_init_si70xx(void);
+    auto_init_si70xx();
+#endif
 
 #endif /* MODULE_AUTO_INIT_SAUL */
 

--- a/sys/auto_init/saul/auto_init_si70xx.c
+++ b/sys/auto_init/saul/auto_init_si70xx.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of Si70xx driver.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#ifdef MODULE_SI70XX
+
+#include "log.h"
+#include "saul_reg.h"
+
+#include "si70xx_params.h"
+#include "si70xx.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define SI70XX_NUMOF    (sizeof(si70xx_params) / sizeof(si70xx_params[0]))
+
+/**
+ * @brief   Allocation of memory for device descriptors
+ */
+static si70xx_t si70xx_devs[SI70XX_NUMOF];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[SI70XX_NUMOF * 2];
+
+/**
+ * @brief   Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t si70xx_temperature_saul_driver;
+extern const saul_driver_t si70xx_relative_humidity_saul_driver;
+/** @} */
+
+void auto_init_si70xx(void)
+{
+    for (int i = 0; i < SI70XX_NUMOF; i++) {
+        int res = si70xx_init(&si70xx_devs[i],
+                              si70xx_params[i].i2c_dev,
+                              si70xx_params[i].address);
+        if (res < 0) {
+            LOG_ERROR("Unable to initialize BMP180 sensor #%i\n", i);
+        }
+        else {
+            /* temperature */
+            saul_entries[i * 2].dev = &si70xx_devs[i];
+            saul_entries[i * 2].name = si70xx_saul_reg_info[i].name;
+            saul_entries[i * 2].driver = &si70xx_temperature_saul_driver;
+
+            /* relative humidity */
+            saul_entries[(i * 2) + 1].dev = &si70xx_devs[i];
+            saul_entries[(i * 2) + 1].name = si70xx_saul_reg_info[i +1].name;
+            saul_entries[(i * 2) + 1].driver = \
+                &si70xx_relative_humidity_saul_driver;
+
+            saul_reg_add(&saul_entries[i * 2]);
+            saul_reg_add(&saul_entries[(i * 2) + 1]);
+        }
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_SI70XX */

--- a/tests/driver_si70xx/Makefile
+++ b/tests/driver_si70xx/Makefile
@@ -1,9 +1,6 @@
 APPLICATION = driver_si70xx
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED += periph_gpio
-FEATURES_REQUIRED += periph_i2c
-
 USEMODULE += si70xx
 USEMODULE += xtimer
 


### PR DESCRIPTION
This PR adds SAUL support for the Si70xx driver. I have based it on the BMP180 driver, but I moved the parameters to the board's includes. It's my first SAUL/auto-init adaption.

Using `examples/default`, one may observe the following:

```
> saul
ID	Class		Name
#0	SENSE_TEMP	si70xx-temp
#1	SENSE_HUM	si70xx-rh
>
> saul read 0
Reading from #0 (si70xx-temp|SENSE_TEMP)
Data:	[0] 27.81°C
>
> saul read 1
Reading from #1 (si70xx-rh|SENSE_HUM)
Data:	[0] 44.94%
>
> saul
ID	Class		Name
#0	SENSE_TEMP	si70xx-temp
#1	SENSE_HUM	si70xx-rh
```

(Yes, it is still too damn hot in The Netherlands)