### PR TITLE
cpu/native: fix thread_stack_init

### DIFF
--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -94,7 +94,7 @@ char *thread_stack_init(thread_task_func_t task_func, void *arg, void *stack_sta
 
     stk = stack_start;
 
-    p = (ucontext_t *)(stk + ((stacksize - sizeof(ucontext_t)) / sizeof(void *)));
+    p = (ucontext_t *)(stk + (stacksize - sizeof(ucontext_t)));
     stacksize -= sizeof(ucontext_t);
 
     if (getcontext(p) == -1) {


### PR DESCRIPTION
The pointer arithmetic for the calculation of the context storage was off due to the change of the stack's pointer type from unsigned int to char.
 Fix offset calculation by not adjusting for unsigned int width anymore.

Fixes https://github.com/RIOT-OS/RIOT/issues/5680

~~Currently based on https://github.com/RIOT-OS/RIOT/pull/5681 to enable testing on arm.~~