### PR TITLE
periph/spi: convert char to uint8_t where applicapable

### DIFF
--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -88,7 +88,7 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     (void) dev;
     (void) conf;
@@ -98,7 +98,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
     return -1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     (void)dev;
     (void)reset_val;
@@ -106,15 +106,15 @@ void spi_transmission_begin(spi_t dev, char reset_val)
     /* not implemented */
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     return spi_transfer_bytes(dev, &out, in, 1);
 }
 
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
+int spi_transfer_bytes(spi_t dev, uint8_t *out, uint8_t *in, unsigned int length)
 {
     for (unsigned int i = 0; i < length; i++) {
-        char tmp = (out) ? out[i] : 0;
+        uint8_t tmp = (out) ? out[i] : 0;
         SPDR = tmp;
         while (!(SPSR & (1 << SPIF))) {}
         tmp = SPDR;
@@ -126,15 +126,15 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     return (int)length;
 }
 
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+int spi_transfer_reg(spi_t dev, uint8_t reg, uint8_t out, uint8_t *in)
 {
-    spi_transfer_bytes(dev, (char *)&reg, NULL, 1);
+    spi_transfer_bytes(dev, &reg, NULL, 1);
     return spi_transfer_bytes(dev, &out, in, 1);
 }
 
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length)
+int spi_transfer_regs(spi_t dev, uint8_t reg, uint8_t *out, uint8_t *in, unsigned int length)
 {
-    spi_transfer_bytes(dev, (char *)&reg, NULL, 1);
+    spi_transfer_bytes(dev, &reg, NULL, 1);
     return spi_transfer_bytes(dev, out, in, length);
 }
 

--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -152,7 +152,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     /* slave mode is not (yet) supported */
     return -1;
@@ -213,9 +213,9 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-static char ssi_flush_input(cc2538_ssi_t *ssi)
+static uint8_t ssi_flush_input(cc2538_ssi_t *ssi)
 {
-    char tmp = 0;
+    uint8_t tmp = 0;
 
     while (ssi->SRbits.RNE) {
         tmp = ssi->DR;
@@ -224,10 +224,10 @@ static char ssi_flush_input(cc2538_ssi_t *ssi)
     return tmp;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     cc2538_ssi_t* ssi = spi_config[dev].dev;
-    char tmp;
+    uint8_t tmp;
 
     ssi_flush_input(ssi);
 
@@ -246,7 +246,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     return 1;
 }
 
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
+int spi_transfer_bytes(spi_t dev, uint8_t *out, uint8_t *in, unsigned int length)
 {
     cc2538_ssi_t* ssi = spi_config[dev].dev;
     typeof(length) tx_n = 0, rx_n = 0;
@@ -283,7 +283,7 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     return rx_n;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     /* slave mode is not (yet) supported */
 }

--- a/cpu/kinetis_common/periph/spi.c
+++ b/cpu/kinetis_common/periph/spi.c
@@ -441,7 +441,7 @@ static mutex_t *locks_map[] = {
 };
 
 typedef struct {
-    char(*cb)(char data);
+    uint8_t (*cb)(uint8_t data);
 } spi_state_t;
 
 static inline void irq_handler_transfer(SPI_Type *spi, spi_t dev);
@@ -781,7 +781,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     SPI_Type *spi_dev;
 
@@ -886,7 +886,7 @@ static inline uint8_t spi_transfer_internal(SPI_Type *spi_dev, uint32_t flags, u
     return (uint8_t)spi_dev->POPR;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
@@ -969,13 +969,13 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     spi_dev->SR = SPI_SR_EOQF_MASK;
 
     if (in != NULL) {
-        *in = (char)byte_in;
+        *in = byte_in;
     }
 
     return 1;
 }
 
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
+int spi_transfer_bytes(spi_t dev, uint8_t *out, uint8_t *in, unsigned int length)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
@@ -1071,7 +1071,7 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
 
         if (in != NULL) {
             /* Save input byte to buffer */
-            in[i] = (char)byte_in;
+            in[i] = byte_in;
         }
     }
 
@@ -1081,7 +1081,7 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     return i;
 }
 
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+int spi_transfer_reg(spi_t dev, uint8_t reg, uint8_t out, uint8_t *in)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
@@ -1168,7 +1168,7 @@ int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
 
     if (in != NULL) {
         /* Save input byte to buffer */
-        *in = (char)byte_in;
+        *in = byte_in;
     }
 
     /* Clear End-of-Queue status flag */
@@ -1177,7 +1177,7 @@ int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
     return 2;
 }
 
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length)
+int spi_transfer_regs(spi_t dev, uint8_t reg, uint8_t *out, uint8_t *in, unsigned int length)
 {
     SPI_Type *spi_dev;
     uint8_t byte_in;
@@ -1278,7 +1278,7 @@ int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int 
 
         if (in != NULL) {
             /* Save input byte to buffer */
-            in[i] = (char)byte_in;
+            in[i] = byte_in;
         }
     }
 
