### PR TITLE
cpu: minor improvements for MSP430 and AVR

### DIFF
--- a/cpu/atmega1281/include/cpu_conf.h
+++ b/cpu/atmega1281/include/cpu_conf.h
@@ -29,13 +29,13 @@ extern "C" {
  * @name Kernel configuration
  *
  * Since printf seems to get memory allocated by the linker/avr-libc the stack
- * size tested sucessfully even with pretty small stacks.k
+ * size tested sucessfully even with pretty small stacks.
  * @{
  */
 #define THREAD_EXTRA_STACKSIZE_PRINTF    (128)
 
 #ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (256)
+#   define THREAD_STACKSIZE_DEFAULT   (256)
 #endif
 
 #define THREAD_STACKSIZE_IDLE      (128)

--- a/cpu/atmega1281/include/cpu_conf.h
+++ b/cpu/atmega1281/include/cpu_conf.h
@@ -38,8 +38,13 @@ extern "C" {
 #   define THREAD_STACKSIZE_DEFAULT   (256)
 #endif
 
-#define THREAD_STACKSIZE_IDLE      (128)
-#define ISR_STACKSIZE              (0)
+#ifndef THREAD_STACKSIZE_IDLE
+#   define THREAD_STACKSIZE_IDLE      (128)
+#endif
+
+#ifndef ISR_STACKSIZE
+#   define ISR_STACKSIZE              (0)
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/msp430-common/include/cpu_conf.h
+++ b/cpu/msp430-common/include/cpu_conf.h
@@ -17,19 +17,29 @@ extern "C" {
  * @name Kernel configuration
  * @{
  */
-#define THREAD_EXTRA_STACKSIZE_PRINTF    (256)
-#define THREAD_EXTRA_STACKSIZE_PRINTF_FLOAT (THREAD_EXTRA_STACKSIZE_PRINTF)
+#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
+#   define THREAD_EXTRA_STACKSIZE_PRINTF    (256)
+#endif
+
+#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
+#   define THREAD_EXTRA_STACKSIZE_PRINTF_FLOAT (THREAD_EXTRA_STACKSIZE_PRINTF)
+#endif
 
 #ifndef THREAD_STACKSIZE_DEFAULT
 #   define THREAD_STACKSIZE_DEFAULT         (256)
 #endif
 
-#define THREAD_STACKSIZE_IDLE      (96)
-#define ISR_STACKSIZE              (256)
+#ifndef THREAD_STACKSIZE_IDLE
+#   define THREAD_STACKSIZE_IDLE            (96)
+#endif
+
+#ifndef ISR_STACKSIZE
+#   define ISR_STACKSIZE                    (256)
+#endif
 
 #ifndef GNRC_PKTBUF_SIZE
-#   define GNRC_PKTBUF_SIZE                (2560)    /* TODO: Make this value
-                                                   * overall MTU dependent */
+/* TODO: Make this value overall MTU dependent */
+#   define GNRC_PKTBUF_SIZE                 (2560)
 #endif
 /** @} */
 

--- a/cpu/msp430-common/include/cpu_conf.h
+++ b/cpu/msp430-common/include/cpu_conf.h
@@ -21,14 +21,14 @@ extern "C" {
 #define THREAD_EXTRA_STACKSIZE_PRINTF_FLOAT (THREAD_EXTRA_STACKSIZE_PRINTF)
 
 #ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT   (256)
+#   define THREAD_STACKSIZE_DEFAULT         (256)
 #endif
 
 #define THREAD_STACKSIZE_IDLE      (96)
 #define ISR_STACKSIZE              (256)
 
 #ifndef GNRC_PKTBUF_SIZE
-#define GNRC_PKTBUF_SIZE                (2560)    /* TODO: Make this value
+#   define GNRC_PKTBUF_SIZE                (2560)    /* TODO: Make this value
                                                    * overall MTU dependent */
 #endif
 /** @} */


### PR DESCRIPTION
Standard stack sizes are not configurable from the application right now.