### PR TITLE
dist/tools/tunslip: fix cppcheck warnings

### DIFF
--- a/dist/tools/tunslip/tapslip6.c
+++ b/dist/tools/tunslip/tapslip6.c
@@ -543,8 +543,7 @@ int
 main(int argc, char **argv)
 {
     int c;
-    int tunfd, slipfd, maxfd;
-    int ret;
+    int tunfd, slipfd;
     fd_set rset, wset;
     FILE *inslip;
     const char *siodev = NULL;
@@ -681,7 +680,7 @@ main(int argc, char **argv)
     ifconf(tundev, ipaddr, netmask);
 
     while (1) {
-        maxfd = 0;
+        int maxfd = 0;
         FD_ZERO(&rset);
         FD_ZERO(&wset);
 
@@ -723,7 +722,7 @@ main(int argc, char **argv)
             }
         }
 
-        ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
+        int ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
 
         if (ret == -1 && errno != EINTR) {
             err(1, "select");

--- a/dist/tools/tunslip/tapslip6.c
+++ b/dist/tools/tunslip/tapslip6.c
@@ -299,7 +299,7 @@ void
 write_to_serial(int outfd, void *inbuf, int len)
 {
     u_int8_t *p = inbuf;
-    int i, ecode;
+    int i;
 
     /*  printf("Got packet of length %d - write SLIP\n", len);*/
     /*  print_packet(p, len);*/

--- a/dist/tools/tunslip/tunslip.c
+++ b/dist/tools/tunslip/tunslip.c
@@ -969,8 +969,7 @@ int
 main(int argc, char **argv)
 {
     int c;
-    int tunfd, slipfd, maxfd;
-    int ret;
+    int tunfd, slipfd;
     fd_set rset, wset;
     FILE *inslip;
     const char *siodev = NULL;
@@ -1196,7 +1195,7 @@ main(int argc, char **argv)
     ifconf(tundev, ipaddr, netmask);
 
     while (1) {
-        maxfd = 0;
+        int maxfd = 0;
         FD_ZERO(&rset);
         FD_ZERO(&wset);
 
@@ -1237,7 +1236,7 @@ main(int argc, char **argv)
             }
         }
 
-        ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
+        int ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
 
         if (ret == -1 && errno != EINTR) {
             err(1, "select");

--- a/dist/tools/tunslip/tunslip.c
+++ b/dist/tools/tunslip/tunslip.c
@@ -274,7 +274,7 @@ relay_dhcp_to_client(int slipfd)
 
             case DHCP_OPTION_MSG_TYPE:
                 msg_type = p[2];
-
+                /* deliberate fall-through */
             case DHCP_OPTION_SUBNET_MASK:
             case DHCP_OPTION_ROUTER:
             case DHCP_OPTION_LEASE_TIME:

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -115,7 +115,6 @@ stamptime(void)
     long secs, msecs;
     struct timeval tv;
     time_t t;
-    struct tm *tmp;
     char timec[20];
 
     gettimeofday(&tv, NULL) ;
@@ -137,7 +136,7 @@ stamptime(void)
         startsecs = secs;
         startmsecs = msecs;
         t = time(NULL);
-        tmp = localtime(&t);
+        struct tm *tmp = localtime(&t);
         strftime(timec, sizeof(timec), "%T", tmp);
         //    fprintf(stderr,"\n%s.%03lu ",timec,msecs);
         fprintf(stderr, "\n%s ", timec);
@@ -899,8 +898,7 @@ int
 main(int argc, char **argv)
 {
     int c;
-    int tunfd, maxfd;
-    int ret;
+    int tunfd;
     fd_set rset, wset;
     FILE *inslip;
     const char *siodev = NULL;
@@ -1187,7 +1185,7 @@ main(int argc, char **argv)
     ifconf(tundev, ipaddr);
 
     while (1) {
-        maxfd = 0;
+        int maxfd = 0;
         FD_ZERO(&rset);
         FD_ZERO(&wset);
 
@@ -1221,7 +1219,7 @@ main(int argc, char **argv)
             }
         }
 
-        ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
+        int ret = select(maxfd + 1, &rset, &wset, NULL, NULL);
 
         if (ret == -1 && errno != EINTR) {
             err(1, "select");
@@ -1254,10 +1252,8 @@ main(int argc, char **argv)
             }
 
             if (delaymsec == 0) {
-                int size;
-
                 if (slip_empty() && FD_ISSET(tunfd, &rset)) {
-                    size = tun_to_serial(tunfd, slipfd);
+                    int size = tun_to_serial(tunfd, slipfd);
                     slip_flushbuf(slipfd);
                     sigalarm_reset();
 

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -130,7 +130,7 @@ stamptime(void)
             msecs += 1000;
         }
 
-        fprintf(stderr, "%04lu.%03lu ", secs, msecs);
+        fprintf(stderr, "%04li.%03li ", secs, msecs);
     }
     else {
         startsecs = secs;


### PR DESCRIPTION
Inspired by #480, I used `cppcheck` to cleanup some things. This commit is part of a series of commits (s.a. #5764).