### PR TITLE
make: remove trailing slash from BINDIR and APPDIR variables

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -9,7 +9,7 @@ MODULE ?= $(shell basename $(CURDIR))
 
 .PHONY: all ${DIRS:%=ALL--%} ${DIRS:%=CLEAN--%}
 
-all: $(BINDIR)$(MODULE).a ..nothing
+all: $(BINDIR)/$(MODULE).a ..nothing
 
 ..nothing:
 	@:
@@ -35,22 +35,22 @@ ifeq ($(strip $(ASSMSRC)),)
     ASSMSRC := $(wildcard *.S)
 endif
 
-OBJC_LTO    := $(SRC:%.c=$(BINDIR)$(MODULE)/%.o)
-OBJC_NOLTO  := $(SRC_NOLTO:%.c=$(BINDIR)$(MODULE)/%.o)
+OBJC_LTO    := $(SRC:%.c=$(BINDIR)/$(MODULE)/%.o)
+OBJC_NOLTO  := $(SRC_NOLTO:%.c=$(BINDIR)/$(MODULE)/%.o)
 OBJC        := $(OBJC_NOLTO) $(OBJC_LTO)
-OBJCXX      := $(SRCXX:%.cpp=$(BINDIR)$(MODULE)/%.o)
-ASMOBJ      := $(ASMSRC:%.s=$(BINDIR)$(MODULE)/%.o)
-ASSMOBJ     := $(ASSMSRC:%.S=$(BINDIR)$(MODULE)/%.o)
+OBJCXX      := $(SRCXX:%.cpp=$(BINDIR)/$(MODULE)/%.o)
+ASMOBJ      := $(ASMSRC:%.s=$(BINDIR)/$(MODULE)/%.o)
+ASSMOBJ     := $(ASSMSRC:%.S=$(BINDIR)/$(MODULE)/%.o)
 
 OBJ := $(OBJC) $(OBJCXX) $(ASMOBJ) $(ASSMOBJ)
 DEP := $(OBJC:.o=.d) $(OBJCXX:.o=.d) $(ASSMOBJ:.o=.d)
 
-$(BINDIR)$(MODULE)/:
+$(BINDIR)/$(MODULE)/:
 	$(AD)mkdir -p $@
 
-$(BINDIR)$(MODULE).a $(OBJ): | $(BINDIR)$(MODULE)/
+$(BINDIR)/$(MODULE).a $(OBJ): | $(BINDIR)/$(MODULE)/
 
-$(BINDIR)$(MODULE).a: $(OBJ) | ${DIRS:%=ALL--%}
+$(BINDIR)/$(MODULE).a: $(OBJ) | ${DIRS:%=ALL--%}
 	$(AD)$(AR) $(ARFLAGS) $@ $?
 
 
@@ -60,22 +60,22 @@ CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
 
 $(OBJC_LTO): CFLAGS+=$(LTOFLAGS)
 
