### PR TITLE
dist: tools: jlink.sh: use printf for JLINK_*_FLASH to allow use of backslash

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -140,11 +140,11 @@ do_flash() {
     /bin/echo -n "" > ${BINDIR}/burn.seg
     # create temporary burn file
     if [ ! -z "${JLINK_PRE_FLASH}" ]; then
-        echo "${JLINK_PRE_FLASH}" >> ${BINDIR}/burn.seg
+        printf "${JLINK_PRE_FLASH}\n" >> ${BINDIR}/burn.seg
     fi
     echo "loadbin ${HEXFILE} ${JLINK_FLASH_ADDR}" >> ${BINDIR}/burn.seg
     if [ ! -z "${JLINK_POST_FLASH}" ]; then
-        echo "${JLINK_POST_FLASH}" >> ${BINDIR}/burn.seg
+        printf "${JLINK_POST_FLASH}\n" >> ${BINDIR}/burn.seg
     fi
     cat ${RIOTBASE}/dist/tools/jlink/reset.seg >> ${BINDIR}/burn.seg
     # flash device


### PR DESCRIPTION
We need JLINK_*_FLASH variables to contain escaped character line "\n" so we can have multiple lines added to the flashing script.
Appropriate way to do that is to replace echo by printf as is not portable between dash and bash to provide such support.