### PR TITLE
periph/i2c: convert char to uint8_t where applicapable

### DIFF
--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -348,12 +348,12 @@ static bool i2c_busy(void) {
     return false;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, char *data)
+int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
 {
     return i2c_read_bytes(dev, address, data, 1);
 }
 
-static int i2c_read_bytes_dumb(uint8_t address, char *data, int length)
+static int i2c_read_bytes_dumb(uint8_t address, uint8_t *data, int length)
 {
     int n = 0;
     uint_fast8_t stat;
@@ -416,7 +416,7 @@ static int i2c_read_bytes_dumb(uint8_t address, char *data, int length)
     return n;
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     switch (dev) {
 #if I2C_0_EN
@@ -447,12 +447,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
     return i2c_read_bytes_dumb(address, data, length);
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data)
+int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
     return i2c_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     uint_fast8_t stat;
 
@@ -492,14 +492,15 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int lengt
     }
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, char data)
+int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
     return i2c_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     int n = 0;
+    const uint8_t *my_data = data;
 
     if (dev != I2C_0) {
         return -1;
@@ -521,7 +522,7 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
     for (n = 0; n < length; n++) {
         if (n >= length - 1) flags |= STOP;
         WARN_IF(I2CM_STAT & BUSY);
-        I2CM_DR = data[n];
+        I2CM_DR = my_data[n];
         i2c_ctrl_blocking(flags);
 
         WARN_IF(I2CM_STAT & ARBLST);
@@ -542,20 +543,21 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
 
         if (n < length) {
             DEBUG("%s(%u, %p, %u): %u/%u bytes delivered.\n",
-                  __FUNCTION__, address, (void *)data, length, n, length);
+                  __FUNCTION__, address, (void *)my_data, length, n, length);
         }
 
     return n;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data)
+int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
     return i2c_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     uint_fast8_t stat;
+    const uint8_t *my_data = data;
 
     if (dev != I2C_0) {
         return -1;
@@ -598,7 +600,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int leng
         for (n = 0; n < length; n++) {
             if (n >= length - 1) flags |= STOP;
             WARN_IF(I2CM_STAT & BUSY);
-            I2CM_DR = data[n];
+            I2CM_DR = my_data[n];
 
             i2c_ctrl_blocking(flags);
 
@@ -623,7 +625,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int leng
                 dev,
                 address,
                 reg,
-                (void *)data,
+                data,
                 length,
                 n,
                 length

--- a/cpu/kinetis_common/periph/i2c.c
+++ b/cpu/kinetis_common/periph/i2c.c
@@ -282,7 +282,7 @@ static inline int _i2c_receive(I2C_Type *dev, uint8_t *data, int length)
             dev->C1 &= ~I2C_C1_MST_MASK;
         }
 
-        data[n] = (char)dev->D;
+        data[n] = dev->D;
         TRACE("i2c: rx: %02x\n", (unsigned int)data[n]);
         n++;
     }
@@ -290,12 +290,12 @@ static inline int _i2c_receive(I2C_Type *dev, uint8_t *data, int length)
     return n;
 }
 
-static inline int _i2c_transmit(I2C_Type *dev, uint8_t *data, int length)
+static inline int _i2c_transmit(I2C_Type *dev, const uint8_t *data, int length)
 {
     int n = 0;
 
     while (length > 0) {
-        TRACE("i2c: tx: %02x\n", (unsigned int)data[n]);
+        TRACE("i2c: tx: %02x\n", data[n]);
         dev->D = data[n];
 
         while (!(dev->S & I2C_S_IICIF_MASK));
@@ -331,12 +331,12 @@ static inline void _i2c_reset(I2C_Type *dev)
 }
 
 
-int i2c_read_byte(i2c_t dev, uint8_t address, char *data)
+int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
 {
     return i2c_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     I2C_Type *i2c;
     int n = 0;
@@ -369,12 +369,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
     return n;
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, char data)
+int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
     return i2c_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     I2C_Type *i2c;
     int n = 0;
@@ -396,19 +396,19 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
         return -1;
     }
 
-    n = _i2c_transmit(i2c, (uint8_t *)data, length);
+    n = _i2c_transmit(i2c, data, length);
     _i2c_stop(i2c);
 
     return n;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data)
+int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
     return i2c_read_regs(dev, address, reg, data, 1);
 
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     I2C_Type *i2c;
     int n = 0;
@@ -454,12 +454,12 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int lengt
     return n;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data)
+int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
     return i2c_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     I2C_Type *i2c;
     int n = 0;
@@ -488,7 +488,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int leng
         return n;
     }
 
-    n = _i2c_transmit(i2c, (uint8_t *)data, length);
+    n = _i2c_transmit(i2c, data, length);
     _i2c_stop(i2c);
 
     return n;

--- a/cpu/sam21_common/periph/i2c.c
+++ b/cpu/sam21_common/periph/i2c.c
@@ -45,8 +45,8 @@ static void _i2c_poweron(SercomI2cm *sercom);
 static void _i2c_poweroff(SercomI2cm *sercom);
 
 static inline int _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag);
-static inline int _write(SercomI2cm *dev, char *data, int length);
-static inline int _read(SercomI2cm *dev, char *data, int length);
+static inline int _write(SercomI2cm *dev, const uint8_t *data, int length);
+static inline int _read(SercomI2cm *dev, uint8_t *data, int length);
 static inline void _stop(SercomI2cm *dev);
 
 /**
@@ -204,12 +204,12 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, char *data)
+int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
 {
     return i2c_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     SercomI2cm *i2c;
 
@@ -232,12 +232,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
     return length;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data)
+int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
     return i2c_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     SercomI2cm *i2c;
 
@@ -252,19 +252,19 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int lengt
     }
 
     /* start transmission and send slave address */
-    if(_start(i2c, address, I2C_FLAG_WRITE) < 0) return 0;
+    if (_start(i2c, address, I2C_FLAG_WRITE) < 0) return 0;
     /* send register address/command and wait for complete transfer to
      * be finished */
-    if(_write(i2c, (char *)(&reg), 1) < 0) return 0;
+    if (_write(i2c, &reg, 1) < 0) return 0;
     return i2c_read_bytes(dev, address, data, length);
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, char data)
+int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
     return i2c_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     SercomI2cm *I2CSercom;
 
@@ -285,12 +285,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
 }
 
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data)
+int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
     return i2c_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     SercomI2cm *i2c;
 
@@ -305,11 +305,11 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int leng
         }
 
     /* start transmission and send slave address */
-    if(_start(i2c, address, I2C_FLAG_WRITE) < 0) return 0;
+    if (_start(i2c, address, I2C_FLAG_WRITE) < 0) return 0;
     /* send register address and wait for complete transfer to be finished */
-    if(_write(i2c, (char *)(&reg), 1) < 0) return 0;
+    if (_write(i2c, &reg, 1) < 0) return 0;
     /* write data to register */
-    if(_write(i2c, data, length) < 0) return 0;
+    if (_write(i2c, data, length) < 0) return 0;
     /* finish transfer */
     _stop(i2c);
     return length;
@@ -405,7 +405,7 @@ static int _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag)
     return 0;
 }
 
-static inline int _write(SercomI2cm *dev, char *data, int length)
+static inline int _write(SercomI2cm *dev, const uint8_t *data, int length)
 {
     uint16_t tmp_data_length = length;
     uint32_t timeout_counter = 0;
@@ -445,7 +445,7 @@ static inline int _write(SercomI2cm *dev, char *data, int length)
     return 0;
 }
 