-$(OBJC): $(BINDIR)$(MODULE)/%.o: %.c $(RIOTBUILD_CONFIG_HEADER_C)
+$(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(RIOTBUILD_CONFIG_HEADER_C)
 	$(AD)$(CCACHE) $(CC) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
-$(OBJCXX): $(BINDIR)$(MODULE)/%.o: %.cpp $(RIOTBUILD_CONFIG_HEADER_C)
+$(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.cpp $(RIOTBUILD_CONFIG_HEADER_C)
 	$(AD)$(CCACHE) $(CXX) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CXXFLAGS) $(INCLUDES) $(CXXINCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
-$(ASMOBJ): $(BINDIR)$(MODULE)/%.o: %.s
+$(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
 	$(AD)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
 
-$(ASSMOBJ): $(BINDIR)$(MODULE)/%.o: %.S
+$(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S
 	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 # pull in dependency info for *existing* .o files

--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -118,7 +118,7 @@ info-objsize:
 	  sort -rnk$${SORTROW}
 
 info-buildsize:
-	@$(SIZE) -dB $(BINDIR)$(APPLICATION).elf || echo ''
+	@$(SIZE) -dB $(BINDIR)/$(APPLICATION).elf || echo ''
 
 info-buildsizes: SHELL=bash
 info-buildsizes:

--- a/Makefile.include
+++ b/Makefile.include
@@ -25,9 +25,9 @@ override RIOTBOARD      := $(abspath $(RIOTBOARD))
 override RIOTPKG        := $(abspath $(RIOTPKG))
 override RIOTPROJECT    := $(abspath $(RIOTPROJECT))
 override GITCACHE       := $(abspath $(GITCACHE))
-override APPDIR         := $(abspath $(APPDIR))/
+override APPDIR         := $(abspath $(APPDIR))
 override BINDIRBASE     := $(abspath $(BINDIRBASE))
-override BINDIR         := $(abspath $(BINDIR))/
+override BINDIR         := $(abspath $(BINDIR))
 
 # Ensure that all directories are set and don't contain spaces.
 ifneq (, $(filter-out 1, $(foreach v,${__DIRECTORY_VARIABLES},$(words ${${v}}))))
@@ -50,7 +50,7 @@ include $(RIOTBASE)/Makefile.docker
 # Static code analysis tools provided by LLVM
 include $(RIOTBASE)/Makefile.scan-build
 
-export RIOTBUILD_CONFIG_HEADER_C = $(BINDIR)riotbuild/riotbuild.h
+export RIOTBUILD_CONFIG_HEADER_C = $(BINDIR)/riotbuild/riotbuild.h
 
 COLOR_GREEN  :=
 COLOR_RED    :=
@@ -213,8 +213,8 @@ CFLAGS += -DCPU_$(CPUDEF)=\"$(CPU)\" -DRIOT_CPU=CPU_$(CPUDEF)
 CFLAGS += -DMCU_$(MCUDEF)=\"$(MCU)\" -DRIOT_MCU=MCU_$(MCUDEF)
 
 # OSX fails to create empty archives. Provide a wrapper to catch that error.
-ifneq (0, $(shell mkdir -p $(BINDIR); $(AR) rc $(BINDIR)empty-archive.a 2> /dev/null; \
-            echo $$?; rm -f $(BINDIR)empty-archive.a 2>&1 > /dev/null))
+ifneq (0, $(shell mkdir -p $(BINDIR); $(AR) rc $(BINDIR)/empty-archive.a 2> /dev/null; \
+            echo $$?; rm -f $(BINDIR)/empty-archive.a 2>&1 > /dev/null))
 	AR := $(RIOTBASE)/dist/ar-wrapper $(AR)
 endif
 
@@ -237,13 +237,13 @@ ifeq ($(origin RIOT_VERSION), undefined)
 endif
 
 # the binaries to link
-BASELIBS += $(BINDIR)${APPLICATION}.a
+BASELIBS += $(BINDIR)/${APPLICATION}.a
 BASELIBS += $(APPDEPS)
 
 .PHONY: all clean flash term doc debug debug-server reset objdump help info-modules
 .PHONY: ..in-docker-container
 
-ELFFILE ?= $(BINDIR)$(APPLICATION).elf
+ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
 
 # variables used to compile and link c++
@@ -258,13 +258,13 @@ ifeq ($(BUILD_IN_DOCKER),1)
 all: ..in-docker-container
 else
 ## make script for your application. Build RIOT-base here!
-all: ..compiler-check ..build-message $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=${BINDIR}%.a) $(APPDEPS)
+all: ..compiler-check ..build-message $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=${BINDIR}/%.a) $(APPDEPS)
 	$(AD)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTBASE)/Makefile.application
 ifeq (,$(RIOTNOLINK))
 ifeq ($(BUILDOSXNATIVE),1)
 	$(AD)$(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $$(find $(BASELIBS) -size +8c) $(LINKFLAGS) $(LINKFLAGPREFIX)-no_pie
 else
-	$(AD)$(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group  $(LINKFLAGPREFIX)-Map=$(BINDIR)$(APPLICATION).map $(LINKFLAGPREFIX)--cref $(LINKFLAGS)
+	$(AD)$(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group  $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map $(LINKFLAGPREFIX)--cref $(LINKFLAGS)
 endif
 	$(AD)$(SIZE) $(ELFFILE)
 	$(AD)$(OBJCOPY) $(OFLAGS) $(ELFFILE) $(HEXFILE)
@@ -303,10 +303,10 @@ USEMODULE_INCLUDES_ = $(shell echo $(USEMODULE_INCLUDES) | tr ' ' '\n' | awk '!a
 
 INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
 
-.PHONY: $(USEPKG:%=${BINDIR}%.a)
-$(USEPKG:%=${BINDIR}%.a): $(RIOTBUILD_CONFIG_HEADER_C)
+.PHONY: $(USEPKG:%=${BINDIR}/%.a)
+$(USEPKG:%=${BINDIR}/%.a): $(RIOTBUILD_CONFIG_HEADER_C)
 	@mkdir -p ${BINDIR}
-	"$(MAKE)" -C $(RIOTPKG)/$(patsubst ${BINDIR}%.a,%,$@)
+	"$(MAKE)" -C $(RIOTPKG)/$(patsubst ${BINDIR}/%.a,%,$@)
 
 clean:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i clean ; done
@@ -469,12 +469,12 @@ else # RIOT_VERSION
   clean:
 	-$(AD)rm -rf $(BINDIR)
 
-  $(BINDIR)riot-version/$(NUM_RIOT_VERSION)/Makefile.include:
+  $(BINDIR)/riot-version/$(NUM_RIOT_VERSION)/Makefile.include:
 	$(AD)rm -rf $(@D)
 	$(AD)mkdir -p $(@D)
 	$(AD)cd $(RIOTBASE) && git archive --format=tar $(NUM_RIOT_VERSION) | ( cd $(@D) && tar x 1>&2 )
 
-  ..delegate: $(BINDIR)riot-version/$(NUM_RIOT_VERSION)/Makefile.include
+  ..delegate: $(BINDIR)/riot-version/$(NUM_RIOT_VERSION)/Makefile.include
 	@$(COLOR_ECHO) '$(COLOR_GREEN)Using RIOT_VERSION=${NUM_RIOT_VERSION}$(COLOR_RESET)' 1>&2
 	@$(COLOR_ECHO)
 	$(MAKE) RIOTBASE=$(<D) $(filter-out clean, ${MAKECMDGOALS})

--- a/Makefile.modules
+++ b/Makefile.modules
@@ -4,7 +4,7 @@ ED = $(addprefix FEATURE_,$(sort $(filter $(FEATURES_PROVIDED), $(FEATURES_REQUI
 ED += $(addprefix MODULE_,$(sort $(USEMODULE) $(USEPKG)))
 EXTDEFINES = $(addprefix -D,$(shell echo '$(ED)' | tr 'a-z-' 'A-Z_'))
 REALMODULES = $(filter-out $(PSEUDOMODULES), $(sort $(USEMODULE) $(USEPKG)))
-export BASELIBS += $(REALMODULES:%=$(BINDIR)%.a)
+export BASELIBS += $(REALMODULES:%=$(BINDIR)/%.a)
 
 CFLAGS += $(EXTDEFINES)
 

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -29,6 +29,6 @@ export INCLUDES += -I$(RIOTBOARD)/msba2-common/include -I$(RIOTBOARD)/msba2-comm
 
 export OFLAGS = -O ihex
 
-export UNDEF += $(BINDIR)cpu/startup.o
+export UNDEF += $(BINDIR)/cpu/startup.o
 
 USEMODULE += msba2-common-drivers

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -6,7 +6,7 @@ export NATIVEINCLUDES += -I$(RIOTBASE)/core/include/
 export NATIVEINCLUDES += -I$(RIOTBASE)/drivers/include/
 
 export CPU = native
-export ELF = $(BINDIR)$(APPLICATION).elf
+export ELF = $(BINDIR)/$(APPLICATION).elf
 
 USEMODULE += native-drivers
 
@@ -174,4 +174,4 @@ eval-gprof:
 eval-cachegrind:
 	$(CGANNOTATE) $(shell ls -rt cachegrind.out* | tail -1)
 
-export UNDEF += $(BINDIR)cpu/startup.o
+export UNDEF += $(BINDIR)/cpu/startup.o

--- a/boards/x86-multiboot-common/Makefile.include
+++ b/boards/x86-multiboot-common/Makefile.include
@@ -55,7 +55,7 @@ LINKFLAGS += -m32 -nostdlib -nostdinc -nostartfiles -nodefaultlibs \
 export CFLAGS += -ffunction-sections -fdata-sections
 export LINKFLAGS += -Wl,--gc-sections
 
-UNDEF += $(BINDIR)x86-multiboot-common/startup.o
+UNDEF += $(BINDIR)/x86-multiboot-common/startup.o
 
 BASELIBS += $(NEWLIB_BASE)/lib/libc.a \
             $(NEWLIB_BASE)/lib/libm.a

--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -85,7 +85,7 @@ endif
 # Explicitly tell the linker to link the startup code.
 #   Without this the interrupt vectors will not be linked correctly!
 ifeq ($(COMMON_STARTUP),)
-export UNDEF += $(BINDIR)cpu/vectors.o
+export UNDEF += $(BINDIR)/cpu/vectors.o
 endif
 
 # CPU depends on the cortex-m common module, so include it:

--- a/cpu/atmega1281/Makefile.include
+++ b/cpu/atmega1281/Makefile.include
@@ -9,7 +9,7 @@ export ATMEGA_COMMON = $(RIOTCPU)/atmega_common/
 
 # explicitly tell the linker to link the syscalls and startup code.
 #   Without this the interrupt vectors will not be linked correctly!
-export UNDEF += $(BINDIR)cpu/startup.o
+export UNDEF += $(BINDIR)/cpu/startup.o
 
 # CPU depends on the atmega common module, so include it
 include $(ATMEGA_COMMON)Makefile.include

--- a/cpu/atmega2560/Makefile.include
+++ b/cpu/atmega2560/Makefile.include
@@ -9,7 +9,7 @@ export ATMEGA_COMMON = $(RIOTCPU)/atmega_common/
 
 # explicitly tell the linker to link the syscalls and startup code.
 #   Without this the interrupt vectors will not be linked correctly!
-export UNDEF += $(BINDIR)cpu/startup.o
+export UNDEF += $(BINDIR)/cpu/startup.o
 
 # CPU depends on the atmega common module, so include it
 include $(ATMEGA_COMMON)Makefile.include

--- a/cpu/k60/Makefile.include
+++ b/cpu/k60/Makefile.include
@@ -19,7 +19,7 @@ export CFLAGS += -DCPU_ARCH_$(ARCH)
 export COMMON_STARTUP = $(KINETIS_COMMON)
 
 # add the CPU specific system calls implementations for the linker
-export UNDEF += $(BINDIR)cpu/vectors.o
-export UNDEF += $(BINDIR)cpu/ssp.o
+export UNDEF += $(BINDIR)/cpu/vectors.o
+export UNDEF += $(BINDIR)/cpu/ssp.o
 
 include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/k64f/Makefile.include
+++ b/cpu/k64f/Makefile.include
@@ -19,6 +19,6 @@ export CFLAGS += -DCPU_ARCH_$(ARCH)
 export COMMON_STARTUP = $(KINETIS_COMMON)
 
 # add the CPU specific system calls implementations for the linker
-export UNDEF += $(BINDIR)cpu/vectors.o
+export UNDEF += $(BINDIR)/cpu/vectors.o
 
 include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/kinetis_common/Makefile.include
+++ b/cpu/kinetis_common/Makefile.include
@@ -5,7 +5,7 @@ export INCLUDES += -I$(RIOTCPU)/kinetis_common/include
 export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
 
 # add the CPU specific code for the linker
-export UNDEF += $(BINDIR)kinetis_common/fcfield.o
+export UNDEF += $(BINDIR)/kinetis_common/fcfield.o
 
 # include kinetis common periph drivers
 export USEMODULE += kinetis_common_periph

--- a/cpu/kw2x/Makefile.include
+++ b/cpu/kw2x/Makefile.include
@@ -19,6 +19,6 @@ export CFLAGS += -DCPU_ARCH_$(ARCH)
 export COMMON_STARTUP = $(KINETIS_COMMON)
 
 # add the CPU specific system calls implementations for the linker
-export UNDEF += $(BINDIR)cpu/vectors.o
+export UNDEF += $(BINDIR)/cpu/vectors.o
 
 include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/msp430-common/Makefile.include
+++ b/cpu/msp430-common/Makefile.include
@@ -1,6 +1,6 @@
 INCLUDES += -I$(RIOTCPU)/msp430-common/include/
 
-export UNDEF += $(BINDIR)msp430_common/startup.o
+export UNDEF += $(BINDIR)/msp430_common/startup.o
 export USEMODULE += msp430_common
 
 DEFAULT_MODULE += oneway_malloc

--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=cmsis-dsp
 PKG_URL=https://github.com/gebart/CMSIS-DSP.git
-PKG_VERSION=v1.4.5a-riot1
+PKG_VERSION=v1.4.5a-riot2
 
 ifneq ($(RIOTBASE),)
 include $(RIOTBASE)/Makefile.base

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -13,9 +13,9 @@ MODULE:=$(PKG_NAME)
 
 all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR)
-	"$(MAKE)" $(BINDIR)$(MODULE).a
+	"$(MAKE)" $(BINDIR)/$(MODULE).a
 
-$(BINDIR)$(MODULE).a: $(BINDIR)oonf_*.a
-	mkdir -p $(BINDIR)$(MODULE); cd $(BINDIR)$(MODULE); for var in $?; do ar -x $$var; done; ar -r -c -s $(BINDIR)$(MODULE).a *.o
+$(BINDIR)/$(MODULE).a: $(BINDIR)/oonf_*.a
+	mkdir -p $(BINDIR)/$(MODULE); cd $(BINDIR)/$(MODULE); for var in $?; do ar -x $$var; done; ar -r -c -s $(BINDIR)/$(MODULE).a *.o
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -11,7 +11,7 @@ endif
 
 all: $(PKG_BUILDDIR)/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR) && \
-	cp $(PKG_BUILDDIR)/lib/librelic_s.a $(BINDIR)$(PKG_NAME).a
+	cp $(PKG_BUILDDIR)/lib/librelic_s.a $(BINDIR)/$(PKG_NAME).a
 
 $(PKG_BUILDDIR)/comp-options.cmake: fix_source
 	cd "$(PKG_BUILDDIR)" && perl $(PKG_DIR)/generate-cmake-xcompile.perl > comp-options.cmake
@@ -24,5 +24,5 @@ fix_source: git-download
 	./fix-old-style-definitions.sh $(PKG_BUILDDIR)
 
 clean::
-	@rm -rf $(BINDIR)$(PKG_NAME).a
+	@rm -rf $(BINDIR)/$(PKG_NAME).a
 include $(RIOTBASE)/pkg/pkg.mk

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -30,7 +30,7 @@ ifneq (,$(filter cpp11-compat,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/sys/cpp11-compat/include
     # make sure cppsupport.o is linked explicitly because __dso_handle is not
     # found if it is hidden away inside a static object.
-    export UNDEF += $(BINDIR)cpp11-compat/cppsupport.o
+    export UNDEF += $(BINDIR)/cpp11-compat/cppsupport.o
 endif
 
 ifneq (,$(filter gnrc_slip,$(USEMODULE)))

--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -1,5 +1,5 @@
 # compile together the Arduino sketches of the application
-SKETCHES = $(wildcard $(APPDIR)*.sketch)
+SKETCHES = $(wildcard $(APPDIR)/*.sketch)
 SRCDIR = $(RIOTBASE)/sys/arduino
 
 # run the Arduino pre-build script

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -1,4 +1,4 @@
-UNDEF := $(BINDIR)newlib_syscalls_default/syscalls.o $(UNDEF)
+UNDEF := $(BINDIR)/newlib_syscalls_default/syscalls.o $(UNDEF)
 
 ifneq (,$(filter newlib_nano,$(USEMODULE)))
   # Test if nano.specs is available

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -57,7 +57,7 @@ DISABLE_MODULE += auto_init
 -include $(UNIT_TESTS:%=$(RIOTBASE)/tests/unittests/%/Makefile.include)
 
 DIRS += $(UNIT_TESTS)
-BASELIBS += $(UNIT_TESTS:%=$(BINDIR)%.a)
+BASELIBS += $(UNIT_TESTS:%=$(BINDIR)/%.a)
 
 INCLUDES += -I$(RIOTBASE)/tests/unittests/common
 


### PR DESCRIPTION
For historical reasons, those two contained the trailing slash, leading to constructs like "$(BINDIR)test.o" and many double slashes all over the place.