### PR TITLE
boards/stm32f4discovery: linux serial name update

### DIFF
--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -3,7 +3,7 @@ export CPU = stm32f4
 export CPU_MODEL = stm32f407vg
 
 # set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
+PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
 # setup serial terminal


### PR DESCRIPTION
This board appears as `ttyACM0` not as `ttyUSB0` in my machine the same as most Nucleo boards I've tried. I'm not sure this is kernel or distribution dependent (tried on Ubuntu [kernel 3.13] and Arch [kernel 4.4]) or were remaining of board copy-paste.

Anyone to confirm this?

(extracted from #5643)