### PR TITLE
boards: add remote-revb

### DIFF
--- a/boards/remote-pa/Makefile.dep
+++ b/boards/remote-pa/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/remote-common/Makefile.dep

--- a/boards/remote-reva/Makefile.dep
+++ b/boards/remote-reva/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/remote-common/Makefile.dep

--- a/boards/remote-revb/Makefile
+++ b/boards/remote-revb/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/remote-common
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/remote-revb/Makefile.dep
+++ b/boards/remote-revb/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/remote-common/Makefile.dep

--- a/boards/remote-revb/Makefile.features
+++ b/boards/remote-revb/Makefile.features
@@ -1,0 +1,14 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/remote-revb/Makefile.include
+++ b/boards/remote-revb/Makefile.include
@@ -1,0 +1,7 @@
+USEMODULE += remote-common
+
+# define the default port depending on the host OS
+PORT_LINUX  ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+include $(RIOTBOARD)/remote-common/Makefile.include

--- a/boards/remote-revb/README.md
+++ b/boards/remote-revb/README.md
@@ -1,0 +1,117 @@
+Zolertia RE-Mote platform
+============================================
+
+The RE-Mote platform (Revision B) is a IoT Hardware development platform based
+on TI's CC2538 system on chip (SoC), featuring an ARM Cortex-M3 with 512KB
+flash, 32Kb RAM, double RF interface (Sub-1GHz CC1200 RF transceiver), and the
+following goodies:
+
+* ISM 2.4-GHz IEEE 802.15.4 & Zigbee compliant.
+* ISM 868-, 915-, 920-, 950-MHz ISM/SRD Band.
+* AES-128/256, SHA2 Hardware Encryption Engine.
+* ECC-128/256, RSA Hardware Acceleration Engine for Secure Key Exchange.
+* Power consumption down to 150nA using our shutdown mode.
+* Flashing over BSL without requiring to press any button to enter bootloader mode.
+* Built-in battery charger (500mA), Energy Harvesting and Solar Panels to be connected to standards LiPo batteries.
+* Power input with wide range 3.7-16VDC.
+
+
+Changes from Revision A
+=========================
+
+The list of changes are summarized in the [Wiki](https://github.com/Zolertia/Resources/wiki/RE-Mote:-Enhancements-from-Rev.A-to-Rev.B)
+
+Port Features
+=============
+In terms of hardware support, the following drivers have been implemented:
+
+  * CC2538 System-on-Chip:
+    * UART
+    * Random number generator
+    * Low Power Modes
+    * General-Purpose Timers
+    * I2C/SPI library
+    * LEDs
+    * Buttons
+    * RF switch to programatically drive either 2.4GHz or sub-1GHz to a single RP-SMA
+    * RF 2.4GHz built-in in CC2538
+
+And under work or pending at cc2538 base cpu:
+
+    * Built-in core temperature and battery sensor.
+    * CC1200 sub-1GHz radio interface.
+    * Micro-SD external storage.
+    * ADC
+    * USB (in CDC-ACM).
+    * uDMA Controller.
+
+Requirements
+============
+
+ * Toolchain to compile RIOT for the CC2538
+ * Drivers to enable your host to communicate with the platform
+ * Built-in BSL programming over USB using cc2538-bsl (included)
+
+
+Install a Toolchain
+-------------------
+The toolchain used to build is arm-gcc, to check if it is currently installed run:
+
+    $ arm-none-eabi-gcc -v
+    Using built-in specs.
+    Target: arm-none-eabi
+    Configured with: /scratch/julian/lite-respin/eabi/src/gcc-4.3/configure
+    ...
+    (skip)
+    ...
+    Thread model: single
+    gcc version 4.3.2 (Sourcery G++ Lite 2008q3-66)
+
+Else install from <https://launchpad.net/gcc-arm-embedded>
+
+
+Drivers
+-------
+The RE-Mote features a CP2104 serial-to-USB module, the driver is commonly found in most OS, but if required it can be downloaded
+from <https://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
+
+
+### For the CC2538EM (USB CDC-ACM)
+The RE-Mote has built-in support for USB 2.0 USB, Vendor and Product IDs are the following:
+
+  * VID 0x0451
+  * PID 0x16C8
+
+On Linux and OS X this is straightforward, on windows you need to install the following driver:
+
+<https://github.com/alignan/lufa/blob/remote-zongle/LUFA/CodeTemplates/WindowsINF/LUFA%20CDC-ACM.inf>
+
+And replace the IDs accordingly.
+
+### Device Enumerations
+For the UART, serial line settings are 115200 8N1, no flow control.
+
+Once all drivers have been installed correctly:
+
+On windows, devices will appear as a virtual `COM` port.
+
+On Linux, devices will appear under `/dev/`.
+
+On OS X, `/dev/tty.SLAB_USBtoUARTx`.
+
+On Linux:
+
+* RE-Mote over CP2104: `ttyUSB0`
+* RE-Mote over USB driver (in CDC-ACM): `ttyACMn` (n=0, 1, ....)
+
+More Reading
+============
+1. [Zolertia RE-Mote website][remote-site]
+2. [Zolertia Wiki page][zolertia-wiki]
+2. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
+3. [CC1200 sub-1GHz RF transceiver][cc1200]
+
+[remote-site]: http://www.zolertia.io/products "Zolertia RE-Mote"
+[zolertia-wiki]: https://github.com/Zolertia/Resources/wiki
+[cc1200]: http://www.ti.com/product/cc1200     "CC1200"
+[cc2538]: http://www.ti.com/product/cc2538     "CC2538"

--- a/boards/remote-revb/board.c
+++ b/boards/remote-revb/board.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 Zolertia SL
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    boards_remote
+ * @ingroup     boards
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the RE-Mote revision B board
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *              Antonio Lignan <alinan@zolertia.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+#include "fancy_leds.h"
+
+static inline void leds_init(void);
+static inline void rf_switch_init(void);
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    leds_init();
+    /* initialize the CPU */
+    cpu_init();
+    /* initialize the 2.4GHz RF switch */
+    rf_switch_init();
+}
+
+/**
+ * @brief Initialize the boards on-board LEDs
+ *
+ * The LED initialization is hard-coded in this function. As the LED (RGB) are
+ * soldered onto the board they are fixed to their CPU pins.
+ */
+static inline void leds_init(void)
+{
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
+
+    /* Shoot rainbows */
+    LED_RAINBOW();
+}
+
+/**
+ * @brief Initialize the Radio interface SW-controlled Switch
+ *
+ * The RE-Mote features an on-board RF switch to programatically select to
+ * enable either the 2.4GHz or Sub-1GHz RF interface to the RP-SMA connector
+ * to use an external antenna.  As default we prefer to use the 2.4GHz RF.
+ *
+ */
+static void rf_switch_init(void)
+{
+    /* Set RF 2.4GHz as default */
+    gpio_init(RF_SWITCH_GPIO, GPIO_OUT);
+    RF_SWITCH_2_4_GHZ;
+}

