### PR TITLE
board/sodaq-autonomo: correct openocd configuration

### DIFF
--- a/boards/sodaq-autonomo/dist/openocd.cfg
+++ b/boards/sodaq-autonomo/dist/openocd.cfg
@@ -1,1 +1,38 @@
-source [find board/sodaq_autonomo.cfg]
+#
+# SODAQ Autonomo
+#
+#  Copyright (c) 2016 SODAQ.  All right reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+#
+# To program the Autonomo you need openocd v0.9.0 or higher
+# Here is an example bash script:
+#  #!/bin/bash
+#  ELF=${1?}
+#  OPENOCD_CMD="telnet_port disabled; init; halt; at91samd bootloader 0; program {{$ELF}} verify reset; shutdown"
+#  openocd -d2 -f boards/sodaq-autonomo/dist/openocd.cfg -c "$OPENOCD_CMD"
+
+source [find interface/cmsis-dap.cfg]
+
+# chip name
+set CHIPNAME at91samd21j18
+set ENDIAN little
+
+# choose a port here
+set telnet_port 0
+
+source [find target/at91samdXX.cfg]


### PR DESCRIPTION
This is a correction of the openocd config. I've added a comment block with a description of the openocd command to burn (flash) new code.