### PR TITLE
make: improve module dependencies

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -8,10 +8,6 @@ OLD_USEPKG := $(sort $(USEPKG))
 # pull dependencies from drivers
 include $(RIOTBASE)/drivers/Makefile.dep
 
-ifneq (,$(filter ccn-lite,$(USEPKG)))
-    export CFLAGS += -DCCNL_RIOT
-endif
-
 ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += xtimer

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -8,11 +8,6 @@ OLD_USEPKG := $(sort $(USEPKG))
 # pull dependencies from drivers
 include $(RIOTBASE)/drivers/Makefile.dep
 
-ifneq (,$(filter libcoap,$(USEPKG)))
-    USEMODULE += posix_sockets
-    USEMODULE += gnrc_conn_udp
-endif
-
 ifneq (,$(filter ccn-lite,$(USEPKG)))
     export CFLAGS += -DCCNL_RIOT
 endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1,3 +1,10 @@
+#
+OLD_USEMODULE := $(sort $(USEMODULE))
+OLD_USEPKG := $(sort $(USEPKG))
+
+# include board dependencies
+-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
 # pull dependencies from drivers
 include $(RIOTBASE)/drivers/Makefile.dep
 
@@ -554,4 +561,14 @@ ifneq (,$(filter random,$(USEMODULE)))
     ifneq (,$(filter prng_tinymt32,$(USEMODULE)))
         USEMODULE += tinymt32
     endif
+endif
+
+# include package dependencies
+-include $(USEPKG:%=$(RIOTPKG)/%/Makefile.dep)
+
+# recursively catch transitive dependencies
+USEMODULE := $(sort $(USEMODULE))
+USEPKG := $(sort $(USEPKG))
+ifneq ($(OLD_USEMODULE) $(OLD_USEPKG),$(USEMODULE) $(USEPKG))
+    include $(RIOTBASE)/Makefile.dep
 endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -352,29 +352,6 @@ ifneq (,$(filter posix_semaphore,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter emb6_conn_udp,$(USEMODULE)))
-  USEMODULE += emb6_sock
-endif
-
-ifneq (,$(filter emb6_%,$(USEMODULE)))
-  USEMODULE += emb6
-endif
-
-ifneq (,$(filter emb6,$(USEMODULE)))
-  USEPKG += emb6
-  USEMODULE += emb6_bsp
-  USEMODULE += emb6_common
-  USEMODULE += emb6_contrib
-  USEMODULE += emb6_ipv6
-  USEMODULE += emb6_ipv6_multicast
-  USEMODULE += emb6_llsec
-  USEMODULE += emb6_mac
-  USEMODULE += emb6_netdev2
-  USEMODULE += emb6_rpl
-  USEMODULE += emb6_sicslowpan
-  USEMODULE += emb6_utils
-endif
-
 ifneq (,$(filter lwip_sixlowpan,$(USEMODULE)))
   USEMODULE += lwip_ipv6_autoconfig
 endif

--- a/boards/arduino-due/Makefile.include
+++ b/boards/arduino-due/Makefile.include
@@ -12,6 +12,3 @@ export OFLAGS = -O binary
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
-
-# also include optional dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/avsextrem/Makefile.dep
+++ b/boards/avsextrem/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/msba2-common/Makefile.dep

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -33,6 +33,3 @@ export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)
 
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
-
-# Include board dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/fox/Makefile.include
+++ b/boards/fox/Makefile.include
@@ -11,6 +11,3 @@ include $(RIOTBOARD)/Makefile.include.serial
 
 # this board uses openocd
 include $(RIOTBOARD)/Makefile.include.openocd
-
-# include board dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/frdm-k64f/Makefile.include
+++ b/boards/frdm-k64f/Makefile.include
@@ -23,8 +23,6 @@ export OPENOCD_PRE_VERIFY_CMDS += \
 export OPENOCD_EXTRA_INIT
 export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/kinetis_common/dist/check-fcfield-elf.sh
 
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 

