### PR TITLE
cpu/atmega_common: fix timer_set_absolute return code

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -141,7 +141,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     *ctx[tim].flag &= ~(1 << (channel + OCF1A));
     *ctx[tim].mask |=  (1 << (channel + OCIE1A));
 
-    return 0;
+    return 1;
 }
 
 int timer_clear(tim_t tim, int channel)


### PR DESCRIPTION
according to [timer documentation](http://riot-os.org/api/group__drivers__periph__timer.html#gaccff2ca33cca64411015f808369cb919), timer_set and timer_set_absolute should
return 1 on succes, not 0.