### PR TITLE
cpu/cc26x0: implement i2c master

### DIFF
--- a/cpu/cc26x0/include/cc26x0.h
+++ b/cpu/cc26x0/include/cc26x0.h
@@ -106,6 +106,7 @@ typedef enum IRQn
   * @{
   */
 #define FLASH_BASE                  0x00000000 /**< FLASH base address */
+#define PERIPH_BASE                 0x40000000 /**< peripheral base address */
 /*@}*/
 
 #ifdef __cplusplus

--- a/cpu/cc26x0/include/cc26x0_i2c.h
+++ b/cpu/cc26x0/include/cc26x0_i2c.h
@@ -63,6 +63,662 @@ typedef struct {
 
 #define I2C ((i2c_regs_t *) (I2C_BASE)) /**< I2C register bank */
 
+/**
+ * @brief   I2C register values
+ * @{
+ */
+//*****************************************************************************
+//
+// Register: I2C_O_SOAR
+//
+//*****************************************************************************
+// Field:   [6:0] OAR
+//
+// I2C slave own address
+// This field specifies bits a6 through a0 of the slave address.
+#define I2C_SOAR_OAR_M                                              0x0000007F
+#define I2C_SOAR_OAR_S                                                       0
+
+//*****************************************************************************
+//
+// Register: I2C_O_SSTAT
+//
+//*****************************************************************************
+// Field:     [2] FBR
+//
+// First byte received
+//
+// 0: The first byte has not been received.
+// 1: The first byte following the slave's own address has been received.
+//
+// This bit is only valid when the RREQ bit is set and is automatically cleared
+// when data has been read from the SDR register.
+// Note: This bit is not used for slave transmit operations.
+#define I2C_SSTAT_FBR                                               0x00000004
+#define I2C_SSTAT_FBR_BITN                                                   2
+#define I2C_SSTAT_FBR_M                                             0x00000004
+#define I2C_SSTAT_FBR_S                                                      2
+
+// Field:     [1] TREQ
+//
+// Transmit request
+//
+// 0: No outstanding transmit request.
+// 1: The I2C controller has been addressed as a slave transmitter and is using
+// clock stretching to delay the master until data has been written to the SDR
+// register.
+#define I2C_SSTAT_TREQ                                              0x00000002
+#define I2C_SSTAT_TREQ_BITN                                                  1
+#define I2C_SSTAT_TREQ_M                                            0x00000002
+#define I2C_SSTAT_TREQ_S                                                     1
+
+// Field:     [0] RREQ
+//
+// Receive request
+//
+// 0: No outstanding receive data
+// 1: The I2C controller has outstanding receive data from the I2C master and
+// is using clock stretching to delay the master until data has been read from
+// the SDR register.
+#define I2C_SSTAT_RREQ                                              0x00000001
+#define I2C_SSTAT_RREQ_BITN                                                  0
+#define I2C_SSTAT_RREQ_M                                            0x00000001
+#define I2C_SSTAT_RREQ_S                                                     0
+
+//*****************************************************************************
+//
+// Register: I2C_O_SCTL
+//
+//*****************************************************************************
+// Field:     [0] DA
+//
+// Device active
+//
+// 0: Disables the I2C slave operation
+// 1: Enables the I2C slave operation
+#define I2C_SCTL_DA                                                 0x00000001
+#define I2C_SCTL_DA_BITN                                                     0
+#define I2C_SCTL_DA_M                                               0x00000001
+#define I2C_SCTL_DA_S                                                        0
+
+//*****************************************************************************
+//
+// Register: I2C_O_SDR
+//
+//*****************************************************************************
+// Field:   [7:0] DATA
+//
+// Data for transfer
+// This field contains the data for transfer during a slave receive or transmit
+// operation.  When written the register data is used as transmit data.  When
+// read, this register returns the last data received.
+// Data is stored until next update, either by a system write for transmit or
+// by an external master for receive.
+#define I2C_SDR_DATA_M                                              0x000000FF
+#define I2C_SDR_DATA_S                                                       0
+
+//*****************************************************************************
+//
+// Register: I2C_O_SIMR
+//
+//*****************************************************************************
+// Field:     [2] STOPIM
+//
+// Stop condition interrupt mask
+//
+// 0: The SRIS.STOPRIS interrupt is suppressed and not sent to the interrupt
+// controller.
+// 1: The SRIS.STOPRIS interrupt is enabled and sent to the interrupt
+// controller.
+// ENUMs:
+// EN                       Enable Interrupt
+// DIS                      Disable Interrupt
+#define I2C_SIMR_STOPIM                                             0x00000004
+#define I2C_SIMR_STOPIM_BITN                                                 2
+#define I2C_SIMR_STOPIM_M                                           0x00000004
+#define I2C_SIMR_STOPIM_S                                                    2
+#define I2C_SIMR_STOPIM_EN                                          0x00000004
+#define I2C_SIMR_STOPIM_DIS                                         0x00000000
+
+// Field:     [1] STARTIM
+//
+// Start condition interrupt mask
+//
+// 0: The SRIS.STARTRIS interrupt is suppressed and not sent to the interrupt
+// controller.
+// 1: The SRIS.STARTRIS interrupt is enabled and sent to the interrupt
+// controller.
+// ENUMs:
+// EN                       Enable Interrupt
+// DIS                      Disable Interrupt
+#define I2C_SIMR_STARTIM                                            0x00000002
+#define I2C_SIMR_STARTIM_BITN                                                1
+#define I2C_SIMR_STARTIM_M                                          0x00000002
+#define I2C_SIMR_STARTIM_S                                                   1
+#define I2C_SIMR_STARTIM_EN                                         0x00000002
+#define I2C_SIMR_STARTIM_DIS                                        0x00000000
+
+// Field:     [0] DATAIM
+//
+// Data interrupt mask
+//
+// 0: The SRIS.DATARIS interrupt is suppressed and not sent to the interrupt
+// controller.
+// 1: The SRIS.DATARIS interrupt is enabled and sent to the interrupt
+// controller.
+#define I2C_SIMR_DATAIM                                             0x00000001
+#define I2C_SIMR_DATAIM_BITN                                                 0
+#define I2C_SIMR_DATAIM_M                                           0x00000001
+#define I2C_SIMR_DATAIM_S                                                    0
+
+//*****************************************************************************
+//
+// Register: I2C_O_SRIS
+//
+//*****************************************************************************
+// Field:     [2] STOPRIS
+//
+// Stop condition raw interrupt status
+//
+// 0: No interrupt
+// 1: A Stop condition interrupt is pending.
+//
+// This bit is cleared by writing a 1 to SICR.STOPIC.
+#define I2C_SRIS_STOPRIS                                            0x00000004
+#define I2C_SRIS_STOPRIS_BITN                                                2
+#define I2C_SRIS_STOPRIS_M                                          0x00000004
+#define I2C_SRIS_STOPRIS_S                                                   2
+
+// Field:     [1] STARTRIS
+//
+// Start condition raw interrupt status
+//
+// 0: No interrupt
+// 1: A Start condition interrupt is pending.
+//
+// This bit is cleared by writing a 1 to SICR.STARTIC.
+#define I2C_SRIS_STARTRIS                                           0x00000002
+#define I2C_SRIS_STARTRIS_BITN                                               1
+#define I2C_SRIS_STARTRIS_M                                         0x00000002
+#define I2C_SRIS_STARTRIS_S                                                  1
+
+// Field:     [0] DATARIS
+//
+// Data raw interrupt status
+//
+// 0: No interrupt
+// 1: A data received or data requested interrupt is pending.
+//
+// This bit is cleared by writing a 1 to the SICR.DATAIC.
+#define I2C_SRIS_DATARIS                                            0x00000001
+#define I2C_SRIS_DATARIS_BITN                                                0
+#define I2C_SRIS_DATARIS_M                                          0x00000001
+#define I2C_SRIS_DATARIS_S                                                   0
+
+//*****************************************************************************
+//
+// Register: I2C_O_SMIS
+//
+//*****************************************************************************
+// Field:     [2] STOPMIS
+//
+// Stop condition masked interrupt status
+//
+// 0: An interrupt has not occurred or is masked/disabled.
+// 1: An unmasked Stop condition interrupt is pending.
+//
+// This bit is cleared by writing a 1 to the SICR.STOPIC.
+#define I2C_SMIS_STOPMIS                                            0x00000004
+#define I2C_SMIS_STOPMIS_BITN                                                2
+#define I2C_SMIS_STOPMIS_M                                          0x00000004
+#define I2C_SMIS_STOPMIS_S                                                   2
+
+// Field:     [1] STARTMIS
+//
+// Start condition masked interrupt status
+//
+// 0: An interrupt has not occurred or is masked/disabled.
+// 1: An unmasked Start condition interrupt is pending.
+//
+// This bit is cleared by writing a 1 to the SICR.STARTIC.
+#define I2C_SMIS_STARTMIS                                           0x00000002
+#define I2C_SMIS_STARTMIS_BITN                                               1
+#define I2C_SMIS_STARTMIS_M                                         0x00000002
+#define I2C_SMIS_STARTMIS_S                                                  1
+
+// Field:     [0] DATAMIS
+//
+// Data masked interrupt status
+//
+// 0: An interrupt has not occurred or is masked/disabled.
+// 1: An unmasked data received or data requested interrupt is pending.
+//
+// This bit is cleared by writing a 1 to the SICR.DATAIC.
+#define I2C_SMIS_DATAMIS                                            0x00000001
+#define I2C_SMIS_DATAMIS_BITN                                                0
+#define I2C_SMIS_DATAMIS_M                                          0x00000001
+#define I2C_SMIS_DATAMIS_S                                                   0
+
+//*****************************************************************************
+//
+// Register: I2C_O_SICR
+//
+//*****************************************************************************
+// Field:     [2] STOPIC
+//
+// Stop condition interrupt clear
+//
+// Writing 1 to this bit clears SRIS.STOPRIS and SMIS.STOPMIS.
+#define I2C_SICR_STOPIC                                             0x00000004
+#define I2C_SICR_STOPIC_BITN                                                 2
+#define I2C_SICR_STOPIC_M                                           0x00000004
+#define I2C_SICR_STOPIC_S                                                    2
+
+// Field:     [1] STARTIC
+//
+// Start condition interrupt clear
+//
+// Writing 1 to this bit clears SRIS.STARTRIS SMIS.STARTMIS.
+#define I2C_SICR_STARTIC                                            0x00000002
+#define I2C_SICR_STARTIC_BITN                                                1
+#define I2C_SICR_STARTIC_M                                          0x00000002
+#define I2C_SICR_STARTIC_S                                                   1
+
+// Field:     [0] DATAIC
+//
+// Data interrupt clear
+//
+// Writing 1 to this bit clears SRIS.DATARIS SMIS.DATAMIS.
+#define I2C_SICR_DATAIC                                             0x00000001
+#define I2C_SICR_DATAIC_BITN                                                 0
+#define I2C_SICR_DATAIC_M                                           0x00000001
+#define I2C_SICR_DATAIC_S                                                    0
+
+//*****************************************************************************
+//
+// Register: I2C_O_MSA
+//
+//*****************************************************************************
+// Field:   [7:1] SA
+//
+// I2C master slave address
+// Defines which slave is addressed for the transaction in master mode
+#define I2C_MSA_SA_M                                                0x000000FE
+#define I2C_MSA_SA_S                                                         1
+
+// Field:     [0] RS
+//
+// Receive or Send
+// This bit-field specifies if the next operation is a receive (high) or a
+// transmit/send (low) from the addressed slave SA.
+// ENUMs:
+// RX                       Receive data from slave
+// TX                       Transmit/send data to slave
+#define I2C_MSA_RS                                                  0x00000001
+#define I2C_MSA_RS_BITN                                                      0
+#define I2C_MSA_RS_M                                                0x00000001
+#define I2C_MSA_RS_S                                                         0
+#define I2C_MSA_RS_RX                                               0x00000001
+#define I2C_MSA_RS_TX                                               0x00000000
+
+//*****************************************************************************
+//
+// Register: I2C_O_MSTAT
+//
+//*****************************************************************************
+// Field:     [6] BUSBSY
+//
+// Bus busy
+//
+// 0: The I2C bus is idle.
+// 1: The I2C bus is busy.
+//
+// The bit changes based on the MCTRL.START and MCTRL.STOP conditions.
+#define I2C_MSTAT_BUSBSY                                            0x00000040
+#define I2C_MSTAT_BUSBSY_BITN                                                6
+#define I2C_MSTAT_BUSBSY_M                                          0x00000040
+#define I2C_MSTAT_BUSBSY_S                                                   6
+
+// Field:     [5] IDLE
+//
+// I2C idle
+//
+// 0: The I2C controller is not idle.
+// 1: The I2C controller is idle.
+#define I2C_MSTAT_IDLE                                              0x00000020
+#define I2C_MSTAT_IDLE_BITN                                                  5
+#define I2C_MSTAT_IDLE_M                                            0x00000020
+#define I2C_MSTAT_IDLE_S                                                     5
+
+// Field:     [4] ARBLST
+//
+// Arbitration lost
+//
+// 0: The I2C controller won arbitration.
+// 1: The I2C controller lost arbitration.
+#define I2C_MSTAT_ARBLST                                            0x00000010
+#define I2C_MSTAT_ARBLST_BITN                                                4
+#define I2C_MSTAT_ARBLST_M                                          0x00000010
+#define I2C_MSTAT_ARBLST_S                                                   4
+
+// Field:     [3] DATACK_N
+//
+// Data Was Not Acknowledge
+//
+// 0: The transmitted data was acknowledged.
+// 1: The transmitted data was not acknowledged.
+#define I2C_MSTAT_DATACK_N                                          0x00000008
+#define I2C_MSTAT_DATACK_N_BITN                                              3
+#define I2C_MSTAT_DATACK_N_M                                        0x00000008
+#define I2C_MSTAT_DATACK_N_S                                                 3
+
+// Field:     [2] ADRACK_N
+//
+// Address Was Not Acknowledge
+//
+// 0: The transmitted address was acknowledged.
+// 1: The transmitted address was not acknowledged.
+#define I2C_MSTAT_ADRACK_N                                          0x00000004
+#define I2C_MSTAT_ADRACK_N_BITN                                              2
+#define I2C_MSTAT_ADRACK_N_M                                        0x00000004
+#define I2C_MSTAT_ADRACK_N_S                                                 2
+
+// Field:     [1] ERR
+//
+// Error
+//
+// 0: No error was detected on the last operation.
+// 1: An error occurred on the last operation.
+#define I2C_MSTAT_ERR                                               0x00000002
+#define I2C_MSTAT_ERR_BITN                                                   1
+#define I2C_MSTAT_ERR_M                                             0x00000002
+#define I2C_MSTAT_ERR_S                                                      1
+
+// Field:     [0] BUSY
+//
+// I2C busy
+//
+// 0: The controller is idle.
+// 1: The controller is busy.
+//
+// When this bit-field is set, the other status bits are not valid.
+//
+// Note: The I2C controller requires four SYSBUS clock cycles to assert the
+// BUSY status after I2C master operation has been initiated through MCTRL
+// register.
+// Hence after programming MCTRL register, application is requested to wait for
+// four SYSBUS clock cycles before issuing a controller status inquiry through
+// MSTAT register.
+// Any prior inquiry would result in wrong status being reported.
+#define I2C_MSTAT_BUSY                                              0x00000001
+#define I2C_MSTAT_BUSY_BITN                                                  0
+#define I2C_MSTAT_BUSY_M                                            0x00000001
+#define I2C_MSTAT_BUSY_S                                                     0
+
+//*****************************************************************************
+//
+// Register: I2C_O_MCTRL
+//
+//*****************************************************************************
+// Field:     [3] ACK
+//
+// Data acknowledge enable
+//
+// 0: The received data byte is not acknowledged automatically by the master.
+// 1: The received data byte is acknowledged automatically by the master.
+//
+// This bit-field must be cleared when the I2C bus controller requires no
+// further data to be transmitted from the slave transmitter.
+// ENUMs:
+// EN                       Enable acknowledge
+// DIS                      Disable acknowledge
+#define I2C_MCTRL_ACK                                               0x00000008
+#define I2C_MCTRL_ACK_BITN                                                   3
+#define I2C_MCTRL_ACK_M                                             0x00000008
+#define I2C_MCTRL_ACK_S                                                      3
+#define I2C_MCTRL_ACK_EN                                            0x00000008
+#define I2C_MCTRL_ACK_DIS                                           0x00000000
+
+// Field:     [2] STOP
+//
+// This bit-field determines if the cycle stops at the end of the data cycle or
+// continues on to a repeated START condition.
+//
+// 0: The controller does not generate the Stop condition.
+// 1: The controller generates the Stop condition.
+// ENUMs:
+// EN                       Enable STOP
+// DIS                      Disable STOP
+#define I2C_MCTRL_STOP                                              0x00000004
+#define I2C_MCTRL_STOP_BITN                                                  2
+#define I2C_MCTRL_STOP_M                                            0x00000004
+#define I2C_MCTRL_STOP_S                                                     2
+#define I2C_MCTRL_STOP_EN                                           0x00000004
+#define I2C_MCTRL_STOP_DIS                                          0x00000000
+
+// Field:     [1] START
+//
+// This bit-field generates the Start or Repeated Start condition.
+//
+// 0: The controller does not generate the Start condition.
+// 1: The controller generates the Start condition.
+// ENUMs:
+// EN                       Enable START
+// DIS                      Disable START
+#define I2C_MCTRL_START                                             0x00000002
+#define I2C_MCTRL_START_BITN                                                 1
+#define I2C_MCTRL_START_M                                           0x00000002
+#define I2C_MCTRL_START_S                                                    1
+#define I2C_MCTRL_START_EN                                          0x00000002
+#define I2C_MCTRL_START_DIS                                         0x00000000
+
+// Field:     [0] RUN
+//
+// I2C master enable
+//
+// 0: The master is disabled.
+// 1: The master is enabled to transmit or receive data.
+// ENUMs:
+// EN                       Enable Master
+// DIS                      Disable Master
+#define I2C_MCTRL_RUN                                               0x00000001
+#define I2C_MCTRL_RUN_BITN                                                   0
+#define I2C_MCTRL_RUN_M                                             0x00000001
+#define I2C_MCTRL_RUN_S                                                      0
+#define I2C_MCTRL_RUN_EN                                            0x00000001
+#define I2C_MCTRL_RUN_DIS                                           0x00000000
+
+//*****************************************************************************
+//
+// Register: I2C_O_MDR
+//
+//*****************************************************************************
+// Field:   [7:0] DATA
+//
+// When Read: Last RX Data is returned
+// When Written: Data is transferred during TX  transaction
+#define I2C_MDR_DATA_M                                              0x000000FF
+#define I2C_MDR_DATA_S                                                       0
+
+//*****************************************************************************
+//
+// Register: I2C_O_MTPR
+//
+//*****************************************************************************
+// Field:     [7] TPR_7
+//
+// Must be set to 0 to set TPR. If set to 1, a write to TPR will be ignored.
+#define I2C_MTPR_TPR_7                                              0x00000080
+#define I2C_MTPR_TPR_7_BITN                                                  7
+#define I2C_MTPR_TPR_7_M                                            0x00000080
+#define I2C_MTPR_TPR_7_S                                                     7
+
+// Field:   [6:0] TPR
+//
+// SCL clock period
+// This field specifies the period of the SCL clock.
+// SCL_PRD = 2*(1+TPR)*(SCL_LP + SCL_HP)*CLK_PRD
+// where:
+// SCL_PRD is the SCL line period (I2C clock).
+// TPR is the timer period register value (range of 1 to 127)
+// SCL_LP is the SCL low period (fixed at 6).
+// SCL_HP is the SCL high period (fixed at 4).
+// CLK_PRD is the system clock period in ns.
+#define I2C_MTPR_TPR_M                                              0x0000007F
+#define I2C_MTPR_TPR_S                                                       0
+
+//*****************************************************************************
+//
+// Register: I2C_O_MIMR
+//
+//*****************************************************************************
+// Field:     [0] IM
+//
+// Interrupt mask
+//
+// 0: The MRIS.RIS interrupt is suppressed and not sent to the interrupt
+// controller.
+// 1: The master interrupt is sent to the interrupt controller when the
+// MRIS.RIS is set.
+// ENUMs:
+// EN                       Enable Interrupt
+// DIS                      Disable Interrupt
+#define I2C_MIMR_IM                                                 0x00000001
+#define I2C_MIMR_IM_BITN                                                     0
+#define I2C_MIMR_IM_M                                               0x00000001
+#define I2C_MIMR_IM_S                                                        0
+#define I2C_MIMR_IM_EN                                              0x00000001
+#define I2C_MIMR_IM_DIS                                             0x00000000
+
+//*****************************************************************************
+//
+// Register: I2C_O_MRIS
+//
+//*****************************************************************************
+// Field:     [0] RIS
+//
+// Raw interrupt status
+//
+// 0: No interrupt
+// 1: A master interrupt is pending.
+//
+// This bit is cleared by writing 1 to the MICR.IC bit .
+#define I2C_MRIS_RIS                                                0x00000001
+#define I2C_MRIS_RIS_BITN                                                    0
+#define I2C_MRIS_RIS_M                                              0x00000001
+#define I2C_MRIS_RIS_S                                                       0
+
+//*****************************************************************************
+//
+// Register: I2C_O_MMIS
+//
+//*****************************************************************************
+// Field:     [0] MIS
+//
+// Masked interrupt status
+//
+// 0: An interrupt has not occurred or is masked.
+// 1: A master interrupt is pending.
+//
+// This bit is cleared by writing 1 to the MICR.IC bit .
+#define I2C_MMIS_MIS                                                0x00000001
+#define I2C_MMIS_MIS_BITN                                                    0
+#define I2C_MMIS_MIS_M                                              0x00000001
+#define I2C_MMIS_MIS_S                                                       0
+
+//*****************************************************************************
+//
+// Register: I2C_O_MICR
+//
+//*****************************************************************************
+// Field:     [0] IC
+//
+// Interrupt clear
+// Writing 1 to this bit clears MRIS.RIS and  MMIS.MIS .
+//
+// Reading this register returns no meaningful data.
+#define I2C_MICR_IC                                                 0x00000001
+#define I2C_MICR_IC_BITN                                                     0
+#define I2C_MICR_IC_M                                               0x00000001
+#define I2C_MICR_IC_S                                                        0
+
+//*****************************************************************************
+//
+// Register: I2C_O_MCR
+//
+//*****************************************************************************
+// Field:     [5] SFE
+//
+// I2C slave function enable
+// ENUMs:
+// EN                       Slave mode is enabled.
+// DIS                      Slave mode is disabled.
+#define I2C_MCR_SFE                                                 0x00000020
+#define I2C_MCR_SFE_BITN                                                     5
+#define I2C_MCR_SFE_M                                               0x00000020
+#define I2C_MCR_SFE_S                                                        5
+#define I2C_MCR_SFE_EN                                              0x00000020
+#define I2C_MCR_SFE_DIS                                             0x00000000
+
+// Field:     [4] MFE
+//
+// I2C master function enable
+// ENUMs:
+// EN                       Master mode is enabled.
+// DIS                      Master mode is disabled.
+#define I2C_MCR_MFE                                                 0x00000010
+#define I2C_MCR_MFE_BITN                                                     4
+#define I2C_MCR_MFE_M                                               0x00000010
+#define I2C_MCR_MFE_S                                                        4
+#define I2C_MCR_MFE_EN                                              0x00000010
+#define I2C_MCR_MFE_DIS                                             0x00000000
+
+// Field:     [0] LPBK
+//
+// I2C loopback
+//
+// 0: Normal operation
+// 1: Loopback operation (test mode)
+// ENUMs:
+// EN                       Enable Test Mode
+// DIS                      Disable Test Mode
+#define I2C_MCR_LPBK                                                0x00000001
+#define I2C_MCR_LPBK_BITN                                                    0
+#define I2C_MCR_LPBK_M                                              0x00000001
+#define I2C_MCR_LPBK_S                                                       0
+#define I2C_MCR_LPBK_EN                                             0x00000001
+#define I2C_MCR_LPBK_DIS                                            0x00000000
+
+//*****************************************************************************
+//
+// I2C Master commands
+//
+//*****************************************************************************
+#define I2C_MASTER_CMD_SINGLE_SEND                                            \
+                                0x00000007
+#define I2C_MASTER_CMD_SINGLE_RECEIVE                                         \
+                                0x00000007
+#define I2C_MASTER_CMD_BURST_SEND_START                                       \
+                                0x00000003
+#define I2C_MASTER_CMD_BURST_SEND_CONT                                        \
+                                0x00000001
+#define I2C_MASTER_CMD_BURST_SEND_FINISH                                      \
+                                0x00000005
+#define I2C_MASTER_CMD_BURST_SEND_ERROR_STOP                                  \
+                                0x00000004
+#define I2C_MASTER_CMD_BURST_RECEIVE_START                                    \
+                                0x0000000b
+#define I2C_MASTER_CMD_BURST_RECEIVE_CONT                                     \
+                                0x00000009
+#define I2C_MASTER_CMD_BURST_RECEIVE_FINISH                                   \
+                                0x00000005
+#define I2C_MASTER_CMD_BURST_RECEIVE_ERROR_STOP                               \
+                                0x00000004
+
+/** @} */
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc26x0/include/cc26x0_ioc.h
+++ b/cpu/cc26x0/include/cc26x0_ioc.h
@@ -128,6 +128,104 @@ typedef struct {
 #define IOCFG_INPUT_ENABLE              0x20000000
 
 #define IOCFG_HYST_ENABLE               0x40000000
+
+//*****************************************************************************
+//
+// Defines for enabling/disabling an IO
+//
+//*****************************************************************************
+#define IOC_SLEW_ENABLE         0x00001000
+#define IOC_SLEW_DISABLE        0x00000000
+#define IOC_INPUT_ENABLE        0x20000000
+#define IOC_INPUT_DISABLE       0x00000000
+#define IOC_HYST_ENABLE         0x40000000
+#define IOC_HYST_DISABLE        0x00000000
+
+//*****************************************************************************
+//
+// Values that can be used to set the shutdown mode of an IO
+//
+//*****************************************************************************
+#define IOC_NO_WAKE_UP          0x00000000
+#define IOC_WAKE_ON_LOW         0x10000000
+#define IOC_WAKE_ON_HIGH        0x18000000
+
+//*****************************************************************************
+//
+// Values that can be used to set the IO Mode of an IO
+//
+//*****************************************************************************
+#define IOC_IOMODE_NORMAL       0x00000000  // Normal Input/Output
+#define IOC_IOMODE_INV          0x01000000  // Inverted Input/Output
+#define IOC_IOMODE_OPEN_DRAIN_NORMAL \
+0x04000000  // Open Drain, Normal Input/Output
+#define IOC_IOMODE_OPEN_DRAIN_INV \
+0x05000000  // Open Drain, Inverted
+// Input/Output
+#define IOC_IOMODE_OPEN_SRC_NORMAL \
+0x06000000  // Open Source, Normal Input/Output
+#define IOC_IOMODE_OPEN_SRC_INV \
+0x07000000  // Open Source, Inverted
+// Input/Output
+
+//*****************************************************************************
+//
+// Values that can be used to set the edge detection on an IO
+//
+//*****************************************************************************
+#define IOC_NO_EDGE             0x00000000  // No edge detection
+#define IOC_FALLING_EDGE        0x00010000  // Edge detection on falling edge
+#define IOC_RISING_EDGE         0x00020000  // Edge detection on rising edge
+#define IOC_BOTH_EDGES          0x00030000  // Edge detection on both edges
+#define IOC_INT_ENABLE          0x00040000  // Enable interrupt on edge detect
+#define IOC_INT_DISABLE         0x00000000  // Disable interrupt on edge detect
+#define IOC_INT_M               0x00070000  // Int config mask
+
+//*****************************************************************************
+//
+// Values that be used to set pull on an IO
+//
+//*****************************************************************************
+#define IOC_NO_IOPULL           0x00006000  // No IO pull
+#define IOC_IOPULL_UP           0x00004000  // Pull up
+#define IOC_IOPULL_DOWN         0x00002000  // Pull down
+#define IOC_IOPULL_M            0x00006000  // Pull config mask
+#define IOC_IOPULL_M            0x00006000
+
+//*****************************************************************************
+//
+// Values that can be used to select the drive strength of an IO
+//
+//*****************************************************************************
+#define IOC_CURRENT_2MA         0x00000000  // 2mA drive strength
+#define IOC_CURRENT_4MA         0x00000400  // 4mA drive strength
+#define IOC_CURRENT_8MA         0x00000800  // 4 or 8mA drive strength
+#define IOC_CURRENT_16MA        0x00000C00  // Up to 16mA drive strength
+
+#define IOC_STRENGTH_AUTO       0x00000000  // Automatic Drive Strength
+// (2/4/8 mA @ VVDS)
+#define IOC_STRENGTH_MAX        0x00000300  // Maximum Drive Strength
+// (2/4/8 mA @ 1.8V)
+#define IOC_STRENGTH_MED        0x00000200  // Medium Drive Strength
+// (2/4/8 mA @ 2.5V)
+#define IOC_STRENGTH_MIN        0x00000100  // Minimum Drive Strength
+// (2/4/8 mA @ 3.3V)
+//*****************************************************************************
+//
+// Defines for standard IO setup
+//
+//*****************************************************************************
+#define IOC_STD_INPUT           (IOC_CURRENT_2MA | IOC_STRENGTH_AUTO |      \
+IOC_NO_IOPULL | IOC_SLEW_DISABLE |         \
+IOC_HYST_DISABLE | IOC_NO_EDGE |           \
+IOC_INT_DISABLE | IOC_IOMODE_NORMAL |      \
+IOC_NO_WAKE_UP | IOC_INPUT_ENABLE )
+#define IOC_STD_OUTPUT          (IOC_CURRENT_2MA | IOC_STRENGTH_AUTO |      \
+IOC_NO_IOPULL | IOC_SLEW_DISABLE |         \
+IOC_HYST_DISABLE | IOC_NO_EDGE |           \
+IOC_INT_DISABLE | IOC_IOMODE_NORMAL |      \
+IOC_NO_WAKE_UP | IOC_INPUT_DISABLE )
+
 /** @} */
 
 

--- a/cpu/cc26x0/include/periph_cpu.h
+++ b/cpu/cc26x0/include/periph_cpu.h
@@ -64,6 +64,14 @@ typedef struct {
     uint8_t irqn; /**< interrupt number */
 } timer_conf_t;
 
+/**
+ * @brief   I2C configuration
+ */
+typedef struct {
+    uint32_t scl_pin; /** GPIO_ID of pin to use as SCL */
+    uint32_t sda_pin; /** GPIO_ID of pin to use as SDA */
+} i2c_conf_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc26x0/periph/i2c.c
+++ b/cpu/cc26x0/periph/i2c.c
@@ -1,0 +1,345 @@
+/*
+ *    Copyright (c) 2016 Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ *    Permission is hereby granted, free of charge, to any person
+ *    obtaining a copy of this software and associated documentation
+ *    files (the "Software"), to deal in the Software without
+ *    restriction, including without limitation the rights to use,
+ *    copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *    copies of the Software, and to permit persons to whom the
+ *    Software is furnished to do so, subject to the following
+ *    conditions:
+ *
+ *    The above copyright notice and this permission notice shall be
+ *    included in all copies or substantial portions of the Software.
+ *
+ *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *    OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @addtogroup  driver_periph
+ * @{
+ *
+ * @file
+ * @brief       Low-level I2C driver implementation
+ *
+ * @author      Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * @}
+ */
+
+#include "periph/i2c.h"
+#include "mutex.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+mutex_t i2c_mutex = MUTEX_INIT;
+mutex_t irq_wait = MUTEX_INIT;
+
+static void _set_address(dev_t dev, uint8_t slave_address, bool read)
+{
+    I2C->MSA = (slave_address << 1) | (read ? 1 : 0);
+}
+
+static uint32_t _speed_t_to_scl_period(i2c_speed_t speed)
+{
+    uint32_t hz;
+    switch (speed) {
+        default:
+        case I2C_SPEED_LOW:
+            hz = 10000;
+            break;
+        case I2C_SPEED_NORMAL:
+            hz = 100000;
+            break;
+        case I2C_SPEED_FAST:
+            hz = 400000;
+            break;
+        case I2C_SPEED_FAST_PLUS:
+            hz = 1000000;
+            break;
+        case I2C_SPEED_HIGH:
+            hz = 3400000;
+            break;
+    }
+
+    /* document SWCU117F page 1506 equation 8 */
+    int32_t scl_period = CLOCK_CORECLOCK / (2 * (6 + 4) * hz) - 1;
+
+    /* valid range is 1 to 127 inclusive */
+    if (scl_period > 127) {
+        /* slowest possible i2c speed for given core clock */
+        scl_period = 127;
+    }
+    else if (scl_period < 1) {
+        /* fastest possible i2c speed for given core clock */
+        scl_period = 1;
+    }
+
+    /* i2c speed = core_speed / ((scl_period + 1) * 20) */
+    return scl_period;
+}
+
+static void _transmit_and_yield_until_done(dev_t dev, uint32_t command)
+{
+#ifndef CC26X0_I2C_NO_INTERRUPTS
+    /* clear interrupt flag */
+    I2C->MICR = I2C_MICR_IC;
+
+    /* enable i2c interrupt */
+    I2C->MIMR = I2C_MIMR_IM;
+
+    /* do first lock early to avoid race condition after MCTRL write */
+    mutex_lock(&irq_wait);
+
+    /* initiate i2c transaction */
+    I2C->MCTRL = command;
+
+    /* wait for interrupt to signal transaction complete */
+    mutex_lock(&irq_wait);
+    mutex_unlock(&irq_wait);
+
+#else
+    /* initiate i2c transaction */
+    I2C->MCTRL = command;
+
+    /* delay 4 SYSBUS clocks after MCTRL write to allow MSTAT_BUSY to be set */
+    xtimer_spin(4);
+
+    /* wait for transaction to complete */
+    while(I2C->MSTAT & I2C_MSTAT_BUSY);
+#endif
+}
+
+int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+{
+    /* make sure dev is valid */
+    if(dev >= I2C_NUMOF){
+        return -1;
+    }
+
+    /* make sure serial power domain is enabled */
+    PRCM->PDCTL0SERIAL = 1;
+    while(!(PRCM->PDSTAT0 & PDSTAT0_SERIAL_ON));
+
+    /* enable i2c peripheral clock */
+    PRCM->I2CCLKGR = 1;
+    PRCM->CLKLOADCTL = CLKLOADCTL_LOAD;
+    while(!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE));
+
+    /* configure pins and route them to i2c peripheral */
+    uint32_t pin_conf = IOC_CURRENT_2MA | IOC_STRENGTH_AUTO | IOC_IOPULL_UP |
+        IOC_SLEW_DISABLE | IOC_HYST_DISABLE | IOC_NO_EDGE | IOC_INT_DISABLE |
+        IOC_IOMODE_OPEN_DRAIN_NORMAL | IOC_NO_WAKE_UP | IOC_INPUT_ENABLE;
+    IOC->CFG[i2c_config[dev].scl_pin] =  IOCFG_PORTID_I2C_MSSCL | pin_conf;
+    IOC->CFG[i2c_config[dev].sda_pin] =  IOCFG_PORTID_I2C_MSSDA | pin_conf;
+
+    /* initialize i2c peripheral in master mode */
+    I2C->MCR = I2C_MCR_MFE;
+
+    /* enable master mode */
+    I2C->MCTRL = I2C_MCTRL_RUN;
+
+    /* configure bus speed */
+    I2C->MTPR = _speed_t_to_scl_period(speed);
+
+    /* enable nvic irq */
+    NVIC_EnableIRQ(I2C_IRQN);
+
+    return 0;
+}
+
+int i2c_init_slave(i2c_t dev, uint8_t address)
+{
+    /* TODO: implement slave mode */
+    return -1;
+}
+
+int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
+{
+    if(length <= 0) {
+        return -1;
+    }
+
+    /* configure slave address */
+    _set_address(dev, address, false);
+
+    /* make sure bus is idle */
+    while(I2C->MSTAT & I2C_MSTAT_BUSBSY);
+
+    /* handle each data byte */
+    for(int i = 0; i < length; i++) {
+
+        /* make sure peripheral is idle */
+        while(I2C->MSTAT & I2C_MSTAT_BUSY);
+
+        /* load data byte into transmit buffer */
+        I2C->MDR = data[i];
+
+        /* choose command */
+        uint32_t command;
+        if(length == 1) { /* only one byte */
+            command = I2C_MASTER_CMD_SINGLE_SEND;
+        }
+        else if(i == 0) { /* first byte of multiple */
+            command = I2C_MASTER_CMD_BURST_SEND_START;
+        }
+        else if(i == length - 1) { /* last byte of multiple */
+            command = I2C_MASTER_CMD_BURST_SEND_FINISH;
+        }
+        else { /* middle byte of multiple */
+            command = I2C_MASTER_CMD_BURST_SEND_CONT;
+        }
+
+        /* begin transaction and wait for completion */
+        _transmit_and_yield_until_done(dev, command);
+
+        /* quit on transaction error */
+        uint32_t mstat = I2C->MSTAT;
+        if(mstat & I2C_MSTAT_ERR) {
+            printf("I2C error; MSTAT: 0x%02lx\n", mstat);
+
+            /* send stop */
+            _transmit_and_yield_until_done(
+                dev, I2C_MASTER_CMD_BURST_SEND_ERROR_STOP
+            );
+
+            return -2;
+        }
+    }
+
+    return 0;
+}
+
+int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
+{
+    if(length <= 0) {
+        return -1;
+    }
+
+    /* configure slave address */
+    _set_address(dev, address, true);
+
+    /* make sure bus is idle */
+    while(I2C->MSTAT & I2C_MSTAT_BUSBSY);
+
+    /* handle each data byte */
+    for(int i = 0; i < length; i++) {
+
+        /* make sure peripheral is idle */
+        while(I2C->MSTAT & I2C_MSTAT_BUSY);
+
+        /* choose command */
+        uint32_t command;
+        if(length == 1) { /* only one byte */
+            command = I2C_MASTER_CMD_SINGLE_RECEIVE;
+        }
+        else if(i == 0) { /* first byte of multiple */
+            command = I2C_MASTER_CMD_BURST_RECEIVE_START;
+        }
+        else if(i == length - 1) { /* last byte of multiple */
+            command = I2C_MASTER_CMD_BURST_RECEIVE_FINISH;
+        }
+        else { /* middle byte of multiple */
+            command = I2C_MASTER_CMD_BURST_RECEIVE_CONT;
+        }
+
+        /* begin transaction and wait for completion */
+        _transmit_and_yield_until_done(dev, command);
+
+        /* quit on transaction error */
+        uint32_t mstat = I2C->MSTAT;
+        if(mstat & I2C_MSTAT_ERR) {
+            DEBUG("I2C error; MSTAT: 0x%02lx\n", mstat);
+
+            /* send stop */
+            _transmit_and_yield_until_done(
+                dev, I2C_MASTER_CMD_BURST_RECEIVE_ERROR_STOP
+            );
+
+            return -2;
+        }
+
+        /* read byte from receive buffer */
+        data[i] = I2C->MDR;
+    }
+
+    return 0;
+}
+
+int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char* data, int length)
+{
+    /* TODO unimplemented */
+    return -1;
+}
+
+int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char* data, int length)
+{
+    /* TODO unimplemented */
+    return -1;
+}
+
+int i2c_acquire(i2c_t dev)
+{
+    if(dev >= I2C_NUMOF){
+        return -1;
+    }
+    mutex_lock(&i2c_mutex);
+    return 0;
+}
+
+int i2c_release(i2c_t dev)
+{
+    if(dev >= I2C_NUMOF){
+        return -1;
+    }
+    mutex_unlock(&i2c_mutex);
+    return 0;
+}
+
+int i2c_read_byte(i2c_t dev, uint8_t address, char* data)
+{
+    return i2c_read_bytes(dev, address, data, 1);
+}
+
+int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char* data)
+{
+    return i2c_read_regs(dev, address, reg, data, 1);
+}
+
+int i2c_write_byte(i2c_t dev, uint8_t address, char data)
+{
+    return i2c_write_bytes(dev, address, &data, 1);
+}
+
+int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data)
+{
+    return i2c_write_regs(dev, address, reg, &data, 1);
+}
+
+#if I2C_0_EN
+void isr_i2c(void)
+{
+    /* disable i2c interrupt */
+    I2C->MIMR = 0;
+
+    /* clear interrupt flag */
+    I2C->MICR = I2C_MICR_IC;
+
+    /* signal transaction complete */
+    mutex_unlock(&irq_wait);
+
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
+}
+#endif


### PR DESCRIPTION
This adds I2C master support to the CC26x0 port.
- tested with CC2650 and SI7006
- slave mode not implemented
- `i2c_write_regs` and `i2c_read_regs` not implemented
- DMA not implemented