--- a/boards/iotlab-a8-m3/Makefile.include
+++ b/boards/iotlab-a8-m3/Makefile.include
@@ -1,7 +1,6 @@
 USEMODULE += iotlab-common
 
 include $(RIOTBOARD)/iotlab-common/Makefile.include
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 
 # add iotlab-a8-m3 include path
 INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/iotlab-m3/Makefile.dep
+++ b/boards/iotlab-m3/Makefile.dep
@@ -1,5 +1,3 @@
-include $(RIOTBOARD)/iotlab-common/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += isl29020
   USEMODULE += lps331ap

--- a/boards/iotlab-m3/Makefile.include
+++ b/boards/iotlab-m3/Makefile.include
@@ -1,7 +1,6 @@
 USEMODULE += iotlab-common
 
 include $(RIOTBOARD)/iotlab-common/Makefile.include
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 
 # add iotlab-m3 include path
 INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -23,7 +23,6 @@ ifeq ($(PORT),)
 endif
 export FFLAGS = $(PORT) $(HEXFILE)
 export TERMFLAGS += -tg -p "$(PORT)"
-include $(RIOTBOARD)/msba2-common/Makefile.dep
 
 export INCLUDES += -I$(RIOTBOARD)/msba2-common/include -I$(RIOTBOARD)/msba2-common/drivers/include
 

--- a/boards/msba2/Makefile.dep
+++ b/boards/msba2/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/msba2-common/Makefile.dep

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -115,6 +115,3 @@ include $(RIOTBOARD)/Makefile.include.openocd
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
-
-# include board dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -1,5 +1,3 @@
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 export NATIVEINCLUDES += -DNATIVE_INCLUDES
 export NATIVEINCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 export NATIVEINCLUDES += -I$(RIOTBASE)/core/include/

--- a/boards/nrf52dk/Makefile.include
+++ b/boards/nrf52dk/Makefile.include
@@ -6,9 +6,6 @@ export CPU_MODEL = nrf52xxaa
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # setup JLink for flashing
 export JLINK_DEVICE := nrf52
 

--- a/boards/nucleo-common/Makefile.include
+++ b/boards/nucleo-common/Makefile.include
@@ -8,8 +8,5 @@ include $(RIOTBOARD)/Makefile.include.serial
 # this board uses openocd
 include $(RIOTBOARD)/Makefile.include.openocd
 
-# include dependencies
-include $(RIOTBOARD)/nucleo-common/Makefile.dep
-
 # add the common header files to the include path
 INCLUDES += -I$(RIOTBOARD)/nucleo-common/include

--- a/boards/nucleo-f072/Makefile.dep
+++ b/boards/nucleo-f072/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep

--- a/boards/nucleo-f091/Makefile.dep
+++ b/boards/nucleo-f091/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep

--- a/boards/nucleo-f103/Makefile.dep
+++ b/boards/nucleo-f103/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep

--- a/boards/nucleo-f207/Makefile.dep
+++ b/boards/nucleo-f207/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep

--- a/boards/nucleo-f303/Makefile.dep
+++ b/boards/nucleo-f303/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep

--- a/boards/nucleo-f334/Makefile.dep
+++ b/boards/nucleo-f334/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep

--- a/boards/nucleo-f401/Makefile.dep
+++ b/boards/nucleo-f401/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep

--- a/boards/nucleo-f446/Makefile.dep
+++ b/boards/nucleo-f446/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -25,6 +25,3 @@ endif
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
-
-# Include board dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -27,8 +27,6 @@ export OPENOCD_PRE_VERIFY_CMDS += \
 export OPENOCD_EXTRA_INIT
 export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/kinetis_common/dist/check-fcfield-elf.sh
 
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # Add board selector (USB serial) to OpenOCD options if specified.
 # Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
 #   Usage: SERIAL="0200..." BOARD="pba-d-01-kw2x" make flash

--- a/boards/pttu/Makefile.dep
+++ b/boards/pttu/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/msba2-common/Makefile.dep

--- a/boards/remote-common/Makefile.include
+++ b/boards/remote-common/Makefile.include
@@ -33,6 +33,3 @@ export INCLUDES += -I$(RIOTBOARD)/remote-common/include
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
-
-# Include board dependencies
-include $(RIOTBOARD)/remote-common/Makefile.dep

