### PR TITLE
auto_init_gnrc_netif: set priorities one lower than 6LoWPAN

### DIFF
--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -35,7 +35,9 @@
  * @{
  */
 #define AT86RF2XX_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
-#define AT86RF2XX_MAC_PRIO          (THREAD_PRIORITY_MAIN - 4)
+#ifndef AT86RF2XX_MAC_PRIO
+#define AT86RF2XX_MAC_PRIO          (GNRC_NETDEV2_MAC_PRIO)
+#endif
 
 #define AT86RF2XX_NUM (sizeof(at86rf2xx_params) / sizeof(at86rf2xx_params[0]))
 

--- a/sys/auto_init/netif/auto_init_cc110x.c
+++ b/sys/auto_init/netif/auto_init_cc110x.c
@@ -35,7 +35,9 @@
  * @{
  */
 #define CC110X_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
-#define CC110X_MAC_PRIO          (THREAD_PRIORITY_MAIN - 3)
+#ifndef CC110X_MAC_PRIO
+#define CC110X_MAC_PRIO          (GNRC_NETDEV2_MAC_PRIO)
+#endif
 
 #define CC110X_NUM (sizeof(cc110x_params)/sizeof(cc110x_params[0]))
 

--- a/sys/auto_init/netif/auto_init_cc2420.c
+++ b/sys/auto_init/netif/auto_init_cc2420.c
@@ -37,7 +37,9 @@
  * @{
  */
 #define CC2420_MAC_STACKSIZE           (THREAD_STACKSIZE_MAIN)
-#define CC2420_MAC_PRIO                (THREAD_PRIORITY_MAIN - 4)
+#ifndef CC2420_MAC_PRIO
+#define CC2420_MAC_PRIO                (GNRC_NETDEV2_MAC_PRIO)
+#endif
 /** @} */
 
 /**

--- a/sys/auto_init/netif/auto_init_cc2538_rf.c
+++ b/sys/auto_init/netif/auto_init_cc2538_rf.c
@@ -32,7 +32,9 @@
  * @{
  */
 #define CC2538_MAC_STACKSIZE       (THREAD_STACKSIZE_DEFAULT)
-#define CC2538_MAC_PRIO            (THREAD_PRIORITY_MAIN - 4)
+#ifndef CC2538_MAC_PRIO
+#define CC2538_MAC_PRIO            (GNRC_NETDEV2_MAC_PRIO)
+#endif
 
 static cc2538_rf_t cc2538_rf_dev;
 static gnrc_netdev2_t gnrc_adpt;

--- a/sys/auto_init/netif/auto_init_enc28j60.c
+++ b/sys/auto_init/netif/auto_init_enc28j60.c
@@ -33,8 +33,10 @@
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define MAC_STACKSIZE   (THREAD_STACKSIZE_DEFAULT)
-#define MAC_PRIO        (THREAD_PRIORITY_MAIN - 4)
+#define ENC28J60_MAC_STACKSIZE   (THREAD_STACKSIZE_DEFAULT)
+#ifndef ENC28J60_MAC_PRIO
+#define ENC28J60_MAC_PRIO        (GNRC_NETDEV2_MAC_PRIO)
+#endif
 /*** @} */
 
 /**
@@ -53,7 +55,7 @@ static gnrc_netdev2_t gnrc_adpt[ENC28J60_NUM];
 /**
  * @brief   Stacks for the MAC layer threads
  */
-static char stack[MAC_STACKSIZE][ENC28J60_NUM];
+static char stack[ENC28J60_MAC_STACKSIZE][ENC28J60_NUM];
 
 
 void auto_init_enc28j60(void)
@@ -65,7 +67,7 @@ void auto_init_enc28j60(void)
         /* initialize netdev2 <-> gnrc adapter state */
         gnrc_netdev2_eth_init(&gnrc_adpt[i], (netdev2_t *)&dev[i]);
         /* start gnrc netdev2 thread */
-        gnrc_netdev2_init(stack[i], MAC_STACKSIZE, MAC_PRIO,
+        gnrc_netdev2_init(stack[i], ENC28J60_MAC_STACKSIZE, ENC28J60_MAC_PRIO,
                           "gnrc_enc28j60", &gnrc_adpt[i]);
     }
 }

--- a/sys/auto_init/netif/auto_init_encx24j600.c
+++ b/sys/auto_init/netif/auto_init_encx24j600.c
@@ -23,6 +23,7 @@
 #include "debug.h"
 
 #include "encx24j600.h"
+#include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/eth.h"
 
 static encx24j600_t encx24j600;
@@ -31,13 +32,15 @@ static encx24j600_t encx24j600;
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
-#define MAC_PRIO                (THREAD_PRIORITY_MAIN - 4)
+#define ENCX24J600_MAC_STACKSIZE    (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#ifndef ENCX24J600_MAC_PRIO
+#define ENCX24J600_MAC_PRIO         (GNRC_NETDEV2_MAC_PRIO)
+#endif
 
 /**
  * @brief   Stacks for the MAC layer threads
  */
-static char _netdev2_eth_stack[MAC_STACKSIZE];
+static char _netdev2_eth_stack[ENCX24J600_MAC_STACKSIZE];
 static gnrc_netdev2_t _gnrc_encx24j600;
 
 void auto_init_encx24j600(void)
@@ -54,8 +57,9 @@ void auto_init_encx24j600(void)
     gnrc_netdev2_eth_init(&_gnrc_encx24j600, (netdev2_t*)&encx24j600);
 
     /* start gnrc netdev2 thread */
-    gnrc_netdev2_init(_netdev2_eth_stack, MAC_STACKSIZE,
-            MAC_PRIO, "gnrc_encx24j600", &_gnrc_encx24j600);
+    gnrc_netdev2_init(_netdev2_eth_stack, ENCX24J600_MAC_STACKSIZE,
+                      ENCX24J600_MAC_PRIO, "gnrc_encx24j600",
+                      &_gnrc_encx24j600);
 }
 
 #else

--- a/sys/auto_init/netif/auto_init_ethos.c
+++ b/sys/auto_init/netif/auto_init_ethos.c
@@ -21,6 +21,7 @@
 
 #include "ethos.h"
 #include "periph/uart.h"
+#include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/eth.h"
 
 #define ENABLE_DEBUG (0)
@@ -35,13 +36,15 @@ ethos_t ethos;
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
-#define MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
-#define MAC_PRIO                (THREAD_PRIORITY_MAIN - 4)
+#define ETHOS_MAC_STACKSIZE (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#ifndef ETHOS_MAC_PRIO
+#define ETHOS_MAC_PRIO      (GNRC_NETDEV2_MAC_PRIO)
+#endif
 
 /**
  * @brief   Stacks for the MAC layer threads
  */
-static char _netdev2_eth_stack[MAC_STACKSIZE];
+static char _netdev2_eth_stack[ETHOS_MAC_STACKSIZE];
 static gnrc_netdev2_t _gnrc_ethos;
 
 static uint8_t _inbuf[2048];
@@ -62,8 +65,8 @@ void auto_init_ethos(void)
     gnrc_netdev2_eth_init(&_gnrc_ethos, (netdev2_t*)&ethos);
 
     /* start gnrc netdev2 thread */
-    gnrc_netdev2_init(_netdev2_eth_stack, MAC_STACKSIZE,
-            MAC_PRIO, "gnrc_ethos", &_gnrc_ethos);
+    gnrc_netdev2_init(_netdev2_eth_stack, ETHOS_MAC_STACKSIZE, ETHOS_MAC_PRIO,
+                      "gnrc_ethos", &_gnrc_ethos);
 }
 
 #else

