### PR TITLE
pkg/tweetnacl: tweetnacl crypto library as a package

### DIFF
--- a/pkg/tweetnacl/Makefile
+++ b/pkg/tweetnacl/Makefile
@@ -1,0 +1,42 @@
+PKG_NAME = tweetnacl
+PKG_VERSION = 20140427
+PKG_FILE_C = tweetnacl.c
+PKG_FILE_H = tweetnacl.h
+PKG_URL = https://tweetnacl.cr.yp.to/
+PKG_DIR=$(CURDIR)
+PKG_BUILDDIR=$(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+
+ifneq ($(RIOTBASE),)
+include $(RIOTBASE)/Makefile.base
+endif
+
+.PHONY: all clean patch distclean
+
+all: patch
+	$(MAKE) -C $(PKG_BUILDDIR)
+	cp $(PKG_BUILDDIR)/$(PKG_NAME).a $(BINDIR)$(PKG_NAME).a
+
+patch: $(PKG_BUILDDIR)/Makefile
+	# Dependancy might be changed accordingly though we think the Makefile
+	# will be the first thing you want to change
+	#
+	# Here might not happen anything besides dependancy checks
+
+$(PKG_BUILDDIR)/Makefile: $(PKG_BUILDDIR)/
+	# Here you apply your patch.
+	# we skip the return of patch 
+	$(AD)cd $(@D) && patch -p0 -N -i $(CURDIR)/patch.txt || exit 0
+
+
+$(PKG_BUILDDIR)/:
+	@mkdir -p $@
+	$(AD)$(DOWNLOAD_TO_FILE) $@/$(PKG_FILE_C) $(PKG_URL)$(PKG_VERSION)/$(PKG_FILE_C)
+	$(AD)$(DOWNLOAD_TO_FILE) $@/$(PKG_FILE_H) $(PKG_URL)$(PKG_VERSION)/$(PKG_FILE_H)
+
+clean::
+	# Reset package to checkout state.
+	rm -rf $(PKG_BUILDDIR) && \
+		$(MAKE) $(PKG_BUILDDIR)/Makefile
+
+distclean::
+	rm -rf $(PKG_BUILDDIR)

--- a/pkg/tweetnacl/Makefile.include
+++ b/pkg/tweetnacl/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(BINDIRBASE)/pkg/$(BOARD)/tweetnacl

--- a/pkg/tweetnacl/patch.txt
+++ b/pkg/tweetnacl/patch.txt
@@ -1,0 +1,16 @@
+--- /dev/null	2016-07-17 11:00:05.792006406 +0200
++++ Makefile	2016-07-25 08:48:09.963160991 +0200
+@@ -0,0 +1,13 @@
++IGNORE_CFLAGS = -Wall -Wextra -pedantic
++LOCAL_CFLAGS = $(filter-out $(IGNORE_CFLAGS),$(CFLAGS))
++
++all : tweetnacl.a
++
++tweetnacl.a : tweetnacl.o
++	$(AD) $(AR) rc tweetnacl.a tweetnacl.o
++
++tweetnacl.o : tweetnacl.c
++	$(AD) $(CC) -c $(LOCAL_CFLAGS) -o tweetnacl.o tweetnacl.c
++
++clean :
++	rm *.o *.a

--- a/tests/unittests/tests-tweetnacl/Makefile
+++ b/tests/unittests/tests-tweetnacl/Makefile
@@ -1,0 +1,9 @@
+MODULE = tests-tweetnacl
+
+# The following boards are known to fail or have not been tested.
+#BOARD_BLACKLIST := arduino-mega2560 chronos f4vi1 msb-430 msb-430h msbiot \
+#                   qemu-i386 redbee-econotag stm32f0discovery \
+#                   stm32f3discovery telosb wsn430-v1_3b wsn430-v1_4 z1 \
+#                   waspmote-pro
+
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-tweetnacl/Makefile.include
+++ b/tests/unittests/tests-tweetnacl/Makefile.include
@@ -1,0 +1,2 @@
+USEPKG += tweetnacl
+USEMODULE += random

--- a/tests/unittests/tests-tweetnacl/tests-tweetnacl.c
+++ b/tests/unittests/tests-tweetnacl/tests-tweetnacl.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       tweetnacl NaCl crypto library tests
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>S
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <malloc.h>
+#include <string.h>
+#include "embUnit.h"
+#include "tests-tweetnacl.h"
+
+#include "tweetnacl.h"
+
+void randombytes(uint8_t *target, uint64_t n)
+{
+    uint32_t random;
+    uint8_t *random_pos = 0;
+    int _n = 0;
+    while (n--) {
+        if (_n++ & 0x3) {
+            random = random_uint32();
+
+            random_pos = (uint8_t*) &random;
+        }
+        if (random_pos) {
+            uint8_t r_pos = *random_pos;
+            *target++ = r_pos++;
+        }
+        else {
+            *target++ = (uint8_t)random_uint32();
+        }
+    }
+}
+
+#define TEST_BUF_SIZE (20)
+static char _buf[crypto_box_ZEROBYTES + TEST_BUF_SIZE];
+
+static void setUp(void)
+{
+    /* Initialize */
+    random_init(0);
+}
+
+static void tearDown(void)
+{
+    /* Finalize */
+}
+
+const unsigned char* bytes_to_message(const char* bytes, unsigned long long len)
+{
+    memset(_buf,'\0', crypto_box_ZEROBYTES);
+    memcpy(_buf + crypto_box_ZEROBYTES, bytes, len);
+
+    return (const unsigned char*) _buf;
+}
+
+struct identity {
+    unsigned char pk[crypto_box_PUBLICKEYBYTES];
+    unsigned char sk[crypto_box_SECRETKEYBYTES];
+};
+
+void identity_create(struct identity *id)
+{
+    crypto_box_keypair(id->pk,id->sk);
+}
+
+static void test_tweetnacl_01(void)
+{
+    int res;
+    const char message[] = "Test String";
+    struct identity id_alice;
+
+    /* Creating keypair ALICE... */
+    identity_create(&id_alice);
+
+    unsigned char bob_pk[crypto_box_PUBLICKEYBYTES];
+    unsigned char bob_sk[crypto_box_SECRETKEYBYTES];
+
+    /* Creating keypair BOB... */
+    crypto_box_keypair(bob_pk,bob_sk);
+
+    const unsigned char *m = bytes_to_message(message,strlen(message)+1);
+    unsigned long long mlen = strlen(message)+crypto_box_ZEROBYTES+1;
+
+    const unsigned char n[crypto_box_NONCEBYTES];
+    unsigned char c[mlen];
+
+    /* Encrypting using pk_bob... */
+    crypto_box(c, m, mlen, n, bob_pk, id_alice.sk);
+
+    unsigned char result[mlen];
+    memset(result, '\0', sizeof(result));
+
+    /* Decrypting... */
+    res = crypto_box_open(result,c,mlen,n,id_alice.pk,bob_sk);
+    TEST_ASSERT_EQUAL_INT(0, res);
+    
+    if (res) {
+        puts("Decryption failed.\n");
+    } else {
+        printf("Decryption successful. content: \"%s\"\n", result+crypto_box_ZEROBYTES);
+    }
+}
+
+Test *tests_tweetnacl_all(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_tweetnacl_01)
+    };
+
+    EMB_UNIT_TESTCALLER(tweetnacl_tests, setUp, tearDown, fixtures);
+    return (Test*)&tweetnacl_tests;
+}
+
+void tests_tweetnacl(void)
+{
+    TESTS_RUN(tests_tweetnacl_all());
+}

--- a/tests/unittests/tests-tweetnacl/tests-tweetnacl.h
+++ b/tests/unittests/tests-tweetnacl/tests-tweetnacl.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 Martin Landsmann
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``tweetnacl`` package
+ *
+ * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ */
+#ifndef TESTS_TWEETNACL_H_
+#define TESTS_TWEETNACL_H_
+#include "embUnit/embUnit.h"
+#include "random.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MANDATORY function for collecting random Bytes
+ *        required by the tweetnacl package
+ */
+void randombytes(uint8_t *target, uint64_t n);
+
+/**
+*  @brief   The entry point of this test suite.
+*/
+void tests_tweetnacl(void);
+
+/**
+ * @brief   Generates tests for tweetnacl
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_tweetnacl_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_TWEETNACL_H_ */
+/** @} */


### PR DESCRIPTION
alternative to #4317, providing the `tweetnacl` crypto library [1] as a package

[1] https://tweetnacl.cr.yp.to/