### PR TITLE
pkg: add nanocoap

### DIFF
--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -1,0 +1,66 @@
+# name of your application
+APPLICATION = nanocoap_server
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
+                          nrf6310 pca10000 pca10005 spark-core \
+                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
+                          yunjia-nrf51822 z1 nucleo-f072 nucleo-f030
+
+# blacklist this until #6022 is sorted out
+BOARD_BLACKLIST := nrf52dk
+
+# Include packages that pull up and auto-init the link layer.
+# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+# Specify the mandatory networking modules for IPv6 and UDP
+USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_udp
+# Add a routing protocol
+USEMODULE += gnrc_rpl
+# Additional networking modules that can be dropped if not needed
+USEMODULE += gnrc_icmpv6_echo
+
+#
+USEMODULE += gnrc_sock_udp
+
+USEPKG += nanocoap
+# optionally enable nanocoap's debug output
+#CFLAGS += -DNANOCOAP_DEBUG
+
+# include this for printing IP addresses
+USEMODULE += shell_commands
+
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+#CFLAGS += -DDEVELHELP
+
+# Use different settings when compiling for one of the following (low-memory)
+# boards
+LOW_MEMORY_BOARDS := nucleo-f334
+
+ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
+$(info Using low-memory configuration for microcoap_server.)
+## low-memory tuning values
+# lower pktbuf buffer size
+CFLAGS += -DGNRC_PKTBUF_SIZE=1000
+# disable fib, rpl
+DISABLE_MODULE += fib gnrc_rpl
+USEMODULE += prng_minstd
+endif
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "nanocoap.h"
+
+static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len)
+{
+    return coap_reply_simple(pkt, buf, len,
+            COAP_FORMAT_TEXT, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
+}
+
+const coap_resource_t coap_resources[] = {
+    COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
+    { "/riot/board", COAP_GET, _riot_board_handler },
+};
+
+const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);

--- a/examples/nanocoap_server/main.c
+++ b/examples/nanocoap_server/main.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       CoAP example server application (using nanocoap)
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "nanocoap.h"
+#include "nanocoap_sock.h"
+
+#include "xtimer.h"
+
+#define COAP_INBUF_SIZE (256U)
+
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+/* import "ifconfig" shell command, used for printing addresses */
+extern int _netif_config(int argc, char **argv);
+
+int main(void)
+{
+    puts("RIOT nanocoap example application");
+
+    /* nanocoap_server uses gnrc sock which uses gnrc which needs a msg queue */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+
+    puts("Waiting for address autoconfiguration...");
+    xtimer_sleep(3);
+
+    /* print network addresses */
+    puts("Configured network interfaces:");
+    _netif_config(0, NULL);
+
+    /* initialize nanocoap server instance */
+    uint8_t buf[COAP_INBUF_SIZE];
+    sock_udp_ep_t local = { .port=COAP_PORT, .family=AF_INET6 };
+    nanocoap_server(&local, buf, sizeof(buf));
+
+    /* should be never reached */
+    return 0;
+}

--- a/pkg/nanocoap/Makefile
+++ b/pkg/nanocoap/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=nanocoap
+PKG_URL=https://github.com/kaspar030/sock
+PKG_VERSION=5649e325a3a9047b48ffbbcc283f7a4558978737
+
+.PHONY: all
+
+all: git-download
+	@cp Makefile.nanocoap $(PKG_BUILDDIR)/nanocoap/Makefile
+	"$(MAKE)" -C $(PKG_BUILDDIR)/nanocoap
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nanocoap/Makefile.include
+++ b/pkg/nanocoap/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(BINDIRBASE)/pkg/$(BOARD)/nanocoap/nanocoap

--- a/pkg/nanocoap/Makefile.nanocoap
+++ b/pkg/nanocoap/Makefile.nanocoap
@@ -1,0 +1,5 @@
+MODULE=nanocoap
+
+SRC := nanocoap.c nanocoap_sock.c
+
+include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
Here's the first PR regarding nanocoap.
While nanocoap contains client functionality, that depends on sock, so I've decided to add that at a later stage.

The PR includes an example application that has almost exactly the same functionality as `microcoap_example` (it's also based on conn for now).

Here's a code/memory comparison:

```
[kaspar@booze nanocoap_server (add_pkg_nanocoap)]$ BOARD=samr21-xpro make info-objsize | grep -E '(coap|main)'
    944       0       0     944     3b0 nanocoap.o (ex nanocoap.a)
    144       0     512     656     290 nanocoap_conn.o (ex nanocoap_server.a)
    178       0      64     242      f2 main.o (ex nanocoap_server.a)
    150       0       0     150      96 coap_handler.o (ex nanocoap_server.a)
[kaspar@booze nanocoap_server (add_pkg_nanocoap)]$
```

```
[kaspar@booze microcoap_server (add_pkg_nanocoap)]$ BOARD=samr21-xpro make info-objsize | grep -E '(coap|main)'
    164       8    1536    1708     6ac microcoap_conn.o (ex microcoap_server.a)
   1244       0       0    1244     4dc coap.o (ex microcoap.a)
    468       0     500     968     3c8 coap.o (ex microcoap_server.a)
    179       0      64     243      f3 main.o (ex microcoap_server.a)
[kaspar@booze microcoap_server (add_pkg_nanocoap)]
```

Thats 1416b code / 576b RAM for nanocoap and 2055b code / 2108b RAM for microcoap.
The comparison is favoring nanocoap, as microcoap currently has a little more functionality (it adds content types to /.well-known/core), and its buffers could _probably_ be made smaller. Then again, it is not easy to determine how big they should be for microcoap, which was one of the main reasons why I started the rewrite.

Also, nanocoap only needs 57 lines of CoAP specific SLOC for this simple example, while microcoap needs ~130.
