### PR TITLE
ieee802154: clean-up (Intra-PAN behavior + broadcast)

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -100,7 +100,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* set default TX power */
     at86rf2xx_set_txpower(dev, AT86RF2XX_DEFAULT_TXPOWER);
     /* set default options */
-    at86rf2xx_set_option(dev, NETDEV2_IEEE802154_PAN_COMP, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_AUTOACK, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_START, false);

--- a/drivers/include/net/netdev2/ieee802154.h
+++ b/drivers/include/net/netdev2/ieee802154.h
@@ -38,7 +38,7 @@ extern "C" {
  * @{
  */
 
-#define NETDEV2_IEEE802154_SEND_MASK        (0x0068)    /**< flags to take for send packets */
+#define NETDEV2_IEEE802154_SEND_MASK        (0x0028)    /**< flags to take for send packets */
 #define NETDEV2_IEEE802154_RESV1            (0x0001)    /**< reserved flag */
 #define NETDEV2_IEEE802154_RAW              (0x0002)    /**< pass raw frame to upper layer */
 /**
@@ -52,7 +52,6 @@ extern "C" {
  * @brief   request ACK from receiver
  */
 #define NETDEV2_IEEE802154_ACK_REQ          (0x0020)
-#define NETDEV2_IEEE802154_PAN_COMP         (0x0040)    /**< compress source PAN ID */
 #define NETDEV2_IEEE802154_RESV3            (0x0080)    /**< reserved flag */
 /**
  * @}

--- a/drivers/include/net/netdev2/ieee802154.h
+++ b/drivers/include/net/netdev2/ieee802154.h
@@ -39,20 +39,20 @@ extern "C" {
  */
 
 #define NETDEV2_IEEE802154_SEND_MASK        (0x0028)    /**< flags to take for send packets */
-#define NETDEV2_IEEE802154_RESV1            (0x0001)    /**< reserved flag */
 #define NETDEV2_IEEE802154_RAW              (0x0002)    /**< pass raw frame to upper layer */
 /**
  * @brief   use long source addres (set) or short source address (unset)
  */
 #define NETDEV2_IEEE802154_SRC_MODE_LONG    (0x0004)
-#define NETDEV2_IEEE802154_SECURITY_EN      (0x0008)    /**< enable security */
-#define NETDEV2_IEEE802154_RESV2            (0x0010)    /**< reserved flag */
+/**
+ * @brief enable security
+ */
+#define NETDEV2_IEEE802154_SECURITY_EN      (IEEE802154_FCF_SECURITY_EN)
 
 /**
  * @brief   request ACK from receiver
  */
-#define NETDEV2_IEEE802154_ACK_REQ          (0x0020)
-#define NETDEV2_IEEE802154_RESV3            (0x0080)    /**< reserved flag */
+#define NETDEV2_IEEE802154_ACK_REQ          (IEEE802154_FCF_ACK_REQ)
 /**
  * @}
  */

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -78,12 +78,24 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Flag for @ref ieee802154_set_frame_hdr to indicate to ignore @p dst
- *          and @p dst_len and send broadcast.
- * @note    This flag is RIOT internal and shall not be used in the FCF of
- *          packets send over the air
+ * @brief   Special address defintions
+ * @{
  */
-#define IEEE802154_BCAST                    (0x80)
+/**
+ * @brief   Static initializer for broadcast address
+ */
+#define IEEE802154_ADDR_BCAST               { 0xff, 0xff }
+
+/**
+ * @brief   Length in byte of @ref IEEE802154_ADDR_BCAST
+ */
+#define IEEE802154_ADDR_BCAST_LEN           (IEEE802154_SHORT_ADDRESS_LEN)
+
+/**
+ * @brief   Broadcast address
+ */
+extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
+/** @} */
 
 /**
  * @brief   Initializes an IEEE 802.15.4 MAC frame header in @p buf.
@@ -121,9 +133,6 @@ extern "C" {
  *                      @ref IEEE802154_FCF_SECURITY_EN,
  *                      @ref IEEE802154_FCF_FRAME_PEND, and
  *                      @ref IEEE802154_FCF_ACK_REQ.
- *                      Additionally the @ref IEEE802154_BCAST flag can be set
- *                      do ignore @p dst and @p dst_len and just set `ff:ff`
- *                      (broadcast) as destination address
  * @param[in] seq       Sequence number for frame.
  *
  * The version field in the FCF will be set implicitly to version 1.

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -119,9 +119,8 @@ extern "C" {
  *                      first byte of the IEEE 802.15.4 FCF. This means that
  *                      it encompasses the type values,
  *                      @ref IEEE802154_FCF_SECURITY_EN,
- *                      @ref IEEE802154_FCF_FRAME_PEND,
- *                      @ref IEEE802154_FCF_ACK_REQ, and
- *                      @ref IEEE802154_FCF_PAN_COMP.
+ *                      @ref IEEE802154_FCF_FRAME_PEND, and
+ *                      @ref IEEE802154_FCF_ACK_REQ.
  *                      Additionally the @ref IEEE802154_BCAST flag can be set
  *                      do ignore @p dst and @p dst_len and just set `ff:ff`
  *                      (broadcast) as destination address

--- a/sys/net/link_layer/ieee802154/ieee802154.c
+++ b/sys/net/link_layer/ieee802154/ieee802154.c
@@ -82,10 +82,15 @@ size_t ieee802154_set_frame_hdr(uint8_t *buf, const uint8_t *src, size_t src_len
     }
 
     /* fill in source PAN ID (if applicable) */
-    if (!(flags & IEEE802154_FCF_PAN_COMP) && (src_len != 0)) {
-        /* (little endian) */
-        buf[pos++] = src_pan.u8[0];
-        buf[pos++] = src_pan.u8[1];
+    if (src_len != 0) {
+        if ((dst_len != 0) && (src_pan.u16 == dst_pan.u16)) {
+            buf[0] |= IEEE802154_FCF_PAN_COMP;
+        }
+        else {
+            /* (little endian) */
+            buf[pos++] = src_pan.u8[0];
+            buf[pos++] = src_pan.u8[1];
+        }
     }
 
     /* fill in source address */

--- a/tests/unittests/tests-ieee802154/tests-ieee802154.c
+++ b/tests/unittests/tests-ieee802154/tests-ieee802154.c
@@ -173,83 +173,20 @@ static void test_ieee802154_set_frame_hdr_bcast_src8(void)
                                 IEEE802154_FCF_SRC_ADDR_LONG,
                             TEST_UINT8,
                             dst_pan.u8[0], dst_pan.u8[1],
-                            0xff, 0xff,
+                            ieee802154_addr_bcast[0], ieee802154_addr_bcast[1],
                             src_pan.u8[0], src_pan.u8[1],
                             src.u8[7], src.u8[6], src.u8[5], src.u8[4],
                             src.u8[3], src.u8[2], src.u8[1], src.u8[0] };
     uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_BCAST;
+    const uint8_t flags = 0;
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp),
                           ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
-                                                   NULL, 0,
+                                                   ieee802154_addr_bcast,
+                                                   IEEE802154_ADDR_BCAST_LEN,
                                                    src_pan, dst_pan,
                                                    flags, TEST_UINT8));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp, res, sizeof(exp)));
