### PR TITLE
ports: mips: Add Support for mips32r2.

### DIFF
--- a/boards/mips-malta/Makefile
+++ b/boards/mips-malta/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/mips-malta/Makefile.features
+++ b/boards/mips-malta/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += cpp

--- a/boards/mips-malta/Makefile.include
+++ b/boards/mips-malta/Makefile.include
@@ -1,0 +1,1 @@
+# This file must exist for RIOT to build.

--- a/boards/mips-malta/include/board.h
+++ b/boards/mips-malta/include/board.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#ifndef _BOARD_H_
+#define _BOARD_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TICKS_PER_US 15 /* needed by timer code */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* _BOARD_H_ */

--- a/boards/mips-malta/include/periph_conf.h
+++ b/boards/mips-malta/include/periph_conf.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+#ifndef _PERIPH_CONF_H_
+#define _PERIPH_CONF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Note this file must exist for xtimer code to build */
+#define TIMER_NUMOF         (1U)
+#define TIMER_0_CHANNELS    3
+
+/* This value must exist even if no uart in use */
+#define UART_NUMOF          (0U)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*_PERIPH_CONF_H_*/

--- a/boards/mips-malta/include/periph_cpu.h
+++ b/boards/mips-malta/include/periph_cpu.h
@@ -1,0 +1,1 @@
+/* This file must exist to get timer code to build */

--- a/boards/mips-malta/malta.c
+++ b/boards/mips-malta/malta.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+
+
+#include <stdio.h>
+
+#include "periph/uart.h"
+
+#define MIPS_MALTA_ADDR 0xbf000500
+#define MIPS_MALTA_VAL_RST 0x42
+
+static void malta_reset(void)
+{
+	*(volatile long *)MIPS_MALTA_ADDR = MIPS_MALTA_VAL_RST;
+	asm volatile ("wait");
+}
+
+void board_init(void)
+{
+
+}
+
+void reboot(void)
+{
+	malta_reset();
+}

--- a/boards/pic32-clicker/Makefile
+++ b/boards/pic32-clicker/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/pic32-clicker/Makefile.features
+++ b/boards/pic32-clicker/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += cpp

--- a/boards/pic32-clicker/Makefile.include
+++ b/boards/pic32-clicker/Makefile.include
@@ -1,0 +1,1 @@
+#This file must exist for RIOT to build.

--- a/boards/pic32-clicker/clicker.c
+++ b/boards/pic32-clicker/clicker.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+#include <stdio.h>
+#include "periph/uart.h"
+
+void board_init(void)
+{
+	volatile uint32_t * const _U3RXR = (uint32_t *) 0xBF80FA60;
+	volatile uint32_t * const _RPF4R = (uint32_t *) 0xBF80FC50;
+
+	volatile uint32_t * const _PORTFCLR = (uint32_t *) 0xBF886524;
+	volatile uint32_t * const _TRISFCLR = (uint32_t *) 0xBF886514;
+	volatile uint32_t * const _TRISFSET = (uint32_t *) 0xBF886518;
+	volatile uint32_t * const _ODCFCLR  = (uint32_t *) 0xBF886544;
+
+	/*
+	 * Setup pin mux for UART3 this is the one connected
+	 * to the mickroBUS
+	 */
+	*_U3RXR = 0x2;
+	*_RPF4R = 0x1;
+	*_PORTFCLR = 0x30;
+	*_TRISFCLR = 0x10;
+	*_TRISFSET = 0x20;
+	*_ODCFCLR = 0x30;
+
+	/* intialise UART used for debug (printf) */
+#ifdef DEBUG_VIA_UART
+	uart_init(DEBUG_VIA_UART, 9600, NULL, 0);
+#endif
+}
+

--- a/boards/pic32-clicker/include/board.h
+++ b/boards/pic32-clicker/include/board.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#ifndef _BOARD_H_
+#define _BOARD_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Peripheral clock frequency need for UART baud rate calculation */
+#define PERIPHERAL_CLOCK 120000000  /* Hz */
+
+/* Tick per uS need by timer code */
+#define TICKS_PER_US 60
+
+/* PIC32 Interrupt Routing */
+#define PIC32MX 1
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* _BOARD_H_ */

--- a/boards/pic32-clicker/include/periph_conf.h
+++ b/boards/pic32-clicker/include/periph_conf.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+#ifndef _PERIPH_CONF_H_
+#define _PERIPH_CONF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Note this file must exist for xtimer code to build */
+#define TIMER_NUMOF         (1U)
+#define TIMER_0_CHANNELS    3
+
+/* This value must exist even if no uart in use */
+#define UART_NUMOF          (4U)
+
+/* Route debug output to UART 4 (the USB one via FTDI chip) */
+#define DEBUG_VIA_UART 3
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/boards/pic32-clicker/include/periph_cpu.h
+++ b/boards/pic32-clicker/include/periph_cpu.h
@@ -1,0 +1,1 @@
+/* This file must exist to get timer code to build */

--- a/boards/pic32-wifire/Makefile
+++ b/boards/pic32-wifire/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/pic32-wifire/Makefile.features
+++ b/boards/pic32-wifire/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += cpp

--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -1,0 +1,1 @@
+# File must exist for RIOT to build.

--- a/boards/pic32-wifire/include/board.h
+++ b/boards/pic32-wifire/include/board.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#ifndef _BOARD_H_
+#define _BOARD_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Peripheral clock frequency need for UART baud rate calculation */
+#define PERIPHERAL_CLOCK 100000000  /* Hz */
+
+/* Tick per uS need by timer code */
+#define TICKS_PER_US 100
+
+/* PIC32 Interrupt Routing */
+#define PIC32MZ 1
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* _BOARD_H_ */
+

--- a/boards/pic32-wifire/include/periph_conf.h
+++ b/boards/pic32-wifire/include/periph_conf.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+#ifndef _PERIPH_CONF_H_
+#define _PERIPH_CONF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Note this file must exist for xtimer code to build */
+#define TIMER_NUMOF         (1U)
+#define TIMER_0_CHANNELS    3
+
+/* This value must exist even if no uart in use */
+#define UART_NUMOF          (6U)
+
+/* Route debug output to UART 4 (the USB one via FTDI chip) */
+#define DEBUG_VIA_UART 4
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/boards/pic32-wifire/include/periph_cpu.h
+++ b/boards/pic32-wifire/include/periph_cpu.h
@@ -1,0 +1,1 @@
+/* This file must exist to get timer code to build */

--- a/boards/pic32-wifire/wifire.c
+++ b/boards/pic32-wifire/wifire.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#include <stdio.h>
+#include "periph/uart.h"
+
+void board_init(void)
+{
+	/* Pin ctrl regs */
+	volatile uint32_t * const _U4RXR = (uint32_t *) 0xBF801480;
+	volatile uint32_t * const _RPF8R = (uint32_t *) 0xBF801660;
+	volatile uint32_t * const _PORTFCLR = (uint32_t *) 0xBF860524;
+	volatile uint32_t * const _TRISFCLR = (uint32_t *) 0xBF860514;
+	volatile uint32_t * const _TRISFSET = (uint32_t *) 0xBF860518;
+	volatile uint32_t * const _ODCFCLR = (uint32_t *) 0xBF860544;
+
+	/*
+	 * Setup pin mux for UART4 this is the one connected
+	 * to the ftdi chip (usb<->uart)
+	 */
+	*_U4RXR = 0xb;
+	*_RPF8R = 2;
+	*_PORTFCLR = 0xa;
+	*_TRISFCLR = 2;
+	*_TRISFSET = 8;
+	*_ODCFCLR = 0xa;
+
+	/* intialise UART used for debug (printf) */
+#ifdef DEBUG_VIA_UART
+	uart_init(DEBUG_VIA_UART, 9600, NULL, 0);
+#endif
+}
+

--- a/cpu/mips32r2_common/Makefile
+++ b/cpu/mips32r2_common/Makefile
@@ -1,0 +1,10 @@
+ifeq ("$(OS)","Windows_NT")
+MIPS_ELF_ROOT?=C:\cross-mips-mti-elf
+else
+MIPS_ELF_ROOT?=/opt/imgtec/Toolchains/mips-mti-elf/2016.05-03
+endif
+
+MODULE = cpu
+DIRS = periph
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -1,0 +1,33 @@
+# Target triple for the build.
+export TARGET_ARCH ?= mips-mti-elf
+
+export ABI=32
+export MEMORY_BASE=0x80000000
+export MEMORY_SIZE=1M
+export APP_START=0x80000000
+
+include $(MIPS_ELF_ROOT)/share/mips/rules/mipshal.mk
+
+# define build specific options
+export CFLAGS_CPU   = -EL -march=mips32r2 -msoft-float
+export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+export CFLAGS_DBG = -O0 -g2
+export CFLAGS_OPT = -Os
+
+export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG)
+#$(CFLAGS_OPT)
+
+export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
+
+export LINKFLAGS += $(MIPS_HAL_LDFLAGS) -mabi=$(ABI)
+export LINKFLAGS += -Tuhi32.ld
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT)
+export LINKFLAGS += -Wl,--gc-sections
+
+# This CPU implementation is using the new core/CPU interface:
+export CFLAGS += -DCOREIF_NG=1
+
+# use newlib as libc, Actually use toolchains newlib.
+#export USEMODULE += newlib
+
+export USEMODULE += periph

--- a/cpu/mips32r2_common/cpu.c
+++ b/cpu/mips32r2_common/cpu.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#include <mips/m32c0.h>
+#include <mips/regdef.h>
+#include <mips/asm.h>
+#include <string.h>
+
+#include "periph/uart.h"
+#include "cpu.h"
+#include "kernel_init.h"
+#include "arch/panic_arch.h"
+#include <periph/timer.h>
+#include <assert.h>
+
+void mips_start(void);
+
+extern void _fini(void);
+extern void atexit(void (*)(void));
+extern void _init(void);
+extern void exit(int);
+
+#ifdef FLASH_XIP
+extern char _rom_data_copy __attribute__((section("data")));
+extern char _fdata __attribute__((section("data")));
+extern char _edata __attribute__((section("data")));
+#endif
+
+/*
+ * Note the mips toolchain crt expects to jump to main but RIOT wants the user
+ * code to start at main for some perverse reason, but thankfully the crt
+ * does provide this hook function which gets called fairly close to the jump
+ * to main, thus if we finish off the job of the crt here and never returns
+ * we can support this madness.
+ */
+void software_init_hook(void)
+{
+#ifdef FLASH_XIP
+	/* copy initialised data from its LMA to VMA */
+	memcpy(&_fdata, &_rom_data_copy, (int)&_edata -(int)&_fdata);
+#endif
+
+	atexit(_fini);
+	_init();
+
+	mips_start();
+
+	exit(-1);
+}
+
+
+void mips_start(void)
+{
+	cpu_init_early();
+	board_init();
+
+#if MODULE_NEWLIB
+#error "This Port is designed to work with the (newlib) C library provided with the mips sdk toolchain"
+#endif
+
+	/* kernel_init */
+	kernel_init();
+}
+
+void panic_arch(void)
+{
+	printf("\nPANIC!\n");
+	assert(0);
+	while (1) {}
+}
+

--- a/cpu/mips32r2_common/include/cpu.h
+++ b/cpu/mips32r2_common/include/cpu.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#ifndef CPU_H_
+#define CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "irq.h"
+
+/* This file must exist else RIOT won't compile */
+
+static inline void cpu_init_early(void)
+{
+}
+
+static inline void cpu_print_last_instruction(void)
+{
+}
+
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cpu/mips32r2_common/include/cpu_conf.h
+++ b/cpu/mips32r2_common/include/cpu_conf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#ifndef _CPU_CONF_H_
+#define _CPU_CONF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
+#define THREAD_EXTRA_STACKSIZE_PRINTF   (1024)
+#endif
+#ifndef THREAD_STACKSIZE_DEFAULT
+#define THREAD_STACKSIZE_DEFAULT        (4096)
+#endif
+#ifndef THREAD_STACKSIZE_IDLE
+
+/*
+ * EXTRA PRINTF needed when debug logging turned on on code which
+ * runs on this thread eg timer debug
+ */
+#define THREAD_STACKSIZE_IDLE           (1024 + THREAD_EXTRA_STACKSIZE_PRINTF)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cpu/mips32r2_common/irq_arch.c
+++ b/cpu/mips32r2_common/irq_arch.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#include <mips/m32c0.h>
+#include "arch/irq_arch.h"
+
+
+unsigned int irq_arch_enable(void)
+{
+	unsigned int status;
+	asm volatile ("ei %0" : "=r"(status));
+	return status;
+}
+
+unsigned int irq_arch_disable(void)
+{
+	unsigned int status;
+	asm volatile ("di %0" : "=r"(status));
+	return status;
+}
+
+void irq_arch_restore(unsigned int state)
+{
+	if (state & SR_IE) {
+		mips32_bs_c0(C0_STATUS, SR_IE);
+	} else {
+		mips32_bc_c0(C0_STATUS, SR_IE);
+	}
+}
+
+int irq_arch_in(void)
+{
+	return (mips32_get_c0(C0_STATUS) & SR_EXL) != 0;
+}

--- a/cpu/mips32r2_common/lpm_arch.c
+++ b/cpu/mips32r2_common/lpm_arch.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#include <mips/m32c0.h>
+#include "arch/lpm_arch.h"
+
+void lpm_arch_init(void)
+{
+
+}
+
+enum lpm_mode lpm_arch_set(enum lpm_mode target)
+{
+	if (target == LPM_IDLE || target == LPM_SLEEP) {
+	/* Dont wait if interrupts are not enabled - we would never return!*/
+		if (mips32_get_c0(C0_STATUS) & SR_IE)
+			asm volatile("wait");
+	}
+	return LPM_ON; /* once wait returns we are back 'on' */
+}
+
+enum lpm_mode lpm_arch_get(void)
+{
+	return 0;
+}
+
+void lpm_arch_awake(void)
+{
+
+}
+
+void lpm_arch_begin_awake(void)
+{
+
+}
+
+void lpm_arch_end_awake(void)
+{
+
+}

