### PR TITLE
drivers/l1-nvram-eeprom: stm32l1 internal EEPROM driver

### DIFF
--- a/drivers/include/l1-nvram-eeprom.h
+++ b/drivers/include/l1-nvram-eeprom.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 Unwired Devices <info@unwds.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     nvram
+ * @{
+ *
+ * @file		l1-nvram-eeprom.h
+ *
+ * @brief       STM32L1 Data EEPROM driver definitions
+ *
+ * Tested on:
+ * - STM32L151CCU6
+ *
+ * @author      EP <ep@unwds.com>
+ */
+#ifndef L1_NVRAM_EEPROM_H_
+#define L1_NVRAM_EEPROM_H_
+
+#include "nvram.h"
+
+/**
+ * @brief Initializes an nvram_t structure
+ *
+ * @param[out]	dev		Pointer to NVRAM device structure
+ *
+ * @return	0 on success
+ * @return	<0 on error
+ */
+int nvram_l1_eeprom_init(nvram_t *dev);
+
+/** @defgroup FLASH_Flags
+ * @{
+ */
+#define FLASH_FLAG_BSY                 FLASH_SR_BSY         /*!< FLASH Busy flag */
+#define FLASH_FLAG_EOP                 FLASH_SR_EOP         /*!< FLASH End of Programming flag */
+#define FLASH_FLAG_ENDHV               FLASH_SR_ENHV        /*!< FLASH End of High Voltage flag */
+#define FLASH_FLAG_READY               FLASH_SR_READY       /*!< FLASH Ready flag after low power mode */
+#define FLASH_FLAG_WRPERR              FLASH_SR_WRPERR      /*!< FLASH Write protected error flag */
+#define FLASH_FLAG_PGAERR              FLASH_SR_PGAERR      /*!< FLASH Programming Alignment error flag */
+#define FLASH_FLAG_SIZERR              FLASH_SR_SIZERR      /*!< FLASH Size error flag  */
+#define FLASH_FLAG_OPTVERR             FLASH_SR_OPTVERR     /*!< FLASH Option Validity error flag  */
+#define FLASH_FLAG_OPTVERRUSR          FLASH_SR_OPTVERRUSR  /*!< FLASH Option User Validity error flag  */
+#define FLASH_FLAG_RDERR               FLASH_SR_RDERR       /*!< FLASH Read protected error flag
+                                                                 (available only in STM32L1XX_MDP devices)  */
+
+#define IS_FLASH_CLEAR_FLAG(FLAG) ((((FLAG) &(uint32_t)0xFFFFC0FD) == 0x00000000) && ((FLAG) != 0x00000000))
+
+#define IS_FLASH_GET_FLAG(FLAG)  (((FLAG) == FLASH_FLAG_BSY) || ((FLAG) == FLASH_FLAG_EOP) || \
+                                  ((FLAG) == FLASH_FLAG_ENDHV) || ((FLAG) == FLASH_FLAG_READY) || \
+                                  ((FLAG) ==  FLASH_FLAG_WRPERR) || ((FLAG) == FLASH_FLAG_PGAERR) || \
+                                  ((FLAG) ==  FLASH_FLAG_SIZERR) || ((FLAG) == FLASH_FLAG_OPTVERR) || \
+                                  ((FLAG) ==  FLASH_FLAG_OPTVERRUSR) || ((FLAG) ==  FLASH_FLAG_RDERR))
+/**
+ * @}
+ */
+
+/**
+ * @brief STM32 Data EEPROM unlock keys
+ */
+#define FLASH_PEKEY1               ((uint32_t)0x89ABCDEF)
+#define FLASH_PEKEY2               ((uint32_t)0x02030405)
+
+/**
+ * @brief Checks that given address is within the FLASH area
+ */
+#define IS_FLASH_DATA_ADDRESS(ADDRESS) (((ADDRESS) >= 0x08080000) && ((ADDRESS) <= 0x08083FFF))
+
+/**
+ * @brief Timeout of FLASH programming
+ */
+#define FLASH_ER_PRG_TIMEOUT         ((uint32_t)0x8000)
+
+/**
+ * @brief Data EEPROM base address
+ */
+#define EEPROM_BASE ((uint32_t) 0x08080000)
+
+#endif /* L1_NVRAM_EEPROM_H_ */