--- a/boards/remote-revb/include/board.h
+++ b/boards/remote-revb/include/board.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 Zolertia SL
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_remote
+ * @brief       Support for the RE-Mote board Revision B
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the RE-Mote board Revision B
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *              Antonio Lignan <alinan@zolertia.com>
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#include "cpu.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name LED pin definitions
+ * @{
+ */
+#define LED0_PIN        GPIO_PD4
+#define LED1_PIN        GPIO_PB7
+#define LED2_PIN        GPIO_PB6
+
+#define LED0_MASK       (1 << 4)
+#define LED1_MASK       (1 << 7)
+#define LED2_MASK       (1 << 6)
+
+#define LED0_ON         (GPIO_D->DATA |=  LED0_MASK)
+#define LED0_OFF        (GPIO_D->DATA &= ~LED0_MASK)
+#define LED0_TOGGLE     (GPIO_D->DATA ^=  LED0_MASK)
+
+#define LED1_ON         (GPIO_B->DATA |=  LED1_MASK)
+#define LED1_OFF        (GPIO_B->DATA &= ~LED1_MASK)
+#define LED1_TOGGLE     (GPIO_B->DATA ^=  LED1_MASK)
+
+#define LED2_ON         (GPIO_B->DATA |=  LED2_MASK)
+#define LED2_OFF        (GPIO_B->DATA &= ~LED2_MASK)
+#define LED2_TOGGLE     (GPIO_B->DATA ^=  LED2_MASK)
+/** @} */
+
+/**
+ * @name  RF switch controlled by SW
+ * @brief Controls which RF interface goes to the RP-SMA external antenna
+ *
+ * These values configure the required pin to drive the RF antenna switch, to
+ * either enable the sub-1Ghz RF interface (power-up the CC1200) or the 2.4GHz
+ * RF interface of the CC2538, both alternatively routed to a RP-SMA connector
+ * to allow using an external antenna for both cases.
+ *
+ * Note it is also possible to enable both RF interfaces at the same time, by
+ * switching On the sub-1GHz RF interface, and placing an 0Ohm resistor (R19),
+ * to select between using a ceramic chip antenna (not mounted), or to connect
+ * and external antenna over a pigtail to the U.Fl connector (not mounted).
+ *
+ * RF switch state:
+ * - LOW: 2.4GHz RF interface on RP-SMA connector, CC1200 powered-off.
+ * - HIGH: Sub-1GHz RF interface on RP-SMA connector.
+ *
+ * @{
+ */
+#define RF_SWITCH_GPIO      GPIO_PD2
+#define RF_SWITCH_SUB_GHZ   gpio_set(RF_SWITCH_GPIO)
+#define RF_SWITCH_2_4_GHZ   gpio_clear(RF_SWITCH_GPIO)
+#define RF_SWITCH_TOGGLE    gpio_toggle(RF_SWITCH_GPIO)
+/** @} */
+
+/**
+ * @name Power management enable pin
+ * @{
+ */
+#define SHUTDOWN_EN_GPIO    GPIO_PD1
+/** @} */
+
+/**
+ * @name CC1200 SPI and pins definitions
+ * @{
+ */
+#define CC1200_SPI_DEV      SSI0
+#define CC1200_MOSI_GPIO    GPIO_PB1
+#define CC1200_MISO_GPIO    GPIO_PB3
+#define CC1200_SCLK_GPIO    GPIO_PB2
+#define CC1200_CSN_GPIO     GPIO_PB5
+#define CC1200_RESET_GPIO   GPIO_PC7
+#define CC1200_GPD0_GPIO    GPIO_PB4
+#define CC1200_GPD2_GPIO    GPIO_PB0
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+#endif /* BOARD_H_ */
+/** @} */

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 Zolertia SL
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     board_remote
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the RE-Mote board revision B
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *              Antonio Lignan <alinan@zolertia.com>
+ */
+
+#ifndef PERIPH_CONF_H_
+#define PERIPH_CONF_H_
+
+#include "cc2538_gpio.h"
+#include "periph_cpu.h"
+#include "periph_common.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_0_EN           1
+#define UART_IRQ_PRIO       1
+
+/* UART 0 device configuration */
+#define UART_0_DEV          UART0
+#define UART_0_IRQ          UART0_IRQn
+#define UART_0_ISR          isr_uart0
+/* UART 0 pin configuration */
+#define UART_0_TX_PIN       GPIO_PA1
+#define UART_0_RX_PIN       GPIO_PA0
+
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF               1
+#define I2C_0_EN                1
+#define I2C_IRQ_PRIO            1
+
+/* I2C 0 device configuration */
+#define I2C_0_DEV               0
+#define I2C_0_IRQ               I2C_IRQn
+#define I2C_0_IRQ_HANDLER       isr_i2c
+#define I2C_0_SCL_PIN           GPIO_PC3
+#define I2C_0_SDA_PIN           GPIO_PC2
+
+static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+    {
+        .scl_pin = I2C_0_SCL_PIN,
+        .sda_pin = I2C_0_SDA_PIN,
+    },
+};
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+#define SPI_NUMOF           2
+#define SPI_0_EN            1
+#define SPI_1_EN            1
+
+#ifdef HAVE_PERIPH_SPI_CONF_T
+static const periph_spi_conf_t spi_config[SPI_NUMOF] = {
+    {
+        .dev      = SSI0,
+        .mosi_pin = GPIO_PB1,
+        .miso_pin = GPIO_PB3,
+        .sck_pin  = GPIO_PB2,
+        .cs_pin   = GPIO_PB5,
+    },
+    {
+        .dev      = SSI1,
+        .mosi_pin = GPIO_PC5,
+        .miso_pin = GPIO_PC6,
+        .sck_pin  = GPIO_PC4,
+        .cs_pin   = GPIO_PA7,
+    },
+};
+#endif
+/** @} */
+
+/**
+ * @name GPIO configuration
+ * @{
+ */
+#define GPIO_IRQ_PRIO       1
+
+/* Enable only up to PD5 as PD6-PD7 are used with the 32KHz XOSC */
+#define GPIO_0_EN           1
+#define GPIO_1_EN           1
+#define GPIO_2_EN           1
+#define GPIO_3_EN           1
+#define GPIO_4_EN           1
+#define GPIO_5_EN           1
+#define GPIO_6_EN           1
+#define GPIO_7_EN           1
+#define GPIO_8_EN           1
+#define GPIO_9_EN           1
+#define GPIO_10_EN          1
+#define GPIO_11_EN          1
+#define GPIO_12_EN          1
+#define GPIO_13_EN          1
+#define GPIO_14_EN          1
+#define GPIO_15_EN          1
+#define GPIO_16_EN          1
+#define GPIO_17_EN          1
+#define GPIO_18_EN          1
+#define GPIO_19_EN          1
+#define GPIO_20_EN          1
+#define GPIO_21_EN          1
+#define GPIO_22_EN          1
+#define GPIO_23_EN          1
+#define GPIO_24_EN          1
+#define GPIO_25_EN          1
+#define GPIO_26_EN          1
+#define GPIO_27_EN          1
+#define GPIO_28_EN          1
+#define GPIO_29_EN          1
+
+/**
+ * @brief Port config
+ *
+ * These defines configures the port settings
+ */
+/* UART0 RX */
+#define GPIO_0_PIN          GPIO_PA0
+/* UART0 TX */
+#define GPIO_1_PIN          GPIO_PA1
+/* ADC3 */
+#define GPIO_2_PIN          GPIO_PA2
+/* User button/Bootloader */
+#define GPIO_3_PIN          GPIO_PA3
+/* ADC2 */
+#define GPIO_4_PIN          GPIO_PA4
+/* ADC1 */
+#define GPIO_5_PIN          GPIO_PA5
+/* SEL MicroSD or AIN6/ADC4 */
+#define GPIO_6_PIN          GPIO_PA6
+/* CSn MicroSD or AIN7/ADC5 */
+#define GPIO_7_PIN          GPIO_PA7
+/* CC1200 GDO2 */
+#define GPIO_8_PIN          GPIO_PB0
+/* SSI0 CC1200 MOSI */
+#define GPIO_9_PIN          GPIO_PB1
+/* SSI0 CC1200 CLK */
+#define GPIO_10_PIN         GPIO_PB2
+/* SSI0 CC1200 MISO */
+#define GPIO_11_PIN         GPIO_PB3
+/* CC1200 GDO0 */
+#define GPIO_12_PIN         GPIO_PB4
+/* CC1200 CSn */
+#define GPIO_13_PIN         GPIO_PB5
+/* JTAG TDI & LED3 */
+#define GPIO_14_PIN         GPIO_PB6
+/* JTAG TDO & LED2 */
+#define GPIO_15_PIN         GPIO_PB7
+/* UART1 TX */
+#define GPIO_16_PIN         GPIO_PC0
+/* UART1 RX */
+#define GPIO_17_PIN         GPIO_PC1
+/* I2C SDA */
+#define GPIO_18_PIN         GPIO_PC2
+/* I2C SCL */
+#define GPIO_19_PIN         GPIO_PC3
+/* SSI1 MicroSD CLK */
+#define GPIO_20_PIN         GPIO_PC4
+/* SSI1 MicroSD MOSI */
+#define GPIO_21_PIN         GPIO_PC5
+/* SSI1 MicroSD MISO */
+#define GPIO_22_PIN         GPIO_PC6
+/* CC1200 Reset */
+#define GPIO_23_PIN         GPIO_PC7
+/* GPIO */
+#define GPIO_24_PIN         GPIO_PD0
+/* Power Management enable */
+#define GPIO_25_PIN         GPIO_PD1
+/* RF SWITCH */
+#define GPIO_26_PIN         GPIO_PD2
+/* RTCC INT1 */
+#define GPIO_27_PIN         GPIO_PD3
+/* LED1 */
+#define GPIO_28_PIN         GPIO_PD4
+/* External WDT */
+#define GPIO_29_PIN         GPIO_PD5
+
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* PERIPH_CONF_H_ */
+/** @} */


### PR DESCRIPTION
This PR replaces #5840 without depending on #5823 and adapts to #5891. 

Hopefully, that way we can get `remote-revb` into the upcoming release and fix ADC stuff in #5823 later on.