### PR TITLE
cpu: cortexm_common: allow overriding of linker script

### DIFF
--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -16,7 +16,9 @@ export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)
 
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG)
 export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/cortexm_common/ldscripts
-export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld -Wl,--fatal-warnings
+export LINKER_SCRIPT ?= $(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL).ld
+export LINKFLAGS += -T$(LINKER_SCRIPT) -Wl,--fatal-warnings
+
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
 export LINKFLAGS += -Wl,--gc-sections
 


### PR DESCRIPTION
Without this fix, the microcoap_server application will not work for instance.
This patch was merged on July 9th but removed on July 13th with other things.
https://github.com/RIOT-OS/RIOT/commits/master/cpu/Makefile.include.cortexm_common

Re-submitting as this is needed for nRF52 softdevice based code to work.