### PR TITLE
cpu/atmega_common: include time.h for time_t

### DIFF
--- a/cpu/atmega_common/include/sys/time.h
+++ b/cpu/atmega_common/include/sys/time.h
@@ -10,6 +10,7 @@
 #define ATMEGA_TIME_H
 
 #include <sys/types.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
building applications that use `timeval` for `atmega_common` breaks, because `time_t` is not found. This commit includes avr-libc's `time.h` for `time_t`.

@rfuentess is this fixing your problem with tinydtls?