--- a/drivers/l1-nvram-eeprom/Makefile
+++ b/drivers/l1-nvram-eeprom/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/l1-nvram-eeprom/l1-nvram-eeprom.c
+++ b/drivers/l1-nvram-eeprom/l1-nvram-eeprom.c
@@ -12,7 +12,6 @@
 #include "stm32l1xx.h"
 
 #include "nvram.h"
-#include "xtimer.h"
 #include "assert.h"
 
 #include "l1-nvram-eeprom.h"

--- a/drivers/l1-nvram-eeprom/l1-nvram-eeprom.c
+++ b/drivers/l1-nvram-eeprom/l1-nvram-eeprom.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2016 Unwired Devices <info@unwds.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "stm32l1xx.h"
+
+#include "nvram.h"
+#include "xtimer.h"
+#include "assert.h"
+
+#include "l1-nvram-eeprom.h"
+
+/**
+ * @ingroup     nvram
+ * @{
+ *
+ * @file	l1-nvram-eeprom.c
+ *
+ * @brief       STM32L1 Data EEPROM driver
+ *
+ * Tested on:
+ * - STM32L151CCU6
+ *
+ * @author      EP <ep@unwds.com>
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum
+{
+  FLASH_BUSY = 1,
+  FLASH_ERROR_WRP,
+  FLASH_ERROR_PROGRAM,
+  FLASH_COMPLETE,
+  FLASH_TIMEOUT
+} l1_flash_status_t;
+
+/**
+  * @brief  Unlocks the data memory and FLASH_PECR register access.
+  * @param  None
+  * @return None
+  */
+static void eeprom_unlock(void)
+{
+  if((FLASH->PECR & FLASH_PECR_PELOCK) != RESET)
+  {
+    /* Unlocking the Data memory and FLASH_PECR register access*/
+    FLASH->PEKEYR = FLASH_PEKEY1;
+    FLASH->PEKEYR = FLASH_PEKEY2;
+  }
+}
+
+/**
+  * @brief  Locks the Data memory and FLASH_PECR register access.
+  * @param  None
+  * @return None
+  */
+static void eeprom_lock(void)
+{
+  /* Set the PELOCK Bit to lock the data memory and FLASH_PECR register access */
+  FLASH->PECR |= FLASH_PECR_PELOCK;
+}
+
+/**
+ * @brief Returns the current FLASH device status
+ */
+static l1_flash_status_t get_status(void)
+{
+  l1_flash_status_t status = FLASH_COMPLETE;
+
+  if((FLASH->SR & FLASH_FLAG_BSY) == FLASH_FLAG_BSY)
+  {
+    status = FLASH_BUSY;
+  }
+  else
+  {
+    if((FLASH->SR & (uint32_t)FLASH_FLAG_WRPERR)!= (uint32_t)0x00)
+    {
+      status = FLASH_ERROR_WRP;
+    }
+    else
+    {
+      if((FLASH->SR & (uint32_t)0x1E00) != (uint32_t)0x00)
+      {
+        status = FLASH_ERROR_PROGRAM;
+      }
+      else
+      {
+        status = FLASH_COMPLETE;
+      }
+    }
+  }
+
+  /* Return the FLASH Status */
+  return status;
+}
+
+/**
+ * @brief Busy-waits within a timeout if the FLASH peripheral is performing an operation
+ *
+ * @param[in] timeout timeout value in cycles
+ * @return current status of FLASH device
+ */
+static l1_flash_status_t flash_wait_for_last_operation(uint32_t timeout) {
+	l1_flash_status_t status = FLASH_COMPLETE;
+
+	/* Check for the FLASH Status */
+	status = get_status();
+
+	/* Wait for a FLASH operation to complete or a TIMEOUT to occur */
+	while((status == FLASH_BUSY) && (timeout != 0x00))
+	{
+		status = get_status();
+		timeout--;
+	}
+
+	if(timeout == 0x00)
+	{
+		status = FLASH_TIMEOUT;
+	}
+
+	/* Return the operation status */
+	return status;
+}
+
+/**
+  * @brief  Write a Byte at a specified address in data EEPROM.
+  * @param  address: specifies the address to be written.
+  * @param  data: specifies the data to be written.
+  * @retval FLASH Status: The returned value can be:
+  *   FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+static l1_flash_status_t program_byte(uint32_t address, uint8_t data)
+{
+	l1_flash_status_t status = FLASH_COMPLETE;
+#if !defined (STM32L1XX_HD) && !defined (STM32L1XX_MDP) && !defined (STM32L1XX_XL)
+  uint32_t tmp = 0, tmpaddr = 0;
+#endif
+
+  /* Check the parameters */
+  assert(IS_FLASH_DATA_ADDRESS(address));
+
+  /* Wait for last operation to be completed */
+  status = flash_wait_for_last_operation(FLASH_ER_PRG_TIMEOUT);
+
+  if(status == FLASH_COMPLETE)
+  {
+#if !defined (STM32L1XX_HD) && !defined (STM32L1XX_MDP) && !defined (STM32L1XX_XL)
+    if(data != (uint8_t) 0x00)
+    {
+      *(__IO uint8_t *)address = data;
+
+      /* Wait for last operation to be completed */
+      status = flash_wait_for_last_operation(FLASH_ER_PRG_TIMEOUT);
+    }
+    else
+    {
+      tmpaddr = address & 0xFFFFFFFC;
+      tmp = * (__IO uint32_t *) tmpaddr;
+      tmpaddr = 0xFF << ((uint32_t) (0x8 * (Address & 0x3)));
+      tmp &= ~tmpaddr;
+      status = DATA_EEPROM_EraseWord(address & 0xFFFFFFFC);
+      status = DATA_EEPROM_FastProgramWord((address & 0xFFFFFFFC), tmp);
+    }
+#elif defined (STM32L1XX_HD) || defined (STM32L1XX_MDP) || defined (STM32L1XX_XL)
+    *(__IO uint8_t *)address = data;
+
+    /* Wait for last operation to be completed */
+    status = flash_wait_for_last_operation(FLASH_ER_PRG_TIMEOUT);
+#endif
+  }
+
+  /* Return the Write Status */
+  return status;
+}
+
+/**
+ * @brief Copy data from system memory to NVRAM.
+ *
+ * @param[in]  dev   Pointer to NVRAM device descriptor
+ * @param[in]  src   Pointer to the first byte in the system memory address space
+ * @param[in]  dst   Starting address in the NVRAM device address space
+ * @param[in]  len   Number of bytes to copy
+ *
+ * @return           Number of bytes written on success
+ * @return           <0 on errors
+ */
+static int nvram_write(nvram_t *dev, const uint8_t *src, uint32_t dst, size_t len);
+
+/**
+ * @brief Copy data from NVRAM to system memory.
+ *
+ * @param[in]  dev   Pointer to NVRAM device descriptor
+ * @param[out] dst   Pointer to the first byte in the system memory address space
+ * @param[in]  src   Starting address in the NVRAM device address space
+ * @param[in]  len   Number of bytes to copy
+ *
+ * @return           Number of bytes read on success
+ * @return           <0 on errors
+ */
+static int nvram_read(nvram_t *dev, uint8_t *dst, uint32_t src, size_t len);
+
+int nvram_l1_eeprom_init(nvram_t *dev) {
+	dev->write = nvram_write;
+	dev->read = nvram_read;
+
+	return 0;
+}
+
+static int nvram_read(nvram_t *dev, uint8_t *dst, uint32_t src, size_t len) {
+	uint32_t eeprom_addr = EEPROM_BASE + src;
+	uint32_t i = 0;
+	for (i = 0; i < len; i++) {
+		/* Read byte from EEPROM memory */
+		dst[i] = *((uint8_t *) (eeprom_addr + i));
+	}
+
+	return i;
+}
+
+static int nvram_write(nvram_t *dev, const uint8_t *src, uint32_t dst, size_t len) {
+	eeprom_unlock();
+
+	uint32_t eeprom_addr = EEPROM_BASE + dst;
+	uint32_t i = 0;
+	for (i = 0; i < len; i++) {
+		/* Program byte */
+		program_byte(eeprom_addr + i, src[i]);
+	}
+
+	eeprom_lock();
+
+	return i;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/driver_l1_nvram_eeprom/Makefile
+++ b/tests/driver_l1_nvram_eeprom/Makefile
@@ -1,0 +1,8 @@
+APPLICATION = driver_l1_nvram_eeprom
+include ../Makefile.tests_common
+
+USEMODULE += l1-nvram-eeprom
+USEMODULE += xtimer
+USEMODULE += random
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_l1_nvram_eeprom/README.md
+++ b/tests/driver_l1_nvram_eeprom/README.md
@@ -1,0 +1,6 @@
+# About
+This is a manual test application for the STM32L1 Data EEPROM NVRAM driver.
+
+# Warning
+The existing memory will be overwritten by the test application! The original contents
+will not be restored after the test.

--- a/tests/driver_l1_nvram_eeprom/main.c
+++ b/tests/driver_l1_nvram_eeprom/main.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2016 Unwired Devices <info@unwds.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup
+ * @{
+ *
+ * @file
+ * @brief       Test application for the STM32L1 Data EEPROM driver
+ *
+ * @author      EP <ep@unwds.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "board.h"
+#include "xtimer.h"
+#include "random.h"
+
+#include "l1-nvram-eeprom.h"
+
+#define TEST_NVRAM_SIZE 4096 * 2
+
+/* This will only work on small memories. Modify if you need to test NVRAM
+ * memories which do not fit inside free RAM */
+static uint8_t buf_out[TEST_NVRAM_SIZE];
+static uint8_t buf_in[TEST_NVRAM_SIZE];
+
+/**
+ * @brief xxd-like printing of a binary buffer
+ */
+static void print_buffer(const uint8_t *buf, size_t length)
+{
+    static const unsigned int bytes_per_line = 16;
+    static const unsigned int bytes_per_group = 2;
+    unsigned long i = 0;
+
+    while (i < length) {
+        unsigned int col;
+        for (col = 0; col < bytes_per_line; ++col) {
+            /* Print hex data */
+            if (col == 0) {
+                printf("\n%08lx: ", i);
+            }
+            else if ((col % bytes_per_group) == 0) {
+                putchar(' ');
+            }
+            if ((i + col) < length) {
+                printf("%02x", buf[i + col]);
+            }
+            else {
+                putchar(' ');
+                putchar(' ');
+            }
+        }
+
+        putchar(' ');
+        for (col = 0; col < bytes_per_line; ++col) {
+            if ((i + col) < length) {
+                /* Echo only printable chars */
+                if (isprint(buf[i + col])) {
+                    putchar(buf[i + col]);
+                }
+                else {
+                    putchar('.');
+                }
+            }
+            else {
+                putchar(' ');
+            }
+        }
+
+        i += bytes_per_line;
+    }
+
+    /* end with a new line */
+    puts("");
+}
+
+int main(void)
+{
+    uint32_t i;
+    nvram_t dev;
+
+    xtimer_init();
+    random_init(xtimer_now());
+
+    puts("NVRAM STM32L1 EEPROM test application starting...");
+    nvram_l1_eeprom_init(&dev);
+
+    puts("Reading current memory contents...");
+    for (i = 0; i < TEST_NVRAM_SIZE; ++i) {
+        if (dev.read(&dev, &buf_in[i], i, 1) != 1) {
+            puts("[Failed]\n");
+            return 1;
+        }
+    }
+    puts("[OK]");
+    puts("NVRAM contents before test:");
+    print_buffer(buf_in, sizeof(buf_in));
+
+    puts("Writing bytewise 0xFF to device");
+    memset(buf_out, 0xff, sizeof(buf_out));
+    for (i = 0; i < TEST_NVRAM_SIZE; ++i) {
+        if (dev.write(&dev, &buf_out[i], i, 1) != 1) {
+            puts("[Failed]\n");
+            return 1;
+        }
+        if (buf_out[i] != 0xff) {
+            puts("nvram_spi_write modified *src!");
+            printf(" i = %08lx\n", (unsigned long) i);
+            puts("[Failed]\n");
+            return 1;
+        }
+    }
+
+    puts("Reading back blockwise");
+    memset(buf_in, 0x00, sizeof(buf_in));
+    if (dev.read(&dev, buf_in, 0, TEST_NVRAM_SIZE) != TEST_NVRAM_SIZE) {
+        puts("[Failed]\n");
+        return 1;
+    }
+    puts("[OK]");
+    puts("Verifying contents...");
+    if (memcmp(buf_in, buf_out, TEST_NVRAM_SIZE) != 0) {
+        puts("[Failed]\n");
+        return 1;
+    }
+    puts("[OK]");
+
+    puts("Writing blockwise address complement to device");
+    for (i = 0; i < TEST_NVRAM_SIZE; ++i) {
+        buf_out[i] = (~(i)) & 0xff;
+    }
+    if (dev.write(&dev, buf_out, 0, TEST_NVRAM_SIZE) != TEST_NVRAM_SIZE) {
+        puts("[Failed]\n");
+        return 1;
+    }
+    puts("[OK]");
+
+    puts("buf_out:");
+    print_buffer(buf_out, sizeof(buf_out));
+    puts("Reading back blockwise");
+    memset(buf_in, 0x00, sizeof(buf_in));
+    if (dev.read(&dev, buf_in, 0, TEST_NVRAM_SIZE) != TEST_NVRAM_SIZE) {
+        puts("[Failed]\n");
+        return 1;
+    }
+
+    puts("[OK]");
+    puts("Verifying contents...");
+    if (memcmp(buf_in, buf_out, TEST_NVRAM_SIZE) != 0) {
+        puts("buf_in:");
+        print_buffer(buf_in, sizeof(buf_in));
+        puts("[Failed]\n");
+        return 1;
+    }
+    puts("[OK]");
+
+    puts("Generating pseudo-random test data...");
+
+    for (i = 0; i < TEST_NVRAM_SIZE; ++i) {
+        buf_out[i] = random_uint32() & 0xFF; /* Take one byte */
+    }
+
+    puts("buf_out:");
+    print_buffer(buf_out, sizeof(buf_out));
+
+    puts("Writing blockwise data to device");
+    if (dev.write(&dev, buf_out, 0, TEST_NVRAM_SIZE) != TEST_NVRAM_SIZE) {
+        puts("[Failed]\n");
+        return 1;
+    }
+    puts("[OK]");
+
+    puts("Reading back blockwise");
+    memset(buf_in, 0x00, sizeof(buf_in));
+    if (dev.read(&dev, buf_in, 0, TEST_NVRAM_SIZE) != TEST_NVRAM_SIZE) {
+        puts("[Failed]\n");
+        return 1;
+    }
+    puts("[OK]");
+    puts("Verifying contents...");
+    if (memcmp(buf_in, buf_out, TEST_NVRAM_SIZE) != 0) {
+        puts("buf_in:");
+        print_buffer(buf_in, sizeof(buf_in));
+        puts("[Failed]\n");
+        return 1;
+    }
+    puts("[OK]");
+
+    puts("All tests passed!");
+
+    /* Hang with doing nothing */
+    while (1) {
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Hello everyone,
I'm glad to introduce a simple driver for the STM32L1 Data EEPROM based on the RIOT's NVRAM interface.

Tested on my STM32L151CCU6-based device with testing app located in tests/driver_l1_nvram_eeprom
