### PR TITLE
core: clist: clist_lpeek(): add missing return statement

### DIFF
--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -197,6 +197,7 @@ static inline clist_node_t *clist_lpeek(const clist_node_t *list)
     if (list->next) {
         return list->next->next;
     }
+    return NULL;
 }
 
 /**


### PR DESCRIPTION
Missing return statement spotted by Bas: https://github.com/RIOT-OS/RIOT/pull/5629#issuecomment-234069922