### PR TITLE
sys/base64: fix variableScope (cppcheck)

### DIFF
--- a/sys/base64/base64.c
+++ b/sys/base64/base64.c
@@ -83,9 +83,9 @@ int base64_encode(unsigned char *data_in, size_t data_in_size, \
     unsigned char nNum = 0;
     int nLst = 0;
     int njump = 0;
-    unsigned char tmpval;
 
     for (int i = 0; i < (int)(data_in_size); ++i) {
+        unsigned char tmpval;
         njump++;
         tmpval = *(data_in + i);
 


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).