### PR TITLE
cbor: fix off-by-one error

### DIFF
--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -522,7 +522,7 @@ size_t cbor_deserialize_float(const cbor_stream_t *stream, size_t offset, float 
 
     if (*data == CBOR_FLOAT32) {
         *val = ntohf(*(uint32_t *)(data + 1));
-        return 4;
+        return 5;
     }
 
     return 0;

--- a/sys/include/cbor.h
+++ b/sys/include/cbor.h
@@ -221,7 +221,7 @@ size_t cbor_serialize_int(cbor_stream_t *stream, int val);
  * @param[in] offset The offset within the stream where to start deserializing
  * @param[out] val   Pointer to destination array
  *
- * @return Number of bytes written into @p val
+ * @return Number of bytes read from @p stream
  */
 size_t cbor_deserialize_int(const cbor_stream_t *stream, size_t offset,
                             int *val);
@@ -243,7 +243,7 @@ size_t cbor_serialize_uint64_t(cbor_stream_t *stream, uint64_t val);
  * @param[in] offset The offset within the stream where to start deserializing
  * @param[out] val   Pointer to destination array
  *
- * @return Number of bytes written into @p val
+ * @return Number of bytes read from @p stream
  */
 size_t cbor_deserialize_uint64_t(const cbor_stream_t *stream, size_t offset,
                                  uint64_t *val);
@@ -265,7 +265,7 @@ size_t cbor_serialize_int64_t(cbor_stream_t *stream, int64_t val);
  * @param[in] offset The offset within the stream where to start deserializing
  * @param[out] val   Pointer to destination array
  *
- * @return Number of bytes written into @p val
+ * @return Number of bytes read from @p stream
  */
 size_t cbor_deserialize_int64_t(const cbor_stream_t *stream, size_t offset,
                                 int64_t *val);
@@ -287,7 +287,7 @@ size_t cbor_serialize_bool(cbor_stream_t *stream, bool val);
  * @param[in] offset The offset within the stream where to start deserializing
  * @param[out] val   Pointer to destination array
  *
- * @return Number of bytes written into @p val
+ * @return Number of bytes read from @p stream
  */
 size_t cbor_deserialize_bool(const cbor_stream_t *stream, size_t offset,
                              bool *val);
@@ -311,7 +311,7 @@ size_t cbor_serialize_float_half(cbor_stream_t *stream, float val);
  * @param[in] offset The offset within the stream where to start deserializing
  * @param[out] val   Pointer to destination array
  *
- * @return Number of bytes written into @p val
+ * @return Number of bytes read from @p stream
  */
 size_t cbor_deserialize_float_half(const cbor_stream_t *stream, size_t offset,
                                    float *val);
@@ -332,7 +332,7 @@ size_t cbor_serialize_float(cbor_stream_t *stream, float val);
  * @param[in] offset The offset within the stream where to start deserializing
  * @param[out] val   Pointer to destination array
  *
- * @return Number of bytes written into @p val
+ * @return Number of bytes read from @p stream
  */
 size_t cbor_deserialize_float(const cbor_stream_t *stream, size_t offset,
                               float *val);
@@ -354,7 +354,7 @@ size_t cbor_serialize_double(cbor_stream_t *stream, double val);
  * @param[in] offset The offset within the stream where to start deserializing
  * @param[out] val   Pointer to destination array
  *
- * @return Number of bytes written into @p val
+ * @return Number of bytes read from @p stream
  */
 size_t cbor_deserialize_double(const cbor_stream_t *stream, size_t offset,
                                double *val);
@@ -389,7 +389,7 @@ size_t cbor_serialize_byte_stringl(cbor_stream_t *stream, const char *val, size_
  * @param[out] val   Pointer to destination array
  * @param[in] length Length of destination array
  *
- * @return Number of bytes written into @p val
+ * @return Number of bytes read from @p stream
  */
 size_t cbor_deserialize_byte_string(const cbor_stream_t *stream, size_t offset,
                                     char *val, size_t length);
@@ -404,7 +404,7 @@ size_t cbor_serialize_unicode_string(cbor_stream_t *stream, const char *val);
  * @param[out] val   Pointer to destination array
  * @param[in] length Length of destination array
  *
- * @return Number of bytes written into @p val
+ * @return Number of bytes read from @p stream
  */
 size_t cbor_deserialize_unicode_string(const cbor_stream_t *stream,
                                        size_t offset, char *val, size_t length);

--- a/tests/unittests/tests-cbor/tests-cbor.c
+++ b/tests/unittests/tests-cbor/tests-cbor.c
@@ -61,7 +61,7 @@ static void my_cbor_print(const cbor_stream_t *stream)
     TEST_ASSERT(cbor_serialize_##function_suffix(&stream, input)); \
     CBOR_CHECK_SERIALIZED(stream, data, sizeof(data)); \
     cbor_stream_t tmp = {data, sizeof(data), sizeof(data)}; \
-    TEST_ASSERT(cbor_deserialize_##function_suffix(&tmp, 0, &buffer)); \
+    TEST_ASSERT_EQUAL_INT(sizeof(data), cbor_deserialize_##function_suffix(&tmp, 0, &buffer)); \
     CBOR_CHECK_DESERIALIZED(input, buffer, comparator); \
 } while (0)
 


### PR DESCRIPTION
Fixes #5420. I don't understand the unittests enough to see if they pick it up, and if yes, how to fix them. (or how to fix them that they *can* register such off by one errors, if they are not testing for it).