### PR TITLE
gnrc_udp: consider netif header in send dispatch

### DIFF
--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -165,6 +165,7 @@ static void _send(gnrc_pktsnip_t *pkt)
 {
     udp_hdr_t *hdr;
     gnrc_pktsnip_t *udp_snip, *tmp;
+    gnrc_nettype_t target_type = pkt->type;
 
     /* write protect first header */
     tmp = gnrc_pktbuf_start_write(pkt);
@@ -202,8 +203,14 @@ static void _send(gnrc_pktsnip_t *pkt)
     /* fill in size field */
     hdr->length = byteorder_htons(gnrc_pkt_len(udp_snip));
 
+    /* set to IPv6, if first header is netif header */
+    if (target_type == GNRC_NETTYPE_NETIF) {
+        target_type = pkt->next->type;
+    }
+
     /* and forward packet to the network layer */
-    if (!gnrc_netapi_dispatch_send(pkt->type, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {
+    if (!gnrc_netapi_dispatch_send(target_type, GNRC_NETREG_DEMUX_CTX_ALL,
+                                   pkt)) {
         DEBUG("udp: cannot send packet: network layer not found\n");
         gnrc_pktbuf_release(pkt);
     }


### PR DESCRIPTION
Another tiny fix of UDP. If a netif header is present (e.g. to send via a specific interface), [this line](https://github.com/RIOT-OS/RIOT/compare/master...miri64:gnrc_udp/fix/consider-netif-hdr?expand=1#diff-a743a0dcf90d0eb32c837f1a047918c1L206) would result in 0, since it searches for `GNRC_NETTYPE_NETIF` (which is never present in netreg and it doesn't make sense either, since IPv6 [or IPv4 later on] is the layer we are searching for).