### PR TITLE
sys/net/gnrc: fix cppcheck errors/ warnings

### DIFF
--- a/sys/net/gnrc/application_layer/zep/gnrc_zep.c
+++ b/sys/net/gnrc/application_layer/zep/gnrc_zep.c
@@ -198,18 +198,18 @@ static inline uint16_t *_get_uint16_ptr(void *ptr)
 
 static int _send(gnrc_netdev_t *netdev, gnrc_pktsnip_t *pkt)
 {
+    if ((netdev == NULL) || (netdev->driver != &_zep_driver)) {
+        DEBUG("zep: wrong device on sending\n");
+        gnrc_pktbuf_release(pkt);
+        return -ENODEV;
+    }
+
     gnrc_zep_t *dev = (gnrc_zep_t *)netdev;
     gnrc_pktsnip_t *ptr, *new_pkt, *hdr;
     gnrc_zep_hdr_t *zep;
     size_t payload_len = gnrc_pkt_len(pkt->next), hdr_len, mhr_offset;
     uint8_t mhr[IEEE802154_MAX_HDR_LEN], *data;
     uint16_t fcs = 0;
-
-    if ((netdev == NULL) || (netdev->driver != &_zep_driver)) {
-        DEBUG("zep: wrong device on sending\n");
-        gnrc_pktbuf_release(pkt);
-        return -ENODEV;
-    }
 
     /* create 802.15.4 header */
     hdr_len = _make_data_frame_hdr(dev, mhr, (gnrc_netif_hdr_t *)pkt->data);

--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -100,11 +100,12 @@ static enum gnrc_ipv6_ext_demux_status _handle_rh(gnrc_pktsnip_t *current, gnrc_
 static gnrc_pktsnip_t *_mark_extension_header(gnrc_pktsnip_t *current,
                                               gnrc_pktsnip_t **pkt)
 {
-    gnrc_pktsnip_t *ext_snip, *tmp, *next;
+    gnrc_pktsnip_t *tmp, *next;
     ipv6_ext_t *ext = (ipv6_ext_t *) current->data;
     size_t offset = ((ext->len * IPV6_EXT_LEN_UNIT) + IPV6_EXT_LEN_UNIT);
 
     if (current == *pkt) {
+        gnrc_pktsnip_t *ext_snip;
         if ((tmp = gnrc_pktbuf_start_write(*pkt)) == NULL) {
             DEBUG("ipv6: could not get a copy of pkt\n");
             gnrc_pktbuf_release(*pkt);

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -720,7 +720,6 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
 
     /* add external and RPL FIB entries */
     for (size_t i = 0; i < gnrc_ipv6_fib_table.size; ++i) {
-        ipv6_addr_t *addr;
         fib_entry_t *fentry = &gnrc_ipv6_fib_table.data.entries[i];
         if (fentry->lifetime != 0) {
             if (!(fentry->next_hop_flags & FIB_FLAG_RPL_ROUTE)) {
@@ -747,7 +746,7 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
                     int_processed = true;
                 }
             }
-            addr = (ipv6_addr_t *) fentry->global->address;
+            ipv6_addr_t *addr = (ipv6_addr_t *) fentry->global->address;
             if (ipv6_addr_is_global(addr)) {
                 size_t prefix_length = (fentry->global_flags >> FIB_FLAG_NET_PREFIX_SHIFT);
 


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).