### PR TITLE
gnrc: Add priority packet queue module to gnrc

### DIFF
--- a/sys/include/net/gnrc/priority_pktqueue.h
+++ b/sys/include/net/gnrc/priority_pktqueue.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @defgroup    net_gnrc_priority_pktqueue Priority packet queue
+ * @ingroup     net_gnrc
+ * @file
+ * @brief       Wrapper for priority_queue that holds gnrc_pktsnip_t* and is
+ *              aware of it's length.
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>
+ * @}
+ */
+
+#ifndef GNRC_PRIORITY_PKTQUEUE_H
+#define GNRC_PRIORITY_PKTQUEUE_H
+
+#include <stdint.h>
+#include <priority_queue.h>
+#include <net/gnrc/pkt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief data type for gnrc priority packet queue nodes
+ */
+typedef struct gnrc_priority_pktqueue_node {
+    struct gnrc_priority_pktqueue_node *next;   /**< next queue node */
+    uint32_t priority;                          /**< queue node priority */
+    gnrc_pktsnip_t *pkt;                        /**< queue node data */
+} gnrc_priority_pktqueue_node_t;
+
+/**
+ * @brief data type for gnrc priority packet queues
+ */
+typedef priority_queue_t gnrc_priority_pktqueue_t;
+
+/**
+ * @brief Static initializer for gnrc_priority_pktqueue_node_t.
+ */
+#define PRIORITY_PKTQUEUE_NODE_INIT(priority, pkt) { NULL, priority, pkt }
+
+/**
+ * @brief Static initializer for gnrc_priority_pktqueue_t.
+ */
+#define PRIORITY_PKTQUEUE_INIT { NULL }
+
+/**
+ * @brief   Initialize a gnrc priority packet queue node object.
+ *
+ * @param[out] node
+ *          pre-allocated gnrc_priority_pktqueue_node_t object, must not be NULL.
+ * @param[in]  priority
+ *          the priority of the gnrc packet snip
+ * @param[in]  pkt
+ *          the gnrc packet snip
+ */
+static inline void gnrc_priority_pktqueue_node_init(gnrc_priority_pktqueue_node_t *node,
+                                                    uint32_t priority,
+                                                    gnrc_pktsnip_t *pkt)
+{
+    node->next = NULL;
+    node->priority = priority;
+    node->pkt = pkt;
+}
+
+/**
+ * @brief   Initialize a gnrc priority packet queue object.
+ *
+ * @param[out] queue
+ *          pre-allocated gnrc_priority_pktqueue_t object, must not be NULL.
+ */
+static inline void gnrc_priority_pktqueue_init(gnrc_priority_pktqueue_t *queue)
+{
+    gnrc_priority_pktqueue_t qn = PRIORITY_PKTQUEUE_INIT;
+    *queue = qn;
+}
+
+/**
+ * @brief   Get the length information of a gnrc priority packet queue object.
+ *
+ * @param[in] queue
+ *          pre-allocated gnrc_priority_pktqueue_t object, must not be NULL.
+ * @return  the length of @p queue
+ */
+uint32_t gnrc_priority_pktqueue_length(gnrc_priority_pktqueue_t *queue);
+
+/**
+ * @brief flush the gnrc priority packet queue
+ *
+ * @param[out]  queue    the gnrc priority packet queue, must not be NULL
+ */
+void gnrc_priority_pktqueue_flush(gnrc_priority_pktqueue_t* queue);
+
+/**
+ * @brief Get first element and remove it from @p queue
+ *
+ * @param[out]  queue   the gnrc priority packet queue, may not be NULL
+ *
+ * @return              the old head
+ */
+gnrc_pktsnip_t* gnrc_priority_pktqueue_pop(gnrc_priority_pktqueue_t* queue);
+
+/**
+ * @brief Get first element from @p queue without removing
+ *
+ * @param[in]  queue    the gnrc priority packet queue, may not be NULL
+ *
+ * @return              the head of @p queue
+ */
+gnrc_pktsnip_t* gnrc_priority_pktqueue_head(gnrc_priority_pktqueue_t* queue);
+
+/**
+ * @brief       add @p node into @p queue based on its priority
+ *
+ * @param[in,out]   queue   the gnrc priority packet queue, must not be NULL
+ * @param[in]       node    the node to add.
+ */
+void gnrc_priority_pktqueue_push(gnrc_priority_pktqueue_t* queue,
+                                 gnrc_priority_pktqueue_node_t *node);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_PRIORITY_PKTQUEUE_H */

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -76,6 +76,9 @@ endif
 ifneq (,$(filter gnrc_pktbuf_static,$(USEMODULE)))
     DIRS += pktbuf_static
 endif
