### PR TITLE
hashes: support unaligned memory access in be32enc_vect

### DIFF
--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -64,11 +64,23 @@
  */
 static void be32enc_vect(void *dst_, const void *src_, size_t len)
 {
-    uint32_t *dst = dst_;
-    const uint32_t *src = src_;
-
-    for (size_t i = 0; i < len / 4; i++) {
-        dst[i] = __builtin_bswap32(src[i]);
+    if ((uintptr_t)dst_ % sizeof(uint32_t) == 0 &&
+        (uintptr_t)src_ % sizeof(uint32_t) == 0) {
+        uint32_t *dst = dst_;
+        const uint32_t *src = src_;
+        for (size_t i = 0; i < len / 4; i++) {
+            dst[i] = __builtin_bswap32(src[i]);
+        }
+    }
+    else {
+        uint8_t *dst = dst_;
+        const uint8_t *src = src_;
+        for (size_t i = 0; i < len; i += 4) {
+            dst[i] = src[i + 3];
+            dst[i + 1] = src[i + 2];
+            dst[i + 2] = src[i + 1];
+            dst[i + 3] = src[i];
+        }
     }
 }
 


### PR DESCRIPTION
This patch allows `be32enc_vect` to be executed on any memory location, including unaligned memory. If the memory is 4-byte aligned, it will access the data using a pointer of type `uint32_t*`; otherwise it will access each byte of the data separately and therefore prevents hardware fault on ARM-based CPUs.

See more description in #5102 