### PR TITLE
gnrc: provide my master thesis in documentation

### DIFF
--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -10,6 +10,9 @@
  * @defgroup    net_gnrc    Generic (GNRC) network stack
  * @ingroup     net
  * @brief       RIOT's modular default IP network stack.
+ * @see         [Martine Lenders' master thesis](http://doc.riot-os.org/mlenders_msc.pdf)
+ *              about GNRC's design and evaluation and the slide set of
+ *              [its defense](http://doc.riot-os.org/mlenders_msc_def.pdf).
  *
  * About
  * =====


### PR DESCRIPTION
A request by @adjih reminded me to finally add my master thesis to the doc.

Issue/TODO: Doxygen somehow doesn't pick up the PDFs from the `src/` directory, so the browser in the compiled doc is issuing a 404. Do we have some external server were we could store that? I'm not sure my FU user source is such a stable place for that.

I know I'm late to the game, but maybe @kYc0o can be so nice to still add this to the current release.