### PR TITLE
cpu: cortex-M: disable wchar warnings

### DIFF
--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -6,6 +6,7 @@ ifneq (,$(filter newlib_nano,$(USEMODULE)))
     USE_NEWLIB_NANO = 1
     ifeq ($(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(CC) -xc - -o /dev/null -lc -specs=nano.specs -Wall -Wextra -pedantic 2>&1 | grep -q "use of wchar_t values across objects may fail" ; echo $$?),0)
         CFLAGS += -fshort-wchar
+        LINKFLAGS += -Wl,--no-wchar-size-warning
     endif
   endif
 endif


### PR DESCRIPTION
Otherwise the toolchain in Ubuntu 16.04 throws warnings:
```
/usr/lib/gcc/arm-none-eabi/4.9.3/../../../arm-none-eabi/bin/ld: warning: /usr/lib/gcc/arm-none-eabi/4.9.3/armv7-m/libgcc.a(bpabi.o) uses 4-byte wchar_t yet the output is to use 2-byte wchar_t; use of wchar_t values across objects may fail
/usr/lib/gcc/arm-none-eabi/4.9.3/../../../arm-none-eabi/bin/ld: warning: /usr/lib/gcc/arm-none-eabi/4.9.3/armv7-m/libgcc.a(_divdi3.o) uses 4-byte wchar_t yet the output is to use 2-byte wchar_t; use of wchar_t values across objects may fail
/usr/lib/gcc/arm-none-eabi/4.9.3/../../../arm-none-eabi/bin/ld: warning: /usr/lib/gcc/arm-none-eabi/4.9.3/armv7-m/libgcc.a(_udivdi3.o) uses 4-byte wchar_t yet the output is to use 2-byte wchar_t; use of wchar_t values across objects may fail
```

Isn't relevant for us anyway since we're not using `wchar_t` anywhere.