### PR TITLE
sys/shell: fix cppcheck warnings

### DIFF
--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -148,11 +148,10 @@ int _ccnl_content(int argc, char **argv)
 static struct ccnl_face_s *_intern_face_get(char *addr_str)
 {
     /* initialize address with 0xFF for broadcast */
-    size_t addr_len = MAX_ADDR_LEN;
     uint8_t relay_addr[MAX_ADDR_LEN];
     memset(relay_addr, UINT8_MAX, MAX_ADDR_LEN);
+    size_t addr_len = gnrc_netif_addr_from_str(relay_addr, sizeof(relay_addr), addr_str);
 
-    addr_len = gnrc_netif_addr_from_str(relay_addr, sizeof(relay_addr), addr_str);
     if (addr_len == 0) {
         printf("Error: %s is not a valid link layer address\n", addr_str);
         return NULL;

--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -244,7 +244,7 @@ int _icmpv6_ping(int argc, char **argv)
 
     while ((remaining--) > 0) {
         gnrc_pktsnip_t *pkt;
-        uint32_t start, stop, timeout = 1 * SEC_IN_USEC;
+        uint32_t start, timeout = 1 * SEC_IN_USEC;
 
         pkt = gnrc_icmpv6_echo_build(ICMPV6_ECHO_REQ, id, ++max_seq_expected,
                                      NULL, payload_len);
@@ -285,6 +285,7 @@ int _icmpv6_ping(int argc, char **argv)
 
         /* TODO: replace when #4219 was fixed */
         if (xtimer_msg_receive_timeout64(&msg, (uint64_t)timeout) >= 0) {
+            uint32_t stop;
             switch (msg.type) {
                 case GNRC_NETAPI_MSG_TYPE_RCV:
                     stop = xtimer_now() - start;


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).