### PR TITLE
make: use gobjcopy if objcopy is not available

### DIFF
--- a/cpu/Makefile.include.gnu
+++ b/cpu/Makefile.include.gnu
@@ -9,11 +9,16 @@ endif
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
-ifneq ("$(wildcard $(PREFIX)objcopy)","")
-export OBJCOPY ?= $(PREFIX)objcopy
+ifeq (,$(OBJCOPY))
+ifneq (,$(shell command -v $(PREFIX)objcopy 2>/dev/null))
+export OBJCOPY = $(PREFIX)objcopy
 else
-export OBJCOPY ?= gobjcopy
-export OFLAGS ?= -O ihex
+ifneq (,$(shell command -v gobjcopy 2>/dev/null))
+export OBJCOPY = gobjcopy
+else
+export OBJCOPY = objcopy
+endif
+endif
 endif
 export OBJDUMP = $(PREFIX)objdump
 export DBG = $(GDBPREFIX)gdb

--- a/cpu/Makefile.include.gnu
+++ b/cpu/Makefile.include.gnu
@@ -9,6 +9,11 @@ endif
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
-export OBJCOPY = $(PREFIX)objcopy
+ifneq ("$(wildcard $(PREFIX)objcopy)","")
+export OBJCOPY ?= $(PREFIX)objcopy
+else
+export OBJCOPY ?= gobjcopy
+export OFLAGS ?= -O ihex
+endif
 export OBJDUMP = $(PREFIX)objdump
 export DBG = $(GDBPREFIX)gdb

--- a/cpu/Makefile.include.gnu
+++ b/cpu/Makefile.include.gnu
@@ -9,6 +9,10 @@ endif
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
-export OBJCOPY = $(shell command -v $(PREFIX)objcopy gobjcopy objcopy touch | head -n 1)
+export OBJCOPY = $(shell command -v $(PREFIX)objcopy gobjcopy objcopy | head -n 1)
+ifeq ($(OBJCOPY),)
+$(warning objcopy not found. Hex file will not be created.)
+export OBJCOPY = true
+endif
 export OBJDUMP = $(PREFIX)objdump
 export DBG = $(GDBPREFIX)gdb

--- a/cpu/Makefile.include.gnu
+++ b/cpu/Makefile.include.gnu
@@ -9,16 +9,6 @@ endif
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
-ifeq (,$(OBJCOPY))
-ifneq (,$(shell command -v $(PREFIX)objcopy 2>/dev/null))
-export OBJCOPY = $(PREFIX)objcopy
-else
-ifneq (,$(shell command -v gobjcopy 2>/dev/null))
-export OBJCOPY = gobjcopy
-else
-export OBJCOPY = objcopy
-endif
-endif
-endif
+export OBJCOPY = $(shell command -v $(PREFIX)objcopy gobjcopy objcopy touch | head -n 1)
 export OBJDUMP = $(PREFIX)objdump
 export DBG = $(GDBPREFIX)gdb


### PR DESCRIPTION
Fixes #5960

BTW, `make TOOLCHAIN=llvm` results in `error: unknown target triple '-Wall', please use -triple or -arch`. We should investigate this later as another issue.