--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -22,6 +22,7 @@
 #ifdef MODULE_KW2XRF
 
 #include "board.h"
+#include "net/gnrc/netdev2.h"
 #include "net/gnrc/nomac.h"
 #include "net/gnrc.h"
 
@@ -36,7 +37,9 @@
  * @{
  */
 #define KW2XRF_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
-#define KW2XRF_MAC_PRIO          (THREAD_PRIORITY_MAIN - 4)
+#ifndef KW2XRF_MAC_PRIO
+#define KW2XRF_MAC_PRIO          (GNRC_NETDEV2_MAC_PRIO)
+#endif
 
 #define KW2XRF_NUM (sizeof(kw2xrf_params)/sizeof(kw2xrf_params[0]))
 

--- a/sys/auto_init/netif/auto_init_netdev2_tap.c
+++ b/sys/auto_init/netif/auto_init_netdev2_tap.c
@@ -23,6 +23,7 @@
 #include "debug.h"
 
 #include "netdev2_tap.h"
+#include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/eth.h"
 
 extern netdev2_tap_t netdev2_tap;
@@ -32,7 +33,9 @@ extern netdev2_tap_t netdev2_tap;
  * @{
  */
 #define TAP_MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
-#define TAP_MAC_PRIO                (THREAD_PRIORITY_MAIN - 3)
+#ifndef TAP_MAC_PRIO
+#define TAP_MAC_PRIO                (GNRC_NETDEV2_MAC_PRIO)
+#endif
 
 /**
  * @brief   Stacks for the MAC layer threads

--- a/sys/auto_init/netif/auto_init_slip.c
+++ b/sys/auto_init/netif/auto_init_slip.c
@@ -20,6 +20,7 @@
 #ifdef MODULE_GNRC_SLIP
 
 #include "board.h"
+#include "net/gnrc/netdev2.h"
 #include "net/gnrc/nomac.h"
 #include "net/gnrc.h"
 
@@ -38,7 +39,9 @@ static gnrc_slip_dev_t slip_devs[SLIP_NUM];
  * @{
  */
 #define SLIP_STACKSIZE          (THREAD_STACKSIZE_DEFAULT)
-#define SLIP_PRIO               (THREAD_PRIORITY_MAIN - 4)
+#ifndef SLIP_PRIO
+#define SLIP_PRIO               (GNRC_NETDEV2_MAC_PRIO)
+#endif
 
 /**
  * @brief   Stacks for the MAC layer threads

--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -20,6 +20,7 @@
 #ifdef MODULE_XBEE
 
 #include "board.h"
+#include "net/gnrc/netdev2.h"
 #include "net/gnrc/nomac.h"
 #include "net/gnrc.h"
 
@@ -38,7 +39,9 @@ static xbee_t xbee_devs[XBEE_NUM];
  * @{
  */
 #define XBEE_MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT)
-#define XBEE_MAC_PRIO                (THREAD_PRIORITY_MAIN - 4)
+#ifndef XBEE_MAC_PRIO
+#define XBEE_MAC_PRIO                (GNRC_NETDEV2_MAC_PRIO)
+#endif
 
 /**
  * @brief   Stacks for the MAC layer threads

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -37,6 +37,10 @@
 extern "C" {
 #endif
 
+#ifndef GNRC_NETDEV2_MAC_PRIO
+#define GNRC_NETDEV2_MAC_PRIO   (THREAD_PRIORITY_MAIN - 5)
+#endif
+
 /**
  * @brief   Type for @ref msg_t if device fired an event
  */


### PR DESCRIPTION
In #5795 we realized, basically all GNRC MAC threads currently have either the same (or in case of cc11xx even higher) niceness than 6LoWPAN. Originally however they should have had a lower one.