### PR TITLE
core: Add function name and line number to standard debug macro

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -92,7 +92,8 @@ extern "C" {
  *
  * @note Another name for ::DEBUG_PRINT
  */
-#define DEBUG(...) DEBUG_PRINT(__VA_ARGS__)
+#define DEBUG(...) DEBUG_PRINT("%s:%d: ", DEBUG_FUNC, __LINE__); \
+                   DEBUG_PRINT(__VA_ARGS__)
 #else
 #define DEBUG(...)
 #endif


### PR DESCRIPTION
After discussing it at the Hack'n'Ack in Hamburg, I'm proposing this change as an improvement to the existing `DEBUG` macro. Given the following code:

```
10    int test() {
11        DEBUG("foobar");
12    }
```

The current DEBUG macro will print `foobar` whereas the modified version would print `test:11: foobar`. I think that this significantly enhances the "debuggability" of code that uses the macro.
