### PR TITLE
gnrc_pktqueue: fix doc

### DIFF
--- a/sys/include/net/gnrc/pktqueue.h
+++ b/sys/include/net/gnrc/pktqueue.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @defgroup    net_gnrc_pktqueue Packet Queue
+ * @defgroup    net_gnrc_pktqueue Packet queue
  * @ingroup     net_gnrc
- * @brief       Packet wrapper for the Priority Queue
+ * @brief       @ref gnrc_pktsnip_t queue
  * @{
  *
  * @file
- * @brief       gnrc_pktsnip_t-centric wrapper for @ref priority_queue_t
+ * @brief       Packet queue definitions
  *
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
@@ -33,8 +33,6 @@ extern "C" {
 
 /**
  * @brief   data type for packet queue nodes
- *
- * @extends priority_queue_node_t
  */
 typedef struct gnrc_pktqueue {
     struct gnrc_pktqueue *next; /**< next node in queue */
@@ -42,10 +40,7 @@ typedef struct gnrc_pktqueue {
 } gnrc_pktqueue_t;
 
 /**
- * @brief       add @p node into @p queue based on its priority
- *
- * @details     The new node will be appended after objects with the same
- *              priority.
+ * @brief       add @p node into @p queue.
  *
  * @param[in,out]   queue   the queue, may not be NULL
  * @param[in]       node    the node to add.


### PR DESCRIPTION
The doc for this module was still talking about it as if it were a priority queue which is not the case.