### PR TITLE
cpu/sam21: removed superfluous gpio_init_sercom

### DIFF
--- a/cpu/sam21_common/include/periph_cpu_common.h
+++ b/cpu/sam21_common/include/periph_cpu_common.h
@@ -152,17 +152,6 @@ typedef enum
  */
 void gpio_init_mux(gpio_t pin, gpio_mux_t mux);
 
-/**
- * @brief   Set up PORT pin for SERCOM usage
- *
- * This function initializes the pin for SERCOM usage. It is derived
- * from Arduino's pinPeripheral() in wiring_private.c
- *
- * @param[in] pin   Pin to set the multiplexing for
- * @param[in] mux   Mux value
- */
-void gpio_init_sercom(gpio_t pin, gpio_mux_t mux);
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/sam21_common/periph/i2c.c
+++ b/cpu/sam21_common/periph/i2c.c
@@ -131,8 +131,8 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     }
 
     /************ SERCOM PAD0 - SDA and SERCOM PAD1 - SCL *************/
-    gpio_init_sercom(pin_sda, mux);
-    gpio_init_sercom(pin_scl, mux);
+    gpio_init_mux(pin_sda, mux);
+    gpio_init_mux(pin_scl, mux);
 
     /* I2C CONFIGURATION */
     while(I2CSercom->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}

--- a/cpu/samd21/periph/gpio.c
+++ b/cpu/samd21/periph/gpio.c
@@ -120,27 +120,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-void gpio_init_sercom(gpio_t pin, gpio_mux_t mux)
-{
-    PortGroup* port = _port(pin);
-    int pin_pos = _pin_pos(pin);
-    uint32_t temp;
-
-    if ( (pin_pos & 1) ) { // is pin odd?
-        // Get whole current setup for both odd and even pins and remove odd one
-        temp = port->PMUX[pin_pos >> 1].reg & PORT_PMUX_PMUXE(0xF);
-        // Set new muxing
-        port->PMUX[pin_pos >> 1].reg = temp | PORT_PMUX_PMUXO(mux);
-    } else {
-        // Get whole current setup for both odd and even pins and remove even one
-        temp = port->PMUX[pin_pos >> 1].reg & PORT_PMUX_PMUXO(0xF);
-        // Set new muxing
-        port->PMUX[pin_pos >> 1].reg = temp | PORT_PMUX_PMUXE(mux);
-    }
-    // Enable port mux
-    port->PINCFG[pin_pos].reg |= PORT_PINCFG_PMUXEN;
-}
-
 int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
                     gpio_cb_t cb, void *arg)
 {

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -159,9 +159,9 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
      *  - enable SPI
      */
     gpio_init(pin_miso, GPIO_IN_PD);
-    gpio_init_sercom(pin_sclk, mux_sclk);
-    gpio_init_sercom(pin_miso, mux_miso);
-    gpio_init_sercom(pin_mosi, mux_mosi);
+    gpio_init_mux(pin_sclk, mux_sclk);
+    gpio_init_mux(pin_miso, mux_miso);
+    gpio_init_mux(pin_mosi, mux_mosi);
 
     /* Disable spi to write confs */
     _spi_poweroff(spi_dev);


### PR DESCRIPTION
#5743 introduced some inconsistencies, one step towards cleanup...

The `gpio_init_sercom` function was a duplication of the existing gpio_init_mux, where the exiting function is the more general one, as the mux inititalization is not only valid for the sercom module...