### PR TITLE
ieee802154: Set intra-PAN flag for packets where src/dst PANs match

### DIFF
--- a/sys/net/link_layer/ieee802154/ieee802154.c
+++ b/sys/net/link_layer/ieee802154/ieee802154.c
@@ -27,6 +27,14 @@ size_t ieee802154_set_frame_hdr(uint8_t *buf, const uint8_t *src, size_t src_len
     uint8_t type = (flags & IEEE802154_FCF_TYPE_MASK);
     uint8_t bcast = (flags & IEEE802154_BCAST);
 
+    if (dst_pan.u16 == src_pan.u16 &&
+        (src_len != 0 && dst_len != 0)) {
+        flags |= IEEE802154_FCF_PAN_COMP;
+    }
+    else {
+        flags &= ~IEEE802154_FCF_PAN_COMP;
+    }
+
     buf[0] = flags & (~IEEE802154_BCAST);
     buf[1] = IEEE802154_FCF_VERS_V1;
 


### PR DESCRIPTION
According to section 7.5.6.1 of 802.15.4-2003, packets destined for
the same PAN from which they were sent must have their intra-PAN
flag set, and the source PAN omitted from the transmitted frame.