### PR TITLE
cpu/cc2538: Wait for transmission to complete before returning from send()

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -283,6 +283,9 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 
     RFCORE_SFR_RFST = ISTXON;
 
+    /* Wait for transmission to complete */
+    RFCORE_WAIT_UNTIL(RFCORE->XREG_FSMSTAT1bits.TX_ACTIVE == 0);
+
     return pkt_len;
 }
 


### PR DESCRIPTION
It seems that the cc2538 is capable of sending frames faster than  some other radios are capable of processing them, resulting in high levels of packet loss when fragmentation is used. This PR introduces a non-blocking wait for transmission of each frame to complete before beginning construction of the next, which seems to slow things down enough to be compatible with other radios.

I would like the reviewer to please consider whether a non-blocking wait is most appropriate here, or whether we should use a blocking wait instead. Since #5803 has been merged I believe a non-blocking wait should be okay, since it will only yield to threads with higher priority, and the `cc2538_rf` thread should now have higher priority than the network-layer threads. Before #5803, this non-blocking wait would have yielded to the 6lo thread during sending of large multi-fragment packets, allowing 6lo to fill and overflow the message queue before cc2538_rf had a chance to process them (since it is waiting).

Fixes(?) #5786 and #5719 