### PR TITLE
cpu/cc2538: Remove superfluous mutex lock

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -24,7 +24,6 @@
 
 #include <stdbool.h>
 
-#include "mutex.h"
 #include "net/netdev2.h"
 #include "net/netdev2/ieee802154.h"
 
@@ -179,7 +178,6 @@ enum {
 typedef struct {
     netdev2_ieee802154_t netdev;  /**< netdev2 parent struct */
     uint8_t state;                /**< current state of the radio */
-    mutex_t mutex;                /**< device access lock */
 } cc2538_rf_t;
 
 /**

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -174,7 +174,5 @@ void cc2538_setup(cc2538_rf_t *dev)
 
     netdev->driver = &cc2538_rf_driver;
 
-    mutex_init(&dev->mutex);
-
     cc2538_init();
 }

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -257,9 +257,6 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 {
     int pkt_len = 0;
 
-    cc2538_rf_t *dev = (cc2538_rf_t *) netdev;
-    mutex_lock(&dev->mutex);
-
     /* Flush TX FIFO once no transmission in progress */
     RFCORE_WAIT_UNTIL(RFCORE->XREG_FSMSTAT1bits.TX_ACTIVE == 0);
     RFCORE_SFR_RFST = ISFLUSHTX;
@@ -285,19 +282,15 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
     rfcore_poke_tx_fifo(0, pkt_len + CC2538_AUTOCRC_LEN);
 
     RFCORE_SFR_RFST = ISTXON;
-    mutex_unlock(&dev->mutex);
 
     return pkt_len;
 }
 
 static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
 {
-    cc2538_rf_t *dev = (cc2538_rf_t *) netdev;
     uint8_t corr_val;
     int8_t rssi_val;
     size_t pkt_len;
-
-    mutex_lock(&dev->mutex);
 
     if (buf == NULL) {
         /* GNRC wants to know how much data we've got for it */
@@ -306,7 +299,6 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
         /* Make sure pkt_len is sane */
         if (pkt_len > CC2538_RF_MAX_DATA_LEN) {
             RFCORE_SFR_RFST = ISFLUSHRX;
-            mutex_unlock(&dev->mutex);
             return -EOVERFLOW;
         }
 
@@ -314,7 +306,6 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
         if (!(rfcore_peek_rx_fifo(pkt_len) & 0x80)) {
             /* CRC failed; discard packet */
             RFCORE_SFR_RFST = ISFLUSHRX;
-            mutex_unlock(&dev->mutex);
             return -ENODATA;
         }
 
@@ -323,7 +314,6 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
             RFCORE_SFR_RFST = ISFLUSHRX;
         }
 
-        mutex_unlock(&dev->mutex);
         return pkt_len - IEEE802154_FCS_LEN;
     }
     else {
@@ -359,7 +349,6 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
     }
 
     RFCORE_SFR_RFST = ISFLUSHRX;
-    mutex_unlock(&dev->mutex);
 
     return pkt_len;
 }
@@ -373,8 +362,6 @@ static int _init(netdev2_t *netdev)
 {
     cc2538_rf_t *dev = (cc2538_rf_t *) netdev;
     _dev = netdev;
-
-    mutex_lock(&dev->mutex);
 
     uint16_t pan = cc2538_get_pan();
     uint16_t chan = cc2538_get_chan();
@@ -399,8 +386,6 @@ static int _init(netdev2_t *netdev)
 #elif MODULE_GNRC
     dev->netdev.proto = GNRC_NETTYPE_UNDEF;
 #endif
-
-    mutex_unlock(&dev->mutex);
 
     return 0;
 }


### PR DESCRIPTION
AFAICT, these mutex locks are unnecessary and simply introduce delays. The sequential nature of RIOT's packet handling and the TX_ACTIVE wait in send() should be enough to ensure exclusivity.