### PR TITLE
gnrc: add l2_address into gnrc_netdev2_t

### DIFF
--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -29,8 +29,8 @@
 #include <xtimer.h>
 #include <net/netdev2.h>
 #include <net/gnrc/netdev2.h>
+#include <net/gnrc/netif/hdr.h>
 #include <net/gnrc.h>
-
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -29,8 +29,8 @@
 #include <xtimer.h>
 #include <net/netdev2.h>
 #include <net/gnrc/netdev2.h>
-#include <net/gnrc/netif/hdr.h>
 #include <net/gnrc.h>
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -102,6 +102,16 @@ typedef struct gnrc_netdev2 {
      * @brief general information for the MAC protocol
      */
     uint16_t mac_info;
+
+    /**
+     * @brief device's l2 address
+     */
+    uint8_t  l2_addr[GNRC_NETIF_HDR_L2ADDR_MAX_LEN];
+
+    /**
+     * @brief device's l2 address length
+     */
+    uint8_t  l2_addr_len;
 #endif
 } gnrc_netdev2_t;
 

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -36,6 +36,7 @@
 #include "net/netdev2.h"
 #include "net/gnrc.h"
 #include "net/gnrc/mac/types.h"
+#include "net/ieee802154.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -106,7 +107,7 @@ typedef struct gnrc_netdev2 {
     /**
      * @brief device's l2 address
      */
-    uint8_t  l2_addr[GNRC_NETIF_HDR_L2ADDR_MAX_LEN];
+    uint8_t  l2_addr[IEEE802154_LONG_ADDRESS_LEN];
 
     /**
      * @brief device's l2 address length


### PR DESCRIPTION
This is based on [#5941](https://github.com/RIOT-OS/RIOT/pull/5941),  add l2_address into `gnrc_netdev2_t`.
