### PR TITLE
cortexm_common: suppress cppcheck uninitvar errors

### DIFF
--- a/dist/tools/cppcheck/check.sh
+++ b/dist/tools/cppcheck/check.sh
@@ -18,7 +18,7 @@ fi
 
 BRANCH=${1}
 FILEREGEX='\.([sScHh]|cpp)$'
-EXCLUDE='^(cpu/saml21/include/atmel/)'
+EXCLUDE='^(cpu/saml21/include/atmel/)|^(cpu/cortexm_common/include/)'
 
 # If no branch but an option is given, unset BRANCH.
 # Otherwise, consume this parameter.


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).
