### PR TITLE
dist/tools/cc2538-bsl: wait for bootloader before flashing

### DIFF
--- a/dist/tools/cc2538-bsl/cc2538-bsl.py
+++ b/dist/tools/cc2538-bsl/cc2538-bsl.py
@@ -48,6 +48,7 @@ import os
 import subprocess
 import struct
 import binascii
+import time
 
 #version
 VERSION_STRING = "1.0"
@@ -121,6 +122,9 @@ class CommandInterface(object):
         self.sp.setRTS(1)
         self.sp.setRTS(0)
         self.sp.setDTR(0)
+
+        # Wait for the board to reset
+        time.sleep(0.5)
 
     def close(self):
         self.sp.close()


### PR DESCRIPTION
When I flash the remote-reva then I get:
```
Connecting to target...
ERROR: Can't connect to target. Ensure boot loader is started. (no answer on synch sequence)
```
Waiting ~500ms after invoking the bootloader by setting/unsetting the DTS/RTS pins fixes this issue for me. For some people the script works without this modification, for me it doesn't.