### PR TITLE
vagrant: sync Tutorials folder into vbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,8 @@ Vagrant.configure(2) do |config|
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
+  config.vm.define "RIOT", primary: true
+
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "boxcutter/ubuntu1604"
@@ -22,6 +24,13 @@ Vagrant.configure(2) do |config|
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
   config.vm.synced_folder ".", "/home/vagrant/RIOT"
+
+  config.vm.define "tutorials", autostart: false do |tutorials|
+      tutorials.vm.synced_folder "../.", "/home/vagrant/Tutorials"
+      config.vm.provider "virtualbox" do |vb|
+        vb.name = "RIOT VM - Tutorials"
+      end
+  end
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
This addition to the `Vagrantfile` syncs the parent folder of RIOT into the vbox machine with the name `Tutorials`, which is necessary for the RIOT  Tutorial [1] to work. Otherwise, it is always necessary to clone the tutorials folder seperately into the vbox machine.

How does this work:
The `Vagrantfile` defines a primary `RIOT` machine, which is booted and ssh'ed into with `vagrant up` and `vagrant ssh`. To boot the `tutorials` machine definition and ssh into it, you must use `vagrant up tutorials` and `vagrant ssh tutorials`. This `tutorials` machine will sync the `RIOT` folder to `$HOME` and also the `Tutorials` folder, which is the parent folder if cloned from [1].

[1] https://github.com/RIOT-OS/Tutorials