### PR TITLE
vagrant: minimize Vagrantfile and make it loadable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,49 +3,16 @@
 
 require 'fileutils'
 
+RIOTBASE ||= "./"
+
 Vagrant.configure(2) do |config|
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
+  # For a complete reference, please see the online documentation at https://docs.vagrantup.com.
 
-  config.vm.define "RIOT", primary: true
-
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "boxcutter/ubuntu1604"
+  config.vm.synced_folder RIOTBASE, "/home/vagrant/RIOT"
 
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  config.vm.network "forwarded_port", guest: 4242, host: 4242
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-  config.vm.synced_folder ".", "/home/vagrant/RIOT"
-
-  config.vm.define "tutorials", autostart: false do |tutorials|
-      tutorials.vm.synced_folder "../.", "/home/vagrant/Tutorials"
-      config.vm.provider "virtualbox" do |vb|
-        vb.name = "RIOT VM - Tutorials"
-      end
-  end
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
   config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Set name of the VM
     vb.name = "RIOT VM"
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  #   # enable usb passthrough
     vb.customize ["modifyvm", :id, "--usb", "on"]
     vb.customize ["modifyvm", :id, "--usbxhci", "on"]
     vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'FTDI USB-TTL',
@@ -70,5 +37,5 @@ Vagrant.configure(2) do |config|
     config.vm.provision "file", source: File.join(Dir.home, ".gitconfig"), destination: ".gitconfig"
   end
 
-  config.vm.provision "shell", path: "dist/tools/vagrant/bootstrap.sh"
+  config.vm.provision "shell", path: File.join(RIOTBASE,'/dist/tools/vagrant/bootstrap.sh')
 end

--- a/dist/tools/vagrant/README.md
+++ b/dist/tools/vagrant/README.md
@@ -56,3 +56,8 @@ your host system and use the VM for compiling, flashing devices and running the 
     The needed `vendor id` and `product id` can be obtained by running `vboxmanage list usbhost`.
   * For Linux Host Systems: Additionally, in order to allow USB access from within the guest system, the host system user
     must be a member of the `vboxusers` group (see [here](https://www.virtualbox.org/manual/ch02.html#idm1051)).
+2. You can forward ports on the virtual machine with the following command:
+
+   ```
+   config.vm.network "forwarded_port", guest: <port_1>, host: <port_2>
+   ```


### PR DESCRIPTION
By parameterizing certain paths with `RIOTBASE`, it is possible to load
this Vagrantfile from other Vagrantfiles. This feature will be used by the
Tutorials repository, so that this Vagrantfile has no knowledge about
the tutorials, hence the deletion of the `tutorials` definition at this
place.