### PR TITLE
samd21: spi: fix power regression

### DIFF
--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -158,7 +158,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
      *  - init cpha/cpol, BAUD.reg
      *  - enable SPI
      */
-
+    gpio_init(pin_miso, GPIO_IN_PD);
     gpio_init_sercom(pin_sclk, mux_sclk);
     gpio_init_sercom(pin_miso, mux_miso);
     gpio_init_sercom(pin_mosi, mux_mosi);


### PR DESCRIPTION
tl;dr commit 845ef0decdf28 introduced a power consumption regression by leaving the MISO pin floating

Despite this being a one line fix, this took us four days to find, so allow me to elaborate. @hyungsin and I have been working on getting RIOT running at ~10uA average current for a duty cycling SAMR21 based mote, basically we have #2309 and #5608 along with a set of changes here and there. We got everything working, sampling temperature at 1Hz with ~10uA consumption and we patted ourselves on the back with a "lets quickly rebase and then submit patches upstream". We rebased, (it was just four days of commits) and one of those commits was merging #5743. 

Nothing worked.

Ah well, we consoled ourselves, at least this means RIOT is active, this is a good problem to have. So we got everything to compile and redid the platform support only to find that our MCU-only power consumption had gone from 2.5uA in idle to over 70 uA. Somewhere in the more than 10k changed lines, there was a problem. We spent a few days inspecting all the clocking config (we thought there must be a new RUNSTDBY clock). We scoured the PM registers, nothing. Eventually I started bisecting the PR, and discovered that 845ef0decdf was to blame, but nothing seemed blatantly wrong. Eventually by reverting it line by line we discovered that the new code does not configure the pullup resistor on MISO. Adding that brought us back :+1: 

![img_20160926_195730](https://cloud.githubusercontent.com/assets/4234131/18859199/c8596496-8426-11e6-92ac-e543f2cffe14.jpg)

Hallelujah: 

![img_20160926_195538](https://cloud.githubusercontent.com/assets/4234131/18859200/cb6d8cfc-8426-11e6-9ccd-bc2de0e3ac11.jpg)

I guess to make this kind of thing easier to find in future we 

a) might want to add power consumption tests of a physical device to the CI
b) might want to split large PR's into mostly-harmless refactor (updating the ASF and moving headers for example) and things that change implementation details, so that problems don't get buried in 10kloc batches. 

Now that this is sorted out, I will get back to preparing a PR for low-power SAMR21 platforms.


