### PR TITLE
make: build quiet as default

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -80,6 +80,8 @@ else
   OPEN   := xdg-open
 endif
 
+QUIET ?= 1
+
 ifeq ($(QUIET),1)
   AD=@
   MAKEFLAGS += --no-print-directory


### PR DESCRIPTION
Currently every application needs to set this variable to not be flooded with gcc build lines. Is there a reason why we don't set it to 1 as default?