### PR TITLE
cpu/Makefile.include.cortexm_common: Fixing inclusion of the linker script. [bug]

### DIFF
--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -16,7 +16,12 @@ export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
-export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
+ifneq (,$(LINKER_SCRIPT))
+export LINKFLAGS += -T$(LINKER_SCRIPT)
+else
+export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld 
+endif
+export LINKFLAGS += -Wl,--fatal-warnings
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
 export LINKFLAGS += -Wl,--gc-sections
 


### PR DESCRIPTION
Linker script referenced by nordic_softdevice_ble package is not being included for during link phase. As a result, the microcoap example fails to link at the correct address and run on the NRF52.