### PR TITLE
lint: take care of various warnings/ errors issued by cppcheck

### DIFF
--- a/cpu/cortexm_common/include/cmsis_armcc_V6.h
+++ b/cpu/cortexm_common/include/cmsis_armcc_V6.h
@@ -77,6 +77,9 @@ __attribute__((always_inline)) __STATIC_INLINE uint32_t __get_CONTROL(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, control" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -131,6 +134,9 @@ __attribute__((always_inline)) __STATIC_INLINE uint32_t __get_IPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -161,6 +167,9 @@ __attribute__((always_inline)) __STATIC_INLINE uint32_t __get_APSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -191,6 +200,9 @@ __attribute__((always_inline)) __STATIC_INLINE uint32_t __get_xPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -221,6 +233,9 @@ __attribute__((always_inline)) __STATIC_INLINE uint32_t __get_PSP(void)
   register uint32_t result;
 
   __ASM volatile ("MRS %0, psp"  : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -275,6 +290,9 @@ __attribute__((always_inline)) __STATIC_INLINE uint32_t __get_MSP(void)
   register uint32_t result;
 
   __ASM volatile ("MRS %0, msp" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -329,6 +347,9 @@ __attribute__((always_inline)) __STATIC_INLINE uint32_t __get_PRIMASK(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 

--- a/cpu/cortexm_common/include/cmsis_gcc.h
+++ b/cpu/cortexm_common/include/cmsis_gcc.h
@@ -86,6 +86,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_CONTROL(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, control" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -111,6 +114,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_IPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -125,6 +131,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_APSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -140,6 +149,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -154,6 +166,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -179,6 +194,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 
@@ -205,6 +223,9 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PRIMASK(void)
   uint32_t result;
 
   __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  /* cppcheck thinks result may be uninitialized here, but the variable is
+   * assigned via the above inline assembler instruction. */
+  /* cppcheck-suppress uninitvar */
   return(result);
 }
 

--- a/cpu/stm32f0/periph/uart.c
+++ b/cpu/stm32f0/periph/uart.c
@@ -113,24 +113,38 @@ int init_base(uart_t uart, uint32_t baudrate)
             return -1;
     }
 
+    /* cppcheck thinks port and dev may be NULL here, but both variables are
+     * assigned in all non-returning branches of the switch at the top of
+     * this function. */
+
     /* configure RX and TX pins, set pin to use alternative function mode */
+    /* cppcheck-suppress nullPointer */
     port->MODER &= ~(3 << (rx_pin * 2) | 3 << (tx_pin * 2));
+    /* cppcheck-suppress nullPointer */
     port->MODER |= 2 << (rx_pin * 2) | 2 << (tx_pin * 2);
     /* and assign alternative function */
     if (rx_pin < 8) {
+        /* cppcheck-suppress nullPointer */
         port->AFR[0] &= ~(0xf << (rx_pin * 4));
+        /* cppcheck-suppress nullPointer */
         port->AFR[0] |= af << (rx_pin * 4);
     }
     else {
+        /* cppcheck-suppress nullPointer */
         port->AFR[1] &= ~(0xf << ((rx_pin - 8) * 4));
+        /* cppcheck-suppress nullPointer */
         port->AFR[1] |= af << ((rx_pin - 8) * 4);
     }
     if (tx_pin < 8) {
+        /* cppcheck-suppress nullPointer */
         port->AFR[0] &= ~(0xf << (tx_pin * 4));
+        /* cppcheck-suppress nullPointer */
         port->AFR[0] |= af << (tx_pin * 4);
     }
     else {
+        /* cppcheck-suppress nullPointer */
         port->AFR[1] &= ~(0xf << ((tx_pin - 8) * 4));
+        /* cppcheck-suppress nullPointer */
         port->AFR[1] |= af << ((tx_pin - 8) * 4);
     }
 
@@ -138,9 +152,11 @@ int init_base(uart_t uart, uint32_t baudrate)
     mid = (CLOCK_CORECLOCK / baudrate);
     mantissa = (uint16_t)(mid / 16);
     fraction = (uint8_t)(mid - (mantissa * 16));
+    /* cppcheck-suppress nullPointer */
     dev->BRR = ((mantissa & 0x0fff) << 4) | (0x0f & fraction);
 
     /* enable receive and transmit mode */
+    /* cppcheck-suppress nullPointer */
     dev->CR1 |= USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;
 
     return 0;

--- a/cpu/stm32f3/periph/uart.c
+++ b/cpu/stm32f3/periph/uart.c
@@ -119,24 +119,38 @@ static int init_base(uart_t uart, uint32_t baudrate)
             return -1;
     }
 
+    /* cppcheck thinks port and dev may be NULL here, but both variables are
+     * assigned in all non-returning branches of the switch at the top of
+     * this function. */
+
     /* uart_configure RX and TX pins, set pin to use alternative function mode */
+    /* cppcheck-suppress nullPointer */
     port->MODER &= ~(3 << (rx_pin * 2) | 3 << (tx_pin * 2));
+    /* cppcheck-suppress nullPointer */
     port->MODER |= 2 << (rx_pin * 2) | 2 << (tx_pin * 2);
     /* and assign alternative function */
     if (rx_pin < 8) {
+        /* cppcheck-suppress nullPointer */
         port->AFR[0] &= ~(0xf << (rx_pin * 4));
+        /* cppcheck-suppress nullPointer */
         port->AFR[0] |= af << (rx_pin * 4);
     }
     else {
+        /* cppcheck-suppress nullPointer */
         port->AFR[1] &= ~(0xf << ((rx_pin - 8) * 4));
+        /* cppcheck-suppress nullPointer */
         port->AFR[1] |= af << ((rx_pin - 8) * 4);
     }
     if (tx_pin < 8) {
+        /* cppcheck-suppress nullPointer */
         port->AFR[0] &= ~(0xf << (tx_pin * 4));
+        /* cppcheck-suppress nullPointer */
         port->AFR[0] |= af << (tx_pin * 4);
     }
     else {
+        /* cppcheck-suppress nullPointer */
         port->AFR[1] &= ~(0xf << ((tx_pin - 8) * 4));
+        /* cppcheck-suppress nullPointer */
         port->AFR[1] |= af << ((tx_pin - 8) * 4);
     }
 
@@ -144,11 +158,15 @@ static int init_base(uart_t uart, uint32_t baudrate)
     clk /= baudrate;
     mantissa = (uint16_t)(clk / 16);
     fraction = (uint8_t)(clk - (mantissa * 16));
+    /* cppcheck-suppress nullPointer */
     dev->BRR = ((mantissa & 0x0fff) << 4) | (0x0f & fraction);
 
     /* enable receive and transmit mode */
+    /* cppcheck-suppress nullPointer */
     dev->CR3 = 0;
+    /* cppcheck-suppress nullPointer */
     dev->CR2 = 0;
+    /* cppcheck-suppress nullPointer */
     dev->CR1 |= USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;
 
     return 0;
@@ -178,8 +196,12 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
             return;
     }
 
+    /* cppcheck thinks dev may be NULL here, but the variable is
+     * assigned in all non-returning branches of the switch at the top of
+     * this function. */
     for (size_t i = 0; i < len; i++) {
         while (!(dev->ISR & USART_ISR_TXE)) {}
+        /* cppcheck-suppress nullPointer */
         dev->TDR = data[i];
     }
 }

