### PR TITLE
cpu/msp430fxyz: improved SPI driver speed

### DIFF
--- a/cpu/msp430fxyz/include/msp430_regs.h
+++ b/cpu/msp430fxyz/include/msp430_regs.h
@@ -261,16 +261,26 @@ typedef struct {
  * @brief   USCI control register 0 bitmap SPI mode
  * @{
  */
-#define USCI_SPI_CTL0_UCSYNC           (0x01)
-#define USCI_SPI_CTL0_MODE_3           (0x06)
-#define USCI_SPI_CTL0_MODE_0           (0x00)
-#define USCI_SPI_CTL0_MODE_1           (0x02)
-#define USCI_SPI_CTL0_MODE_2           (0x04)
-#define USCI_SPI_CTL0_MST              (0x08)
-#define USCI_SPI_CTL0_7BIT             (0x10)
-#define USCI_SPI_CTL0_MSB              (0x20)
-#define USCI_SPI_CTL0_CKPL             (0x40)
-#define USCI_SPI_CTL0_CKPH             (0x80)
+#define USCI_SPI_CTL0_UCSYNC        (0x01)
+#define USCI_SPI_CTL0_MODE_3        (0x06)
+#define USCI_SPI_CTL0_MODE_0        (0x00)
+#define USCI_SPI_CTL0_MODE_1        (0x02)
+#define USCI_SPI_CTL0_MODE_2        (0x04)
+#define USCI_SPI_CTL0_MST           (0x08)
+#define USCI_SPI_CTL0_7BIT          (0x10)
+#define USCI_SPI_CTL0_MSB           (0x20)
+#define USCI_SPI_CTL0_CKPL          (0x40)
+#define USCI_SPI_CTL0_CKPH          (0x80)
+/** @} */
+
+/**
+ * @brief   USCI status register bitmap SPI mode
+ * @{
+ */
+#define USCI_SPI_STAT_UCBUSY        (0x01)
+#define USCI_SPI_STAT_UCOE          (0x20)
+#define USCI_SPI_STAT_UCFE          (0x40)
+#define USCI_SPI_STAT_UCLISTEN      (0x80)
 /** @} */
 
 /**

--- a/cpu/msp430fxyz/include/periph_cpu.h
+++ b/cpu/msp430fxyz/include/periph_cpu.h
@@ -83,7 +83,7 @@ void gpio_periph_mode(gpio_t pin, bool enable);
  * @brief declare needed generic SPI functions
  * @{
  */
-#define PERIPH_SPI_NEEDS_TRANSFER_BYTES
+#define PERIPH_SPI_NEEDS_TRANSFER_BYTE
 #define PERIPH_SPI_NEEDS_TRANSFER_REG
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */

--- a/drivers/periph_common/spi.c
+++ b/drivers/periph_common/spi.c
@@ -52,6 +52,13 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
 }
 #endif
 
+#ifdef PERIPH_SPI_NEEDS_TRANSFER_BYTE
+int spi_transfer_byte(spi_t dev, char out, char *in)
+{
+    return spi_transfer_bytes(dev, &out, in, 1);
+}
+#endif
+
 #ifdef PERIPH_SPI_NEEDS_TRANSFER_REG
 int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
 {


### PR DESCRIPTION
From the discussion in #4780 we heard, that the SPI driver speed for the MSP430 platform performs poorly when writing a burst of data (e.g. when transferring network packets to the radio). This PR should improve the situation quite a bit.

Changes:
- improved the transfer function when only writing data to a device
- added the `transfer_byte()` (convenience) function to the periph_common module while making the `transfer_bytes()` function local to the driver. This will significantly reduce the number of function calls while transferring data...

@PeterKietzmann would you mind to test this and benchmark this against your existing numbers? Thx

