### PR TITLE
conn.h: fix ascii art

### DIFF
--- a/sys/include/net/conn.h
+++ b/sys/include/net/conn.h
@@ -15,6 +15,7 @@
  * About
  * =====
  *
+ * ~~~~~~~~~~~~~~~~~~~~~
  *    +---------------+
  *    |  Application  |
  *    +---------------+
@@ -28,6 +29,7 @@
  *    +---------------+
  *    | Network Stack |
  *    +---------------+
+ * ~~~~~~~~~~~~~~~~~~~~~
  *
  * This module provides a minimal set of functions to establish a connection using
  * different types of connections. Together, they serve as a common API


### PR DESCRIPTION
The little ASCII art in conn.h currently doesn't get displayed correctly in the HTMLized documentation (see http://doc.riot-os.org/group__net__conn.html), this PR should fix that :)