-}
-
-static void test_ieee802154_set_frame_hdr_dst0_src2(void)
-{
-    const network_uint16_t src = byteorder_htons(TEST_UINT16);
-    const le_uint16_t src_pan = byteorder_htols(TEST_UINT16 + 1);
-    const le_uint16_t dst_pan = byteorder_htols(0);
-    /* IEEE 802.15.4 is little endian! */
-    const uint8_t exp[] = { IEEE802154_FCF_ACK_REQ,
-                            IEEE802154_FCF_VERS_V1 |
-                                IEEE802154_FCF_DST_ADDR_VOID |
-                                IEEE802154_FCF_SRC_ADDR_SHORT,
-                            TEST_UINT8,
-                            src_pan.u8[0], src_pan.u8[1],
-                            src.u8[1], src.u8[0] };
-    uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_FCF_ACK_REQ;
-
-    TEST_ASSERT_EQUAL_INT(sizeof(exp),
-                          ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
-                                                   NULL, 0,
-                                                   src_pan, dst_pan,
-                                                   flags, TEST_UINT8));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(exp, res, sizeof(exp)));
-}
-
-static void test_ieee802154_set_frame_hdr_dst0_src8(void)
-{
-    const network_uint64_t src = byteorder_htonll(TEST_UINT64);
-    const le_uint16_t src_pan = byteorder_htols(TEST_UINT16);
-    const le_uint16_t dst_pan = byteorder_htols(0);
-    /* IEEE 802.15.4 is little endian! */
-    const uint8_t exp[] = { IEEE802154_FCF_FRAME_PEND,
-                            IEEE802154_FCF_VERS_V1 |
-                                IEEE802154_FCF_DST_ADDR_VOID |
-                                IEEE802154_FCF_SRC_ADDR_LONG,
-                            TEST_UINT8,
-                            src_pan.u8[0], src_pan.u8[1],
-                            src.u8[7], src.u8[6], src.u8[5], src.u8[4],
-                            src.u8[3], src.u8[2], src.u8[1], src.u8[0] };
-    uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_FCF_FRAME_PEND;
-
-    TEST_ASSERT_EQUAL_INT(sizeof(exp),
-                          ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
-                                                   NULL, 0,
-                                                   src_pan, dst_pan,
-                                                   flags, TEST_UINT8));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(exp, res, sizeof(exp)));
-}
-
-static void test_ieee802154_set_frame_hdr_dst0_src8_pancomp(void)
-{
-    const network_uint64_t src = byteorder_htonll(TEST_UINT64);
-    const le_uint16_t src_pan = byteorder_htols(TEST_UINT16);
-    const le_uint16_t dst_pan = byteorder_htols(0);
-    uint8_t res;
-    const uint8_t flags = IEEE802154_FCF_PAN_COMP;
-
-    TEST_ASSERT_EQUAL_INT(0,
-                          ieee802154_set_frame_hdr(&res, src.u8, sizeof(src),
-                                                   NULL, 0,
-                                                   src_pan, dst_pan,
-                                                   flags, TEST_UINT8));
 }
 
 static void test_ieee802154_set_frame_hdr_dst2_src0(void)
