### PR TITLE
cpu/sam21_common: support SAMR21E18

### DIFF
--- a/cpu/sam21_common/include/sam0.h
+++ b/cpu/sam21_common/include/sam0.h
@@ -25,6 +25,8 @@ extern "C" {
 
 #if defined(__SAMR21G18A__) || defined(__ATSAMR21G18A__)
 #include "cmsis/samr21/include/samr21g18a.h"
+#elif defined(__SAMR21E18A__) || defined(__ATSAMR21E18A__)
+#include "cmsis/samr21/include/samr21e18a.h"
 #else
   #error "Unsupported SAM0 variant."
 #endif


### PR DESCRIPTION
#5743 merged a couple hours ago inadvertently removed support for the SAMR21E18A (the 32 pin variant). This trivial fix adds support back in.