### PR TITLE
nRF52/CortexM: add variable initialization to remove compiler warning preventing compilation

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -205,8 +205,8 @@ __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, 
     uint32_t dfsr  = SCB->DFSR;
     uint32_t afsr  = SCB->AFSR;
 #endif
-    uint32_t pc=0;
-    uint32_t* orig_sp=NULL;
+    uint32_t pc = 0;
+    uint32_t* orig_sp = NULL;
 
     /* Check if the ISR stack overflowed previously. Not possible to detect
      * after output may also have overflowed it. */

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -205,8 +205,8 @@ __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, 
     uint32_t dfsr  = SCB->DFSR;
     uint32_t afsr  = SCB->AFSR;
 #endif
-    uint32_t pc;
-    uint32_t* orig_sp;
+    uint32_t pc=0;
+    uint32_t* orig_sp=NULL;
 
     /* Check if the ISR stack overflowed previously. Not possible to detect
      * after output may also have overflowed it. */


### PR DESCRIPTION
Trying to compile the example/hello-world for nRF52DK board, I'm getting the compilation error below due to uninitialized variable as a side effect of inline assembly code.

Fix proposal is to initialized those variable so the false warning is removed.

With this fix I can compile and run the hello-world application for nRF52DK board.

~/riotos/examples/hello-world$ BOARD=nrf52dk PORT=/dev/ttyACM0 make 
Building application "hello-world" for "nrf52dk" with MCU "nrf52".

"make" -C /home/jeff/riotos/boards/nrf52dk
"make" -C /home/jeff/riotos/core
"make" -C /home/jeff/riotos/cpu/nrf52
"make" -C /home/jeff/riotos/cpu/cortexm_common
/home/jeff/riotos/cpu/cortexm_common/vectors_cortexm.c: In function 'hard_fault_handler':
/home/jeff/riotos/cpu/cortexm_common/vectors_cortexm.c:276:9: error: 'orig_sp' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         __asm__ volatile (
         ^
/home/jeff/riotos/cpu/cortexm_common/vectors_cortexm.c:271:15: error: 'pc' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         printf("In GDB:\n  set $pc=0x%" PRIx32 "\n  frame 0\n  bt\n", pc);
               ^
cc1: all warnings being treated as errors
make[3]: *** [/home/jeff/riotos/examples/hello-world/bin/nrf52dk/cortexm_common/vectors_cortexm.o] Error 1
make[2]: *** [ALL--/home/jeff/riotos/cpu/cortexm_common] Error 2
make[1]: *** [ALL--/home/jeff/riotos/cpu/nrf52] Error 2
make: *** [all] Error 2