--- a/cpu/stm32l1/periph/uart.c
+++ b/cpu/stm32l1/periph/uart.c
@@ -119,15 +119,23 @@ static int init_base(uart_t uart, uint32_t baudrate)
     gpio_init(rx_pin, GPIO_IN);
     gpio_init_af(rx_pin, af);
 
+    /* cppcheck thinks dev may be NULL here, but the variable is
+     * assigned in all non-returning branches of the switch at the top of
+     * this function. */
+
     /* uart_configure UART to mode 8N1 with given baudrate */
     clk /= baudrate;
     mantissa = (uint16_t)(clk / 16);
     fraction = (uint8_t)(clk - (mantissa * 16));
+    /* cppcheck-suppress nullPointer */
     dev->BRR = ((mantissa & 0x0fff) << 4) | (0x0f & fraction);
 
     /* enable receive and transmit mode */
+    /* cppcheck-suppress nullPointer */
     dev->CR3 = 0;
+    /* cppcheck-suppress nullPointer */
     dev->CR2 = 0;
+    /* cppcheck-suppress nullPointer */
     dev->CR1 |= USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;
 
     return 0;
@@ -157,8 +165,12 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
             return;
     }
 
+    /* cppcheck thinks dev may be NULL here, but the variable is
+     * assigned in all non-returning branches of the switch at the top of
+     * this function. */
     for (size_t i = 0; i < len; i++) {
         while (!(dev->SR & USART_SR_TXE)) {}
+        /* cppcheck-suppress nullPointer */
         dev->DR = data[i];
     }
 }