+ifneq (,$(filter gnrc_priority_pktqueue,$(USEMODULE)))
+    DIRS += priority_pktqueue
+endif
 ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))
     DIRS += pktdump
 endif

--- a/sys/net/gnrc/priority_pktqueue/Makefile
+++ b/sys/net/gnrc/priority_pktqueue/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_priority_pktqueue
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/priority_pktqueue/priority_pktqueue.c
+++ b/sys/net/gnrc/priority_pktqueue/priority_pktqueue.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015 Daniel Krebs
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @defgroup    net_gnrc_priority_pktqueue Priority packet queue
+ * @ingroup     net_gnrc
+ * @file
+ * @brief       Wrapper for priority_queue that holds gnrc_pktsnip_t* and is
+ *              aware of it's length.
+ *
+ * @author      Daniel Krebs <github@daniel-krebs.net>
+ * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>
+ * @}
+ */
+
+#include "net/gnrc/pktbuf.h"
+#include <net/gnrc/priority_pktqueue.h>
+
+/******************************************************************************/
+
+static inline void _free_node(gnrc_priority_pktqueue_node_t *node)
+{
+    assert(node != NULL);
+
+    priority_queue_node_init((priority_queue_node_t *)node);
+}
+
+/******************************************************************************/
+
+gnrc_pktsnip_t* gnrc_priority_pktqueue_pop(gnrc_priority_pktqueue_t* queue)
+{
+    if(!queue || (gnrc_priority_pktqueue_length(queue) == 0)){
+        return NULL;
+    }
+    priority_queue_node_t *head = priority_queue_remove_head(queue);
+    gnrc_pktsnip_t* pkt = (gnrc_pktsnip_t*) head->data;
+    _free_node((gnrc_priority_pktqueue_node_t *)head);
+    return pkt;
+}
+
+/******************************************************************************/
+
+gnrc_pktsnip_t* gnrc_priority_pktqueue_head(gnrc_priority_pktqueue_t* queue)
+{
+    if(!queue || (gnrc_priority_pktqueue_length(queue) == 0)){
+        return NULL;
+    }
+    return (gnrc_pktsnip_t *)queue->first->data;
+}
+/******************************************************************************/
+
+void gnrc_priority_pktqueue_push(gnrc_priority_pktqueue_t* queue,
+                            gnrc_priority_pktqueue_node_t *node)
+{
+    assert(queue != NULL);
+    assert(node != NULL);
+    assert(node->pkt != NULL);
+    assert(sizeof(unsigned int) == sizeof(gnrc_pktsnip_t*));
+
+    priority_queue_add(queue, (priority_queue_node_t *)node);
+}
+
+/******************************************************************************/
+
+void gnrc_priority_pktqueue_flush(gnrc_priority_pktqueue_t* queue)
+{
+    assert(queue != NULL);
+
+    if(gnrc_priority_pktqueue_length(queue) == 0){
+        return;
+    }
+    gnrc_priority_pktqueue_node_t* node;
+    while( (node = (gnrc_priority_pktqueue_node_t *)priority_queue_remove_head(queue)) )
+    {
+        gnrc_pktbuf_release(node->pkt);
+        _free_node(node);
+    }
+}
+
+/******************************************************************************/
+uint32_t gnrc_priority_pktqueue_length(gnrc_priority_pktqueue_t *queue)
+{
+    assert(queue != NULL);
+
+    uint32_t length = 0;
+    priority_queue_node_t *node = queue->first;
+    if(!node){
+        return length;
+    }
+
+    length ++;
+    while(node->next!=NULL){
+        length ++;
+        node = node->next;
+    }
+    return length;
+}

