### PR TITLE
cc2538: disable l2 ack recv irq

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -28,6 +28,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#define CC2538_ACCEPT_FT_2_ACK     (1 << 5)
+
 typedef struct {
     cc2538_reg_t *reg_addr;
     uint32_t value;
@@ -134,7 +136,8 @@ void cc2538_init(void)
     /* Flush the receive and transmit FIFOs */
     RFCORE_SFR_RFST = ISFLUSHTX;
     RFCORE_SFR_RFST = ISFLUSHRX;
-
+    /* Disable/filter l2 Acks */
+    RFCORE_XREG_FRMFILT1 &= ~CC2538_ACCEPT_FT_2_ACK;
     cc2538_on();
 }
 


### PR DESCRIPTION
This disables a filtering option that otherwise raises an recv IRQ when any layer 2 ACK is received, even if it does not match any pending ACK of the node iftself. This leads to a kernel panic caused by a failed assertion, as described in #5840 and further discussed in #5786.