@@ -274,21 +211,6 @@ static void test_ieee802154_set_frame_hdr_dst2_src0(void)
                                                    src_pan, dst_pan,
                                                    flags, TEST_UINT8));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp, res, sizeof(exp)));
-}
-
-static void test_ieee802154_set_frame_hdr_dst2_src0_pancomp(void)
-{
-    const network_uint16_t dst = byteorder_htons(TEST_UINT16);
-    const le_uint16_t src_pan = byteorder_htols(0);
-    const le_uint16_t dst_pan = byteorder_htols(TEST_UINT16 + 1);
-    uint8_t res;
-    const uint8_t flags = IEEE802154_FCF_PAN_COMP;
-
-    TEST_ASSERT_EQUAL_INT(0,
-                          ieee802154_set_frame_hdr(&res, NULL, 0,
-                                                   dst.u8, sizeof(dst),
-                                                   src_pan, dst_pan,
-                                                   flags, TEST_UINT8));
 }
 
 static void test_ieee802154_set_frame_hdr_dst2_src2(void)
@@ -323,7 +245,7 @@ static void test_ieee802154_set_frame_hdr_dst2_src2_pancomp(void)
     const network_uint16_t src = byteorder_htons(TEST_UINT16);
     const le_uint16_t src_pan = byteorder_htols(TEST_UINT16 + 1);
     const network_uint16_t dst = byteorder_htons(TEST_UINT16 + 2);
-    const le_uint16_t dst_pan = byteorder_htols(TEST_UINT16 + 3);
+    const le_uint16_t dst_pan = src_pan;
     /* IEEE 802.15.4 is little endian! */
     const uint8_t exp[] = { IEEE802154_FCF_TYPE_DATA | IEEE802154_FCF_PAN_COMP,
                             IEEE802154_FCF_VERS_V1 |
@@ -335,7 +257,7 @@ static void test_ieee802154_set_frame_hdr_dst2_src2_pancomp(void)
                             /* src_pan compressed (and assumed equal to dst_pan) */
                             src.u8[1], src.u8[0] };
     uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_FCF_TYPE_DATA | IEEE802154_FCF_PAN_COMP;
+    const uint8_t flags = IEEE802154_FCF_TYPE_DATA;
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp),
                           ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
