### PR TITLE
sys/ecc/hamming256: fix variableScope (cppcheck)

### DIFF
--- a/sys/ecc/hamming256/hamming256.c
+++ b/sys/ecc/hamming256/hamming256.c
@@ -273,9 +273,8 @@ void hamming_compute256x( const uint8_t *pucData, uint32_t dwSize, uint8_t *puCo
 {
     DEBUG("hamming_compute256x()\n\r");
 
-    uint8_t padding;
     while (dwSize > 0) {
-        padding = 0;
+        uint8_t padding = 0;
         if (dwSize < 256) {
             padding = 256 - dwSize;
         }
@@ -290,14 +289,12 @@ void hamming_compute256x( const uint8_t *pucData, uint32_t dwSize, uint8_t *puCo
 
 uint8_t hamming_verify256x( uint8_t *pucData, uint32_t dwSize, const uint8_t *pucCode )
 {
-    uint8_t error;
     uint8_t result = 0;
 
     DEBUG( "hamming_verify256x()\n\r" );
 
-    uint8_t padding;
     while (dwSize > 0) {
-        padding = 0;
+        uint8_t error, padding = 0;
         if (dwSize < 256) {
             padding = 256 - dwSize;
         }


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).