### PR TITLE
doc: Set QUIET=YES in Doxyfile

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -693,7 +693,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error ( stderr) by doxygen. If WARNINGS is set to YES


### PR DESCRIPTION
(Warnings are still shown because `WARNINGS=YES`)

The output from `make doc` is a bit too verbose for finding the actual warnings in my opinion. This hides all the status updates such as `Generating docs for compound gnrc_rpl_dodag...` and `Preprocessing /home/jgn/work/src/riot/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h...`