@@ -378,7 +300,7 @@ static void test_ieee802154_set_frame_hdr_dst2_src8_pancomp(void)
     const network_uint64_t src = byteorder_htonll(TEST_UINT64);
     const le_uint16_t src_pan = byteorder_htols(TEST_UINT16);
     const network_uint16_t dst = byteorder_htons(TEST_UINT16 + 1);
-    const le_uint16_t dst_pan = byteorder_htols(TEST_UINT16 + 2);
+    const le_uint16_t dst_pan = src_pan;
     /* IEEE 802.15.4 is little endian! */
     const uint8_t exp[] = { IEEE802154_FCF_TYPE_DATA | IEEE802154_FCF_PAN_COMP,
                             IEEE802154_FCF_VERS_V1 |
@@ -391,7 +313,7 @@ static void test_ieee802154_set_frame_hdr_dst2_src8_pancomp(void)
                             src.u8[7], src.u8[6], src.u8[5], src.u8[4],
                             src.u8[3], src.u8[2], src.u8[1], src.u8[0] };
     uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_FCF_TYPE_DATA | IEEE802154_FCF_PAN_COMP;
+    const uint8_t flags = IEEE802154_FCF_TYPE_DATA;
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp),
                           ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
@@ -424,21 +346,6 @@ static void test_ieee802154_set_frame_hdr_dst8_src0(void)
                                                    src_pan, dst_pan,
                                                    flags, TEST_UINT8));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp, res, sizeof(exp)));
-}
-
-static void test_ieee802154_set_frame_hdr_dst8_src0_pancomp(void)
-{
-    const network_uint64_t dst = byteorder_htonll(TEST_UINT64);
-    const le_uint16_t src_pan = byteorder_htols(0);
-    const le_uint16_t dst_pan = byteorder_htols(TEST_UINT16);
-    uint8_t res;
-    const uint8_t flags = IEEE802154_FCF_PAN_COMP;
-
-    TEST_ASSERT_EQUAL_INT(0,
-                          ieee802154_set_frame_hdr(&res, NULL, 0,
-                                                   dst.u8, sizeof(dst),
-                                                   src_pan, dst_pan,
-                                                   flags, TEST_UINT8));
 }
 
 static void test_ieee802154_set_frame_hdr_dst8_src2(void)
@@ -474,7 +381,7 @@ static void test_ieee802154_set_frame_hdr_dst8_src2_pancomp(void)
     const network_uint16_t src = byteorder_htons(TEST_UINT16);
     const le_uint16_t src_pan = byteorder_htols(TEST_UINT16 + 1);
     const network_uint64_t dst = byteorder_htonll(TEST_UINT64);
-    const le_uint16_t dst_pan = byteorder_htols(TEST_UINT16 + 2);
+    const le_uint16_t dst_pan = src_pan;
     /* IEEE 802.15.4 is little endian! */
     const uint8_t exp[] = { IEEE802154_FCF_TYPE_BEACON | IEEE802154_FCF_PAN_COMP,
                             IEEE802154_FCF_VERS_V1 |
@@ -487,7 +394,7 @@ static void test_ieee802154_set_frame_hdr_dst8_src2_pancomp(void)
                             /* src_pan compressed (and assumed equal to dst_pan) */
                             src.u8[1], src.u8[0] };
     uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_FCF_TYPE_BEACON | IEEE802154_FCF_PAN_COMP;
+    const uint8_t flags = IEEE802154_FCF_TYPE_BEACON;
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp),
                           ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
@@ -531,7 +438,7 @@ static void test_ieee802154_set_frame_hdr_dst8_src8_pancomp(void)
     const network_uint64_t src = byteorder_htonll(TEST_UINT64);
     const le_uint16_t src_pan = byteorder_htols(TEST_UINT16);
     const network_uint64_t dst = byteorder_htonll(TEST_UINT64);
-    const le_uint16_t dst_pan = byteorder_htols(TEST_UINT16 + 1);
+    const le_uint16_t dst_pan = src_pan;
     /* IEEE 802.15.4 is little endian! */
     const uint8_t exp[] = { IEEE802154_FCF_TYPE_BEACON | IEEE802154_FCF_PAN_COMP,
                             IEEE802154_FCF_VERS_V1 |
@@ -545,7 +452,7 @@ static void test_ieee802154_set_frame_hdr_dst8_src8_pancomp(void)
                             src.u8[7], src.u8[6], src.u8[5], src.u8[4],
                             src.u8[3], src.u8[2], src.u8[1], src.u8[0] };
     uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_FCF_TYPE_BEACON | IEEE802154_FCF_PAN_COMP;
