### PR TITLE
boards/iotlab-common: small fix to select right serial port

### DIFF
--- a/boards/iotlab-common/Makefile.include
+++ b/boards/iotlab-common/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f103re
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*B)))
 
 # setup serial terminal
 export BAUD = 500000


### PR DESCRIPTION
Small change to select the right serial port on iotlab-m3 boards for OS X. Without this the default selected port is the "A", which is not the STDIO.