### PR TITLE
tests/driver_dht: fix invalidPrintfArgType_sint (cppcheck)

### DIFF
--- a/tests/driver_dht/main.c
+++ b/tests/driver_dht/main.c
@@ -53,7 +53,7 @@ int main(void)
             int_hum = hum / 10;
             dec_hum = hum - (int_hum * 10);
 
-            printf("DHT device #%i - ", i);
+            printf("DHT device #%u - ", i);
             printf("temp: %i.%i°C, ", int_temp, dec_temp);
             printf("relative humidity: %i.%i%%\n", int_hum, dec_hum);
 


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).