### PR TITLE
at86rf2xx: fix warnings when building with -Wextra -pedantic

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -154,6 +154,7 @@ uint8_t at86rf2xx_get_page(at86rf2xx_t *dev)
 #ifdef MODULE_AT86RF212B
     return dev->page;
 #else
+    (void) dev;
     return 0;
 #endif
 }
@@ -167,6 +168,9 @@ void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page)
     dev->page = page;
 
     at86rf2xx_configure_phy(dev);
+#else
+    (void) dev;
+    (void) page;
 #endif
 }
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -30,6 +30,7 @@
 #define AT86RF2XX_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "board.h"
 #include "periph/spi.h"


### PR DESCRIPTION
I ran into some compile errors when compiling the at86rf2xx module with settings for the native board. Don't ask why I would do that :smile:

However, this fixes those compile errors.