### PR TITLE
sam21_common:i2c refactor a function to wait for response

### DIFF
--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -44,7 +44,7 @@
 static void _i2c_poweron(SercomI2cm *sercom);
 static void _i2c_poweroff(SercomI2cm *sercom);
 
-static inline int _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag);
+static int _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag);
 static inline int _write(SercomI2cm *dev, const uint8_t *data, int length);
 static inline int _read(SercomI2cm *dev, uint8_t *data, int length);
 static inline void _stop(SercomI2cm *dev);

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -89,7 +89,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
             mux = I2C_0_MUX;
             clock_source_speed = CLOCK_CORECLOCK;
             sercom_gclk_id = I2C_0_GCLK_ID;
-            sercom_gclk_id_slow = I2C_0_GCLK_ID_SLOW ;
+            sercom_gclk_id_slow = I2C_0_GCLK_ID_SLOW;
             break;
 #endif
         default:
@@ -102,7 +102,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
 
     /* Reset I2C */
     I2CSercom->CTRLA.reg = SERCOM_I2CS_CTRLA_SWRST;
-    while(I2CSercom->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
+    while (I2CSercom->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
 
     /* Turn on power manager for sercom */
     PM->APBCMASK.reg |= (PM_APBCMASK_SERCOM0 << (sercom_gclk_id - GCLK_CLKCTRL_ID_SERCOM0_CORE_Val));
@@ -135,7 +135,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     gpio_init_mux(pin_scl, mux);
 
     /* I2C CONFIGURATION */
-    while(I2CSercom->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
+    while (I2CSercom->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
 
     /* Set sercom module to operate in I2C master mode. */
     I2CSercom->CTRLA.reg = SERCOM_I2CM_CTRLA_MODE_I2C_MASTER;
@@ -148,24 +148,24 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
      * kHz and Fast-mode (Fm) up to 400 kHz */
     switch (speed) {
         case I2C_SPEED_NORMAL:
-            tmp_baud = (int32_t)(((clock_source_speed + (2*(100000)) - 1) / (2*(100000))) - 5);
+            tmp_baud = (int32_t)(((clock_source_speed + (2 * (100000)) - 1) / (2 * (100000))) - 5);
             if (tmp_baud < 255 && tmp_baud > 0) {
                 I2CSercom->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(0);
                 I2CSercom->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(tmp_baud);
             }
             break;
         case I2C_SPEED_FAST:
-            tmp_baud = (int32_t)(((clock_source_speed + (2*(400000)) - 1) / (2*(400000))) - 5);
+            tmp_baud = (int32_t)(((clock_source_speed + (2 * (400000)) - 1) / (2 * (400000))) - 5);
             if (tmp_baud < 255 && tmp_baud > 0) {
                 I2CSercom->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(0);
                 I2CSercom->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(tmp_baud);
             }
             break;
         case I2C_SPEED_HIGH:
-            tmp_baud = (int32_t)(((clock_source_speed + (2*(3400000)) - 1) / (2*(3400000))) - 1);
+            tmp_baud = (int32_t)(((clock_source_speed + (2 * (3400000)) - 1) / (2 * (3400000))) - 1);
             if (tmp_baud < 255 && tmp_baud > 0) {
                 I2CSercom->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(2);
-                I2CSercom->BAUD.reg =SERCOM_I2CM_BAUD_HSBAUD(tmp_baud);
+                I2CSercom->BAUD.reg = SERCOM_I2CM_BAUD_HSBAUD(tmp_baud);
             }
             break;
         default:
@@ -178,7 +178,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
 
     /* Start timeout if bus state is unknown. */
     while ((I2CSercom->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk) == BUSSTATE_UNKNOWN) {
-        if(timeout_counter++ >= SAMD21_I2C_TIMEOUT) {
+        if (timeout_counter++ >= SAMD21_I2C_TIMEOUT) {
             /* Timeout, force bus state to idle. */
             I2CSercom->STATUS.reg = BUSSTATE_IDLE;
         }
@@ -224,9 +224,13 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
     }
 
     /* start transmission and send slave address */
-    if(_start(i2c, address, I2C_FLAG_READ) < 0) return 0;
+    if (_start(i2c, address, I2C_FLAG_READ) < 0) {
+        return 0;
+    }
     /* read data to register */
-    if(_read(i2c, data, length) < 0) return 0;
+    if (_read(i2c, data, length) < 0) {
+        return 0;
+    }
     _stop(i2c);
     /* return number of bytes sent */
     return length;
@@ -252,10 +256,14 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
     }
 
     /* start transmission and send slave address */
-    if (_start(i2c, address, I2C_FLAG_WRITE) < 0) return 0;
+    if (_start(i2c, address, I2C_FLAG_WRITE) < 0) {
+        return 0;
+    }
     /* send register address/command and wait for complete transfer to
      * be finished */
-    if (_write(i2c, &reg, 1) < 0) return 0;
+    if (_write(i2c, &reg, 1) < 0) {
+        return 0;
+    }
     return i2c_read_bytes(dev, address, data, length);
 }
 
@@ -278,8 +286,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
             return -1;
     }
 
-    if(_start(I2CSercom, address, I2C_FLAG_WRITE) < 0) return 0;
-    if(_write(I2CSercom, data, length) < 0) return 0;
+    if (_start(I2CSercom, address, I2C_FLAG_WRITE) < 0) {
+        return 0;
+    }
+    if (_write(I2CSercom, data, length) < 0) {
+        return 0;
+    }
     _stop(I2CSercom);
     return length;
 }
@@ -302,14 +314,20 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
 #endif
         default:
             return -1;
-        }
+    }
 
     /* start transmission and send slave address */
