### PR TITLE
ndp: add missing header include

### DIFF
--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 
 #include "byteorder.h"
+#include "net/ipv6/addr.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
sys/include/net/ndp.h uses IPv6 addresses in NDP message type definitions but up
until now the according header wasn't included.