### PR TITLE
cpu/cc2538: wait for ongoing transmission before flushing TX FIFO

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -260,7 +260,8 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
     cc2538_rf_t *dev = (cc2538_rf_t *) netdev;
     mutex_lock(&dev->mutex);
 
-    /* Flush TX FIFO */
+    /* Flush TX FIFO once no transmission in progress */
+    RFCORE_WAIT_UNTIL(RFCORE->XREG_FSMSTAT1bits.TX_ACTIVE == 0);
     RFCORE_SFR_RFST = ISFLUSHTX;
 
     /* The first byte of the TX FIFO must be the packet length,


### PR DESCRIPTION
For larger packet sizes and/or fast consecutive sends, the mutex lock is not enough to guarantee exclusive TX FIFO access. Since the TX operation is non-blocking, the lock may be released and re-taken again before transmission has completed. Flushing the TX FIFO while a transmission is in progress will result in TX underflow errors and lost packets, so make sure there's no active transmission before we claim it.

Perform the wait here rather than after the send, in case a non-netdev TX operation is in progress (e.g. AUTOACK).