--- a/cpu/mips32r2_common/mips_excpt_entry.S
+++ b/cpu/mips32r2_common/mips_excpt_entry.S
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2014-2015, Imagination Technologies Limited and/or its
+ *                      affiliated group companies.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+/* ************ PLEASE READ ME !!!!  ****************
+
+	This file is a copy of the mips_excpt_entry.S from $MIPS_ELF_ROOT/share/mips/hal
+	(from the 2016.05-03 version) with a single modification, we add a global flag
+	'__exception_restore' so we can jump to the restore code sequence from C.
+
+	Future toolchain versions will have this change included and this file will
+	be no longer needed.
+
+	Thanks for reading.
+*/
+
+
+# Keep each function in a separate named section
+#define _FUNCTION_SECTIONS_
+.set nomips16
+
+#include <mips/asm.h>
+#include <mips/regdef.h>
+#include <mips/cpu.h>
+#include <mips/hal.h>
+
+# Context size, adjusted for ABI parameter area
+#define ADJ (NARGSAVE * SZARG)
+# Round up to 16-byte boundary (maximum stack alignment required for any
+# supported ABI)
+#define CTX_SIZEROUND ((CTX_SIZE + ALSZ) & ALMASK)
+#define CTX_SIZEADJ (CTX_SIZEROUND + ADJ)
+
+#define e_ISR	s1
+#define e_CR	s3
+#define e_BADV	s4
+#define e_SR	s5
+#define e_EPC	s6
+#define e_RA	s7
+
+# DESCRIPTION: Exception entry point. This is small because it must go at
+#			   EBASE+0x180. It saves enough context to chain onwards to
+#			   __exception_save.
+#
+LEAF(__exception_entry)
+	.set	push
+	.set	noat
+.weak   _mips_tlb_refill
+	_mips_tlb_refill = __exception_save
+__tlb_refill_loop:
+	# Support an alternative entry point at the start of the exception
+	# vector.  Since the exception vector is normally placed first
+	# in the link map this allows a user to start execution from the
+	# same address that an executable is loaded to.
+	LA	k1, __first_boot
+	lw	k1, 0(k1)
+	beqz	k1, 1f
+	# The start code is responsible for clearing __first_boot prior
+	# to installing the exception handlers.
+	j	_start
+1:
+	LA	k1, _mips_tlb_refill
+	beqz	k1, __tlb_refill_loop
+	jr	k1
+
+	.org 0x80
+.weak   _mips_xtlb_refill
+	_mips_xtlb_refill = __exception_save
+__xtlb_refill_loop:
+	LA	k1, _mips_xtlb_refill
+	beqz	k1, __xtlb_refill_loop
+	jr	k1
+
+	.org 0x100
+.weak   _mips_cache_error
+__cache_error_loop:
+	LA	k1, _mips_cache_error
+	beqz	k1, __cache_error_loop
+	jr	k1
+
+	.org 0x180
+	# Free up k1, defering sp adjustment until later
+	REG_S	k1, (-CTX_SIZEROUND + CTX_K1)(sp)
+
+	# Use k1 to invoke __exception_save
+	LA	k1, _mips_general_exception
+	jr	k1
+	.set    pop
+END(__exception_entry)
+
+#
+# FUNCTION:	__exception_save
+#
+# DESCRIPTION: Exception context save. Save the context, then fake up a call
+#              frame.
+#
+ANESTED(__exception_save, _mips_general_exception, CTX_SIZEADJ, zero)
+	.globl  __exception_save;
+    .globl  __exception_restore;
+	.set	push
+	.set	noat
+
+	# k1 is already saved, so use it to save the users sp
+	move	k1, sp
+	# Finally adjust sp
+	PTR_ADDU sp, sp, -CTX_SIZEADJ	# This should be picked up by the backtracer
+
+	# Save context
+	REG_S	$1, CTX_REG(1) + ADJ(sp)
+	REG_S	$2, CTX_REG(2) + ADJ(sp)
+	REG_S	$3, CTX_REG(3) + ADJ(sp)
+	REG_S	$4, CTX_REG(4) + ADJ(sp)
+	REG_S	$5, CTX_REG(5) + ADJ(sp)
+	REG_S	$6, CTX_REG(6) + ADJ(sp)
+	REG_S	$7, CTX_REG(7) + ADJ(sp)
+	REG_S	$8, CTX_REG(8) + ADJ(sp)
+	REG_S	$9, CTX_REG(9) + ADJ(sp)
+	REG_S	$10, CTX_REG(10) + ADJ(sp)
+	REG_S	$11, CTX_REG(11) + ADJ(sp)
+	REG_S	$12, CTX_REG(12) + ADJ(sp)
+	REG_S	$13, CTX_REG(13) + ADJ(sp)
+	REG_S	$14, CTX_REG(14) + ADJ(sp)
+	REG_S	$15, CTX_REG(15) + ADJ(sp)
+	REG_S	$16, CTX_REG(16) + ADJ(sp)
+	REG_S	$17, CTX_REG(17) + ADJ(sp)
+	REG_S	$18, CTX_REG(18) + ADJ(sp)
+	REG_S	$19, CTX_REG(19) + ADJ(sp)
+	REG_S	$20, CTX_REG(20) + ADJ(sp)
+	REG_S	$21, CTX_REG(21) + ADJ(sp)
+	REG_S	$22, CTX_REG(22) + ADJ(sp)
+	REG_S	$23, CTX_REG(23) + ADJ(sp)
+	REG_S	$24, CTX_REG(24) + ADJ(sp)
+	REG_S	$25, CTX_REG(25) + ADJ(sp)
+	REG_S	$26, CTX_REG(26) + ADJ(sp)
+	# k1/$27 has already been saved
+	REG_S	$28, CTX_REG(28) + ADJ(sp)
+	REG_S	k1, CTX_REG(29) + ADJ(sp) # Use saved sp from earlier
+	REG_S	$30, CTX_REG(30) + ADJ(sp)
+	REG_S	$31, CTX_REG(31) + ADJ(sp)
+	PTR_S	$0, CTX_LINK + ADJ(sp) # Clear the link field
+
+#if (__mips_isa_rev < 6)
+	mfhi	$9
+	mflo	$10
+	REG_S	$9, CTX_HI0 + ADJ(sp)
+	REG_S	$10, CTX_LO0 + ADJ(sp)
+#endif
+
+	# Trick the backtracer into stepping back to the point where the exception
+	# occurred.
+	PTR_MFC0 ra, C0_EPC
+	mfc0	e_CR, C0_CR
+	REG_S	ra, CTX_EPC + ADJ(sp)
+
+	# Finish storing the rest of the CP0 registers
+	PTR_MFC0 $9, C0_BADVADDR
+	REG_S	$9, CTX_BADVADDR + ADJ(sp)
+	sw	e_CR, CTX_CAUSE + ADJ(sp)
+
+	move	$11, $0
+	move	$12, $0
+	mfc0	$9, C0_CONFIG3
+	ext	$10, $9, CFG3_BP_SHIFT, 1
+	beqz	$10, 1f
+	mfc0	$11, C0_BADPINSTR
+1:
+	ext	$9, $9, CFG3_BI_SHIFT, 1
+	beqz	$9, 1f
+	mfc0	$12, C0_BADINSTR
+1:
+	sw	$11, CTX_BADPINSTR + ADJ(sp)
+	sw	$12, CTX_BADINSTR + ADJ(sp)
+
+	# Start computing the address of the context for a0
+	move	a0, sp
+
+	# Clear EXL.  Exceptions can now nest.
+	mfc0	e_SR, C0_SR
+	sw	e_SR, CTX_STATUS + ADJ(sp)
+	lui	$9, %hi(~SR_EXL)
+	addiu	$9, $9, %lo(~SR_EXL)
+	and	e_SR, e_SR, $9
+	mtc0	e_SR, C0_SR
+
+	# Manually set up the return address to restore the context below
+	LA	ra, __exception_restore
+	# Extract the cause code
+	and	a1, e_CR, CR_XMASK
+
+	# Finish computing the address of the context for a0
+	addiu	a0, a0, ADJ
+
+	# Shift exception number down into expected range
+	srl	a1, a1, 2
+
+	# Call the handler, indirect through t9 albeit not for any specific
+	# reason
+	LA	t9, _mips_handle_exception
+	jr	t9
+
+# Return point from handler
+# Load context
+# now a function on its own, note save code just falls through.
+
+
+__exception_restore:
+
+#if (__mips_isa_rev < 6)
+	REG_L	$9, CTX_HI0 + ADJ(sp)
+	REG_L	$10, CTX_LO0 + ADJ(sp)
+	mthi	$9
+	mtlo	$10
+#endif
+
+	REG_L	$1, CTX_REG(1) + ADJ(sp)
+	REG_L	$2, CTX_REG(2) + ADJ(sp)
+	REG_L	$3, CTX_REG(3) + ADJ(sp)
+	REG_L	$4, CTX_REG(4) + ADJ(sp)
+	REG_L	$5, CTX_REG(5) + ADJ(sp)
+	REG_L	$6, CTX_REG(6) + ADJ(sp)
+	REG_L	$7, CTX_REG(7) + ADJ(sp)
+	REG_L	$8, CTX_REG(8) + ADJ(sp)
+	REG_L	$9, CTX_REG(9) + ADJ(sp)
+	REG_L	$10, CTX_REG(10) + ADJ(sp)
+	REG_L	$11, CTX_REG(11) + ADJ(sp)
+	REG_L	$12, CTX_REG(12) + ADJ(sp)
+	REG_L	$13, CTX_REG(13) + ADJ(sp)
+	REG_L	$14, CTX_REG(14) + ADJ(sp)
+	REG_L	$15, CTX_REG(15) + ADJ(sp)
+	REG_L	$16, CTX_REG(16) + ADJ(sp)
+	REG_L	$17, CTX_REG(17) + ADJ(sp)
+	REG_L	$18, CTX_REG(18) + ADJ(sp)
+	REG_L	$19, CTX_REG(19) + ADJ(sp)
+	REG_L	$20, CTX_REG(20) + ADJ(sp)
+	REG_L	$21, CTX_REG(21) + ADJ(sp)
+	REG_L	$22, CTX_REG(22) + ADJ(sp)
+	REG_L	$23, CTX_REG(23) + ADJ(sp)
+	REG_L	$24, CTX_REG(24) + ADJ(sp)
+	REG_L	$25, CTX_REG(25) + ADJ(sp)
+	# $26/K0 and $27/K1 are restored with interrupts disabled
+	REG_L	$28, CTX_REG(28) + ADJ(sp)
+	# $29/SP is restored last
+	REG_L	$30, CTX_REG(30) + ADJ(sp)
+	REG_L	$31, CTX_REG(31) + ADJ(sp)
+	di
+	lw	k0, CTX_STATUS + ADJ(sp)
+	REG_L	k1, CTX_EPC + ADJ(sp)
+	mtc0	k0, C0_SR
+	PTR_MTC0 k1, C0_EPC
+	ehb
+	REG_L	k0, CTX_K0 + ADJ(sp)
+	REG_L	k1, CTX_K1 + ADJ(sp)
+	REG_L	sp, CTX_SP + ADJ(sp)
+	# Return from exception
+	eret
+	.set	pop
+END(__exception_save)

