### PR TITLE
drivers/bmp180: add dependency to periph_i2c

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -22,6 +22,10 @@ ifneq (,$(filter bh1750fvi,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter bmp180,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter cc110x,$(USEMODULE)))
   USEMODULE += ieee802154
   ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))

--- a/tests/driver_bmp180/Makefile
+++ b/tests/driver_bmp180/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = driver_bmp180
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += bmp180
 USEMODULE += xtimer
 USEMODULE += printf_float


### PR DESCRIPTION
Not sure if it's really required. As removing
`FEATURES_REQUIRED += periph_i2c` in the test Makefile still works, even without the directives added in `drivers/Makefile.dep`
ping @basilfx 