### PR TITLE
boards: msp430: garbage collect dead code when linking.

### DIFF
--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -3,7 +3,7 @@ export TARGET_ARCH ?= msp430
 
 # define build specific options
 CFLAGS_CPU   = -mmcu=$(CPU_MODEL)
-CFLAGS_LINK  =
+CFLAGS_LINK  = -ffunction-sections -fdata-sections
 CFLAGS_DBG   = -gdwarf-2
 CFLAGS_OPT  ?= -Os
 # export compiler flags
@@ -11,7 +11,7 @@ export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 # export assmebly flags
 export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 # export linker flags
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc
 
 # Import all toolchain settings
 include $(RIOTCPU)/Makefile.include.gnu


### PR DESCRIPTION
The MSP430-based board are blacklisted from U8g2 package, because the flash file size exceeds the memory size. There was a similar problem with the ATMega targets, which was fixed with #5632.

This PR does the same for MSP430-based boards. However, I don't have any boards to test it with and I don't know what implications it has for other programs. Without this patch the U8g2 test application fails to compile, with this patch it succeeds.

```
msp430-size /home/basilfx/Desktop/RIOT/tests/pkg_u8g2/bin/chronos/pkg_u8g2.elf
   text	   data	    bss	    dec	    hex	filename
  14472	     90	   2644	  17206	   4336	/home/basilfx/Desktop/RIOT/tests/pkg_u8g2/bin/chronos/pkg_u8g2.elf
```

```
msp430-size /home/basilfx/Desktop/RIOT/tests/pkg_u8g2/bin/msb-430/pkg_u8g2.elf
   text	   data	    bss	    dec	    hex	filename
  14886	     18	   2702	  17606	   44c6	/home/basilfx/Desktop/RIOT/tests/pkg_u8g2/bin/msb-430/pkg_u8g2.elf
```

```
msp430-size /home/basilfx/Desktop/RIOT/tests/pkg_u8g2/bin/wsn430-v1_3b/pkg_u8g2.elf
   text	   data	    bss	    dec	    hex	filename
  14838	     18	   2702	  17558	   4496	/home/basilfx/Desktop/RIOT/tests/pkg_u8g2/bin/wsn430-v1_3b/pkg_u8g2.elf
```