--- a/cpu/mips32r2_common/periph/Makefile
+++ b/cpu/mips32r2_common/periph/Makefile
@@ -1,0 +1,3 @@
+MODULE = periph
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/mips32r2_common/periph/timer.c
+++ b/cpu/mips32r2_common/periph/timer.c
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#include <mips/cpu.h>
+#include <mips/m32c0.h>
+#include <mips/regdef.h>
+#include <mips/asm.h>
+
+#include <periph/timer.h>
+#include "cpu_conf.h"
+#include <stdio.h>
+#include "sched.h"
+#include "thread.h"
+#include "board.h"
+#include "irq.h"
+
+/*
+ * setting TIMER_ACCURACY_SHIFT lower will improve accuracy
+ * at the cost of more regular interrupts (hence less power efficient).
+ * */
+#define TIMER_ACCURACY_SHIFT 10
+#define TIMER_ACCURACY (1 << TIMER_ACCURACY_SHIFT)
+#define CHANNELS 3
+
+/* TICKS_PER_US must be set in the board file */
+#ifndef TICKS_PER_US
+#error "Please set TICK_PER_US in your board file"
+#endif
+
+/*
+ * The base MIPS count / compare timer is fixed frequency at core clock / 2
+ * and is pretty basic This timer is currently only supported in Vectored
+ * Interrupt Mode (VI), EIC mode is not supported yet.
+ *
+ * RIOT's xtimer expects the timer to operate at 1MHZ or any 2^n multiple or
+ * factor of this, thus we maintain a software timer which counts at 1MHz.
+ * This is not particularly power efficient and may add latency too.
+ *
+ * If other SoC specific timers are available which are more flexible then
+ * it is advised to use them, this timer is a fallback version
+ * that should work on all MIPS implementations.
+ *
+ */
+
+static timer_isr_ctx_t timer_isr_ctx;
+volatile unsigned int counter;
+volatile unsigned int compares[CHANNELS];
+static volatile int spurious_int;
+
+int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+{
+	int i;
+
+	if (dev != 0) {
+		return -1;
+	}
+
+	(void)freq; /*Cannot adjust Frequency */
+
+	timer_isr_ctx.cb = cb;
+	timer_isr_ctx.arg = arg;
+
+	/* Clear down soft counters */
+	for (i = 0; i < CHANNELS; i++) {
+		compares[i] = 0;
+	}
+
+	counter = 1 << TIMER_ACCURACY_SHIFT;
+
+	/* Set compare up */
+	mips_setcompare(mips_getcount() + TICKS_PER_US * TIMER_ACCURACY);
+
+	/* Start the timer if stopped */
+	mips32_bc_c0(C0_CAUSE, CR_DC);
+
+	/* Enable Timer Interrupts */
+#if defined (PIC32MX) || defined(PIC32MZ)
+
+#ifdef PIC32MZ
+	volatile uint32_t * const _IEC0_SET = (uint32_t *) 0xbf8100c8;
+	volatile uint32_t * const _IPC0 = (uint32_t *) 0xbf810140;
+#else /*MX*/
+	volatile uint32_t * const _IEC0_SET = (uint32_t *) 0xbf881068;
+	volatile uint32_t * const _IPC0 = (uint32_t *) 0xbf881090;
+#endif
+	/* Enable IRQ 0 CPU timer interrupt */
+	*_IEC0_SET = 0x1;
+
+	/* Set IRQ 0 to priority 1.0 */
+	*_IPC0 = 0x4;
+#else
+	mips32_bs_c0(C0_STATUS, SR_HINT5);
+#endif
+
+	return 0;
+}
+
+int timer_set(tim_t dev, int channel, unsigned int timeout)
+{
+	if (dev != 0) {
+		return -1;
+	}
+
+	if (channel >= CHANNELS) {
+		return -1;
+	}
+
+	timeout >>= TIMER_ACCURACY_SHIFT;
+	timeout <<= TIMER_ACCURACY_SHIFT;
+
+	uint32_t status = irq_arch_disable();
+	compares[channel] = counter + timeout;
+	irq_arch_restore(status);
+
+	return channel;
+}
+
+int timer_set_absolute(tim_t dev, int channel, unsigned int value)
+{
+	if (dev != 0) {
+		return -1;
+	}
+
+	if (channel >= CHANNELS) {
+		return -1;
+	}
+
+	value >>= TIMER_ACCURACY_SHIFT;
+	value <<= TIMER_ACCURACY_SHIFT;
+
+	uint32_t status = irq_arch_disable();
+	compares[channel] = value;
+	irq_arch_restore(status);
+
+	return channel;
+}
+
+int timer_clear(tim_t dev, int channel)
+{
+	if (dev != 0) {
+		return -1;
+	}
+
+	if (channel >= CHANNELS) {
+		return -1;
+	}
+
+	uint32_t status = irq_arch_disable();
+	compares[channel] = 0;
+	irq_arch_restore(status);
+
+	return channel;
+}
+
+unsigned int timer_read(tim_t dev)
+{
+	if (dev != 0) {
+		return -1;
+	}
+	return counter;
+}
+
+void timer_start(tim_t dev)
+{
+	mips32_bc_c0(C0_CAUSE, CR_DC);
+}
+
+void timer_stop(tim_t dev)
+{
+	mips32_bs_c0(C0_CAUSE, CR_DC);
+}
+
+void timer_irq_enable(tim_t dev)
+{
+#if defined (PIC32MX) || defined(PIC32MZ)
+#ifdef PIC32MZ
+	volatile uint32_t * const _IEC0_SET = (uint32_t *) 0xbf8100c8;
+#else /*MX*/
+	volatile uint32_t * const _IEC0_SET = (uint32_t *) 0xbf881068;
+#endif
+	*_IEC0_SET = 0x1;
+#else
+	mips32_bs_c0(C0_STATUS, SR_HINT5);
+#endif
+}
+
+void timer_irq_disable(tim_t dev)
+{
+#if defined (PIC32MX) || defined(PIC32MZ)
+#ifdef PIC32MZ
+	volatile uint32_t * const _IEC0_CLR = (uint32_t *) 0xbf8100c4;
+#else /*MX*/
+	volatile uint32_t * const _IEC0_CLR = (uint32_t *) 0xbf881064;
+#endif
+	*_IEC0_CLR = 0x1;
+#else
+	mips32_bc_c0(C0_STATUS, SR_HINT5);
+#endif
+}
+
+/* note Compiler inserts GP context save + restore code (to current stack).*/
+#if defined (PIC32MX) || defined(PIC32MZ)
+/*
+ * This is a hack - PIC32 uses EIC mode + MCU-ASE, currently the toolchain
+ * does not support correct placement of EIC mode vectors (it is coming though)
+ * But the default PIC interrupt controller defaults to non vectored mode
+ * anyway with all interrupts coming via vector 0 which is equivalent to 'sw0'
+ * in 'VI' mode.
+ *
+ * Thus all PIC32 interrupts should be decoded here (currently only Timer is
+ * used)
+ *
+ * When toolchain support is available we could move to full vector mode but
+ * this does take up significant space (MCU-ASE provides 256 vectors at 32B
+ * spacing (the default) thats 8KB of vector space!), So a single entry point
+ * may be better anyway.
+ *
+ */
+void __attribute__ ((interrupt("vector=sw0"), keep_interrupts_masked)) _mips_isr_sw0(void)
+#else
+void __attribute__ ((interrupt("vector=hw5"))) _mips_isr_hw5(void)
+#endif
+{
+	register int cr = mips_getcr();
+	if (cr & CR_TI) {
+
+#if defined(PIC32MX) || defined(PIC32MZ)
+		/* ACK The timer interrupt*/
+#ifdef PIC32MZ
+		volatile uint32_t * const _IFS0_CLR = (uint32_t *) 0xbf810044;
+#else /*MX*/
+		volatile uint32_t * const _IFS0_CLR = (uint32_t *) 0xbf881034;
+#endif
+		*_IFS0_CLR = 0x1;
+#endif
+
+
+		uint32_t status = irq_arch_disable();
+		counter += TIMER_ACCURACY;
+		irq_arch_restore(status);
+
+		if (counter == compares[0]) {
+		/*
+		 * The Xtimer code expects the ISR to take some time
+		 * but our counter is a fake software one, so bump it a
+		 * bit to give the impression some time elapsed in the ISR.
+		 * Without this the callback ( _shoot(timer) on xtimer_core.c )
+		 * never fires.
+		 */
+			counter += TIMER_ACCURACY;
+			timer_isr_ctx.cb(timer_isr_ctx.arg, 0);
+
+			if (sched_context_switch_request)
+				thread_yield();
+		}
+		if (counter == compares[1]) {
+			timer_isr_ctx.cb(timer_isr_ctx.arg, 1);
+
+			if (sched_context_switch_request)
+				thread_yield();
+		}
+		if (counter == compares[2]) {
+			timer_isr_ctx.cb(timer_isr_ctx.arg, 2);
+
+			if(sched_context_switch_request)
+				thread_yield();
+		}
+
+		mips_setcompare(mips_getcount() + TICKS_PER_US * TIMER_ACCURACY);
+
+	} else {
+		spurious_int++;
+	}
+}
+

--- a/cpu/mips32r2_common/thread_arch.c
+++ b/cpu/mips32r2_common/thread_arch.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+#include <mips/cpu.h>
+#include <mips/hal.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <stdio.h>
+
+#include "thread.h"
+#include "cpu.h"
+#include "irq.h"
+#include "cpu_conf.h"
+#include "periph_conf.h" /* for debug uart number */
+#include "periph/uart.h"
+
+#define STACK_END_PAINT 0xdeadc0de
+#define C0_STATUS_EXL 2
+
+/*
+ *    Stack Layout, note struct gpctx is defined in
+ *    $MIPS_ELF_ROOT/mips-mti-elf/include/mips/hal.h
+ *
+ *    Top Of Stack
+ *     ---------------
+ *    |               |
+ *    |  User Code    |
+ *    |               |
+ *     ---------------  <--- gpctx->sp
+ *    |               |
+ *    |    gpctx      |
+ *    |               |
+ *     ---------------
+ *    |  16 byte pad  |
+ *     ---------------   <--- sched_active_thread->sp
+ */
+
+char *thread_arch_stack_init(thread_task_func_t task_func, void *arg,
+		void *stack_start, int stack_size)
+{
+	/* make sure it is aligned to 8 bytes this is a requirement of the O32 ABI */
+	uintptr_t *p = (uintptr_t *)((long)(stack_start + stack_size) & ~7);
+	uintptr_t *fp;
+
+	/* paint */
+	*p = STACK_END_PAINT;
+
+	/* prepare stack for __exception_restore() */
+	fp = p;
+	p -= sizeof(struct gpctx) / sizeof(unsigned int);
+
+	struct gpctx *initial_ctx = (struct gpctx *)p;
+	initial_ctx->a[0] = (reg_t)arg;
+	initial_ctx->status = mips32_get_c0(C0_STATUS) | SR_IE; /* Enable interrupts */
+	asm volatile ("sw    $gp, 0(%0)" : : "r"(&initial_ctx->gp));
+	initial_ctx->epc = (reg_t)task_func;
+	initial_ctx->ra = (reg_t)sched_task_exit;
+	initial_ctx->sp = (reg_t)fp;
+
+	/*
+	 * note the -4 (-16 bytes) as the toolchain exception handling code
+	 * adjusts the sp for alignment
+	 */
+	p -= 4;
+
+	return (void *)p;
+}
+
+void thread_arch_stack_print(void)
+{
+	uintptr_t *sp = (void *)sched_active_thread->sp;
+
+	printf("Stack trace:\n");
+	while (*sp != STACK_END_PAINT) {
+		printf(" 0x%p: 0x%08lx\n", sp, *sp);
+		sp++;
+	}
+}
+
+extern void __exception_restore(void);
+void thread_arch_start_threading(void)
+{
+	unsigned int status = mips32_get_c0(C0_STATUS);
+
+	/*
+	 * Set Exception level if we are not already running at it
+	 * the EXL mode depends on the bootloader.
+	 */
+
+	if ((status & C0_STATUS_EXL) == 0) {
+		mips32_set_c0(C0_STATUS, status | C0_STATUS_EXL);
+	}
+
+	sched_run();
+
+	asm volatile ("lw    $sp, 0(%0)" : : "r"(&sched_active_thread->sp));
+
+	__exception_restore();
+
+	UNREACHABLE();
+}
+
+void thread_arch_yield(void)
+{
+	/*
+	 * throw a syscall exception to get into exception level
+	 * we context switch at exception level.
+	 *
+	 * Note syscall 1 is reserved for UHI see:
+	 * http://wiki.prplfoundation.org/w/images/4/42/UHI_Reference_Manual.pdf
+	 */
+	asm volatile("syscall 2");
+}
+
+/*
+ * This attribute should not really be needed, it works around a toolchain
+ * issue in 2016.05-03.
+ */
+void __attribute__((nomips16))
+_mips_handle_exception(struct gpctx *ctx, int exception)
+{
+	unsigned int syscall_num = 0, return_instruction = 0;
+	struct gpctx *new_ctx;
+
+	switch (exception) {
+
+	case EXC_SYS:
+		syscall_num = (*((unsigned int *)(ctx->epc)) >> 6) & 0xFFFF;
+#ifdef DEBUG_VIA_UART
+#include <mips/uhi_syscalls.h>
+		/*
+		 * intercept UHI write syscalls (printf) which would normally
+		 * get routed to debug probe or bootloader handler and output
+		 * via a UART
+		 */
+
+		if (syscall_num == __MIPS_UHI_SYSCALL_NUM) {
+			if (ctx->t2[1] == __MIPS_UHI_WRITE &&
+			   (ctx->a[0] == STDOUT_FILENO || ctx->a[0] == STDERR_FILENO)) {
+				uint32_t status = irq_arch_disable();
+				uart_write(DEBUG_VIA_UART, (uint8_t *)ctx->a[1], ctx->a[2]);
+				ctx->v[0] = ctx->a[2];
+				ctx->epc += 4; /* move PC past the syscall */
+				irq_arch_restore(status);
+				return;
+			} else if (ctx->t2[1] == __MIPS_UHI_FSTAT &&
+				(ctx->a[0] == STDOUT_FILENO || ctx->a[0] == STDERR_FILENO)) {
+				/*
+				 * Printf fstat's the stdout/stderr file so
+				 * fill out a minimal struct stat.
+				 */
+				struct stat *sbuf = (struct stat *)ctx->a[1];
+				sbuf->st_mode = S_IRUSR | S_IWUSR | S_IWGRP;
+				sbuf->st_blksize = BUFSIZ;
+				sbuf->st_dev = 0;
+				sbuf->st_ino = 0;
+				sbuf->st_nlink = 0;
+				sbuf->st_uid = 0;
+				sbuf->st_gid = 0;
+				sbuf->st_rdev = 0;
+				sbuf->st_size = 0;
+				sbuf->st_atime = (time_t) 0;
+				sbuf->st_spare1 = 0;
+				sbuf->st_mtime = (time_t) 0;
+				sbuf->st_spare2 = 0;
+				sbuf->st_ctime = (time_t) 0;
+				sbuf->st_spare3 = 0;
+				sbuf->st_blocks = 0;
+				sbuf->st_spare4[0] = 0;
+				sbuf->st_spare4[1] = 0;
+				/* return 0 */
+				ctx->v[0] = 0;
+				ctx->epc += 4; /* move PC past the syscall */
+				return;
+			}
+		} else
+#endif
+		if (syscall_num == 2) {
+			/*
+			 * Syscall 1 is reserved for UHI.
+			 *
+			 * save the stack pointer in the thread info
+			 * note we want the saved value to include the
+			 * saved off context and the 16 bytes padding.
+			 * Note we cannot use the current sp value as
+			 * the prologue of this function has adjusted it
+			 */
+			sched_active_thread->sp = (char *)(ctx->sp
+					- sizeof(struct gpctx) - 16);
+
+			sched_run();
+
+			new_ctx = (struct gpctx *)((int)sched_active_thread->sp + 16);
+
+			return_instruction = *((unsigned int *)(new_ctx->epc));
+
+			if ((return_instruction & 0xfc00003f) == 0xC) {/* syscall */
+				new_ctx->epc += 4; /* move PC past the syscall */
+			}
+
+			/*
+			 * The toolchain Exception restore code just wholesale copies the
+			 * status register from the context back to the register loosing
+			 * any changes that may have occured, 'status' is really global state
+			 * You dont enable interrupts on one thread and not another...
+			 * So we just copy the current status value into the saved value
+			 * so nothing changes on the restore
+			 */
+
+			new_ctx->status = mips32_get_c0(C0_STATUS);
+
+			asm volatile ("lw    $sp, 0(%0)" : : "r"(&sched_active_thread->sp));
+
+			/*
+			 * Jump straight to the exception restore code
+			 * if we return this functions prologue messes up
+			 * the stack  pointer
+			 */
+			__exception_restore();
+
+			UNREACHABLE();
+		}
+		break;
+
+		/* default: */
+	}
+	/* Pass all other exceptions through to the toolchain handler */
+	__exception_handle(ctx, exception);
+}
+

--- a/cpu/mips_pic32mx/Makefile
+++ b/cpu/mips_pic32mx/Makefile
@@ -1,0 +1,15 @@
+ifeq ("$(OS)","Windows_NT")
+MIPS_ELF_ROOT?=C:\cross-mips-mti-elf
+else
+MIPS_ELF_ROOT?=/opt/imgtec/Toolchains/mips-mti-elf/2016.05-03
+endif
+
+# define the module that is build
+MODULE = cpu
+
+# add a list of subdirectories, that should also be build
+DIRS += periph $(RIOTCPU)/mips32r2_common
+
+include $(RIOTBASE)/Makefile.base
+
+

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -1,0 +1,49 @@
+# Target triple for the build.
+export TARGET_ARCH ?= mips-mti-elf
+
+export ABI=32
+export MEMORY_BASE=0x80000000
+export MEMORY_SIZE=128K
+export APP_START=0x80000000
+export ROMABLE = 1
+
+include $(MIPS_ELF_ROOT)/share/mips/rules/mipshal.mk
+
+# define build specific options
+export CFLAGS_CPU   = -EL -march=m4k
+export CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums
+export CFLAGS_DBG = -O0 -g2
+export CFLAGS_OPT = -Os
+
+export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) -DSKIP_COPY_TO_RAM
+#$(CFLAGS_OPT)
+
+export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
+
+export LINKFLAGS += $(MIPS_HAL_LDFLAGS) -mabi=$(ABI) -Wl,--defsym,__use_excpt_boot=0
+export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/pic32mx512_12_128_uhi.ld
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) #$(CFLAGS_OPT)
+export LINKFLAGS += -Wl,--print-gc-sections #-Wl,--no-gc-sections #DONT GARBAGE COLLECT AS WE NEED TO KEEP THE CONFIG SETTINGS
+
+# This CPU implementation is using the new core/CPU interface:
+export CFLAGS += -DCOREIF_NG=1
+
+export USEMODULE += periph
+
+# the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
+export OBJCOPY = objcopy #use system objcopy as toolchain one is broken.
+export OFLAGS += -O ihex \
+				--change-section-lma .bootflash-0xA0000000 \
+				--change-section-lma .exception_vector-0x80000000 \
+				--change-section-lma .text-0x80000000 \
+				--change-section-lma .init-0x80000000 \
+				--change-section-lma .fini-0x80000000 \
+				--change-section-lma .eh_frame-0x80000000 \
+				--change-section-lma .gcc_except_table-0x80000000 \
+				--change-section-lma .jcr-0x80000000 \
+				--change-section-lma .ctors-0x80000000 \
+				--change-section-lma .dtors-0x80000000 \
+				--change-section-lma .rodata-0x80000000 \
+				--change-section-lma .data-0x80000000 \
+				--change-section-lma .bss-0x80000000 \
+				--change-section-lma .startdata-0x80000000 \

