### PR TITLE
at86rf2xx: do not set src pan compression on init

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -100,7 +100,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* set default TX power */
     at86rf2xx_set_txpower(dev, AT86RF2XX_DEFAULT_TXPOWER);
     /* set default options */
-    at86rf2xx_set_option(dev, NETDEV2_IEEE802154_PAN_COMP, true);
+    at86rf2xx_set_option(dev, NETDEV2_IEEE802154_PAN_COMP, false);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_AUTOACK, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_START, false);

--- a/sys/net/link_layer/ieee802154/ieee802154.c
+++ b/sys/net/link_layer/ieee802154/ieee802154.c
@@ -27,6 +27,10 @@ size_t ieee802154_set_frame_hdr(uint8_t *buf, const uint8_t *src, size_t src_len
     uint8_t type = (flags & IEEE802154_FCF_TYPE_MASK);
     uint8_t bcast = (flags & IEEE802154_BCAST);
 
+    if (dst_pan.u16 == src_pan.u16) {
+        flags |= IEEE802154_FCF_PAN_COMP;
+    }
+
     buf[0] = flags & (~IEEE802154_BCAST);
     buf[1] = IEEE802154_FCF_VERS_V1;
 


### PR DESCRIPTION
Depends on ~~#5525~~ #5685 

Currently, the at86rf2xx driver sets the src pan compression on initialization. Doing this when building the 802.15.4 header instead (like e.g. proposed by @aeneby in ~~#5525~~ #5685 ) is more dynamic, so that the flag is still set/unset correctly *iff* the pan id changes.