-static inline int _read(SercomI2cm *dev, char *data, int length)
+static inline int _read(SercomI2cm *dev, uint8_t *data, int length)
 {
     uint32_t timeout_counter = 0;
     uint8_t count = 0;

--- a/cpu/stm32f3/periph/i2c.c
+++ b/cpu/stm32f3/periph/i2c.c
@@ -46,8 +46,8 @@ static void _pin_config(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda,
                         int pin_scl, int pin_sda);
 static void _start(I2C_TypeDef *dev, uint8_t address, uint8_t length,
                    uint8_t rw_flag);
-static inline void _read(I2C_TypeDef *dev, char *data, int length);
-static inline void _write(I2C_TypeDef *dev, char *data, int length);
+static inline void _read(I2C_TypeDef *dev, uint8_t *data, int length);
+static inline void _write(I2C_TypeDef *dev, const uint8_t *data, int length);
 static inline void _stop(I2C_TypeDef *dev);
 
 /**
@@ -245,12 +245,12 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, char *data)
+int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
 {
     return i2c_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -282,12 +282,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
     return length;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data)
+int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
     return i2c_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -323,12 +323,12 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int lengt
     return i2c_read_bytes(dev, address, data, length);
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, char data)
+int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
     return i2c_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -360,12 +360,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
     return length;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data)
+int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
     return i2c_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -467,7 +467,7 @@ static void _start(I2C_TypeDef *dev, uint8_t address, uint8_t length, uint8_t rw
     dev->CR2 |= I2C_CR2_START;
 }
 
-static inline void _read(I2C_TypeDef *dev, char *data, int length)
+static inline void _read(I2C_TypeDef *dev, uint8_t *data, int length)
 {
     for (int i = 0; i < length; i++) {
         /* wait for transfer to finish */
@@ -476,12 +476,12 @@ static inline void _read(I2C_TypeDef *dev, char *data, int length)
         DEBUG("DR is now full\n");
 
         /* read data from data register */
-        data[i] = (uint8_t)dev->RXDR;
+        data[i] = dev->RXDR;
         DEBUG("Read byte %i from DR\n", i);
     }
 }
 
-static inline void _write(I2C_TypeDef *dev, char *data, int length)
+static inline void _write(I2C_TypeDef *dev, const uint8_t *data, int length)
 {
     for (int i = 0; i < length; i++) {
         /* wait for ack */
@@ -490,7 +490,7 @@ static inline void _write(I2C_TypeDef *dev, char *data, int length)
 
         /* write data to data register */
         DEBUG("Write byte %i to DR\n", i);
-        dev->TXDR = (uint8_t)data[i];
+        dev->TXDR = data[i];
         DEBUG("Sending data\n");
     }
 }

--- a/cpu/stm32l1/periph/i2c.c
+++ b/cpu/stm32l1/periph/i2c.c
@@ -43,7 +43,7 @@
 static void _i2c_init(I2C_TypeDef *i2c, int ccr);
 static void _start(I2C_TypeDef *i2c, uint8_t address, uint8_t rw_flag);
 static inline void _clear_addr(I2C_TypeDef *i2c);
-static inline void _write(I2C_TypeDef *i2c, char *data, int length);
+static inline void _write(I2C_TypeDef *i2c, const uint8_t *data, int length);
 static inline void _stop(I2C_TypeDef *i2c);
 
 /**
@@ -140,15 +140,16 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, char *data)
+int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
 {
     return i2c_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     unsigned int state;
     int i = 0;
+    uint8_t *my_data = data;
 
     if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
@@ -174,7 +175,7 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
             while (!(i2c->SR1 & I2C_SR1_RXNE)) {}
 
             DEBUG("Read received data\n");
-            *data = (char)i2c->DR;
+            *my_data = i2c->DR;
 
             /* wait until STOP is cleared by hardware */
             while (i2c->CR1 & I2C_CR1_STOP) {}
@@ -201,11 +202,11 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
             DEBUG("Crit block: set STOP and read first byte\n");
             state = irq_disable();
             i2c->CR1 |= (I2C_CR1_STOP);
-            data[0] = (char)i2c->DR;
+            my_data[0] = i2c->DR;
             irq_restore(state);
 
             DEBUG("read second byte\n");
-            data[1] = (char)i2c->DR;
+            my_data[1] = i2c->DR;
 
             DEBUG("wait for STOP bit to be cleared again\n");
 
@@ -227,7 +228,7 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
                 while (!(i2c->SR1 & I2C_SR1_RXNE)) {}
 
                 DEBUG("Copy byte from DR\n");
-                data[i++] = (char)i2c->DR;
+                my_data[i++] = i2c->DR;
             }
 
             DEBUG("Reading the last 3 bytes, waiting for BTF flag\n");
@@ -239,18 +240,18 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
 
             DEBUG("Crit block: set STOP and read N-2 byte\n");
             state = irq_disable();
-            data[i++] = (char)i2c->DR;
+            my_data[i++] = i2c->DR;
             i2c->CR1 |= (I2C_CR1_STOP);
             irq_restore(state);
 
             DEBUG("Read N-1 byte\n");
-            data[i++] = (char)i2c->DR;
+            my_data[i++] = i2c->DR;
 
             while (!(i2c->SR1 & I2C_SR1_RXNE)) {}
 
             DEBUG("Read last byte\n");
 
-            data[i++] = (char)i2c->DR;
+            my_data[i++] = i2c->DR;
 
             DEBUG("wait for STOP bit to be cleared again\n");
 
@@ -264,12 +265,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length)
     return length;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data)
+int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
     return i2c_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
@@ -288,12 +289,12 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int lengt
     return i2c_read_bytes(dev, address, data, length);
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, char data)
+int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
     return i2c_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
+int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
@@ -314,12 +315,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length)
     return length;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data)
+int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
     return i2c_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int length)
+int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
@@ -331,7 +332,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, char *data, int leng
     _start(i2c, address, I2C_FLAG_WRITE);
     _clear_addr(i2c);
     /* send register address and wait for complete transfer to be finished*/
-    _write(i2c, (char *)(&reg), 1);
+    _write(i2c, &reg, 1);
     /* write data to register */
     _write(i2c, data, length);
     /* finish transfer */
@@ -385,13 +386,13 @@ static inline void _clear_addr(I2C_TypeDef *i2c)
     DEBUG("Cleared address\n");
 }
 