--- a/cpu/mips_pic32mx/include/cpu.h
+++ b/cpu/mips_pic32mx/include/cpu.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+#ifndef _CPU_H_
+#define _CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <assert.h>
+#include "irq.h"
+
+/* We run from flash on PIC32 */
+#define FLASH_XIP 1
+
+extern void dummy(void);
+static inline void cpu_init_early(void)
+{
+	/* Stop the linker from throwing away the PIC32 config register settings */
+	dummy();
+}
+
+
+/* This file must exist else RIOT won't compile */
+static inline void cpu_print_last_instruction(void)
+{
+
+}
+
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cpu/mips_pic32mx/include/cpu_conf.h
+++ b/cpu/mips_pic32mx/include/cpu_conf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#ifndef _CPU_CONF_H_
+#define _CPU_CONF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
+#define THREAD_EXTRA_STACKSIZE_PRINTF   (2048)
+#endif
+#ifndef THREAD_STACKSIZE_DEFAULT
+#define THREAD_STACKSIZE_DEFAULT        (4096)
+#endif
+#ifndef THREAD_STACKSIZE_IDLE
+
+/*
+ * EXTRA PRINTF needed when debug logging turned on on code which
+ * runs on this thread eg timer debug
+ */
+#define THREAD_STACKSIZE_IDLE           (1024 + THREAD_EXTRA_STACKSIZE_PRINTF)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cpu/mips_pic32mx/ldscripts/pic32mx512_12_128_uhi.ld
+++ b/cpu/mips_pic32mx/ldscripts/pic32mx512_12_128_uhi.ld
@@ -1,0 +1,324 @@
+/*
+ * For all MX devices with 512K program flash / 12KB boot flash and 128KB Ram
+ *
+ * A platform and target independent link script to produce UHI
+ * compliant binaries with varying levels of system initialization
+ * support.
+ */
+
+__entry = DEFINED(__reset_vector) ? 0xbfc00000 : _start;
+ENTRY(__entry)
+OUTPUT_FORMAT("elf32-tradlittlemips", "elf32-tradbigmips", "elf32-tradlittlemips")
+GROUP(-lc -luhi -lgcc -lhal)
+SEARCH_DIR(.)
+__DYNAMIC  =  0;
+STARTUP(crt0.o)
+/* Force the exception handler to be registered */
+EXTERN(__register_excpt_handler)
+/* Force the exception handler to be included in the link */
+EXTERN(__exception_entry)
+/*
+ * Require verbose exceptions. This can be changed to pull in
+ * __exception_handle_quiet to reduce code size but be less
+ * informative
+ */
+EXTERN(__exception_handle_verbose)
+/* Force the interrupt handlers to tbe included in the link */
+EXTERN(__isr_vec)
+/* Require the UHI getargs support */
+EXTERN(__getargs)
+
+/*
+ * Set the location of the top of the stack.  A value of 0 means
+ * that it will be automatically placed at the highest address
+ * available as described by the __memory_* setttings
+ */
+PROVIDE (__stack = 0);
+
+/* Size of the memory returned by _get_ram_range */
+PROVIDE (__memory_size = 128K);
+
+/* Base of the memory returned by _get_ram_range */
+PROVIDE (__memory_base = 0x80000000);
+
+/* Stride length for tlb software invalidate for tlbinvf
+ * (mipsXXr3+). Some MIPS implementations may layout the sets/ways
+ * differently in the index register. Either sets LSB or ways LSB.
+ *
+ * By setting this to 1 we presume that sets come first. The default boot
+ * code will decrement this value from the Number of TLB entries.
+ */
+PROVIDE (__tlb_stride_length = 1);
+
+/* By default, XPA is not used even if available. To enable XPA,
+ * __enable_xpa should be 1.
+ */
+PROVIDE (__enable_xpa = 0);
+
+/*
+ * 0 = Do not use exception handler present in boot for UHI
+ * 1 = Use exception handler present in boot for UHI if BEV is 0 at
+ *     startup
+ * 2 = Always use exception handler present in boot for UHI
+ */
+PROVIDE (__use_excpt_boot = 0);
+/*
+ * Include the code to be able to return to boot context.  This is
+ * necessary if __use_excpt_boot != 0.
+ */
+EXTERN (__register_excpt_boot);
+
+ASSERT (DEFINED(__register_excpt_boot) || __use_excpt_boot == 0,
+	"Registration for boot context is required for UHI chaining")
+
+/* Control if subnormal floating-point values are flushed to zero in
+   hardware.  This applies to both FPU and MSA operations.  */
+PROVIDE (__flush_to_zero = 1);
+
+/* Set up the public symbols depending on whether the user has chosen
+   quiet or verbose exception handling above */
+EXTERN (__exception_handle);
+PROVIDE(__exception_handle = (DEFINED(__exception_handle_quiet)
+				      ? __exception_handle_quiet
+				      : __exception_handle_verbose));
+PROVIDE(_mips_handle_exception = __exception_handle);
+
+/*
+ * Initalize some symbols to be zero so we can reference them in the
+ * crt0 without core dumping. These functions are all optional, but
+ * we do this so we can have our crt0 always use them if they exist.
+ * This is so BSPs work better when using the crt0 installed with gcc.
+ * We have to initalize them twice, so we multiple object file
+ * formats, as some prepend an underscore.
+ */
+PROVIDE (hardware_exit_hook = 0);
+PROVIDE (hardware_hazard_hook = 0);
+PROVIDE (hardware_init_hook = 0);
+PROVIDE (software_init_hook = 0);
+
+/* The default base address for application flash code is 0x9D001000 */
+PROVIDE (__app_start = 0x9D001000) ;
+/* Set default vector spacing to 32 bytes. */
+PROVIDE (__isr_vec_space = 32);
+/* Leave space for 9 vector entries by default. 8 entry points and one
+   fallback handler. */
+PROVIDE (__isr_vec_count = 9);
+/*
+ * The start of boot flash must be set if including boot code.  By default
+ * the use of boot code will mean that application code is copied
+ * from flash to RAM at runtime before being executed.
+ */
+PROVIDE (__boot_flash_start = DEFINED(__reset_vector) ? 0xbfc00000 : __app_start);
+
+PROVIDE (__bev_override = 0x9fc00000);
+
+PROVIDE (__flash_vector_start = 0x9D000000);
+
+PROVIDE (__flash_app_start = 0x9D001000);
+
+SECTIONS
+{
+  /* Start of bootrom */
+  .bootflash __bev_override : /* Runs uncached (from 0xBfc00000) until I$ is
+			       initialized. */
+  AT (__boot_flash_start)
+  {
+    __base = .;
+
+    *(.reset)		/* Reset entry point. */
+    *(.boot)		/* Boot code. */
+    . = ALIGN(8);
+
+    . = __base + 0x2ff0; /*Alternate Config bits (lower Alias)*/
+    *(.devcfg3)
+    *(.devcfg2)
+    *(.devcfg1)
+    *(.devcfg0)
+  } = 0xFFFFFFFF
+
+  /* Start of the application */
+  .exception_vector ALIGN(__flash_vector_start, 0x1000) :
+  AT (__flash_vector_start)
+  {
+    PROVIDE (__excpt_ebase = ABSOLUTE(.));
+    __base = .;
+    KEEP(* (.text.__exception_entry))
+
+    . = __base + 0x200;
+    KEEP(* (SORT(.text.__isr_vec*)))
+    /* Leave space for all the vector entries */
+    . = __base + 0x200 + (__isr_vec_space * __isr_vec_count);
+    ASSERT(__isr_vec_space == (DEFINED(__isr_vec_sw0)
+			       ? __isr_vec_sw1 - __isr_vec_sw0
+			       : __isr_vec_space),
+	   "Actual ISR vector spacing does not match __isr_vec_space");
+    ASSERT(__base + 0x200 == (DEFINED(__isr_vec_sw0)
+			      ? __isr_vec_sw0 & 0xfffffffe : __base + 0x200),
+	   "__isr_vec_sw0 is not placed at EBASE + 0x200");
+    . = ALIGN(8);
+  } = 0
+
+  . = __flash_app_start;
+
+  .text : {
+     _ftext = . ;
+    PROVIDE (eprol  =  .);
+    *(.text)
+    *(.text.*)
+    *(.gnu.linkonce.t.*)
+    *(.mips16.fn.*)
+    *(.mips16.call.*)
+  }
+  .init : {
+    KEEP (*(.init))
+  }
+  .fini : {
+    KEEP (*(.fini))
+  }
+  .rel.sdata : {
+    PROVIDE (__runtime_reloc_start = .);
+    *(.rel.sdata)
+    PROVIDE (__runtime_reloc_stop = .);
+  }
+  PROVIDE (etext  =  .);
+  _etext  =  .;
+
+  .eh_frame_hdr : { *(.eh_frame_hdr) }
+  .eh_frame : { KEEP (*(.eh_frame)) }
+  .gcc_except_table : { *(.gcc_except_table*) }
+  .jcr : { KEEP (*(.jcr)) }
+  .ctors    :
+  {
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+
+    KEEP (*crtbegin.o(.ctors))
+
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+  }
+
+  .dtors    :
+  {
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+  }
+
+  . = .;
+  .MIPS.abiflags : {
+    __MIPS_abiflags_start = .;
+    *(.MIPS.abiflags)
+    __MIPS_abiflags_end = .;
+  }
+  .rodata : {
+    *(.rdata)
+    *(.rodata)
+    *(.rodata.*)
+    *(.gnu.linkonce.r.*)
+  }
+  _rom_data_copy = .;
+
+  .data ALIGN(__memory_base + 0x1000, 16) :
+  AT (_rom_data_copy)
+  {
+     _fdata = .;
+
+      *(.data)
+      *(.data.*)
+      *(.gnu.linkonce.d.*)
+
+    . = ALIGN(8);
+    _gp = . + 0x8000;
+    __global = _gp;
+
+      *(.lit8)
+      *(.lit4)
+      *(.sdata)
+      *(.sdata.*)
+      *(.gnu.linkonce.s.*)
+  }
+  . = ALIGN(4);
+  PROVIDE (edata  =  .);
+  _edata  =  .;
+  _fbss = .;
+  .sbss : {
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+  }
+  .bss : {
+    _bss_start = . ;
+    *(.bss)
+    *(.bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+  }
+
+  . = ALIGN(4);
+  PROVIDE (end = .);
+  _end = .;
+  /* Now place the data that is only needed within start.S and can be
+     overwritten by the heap.  */
+  .startdata : {
+    *(.startdata)
+  }
+
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to
+     the beginning of the section so we begin them at 0.  */
+
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+
+  /* Special sections generated by gcc */
+  /* Newer GNU linkers strip by default */
+  .mdebug.abi32            0 : { KEEP(*(.mdebug.abi32)) }
+  .mdebug.abiN32           0 : { KEEP(*(.mdebug.abiN32)) }
+  .mdebug.abi64            0 : { KEEP(*(.mdebug.abi64)) }
+  .mdebug.abiO64           0 : { KEEP(*(.mdebug.abiO64)) }
+  .mdebug.eabi32           0 : { KEEP(*(.mdebug.eabi32)) }
+  .mdebug.eabi64           0 : { KEEP(*(.mdebug.eabi64)) }
+  .gcc_compiled_long32     0 : { KEEP(*(.gcc_compiled_long32)) }
+  .gcc_compiled_long64     0 : { KEEP(*(.gcc_compiled_long64)) }
+}

--- a/cpu/mips_pic32mx/periph/Makefile
+++ b/cpu/mips_pic32mx/periph/Makefile
@@ -1,0 +1,3 @@
+MODULE = periph
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/mips_pic32mx/periph/uart.c
+++ b/cpu/mips_pic32mx/periph/uart.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+
+#include "periph/uart.h"
+#include "board.h"
+
+#define UxMODE(U)      U.regs[0x00/4]
+#define UxMODECLR(U)   U.regs[0x04/4]
+#define UxMODESET(U)   U.regs[0x04/4]
+#define ON  0x8000
+#define STSEL   1
+#define PDSEL_9N    6
+#define PDSEL_8O    4
+#define PDSEL_8E    2
+#define PDSEL_8N    0
+#define UEN_CTSRTS  0x200
+#define UxSTA(U)    U.regs[0x10/4]
+#define UxSTACLR(U) U.regs[0x14/4]
+#define UxSTASET(U) U.regs[0x18/4]
+#define URXDA 0x1
+#define TRMT 0x100
+#define UTXBF 0x200
+#define UTXEN 0x400
+#define URXEN 0x1000
+#define UxTXREG(U)  U.regs[0x20/4]
+#define UxRXREG(U)  U.regs[0x30/4]
+#define UxBRG(U)    U.regs[0x40/4]
+#define UART_BASE   0xBF806000
+#define UART_REGS_SPACING 0x200
+
+/* PERIPHERAL_CLOCK must be defined in board file */
+
+
+typedef struct PIC32_UART_tag {
+	volatile uint32_t	*regs;
+	uint32_t		clock;
+} PIC32_UART_T;
+
+/* pic uarts are numbered 1 to 6 */
+PIC32_UART_T pic_uart[UART_NUMOF + 1];
+
+int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
+{
+	if (uart > UART_NUMOF || uart == 0) /*No uart 0 on pic32*/
+		return -1;
+
+	/* Pin Mux should be setup in board file */
+
+	pic_uart[uart].regs = (volatile uint32_t *)(UART_BASE + (uart-1) * UART_REGS_SPACING);
+	pic_uart[uart].clock = PERIPHERAL_CLOCK;
+
+
+	UxBRG(pic_uart[uart]) = (pic_uart[uart].clock / (16 * baudrate)) - 1;
+	UxSTA(pic_uart[uart]) = 0;
+	UxMODE(pic_uart[uart]) = ON;
+	UxSTASET(pic_uart[uart]) = URXEN;
+	UxSTASET(pic_uart[uart]) = UTXEN;
+
+	return 0;
+}
+
+void uart_write(uart_t uart, const uint8_t *data, size_t len)
+{
+	if (uart > UART_NUMOF || uart == 0)
+		return;
+
+	while (len--) {
+		while (UxSTA(pic_uart[uart]) & UTXBF) {}
+		UxTXREG(pic_uart[uart]) = *data++;
+	}
+}
+
+void uart_poweron(uart_t uart)
+{
+	if (uart > UART_NUMOF || uart == 0)
+		return;
+
+	UxMODESET(pic_uart[uart]) = ON;
+
+}
+
+void uart_poweroff(uart_t uart)
+{
+	if (uart > UART_NUMOF || uart == 0)
+		return;
+
+	UxMODECLR(pic_uart[uart]) = ON;
+}

--- a/cpu/mips_pic32mx/pic32_config_settings.c
+++ b/cpu/mips_pic32mx/pic32_config_settings.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#include <stdint.h>
+/*
+ *  DEVCFG3  @ 0x1FC02FF0
+ *
+ *
+ *	USERID
+ *	FSRSSEL		7	Assign IPL 7 to a shadow register set.
+ *	FMIIEN		OFF	Ethernet RMII/MII Enable	RMII Enabled
+ *	FETHIO		ON	Ethernet I/O Pin Select	Default Ethernet I/O
+ *	FUSBIDIO	OFF	USB USBID Selection	Controlled by Port Function
+ *	FVBUSONIO 	ON	VBUSON pin is controlled by the USB module function
+
+ */
+volatile uint32_t DEVCFG3 __attribute__((used, section(".devcfg3"))) = 0x86FFFFFF;
+
+/* Note this sets the PLL to 120MHz which is only supported by 3xx and 4xx parts
+ * and assumes an 8MHz XTAL.
+ *
+ * 1xx/2xx/53x/57x only support 50MHz (use 8 x 24 / 4 = 48Mhz)
+ * 5xx/6xx/7xx only support 80Mhz (use 8/2 * 20 = 80MHz).
+ *
+ *
+ * DEVCFG2  @ 0x1FC02FF4 (
+ *
+ *	FPLLIDIV	DIV_1		System PLL Input Divider	1x Divider
+ *	FPLLMUL		15x		System PLL Multiplier	PLL Multiply by 15, 8 x 15 = 120MHz
+ *	UPLLIDIV	DIV_256		USB PLL divider
+ *	UPLLEN		OFF		USB PLL disabled
+ *	FPLLODIV	DIV_1		System PLL Output Clock Divider	1x Divider
+ */
+
+volatile uint32_t DEVCFG2 __attribute__ ((used, section(".devcfg2"))) = 0xFFF8F888;
+
+
+/*
+ * DEVCFG1  @ 0x1FC02FF8
+ *
+ * FNOSC	PRIPLL	Oscillator Selection Bits	Primary Osc w/PLL (XT+,HS+,EC+PLL)
+ * FSOSCEN	ON	Secondary Oscillator Enable	Enabled
+ * IESO	ON	Internal/External Switch Over	Enabled
+ * OSCIOFNC	OFF	CLKO Output Signal Active on the OSCO Pin	Disabled
+ * FPBDIV	DIV_1	Peripheral Clock Divisor	Pb_Clk is Sys_Clk/1
+ * FCKSM	CSDCMD	Clock Switching and Monitor Selection	Clock Switch Disable, FSCM Disabled
+ * WDTPS	PS2	Watchdog Timer Postscaler	1:2
+ * WINDIS	OFF	Watchdog Timer Window Enable	Watchdog Timer is in Non-Window Mode
+ * FWDTEN	OFF	Watchdog Timer Enable	WDT Disabled (SWDTEN Bit Controls)
+ */
+
+volatile uint32_t DEVCFG1 __attribute__ ((used, section(".devcfg1"))) = 0XFF61CDFB;
+
+
+/*
+ * DEVCFG0  @ 0x1FC02FFC
+ *
+ * DEBUG	OFF		Background Debugger Enable	Debugger is disabled
+ * JTAGEN	ON		JTAG Enable	JTAG Port Enabled
+ * ICESEL	ICS_PGx1	ICE/ICD Comm Channel Select	Communicate on PGEC1/PGED1
+ * PWP	OFF	Program Flash Write Protect	Disable
+ * BWP	OFF	Boot Flash Write Protect bit	Protection Disabled
+ * CP	OFF	Code Protect	Protection Disabled
+ */
+
+volatile uint32_t DEVCFG0 __attribute__ ((used, section(".devcfg0"))) = 0x7FFFFFFF;
+
+/*
+ * Without a reference to this function from elsewhere LD throws the whole compile unit
+ * away even though the data is 'volatile' and 'used' !!!
+ */
+void dummy(void)
+{
+	(void)1;
+}
+

--- a/cpu/mips_pic32mx/reset_mod.S
+++ b/cpu/mips_pic32mx/reset_mod.S
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2014-2015, Imagination Technologies Limited and/or its
+ *                      affiliated group companies.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* ************ PLEASE READ ME !!!!  ****************
+
+	This file is a copy of the reset_mod.S from $MIPS_ELF_ROOT/share/mips/boot
+	(from the 2016.05-03 version) with a couple of modifications:
+
+	#define SKIP_COPY_TO_RAM - prevents the bootloader copying the whole contents
+	of flash to ram (as we want to XIP from flash), we copy initialised data from
+	flash to ram in 'software_init_hook'.
+
+	move .org's to before the labels to make the vector labels appear at the vector
+	addresses.
+
+	In boot_debug_exception vector drop out of debug mode before spining, this allows
+	attachment of an external debug program to investigate a hung system.
+
+	Future toolchain versions will have these changes included and this file will
+	be no longer needed.
+
+	Thanks for reading.
+*/
+
+
+
+#define _RESETCODE
+.set nomips16
+
+#include <mips/regdef.h>
+#include <mips/cpu.h>
+#include <mips/asm.h>
+
+    .set push
+    .set nomicromips
+LEAF(__reset_vector)
+    lui	  a2, %hi(__cpu_init)
+    addiu a2, %lo(__cpu_init)
+    mtc0  $0, C0_COUNT		  # Clear cp0 Count (Used to measure boot time.)
+    jr    a2
+    .space 32			  # Just to cope with a quirk of MIPS malta boards
+				  # this can be deleted for anything else.
+END(__reset_vector)
+    .set pop
+
+LEAF(__cpu_init)
+
+    # Verify the code is here due to a reset and not NMI. If this is an NMI then trigger
+    # a debugger breakpoint using a sdbp instruction.
+
+    mfc0  s1, C0_STATUS		  # Read CP0 Status
+    ext	  s1, s1, SR_NMI_SHIFT, 1 # extract NMI
+    beqz  s1, init_resources	  # Branch if this is NOT an NMI exception.
+    move  k0, t9		  # Preserve t9
+    move  k1, a0		  # Preserve a0
+    li	  $25, 15		  # UHI exception operation
+    li	  $4, 0			  # Use hard register context
+    sdbbp 1			  # Invoke UHI operation
+
+init_resources:
+
+    # Init CP0 Status, Count, Compare, Watch*, and Cause.
+    jal	  __init_cp0
+
+    # Initialise L2/L3 cache
+    # This could be done from cached code if there is a cca override or similar
+
+    # Determine L2/L3 cache config.
+
+    lui   a2, %hi(__init_l23cache)
+    addiu a2, a2, %lo(__init_l23cache)
+    jal	  a2
+
+init_ic:
+    # Initialize the L1 instruction cache.
+    jal	  __init_icache
+
+    # The changing of Kernel mode cacheability must be done from KSEG1
+    # Since the code is executing from KSEG0 It needs to do a jump to KSEG1 change K0
+    # and jump back to KSEG0
+
+    lui	  a2, %hi(__change_k0_cca)
+    addiu a2, a2, %lo(__change_k0_cca)
+    li	  a1, 0xf
+    ins	  a2, a1, 29, 1		      # changed to KSEG1 address by setting bit 29
+    jalr  a2
+
+    .weak __init_l23cache_cached
+    lui   a2, %hi(__init_l23cache_cached)
+    addiu a2, a2, %lo(__init_l23cache_cached)
+    beqz  a2, init_dc
+    jal   a2
+
+init_dc:
+    # Initialize the L1 data cache
+    jal	  __init_dcache
+
+    # Initialize the TLB.
+    jal	  __init_tlb
+
+    # Allow everything else to be initialized via a hook.
+    .weak __boot_init_hook
+    lui	  a2, %hi(__boot_init_hook)
+    addiu a2, a2, %lo(__boot_init_hook)
+    beqz  a2, 1f
+    jalr  a2
+1:
+
+#ifndef SKIP_COPY_TO_RAM
+
+    # Copy code and data to RAM
+    li    s1, 0xffffffff
+
+    # Copy code and read-only/initialized data from FLASH to (uncached) RAM.
+    lui   a1, %hi(__flash_app_start)
+    addiu a1, a1, %lo(__flash_app_start)
+    ins   a1, s1, 29, 1			# Make it uncached (kseg1)
+    lui   a2, %hi(__app_start)
+    addiu a2, a2, %lo(__app_start)
+    ins   a2, s1, 29, 1			# Make it uncached (kseg1)
+    lui   a3, %hi(_edata)
+    addiu a3, a3, %lo(_edata)
+    ins   a3, s1, 29, 1			# Make it uncached (kseg1)
+    beq   a2, a3, $Lcopy_to_ram_done
+$Lnext_ram_word:
+    lw    a0, 0(a1)
+    sw    a0, 0(a2)
+    addiu a2, a2, 4
+    addiu a1, a1, 4
+    bne   a3, a2, $Lnext_ram_word
+$Lcopy_to_ram_done:
+
+#endif
+
+    # Prepare for eret to _start
+    lui   ra, %hi($Lall_done)		# If main returns then go to all_done.
+    addiu ra, ra, %lo($Lall_done)
+    lui   v0, %hi(_start)		# Load the address of _start
+    addiu v0, v0, %lo(_start)
+    mtc0  v0, C0_ERRPC			# Set ErrorEPC to _start
+    ehb					# Clear hazards (makes sure write to
+					# ErrorPC has completed)
+    li	  a0, 0				# UHI compliant null argument setup
+
+    # Return from exception will now execute the application startup code
+    eret
+
+$Lall_done:
+    # If _start returns it will return to this point.
+    # Just spin here reporting the exit.
+    li	    $25, 1			# UHI exit operation
+    move    $4, v0			# Collect exit code for UHI exit
+    sdbbp   1				# Invoke UHI operation
+    b       $Lall_done
+END(__cpu_init)
+
+/**************************************************************************************
+    B O O T   E X C E P T I O N   H A N D L E R S (CP0 Status[BEV] = 1)
+**************************************************************************************/
+/* NOTE: the linker script must insure that this code starts at start + 0x200 so the exception */
+/* vectors will be addressed properly. All .org assume this! */
+/* TLB refill, 32 bit task. */
+.org 0x200				# TLB refill, 32 bit task.
+LEAF(__boot_tlb_refill)
+    move  k0, t9			# Preserve t9
+    move  k1, a0			# Preserve a0
+    li	  $25, 15			# UHI exception operation
+    li	  $4, 0				# Use hard register context
+    sdbbp 1				# Invoke UHI operation
+END(__boot_tlb_refill)
+
+.org 0x280				# XTLB refill, 64 bit task. BEV + 0x280
+LEAF(__boot_xtlb_refill)
+    move  k0, t9			# Preserve t9
+    move  k1, a0			# Preserve a0
+    li	  $25, 15			# UHI exception operation
+    li	  $4, 0				# Use hard register context
+    sdbbp 1				# Invoke UHI operation
+END(__boot_xtlb_refill)
+
+.org 0x300				# Cache error exception. BEV + 0x300
+LEAF(__boot_cache_error)
+    move  k0, t9			# Preserve t9
+    move  k1, a0			# Preserve a0
+    li	  $25, 15			# UHI exception operation
+    li	  $4, 0				# Use hard register context
+    sdbbp 1				# Invoke UHI operation
+END(__boot_cache_error)
+
+.org 0x380				# General exception. BEV + 0x380
+LEAF(__boot_general_exception)
+    move  k0, t9			# Preserve t9
+    move  k1, a0			# Preserve a0
+    li	  $25, 15			# UHI exception operation
+    li	  $4, 0				# Use hard register context
+    sdbbp 1				# Invoke UHI operation
+END(__boot_general_exception)
+
+# If you want the above code to fit into 1k flash you will need to leave
+# out the code below. This is the code that covers the debug exception
+#which you normally will not get.
+.org 0x480
+LEAF(__boot_debug_exception)
+	# EJTAG Debug (with ProbEn = 0 in the EJTAG Control Register)
+    mfc0 k1, C0_DEPC	# Save Debug exception point in DESAVE
+    mtc0 k1, C0_DESAVE
+    LA k1, 1f
+	# Drop out of debug mode before spinning (To allow a JTAG probe in).
+    mtc0 k1, C0_DEPC
+    ehb
+    deret
+1:
+    b 1b			 	#Spin indefinately
+END(__boot_debug_exception)

--- a/cpu/mips_pic32mz/Makefile
+++ b/cpu/mips_pic32mz/Makefile
@@ -1,0 +1,15 @@
+ifeq ("$(OS)","Windows_NT")
+MIPS_ELF_ROOT?=C:\cross-mips-mti-elf
+else
+MIPS_ELF_ROOT?=/opt/imgtec/Toolchains/mips-mti-elf/2016.05-03
+endif
+
+# define the module that is build
+MODULE = cpu
+
+# add a list of subdirectories, that should also be build
+DIRS += periph $(RIOTCPU)/mips32r2_common
+
+include $(RIOTBASE)/Makefile.base
+
+

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -1,0 +1,51 @@
+# Target triple for the build.
+export TARGET_ARCH ?= mips-mti-elf
+
+export ABI=32
+export MEMORY_BASE=0x80000000
+export MEMORY_SIZE=512K
+export APP_START=0x80000000
+export ROMABLE = 1
+
+include $(MIPS_ELF_ROOT)/share/mips/rules/mipshal.mk
+
+# define build specific options
+export CFLAGS_CPU   = -EL -march=m5101
+export CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums
+export CFLAGS_DBG = -O0 -g2
+export CFLAGS_OPT = -Os
+
+export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) -DSKIP_COPY_TO_RAM
+#$(CFLAGS_OPT)
+
+export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
+
+export LINKFLAGS += $(MIPS_HAL_LDFLAGS) -mabi=$(ABI) -Wl,--defsym,__use_excpt_boot=0
+export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/pic32mz2048_uhi.ld
+export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) #$(CFLAGS_OPT)
+export LINKFLAGS += -Wl,--print-gc-sections #-Wl,--no-gc-sections #DONT GARBAGE COLLECT AS WE NEED TO KEEP THE CONFIG SETTINGS
+
+# This CPU implementation is using the new core/CPU interface:
+export CFLAGS += -DCOREIF_NG=1
+
+export USEMODULE += periph
+
+# the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
+export OBJCOPY = objcopy #use system objcopy as toolchain one is broken.
+export OFLAGS += -O ihex \
+				--change-section-lma .lowerbootflashalias-0xA0000000 \
+				--change-section-lma .bootflash1-0xA0000000 \
+				--change-section-lma .bootflash2-0xA0000000 \
+				--change-section-lma .exception_vector-0x80000000 \
+				--change-section-lma .text-0x80000000 \
+				--change-section-lma .init-0x80000000 \
+				--change-section-lma .fini-0x80000000 \
+				--change-section-lma .eh_frame-0x80000000 \
+				--change-section-lma .gcc_except_table-0x80000000 \
+				--change-section-lma .jcr-0x80000000 \
+				--change-section-lma .ctors-0x80000000 \
+				--change-section-lma .dtors-0x80000000 \
+				--change-section-lma .rodata-0x80000000 \
+				--change-section-lma .data-0x80000000 \
+				--change-section-lma .bss-0x80000000 \
+				--change-section-lma .startdata-0x80000000 \

