### PR TITLE
drivers/cc2420: improve z1 init and send routine

### DIFF
--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -111,7 +111,7 @@ extern "C" {
  * @brief   Definition of the interface to the CC2420 radio
  */
 #define CC2420_PARAMS_BOARD         {.spi        = SPI_0, \
-                                     .spi_clk    = SPI_SPEED_1MHZ, \
+                                     .spi_clk    = SPI_SPEED_5MHZ, \
                                      .pin_cs     = GPIO_PIN(P3, 0), \
                                      .pin_fifo   = GPIO_PIN(P1, 3), \
                                      .pin_fifop  = GPIO_PIN(P1, 2), \

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -160,6 +160,7 @@ size_t cc2420_tx_prepare(cc2420_t *dev, const struct iovec *data, unsigned count
     size_t pkt_len = 2;     /* include the FCS (frame check sequence) */
 
     /* wait for any ongoing transmissions to be finished */
+    DEBUG("cc2420: tx_exec: waiting for any ongoing transmission\n");
     while (cc2420_get_state(dev) & NETOPT_STATE_TX) {}
 
     /* get and check the length of the packet */
@@ -186,9 +187,6 @@ size_t cc2420_tx_prepare(cc2420_t *dev, const struct iovec *data, unsigned count
 
 void cc2420_tx_exec(cc2420_t *dev)
 {
-    /* make sure, any ongoing transmission is finished */
-    DEBUG("cc2420: tx_exec: waiting for any ongoing transmission\n");
-    while (cc2420_get_state(dev) & NETOPT_STATE_TX) {}
     /* trigger the transmission */
     if (dev->options & CC2420_OPT_TELL_TX_START) {
         dev->netdev.netdev.event_callback(&dev->netdev.netdev,
@@ -203,15 +201,6 @@ void cc2420_tx_exec(cc2420_t *dev)
         DEBUG("cc2420: tx_exec: triggering TX without CCA\n");
         cc2420_strobe(dev, CC2420_STROBE_TXON);
     }
-
-    while (gpio_read(dev->params.pin_sfd)) {
-        puts("\t...ongoing}");
-    }
-    if (dev->options & CC2420_OPT_TELL_TX_END) {
-        dev->netdev.netdev.event_callback(&dev->netdev.netdev,
-                                          NETDEV2_EVENT_TX_COMPLETE);
-    }
-    DEBUG("cc2420: tx_exec: TX_DONE\n");
 }
 
 int cc2420_rx(cc2420_t *dev, uint8_t *buf, size_t max_len, void *info)


### PR DESCRIPTION
First commit increases the SPI bus speed for the cc2420 radio on the z1. ~~Second commit needs some more testing from my side~~ (marked PR as WIP). But feedback is already welcome.

Edit:
- Testing for ongoing transmissions just needs to be done once IMO
- Waiting for the SFD pin to be unset (i) did not work correctly and (ii) is not needed IMO. (i) According to the [datasheet](http://www.ti.com/lit/ds/symlink/cc2420.pdf) (Fig. 15) the pin is low until the preamble + SFD have been sent by the radio. That point in time when we poll the pin state, it hasn't even been set, so the loop does basically nothing. (ii) I guess the idea was to wait until the transmission finished but this would block the driver even if the transmission is done by the hardware. We will loose the `NETDEV2_EVENT_TX_COMPLETE` notification cause there is no other way (e.g. interrupt) on that device, to signal the end of a transmission. But we don't really use this notification anyway.
- I've tested transmission between two z1 nodes of small UDP packets with maximum rate  with success
