### PR TITLE
drivers/adxl362: Initial support for ADXL362 accelerometer

### DIFF
--- a/drivers/adxl362/Makefile
+++ b/drivers/adxl362/Makefile
@@ -1,0 +1,3 @@
+MODULE = adxl362
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/adxl362/adxl362.c
+++ b/drivers/adxl362/adxl362.c
@@ -1,0 +1,652 @@
+/*
+ * Copyright (C) 2015-2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_adxl362
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for Analog Devices ADXL362
+ *              Micropower, 3-Axis, ±2 g/±4 g/±8 g Digital Output MEMS Accelerometer
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <errno.h>
+
+#include "adxl362.h"
+#include "log.h"
+#include "xtimer.h"
+#include "timex.h"
+#include "periph/spi.h"
+#include "periph/gpio.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* Expected device identification values */
+#define ADXL362_EXPECTED_DEVID_AD  (0xAD)
+#define ADXL362_EXPECTED_DEVID_MST (0x1D)
+
+/* Temperature sensor parameters, taken straight from the data sheet. */
+/* 25 degrees Celsius equals this many LSB */
+#define ADXL362_TEMP_25CEL_BIAS      (390)
+/* Slope, milli-Celsius per LSB */
+#define ADXL362_TEMP_SLOPE_MULT      (65)
+/* To clarify how the above constants will be used: */
+/* temp = (adc_val - bias) * slope + 25000; */
+
+/* Command set */
+enum {
+    ADXL362_CMD_WRITE_REG = 0x0A,
+    ADXL362_CMD_READ_REG  = 0x0B,
+    ADXL362_CMD_READ_FIFO = 0x0D,
+};
+
+/* Register map */
+enum {
+    ADXL362_REG_DEVID_AD       = 0x00,
+    ADXL362_REG_DEVID_MST      = 0x01,
+    ADXL362_REG_PARTID         = 0x02,
+    ADXL362_REG_REVID          = 0x03,
+    ADXL362_REG_XDATA          = 0x08,
+    ADXL362_REG_YDATA          = 0x09,
+    ADXL362_REG_ZDATA          = 0x0A,
+    ADXL362_REG_STATUS         = 0x0B,
+    ADXL362_REG_FIFO_ENTRIES_L = 0x0C,
+    ADXL362_REG_FIFO_ENTRIES_H = 0x0D,
+    ADXL362_REG_XDATA_L        = 0x0E,
+    ADXL362_REG_XDATA_H        = 0x0F,
+    ADXL362_REG_YDATA_L        = 0x10,
+    ADXL362_REG_YDATA_H        = 0x11,
+    ADXL362_REG_ZDATA_L        = 0x12,
+    ADXL362_REG_ZDATA_H        = 0x13,
+    ADXL362_REG_TEMP_L         = 0x14,
+    ADXL362_REG_TEMP_H         = 0x15,
+    ADXL362_REG_RESERVED1      = 0x16,
+    ADXL362_REG_RESERVED2      = 0x17,
+    ADXL362_REG_SOFT_RESET     = 0x1F,
+    ADXL362_REG_THRESH_ACT_L   = 0x20,
+    ADXL362_REG_THRESH_ACT_H   = 0x21,
+    ADXL362_REG_TIME_ACT       = 0x22,
+    ADXL362_REG_THRESH_INACT_L = 0x23,
+    ADXL362_REG_THRESH_INACT_H = 0x24,
+    ADXL362_REG_TIME_INACT_L   = 0x25,
+    ADXL362_REG_TIME_INACT_H   = 0x26,
+    ADXL362_REG_ACT_INACT_CTL  = 0x27,
+    ADXL362_REG_FIFO_CONTROL   = 0x28,
+    ADXL362_REG_FIFO_SAMPLES   = 0x29,
+    ADXL362_REG_INTMAP1        = 0x2A,
+    ADXL362_REG_INTMAP2        = 0x2B,
+    ADXL362_REG_FILTER_CTL     = 0x2C,
+    ADXL362_REG_POWER_CTL      = 0x2D,
+    ADXL362_REG_SELF_TEST      = 0x2E,
+};
+
+/* The values for the axis field of the FIFO buffer data */
+enum {
+    ADXL362_AXIS_X             = 0x00,
+    ADXL362_AXIS_Y             = 0x01,
+    ADXL362_AXIS_Z             = 0x02,
+    ADXL362_AXIS_TEMP          = 0x03, /* built-in temperature sensor */
+};
+
+#define ADXL362_FIFO_AXIS_SHIFT            (14)
+#define ADXL362_FIFO_AXIS_MASK             (0x03 << ADXL362_FIFO_AXIS_SHIFT)
+#define ADXL362_FIFO_DATA_SHIFT            (0)
+#define ADXL362_FIFO_DATA_MASK             (0x3fff << ADXL362_FIFO_DATA_SHIFT)
+#define ADXL362_FIFO_DATA_WIDTH            (14)
+#define ADXL362_FIFO_ENTRIES_MASK          (0x3ff)
+
+#define ADXL362_POWER_CTL_MEASURE          (0x02) /* set Measurement mode, see data sheet for details */
+
+#define ADXL362_STATUS_DATA_READY_MASK     (0x01)
+#define ADXL362_STATUS_FIFO_READY_MASK     (0x02)
+#define ADXL362_STATUS_FIFO_WATERMARK_MASK (0x04)
+#define ADXL362_STATUS_FIFO_OVERRUN_MASK   (0x08)
+#define ADXL362_STATUS_ACT_MASK            (0x10)
+#define ADXL362_STATUS_INACT_MASK          (0x20)
+#define ADXL362_STATUS_AWAKE_MASK          (0x40)
+#define ADXL362_STATUS_ERR_USER_REGS_MASK  (0x80)
+
+#define ADXL362_FILTER_RANGE_SHIFT         (6)
+#define ADXL362_FILTER_RANGE_MASK          (0x03 << ADXL362_FILTER_RANGE_SHIFT)
+#define ADXL362_FILTER_HALF_BW_SHIFT       (4)
+#define ADXL362_FILTER_HALF_BW_MASK        (0x01 << ADXL362_FILTER_HALF_BW_SHIFT)
+#define ADXL362_FILTER_ODR_SHIFT           (0)
+#define ADXL362_FILTER_ODR_MASK            (0x07 << ADXL362_FILTER_ODR_SHIFT)
+
+#define ADXL362_FIFO_CONTROL_TEMP_SHIFT    (2)
+#define ADXL362_FIFO_CONTROL_TEMP_MASK     (0x01 << ADXL362_FILTER_RANGE_SHIFT)
+#define ADXL362_FIFO_CONTROL_AH_SHIFT      (3)
+#define ADXL362_FIFO_CONTROL_AH_MASK       (0x01 << ADXL362_FILTER_HALF_BW_SHIFT)
+#define ADXL362_FIFO_CONTROL_MODE_SHIFT    (0)
+#define ADXL362_FIFO_CONTROL_MODE_MASK     (0x03 << ADXL362_FILTER_ODR_SHIFT)
+
+#define ADXL362_SELF_TEST_MASK             (0x01)
+/* Time to wait during self test until values have stabilized */
+#define ADXL362_SELF_TEST_SLEEP            (100 * MS_IN_USEC)
+/* Self test expected values */
+#define ADXL362_SELF_TEST_XOFF_MIN         (450)
+#define ADXL362_SELF_TEST_XOFF_MAX         (710)
+#define ADXL362_SELF_TEST_YOFF_MIN         (-710)
+#define ADXL362_SELF_TEST_YOFF_MAX         (-450)
+#define ADXL362_SELF_TEST_ZOFF_MIN         (350)
+#define ADXL362_SELF_TEST_ZOFF_MAX         (650)
+/* The self-test offset is dependent on the supply voltage, see data sheet:
+ * Table 22. Self Test Output Scale Factors for Different Supply Voltages, Vs */
+/* represented as a power of two fraction (FACTOR / 2**SHIFT) */
+/* Choose this shift so that the 32 bit intermediate variable does not overflow,
+ * 16 bits should be safe for the whole sensor range and still close to optimum */
+#define ADXL362_SELF_TEST_VSS_SCALE_SHIFT  (16)    /* denominator exponent */
+/* The values below were interpolated from the given table for a 3.3 V supply
+ * voltage (2.95x is the resulting factor) */
+/* The division by 100 is placed here with only numeric constants to allow the
+ * compiler to optimize away the division completely */
+#define ADXL362_SELF_TEST_VSS_SCALE_FACTOR ((295UL << ADXL362_SELF_TEST_VSS_SCALE_SHIFT) / 100)
+/* convenience macro */
+#define ADXL362_SELF_TEST_RESCALE_LIMIT(x) \
+    (((x) * ADXL362_SELF_TEST_VSS_SCALE_FACTOR) >> ADXL362_SELF_TEST_VSS_SCALE_SHIFT)
+
+/**
+ * @internal
+ * @brief Read registers from the device
+ *
+ * @param[in]  dev   pointer to device descriptor
+ * @param[in]  addr  register address
+ * @param[out] buf   output buffer
+ * @param[in]  count number of bytes to read
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+static int adxl362_read_regs(const adxl362_t *dev, uint8_t addr, uint8_t *buf, size_t count)
+{
+    DEBUG("adxl362_read_regs: %p, 0x%02x, %p, %lu\n", (void *)dev,
+        (unsigned int)addr, (void *)buf, (unsigned long)count);
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs);
+    int res;
+    res = spi_transfer_byte(dev->spi, ADXL362_CMD_READ_REG, NULL);
+    if (res < 0) {
+        DEBUG("adxl362_read_regs: SPI ERR!\n");
+        return res;
+    }
+    res = spi_transfer_regs(dev->spi, addr, NULL, (char *)buf, count);
+    if (res < 0) {
+        DEBUG("adxl362_read_regs: SPI ERR!\n");
+        return res;
+    }
+    gpio_set(dev->cs);
+    spi_release(dev->spi);
+    return 0;
+}
+
+/**
+ * @internal
+ * @brief Read registers from the device
+ *
+ * @param[in]  dev   pointer to device descriptor
+ * @param[in]  addr  register address
+ * @param[in]  val   register value
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+static int adxl362_write_reg(const adxl362_t *dev, uint8_t addr, uint8_t val)
+{
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs);
+    int res;
+    res = spi_transfer_byte(dev->spi, ADXL362_CMD_WRITE_REG, NULL);
+    if (res < 0) {
+        return res;
+    }
+    res = spi_transfer_reg(dev->spi, addr, val, NULL);
+    if (res < 0) {
+        return res;
+    }
+    gpio_set(dev->cs);
+    spi_release(dev->spi);
+    return 0;
+}
+
+/**
+ * @internal
+ * @brief Read FIFO contents from the device
+ *
+ * @param[in]  dev     pointer to device descriptor
+ * @param[out] buf     output buffer
+ * @param[in]  bufsize size of output buffer, in bytes
+ *
+ * @return number of read FIFO values on success
+ * @return <0 on error
+ */
+static int adxl362_read_fifo(const adxl362_t *dev, uint8_t *buf, size_t bufsize)
+{
+    DEBUG("adxl362_read_fifo: %p, %p, %lu\n", (void *)dev, (void *)buf, (unsigned long) bufsize);
+    int res;
+    /* Check how many values are available in the FIFO */
+    union {
+        uint16_t u16;
+        uint8_t u8[2];
+    } tmp;
+    res = adxl362_read_regs(dev, ADXL362_REG_FIFO_ENTRIES_L, tmp.u8, sizeof(tmp.u8));
+    DEBUG("adxl362: FIFO_ENTRIES=%02x %02x\n", (unsigned int)tmp.u8[0], (unsigned int)tmp.u8[1]);
+    /* FIFO_ENTRIES is stored little endian on the device, the below or+shift
+     * should be a no-op on LE machines (byteorder.h is missing
+     * host-to-little-endian functions, 2016-08-10) */
+    uint16_t nentries = ((tmp.u8[1] << 8) | tmp.u8[0]) & ADXL362_FIFO_ENTRIES_MASK;
+    DEBUG("adxl362: nfifo=%u\n", (unsigned int) nentries);
+    if (nentries == 0) {
+        return 0;
+    }
+    /* nentries is the number of 16 bit values in the FIFO */
+    if (nentries > (bufsize / sizeof(uint16_t))) {
+        nentries = bufsize / sizeof(uint16_t);
+    }
+    spi_acquire(dev->spi);
+    gpio_clear(dev->cs);
+    res = spi_transfer_regs(dev->spi, ADXL362_CMD_READ_FIFO, NULL, (char *)buf, nentries * sizeof(uint16_t));
+    if (res < 0) {
+        return res;
+    }
+    gpio_set(dev->cs);
+    spi_release(dev->spi);
+    DEBUG("adxl362_read_fifo: read=%lu\n", (unsigned long) nentries);
+    return nentries;
+}
+
+/**
+ * @internal
+ * @brief Read the status register from the device
+ *
+ * @param[in]  dev  pointer to device descriptor
+ *
+ * @return status byte
+ * @return 0xff on error
+ */
+static uint8_t adxl362_get_status(const adxl362_t *dev)
+{
+    uint8_t buf;
+    int res = adxl362_read_regs(dev, ADXL362_REG_STATUS, &buf, 1);
+    if (res < 0) {
+        buf = 0xff;
+    }
+    return buf;
+}
+
+int adxl362_init(adxl362_t *dev, spi_t spi, gpio_t cs)
+{
+    DEBUG("adxl362_init %p\n", (void *)dev);
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+    dev->spi = spi;
+    dev->cs = cs;
+
+    gpio_init(dev->cs, GPIO_OUT);
+    gpio_set(dev->cs);
+
+    /* Read chip identification */
+    uint8_t buf[4];
+    DEBUG("adxl362: Checking device identification\n");
+    int res = adxl362_read_regs(dev, ADXL362_REG_DEVID_AD, buf, sizeof(buf));
+    if (res < 0) {
+        DEBUG("adxl362: SPI error!\n");
+        return -EIO;
+    }
+    DEBUG("adxl362: ID: AD=0x%02x MST=0x%02x PART=0%03o REV=0x%02x\n",
+        (unsigned int)buf[0], (unsigned int)buf[1],
+        (unsigned int)buf[2], (unsigned int)buf[3]);
+
+    if ((buf[0] != ADXL362_EXPECTED_DEVID_AD) ||
+        (buf[1] != ADXL362_EXPECTED_DEVID_MST)) {
+        /* PARTID is 0362 (octal) for the ADXL362, but this driver might work
+         * with other variants as well (untested), so there's no reason to
+         * further restrict us right now. */
+        LOG_ERROR("adxl362: ID: AD=0x%02x MST=0x%02x PART=0%03o REV=0x%02x\n",
+            (unsigned int)buf[0], (unsigned int)buf[1],
+            (unsigned int)buf[2], (unsigned int)buf[3]);
+        LOG_ERROR("adxl362: Unknown ID, expected AD=0x%02x MST=0x%02x\n",
+            (unsigned int)ADXL362_EXPECTED_DEVID_AD,
+            (unsigned int)ADXL362_EXPECTED_DEVID_MST);
+        return -ENODEV;
+    }
+
+    /* Perform a soft reset */
+    res = adxl362_write_reg(dev, ADXL362_REG_SOFT_RESET, 'R');
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+    /* There's no mention of it in the data sheet, but empirical evidence
+     * suggests that there has to be a short delay between writing soft reset,
+     * and writing other registers, or else the second write is sometimes
+     * ignored. 5 ms seem to work fine (picked at random during testing) */
+    xtimer_usleep(5 * MS_IN_USEC);
+
+    /* Set some valid default filter settings */
+    res = adxl362_set_filter(dev, ADXL362_RANGE_4G, ADXL362_ODR_100HZ, 1);
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+
+    res = adxl362_set_fifo(dev, false, ADXL362_FIFO_MODE_DISABLED, ADXL362_FIFO_WATERMARK_DEFAULT);
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+
+    uint8_t power_ctl = ADXL362_POWER_CTL_MEASURE;
+
+    DEBUG("adxl362: write POWER_CTL=0x%02x\n", power_ctl);
+    res = adxl362_write_reg(dev, ADXL362_REG_POWER_CTL, power_ctl);
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+
+    return 0;
+}
+
+int adxl362_set_filter(adxl362_t *dev, adxl362_range_t range, adxl362_odr_t odr, bool half_bw)
+{
+    DEBUG("adxl362_set_filter %p, range=%u (%u g), half_bw=%u, odr=%u (%u Hz)\n",
+        (void *)dev, (unsigned int)range, (2U << (unsigned int)range), (unsigned int)half_bw,
+        (unsigned int)odr, (400U >> (ADXL362_ODR_400HZ - (unsigned int)odr)));
+    uint8_t filter_ctl =
+        ((range << ADXL362_FILTER_RANGE_SHIFT) & ADXL362_FILTER_RANGE_MASK) |
+        ((half_bw << ADXL362_FILTER_HALF_BW_SHIFT) & ADXL362_FILTER_HALF_BW_MASK) |
+        ((odr << ADXL362_FILTER_ODR_SHIFT) & ADXL362_FILTER_ODR_MASK);
+    DEBUG("adxl362: write FILTER_CTL=0x%02x\n", filter_ctl);
+    int res = adxl362_write_reg(dev, ADXL362_REG_FILTER_CTL, filter_ctl);
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+    /* The hardware values for the valid range settings are the number of left
+     * shifts needed to go from 2 to the chosen range */
+    dev->scale_shift = range;
+    return 0;
+}
+
+int adxl362_set_fifo(const adxl362_t *dev, bool store_temp, adxl362_fifo_mode_t mode, unsigned int watermark)
+{
+    DEBUG("adxl362_set_fifo %p, store_temp=%u, mode=%u, size=%u\n",
+        (void *)dev, (unsigned int)store_temp, (unsigned int)mode, watermark);
+    if (watermark >= ADXL362_FIFO_SIZE) {
+        watermark = ADXL362_FIFO_SIZE - 1;
+    }
+
+    uint8_t watermark_lsb = watermark & 0xff;
+    uint8_t fifo_control =
+        ((store_temp << ADXL362_FIFO_CONTROL_TEMP_SHIFT) & ADXL362_FIFO_CONTROL_TEMP_MASK) |
+        ((mode << ADXL362_FIFO_CONTROL_MODE_SHIFT) & ADXL362_FIFO_CONTROL_MODE_MASK) |
+        (((watermark >> 8) << ADXL362_FIFO_CONTROL_AH_SHIFT) & ADXL362_FIFO_CONTROL_AH_MASK);
+    int res;
+    DEBUG("adxl362: write FIFO_CONTROL=0x%02x\n", fifo_control);
+    res = adxl362_write_reg(dev, ADXL362_REG_FIFO_CONTROL, fifo_control);
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+    DEBUG("adxl362: write FIFO_SAMPLES=0x%02x\n", watermark_lsb);
+    res = adxl362_write_reg(dev, ADXL362_REG_FIFO_SAMPLES, watermark_lsb);
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+    return 0;
+}
+
+int adxl362_read_acc_fifo(const adxl362_t *dev, adxl362_data_t *acc, size_t count)
+{
+    DEBUG("adxl362_read_acc %p, %p, %lu\n", (void *)dev, (void *)acc, (unsigned long)count);
+    /* Check status */
+    uint8_t status = adxl362_get_status(dev);
+    if (status == 0xff) {
+        LOG_ERROR("adxl362: Status error!\n");
+        return -EIO;
+    }
+    DEBUG("adxl362: status=0x%02x\n", (unsigned int)status);
+    if ((status & ADXL362_STATUS_FIFO_READY_MASK) == 0) {
+        DEBUG("adxl362: FIFO ready is not set\n");
+    }
+    if (ENABLE_DEBUG != 0) {
+        uint8_t tmp = 0;
+        adxl362_read_regs(dev, ADXL362_REG_FILTER_CTL, &tmp, 1);
+        DEBUG("adxl362: filter=0x%02x\n", tmp);
+        adxl362_read_regs(dev, ADXL362_REG_FIFO_CONTROL, &tmp, 1);
+        DEBUG("adxl362:   fifo=0x%02x\n", tmp);
+    }
+    if (count == 0) {
+        return 0;
+    }
+
+    /* Unpacking/decoding values in-place to reduce memory usage */
+    uint8_t *buf = (uint8_t*)acc;
+    size_t bufsize = count * sizeof(*acc);
+    int nentries = adxl362_read_fifo(dev, buf, bufsize);
+    if (nentries < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+    bool found_beginning = false;
+    int ret = 0;
+    while (nentries > 0) {
+        /* Pop a FIFO value off the beginning of the buffer */
+        /* Data is stored little endian on the device */
+        uint16_t data = (buf[1] << 8) | buf[0];
+        buf += sizeof(data);
+        --nentries;
+
+        /* Decode axis identification */
+        unsigned int axis = (data & ADXL362_FIFO_AXIS_MASK) >> ADXL362_FIFO_AXIS_SHIFT;
+        if (!found_beginning) {
+            /* Data order on the device is X1, Y1, Z1, (Temp1, ) X2, Y2, Z2,
+             * (Temp2, ) etc. Skip values until we are at an X axis value, to
+             * get the measurements in sync */
+            if (axis != ADXL362_AXIS_X) {
+                DEBUG("adxl362: Skipping value axis=%u\n", axis);
+                continue;
+            }
+            found_beginning = true;
+        }
+        int32_t value = ((data & ADXL362_FIFO_DATA_MASK) >> ADXL362_FIFO_DATA_SHIFT);
+        /* Sign extend */
+        value = (int32_t)(value << (sizeof(value) * 8 - ADXL362_FIFO_DATA_WIDTH))
+            >> (sizeof(value) * 8 - ADXL362_FIFO_DATA_WIDTH);
+        /* rescale to milli-g */
+        value <<= dev->scale_shift;
+
+        switch(axis) {
+            case ADXL362_AXIS_X:
+                DEBUG("adxl362: %4d X=%6" PRId32 "\n", ret, value);
+                acc->acc_x = (int16_t)value;
+                break;
+            case ADXL362_AXIS_Y:
+                DEBUG("adxl362: %4d Y=%6" PRId32 "\n", ret, value);
+                acc->acc_y = (int16_t)value;
+                break;
+            case ADXL362_AXIS_Z:
+                DEBUG("adxl362: %4d Z=%6" PRId32 "\n", ret, value);
+                acc->acc_z = (int16_t)value;
+                /* Z should be the last value in the sequence, move to next point */
+                ++acc;
+                /* We only return the number of complete readings */
+                ++ret;
+                break;
+            default:
+                /* Ignoring temperature for now */
+                break;
+        }
+    }
+    return ret;
+}
+
+int adxl362_read_acc_now(const adxl362_t *dev, adxl362_data_t *acc)
+{
+    DEBUG("adxl362_read_acc_now: %p, %p\n", (void *)dev, (void *)acc);
+    uint8_t buf[sizeof(*acc)];
+    /* The acceleration data registers are located next to each other in the
+     * register map, get all of them in one transaction */
+    if (ENABLE_DEBUG != 0) {
+        uint8_t tmp = 0;
+        adxl362_read_regs(dev, ADXL362_REG_FILTER_CTL, &tmp, 1);
+        DEBUG("adxl362: filter=0x%02x\n", tmp);
+        adxl362_read_regs(dev, ADXL362_REG_FIFO_CONTROL, &tmp, 1);
+        DEBUG("adxl362:   fifo=0x%02x\n", tmp);
+    }
+    uint8_t status = adxl362_get_status(dev);
+    DEBUG("adxl362: status=0x%02x\n", (unsigned int)status);
+    if ((status & ADXL362_STATUS_DATA_READY_MASK) == 0) {
+        LOG_WARNING("adxl362: no data available\n");
+        return -EAGAIN;
+    }
+    DEBUG("adxl362: dev->scale_shift=%u\n", (unsigned int)dev->scale_shift);
+    int res = adxl362_read_regs(dev, ADXL362_REG_XDATA_L, buf, sizeof(buf));
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+    DEBUG("adxl362: buf: %02x %02x %02x %02x %02x %02x\n",
+        (unsigned int)buf[0], (unsigned int)buf[1],
+        (unsigned int)buf[2], (unsigned int)buf[3],
+        (unsigned int)buf[4], (unsigned int)buf[5]);
+
+    acc->acc_x = ((buf[1] << 8) | buf[0]) << dev->scale_shift;
+    acc->acc_y = ((buf[3] << 8) | buf[2]) << dev->scale_shift;
+    acc->acc_z = ((buf[5] << 8) | buf[4]) << dev->scale_shift;
+
+    return 0;
+}
+
+int adxl362_read_temp(const adxl362_t *dev, int32_t *temp)
+{
+    uint8_t buf[2];
+    /* TEMP_L and TEMP_H are located next to each other in the register map, get
+     * both using a single 2 byte read transaction */
+    int res = adxl362_read_regs(dev, ADXL362_REG_TEMP_L, buf, sizeof(buf));
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+
+    /* byte ordering and alignment */
+    int32_t adc_val = (buf[1] << 8) | buf[0];
+
+    (*temp) = (adc_val - ADXL362_TEMP_25CEL_BIAS) * ADXL362_TEMP_SLOPE_MULT + 25000;
+    return 0;
+}
+
+static bool adxl362_self_test_check(int16_t value, int16_t min, int16_t max)
+{
+    bool pass = true;
+    DEBUG("adxl362_self_test_check:   [%6d, %6d]  ", (int)min, (int)max);
+    if (value > max) {
+        pass = false;
+    }
+    if (value < min) {
+        pass = false;
+    }
+    DEBUG("%s", (pass ? "OK\n" : "<--- NOT OK\n"));
+    return pass;
+}
+
+int adxl362_self_test(const adxl362_t *dev)
+{
+    /*
+     * Algorithm outline (from data sheet):
+     *
+     * 1. Read acceleration data for the x-, y-, and z-axes.
+     * 2. Assert self test by setting the ST bit in the SELF_TEST register
+     * 3. Wait 1/ODR for the output to settle to its new value.
+     * 4. Read acceleration data for the x-, y-, and z-axes.
+     * 5. Compare to the values from Step 1, and convert the difference from LSB
+     *    to mg by multiplying by the sensitivity. If the observed difference
+     *    falls within the self test output change specification listed in
+     *    Table 1, then the device passes self test and is deemed operational.
+     * 6. Deassert self test by clearing the ST bit in the SELF_TEST register
+     */
+    DEBUG("adxl362_self_test: %p\n", (void *)dev);
+    /* Let values stabilize */
+    xtimer_usleep(ADXL362_SELF_TEST_SLEEP);
+    /* read current values of X, Y, Z */
+    adxl362_data_t baseline;
+    int res;
+    res = adxl362_read_acc_now(dev, &baseline);
+    if (res < 0) {
+        return res;
+    }
+
+    DEBUG("adxl362_self_test:    baseline: %6d %6d %6d\n",
+        (int)baseline.acc_x, (int)baseline.acc_y, (int)baseline.acc_z);
+    DEBUG("adxl362_self_test: enable self-test bit\n");
+    res = adxl362_write_reg(dev, ADXL362_REG_SELF_TEST, ADXL362_SELF_TEST_MASK);
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+    /* Let values stabilize */
+    xtimer_usleep(ADXL362_SELF_TEST_SLEEP);
+    /* read new values of X, Y, Z */
+    adxl362_data_t self_test_data;
+    res = adxl362_read_acc_now(dev, &self_test_data);
+    if (res < 0) {
+        return res;
+    }
+
+    DEBUG("adxl362_self_test: disable self-test bit\n");
+    res = adxl362_write_reg(dev, ADXL362_REG_SELF_TEST, 0);
+    if (res < 0) {
+        LOG_ERROR("adxl362: SPI error!\n");
+        return -EIO;
+    }
+
+    DEBUG("adxl362_self_test: with ST bit: %6d %6d %6d\n",
+        (int)self_test_data.acc_x, (int)self_test_data.acc_y, (int)self_test_data.acc_z);
+
+    self_test_data.acc_x -= baseline.acc_x;
+    self_test_data.acc_y -= baseline.acc_y;
+    self_test_data.acc_z -= baseline.acc_z;
+    DEBUG("adxl362_self_test:  difference: %6d %6d %6d\n",
+        (int)self_test_data.acc_x, (int)self_test_data.acc_y, (int)self_test_data.acc_z);
+
+    bool pass = true;
+    bool check;
+    DEBUG("adxl362_self_test: Check X:\n");
+    check = adxl362_self_test_check(self_test_data.acc_x,
+        ADXL362_SELF_TEST_RESCALE_LIMIT(ADXL362_SELF_TEST_XOFF_MIN),
+        ADXL362_SELF_TEST_RESCALE_LIMIT(ADXL362_SELF_TEST_XOFF_MAX));
+    if (!check) {
+        pass = false;
+    }
+    DEBUG("adxl362_self_test: Check Y:\n");
+    check = adxl362_self_test_check(self_test_data.acc_y,
+        ADXL362_SELF_TEST_RESCALE_LIMIT(ADXL362_SELF_TEST_YOFF_MIN),
+        ADXL362_SELF_TEST_RESCALE_LIMIT(ADXL362_SELF_TEST_YOFF_MAX));
+    if (!check) {
+        pass = false;
+    }
+    DEBUG("adxl362_self_test: Check Z:\n");
+    check = adxl362_self_test_check(self_test_data.acc_z,
+        ADXL362_SELF_TEST_RESCALE_LIMIT(ADXL362_SELF_TEST_ZOFF_MIN),
+        ADXL362_SELF_TEST_RESCALE_LIMIT(ADXL362_SELF_TEST_ZOFF_MAX));
+    if (!check) {
+        pass = false;
+    }
+    return (pass ? 1 : 0);
+}

--- a/drivers/adxl362/adxl362_saul.c
+++ b/drivers/adxl362/adxl362_saul.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_adxl362
+ * @{
+ *
+ * @file
+ * @brief       SAUL adaptation layer for ADXL362 accelerometer
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include "saul.h"
+
+#include "adxl362.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+static int read_acceleration(void *ptr, phydat_t *res)
+{
+    adxl362_t *dev = ptr;
+
+    adxl362_data_t data;
+
+    int status = adxl362_read_acc_now(dev, &data);
+    if (status < 0) {
+        DEBUG("adxl362_saul: Communication error!\n");
+        return -ECANCELED;
+    }
+
+    res->val[0] = (int32_t)data.acc_x;
+    res->val[1] = (int32_t)data.acc_y;
+    res->val[2] = (int32_t)data.acc_z;
+    res->unit = UNIT_G;
+    res->scale = -3; /* low level device driver uses milli-G */
+
+    return 3;
+}
+
+static int read_temperature(void *ptr, phydat_t *res)
+{
+    adxl362_t *dev = ptr;
+    int32_t temp = 0;
+
+    int status = adxl362_read_temp(dev, &temp);
+    if (status < 0) {
+        DEBUG("adxl362_saul: Communication error!\n");
+        return -ECANCELED;
+    }
+
+    res->val[0] = temp;
+    res->unit = UNIT_TEMP_C;
+    res->scale = -3; /* low level device driver uses milli-Celsius */
+
+    return 1;
+}
+
+const saul_driver_t adxl362_temperature_saul_driver = {
+    .read = read_temperature,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TEMP
+};
+
+const saul_driver_t adxl362_acceleration_saul_driver = {
+    .read = read_acceleration,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_ACCEL
+};

--- a/drivers/adxl362/example_adxl362_params.txt
+++ b/drivers/adxl362/example_adxl362_params.txt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/* Copy this file to adxl362_params.h and modify to fit your setup. */
+
+/**
+ * @ingroup   boards_xxx
+ * @{
+ *
+ * @file
+ * @brief     ADXL362 board specific configuration
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef ADXL362_PARAMS_H
+#define ADXL362_PARAMS_H
+
+#include "board.h"
+#include "adxl362.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADXL362 configuration
+ */
+static const  adxl362_params_t adxl362_params[] =
+{
+    {
+        .spi   = SPI_DEV(1),
+        .cs    = GPIO_PIN(PORT_E,4),
+        .range = ADXL362_RANGE_4G,
+        .odr   = ADXL362_ODR_100HZ,
+    },
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t adxl362_saul_reg_info[] =
+{
+    {
+        /* acceleration SAUL provider name */
+        .name = "adxl362-acc",
+    },
+    {
+        /* temperature SAUL provider name */
+        .name = "adxl362-temp",
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADXL362_PARAMS_H */
+/** @} */

--- a/drivers/include/adxl362.h
+++ b/drivers/include/adxl362.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2015-2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_adxl362 ADXL362 Accelerometer
+ * @ingroup     drivers_sensors
+ * @brief       Device driver for Analog Devices ADXL362 Micropower, 3-Axis,
+ *              ±2 g/±4 g/±8 g Digital Output MEMS Accelerometer
+ * @{
+ *
+ * @file
+ * @brief       Device driver for Analog Devices ADXL362 Micropower, 3-Axis,
+ *              ±2 g/±4 g/±8 g Digital Output MEMS Accelerometer
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef ADXL362_H_
+#define ADXL362_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Size of the internal FIFO buffer
+ */
+#define ADXL362_FIFO_SIZE                  (512)
+/**
+ * @brief Default watermark level when initializing the FIFO.
+ *
+ * same as power on default
+ */
+#define ADXL362_FIFO_WATERMARK_DEFAULT     (0x80)
+
+/**
+ * @brief Device descriptor for ADXL362 sensors
+ */
+typedef struct {
+    spi_t spi;            /**< SPI bus the sensor is connected to */
+    gpio_t cs;            /**< Chip select line used */
+    uint8_t scale_shift;  /**< Current scale setting, in number of bit shifts */
+} adxl362_t;
+
+/**
+ * @brief Result vector for accelerometer measurement
+ */
+typedef struct
+{
+    int16_t acc_x;          /**< Acceleration in the X direction in milli-G */
+    int16_t acc_y;          /**< Acceleration in the Y direction in milli-G */
+    int16_t acc_z;          /**< Acceleration in the Z direction in milli-G */
+} adxl362_data_t;
+
+/**
+ * @brief Output data rate valid parameter values
+ */
+typedef enum {
+    ADXL362_ODR_12_5HZ = 0x00, /**< 12.5 Hz output data rate */
+    ADXL362_ODR_25HZ   = 0x01, /**< 25 Hz output data rate */
+    ADXL362_ODR_50HZ   = 0x02, /**< 50 Hz output data rate */
+    ADXL362_ODR_100HZ  = 0x03, /**< 100 Hz output data rate */
+    ADXL362_ODR_200HZ  = 0x04, /**< 200 Hz output data rate */
+    ADXL362_ODR_400HZ  = 0x05, /**< 400 Hz output data rate */
+} adxl362_odr_t;
+
+/**
+ * @brief Range valid parameter values
+ */
+typedef enum {
+    ADXL362_RANGE_2G   = 0x00, /**< range = +/- 2 g */
+    ADXL362_RANGE_4G   = 0x01, /**< range = +/- 4 g */
+    ADXL362_RANGE_8G   = 0x02, /**< range = +/- 8 g */
+} adxl362_range_t;
+
+/**
+ * @brief FIFO mode valid parameter values
+ */
+typedef enum {
+    ADXL362_FIFO_MODE_DISABLED  = 0x00, /**< FIFO disabled */
+    ADXL362_FIFO_MODE_FIRST_N   = 0x01, /**< Keep old values, discard new if FIFO is full */
+    ADXL362_FIFO_MODE_LAST_N    = 0x02, /**< Discard old values if FIFO is full, keep new values */
+    ADXL362_FIFO_MODE_TRIGGERED = 0x03, /**< Event triggered, see data sheet */
+} adxl362_fifo_mode_t;
+
+/**
+ * @brief Auto-init parameters for ADXL362 sensors
+ */
+typedef struct {
+    spi_t spi;             /**< SPI bus the sensor is connected to */
+    gpio_t cs;             /**< Chip select line used */
+    adxl362_range_t range; /**< Range setting */
+    adxl362_odr_t odr;     /**< ODR setting */
+} adxl362_params_t;
+
+/**
+ * @brief Initialize a sensor
+ *
+ * @param[in]  dev      device descriptor of sensor to initialize
+ * @param[in]  spi      SPI bus the sensor is connected to
+ * @param[in]  cs       GPIO pin the chip select signal is connected to
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int adxl362_init(adxl362_t *dev, spi_t spi, gpio_t cs);
+
+/**
+ * @brief Read acceleration data from FIFO on the device
+ *
+ * @param[in]  dev      Sensor device descriptor
+ * @param[out] acc      Pointer to output buffer for acceleration data
+ * @param[in]  count    available space in output buffer, in number of elements
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int adxl362_read_acc_fifo(const adxl362_t *dev, adxl362_data_t *acc, size_t count);
+
+/**
+ * @brief Read the latest acceleration data from the device
+ *
+ * This bypasses the FIFO and reads straight from the DATA_XYZ registers on the
+ * device.
+ *
+ * @param[in]  dev      Sensor device descriptor
+ * @param[out] acc      Pointer to output buffer for acceleration data
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int adxl362_read_acc_now(const adxl362_t *dev, adxl362_data_t *acc);
+
+/**
+ * @brief Read temperature data from the device, in milli-Celsius
+ *
+ * @param[in]  dev      Sensor device descriptor
+ * @param[out] temp     Pointer to output buffer for temperature data
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int adxl362_read_temp(const adxl362_t *dev, int32_t *temp);
+
+/**
+ * @brief Configure filter parameters in the device
+ *
+ * See data sheet for details on how to configure the sensor parameters for your application.
+ *
+ * @param[in]  dev      Sensor device descriptor
+ * @param[in]  range    Sensitivity
+ * @param[in]  half_bw  true: Use ODR / 4 as the filter frequency for antialiasing filter,
+ *                      false: Use ODR / 2 as the filter frequency for antialiasing filter.
+ * @param[in]  odr      Output data rate, the rate of new samples added to the FIFO
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int adxl362_set_filter(adxl362_t *dev, adxl362_range_t range, adxl362_odr_t odr, bool half_bw);
+
+/**
+ * @brief Configure FIFO parameters in the device
+ *
+ * See data sheet for details on how to configure the FIFO for your application.
+ *
+ * @param[in]  dev         Sensor device descriptor
+ * @param[in]  store_temp  Store temperature data along with X,Y,Z acceleration in FIFO (default: no)
+ * @param[in]  mode        FIFO discard mode (first N, last N)
+ * @param[in]  watermark   FIFO watermark level (max 511)
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int adxl362_set_fifo(const adxl362_t *dev, bool store_temp, adxl362_fifo_mode_t mode, unsigned int watermark);
+
+/**
+ * @brief Perform device self test
+ *
+ * Vendor provided algorithm
+ *
+ * @param[in]  dev         Sensor device descriptor
+ *
+ * @return 1 on self-test passed
+ * @return 0 on self-test failed
+ * @return <0 on error
+ */
+int adxl362_self_test(const adxl362_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADXL362_H_ */
+/** @} */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -275,6 +275,10 @@ void auto_init(void)
     extern void auto_init_adc(void);
     auto_init_adc();
 #endif
+#ifdef MODULE_ADXL362
+    extern void auto_init_adxl362(void);
+    auto_init_adxl362();
+#endif
 #ifdef MODULE_LSM303DLHC
     extern void auto_init_lsm303dlhc(void);
     auto_init_lsm303dlhc();

--- a/sys/auto_init/saul/auto_init_adxl362.c
+++ b/sys/auto_init/saul/auto_init_adxl362.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of ADXL362 driver
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#ifdef MODULE_ADXL362
+
+#include "log.h"
+#include "saul_reg.h"
+
+#include "adxl362_params.h"
+#include "adxl362.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define ADXL362_NUMOF    (sizeof(adxl362_params) / sizeof(adxl362_params[0]))
+
+/**
+ * @brief   Allocation of memory for device descriptors
+ */
+static adxl362_t adxl362_devs[ADXL362_NUMOF];
+
+/**
+ * @brief   Memory for the SAUL registry temperature sensor entries
+ */
+static saul_reg_t saul_entries_temp[ADXL362_NUMOF];
+
+/**
+ * @brief   Memory for the SAUL registry acceleration sensor entries
+ */
+static saul_reg_t saul_entries_acc[ADXL362_NUMOF];
+
+/**
+ * @brief   Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t adxl362_temperature_saul_driver;
+extern const saul_driver_t adxl362_acceleration_saul_driver;
+/** @} */
+
+void auto_init_adxl362(void)
+{
+    for (unsigned int i = 0; i < ADXL362_NUMOF; i++) {
+        int res;
+        adxl362_t *dev = &adxl362_devs[i];
+        const adxl362_params_t *params = &adxl362_params[i];
+        res = spi_init_master(params->spi, SPI_CONF_FIRST_RISING, SPI_SPEED_1MHZ);
+        if (res < 0) {
+            LOG_ERROR("Unable to initialize SPI bus #%u\n", dev->spi);
+            continue;
+        }
+        res = adxl362_init(dev, params->spi, params->cs);
+        if (res < 0) {
+            LOG_ERROR("Unable to initialize ADXL362 sensor #%u\n", i);
+            continue;
+        }
+        res = adxl362_set_filter(dev, params->range, params->odr, 0);
+        if (res < 0) {
+            LOG_ERROR("Unable to set filter parameters on ADXL362 sensor #%u\n", i);
+            continue;
+        }
+        /* acceleration */
+        saul_entries_acc[i].dev = &adxl362_devs[i];
+        saul_entries_acc[i].name = adxl362_saul_reg_info[i].name;
+        saul_entries_acc[i].driver = &adxl362_acceleration_saul_driver;
+        saul_reg_add(&saul_entries_acc[i]);
+
+        /* temperature ADC */
+        saul_entries_temp[i].dev = &adxl362_devs[i];
+        saul_entries_temp[i].name = adxl362_saul_reg_info[i + 1].name;
+        saul_entries_temp[i].driver = &adxl362_temperature_saul_driver;
+        saul_reg_add(&saul_entries_temp[i]);
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_ADXL362 */

--- a/tests/driver_adxl362/Makefile
+++ b/tests/driver_adxl362/Makefile
@@ -1,0 +1,18 @@
+APPLICATION = driver_adxl362
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_spi
+FEATURES_REQUIRED = periph_gpio
+
+USEMODULE += adxl362
+USEMODULE += xtimer
+
+# set default device parameters in case they are undefined
+TEST_ADXL362_SPI  ?= SPI_1
+TEST_ADXL362_CS   ?= 'GPIO_PIN(PORT_E,4)'
+
+# export parameters
+CFLAGS += -DTEST_ADXL362_SPI=$(TEST_ADXL362_SPI)
+CFLAGS += -DTEST_ADXL362_CS=$(TEST_ADXL362_CS)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_adxl362/README.md
+++ b/tests/driver_adxl362/README.md
@@ -1,0 +1,7 @@
+# About
+This is a manual test application for the ADXL362 accelerometer sensor.
+
+# Usage
+
+After initialization, the sensor reads the measurement values every 100ms
+and prints them to the STDOUT.

--- a/tests/driver_adxl362/main.c
+++ b/tests/driver_adxl362/main.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2015-2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the ADXL362 sensor driver
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#ifndef TEST_ADXL362_SPI
+#error "TEST_ADXL362_SPI not defined"
+#endif
+#ifndef TEST_ADXL362_CS
+#error "TEST_ADXL362_CS not defined"
+#endif
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "xtimer.h"
+#include "timex.h"
+#include "adxl362.h"
+
+#define SLEEP    (100 * MS_IN_USEC)
+
+int main(void)
+{
+    int res;
+    adxl362_t dev;
+
+    puts("ADXL362 sensor driver test application\n");
+    printf("Initializing SPI_%i... ", TEST_ADXL362_SPI);
+    /* ADXL362 requires SPI Mode 0 */
+    /* Max fSCK is 1 MHz, according to the data sheet, but the device seem to
+     * work fine with higher speeds as well. */
+    res = spi_init_master(TEST_ADXL362_SPI, SPI_CONF_FIRST_RISING, SPI_SPEED_1MHZ);
+    if (res < 0) {
+        puts("[Failed]");
+        return -1;
+    }
+    puts("[OK]");
+
+    printf("Initializing ADXL362 sensor at SPI_%i, CS 0x%04x... ",
+        TEST_ADXL362_SPI, TEST_ADXL362_CS);
+    res = adxl362_init(&dev, TEST_ADXL362_SPI, TEST_ADXL362_CS);
+    if (res < 0) {
+        puts("[failed]");
+        return -1;
+    }
+    puts("[OK]");
+
+    uint32_t last_wakeup = xtimer_now();
+    printf("Performing sensor self-test...");
+    res = adxl362_self_test(&dev);
+    if (res < 0) {
+        puts("[Error!]");
+    }
+    else if (res > 0) {
+        puts("[OK]");
+    }
+    else {
+        puts("[failed]");
+    }
+
+    printf("Enable ADXL362 FIFO... ");
+    res = adxl362_set_fifo(&dev, false, ADXL362_FIFO_MODE_LAST_N, ADXL362_FIFO_WATERMARK_DEFAULT);
+    if (res < 0) {
+        puts("[failed]");
+        return -1;
+    }
+    puts("[OK]");
+
+    while (1) {
+        adxl362_data_t values[32];
+        int status;
+
+        xtimer_periodic_wakeup(&last_wakeup, SLEEP);
+
+        int32_t temp = 0;
+        status = adxl362_read_temp(&dev, &temp);
+        if (status < 0) {
+            printf("Communication error: %d\n", status);
+            continue;
+        }
+        printf("temp = %6" PRId32 "\n", temp);
+
+        status = adxl362_read_acc_fifo(&dev, values, sizeof(values) / sizeof(values[0]));
+        if (status < 0) {
+            printf("Communication error: %d\n", status);
+            continue;
+        } else if (status == 0) {
+            puts("Empty FIFO");
+            continue;
+        }
+        for (int i = 0; i < status; ++i)
+        {
+            printf("%4d: x: %6d y: %6d z: %6d\n", i,
+                (int)values[i].acc_x, (int)values[i].acc_y, (int)values[i].acc_z);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds a device driver for Analog Devices ADXL362 Micropower, 3-Axis, ±2 g/±4 g/±8 g Digital Output MEMS Accelerometer.

Including:
- Support for direct read and FIFO modes
- Filter settings
- Sample rate settings
- FIFO settings
- SAUL support for acceleration data (using direct read)
- SAUL support for temperature sensor ADC
- Test application for FIFO mode
- Self-test algorithm to check that the device is within spec

Data sheet: http://www.analog.com/media/en/technical-documentation/data-sheets/ADXL362.pdf
Product page: http://www.analog.com/en/products/mems/accelerometers/adxl362.html
Sparkfun breakout board: https://www.sparkfun.com/products/11446

This sensor has very good performance specs on paper, both noise level and power consumption.

PS. My Sparkfun SEN-11446 board seem to have some communication issues when connected with jumper wires, sometimes the ID comes out as `AD=0xac MST=0x3b PART=0344 REV=0x04` instead of `AD=0xad MST=0x1d PART=0362 REV=0x01`. Retrying usually makes it work again. I have tried to find any mistakes in the code but I can't find anything. I did not connect a scope to the signal lines, but it looks like it might be some noise on the clock line that messes with it. Possibly the Sparkfun board needs more decoupling or some termination to reduce the reflections.
