### PR TITLE
tests/periph_uart: include uart_stdio.h

### DIFF
--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -28,6 +28,7 @@
 #include "msg.h"
 #include "ringbuffer.h"
 #include "periph/uart.h"
+#include "uart_stdio.h"
 
 #define SHELL_BUFSIZE       (128U)
 #define UART_BUFSIZE        (128U)


### PR DESCRIPTION
This makes sure UART_STDIO_DEV is defined, so the init command fails when trying to use the shell UART as a parameter.

Before this was part of https://github.com/RIOT-OS/RIOT/pull/5397 but I guess it's cleaner as a separate pull request.