### PR TITLE
tests/nhdp: changed printf to puts

### DIFF
--- a/tests/nhdp/main.c
+++ b/tests/nhdp/main.c
@@ -18,6 +18,6 @@
 
 int main(void)
 {
-    printf("NHDP compiled!");
+    puts("NHDP compiled!");
     return 0;
 }


### PR DESCRIPTION
as it states.
the former `printf`ed string has not been escaped at the end. 
In some situations the string has not been printed when flashing, e.g. a samr21-xpro board.