### PR TITLE
cpu/samd21: cleaned up pad selection macros

### DIFF
--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -106,9 +106,22 @@ extern "C" {
  * @{
  */
 static const uart_conf_t uart_config[] = {
-    /* device, RX pin, TX pin, mux, RX pad, TX pad */
-    {&SERCOM5->USART, GPIO_PIN(PB,23), GPIO_PIN(PB,22), GPIO_MUX_D, SERCOM_RX_PAD_3, UART_TX_PAD_2},
-    {&SERCOM0->USART, GPIO_PIN(PA,11), GPIO_PIN(PA,10), GPIO_MUX_C, SERCOM_RX_PAD_3, UART_TX_PAD_2},
+    {
+        .dev    = &SERCOM5->USART,
+        .rx_pin = GPIO_PIN(PB,23),
+        .tx_pin = GPIO_PIN(PB,22),
+        .mux    = GPIO_MUX_D,
+        .rx_pad = UART_PAD_RX_3,
+        .tx_pad = UART_PAD_TX_2
+    },
+    {
+        .dev    = &SERCOM0->USART,
+        .rx_pin = GPIO_PIN(PA,11),
+        .tx_pin = GPIO_PIN(PA,10),
+        .mux    = GPIO_MUX_C,
+        .rx_pad = UART_PAD_RX_3,
+        .tx_pad = UART_PAD_TX_2
+    }
 };
 
 /* interrupt function name mapping */
@@ -182,10 +195,10 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_0_SCLK_MUX     GPIO_MUX_D
 #define SPI_0_MISO         GPIO_PIN(PA, 12)
 #define SPI_0_MISO_MUX     GPIO_MUX_D
-#define SPI_0_MISO_PAD     SERCOM_RX_PAD_0
+#define SPI_0_MISO_PAD     SPI_PAD_MISO_0
 #define SPI_0_MOSI         GPIO_PIN(PB, 10)
 #define SPI_0_MOSI_MUX     GPIO_MUX_D
-#define SPI_0_MOSI_PAD     SPI_PAD_2_SCK_3
+#define SPI_0_MOSI_PAD     SPI_PAD_MOSI_2_SCK_3
 
 /** @} */
 

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -104,9 +104,22 @@ extern "C" {
  * @{
  */
 static const uart_conf_t uart_config[] = {
-    /* device, RX pin, TX pin, mux */
-    {&SERCOM0->USART, GPIO_PIN(PA,5),  GPIO_PIN(PA,4),  GPIO_MUX_D, SERCOM_RX_PAD_1, UART_TX_PAD_0},
-    {&SERCOM5->USART, GPIO_PIN(PA,23), GPIO_PIN(PA,22), GPIO_MUX_D, SERCOM_RX_PAD_1, UART_TX_PAD_0},
+    {
+        .dev    = &SERCOM0->USART,
+        .rx_pin = GPIO_PIN(PA,5),
+        .tx_pin = GPIO_PIN(PA,4),
+        .mux    = GPIO_MUX_D,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_0
+    },
+    {
+        .dev    = &SERCOM5->USART,
+        .rx_pin = GPIO_PIN(PA,23),
+        .tx_pin = GPIO_PIN(PA,22),
+        .mux    = GPIO_MUX_D,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_0
+    }
 };
 
 /* interrupt function name mapping */
@@ -168,10 +181,10 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_0_SCLK_MUX      GPIO_MUX_F
 #define SPI_0_MISO          GPIO_PIN(PC, 19)
 #define SPI_0_MISO_MUX      GPIO_MUX_F
-#define SPI_0_MISO_PAD      SERCOM_RX_PAD_0
+#define SPI_0_MISO_PAD      SPI_PAD_MISO_0
 #define SPI_0_MOSI          GPIO_PIN(PB, 30)
 #define SPI_0_MOSI_MUX      GPIO_MUX_F
-#define SPI_0_MOSI_PAD      SPI_PAD_2_SCK_3
+#define SPI_0_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
 
 /*      SPI1             */
 #define SPI_1_DEV           SERCOM5->SPI
@@ -182,10 +195,10 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_1_SCLK_MUX      GPIO_MUX_D
 #define SPI_1_MISO          GPIO_PIN(PB, 02)
 #define SPI_1_MISO_MUX      GPIO_MUX_D
-#define SPI_1_MISO_PAD      SERCOM_RX_PAD_0
+#define SPI_1_MISO_PAD      SPI_PAD_MISO_0
 #define SPI_1_MOSI          GPIO_PIN(PB, 22)
 #define SPI_1_MOSI_MUX      GPIO_MUX_D
-#define SPI_1_MOSI_PAD      SPI_PAD_2_SCK_3
+#define SPI_1_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
 /** @} */
 
 /**

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -102,11 +102,38 @@ extern "C" {
  * See Table 6.1 of the SAM D21 Datasheet
  */
 static const uart_conf_t uart_config[] = {
-    /* device, RX pin, TX pin, mux, RX pad, TX pad */
-    {&SERCOM0->USART, GPIO_PIN(PA,9),  GPIO_PIN(PA,10), GPIO_MUX_C, SERCOM_RX_PAD_1, UART_TX_PAD_2},
-    {&SERCOM5->USART, GPIO_PIN(PB,31), GPIO_PIN(PB,30), GPIO_MUX_D, SERCOM_RX_PAD_1, UART_TX_RTS_CTS_PAD_0_2_3},
-    {&SERCOM4->USART, GPIO_PIN(PB,13), GPIO_PIN(PA,14), GPIO_MUX_C, SERCOM_RX_PAD_1, UART_TX_PAD_2},
-    {&SERCOM1->USART, GPIO_PIN(PA,17), GPIO_PIN(PA,18), GPIO_MUX_C, SERCOM_RX_PAD_1, UART_TX_PAD_2},
+    {
+        .dev    = &SERCOM0->USART,
+        .rx_pin = GPIO_PIN(PA,9),
+        .tx_pin = GPIO_PIN(PA,10),
+        .mux    = GPIO_MUX_C,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_2
+    },
+    {
+        .dev    = &SERCOM5->USART,
+        .rx_pin = GPIO_PIN(PB,31),
+        .tx_pin = GPIO_PIN(PB,30),
+        .mux    = GPIO_MUX_D,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_0_RTS_2_CTS_3
+    },
+    {
+        .dev    = &SERCOM4->USART,
+        .rx_pin = GPIO_PIN(PB,13),
+        .tx_pin = GPIO_PIN(PA,14),
+        .mux    = GPIO_MUX_C,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_2
+    },
+    {
+        .dev    = &SERCOM1->USART,
+        .rx_pin = GPIO_PIN(PA,17),
+        .tx_pin = GPIO_PIN(PA,18),
+        .mux    = GPIO_MUX_C,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_2
+    }
 };
 
 /* interrupt function name mapping */
@@ -170,10 +197,10 @@ static const pwm_conf_t pwm_config[] = {
 #define SPI_0_SCLK_MUX      GPIO_MUX_D
 #define SPI_0_MISO          GPIO_PIN(PA, 22)
 #define SPI_0_MISO_MUX      GPIO_MUX_C
-#define SPI_0_MISO_PAD      SERCOM_RX_PAD_0
+#define SPI_0_MISO_PAD      SPI_PAD_MISO_0
 #define SPI_0_MOSI          GPIO_PIN(PA, 20)
 #define SPI_0_MOSI_MUX      GPIO_MUX_D
-#define SPI_0_MOSI_PAD      SPI_PAD_2_SCK_3
+#define SPI_0_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
 
 // How/where do we define SS?
 #define SPI_0_SS            GPIO_PIN(PA, 23)

--- a/cpu/sam21_common/include/periph_cpu_common.h
+++ b/cpu/sam21_common/include/periph_cpu_common.h
@@ -87,33 +87,44 @@ typedef enum {
 } gpio_mux_t;
 
 /**
- * @brief   Possible pad selections for SERCOM RX (inspired by Arduino)
+ * @brief   Available values for SERCOM UART RX pad selection
  */
 typedef enum {
-    SERCOM_RX_PAD_0 = 0x0,  /**< select pad 0 */
-    SERCOM_RX_PAD_1 = 0x1,  /**< select pad 1 */
-    SERCOM_RX_PAD_2 = 0x2,  /**< select pad 2 */
-    SERCOM_RX_PAD_3 = 0x3,  /**< select pad 3 */
-} sercom_rxpad_t;
+    UART_PAD_RX_0 = 0x0,    /**< use pad 0 for RX line */
+    UART_PAD_RX_1 = 0x1,    /**< select pad 1 */
+    UART_PAD_RX_2 = 0x2,    /**< select pad 2 */
+    UART_PAD_RX_3 = 0x3,    /**< select pad 3 */
+} uart_rxpad_t;
 
 /**
- * @brief   Possible pad selections for SERCOM UART TX (inspired by Arduino)
+ * @brief   Available values for SERCOM UART TX pad selection
  */
 typedef enum {
-    UART_TX_PAD_0 = 0x0,    /**< select pad 0, only UART */
-    UART_TX_PAD_2 = 0x1,    /**< select pad 2, only UART */
-    UART_TX_RTS_CTS_PAD_0_2_3 = 0x2,    /**< select pad 0, 2 and 3, only UART, TX on PAD0, RTS on PAD2 and CTS on PAD3 */
-} sercom_uart_txpad_t;
+    UART_PAD_TX_0             = 0x0,    /**< select pad 0 */
+    UART_PAD_TX_2             = 0x1,    /**< select pad 2 */
+    UART_PAD_TX_0_RTS_2_CTS_3 = 0x2,    /**< TX is pad 0, on top RTS on pad 2
+                                         *   and CTS on pad 3 */
+} uart_txpad_t;
 
 /**
- * @brief   Possible pad selections for SERCOM SPI output (inspired by Arduino)
+ * @brief   Available values for SERCOM SPI MISO pad selection
  */
 typedef enum {
-    SPI_PAD_0_SCK_1 = 0,    /**< select pad 0, SCK pad1, only SPI */
-    SPI_PAD_2_SCK_3 = 1,    /**< select pad 2, SCK pad3, only SPI */
-    SPI_PAD_3_SCK_1 = 2,    /**< select pad 3, SCK pad1, only SPI */
-    SPI_PAD_0_SCK_3 = 3,    /**< select pad 0, SCK pad3, only SPI */
-} sercom_spi_txpad_t;
+    SPI_PAD_MISO_0 = 0x0,       /**< use pad 0 for MISO line */
+    SPI_PAD_MISO_1 = 0x1,       /**< use pad 0 for MISO line */
+    SPI_PAD_MISO_2 = 0x2,       /**< use pad 0 for MISO line */
+    SPI_PAD_MISO_3 = 0x3,       /**< use pad 0 for MISO line */
+} spi_misopad_t;
+
+/**
+ * @brief   Available values for SERCOM SPI MOSI and SCK pad selection
+ */
+typedef enum {
+    SPI_PAD_MOSI_0_SCK_1 = 0x0, /**< use pad 0 for MOSI, pad 1 for SCK */
+    SPI_PAD_MOSI_2_SCK_3 = 0x1, /**< use pad 2 for MOSI, pad 3 for SCK */
+    SPI_PAD_MOSI_3_SCK_1 = 0x2, /**< use pad 3 for MOSI, pad 1 for SCK */
+    SPI_PAD_MOSI_0_SCK_3 = 0x3, /**< use pad 0 for MOSI, pad 3 for SCK */
+} spi_mosipad_t;
 
 /**
  * @brief   Possible selections for SERCOM SPI clock mode (inspired by Arduino)

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -86,8 +86,8 @@ typedef struct {
     gpio_t rx_pin;          /**< pin used for RX */
     gpio_t tx_pin;          /**< pin used for TX */
     gpio_mux_t mux;         /**< alternative function for pins */
-    sercom_rxpad_t rx_pad;  /**< pad selection for RX */
-    sercom_uart_txpad_t tx_pad; /**< pad selection for TX */
+    uart_rxpad_t rx_pad;    /**< pad selection for RX line */
+    uart_txpad_t tx_pad;    /**< pad selection for TX line */
 } uart_conf_t;
 
 /**

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -67,8 +67,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     gpio_mux_t mux_sclk = 0;
     gpio_mux_t mux_miso = 0;
     gpio_mux_t mux_mosi = 0;
-    sercom_spi_txpad_t  dopo = 0;
-    sercom_rxpad_t      dipo = 0;
+    spi_mosipad_t mosi_pad = 0;
+    spi_misopad_t miso_pad = 0;
     uint32_t   cpha = 0;
     uint32_t   cpol = 0;
     uint32_t   f_baud = 0;
@@ -129,8 +129,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         mux_miso = SPI_0_MISO_MUX;
         pin_mosi = SPI_0_MOSI;
         mux_mosi = SPI_0_MOSI_MUX;
-        dopo = SPI_0_MOSI_PAD;
-        dipo = SPI_0_MISO_PAD;
+        mosi_pad = SPI_0_MOSI_PAD;
+        miso_pad = SPI_0_MISO_PAD;
         break;
 #endif
 #if SPI_1_EN
@@ -143,8 +143,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         mux_miso = SPI_1_MISO_MUX;
         pin_mosi = SPI_1_MOSI;
         mux_mosi = SPI_1_MOSI_MUX;
-        dopo = SPI_1_MOSI_PAD;
-        dipo = SPI_1_MISO_PAD;
+        mosi_pad = SPI_1_MOSI_PAD;
+        miso_pad = SPI_1_MISO_PAD;
         break;
 #endif
     default:
@@ -191,8 +191,8 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 
     spi_dev->BAUD.bit.BAUD = (uint8_t) (((uint32_t)CLOCK_CORECLOCK) / (2 * f_baud) - 1); /* Synchronous mode*/
 
-    spi_dev->CTRLA.reg |= SERCOM_SPI_CTRLA_DOPO(dopo)
-                       |  SERCOM_SPI_CTRLA_DIPO(dipo)
+    spi_dev->CTRLA.reg |= SERCOM_SPI_CTRLA_DOPO(mosi_pad)
+                       |  SERCOM_SPI_CTRLA_DIPO(miso_pad)
                        |  cpha
                        |  cpol;
     while (spi_dev->SYNCBUSY.reg) {}	// ???? not needed

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -86,12 +86,12 @@ static int init_base(uart_t uart, uint32_t baudrate)
     /* reset the UART device */
     dev->CTRLA.reg = SERCOM_USART_CTRLA_SWRST;
     while (dev->SYNCBUSY.reg & SERCOM_USART_SYNCBUSY_SWRST) {}
-    /* set asynchronous mode w/o parity, LSB first, PADn to TX, PADn to RX and
-     * use internal clock */
+    /* set asynchronous mode w/o parity, LSB first, TX and RX pad as specified
+     * by the board in the periph_conf.h, x16 sampling and use internal clock */
     dev->CTRLA.reg = (SERCOM_USART_CTRLA_DORD |
+                      SERCOM_USART_CTRLA_SAMPR(0x1) |
                       SERCOM_USART_CTRLA_TXPO(uart_config[uart].tx_pad) |
                       SERCOM_USART_CTRLA_RXPO(uart_config[uart].rx_pad) |
-                      SERCOM_USART_CTRLA_SAMPR(0x1) |			// 1: x16 sample rate
                       SERCOM_USART_CTRLA_MODE_USART_INT_CLK);
     /* set baudrate */
     dev->BAUD.FRAC.FP = (baud % 10);


### PR DESCRIPTION
- gave pad selection macros some more consistent naming scheme
- adapted spi and uart implementation
- adapted board configuration for `samr21-xpro` and `sodaq-autonomo`