--- a/boards/saml21-xpro/Makefile.include
+++ b/boards/saml21-xpro/Makefile.include
@@ -3,9 +3,6 @@ export CPU = saml21
 export CPU_MODEL = saml21j18a
 export CFLAGS += -D__SAML21J18A__
 
-# include dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # setup serial terminal
 PORT_LINUX ?= /dev/ttyACM0
 include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -7,9 +7,6 @@ CFLAGS += -D__SAMR21G18A__
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 

--- a/boards/slwstk6220a/Makefile.include
+++ b/boards/slwstk6220a/Makefile.include
@@ -6,9 +6,6 @@ export CPU_MODEL = ezr32wg330f256r60
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # setup JLink for flashing
 export JLINK_DEVICE := ezr32wg330f256
 include $(RIOTBOARD)/Makefile.include.jlink

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -9,9 +9,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-MXV*)))
 export BAUD ?= 9600
 include $(RIOTBOARD)/Makefile.include.serial
 
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # flash tool configuration
 export OFLAGS = -O ihex
 export FLASHER = $(RIOTBASE)/dist/tools/goodfet/goodfet.bsl

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -26,10 +26,6 @@ else
   # TODO: fix for building under windows
 endif
 
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
-
 export FLASHER
 export PORT
 export DIST_PATH = $(RIOTBOARD)/$(BOARD)/dist

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -8,9 +8,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # setup flash tool
 export OFLAGS = -O ihex
 export FLASHER = $(RIOTBASE)/dist/tools/goodfet/goodfet.bsl

--- a/pkg/ccn-lite/Makefile.include
+++ b/pkg/ccn-lite/Makefile.include
@@ -1,2 +1,4 @@
 INCLUDES += -I$(RIOTPKG)/ccn-lite -I$(BINDIRBASE)/pkg/$(BOARD)/ccn-lite/src
 INCLUDES += -I$(RIOTBASE)/sys/posix/include
+
+CFLAGS += -DCCNL_RIOT

--- a/pkg/emb6/Makefile.dep
+++ b/pkg/emb6/Makefile.dep
@@ -1,0 +1,22 @@
+ifneq (,$(filter emb6_conn_udp,$(USEMODULE)))
+  USEMODULE += emb6_sock
+endif
+
+ifneq (,$(filter emb6_%,$(USEMODULE)))
+  USEMODULE += emb6
+endif
+
+ifneq (,$(filter emb6,$(USEMODULE)))
+  USEPKG += emb6
+  USEMODULE += emb6_bsp
+  USEMODULE += emb6_common
+  USEMODULE += emb6_contrib
+  USEMODULE += emb6_ipv6
+  USEMODULE += emb6_ipv6_multicast
+  USEMODULE += emb6_llsec
+  USEMODULE += emb6_mac
+  USEMODULE += emb6_netdev2
+  USEMODULE += emb6_rpl
+  USEMODULE += emb6_sicslowpan
+  USEMODULE += emb6_utils
+endif

--- a/pkg/libcoap/Makefile.dep
+++ b/pkg/libcoap/Makefile.dep
@@ -1,0 +1,4 @@
+ifneq (,$(filter libcoap,$(USEPKG)))
+    USEMODULE += posix_sockets
+    USEMODULE += gnrc_conn_udp
+endif

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -8,6 +8,8 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := msb-430h stm32f0discovery telosb weio z1
 
+USEPKG += emb6
+
 USEMODULE += emb6_router
 USEMODULE += emb6_conn_udp
 USEMODULE += ipv6_addr


### PR DESCRIPTION
This PR tries to improve our module dependency system:

- Makefile.dep is now recursively evaluated until all transitive dependencies are sorted out
- Makefile.dep now implicitly includes boards/$board/Makefile.dep (if it exists)
- Makefile.dep now implicitly includes boards/$pkg/Makefile.dep (if it exists) for each package, allowing packages to have dependencies without modifying the main Makefile.dep

I've adapted some packages, but would like to hear comments for the approach in general before investing more work.