### PR TITLE
emb6: remove double inclusion in Makefile.dep

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -426,25 +426,6 @@ ifneq (,$(filter lwip_contrib,$(USEMODULE)))
   USEMODULE += sema
 endif
 
-ifneq (,$(filter emb6_%,$(USEMODULE)))
-  USEMODULE += emb6
-endif
-
-ifneq (,$(filter emb6,$(USEMODULE)))
-  USEPKG += emb6
-  USEMODULE += emb6_bsp
-  USEMODULE += emb6_common
-  USEMODULE += emb6_contrib
-  USEMODULE += emb6_ipv6
-  USEMODULE += emb6_ipv6_multicast
-  USEMODULE += emb6_llsec
-  USEMODULE += emb6_mac
-  USEMODULE += emb6_netdev2
-  USEMODULE += emb6_rpl
-  USEMODULE += emb6_sicslowpan
-  USEMODULE += emb6_utils
-endif
-
 ifneq (,$(filter sema,$(USEMODULE)))
   USEMODULE += xtimer
 endif


### PR DESCRIPTION
For some reason, the dependency tree from emb6 was included twice in Makefile.dep: once at [ll. 356-374](https://github.com/RIOT-OS/RIOT/blob/fa475a6730efbe3853364e4ec26c250d68a22f92/Makefile.dep#L356-L373) and once at ll. 429-447. This PR removes the latter.