### PR TITLE
sock: define behavior on invalid addresses

### DIFF
--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -316,9 +316,10 @@ typedef struct sock_ip sock_ip_t;
  *          elsewhere
  * @return  -EAFNOSUPPORT, if `local != NULL` or `remote != NULL` and
  *          sock_ip_ep_t::family of @p local or @p remote is not supported.
- * @return  -EINVAL, if `proto` is not supported or if sock_ip_ep_t::netif of
- *          @p local or @p remote is not a valid interface or contradict each
- *          other (i.e. `(local->netif != remote->netif) &&
+ * @return  -EINVAL, if sock_ip_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_ip_ep_t::netif of @p local or @p remote are not
+ *          valid interfaces or contradict each other
+ *          (i.e. `(local->netif != remote->netif) &&
  *          ((local->netif != SOCK_ADDR_ANY_NETIF) ||
  *          (remote->netif != SOCK_ADDR_ANY_NETIF))` if neither is `NULL`).
  * @return  -ENOMEM, if not enough resources can be provided for `sock` to be
@@ -432,6 +433,9 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
  * @return  The number of bytes sent on success.
  * @return  -EAFNOSUPPORT, if `remote != NULL` and sock_ip_ep_t::family of
  *          @p remote is != AF_UNSPEC and not supported.
+ * @return  -EINVAL, if sock_ip_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_ip_ep_t::netif of @p remote is not a
+ *          valid interface or contradicts the local interface of @p sock.
  * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not
  *          reachable.
  * @return  -ENOMEM, if no memory was available to send @p data.

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -83,6 +83,7 @@ typedef struct sock_tcp_queue sock_tcp_queue_t;
  * @return  -EAFNOSUPPORT, if sock_tcp_ep_t::family of @p remote is not
  *          supported.
  * @return  -ECONNREFUSED, if no-one is listening on the @p remote end point.
+ * @return  -EINVAL, if sock_tcp_ep_t::addr of @p remote is an invalid address.
  * @return  -EINVAL, if sock_tcp_ep_t::netif of @p remote is not a valid
  *          interface.
  * @return  -ENETUNREACH, if network defined by @p remote is not reachable.

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -322,8 +322,9 @@ typedef struct sock_udp sock_udp_t;
  *         elsewhere
  * @return  -EAFNOSUPPORT, if `local != NULL` or `remote != NULL` and
  *          sock_udp_ep_t::family of @p local or @p remote is not supported.
- * @return  -EINVAL, if sock_udp_ep_t::netif of @p local or @p remote is not a
- *          valid interface or contradict each other (i.e.
+ * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_udp_ep_t::netif of @p local or @p remote are not a
+ *          valid interfaces or contradict each other (i.e.
  *          `(local->netif != remote->netif) &&
  *          ((local->netif != SOCK_ADDR_ANY_NETIF) ||
  *          (remote->netif != SOCK_ADDR_ANY_NETIF))` if neither is `NULL`).
@@ -420,6 +421,7 @@ ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
  *          @p remote is != AF_UNSPEC and not supported.
  * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not
  *          reachable.
+ * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote is an invalid address.
  * @return  -EINVAL, if sock_udp_ep_t::netif of @p remote is not a valid
  *          interface or contradicts the given local interface (i.e.
  *          neither the local end point of `sock` nor remote are assigned to


### PR DESCRIPTION
While sock for lwIP I realized that we currently have no behavior defined if the remote address is an invalid address (e.g. `::` for IPv6). This fixes that.