### PR TITLE
hashes/sha256: changed data-pointer parameters to `void *`

### DIFF
--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -89,51 +89,48 @@ void sha256_init(sha256_context_t *ctx);
 /**
  * @brief Add bytes into the hash
  *
- * @param ctx  sha256_context_t handle to use
- * @param[in] data      Input data
- * @param[in] len       Length of @p data
+ * @param ctx      sha256_context_t handle to use
+ * @param[in] data Input data
+ * @param[in] len  Length of @p data
  */
-void sha256_update(sha256_context_t *ctx, const uint8_t *data, size_t len);
+void sha256_update(sha256_context_t *ctx, const void *data, size_t len);
 
 /**
  * @brief SHA-256 finalization.  Pads the input data, exports the hash value,
  * and clears the context state.
  *
- * @param digest resulting digest, this is the hash of all the bytes
  * @param ctx    sha256_context_t handle to use
+ * @param digest resulting digest, this is the hash of all the bytes
  */
-void sha256_final(sha256_context_t *ctx, uint8_t *dst);
+void sha256_final(sha256_context_t *ctx, void *digest);
 
 /**
  * @brief A wrapper function to simplify the generation of a hash, this is
  * usefull for generating sha256 for one buffer
  *
- * @param d pointer to the buffer to generate hash from
- * @param n length of the buffer
- * @param md optional pointer to an array for the result, length must be
- *           SHA256_DIGEST_LENGTH
- *           if md == NULL, one static buffer is used
+ * @param data   pointer to the buffer to generate hash from
+ * @param len    length of the buffer
+ * @param digest optional pointer to an array for the result, length must be
+ *               SHA256_DIGEST_LENGTH
+ *               if digest == NULL, one static buffer is used
  */
-unsigned char *sha256(const unsigned char *d, size_t n, unsigned char *md);
+void *sha256(const void *data, size_t len, void *digest);
 
 /**
  * @brief function to compute a hmac-sha256 from a given message
  *
  * @param[in] key key used in the hmac-sha256 computation
  * @param[in] key_length the size in bytes of the key
- * @param[in] message pointer to the message to generate the hmac-sha256
- * @param[in] message_length the length of the message in bytes
- * @param[out] result the computed hmac-sha256,
+ * @param[in] data pointer to the buffer to generate the hmac-sha256
+ * @param[in] len the length of the message in bytes
+ * @param[out] digest the computed hmac-sha256,
  *             length MUST be SHA256_DIGEST_LENGTH
- *             if result == NULL, a static buffer is used
+ *             if digest == NULL, a static buffer is used
  * @returns pointer to the resulting digest.
  *          if result == NULL the pointer points to the static buffer
  */
-const unsigned char *hmac_sha256(const unsigned char *key,
-                                 size_t key_length,
-                                 const unsigned *message,
-                                 size_t message_length,
-                                 unsigned char *result);
+const void *hmac_sha256(const void *key, size_t key_length,
+                        const void *data, size_t len, void *digest);
 
 /**
  * @brief function to produce a hash chain statring with a given seed element.
@@ -149,8 +146,8 @@ const unsigned char *hmac_sha256(const unsigned char *key,
  *
  * @returns pointer to tail_element
  */
-unsigned char *sha256_chain(const unsigned char *seed, size_t seed_length,
-                            size_t elements, unsigned char *tail_element);
+void *sha256_chain(const void *seed, size_t seed_length,
+                   size_t elements, void *tail_element);
 
 /**
  * @brief function to produce a hash chain statring with a given seed element.
@@ -180,12 +177,10 @@ unsigned char *sha256_chain(const unsigned char *seed, size_t seed_length,
  *
  * @returns pointer to tail_element
  */
