### PR TITLE
cpu/cc2538: ADC driver

### DIFF
--- a/boards/cc2538dk/Makefile.features
+++ b/boards/cc2538dk/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -138,7 +138,7 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
  * @{
  */
 #define ADC_NUMOF           (1)
-#define ADC_ALS_PIN         6
+#define ADC_ALS_PIN         GPIO_PA6
 
 static const uint8_t periph_adc_map[ADC_NUMOF] = {
     ADC_ALS_PIN,

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -139,6 +139,13 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
  */
 #define ADC_NUMOF           (1)
 #define ADC_ALS_PIN         6
+
+static const uint8_t periph_adc_map[ADC_NUMOF] = {
+    ADC_ALS_PIN,
+};
+
+#define ADC_LINE(x)         periph_adc_map[x]
+
 /** @} */
 
 /**

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -134,6 +134,14 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
 /** @} */
 
 /**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (1)
+#define ADC_ALS_PIN         6
+/** @} */
+
+/**
  * @name GPIO configuration
  * @{
  */

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -145,6 +145,7 @@ static const uint8_t periph_adc_map[ADC_NUMOF] = {
 };
 
 #define ADC_LINE(x)         periph_adc_map[x]
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
 
 /** @} */
 

--- a/boards/openmote-cc2538/Makefile.features
+++ b/boards/openmote-cc2538/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -89,6 +89,7 @@ static const uint8_t periph_adc_map[ADC_NUMOF] = {
 };
 
 #define ADC_LINE(x)         periph_adc_map[x]
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
 /** @} */
 
 /**

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -68,7 +68,27 @@ static const timer_conf_t timer_config[] = {
  * @name ADC configuration
  * @{
  */
-#define ADC_NUMOF           (8)
+#define ADC_NUMOF           (7)
+
+#define AD4_PIN             2   /* Single Channel Input to pin AIN2 */
+#define CTS_DI07_PIN        3   /* Single Channel Input to pin AIN3 */
+#define AD5_PIN             4   /* Single Channel Input to pin AIN4 */
+#define AD6_PIN             5   /* Single Channel Input to pin AIN5 */
+#define ON_SLEEP_PIN        6   /* Single Channel Input to pin AIN6 */
+#define DIFF_PINS_2_3       9   /* Differential Input to pins AIN2-AIN3 */
+#define DIFF_PINS_4_5       10  /* Differential Input to pins AIN4-AIN5 */
+
+static const uint8_t periph_adc_map[ADC_NUMOF] = {
+    AD4_PIN,
+    CTS_DI07_PIN,
+    AD5_PIN,
+    AD6_PIN,
+    ON_SLEEP_PIN,
+    DIFF_PINS_2_3,
+    DIFF_PINS_4_5,
+};
+
+#define ADC_LINE(x)         periph_adc_map[x]
 /** @} */
 
 /**
@@ -209,19 +229,6 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
  * @{
  */
 #define RADIO_IRQ_PRIO      1
-/** @} */
-
-/**
- * @name OpenMote pin to ADC Line Mapping
- * @{
- */
-#define AD4_PIN             2   /* Single Channel Input to pin AIN2 */
-#define CTS_DI07_PIN        3   /* Single Channel Input to pin AIN3 */
-#define AD5_PIN             4   /* Single Channel Input to pin AIN4 */
-#define AD6_PIN             5   /* Single Channel Input to pin AIN5 */
-#define ON_SLEEP_PIN        6   /* Single Channel Input to pin AIN6 */
-#define DIFF_PINS_2_3       9   /* Differential Input to pins AIN2-AIN3 */
-#define DIFF_PINS_4_5       10  /* Differential Input to pins AIN4-AIN5 */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -65,6 +65,13 @@ static const timer_conf_t timer_config[] = {
 /** @} */
 
 /**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (8)
+/** @} */
+
+/**
  * @name UART configuration
  * @{
  */
@@ -202,6 +209,19 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
  * @{
  */
 #define RADIO_IRQ_PRIO      1
+/** @} */
+
+/**
+ * @name OpenMote pin to ADC Line Mapping
+ * @{
+ */
+#define AD4_PIN             2   /* Single Channel Input to pin AIN2 */
+#define CTS_DI07_PIN        3   /* Single Channel Input to pin AIN3 */
+#define AD5_PIN             4   /* Single Channel Input to pin AIN4 */
+#define AD6_PIN             5   /* Single Channel Input to pin AIN5 */
+#define ON_SLEEP_PIN        6   /* Single Channel Input to pin AIN6 */
+#define DIFF_PINS_2_3       9   /* Differential Input to pins AIN2-AIN3 */
+#define DIFF_PINS_4_5       10  /* Differential Input to pins AIN4-AIN5 */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/remote-common/Makefile.dep
+++ b/boards/remote-common/Makefile.dep
@@ -4,6 +4,8 @@ ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += gnrc_netdev2
     USEMODULE += netdev2_ieee802154
 endif
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_adc
 endif

--- a/boards/remote-pa/Makefile.features
+++ b/boards/remote-pa/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/remote-pa/include/adc_params.h
+++ b/boards/remote-pa/include/adc_params.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_remote
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Antonio Lignan <alinan@zolertia.com>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "ADC2",
+        .line = ADC2_PIN,
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC3",
+        .line = ADC3_PIN,
+        .res  = ADC_RES_12BIT,
+    }
+};
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -103,8 +103,8 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
  * @{
  */
 #define ADC_NUMOF           (2)
-#define ADC2_PIN            6
-#define ADC3_PIN            7
+#define ADC2_PIN            GPIO_PA6
+#define ADC3_PIN            GPIO_PA7
 
 static const uint8_t periph_adc_map[ADC_NUMOF] = {
   ADC2_PIN,

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -112,6 +112,7 @@ static const uint8_t periph_adc_map[ADC_NUMOF] = {
 };
 
 #define ADC_LINE(x)         periph_adc_map[x]
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
 /** @} */
 
 /**

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -99,6 +99,22 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
 /** @} */
 
 /**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (2)
+#define ADC2_PIN            6
+#define ADC3_PIN            7
+
+static const uint8_t periph_adc_map[ADC_NUMOF] = {
+  ADC2_PIN,
+  ADC3_PIN,
+};
+
+#define ADC_LINE(x)         periph_adc_map[x]
+/** @} */
+
+/**
  * @name GPIO configuration
  * @{
  */

--- a/boards/remote-reva/Makefile.features
+++ b/boards/remote-reva/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/remote-reva/README.md
+++ b/boards/remote-reva/README.md
@@ -27,6 +27,7 @@ In terms of hardware support, the following drivers have been implemented:
     * I2C/SPI library
     * LEDs
     * Buttons
+    * ADC
     * RF switch to programatically drive either 2.4GHz or sub-1GHz to a single RP-SMA
     * RF 2.4GHz built-in in CC2538
 
@@ -35,7 +36,6 @@ And under work or pending at cc2538 base cpu:
     * Built-in core temperature and battery sensor.
     * CC1200 sub-1GHz radio interface.
     * Micro-SD external storage.
-    * ADC
     * USB (in CDC-ACM).
     * uDMA Controller.
 

--- a/boards/remote-reva/include/adc_params.h
+++ b/boards/remote-reva/include/adc_params.h
@@ -34,17 +34,17 @@ static const  saul_adc_params_t saul_adc_params[] =
 {
     {
         .name = "ADC1",
-        .line = ADC_LINE(ADC1_PIN),
+        .line = ADC1_PIN,
         .res  = ADC_RES_12BIT,
     },
     {
         .name = "ADC2",
-        .line = ADC_LINE(ADC2_PIN),
+        .line = ADC2_PIN,
         .res  = ADC_RES_12BIT,
     },
     {
         .name = "ADC3",
-        .line = ADC_LINE(ADC3_PIN),
+        .line = ADC3_PIN,
         .res  = ADC_RES_12BIT,
     }
 };

--- a/boards/remote-reva/include/adc_params.h
+++ b/boards/remote-reva/include/adc_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_remote
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Antonio Lignan <alinan@zolertia.com>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "ADC1",
+        .line = ADC_LINE(ADC1_PIN),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC2",
+        .line = ADC_LINE(ADC2_PIN),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC3",
+        .line = ADC_LINE(ADC3_PIN),
+        .res  = ADC_RES_12BIT,
+    }
+};
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -110,7 +110,7 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
 static const uint8_t periph_adc_map[ADC_NUMOF] = {
   ADC1_PIN,
   ADC2_PIN,
-  ADC3_PIN,
+  ADC3_PIN, /* voltage divider with 5/3 relationship to allow 5V sensors */
 };
 
 #define ADC_LINE(x)         periph_adc_map[x]

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -99,6 +99,16 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
 /** @} */
 
 /**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (3)
+#define ADC1_PIN            5
+#define ADC2_PIN            4
+#define ADC3_PIN            2
+/** @} */
+
+/**
  * @name GPIO configuration
  * @{
  */

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -114,6 +114,7 @@ static const uint8_t periph_adc_map[ADC_NUMOF] = {
 };
 
 #define ADC_LINE(x)         periph_adc_map[x]
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
 /** @} */
 
 /**

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -106,6 +106,14 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
 #define ADC1_PIN            5
 #define ADC2_PIN            4
 #define ADC3_PIN            2
+
+static const uint8_t periph_adc_map[ADC_NUMOF] = {
+  ADC1_PIN,
+  ADC2_PIN,
+  ADC3_PIN,
+};
+
+#define ADC_LINE(x)         periph_adc_map[x]
 /** @} */
 
 /**

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -103,9 +103,9 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
  * @{
  */
 #define ADC_NUMOF           (3)
-#define ADC1_PIN            5
-#define ADC2_PIN            4
-#define ADC3_PIN            2
+#define ADC1_PIN            GPIO_PA5
+#define ADC2_PIN            GPIO_PA4
+#define ADC3_PIN            GPIO_PA2
 
 static const uint8_t periph_adc_map[ADC_NUMOF] = {
   ADC1_PIN,

--- a/boards/remote-revb/Makefile.features
+++ b/boards/remote-revb/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/remote-revb/include/adc_params.h
+++ b/boards/remote-revb/include/adc_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_remote
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC in Revision B
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Antonio Lignan <alinan@zolertia.com>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "ADC1",
+        .line = ADC1_PIN,
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC2",
+        .line = ADC2_PIN,
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC3",
+        .line = ADC3_PIN,
+        .res  = ADC_RES_12BIT,
+    }
+};
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -110,7 +110,7 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
 static const uint8_t periph_adc_map[ADC_NUMOF] = {
   ADC1_PIN,
   ADC2_PIN,
-  ADC3_PIN,
+  ADC3_PIN, /* voltage divider with 5/3 relationship to allow 5V sensors */
 };
 
 #define ADC_LINE(x)         periph_adc_map[x]

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -114,6 +114,7 @@ static const uint8_t periph_adc_map[ADC_NUMOF] = {
 };
 
 #define ADC_LINE(x)         periph_adc_map[x]
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
 /** @} */
 
 /**

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -99,6 +99,24 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
 /** @} */
 
 /**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (3)
+#define ADC1_PIN            5
+#define ADC2_PIN            4
+#define ADC3_PIN            2
+
+static const uint8_t periph_adc_map[ADC_NUMOF] = {
+  ADC1_PIN,
+  ADC2_PIN,
+  ADC3_PIN,
+};
+
+#define ADC_LINE(x)         periph_adc_map[x]
+/** @} */
+
+/**
  * @name GPIO configuration
  * @{
  */

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -103,9 +103,9 @@ static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
  * @{
  */
 #define ADC_NUMOF           (3)
-#define ADC1_PIN            5
-#define ADC2_PIN            4
-#define ADC3_PIN            2
+#define ADC1_PIN            GPIO_PA5
+#define ADC2_PIN            GPIO_PA4
+#define ADC3_PIN            GPIO_PA2
 
 static const uint8_t periph_adc_map[ADC_NUMOF] = {
   ADC1_PIN,

--- a/cpu/cc2538/include/cc2538_soc_adc.h
+++ b/cpu/cc2538/include/cc2538_soc_adc.h
@@ -75,7 +75,7 @@ typedef struct {
 #define SOC_ADC_ADCCON_REF_EXT_DIFF     (3 << 6)    /**< External reference on AIN6-AIN7 differential input */
 #define SOC_ADC_ADCCON_CH_GND           0xC         /**< GND */
 /** @} */
-    
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/cpu/cc2538/include/cc2538_soc_adc.h
+++ b/cpu/cc2538/include/cc2538_soc_adc.h
@@ -58,6 +58,24 @@ typedef struct {
 
 #define SOC_ADC ( (cc2538_soc_adc_t*)0x400d7000 ) /**< One and only instance of the SOC ADC component */
 
+/** @name SOC_ADC_ADCCON3 register bit masks
+ * @{
+ */
+#define SOC_ADC_ADCCON3_EREF    0x000000C0          /**< Reference voltage for extra */
+#define SOC_ADC_ADCCON3_EDIV    0x00000030          /**< Decimation rate for extra */
+#define SOC_ADC_ADCCON3_ECH     0x0000000F          /**< Single channel select */
+/** @} */
+
+/** @name SOC_ADC_ADCCONx registers field values
+ * @{
+ */
+#define SOC_ADC_ADCCON_REF_INT          (0 << 6)    /**< Internal reference */
+#define SOC_ADC_ADCCON_REF_EXT_SINGLE   (1 << 6)    /**< External reference on AIN7 pin */
+#define SOC_ADC_ADCCON_REF_AVDD5        (2 << 6)    /**< AVDD5 pin */
+#define SOC_ADC_ADCCON_REF_EXT_DIFF     (3 << 6)    /**< External reference on AIN6-AIN7 differential input */
+#define SOC_ADC_ADCCON_CH_GND           0xC         /**< GND */
+/** @} */
+    
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -83,6 +83,31 @@ typedef struct {
     uint_fast8_t cfg;       /**< timer config word */
 } timer_conf_t;
 
+/**
+ * @brief   Override resolution options
+ */
+#define HAVE_ADC_RES_T
+typedef enum {
+    ADC_RES_6BIT  = 0xa00,          /**< not supported by hardware */
+    ADC_RES_7BIT  = (0 << 4),       /**< ADC resolution: 7 bit */
+    ADC_RES_8BIT  = 0xb00,          /**< not supported by hardware */
+    ADC_RES_9BIT  = (1 << 4),       /**< ADC resolution: 9 bit */
+    ADC_RES_10BIT = (2 << 4),       /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (3 << 4),       /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = 0xc00,          /**< not supported by hardware */
+    ADC_RES_16BIT = 0xd00,          /**< not supported by hardware */
+} adc_res_t;
+
+/**
+ * @brief Masks for getting data
+ * @{
+ */
+#define SOCADC_7_BIT_RSHIFT        9 /**< Mask for getting data( 7 bits ENOB) */
+#define SOCADC_9_BIT_RSHIFT        7 /**< Mask for getting data( 9 bits ENOB) */
+#define SOCADC_10_BIT_RSHIFT       6 /**< Mask for getting data(10 bits ENOB) */
+#define SOCADC_12_BIT_RSHIFT       4 /**< Mask for getting data(12 bits ENOB) */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -100,6 +100,6 @@ int adc_sample(adc_t line, adc_res_t res)
     result  = (((adcaccess->ADCL) & 0xfc));
     result |= (((adcaccess->ADCH) & 0xff) << 8);
 
-    /* Return conversion result in mV */
-    return result / 10;
+    /* Return conversion result */
+    return result;
 }

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -54,8 +54,7 @@
 #include "periph/adc.h"
 #include "cc2538.h"
 
-enum{
-
+enum {
     EOC = 1,  
     STSEL = 3, 
 };
@@ -64,7 +63,7 @@ int adc_init(adc_t line)
 {
     cc2538_soc_adc_t *adcaccess;
     adcaccess = SOC_ADC;
-    
+
     /* Setting up ADC */
     gpio_hardware_control(GPIO_PXX_TO_NUM(PORT_A, line));
     IOC_PXX_OVER[GPIO_PXX_TO_NUM(PORT_A, line)] = IOC_OVERRIDE_ANA;
@@ -72,21 +71,21 @@ int adc_init(adc_t line)
     /* Start conversions when ADCCON1.STSEL = 1 */
     adcaccess->cc2538_adc_adccon1.ADCCON1 |= 
         adcaccess->cc2538_adc_adccon1.ADCCON1bits.STSEL;
-    
+
     return 0;
 }
 
 int adc_sample(adc_t line, adc_res_t res)
 {
-
     cc2538_soc_adc_t *adcaccess = SOC_ADC;
     int16_t result;
 
     /* Note - This has been hard coded . 
-        Can choose from any of the choices below: 
-        SOC_ADC_ADCCON_REF_INT or 
-        SOC_ADC_ADCCON_REF_EXT_SINGLE or 
-        SOC_ADC_ADCCON_REF_AVDD5  */
+     *  Can choose from any of the choices below: 
+     *  SOC_ADC_ADCCON_REF_INT or 
+     *  SOC_ADC_ADCCON_REF_EXT_SINGLE or 
+     *  SOC_ADC_ADCCON_REF_AVDD5
+     */
     uint8_t refvoltage = SOC_ADC_ADCCON_REF_AVDD5; 
 
     /* Start a single extra conversion with the given parameters. */
@@ -103,24 +102,6 @@ int adc_sample(adc_t line, adc_res_t res)
     result  = (((adcaccess->ADCL) & 0xfc));
     result |= (((adcaccess->ADCH) & 0xff) << 8);
 
-    switch (res)
-    {
-        case ADC_RES_7BIT:
-            result = result >> SOCADC_7_BIT_RSHIFT;
-            break;
-        case ADC_RES_9BIT:
-            result = result >> SOCADC_9_BIT_RSHIFT;
-            break;
-        case ADC_RES_10BIT:
-            result = result >> SOCADC_10_BIT_RSHIFT;
-            break;
-        case ADC_RES_12BIT:
-            result = result >> SOCADC_12_BIT_RSHIFT;
-            break;
-        default:
-            return -1;
-    }
-
-    /* Return conversion result */
-    return result;
+    /* Return conversion result in mV */
+    return result / 10;
 }

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2013, ADVANSEE - http://www.advansee.com/
+ * Benoît Thébaudeau <benoit.thebaudeau@advansee.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+ /**
+ * @ingroup     cpu_cc2538
+ * @{
+ *
+ * @file
+ * @brief       Low-Level ADC driver interface implementation
+ *
+ * @author      Benoît Thébaudeau <benoit.thebaudeau@advansee.com>
+ * @author      Ankith ShashiKanthReddy (anrg.usc.edu) <ashashik@usc.edu>
+ * @author      Jason A. Tran (anrg.usc.edu) <jasontra@usc.edu>
+ * 
+ * @}
+  */
+
+#include <stdio.h>
+#include "board.h"
+#include "cpu.h"
+#include "sched.h"
+#include "thread.h"
+#include "periph_conf.h"
+#include "cpu_conf.h"
+#include "periph/adc.h"
+#include "cc2538.h"
+
+enum{
+
+    EOC = 1,  
+    STSEL = 3, 
+};
+
+int adc_init(adc_t line)
+{
+    cc2538_soc_adc_t *adcaccess;
+    adcaccess = SOC_ADC;
+    
+    /* Setting up ADC */
+    gpio_hardware_control(GPIO_PXX_TO_NUM(PORT_A, line));
+    IOC_PXX_OVER[GPIO_PXX_TO_NUM(PORT_A, line)] = IOC_OVERRIDE_ANA;
+
+    /* Start conversions when ADCCON1.STSEL = 1 */
+    adcaccess->cc2538_adc_adccon1.ADCCON1 |= 
+        adcaccess->cc2538_adc_adccon1.ADCCON1bits.STSEL;
+    
+    return 0;
+}
+
+int adc_sample(adc_t line, adc_res_t res)
+{
+
+    cc2538_soc_adc_t *adcaccess = SOC_ADC;
+    int16_t result;
+
+    /* Note - This has been hard coded . 
+        Can choose from any of the choices below: 
+        SOC_ADC_ADCCON_REF_INT or 
+        SOC_ADC_ADCCON_REF_EXT_SINGLE or 
+        SOC_ADC_ADCCON_REF_AVDD5  */
+    uint8_t refvoltage = SOC_ADC_ADCCON_REF_AVDD5; 
+
+    /* Start a single extra conversion with the given parameters. */
+    adcaccess->ADCCON3 = ((adcaccess->ADCCON3) & 
+        ~(SOC_ADC_ADCCON3_EREF | SOC_ADC_ADCCON3_EDIV | SOC_ADC_ADCCON3_ECH)) |
+            refvoltage | res | line;
+
+    /* Poll until end of conversion */
+    while ((adcaccess->cc2538_adc_adccon1.ADCCON1 & 
+        adcaccess->cc2538_adc_adccon1.ADCCON1bits.EOC) == 0);
+
+    /* Read conversion result, reading SOC_ADC_ADCH last to clear
+        SOC_ADC_ADCCON1.EOC */
+    result  = (((adcaccess->ADCL) & 0xfc));
+    result |= (((adcaccess->ADCH) & 0xff) << 8);
+
+    switch (res)
+    {
+        case ADC_RES_7BIT:
+            result = result >> SOCADC_7_BIT_RSHIFT;
+            break;
+        case ADC_RES_9BIT:
+            result = result >> SOCADC_9_BIT_RSHIFT;
+            break;
+        case ADC_RES_10BIT:
+            result = result >> SOCADC_10_BIT_RSHIFT;
+            break;
+        case ADC_RES_12BIT:
+            result = result >> SOCADC_12_BIT_RSHIFT;
+            break;
+        default:
+            return -1;
+    }
+
+    /* Return conversion result */
+    return result;
+}

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -80,18 +80,16 @@ int adc_sample(adc_t line, adc_res_t res)
     cc2538_soc_adc_t *adcaccess = SOC_ADC;
     int16_t result;
 
-    /* Note - This has been hard coded .
-     *  Can choose from any of the choices below:
+    /*  Allowed values for SOC_ADC_ADCCON_REF:
      *  SOC_ADC_ADCCON_REF_INT or
      *  SOC_ADC_ADCCON_REF_EXT_SINGLE or
      *  SOC_ADC_ADCCON_REF_AVDD5
      */
-    uint8_t refvoltage = SOC_ADC_ADCCON_REF_AVDD5;
 
     /* Start a single extra conversion with the given parameters. */
     adcaccess->ADCCON3 = ((adcaccess->ADCCON3) &
         ~(SOC_ADC_ADCCON3_EREF | SOC_ADC_ADCCON3_EDIV | SOC_ADC_ADCCON3_ECH)) |
-            refvoltage | res | line;
+            SOC_ADC_ADCCON_REF | res | line;
 
     /* Poll until end of conversion */
     while ((adcaccess->cc2538_adc_adccon1.ADCCON1 &

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -40,7 +40,7 @@
  * @author      Benoît Thébaudeau <benoit.thebaudeau@advansee.com>
  * @author      Ankith ShashiKanthReddy (anrg.usc.edu) <ashashik@usc.edu>
  * @author      Jason A. Tran (anrg.usc.edu) <jasontra@usc.edu>
- * 
+ *
  * @}
   */
 
@@ -55,8 +55,8 @@
 #include "cc2538.h"
 
 enum {
-    EOC = 1,  
-    STSEL = 3, 
+    EOC = 1,
+    STSEL = 3,
 };
 
 int adc_init(adc_t line)
@@ -69,7 +69,7 @@ int adc_init(adc_t line)
     IOC_PXX_OVER[GPIO_PXX_TO_NUM(PORT_A, line)] = IOC_OVERRIDE_ANA;
 
     /* Start conversions when ADCCON1.STSEL = 1 */
-    adcaccess->cc2538_adc_adccon1.ADCCON1 |= 
+    adcaccess->cc2538_adc_adccon1.ADCCON1 |=
         adcaccess->cc2538_adc_adccon1.ADCCON1bits.STSEL;
 
     return 0;
@@ -80,21 +80,21 @@ int adc_sample(adc_t line, adc_res_t res)
     cc2538_soc_adc_t *adcaccess = SOC_ADC;
     int16_t result;
 
-    /* Note - This has been hard coded . 
-     *  Can choose from any of the choices below: 
-     *  SOC_ADC_ADCCON_REF_INT or 
-     *  SOC_ADC_ADCCON_REF_EXT_SINGLE or 
+    /* Note - This has been hard coded .
+     *  Can choose from any of the choices below:
+     *  SOC_ADC_ADCCON_REF_INT or
+     *  SOC_ADC_ADCCON_REF_EXT_SINGLE or
      *  SOC_ADC_ADCCON_REF_AVDD5
      */
-    uint8_t refvoltage = SOC_ADC_ADCCON_REF_AVDD5; 
+    uint8_t refvoltage = SOC_ADC_ADCCON_REF_AVDD5;
 
     /* Start a single extra conversion with the given parameters. */
-    adcaccess->ADCCON3 = ((adcaccess->ADCCON3) & 
+    adcaccess->ADCCON3 = ((adcaccess->ADCCON3) &
         ~(SOC_ADC_ADCCON3_EREF | SOC_ADC_ADCCON3_EDIV | SOC_ADC_ADCCON3_ECH)) |
             refvoltage | res | line;
 
     /* Poll until end of conversion */
-    while ((adcaccess->cc2538_adc_adccon1.ADCCON1 & 
+    while ((adcaccess->cc2538_adc_adccon1.ADCCON1 &
         adcaccess->cc2538_adc_adccon1.ADCCON1bits.EOC) == 0);
 
     /* Read conversion result, reading SOC_ADC_ADCH last to clear


### PR DESCRIPTION
This PR supersedes https://github.com/RIOT-OS/RIOT/pull/5545 and implements the ADC driver for CC2538-based platforms.
- Removed the decimation offsets to return the result in mV
- Added ADC support for the `RE-Mote`, `openmote-cc2538` and `cc2538dk`
- Added SAUL support for the `RE-Mote` and the ADC module, tested with `tests/saul`
- Added `ADC_LINE` macro to iterate ADC channels using `ADC_NUMOF` (required for the `tests/periph_adc`)

All credits to @ashashik 
