### PR TITLE
boards/nucleo-f207: Use cortex_m3_2 MCU_GROUP

### DIFF
--- a/boards/nucleo-f207/Makefile.features
+++ b/boards/nucleo-f207/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex-m3
+FEATURES_MCU_GROUP = cortex_m3_2


### PR DESCRIPTION
The group cortex-m3 is not used anywhere else.