### PR TITLE
packer: initial packer configuration to build virtualbox/vagrant boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,34 +8,19 @@ RIOTBASE ||= "./"
 Vagrant.configure(2) do |config|
   # For a complete reference, please see the online documentation at https://docs.vagrantup.com.
 
-  config.vm.box = "boxcutter/ubuntu1604"
-  config.vm.synced_folder RIOTBASE, "/home/vagrant/RIOT"
+  config.vm.box = "RIOT/ubuntu1604"
 
   config.vm.provider "virtualbox" do |vb|
-    vb.name = "RIOT VM"
-    vb.customize ["modifyvm", :id, "--usb", "on"]
-    vb.customize ["modifyvm", :id, "--usbxhci", "on"]
-    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'FTDI USB-TTL',
-                  '--vendorid', '0x0403', '--productid',  '0x6001']
-    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'CP2102 USB to UART',
-                  '--vendorid', '0x10c4', '--productid',  '0xea60']
-    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'STM32 STLink',
-                  '--vendorid', '0x0483', '--productid',  '0x3748']
-    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'USBasp',
-                  '--vendorid', '0x16c0', '--productid',  '0x05dc']
-    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'iotlab-m3',
-                  '--vendorid', '0x0403', '--productid',  '0x6010']
-    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'samr21-xpro',
-                  '--vendorid', '0x03eb', '--productid',  '0x2111']
-    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'Arduino Mega 2560',
-                  '--vendorid', '0x2341', '--productid',  '0x0042']
-    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'Phytec phyWAVE KW22',
-                  '--vendorid', '0x0d28', '--productid',  '0x0204']
+    vb.name = "RIOT-VM"
+    # additional USB passthrough entries
+    # vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', '<custom_name>', '--vendorid', '<vID>', '--productid', '<pID>']
   end
+
+  config.vm.synced_folder RIOTBASE, "/home/vagrant/RIOT"
 
   if File.exists?(File.join(Dir.home, ".gitconfig"))
     config.vm.provision "file", source: File.join(Dir.home, ".gitconfig"), destination: ".gitconfig"
   end
-
-  config.vm.provision "shell", path: File.join(RIOTBASE,'/dist/tools/vagrant/bootstrap.sh')
+# use a custom provisioning script
+# config.vm.provision "shell", path: "dist/tools/vagrant/bootstrap.sh"
 end

--- a/dist/tools/packer/.gitignore
+++ b/dist/tools/packer/.gitignore
@@ -1,0 +1,2 @@
+packer_cache
+*.box

--- a/dist/tools/packer/preseed.cfg
+++ b/dist/tools/packer/preseed.cfg
@@ -1,0 +1,32 @@
+choose-mirror-bin mirror/http/proxy string
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+d-i passwd/user-default-groups string adm cdrom dialout lxd plugdev sudo
+
+d-i pkgsel/include string openssh-server ntp curl nfs-common linux-headers-$(uname -r) build-essential perl dkms \
+    pcregrep libpcre3 python3 git gcc-arm-none-eabi gcc-msp430 unzip vim \
+    qemu-system-x86 g++-multilib gcc-multilib build-essential gcc-avr binutils-avr avr-libc \
+    avrdude doxygen cppcheck python-setuptools libusb-1.0-0 libusb-1.0-0-dev libftdi1 libftdi-dev \
+    libftdipp1-dev libftdipp1-2v5 libhidapi-dev libhidapi-hidraw0 libhidapi-libusb0 make cmake \
+    autotools-dev autoconf pkg-config jimsh libtool valgrind openocd python-serial python3-serial python-setuptools
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade
+d-i time/zone string UTC
+tasksel tasksel/first multiselect standard, server