+    const uint8_t flags = IEEE802154_FCF_TYPE_BEACON;
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp),
                           ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
@@ -1167,17 +1074,12 @@ Test *tests_ieee802154_tests(void)
         new_TestFixture(test_ieee802154_set_frame_hdr_bcast_dst2_src2),
         new_TestFixture(test_ieee802154_set_frame_hdr_bcast_dst8_src2),
         new_TestFixture(test_ieee802154_set_frame_hdr_bcast_src8),
-        new_TestFixture(test_ieee802154_set_frame_hdr_dst0_src2),
-        new_TestFixture(test_ieee802154_set_frame_hdr_dst0_src8),
-        new_TestFixture(test_ieee802154_set_frame_hdr_dst0_src8_pancomp),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst2_src0),
-        new_TestFixture(test_ieee802154_set_frame_hdr_dst2_src0_pancomp),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst2_src2),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst2_src2_pancomp),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst2_src8),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst2_src8_pancomp),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst8_src0),
-        new_TestFixture(test_ieee802154_set_frame_hdr_dst8_src0_pancomp),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst8_src2),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst8_src2_pancomp),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst8_src8),

--- a/tests/unittests/tests-ieee802154/tests-ieee802154.c
+++ b/tests/unittests/tests-ieee802154/tests-ieee802154.c
@@ -68,13 +68,14 @@ static void test_ieee802154_set_frame_hdr_bcast_src0(void)
                                 IEEE802154_FCF_DST_ADDR_SHORT,
                             TEST_UINT8,
                             dst_pan.u8[0], dst_pan.u8[1],
-                            0xff, 0xff };
+                            ieee802154_addr_bcast[0], ieee802154_addr_bcast[1] };
     uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_BCAST;
+    const uint8_t flags = 0;
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp),
                           ieee802154_set_frame_hdr(res, NULL, 0,
-                                                   NULL, 0,
+                                                   ieee802154_addr_bcast,
+                                                   IEEE802154_ADDR_BCAST_LEN,
                                                    src_pan, dst_pan,
                                                    flags, TEST_UINT8));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp, res, sizeof(exp)));
@@ -92,70 +93,16 @@ static void test_ieee802154_set_frame_hdr_bcast_src2(void)
                                 IEEE802154_FCF_SRC_ADDR_SHORT,
                             TEST_UINT8,
                             dst_pan.u8[0], dst_pan.u8[1],
-                            0xff, 0xff,
+                            ieee802154_addr_bcast[0], ieee802154_addr_bcast[1],
                             src_pan.u8[0], src_pan.u8[1],
                             src.u8[1], src.u8[0] };
     uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_BCAST;