--- a/dist/tools/tunslip/tapslip6.c
+++ b/dist/tools/tunslip/tapslip6.c
@@ -543,8 +543,7 @@ int
 main(int argc, char **argv)
 {
     int c;
-    int tunfd, slipfd, maxfd;
-    int ret;
+    int tunfd, slipfd;
     fd_set rset, wset;
     FILE *inslip;
     const char *siodev = NULL;
@@ -681,7 +680,7 @@ main(int argc, char **argv)
     ifconf(tundev, ipaddr, netmask);
 
     while (1) {
-        maxfd = 0;
+        int maxfd = 0;
         FD_ZERO(&rset);
         FD_ZERO(&wset);
 
@@ -723,7 +722,7 @@ main(int argc, char **argv)
             }
         }
 
-        ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
+        int ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
 
         if (ret == -1 && errno != EINTR) {
             err(1, "select");

--- a/dist/tools/tunslip/tapslip6.c
+++ b/dist/tools/tunslip/tapslip6.c
@@ -299,7 +299,7 @@ void
 write_to_serial(int outfd, void *inbuf, int len)
 {
     u_int8_t *p = inbuf;
-    int i, ecode;
+    int i;
 
     /*  printf("Got packet of length %d - write SLIP\n", len);*/
     /*  print_packet(p, len);*/

--- a/dist/tools/tunslip/tunslip.c
+++ b/dist/tools/tunslip/tunslip.c
@@ -969,8 +969,7 @@ int
 main(int argc, char **argv)
 {
     int c;
-    int tunfd, slipfd, maxfd;
-    int ret;
+    int tunfd, slipfd;
     fd_set rset, wset;
     FILE *inslip;
     const char *siodev = NULL;
@@ -1196,7 +1195,7 @@ main(int argc, char **argv)
     ifconf(tundev, ipaddr, netmask);
 
     while (1) {
-        maxfd = 0;
+        int maxfd = 0;
         FD_ZERO(&rset);
         FD_ZERO(&wset);
 
@@ -1237,7 +1236,7 @@ main(int argc, char **argv)
             }
         }
 
-        ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
+        int ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
 
         if (ret == -1 && errno != EINTR) {
             err(1, "select");

--- a/dist/tools/tunslip/tunslip.c
+++ b/dist/tools/tunslip/tunslip.c
@@ -274,7 +274,7 @@ relay_dhcp_to_client(int slipfd)
 
             case DHCP_OPTION_MSG_TYPE:
                 msg_type = p[2];
-
+                /* deliberate fall-through */
             case DHCP_OPTION_SUBNET_MASK:
             case DHCP_OPTION_ROUTER:
             case DHCP_OPTION_LEASE_TIME:

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -115,7 +115,6 @@ stamptime(void)
     long secs, msecs;
     struct timeval tv;
     time_t t;
-    struct tm *tmp;
     char timec[20];
 
     gettimeofday(&tv, NULL) ;
@@ -137,7 +136,7 @@ stamptime(void)
         startsecs = secs;
         startmsecs = msecs;
         t = time(NULL);
-        tmp = localtime(&t);
+        struct tm *tmp = localtime(&t);
         strftime(timec, sizeof(timec), "%T", tmp);
         //    fprintf(stderr,"\n%s.%03lu ",timec,msecs);
         fprintf(stderr, "\n%s ", timec);
@@ -899,8 +898,7 @@ int
 main(int argc, char **argv)
 {
     int c;
-    int tunfd, maxfd;
-    int ret;
+    int tunfd;
     fd_set rset, wset;
     FILE *inslip;
     const char *siodev = NULL;
@@ -1187,7 +1185,7 @@ main(int argc, char **argv)
     ifconf(tundev, ipaddr);
 
     while (1) {
-        maxfd = 0;
+        int maxfd = 0;
         FD_ZERO(&rset);
         FD_ZERO(&wset);
 
@@ -1221,7 +1219,7 @@ main(int argc, char **argv)
             }
         }
 
-        ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
+        int ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
 
         if (ret == -1 && errno != EINTR) {
             err(1, "select");
@@ -1254,10 +1252,8 @@ main(int argc, char **argv)
             }
 
             if (delaymsec == 0) {
-                int size;
-
                 if (slip_empty() && FD_ISSET(tunfd, &rset)) {
-                    size = tun_to_serial(tunfd, slipfd);
+                    int size = tun_to_serial(tunfd, slipfd);
                     slip_flushbuf(slipfd);
                     sigalarm_reset();
 

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -130,7 +130,7 @@ stamptime(void)
             msecs += 1000;
         }
 
-        fprintf(stderr, "%04lu.%03lu ", secs, msecs);
+        fprintf(stderr, "%04li.%03li ", secs, msecs);
     }
     else {
         startsecs = secs;

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -46,10 +46,10 @@ dht_t dht_devs[DHT_NUMOF];
 
 static uint16_t read(gpio_t pin, int bits)
 {
-    uint32_t start, end;
     uint16_t res = 0;
 
     for (int i = 0; i < bits; i++) {
+        uint32_t start, end;
         res <<= 1;
         /* measure the length between the next rising and falling flanks (the
          * time the pin is high - smoke up :-) */

--- a/pkg/emb6/contrib/conn/udp/emb6_conn_udp.c
+++ b/pkg/emb6/contrib/conn/udp/emb6_conn_udp.c
@@ -230,11 +230,12 @@ static void _input_callback(struct udp_socket *c, void *ptr,
 
 static void _output_callback(c_event_t c_event, p_data_t p_data)
 {
-    _send_cmd_t *send_cmd = (_send_cmd_t *)p_data;
-
     if ((c_event != EVENT_TYPE_CONN_SEND) || (p_data == NULL)) {
         return;
     }
+
+    _send_cmd_t *send_cmd = (_send_cmd_t *)p_data;
+
     if ((send_cmd->res = udp_socket_send(&send_cmd->sock, send_cmd->data, send_cmd->data_len)) < 0) {
         send_cmd->res = -EHOSTUNREACH;
     }

--- a/pkg/nordic_softdevice_ble/src/ble-mac.c
+++ b/pkg/nordic_softdevice_ble/src/ble-mac.c
@@ -172,13 +172,12 @@ int ble_mac_send(uint8_t dest[8], void *data, size_t len)
     od_hex_dump(data, len, OD_WIDTH_DEFAULT);
 #endif
 
-    int i;
     ble_ipsp_handle_t *handle;
     int ret = -1;
 
     if ((!dest) || _is_broadcast(dest)) {
         DEBUG("broadcast\n");
-        for (i = 0; i < BLE_MAC_MAX_INTERFACE_NUM; i++) {
+        for (int i = 0; i < BLE_MAC_MAX_INTERFACE_NUM; i++) {
             if (interfaces[i].handle.cid != 0 && interfaces[i].handle.conn_handle != 0) {
                 ret = _send_to_peer(&interfaces[i].handle, data, len);
                 DEBUG("ret=%i\n", ret);

--- a/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
+++ b/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
@@ -127,6 +127,11 @@ static void _handle_raw_sixlowpan(ble_mac_inbuf_t *inbuf)
 
 static int _send(gnrc_pktsnip_t *pkt)
 {
+    if (pkt == NULL) {
+        DEBUG("_send_ble: pkt was NULL\n");
+        return -EINVAL;
+    }
+
     gnrc_netif_hdr_t *netif_hdr;
     gnrc_pktsnip_t *payload = pkt->next;
     uint8_t *dst;
@@ -139,10 +144,6 @@ static int _send(gnrc_pktsnip_t *pkt)
     uint8_t *buf = _sendbuf;
     unsigned len = 0;
 
-    if (pkt == NULL) {
-        DEBUG("_send_ble: pkt was NULL\n");
-        return -EINVAL;
-    }
     if (pkt->type != GNRC_NETTYPE_NETIF) {
         DEBUG("_send_ble: first header is not generic netif header\n");
         return -EBADMSG;

--- a/sys/base64/base64.c
+++ b/sys/base64/base64.c
@@ -83,9 +83,9 @@ int base64_encode(unsigned char *data_in, size_t data_in_size, \
     unsigned char nNum = 0;
     int nLst = 0;
     int njump = 0;
-    unsigned char tmpval;
 
     for (int i = 0; i < (int)(data_in_size); ++i) {
+        unsigned char tmpval;
         njump++;
         tmpval = *(data_in + i);
 

--- a/sys/ecc/hamming256/hamming256.c
+++ b/sys/ecc/hamming256/hamming256.c
@@ -273,8 +273,8 @@ void hamming_compute256x( const uint8_t *pucData, uint32_t dwSize, uint8_t *puCo
 {
     DEBUG("hamming_compute256x()\n\r");
 
-    uint8_t padding;
     while (dwSize > 0) {
+        uint8_t padding;
         padding = 0;
         if (dwSize < 256) {
             padding = 256 - dwSize;
@@ -290,13 +290,12 @@ void hamming_compute256x( const uint8_t *pucData, uint32_t dwSize, uint8_t *puCo
 
 uint8_t hamming_verify256x( uint8_t *pucData, uint32_t dwSize, const uint8_t *pucCode )
 {
-    uint8_t error;
     uint8_t result = 0;
 
     DEBUG( "hamming_verify256x()\n\r" );
 
-    uint8_t padding;
     while (dwSize > 0) {
+        uint8_t error, padding;
         padding = 0;
         if (dwSize < 256) {
             padding = 256 - dwSize;

--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -198,18 +198,18 @@ static inline uint16_t *_get_uint16_ptr(void *ptr)
 
 static int _send(gnrc_netdev_t *netdev, gnrc_pktsnip_t *pkt)
 {
+    if ((netdev == NULL) || (netdev->driver != &_zep_driver)) {
+        DEBUG("zep: wrong device on sending\n");
+        gnrc_pktbuf_release(pkt);
+        return -ENODEV;
+    }
+
     gnrc_zep_t *dev = (gnrc_zep_t *)netdev;
     gnrc_pktsnip_t *ptr, *new_pkt, *hdr;
     gnrc_zep_hdr_t *zep;
     size_t payload_len = gnrc_pkt_len(pkt->next), hdr_len, mhr_offset;
     uint8_t mhr[IEEE802154_MAX_HDR_LEN], *data;
     uint16_t fcs = 0;
-
-    if ((netdev == NULL) || (netdev->driver != &_zep_driver)) {
-        DEBUG("zep: wrong device on sending\n");
-        gnrc_pktbuf_release(pkt);
-        return -ENODEV;
-    }
 
     /* create 802.15.4 header */
     hdr_len = _make_data_frame_hdr(dev, mhr, (gnrc_netif_hdr_t *)pkt->data);

--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -100,11 +100,12 @@ static enum gnrc_ipv6_ext_demux_status _handle_rh(gnrc_pktsnip_t *current, gnrc_
 static gnrc_pktsnip_t *_mark_extension_header(gnrc_pktsnip_t *current,
                                               gnrc_pktsnip_t **pkt)
 {
-    gnrc_pktsnip_t *ext_snip, *tmp, *next;
+    gnrc_pktsnip_t *tmp, *next;
     ipv6_ext_t *ext = (ipv6_ext_t *) current->data;
     size_t offset = ((ext->len * IPV6_EXT_LEN_UNIT) + IPV6_EXT_LEN_UNIT);
 
     if (current == *pkt) {
+        gnrc_pktsnip_t *ext_snip;
         if ((tmp = gnrc_pktbuf_start_write(*pkt)) == NULL) {
             DEBUG("ipv6: could not get a copy of pkt\n");
             gnrc_pktbuf_release(*pkt);

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -791,9 +791,6 @@ void gnrc_ipv6_netif_init_by_dev(void)
 {
     kernel_pid_t ifs[GNRC_NETIF_NUMOF];
     size_t ifnum = gnrc_netif_get(ifs);
-#ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER
-    bool abr_init = false;
-#endif
 
     for (size_t i = 0; i < ifnum; i++) {
         ipv6_addr_t addr;
@@ -877,6 +874,7 @@ void gnrc_ipv6_netif_init_by_dev(void)
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
         if (ipv6_if->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) {
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER
+            bool abr_init = false;
             /* first interface wins */
             if (!abr_init) {
                 gnrc_sixlowpan_nd_router_abr_create(&addr, 0);

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -720,9 +720,9 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
 
     /* add external and RPL FIB entries */
     for (size_t i = 0; i < gnrc_ipv6_fib_table.size; ++i) {
-        ipv6_addr_t *addr;
         fib_entry_t *fentry = &gnrc_ipv6_fib_table.data.entries[i];
         if (fentry->lifetime != 0) {
+            ipv6_addr_t *addr;
             if (!(fentry->next_hop_flags & FIB_FLAG_RPL_ROUTE)) {
                 ptr = &tmp;
                 if (!ext_processed) {

--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -148,11 +148,10 @@ int _ccnl_content(int argc, char **argv)
 static struct ccnl_face_s *_intern_face_get(char *addr_str)
 {
     /* initialize address with 0xFF for broadcast */
-    size_t addr_len = MAX_ADDR_LEN;
     uint8_t relay_addr[MAX_ADDR_LEN];
     memset(relay_addr, UINT8_MAX, MAX_ADDR_LEN);
+    size_t addr_len = gnrc_netif_addr_from_str(relay_addr, sizeof(relay_addr), addr_str);;
 
-    addr_len = gnrc_netif_addr_from_str(relay_addr, sizeof(relay_addr), addr_str);
     if (addr_len == 0) {
         printf("Error: %s is not a valid link layer address\n", addr_str);
         return NULL;

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -244,7 +244,7 @@ int _icmpv6_ping(int argc, char **argv)
 
     while ((remaining--) > 0) {
         gnrc_pktsnip_t *pkt;
-        uint32_t start, stop, timeout = 1 * SEC_IN_USEC;
+        uint32_t start, timeout = 1 * SEC_IN_USEC;
 
         pkt = gnrc_icmpv6_echo_build(ICMPV6_ECHO_REQ, id, ++max_seq_expected,
                                      NULL, payload_len);
@@ -285,6 +285,7 @@ int _icmpv6_ping(int argc, char **argv)
 
         /* TODO: replace when #4219 was fixed */
         if (xtimer_msg_receive_timeout64(&msg, (uint64_t)timeout) >= 0) {
+            uint32_t stop;
             switch (msg.type) {
                 case GNRC_NETAPI_MSG_TYPE_RCV:
                     stop = xtimer_now() - start;

--- a/tests/driver_dht/main.c
+++ b/tests/driver_dht/main.c
@@ -53,7 +53,7 @@ int main(void)
             int_hum = hum / 10;
             dec_hum = hum - (int_hum * 10);
 
-            printf("DHT device #%i - ", i);
+            printf("DHT device #%u - ", i);
             printf("temp: %i.%i°C, ", int_temp, dec_temp);
             printf("relative humidity: %i.%i%%\n", int_hum, dec_hum);
 

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -84,7 +84,7 @@ static int init_int(int argc, char **argv)
     int po, pi;
     gpio_mode_t mode = GPIO_IN;
     gpio_flank_t flank;
-    int fl, pr;
+    int fl;
 
     if (argc < 4) {
         printf("usage: %s <port> <pin> <flank> [pull_config]\n", argv[0]);
@@ -119,7 +119,7 @@ static int init_int(int argc, char **argv)
     }
 
     if (argc >= 5) {
-        pr = atoi(argv[4]);
+        int pr = atoi(argv[4]);
         switch (pr) {
             case 0:
                 mode = GPIO_IN;

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -53,11 +53,11 @@ static int parse_dev(char *arg)
 {
     unsigned dev = (unsigned)atoi(arg);
     if (dev >= UART_NUMOF) {
-        printf("Error: Invalid UART_DEV device specified (%i).\n", dev);
+        printf("Error: Invalid UART_DEV device specified (%u).\n", dev);
         return -1;
     }
     else if (UART_DEV(dev) == UART_STDIO_DEV) {
-        printf("Error: The selected UART_DEV(%i) is used for the shell!\n", dev);
+        printf("Error: The selected UART_DEV(%u) is used for the shell!\n", dev);
         return -2;
     }
     return dev;

--- a/tests/xtimer_now64_continuity/main.c
+++ b/tests/xtimer_now64_continuity/main.c
@@ -29,11 +29,10 @@
 int main(void)
 {
     uint32_t n = ITERATIONS;
-    uint64_t now;
     uint64_t before = xtimer_now64();
 
     while(--n) {
-        now = xtimer_now64();
+        uint64_t now = xtimer_now64();
         if ((now-before) > MAXDIFF) {
             puts("TEST FAILED.");
             break;


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. Please have a close look at the `variableScope` fixes, since I wonder if this is what you want style-wise.

The remaining issues reported by Cppcheck have to be looked at by somebody with a deeper understanding of the respective module -- especially the `unreachableCode`, `unreadVariable`, and `clarifyStatement` ones.

**Remaining issues found** (Cppcheck v1.67)

    $ ./dist/tools/cppcheck/check.sh 2>&1 |cut -d: -f3|sort|uniq -c|sort -n
          1  performance (redundantCopy)
          1  style (unsignedLessThanZero)
          1  style (variableScope)
          1  warning (clarifyStatement)
          2  style (unreachableCode)
          3  style (unreadVariable)

**Previous issues found**

          1  performance (redundantAssignment)
          1  performance (redundantCopy)
          1  style (unsignedLessThanZero)
          1  style (unusedVariable)
          1  warning (clarifyStatement)
          2  style (unreachableCode)
          2  warning (invalidPrintfArgType_uint)
          3  style (unreadVariable)
          3  warning (invalidPrintfArgType_sint)
          3  warning (nullPointer)
         14  error (uninitvar)
         21  style (variableScope)
         32  error (nullPointer)