### PR TITLE
dist/tools/tunslip: Fix some ugly code

### DIFF
--- a/dist/tools/tunslip/Makefile
+++ b/dist/tools/tunslip/Makefile
@@ -12,4 +12,4 @@ uninstall:
 clean:
 	rm -f $(BIN)
 
-CFLAGS += -Wall -Wextra -pedantic
+CFLAGS += -Wall -Wextra -pedantic -std=c99

--- a/dist/tools/tunslip/Makefile
+++ b/dist/tools/tunslip/Makefile
@@ -9,4 +9,7 @@ install:
 uninstall:
 	rm -f $(foreach bin,$(BIN),$(PREFIX)/bin/$(bin))
 
+clean:
+	rm -f $(BIN)
+
 CFLAGS += -Wall -Wextra -pedantic

--- a/dist/tools/tunslip/Makefile
+++ b/dist/tools/tunslip/Makefile
@@ -8,3 +8,5 @@ install:
 
 uninstall:
 	rm -f $(foreach bin,$(BIN),$(PREFIX)/bin/$(bin))
+
+CFLAGS += -Wall -Wextra -pedantic

--- a/dist/tools/tunslip/tapslip6.c
+++ b/dist/tools/tunslip/tapslip6.c
@@ -32,6 +32,10 @@
  *
  */
 
+/* for cfmakeraw on Linux */
+#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -141,7 +145,7 @@ serial_to_tun(FILE *inslip, int outfd)
     int ret;
     unsigned char c;
 
-#ifdef linux
+#ifdef __linux__
     ret = fread(&c, 1, 1, inslip);
 
     if (ret == -1 || ret == 0) {
@@ -158,7 +162,7 @@ read_more:
     }
 
     ret = fread(&c, 1, 1, inslip);
-#ifdef linux
+#ifdef __linux__
 after_fread:
 #endif
 
@@ -422,7 +426,7 @@ devopen(const char *dev, int flags)
     return open(t, flags);
 }
 
-#ifdef linux
+#ifdef __linux__
 #include <linux/if.h>
 #include <linux/if_tun.h>
 
