### PR TITLE
make: use -std=c99 as default

### DIFF
--- a/Makefile.cflags
+++ b/Makefile.cflags
@@ -1,13 +1,8 @@
 # Test if the input language was specified externally.
-# Otherwise test if the compiler unterstands the "-std=gnu99" flag, and use it if so.
 # Otherwise test if the compiler unterstands the "-std=c99" flag, and use it if so.
 ifeq ($(filter -std=%,$(CFLAGS)),)
-  ifeq ($(shell $(CC) -std=gnu99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-    CFLAGS += -std=gnu99
-  else
-    ifeq ($(shell $(CC) -std=c99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-      CFLAGS += -std=c99
-    endif
+  ifeq ($(shell $(CC) -std=c99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+    CFLAGS += -std=c99
   endif
 endif
 

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -46,7 +46,7 @@ export CGANNOTATE ?= cg_annotate
 export GPROF ?= gprof
 
 # basic cflags:
-export CFLAGS += -Wall -Wextra -pedantic
+export CFLAGS += -Wall -Wextra -pedantic -std=gnu99
 ifeq ($(shell uname -m),x86_64)
 export CFLAGS += -m32
 endif

--- a/boards/remote-common/include/fancy_leds.h
+++ b/boards/remote-common/include/fancy_leds.h
@@ -42,11 +42,11 @@
     j = k > 400 ? 800 - k : k;                \
     led##_ON;                                 \
     for(i = 0; i < j; ++i) {                  \
-      asm("nop");                             \
+      __asm__("nop");                             \
     }                                         \
     led##_OFF;                                \
     for(i = 0; i < 400 - j; ++i) {            \
-      asm("nop");                             \
+      __asm__("nop");                             \
     }                                         \
   }
 

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -2,7 +2,7 @@
 export TARGET_ARCH ?= msp430
 
 # define build specific options
-CFLAGS_CPU   = -mmcu=$(CPU_MODEL)
+CFLAGS_CPU   = -mmcu=$(CPU_MODEL) -std=gnu99
 CFLAGS_LINK  = -ffunction-sections -fdata-sections
 CFLAGS_DBG   = -gdwarf-2
 CFLAGS_OPT  ?= -Os

--- a/cpu/atmega1281/startup.c
+++ b/cpu/atmega1281/startup.c
@@ -49,12 +49,12 @@ void init8_ovr(void) __attribute__((naked)) __attribute__((section(".init8")));
 
 void init7_ovr(void)
 {
-    asm("call reset_handler");
+    __asm__("call reset_handler");
 }
 
 void init8_ovr(void)
 {
-    asm("jmp exit");
+    __asm__("jmp exit");
 }
 /**
  * @brief This function is the entry point after a system reset

--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -249,7 +249,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
 int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
 {
     cc2538_ssi_t* ssi = spi_config[dev].dev;
-    typeof(length) tx_n = 0, rx_n = 0;
+    unsigned int tx_n = 0, rx_n = 0;
 
     if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;


### PR DESCRIPTION
Previously, the fallback was "gnu99", but we don't allow GNU extensions by convention.
