### PR TITLE
cpu/native: rewrite cpu_print_last_instruction

### DIFF
--- a/core/panic.c
+++ b/core/panic.c
@@ -46,7 +46,9 @@ static int crashed = 0;
 /* WARNING: this function NEVER returns! */
 NORETURN void core_panic(core_panic_t crash_code, const char *message)
 {
+#ifdef NDEBUG
     (void) crash_code;
+#endif
 
     if (crashed == 0) {
         /* print panic message to console (if possible) */

--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * Copyright (C) 2013 - 2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -27,13 +27,14 @@ extern "C" {
 #endif
 
 /**
- * @brief   Prints the last instruction's address
+ * @brief   Prints the address the callee will return to
  */
-static inline void cpu_print_last_instruction(void)
+__attribute__((always_inline)) static inline void cpu_print_last_instruction(void)
 {
-    void *p;
-    __asm__("1: mov 1b, %0" : "=r" (p));
-    printf("%p\n", p);
+    /* __builtin_return_address will return the address the calling function
+     * will return to - since cpu_print_last_instruction is forced inline,
+     * it is the return address of the user of this function */
+    printf("%p\n", __builtin_return_address(0));
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Circumvent assembly by using a GCC/LLVM builtin.
Piggybacked is a patch for a missing `#ifdef` in `core/panic.c`.

Fixes https://github.com/RIOT-OS/RIOT/issues/5664

# Testing

1. apply patch below
2. run `make clean all-debug` in `hello-world`
3. copy address that is print after `Hello World!`
4. run `make objdump`, search address, check that it is the line after `core_panic` is called

```diff
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c..1dcc5ea 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,11 +20,14 @@
  */
 
 #include <stdio.h>
+#include "panic.h"
 
 int main(void)
 {
     puts("Hello World!");
 
+    core_panic(PANIC_ASSERT_FAIL, "what's my name?");
+
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
```

edits:
- 2016-07-26 - updated test