### PR TITLE
ieee802154: centralize default values

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -24,6 +24,7 @@
 
 #include <stdbool.h>
 
+#include "net/ieee802154.h"
 #include "net/netdev2.h"
 #include "net/netdev2/ieee802154.h"
 
@@ -45,25 +46,18 @@ extern "C" {
 #define IEEE802154_MIN_FREQ         (2405) /**< Min. frequency (2405 MHz) */
 #define IEEE802154_MAX_FREQ         (2480) /**< Max. frequency (2480 MHz) */
 
-#define IEEE802154_MIN_CHANNEL      (11)   /**< Min. channel (2405 MHz) */
-#define IEEE802154_MAX_CHANNEL      (26)   /**< Max. channel (2480 MHz) */
 #define IEEE802154_CHANNEL_SPACING  (5)    /**< Channel spacing in MHz  */
 
-#define IEEE802154_CHAN2FREQ(chan)  ( IEEE802154_MIN_FREQ + ((chan) - IEEE802154_MIN_CHANNEL) * IEEE802154_CHANNEL_SPACING )
-#define IEEE802154_FREQ2CHAN(freq)  ( IEEE802154_MIN_CHANNEL + ((freq) - IEEE802154_MIN_FREQ) / IEEE802154_CHANNEL_SPACING )
+#define IEEE802154_CHAN2FREQ(chan)  ( IEEE802154_MIN_FREQ + ((chan) - IEEE802154_CHANNEL_MIN) * IEEE802154_CHANNEL_SPACING )
+#define IEEE802154_FREQ2CHAN(freq)  ( IEEE802154_CHANNEL_MIN + ((freq) - IEEE802154_MIN_FREQ) / IEEE802154_CHANNEL_SPACING )
 /* /TODO */
 
 #define CC2538_MIN_FREQ             (2394)
 #define CC2538_MAX_FREQ             (2507)
 
-#define CC2538_RF_POWER_DEFAULT     (3)    /**< Default output power in dBm */
-#ifdef DEFAULT_CHANNEL
-#define CC2538_RF_CHANNEL_DEFAULT   (DEFAULT_CHANNEL)
-#endif
-#ifndef CC2538_RF_CHANNEL_DEFAULT
-#define CC2538_RF_CHANNEL_DEFAULT   (26U)
-#endif
-#define CC2538_RF_PANID_DEFAULT     (0x0023)
+#define CC2538_RF_POWER_DEFAULT     (IEEE802154_DEFAULT_TXPOWER)    /**< Default output power in dBm */
+#define CC2538_RF_CHANNEL_DEFAULT   (IEEE802154_DEFAULT_CHANNEL)
+#define CC2538_RF_PANID_DEFAULT     (IEEE802154_DEFAULT_PANID)
 
 #define OUTPUT_POWER_MIN            (-24)  /**< Min output power in dBm */
 #define OUTPUT_POWER_MAX            (7)    /**< Max output power in dBm */

--- a/cpu/cc2538/radio/cc2538_rf_getset.c
+++ b/cpu/cc2538/radio/cc2538_rf_getset.c
@@ -169,15 +169,15 @@ void cc2538_set_chan(unsigned int chan)
 {
     DEBUG("%s(%u): Setting channel to ", __FUNCTION__, chan);
 
-    if (chan < IEEE802154_MIN_CHANNEL) {
-        chan = IEEE802154_MIN_CHANNEL;
+    if (chan < IEEE802154_CHANNEL_MIN) {
+        chan = IEEE802154_CHANNEL_MIN;
     }
-    else if (chan > IEEE802154_MAX_CHANNEL) {
-        chan = IEEE802154_MAX_CHANNEL;
+    else if (chan > IEEE802154_CHANNEL_MAX) {
+        chan = IEEE802154_CHANNEL_MAX;
     }
 
-    DEBUG("%i (range %i-%i)\n", chan, IEEE802154_MIN_CHANNEL,
-                                      IEEE802154_MAX_CHANNEL);
+    DEBUG("%i (range %i-%i)\n", chan, IEEE802154_CHANNEL_MIN,
+                                      IEEE802154_CHANNEL_MAX);
 
     cc2538_set_freq(IEEE802154_CHAN2FREQ(chan));
 }

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -187,8 +187,8 @@ static int _set(netdev2_t *netdev, netopt_t opt, void *value, size_t value_len)
             }
             else {
                 uint8_t chan = ((uint8_t *)value)[0];
-                if (chan < IEEE802154_MIN_CHANNEL ||
-                    chan > IEEE802154_MAX_CHANNEL) {
+                if (chan < IEEE802154_CHANNEL_MIN ||
+                    chan > IEEE802154_CHANNEL_MAX) {
                     res = -EINVAL;
                 }
                 else {

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -45,7 +45,7 @@ extern "C" {
 /**
  * @brief   Maximum possible packet size in byte
  */
-#define AT86RF2XX_MAX_PKT_LENGTH        (127)
+#define AT86RF2XX_MAX_PKT_LENGTH        (IEEE802154_FRAME_LEN_MAX)
 
 /**
  * @brief   Default addresses used if the CPUID module is not present
@@ -61,23 +61,13 @@ extern "C" {
  */
 #ifdef MODULE_AT86RF212B
 /* the AT86RF212B has a sub-1GHz radio */
-#define AT86RF2XX_MIN_CHANNEL           (0)
-#define AT86RF2XX_MAX_CHANNEL           (10)
-#ifdef DEFAULT_CHANNEL
-#define AT86RF2XX_DEFAULT_CHANNEL (DEFAULT_CHANNEL)
-#endif
-#ifndef AT86RF2XX_DEFAULT_CHANNEL
-#define AT86RF2XX_DEFAULT_CHANNEL       (5)
-#endif
+#define AT86RF2XX_MIN_CHANNEL           (IEEE802154_CHANNEL_MIN_SUBGHZ)
+#define AT86RF2XX_MAX_CHANNEL           (IEEE802154_CHANNEL_MAX_SUBGHZ)
+#define AT86RF2XX_DEFAULT_CHANNEL       (IEEE802154_DEFAULT_SUBGHZ_CHANNEL)
 #else
-#define AT86RF2XX_MIN_CHANNEL           (11U)
-#define AT86RF2XX_MAX_CHANNEL           (26U)
-#ifdef DEFAULT_CHANNEL
-#define AT86RF2XX_DEFAULT_CHANNEL (DEFAULT_CHANNEL)
-#endif
-#ifndef AT86RF2XX_DEFAULT_CHANNEL
-#define AT86RF2XX_DEFAULT_CHANNEL       (26U)
-#endif
+#define AT86RF2XX_MIN_CHANNEL           (IEEE802154_CHANNEL_MIN)
+#define AT86RF2XX_MAX_CHANNEL           (IEEE802154_CHANNEL_MAX)
+#define AT86RF2XX_DEFAULT_CHANNEL       (IEEE802154_DEFAULT_CHANNEL)
 #endif
 /** @} */
 
@@ -86,12 +76,12 @@ extern "C" {
  *
  * @todo    Read some global network stack specific configuration value
  */
-#define AT86RF2XX_DEFAULT_PANID         (0x0023)
+#define AT86RF2XX_DEFAULT_PANID         (IEEE802154_DEFAULT_PANID)
 
 /**
  * @brief   Default TX power (0dBm)
  */
-#define AT86RF2XX_DEFAULT_TXPOWER       (0U)
+#define AT86RF2XX_DEFAULT_TXPOWER       (IEEE802154_DEFAULT_TXPOWER)
 
 /**
  * @brief   Base (minimal) RSSI value in dBm

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -36,7 +36,7 @@ extern "C" {
 /**
  * @brief   Maximum possible packet size in byte
  */
-#define CC2420_PKT_MAXLEN       (127U)
+#define CC2420_PKT_MAXLEN       (IEEE802154_FRAME_LEN_MAX)
 
 /**
  * @brief   Default addresses used if the CPUID module is not present
@@ -49,20 +49,15 @@ extern "C" {
 /**
  * @brief   PAN ID configuration
  */
-#define CC2420_PANID_DEFAULT    (0x0023)
+#define CC2420_PANID_DEFAULT    (IEEE802154_DEFAULT_PANID)
 
 /**
   * @brief   Channel configuration
   * @{
   */
-#define CC2420_CHAN_MIN         (11U)
-#define CC2420_CHAN_MAX         (26U)
-#ifdef DEFAULT_CHANNEL
-#define CC2420_CHAN_DEFAULT     (DEFAULT_CHANNEL)
-#endif
-#ifndef CC2420_CHAN_DEFAULT
-#define CC2420_CHAN_DEFAULT     (26U)
-#endif
+#define CC2420_CHAN_MIN         (IEEE802154_CHANNEL_MIN)
+#define CC2420_CHAN_MAX         (IEEE802154_CHANNEL_MAX)
+#define CC2420_CHAN_DEFAULT     (IEEE802154_DEFAULT_CHANNEL)
 /** @} */
 
 /**
@@ -71,7 +66,7 @@ extern "C" {
  */
 #define CC2420_TXPOWER_MIN      (-25)
 #define CC2420_TXPOWER_MAX      (0)
-#define CC2420_TXPOWER_DEFAULT  (0)
+#define CC2420_TXPOWER_DEFAULT  (IEEE802154_DEFAULT_TXPOWER)
 /** @} */
 
 /**

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -28,6 +28,7 @@
 #include "periph/spi.h"
 #include "periph/gpio.h"
 #include "net/gnrc/netdev.h"
+#include "net/ieee802154.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +37,7 @@ extern "C" {
 /**
  * @brief   Maximum packet length
  */
-#define KW2XRF_MAX_PKT_LENGTH         (127U)
+#define KW2XRF_MAX_PKT_LENGTH         (IEEE802154_FRAME_LEN_MAX)
 
 /**
  * @brief   Default protocol for data that is coming in
@@ -60,7 +61,7 @@ extern "C" {
 /**
  * @brief   Default PAN ID used after initialization
  */
-#define KW2XRF_DEFAULT_PANID          (0x0023)
+#define KW2XRF_DEFAULT_PANID          (IEEE802154_DEFAULT_PANID)
 
 /**
  * @brief   Default channel used after initialization
@@ -69,13 +70,13 @@ extern "C" {
 #define KW2XRF_DEFAULT_CHANNEL (DEFAULT_CHANNEL)
 #endif
 #ifndef KW2XRF_DEFAULT_CHANNEL
-#define KW2XRF_DEFAULT_CHANNEL        (26U)
+#define KW2XRF_DEFAULT_CHANNEL        (IEEE802154_DEFAULT_CHANNEL)
 #endif
 
 /**
  * @brief   Default TX_POWER in dbm used after initialization
  */
-#define KW2XRF_DEFAULT_TX_POWER       (0)
+#define KW2XRF_DEFAULT_TX_POWER       (IEEE802154_DEFAULT_TXPOWER)
 
 /**
  * @brief   Maximum output power of the kw2x device in dBm

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -67,17 +67,12 @@ extern "C" {
 /**
  * @brief   Default PAN ID used after initialization
  */
-#define XBEE_DEFAULT_PANID          (0x0023)
+#define XBEE_DEFAULT_PANID          (IEEE802154_DEFAULT_PANID)
 
 /**
  * @brief   Default channel used after initialization
  */
-#ifdef DEFAULT_CHANNEL
-#define XBEE_DEFAULT_CHANNEL (DEFAULT_CHANNEL)
-#endif
-#ifndef XBEE_DEFAULT_CHANNEL
-#define XBEE_DEFAULT_CHANNEL        (23U)
-#endif
+#define XBEE_DEFAULT_CHANNEL        (IEEE802154_DEFAULT_CHANNEL)
 
 /**
  * @name    Address flags

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -69,8 +69,18 @@ ifneq (,$(filter msba2,$(BOARD)))
   USEMODULE += random
 endif
 
-# Set a custom 802.15.4 channel if needed
-DEFAULT_CHANNEL ?= 26
-CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-
 include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+ifeq (,$(filter cc110x,$(USEMODULE)))     # radio is cc110x sub-GHz
+  DEFAULT_CHANNEL ?= 0
+  CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+else
+  ifeq (,$(filter at86rf212b,$(USEMODULE)))   # radio is IEEE 802.15.4 sub-GHz
+    DEFAULT_CHANNEL ?= 5
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+  else                                      # radio is IEEE 802.15.4 2.4 GHz
+    DEFAULT_CHANNEL ?= 26
+    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+  endif
+endif

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -43,10 +43,6 @@ USEMODULE += ps
 # include UHCP client
 USEMODULE += gnrc_uhcpc
 
-# Set a custom 802.15.4 channel if needed
-DEFAULT_CHANNEL ?= 26
-CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
@@ -66,3 +62,17 @@ term: host-tools
 
 host-tools:
 	$(AD)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools
+
+# Set a custom channel if needed
+ifeq (,$(filter cc110x,$(USEMODULE)))     # radio is cc110x sub-GHz
+  DEFAULT_CHANNEL ?= 0
+  CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+else
+  ifeq (,$(filter at86rf212b,$(USEMODULE)))   # radio is IEEE 802.15.4 sub-GHz
+    DEFAULT_CHANNEL ?= 5
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+  else                                      # radio is IEEE 802.15.4 2.4 GHz
+    DEFAULT_CHANNEL ?= 26
+    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+  endif
+endif

--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -36,13 +36,23 @@ USEMODULE += gnrc_icmpv6_echo
 # Use minimal standard PRNG
 USEMODULE += prng_minstd
 
-# Set a custom 802.15.4 channel if needed
-DEFAULT_CHANNEL ?= 26
-CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-
 CFLAGS += -DGNRC_PKTBUF_SIZE=512 -DGNRC_IPV6_NETIF_ADDR_NUMOF=4 -DGNRC_IPV6_NC_SIZE=1
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+ifeq (,$(filter cc110x,$(USEMODULE)))     # radio is cc110x sub-GHz
+  DEFAULT_CHANNEL ?= 0
+  CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+else
+  ifeq (,$(filter at86rf212b,$(USEMODULE)))   # radio is IEEE 802.15.4 sub-GHz
+    DEFAULT_CHANNEL ?= 5
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+  else                                      # radio is IEEE 802.15.4 2.4 GHz
+    DEFAULT_CHANNEL ?= 26
+    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+  endif
+endif

--- a/examples/microcoap_server/Makefile
+++ b/examples/microcoap_server/Makefile
@@ -33,10 +33,6 @@ CFLAGS += -DMICROCOAP_DEBUG
 # include this for printing IP addresses
 USEMODULE += shell_commands
 
-# Set a custom 802.15.4 channel if needed
-DEFAULT_CHANNEL ?= 26
-CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
@@ -60,3 +56,17 @@ endif
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+ifeq (,$(filter cc110x,$(USEMODULE)))     # radio is cc110x sub-GHz
+  DEFAULT_CHANNEL ?= 0
+  CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+else
+  ifeq (,$(filter at86rf212b,$(USEMODULE)))   # radio is IEEE 802.15.4 sub-GHz
+    DEFAULT_CHANNEL ?= 5
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+  else                                      # radio is IEEE 802.15.4 2.4 GHz
+    DEFAULT_CHANNEL ?= 26
+    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+  endif
+endif

--- a/sys/include/net/gnrc/zep.h
+++ b/sys/include/net/gnrc/zep.h
@@ -82,9 +82,9 @@ extern "C" {
  * @brief   Channel configuration
  * @{
  */
-#define GNRC_ZEP_MIN_CHANNEL        (11U)
-#define GNRC_ZEP_MAX_CHANNEL        (26U)
-#define GNRC_ZEP_DEFAULT_CHANNEL    (26U)
+#define GNRC_ZEP_MIN_CHANNEL        (IEEE802154_CHANNEL_MIN)
+#define GNRC_ZEP_MAX_CHANNEL        (IEEE802154_CHANNEL_MAX)
+#define GNRC_ZEP_DEFAULT_CHANNEL    (IEEE802154_DEFAULT_CHANNEL)
 /**
  * @}
  */
@@ -94,7 +94,7 @@ extern "C" {
  *
  * @todo Read some global network stack specific configuration value
  */
-#define GNRC_ZEP_DEFAULT_PANID  (0x0023)
+#define GNRC_ZEP_DEFAULT_PANID  (IEEE802154_DEFAULT_PANID)
 
 /**
  * @brief   Option flags for the ZEP device

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -78,6 +78,21 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Channel ranges
+ * @{
+ */
+/**
+ * @brief   Minimum channel for sub-GHz band
+ */
+#define IEEE802154_CHANNEL_MIN_SUBGHZ   (0U)
+#define IEEE802154_CHANNEL_MAX_SUBGHZ   (10U)   /**< Maximum channel for sub-GHz band */
+#define IEEE802154_CHANNEL_MIN          (11U)   /**< Minimum channel for 2.4 GHz band */
+#define IEEE802154_CHANNEL_MAX          (26U)   /**< Maximum channel for 2.4 GHz band */
+/** @} */
+
+#define IEEE802154_FRAME_LEN_MAX        (127U)  /**< maximum frame length */
+
+/**
  * @brief   Special address defintions
  * @{
  */
@@ -95,6 +110,28 @@ extern "C" {
  * @brief   Broadcast address
  */
 extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
+/** @} */
+
+/**
+ * @{
+ * @name    Default values
+ * @brief   Default values for devices to choose
+ */
+#ifndef IEEE802154_DEFAULT_SUBGHZ_CHANNEL
+#define IEEE802154_DEFAULT_SUBGHZ_CHANNEL   (5U)
+#endif
+
+#ifndef IEEE802154_DEFAULT_CHANNEL
+#define IEEE802154_DEFAULT_CHANNEL          (26U)
+#endif
+
+#ifndef IEEE802154_DEFAULT_PANID
+#define IEEE802154_DEFAULT_PANID            (0x0023U)
+#endif
+
+#ifndef IEEE802154_DEFAULT_TXPOWER
+#define IEEE802154_DEFAULT_TXPOWER          (0) /* in dBm */
+#endif
 /** @} */
 
 /**

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_uart periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery weio nucleo-f030
+BOARD_INSUFFICIENT_MEMORY := nucleo-f030 nucleo-f334 stm32f0discovery weio
 
 USEMODULE += xbee
 USEMODULE += gnrc_netif


### PR DESCRIPTION
Fixes #3291.

I also changed up the selection of the default channel a little bit, since it was limited to 2.4 GHz IEEE 802.15.4 only. This solution isn't perfect either, but better than the previous one I think.