### PR TITLE
dist: add cmake and bsdmainutils to Dockerfile

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -38,6 +38,8 @@ RUN apt-get -y install build-essential \
  gcc-msp430 \
  pcregrep libpcre3 \
  qemu-system-x86 python3 \
+ cmake \
+ bsdmainutils \
  g++-multilib \
  gcc-avr binutils-avr avr-libc \
  subversion curl wget python p7zip unzip parallel


### PR DESCRIPTION
cmake needed by pkg/relic which is used in tests/unittests/tests-relic
hexdump (in bsdmainutils) is used in sys/crypto