### PR TITLE
samd21: i2c: clear timeout_counter

### DIFF
--- a/cpu/samd21/periph/i2c.c
+++ b/cpu/samd21/periph/i2c.c
@@ -447,6 +447,7 @@ static inline int _write(SercomI2cm *dev, char *data, int length)
         dev->DATA.reg = data[buffer_counter++];
 
         DEBUG("Wait for response.\n");
+        timeout_counter = 0;
         while (!(dev->INTFLAG.reg & SERCOM_I2CM_INTFLAG_MB)
                && !(dev->INTFLAG.reg & SERCOM_I2CM_INTFLAG_SB)) {
             if (++timeout_counter >= SAMD21_I2C_TIMEOUT) {


### PR DESCRIPTION
I was experiencing problems doing large i2c writes as the timeout counter is total, not per byte. I propose resetting the timeout counter after each successful operation, as done in _read()