### PR TITLE
vagrant: update README and add info about vboxusers group

### DIFF
--- a/dist/tools/vagrant/README.md
+++ b/dist/tools/vagrant/README.md
@@ -3,7 +3,7 @@
 
 ## About
 This repository includes a [Vagrantfile](https://github.com/RIOT-OS/RIOT/blob/master/Vagrantfile)
-to create and control a Linux virtual machine based on an Ubuntu Wily (64-bit) image that contains
+to create and control a Linux virtual machine based on an Ubuntu 16.04 (64-bit) image that contains
 all necessary toolchains and dependencies to build and flash compatible devices with RIOT-OS.
 The advantage of using this VM is to have a reproducable, portable and even disposable environment
 that can be used to develop for RIOT-OS with decreased setup times and without the requirement of

--- a/dist/tools/vagrant/README.md
+++ b/dist/tools/vagrant/README.md
@@ -12,7 +12,7 @@ making changes to the underlying host system.
 ## Requirements
 Make sure your system satisfies the latest version of all following dependencies:
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-* [VirtualBox Exntension Pack](https://www.virtualbox.org/wiki/Downloads)
+* [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads)
 * [Vagrant](https://www.vagrantup.com/downloads.html)
 
 ## Usage
@@ -51,10 +51,8 @@ This feature allows you to conveniently develop code for RIOT with your preferre
 your host system and use the VM for compiling, flashing devices and running the native port of RIOT.
 
 ## Additional Information
-For new boards it is necessary to add new udev rules to `dist/tools/vagrant/udev_rules` and
-additional usb filters to the Vagrantfile so that VirtualBox is able to capture the devices.
-The needed `vendor id` and `product id` can be obtained by running `vboxmanage list usbhost`.
-
-### Virtualbox (for Linux Users)
-Additionally, in order to allow USB access from within the guest system, the host system user
-must be a member of the `vboxusers` group (see [here](https://www.virtualbox.org/manual/ch02.html#idm1051)).
+1. VirtualBox: For new boards it is necessary to add missing usb filters to the Vagrantfile so that VirtualBox is able to capture the devices.
+  * For Linux Guest Systems: For new boards it is necessary to add new udev rules to `dist/tools/vagrant/udev_rules`.
+    The needed `vendor id` and `product id` can be obtained by running `vboxmanage list usbhost`.
+  * For Linux Host Systems: Additionally, in order to allow USB access from within the guest system, the host system user
+    must be a member of the `vboxusers` group (see [here](https://www.virtualbox.org/manual/ch02.html#idm1051)).

--- a/dist/tools/vagrant/README.md
+++ b/dist/tools/vagrant/README.md
@@ -54,3 +54,7 @@ your host system and use the VM for compiling, flashing devices and running the 
 For new boards it is necessary to add new udev rules to `dist/tools/vagrant/udev_rules` and
 additional usb filters to the Vagrantfile so that VirtualBox is able to capture the devices.
 The needed `vendor id` and `product id` can be obtained by running `vboxmanage list usbhost`.
+
+### Virtualbox (for Linux Users)
+Additionally, in order to allow USB access from within the guest system, the host system user
+must be a member of the `vboxusers` group (see [here](https://www.virtualbox.org/manual/ch02.html#idm1051)).

--- a/dist/tools/vagrant/README.md
+++ b/dist/tools/vagrant/README.md
@@ -4,9 +4,9 @@
 ## About
 This repository includes a [Vagrantfile](https://github.com/RIOT-OS/RIOT/blob/master/Vagrantfile)
 to create and control a Linux virtual machine based on an Ubuntu 16.04 (64-bit) image that contains
-all necessary toolchains and dependencies to build and flash compatible devices with RIOT-OS.
+all necessary toolchains and dependencies to build and flash compatible devices with RIOT.
 The advantage of using this VM is to have a reproducable, portable and even disposable environment
-that can be used to develop for RIOT-OS with decreased setup times and without the requirement of
+that can be used to develop for RIOT with decreased setup times and without the requirement of
 making changes to the underlying host system.
 
 ## Requirements
@@ -16,7 +16,7 @@ Make sure your system satisfies the latest version of all following dependencies
 * [Vagrant](https://www.vagrantup.com/downloads.html)
 
 ## Usage
-The following commands must be run from the RIOT-OS root directory on the host system.
+The following commands must be run from the RIOT root directory on the host system.
 
 ```
 vagrant up
@@ -42,13 +42,13 @@ vagrant provision
 This will re-run the [provisioning script](https://github.com/RIOT-OS/RIOT/tree/master/dist/tools/vagrant/bootstrap.sh).
 
 ## Inside the VM
-Once logged in to the VM via `vagrant ssh` you can find the RIOT-OS root directory in your
-working directory. This is a shared directory and stays synchronized with your RIOT-OS directory
+Once logged in to the VM via `vagrant ssh` you can find the RIOT root directory in your
+working directory. This is a shared directory and stays synchronized with your RIOT directory
 on the host system. All changes made will be mirrored from the host system to the guest system
 and vice versa.
 
-This feature allows you to conveniently develop code for RIOT-OS with your preferred IDE on
-your host system and use the VM for compiling, flashing devices and running the native port of RIOT-OS.
+This feature allows you to conveniently develop code for RIOT with your preferred IDE on
+your host system and use the VM for compiling, flashing devices and running the native port of RIOT.
 
 ## Additional Information
 For new boards it is necessary to add new udev rules to `dist/tools/vagrant/udev_rules` and


### PR DESCRIPTION
leave a hint about `vboxusers` group.

This PR updates obsolete information in the vagrant READM and replaces `RIOT-OS` with the preferred version: `RIOT`.