### PR TITLE
rtt_stdio: update to use xtimer_ticks

### DIFF
--- a/sys/rtt_stdio/rtt_stdio.c
+++ b/sys/rtt_stdio/rtt_stdio.c
@@ -313,7 +313,7 @@ int uart_stdio_read(char* buffer, int count) {
             /* We only unlock when rtt_stdio_enable_stdin is called
                Note that we assume only one caller invoked this function */
         }
-        uint32_t last_wakeup = xtimer_now();
+        xtimer_ticks32_t last_wakeup = xtimer_now();
         while(1) {
             xtimer_periodic_wakeup(&last_wakeup, STDIO_POLL_INTERVAL);
             res = rtt_read(buffer, count);
@@ -326,7 +326,7 @@ int uart_stdio_read(char* buffer, int count) {
 
 int uart_stdio_write(const char* buffer, int len) {
     int written = rtt_write(buffer, len);
-    uint32_t last_wakeup = xtimer_now();
+    xtimer_ticks32_t last_wakeup = xtimer_now();
     while (blocking_stdout && written < len) {
         xtimer_periodic_wakeup(&last_wakeup, STDIO_POLL_INTERVAL);
         written += rtt_write(&buffer[written], len-written);


### PR DESCRIPTION
This is a quick fix that should be merged at the same time as #5608 so that rtt_stdio doesn't break.