-unsigned char *sha256_chain_with_waypoints(const unsigned char *seed,
-                                           size_t seed_length,
-                                           size_t elements,
-                                           unsigned char *tail_element,
-                                           sha256_chain_idx_elm_t *waypoints,
-                                           size_t *waypoints_length);
+void *sha256_chain_with_waypoints(const void *seed, size_t seed_length,
+                                  size_t elements, void *tail_element,
+                                  sha256_chain_idx_elm_t *waypoints,
+                                  size_t *waypoints_length);
 
 /**
  * @brief function to verify if a given chain element is part of the chain.
@@ -198,9 +193,9 @@ unsigned char *sha256_chain_with_waypoints(const unsigned char *seed,
  * @returns 0 if element is verified to be part of the chain at element_index
  *          1 if the element cannot be verified as part of the chain
  */
-int sha256_chain_verify_element(unsigned char *element,
+int sha256_chain_verify_element(void *element,
                                 size_t element_index,
-                                unsigned char *tail_element,
+                                void *tail_element,
                                 size_t chain_length);
 
 #ifdef __cplusplus

--- a/tests/unittests/tests-hashes/tests-hashes-sha256-hmac.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha256-hmac.c
@@ -22,7 +22,7 @@ static int compare_str_vs_digest(const char *str,
 {
     char ch[3] = { 0, 0, 0 };
     size_t iter_hash = 0;
-    size_t str_length = strlen(str);
+    size_t str_length = strlen((char*)str);
     for (size_t i = 0; i < str_length; i += 2) {
         ch[0] = str[i];
         ch[1] = str[i + 1];
@@ -42,19 +42,19 @@ static void test_hashes_hmac_sha256_hash_sequence(void)
     static uint8_t hmac[SHA256_DIGEST_LENGTH];
 
     /* use an empty message */
-    const unsigned *m = NULL;
+    const unsigned char *m = NULL;
     hmac_sha256(key, sizeof(key), m, 0, hmac);
 
     TEST_ASSERT(compare_str_vs_digest(
                  "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad", hmac));
 
     /* use a real message */
-    const char str[] = "The quick brown fox jumps over the lazy dog";
+    const unsigned char str[] = "The quick brown fox jumps over the lazy dog";
     key[0] = 'k';
     key[1] = 'e';
     key[2] = 'y';
 
-    hmac_sha256(key, sizeof(key), (unsigned*)str, strlen(str), hmac);
+    hmac_sha256(key, sizeof(key), str, strlen((char*)str), hmac);
     TEST_ASSERT(compare_str_vs_digest(
                  "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8", hmac));
 }
@@ -67,12 +67,12 @@ static void test_hashes_hmac_sha256_hash_sequence(void)
 static void test_hashes_hmac_sha256_hash_PRF1(void)
 {
     /* Test Case PRF-1: */
-    const char strPRF1[] = "Hi There";
+    const unsigned char strPRF1[] = "Hi There";
     unsigned char key[20];
     static unsigned char hmac[SHA256_DIGEST_LENGTH];
     memset(key, 0x0b, sizeof(key));
 
-    hmac_sha256(key, sizeof(key), (unsigned*)strPRF1, strlen(strPRF1), hmac);
+    hmac_sha256(key, sizeof(key), strPRF1, strlen((char*)strPRF1), hmac);
     TEST_ASSERT(compare_str_vs_digest(
                  "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7", hmac));
 }
@@ -80,11 +80,11 @@ static void test_hashes_hmac_sha256_hash_PRF1(void)
 static void test_hashes_hmac_sha256_hash_PRF2(void)
 {
     /* Test Case PRF-2: */
-    const char strPRF2[] = "what do ya want for nothing?";
+    const unsigned char strPRF2[] = "what do ya want for nothing?";
     unsigned char key[4] = {'J', 'e', 'f', 'e'};
     static unsigned char hmac[SHA256_DIGEST_LENGTH];
 
-    hmac_sha256(key, sizeof(key), (unsigned*)strPRF2, strlen(strPRF2), hmac);
+    hmac_sha256(key, sizeof(key), strPRF2, strlen((char*)strPRF2), hmac);
     TEST_ASSERT(compare_str_vs_digest(
                  "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843", hmac));
 }
@@ -92,14 +92,14 @@ static void test_hashes_hmac_sha256_hash_PRF2(void)
 static void test_hashes_hmac_sha256_hash_PRF3(void)
 {
     /* Test Case PRF-3: */
-    char strPRF3[50];
+    char unsigned strPRF3[50];
     unsigned char key[20];
     static unsigned char hmac[SHA256_DIGEST_LENGTH];
 
     memset(strPRF3, 0xdd, sizeof(strPRF3));
     memset(key, 0xaa, sizeof(key));
 
-    hmac_sha256(key, sizeof(key), (unsigned*)strPRF3, sizeof(strPRF3), hmac);
+    hmac_sha256(key, sizeof(key), strPRF3, sizeof(strPRF3), hmac);
     TEST_ASSERT(compare_str_vs_digest(
                  "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe", hmac));
 }
@@ -107,7 +107,7 @@ static void test_hashes_hmac_sha256_hash_PRF3(void)
 static void test_hashes_hmac_sha256_hash_PRF4(void)
 {
     /* Test Case PRF-4: */
-    char strPRF4[50];
+    char unsigned strPRF4[50];
     unsigned char key[25];
     static unsigned char hmac[SHA256_DIGEST_LENGTH];
 
@@ -119,7 +119,7 @@ static void test_hashes_hmac_sha256_hash_PRF4(void)
         key[i] = i+1;
     }
 
-    hmac_sha256(key, sizeof(key), (unsigned*)strPRF4, sizeof(strPRF4), hmac);
+    hmac_sha256(key, sizeof(key), strPRF4, sizeof(strPRF4), hmac);
     TEST_ASSERT(compare_str_vs_digest(
                  "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b", hmac));
 }
@@ -127,12 +127,12 @@ static void test_hashes_hmac_sha256_hash_PRF4(void)
 static void test_hashes_hmac_sha256_hash_PRF5(void)
 {
     /* Test Case PRF-5: */
-    const char strPRF5[] = "Test Using Larger Than Block-Size Key - Hash Key First";
+    const unsigned char strPRF5[] = "Test Using Larger Than Block-Size Key - Hash Key First";
     unsigned char longKey[131];
     static unsigned char hmac[SHA256_DIGEST_LENGTH];
     memset(longKey, 0xaa, sizeof(longKey));
 
-    hmac_sha256(longKey, sizeof(longKey), (unsigned*)strPRF5, strlen(strPRF5), hmac);
+    hmac_sha256(longKey, sizeof(longKey), strPRF5, strlen((char*)strPRF5), hmac);
     TEST_ASSERT(compare_str_vs_digest(
                  "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54", hmac));
 }
@@ -140,7 +140,7 @@ static void test_hashes_hmac_sha256_hash_PRF5(void)
 static void test_hashes_hmac_sha256_hash_PRF6(void)
 {
     /* Test Case PRF-6: */
-    const char strPRF6[] = "This is a test using a larger than block-size key and a "
+    const unsigned char strPRF6[] = "This is a test using a larger than block-size key and a "
                            "larger than block-size data. The key needs to be hashed "
                            "before being used by the HMAC algorithm.";
     unsigned char longKey[131];
@@ -148,7 +148,7 @@ static void test_hashes_hmac_sha256_hash_PRF6(void)
     memset(longKey, 0xaa, sizeof(longKey));
 
     /* the same key is used as above: 131 x 0xa */
-    hmac_sha256(longKey, sizeof(longKey), (unsigned*)strPRF6, strlen(strPRF6), hmac);
+    hmac_sha256(longKey, sizeof(longKey), strPRF6, strlen((char*)strPRF6), hmac);
     TEST_ASSERT(compare_str_vs_digest(
                  "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2", hmac));
 }


### PR DESCRIPTION
~~The `message*` parameter of `hmac_sha256(...)` has been just `unsigned`, which required
 unnecessary casting.~~

edit:
I considered the comment from @gebart and changed all data-pointer parameter to `void*`.