--- a/dist/tools/packer/riot.json
+++ b/dist/tools/packer/riot.json
@@ -1,0 +1,103 @@
+{
+  "_comment": "Build with `packer build riot.json`",
+  "builders": [
+    {
+      "boot_command": [
+        "{{ user `boot_command_prefix` }}",
+        "/install/vmlinuz noapic ",
+        "initrd=/install/initrd.gz ",
+        "file=/floppy/{{ user `preseed` }} ",
+        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+        "hostname={{ user `hostname` }} ",
+        "fb=false debconf/frontend=noninteractive ",
+        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+        "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+        "passwd/user-fullname={{ user `ssh_fullname` }} ",
+        "passwd/user-password={{ user `ssh_password` }} ",
+        "passwd/user-password-again={{ user `ssh_password` }} ",
+        "passwd/username={{ user `ssh_username` }} ",
+        "-- <enter>"
+      ],
+      "disk_size": "{{ user `disk_size` }}",
+      "floppy_files": [ "{{ user `preseed` }}" ],
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "{{ user `virtualbox_guest_os_type` }}",
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
+      "iso_urls": [ "{{ user `iso_path` }}/{{ user `iso_name` }}", "{{ user `iso_url` }}" ],
+      "output_directory": "output-{{ user `vm_name` }}-virtualbox-iso",
+      "shutdown_command": "echo '{{ user `ssh_password` }}'|sudo -S shutdown -P now",
+      "ssh_password": "{{ user `ssh_password` }}",
+      "ssh_username": "{{ user `ssh_username` }}",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "{{ user `memory` }}" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "{{ user `cpus` }}" ],
+        [ "modifyvm", "{{.Name}}", "--usb", "on" ],
+        [ "modifyvm", "{{.Name}}", "--usbxhci", "on" ],
+        [ "modifyvm", "{{.Name}}", "--audio", "none"],
+        [ "modifyvm", "{{.Name}}", "--ioapic", "on"],
+        [ "modifyvm", "{{.Name}}", "--rtcuseutc", "on"],
+        [ "modifyvm", "{{.Name}}", "--clipboard", "bidirectional"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "FTDI USB-TTL", "--vendorid", "0x0403", "--productid",  "0x6001"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "CP2102 USB to UART", "--vendorid", "0x10c4", "--productid",  "0xea60"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "STM32 STLink", "--vendorid", "0x0483", "--productid",  "0x3748"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "USBasp", "--vendorid", "0x16c0", "--productid",  "0x05dc"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "iotlab-m3", "--vendorid", "0x0403", "--productid",  "0x6010"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "samr21-xpro", "--vendorid", "0x03eb", "--productid",  "0x2111"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "Arduino Mega 2560", "--vendorid", "0x2341", "--productid",  "0x0042"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "Phytec phyWAVE KW22", "--vendorid", "0x0d28", "--productid",  "0x0204"]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "{{user `vm_name`}}"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "vagrant",
+        "keep_input_artifact": false,
+        "output": "{{user `vm_name`}}_{{.Provider}}.box",
+        "vagrantfile_template": "{{ user `vagrantfile_template` }}"
+      }
+    ]
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "./udev_rules",
+      "destination": "/tmp"
+    },
+    {
+      "environment_vars": [
+        "SSH_USERNAME={{user `ssh_username`}}",
+        "SSH_PASSWORD={{user `ssh_password`}}"
+      ],
+      "execute_command": "echo '{{ user `ssh_password` }}' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "scripts": [ "setup.sh" ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "boot_command_prefix": "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+    "cpus": "1",
+    "disk_size": "65536",
+    "headless": "true",
+    "iso_checksum": "de5ee8665048f009577763efbf4a6f0558833e59",
+    "iso_checksum_type": "sha1",
+    "iso_name": "ubuntu-16.04.1-server-amd64.iso",
+    "iso_path": "/Volumes/Storage/software/ubuntu",
+    "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.1-server-amd64.iso",
+    "memory": "512",
+    "preseed" : "preseed.cfg",
+    "hostname": "vagrant",
+    "ssh_fullname": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_username": "vagrant",
+    "vagrantfile_template": "vagrantfile.tpl",
+    "virtualbox_guest_os_type": "Ubuntu_64",
+    "vm_name": "RIOT-VM"
+  }
+}

