### PR TITLE
gnrc_udp: add missing duplitation step

### DIFF
--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -198,6 +198,7 @@ static void _send(gnrc_pktsnip_t *pkt)
         gnrc_pktbuf_release(pkt);
         return;
     }
+    tmp->next = udp_snip;
     hdr = (udp_hdr_t *)udp_snip->data;
     /* fill in size field */
     hdr->length = byteorder_htons(gnrc_pkt_len(udp_snip));


### PR DESCRIPTION
At the moment UDP is duplicating the UDP header wrong, in case `pkt->users > 1`.

Current behavior:

```
orig dup
==== ====
IPv6 IPv6
  | /
 UDP UDP
  | /
payload
```

With this fix:

```
orig dup
==== ====
IPv6 IPv6
  |    |
 UDP UDP
  | /
payload
```

The previous behavior leads to the original UDP header to be removed from the packet buffer too early (and subsequently resulting in a crash), because its users counter is one less than expected, while the dangling UDP header never gets removed.