@@ -472,7 +476,7 @@ void
 cleanup(void)
 {
     ssystem("ifconfig %s down", tundev);
-#ifndef linux
+#ifndef __linux__
     ssystem("sysctl -w net.ipv6.conf.all.forwarding=1");
 #endif
     /* ssystem("arp -d %s", ipaddr); */
@@ -502,7 +506,7 @@ sigalarm(int signo)
 void
 sigalarm_reset()
 {
-#ifdef linux
+#ifdef __linux__
 #define TIMEOUT (997*1000)
 #else
 #define TIMEOUT (2451*1000)
@@ -517,7 +521,7 @@ ifconf(const char *tundev, const char *ipaddr, const char *netmask)
     struct in_addr netname;
     netname.s_addr = inet_addr(ipaddr) & inet_addr(netmask);
 
-#ifdef linux
+#ifdef __linux__
     ssystem("ifconfig %s inet `hostname` up", tundev);
 
     if (strcmp(ipaddr, "0.0.0.0") != 0) {

--- a/dist/tools/tunslip/tunslip.c
+++ b/dist/tools/tunslip/tunslip.c
@@ -31,6 +31,10 @@
  *
  */
 
+/* for cfmakeraw on Linux */
+#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -504,7 +508,7 @@ serial_to_tun(FILE *inslip, int outfd)
     int ret;
     unsigned char c;
 
-#ifdef linux
+#ifdef __linux__
     ret = fread(&c, 1, 1, inslip);
 
     if (ret == -1 || ret == 0) {
@@ -521,7 +525,7 @@ read_more:
     }
 
     ret = fread(&c, 1, 1, inslip);
-#ifdef linux
+#ifdef __linux__
 after_fread:
 #endif
 
@@ -558,7 +562,7 @@ after_fread:
 
                     /* New address. */
                     if (ipa.s_addr != 0) {
-#ifdef linux
+#ifdef __linux__
                         ssystem("route delete -net %s netmask %s dev %s",
                                 inet_ntoa(ipa), "255.255.255.255", tundev);
 #else
@@ -570,7 +574,7 @@ after_fread:
                     memcpy(&ipa, &uip.inbuf[4], sizeof(ipa));
 
                     if (ipa.s_addr != 0) {
-#ifdef linux
+#ifdef __linux__
                         ssystem("route add -net %s netmask %s dev %s",
                                 inet_ntoa(ipa), "255.255.255.255", tundev);
 #else
@@ -849,7 +853,7 @@ devopen(const char *dev, int flags)
     return open(t, flags);
 }
 
-#ifdef linux
+#ifdef __linux__
 #include <linux/if.h>
 #include <linux/if_tun.h>
 
@@ -899,7 +903,7 @@ void
 cleanup(void)
 {
     ssystem("ifconfig %s down", tundev);
-#ifndef linux
+#ifndef __linux__
     ssystem("sysctl -w net.inet.ip.forwarding=0");
 #endif
     /* ssystem("arp -d %s", ipaddr); */
@@ -928,7 +932,7 @@ sigalarm(int signo)
 void
 sigalarm_reset()
 {
-#ifdef linux
+#ifdef __linux__
 #define TIMEOUT (997*1000)
 #else
 #define TIMEOUT (2451*1000)
@@ -943,7 +947,7 @@ ifconf(const char *tundev, const char *ipaddr, const char *netmask)
     struct in_addr netname;
     netname.s_addr = inet_addr(ipaddr) & inet_addr(netmask);
 
-#ifdef linux
+#ifdef __linux__
     ssystem("ifconfig %s inet `hostname` up", tundev);
 
     if (strcmp(ipaddr, "0.0.0.0") != 0) {
@@ -1085,7 +1089,7 @@ main(int argc, char **argv)
             err(1, "illegal dhcp-server address");
         }
 
-#ifndef linux
+#ifndef __linux__
         dhaddr.sin_len = sizeof(dhaddr);
 #endif
         dhaddr.sin_family = AF_INET;
@@ -1099,7 +1103,7 @@ main(int argc, char **argv)
         }
 
         memset(&myaddr, 0x0, sizeof(myaddr));
-#ifndef linux
+#ifndef __linux__
         myaddr.sin_len = sizeof(myaddr);
 #endif
         myaddr.sin_family = AF_INET;

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -158,7 +158,7 @@ is_sensible_string(const unsigned char *s, size_t len)
 
     int ret = 0;
     for (size_t i = 0; i < len; i++) {
-        if (s[i] == 0 || s[i] == '\r' || s[i] == '\n' || s[i] == '\t') {
+        if (s[i] == '\r' || s[i] == '\n' || s[i] == '\t') {
             continue;
         }
         else if (s[i] < ' ' || '~' < s[i]) {

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -147,7 +147,7 @@ stamptime(void)
 }
 
 int
-is_sensible_string(const unsigned char *s, int len)
+is_sensible_string(const unsigned char *s, size_t len)
 {
     if(len > 0) {
         if (s[0] == 0x60) {
@@ -157,7 +157,7 @@ is_sensible_string(const unsigned char *s, int len)
     }
 
     int ret = 0;
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         if (s[i] == 0 || s[i] == '\r' || s[i] == '\n' || s[i] == '\t') {
             continue;
         }

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -149,18 +149,34 @@ stamptime(void)
 int
 is_sensible_string(const unsigned char *s, int len)
 {
-    int i;
+    if(len > 0) {
+        if (s[0] == 0x60) {
+            /* Possibly IPv6 packet with default traffic class, assume non-printable */
+            return 0;
+        }
+    }
 
-    for (i = 1; i < len; i++) {
+    int ret = 0;
+    for (int i = 1; i < len; i++) {
         if (s[i] == 0 || s[i] == '\r' || s[i] == '\n' || s[i] == '\t') {
             continue;
         }
         else if (s[i] < ' ' || '~' < s[i]) {
             return 0;
         }
+        /* only return 1 if the string contains at least one letter or number */
+        if('A' <= s[i] && s[i] <= 'Z') {
+            ret = 1;
+        }
+        else if('a' <= s[i] && s[i] <= 'z') {
+            ret = 1;
+        }
+        else if('0' <= s[i] && s[i] <= '9') {
+            ret = 1;
+        }
     }
 
-    return 1;
+    return ret;
 }
 
 /*

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -157,7 +157,7 @@ is_sensible_string(const unsigned char *s, int len)
     }
 
     int ret = 0;
-    for (int i = 1; i < len; i++) {
+    for (int i = 0; i < len; i++) {
         if (s[i] == 0 || s[i] == '\r' || s[i] == '\n' || s[i] == '\t') {
             continue;
         }


### PR DESCRIPTION
The tunslip programs were imported from Contiki, and they are probably among the ugliest pieces of code in both Contiki and RIOT. This PR fixes some apparent issues in tunslip6 and makes the warnings visible for tapslip6  and tunslip, to let the user know that it is ugly code.

Added a workaround for a bug where an IPv6 header containing `'\n'` (0x0a) was mistaken for a printable string. <- This was the reason I ventured into this dark corner of the Contiki repo originally.

Also added a `clean` target to dist/tools/tunslip/Makefile 

Tested tunslip6 against Contiki's `examples/ipv6/rpl-border-router` border router implementation.