--- a/dist/tools/packer/setup.sh
+++ b/dist/tools/packer/setup.sh
@@ -1,0 +1,159 @@
+#!/bin/bash -eux
+
+# inspired by https://github.com/boxcutter/ubuntu
+
+echo "==> Disabling the release upgrader"
+sed -i.bak 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
+
+systemctl disable apt-daily.service
+systemctl disable apt-daily.timer
+
+echo "==> Updating list of repositories"
+apt-get -y update
+
+echo "==> Performing dist-upgrade (all packages and kernel)"
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+
+SSH_USER=${SSH_USERNAME:-vagrant}
+SSH_PASS=${SSH_PASSWORD:-vagrant}
+SSH_USER_HOME=${SSH_USER_HOME:-/home/${SSH_USER}}
+VAGRANT_INSECURE_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
+
+echo "==> Giving ${SSH_USER} sudo powers"
+echo "${SSH_USER}        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 440 /etc/sudoers.d/vagrant
+
+if grep -q -E "^mesg n$" /root/.profile && sed -i "s/^mesg n$/tty -s \\&\\& mesg n/g" /root/.profile; then
+  echo "==> Fixed stdin not being a tty."
+fi
+
+echo "==> Installing vagrant key"
+mkdir $SSH_USER_HOME/.ssh
+chmod 700 $SSH_USER_HOME/.ssh
+
+# https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub
+echo "${VAGRANT_INSECURE_KEY}" > $SSH_USER_HOME/.ssh/authorized_keys
+chmod 600 $SSH_USER_HOME/.ssh/authorized_keys
+chown -R $SSH_USER:$SSH_USER $SSH_USER_HOME/.ssh
+
+echo "UseDNS no" >> /etc/ssh/sshd_config
+
+if [[ $PACKER_BUILDER_TYPE =~ virtualbox ]]; then
+    echo "==> Installing VirtualBox guest additions"
+    VBOX_VERSION=$(cat ${SSH_USER_HOME}/.vbox_version)
+    mount -o loop ${SSH_USER_HOME}/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+    sh /mnt/VBoxLinuxAdditions.run
+    umount /mnt
+    rm ${SSH_USER_HOME}/VBoxGuestAdditions_$VBOX_VERSION.iso
+    rm ${SSH_USER_HOME}/.vbox_version
+fi
+
+echo "==> Install stlink"
+wget -qO - https://github.com/texane/stlink/archive/master.tar.gz | tar xz
+mkdir stlink-master/build && cd stlink-master/build && cmake .. && make && make install
+cd ../.. && rm -rf stlink.git
+
+echo "==> Install cli-tools"
+wget -qO - https://github.com/iot-lab/cli-tools/archive/2.1.0.tar.gz | tar xz
+cd cli-tools-* && python setup.py install && cd .. && rm -rf cli-tools-*
+
+# Remove some packages to get a minimal install
+echo "==> Removing all linux kernels except the currrent one"
+dpkg --list | awk '{ print $2 }' | grep 'linux-image-*-generic' | grep -v $(uname -r) | xargs apt-get -y purge
+echo "==> Removing linux source"
+dpkg --list | awk '{ print $2 }' | grep linux-source | xargs apt-get -y purge
+echo "==> Removing documentation"
+dpkg --list | awk '{ print $2 }' | grep -- '-doc$' | xargs apt-get -y purge
+echo "==> Removing default system Ruby"
+apt-get -y purge ruby ri doc
+echo "==> Removing X11 libraries"
+apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6
+echo "==> Removing obsolete networking components"
+apt-get -y purge ppp pppconfig pppoeconf
+echo "==> Removing other oddities"
+apt-get -y purge popularity-contest installation-report landscape-common wireless-tools wpasupplicant
+
+# Clean up the apt cache
+apt-get -y autoremove --purge
+apt-get -y autoclean
+apt-get -y clean
+
+# Clean up orphaned packages with deborphan
+apt-get -y install deborphan
+while [ -n "$(deborphan --guess-all --no-guesspython --libdevel)" ]; do
+    deborphan --guess-all --no-guess-python --libdevel | xargs apt-get -y purge
+done
+apt-get -y purge deborphan dialog
+
+echo "==> Removing man pages"
+rm -rf /usr/share/man/*
+echo "==> Removing APT files"
+find /var/lib/apt -type f | xargs rm -f
+echo "==> Removing any docs"
+rm -rf /usr/share/doc/*
+echo "==> Removing caches"
+find /var/cache -type f -exec rm -rf {} \;
+
+echo "==> Cleaning up leftover dhcp leases"
+if [ -d "/var/lib/dhcp" ]; then
+    rm /var/lib/dhcp/*
+fi
+
+# Add delay to prevent "vagrant reload" from failing
+echo "pre-up sleep 2" >> /etc/network/interfaces
+
+mv /tmp/udev_rules/* /etc/udev/rules.d/
+
+echo "==> Cleaning up tmp"
+rm -rf /tmp/*
+
+# Remove Bash history
+unset HISTFILE
+rm -f /root/.bash_history
+rm -f ${SSH_USER_HOME}/.bash_history
+
+# Clean up log files
+find /var/log -type f | while read f; do echo -ne '' > "${f}"; done;
+
+echo "==> Clearing last login information"
+>/var/log/lastlog
+>/var/log/wtmp
+>/var/log/btmp
+
+echo "==> whiteout /"
+count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
+let count--
+dd if=/dev/zero of=/tmp/whitespace bs=1024 count=$count
+rm /tmp/whitespace
+
+echo "==> whiteout /boot"
+count=$(df --sync -kP /boot | tail -n1 | awk -F ' ' '{print $4}')
+let count--
+dd if=/dev/zero of=/boot/whitespace bs=1024 count=$count
+rm /boot/whitespace
+
+echo '==> Clear out swap and disable until reboot'
+set +e
+swapuuid=$(/sbin/blkid -o value -l -s UUID -t TYPE=swap)
+case "$?" in
+    2|0) ;;
+    *) exit 1 ;;
+esac
+set -e
+if [ "x${swapuuid}" != "x" ]; then
+    # Whiteout the swap partition to reduce box size
+    # Swap is disabled till reboot
+    swappart=$(readlink -f /dev/disk/by-uuid/$swapuuid)
+    /sbin/swapoff "${swappart}"
+    dd if=/dev/zero of="${swappart}" bs=1M || echo "dd exit code $? is suppressed"
+    /sbin/mkswap -U "${swapuuid}" "${swappart}"
+fi
+
+echo "==> whiteout free space"
+dd if=/dev/zero of=/EMPTY bs=1M  || echo "dd exit code $? is suppressed"
+rm -f /EMPTY
+
+sync
+
+echo "==> Disk usage"
+df -h

--- a/dist/tools/packer/udev_rules/99-hidraw.rules
+++ b/dist/tools/packer/udev_rules/99-hidraw.rules
@@ -1,0 +1,1 @@
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0666", OWNER="vagrant"

--- a/dist/tools/packer/udev_rules/99-usb-stlink-v2.rules
+++ b/dist/tools/packer/udev_rules/99-usb-stlink-v2.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="3748", MODE="0666", OWNER="vagrant"

--- a/dist/tools/packer/udev_rules/99-usbasp.rules
+++ b/dist/tools/packer/udev_rules/99-usbasp.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="16c0", ATTR{idProduct}=="05dc", MODE="0666", OWNER="vagrant"

--- a/dist/tools/packer/udev_rules/99-usbttl.rules
+++ b/dist/tools/packer/udev_rules/99-usbttl.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="0403", ATTR{idProduct}=="6001", MODE="0666", OWNER="vagrant"

--- a/dist/tools/packer/vagrantfile.tpl
+++ b/dist/tools/packer/vagrantfile.tpl
@@ -1,0 +1,11 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.define "RIOT-VM"
+    config.vm.box = "RIOT/ubuntu1604"
+
+    config.vm.provider :virtualbox do |v, override|
+        v.gui = false
+    end
+end


### PR DESCRIPTION
`Packer` [1] is a tool to build virtual machine boxes from configuration files.
This initial configuration builds a minimal virtualbox image based on ubuntu server 16.04, which includes all necessary toolchains et cetera to build&flash RIOT applications. For now, this box is uploaded into hashicorps cloud [2], but that's not a hard dependency.
Having all those tools baked into the image allows a simpler distribution of that image in scenarios like tutorials held in locations with bad internet connectivity / low bandwidth. In these scenarios, copying the base image (e.g. via usb) and adding it manually via `vagrant box add RIOT-VM <path to box>` is sufficient and does not require a provisioning from vagrant anymore (i.e. no internet access required).

The base image can be generated with `packer build -var 'vagrant_token=<token>' -var 'box_version=<version>' riot.json`. This command also uploads the image to the RIOT user that I created at hashicorps cloud, hence the necessary token. (Currently with my private mail address, but I will change it to something more generic: riot-os mail?).

@kaspar030 the configuration can be extended to support multiple ubuntu versions and also different OS'es. This might be interesting for murdock to run tests on multiple taget systems.

@kaspar030 To make everything simpler, would it be possible to build a small script for murdock that checks whether a PR contains packer configuration changes, so that a merge of such changes would re-build all virtual machine images + upload them to the cloud?

PS: to skip the `upload to vagrant cloud` step, just remove the  `vagrant-cloud` post-processor in the `riot.json` file, this way, a vagrant box can be built without specifying a token and a version: `packer build riot.json`.

[1] https://www.packer.io/
[2] https://atlas.hashicorp.com/RIOT