### PR TITLE
kinetis: Add stddef, stdint missing includes for gpio.c

### DIFF
--- a/cpu/kinetis_common/periph/gpio.c
+++ b/cpu/kinetis_common/periph/gpio.c
@@ -24,6 +24,8 @@
  * @}
  */
 
+#include <stddef.h>
+#include <stdint.h>
 #include "sched.h"
 #include "thread.h"
 #include "cpu.h"


### PR DESCRIPTION
`NULL` and `uint32_t` are used in the driver.