### PR TITLE
cpu/stm32(_common & f2): implement delay after RCC peripheral clock enable

### DIFF
--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -125,8 +125,8 @@ static const uart_conf_t uart_config[] = {
 
 /* SPI 0 device configuration */
 #define SPI_0_DEV           SPI2
-#define SPI_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
-#define SPI_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI2EN))
+#define SPI_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_SPI2EN))
+#define SPI_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_SPI2EN))
 #define SPI_0_BUS_DIV       0   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
 /* SPI 0 pin configuration */
 #define SPI_0_CLK_PIN       GPIO_PIN(PORT_B,13)
@@ -160,8 +160,8 @@ static const uart_conf_t uart_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn

--- a/boards/iotlab-a8-m3/include/periph_conf.h
+++ b/boards/iotlab-a8-m3/include/periph_conf.h
@@ -36,8 +36,8 @@ extern "C" {
 
 /* SPI 0 device configuration */
 #define SPI_0_DEV           SPI2
-#define SPI_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
-#define SPI_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI2EN))
+#define SPI_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_SPI2EN))
+#define SPI_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_SPI2EN))
 #define SPI_0_BUS_DIV       1   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
 /* SPI 0 pin configuration */
 #define SPI_0_CLK_PIN       GPIO_PIN(PORT_B,13)

--- a/boards/iotlab-common/include/periph_conf_common.h
+++ b/boards/iotlab-common/include/periph_conf_common.h
@@ -150,8 +150,8 @@ static const uart_conf_t uart_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -36,8 +36,8 @@ extern "C" {
 
 /* SPI 0 device configuration */
 #define SPI_0_DEV           SPI1
-#define SPI_0_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()      (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKEN()       (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()      (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_BUS_DIV       1   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
 /* SPI 0 pin configuration */
 #define SPI_0_CLK_PIN       GPIO_PIN(PORT_A,5)

--- a/boards/limifrog-v1/include/periph_conf.h
+++ b/boards/limifrog-v1/include/periph_conf.h
@@ -81,7 +81,7 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART3
-#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART3EN)
+#define UART_0_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART3EN))
 #define UART_0_CLK          (CLOCK_CORECLOCK)
 #define UART_0_IRQ          USART3_IRQn
 #define UART_0_ISR          isr_usart3
@@ -93,7 +93,7 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART1        /* Panasonic PAN1740 BLE module */
-#define UART_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
+#define UART_1_CLKEN()      (periph_clk_en(APB2, RCC_APB2ENR_USART1EN))
 #define UART_1_CLK          (CLOCK_CORECLOCK)
 #define UART_1_IRQ          USART1_IRQn
 #define UART_1_ISR          isr_usart1
@@ -114,12 +114,12 @@ static const timer_conf_t timer_config[] = {
 
 /* SPI 0 device configuration */
 #define SPI_0_DEV           SPI1  /* Densitron DD-160128FC-1a OLED display; external pins */
-#define SPI_0_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()      (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKEN()       (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()      (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_IRQ           SPI1_IRQn
 #define SPI_0_ISR           isr_spi1
 /* SPI 0 pin configuration */
-#define SPI_0_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define SPI_0_PORT          GPIOA
 #define SPI_0_PIN_SCK       5
 #define SPI_0_PIN_MOSI      7
@@ -128,12 +128,12 @@ static const timer_conf_t timer_config[] = {
 
 /* SPI 1 device configuration */
 #define SPI_1_DEV           SPI3          /*  Adesto AT45DB641E data flash */
-#define SPI_1_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_SPI3EN)
-#define SPI_1_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI3EN))
+#define SPI_1_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_SPI3EN))
+#define SPI_1_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_SPI3EN))
 #define SPI_1_IRQ           SPI3_IRQn
 #define SPI_1_ISR           isr_spi3
 /* SPI 1 pin configuration */
-#define SPI_1_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define SPI_1_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 #define SPI_1_PORT          GPIOB
 #define SPI_1_PIN_SCK       3
 #define SPI_1_PIN_MOSI      5

--- a/boards/msbiot/board.c
+++ b/boards/msbiot/board.c
@@ -45,7 +45,7 @@ void board_init(void)
 static void leds_init(void)
 {
     /* enable clock for port GPIOB */
-    RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN;
+    periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN);
 
     /* set output speed to 50MHz */
     LED_PORT->OSPEEDR &= ~(0xF0030000);

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -186,8 +186,8 @@ static const uart_conf_t uart_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV             SPI1
-#define SPI_0_CLKEN()         (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()        (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKEN()         (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()        (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_BUS_DIV         1   /* 1 -> SPI runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_0_IRQ             SPI1_IRQn
 #define SPI_0_IRQ_HANDLER     isr_spi1
@@ -201,9 +201,9 @@ static const uart_conf_t uart_config[] = {
 #define SPI_0_MOSI_PORT       GPIOA
 #define SPI_0_MOSI_PIN        7
 #define SPI_0_MOSI_AF         5
-#define SPI_0_SCK_PORT_CLKEN()      (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
-#define SPI_0_MISO_PORT_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
-#define SPI_0_MOSI_PORT_CLKEN()     (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_SCK_PORT_CLKEN()      (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
+#define SPI_0_MISO_PORT_CLKEN()     (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
+#define SPI_0_MOSI_PORT_CLKEN()     (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 /** @} */
 
 /**
@@ -217,8 +217,8 @@ static const uart_conf_t uart_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
@@ -227,11 +227,11 @@ static const uart_conf_t uart_config[] = {
 #define I2C_0_SCL_PORT      GPIOB
 #define I2C_0_SCL_PIN       6
 #define I2C_0_SCL_AF        4
-#define I2C_0_SCL_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SCL_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define I2C_0_SDA_PORT      GPIOB
 #define I2C_0_SDA_PIN       7
 #define I2C_0_SDA_AF        4
-#define I2C_0_SDA_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SDA_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 
 #ifdef __cplusplus
 }

--- a/boards/nucleo-f030/include/periph_conf.h
+++ b/boards/nucleo-f030/include/periph_conf.h
@@ -73,26 +73,26 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART2
-#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
-#define UART_0_CLKDIS()     (RCC->APB1ENR &= (~RCC_APB1ENR_USART2EN))
+#define UART_0_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART2EN))
+#define UART_0_CLKDIS()     (periph_clk_dis(APB1, RCC_APB1ENR_USART2EN))
 #define UART_0_IRQ          USART2_IRQn
 #define UART_0_ISR          isr_usart2
 /* UART 0 pin configuration */
 #define UART_0_PORT         GPIOA
-#define UART_0_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define UART_0_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define UART_0_RX_PIN       3
 #define UART_0_TX_PIN       2
 #define UART_0_AF           1
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART1
-#define UART_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
-#define UART_1_CLKDIS()     (RCC->APB2ENR &= (~RCC_APB2ENR_USART1EN))
+#define UART_1_CLKEN()      (periph_clk_en(APB2, RCC_APB2ENR_USART1EN))
+#define UART_1_CLKDIS()     (periph_clk_dis(APB2, RCC_APB2ENR_USART1EN))
 #define UART_1_IRQ          USART1_IRQn
 #define UART_1_ISR          isr_usart1
 /* UART 1 pin configuration */
 #define UART_1_PORT         GPIOB
-#define UART_1_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define UART_1_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 #define UART_1_RX_PIN       7
 #define UART_1_TX_PIN       6
 #define UART_1_AF           0

--- a/boards/nucleo-f070/include/periph_conf.h
+++ b/boards/nucleo-f070/include/periph_conf.h
@@ -73,26 +73,26 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART2
-#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
-#define UART_0_CLKDIS()     (RCC->APB1ENR &= (~RCC_APB1ENR_USART2EN))
+#define UART_0_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART2EN))
+#define UART_0_CLKDIS()     (periph_clk_dis(APB1, RCC_APB1ENR_USART2EN))
 #define UART_0_IRQ          USART2_IRQn
 #define UART_0_ISR          isr_usart2
 /* UART 0 pin configuration */
 #define UART_0_PORT         GPIOA
-#define UART_0_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define UART_0_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define UART_0_RX_PIN       3
 #define UART_0_TX_PIN       2
 #define UART_0_AF           1
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART3
-#define UART_1_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART3EN)
-#define UART_1_CLKDIS()     (RCC->APB1ENR &= (~RCC_APB1ENR_USART3EN))
+#define UART_1_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART3EN))
+#define UART_1_CLKDIS()     (periph_clk_dis(APB1, RCC_APB1ENR_USART3EN))
 #define UART_1_IRQ          USART3_4_IRQn
 #define UART_1_ISR          isr_usart3_8
 /* UART 1 pin configuration */
 #define UART_1_PORT         GPIOC
-#define UART_1_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define UART_1_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOCEN))
 #define UART_1_RX_PIN       11
 #define UART_1_TX_PIN       10
 #define UART_1_AF           1

--- a/boards/nucleo-f072/include/periph_conf.h
+++ b/boards/nucleo-f072/include/periph_conf.h
@@ -72,26 +72,26 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART2
-#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
-#define UART_0_CLKDIS()     (RCC->APB1ENR &= (~RCC_APB1ENR_USART2EN))
+#define UART_0_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART2EN))
+#define UART_0_CLKDIS()     (periph_clk_dis(APB1, RCC_APB1ENR_USART2EN))
 #define UART_0_IRQ          USART2_IRQn
 #define UART_0_ISR          isr_usart2
 /* UART 0 pin configuration */
 #define UART_0_PORT         GPIOA
-#define UART_0_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define UART_0_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define UART_0_RX_PIN       3
 #define UART_0_TX_PIN       2
 #define UART_0_AF           1
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART1
-#define UART_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
-#define UART_1_CLKDIS()     (RCC->APB2ENR &= (~RCC_APB2ENR_USART1EN))
+#define UART_1_CLKEN()      (periph_clk_en(APB2, RCC_APB2ENR_USART1EN))
+#define UART_1_CLKDIS()     (periph_clk_dis(APB2, RCC_APB2ENR_USART1EN))
 #define UART_1_IRQ          USART1_IRQn
 #define UART_1_ISR          isr_usart1
 /* UART 1 pin configuration */
 #define UART_1_PORT         GPIOB
-#define UART_1_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define UART_1_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 #define UART_1_RX_PIN       7
 #define UART_1_TX_PIN       6
 #define UART_1_AF           0

--- a/boards/nucleo-f091/include/periph_conf.h
+++ b/boards/nucleo-f091/include/periph_conf.h
@@ -71,26 +71,26 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART2
-#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
-#define UART_0_CLKDIS()     (RCC->APB1ENR &= (~RCC_APB1ENR_USART2EN))
+#define UART_0_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART2EN))
+#define UART_0_CLKDIS()     (periph_clk_dis(APB1, RCC_APB1ENR_USART2EN))
 #define UART_0_IRQ          USART2_IRQn
 #define UART_0_ISR          isr_usart2
 /* UART 0 pin configuration */
 #define UART_0_PORT         GPIOA
-#define UART_0_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define UART_0_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define UART_0_RX_PIN       3
 #define UART_0_TX_PIN       2
 #define UART_0_AF           1
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART1
-#define UART_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
-#define UART_1_CLKDIS()     (RCC->APB2ENR &= (~RCC_APB2ENR_USART1EN))
+#define UART_1_CLKEN()      (periph_clk_en(APB2, RCC_APB2ENR_USART1EN))
+#define UART_1_CLKDIS()     (periph_clk_dis(APB2, RCC_APB2ENR_USART1EN))
 #define UART_1_IRQ          USART1_IRQn
 #define UART_1_ISR          isr_usart1
 /* UART 1 pin configuration */
 #define UART_1_PORT         GPIOB
-#define UART_1_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define UART_1_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 #define UART_1_RX_PIN       7
 #define UART_1_TX_PIN       6
 #define UART_1_AF           0

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -139,8 +139,8 @@ static const uart_conf_t uart_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
@@ -151,8 +151,8 @@ static const uart_conf_t uart_config[] = {
 
 /* I2C 1 device configuration */
 #define I2C_1_DEV           I2C2
-#define I2C_1_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C2EN)
-#define I2C_1_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C2EN))
+#define I2C_1_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C2EN))
+#define I2C_1_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C2EN))
 #define I2C_1_EVT_IRQ       I2C2_EV_IRQn
 #define I2C_1_EVT_ISR       isr_i2c2_ev
 #define I2C_1_ERR_IRQ       I2C2_ER_IRQn
@@ -173,8 +173,8 @@ static const uart_conf_t uart_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKEN()           (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()          (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_IRQ               SPI1_IRQn
 #define SPI_0_IRQ_HANDLER       isr_spi1
 #define SPI_0_BUS_DIV           1
@@ -186,8 +186,8 @@ static const uart_conf_t uart_config[] = {
 
 /* SPI 1 device config */
 #define SPI_1_DEV               SPI2
-#define SPI_1_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
-#define SPI_1_CLKDIS()          (RCC->APB1ENR &= ~RCC_APB1ENR_SPI2EN)
+#define SPI_1_CLKEN()           (periph_clk_en(APB1, RCC_APB1ENR_SPI2EN))
+#define SPI_1_CLKDIS()          (periph_clk_dis(APB1, RCC_APB1ENR_SPI2EN))
 #define SPI_1_IRQ               SPI2_IRQn
 #define SPI_1_IRQ_HANDLER       isr_spi2
 #define SPI_1_BUS_DIV           1

--- a/boards/nucleo-f207/include/periph_conf.h
+++ b/boards/nucleo-f207/include/periph_conf.h
@@ -188,8 +188,8 @@ static const uart_conf_t uart_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKEN()           (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()          (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_BUS_DIV           1   /* 1 -> SPI bus runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_0_IRQ               SPI1_IRQn
 #define SPI_0_IRQ_HANDLER       isr_spi1
@@ -197,20 +197,20 @@ static const uart_conf_t uart_config[] = {
 #define SPI_0_SCK_PORT          GPIOA       /* A5 pin is shared with the green LED. */
 #define SPI_0_SCK_PIN           5
 #define SPI_0_SCK_AF            5
-#define SPI_0_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_SCK_PORT_CLKEN()  (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 #define SPI_0_MISO_PORT         GPIOA
 #define SPI_0_MISO_PIN          6
 #define SPI_0_MISO_AF           5
-#define SPI_0_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_MISO_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 #define SPI_0_MOSI_PORT         GPIOA
 #define SPI_0_MOSI_PIN          7
 #define SPI_0_MOSI_AF           5
-#define SPI_0_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_MOSI_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 
 /* SPI 1 device config */
 #define SPI_1_DEV               SPI2
-#define SPI_1_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
-#define SPI_1_CLKDIS()          (RCC->APB1ENR &= ~RCC_APB1ENR_SPI2EN)
+#define SPI_1_CLKEN()           (periph_clk_en(APB1, RCC_APB1ENR_SPI2EN))
+#define SPI_1_CLKDIS()          (periph_clk_dis(APB1, RCC_APB1ENR_SPI2EN))
 #define SPI_1_BUS_DIV           0   /* 1 -> SPI bus runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_1_IRQ               SPI2_IRQn
 #define SPI_1_IRQ_HANDLER       isr_spi2
@@ -218,15 +218,15 @@ static const uart_conf_t uart_config[] = {
 #define SPI_1_SCK_PORT          GPIOB
 #define SPI_1_SCK_PIN           3
 #define SPI_1_SCK_AF            5
-#define SPI_1_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define SPI_1_SCK_PORT_CLKEN()  (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define SPI_1_MISO_PORT         GPIOB
 #define SPI_1_MISO_PIN          4
 #define SPI_1_MISO_AF           5
-#define SPI_1_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define SPI_1_MISO_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define SPI_1_MOSI_PORT         GPIOB
 #define SPI_1_MOSI_PIN          5
 #define SPI_1_MOSI_AF           5
-#define SPI_1_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define SPI_1_MOSI_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 /** @} */
 
 
@@ -241,8 +241,8 @@ static const uart_conf_t uart_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
@@ -252,12 +252,12 @@ static const uart_conf_t uart_config[] = {
 #define I2C_0_SCL_PIN       8
 #define I2C_0_SCL_AF        4
 #define I2C_0_SCL_PULLUP    0
-#define I2C_0_SCL_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SCL_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define I2C_0_SDA_PORT      GPIOB
 #define I2C_0_SDA_PIN       9
 #define I2C_0_SDA_AF        4
 #define I2C_0_SDA_PULLUP    0
-#define I2C_0_SDA_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SDA_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 /** @} */
 
 /**

--- a/boards/nucleo-f303/include/periph_conf.h
+++ b/boards/nucleo-f303/include/periph_conf.h
@@ -85,12 +85,12 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART2
-#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
+#define UART_0_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART2EN))
 #define UART_0_CLK          (CLOCK_CORECLOCK / 2)   /* UART clock runs with 36MHz (F_CPU / 2) */
 #define UART_0_IRQ_CHAN     USART2_IRQn
 #define UART_0_ISR          isr_usart2
 /* UART 0 pin configuration */
-#define UART_0_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define UART_0_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define UART_0_PORT         GPIOA
 #define UART_0_TX_PIN       2
 #define UART_0_RX_PIN       3
@@ -98,12 +98,12 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART1
-#define UART_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
+#define UART_1_CLKEN()      (periph_clk_en(APB2, RCC_APB2ENR_USART1EN))
 #define UART_1_CLK          (CLOCK_CORECLOCK / 1)   /* UART clock runs with 72MHz (F_CPU / 1) */
 #define UART_1_IRQ_CHAN     USART1_IRQn
 #define UART_1_ISR          isr_usart1
 /* UART 1 pin configuration */
-#define UART_1_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define UART_1_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define UART_1_PORT         GPIOA
 #define UART_1_TX_PIN       9
 #define UART_1_RX_PIN       10
@@ -111,12 +111,12 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 2 device configuration */
 #define UART_2_DEV          USART3
-#define UART_2_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART3EN)
+#define UART_2_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART3EN))
 #define UART_2_CLK          (CLOCK_CORECLOCK / 2)   /* UART clock runs with 36MHz (F_CPU / 2) */
 #define UART_2_IRQ_CHAN     USART3_IRQn
 #define UART_2_ISR          isr_usart3
 /* UART 2 pin configuration */
-#define UART_2_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define UART_2_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 #define UART_2_PORT         GPIOB
 #define UART_2_TX_PIN       10
 #define UART_2_RX_PIN       11
@@ -153,43 +153,43 @@ static const pwm_conf_t pwm_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKEN()           (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()          (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_IRQ               SPI1_IRQn
 #define SPI_0_IRQ_HANDLER       isr_spi1
 /* SPI 0 pin configuration */
 #define SPI_0_SCK_PORT          GPIOA
 #define SPI_0_SCK_PIN           5
 #define SPI_0_SCK_AF            5
-#define SPI_0_SCK_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_SCK_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define SPI_0_MISO_PORT         GPIOA
 #define SPI_0_MISO_PIN          6
 #define SPI_0_MISO_AF           5
-#define SPI_0_MISO_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_MISO_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define SPI_0_MOSI_PORT         GPIOA
 #define SPI_0_MOSI_PIN          7
 #define SPI_0_MOSI_AF           5
-#define SPI_0_MOSI_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_MOSI_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 
 /* SPI 1 device config */
 #define SPI_1_DEV               SPI3
-#define SPI_1_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI3EN)
-#define SPI_1_CLKDIS()          (RCC->APB1ENR &= ~RCC_APB1ENR_SPI3EN)
+#define SPI_1_CLKEN()           (periph_clk_en(APB1, RCC_APB1ENR_SPI3EN))
+#define SPI_1_CLKDIS()          (periph_clk_dis(APB1, RCC_APB1ENR_SPI3EN))
 #define SPI_1_IRQ               SPI3_IRQn
 #define SPI_1_IRQ_HANDLER       isr_spi3
 /* SPI 1 pin configuration */
 #define SPI_1_SCK_PORT          GPIOC
 #define SPI_1_SCK_PIN           10
 #define SPI_1_SCK_AF            6
-#define SPI_1_SCK_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define SPI_1_SCK_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOCEN))
 #define SPI_1_MISO_PORT         GPIOC
 #define SPI_1_MISO_PIN          11
 #define SPI_1_MISO_AF           6
-#define SPI_1_MISO_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define SPI_1_MISO_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOCEN))
 #define SPI_1_MOSI_PORT         GPIOC
 #define SPI_1_MOSI_PIN          12
 #define SPI_1_MOSI_AF           6
-#define SPI_1_MOSI_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define SPI_1_MOSI_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOCEN))
 /** @} */
 
 /**
@@ -204,8 +204,8 @@ static const pwm_conf_t pwm_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
@@ -214,16 +214,16 @@ static const pwm_conf_t pwm_config[] = {
 #define I2C_0_SCL_PORT      GPIOB
 #define I2C_0_SCL_PIN       8
 #define I2C_0_SCL_AF        4
-#define I2C_0_SCL_CLKEN()   (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define I2C_0_SCL_CLKEN()   (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 #define I2C_0_SDA_PORT      GPIOB
 #define I2C_0_SDA_PIN       9
 #define I2C_0_SDA_AF        4
-#define I2C_0_SDA_CLKEN()   (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define I2C_0_SDA_CLKEN()   (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 
 /* I2C 1 device configuration */
 #define I2C_1_DEV           I2C3
-#define I2C_1_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C3EN)
-#define I2C_1_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C3EN))
+#define I2C_1_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C3EN))
+#define I2C_1_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C3EN))
 #define I2C_1_EVT_IRQ       I2C3_EV_IRQn
 #define I2C_1_EVT_ISR       isr_i2c3_ev
 #define I2C_1_ERR_IRQ       I2C3_ER_IRQn
@@ -232,11 +232,11 @@ static const pwm_conf_t pwm_config[] = {
 #define I2C_1_SCL_PORT      GPIOA
 #define I2C_1_SCL_PIN       8
 #define I2C_1_SCL_AF        3
-#define I2C_1_SCL_CLKEN()   (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define I2C_1_SCL_CLKEN()   (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define I2C_1_SDA_PORT      GPIOB
 #define I2C_1_SDA_PIN       5
 #define I2C_1_SDA_AF        8
-#define I2C_1_SDA_CLKEN()   (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define I2C_1_SDA_CLKEN()   (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f334/include/periph_conf.h
+++ b/boards/nucleo-f334/include/periph_conf.h
@@ -89,13 +89,13 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART2
-#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
+#define UART_0_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART2EN))
 #define UART_0_CLK          (CLOCK_CORECLOCK / 2)   /* UART clock runs with 32MHz (F_CPU / 1) */
 #define UART_0_IRQ_CHAN     USART2_IRQn
 #define UART_0_ISR          isr_usart2
 /* UART 0 pin configuration */
 #define UART_0_PORT         GPIOA
-#define UART_0_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define UART_0_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define UART_0_RX_PIN       3
 #define UART_0_TX_PIN       2
 #define UART_0_AF           7
@@ -130,23 +130,23 @@ static const pwm_conf_t pwm_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKEN()           (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()          (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_IRQ               SPI1_IRQn
 #define SPI_0_IRQ_HANDLER       isr_spi1
 /* SPI 0 pin configuration */
 #define SPI_0_SCK_PORT          GPIOA
 #define SPI_0_SCK_PIN           5
 #define SPI_0_SCK_AF            5
-#define SPI_0_SCK_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_SCK_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define SPI_0_MISO_PORT         GPIOA
 #define SPI_0_MISO_PIN          6
 #define SPI_0_MISO_AF           5
-#define SPI_0_MISO_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_MISO_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define SPI_0_MOSI_PORT         GPIOA
 #define SPI_0_MOSI_PIN          7
 #define SPI_0_MOSI_AF           5
-#define SPI_0_MOSI_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_MOSI_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f401/include/periph_conf.h
+++ b/boards/nucleo-f401/include/periph_conf.h
@@ -111,8 +111,8 @@ static const uart_conf_t uart_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKEN()           (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()          (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_BUS_DIV           1   /* 1 -> SPI bus runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_0_IRQ               SPI1_IRQn
 #define SPI_0_IRQ_HANDLER       isr_spi1
@@ -120,15 +120,15 @@ static const uart_conf_t uart_config[] = {
 #define SPI_0_SCK_PORT          GPIOA       /* A5 pin is shared with the green LED. */
 #define SPI_0_SCK_PIN           5
 #define SPI_0_SCK_AF            5
-#define SPI_0_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_SCK_PORT_CLKEN()  (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 #define SPI_0_MISO_PORT         GPIOA
 #define SPI_0_MISO_PIN          6
 #define SPI_0_MISO_AF           5
-#define SPI_0_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_MISO_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 #define SPI_0_MOSI_PORT         GPIOA
 #define SPI_0_MOSI_PIN          7
 #define SPI_0_MOSI_AF           5
-#define SPI_0_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_MOSI_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 /** @} */
 
 
@@ -143,8 +143,8 @@ static const uart_conf_t uart_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
@@ -153,11 +153,11 @@ static const uart_conf_t uart_config[] = {
 #define I2C_0_SCL_PORT      GPIOB
 #define I2C_0_SCL_PIN       8
 #define I2C_0_SCL_AF        4
-#define I2C_0_SCL_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SCL_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define I2C_0_SDA_PORT      GPIOB
 #define I2C_0_SDA_PIN       9
 #define I2C_0_SDA_AF        4
-#define I2C_0_SDA_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SDA_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 /** @} */
 
 /**

--- a/boards/nucleo-f446/include/periph_conf.h
+++ b/boards/nucleo-f446/include/periph_conf.h
@@ -111,8 +111,8 @@ static const uart_conf_t uart_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKEN()           (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()          (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_BUS_DIV           1   /* 1 -> SPI bus runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_0_IRQ               SPI1_IRQn
 #define SPI_0_IRQ_HANDLER       isr_spi1
@@ -120,15 +120,15 @@ static const uart_conf_t uart_config[] = {
 #define SPI_0_SCK_PORT          GPIOA       /* A5 pin is shared with the green LED. */
 #define SPI_0_SCK_PIN           5
 #define SPI_0_SCK_AF            5
-#define SPI_0_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_SCK_PORT_CLKEN()  (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 #define SPI_0_MISO_PORT         GPIOA
 #define SPI_0_MISO_PIN          6
 #define SPI_0_MISO_AF           5
-#define SPI_0_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_MISO_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 #define SPI_0_MOSI_PORT         GPIOA
 #define SPI_0_MOSI_PIN          7
 #define SPI_0_MOSI_AF           5
-#define SPI_0_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_MOSI_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 /** @} */
 
 
@@ -143,8 +143,8 @@ static const uart_conf_t uart_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
@@ -153,11 +153,11 @@ static const uart_conf_t uart_config[] = {
 #define I2C_0_SCL_PORT      GPIOB
 #define I2C_0_SCL_PIN       8
 #define I2C_0_SCL_AF        4
-#define I2C_0_SCL_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SCL_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define I2C_0_SDA_PORT      GPIOB
 #define I2C_0_SDA_PIN       9
 #define I2C_0_SDA_AF        4
-#define I2C_0_SDA_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SDA_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 /** @} */
 
 /**

--- a/boards/nucleo-l1/include/periph_conf.h
+++ b/boards/nucleo-l1/include/periph_conf.h
@@ -89,7 +89,7 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART2
-#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
+#define UART_0_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART2EN))
 #define UART_0_CLK          (CLOCK_CORECLOCK)   /* UART clock runs with 32MHz (F_CPU / 1) */
 #define UART_0_IRQ          USART2_IRQn
 #define UART_0_ISR          isr_usart2
@@ -108,12 +108,12 @@ static const timer_conf_t timer_config[] = {
 
 /* SPI 0 device configuration */
 #define SPI_0_DEV           SPI1
-#define SPI_0_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()      (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKEN()       (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()      (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_IRQ           SPI1_IRQn
 #define SPI_0_ISR           isr_spi1
 /* SPI 0 pin configuration */
-#define SPI_0_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define SPI_0_PORT          GPIOA
 #define SPI_0_PIN_SCK       5
 #define SPI_0_PIN_MOSI      7

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -116,8 +116,8 @@ static const uart_conf_t uart_config[] = {
 
 /* SPI 0 device configuration */
 #define SPI_0_DEV           SPI1
-#define SPI_0_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()      (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKEN()       (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()      (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_BUS_DIV       0   /* 1 -> SPI runs with full CPU clock, 0 -> half CPU clock */
 /* SPI 0 pin configuration */
 #define SPI_0_CLK_PIN       GPIO_PIN(PORT_B,15)

--- a/boards/stm32f0discovery/include/periph_conf.h
+++ b/boards/stm32f0discovery/include/periph_conf.h
@@ -71,26 +71,26 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART1
-#define UART_0_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
-#define UART_0_CLKDIS()     (RCC->APB2ENR &= (~RCC_APB2ENR_USART1EN))
+#define UART_0_CLKEN()      (periph_clk_en(APB2, RCC_APB2ENR_USART1EN))
+#define UART_0_CLKDIS()     (periph_clk_dis(APB2, RCC_APB2ENR_USART1EN))
 #define UART_0_IRQ          USART1_IRQn
 #define UART_0_ISR          isr_usart1
 /* UART 0 pin configuration */
 #define UART_0_PORT         GPIOB
-#define UART_0_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define UART_0_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 #define UART_0_RX_PIN       7
 #define UART_0_TX_PIN       6
 #define UART_0_AF           0
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART2
-#define UART_1_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
-#define UART_1_CLKDIS()     (RCC->APB1ENR &= (~RCC_APB1ENR_USART2EN))
+#define UART_1_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART2EN))
+#define UART_1_CLKDIS()     (periph_clk_dis(APB1, RCC_APB1ENR_USART2EN))
 #define UART_1_IRQ          USART2_IRQn
 #define UART_1_ISR          isr_usart2
 /* UART 1 pin configuration */
 #define UART_1_PORT         GPIOA
-#define UART_1_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define UART_1_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define UART_1_RX_PIN       3
 #define UART_1_TX_PIN       2
 #define UART_1_AF           1
@@ -133,13 +133,13 @@ static const timer_conf_t timer_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV           SPI1
-#define SPI_0_CLKEN()       (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()      (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKEN()       (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()      (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_IRQ           SPI1_IRQn
 #define SPI_0_ISR           isr_spi1
 /* SPI 1 pin configuration */
 #define SPI_0_PORT          GPIOA
-#define SPI_0_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define SPI_0_PIN_SCK       5
 #define SPI_0_PIN_MISO      6
 #define SPI_0_PIN_MOSI      7
@@ -147,13 +147,13 @@ static const timer_conf_t timer_config[] = {
 
 /* SPI 1 device config */
 #define SPI_1_DEV           SPI2
-#define SPI_1_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
-#define SPI_1_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI2EN))
+#define SPI_1_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_SPI2EN))
+#define SPI_1_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_SPI2EN))
 #define SPI_1_IRQ           SPI2_IRQn
 #define SPI_1_ISR           isr_spi2
 /* SPI 1 pin configuration */
 #define SPI_1_PORT          GPIOB
-#define SPI_1_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define SPI_1_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 #define SPI_1_PIN_SCK       13
 #define SPI_1_PIN_MISO      14
 #define SPI_1_PIN_MOSI      15

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -87,12 +87,12 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 0 device configuration */
 #define UART_0_DEV          USART1
-#define UART_0_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
+#define UART_0_CLKEN()      (periph_clk_en(APB2, RCC_APB2ENR_USART1EN))
 #define UART_0_CLK          (CLOCK_CORECLOCK / 1)   /* UART clock runs with 72MHz (F_CPU / 1) */
 #define UART_0_IRQ_CHAN     USART1_IRQn
 #define UART_0_ISR          isr_usart1
 /* UART 0 pin configuration */
-#define UART_0_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define UART_0_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define UART_0_PORT         GPIOA
 #define UART_0_TX_PIN       9
 #define UART_0_RX_PIN       10
@@ -100,12 +100,12 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 1 device configuration */
 #define UART_1_DEV          USART2
-#define UART_1_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
+#define UART_1_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART2EN))
 #define UART_1_CLK          (CLOCK_CORECLOCK / 2)   /* UART clock runs with 36MHz (F_CPU / 2) */
 #define UART_1_IRQ_CHAN     USART2_IRQn
 #define UART_1_ISR          isr_usart2
 /* UART 1 pin configuration */
-#define UART_1_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIODEN)
+#define UART_1_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIODEN))
 #define UART_1_PORT         GPIOD
 #define UART_1_TX_PIN       5
 #define UART_1_RX_PIN       6
@@ -113,12 +113,12 @@ static const timer_conf_t timer_config[] = {
 
 /* UART 1 device configuration */
 #define UART_2_DEV          USART3
-#define UART_2_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART3EN)
+#define UART_2_CLKEN()      (periph_clk_en(APB1, RCC_APB1ENR_USART3EN))
 #define UART_2_CLK          (CLOCK_CORECLOCK / 2)  /* UART clock runs with 36MHz (F_CPU / 2) */
 #define UART_2_IRQ_CHAN     USART3_IRQn
 #define UART_2_ISR          isr_usart3
 /* UART 1 pin configuration */
-#define UART_2_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIODEN)
+#define UART_2_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIODEN))
 #define UART_2_PORT         GPIOD
 #define UART_2_TX_PIN       8
 #define UART_2_RX_PIN       9
@@ -164,43 +164,43 @@ static const pwm_conf_t pwm_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKEN()           (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()          (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_IRQ               SPI1_IRQn
 #define SPI_0_IRQ_HANDLER       isr_spi1
 /* SPI 0 pin configuration */
 #define SPI_0_SCK_PORT          GPIOA
 #define SPI_0_SCK_PIN           5
 #define SPI_0_SCK_AF            5
-#define SPI_0_SCK_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_SCK_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define SPI_0_MISO_PORT         GPIOA
 #define SPI_0_MISO_PIN          6
 #define SPI_0_MISO_AF           5
-#define SPI_0_MISO_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_MISO_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 #define SPI_0_MOSI_PORT         GPIOA
 #define SPI_0_MOSI_PIN          7
 #define SPI_0_MOSI_AF           5
-#define SPI_0_MOSI_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
+#define SPI_0_MOSI_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOAEN))
 
 /* SPI 1 device config */
 #define SPI_1_DEV               SPI3
-#define SPI_1_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI3EN)
-#define SPI_1_CLKDIS()          (RCC->APB1ENR &= ~RCC_APB1ENR_SPI3EN)
+#define SPI_1_CLKEN()           (periph_clk_en(APB1, RCC_APB1ENR_SPI3EN))
+#define SPI_1_CLKDIS()          (periph_clk_dis(APB1, RCC_APB1ENR_SPI3EN))
 #define SPI_1_IRQ               SPI3_IRQn
 #define SPI_1_IRQ_HANDLER       isr_spi3
 /* SPI 1 pin configuration */
 #define SPI_1_SCK_PORT          GPIOC
 #define SPI_1_SCK_PIN           10
 #define SPI_1_SCK_AF            6
-#define SPI_1_SCK_PORT_CLKEN()  (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define SPI_1_SCK_PORT_CLKEN()  (periph_clk_en(AHB, RCC_AHBENR_GPIOCEN))
 #define SPI_1_MISO_PORT         GPIOC
 #define SPI_1_MISO_PIN          11
 #define SPI_1_MISO_AF           6
-#define SPI_1_MISO_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define SPI_1_MISO_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOCEN))
 #define SPI_1_MOSI_PORT         GPIOC
 #define SPI_1_MOSI_PIN          12
 #define SPI_1_MOSI_AF           6
-#define SPI_1_MOSI_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOCEN)
+#define SPI_1_MOSI_PORT_CLKEN() (periph_clk_en(AHB, RCC_AHBENR_GPIOCEN))
 /** @} */
 
 /**
@@ -215,8 +215,8 @@ static const pwm_conf_t pwm_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
@@ -225,16 +225,16 @@ static const pwm_conf_t pwm_config[] = {
 #define I2C_0_SCL_PORT      GPIOB
 #define I2C_0_SCL_PIN       6
 #define I2C_0_SCL_AF        4
-#define I2C_0_SCL_CLKEN()   (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define I2C_0_SCL_CLKEN()   (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 #define I2C_0_SDA_PORT      GPIOB
 #define I2C_0_SDA_PIN       7
 #define I2C_0_SDA_AF        4
-#define I2C_0_SDA_CLKEN()   (RCC->AHBENR |= RCC_AHBENR_GPIOBEN)
+#define I2C_0_SDA_CLKEN()   (periph_clk_en(AHB, RCC_AHBENR_GPIOBEN))
 
 /* I2C 1 device configuration */
 #define I2C_1_DEV           I2C2
-#define I2C_1_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C2EN)
-#define I2C_1_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C2EN))
+#define I2C_1_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C2EN))
+#define I2C_1_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C2EN))
 #define I2C_1_EVT_IRQ       I2C2_EV_IRQn
 #define I2C_1_EVT_ISR       isr_i2c2_ev
 #define I2C_1_ERR_IRQ       I2C2_ER_IRQn
@@ -243,11 +243,11 @@ static const pwm_conf_t pwm_config[] = {
 #define I2C_1_SCL_PORT      GPIOF
 #define I2C_1_SCL_PIN       1
 #define I2C_1_SCL_AF        4
-#define I2C_1_SCL_CLKEN()   (RCC->AHBENR |= RCC_AHBENR_GPIOFEN)
+#define I2C_1_SCL_CLKEN()   (periph_clk_en(AHB, RCC_AHBENR_GPIOFEN))
 #define I2C_1_SDA_PORT      GPIOF
 #define I2C_1_SDA_PIN       0
 #define I2C_1_SDA_AF        4
-#define I2C_1_SDA_CLKEN()   (RCC->AHBENR |= RCC_AHBENR_GPIOFEN)
+#define I2C_1_SDA_CLKEN()   (periph_clk_en(AHB, RCC_AHBENR_GPIOFEN))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -186,8 +186,8 @@ static const pwm_conf_t pwm_config[] = {
 
 /* SPI 0 device config */
 #define SPI_0_DEV               SPI1
-#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
-#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKEN()           (periph_clk_en(APB2, RCC_APB2ENR_SPI1EN))
+#define SPI_0_CLKDIS()          (periph_clk_dis(APB2, RCC_APB2ENR_SPI1EN))
 #define SPI_0_BUS_DIV           1   /* 1 -> SPI runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_0_IRQ               SPI1_IRQn
 #define SPI_0_IRQ_HANDLER       isr_spi1
@@ -195,20 +195,20 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_0_SCK_PORT          GPIOA
 #define SPI_0_SCK_PIN           5
 #define SPI_0_SCK_AF            5
-#define SPI_0_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_SCK_PORT_CLKEN()  (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 #define SPI_0_MISO_PORT         GPIOA
 #define SPI_0_MISO_PIN          6
 #define SPI_0_MISO_AF           5
-#define SPI_0_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_MISO_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 #define SPI_0_MOSI_PORT         GPIOA
 #define SPI_0_MOSI_PIN          7
 #define SPI_0_MOSI_AF           5
-#define SPI_0_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN)
+#define SPI_0_MOSI_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
 
 /* SPI 1 device config */
 #define SPI_1_DEV               SPI2
-#define SPI_1_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
-#define SPI_1_CLKDIS()          (RCC->APB1ENR &= ~RCC_APB1ENR_SPI2EN)
+#define SPI_1_CLKEN()           (periph_clk_en(APB1, RCC_APB1ENR_SPI2EN))
+#define SPI_1_CLKDIS()          (periph_clk_dis(APB1, RCC_APB1ENR_SPI2EN))
 #define SPI_1_BUS_DIV           0   /* 1 -> SPI runs with half CPU clock, 0 -> quarter CPU clock */
 #define SPI_1_IRQ               SPI2_IRQn
 #define SPI_1_IRQ_HANDLER       isr_spi2
@@ -216,15 +216,15 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_1_SCK_PORT          GPIOB
 #define SPI_1_SCK_PIN           13
 #define SPI_1_SCK_AF            5
-#define SPI_1_SCK_PORT_CLKEN()  (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define SPI_1_SCK_PORT_CLKEN()  (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define SPI_1_MISO_PORT         GPIOB
 #define SPI_1_MISO_PIN          14
 #define SPI_1_MISO_AF           5
-#define SPI_1_MISO_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define SPI_1_MISO_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define SPI_1_MOSI_PORT         GPIOB
 #define SPI_1_MOSI_PIN          15
 #define SPI_1_MOSI_AF           5
-#define SPI_1_MOSI_PORT_CLKEN() (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define SPI_1_MOSI_PORT_CLKEN() (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 /** @} */
 
 /**
@@ -238,8 +238,8 @@ static const pwm_conf_t pwm_config[] = {
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
-#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
 #define I2C_0_EVT_IRQ       I2C1_EV_IRQn
 #define I2C_0_EVT_ISR       isr_i2c1_ev
 #define I2C_0_ERR_IRQ       I2C1_ER_IRQn
@@ -248,11 +248,11 @@ static const pwm_conf_t pwm_config[] = {
 #define I2C_0_SCL_PORT      GPIOB
 #define I2C_0_SCL_PIN       6
 #define I2C_0_SCL_AF        4
-#define I2C_0_SCL_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SCL_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define I2C_0_SDA_PORT      GPIOB
 #define I2C_0_SDA_PIN       7
 #define I2C_0_SDA_AF        4
-#define I2C_0_SDA_CLKEN()   (RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN)
+#define I2C_0_SDA_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/stm32_common/cpu_common.c
+++ b/cpu/stm32_common/cpu_common.c
@@ -21,6 +21,9 @@
 #include "periph_conf.h"
 #include "periph_cpu_common.h"
 
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
 uint32_t periph_apb_clk(uint8_t bus)
 {
     if (bus == APB1) {
@@ -31,20 +34,66 @@ uint32_t periph_apb_clk(uint8_t bus)
     }
 }
 
-void periph_clk_en(uint8_t bus, uint32_t mask)
+void periph_clk_en(bus_t bus, uint32_t mask)
 {
-    if (bus == APB1) {
-        RCC->APB1ENR |= mask;
-    } else {
-        RCC->APB2ENR |= mask;
+    switch (bus) {
+        case APB1:
+            RCC->APB1ENR |= mask;
+            break;
+        case APB2:
+            RCC->APB2ENR |= mask;
+            break;
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32F1) \
+            || defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+        case AHB:
+            RCC->AHBENR |= mask;
+            break;
+#elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
+        case AHB1:
+            RCC->AHB1ENR |= mask;
+            break;
+        case AHB2:
+            RCC->AHB2ENR |= mask;
+            break;
+        case AHB3:
+            RCC->AHB3ENR |= mask;
+            break;
+#endif
+        default:
+            DEBUG("unsupported bus %d\n", (int)bus);
+            break;
     }
+    /* stm32xx-errata: Delay after a RCC peripheral clock enable */
+    __DSB();
 }
 
-void periph_clk_dis(uint8_t bus, uint32_t mask)
+void periph_clk_dis(bus_t bus, uint32_t mask)
 {
-    if (bus == APB1) {
-        RCC->APB1ENR &= ~(mask);
-    } else {
-        RCC->APB2ENR &= ~(mask);
+    switch (bus) {
+        case APB1:
+            RCC->APB1ENR &= ~(mask);
+            break;
+        case APB2:
+            RCC->APB2ENR &= ~(mask);
+            break;
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32F1) \
+            || defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+        case AHB:
+            RCC->AHBENR &= ~(mask);
+            break;
+#elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
+        case AHB1:
+            RCC->AHB1ENR &= ~(mask);
+            break;
+        case AHB2:
+            RCC->AHB2ENR &= ~(mask);
+            break;
+        case AHB3:
+            RCC->AHB3ENR &= ~(mask);
+            break;
+#endif
+        default:
+            DEBUG("unsupported bus %d\n", (int)bus);
+            break;
     }
 }

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -47,10 +47,20 @@ extern "C" {
 /**
  * @brief   Available peripheral buses
  */
-enum {
+typedef enum {
     APB1,           /**< APB1 bus */
-    APB2            /**< APB2 bus */
-};
+    APB2,           /**< APB2 bus */
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32F1)\
+    || defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+    AHB,            /**< AHB bus */
+#elif defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
+    AHB1,           /**< AHB1 bus */
+    AHB2,           /**< AHB2 bus */
+    AHB3            /**< AHB3 bus */
+#else
+#warning "unsupported stm32XX family"
+#endif
+} bus_t;
 
 /**
  * @brief   Overwrite the default gpio_t type definition
@@ -132,7 +142,7 @@ uint32_t periph_apb_clk(uint8_t bus);
  * @param[in] bus       bus the peripheral is connected to
  * @param[in] mask      bit in the RCC enable register
  */
-void periph_clk_en(uint8_t bus, uint32_t mask);
+void periph_clk_en(bus_t bus, uint32_t mask);
 
 /**
  * @brief   Disable the given peripheral clock
@@ -140,7 +150,7 @@ void periph_clk_en(uint8_t bus, uint32_t mask);
  * @param[in] bus       bus the peripheral is connected to
  * @param[in] mask      bit in the RCC enable register
  */
-void periph_clk_dis(uint8_t bus, uint32_t mask);
+void periph_clk_dis(bus_t bus, uint32_t mask);
 
 /**
  * @brief   Configure the given pin to be used as ADC input

--- a/cpu/stm32_common/periph/dac.c
+++ b/cpu/stm32_common/periph/dac.c
@@ -48,15 +48,13 @@ int8_t dac_init(dac_t line)
     gpio_init_analog(dac_config[line].pin);
     /* enable the DAC's clock */
 #if defined(DAC2)
-    RCC->APB1ENR |= dac_config[line].dac
-            ? RCC_APB1ENR_DAC2EN
-            : RCC_APB1ENR_DAC1EN;
+    periph_clk_en(APB1, dac_config[line].dac ?
+                  RCC_APB1ENR_DAC2EN : RCC_APB1ENR_DAC1EN);
 #elif defined(DAC1)
-    RCC->APB1ENR |= RCC_APB1ENR_DAC1EN;
+    periph_clk_en(APB1, RCC_APB1ENR_DAC1EN);
 #else
-    RCC->APB1ENR |= RCC_APB1ENR_DACEN;
+    periph_clk_en(APB1, RCC_APB1ENR_DACEN);
 #endif
-
     /* reset output and enable the line's channel */
     dac_set(line, 0);
     dac_poweron(line);

--- a/cpu/stm32f0/periph/adc.c
+++ b/cpu/stm32f0/periph/adc.c
@@ -44,12 +44,12 @@ static mutex_t lock = MUTEX_INIT;
 static inline void prep(void)
 {
     mutex_lock(&lock);
-    RCC->APB2ENR |= RCC_APB2ENR_ADCEN;
+    periph_clk_en(APB2, RCC_APB2ENR_ADCEN);
 }
 
 static inline void done(void)
 {
-    RCC->APB2ENR &= ~(RCC_APB2ENR_ADCEN);
+    periph_clk_dis(APB2, RCC_APB2ENR_ADCEN);
     mutex_unlock(&lock);
 }
 

--- a/cpu/stm32f0/periph/gpio.c
+++ b/cpu/stm32f0/periph/gpio.c
@@ -67,7 +67,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     int pin_num = _pin_num(pin);
 
     /* enable clock */
-    RCC->AHBENR |= (RCC_AHBENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB, (RCC_AHBENR_GPIOAEN << _port_num(pin)));
 
     /* set mode */
     port->MODER &= ~(0x3 << (2 * pin_num));
@@ -96,7 +96,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     isr_ctx[pin_num].arg = arg;
 
     /* enable clock of the SYSCFG module for EXTI configuration */
-    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGCOMPEN;
+    periph_clk_en(APB2, RCC_APB2ENR_SYSCFGCOMPEN);
 
     /* initialize pin as input */
     gpio_init(pin, mode);
@@ -145,7 +145,7 @@ void gpio_init_analog(gpio_t pin)
 {
     /* enable clock, needed as this function can be used without calling
      * gpio_init first */
-    RCC->AHBENR |= (RCC_AHBENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB, (RCC_AHBENR_GPIOAEN << _port_num(pin)));
     /* set to analog mode */
     _port(pin)->MODER |= (0x3 << (2 * _pin_num(pin)));
 }

--- a/cpu/stm32f0/periph/rtc.c
+++ b/cpu/stm32f0/periph/rtc.c
@@ -53,7 +53,7 @@ void rtc_init(void)
 {
 
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Reset RTC domain */
@@ -102,7 +102,7 @@ void rtc_init(void)
 int rtc_set_time(struct tm *time)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Unlock RTC write protection */
@@ -146,7 +146,7 @@ int rtc_get_time(struct tm *time)
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Unlock RTC write protection */
@@ -217,7 +217,7 @@ void rtc_poweron(void)
 void rtc_poweroff(void)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Reset RTC domain */

--- a/cpu/stm32f1/periph/adc.c
+++ b/cpu/stm32f1/periph/adc.c
@@ -57,12 +57,12 @@ static inline ADC_TypeDef *dev(adc_t line)
 static inline void prep(adc_t line)
 {
     mutex_lock(&locks[adc_config[line].dev]);
-    RCC->APB2ENR |= (RCC_APB2ENR_ADC1EN << adc_config[line].dev);
+    periph_clk_en(APB2, (RCC_APB2ENR_ADC1EN << adc_config[line].dev));
 }
 
 static inline void done(adc_t line)
 {
-    RCC->APB2ENR &= ~(RCC_APB2ENR_ADC1EN << adc_config[line].dev);
+    periph_clk_dis(APB2, (RCC_APB2ENR_ADC1EN << adc_config[line].dev));
     mutex_unlock(&locks[adc_config[line].dev]);
 }
 

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -85,7 +85,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     }
 
     /* enable the clock for the selected port */
-    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN << _port_num(pin));
+    periph_clk_en(APB2, (RCC_APB2ENR_IOPAEN << _port_num(pin)));
 
     /* set pin mode */
     port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
@@ -110,7 +110,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     exti_ctx[pin_num].cb = cb;
     exti_ctx[pin_num].arg = arg;
     /* enable alternate function clock for the GPIO module */
-    RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
+    periph_clk_en(APB2, RCC_APB2ENR_AFIOEN);
     /* configure the EXTI channel */
     AFIO->EXTICR[pin_num >> 2] &= ~(0xf << ((pin_num & 0x3) * 4));
     AFIO->EXTICR[pin_num >> 2] |=  (_port_num(pin) << ((pin_num & 0x3) * 4));
@@ -142,7 +142,7 @@ void gpio_init_af(gpio_t pin, gpio_af_out_t af)
     GPIO_TypeDef *port = _port(pin);
 
     /* enable the clock for the selected port */
-    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN << _port_num(pin));
+    periph_clk_en(APB2, (RCC_APB2ENR_IOPAEN << _port_num(pin)));
     /* configure the pin */
     port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
     port->CR[pin_num >> 3] |=  (af << ((pin_num & 0x7) * 4));
@@ -151,7 +151,7 @@ void gpio_init_af(gpio_t pin, gpio_af_out_t af)
 void gpio_init_analog(gpio_t pin)
 {
     /* enable the GPIO port RCC */
-    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN << _port_num(pin));
+    periph_clk_en(APB2, (RCC_APB2ENR_IOPAEN << _port_num(pin)));
 
     /* map the pin as analog input */
     int pin_num = _pin_num(pin);

--- a/cpu/stm32f1/periph/rtt.c
+++ b/cpu/stm32f1/periph/rtt.c
@@ -155,7 +155,7 @@ void rtt_clear_alarm(void)
 
 void rtt_poweron(void)
 {
-    RCC->APB1ENR |= (RCC_APB1ENR_BKPEN|RCC_APB1ENR_PWREN); /* enable BKP and PWR, Clock */
+    periph_clk_en(APB1, (RCC_APB1ENR_BKPEN|RCC_APB1ENR_PWREN)); /* enable BKP and PWR, Clock */
     /* RTC clock source configuration */
     PWR->CR |= PWR_CR_DBP;                   /* Allow access to BKP Domain */
     RCC->BDCR |= RCC_BDCR_LSEON;             /* Enable LSE OSC */
@@ -168,7 +168,7 @@ void rtt_poweroff(void)
 {
     PWR->CR |= PWR_CR_DBP;                   /* Allow access to BKP Domain */
     RCC->BDCR &= ~RCC_BDCR_RTCEN;            /* disable RTC */
-    RCC->APB1ENR &= ~(RCC_APB1ENR_BKPEN|RCC_APB1ENR_PWREN); /* disable BKP and PWR, Clock */
+    periph_clk_dis(APB1, (RCC_APB1ENR_BKPEN|RCC_APB1ENR_PWREN)); /* disable BKP and PWR, Clock */
 }
 
 inline void _rtt_enter_config_mode(void)

--- a/cpu/stm32f1/periph/uart.c
+++ b/cpu/stm32f1/periph/uart.c
@@ -43,10 +43,10 @@ static inline USART_TypeDef *dev(uart_t uart)
 static void clk_en(uart_t uart)
 {
     if (uart_config[uart].bus == APB1) {
-        RCC->APB1ENR |= uart_config[uart].rcc_pin;
+        periph_clk_en(APB1, uart_config[uart].rcc_pin);
     }
     else {
-        RCC->APB2ENR |= uart_config[uart].rcc_pin;
+        periph_clk_en(APB2, uart_config[uart].rcc_pin);
     }
 }
 

--- a/cpu/stm32f2/include/periph_cpu.h
+++ b/cpu/stm32f2/include/periph_cpu.h
@@ -53,15 +53,6 @@ typedef enum {
 /** @} */
 
 /**
- * @brief   Available peripheral buses
- */
-enum {
-    AHB1,           /**< AHB1 bus */
-    AHB2,           /**< AHB2 bus */
-    AHB3            /**< AHB3 bus */
-};
-
-/**
  * @brief   Available ports on the STM32F2 family
  */
 enum {
@@ -161,9 +152,9 @@ void gpio_init_analog(gpio_t pin);
 static inline void dma_poweron(int stream)
 {
     if (stream < 8) {
-        RCC->AHB1ENR |= RCC_AHB1ENR_DMA1EN;
+        periph_clk_en(AHB1, RCC_AHB1ENR_DMA1EN);
     } else {
-        RCC->AHB1ENR |= RCC_AHB1ENR_DMA2EN;
+        periph_clk_en(AHB1, RCC_AHB1ENR_DMA2EN);
     }
 }
 

--- a/cpu/stm32f2/periph/adc.c
+++ b/cpu/stm32f2/periph/adc.c
@@ -60,12 +60,12 @@ static inline ADC_TypeDef *dev(adc_t line)
 static inline void prep(adc_t line)
 {
     mutex_lock(&locks[adc_config[line].dev]);
-    RCC->APB2ENR |= (RCC_APB2ENR_ADC1EN << adc_config[line].dev);
+    periph_clk_en(APB2, (RCC_APB2ENR_ADC1EN << adc_config[line].dev));
 }
 
 static inline void done(adc_t line)
 {
-    RCC->APB2ENR &= ~(RCC_APB2ENR_ADC1EN << adc_config[line].dev);
+    periph_clk_dis(APB2, (RCC_APB2ENR_ADC1EN << adc_config[line].dev));
     mutex_unlock(&locks[adc_config[line].dev]);
 }
 

--- a/cpu/stm32f2/periph/dac.c
+++ b/cpu/stm32f2/periph/dac.c
@@ -45,7 +45,7 @@ int8_t dac_init(dac_t line)
     /* configure pin */
     gpio_init_analog(dac_config[line].pin);
     /* enable the DAC's clock */
-    RCC->APB1ENR |= RCC_APB1ENR_DACEN;
+    periph_clk_en(APB1, RCC_APB1ENR_DACEN);
     /* reset output and enable the line's channel */
     dac_set(line, 0);
     dac_poweron(line);

--- a/cpu/stm32f2/periph/gpio.c
+++ b/cpu/stm32f2/periph/gpio.c
@@ -68,7 +68,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     int pin_num = _pin_num(pin);
 
     /* enable clock */
-    RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB1, (RCC_AHB1ENR_GPIOAEN << _port_num(pin)));
 
     /* set mode */
     port->MODER &= ~(0x3 << (2 * pin_num));
@@ -96,7 +96,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     exti_chan[pin_num].cb = cb;
     exti_chan[pin_num].arg = arg;
     /* enable the SYSCFG clock */
-    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
+    periph_clk_en(APB2, RCC_APB2ENR_SYSCFGEN);
     /* initialize pin as input */
     gpio_init(pin, mode);
     /* enable global pin interrupt */
@@ -150,7 +150,7 @@ void gpio_init_af(gpio_t pin, gpio_af_t af)
 void gpio_init_analog(gpio_t pin)
 {
     /* enable clock */
-    RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB1, (RCC_AHB1ENR_GPIOAEN << _port_num(pin)));
     /* set to analog mode */
     _port(pin)->MODER |= (0x3 << (2 * _pin_num(pin)));
 }

--- a/cpu/stm32f2/periph/hwrng.c
+++ b/cpu/stm32f2/periph/hwrng.c
@@ -30,9 +30,9 @@
 void hwrng_init(void)
 {
     /* enable RNG reset state */
-    RCC->AHB2ENR |= RCC_AHB2ENR_RNGEN;
+    periph_clk_en(AHB2, RCC_AHB2ENR_RNGEN);
     /* release RNG from reset state */
-    RCC->AHB2ENR &= ~RCC_AHB2ENR_RNGEN;
+    periph_clk_dis(AHB2, RCC_AHB2ENR_RNGEN);
 }
 
 
@@ -43,7 +43,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
     unsigned int count = 0;
 
     /* enable RNG reset state */
-    RCC->AHB2ENR |= RCC_AHB2ENR_RNGEN;
+    periph_clk_en(AHB2, RCC_AHB2ENR_RNGEN);
     /* enable the RNG */
     RNG->CR |= RNG_CR_RNGEN;
 
@@ -62,7 +62,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
     /* disable the RNG */
     RNG->CR &= ~RNG_CR_RNGEN;
     /* release RNG from reset state */
-    RCC->AHB2ENR &= ~RCC_AHB2ENR_RNGEN;
+    periph_clk_dis(AHB2, RCC_AHB2ENR_RNGEN);
 }
 
 #endif /* RANDOM_NUMOF */

--- a/cpu/stm32f2/periph/rtc.c
+++ b/cpu/stm32f2/periph/rtc.c
@@ -52,7 +52,7 @@ void rtc_init(void)
 {
 
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Reset RTC domain */
@@ -103,7 +103,7 @@ void rtc_init(void)
 int rtc_set_time(struct tm *time)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Unlock RTC write protection */
@@ -158,7 +158,7 @@ int rtc_get_time(struct tm *time)
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Unlock RTC write protection */
@@ -232,7 +232,7 @@ void rtc_poweron(void)
 void rtc_poweroff(void)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Reset RTC domain */

--- a/cpu/stm32f2/periph/uart.c
+++ b/cpu/stm32f2/periph/uart.c
@@ -177,20 +177,20 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 void uart_poweron(uart_t uart)
 {
     if (_bus(uart) == 1) {
-        RCC->APB1ENR |= uart_config[uart].rcc_mask;
+        periph_clk_en(APB1, uart_config[uart].rcc_mask);
     }
     else {
-        RCC->APB2ENR |= uart_config[uart].rcc_mask;
+        periph_clk_en(APB2, uart_config[uart].rcc_mask);
     }
 }
 
 void uart_poweroff(uart_t uart)
 {
     if (_bus(uart) == 1) {
-        RCC->APB1ENR &= ~(uart_config[uart].rcc_mask);
+        periph_clk_dis(APB1, uart_config[uart].rcc_mask);
     }
     else {
-        RCC->APB2ENR &= ~(uart_config[uart].rcc_mask);
+        periph_clk_dis(APB2, uart_config[uart].rcc_mask);
     }
 }
 

--- a/cpu/stm32f3/periph/gpio.c
+++ b/cpu/stm32f3/periph/gpio.c
@@ -67,7 +67,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     int pin_num = _pin_num(pin);
 
     /* enable clock */
-    RCC->AHBENR |= (RCC_AHBENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB, (RCC_AHBENR_GPIOAEN << _port_num(pin)));
 
     /* set mode */
     port->MODER &= ~(0x3 << (2 * pin_num));
@@ -95,7 +95,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     exti_chan[pin_num].cb = cb;
     exti_chan[pin_num].arg = arg;
     /* enable the SYSCFG clock */
-    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
+    periph_clk_en(APB2, RCC_APB2ENR_SYSCFGEN);
     /* configure pin as input */
     gpio_init(pin, mode);
     /* enable global pin interrupt */
@@ -150,7 +150,7 @@ void gpio_init_analog(gpio_t pin)
 {
     /* enable clock, needed as this function can be used without calling
      * gpio_init first */
-    RCC->AHBENR |= (RCC_AHBENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB, (RCC_AHBENR_GPIOAEN << _port_num(pin)));
     /* set to analog mode */
     _port(pin)->MODER |= (0x3 << (2 * _pin_num(pin)));
 }

--- a/cpu/stm32f4/cpu.c
+++ b/cpu/stm32f4/cpu.c
@@ -89,7 +89,7 @@ static void cpu_clock_init(void)
     /* setup power module */
 
     /* enable the power module */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     /* set the voltage scaling to 1 to enable the maximum frequency */
     PWR->CR |= PWR_CR_VOS_1;
 

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -154,10 +154,10 @@ void gpio_init_af(gpio_t pin, gpio_af_t af);
 static inline void dma_poweron(int stream)
 {
     if (stream < 8) {
-        RCC->AHB1ENR |= RCC_AHB1ENR_DMA1EN;
+        periph_clk_en(AHB1, RCC_AHB1ENR_DMA1EN);
     }
     else {
-        RCC->AHB1ENR |= RCC_AHB1ENR_DMA2EN;
+        periph_clk_en(AHB1, RCC_AHB1ENR_DMA2EN);
     }
 }
 

--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -56,12 +56,12 @@ static inline ADC_TypeDef *dev(adc_t line)
 static inline void prep(adc_t line)
 {
     mutex_lock(&locks[adc_config[line].dev]);
-    RCC->APB2ENR |= (RCC_APB2ENR_ADC1EN << adc_config[line].dev);
+    periph_clk_en(APB2, (RCC_APB2ENR_ADC1EN << adc_config[line].dev));
 }
 
 static inline void done(adc_t line)
 {
-    RCC->APB2ENR &= ~(RCC_APB2ENR_ADC1EN << adc_config[line].dev);
+    periph_clk_dis(APB2, (RCC_APB2ENR_ADC1EN << adc_config[line].dev));
     mutex_unlock(&locks[adc_config[line].dev]);
 }
 

--- a/cpu/stm32f4/periph/gpio.c
+++ b/cpu/stm32f4/periph/gpio.c
@@ -68,7 +68,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     int pin_num = _pin_num(pin);
 
     /* enable clock */
-    RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB1, (RCC_AHB1ENR_GPIOAEN << _port_num(pin)));
 
     /* set mode */
     port->MODER &= ~(0x3 << (2 * pin_num));
@@ -96,7 +96,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     exti_chan[pin_num].cb = cb;
     exti_chan[pin_num].arg = arg;
     /* enable the SYSCFG clock */
-    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
+    periph_clk_en(APB2, RCC_APB2ENR_SYSCFGEN);
     /* initialize pin as input */
     gpio_init(pin, mode);
     /* enable global pin interrupt */
@@ -150,7 +150,7 @@ void gpio_init_af(gpio_t pin, gpio_af_t af)
 void gpio_init_analog(gpio_t pin)
 {
     /* enable clock */
-    RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB1, (RCC_AHB1ENR_GPIOAEN << _port_num(pin)));
     /* set to analog mode */
     _port(pin)->MODER |= (0x3 << (2 * _pin_num(pin)));
 }

--- a/cpu/stm32f4/periph/hwrng.c
+++ b/cpu/stm32f4/periph/hwrng.c
@@ -19,6 +19,7 @@
  */
 
 #include "cpu.h"
+#include "periph_conf.h"
 #include "periph/hwrng.h"
 
 /* only build if the CPU actually provides a RNG peripheral */
@@ -34,7 +35,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
     unsigned int count = 0;
 
     /* power on and enable the device */
-    RCC->AHB2ENR |= RCC_AHB2ENR_RNGEN;
+    periph_clk_en(AHB2, RCC_AHB2ENR_RNGEN);
     RNG->CR = RNG_CR_RNGEN;
 
     /* get random data */
@@ -52,7 +53,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
 
     /* finally disable the device again */
     RNG->CR = 0;
-    RCC->AHB2ENR &= ~RCC_AHB2ENR_RNGEN;
+    periph_clk_dis(AHB2, RCC_AHB2ENR_RNGEN);
 }
 
 #endif /* CPUID_LEN */

--- a/cpu/stm32l1/cpu.c
+++ b/cpu/stm32l1/cpu.c
@@ -75,7 +75,7 @@ static void clk_init(void)
     /* Flash 1 wait state */
     FLASH->ACR |= CLOCK_FLASH_LATENCY;
     /* Power enable */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     /* Select the Voltage Range 1 (1.8 V) */
     PWR->CR = PWR_CR_VOS_0;
     /* Wait Until the Voltage Regulator is ready */

--- a/cpu/stm32l1/periph/gpio.c
+++ b/cpu/stm32l1/periph/gpio.c
@@ -69,7 +69,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     int pin_num = _pin_num(pin);
 
     /* enable clock */
-    RCC->AHBENR |= (RCC_AHBENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB, (RCC_AHBENR_GPIOAEN << _port_num(pin)));
 
     /* set mode */
     port->MODER &= ~(0x3 << (2 * pin_num));
@@ -97,7 +97,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     exti_chan[pin_num].cb = cb;
     exti_chan[pin_num].arg = arg;
     /* enable the SYSCFG clock */
-    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
+    periph_clk_en(APB2, RCC_APB2ENR_SYSCFGEN);
     /* initialize pin as input */
     gpio_init(pin, mode);
     /* enable global pin interrupt */
@@ -152,7 +152,7 @@ void gpio_init_analog(gpio_t pin)
 {
     /* enable clock, needed as this function can be used without calling
      * gpio_init first */
-    RCC->AHBENR |= (RCC_AHBENR_GPIOAEN << _port_num(pin));
+    periph_clk_en(AHB, (RCC_AHBENR_GPIOAEN << _port_num(pin)));
     /* set to analog mode */
     _port(pin)->MODER |= (0x3 << (2 * _pin_num(pin)));
 }

--- a/cpu/stm32l1/periph/i2c.c
+++ b/cpu/stm32l1/periph/i2c.c
@@ -344,7 +344,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
 void i2c_poweron(i2c_t dev)
 {
     if ((unsigned int)dev < I2C_NUMOF) {
-        RCC->APB1ENR |= (RCC_APB1ENR_I2C1EN << dev);
+        periph_clk_en(APB1, (RCC_APB1ENR_I2C1EN << dev));
     }
 }
 
@@ -352,7 +352,7 @@ void i2c_poweroff(i2c_t dev)
 {
     if ((unsigned int)dev < I2C_NUMOF) {
         while (i2c_config[dev].dev->SR2 & I2C_SR2_BUSY) {}
-        RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN << dev);
+        periph_clk_dis(APB1, (RCC_APB1ENR_I2C1EN << dev));
     }
 }
 

--- a/cpu/stm32l1/periph/rtc.c
+++ b/cpu/stm32l1/periph/rtc.c
@@ -83,7 +83,7 @@ void rtc_init(void)
 int rtc_set_time(struct tm *time)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Unlock RTC write protection */
@@ -127,7 +127,7 @@ int rtc_get_time(struct tm *time)
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Unlock RTC write protection */
@@ -193,7 +193,7 @@ void rtc_clear_alarm(void)
 void rtc_poweron(void)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Reset RTC domain */
@@ -217,7 +217,7 @@ void rtc_poweron(void)
 void rtc_poweroff(void)
 {
     /* Enable write access to RTC registers */
-    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     PWR->CR |= PWR_CR_DBP;
 
     /* Reset RTC domain */


### PR DESCRIPTION
From the stm32XX erratas:

> Delay after an RCC peripheral clock enabling:
> 
> Description
> A delay between an RCC peripheral clock enable and the effective peripheral enabling 
> should be taken into account in order to manage the peripheral read/write to registers.
> This delay depends on the peripheral’s mapping:
> • If the peripheral is mapped on AHB: the delay should be equal to 2 AHB cycles.
> • If the peripheral is mapped on APB: the delay should be equal to 1 + (AHB/APB prescaler) cycles.
> 
> Workarounds
> 1.Use the DSB instruction to stall the Cortex-MX CPU pipeline until the instruction is completed.
> 2.Insert “n” NOPs between the RCC enable bit write and the peripheral register writes. n = 2 for AHB peripherals, n = 1 + AHB/APB prescaler in case of APB peripherals)

Workaround 1 is implemented in this pull request.
