### PR TITLE
make: export RIOT_VERSION to CFLAGS_WITH_MACROS

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -510,13 +510,14 @@ $(RIOTBUILD_CONFIG_HEADER_C):
 	@mkdir -p '$(dir $@)'
 	$(AD)'$(RIOTBASE)/dist/tools/genconfigheader/genconfigheader.sh' '$@' $(CFLAGS_WITH_MACROS)
 
+CFLAGS_WITH_MACROS := $(CFLAGS)
+
 ifneq (,$(RIOT_VERSION_OVERRIDE))
-export CFLAGS += -DRIOT_VERSION=\"$(RIOT_VERSION_OVERRIDE)\"
+export CFLAGS_WITH_MACROS += -DRIOT_VERSION=\"$(RIOT_VERSION_OVERRIDE)\"
 else
-export CFLAGS += -DRIOT_VERSION=\"$(RIOT_VERSION)\"
+export CFLAGS_WITH_MACROS += -DRIOT_VERSION=\"$(RIOT_VERSION)\"
 endif
 
-CFLAGS_WITH_MACROS := $(CFLAGS)
 CFLAGS := $(patsubst -D%,,$(CFLAGS))
 CFLAGS := $(patsubst -U%,,$(CFLAGS))
 CFLAGS += -include '$(RIOTBUILD_CONFIG_HEADER_C)'


### PR DESCRIPTION
All macros are filtered out of the `CFLAGS` variable and during this
process, the `CFLAGS` string is destroyed. This is due to the fact that
the `RIOT_VERSION` string contains spaces, but the filtering process does
not take the whole string into account (following the first space). This
leads to some parts of the `RIOT_VERSION` string be sill existent in the
`CFLAGS` string.

Instead of exporting the `RIOT_VERSION` string to the `CFLAGS` macro to
just remove it again from there, I exported it to `CFLAGS_WITH_MACROS`.

Fixes #5859