### PR TITLE
sock: make queue_array parameter a pointer

### DIFF
--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -116,7 +116,7 @@ int sock_tcp_connect(sock_tcp_t *sock, const sock_tcp_ep_t *remote,
  * @return  -ENOMEM, if no memory was available to listen on @p queue.
  */
 int sock_tcp_listen(sock_tcp_queue_t *queue, const sock_tcp_ep_t *local,
-                    sock_tcp_t[] queue_array, unsigned queue_len,
+                    sock_tcp_t *queue_array, unsigned queue_len,
                     uint16_t flags);
 
 /**


### PR DESCRIPTION
Since sock_tcp_t isn't defined at this moment (only declared) the
ompiler is complaining about the use of an array in the parameter list
here.

```
sys/include/net/sock/tcp.h:119:32: error: array type has incomplete element type ‘sock_tcp_t {aka struct
sock_tcp}’
                     sock_tcp_t queue_array[], unsigned queue_len,
                                ^
```