+    const uint8_t flags = 0;
 
     TEST_ASSERT_EQUAL_INT(sizeof(exp),
                           ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
-                                                   NULL, 0,
-                                                   src_pan, dst_pan,
-                                                   flags, TEST_UINT8));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(exp, res, sizeof(exp)));
-}
-
-static void test_ieee802154_set_frame_hdr_bcast_dst2_src2(void)
-{
-    const network_uint16_t src = byteorder_htons(TEST_UINT16);
-    const le_uint16_t src_pan = byteorder_htols(TEST_UINT16 + 1);
-    const network_uint16_t dst = byteorder_htons(TEST_UINT16);
-    const le_uint16_t dst_pan = byteorder_htols(TEST_UINT16 + 2);
-    /* IEEE 802.15.4 is little endian! */
-    const uint8_t exp[] = { 0x00,
-                            IEEE802154_FCF_VERS_V1 |
-                                IEEE802154_FCF_DST_ADDR_SHORT |
-                                IEEE802154_FCF_SRC_ADDR_SHORT,
-                            TEST_UINT8,
-                            dst_pan.u8[0], dst_pan.u8[1],
-                            0xff, 0xff,
-                            src_pan.u8[0], src_pan.u8[1],
-                            src.u8[1], src.u8[0] };
-    uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_BCAST; /* broadcast flag lets dst be ignored */
-
-    TEST_ASSERT_EQUAL_INT(sizeof(exp),
-                          ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
-                                                   dst.u8, sizeof(dst),
-                                                   src_pan, dst_pan,
-                                                   flags, TEST_UINT8));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(exp, res, sizeof(exp)));
-}
-
-static void test_ieee802154_set_frame_hdr_bcast_dst8_src2(void)
-{
-    const network_uint16_t src = byteorder_htons(TEST_UINT16);
-    const le_uint16_t src_pan = byteorder_htols(TEST_UINT16 + 1);
-    const network_uint64_t dst = byteorder_htonll(TEST_UINT64);
-    const le_uint16_t dst_pan = byteorder_htols(TEST_UINT16 + 2);
-    /* IEEE 802.15.4 is little endian! */
-    const uint8_t exp[] = { 0x00,
-                            IEEE802154_FCF_VERS_V1 |
-                                /* broadcast address is short */
-                                IEEE802154_FCF_DST_ADDR_SHORT |
-                                IEEE802154_FCF_SRC_ADDR_SHORT,
-                            TEST_UINT8,
-                            dst_pan.u8[0], dst_pan.u8[1],
-                            0xff, 0xff,
-                            src_pan.u8[0], src_pan.u8[1],
-                            src.u8[1], src.u8[0] };
-    uint8_t res[sizeof(exp)];
-    const uint8_t flags = IEEE802154_BCAST; /* broadcast flag lets dst be ignored */
-
-    TEST_ASSERT_EQUAL_INT(sizeof(exp),
-                          ieee802154_set_frame_hdr(res, src.u8, sizeof(src),
-                                                   dst.u8, sizeof(dst),
+                                                   ieee802154_addr_bcast,
+                                                   IEEE802154_ADDR_BCAST_LEN,
                                                    src_pan, dst_pan,
                                                    flags, TEST_UINT8));
     TEST_ASSERT_EQUAL_INT(0, memcmp(exp, res, sizeof(exp)));
@@ -1071,8 +1018,6 @@ Test *tests_ieee802154_tests(void)
         new_TestFixture(test_ieee802154_set_frame_hdr_flags0_non_beacon_non_ack),
         new_TestFixture(test_ieee802154_set_frame_hdr_bcast_src0),
         new_TestFixture(test_ieee802154_set_frame_hdr_bcast_src2),
-        new_TestFixture(test_ieee802154_set_frame_hdr_bcast_dst2_src2),
-        new_TestFixture(test_ieee802154_set_frame_hdr_bcast_dst8_src2),
         new_TestFixture(test_ieee802154_set_frame_hdr_bcast_src8),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst2_src0),
         new_TestFixture(test_ieee802154_set_frame_hdr_dst2_src2),


### PR DESCRIPTION
In https://github.com/RIOT-OS/RIOT/pull/5685#discussion_r81125490 we realized, that correcting our Intra-PAN behavior would also effect broadcasting behavior due to inconsistent handling of the broadcast/multicast flags from GNRC. This PR fixes that by getting rid of the IEEE802154_BCAST flag and replacing it with the IEEE802154_ADDR_BCAST constant. This way the broadcast address is handled like any other address in `ieee802154_set_frame_hdr()` since the GNRC glue code now translates the (GNRC-internal) broadcast/multicast flags into the broadcast address, and not that function.

Since this cleanup is tightly bound to the PAN_COMP clean-up (and it would have been more complicated to work around this changes, since I needed to touch that lines anyway) I decided to incorporate #5685 (due to the dropping of the `bcast` variable that change looks a little different though, so its more of an alternative) and #5759 in here. Hope @aeneby and @cgundogan won't mind ;).

# Summary of the changes

* Removal of the device state flag `NETDEV2_IEEE802154_PAN_COMP` + change of the header setting behavior for PANs so that it is independent of external state (except the value of the given PAN IDs ;-))
* Removal of the need for an IEEE802154_BCAST flag. The IEEE 802.15.4 broadcast address is now a global constant and thus can be set outside `ieee802154_set_frame_hdr()` so that it can be handled like any other destination address.
* (clean-up of the `netdev2_ieee802154` flags) 
* (adaptation of the unittests)