### PR TITLE
boards: removed some superfluous definitions

### DIFF
--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Use the UART 0 for STDIO on this board
- */
-#define UART_STDIO_DEV      UART_DEV(0)
-
-/**
 * @brief As the CPU is too slow to handle 115200 baud, we set the default
 *        baudrate to 9600 for this board
 */

--- a/boards/nucleo-f207/include/board.h
+++ b/boards/nucleo-f207/include/board.h
@@ -27,6 +27,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 /**
  * @brief   LED pin definitions and handlers
  * @{
@@ -55,16 +56,6 @@ extern "C" {
 #define LED2_OFF            (GPIOB->BSRR = (LED2_MASK << 16))
 #define LED2_TOGGLE         (GPIOB->ODR  ^= LED2_MASK)
 /** @} */
-
-/**
- * @brief Use the 1st UART for STDIO on this board
- */
-#define UART_STDIO_DEV      UART_DEV(0)
-
-/**
- * @brief   User button
- */
-#define BTN_B1_PIN          GPIO_PIN(PORT_C, 13)
 
 /**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO

--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -55,15 +55,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Standard input/output device configuration
- * @{
- */
-#define UART_STDIO_DEV              (UART_DEV(0))
-#define UART_STDIO_BAUDRATE         (115200U)
-#define UART_STDIO_RX_BUFSIZE       (64U)
-/** @} */
-
-/**
  * @brief   CPU core configuration
  *
  * @todo    Move this to the periph_conf.h


### PR DESCRIPTION
- removed UART_STDIO_DEV as they use the default value
- removed BTN_B1_PIN for nucleo-207, as its already defined in the common header