### PR TITLE
cpu: cortexm_common: fix compile warning

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -205,8 +205,11 @@ __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, 
     uint32_t dfsr  = SCB->DFSR;
     uint32_t afsr  = SCB->AFSR;
 #endif
-    uint32_t pc;
-    uint32_t* orig_sp;
+
+    /* Initialize these variables even if they're never used uninitialized.
+     * Fixes wrong compiler warning by gcc < 6.0. */
+    uint32_t pc = 0;
+    uint32_t* orig_sp = NULL;
 
     /* Check if the ISR stack overflowed previously. Not possible to detect
      * after output may also have overflowed it. */


### PR DESCRIPTION
Some gcc complain (wrongly) about possibly uninitialized variables.

Fixes #5726.