### PR TITLE
tests/periph_uart: fix invalidPrintfArgType_sint (cppcheck)

### DIFF
--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -53,11 +53,11 @@ static int parse_dev(char *arg)
 {
     unsigned dev = (unsigned)atoi(arg);
     if (dev >= UART_NUMOF) {
-        printf("Error: Invalid UART_DEV device specified (%i).\n", dev);
+        printf("Error: Invalid UART_DEV device specified (%u).\n", dev);
         return -1;
     }
     else if (UART_DEV(dev) == UART_STDIO_DEV) {
-        printf("Error: The selected UART_DEV(%i) is used for the shell!\n", dev);
+        printf("Error: The selected UART_DEV(%u) is used for the shell!\n", dev);
         return -2;
     }
     return dev;


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).