### PR TITLE
gnrc_netif_hdr: Packet dump format of if_pid, rssi and lqi

### DIFF
--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
@@ -22,9 +22,9 @@ void gnrc_netif_hdr_print(gnrc_netif_hdr_t *hdr)
 {
     char addr_str[GNRC_NETIF_HDR_L2ADDR_PRINT_LEN];
 
-    printf("if_pid: %" PRIkernel_pid "  ", hdr->if_pid);
-    printf("rssi: %" PRIu8 "  ", hdr->rssi);
-    printf("lqi: %" PRIu8 "\n", hdr->lqi);
+    printf("if_pid: %u  ", (unsigned) hdr->if_pid);
+    printf("rssi: %u  ", (unsigned) hdr->rssi);
+    printf("lqi: %u\n", (unsigned) hdr->lqi);
     printf("flags: ");
 
     if (hdr->flags) {


### PR DESCRIPTION
The output showed "hu" as if_pid, rssi and lqi. This will fix it.