### PR TITLE
tests/xtimer_now64_continuity: fix variableScope (cppcheck)

### DIFF
--- a/tests/xtimer_now64_continuity/main.c
+++ b/tests/xtimer_now64_continuity/main.c
@@ -29,11 +29,10 @@
 int main(void)
 {
     uint32_t n = ITERATIONS;
-    uint64_t now;
     uint64_t before = xtimer_now64();
 
     while(--n) {
-        now = xtimer_now64();
+        uint64_t now = xtimer_now64();
         if ((now-before) > MAXDIFF) {
             puts("TEST FAILED.");
             break;


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).