### PR TITLE
cpu/stm32f3: uart: suppress cppcheck nullPointer errors

### DIFF
--- a/cpu/stm32f3/periph/uart.c
+++ b/cpu/stm32f3/periph/uart.c
@@ -119,6 +119,12 @@ static int init_base(uart_t uart, uint32_t baudrate)
             return -1;
     }
 
+    /* Make sure port and dev are != NULL here, i.e. that the variables are
+     * assigned in all non-returning branches of the switch at the top of this
+     * function. */
+    assert(port != NULL);
+    assert(dev != NULL);
+
     /* uart_configure RX and TX pins, set pin to use alternative function mode */
     port->MODER &= ~(3 << (rx_pin * 2) | 3 << (tx_pin * 2));
     port->MODER |= 2 << (rx_pin * 2) | 2 << (tx_pin * 2);
@@ -177,6 +183,10 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         default:
             return;
     }
+
+    /* Make sure dev is != NULL here, i.e. that the variable is assigned in
+     * all non-returning branches of the switch at the top of this function. */
+    assert(dev != NULL);
 
     for (size_t i = 0; i < len; i++) {
         while (!(dev->ISR & USART_ISR_TXE)) {}


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).