### PR TITLE
boards/atmega_common: remove dead code on link

### DIFF
--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -35,12 +35,12 @@ endif
 
 # define build specific options
 export CFLAGS_CPU   = -mmcu=atmega2560  $(CFLAGS_FPU)
-export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+export CFLAGS_LINK  = -fno-builtin -fshort-enums
 export CFLAGS_DBG   = -ggdb -g3
 export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc -e reset_handler
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -e reset_handler
 export OFLAGS += -j .text -j .data -O ihex
 export FFLAGS += -p m2560 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -D -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -49,12 +49,12 @@ endif
 
 # define build specific options
 export CFLAGS_CPU   = -mmcu=atmega1281  $(CFLAGS_FPU)
-export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+export CFLAGS_LINK  = -fno-builtin -fshort-enums
 export CFLAGS_DBG   = -ggdb -g3
 export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
-export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc -e reset_handler
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -e reset_handler
 export OFLAGS += -j .text -j .data -O ihex
 export FFLAGS += -p m1281 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex

--- a/cpu/atmega_common/Makefile.include
+++ b/cpu/atmega_common/Makefile.include
@@ -1,6 +1,15 @@
 # Target architecture for the build. Use avr if you are unsure.
 export TARGET_ARCH ?= avr
 
+# define build specific options
+CFLAGS_LINK  = -ffunction-sections -fdata-sections
+
+# export compiler flags
+export CFLAGS += $(CFLAGS_LINK)
+
+# export linker flags
+export LINKFLAGS += -Wl,--gc-sections -static -lgcc
+
 # export the peripheral drivers to be linked into the final binary
 export USEMODULE += periph
 


### PR DESCRIPTION
Don't include unused functions and data in binary.
as done in https://github.com/RIOT-OS/RIOT/pull/5713
tested by building and running examples/ipc_pingpong with simavr on
* **arduino-mega2560 :**

text  |  data  |   bss  |   dec  |   hex | |
-------|--------|----------|--------|-------- |---- |
6236  |   344  |  1099  |  7679  |  1dff |   *<= without patch* |
6224  |   340  |  1099  |  7663  |  1def |  *<= with patch* |
* **arduino-uno :**

text  |  data  |   bss  |   dec  |   hex | |
-------|--------|----------|--------|-------- |---- |
7238  |   538  |  1087  |  8863  |  229f | *<= without patch* |
5688  |   332  |  1087  |  7107  |  1bc3 | *<= with patch* |

* **waspmote-pro :**

text  |  data  |   bss  |   dec  |   hex | |
-------|--------|----------|--------|-------- |---- |
6002  |   340  |  1091  |  7433 |   1d09 | *<= without patch* |
5990  |   336  |  1091  |  7417 |   1cf9 |*<= with patch* |


