### PR TITLE
drivers/at86rf2xx: fix reliance on typical timings

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -127,22 +127,26 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev)
         gpio_clear(dev->params.sleep_pin);
         xtimer_usleep(AT86RF2XX_WAKEUP_DELAY);
 
-        /* update state */
-        dev->state = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
-                         & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
+        /* on some platforms, the timer behind xtimer may be inaccurate
+         * or the radio itself may take longer to wake up due to extra
+         * capacitance on the oscillator. Spin until we are actually
+         * awake
+         */
+        do {
+          dev->state = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
+                           & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
+        } while(dev->state != AT86RF2XX_TRX_STATUS__TRX_OFF);
     }
 }
 
 void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
 {
-    /* wake up from sleep in case radio is sleeping */
-    at86rf2xx_assert_awake(dev);
-
     /* trigger hardware reset */
     gpio_clear(dev->params.reset_pin);
     xtimer_usleep(AT86RF2XX_RESET_PULSE_WIDTH);
     gpio_set(dev->params.reset_pin);
     xtimer_usleep(AT86RF2XX_RESET_DELAY);
+    dev->state = AT86RF2XX_STATE_P_ON;
 }
 
 void at86rf2xx_configure_phy(at86rf2xx_t *dev)

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -77,8 +77,8 @@ static int _init(netdev_t *netdev)
     gpio_set(dev->params.reset_pin);
     gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, _irq_handler, dev);
 
-    /* make sure device is not sleeping, so we can query part number */
-    at86rf2xx_assert_awake(dev);
+    /* reset device to default values and put it into RX state */
+    at86rf2xx_reset(dev);
 
     /* test if the SPI is set up correctly and the device is responding */
     if (at86rf2xx_reg_read(dev, AT86RF2XX_REG__PART_NUM) !=
@@ -90,8 +90,6 @@ static int _init(netdev_t *netdev)
 #ifdef MODULE_NETSTATS_L2
     memset(&netdev->stats, 0, sizeof(netstats_t));
 #endif
-    /* reset device to default values and put it into RX state */
-    at86rf2xx_reset(dev);
 
     return 0;
 }

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -35,18 +35,21 @@ extern "C" {
  * @brief   Transition time from SLEEP to TRX_OFF in us, refer figure 7-4, p.42.
  *          For different environments refer figure 13-13, p.201
  */
-#define AT86RF2XX_WAKEUP_DELAY          (300U)
+#define AT86RF2XX_WAKEUP_DELAY          (306U)
 
 /**
- * @brief   Minimum reset pulse width, refer p.190
+ * @brief   The minimum reset pulse width is 1us, refer p.190. We use 62us so
+ *          that it is at least one tick on platforms with coarse xtimers
  */
-#define AT86RF2XX_RESET_PULSE_WIDTH     (1U)
+#define AT86RF2XX_RESET_PULSE_WIDTH     (62U)
 
 /**
- * @brief   Transition time to TRX_OFF after reset pulse in us, refer
- *          figure 7-8, p. 44.
+ * @brief   The typical transition time to TRX_OFF after reset pulse is 26 us,
+ *          refer to figure 7-8, p. 44. We use 62 us so that it is at least one
+ *          tick on platforms that use a 16384 Hz oscillator or have slow start
+ *          up times due to parasitic capacitance on the oscillator
  */
-#define AT86RF2XX_RESET_DELAY           (26U)
+#define AT86RF2XX_RESET_DELAY           (62U)
 
 /**
  * @brief   Read from a register at address `addr` from device `dev`.

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -95,6 +95,7 @@ extern "C" {
  * @brief   Flags for device internal states (see datasheet)
  * @{
  */
+#define AT86RF2XX_STATE_P_ON           (0x00)     /**< initial power on */
 #define AT86RF2XX_STATE_FORCE_TRX_OFF  (0x03)     /**< force transition to idle */
 #define AT86RF2XX_STATE_TRX_OFF        (0x08)     /**< idle */
 #define AT86RF2XX_STATE_PLL_ON         (0x09)     /**< ready to transmit */


### PR DESCRIPTION
While doing testing of #5608 I discovered that the radio driver for the at86rf2xx uses typical timings for sleeps, and fails pretty badly if those timings are incorrect. In reality, state transition timings can be greater than the typical values quoted in the datasheet. For example:
- The temperature of the radio is different
- The capacitance on the radio oscillator is higher than expected due to parasitics, temperature or contamination
- The oscillator used to measure the state transition is running slow or has low precision.

In particular with #5608, the time intervals will be rounded down when converted to ticks. On some chips, the timer behind xtimer may be as slow as 16384 Hz (like on the Atmel SAM4L where the RTT cannot actually be used at 32khz) which means a tick is roughly 61us. 

This PR does a few things:
- Change one-off state transitions like reset to be longer than a tick. This is quite a bit longer, but resets are infrequent so I don't think the cost is significant.
- Round up WAKEUP_DELAY from 300 us to 306 us so that it goes from 4.9 ticks to 5 ticks for 16384 Hz systems
- Add logic to spin wait after WAKEUP_DELAY in assert_wake to compensate for the extra error that low power oscillators, temperature or contamination may introduce.

For the common case where 306 us was enough for the wakeup, this introduces no additional overhead.

In our testing deployment this fixed many weird radio errors that we got with #5608 pulled in.
