### PR TITLE
hashes/md5: changed data-parameter types to `void*`

### DIFF
--- a/sys/hashes/md5.c
+++ b/sys/hashes/md5.c
@@ -232,7 +232,7 @@ void md5_init(md5_ctx_t *ctx)
     ctx->abcd[3] = 0x10325476;
 }
 
-void md5_update(md5_ctx_t *ctx, const uint8_t *data, size_t len)
+void md5_update(md5_ctx_t *ctx, const void *data, size_t len)
 {
     /* Add the new block's length to the total length. */
     ctx->len += (uint32_t)len;
@@ -240,7 +240,9 @@ void md5_update(md5_ctx_t *ctx, const uint8_t *data, size_t len)
     /* Copy the new block's data into the context block.
      * Call the permute() function whenever the context block is full. */
     for (size_t i = 0; i < len; i++) {
-        ctx->block[ctx->b_used] = data[i];
+        const uint8_t *d = data;
+
+        ctx->block[ctx->b_used] = d[i];
         (ctx->b_used)++;
         if (64 == ctx->b_used) {
             permute(ctx->abcd, ctx->block);
@@ -250,7 +252,7 @@ void md5_update(md5_ctx_t *ctx, const uint8_t *data, size_t len)
 }
 
 
-void md5_final(md5_ctx_t *ctx, uint8_t *dst)
+void md5_final(md5_ctx_t *ctx, void *digest)
 {
     uint32_t l;
 
@@ -289,18 +291,20 @@ void md5_final(md5_ctx_t *ctx, uint8_t *dst)
 
     /* Now copy the result into the output buffer and we're done */
     for (int i = 0; i < 4; i++) {
-        dst[ 0 + i] = GETBYTE(ctx->abcd[0], i);
-        dst[ 4 + i] = GETBYTE(ctx->abcd[1], i);
-        dst[ 8 + i] = GETBYTE(ctx->abcd[2], i);
-        dst[12 + i] = GETBYTE(ctx->abcd[3], i);
+        uint8_t *d = digest;
+
+        d[ 0 + i] = GETBYTE(ctx->abcd[0], i);
+        d[ 4 + i] = GETBYTE(ctx->abcd[1], i);
+        d[ 8 + i] = GETBYTE(ctx->abcd[2], i);
+        d[12 + i] = GETBYTE(ctx->abcd[3], i);
     }
 }
 
-void md5(uint8_t *dst, const uint8_t *src, size_t len)
+void md5(void *digest, const void *data, size_t len)
 {
     md5_ctx_t ctx;
 
     md5_init(&ctx);
-    md5_update(&ctx, src, len);
-    md5_final(&ctx, dst);
+    md5_update(&ctx, data, len);
+    md5_final(&ctx, digest);
 }

--- a/sys/include/hashes/md5.h
+++ b/sys/include/hashes/md5.h
@@ -101,24 +101,24 @@ void md5_init(md5_ctx_t *ctx);
  * @param[in] data      Input data
  * @param[in] len       Length of @p data
  */
-void md5_update(md5_ctx_t *ctx, const uint8_t *data, size_t len);
+void md5_update(md5_ctx_t *ctx, const void *data, size_t len);
 
 /**
  * @brief   Finish up the current MD5 hash calculation generate the final hash
  *
  * @param[in] ctx       Context of the current calculation
- * @param[out] dst      Result location, must be 16 byte
+ * @param[out] digest   Result location, must be 16 byte
  */
-void md5_final(md5_ctx_t *ctx, uint8_t *dst);
+void md5_final(md5_ctx_t *ctx, void *digest);
 
 /**
  * @brief   Calculate a MD5 hash from the given data
  *
- * @param[out] dst      Result location, must be 16 byte
- * @param[in] src       Input data
- * @param[in] len       Length of @p src
+ * @param[out] digest Result location, must be 16 byte
+ * @param[in] data    Input data
+ * @param[in] len     Length of @p src
  */
-void md5(uint8_t *dst, const uint8_t *src, size_t len);
+void md5(void *digest, const void *data, size_t len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR changes all data-pointer parameter to void* [1].
Additionally I made some minor cosmetic cleanup on the parameter names to make them consistent.

[1] https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions#types