### PR TITLE
CC2538 periph/timer overhaul

### DIFF
--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -76,9 +76,9 @@ extern "C" {
  * @name xtimer configuration
  * @{
  */
-#define XTIMER_DEV          TIMER_0
+#define XTIMER_DEV          (0)
 #define XTIMER_CHAN         (0)
-#define XTIMER_SHIFT        (-4)
+#define XTIMER_WIDTH        (16)
 #define XTIMER_BACKOFF      (50)
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -30,49 +30,32 @@ extern "C" {
  * @name Timer peripheral configuration
  * @{
  */
-#define TIMER_NUMOF         GPTIMER_NUMOF
-#define TIMER_0_EN          1
-#define TIMER_1_EN          1
-#define TIMER_2_EN          1
-#define TIMER_3_EN          1
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = GPTIMER0,
+        .channels = 2,
+        .cfg      = GPTMCFG_16_BIT_TIMER, /* required for XTIMER */
+    },
+    {
+        .dev      = GPTIMER1,
+        .channels = 1,
+        .cfg      = GPTMCFG_32_BIT_TIMER,
+    },
+    {
+        .dev      = GPTIMER2,
+        .channels = 1,
+        .cfg      = GPTMCFG_32_BIT_TIMER,
+    },
+    {
+        .dev      = GPTIMER3,
+        .channels = 1,
+        .cfg      = GPTMCFG_32_BIT_TIMER,
+    },
+};
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 
 #define TIMER_IRQ_PRIO      1
-
-/* Timer 0 configuration */
-#define TIMER_0_DEV         GPTIMER0
-#define TIMER_0_CHANNELS    1
-#define TIMER_0_MAX_VALUE   0xffffffff
-#define TIMER_0_IRQn_1      GPTIMER_0A_IRQn
-#define TIMER_0_IRQn_2      GPTIMER_0B_IRQn
-#define TIMER_0_ISR_1       isr_timer0_chan0
-#define TIMER_0_ISR_2       isr_timer0_chan1
-
-/* Timer 1 configuration */
-#define TIMER_1_DEV         GPTIMER1
-#define TIMER_1_CHANNELS    1
-#define TIMER_1_MAX_VALUE   0xffffffff
-#define TIMER_1_IRQn_1      GPTIMER_1A_IRQn
-#define TIMER_1_IRQn_2      GPTIMER_1B_IRQn
-#define TIMER_1_ISR_1       isr_timer1_chan0
-#define TIMER_1_ISR_2       isr_timer1_chan1
-
-/* Timer 2 configuration */
-#define TIMER_2_DEV         GPTIMER2
-#define TIMER_2_CHANNELS    1
-#define TIMER_2_MAX_VALUE   0xffffffff
-#define TIMER_2_IRQn_1      GPTIMER_2A_IRQn
-#define TIMER_2_IRQn_2      GPTIMER_2B_IRQn
-#define TIMER_2_ISR_1       isr_timer2_chan0
-#define TIMER_2_ISR_2       isr_timer2_chan1
-
-/* Timer 3 configuration */
-#define TIMER_3_DEV         GPTIMER3
-#define TIMER_3_CHANNELS    1
-#define TIMER_3_MAX_VALUE   0xffffffff
-#define TIMER_3_IRQn_1      GPTIMER_3A_IRQn
-#define TIMER_3_IRQn_2      GPTIMER_3B_IRQn
-#define TIMER_3_ISR_1       isr_timer3_chan0
-#define TIMER_3_ISR_2       isr_timer3_chan1
 /** @} */
 
 

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -64,9 +64,9 @@
  * @name xtimer configuration
  * @{
  */
-#define XTIMER_DEV          TIMER_0
+#define XTIMER_DEV          (0)
 #define XTIMER_CHAN         (0)
-#define XTIMER_SHIFT        (-4)
+#define XTIMER_WIDTH        (16)
 #define XTIMER_BACKOFF      (50)
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -37,48 +37,31 @@
  * @name Timer configuration
  * @{
  */
-#define TIMER_NUMOF         (4U)
-#define TIMER_0_EN          1
-#define TIMER_1_EN          1
-#define TIMER_2_EN          1
-#define TIMER_3_EN          1
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = GPTIMER0,
+        .channels = 2,
+        .cfg      = GPTMCFG_16_BIT_TIMER, /* required for XTIMER */
+    },
+    {
+        .dev      = GPTIMER1,
+        .channels = 1,
+        .cfg      = GPTMCFG_32_BIT_TIMER,
+    },
+    {
+        .dev      = GPTIMER2,
+        .channels = 1,
+        .cfg      = GPTMCFG_32_BIT_TIMER,
+    },
+    {
+        .dev      = GPTIMER3,
+        .channels = 1,
+        .cfg      = GPTMCFG_32_BIT_TIMER,
+    },
+};
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 #define TIMER_IRQ_PRIO      1
-
-/* Timer 0 configuration */
-#define TIMER_0_DEV         GPTIMER0
-#define TIMER_0_CHANNELS    1
-#define TIMER_0_MAX_VALUE   0xffffffff
-#define TIMER_0_IRQn_1      GPTIMER_0A_IRQn
-#define TIMER_0_IRQn_2      GPTIMER_0B_IRQn
-#define TIMER_0_ISR_1       isr_timer0_chan0
-#define TIMER_0_ISR_2       isr_timer0_chan1
-
-/* Timer 1 configuration */
-#define TIMER_1_DEV         GPTIMER1
-#define TIMER_1_CHANNELS    1
-#define TIMER_1_MAX_VALUE   0xffffffff
-#define TIMER_1_IRQn_1      GPTIMER_1A_IRQn
-#define TIMER_1_IRQn_2      GPTIMER_1B_IRQn
-#define TIMER_1_ISR_1       isr_timer1_chan0
-#define TIMER_1_ISR_2       isr_timer1_chan1
-
-/* Timer 2 configuration */
-#define TIMER_2_DEV         GPTIMER2
-#define TIMER_2_CHANNELS    1
-#define TIMER_2_MAX_VALUE   0xffffffff
-#define TIMER_2_IRQn_1      GPTIMER_2A_IRQn
-#define TIMER_2_IRQn_2      GPTIMER_2B_IRQn
-#define TIMER_2_ISR_1       isr_timer2_chan0
-#define TIMER_2_ISR_2       isr_timer2_chan1
-
-/* Timer 3 configuration */
-#define TIMER_3_DEV         GPTIMER3
-#define TIMER_3_CHANNELS    1
-#define TIMER_3_MAX_VALUE   0xffffffff
-#define TIMER_3_IRQn_1      GPTIMER_3A_IRQn
-#define TIMER_3_IRQn_2      GPTIMER_3B_IRQn
-#define TIMER_3_ISR_1       isr_timer3_chan0
-#define TIMER_3_ISR_2       isr_timer3_chan1
 /** @} */
 
 /**

--- a/boards/remote-common/include/board_common.h
+++ b/boards/remote-common/include/board_common.h
@@ -77,9 +77,9 @@
  * @name xtimer configuration
  * @{
  */
-#define XTIMER_DEV          TIMER_0
+#define XTIMER_DEV          (0)
 #define XTIMER_CHAN         (0)
-#define XTIMER_SHIFT        (-4)
+#define XTIMER_WIDTH        (16)
 #define XTIMER_BACKOFF      (50)
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */

--- a/boards/remote-common/include/periph_common.h
+++ b/boards/remote-common/include/periph_common.h
@@ -39,49 +39,32 @@
  * @name Timer configuration
  * @{
  */
-#define TIMER_NUMOF         (4U)
-#define TIMER_0_EN          1
-#define TIMER_1_EN          1
-#define TIMER_2_EN          1
-#define TIMER_3_EN          1
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = GPTIMER0,
+        .channels = 2,
+        .cfg      = GPTMCFG_16_BIT_TIMER, /* required for XTIMER */
+    },
+    {
+        .dev      = GPTIMER1,
+        .channels = 1,
+        .cfg      = GPTMCFG_32_BIT_TIMER,
+    },
+    {
+        .dev      = GPTIMER2,
+        .channels = 1,
+        .cfg      = GPTMCFG_32_BIT_TIMER,
+    },
+    {
+        .dev      = GPTIMER3,
+        .channels = 1,
+        .cfg      = GPTMCFG_32_BIT_TIMER,
+    },
+};
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 
 #define TIMER_IRQ_PRIO      1
-
-/* Timer 0 configuration */
-#define TIMER_0_DEV         GPTIMER0
-#define TIMER_0_CHANNELS    1
-#define TIMER_0_MAX_VALUE   0xffffffff
-#define TIMER_0_IRQn_1      GPTIMER_0A_IRQn
-#define TIMER_0_IRQn_2      GPTIMER_0B_IRQn
-#define TIMER_0_ISR_1       isr_timer0_chan0
-#define TIMER_0_ISR_2       isr_timer0_chan1
-
-/* Timer 1 configuration */
-#define TIMER_1_DEV         GPTIMER1
-#define TIMER_1_CHANNELS    1
-#define TIMER_1_MAX_VALUE   0xffffffff
-#define TIMER_1_IRQn_1      GPTIMER_1A_IRQn
-#define TIMER_1_IRQn_2      GPTIMER_1B_IRQn
-#define TIMER_1_ISR_1       isr_timer1_chan0
-#define TIMER_1_ISR_2       isr_timer1_chan1
-
-/* Timer 2 configuration */
-#define TIMER_2_DEV         GPTIMER2
-#define TIMER_2_CHANNELS    1
-#define TIMER_2_MAX_VALUE   0xffffffff
-#define TIMER_2_IRQn_1      GPTIMER_2A_IRQn
-#define TIMER_2_IRQn_2      GPTIMER_2B_IRQn
-#define TIMER_2_ISR_1       isr_timer2_chan0
-#define TIMER_2_ISR_2       isr_timer2_chan1
-
-/* Timer 3 configuration */
-#define TIMER_3_DEV         GPTIMER3
-#define TIMER_3_CHANNELS    1
-#define TIMER_3_MAX_VALUE   0xffffffff
-#define TIMER_3_IRQn_1      GPTIMER_3A_IRQn
-#define TIMER_3_IRQn_2      GPTIMER_3B_IRQn
-#define TIMER_3_ISR_1       isr_timer3_chan0
-#define TIMER_3_ISR_2       isr_timer3_chan1
 /** @} */
 
 /**

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 
+#include "cc2538_gptimer.h"
 #include "cc2538_ssi.h"
 #include "cc2538_gpio.h"
 
@@ -72,6 +73,15 @@ typedef struct {
     gpio_t sck_pin;         /**< pin used for SCK */
     gpio_t cs_pin;          /**< pin used for CS */
 } periph_spi_conf_t;
+
+/**
+ * @brief   Timer configuration data
+ */
+typedef struct {
+    cc2538_gptimer_t *dev;  /**< timer device */
+    uint_fast8_t channels;  /**< number of channels */
+    uint_fast8_t cfg;       /**< timer config word */
+} timer_conf_t;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The old driver supported only one mode, which wasn't xtimer friendly:
- 32-bit, single channel, fixed frequency.

The new driver adds two new modes, both of which are xtimer friendly:
- 16-bit, single channel, variable frequency.
- 16-bit, dual channel, variable frequency.

Tested on `cc2538dk`. xtimers are more robust. Previously they would hang after a few hours.
