### PR TITLE
dist/tools: include uname check for FreeBSD in genconfigheader

### DIFF
--- a/dist/tools/genconfigheader/genconfigheader.sh
+++ b/dist/tools/genconfigheader/genconfigheader.sh
@@ -22,7 +22,7 @@ OUTPUTFILE="$1"
 shift
 
 MD5SUM=md5sum
-if [ "$(uname -s)" = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" -o "$(uname -s)" = "FreeBSD" ]; then
   MD5SUM="md5 -r"
 fi
 


### PR DESCRIPTION
Analog to Darwin set `MD5SUM` to `md5 -r`.