### PR TITLE
boards/nucleo-common: add saul support for on-board user led and button

### DIFF
--- a/boards/nucleo-common/Makefile.dep
+++ b/boards/nucleo-common/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/nucleo-common/Makefile.include
+++ b/boards/nucleo-common/Makefile.include
@@ -8,5 +8,8 @@ include $(RIOTBOARD)/Makefile.include.serial
 # this board uses openocd
 include $(RIOTBOARD)/Makefile.include.openocd
 
+# include dependencies
+include $(RIOTBOARD)/nucleo-common/Makefile.dep
+
 # add the common header files to the include path
 INCLUDES += -I$(RIOTBOARD)/nucleo-common/include

--- a/boards/nucleo-common/include/gpio_params.h
+++ b/boards/nucleo-common/include/gpio_params.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) Inria 2016
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_nucleo-common
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(green)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Button(B1 User)",
+        .pin = BTN_B1_PIN,
+        .mode = GPIO_IN_PU
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
Did that in #5706 but as this change is quite independent and fairly straight forward, it's better to open a dedicated PR for it.