### PR TITLE
nRF52 Fix softdevice.hex flashing issue

### DIFF
--- a/boards/nrf52dk/Makefile.include
+++ b/boards/nrf52dk/Makefile.include
@@ -14,7 +14,7 @@ export JLINK_DEVICE := nrf52
 
 # special options when using SoftDevice
 ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
-export JLINK_PRE_FLASH := loadfile $(BINDIR)/softdevice.hex
+export JLINK_PRE_FLASH := erase\nloadfile $(BINDIR)/softdevice.hex
 export JLINK_FLASH_ADDR := 0x1f000
 export LINKER_SCRIPT ?= $(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL)_sd.ld
 endif


### PR DESCRIPTION
I found the following issue with nRF52DK board:
When flashing the microcoap_server example after the hello_world example, the microcoap_server application will not work (nothing on the serial interface).
This is due to the fact that the microcoap_server uses the softdevice.hex stack and this stack is checking that value at 0x2000 is 0xFFFFFFFF. This address is not present in the softdevice.hex.
The work around found on the forums is to do an "nrfjprog --family NRF52 --recover" before flashing the microcoap_server application(and the softdevice).

This patch avoid to do a manual "nrfjprog --family NRF52 --recover" by including an erase command to the JLink pre flash command before flashing the softdevice.hex.