### PR TITLE
vagrant: use ubuntu 16.04 LTS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "boxcutter/ubuntu1510"
+  config.vm.box = "boxcutter/ubuntu1604"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
The `ubuntu1504` image doesn't exist anymore in vagrant's default cloud. For now, I adjusted the Vagrantfile to use `ubuntu1604` (LTS). WIthout this fix, vagrant will complain about a missing image (if it wasn't downloaded before).

PS: I will look into a solution of baking our own image and maybe hosting that on the riot server/FU/HAW? This way, we will have more control of pre-installed packages and we can guarantee availability.