### PR TITLE
sock: doxygen: some doxygen improvements

### DIFF
--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -126,7 +126,7 @@ extern "C" {
 #define SOCK_IPV4_EP_ANY        { .family = AF_INET, \
                                   .netif = SOCK_ADDR_ANY_NETIF }
 
-#if defined(SOCK_HAS_IPV6) || defined(DOXYGEN)
+#if defined(SOCK_HAS_IPV6)
 /**
  * @brief   Address to bind to any IPv6 address
  */
@@ -146,7 +146,7 @@ typedef struct {
     int family;
 
     union {
-#if defined(SOCK_HAS_IPV6) || defined(DOXYGEN)
+#if defined(SOCK_HAS_IPV6)
         /**
          * @brief IPv6 address mode
          *
@@ -182,7 +182,7 @@ struct _sock_tl_ep {
     int family;
 
     union {
-#if defined(SOCK_HAS_IPV6) || defined(DOXYGEN)
+#if defined(SOCK_HAS_IPV6)
         /**
          * @brief IPv6 address mode
          *

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -94,9 +94,15 @@ extern "C" {
 
 #if defined(DOXYGEN)
 /**
- * @brief compile flag to activate IPv6 support for sock
+ * @name Compile Flags
+ * @brief Flags to de/activate certain functionalities
+ * @{
+ */
+/**
+ * @brief activate IPv6 support for sock
  */
 #define SOCK_HAS_IPV6
+/** @} */
 #endif
 
 /**


### PR DESCRIPTION
Put `compile flags` into a separete group, so that it stands out in the documentation. Otherwise, it will just blend into the more generic `Macros` group.
Furthermore, remov some unnecessary checks to `DOXYGEN`