--- a/cpu/mips_pic32mz/include/cpu.h
+++ b/cpu/mips_pic32mz/include/cpu.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+#ifndef CPU_H_
+#define CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <assert.h>
+#include "irq.h"
+
+/* We run from flash on PIC32 */
+#define FLASH_XIP 1
+
+extern void dummy(void);
+static inline void cpu_init_early(void)
+{
+	/* Stop the linker from throwing away the PIC32 config register settings */
+	dummy();
+}
+
+
+/* This file must exist else RIOT won't compile */
+static inline void cpu_print_last_instruction(void)
+{
+
+}
+
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cpu/mips_pic32mz/include/cpu_conf.h
+++ b/cpu/mips_pic32mz/include/cpu_conf.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+
+#ifndef _CPU_CONF_H_
+#define _CPU_CONF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
+#define THREAD_EXTRA_STACKSIZE_PRINTF   (2048)
+#endif
+#ifndef THREAD_STACKSIZE_DEFAULT
+#define THREAD_STACKSIZE_DEFAULT        (4096)
+#endif
+#ifndef THREAD_STACKSIZE_IDLE
+
+/*
+ * EXTRA PRINTF needed when debug logging turned on on code which
+ * runs on this thread eg timer debug
+ */
+#define THREAD_STACKSIZE_IDLE           (1024 + THREAD_EXTRA_STACKSIZE_PRINTF)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cpu/mips_pic32mz/ldscripts/pic32mz2048_uhi.ld
+++ b/cpu/mips_pic32mz/ldscripts/pic32mz2048_uhi.ld
@@ -1,0 +1,410 @@
+/*
+ * A platform and target independent link script to produce UHI
+ * compliant binaries with varying levels of system initialization
+ * support.
+ */
+
+__entry = DEFINED(__reset_vector) ? 0xbfc00000 : _start;
+ENTRY(__entry)
+OUTPUT_FORMAT("elf32-tradlittlemips", "elf32-tradbigmips", "elf32-tradlittlemips")
+GROUP(-lc -luhi -lgcc -lhal)
+SEARCH_DIR(.)
+__DYNAMIC  =  0;
+STARTUP(crt0.o)
+/* Force the exception handler to be registered */
+EXTERN(__register_excpt_handler)
+/* Force the exception handler to be included in the link */
+EXTERN(__exception_entry)
+/*
+ * Require verbose exceptions. This can be changed to pull in
+ * __exception_handle_quiet to reduce code size but be less
+ * informative
+ */
+EXTERN(__exception_handle_verbose)
+/* Force the interrupt handlers to tbe included in the link */
+EXTERN(__isr_vec)
+/* Require the UHI getargs support */
+EXTERN(__getargs)
+
+/*
+ * Set the location of the top of the stack.  A value of 0 means
+ * that it will be automatically placed at the highest address
+ * available as described by the __memory_* setttings
+ */
+PROVIDE (__stack = 0);
+
+/* Size of the memory returned by _get_ram_range */
+PROVIDE (__memory_size = 512K);
+
+/* Base of the memory returned by _get_ram_range */
+PROVIDE (__memory_base = 0x80000000);
+
+/* Stride length for tlb software invalidate for tlbinvf
+ * (mipsXXr3+). Some MIPS implementations may layout the sets/ways
+ * differently in the index register. Either sets LSB or ways LSB.
+ *
+ * By setting this to 1 we presume that sets come first. The default boot
+ * code will decrement this value from the Number of TLB entries.
+ */
+PROVIDE (__tlb_stride_length = 1);
+
+/* By default, XPA is not used even if available. To enable XPA,
+ * __enable_xpa should be 1.
+ */
+PROVIDE (__enable_xpa = 0);
+
+/*
+ * 0 = Do not use exception handler present in boot for UHI
+ * 1 = Use exception handler present in boot for UHI if BEV is 0 at
+ *     startup
+ * 2 = Always use exception handler present in boot for UHI
+ */
+PROVIDE (__use_excpt_boot = 0);
+/*
+ * Include the code to be able to return to boot context.  This is
+ * necessary if __use_excpt_boot != 0.
+ */
+EXTERN (__register_excpt_boot);
+
+ASSERT (DEFINED(__register_excpt_boot) || __use_excpt_boot == 0,
+	"Registration for boot context is required for UHI chaining")
+
+/* Control if subnormal floating-point values are flushed to zero in
+   hardware.  This applies to both FPU and MSA operations.  */
+PROVIDE (__flush_to_zero = 1);
+
+/* Set up the public symbols depending on whether the user has chosen
+   quiet or verbose exception handling above */
+EXTERN (__exception_handle);
+PROVIDE(__exception_handle = (DEFINED(__exception_handle_quiet)
+				      ? __exception_handle_quiet
+				      : __exception_handle_verbose));
+PROVIDE(_mips_handle_exception = __exception_handle);
+
+/*
+ * Initalize some symbols to be zero so we can reference them in the
+ * crt0 without core dumping. These functions are all optional, but
+ * we do this so we can have our crt0 always use them if they exist.
+ * This is so BSPs work better when using the crt0 installed with gcc.
+ * We have to initalize them twice, so we multiple object file
+ * formats, as some prepend an underscore.
+ */
+PROVIDE (hardware_exit_hook = 0);
+PROVIDE (hardware_hazard_hook = 0);
+PROVIDE (hardware_init_hook = 0);
+PROVIDE (software_init_hook = 0);
+
+/* The default base address for application flash code is 0x9D001000 */
+PROVIDE (__app_start = 0x9D001000) ;
+/* Set default vector spacing to 32 bytes. */
+PROVIDE (__isr_vec_space = 32);
+/* Leave space for 9 vector entries by default. 8 entry points and one
+   fallback handler. */
+PROVIDE (__isr_vec_count = 9);
+/*
+ * The start of boot flash must be set if including boot code.  By default
+ * the use of boot code will mean that application code is copied
+ * from flash to RAM at runtime before being executed.
+ */
+PROVIDE (__lower_boot_flash_start = DEFINED(__reset_vector) ? 0xbfc00000 : __app_start);
+
+PROVIDE (__boot_flash1_start = 0xbfc40000);
+
+PROVIDE (__boot_flash2_start = 0xbfc60000);
+
+PROVIDE (__bev_override = 0x9fc00000);
+
+PROVIDE (__flash_vector_start = 0x9D000000);
+
+PROVIDE (__flash_app_start = 0x9D001000);
+
+SECTIONS
+{
+  /* Start of bootrom */
+  .lowerbootflashalias __bev_override : /* Runs uncached (from 0xBfc00000) until I$ is
+			       initialized. */
+  AT (__lower_boot_flash_start)
+  {
+    __base = .;
+
+    *(.reset)		/* Reset entry point. */
+    *(.boot)		/* Boot code. */
+    . = ALIGN(8);
+
+    . = __base + 0xff40; /*Alternate Config bits (lower Alias)*/
+    *(.adevcfg3_la)
+    *(.adevcfg2_la)
+    *(.adevcfg1_la)
+    *(.adevcfg0_la)
+    . = __base + 0xff5c;
+    *(.adevcp0_la)
+    . = __base + 0xff6c;
+    *(.adevsign_la)
+
+    . = __base + 0xffc0; /*Config bits (lower Alias)*/
+    *(.devcfg3_la)
+    *(.devcfg2_la)
+    *(.devcfg1_la)
+    *(.devcfg0_la)
+    . = __base + 0xffdc;
+    *(.devcp0_la)
+    . = __base + 0xffec;
+    *(.devsign_la)
+
+    . = __base + 0xfff0;
+    *(.seq_la)
+
+  } = 0xFFFFFFFF
+
+  /*
+   * We only add this block to keep the MPLAB programmer happy
+   * It seems to want the config regs values in the non aliased locations
+   */
+  . = __base + 0x40000 + 0xff40;
+  .bootflash1 :
+  AT(__boot_flash1_start + 0xff40)
+  {
+    __altbase = .;
+
+    . = __altbase; /* Alternate Config Bits (boot flash 1) */
+    *(.adevcfg3_b1)
+    *(.adevcfg2_b1)
+    *(.adevcfg1_b1)
+    *(.adevcfg0_b1)
+    . = __altbase + 0x1c;
+    *(.adevcp0_b1)
+    . = __altbase + 0x2c;
+    *(.adevsign_b1)
+
+    . = __altbase + 0x80;
+    *(.devcfg3_b1)
+    *(.devcfg2_b1)
+    *(.devcfg1_b1)
+    *(.devcfg0_b1)
+    . = __altbase + 0x9c;
+    *(.devcp0_b1)
+    . = __altbase + 0xAc;
+    *(.devsign_b1)
+    . = __altbase + 0xB0;
+    *(.seq_b1)
+   }  = 0xFFFFFFFF
+
+  /*
+   * We only add this block to keep the MPLAB programmer happy
+   * It seems to want the config regs values in the non aliased locations
+   */
+  . = __base + 0x60000 + 0xff40;
+  .bootflash2 :
+  AT(__boot_flash2_start + 0xff40)
+  {
+    __altbase = .;
+
+    . = __altbase; /* Alternate Config Bits (boot flash 1) */
+    *(.adevcfg3_b2)
+    *(.adevcfg2_b2)
+    *(.adevcfg1_b2)
+    *(.adevcfg0_b2)
+    . = __altbase + 0x1c;
+    *(.adevcp0_b2)
+     . = __altbase + 0x2c;
+    *(.adevsign_b2)
+
+    . = __altbase + 0x80;
+    *(.devcfg3_b2)
+    *(.devcfg2_b2)
+    *(.devcfg1_b2)
+    *(.devcfg0_b2)
+    . = __altbase + 0x9c;
+    *(.devcp0_b2)
+    . = __altbase + 0xAc;
+    *(.devsign_b2)
+    . = __altbase + 0xB0;
+    *(.seq_b2)
+  } = 0xFFFFFFFF
+
+  /* Start of the application */
+  .exception_vector ALIGN(__flash_vector_start, 0x1000) :
+  AT (__flash_vector_start)
+  {
+    PROVIDE (__excpt_ebase = ABSOLUTE(.));
+    __base = .;
+    KEEP(* (.text.__exception_entry))
+
+    . = __base + 0x200;
+    KEEP(* (SORT(.text.__isr_vec*)))
+    /* Leave space for all the vector entries */
+    . = __base + 0x200 + (__isr_vec_space * __isr_vec_count);
+    ASSERT(__isr_vec_space == (DEFINED(__isr_vec_sw0)
+			       ? __isr_vec_sw1 - __isr_vec_sw0
+			       : __isr_vec_space),
+	   "Actual ISR vector spacing does not match __isr_vec_space");
+    ASSERT(__base + 0x200 == (DEFINED(__isr_vec_sw0)
+			      ? __isr_vec_sw0 & 0xfffffffe : __base + 0x200),
+	   "__isr_vec_sw0 is not placed at EBASE + 0x200");
+    . = ALIGN(8);
+  } = 0
+
+  . = __flash_app_start;
+
+  .text : {
+     _ftext = . ;
+    PROVIDE (eprol  =  .);
+    *(.text)
+    *(.text.*)
+    *(.gnu.linkonce.t.*)
+    *(.mips16.fn.*)
+    *(.mips16.call.*)
+  }
+  .init : {
+    KEEP (*(.init))
+  }
+  .fini : {
+    KEEP (*(.fini))
+  }
+  .rel.sdata : {
+    PROVIDE (__runtime_reloc_start = .);
+    *(.rel.sdata)
+    PROVIDE (__runtime_reloc_stop = .);
+  }
+  PROVIDE (etext  =  .);
+  _etext  =  .;
+
+  .eh_frame_hdr : { *(.eh_frame_hdr) }
+  .eh_frame : { KEEP (*(.eh_frame)) }
+  .gcc_except_table : { *(.gcc_except_table*) }
+  .jcr : { KEEP (*(.jcr)) }
+  .ctors    :
+  {
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+
+    KEEP (*crtbegin.o(.ctors))
+
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+  }
+
+  .dtors    :
+  {
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+  }
+
+  . = .;
+  .MIPS.abiflags : {
+    __MIPS_abiflags_start = .;
+    *(.MIPS.abiflags)
+    __MIPS_abiflags_end = .;
+  }
+  .rodata : {
+    *(.rdata)
+    *(.rodata)
+    *(.rodata.*)
+    *(.gnu.linkonce.r.*)
+  }
+  _rom_data_copy = .;
+
+  .data ALIGN(__memory_base + 0x1000, 16) :
+  AT (_rom_data_copy)
+  {
+     _fdata = .;
+
+      *(.data)
+      *(.data.*)
+      *(.gnu.linkonce.d.*)
+
+    . = ALIGN(8);
+    _gp = . + 0x8000;
+    __global = _gp;
+
+      *(.lit8)
+      *(.lit4)
+      *(.sdata)
+      *(.sdata.*)
+      *(.gnu.linkonce.s.*)
+  }
+  . = ALIGN(4);
+  PROVIDE (edata  =  .);
+  _edata  =  .;
+  _fbss = .;
+  .sbss : {
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+  }
+  .bss : {
+    _bss_start = . ;
+    *(.bss)
+    *(.bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+  }
+
+  . = ALIGN(4);
+  PROVIDE (end = .);
+  _end = .;
+  /* Now place the data that is only needed within start.S and can be
+     overwritten by the heap.  */
+  .startdata : {
+    *(.startdata)
+  }
+
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to
+     the beginning of the section so we begin them at 0.  */
+
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+
+  /* Special sections generated by gcc */
+  /* Newer GNU linkers strip by default */
+  .mdebug.abi32            0 : { KEEP(*(.mdebug.abi32)) }
+  .mdebug.abiN32           0 : { KEEP(*(.mdebug.abiN32)) }
+  .mdebug.abi64            0 : { KEEP(*(.mdebug.abi64)) }
+  .mdebug.abiO64           0 : { KEEP(*(.mdebug.abiO64)) }
+  .mdebug.eabi32           0 : { KEEP(*(.mdebug.eabi32)) }
+  .mdebug.eabi64           0 : { KEEP(*(.mdebug.eabi64)) }
+  .gcc_compiled_long32     0 : { KEEP(*(.gcc_compiled_long32)) }
+  .gcc_compiled_long64     0 : { KEEP(*(.gcc_compiled_long64)) }
+}

--- a/cpu/mips_pic32mz/periph/Makefile
+++ b/cpu/mips_pic32mz/periph/Makefile
@@ -1,0 +1,3 @@
+MODULE = periph
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/mips_pic32mz/periph/uart.c
+++ b/cpu/mips_pic32mz/periph/uart.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+
+#include "periph/uart.h"
+#include "board.h"
+
+#define UxMODE(U)      U.regs[0x00/4]
+#define UxMODECLR(U)   U.regs[0x04/4]
+#define UxMODESET(U)   U.regs[0x04/4]
+#define ON  0x8000
+#define STSEL   1
+#define PDSEL_9N    6
+#define PDSEL_8O    4
+#define PDSEL_8E    2
+#define PDSEL_8N    0
+#define UEN_CTSRTS  0x200
+#define UxSTA(U)    U.regs[0x10/4]
+#define UxSTACLR(U) U.regs[0x14/4]
+#define UxSTASET(U) U.regs[0x18/4]
+#define URXDA 0x1
+#define TRMT 0x100
+#define UTXBF 0x200
+#define UTXEN 0x400
+#define URXEN 0x1000
+#define UxTXREG(U)  U.regs[0x20/4]
+#define UxRXREG(U)  U.regs[0x30/4]
+#define UxBRG(U)    U.regs[0x40/4]
+#define UART_BASE   0xBF822000
+#define UART_REGS_SPACING 0x200
+
+/* PERIPHERAL_CLOCK must be defined in board file */
+
+
+typedef struct PIC32_UART_tag {
+	volatile uint32_t	*regs;
+	uint32_t		clock;
+} PIC32_UART_T;
+
+/* pic uarts are numbered 1 to 6 */
+PIC32_UART_T pic_uart[UART_NUMOF + 1];
+
+int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
+{
+	if (uart > UART_NUMOF || uart == 0) /*No uart 0 on pic32*/
+		return -1;
+
+	/* Pin Mux should be setup in board file */
+
+	pic_uart[uart].regs = (volatile uint32_t *)(UART_BASE + (uart-1) * UART_REGS_SPACING);
+	pic_uart[uart].clock = PERIPHERAL_CLOCK;
+
+
+	UxBRG(pic_uart[uart]) = (pic_uart[uart].clock / (16 * baudrate)) - 1;
+	UxSTA(pic_uart[uart]) = 0;
+	UxMODE(pic_uart[uart]) = ON;
+	UxSTASET(pic_uart[uart]) = URXEN;
+	UxSTASET(pic_uart[uart]) = UTXEN;
+
+	return 0;
+}
+
+void uart_write(uart_t uart, const uint8_t *data, size_t len)
+{
+	if (uart > UART_NUMOF || uart == 0)
+		return;
+
+	while (len--) {
+		while (UxSTA(pic_uart[uart]) & UTXBF) {}
+		UxTXREG(pic_uart[uart]) = *data++;
+	}
+}
+
+void uart_poweron(uart_t uart)
+{
+	if (uart > UART_NUMOF || uart == 0)
+		return;
+
+	UxMODESET(pic_uart[uart]) = ON;
+
+}
+
+void uart_poweroff(uart_t uart)
+{
+	if (uart > UART_NUMOF || uart == 0)
+		return;
+
+	UxMODECLR(pic_uart[uart]) = ON;
+}

--- a/cpu/mips_pic32mz/pic32_config_settings.c
+++ b/cpu/mips_pic32mz/pic32_config_settings.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2016, Imagination Technologies Limited and/or its
+ *                 affiliated group companies.
+ */
+
+#include <stdint.h>
+
+/*
+ * Note banked access only applies to MZ part MX only has 1 set of registers similar to the MZ's lower alias.
+ * Thus when working with MX parts comment out the *_B* entries, not the address in the comments are different for MX too
+ * so a different linker script is required between MX and MZ to place these registers at the correct addresses.
+ * MM parts have completely different config registers, so this file is not applicable.
+ *
+ * Note when programming via Microchip IPE (tested using a Pickit-3) entries need to exist in the programming
+ * file for both the lower alias and the config1 configuration spaces (starting at 0x1FC0FFC0 and 0x1FC4FFC0)
+ * hence the duplicate entries in different sections allowing the linker to place them at different addresses.
+ */
+
+
+/*
+ *  DEVCFG3_LA  @ 0x1FC0FFC0 (lower alias)
+ *  ADEVFGC3_LA @ 0x1FC0FF40 (alternate devcfg3 in lower alias)
+ *  DEVCFG3_B1  @ 0x1FC4FFC0 (config space 1)
+ *  ADEVCFG3_B1 @ 0x1FC4FF40 (alternate devcfg3 in config space 1)
+ *  DEVCFG3_B2  @ 0x1FC6FFC0 (config space 1)
+ *  ADEVCFG3_B2 @ 0x1FC6FF40 (alternate devcfg3 in config space 2)
+ *
+ *
+ *	USERID
+ *	FMIIEN		OFF	Ethernet RMII/MII Enable	RMII Enabled
+ *	FETHIO		ON	Ethernet I/O Pin Select	Default Ethernet I/O
+ *	PGL1WAY		OFF	Permission Group Lock One Way Configuration	Allow multiple reconfigurations
+ *	PMDL1WAY	OFF	Peripheral Module Disable Configuration	Allow multiple reconfigurations
+ *	IOL1WAY		OFF	Peripheral Pin Select Configuration	Allow multiple reconfigurations
+ *	FUSBIDIO	OFF	USB USBID Selection	Controlled by Port Function
+ */
+volatile uint32_t DEVCFG3_LA  __attribute__((used, section(".devcfg3_la"))) = 0x86FFFFFF;
+volatile uint32_t ADEVCFG3_LA __attribute__((used, section(".adevcfg3_la"))) = 0x86FFFFFF;
+volatile uint32_t DEVCFG3_B1  __attribute__((used, section(".devcfg3_b1"))) = 0x86FFFFFF;
+volatile uint32_t ADEVCFG3_B1 __attribute__((used, section(".adevcfg3_b1"))) = 0x86FFFFFF;
+/* volatile uint32_t DEVCFG3_B2 __attribute__((used,section(".devcfg3_b2"))) = 0x86FFFFFF; Not needed by default. */
+/* volatile uint32_t ADEVCFG3_B2 __attribute__((used,section(".adevcfg3_la"))) = 0x86FFFFFF; Not needed by default */
+
+/*
+ * DEVCFG2_LA  @ 0x1FC0FFC4 (lower alias)
+ * ADEVFGC2_LA @ 0x1FC0FF44 (alternate devcfg2 in lower alias)
+ * DEVCFG2_B1  @ 0x1FC4FFC4 (config space 1)
+ * ADEVCFG2_B1 @ 0x1FC4FF44 (alternate devcfg2 in config space 1)
+ * DEVCFG2_B2  @ 0x1FC6FFC4 (config space 1)
+ * ADEVCFG2_B2 @ 0x1FC6FF44 (alternate devcfg2 in config space 2)
+ *
+ *	FPLLIDIV	DIV_3		System PLL Input Divider	3x Divider
+ *	FPLLRNG		RANGE_5_10_MHZ	System PLL Input Range	5-10 MHz Input
+ *	FPLLICLK	PLL_POSC	System PLL Input Clock Selection	POSC is input to the System PLL
+ *	FPLLMULT	MUL_50		System PLL Multiplier	PLL Multiply by 50
+ *	FPLLODIV	DIV_2		System PLL Output Clock Divider	2x Divider
+ *	UPLLFSEL	FREQ_24MHZ	USB PLL Input Frequency Selection	USB PLL input is 24 MHz
+ */
+
+volatile uint32_t DEVCFG2_LA  __attribute__ ((used, section(".devcfg2_la"))) = 0xFFF9B11A;
+volatile uint32_t ADEVCFG2_LA __attribute__ ((used, section(".adevcfg2_la"))) = 0xFFF9B11A;
+volatile uint32_t DEVCFG2_B1  __attribute__ ((used, section(".devcfg2_b1"))) = 0xFFF9B11A;
+volatile uint32_t ADEVCFG2_B1 __attribute__ ((used, section(".adevcfg2_b1"))) = 0xFFF9B11A;
+/* uint32_t DEVCFG2_B2 __attribute__ ((section(".devcfg2_b2"))) = 0xFFF9B11A; Not needed by default. */
+/* uint32_t ADEVCFG2_B2 __attribute__ ((section(".adevcfg2_b2"))) = 0xFFF9B11A; Not needed by default. */
+
+
+/*
+ * DEVCFG1_LA  @ 0x1FC0FFC8 (lower alias)
+ * ADEVFGC1_LA @ 0x1FC0FF48 (alternate devcfg1 in lower alias)
+ * DEVCFG1_B1  @ 0x1FC4FFC8 (config space 1)
+ * ADEVCFG1_B1 @ 0x1FC4FF48 (alternate devcfg1 in config space 1)
+ * DEVCFG1_B2  @ 0x1FC6FFC8 (config space 1)
+ * ADEVCFG1_B2 @ 0x1FC6FF48 (alternate devcfg1 in config space 2)
+ *
+ * 	FNOSC		SPLL		Oscillator Selection Bits	System PLL
+ *	DMTINTV		WIN_127_128	DMT Count Window Interval	Window/Interval value is 127/128 counter value
+ *	FSOSCEN		OFF		Secondary Oscillator Enable	Disable SOSC
+ *	IESO		ON		Internal/External Switch Over	Enabled
+ *	POSCMOD		EC		Primary Oscillator Configuration	External clock mode
+ *	OSCIOFNC	OFF		CLKO Output Signal Active on the OSCO Pin	Disabled
+ *	FCKSM		CSDCMD		Clock Switching and Monitor Selection	Clock Switch Disabled, FSCM Disabled
+ *	WDTPS		PS1048576	Watchdog Timer Postscaler	1:1048576
+ *	WDTSPGM		STOP		Watchdog Timer Stop During Flash Programming	WDT stops during Flash programming
+ *	WINDIS		NORMAL		Watchdog Timer Window Mode	Watchdog Timer is in non-Window mode
+ *	FWDTEN		OFF		Watchdog Timer Enable	WDT Disabled
+ *	FWDTWINSZ	WINSZ_25	Watchdog Timer Window Size	Window size is 25%
+ *	DMTCNT		DMT8		Deadman Timer Count Selection	2^8 (256)
+ *	FDMTEN		OFF		Deadman Timer Enable	Deadman Timer is disabled
+ */
+
+volatile uint32_t DEVCFG1_LA  __attribute__ ((used, section(".devcfg1_la"))) = 0x3743CB9;
+volatile uint32_t ADEVCFG1_LA __attribute__ ((used, section(".adevcfg1_la"))) = 0x3743CB9;
+volatile uint32_t DEVCFG1_B1  __attribute__ ((used, section(".devcfg1_b1"))) = 0x3743CB9;
+volatile uint32_t ADEVCFG1_B1 __attribute__ ((used, section(".adevcfg1_b1"))) = 0x3743CB9;
+/* uint32_t DEVCFG1_B2 __attribute__ ((section(".devcfg1_b2"))) = 0x3743CB9; */
+/* uint32_t ADEVCFG1_B2 __attribute__ ((section(".adevcfg1_b2"))) = 0x3743 */
+
+/*
+ * DEVCFG0_LA  @ 0x1FC0FFCC (lower alias)
+ * ADEVFGC0_LA @ 0x1FC0FF4C (alternate devcfg0 in lower alias)
+ * DEVCFG0_B1  @ 0x1FC4FFCC (config space 1)
+ * ADEVCFG0_B1 @ 0x1FC4FF4C (alternate devcfg0 in config space 1)
+ * DEVCFG0_B2  @ 0x1FC6FFCC (config space 1)
+ * ADEVCFG0_B2 @ 0x1FC6FF4C (alternate devcfg0 in config space 2)
+ *
+ * DEBUG	OFF		Background Debugger Enable	Debugger is disabled
+ * JTAGEN	ON		JTAG Enable	JTAG Port Enabled
+ * ICESEL	ICS_PGx2	ICE/ICD Comm Channel Select	Communicate on PGEC2/PGED2
+ * TRCEN	OFF		Trace Enable	Trace features in the CPU are disabled
+ * BOOTISA	MIPS32		Boot ISA Selection	Boot code and Exception code is MIPS32
+ * FECCCON	OFF_UNLOCKED	Dynamic Flash ECC Configuration	ECC and Dynamic ECC are disabled (ECCCON bits are writable)
+ * FSLEEP	OFF		Flash Sleep Mode	Flash is powered down when the device is in Sleep mode
+ * DBGPER	PG_ALL		Debug Mode CPU Access Permission	Allow CPU access to all permission regions
+ * SMCLR	MCLR_NORM	Soft Master Clear Enable bit	MCLR pin generates a normal system Reset
+ * SOSCGAIN	GAIN_2X		Secondary Oscillator Gain Control bits	2x gain setting
+ * SOSCBOOST	ON		Secondary Oscillator Boost Kick Start Enable bit	Boost the kick start of the oscillator
+ * POSCGAIN	GAIN_2X		Primary Oscillator Gain Control bits	2x gain setting
+ * POSCBOOST	ON		Primary Oscillator Boost Kick Start Enable bit	Boost the kick start of the oscillator
+ * EJTAGBEN	NORMAL		EJTAG Boot	Normal EJTAG functionality
+ */
+
+volatile uint32_t DEVCFG0_LA   __attribute__ ((used, section(".devcfg0_la"))) = 0xFFFFF7D7;
+volatile uint32_t ADEVCFG0_LA  __attribute__ ((used, section(".adevcfg0_la"))) = 0xFFFFF7D7;
+volatile uint32_t DEVCFG0_B1   __attribute__ ((used, section(".devcfg0_b1"))) = 0xFFFFF7D7;
+volatile uint32_t ADEVCFG0_B1  __attribute__ ((used, section(".adevcfg0_b1"))) = 0xFFFFF7D7;
+/* uint32_t DEVCFG0_B2  __attribute__ ((section(".devcfg0_b2"))) = 0xFFFFF7D7; Not needed by default */
+/* uint32_t ADEVCFG0_B2  __attribute__ ((section(".adevcfg0_b2"))) = 0xFFFFF7D7; Not needed by default */
+
+
+/*
+ * DEVCP0_LA  @ 0x1FC0FFDC (lower alias)
+ * ADEVCP0_LA @ 0x1FC0FF5C (alternate devcp0 in lower alias)
+ * DEVCP0_B1  @ 0x1FC4FFDC (config space 1)
+ * ADEVCP0_B1 @ 0x1FC4FF5C (alternate devcp0 in config space 1)
+ * DEVCP0_B2  @ 0x1FC6FFDC (config space 1)
+ * ADEVCP0_B2 @ 0x1FC6FF5C (alternate devcp0 in config space 2
+ *
+ * CP	OFF	Code Protect	Protection Disabled
+ */
+
+volatile uint32_t DEVCP0_LA	__attribute__ ((used, section(".devcp0_la"))) = 0xFFFFFFFF;
+volatile uint32_t ADEVCP0_LA	__attribute__ ((used, section(".adevcp0_la"))) = 0xFFFFFFFF;
+volatile uint32_t DEVCP0_B1	__attribute__ ((used, section(".devcp0_b1"))) = 0xFFFFFFFF;
+volatile uint32_t ADEVCP0_B1	__attribute__ ((used, section(".adevcp0_b1"))) = 0xFFFFFFFF;
+/* uint32_t DEVCP0_B2	__attribute__ ((section(".devcp0_b1"))) = 0xFFFFFFFF; not needed by default */
+/* uint32_t ADEVCP0_B2	__attribute__ ((section(".adevcp0_b1"))) = 0xFFFFFFFF; not needed by default */
+
+/*
+ * SEQ_B1[0..3] @ 1FC0FFF0
+ * SEQ_B1[0..3] @ 1FC4FFF0
+ *
+ * TSEQ		Boot Flash True Sequence Number
+ * CSEQ		Boot Flash Complement Sequence Number
+ */
+
+volatile uint32_t SEQ_LA[4] __attribute__ ((used, section(".seq_la"))) = {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+volatile uint32_t SEQ_B1[4] __attribute__ ((used, section(".seq_b1"))) = {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+/* uint32_t SEQ_B2[4] __attribute__ ((section(".seq_b2"))) = {0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF}; Not needed by default */
+
+
+/*
+ * STUPIDLY Microchip has hard coded the MSB bit of devsign to 0, So even if you erase the whole device,
+ * eveything returns 0xFFFFFFF except this 1 register (and its alternate) which return 0x7FFFFFF!!
+ *
+ * We set it in the output image so verification doesn't fail
+ *
+ * DEVSIGN0 @ 0xBFC0FFEC
+ * ADEVSIGN0 @ 0xBFC0FF6C
+ *
+ */
+
+volatile uint32_t DEVSIGN_LA  __attribute__ ((used, section(".devsign_la"))) = 0x7FFFFFFF;
+volatile uint32_t ADEVSIGN_LA __attribute__ ((used, section(".adevsign_la"))) = 0x7FFFFFFF;
+volatile uint32_t DEVSIGN_B1  __attribute__ ((used, section(".devsign_b1"))) = 0x7FFFFFFF;
+volatile uint32_t ADEVSIGN_B1 __attribute__ ((used, section(".adevsign_b1"))) = 0x7FFFFFFF;
+volatile uint32_t DEVSIGN_B2  __attribute__ ((used, section(".devsign_b2"))) = 0x7FFFFFFF;
+volatile uint32_t ADEVSIGN_B2 __attribute__ ((used, section(".adevsign_b2"))) = 0x7FFFFFFF;
+
+
+/*
+ * Without a reference to this function from elsewhere LD throws the whole compile unit
+ * away even though the data is 'volatile' and 'used' !!!
+ */
+void dummy(void)
+{
+	(void)1;
+}
+

--- a/cpu/mips_pic32mz/reset_mod.S
+++ b/cpu/mips_pic32mz/reset_mod.S
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2014-2015, Imagination Technologies Limited and/or its
+ *                      affiliated group companies.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* ************ PLEASE READ ME !!!!  ****************
+
+	This file is a copy of the reset_mod.S from $MIPS_ELF_ROOT/share/mips/boot
+	(from the 2016.05-03 version) with a couple of modifications:
+
+	#define SKIP_COPY_TO_RAM - prevents the bootloader copying the whole contents
+	of flash to ram (as we want to XIP from flash), we copy initialised data from
+	flash to ram in 'software_init_hook'.
+
+	move .org's to before the labels to make the vector labels appear at the vector
+	addresses.
+
+	In boot_debug_exception vector drop out of debug mode before spining, this allows
+	attachment of an external debug program to investigate a hung system.
+
+	Future toolchain versions will have these changes included and this file will
+	be no longer needed.
+
+	Thanks for reading.
+*/
+
+
+#define _RESETCODE
+.set nomips16
+
+#include <mips/regdef.h>
+#include <mips/cpu.h>
+#include <mips/asm.h>
+
+    .set push
+    .set nomicromips
+LEAF(__reset_vector)
+    lui	  a2, %hi(__cpu_init)
+    addiu a2, %lo(__cpu_init)
+    mtc0  $0, C0_COUNT		  # Clear cp0 Count (Used to measure boot time.)
+    jr    a2
+    .space 32			  # Just to cope with a quirk of MIPS malta boards
+				  # this can be deleted for anything else.
+END(__reset_vector)
+    .set pop
+
+LEAF(__cpu_init)
+
+    # Verify the code is here due to a reset and not NMI. If this is an NMI then trigger
+    # a debugger breakpoint using a sdbp instruction.
+
+    mfc0  s1, C0_STATUS		  # Read CP0 Status
+    ext	  s1, s1, SR_NMI_SHIFT, 1 # extract NMI
+    beqz  s1, init_resources	  # Branch if this is NOT an NMI exception.
+    move  k0, t9		  # Preserve t9
+    move  k1, a0		  # Preserve a0
+    li	  $25, 15		  # UHI exception operation
+    li	  $4, 0			  # Use hard register context
+    sdbbp 1			  # Invoke UHI operation
+
+init_resources:
+
+    # Init CP0 Status, Count, Compare, Watch*, and Cause.
+    jal	  __init_cp0
+
+    # Initialise L2/L3 cache
+    # This could be done from cached code if there is a cca override or similar
+
+    # Determine L2/L3 cache config.
+
+    lui   a2, %hi(__init_l23cache)
+    addiu a2, a2, %lo(__init_l23cache)
+    jal	  a2
+
+init_ic:
+    # Initialize the L1 instruction cache.
+    jal	  __init_icache
+
+    # The changing of Kernel mode cacheability must be done from KSEG1
+    # Since the code is executing from KSEG0 It needs to do a jump to KSEG1 change K0
+    # and jump back to KSEG0
+
+    lui	  a2, %hi(__change_k0_cca)
+    addiu a2, a2, %lo(__change_k0_cca)
+    li	  a1, 0xf
+    ins	  a2, a1, 29, 1		      # changed to KSEG1 address by setting bit 29
+    jalr  a2
+
+    .weak __init_l23cache_cached
+    lui   a2, %hi(__init_l23cache_cached)
+    addiu a2, a2, %lo(__init_l23cache_cached)
+    beqz  a2, init_dc
+    jal   a2
+
+init_dc:
+    # Initialize the L1 data cache
+    jal	  __init_dcache
+
+    # Initialize the TLB.
+    jal	  __init_tlb
+
+    # Allow everything else to be initialized via a hook.
+    .weak __boot_init_hook
+    lui	  a2, %hi(__boot_init_hook)
+    addiu a2, a2, %lo(__boot_init_hook)
+    beqz  a2, 1f
+    jalr  a2
+1:
+
+#ifndef SKIP_COPY_TO_RAM
+
+    # Copy code and data to RAM
+    li    s1, 0xffffffff
+
+    # Copy code and read-only/initialized data from FLASH to (uncached) RAM.
+    lui   a1, %hi(__flash_app_start)
+    addiu a1, a1, %lo(__flash_app_start)
+    ins   a1, s1, 29, 1			# Make it uncached (kseg1)
+    lui   a2, %hi(__app_start)
+    addiu a2, a2, %lo(__app_start)
+    ins   a2, s1, 29, 1			# Make it uncached (kseg1)
+    lui   a3, %hi(_edata)
+    addiu a3, a3, %lo(_edata)
+    ins   a3, s1, 29, 1			# Make it uncached (kseg1)
+    beq   a2, a3, $Lcopy_to_ram_done
+$Lnext_ram_word:
+    lw    a0, 0(a1)
+    sw    a0, 0(a2)
+    addiu a2, a2, 4
+    addiu a1, a1, 4
+    bne   a3, a2, $Lnext_ram_word
+$Lcopy_to_ram_done:
+
+#endif
+
+    # Prepare for eret to _start
+    lui   ra, %hi($Lall_done)		# If main returns then go to all_done.
+    addiu ra, ra, %lo($Lall_done)
+    lui   v0, %hi(_start)		# Load the address of _start
+    addiu v0, v0, %lo(_start)
+    mtc0  v0, C0_ERRPC			# Set ErrorEPC to _start
+    ehb					# Clear hazards (makes sure write to
+					# ErrorPC has completed)
+    li	  a0, 0				# UHI compliant null argument setup
+
+    # Return from exception will now execute the application startup code
+    eret
+
+$Lall_done:
+    # If _start returns it will return to this point.
+    # Just spin here reporting the exit.
+    li	    $25, 1			# UHI exit operation
+    move    $4, v0			# Collect exit code for UHI exit
+    sdbbp   1				# Invoke UHI operation
+    b       $Lall_done
+END(__cpu_init)
+
+/**************************************************************************************
+    B O O T   E X C E P T I O N   H A N D L E R S (CP0 Status[BEV] = 1)
+**************************************************************************************/
+/* NOTE: the linker script must insure that this code starts at start + 0x200 so the exception */
+/* vectors will be addressed properly. All .org assume this! */
+/* TLB refill, 32 bit task. */
+.org 0x200				# TLB refill, 32 bit task.
+LEAF(__boot_tlb_refill)
+    move  k0, t9			# Preserve t9
+    move  k1, a0			# Preserve a0
+    li	  $25, 15			# UHI exception operation
+    li	  $4, 0				# Use hard register context
+    sdbbp 1				# Invoke UHI operation
+END(__boot_tlb_refill)
+
+.org 0x280				# XTLB refill, 64 bit task. BEV + 0x280
+LEAF(__boot_xtlb_refill)
+    move  k0, t9			# Preserve t9
+    move  k1, a0			# Preserve a0
+    li	  $25, 15			# UHI exception operation
+    li	  $4, 0				# Use hard register context
+    sdbbp 1				# Invoke UHI operation
+END(__boot_xtlb_refill)
+
+.org 0x300				# Cache error exception. BEV + 0x300
+LEAF(__boot_cache_error)
+    move  k0, t9			# Preserve t9
+    move  k1, a0			# Preserve a0
+    li	  $25, 15			# UHI exception operation
+    li	  $4, 0				# Use hard register context
+    sdbbp 1				# Invoke UHI operation
+END(__boot_cache_error)
+
+.org 0x380				# General exception. BEV + 0x380
+LEAF(__boot_general_exception)
+    move  k0, t9			# Preserve t9
+    move  k1, a0			# Preserve a0
+    li	  $25, 15			# UHI exception operation
+    li	  $4, 0				# Use hard register context
+    sdbbp 1				# Invoke UHI operation
+END(__boot_general_exception)
+
+# If you want the above code to fit into 1k flash you will need to leave
+# out the code below. This is the code that covers the debug exception
+#which you normally will not get.
+.org 0x480
+LEAF(__boot_debug_exception)
+	# EJTAG Debug (with ProbEn = 0 in the EJTAG Control Register)
+    mfc0 k1, C0_DEPC	# Save Debug exception point in DESAVE
+    mtc0 k1, C0_DESAVE
+    LA k1, 1f
+    # Drop out of debug mode before spinning (To allow a JTAG probe in).
+    mtc0 k1, C0_DEPC
+    ehb
+    deret
+1:
+    b 1b			 	#Spin indefinately
+END(__boot_debug_exception)


### PR DESCRIPTION
Add support for the mips32r2 architecture to RIOT.

cpu/mips32r2_common adds base architecture support for mips32r2 cores it can be
built in it own right as a 'CPU', but is dependant on a bootloader (like u-boot)
to have bootstrapped the system, this has been tested on a 'malta' FPGA system
(BOARD=mips-malta) with various mips32r2 compliant cores (interAptiv, P5600,
etc).

cpu/mips_pic32mz adds basic support for Microchip PIC32MZ devices, including
bootstrapping the device, the build system produces a hex image loadable via
MPLAB-IPE. It has been tested on a Digilent Wifire board.

cpu/mips_pic32mx adds basic support for Microchip PIC32MX devices, including
bootstrapping the device, the build system produces a hex image loadable via
MPLAB-IPE. It has been tested on a MikroElectronic Clicker board.

NOTE: This port requires the use of the GCC based MIPS Codescape SDK toolchain
available here:

https://community.imgtec.com/developers/mips/tools/codescape-mips-sdk/download-codescape-mips-sdk-essentials/

You cannot use Microchip's MPLAB / Harmony tools to build this port.

All 3 'CPU' types have been tested against the following examples:
hello-world
ipc_pingpong
timer_periodic_wakeup
riot_and_cpp

The following CPU / BOARD combinations are valid:

CPU=mips32r2_common BOARD=mips-malta
CPU=mips_pic32mz BOARD=pic32-wifire
CPU=mips_pic32mx BOARD=pic32-clicker