### PR TITLE
new: board: nRF52 mini development

### DIFF
--- a/boards/nrf52-minidev/Makefile
+++ b/boards/nrf52-minidev/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nrf52-minidev/Makefile.dep
+++ b/boards/nrf52-minidev/Makefile.dep
@@ -1,0 +1,7 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+  USEPKG += nordic_softdevice_ble
+endif

--- a/boards/nrf52-minidev/Makefile.features
+++ b/boards/nrf52-minidev/Makefile.features
@@ -1,0 +1,14 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += arduino
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/nrf52-minidev/Makefile.include
+++ b/boards/nrf52-minidev/Makefile.include
@@ -1,0 +1,29 @@
+# define the cpu used by the nRF52 DK
+export CPU = nrf52
+export CPU_MODEL = nrf52xxaa
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# setup the boards dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+
+# Define the flash-tool and default port:
+export PROGRAMMER ?= openocd
+
+ifeq ($(PROGRAMMER),openocd)
+else ifeq ($(PROGRAMMER),jlink)
+	# setup JLink for flashing
+	export JLINK_DEVICE := nrf52
+	# special options when using SoftDevice
+	ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
+		export JLINK_PRE_FLASH := erase\nloadfile $(BINDIR)/softdevice.hex
+		export JLINK_FLASH_ADDR := 0x1f000
+		export LINKER_SCRIPT ?= $(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL)_sd.ld
+	endif
+endif
+include $(RIOTBOARD)/Makefile.include.$(PROGRAMMER)
+
+# setup serial terminal
+include $(RIOTBOARD)/Makefile.include.serial

--- a/boards/nrf52-minidev/board.c
+++ b/boards/nrf52-minidev/board.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2016 Frank Holtz <frank-riot2015@holtznet.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52-minidev
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the nRF52 mini development
+ *              board. https://github.com/RIOT-OS/RIOT/wiki/Board:-nRF52-minidev
+ *
+ * @author      Frank Holtz <frank-riot2015@holtznet.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    NRF_P0->DIRSET = (LED0_MASK | LED1_MASK );
+    NRF_P0->OUTSET = (LED0_MASK | LED1_MASK );
+    NRF_P0->OUTSET = (LED0_MASK | LED1_MASK );
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/nrf52-minidev/dist/openocd.cfg
+++ b/boards/nrf52-minidev/dist/openocd.cfg
@@ -1,0 +1,5 @@
+source [find interface/stlink-v2.cfg]
+transport select hla_swd
+
+set WORKAREASIZE 0x4000
+source [find target/nrf52.cfg]

--- a/boards/nrf52-minidev/include/arduino_board.h
+++ b/boards/nrf52-minidev/include/arduino_board.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2016 Frank Holtz <frank-riot2015@holtznet.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52-minidev
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Hauke Petersen  <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ARDUINO_LED         (5)
+
+static const gpio_t arduino_pinmap[] = {
+    GPIO_PIN(0, 25), // D00
+    GPIO_PIN(0, 26), // D01
+    GPIO_PIN(0, 27), // D02
+    GPIO_PIN(0, 28), // D03
+    GPIO_PIN(0, 29), // D04
+    GPIO_PIN(0, 30), // D05, LED0
+    GPIO_PIN(0, 31), // D06, LED1
+    GPIO_PIN(0,  2), // D07
+    GPIO_PIN(0,  3), // D08
+    GPIO_PIN(0,  4), // D09, BUTTON
+    GPIO_PIN(0,  5), // D10
+    GPIO_PIN(0,  0), // D11, 32kHZ XTAL ?
+    GPIO_PIN(0,  1), // D12, 32kHZ XTAL ?
+    0,               // D13 (not connected)
+    GPIO_PIN(0,  7), // D14 
+    0,               // D15 (not connected)
+    0,               // D16 (not connected)
+    0,               // D17 (not connected)
+    GPIO_PIN(0, 11), // D18, RXD (not via ISP header)
+    GPIO_PIN(0, 12), // D19, TXD (not via ISP header)
+    GPIO_PIN(0, 13), // D20
+    GPIO_PIN(0, 14), // D21
+    GPIO_PIN(0, 15), // D22
+    GPIO_PIN(0, 16), // D23
+    GPIO_PIN(0, 13), // D24
+    GPIO_PIN(0, 18), // D25
+    GPIO_PIN(0, 19), // D26
+    GPIO_PIN(0, 20), // D27
+    GPIO_PIN(0, 22), // D28
+    GPIO_PIN(0, 23), // D29
+    GPIO_PIN(0, 24), // D30
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/nrf52-minidev/include/board.h
+++ b/boards/nrf52-minidev/include/board.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2016 Frank Holtz <frank-riot2015@holtznet.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_nrf52-minidev nRF52 minidev
+ * @ingroup     boards
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuaration for the nRF52 minidev
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Frank Holtz <frank-riot2015@holtznet.de>
+ *
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 30)
+#define LED1_PIN            GPIO_PIN(0, 31)
+
+#define LED0_MASK           (1 << 17)
+#define LED1_MASK           (1 << 18)
+
+#define LED0_ON             (NRF_P0->OUTCLR = LED0_MASK)
+#define LED0_OFF            (NRF_P0->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (NRF_P0->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (NRF_P0->OUTCLR = LED1_MASK)
+#define LED1_OFF            (NRF_P0->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (NRF_P0->OUT   ^= LED1_MASK)
+/** @} */
+
+/**
+ * @brief   Button pin configuration
+ * @{
+ */
+#define BUTTON1_PIN         (GPIO_PIN(0, 13))
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /** BOARD_H */
+/** @} */

--- a/boards/nrf52-minidev/include/gpio_params.h
+++ b/boards/nrf52-minidev/include/gpio_params.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2016 Frank Holtz <frank-riot2015@holtznet.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52-minidev
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Frank Holtz <frank-riot2015@holtznet.de>
+ *
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED 1",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED 2",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Button 1",
+        .pin = BUTTON1_PIN,
+        .mode = GPIO_IN_PU
+    },
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/nrf52-minidev/include/periph_conf.h
+++ b/boards/nrf52-minidev/include/periph_conf.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2016 Frank Holtz <frank-riot2015@holtznet.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52-minidev
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the nRF52 minidev
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Frank Holtz <frank-riot2015@holtznet.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Clock configuration
+ *
+ * @note    The radio will not work with the internal RC oscillator!
+ *
+ * @{
+ */
+#define CLOCK_CORECLOCK     (64000000U)     /* fixed for all NRF52832 */
+#define CLOCK_CRYSTAL       (32U)           /* set to  0: internal RC oscillator
+                                                      32: 32MHz crystal */
+/** @} */
+
+/**
+ * @brief Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    /* dev, channels, width, IRQn */
+    { NRF_TIMER1, 3, TIMER_BITMODE_BITMODE_32Bit, TIMER1_IRQn }
+};
+
+#define TIMER_0_ISR         isr_timer1
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @brief Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             NRF_RTC1
+#define RTT_IRQ             RTC1_IRQn
+#define RTT_ISR             isr_rtc1
+#define RTT_MAX_VALUE       (0xffffff)
+#define RTT_FREQUENCY       (10)            /* in Hz */
+#define RTT_PRESCALER       (3275U)         /* run with 10 Hz */
+/** @} */
+
+/**
+ * @brief UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_PIN_RX         11
+#define UART_PIN_TX         12
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PERIPH_CONF_H */


### PR DESCRIPTION
This change is for a nameless development board available via aliexpress. https://github.com/RIOT-OS/RIOT/wiki/Board:-nRF52-minidev
