### PR TITLE
gnrc_ipv6: fix UDP issue

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -855,7 +855,9 @@ static void _receive(gnrc_pktsnip_t *pkt)
         ipv6 = gnrc_pktbuf_mark(pkt, sizeof(ipv6_hdr_t), GNRC_NETTYPE_IPV6);
 
         first_ext = pkt;
+#ifndef MODULE_GNRC_SIXLOWPAN 
         pkt->type = GNRC_NETTYPE_UNDEF; /* snip is no longer IPv6 */
+#endif
 
         if (ipv6 == NULL) {
             DEBUG("ipv6: error marking IPv6 header, dropping packet\n");
@@ -888,11 +890,19 @@ static void _receive(gnrc_pktsnip_t *pkt)
     if (byteorder_ntohs(hdr->len) < pkt->size) {
         gnrc_pktbuf_realloc_data(pkt, byteorder_ntohs(hdr->len));
     }
+#ifdef MODULE_GNRC_SIXLOWPAN 
+    else if (byteorder_ntohs(hdr->len) >
+             (gnrc_pkt_len_upto(pkt, GNRC_NETTYPE_IPV6))) {
+        DEBUG("ipv6: invalid payload length: %d, actual: %d, dropping packet\n",
+              (int) byteorder_ntohs(hdr->len),
+              (int) (gnrc_pkt_len_upto(pkt, GNRC_NETTYPE_IPV6)));
+#else
     else if (byteorder_ntohs(hdr->len) >
              (gnrc_pkt_len_upto(pkt, GNRC_NETTYPE_IPV6) - sizeof(ipv6_hdr_t))) {
         DEBUG("ipv6: invalid payload length: %d, actual: %d, dropping packet\n",
               (int) byteorder_ntohs(hdr->len),
               (int) (gnrc_pkt_len_upto(pkt, GNRC_NETTYPE_IPV6) - sizeof(ipv6_hdr_t)));
+#endif /* MODULE_GNRC_SIXLOWPAN */
         gnrc_pktbuf_release(pkt);
         return;
     }


### PR DESCRIPTION
Hi All,
in #5596 we discussed about the problem of propagation of a UDP packet when it passes through another 6LoWPAN node. I closed that PR and I open this new one with the updated code. It should work also for non-6LoWPAN networks.
