### PR TITLE
doc: update getting started link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ but not limited to:
 
 
 ## GETTING STARTED
-* You want to start the RIOT? Just follow our [Getting started
-  documentation](https://github.com/RIOT-OS/RIOT/wiki/Introduction)
+* You want to start the RIOT? Just follow our [quickstart guide](http://doc.riot-os.org/index.html#the-quickest-start) or the [getting started documentation](http://doc.riot-os.org/getting-started.html).
 * The RIOT API itself can be built from the code using doxygen. The latest
   version is uploaded daily to http://riot-os.org/api.
 


### PR DESCRIPTION
Update the "getting started" link in our README.md from the (less maintained) wiki page to appropriate docs.riot-os.org links.