-    if (_start(i2c, address, I2C_FLAG_WRITE) < 0) return 0;
+    if (_start(i2c, address, I2C_FLAG_WRITE) < 0) {
+        return 0;
+    }
     /* send register address and wait for complete transfer to be finished */
-    if (_write(i2c, &reg, 1) < 0) return 0;
+    if (_write(i2c, &reg, 1) < 0) {
+        return 0;
+    }
     /* write data to register */
-    if (_write(i2c, data, length) < 0) return 0;
+    if (_write(i2c, data, length) < 0) {
+        return 0;
+    }
     /* finish transfer */
     _stop(i2c);
     return length;
@@ -365,7 +383,7 @@ static int _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag)
 
     /* Wait for hardware module to sync */
     DEBUG("Wait for device to be ready\n");
-    while(dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
+    while (dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
 
     /* Set action to ACK. */
     dev->CTRLB.reg &= ~SERCOM_I2CM_CTRLB_ACKACT;
@@ -421,7 +439,7 @@ static inline int _write(SercomI2cm *dev, const uint8_t *data, int length)
         }
 
         /* Wait for hardware module to sync */
-        while(dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
+        while (dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
 
         DEBUG("Written byte #%i to data reg, now waiting for DR to be empty again\n", buffer_counter);
         dev->DATA.reg = data[buffer_counter++];
@@ -462,7 +480,7 @@ static inline int _read(SercomI2cm *dev, uint8_t *data, int length)
         }
 
         /* Wait for hardware module to sync */
-        while(dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
+        while (dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
         /* Save data to buffer. */
         data[count] = dev->DATA.reg;
 
@@ -485,11 +503,11 @@ static inline int _read(SercomI2cm *dev, uint8_t *data, int length)
 static inline void _stop(SercomI2cm *dev)
 {
     /* Wait for hardware module to sync */
-    while(dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
+    while (dev->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
     /* Stop command */
     dev->CTRLB.reg |= SERCOM_I2CM_CTRLB_CMD(3);
     /* Wait for bus to be idle again */
-    while((dev->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk) != BUSSTATE_IDLE) {}
+    while ((dev->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk) != BUSSTATE_IDLE) {}
     DEBUG("Stop sent\n");
 }
 


### PR DESCRIPTION
This PR is in preparation to add a driver for SHT2x.

As you can see in the commits below, first there is a uncrustify. (I like to work on source code which follows the coding conventions.)

Then a new function is introduced to replace source lines that occur a few times.

The third commit is to increase the waiting for the read, because the SHT2x can hold the bus much longer than other devices.
