### PR TITLE
lpc2387: Fix wrong factor in driver poll-timer

### DIFF
--- a/cpu/lpc2387/mci/lpc2387-mci.c
+++ b/cpu/lpc2387/mci/lpc2387-mci.c
@@ -477,7 +477,7 @@ static int wait_ready(unsigned short tmr)
 {
     unsigned long rc;
 
-    uint32_t stoppoll = xtimer_now() + tmr * 100;
+    uint32_t stoppoll = xtimer_now() + tmr * MS_IN_USEC;
     bool bBreak = false;
 
     while (xtimer_now() < stoppoll/*Timer[0]*/) {


### PR DESCRIPTION
Fixes #4530