@@ -1288,7 +1288,7 @@ int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int 
     return i;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
 
     switch (dev) {
@@ -1489,8 +1489,8 @@ static inline void irq_handler_transfer(SPI_Type *spi, spi_t dev)
 {
 
     if (spi->SR & SPI_SR_RFDF_MASK) {
-        char data;
-        data = (char)spi->POPR;
+        uint8_t data;
+        data = spi->POPR;
         data = spi_config[dev].cb(data);
         spi->PUSHR = SPI_PUSHR_CTAS(0)
                      | SPI_PUSHR_EOQ_MASK

--- a/cpu/lpc11u34/periph/spi.c
+++ b/cpu/lpc11u34/periph/spi.c
@@ -102,7 +102,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     /* Slave mode not supported */
     return -1;
@@ -155,9 +155,9 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
-    char tmp;
+    uint8_t tmp;
     LPC_SSPx_Type *spi;
 
     switch (dev) {
@@ -191,7 +191,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     return 1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     /* Slave mode not supported */
 }

--- a/cpu/lpc2387/periph/spi.c
+++ b/cpu/lpc2387/periph/spi.c
@@ -133,7 +133,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t))
 {
     (void)dev;
     (void)conf;
@@ -143,7 +143,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
     return -1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     (void)dev;
     (void)reset_val;
@@ -169,7 +169,7 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     (void) dev;
     while (!SPI_TX_EMPTY) {}
@@ -177,7 +177,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     while (SPI_BUSY) {}
     while (!SPI_RX_AVAIL) {}
 
-    char tmp = (char)SSP0DR;
+    uint8_t tmp = SSP0DR;
 
     if (in != NULL) {
         *in = tmp;

--- a/cpu/msp430fxyz/periph/spi.c
+++ b/cpu/msp430fxyz/periph/spi.c
@@ -171,7 +171,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 
 #endif  /* SPI_USE_USCI */
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     /* not supported so far */
     (void)dev;
@@ -180,7 +180,7 @@ int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
     return -1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     /* not supported so far */
     (void)dev;
@@ -210,14 +210,14 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     (void)dev;
-    char tmp;
+    uint8_t tmp;
     while (!(SPI_IF & SPI_IE_TX_BIT)) {}
     SPI_DEV->TXBUF = (uint8_t)out;
     while (!(SPI_IF & SPI_IE_RX_BIT)) {}
-    tmp = (char)SPI_DEV->RXBUF;
+    tmp = SPI_DEV->RXBUF;
     if (in) {
         *in = tmp;
     }

--- a/cpu/nrf51/periph/spi.c
+++ b/cpu/nrf51/periph/spi.c
@@ -117,7 +117,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     (void) dev;
     (void) conf;
@@ -175,23 +175,23 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     return spi_transfer_bytes(dev, &out, in, 1);
 }
 
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
+int spi_transfer_bytes(spi_t dev, uint8_t *out, uint8_t *in, unsigned int length)
 {
     if ((unsigned int)dev >= SPI_NUMOF) {
         return -1;
     }
 
     for (unsigned i = 0; i < length; i++) {
-        char tmp = (out) ? out[i] : 0;
+        uint8_t tmp = (out) ? out[i] : 0;
         spi[dev]->EVENTS_READY = 0;
         spi[dev]->TXD = (uint8_t)tmp;
         while (spi[dev]->EVENTS_READY != 1) {}
-        tmp = (char)spi[dev]->RXD;
+        tmp = spi[dev]->RXD;
         if (in) {
             in[i] = tmp;
         }
@@ -200,19 +200,19 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     return length;
 }
 
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+int spi_transfer_reg(spi_t dev, uint8_t reg, uint8_t out, uint8_t *in)
 {
     spi_transfer_byte(dev, reg, 0);
     return spi_transfer_byte(dev, out, in);
 }
 
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length)
+int spi_transfer_regs(spi_t dev, uint8_t reg, uint8_t *out, uint8_t *in, unsigned int length)
 {
     spi_transfer_byte(dev, reg, 0);
     return spi_transfer_bytes(dev, out, in, length);
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     (void) dev;
     (void) reset_val;

--- a/cpu/nrf52/periph/spi.c
+++ b/cpu/nrf52/periph/spi.c
@@ -134,7 +134,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     /* This API is incompatible with nRF51 SPIS */
     return -1;
@@ -196,25 +196,25 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     return spi_transfer_bytes(dev, &out, in, 1);
 }
 
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
+int spi_transfer_bytes(spi_t dev, uint8_t *out, uint8_t *in, unsigned int length)
 {
     if (dev >= SPI_NUMOF) {
         return -1;
     }
 
     for (int i = 0; i < length; i++) {
-        char tmp = (out) ? out[i] : 0;
+        uint8_t tmp = (out) ? out[i] : 0;
         spi[dev]->EVENTS_READY = 0;
         spi[dev]->TXD = (uint8_t)tmp;
 
         while (spi[dev]->EVENTS_READY != 1);
 
-        tmp = (char)spi[dev]->RXD;
+        tmp = spi[dev]->RXD;
 
         if (in) {
             in[i] = tmp;
@@ -224,19 +224,19 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
     return length;
 }
 
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+int spi_transfer_reg(spi_t dev, uint8_t reg, uint8_t out, uint8_t *in)
 {
     spi_transfer_byte(dev, reg, 0);
     return spi_transfer_byte(dev, out, in);
 }
 
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length)
+int spi_transfer_regs(spi_t dev, uint8_t reg, uint8_t *out, uint8_t *in, unsigned int length)
 {
     spi_transfer_byte(dev, reg, 0);
     return spi_transfer_bytes(dev, out, in, length);
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     /* spi slave is not implemented */
 }

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -49,7 +49,7 @@ static mutex_t locks[] =  {
 };
 
 typedef struct {
-    char(*cb)(char data);
+    uint8_t (*cb)(uint8_t data);
 } spi_state_t;
 
 static inline void irq_handler_transfer(Spi *spi, spi_t dev);
@@ -169,7 +169,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     Spi *spi_port;
 
@@ -310,7 +310,7 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     Spi *spi_port;
 
@@ -335,7 +335,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     return 1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     switch (dev) {
 #if SPI_0_EN
@@ -349,7 +349,7 @@ void spi_transmission_begin(spi_t dev, char reset_val)
 static inline void irq_handler_transfer(Spi *spi, spi_t dev)
 {
     if (spi->SPI_SR & SPI_SR_RDRF) {
-        char data;
+        uint8_t data;
         data = spi->SPI_RDR & SPI_RDR_RD_Msk;
         data = spi_config[dev].cb(data);
         spi->SPI_TDR = SPI_TDR_TD(data);

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -206,13 +206,13 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t))
 {
     /* TODO */
     return -1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     /* TODO*/
 }
@@ -235,10 +235,10 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     SercomSpi* spi_dev = 0;
-    char tmp;
+    uint8_t tmp;
 
     switch(dev)
     {
@@ -258,7 +258,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     spi_dev->DATA.bit.DATA = out;
 
     while (!spi_dev->INTFLAG.bit.DRE || !spi_dev->INTFLAG.bit.RXC) {} /* while receive is not complete*/
-    tmp = (char)spi_dev->DATA.bit.DATA;
+    tmp = spi_dev->DATA.bit.DATA;
 
     if (in != NULL)
     {

--- a/cpu/saml21/periph/spi.c
+++ b/cpu/saml21/periph/spi.c
@@ -170,13 +170,13 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t))
 {
     /* TODO */
     return -1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     /* TODO*/
 }
@@ -199,7 +199,7 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     SercomSpi* spi_dev = spi[dev].dev;
 

--- a/cpu/stm32f0/periph/spi.c
+++ b/cpu/stm32f0/periph/spi.c
@@ -112,7 +112,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     /* due to issues with the send buffer, the master mode is not (yet) supported */
     return -1;
@@ -178,9 +178,9 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
-    char tmp;
+    uint8_t tmp;
     SPI_TypeDef *spi = 0;
 
     switch (dev) {
@@ -214,7 +214,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     return 1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     /* slave mode is not (yet) supported */
 }

--- a/cpu/stm32f1/periph/spi.c
+++ b/cpu/stm32f1/periph/spi.c
@@ -117,7 +117,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t))
 {
     (void) dev;
     (void) conf;
@@ -183,7 +183,7 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     SPI_TypeDef *spi;
     int transferred = 0;
@@ -237,7 +237,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     return transferred;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     (void) dev;
     (void) reset_val;

--- a/cpu/stm32f2/periph/spi.c
+++ b/cpu/stm32f2/periph/spi.c
@@ -39,7 +39,7 @@
  * @brief Data-structure holding the state for a SPI device
  */
 typedef struct {
-    char(*cb)(char data);
+    uint8_t(*cb)(uint8_t data);
 } spi_state_t;
 
 static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev);
@@ -154,7 +154,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t(*cb)(uint8_t data))
 {
     SPI_TypeDef *spi_port;
 
@@ -310,7 +310,7 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     SPI_TypeDef *spi_port;
 
@@ -349,7 +349,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     return 1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
 
     switch (dev) {

--- a/cpu/stm32f3/periph/spi.c
+++ b/cpu/stm32f3/periph/spi.c
@@ -40,7 +40,7 @@
 #if SPI_NUMOF
 
 typedef struct {
-    char(*cb)(char data);
+    uint8_t (*cb)(uint8_t data);
 } spi_state_t;
 
 /* static device mapping */
@@ -154,7 +154,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     switch (dev) {
 #if SPI_0_EN
@@ -306,9 +306,9 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
-    char tmp;
+    uint8_t tmp;
 
     /* recast to uint_8 to force 8bit access */
     volatile uint8_t *DR = (volatile uint8_t*) &spi[dev]->DR;
@@ -333,7 +333,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     return 1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     if ((unsigned int)dev < SPI_NUMOF) {
         spi[dev]->DR = reset_val;
@@ -389,7 +389,7 @@ static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev)
 {
 
     if (spi->SR & SPI_SR_RXNE) {
-        char data;
+        uint8_t data;
         data = spi->DR;
         data = spi_config[dev].cb(data);
         spi->DR = data;

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -39,7 +39,7 @@
  * @brief Data-structure holding the state for a SPI device
  */
 typedef struct {
-    char(*cb)(char data);
+    uint8_t (*cb)(uint8_t data);
 } spi_state_t;
 
 static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev);
@@ -154,7 +154,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char(*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     SPI_TypeDef *spi_port;
 
@@ -310,7 +310,7 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
     SPI_TypeDef *spi_port;
 
@@ -349,7 +349,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     return 1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
 
     switch (dev) {
@@ -420,7 +420,7 @@ static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev)
 {
 
     if (spi->SR & SPI_SR_RXNE) {
-        char data;
+        uint8_t data;
         data = spi->DR;
         data = spi_config[dev].cb(data);
         spi->DR = data;

--- a/cpu/stm32l1/periph/spi.c
+++ b/cpu/stm32l1/periph/spi.c
@@ -108,7 +108,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     return 0;
 }
 
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data))
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data))
 {
     /* due to issues with the send buffer, the slave mode is not (yet) supported */
     return -1;
@@ -174,9 +174,9 @@ int spi_release(spi_t dev)
     return 0;
 }
 
-int spi_transfer_byte(spi_t dev, char out, char *in)
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in)
 {
-    char tmp;
+    uint8_t tmp;
     SPI_TypeDef *spi = 0;
 
     switch (dev) {
@@ -219,7 +219,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in)
     return 1;
 }
 
-void spi_transmission_begin(spi_t dev, char reset_val)
+void spi_transmission_begin(spi_t dev, uint8_t reset_val)
 {
     /* slave mode is not (yet) supported */
 }

--- a/drivers/adt7310/adt7310.c
+++ b/drivers/adt7310/adt7310.c
@@ -99,7 +99,7 @@ static int adt7310_read_reg(const adt7310_t *dev, const uint8_t addr, const uint
     /* Perform the transaction */
     gpio_clear(dev->cs);
 
-    if (spi_transfer_regs(dev->spi, command, NULL, (char *)buf, len) < len) {
+    if (spi_transfer_regs(dev->spi, command, NULL, buf, len) < len) {
         status = -1;
     }
 
@@ -131,7 +131,7 @@ static int adt7310_write_reg(const adt7310_t *dev, const uint8_t addr,
     /* Perform the transaction */
     gpio_clear(dev->cs);
 
-    if (spi_transfer_regs(dev->spi, command, (char *)buf, NULL, len) < len) {
+    if (spi_transfer_regs(dev->spi, command, buf, NULL, len) < len) {
         status = -1;
     }
 

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -43,7 +43,7 @@ void at86rf2xx_reg_write(const at86rf2xx_t *dev,
 
 uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, const uint8_t addr)
 {
-    char value;
+    uint8_t value;
 
     spi_acquire(dev->params.spi);
     gpio_clear(dev->params.cs_pin);
@@ -65,8 +65,8 @@ void at86rf2xx_sram_read(const at86rf2xx_t *dev,
     gpio_clear(dev->params.cs_pin);
     spi_transfer_reg(dev->params.spi,
                      AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_READ,
-                     (char)offset, NULL);
-    spi_transfer_bytes(dev->params.spi, NULL, (char *)data, len);
+                     (uint8_t)offset, NULL);
+    spi_transfer_bytes(dev->params.spi, NULL, data, len);
     gpio_set(dev->params.cs_pin);
     spi_release(dev->params.spi);
 }
@@ -80,8 +80,8 @@ void at86rf2xx_sram_write(const at86rf2xx_t *dev,
     gpio_clear(dev->params.cs_pin);
     spi_transfer_reg(dev->params.spi,
                      AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_WRITE,
-                     (char)offset, NULL);
-    spi_transfer_bytes(dev->params.spi, (char *)data, NULL, len);
+                     (uint8_t)offset, NULL);
+    spi_transfer_bytes(dev->params.spi, (uint8_t *)data, NULL, len);
     gpio_set(dev->params.cs_pin);
     spi_release(dev->params.spi);
 }
@@ -99,7 +99,7 @@ void at86rf2xx_fb_read(const at86rf2xx_t *dev,
                        uint8_t *data,
                        const size_t len)
 {
-    spi_transfer_bytes(dev->params.spi, NULL, (char *)data, len);
+    spi_transfer_bytes(dev->params.spi, NULL, data, len);
 }
 
 void at86rf2xx_fb_stop(const at86rf2xx_t *dev)

--- a/drivers/cc110x/cc110x-defaultsettings.c
+++ b/drivers/cc110x/cc110x-defaultsettings.c
@@ -29,7 +29,7 @@
  * @note    If changed in size, adjust MAX_OUTPUT_POWER definition
  *          in CC110x interface
 */
-const char cc110x_default_pa_table[8] = {
+const uint8_t cc110x_default_pa_table[8] = {
     0x00,   /*< -52 dBm */
     0x0D,   /*< -20 dBm */
     0x34,   /*< -10 dBm */
@@ -40,12 +40,12 @@ const char cc110x_default_pa_table[8] = {
     0xC3    /*< +10 dBm */
 };
 
-const char cc110x_default_base_freq[3] = { 0x21, 0x71, 0x7F };
+const uint8_t cc110x_default_base_freq[3] = { 0x21, 0x71, 0x7F };
 
 /**
  * @brief cc110x default settings
  */
-const char cc110x_default_conf[] = {
+const uint8_t cc110x_default_conf[] = {
     0x06, /* IOCFG2 */
     0x2E, /* IOCFG1 */
     /* some boards use cc110x' GDO0 as clock source, so for those, we allow

--- a/drivers/cc110x/cc110x-rxtx.c
+++ b/drivers/cc110x/cc110x-rxtx.c
@@ -100,7 +100,7 @@ static void _rx_read_data(cc110x_t *dev, void(*callback)(void*), void*arg)
 
     if (to_read) {
         cc110x_readburst_reg(dev, CC110X_RXFIFO,
-                ((char *)&pkt_buf->packet)+pkt_buf->pos, to_read);
+                ((uint8_t *)&pkt_buf->packet)+pkt_buf->pos, to_read);
         pkt_buf->pos += to_read;
     }
 
@@ -108,7 +108,7 @@ static void _rx_read_data(cc110x_t *dev, void(*callback)(void*), void*arg)
         uint8_t status[2];
         /* full packet received. */
         /* Read the 2 appended status bytes (status[0] = RSSI, status[1] = LQI) */
-        cc110x_readburst_reg(dev, CC110X_RXFIFO, (char *)status, 2);
+        cc110x_readburst_reg(dev, CC110X_RXFIFO, status, 2);
 
         /* Store RSSI value of packet */
         pkt_buf->rssi = status[I_RSSI];
@@ -195,7 +195,7 @@ static void _tx_continue(cc110x_t *dev)
     int to_send = left > fifo ? fifo : left;
 
     /* Write packet into TX FIFO */
-    cc110x_writeburst_reg(dev, CC110X_TXFIFO, ((char *)pkt)+dev->pkt_buf.pos, to_send);
+    cc110x_writeburst_reg(dev, CC110X_TXFIFO, ((uint8_t *)pkt) + dev->pkt_buf.pos, to_send);
     dev->pkt_buf.pos += to_send;
 
     if (left == size) {

--- a/drivers/cc110x/cc110x-spi.c
+++ b/drivers/cc110x/cc110x-spi.c
@@ -72,19 +72,19 @@ void cc110x_cs(cc110x_t *dev)
 #endif
 }
 
-void cc110x_writeburst_reg(cc110x_t *dev, uint8_t addr, const char *src, uint8_t count)
+void cc110x_writeburst_reg(cc110x_t *dev, uint8_t addr, const uint8_t *src, uint8_t count)
 {
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
     cpsr = irq_disable();
     cc110x_cs(dev);
-    spi_transfer_regs(dev->params.spi, addr | CC110X_WRITE_BURST, (char *)src, 0, count);
+    spi_transfer_regs(dev->params.spi, addr | CC110X_WRITE_BURST, (uint8_t *)src, 0, count);
     gpio_set(dev->params.cs);
     irq_restore(cpsr);
     spi_release(dev->params.spi);
 }
 
-void cc110x_readburst_reg(cc110x_t *dev, uint8_t addr, char *buffer, uint8_t count)
+void cc110x_readburst_reg(cc110x_t *dev, uint8_t addr, uint8_t *buffer, uint8_t count)
 {
     int i = 0;
     unsigned int cpsr;
@@ -115,7 +115,7 @@ void cc110x_write_reg(cc110x_t *dev, uint8_t addr, uint8_t value)
 
 uint8_t cc110x_read_reg(cc110x_t *dev, uint8_t addr)
 {
-    char result;
+    uint8_t result;
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
     cpsr = irq_disable();
@@ -129,7 +129,7 @@ uint8_t cc110x_read_reg(cc110x_t *dev, uint8_t addr)
 
 uint8_t cc110x_read_status(cc110x_t *dev, uint8_t addr)
 {
-    char result;
+    uint8_t result;
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
     cpsr = irq_disable();
@@ -143,7 +143,7 @@ uint8_t cc110x_read_status(cc110x_t *dev, uint8_t addr)
 
 uint8_t cc110x_get_reg_robust(cc110x_t *dev, uint8_t addr)
 {
-    char result, result2;
+    uint8_t result, result2;
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
     cpsr = irq_disable();
@@ -166,7 +166,7 @@ uint8_t cc110x_strobe(cc110x_t *dev, uint8_t c)
     }
 #endif
 
-    char result;
+    uint8_t result;
     unsigned int cpsr;
     spi_acquire(dev->params.spi);
     cpsr = irq_disable();

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -118,7 +118,7 @@ uint8_t cc110x_set_address(cc110x_t *dev, uint8_t address)
     return 0;
 }
 
-void cc110x_set_base_freq_raw(cc110x_t *dev, const char* freq_array)
+void cc110x_set_base_freq_raw(cc110x_t *dev, const uint8_t* freq_array)
 {
 #if ENABLE_DEBUG == 1
     uint8_t _tmp[] = { freq_array[2], freq_array[1], freq_array[0], 0x00};

--- a/drivers/cc110x/include/cc110x-defaultsettings.h
+++ b/drivers/cc110x/include/cc110x-defaultsettings.h
@@ -30,12 +30,12 @@ extern "C" {
 
 #ifndef CC110X_DEFAULT_PATABLE
 #define CC110X_DEFAULT_PATABLE cc110x_default_pa_table
-extern const char cc110x_default_pa_table[8];
+extern const uint8_t cc110x_default_pa_table[8];
 #endif
 
 #ifndef CC110X_DEFAULT_FREQ
 #define CC110X_DEFAULT_FREQ cc110x_default_base_freq
-extern const char cc110x_default_base_freq[3];
+extern const uint8_t cc110x_default_base_freq[3];
 #endif
 
 #ifdef __cplusplus

--- a/drivers/cc110x/include/cc110x-interface.h
+++ b/drivers/cc110x/include/cc110x-interface.h
@@ -39,14 +39,14 @@ char *cc110x_state_to_text(uint8_t state);
 int cc110x_rd_set_mode(cc110x_t *dev, int mode);
 uint8_t cc110x_get_buffer_pos(cc110x_t *dev);
 void cc110x_isr_handler(cc110x_t *dev, void(*callback)(void*), void*arg);
-void cc110x_set_base_freq_raw(cc110x_t *dev, const char* freq_array);
+void cc110x_set_base_freq_raw(cc110x_t *dev, const uint8_t* freq_array);
 void cc110x_setup_rx_mode(cc110x_t *dev);
 void cc110x_switch_to_pwd(cc110x_t *dev);
 void cc110x_switch_to_rx(cc110x_t *dev);
 void cc110x_wakeup_from_rx(cc110x_t *dev);
 void cc110x_write_register(cc110x_t *dev, uint8_t r, uint8_t value);
 
-extern const char cc110x_default_conf[];
+extern const uint8_t cc110x_default_conf[];
 extern const uint8_t cc110x_default_conf_size;
 extern const uint8_t cc110x_pa_table[];
 

--- a/drivers/cc110x/include/cc110x-spi.h
+++ b/drivers/cc110x/include/cc110x-spi.h
@@ -37,7 +37,7 @@ extern "C" {
  * @param buffer    Data to be written
  * @param count     Size of data
  */
-void cc110x_writeburst_reg(cc110x_t *dev, uint8_t addr, const char *buffer, uint8_t count);
+void cc110x_writeburst_reg(cc110x_t *dev, uint8_t addr, const uint8_t *buffer, uint8_t count);
 
 /**
  * @brief Read a set of bytes using burst mode (if available)
@@ -47,7 +47,7 @@ void cc110x_writeburst_reg(cc110x_t *dev, uint8_t addr, const char *buffer, uint
  * @param buffer    Buffer to store read data
  * @param count     Size of data to be read
  */
-void cc110x_readburst_reg(cc110x_t *dev, uint8_t addr, char *buffer, uint8_t count);
+void cc110x_readburst_reg(cc110x_t *dev, uint8_t addr, uint8_t *buffer, uint8_t count);
 
 /**
  * @brief Write one byte to a register

--- a/drivers/cc2420/cc2420_internal.c
+++ b/drivers/cc2420/cc2420_internal.c
@@ -29,11 +29,11 @@
 
 uint8_t cc2420_strobe(const cc2420_t *dev, const uint8_t command)
 {
-    char res;
+    uint8_t res;
 
     spi_acquire(dev->params.spi);
     gpio_clear(dev->params.pin_cs);
-    spi_transfer_byte(dev->params.spi, (char)command, (char *)&res);
+    spi_transfer_byte(dev->params.spi, (uint8_t)command, &res);
     gpio_set(dev->params.pin_cs);
     spi_release(dev->params.spi);
 
@@ -49,7 +49,7 @@ void cc2420_reg_write(const cc2420_t *dev,
     spi_acquire(dev->params.spi);
     gpio_clear(dev->params.pin_cs);
     spi_transfer_regs(dev->params.spi, CC2420_REG_WRITE | addr,
-                      (char *)&tmp, NULL, 2);
+                      (uint8_t *)&tmp, NULL, 2);
     gpio_set(dev->params.pin_cs);
     spi_release(dev->params.spi);
 }
@@ -61,7 +61,7 @@ uint16_t cc2420_reg_read(const cc2420_t *dev, const uint8_t addr)
     spi_acquire(dev->params.spi);
     gpio_clear(dev->params.pin_cs);
     spi_transfer_regs(dev->params.spi, CC2420_REG_READ | addr,
-                      NULL, (char *)&tmp, 2);
+                      NULL, (uint8_t *)&tmp, 2);
     gpio_set(dev->params.pin_cs);
     spi_release(dev->params.spi);
 
@@ -71,13 +71,13 @@ uint16_t cc2420_reg_read(const cc2420_t *dev, const uint8_t addr)
 void cc2420_ram_read(const cc2420_t *dev, const uint16_t addr,
                      uint8_t *data, const size_t len)
 {
-    char tmp[] = { (CC2420_RAM      | (addr & 0x7f)),
-                   (CC2420_RAM_READ | ((addr >> 1) & 0xc0)) };
+    uint8_t tmp[] = { (CC2420_RAM      | (addr & 0x7f)),
+                      (CC2420_RAM_READ | ((addr >> 1) & 0xc0)) };
 
     spi_acquire(dev->params.spi);
     gpio_clear(dev->params.pin_cs);
     spi_transfer_bytes(dev->params.spi, tmp, NULL, 2);
-    spi_transfer_bytes(dev->params.spi, NULL, (char*)data, len);
+    spi_transfer_bytes(dev->params.spi, NULL, data, len);
     gpio_set(dev->params.pin_cs);
     spi_release(dev->params.spi);
 }
@@ -85,13 +85,13 @@ void cc2420_ram_read(const cc2420_t *dev, const uint16_t addr,
 void cc2420_ram_write(const cc2420_t *dev, const uint16_t addr,
                       const uint8_t *data, const size_t len)
 {
-    char tmp[] = { (CC2420_RAM       | (addr & 0x7f)),
-                   (CC2420_RAM_WRITE | ((addr >> 1) & 0xc0)) };
+    uint8_t tmp[] = { (CC2420_RAM       | (addr & 0x7f)),
+                      (CC2420_RAM_WRITE | ((addr >> 1) & 0xc0)) };
 
     spi_acquire(dev->params.spi);
     gpio_clear(dev->params.pin_cs);
     spi_transfer_bytes(dev->params.spi, tmp, NULL, 2);
-    spi_transfer_bytes(dev->params.spi, (char*)data, NULL, len);
+    spi_transfer_bytes(dev->params.spi, (uint8_t *)data, NULL, len);
     gpio_set(dev->params.pin_cs);
     spi_release(dev->params.spi);
 }
@@ -101,7 +101,7 @@ void cc2420_fifo_read(const cc2420_t *dev, uint8_t *data, const size_t len)
     spi_acquire(dev->params.spi);
     gpio_clear(dev->params.pin_cs);
     spi_transfer_regs(dev->params.spi, CC2420_FIFO_READ,
-                      NULL, (char *)data, len);
+                      NULL, data, len);
     gpio_set(dev->params.pin_cs);
     spi_release(dev->params.spi);
 }
@@ -111,7 +111,7 @@ void cc2420_fifo_write(const cc2420_t *dev, uint8_t *data, const size_t len)
     spi_acquire(dev->params.spi);
     gpio_clear(dev->params.pin_cs);
     spi_transfer_regs(dev->params.spi, CC2420_FIFO_WRITE,
-                      (char *)data, NULL, len);
+                      data, NULL, len);
     gpio_set(dev->params.pin_cs);
     spi_release(dev->params.spi);
 }

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -98,7 +98,7 @@ static void switch_bank(enc28j60_t *dev, int8_t bank)
 
 static uint8_t cmd_rcr(enc28j60_t *dev, uint8_t reg, int8_t bank)
 {
-    char res;
+    uint8_t res;
 
     switch_bank(dev, bank);
     gpio_clear(dev->cs_pin);
@@ -109,7 +109,7 @@ static uint8_t cmd_rcr(enc28j60_t *dev, uint8_t reg, int8_t bank)
 
 static uint8_t cmd_rcr_miimac(enc28j60_t *dev, uint8_t reg, int8_t bank)
 {
-    char res[2];
+    uint8_t res[2];
 
     switch_bank(dev, bank);
     gpio_clear(dev->cs_pin);
@@ -122,7 +122,7 @@ static void cmd_wcr(enc28j60_t *dev, uint8_t reg, int8_t bank, uint8_t value)
 {
     switch_bank(dev, bank);
     gpio_clear(dev->cs_pin);
-    spi_transfer_reg(dev->spi, CMD_WCR | reg, (char)value, 0);
+    spi_transfer_reg(dev->spi, CMD_WCR | reg, value, 0);
     gpio_set(dev->cs_pin);
 }
 
@@ -182,14 +182,14 @@ static void cmd_w_phy(enc28j60_t *dev, uint8_t reg, uint16_t val)
 static void cmd_rbm(enc28j60_t *dev, uint8_t *data, size_t len)
 {
     gpio_clear(dev->cs_pin);
-    spi_transfer_regs(dev->spi, CMD_RBM, NULL, (char *)data, len);
+    spi_transfer_regs(dev->spi, CMD_RBM, NULL, data, len);
     gpio_set(dev->cs_pin);
 }
 
 static void cmd_wbm(enc28j60_t *dev, uint8_t *data, size_t len)
 {
     gpio_clear(dev->cs_pin);
-    spi_transfer_regs(dev->spi, CMD_WBM, (char *)data, NULL, len);
+    spi_transfer_regs(dev->spi, CMD_WBM, data, NULL, len);
     gpio_set(dev->cs_pin);
 }
 

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -50,7 +50,7 @@
 #define TX_BUFFER_END   (RX_BUFFER_START)
 #define TX_BUFFER_START (TX_BUFFER_END - TX_BUFFER_LEN)
 
-static void cmd(encx24j600_t *dev, char cmd);
+static void cmd(encx24j600_t *dev, uint8_t cmd);
 static void reg_set(encx24j600_t *dev, uint8_t reg, uint16_t value);
 static uint16_t reg_get(encx24j600_t *dev, uint8_t reg);
 static void reg_clear_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask);
@@ -145,7 +145,7 @@ static void _isr(netdev2_t *netdev)
     unlock(dev);
 }
 
-static inline void enc_spi_transfer(encx24j600_t *dev, char *out, char *in, int len)
+static inline void enc_spi_transfer(encx24j600_t *dev, uint8_t *out, uint8_t *in, int len)
 {
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
@@ -156,8 +156,8 @@ static inline void enc_spi_transfer(encx24j600_t *dev, char *out, char *in, int 
 
 static inline uint16_t reg_get(encx24j600_t *dev, uint8_t reg)
 {
-    char cmd[4] = { ENC_RCRU, reg, 0, 0 };
-    char result[4];
+    uint8_t cmd[4] = { ENC_RCRU, reg, 0, 0 };
+    uint8_t result[4];
 
     enc_spi_transfer(dev, cmd, result, 4);
 
@@ -169,7 +169,7 @@ static void phy_reg_set(encx24j600_t *dev, uint8_t reg, uint16_t value) {
     reg_set(dev, ENC_MIWR, value);
 }
 
-static void cmd(encx24j600_t *dev, char cmd) {
+static void cmd(encx24j600_t *dev, uint8_t cmd) {
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     spi_transfer_byte(dev->spi, cmd, NULL);
@@ -177,7 +177,7 @@ static void cmd(encx24j600_t *dev, char cmd) {
     spi_release(dev->spi);
 }
 
-static void cmdn(encx24j600_t *dev, uint8_t cmd, char *out, char *in, int len) {
+static void cmdn(encx24j600_t *dev, uint8_t cmd, uint8_t *out, uint8_t *in, int len) {
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
     spi_transfer_byte(dev->spi, cmd, NULL);
@@ -188,19 +188,19 @@ static void cmdn(encx24j600_t *dev, uint8_t cmd, char *out, char *in, int len) {
 
 static void reg_set(encx24j600_t *dev, uint8_t reg, uint16_t value)
 {
-    char cmd[4] = { ENC_WCRU, reg, value, value >> 8 };
+    uint8_t cmd[4] = { ENC_WCRU, reg, value, value >> 8 };
     enc_spi_transfer(dev, cmd, NULL, 4);
 }
 
 static void reg_set_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask)
 {
-    char cmd[4] = { ENC_BFSU, reg, mask, mask >> 8 };
+    uint8_t cmd[4] = { ENC_BFSU, reg, mask, mask >> 8 };
     enc_spi_transfer(dev, cmd, NULL, 4);
 }
 
 static void reg_clear_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask)
 {
-    char cmd[4] = { ENC_BFCU, reg, mask, mask >> 8 };
+    uint8_t cmd[4] = { ENC_BFCU, reg, mask, mask >> 8 };
     enc_spi_transfer(dev, cmd, NULL, 4);
 }
 
@@ -213,11 +213,11 @@ static void reg_clear_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask)
  * @param     ptr   pointer to buffer to read from / write to
  * @param[in] len   nr of bytes to read/write
  */
-static void sram_op(encx24j600_t *dev, uint16_t cmd, uint16_t addr, char *ptr, int len)
+static void sram_op(encx24j600_t *dev, uint16_t cmd, uint16_t addr, uint8_t *ptr, int len)
 {
     uint16_t reg;
-    char* in = NULL;
-    char* out = NULL;
+    uint8_t* in = NULL;
+    uint8_t* out = NULL;
 
     /* determine pointer addr
      *
@@ -367,7 +367,7 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
     lock(dev);
 
     /* read frame header */
-    sram_op(dev, ENC_RRXDATA, dev->rx_next_ptr, (char*)&hdr, sizeof(hdr));
+    sram_op(dev, ENC_RRXDATA, dev->rx_next_ptr, (uint8_t*)&hdr, sizeof(hdr));
 
     /* hdr.frame_len given by device contains 4 bytes checksum */
     size_t payload_len = hdr.frame_len - 4;

--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -133,7 +133,7 @@ typedef enum {
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer);
+int nrf24l01p_read_reg(nrf24l01p_t *dev, uint8_t reg, uint8_t *answer);
 
 /**
 * @brief Write one register to the nrf24l01+ transceiver.
@@ -145,7 +145,7 @@ int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_write_reg(nrf24l01p_t *dev, char reg, char write);
+int nrf24l01p_write_reg(nrf24l01p_t *dev, uint8_t reg, uint8_t write);
 
 /**
 * @brief Initialize the nrf24l01+ transceiver.
@@ -202,7 +202,7 @@ void nrf24l01p_transmit(nrf24l01p_t *dev);
 * @return           Number of bytes that were transfered.
 * @return           -1 on error.
 */
-int nrf24l01p_read_payload(nrf24l01p_t *dev, char *answer, unsigned int size);
+int nrf24l01p_read_payload(nrf24l01p_t *dev, uint8_t *answer, unsigned int size);
 
 /**
 * @brief Register a given ID to the nrf24l01+ transceiver.
@@ -280,7 +280,7 @@ void nrf24l01p_stop(nrf24l01p_t *dev);
 * @return           Number of bytes that were transfered.
 * @return           -1 on error.
 */
-int nrf24l01p_preload(nrf24l01p_t *dev, char *data, unsigned int size);
+int nrf24l01p_preload(nrf24l01p_t *dev, uint8_t *data, unsigned int size);
 
 /**
 * @brief Set the RF channel for the nrf24l01+ transceiver.
@@ -322,7 +322,7 @@ int nrf24l01p_set_address_width(nrf24l01p_t *dev, nrf24l01p_aw_t aw);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char width);
+int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint8_t width);
 
 /**
 * @brief Set the TX address for the nrf24l01+ transceiver (byte array).
@@ -339,7 +339,7 @@ int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_tx_address(nrf24l01p_t *dev, char *saddr, unsigned int length);
+int nrf24l01p_set_tx_address(nrf24l01p_t *dev, uint8_t *saddr, unsigned int length);
 
 /**
 * @brief Set the TX address for the nrf24l01+ transceiver (long int).
@@ -369,7 +369,7 @@ int nrf24l01p_set_tx_address_long(nrf24l01p_t *dev, uint64_t saddr, unsigned int
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *saddr, unsigned int length);
+int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint8_t *saddr, unsigned int length);
 
 /**
 * @brief Set the RX address for the nrf24l01+ transceiver (long int).
@@ -490,7 +490,7 @@ int nrf24l01p_reset_all_interrupts(nrf24l01p_t *dev);
 * @return           1 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_reset_interrupts(nrf24l01p_t *dev, char intrs);
+int nrf24l01p_reset_interrupts(nrf24l01p_t *dev, uint8_t intrs);
 
 /**
 * @brief Mask one interrupt on the nrf24l01+ transceiver.
@@ -506,7 +506,7 @@ int nrf24l01p_reset_interrupts(nrf24l01p_t *dev, char intrs);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, char intr);
+int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, uint8_t intr);
 
 /**
 * @brief Unmask one interrupt on the nrf24l01+ transceiver.
@@ -522,7 +522,7 @@ int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, char intr);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_unmask_interrupt(nrf24l01p_t *dev, char intr);
+int nrf24l01p_unmask_interrupt(nrf24l01p_t *dev, uint8_t intr);
 
 /**
 * @brief Enable RX datapipe on the nrf24l01+ transceiver.
@@ -573,7 +573,7 @@ int nrf24l01p_enable_crc(nrf24l01p_t *dev, nrf24l01p_crc_t crc);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_setup_auto_ack(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l01p_retransmit_delay_t delay_retrans, char count_retrans);
+int nrf24l01p_setup_auto_ack(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l01p_retransmit_delay_t delay_retrans, uint8_t count_retrans);
 
 /**
 * @brief Disable automatic ACK on the nrf24l01+ transceiver.

--- a/drivers/include/pcd8544.h
+++ b/drivers/include/pcd8544.h
@@ -110,7 +110,7 @@ void pcd8544_set_bias(pcd8544_t *dev, uint8_t bias);
 /**
  * @brief   Write an image to memory of the given display
  *
- * The image must be given as a char array with 504 elements. Each bit in the
+ * The image must be given as a byte array with 504 elements. Each bit in the
  * array represents one pixel on the display. Each byte in the array contains
  * 8 stacked pixels, from top to bottom. So byte[0] contains the pixels from
  * (0,0) to (0,7), byte[1] (1,0) to (1,7) and byte[503] the pixels from
@@ -118,9 +118,9 @@ void pcd8544_set_bias(pcd8544_t *dev, uint8_t bias);
  * datasheet.
  *
  * @param[in] dev           device descriptor of display to use
- * @param[in] img           char array with image data (must be of size := 504)
+ * @param[in] img           byte array with image data (must be of size := 504)
  */
-void pcd8544_write_img(pcd8544_t *dev, const char img[]);
+void pcd8544_write_img(pcd8544_t *dev, const uint8_t img[]);
 
 /**
  * @brief   Write a single ASCII character to the display

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -142,7 +142,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed);
  * @return              0 on success
  * @return              -1 on error
  */
-int spi_init_slave(spi_t dev, spi_conf_t conf, char (*cb)(char data));
+int spi_init_slave(spi_t dev, spi_conf_t conf, uint8_t (*cb)(uint8_t data));
 
 /**
  * @brief Configure SCK, MISO and MOSI pins for the given SPI device
@@ -186,7 +186,7 @@ int spi_release(spi_t dev);
  * @return              Number of bytes that were transfered
  * @return              -1 on error
  */
-int spi_transfer_byte(spi_t dev, char out, char *in);
+int spi_transfer_byte(spi_t dev, uint8_t out, uint8_t *in);
 
 /**
  * @brief Transfer a number bytes on the given SPI bus
@@ -199,7 +199,7 @@ int spi_transfer_byte(spi_t dev, char out, char *in);
  * @return              Number of bytes that were transfered
  * @return              -1 on error
  */
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length);
+int spi_transfer_bytes(spi_t dev, uint8_t *out, uint8_t *in, unsigned int length);
 
 /**
  * @brief Transfer one byte to/from a given register address
@@ -216,7 +216,7 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length);
  * @return              Number of bytes that were transfered
  * @return              -1 on error
  */
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in);
+int spi_transfer_reg(spi_t dev, uint8_t reg, uint8_t out, uint8_t *in);
 
 /**
  * @brief Transfer a number of bytes from/to a given register address
@@ -234,7 +234,7 @@ int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in);
  * @return              Number of bytes that were transfered
  * @return              -1 on error
  */
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length);
+int spi_transfer_regs(spi_t dev, uint8_t reg, uint8_t *out, uint8_t *in, unsigned int length);
 
 /**
  * @brief Tell the SPI driver that a new transaction was started. Call only when SPI in slave mode!
@@ -242,7 +242,7 @@ int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int 
  * @param[in] dev       SPI device that is active
  * @param[in] reset_val The byte that is send to the master as first byte
  */
-void spi_transmission_begin(spi_t dev, char reset_val);
+void spi_transmission_begin(spi_t dev, uint8_t reset_val);
 
 /**
  * @brief Power on the given SPI device

--- a/drivers/kw2xrf/kw2xrf_spi.c
+++ b/drivers/kw2xrf/kw2xrf_spi.c
@@ -90,7 +90,7 @@ uint8_t kw2xrf_read_dreg(uint8_t addr)
     uint8_t value;
     kw2xrf_spi_transfer_head();
     spi_transfer_reg(kw2xrf_spi, (addr | MKW2XDRF_REG_READ),
-                     0x0, (char *)&value);
+                     0x0, &value);
     kw2xrf_spi_transfer_tail();
     return value;
 }
@@ -109,7 +109,7 @@ void kw2xrf_write_iregs(uint8_t addr, uint8_t *buf, uint8_t length)
 
     kw2xrf_spi_transfer_head();
     spi_transfer_regs(kw2xrf_spi, MKW2XDM_IAR_INDEX,
-                      (char *)ibuf, NULL, length + 1);
+                      ibuf, NULL, length + 1);
     kw2xrf_spi_transfer_tail();
 
     return;
@@ -125,7 +125,7 @@ void kw2xrf_read_iregs(uint8_t addr, uint8_t *buf, uint8_t length)
 
     kw2xrf_spi_transfer_head();
     spi_transfer_regs(kw2xrf_spi, MKW2XDM_IAR_INDEX | MKW2XDRF_REG_READ,
-                      (char *)ibuf, (char *)ibuf, length + 1);
+                      ibuf, ibuf, length + 1);
     kw2xrf_spi_transfer_tail();
 
     for (uint8_t i = 0; i < length; i++) {
@@ -139,7 +139,7 @@ void kw2xrf_write_fifo(uint8_t *data, uint8_t length)
 {
     kw2xrf_spi_transfer_head();
     spi_transfer_regs(kw2xrf_spi, MKW2XDRF_BUF_WRITE,
-                      (char *)data, NULL, length);
+                      data, NULL, length);
     kw2xrf_spi_transfer_tail();
 }
 
@@ -147,7 +147,7 @@ void kw2xrf_read_fifo(uint8_t *data, uint8_t length)
 {
     kw2xrf_spi_transfer_head();
     spi_transfer_regs(kw2xrf_spi, MKW2XDRF_BUF_READ, NULL,
-                      (char *)data, length);
+                      data, length);
     kw2xrf_spi_transfer_tail();
 }
 /** @} */

--- a/drivers/lis3dh/lis3dh.c
+++ b/drivers/lis3dh/lis3dh.c
@@ -85,7 +85,7 @@ int lis3dh_read_xyz(const lis3dh_t *dev, lis3dh_data_t *acc_data)
     /* Perform the transaction */
     gpio_clear(dev->cs);
 
-    if (spi_transfer_regs(dev->spi, addr, NULL, (char *)acc_data,
+    if (spi_transfer_regs(dev->spi, addr, NULL, (uint8_t *)acc_data,
                           sizeof(lis3dh_data_t)) != sizeof(lis3dh_data_t)) {
         /* Transfer error */
         gpio_set(dev->cs);
@@ -234,7 +234,7 @@ static int lis3dh_read_regs(const lis3dh_t *dev, const lis3dh_reg_t reg, const u
     /* Perform the transaction */
     gpio_clear(dev->cs);
 
-    if (spi_transfer_regs(dev->spi, addr, NULL, (char *)buf, len) < 0) {
+    if (spi_transfer_regs(dev->spi, addr, NULL, buf, len) < 0) {
         /* Transfer error */
         gpio_set(dev->cs);
         /* Release the bus for other threads. */

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -28,7 +28,7 @@
 #include "debug.h"
 
 
-int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer)
+int nrf24l01p_read_reg(nrf24l01p_t *dev, uint8_t reg, uint8_t *answer)
 {
     int status;
 
@@ -47,10 +47,10 @@ int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer)
     return (status < 0) ? status : 0;
 }
 
-int nrf24l01p_write_reg(nrf24l01p_t *dev, char reg, char write)
+int nrf24l01p_write_reg(nrf24l01p_t *dev, uint8_t reg, uint8_t write)
 {
     int status;
-    char reg_content;
+    uint8_t reg_content;
 
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);
@@ -71,8 +71,8 @@ int nrf24l01p_write_reg(nrf24l01p_t *dev, char reg, char write)
 int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq)
 {
     int status;
-    char INITIAL_TX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
-    char INITIAL_RX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
+    uint8_t INITIAL_TX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
+    uint8_t INITIAL_RX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
 
     dev->spi = spi;
     dev->ce = ce;
@@ -199,7 +199,7 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq
 
 int nrf24l01p_on(nrf24l01p_t *dev)
 {
-    char read;
+    uint8_t read;
     int status;
 
     nrf24l01p_read_reg(dev, REG_CONFIG, &read);
@@ -212,7 +212,7 @@ int nrf24l01p_on(nrf24l01p_t *dev)
 
 int nrf24l01p_off(nrf24l01p_t *dev)
 {
-    char read;
+    uint8_t read;
     int status;
 
     nrf24l01p_read_reg(dev, REG_CONFIG, &read);
@@ -232,7 +232,7 @@ void nrf24l01p_transmit(nrf24l01p_t *dev)
     xtimer_spin(DELAY_CHANGE_TXRX_US);
 }
 
-int nrf24l01p_read_payload(nrf24l01p_t *dev, char *answer, unsigned int size)
+int nrf24l01p_read_payload(nrf24l01p_t *dev, uint8_t *answer, unsigned int size)
 {
     int status;
 
@@ -283,7 +283,7 @@ void nrf24l01p_stop(nrf24l01p_t *dev)
     gpio_clear(dev->ce);
 }
 
-int nrf24l01p_preload(nrf24l01p_t *dev, char *data, unsigned int size)
+int nrf24l01p_preload(nrf24l01p_t *dev, uint8_t *data, unsigned int size)
 {
     int status;
 
@@ -316,7 +316,7 @@ int nrf24l01p_set_channel(nrf24l01p_t *dev, uint8_t chan)
 
 int nrf24l01p_set_address_width(nrf24l01p_t *dev, nrf24l01p_aw_t aw)
 {
-    char aw_setup;
+    uint8_t aw_setup;
     nrf24l01p_read_reg(dev, REG_SETUP_AW, &aw_setup);
 
     xtimer_spin(DELAY_AFTER_FUNC_TICKS);
@@ -344,9 +344,9 @@ int nrf24l01p_set_address_width(nrf24l01p_t *dev, nrf24l01p_aw_t aw)
     return nrf24l01p_write_reg(dev, REG_SETUP_AW, aw_setup);
 }
 
-int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char width)
+int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint8_t width)
 {
-    char pipe_pw_address;
+    uint8_t pipe_pw_address;
 
     switch (pipe) {
         case NRF24L01P_PIPE0:
@@ -390,7 +390,7 @@ int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char
 
 
 
-int nrf24l01p_set_tx_address(nrf24l01p_t *dev, char *saddr, unsigned int length)
+int nrf24l01p_set_tx_address(nrf24l01p_t *dev, uint8_t *saddr, unsigned int length)
 {
     int status;
 
@@ -413,7 +413,7 @@ int nrf24l01p_set_tx_address_long(nrf24l01p_t *dev, uint64_t saddr, unsigned int
 {
     int status;
 
-    char buf[length];
+    uint8_t buf[length];
 
     if (length <= INITIAL_ADDRESS_WIDTH) {
         for (int i = 0; i < length; i++) {
@@ -444,7 +444,7 @@ uint64_t nrf24l01p_get_tx_address_long(nrf24l01p_t *dev)
 {
     int status;
     uint64_t saddr_64 = 0;
-    char addr_array[INITIAL_ADDRESS_WIDTH];
+    uint8_t addr_array[INITIAL_ADDRESS_WIDTH];
 
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);
@@ -472,10 +472,10 @@ uint64_t nrf24l01p_get_tx_address_long(nrf24l01p_t *dev)
 }
 
 
-int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *saddr, unsigned int length)
+int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint8_t *saddr, unsigned int length)
 {
     int status;
-    char pipe_addr;
+    uint8_t pipe_addr;
 
     switch (pipe) {
         case NRF24L01P_PIPE0:
@@ -525,7 +525,7 @@ int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *s
 
 int nrf24l01p_set_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint64_t saddr, unsigned int length)
 {
-    char buf[length];
+    uint8_t buf[length];
 
     if (length <= INITIAL_ADDRESS_WIDTH) {
         for (int i = 0; i < length; i++) {
@@ -544,10 +544,10 @@ int nrf24l01p_set_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, ui
 uint64_t nrf24l01p_get_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 {
     int status;
-    char pipe_addr;
+    uint8_t pipe_addr;
     uint64_t saddr_64 = 0;
 
-    char addr_array[INITIAL_ADDRESS_WIDTH];
+    uint8_t addr_array[INITIAL_ADDRESS_WIDTH];
 
     switch (pipe) {
         case NRF24L01P_PIPE0:
@@ -604,7 +604,7 @@ uint64_t nrf24l01p_get_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pip
 
 int nrf24l01p_set_datarate(nrf24l01p_t *dev, nrf24l01p_dr_t dr)
 {
-    char rf_setup;
+    uint8_t rf_setup;
 
     nrf24l01p_read_reg(dev, REG_RF_SETUP, &rf_setup);
 
@@ -632,7 +632,7 @@ int nrf24l01p_set_datarate(nrf24l01p_t *dev, nrf24l01p_dr_t dr)
 
 int nrf24l01p_get_status(nrf24l01p_t *dev)
 {
-    char status;
+    uint8_t status;
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);
     gpio_clear(dev->cs);
@@ -650,7 +650,7 @@ int nrf24l01p_get_status(nrf24l01p_t *dev)
 
 int nrf24l01p_set_power(nrf24l01p_t *dev, int pwr)
 {
-    char rf_setup;
+    uint8_t rf_setup;
 
     nrf24l01p_read_reg(dev, REG_RF_SETUP, &rf_setup);
 
@@ -678,7 +678,7 @@ int nrf24l01p_set_power(nrf24l01p_t *dev, int pwr)
 
 int nrf24l01p_get_power(nrf24l01p_t *dev)
 {
-    char rf_setup;
+    uint8_t rf_setup;
     int pwr;
 
     nrf24l01p_read_reg(dev, REG_RF_SETUP, &rf_setup);
@@ -705,7 +705,7 @@ int nrf24l01p_get_power(nrf24l01p_t *dev)
 
 int nrf24l01p_set_txmode(nrf24l01p_t *dev)
 {
-    char conf;
+    uint8_t conf;
     int status;
 
     nrf24l01p_stop(dev);
@@ -725,7 +725,7 @@ int nrf24l01p_set_txmode(nrf24l01p_t *dev)
 
 int nrf24l01p_set_rxmode(nrf24l01p_t *dev)
 {
-    char conf;
+    uint8_t conf;
     int status;
 
     nrf24l01p_unmask_interrupt(dev, MASK_RX_DR);
@@ -745,7 +745,7 @@ int nrf24l01p_set_rxmode(nrf24l01p_t *dev)
 }
 
 
-int nrf24l01p_reset_interrupts(nrf24l01p_t *dev, char intrs)
+int nrf24l01p_reset_interrupts(nrf24l01p_t *dev, uint8_t intrs)
 {
     return nrf24l01p_write_reg(dev, REG_STATUS, intrs);
 }
@@ -755,9 +755,9 @@ int nrf24l01p_reset_all_interrupts(nrf24l01p_t *dev)
     return nrf24l01p_write_reg(dev, REG_STATUS, ALL_INT_MASK);
 }
 
-int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, char intr)
+int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, uint8_t intr)
 {
-    char conf;
+    uint8_t conf;
 
     nrf24l01p_read_reg(dev, REG_CONFIG, &conf);
     conf |= intr;
@@ -765,9 +765,9 @@ int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, char intr)
     return nrf24l01p_write_reg(dev, REG_CONFIG, conf);
 }
 
-int nrf24l01p_unmask_interrupt(nrf24l01p_t *dev, char intr)
+int nrf24l01p_unmask_interrupt(nrf24l01p_t *dev, uint8_t intr)
 {
-    char conf;
+    uint8_t conf;
 
     nrf24l01p_read_reg(dev, REG_CONFIG, &conf);
     conf &= ~intr;
@@ -777,9 +777,9 @@ int nrf24l01p_unmask_interrupt(nrf24l01p_t *dev, char intr)
 
 int nrf24l01p_enable_dynamic_payload(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 {
-    char feature_val;
-    char en_aa_val;
-    char dynpd_val;
+    uint8_t feature_val;
+    uint8_t en_aa_val;
+    uint8_t dynpd_val;
     int pipe_mask = 0;
     int dpl_mask = 0;
 
@@ -852,7 +852,7 @@ int nrf24l01p_enable_dynamic_payload(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 
 int nrf24l01p_enable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 {
-    char pipe_conf;
+    uint8_t pipe_conf;
 
     nrf24l01p_read_reg(dev, REG_EN_RXADDR, &pipe_conf);
     pipe_conf |= (1 << pipe);
@@ -862,7 +862,7 @@ int nrf24l01p_enable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 
 int nrf24l01p_disable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 {
-    char pipe_conf;
+    uint8_t pipe_conf;
 
     nrf24l01p_read_reg(dev, REG_EN_RXADDR, &pipe_conf);
     pipe_conf &= ~(1 << pipe);
@@ -874,7 +874,7 @@ int nrf24l01p_disable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 
 int nrf24l01p_enable_crc(nrf24l01p_t *dev, nrf24l01p_crc_t crc)
 {
-    char conf;
+    uint8_t conf;
 
     nrf24l01p_read_reg(dev, REG_CONFIG, &conf);
 
@@ -894,9 +894,9 @@ int nrf24l01p_enable_crc(nrf24l01p_t *dev, nrf24l01p_crc_t crc)
     return nrf24l01p_write_reg(dev, REG_CONFIG, (conf | EN_CRC));
 }
 
-int nrf24l01p_setup_auto_ack(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l01p_retransmit_delay_t delay_retrans, char count_retrans)
+int nrf24l01p_setup_auto_ack(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l01p_retransmit_delay_t delay_retrans, uint8_t count_retrans)
 {
-    char en_aa;
+    uint8_t en_aa;
     int status;
     nrf24l01p_read_reg(dev, REG_EN_AA, &en_aa);
 
@@ -944,7 +944,7 @@ int nrf24l01p_setup_auto_ack(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l0
 
 int nrf24l01p_enable_dynamic_ack(nrf24l01p_t *dev)
 {
-    char feature;
+    uint8_t feature;
 
     if (nrf24l01p_read_reg(dev, REG_FEATURE, &feature) < 0){
         DEBUG("Can't read FEATURE reg\n");
@@ -969,7 +969,7 @@ int nrf24l01p_disable_all_auto_ack(nrf24l01p_t *dev)
 int nrf24l01p_flush_tx_fifo(nrf24l01p_t *dev)
 {
     int status;
-    char reg_content;
+    uint8_t reg_content;
 
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);
@@ -989,7 +989,7 @@ int nrf24l01p_flush_tx_fifo(nrf24l01p_t *dev)
 int nrf24l01p_flush_rx_fifo(nrf24l01p_t *dev)
 {
     int status;
-    char reg_content;
+    uint8_t reg_content;
 
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi);

--- a/drivers/nvram_spi/nvram-spi.c
+++ b/drivers/nvram_spi/nvram-spi.c
@@ -126,7 +126,7 @@ static int nvram_spi_write(nvram_t *dev, const uint8_t *src, uint32_t dst, size_
     int status;
     union {
         uint32_t u32;
-        char c[4];
+        uint8_t c[4];
     } addr;
     /* Address is expected by the device as big-endian, i.e. network byte order,
      * we utilize the network byte order macros here. */
@@ -155,7 +155,7 @@ static int nvram_spi_write(nvram_t *dev, const uint8_t *src, uint32_t dst, size_
         return status;
     }
     /* Keep holding CS and write data */
-    status = spi_transfer_bytes(spi_dev->spi, (char *)src, NULL, len);
+    status = spi_transfer_bytes(spi_dev->spi, (uint8_t *)src, NULL, len);
     if (status < 0)
     {
         return status;
@@ -173,7 +173,7 @@ static int nvram_spi_read(nvram_t *dev, uint8_t *dst, uint32_t src, size_t len)
     int status;
     union {
         uint32_t u32;
-        char c[4];
+        uint8_t c[4];
     } addr;
     /* Address is expected by the device as big-endian, i.e. network byte order,
      * we utilize the network byte order macros here. */
@@ -191,7 +191,7 @@ static int nvram_spi_read(nvram_t *dev, uint8_t *dst, uint32_t src, size_t len)
         return status;
     }
     /* Keep holding CS and read data */
-    status = spi_transfer_bytes(spi_dev->spi, NULL, (char *)dst, len);
+    status = spi_transfer_bytes(spi_dev->spi, NULL, dst, len);
     if (status < 0)
     {
         return status;
@@ -237,7 +237,7 @@ static int nvram_spi_write_9bit_addr(nvram_t *dev, const uint8_t *src, uint32_t 
         return status;
     }
     /* Keep holding CS and write data */
-    status = spi_transfer_bytes(spi_dev->spi, (char *)src, NULL, len);
+    status = spi_transfer_bytes(spi_dev->spi, (uint8_t *)src, NULL, len);
     if (status < 0)
     {
         return status;
@@ -265,13 +265,13 @@ static int nvram_spi_read_9bit_addr(nvram_t *dev, uint8_t *dst, uint32_t src, si
     spi_acquire(spi_dev->spi);
     gpio_clear(spi_dev->cs);
     /* Write command and address */
-    status = spi_transfer_reg(spi_dev->spi, (char)cmd, addr, NULL);
+    status = spi_transfer_reg(spi_dev->spi, cmd, addr, NULL);
     if (status < 0)
     {
         return status;
     }
     /* Keep holding CS and read data */
-    status = spi_transfer_bytes(spi_dev->spi, NULL, (char *)dst, len);
+    status = spi_transfer_bytes(spi_dev->spi, NULL, dst, len);
     if (status < 0)
     {
         return status;

--- a/drivers/pcd8544/pcd8544.c
+++ b/drivers/pcd8544/pcd8544.c
@@ -130,7 +130,7 @@ static const uint8_t _ascii[][5] = {
     {0x10, 0x08, 0x08, 0x10, 0x08},/* 7e ~ */
 };
 
-static const char _riot[] = {
+static const uint8_t _riot[] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -197,7 +197,7 @@ static const char _riot[] = {
 };
 
 
-static void _write(pcd8544_t *dev, uint8_t is_data, char data)
+static void _write(pcd8544_t *dev, uint8_t is_data, uint8_t data)
 {
     /* set command or data mode */
     gpio_write(dev->mode, is_data);
@@ -293,7 +293,7 @@ void pcd8544_riot(pcd8544_t *dev)
     pcd8544_write_img(dev, _riot);
 }
 
-void pcd8544_write_img(pcd8544_t *dev, const char img[])
+void pcd8544_write_img(pcd8544_t *dev, const uint8_t img[])
 {
     /* set initial position */
     _set_x(dev, 0);

--- a/drivers/periph_common/spi.c
+++ b/drivers/periph_common/spi.c
@@ -27,11 +27,11 @@
 #if SPI_NUMOF
 
 #ifdef PERIPH_SPI_NEEDS_TRANSFER_BYTES
-int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
+int spi_transfer_bytes(spi_t dev, uint8_t *out, uint8_t *in, unsigned int length)
 {
     int trans_ret;
     unsigned trans_bytes = 0;
-    char in_temp;
+    uint8_t in_temp;
 
     for (trans_bytes = 0; trans_bytes < length; trans_bytes++) {
         if (out != NULL) {
@@ -53,7 +53,7 @@ int spi_transfer_bytes(spi_t dev, char *out, char *in, unsigned int length)
 #endif
 
 #ifdef PERIPH_SPI_NEEDS_TRANSFER_REG
-int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
+int spi_transfer_reg(spi_t dev, uint8_t reg, uint8_t out, uint8_t *in)
 {
     int trans_ret;
 
@@ -71,7 +71,7 @@ int spi_transfer_reg(spi_t dev, uint8_t reg, char out, char *in)
 #endif
 
 #ifdef PERIPH_SPI_NEEDS_TRANSFER_REGS
-int spi_transfer_regs(spi_t dev, uint8_t reg, char *out, char *in, unsigned int length)
+int spi_transfer_regs(spi_t dev, uint8_t reg, uint8_t *out, uint8_t *in, unsigned int length)
 {
     int trans_ret;
 

--- a/pkg/u8g2/patches/0002-u8g2-add-riot-os-interface.patch
+++ b/pkg/u8g2/patches/0002-u8g2-add-riot-os-interface.patch
@@ -134,7 +134,7 @@ index 0000000..7106e07
 +
 +    switch (msg) {
 +        case U8X8_MSG_BYTE_SEND:
-+            spi_transfer_bytes(dev, (char *) arg_ptr, NULL, arg_int);
++            spi_transfer_bytes(dev, (uint8_t *) arg_ptr, NULL, arg_int);
 +            break;
 +        case U8X8_MSG_BYTE_INIT:
 +            spi_init_master(dev,

--- a/tests/driver_nrf24l01p_lowlevel/main.c
+++ b/tests/driver_nrf24l01p_lowlevel/main.c
@@ -55,7 +55,7 @@ static int cmd_print_regs(int argc, char **argv);
 static int cmd_its(int argc, char **argv);
 
 void printbin(unsigned byte);
-void print_register(char reg, int num_bytes);
+void print_register(uint8_t reg, int num_bytes);
 
 static nrf24l01p_t nrf24l01p_0;
 
@@ -81,10 +81,10 @@ void prtbin(unsigned byte)
 /**
  * @print register
  */
-void print_register(char reg, int num_bytes)
+void print_register(uint8_t reg, int num_bytes)
 {
 
-    char buf_return[num_bytes];
+    uint8_t buf_return[num_bytes];
     int ret;
 
 
@@ -124,7 +124,7 @@ void *nrf24l01p_rx_handler(void *arg)
     msg_t msg_q[1];
     msg_init_queue(msg_q, 1);
     unsigned int pid = thread_getpid();
-    char rx_buf[NRF24L01P_MAX_DATA_LENGTH];
+    uint8_t rx_buf[NRF24L01P_MAX_DATA_LENGTH];
 
     puts("Registering nrf24l01p_rx_handler thread...");
     nrf24l01p_register(&nrf24l01p_0, &pid);
@@ -214,7 +214,7 @@ int cmd_send(int argc, char **argv)
     puts("Send");
 
     int status = 0;
-    char tx_buf[NRF24L01P_MAX_DATA_LENGTH];
+    uint8_t tx_buf[NRF24L01P_MAX_DATA_LENGTH];
 
     /* fill TX buffer with numbers 32..1 */
     for (int i = 0; i < sizeof(tx_buf); i++) {

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -47,8 +47,8 @@ static int spi_master = -1;
 static int port = -1;
 static int pin = -1;
 
-static char buffer[256];       /* temporary buffer */
-static char rx_buffer[256];    /* global receive buffer */
+static uint8_t buffer[256];       /* temporary buffer */
+static uint8_t rx_buffer[256];    /* global receive buffer */
 static int rx_counter = 0;
 
 static volatile int state;
@@ -143,7 +143,7 @@ int parse_spi_dev(int argc, char **argv)
     return 0;
 }
 
-void print_bytes(char* title, char* chars, int length)
+void print_bytes(char* title, uint8_t* chars, int length)
 {
     printf("%4s", title);
     for (int i = 0; i < length; i++) {
@@ -174,7 +174,7 @@ void slave_on_cs(void *arg)
     rw = INIT;
 }
 
-char slave_on_data(char data)
+uint8_t slave_on_data(uint8_t data)
 {
     rx_buffer[rx_counter] = data;
     rx_counter++;
@@ -280,7 +280,7 @@ int cmd_transfer(int argc, char **argv)
     /* do the actual data transfer */
     spi_acquire(spi_dev);
     gpio_clear(spi_cs);
-    res = spi_transfer_bytes(spi_dev, hello, buffer, strlen(hello));
+    res = spi_transfer_bytes(spi_dev, (uint8_t *)hello, buffer, strlen(hello));
     gpio_set(spi_cs);
     spi_release(spi_dev);
 
@@ -291,7 +291,7 @@ int cmd_transfer(int argc, char **argv)
     }
     else {
         printf("Transfered %i bytes:\n", res);
-        print_bytes("MOSI", hello, res);
+        print_bytes("MOSI", (uint8_t *)hello, res);
         print_bytes("MISO", buffer, res);
         return 0;
     }


### PR DESCRIPTION
In general, data transferred through SPI are bytes and thus should have
type uint8_t, not char.

This was discussed briefly on riot-devel (Subject: Byte array should be uint8_t, not char, Date: July 2016)
