### PR TITLE
atmega: use software interrupt for context swap

### DIFF
--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -52,6 +52,22 @@ extern "C" {
 #define LED0_TOGGLE         (PORTB ^=  LED0_MASK)
 /** @} */
 
+
+/**
+ * Context swap defines
+ * Setup to use PJ6 which is pin change interrupt 15 (PCINT15)
+ * This emulates a software triggered interrupt
+ **/
+#define AVR_CONTEXT_SWAP_INIT do { \
+    DDRJ |= (1 << PJ6); \
+    PCICR |= (1 << PCIE1); \
+    PCMSK1 |= (1 << PCINT15); \
+} while (0)
+#define AVR_CONTEXT_SWAP_INTERRUPT_VECT  PCINT1_vect
+#define AVR_CONTEXT_SWAP_TRIGGER   PORTJ ^= (1 << PJ6)
+
+
+
 /**
  * @brief xtimer configuration values
  * @{

--- a/boards/waspmote-pro/include/board.h
+++ b/boards/waspmote-pro/include/board.h
@@ -151,6 +151,19 @@ extern "C" {
 /** @} */
 
 /**
+ * Context swap defines
+ * Setup to use PB5 which is pin change interrupt 5
+ * This emulates a software triggered interrupt
+ **/
+#define AVR_CONTEXT_SWAP_INIT do { \
+    DDRB |= (1 << PB5); \
+    PCICR |= (1 << PCIE0); \
+    PCMSK0 |= (1 << PCINT5); \
+} while (0)
+#define AVR_CONTEXT_SWAP_INTERRUPT_VECT  PCINT0_vect
+#define AVR_CONTEXT_SWAP_TRIGGER   PORTB ^= (1 << PB5)
+
+/**
  * @brief xtimer configuration values
  * @{
  */


### PR DESCRIPTION
Fixes #5745
For AVR based boards, three defines must be defined AVR_CONTEXT_SWAP_INIT,
AVR_CONTEXT_SWAP_INTERRUPT_VECT, and AVR_CONTEXT_SWAP_TRIGGER.
These defines are used to trigger a software interrupt used for context
switching.

When AVR_CONTEXT_SWAP_INTERRUPT_VECT is handled, the scheduler is run
and a context swap will happen if necessary, with the resulting thread
starting following the reti instruction. This results in threads running
at normal priority instead of at interrupt priority.

Atmega devices do provide a pure software interrupt. The method used
here for waspmote-pro and arduino-mega2560 is to use pin change
interrupts, set the pin to act as an output, and toggle the value to
simulate a software interrupt. The main limitation here is that a
physical pin is now occupied and must be defined for each board
supported by RIOT. On the plus side, it provides an easy method for
detecting context swaps with an oscilloscope.

I don't have access to either the arduino or waspmote boards, so it would be good to verify that the pins chosen are ok. The waspmote seems to use all the PCINT and INT pins, so I just chose one that looked generic.