### PR TITLE
make: allow "pseudo-packages"

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -236,7 +236,6 @@ endif
 
 # the binaries to link
 BASELIBS += $(BINDIR)${APPLICATION}.a
-BASELIBS += $(USEPKG:%=${BINDIR}%.a)
 BASELIBS += $(APPDEPS)
 
 .PHONY: all clean flash term doc debug debug-server reset objdump help info-modules

--- a/Makefile.modules
+++ b/Makefile.modules
@@ -3,7 +3,7 @@ USEMODULE := $(filter-out $(filter-out $(FEATURES_PROVIDED), $(FEATURES_OPTIONAL
 ED = $(addprefix FEATURE_,$(sort $(filter $(FEATURES_PROVIDED), $(FEATURES_REQUIRED))))
 ED += $(addprefix MODULE_,$(sort $(USEMODULE) $(USEPKG)))
 EXTDEFINES = $(addprefix -D,$(shell echo '$(ED)' | tr 'a-z-' 'A-Z_'))
-REALMODULES = $(filter-out $(PSEUDOMODULES), $(sort $(USEMODULE)))
+REALMODULES = $(filter-out $(PSEUDOMODULES), $(sort $(USEMODULE) $(USEPKG)))
 export BASELIBS += $(REALMODULES:%=$(BINDIR)%.a)
 
 CFLAGS += $(EXTDEFINES)

--- a/tests/pkg_micro-ecc/Makefile
+++ b/tests/pkg_micro-ecc/Makefile
@@ -1,4 +1,4 @@
-APPLICATION = micro-ecc
+APPLICATION = pkg_micro-ecc
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_hwrng


### PR DESCRIPTION
Currently, it is not possible to have a package which does not actually compile an archive.

This PR applies the same PSEUDOMODULE filter to package-"modules". See #5670 for use-case.

(piggybacked a fix for pkg_micro-ecc which I stumpled upon while testing.)