-static inline void _write(I2C_TypeDef *i2c, char *data, int length)
+static inline void _write(I2C_TypeDef *i2c, const uint8_t *data, int length)
 {
     DEBUG("Looping through bytes\n");
 
     for (int i = 0; i < length; i++) {
         /* write data to data register */
-        i2c->DR = (uint8_t)data[i];
+        i2c->DR = data[i];
         DEBUG("Written %i byte to data reg, now waiting for DR to be empty again\n", i);
 
         /* wait for transfer to finish */

--- a/drivers/at30tse75x/at30tse75x.c
+++ b/drivers/at30tse75x/at30tse75x.c
@@ -38,7 +38,7 @@ static int at30tse75x_get_register(at30tse75x_t* dev, uint8_t reg, uint16_t* dat
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_US);
-    if(i2c_read_regs(dev->i2c, dev->addr, reg, (char*) data, 2) <= 0) {
+    if (i2c_read_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
         DEBUG("[at30tse75x] Can't read register 0x%x\n", reg);
         i2c_release(dev->i2c);
         return -1;
@@ -52,7 +52,7 @@ static int at30tse75x_set_register(at30tse75x_t* dev, uint8_t reg, uint16_t* dat
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_US);
-    if(i2c_write_regs(dev->i2c, dev->addr, reg, (char*) data, 2) <= 0) {
+    if (i2c_write_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
         DEBUG("[at30tse75x] Can't write to register 0x%x\n", reg);
         i2c_release(dev->i2c);
         return -1;
@@ -80,7 +80,7 @@ int at30tse75x_get_config(at30tse75x_t* dev, uint8_t* data)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_US);
-    if(i2c_read_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, (char*) data) <= 0) {
+    if (i2c_read_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data) <= 0) {
         DEBUG("[at30tse75x] Can't read CONFIG register\n");
         i2c_release(dev->i2c);
         return -1;
@@ -94,7 +94,7 @@ int at30tse75x_set_config(at30tse75x_t* dev, uint8_t data)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_US);
-    if(i2c_write_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, (char) data) <= 0) {
+    if (i2c_write_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data) <= 0) {
         DEBUG("[at30tse75x] Can't write to CONFIG register\n");
         i2c_release(dev->i2c);
         return -1;

--- a/drivers/bh1750fvi/bh1750fvi.c
+++ b/drivers/bh1750fvi/bh1750fvi.c
@@ -49,7 +49,7 @@ int bh1750fvi_init(bh1750fvi_t *dev, bh1750fvi_params_t *params)
 uint16_t bh1750fvi_sample(bh1750fvi_t *dev)
 {
     uint32_t tmp;
-    char raw[2];
+    uint8_t raw[2];
 
     /* power on the device and send single H-mode measurement command */
     i2c_acquire(dev->i2c);

--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -66,7 +66,7 @@ int bmp180_init(bmp180_t *dev, i2c_t i2c, uint8_t mode)
     i2c_acquire(dev->i2c_dev);
 
     /* Check sensor ID */
-    char checkid;
+    uint8_t checkid;
     i2c_read_reg(dev->i2c_dev, BMP180_ADDR, BMP180_REGISTER_ID, &checkid);
     if (checkid != 0x55) {
         DEBUG("[Error] Wrong device ID\n");
@@ -77,7 +77,7 @@ int bmp180_init(bmp180_t *dev, i2c_t i2c, uint8_t mode)
     /* adding delay before reading calibration values to avoid timing issues */
     xtimer_usleep(BMP180_ULTRALOWPOWER_DELAY);
 
-    char buffer[22] = {0};
+    uint8_t buffer[22] = {0};
     /* Read calibration values, using contiguous register addresses */
     if (i2c_read_regs(dev->i2c_dev, BMP180_ADDR, BMP180_CALIBRATION_AC1, buffer, 22) < 0) {
         DEBUG("[Error] Cannot read calibration registers.\n");
@@ -216,8 +216,8 @@ int bmp180_sealevel_pressure(bmp180_t *dev, int32_t altitude, int32_t *pressure_
 static int _read_ut(bmp180_t *dev, int32_t *output)
 {
     /* Read UT (Uncompsensated Temperature value) */
-    char ut[2] = {0};
-    char control[2] = { BMP180_REGISTER_CONTROL, BMP180_TEMPERATURE_COMMAND };
+    uint8_t ut[2] = {0};
+    uint8_t control[2] = { BMP180_REGISTER_CONTROL, BMP180_TEMPERATURE_COMMAND };
     i2c_write_bytes(dev->i2c_dev, BMP180_ADDR, control, 2);
     xtimer_usleep(BMP180_ULTRALOWPOWER_DELAY);
     if (i2c_read_regs(dev->i2c_dev, BMP180_ADDR, BMP180_REGISTER_DATA, ut, 2) < 0) {
@@ -235,8 +235,8 @@ static int _read_ut(bmp180_t *dev, int32_t *output)
 static int _read_up(bmp180_t *dev, int32_t *output)
 {
     /* Read UP (Uncompsensated Pressure value) */
-    char up[3] = {0};
-    char control[2] = { BMP180_REGISTER_CONTROL, BMP180_PRESSURE_COMMAND | (dev->oversampling & 0x3) << 6 };
+    uint8_t up[3] = {0};
+    uint8_t control[2] = { BMP180_REGISTER_CONTROL, BMP180_PRESSURE_COMMAND | (dev->oversampling & 0x3) << 6 };
     i2c_write_bytes(dev->i2c_dev, BMP180_ADDR, control, 2);
     switch (dev->oversampling) {
     case BMP180_ULTRALOWPOWER:

--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -64,7 +64,7 @@
 
 int hdc1000_test(hdc1000_t *dev)
 {
-    char reg[2];
+    uint8_t reg[2];
     uint16_t tmp;
 
     i2c_acquire(dev->i2c);
@@ -84,7 +84,7 @@ int hdc1000_test(hdc1000_t *dev)
 
 int hdc1000_init(hdc1000_t *dev, i2c_t i2c, uint8_t address)
 {
-    char reg[2];
+    uint8_t reg[2];
 
     /* write device descriptor */
     dev->i2c = i2c;
@@ -105,8 +105,8 @@ int hdc1000_init(hdc1000_t *dev, i2c_t i2c, uint8_t address)
 
     /* set 14 bit resolution for both sensors and sequence mode */
     uint16_t tmp = HDC1000_CONFG_SEQ_MOD;
-    reg[0] = (uint8_t)(tmp >> 8);
-    reg[1] = (uint8_t)tmp;
+    reg[0] = (tmp >> 8);
+    reg[1] = tmp;
 
     i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, HDC1000_CONFG, reg, 2) != 2) {
@@ -121,10 +121,10 @@ int hdc1000_init(hdc1000_t *dev, i2c_t i2c, uint8_t address)
 
 int hdc1000_reset(hdc1000_t *dev)
 {
-    char reg[2];
+    uint8_t reg[2];
     uint16_t tmp = HDC1000_CONFG_RST;
-    reg[0] = (uint8_t)(tmp >> 8);
-    reg[1] = (uint8_t)tmp;
+    reg[0] = (tmp >> 8);
+    reg[1] = tmp;
     dev->initialized = false;
 
     i2c_acquire(dev->i2c);
@@ -159,7 +159,7 @@ int hdc1000_startmeasure(hdc1000_t *dev)
 
 int hdc1000_read(hdc1000_t *dev, uint16_t *rawtemp, uint16_t *rawhum)
 {
-    char buf[4];
+    uint8_t buf[4];
 
     if (dev->initialized == false) {
         return -1;

--- a/drivers/hih6130/hih6130.c
+++ b/drivers/hih6130/hih6130.c
@@ -60,7 +60,7 @@ static inline int hih6130_measurement_request(hih6130_t *dev)
     i2c_acquire(dev->i2c);
 
     /* An empty write request triggers a new measurement */
-    if (i2c_write_bytes(dev->i2c, dev->addr, (char *)NULL, 0) < 0) {
+    if (i2c_write_bytes(dev->i2c, dev->addr, NULL, 0) < 0) {
         i2c_release(dev->i2c);
         return -1;
     }
@@ -84,7 +84,7 @@ static inline int hih6130_get_humidity_temperature_raw(hih6130_t *dev, uint16_t 
 
     i2c_acquire(dev->i2c);
 
-    if (i2c_read_bytes(dev->i2c, dev->addr, (char*)&buf[0], sizeof(buf)) != sizeof(buf)) {
+    if (i2c_read_bytes(dev->i2c, dev->addr, &buf[0], sizeof(buf)) != sizeof(buf)) {
         i2c_release(dev->i2c);
         return -1;
     }

--- a/drivers/ina220/ina220.c
+++ b/drivers/ina220/ina220.c
@@ -34,7 +34,7 @@
 static int ina220_read_reg(ina220_t *dev, uint8_t reg, uint16_t *out)
 {
     union {
-        char c[2];
+        uint8_t c[2];
         uint16_t u16;
     } tmp = { .u16 = 0 };
     int status = 0;
@@ -53,7 +53,7 @@ static int ina220_read_reg(ina220_t *dev, uint8_t reg, uint16_t *out)
 static int ina220_write_reg(ina220_t *dev, uint8_t reg, uint16_t in)
 {
     union {
-        char c[2];
+        uint8_t c[2];
         uint16_t u16;
     } tmp = { .u16 = 0 };
     int status = 0;

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -166,7 +166,7 @@ int i2c_release(i2c_t dev);
  * @return                  -1 on undefined device given
  * @return                  -2 on invalid address
  */
-int i2c_read_byte(i2c_t dev, uint8_t address, char *data);
+int i2c_read_byte(i2c_t dev, uint8_t address, void *data);
 
 /**
  * @brief   Read multiple bytes from an I2C device with the given address
@@ -179,7 +179,7 @@ int i2c_read_byte(i2c_t dev, uint8_t address, char *data);
  * @return                  the number of bytes that were read
  * @return                  -1 on undefined device given
  */
-int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length);
+int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length);
 
 /**
  * @brief   Read one byte from a register at the I2C slave with the given
@@ -193,7 +193,7 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length);
  * @return                  the number of bytes that were read
  * @return                  -1 on undefined device given
  */
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data);
+int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data);
 
 /**
  * @brief   Read multiple bytes from a register at the I2C slave with the given
@@ -209,7 +209,7 @@ int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data);
  * @return                  -1 on undefined device given
  */
 int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg,
-                  char *data, int length);
+                  void *data, int length);
 
 /**
  * @brief   Write one byte to an I2C device with the given address
@@ -221,7 +221,7 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg,
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_byte(i2c_t dev, uint8_t address, char data);
+int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data);
 
 /**
  * @brief   Write multiple bytes to an I2C device with the given address
@@ -234,7 +234,7 @@ int i2c_write_byte(i2c_t dev, uint8_t address, char data);
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length);
+int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length);
 
 /**
  * @brief   Write one byte to a register at the I2C slave with the given address
@@ -247,7 +247,7 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length);
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data);
+int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data);
 
 /**
  * @brief   Write multiple bytes to a register at the I2C slave with the given
@@ -263,7 +263,7 @@ int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data);
  * @return                  -1 on undefined device given
  */
 int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg,
-                   char *data, int length);
+                   const void *data, int length);
 
 /**
  * @brief   Power on the given I2C peripheral

--- a/drivers/isl29020/isl29020.c
+++ b/drivers/isl29020/isl29020.c
@@ -30,7 +30,7 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
                   isl29020_range_t range, isl29020_mode_t mode)
 {
     int res;
-    char tmp;
+    uint8_t tmp;
 
     /* initialize device descriptor */
     dev->i2c = i2c;
@@ -55,7 +55,7 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
 
 int isl29020_read(isl29020_t *dev)
 {
-    char low, high;
+    uint8_t low, high;
     uint16_t res;
     int ret;
 
@@ -76,7 +76,7 @@ int isl29020_read(isl29020_t *dev)
 int isl29020_enable(isl29020_t *dev)
 {
     int res;
-    char tmp;
+    uint8_t tmp;
 
     i2c_acquire(dev->i2c);
     res = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_CMD, &tmp);
@@ -97,7 +97,7 @@ int isl29020_enable(isl29020_t *dev)
 int isl29020_disable(isl29020_t *dev)
 {
     int res;
-    char tmp;
+    uint8_t tmp;
 
     i2c_acquire(dev->i2c);
     res = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_CMD, &tmp);

--- a/drivers/isl29125/isl29125.c
+++ b/drivers/isl29125/isl29125.c
@@ -46,7 +46,7 @@ int isl29125_init(isl29125_t *dev, i2c_t i2c, gpio_t gpio,
     dev->gpio = gpio;
 
     /* configuration 1: operation mode, range, resolution */
-    char conf1 = 0x00;
+    uint8_t conf1 = 0x00;
     conf1 |= mode;
     conf1 |= range;
     conf1 |= resolution;
@@ -66,7 +66,7 @@ int isl29125_init(isl29125_t *dev, i2c_t i2c, gpio_t gpio,
 
     /* verify the device ID */
     DEBUG("isl29125_init: i2c_read_reg\n");
-    char reg_id;
+    uint8_t reg_id;
     int ret = i2c_read_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_ID, &reg_id);
     if ((reg_id == ISL29125_ID) && (ret == 1)) {
         DEBUG("isl29125_init: ID successfully verified\n");
@@ -98,7 +98,7 @@ void isl29125_read_rgb_lux(isl29125_t *dev, isl29125_rgb_t *dest)
     (void) i2c_acquire(dev->i2c);
 
     /* read values */
-    char bytes[6];
+    uint8_t bytes[6];
     (void) i2c_read_regs(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6);
 
     /* release the I2C bus */
@@ -126,7 +126,7 @@ void isl29125_read_rgb_color(isl29125_t *dev, color_rgb_t *dest)
     (void) i2c_acquire(dev->i2c);
 
     /* read values */
-    char bytes[6];
+    uint8_t bytes[6];
     (void) i2c_read_regs(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6);
 
     /* release the I2C bus */
@@ -142,7 +142,7 @@ void isl29125_read_rgb_color(isl29125_t *dev, color_rgb_t *dest)
 
 void isl29125_set_mode(isl29125_t *dev, isl29125_mode_t mode)
 {
-    char conf1;
+    uint8_t conf1;
 
     (void) i2c_acquire(dev->i2c);
 

--- a/drivers/l3g4200d/l3g4200d.c
+++ b/drivers/l3g4200d/l3g4200d.c
@@ -37,7 +37,7 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
                   gpio_t int1_pin, gpio_t int2_pin,
                   l3g4200d_mode_t mode, l3g4200d_scale_t scale)
 {
-    char tmp;
+    uint8_t tmp;
 
     /* write device descriptor */
     dev->i2c = i2c;
@@ -86,7 +86,7 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
 
 int l3g4200d_read(l3g4200d_t *dev, l3g4200d_data_t *data)
 {
-    char tmp[6];
+    uint8_t tmp[6];
     int16_t res;
 
     i2c_acquire(dev->i2c);
@@ -106,7 +106,7 @@ int l3g4200d_read(l3g4200d_t *dev, l3g4200d_data_t *data)
 
 int l3g4200d_enable(l3g4200d_t *dev)
 {
-    char tmp;
+    uint8_t tmp;
     int res;
 
     i2c_acquire(dev->i2c);
@@ -126,7 +126,7 @@ int l3g4200d_enable(l3g4200d_t *dev)
 
 int l3g4200d_disable(l3g4200d_t *dev)
 {
-    char tmp;
+    uint8_t tmp;
     int res;
 
     i2c_acquire(dev->i2c);

--- a/drivers/lis3mdl/lis3mdl.c
+++ b/drivers/lis3mdl/lis3mdl.c
@@ -59,7 +59,7 @@ int lis3mdl_init(lis3mdl_t *dev,
                  lis3mdl_odr_t odr,
                  lis3mdl_scale_t scale,
                  lis3mdl_op_t op_mode) {
-    char tmp;
+    uint8_t tmp;
 
     dev->i2c = i2c;
     dev->addr = address;
@@ -98,7 +98,7 @@ int lis3mdl_init(lis3mdl_t *dev,
 
 void lis3mdl_read_mag(lis3mdl_t *dev, lis3mdl_3d_data_t *data)
 {
-    char tmp[2] = {0, 0};
+    uint8_t tmp[2] = {0, 0};
 
     i2c_acquire(dev->i2c);
 
@@ -126,7 +126,7 @@ void lis3mdl_read_mag(lis3mdl_t *dev, lis3mdl_3d_data_t *data)
 void lis3mdl_read_temp(lis3mdl_t *dev, int16_t *value)
 {
     i2c_acquire(dev->i2c);
-    i2c_read_regs(dev->i2c, dev->addr, LIS3MDL_TEMP_OUT_L_REG, (char*)value, 2);
+    i2c_read_regs(dev->i2c, dev->addr, LIS3MDL_TEMP_OUT_L_REG, (uint8_t*)value, 2);
     i2c_release(dev->i2c);
 
     *value = _twos_complement(*value);
@@ -145,8 +145,8 @@ void lis3mdl_enable(lis3mdl_t *dev)
 
 void lis3mdl_disable(lis3mdl_t *dev)
 {
-    char tmp = ( LIS3MDL_MASK_REG3_LOW_POWER_EN   /**< enable power-down mode */
-               | LIS3MDL_MASK_REG3_Z_LOW_POWER);  /**< Z-axis low-power mode */
+    uint8_t tmp = ( LIS3MDL_MASK_REG3_LOW_POWER_EN   /**< enable power-down mode */
+                  | LIS3MDL_MASK_REG3_Z_LOW_POWER);  /**< Z-axis low-power mode */
 
     i2c_acquire(dev->i2c);
     i2c_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG3, tmp);

--- a/drivers/lps331ap/lps331ap.c
+++ b/drivers/lps331ap/lps331ap.c
@@ -48,7 +48,7 @@
 
 int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t rate)
 {
-    char tmp;
+    uint8_t tmp;
 
     /* save device specifics */
     dev->i2c = i2c;
@@ -77,7 +77,7 @@ int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t r
 
 int lps331ap_read_temp(lps331ap_t *dev)
 {
-    char tmp;
+    uint8_t tmp;
     int16_t val = 0;
     float res = TEMP_BASE;      /* reference value -> see datasheet */
 
@@ -97,7 +97,7 @@ int lps331ap_read_temp(lps331ap_t *dev)
 
 int lps331ap_read_pres(lps331ap_t *dev)
 {
-    char tmp;
+    uint8_t tmp;
     int32_t val = 0;
     float res;
 
@@ -123,7 +123,7 @@ int lps331ap_read_pres(lps331ap_t *dev)
 
 int lps331ap_enable(lps331ap_t *dev)
 {
-    char tmp;
+    uint8_t tmp;
     int status;
 
     i2c_acquire(dev->i2c);
@@ -140,7 +140,7 @@ int lps331ap_enable(lps331ap_t *dev)
 
 int lps331ap_disable(lps331ap_t *dev)
 {
-    char tmp;
+    uint8_t tmp;
     int status;
 
     i2c_acquire(dev->i2c);

--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -34,7 +34,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
                     lsm303dlhc_mag_gain_t mag_gain)
 {
     int res;
-    char tmp;
+    uint8_t tmp;
 
     dev->i2c = i2c;
     dev->acc_address = acc_address;
@@ -95,7 +95,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
 int lsm303dlhc_read_acc(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
 {
     int res;
-    char tmp;
+    uint8_t tmp;
 
     i2c_acquire(dev->i2c);
     i2c_read_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_STATUS_A, &tmp);
@@ -147,7 +147,7 @@ int lsm303dlhc_read_mag(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
 
     i2c_acquire(dev->i2c);
     res = i2c_read_regs(dev->i2c, dev->mag_address,
-                        LSM303DLHC_REG_OUT_X_H_M, (char*)data, 6);
+                        LSM303DLHC_REG_OUT_X_H_M, data, 6);
     i2c_release(dev->i2c);
 
     if (res < 6) {
@@ -174,7 +174,7 @@ int lsm303dlhc_read_temp(lsm303dlhc_t *dev, int16_t *value)
     int res;
 
     i2c_acquire(dev->i2c);
-    res = i2c_read_regs(dev->i2c, dev->mag_address, LSM303DLHC_REG_TEMP_OUT_H, (char*)value, 2);
+    res = i2c_read_regs(dev->i2c, dev->mag_address, LSM303DLHC_REG_TEMP_OUT_H, value, 2);
     i2c_release(dev->i2c);
 
     if (res < 2) {
@@ -207,10 +207,10 @@ int lsm303dlhc_disable(lsm303dlhc_t *dev)
 int lsm303dlhc_enable(lsm303dlhc_t *dev)
 {
     int res;
-    char tmp = (LSM303DLHC_CTRL1_A_XEN
-                | LSM303DLHC_CTRL1_A_YEN
-                | LSM303DLHC_CTRL1_A_ZEN
-                | LSM303DLHC_CTRL1_A_N1344HZ_L5376HZ);
+    uint8_t tmp = (LSM303DLHC_CTRL1_A_XEN
+                  | LSM303DLHC_CTRL1_A_YEN
+                  | LSM303DLHC_CTRL1_A_ZEN
+                  | LSM303DLHC_CTRL1_A_N1344HZ_L5376HZ);
     i2c_acquire(dev->i2c);
     res = i2c_write_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_CTRL1_A, tmp);
 

--- a/drivers/mag3110/mag3110.c
+++ b/drivers/mag3110/mag3110.c
@@ -33,7 +33,7 @@
 
 int mag3110_test(mag3110_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     /* Acquire exclusive access to the bus. */
     i2c_acquire(dev->i2c);
@@ -53,7 +53,7 @@ int mag3110_test(mag3110_t *dev)
 
 int mag3110_init(mag3110_t *dev, i2c_t i2c, uint8_t address, uint8_t dros)
 {
-    char reg;
+    uint8_t reg;
 
     /* write device descriptor */
     dev->i2c = i2c;
@@ -100,14 +100,14 @@ int mag3110_init(mag3110_t *dev, i2c_t i2c, uint8_t address, uint8_t dros)
 
 int mag3110_set_user_offset(mag3110_t *dev, int16_t x, int16_t y, int16_t z)
 {
-    char buf[6];
+    uint8_t buf[6];
 
-    buf[0] = (char)(x >> 8);
-    buf[1] = (char)x;
-    buf[2] = (char)(y >> 8);
-    buf[3] = (char)y;
-    buf[4] = (char)(z >> 8);
-    buf[5] = (char)z;
+    buf[0] = (x >> 8);
+    buf[1] = x;
+    buf[2] = (y >> 8);
+    buf[3] = y;
+    buf[4] = (z >> 8);
+    buf[5] = z;
 
     i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_OFF_X_MSB, buf, 6) != 6) {
@@ -121,7 +121,7 @@ int mag3110_set_user_offset(mag3110_t *dev, int16_t x, int16_t y, int16_t z)
 
 int mag3110_set_active(mag3110_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     if (dev->initialized == false) {
         return -1;
@@ -146,7 +146,7 @@ int mag3110_set_active(mag3110_t *dev)
 
 int mag3110_set_standby(mag3110_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
@@ -167,7 +167,7 @@ int mag3110_set_standby(mag3110_t *dev)
 
 int mag3110_is_ready(mag3110_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     if (dev->initialized == false) {
         return -1;
@@ -185,7 +185,7 @@ int mag3110_is_ready(mag3110_t *dev)
 
 int mag3110_read(mag3110_t *dev, int16_t *x, int16_t *y, int16_t *z, uint8_t *status)
 {
-    char buf[7];
+    uint8_t buf[7];
 
     if (dev->initialized == false) {
         return -1;
@@ -213,7 +213,7 @@ int mag3110_read_dtemp(mag3110_t *dev, int8_t *dtemp)
     }
 
     i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_DIE_TEMP, (char *)dtemp, 1) != 1) {
+    if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_DIE_TEMP, dtemp, 1) != 1) {
         i2c_release(dev->i2c);
         return -1;
     }

--- a/drivers/mma8652/mma8652.c
+++ b/drivers/mma8652/mma8652.c
@@ -33,7 +33,7 @@
 
 int mma8652_test(mma8652_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     /* Acquire exclusive access to the bus. */
     i2c_acquire(dev->i2c);
@@ -53,7 +53,7 @@ int mma8652_test(mma8652_t *dev)
 
 int mma8652_init(mma8652_t *dev, i2c_t i2c, uint8_t address, uint8_t dr, uint8_t range)
 {
-    char reg;
+    uint8_t reg;
 
     /* write device descriptor */
     dev->i2c = i2c;
@@ -104,11 +104,11 @@ int mma8652_init(mma8652_t *dev, i2c_t i2c, uint8_t address, uint8_t dr, uint8_t
 
 int mma8652_set_user_offset(mma8652_t *dev, int8_t x, int8_t y, int8_t z)
 {
-    char buf[3];
+    uint8_t buf[3];
 
-    buf[0] = (char)x;
-    buf[1] = (char)y;
-    buf[2] = (char)z;
+    buf[0] = (uint8_t)x;
+    buf[1] = (uint8_t)y;
+    buf[2] = (uint8_t)z;
 
     i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, MMA8652_OFF_X, buf, 3) != 3) {
@@ -122,7 +122,7 @@ int mma8652_set_user_offset(mma8652_t *dev, int8_t x, int8_t y, int8_t z)
 
 int mma8652_reset(mma8652_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     dev->initialized = false;
     reg = MMA8652_CTRL_REG2_RST;
@@ -139,7 +139,7 @@ int mma8652_reset(mma8652_t *dev)
 
 int mma8652_set_active(mma8652_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     if (dev->initialized == false) {
         return -1;
@@ -164,7 +164,7 @@ int mma8652_set_active(mma8652_t *dev)
 
 int mma8652_set_standby(mma8652_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MMA8652_CTRL_REG1, &reg, 1) != 1) {
@@ -185,7 +185,7 @@ int mma8652_set_standby(mma8652_t *dev)
 
 int mma8652_is_ready(mma8652_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     if (dev->initialized == false) {
         return -1;
@@ -203,7 +203,7 @@ int mma8652_is_ready(mma8652_t *dev)
 
 int mma8652_read(mma8652_t *dev, int16_t *x, int16_t *y, int16_t *z, uint8_t *status)
 {
-    char buf[7];
+    uint8_t buf[7];
 
     if (dev->initialized == false) {
         return -1;

--- a/drivers/mpl3115a2/mpl3115a2.c
+++ b/drivers/mpl3115a2/mpl3115a2.c
@@ -33,7 +33,7 @@
 
 int mpl3115a2_test(mpl3115a2_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     /* Acquire exclusive access to the bus. */
     i2c_acquire(dev->i2c);
@@ -53,7 +53,7 @@ int mpl3115a2_test(mpl3115a2_t *dev)
 
 int mpl3115a2_init(mpl3115a2_t *dev, i2c_t i2c, uint8_t address, uint8_t os_ratio)
 {
-    char reg;
+    uint8_t reg;
 
     /* write device descriptor */
     dev->i2c = i2c;
@@ -103,7 +103,7 @@ int mpl3115a2_init(mpl3115a2_t *dev, i2c_t i2c, uint8_t address, uint8_t os_rati
 
 int mpl3115a2_reset(mpl3115a2_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     dev->initialized = false;
     reg = MPL3115A2_CTRL_REG1_RST;
@@ -120,7 +120,7 @@ int mpl3115a2_reset(mpl3115a2_t *dev)
 
 int mpl3115a2_set_active(mpl3115a2_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     if (dev->initialized == false) {
         return -1;
@@ -145,7 +145,7 @@ int mpl3115a2_set_active(mpl3115a2_t *dev)
 
 int mpl3115a2_set_standby(mpl3115a2_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
@@ -166,7 +166,7 @@ int mpl3115a2_set_standby(mpl3115a2_t *dev)
 
 int mpl3115a2_is_ready(mpl3115a2_t *dev)
 {
-    char reg;
+    uint8_t reg;
 
     if (dev->initialized == false) {
         return -1;
@@ -184,7 +184,7 @@ int mpl3115a2_is_ready(mpl3115a2_t *dev)
 
 int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status)
 {
-    char buf[4];
+    uint8_t buf[4];
 
     if (dev->initialized == false) {
         return -1;
@@ -207,7 +207,7 @@ int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status)
 
 int mpl3115a2_read_temp(mpl3115a2_t *dev, int16_t *temp)
 {
-    char buf[2];
+    uint8_t buf[2];
 
     if (dev->initialized == false) {
         return -1;

--- a/drivers/mpu9150/mpu9150.c
+++ b/drivers/mpu9150/mpu9150.c
@@ -55,7 +55,7 @@ static void conf_lpf(mpu9150_t *dev, uint16_t rate);
 int mpu9150_init(mpu9150_t *dev, i2c_t i2c, mpu9150_hw_addr_t hw_addr,
         mpu9150_comp_addr_t comp_addr)
 {
-    char temp;
+    uint8_t temp;
 
     dev->i2c_dev = i2c;
     dev->hw_addr = hw_addr;
@@ -110,7 +110,7 @@ int mpu9150_init(mpu9150_t *dev, i2c_t i2c, mpu9150_hw_addr_t hw_addr,
 
 int mpu9150_set_accel_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
 {
-    char pwr_1_setting, pwr_2_setting;
+    uint8_t pwr_1_setting, pwr_2_setting;
 
     if (dev->conf.accel_pwr == pwr_conf) {
         return 0;
@@ -151,7 +151,7 @@ int mpu9150_set_accel_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
 
 int mpu9150_set_gyro_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
 {
-    char pwr_2_setting;
+    uint8_t pwr_2_setting;
 
     if (dev->conf.gyro_pwr == pwr_conf) {
         return 0;
@@ -199,7 +199,7 @@ int mpu9150_set_gyro_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
 
 int mpu9150_set_compass_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
 {
-    char pwr_1_setting, usr_ctrl_setting, s1_do_setting;
+    uint8_t pwr_1_setting, usr_ctrl_setting, s1_do_setting;
 
     if (dev->conf.compass_pwr == pwr_conf) {
         return 0;
@@ -244,7 +244,7 @@ int mpu9150_set_compass_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
 
 int mpu9150_read_gyro(mpu9150_t *dev, mpu9150_results_t *output)
 {
-    char data[6];
+    uint8_t data[6];
     int16_t temp;
     float fsr;
 
@@ -287,7 +287,7 @@ int mpu9150_read_gyro(mpu9150_t *dev, mpu9150_results_t *output)
 
 int mpu9150_read_accel(mpu9150_t *dev, mpu9150_results_t *output)
 {
-    char data[6];
+    uint8_t data[6];
     int16_t temp;
     float fsr;
 
@@ -330,7 +330,7 @@ int mpu9150_read_accel(mpu9150_t *dev, mpu9150_results_t *output)
 
 int mpu9150_read_compass(mpu9150_t *dev, mpu9150_results_t *output)
 {
-    char data[6];
+    uint8_t data[6];
 
     /* Acquire exclusive access */
     if (i2c_acquire(dev->i2c_dev)) {
@@ -363,7 +363,7 @@ int mpu9150_read_compass(mpu9150_t *dev, mpu9150_results_t *output)
 
 int mpu9150_read_temperature(mpu9150_t *dev, int32_t *output)
 {
-    char data[2];
+    uint8_t data[2];
     int16_t temp;
 
     /* Acquire exclusive access */
@@ -396,7 +396,7 @@ int mpu9150_set_gyro_fsr(mpu9150_t *dev, mpu9150_gyro_ranges_t fsr)
                 return -1;
             }
             i2c_write_reg(dev->i2c_dev, dev->hw_addr,
-                    MPU9150_GYRO_CFG_REG, (char)(fsr << 3));
+                    MPU9150_GYRO_CFG_REG, (fsr << 3));
             i2c_release(dev->i2c_dev);
             dev->conf.gyro_fsr = fsr;
             break;
@@ -422,7 +422,7 @@ int mpu9150_set_accel_fsr(mpu9150_t *dev, mpu9150_accel_ranges_t fsr)
                 return -1;
             }
             i2c_write_reg(dev->i2c_dev, dev->hw_addr,
-                    MPU9150_ACCEL_CFG_REG, (char)(fsr << 3));
+                    MPU9150_ACCEL_CFG_REG, (fsr << 3));
             i2c_release(dev->i2c_dev);
             dev->conf.accel_fsr = fsr;
             break;
@@ -450,7 +450,7 @@ int mpu9150_set_sample_rate(mpu9150_t *dev, uint16_t rate)
     if (i2c_acquire(dev->i2c_dev)) {
         return -1;
     }
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_RATE_DIV_REG, (char) divider);
+    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_RATE_DIV_REG, divider);
 
     /* Store configured sample rate */
     dev->conf.sample_rate = 1000 / (((uint16_t) divider) + 1);
@@ -480,7 +480,7 @@ int mpu9150_set_compass_sample_rate(mpu9150_t *dev, uint8_t rate)
     if (i2c_acquire(dev->i2c_dev)) {
         return -1;
     }
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE4_CTRL_REG, (char) divider);
+    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE4_CTRL_REG, divider);
     i2c_release(dev->i2c_dev);
 
     /* Store configured sample rate */
@@ -500,7 +500,7 @@ int mpu9150_set_compass_sample_rate(mpu9150_t *dev, uint8_t rate)
  */
 static int compass_init(mpu9150_t *dev)
 {
-    char data[3];
+    uint8_t data[3];
 
     /* Enable Bypass Mode to speak to compass directly */
     conf_bypass(dev, 1);
@@ -569,7 +569,7 @@ static int compass_init(mpu9150_t *dev)
  */
 static void conf_bypass(mpu9150_t *dev, uint8_t bypass_enable)
 {
-   char data;
+   uint8_t data;
    i2c_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, &data);
 
    if (bypass_enable) {
@@ -616,5 +616,5 @@ static void conf_lpf(mpu9150_t *dev, uint16_t half_rate)
     }
 
     /* Write LPF setting to configuration register */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_LPF_REG, (char)lpf_setting);
+    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_LPF_REG, lpf_setting);
 }

--- a/drivers/si70xx/si70xx.c
+++ b/drivers/si70xx/si70xx.c
@@ -32,7 +32,7 @@ static uint32_t si70xx_measure(si70xx_t *dev, uint8_t command)
 
     i2c_acquire(dev->i2c_dev);
     i2c_write_byte(dev->i2c_dev, dev->address, command);
-    i2c_read_bytes(dev->i2c_dev, dev->address, (char *) result, 2);
+    i2c_read_bytes(dev->i2c_dev, dev->address, result, 2);
     i2c_release(dev->i2c_dev);
 
     /* reconstruct raw result */
@@ -137,15 +137,15 @@ uint64_t si70xx_get_serial(si70xx_t *dev)
     out[1] = SI70XX_READ_ID_FIRST_B;
 
     i2c_acquire(dev->i2c_dev);
-    i2c_write_bytes(dev->i2c_dev, dev->address, (char *) out, 2);
-    i2c_read_bytes(dev->i2c_dev, dev->address, (char *) in_first, 8);
+    i2c_write_bytes(dev->i2c_dev, dev->address, out, 2);
+    i2c_read_bytes(dev->i2c_dev, dev->address, in_first, 8);
 
     /* read the higher bytes */
     out[0] = SI70XX_READ_ID_SECOND_A;
     out[1] = SI70XX_READ_ID_SECOND_B;
 
-    i2c_write_bytes(dev->i2c_dev, dev->address, (char *) out, 2);
-    i2c_read_bytes(dev->i2c_dev, dev->address, (char *) in_second, 8);
+    i2c_write_bytes(dev->i2c_dev, dev->address, out, 2);
+    i2c_read_bytes(dev->i2c_dev, dev->address, in_second, 8);
     i2c_release(dev->i2c_dev);
 
     /* calculate the ID */
@@ -172,8 +172,8 @@ uint8_t si70xx_get_revision(si70xx_t *dev)
     out[1] = SI70XX_READ_REVISION_B;
 
     i2c_acquire(dev->i2c_dev);
-    i2c_write_bytes(dev->i2c_dev, dev->address, (char *) out, 2);
-    i2c_read_byte(dev->i2c_dev, dev->address, (char *) &in);
+    i2c_write_bytes(dev->i2c_dev, dev->address, out, 2);
+    i2c_read_byte(dev->i2c_dev, dev->address, &in);
     i2c_release(dev->i2c_dev);
 
     return in;

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -61,7 +61,7 @@ int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr)
 {
     dev->i2c = i2c;
     dev->addr = (addr >> 1);    /* internally we right align the 7-bit addr */
-    char rev;
+    uint8_t rev;
 
     /* Acquire exclusive access to the bus. */
     i2c_acquire(dev->i2c);
@@ -97,7 +97,7 @@ void srf02_trigger(srf02_t *dev, srf02_mode_t mode)
 
 uint16_t srf02_read(srf02_t *dev)
 {
-    char res[2];
+    uint8_t res[2];
 
     /* read the results */
     i2c_acquire(dev->i2c);

--- a/drivers/srf08/srf08.c
+++ b/drivers/srf08/srf08.c
@@ -95,8 +95,8 @@ int srf08_get_distances(srf08_t *dev, uint16_t *range_array, int num_echos, srf0
 {
     int status;
     int echo_number = 0;
-    char range_bytes[sizeof(uint16_t)];
-    char register_location;
+    uint8_t range_bytes[sizeof(uint16_t)];
+    uint8_t register_location;
     char max_reg_no_read = (num_echos * sizeof(range_bytes)) +1;
 
     /* Acquire exclusive access to the bus. */

--- a/drivers/tcs37727/tcs37727.c
+++ b/drivers/tcs37727/tcs37727.c
@@ -33,7 +33,7 @@
 
 static int tcs37727_test(tcs37727_t *dev)
 {
-    char id;
+    uint8_t id;
 
     i2c_acquire(dev->i2c);
 
@@ -103,7 +103,7 @@ int tcs37727_set_rgbc_active(tcs37727_t *dev)
     }
 
     i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, TCS37727_ENABLE, (char *)&reg, 1) != 1) {
+    if (i2c_read_regs(dev->i2c, dev->addr, TCS37727_ENABLE, &reg, 1) != 1) {
         i2c_release(dev->i2c);
         return -1;
     }
@@ -128,7 +128,7 @@ int tcs37727_set_rgbc_standby(tcs37727_t *dev)
     }
 
     i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, TCS37727_ENABLE, (char *)&reg, 1) != 1) {
+    if (i2c_read_regs(dev->i2c, dev->addr, TCS37727_ENABLE, &reg, 1) != 1) {
         i2c_release(dev->i2c);
         return -1;
     }
@@ -206,7 +206,7 @@ static uint8_t tcs37727_trim_gain(tcs37727_t *dev, int rawc)
 
     i2c_acquire(dev->i2c);
     uint8_t reg = 0;
-    if (i2c_read_reg(dev->i2c, dev->addr, TCS37727_CONTROL, (char *)&reg) != 1) {
+    if (i2c_read_reg(dev->i2c, dev->addr, TCS37727_CONTROL, &reg) != 1) {
         i2c_release(dev->i2c);
         return -2;
     }
@@ -224,7 +224,7 @@ static uint8_t tcs37727_trim_gain(tcs37727_t *dev, int rawc)
 
 int tcs37727_read(tcs37727_t *dev, tcs37727_data_t *data)
 {
-    char buf[8];
+    uint8_t buf[8];
 
     if (dev->initialized == false) {
         return -1;

--- a/drivers/tmp006/tmp006.c
+++ b/drivers/tmp006/tmp006.c
@@ -60,7 +60,7 @@
 int tmp006_test(tmp006_t *dev)
 {
     int status;
-    char reg[2];
+    uint8_t reg[2];
     uint16_t tmp;
 
     /* Acquire exclusive access to the bus. */
@@ -84,7 +84,7 @@ int tmp006_test(tmp006_t *dev)
 int tmp006_init(tmp006_t *dev, i2c_t i2c, uint8_t address, uint8_t conv_rate)
 {
     int status;
-    char reg[2];
+    uint8_t reg[2];
 
     /* write device descriptor */
     dev->i2c = i2c;
@@ -109,8 +109,8 @@ int tmp006_init(tmp006_t *dev, i2c_t i2c, uint8_t address, uint8_t conv_rate)
     }
 
     uint16_t tmp = TMP006_CONFIG_CR(conv_rate);
-    reg[0] = (uint8_t)(tmp >> 8);
-    reg[1] = (uint8_t)tmp;
+    reg[0] = (tmp >> 8);
+    reg[1] = tmp;
 
     /* Acquire exclusive access to the bus. */
     i2c_acquire(dev->i2c);
@@ -127,10 +127,10 @@ int tmp006_init(tmp006_t *dev, i2c_t i2c, uint8_t address, uint8_t conv_rate)
 int tmp006_reset(tmp006_t *dev)
 {
     int status;
-    char reg[2];
+    uint8_t reg[2];
     uint16_t tmp = TMP006_CONFIG_RST;
-    reg[0] = (uint8_t)(tmp >> 8);
-    reg[1] = (uint8_t)tmp;
+    reg[0] = (tmp >> 8);
+    reg[1] = tmp;
     dev->initialized = false;
 
     /* Acquire exclusive access to the bus. */
@@ -147,7 +147,7 @@ int tmp006_reset(tmp006_t *dev)
 int tmp006_set_active(tmp006_t *dev)
 {
     int status;
-    char reg[2];
+    uint8_t reg[2];
 
     if (dev->initialized == false) {
         return -1;
@@ -160,7 +160,7 @@ int tmp006_set_active(tmp006_t *dev)
         return -1;
     }
 
-    reg[0] |= (uint8_t)(TMP006_CONFIG_MOD(TMP006_CONFIG_MOD_CC) >> 8);
+    reg[0] |= (TMP006_CONFIG_MOD(TMP006_CONFIG_MOD_CC) >> 8);
 
     status = i2c_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
     if (status != 2) {
@@ -174,7 +174,7 @@ int tmp006_set_active(tmp006_t *dev)
 int tmp006_set_standby(tmp006_t *dev)
 {
     int status;
-    char reg[2];
+    uint8_t reg[2];
 
     i2c_acquire(dev->i2c);
     status = i2c_read_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
@@ -184,7 +184,7 @@ int tmp006_set_standby(tmp006_t *dev)
     }
     i2c_release(dev->i2c);
 
-    reg[0] &= ~(uint8_t)(TMP006_CONFIG_MOD(TMP006_CONFIG_MOD_CC) >> 8);
+    reg[0] &= ~(TMP006_CONFIG_MOD(TMP006_CONFIG_MOD_CC) >> 8);
 
     i2c_acquire(dev->i2c);
     status = i2c_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
@@ -199,7 +199,7 @@ int tmp006_set_standby(tmp006_t *dev)
 int tmp006_read(tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy)
 {
     int status;
-    char buf[2];
+    uint8_t buf[2];
 
     if (dev->initialized == false) {
         return -1;
@@ -214,7 +214,7 @@ int tmp006_read(tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy)
     }
     i2c_release(dev->i2c);
 
-    *drdy = buf[1] & (uint8_t)(TMP006_CONFIG_DRDY);
+    *drdy = buf[1] & (TMP006_CONFIG_DRDY);
 
     if (!(*drdy)) {
         /* conversion in progress */

--- a/pkg/u8g2/patches/0002-u8g2-add-riot-os-interface.patch
+++ b/pkg/u8g2/patches/0002-u8g2-add-riot-os-interface.patch
@@ -188,7 +188,7 @@ index 0000000..7106e07
 +            index = 0;
 +            break;
 +        case U8X8_MSG_BYTE_END_TRANSFER:
-+            i2c_write_bytes(dev, u8x8_GetI2CAddress(u8g2), (char *) buffer, index);
++            i2c_write_bytes(dev, u8x8_GetI2CAddress(u8g2), buffer, index);
 +            i2c_release(dev);
 +            break;
 +        default:

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -74,7 +74,7 @@ int cmd_write(int argc, char **argv)
     int res;
     uint8_t addr;
     int length = argc - 2;
-    char data[BUFSIZE];
+    uint8_t data[BUFSIZE];
 
     if (i2c_dev < 0) {
         puts("Error: no I2C device was initialized");
@@ -86,19 +86,19 @@ int cmd_write(int argc, char **argv)
         return 1;
     }
 
-    addr = (uint8_t)atoi(argv[1]);
+    addr = atoi(argv[1]);
     for (int i = 0; i < length; i++) {
-        data[i] = (char)atoi(argv[i + 2]);
+        data[i] = atoi(argv[i + 2]);
     }
 
     if (length == 1) {
-        printf("i2c_write_byte(I2C_%i, 0x%02x, 0x%02x)\n", i2c_dev, addr, (unsigned int)data[0]);
+        printf("i2c_write_byte(I2C_%i, 0x%02x, 0x%02x)\n", i2c_dev, addr, data[0]);
         res = i2c_write_byte(i2c_dev, addr, data[0]);
     }
     else {
         printf("i2c_write_bytes(I2C_%i, 0x%02x, [", i2c_dev, addr);
         for (int i = 0; i < length; i++) {
-            printf(", 0x%02x", (unsigned int)data[i]);
+            printf(", 0x%02x", data[i]);
         }
         puts("])");
         res = i2c_write_bytes(i2c_dev, addr, data, length);
@@ -119,7 +119,7 @@ int cmd_write_reg(int argc, char **argv)
     int res;
     uint8_t addr, reg;
     int length = argc - 3;
-    char data[BUFSIZE];
+    uint8_t data[BUFSIZE];
 
     if (i2c_dev < 0) {
         puts("Error: no I2C device initialized");
@@ -131,21 +131,21 @@ int cmd_write_reg(int argc, char **argv)
         return 1;
     }
 
-    addr = (uint8_t)atoi(argv[1]);
-    reg = (uint8_t)atoi(argv[2]);
+    addr = atoi(argv[1]);
+    reg = atoi(argv[2]);
     for (int i = 0; i < length; i++) {
-        data[i] = (char)atoi(argv[i + 3]);
+        data[i] = atoi(argv[i + 3]);
     }
 
     if (length == 1) {
         printf("i2c_write_reg(I2C_%i, 0x%02x, 0x%02x, 0x%02x)\n",
-               i2c_dev, addr, reg, (unsigned int)data[0]);
+               i2c_dev, addr, reg, data[0]);
         res = i2c_write_reg(i2c_dev, addr, reg, data[0]);
     }
     else {
         printf("i2c_write_regs(I2C_%i, 0x%02x, 0x%02x, [", i2c_dev, addr, reg);
         for (int i = 0; i < length; i++) {
-            printf("0x%02x, ", (unsigned int)data[i]);
+            printf("0x%02x, ", data[i]);
         }
         puts("])");
         res = i2c_write_regs(i2c_dev, addr, reg, data, length);
@@ -166,7 +166,7 @@ int cmd_read(int argc, char **argv)
     int res;
     uint8_t addr;
     int length;
-    char data[BUFSIZE];
+    uint8_t data[BUFSIZE];
 
     if (i2c_dev < 0) {
         puts("Error: no I2C device initialized");
@@ -178,7 +178,7 @@ int cmd_read(int argc, char **argv)
         return 1;
     }
 
-    addr = (uint8_t)atoi(argv[1]);
+    addr = atoi(argv[1]);
     length = atoi(argv[2]);
 
     if (length < 1 || length > BUFSIZE) {
@@ -186,11 +186,11 @@ int cmd_read(int argc, char **argv)
         return 1;
     }
     else if (length == 1) {
-        printf("i2c_read_byte(I2C_%i, 0x%02x, char *res)\n", i2c_dev, addr);
+        printf("i2c_read_byte(I2C_%i, 0x%02x, uint8_t *res)\n", i2c_dev, addr);
         res = i2c_read_byte(i2c_dev, addr, data);
     }
     else {
-        printf("i2c_read_bytes(I2C_%i, 0x%02x, char *res, %i)\n", i2c_dev, addr, length);
+        printf("i2c_read_bytes(I2C_%i, 0x%02x, uint8_t *res, %i)\n", i2c_dev, addr, length);
         res = i2c_read_bytes(i2c_dev, addr, data, length);
     }
 
@@ -201,7 +201,7 @@ int cmd_read(int argc, char **argv)
     else {
         printf("I2C_%i: successfully read %i bytes:\n  [", i2c_dev, res);
         for (int i = 0; i < res; i++) {
-            printf("0x%02x, ", (unsigned int)data[i]);
+            printf("0x%02x, ", data[i]);
         }
         puts("])");
         return 0;
@@ -213,7 +213,7 @@ int cmd_read_reg(int argc, char **argv)
     int res;
     uint8_t addr, reg;
     int length;
-    char data[BUFSIZE];
+    uint8_t data[BUFSIZE];
 
     if (i2c_dev < 0) {
         puts("Error: no I2C device initialized");
@@ -225,8 +225,8 @@ int cmd_read_reg(int argc, char **argv)
         return 1;
     }
 
-    addr = (uint8_t)atoi(argv[1]);
-    reg = (uint8_t)atoi(argv[2]);
+    addr = atoi(argv[1]);
+    reg = atoi(argv[2]);
     length = atoi(argv[3]);
 
     if (length < 1 || length > BUFSIZE) {
@@ -234,11 +234,11 @@ int cmd_read_reg(int argc, char **argv)
         return 1;
     }
     else if (length == 1) {
-        printf("i2c_read_reg(I2C_%i, 0x%02x, 0x%02x, char *res)\n", i2c_dev, addr, reg);
+        printf("i2c_read_reg(I2C_%i, 0x%02x, 0x%02x, uint8_t *res)\n", i2c_dev, addr, reg);
         res = i2c_read_reg(i2c_dev, addr, reg, data);
     }
     else {
-        printf("i2c_read_regs(I2C_%i, 0x%02x, 0x%02x, char *res, %i)\n", i2c_dev, addr, reg, length);
+        printf("i2c_read_regs(I2C_%i, 0x%02x, 0x%02x, uint8_t *res, %i)\n", i2c_dev, addr, reg, length);
         res = i2c_read_regs(i2c_dev, addr, reg, data, length);
     }
 
@@ -249,7 +249,7 @@ int cmd_read_reg(int argc, char **argv)
     else {
         printf("I2C_%i: successfully read %i bytes from reg 0x%02x:\n  [", i2c_dev, res, reg);
         for (int i = 0; i < res; i++) {
-            printf("0x%02x, ", (unsigned int)data[i]);
+            printf("0x%02x, ", data[i]);
         }
         puts("])");
         return 0;


### PR DESCRIPTION
In general, data transferred through I2C are bytes and thus should have type uint8_t, not char.