--- a/tests/unittests/tests-priority_pktqueue/Makefile
+++ b/tests/unittests/tests-priority_pktqueue/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-priority_pktqueue/Makefile.include
+++ b/tests/unittests/tests-priority_pktqueue/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += gnrc_priority_pktqueue

--- a/tests/unittests/tests-priority_pktqueue/tests-priority_pktqueue.c
+++ b/tests/unittests/tests-priority_pktqueue/tests-priority_pktqueue.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2016, 2016 Shuguo Zhuo <shuguo.zhuo@inria.fr>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+#include <string.h>
+
+#include "embUnit.h"
+
+#include "net/gnrc/pkt.h"
+#include "net/gnrc/priority_pktqueue.h"
+
+#include "unittests-constants.h"
+#include "tests-priority_pktqueue.h"
+
+#define PKT_INIT_ELEM(len, data, next) \
+    { 1, (next), (data), (len), GNRC_NETTYPE_UNDEF }
+#define PKT_INIT_ELEM_STATIC_DATA(data, next) PKT_INIT_ELEM(sizeof(data), data, next)
+#define PKTQUEUE_INIT_ELEM(pkt) { NULL, pkt }
+
+static gnrc_priority_pktqueue_t pkt_queue;
+
+static void set_up(void)
+{
+    pkt_queue.first = NULL;
+}
+
+static void test_gnrc_priority_pktqueue_init(void)
+{
+    gnrc_priority_pktqueue_node_t elem;
+
+    pkt_queue.first = (priority_queue_node_t *)(&elem);
+    gnrc_priority_pktqueue_init(&pkt_queue);
+
+    TEST_ASSERT_NULL(pkt_queue.first);
+}
+
+static void test_gnrc_priority_pktqueue_node_init(void)
+{
+    gnrc_pktsnip_t pkt = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    gnrc_priority_pktqueue_node_t elem;
+
+    gnrc_priority_pktqueue_node_init(&elem,TEST_UINT32,&pkt);
+
+    TEST_ASSERT_NULL(elem.next);
+    TEST_ASSERT(elem.pkt == &pkt);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT32, elem.priority);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING8, elem.pkt->data);
+}
+
+static void test_gnrc_priority_pktqueue_push_one(void)
+{
+    gnrc_pktsnip_t pkt = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    gnrc_priority_pktqueue_node_t elem = PRIORITY_PKTQUEUE_NODE_INIT(TEST_UINT32,&pkt);
+
+    gnrc_priority_pktqueue_push(&pkt_queue,&elem);
+
+    TEST_ASSERT((gnrc_priority_pktqueue_node_t *)(pkt_queue.first) == &elem);
+    TEST_ASSERT_NULL(((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->next);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT32, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->priority);
+    TEST_ASSERT_EQUAL_INT(1, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->users);
+    TEST_ASSERT_NULL(((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING8, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->size);
+    TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_UNDEF, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->type);
+}
+
+static void test_gnrc_priority_pktqueue_push_two(void)
+{
+    gnrc_pktsnip_t pkt1 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    gnrc_pktsnip_t pkt2 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING16, NULL);
+    gnrc_priority_pktqueue_node_t elem1 = PRIORITY_PKTQUEUE_NODE_INIT(1,&pkt1);
+    gnrc_priority_pktqueue_node_t elem2 = PRIORITY_PKTQUEUE_NODE_INIT(0,&pkt2);
+
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem1);
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem2);
+
+    TEST_ASSERT((gnrc_priority_pktqueue_node_t *)(pkt_queue.first) == &elem2);
+    TEST_ASSERT((gnrc_priority_pktqueue_node_t *)(pkt_queue.first->next) == &elem1);
+    TEST_ASSERT_NULL(((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->next->next);
+    TEST_ASSERT_EQUAL_INT(0, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->priority);
+    TEST_ASSERT_EQUAL_INT(1, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->next->priority);
+    TEST_ASSERT_EQUAL_INT(1, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->users);
+    TEST_ASSERT_NULL(((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING16, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING16), ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->size);
+    TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_UNDEF, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->pkt->type);
+    TEST_ASSERT_EQUAL_INT(1, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->next->pkt->users);
+    TEST_ASSERT_NULL(((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->next->pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING8, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->next->pkt->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->next->pkt->size);
+    TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_UNDEF, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->next->pkt->type);
+}
+
+static void test_gnrc_priority_pktqueue_length(void)
+{
+    gnrc_pktsnip_t pkt1 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    gnrc_pktsnip_t pkt2 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING16, NULL);
+    gnrc_priority_pktqueue_node_t elem1 = PRIORITY_PKTQUEUE_NODE_INIT(1,&pkt1);
+    gnrc_priority_pktqueue_node_t elem2 = PRIORITY_PKTQUEUE_NODE_INIT(0,&pkt2);
+
+    TEST_ASSERT_EQUAL_INT(0, gnrc_priority_pktqueue_length(&pkt_queue));
+
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem1);
+    TEST_ASSERT_EQUAL_INT(1, gnrc_priority_pktqueue_length(&pkt_queue));
+
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem2);
+    TEST_ASSERT_EQUAL_INT(2, gnrc_priority_pktqueue_length(&pkt_queue));
+}
+
+static void test_gnrc_priority_pktqueue_flush(void)
+{
+    gnrc_pktsnip_t pkt1 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    gnrc_pktsnip_t pkt2 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING16, NULL);
+    gnrc_priority_pktqueue_node_t elem1 = PRIORITY_PKTQUEUE_NODE_INIT(1,&pkt1);
+    gnrc_priority_pktqueue_node_t elem2 = PRIORITY_PKTQUEUE_NODE_INIT(0,&pkt2);
+
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem1);
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem2);
+
+    gnrc_priority_pktqueue_flush(&pkt_queue);
+
+    TEST_ASSERT_NULL(pkt_queue.first);
+    TEST_ASSERT_EQUAL_INT(0, gnrc_priority_pktqueue_length(&pkt_queue));
+}
+
+static void test_gnrc_priority_pktqueue_head(void)
+{
+    gnrc_pktsnip_t pkt1 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    gnrc_pktsnip_t pkt2 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING12, NULL);
+    gnrc_pktsnip_t pkt3 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING16, NULL);
+    gnrc_priority_pktqueue_node_t elem1 = PRIORITY_PKTQUEUE_NODE_INIT(1,&pkt1);
+    gnrc_priority_pktqueue_node_t elem2 = PRIORITY_PKTQUEUE_NODE_INIT(1,&pkt2);
+    gnrc_priority_pktqueue_node_t elem3 = PRIORITY_PKTQUEUE_NODE_INIT(0,&pkt3);
+
+    gnrc_pktsnip_t *head = gnrc_priority_pktqueue_head(&pkt_queue);
+    TEST_ASSERT_NULL(head);
+
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem1);
+    head = gnrc_priority_pktqueue_head(&pkt_queue);
+    TEST_ASSERT(head == &pkt1);
+
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem2);
+    head = gnrc_priority_pktqueue_head(&pkt_queue);
+
+    TEST_ASSERT(head == &pkt1);
+
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem3);
+    head = gnrc_priority_pktqueue_head(&pkt_queue);
+
+    TEST_ASSERT(head == &pkt3);
+
+    gnrc_priority_pktqueue_flush(&pkt_queue);
+
+    head = gnrc_priority_pktqueue_head(&pkt_queue);
+    TEST_ASSERT_NULL(head);
+
+}
+
+static void test_gnrc_priority_pktqueue_pop_empty(void)
+{
+    gnrc_pktsnip_t *res;
+
+    res = gnrc_priority_pktqueue_pop(&pkt_queue);
+
+    TEST_ASSERT_NULL(pkt_queue.first);
+    TEST_ASSERT_NULL(res);
+    TEST_ASSERT_EQUAL_INT(0, gnrc_priority_pktqueue_length(&pkt_queue));
+}
+
+
+static void test_gnrc_priority_pktqueue_pop(void)
+{
+    gnrc_pktsnip_t pkt1 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING8, NULL);
+    gnrc_pktsnip_t pkt2 = PKT_INIT_ELEM_STATIC_DATA(TEST_STRING16, NULL);
+    gnrc_priority_pktqueue_node_t elem1 = PRIORITY_PKTQUEUE_NODE_INIT(1,&pkt1);
+    gnrc_priority_pktqueue_node_t elem2 = PRIORITY_PKTQUEUE_NODE_INIT(0,&pkt2);
+    gnrc_pktsnip_t *res;
+    gnrc_pktsnip_t *head;
+
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem1);
+    gnrc_priority_pktqueue_push(&pkt_queue, &elem2);
+
+    res = gnrc_priority_pktqueue_pop(&pkt_queue);
+
+    TEST_ASSERT(res == &pkt2);
+    TEST_ASSERT_NULL(elem2.pkt);
+    TEST_ASSERT_NULL(elem2.next);
+    TEST_ASSERT_EQUAL_INT(0,elem2.priority);
+    TEST_ASSERT((gnrc_priority_pktqueue_node_t *)(pkt_queue.first) == &elem1);
+    TEST_ASSERT_EQUAL_INT(1, ((gnrc_priority_pktqueue_node_t *)(pkt_queue.first))->priority);
+    TEST_ASSERT_EQUAL_INT(1, res->users);
+    TEST_ASSERT_NULL(res->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING16, res->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING16), res->size);
+    TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_UNDEF, res->type);
+
+    res = gnrc_priority_pktqueue_pop(&pkt_queue);
+
+    TEST_ASSERT_NULL(pkt_queue.first);
+    TEST_ASSERT_NULL(elem1.pkt);
+    TEST_ASSERT_NULL(elem1.next);
+    TEST_ASSERT_EQUAL_INT(0,elem1.priority);
+    TEST_ASSERT(res == &pkt1);
+    TEST_ASSERT_EQUAL_INT(1, res->users);
+    TEST_ASSERT_NULL(res->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING8, res->data);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING8), res->size);
+    TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_UNDEF, res->type);
+
+    head = gnrc_priority_pktqueue_head(&pkt_queue);
+
+    TEST_ASSERT_NULL(pkt_queue.first);
+    TEST_ASSERT_NULL(head);
+
+}
+
+Test *tests_priority_pktqueue_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_gnrc_priority_pktqueue_init),
+        new_TestFixture(test_gnrc_priority_pktqueue_node_init),
+        new_TestFixture(test_gnrc_priority_pktqueue_push_one),
+        new_TestFixture(test_gnrc_priority_pktqueue_push_two),
+        new_TestFixture(test_gnrc_priority_pktqueue_length),
+        new_TestFixture(test_gnrc_priority_pktqueue_flush),
+        new_TestFixture(test_gnrc_priority_pktqueue_head),
+        new_TestFixture(test_gnrc_priority_pktqueue_pop_empty),
+        new_TestFixture(test_gnrc_priority_pktqueue_pop),
+    };
+
+    EMB_UNIT_TESTCALLER(priority_pktqueue_tests, set_up, NULL, fixtures);
+
+    return (Test *)&priority_pktqueue_tests;
+}
+
+void tests_priority_pktqueue(void)
+{
+    TESTS_RUN(tests_priority_pktqueue_tests());
+}
+/** @} */

--- a/tests/unittests/tests-priority_pktqueue/tests-priority_pktqueue.h
+++ b/tests/unittests/tests-priority_pktqueue/tests-priority_pktqueue.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Shuguo Zhuo <shuguo.zhuo@inria.fr>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``gnrc_priority_pktqueue`` module
+ *
+ * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>
+ */
+#ifndef TESTS_PRIORITY_PKTQUEUE_H_
+#define TESTS_PRIORITY_PKTQUEUE_H_
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_priority_pktqueue(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_PRIORITY_PKTQUEUE_H_ */
+/** @} */


### PR DESCRIPTION
This PR aim to priority packet queue module to gnrc. 

PS: this module here is extracted/sorted from the packet queue management block of [Lw-MAC](https://github.com/RIOT-OS/RIOT/pull/3730/).
