### PR TITLE
periph_timer: Remove timer_irq_enable and timer_irq_disable

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -170,17 +170,6 @@ void timer_start(tim_t tim)
     ctx[tim].dev->CRB = ctx[tim].mode;
 }
 
-void timer_irq_enable(tim_t tim)
-{
-    *ctx[tim].mask = ctx[tim].isrs;
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    ctx[tim].isrs = *(ctx[tim].mask);
-    *ctx[tim].mask = 0;
-}
-
 #ifdef TIMER_NUMOF
 static inline void _isr(tim_t tim, int chan)
 {

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -95,9 +95,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     gptimer->cc2538_gptimer_tamr.TAMRbits.TACDIR = 1; /**< Count up */
     gptimer->cc2538_gptimer_tamr.TAMRbits.TAMIE  = 1; /**< Enable the Timer A Match Interrupt */
 
-    /* Enable interrupts for given timer: */
-    timer_irq_enable(dev);
-
     /* Enable the timer: */
     gptimer->cc2538_gptimer_ctl.CTLbits.TAEN = 1;
 
@@ -331,82 +328,6 @@ void timer_start(tim_t dev)
 
         case TIMER_UNDEFINED:
             break;
-    }
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_SetPriority(TIMER_0_IRQn_1, TIMER_IRQ_PRIO);
-            NVIC_SetPriority(TIMER_0_IRQn_2, TIMER_IRQ_PRIO);
-            NVIC_EnableIRQ(TIMER_0_IRQn_1);
-            NVIC_EnableIRQ(TIMER_0_IRQn_2);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_SetPriority(TIMER_1_IRQn_1, TIMER_IRQ_PRIO);
-            NVIC_SetPriority(TIMER_1_IRQn_2, TIMER_IRQ_PRIO);
-            NVIC_EnableIRQ(TIMER_1_IRQn_1);
-            NVIC_EnableIRQ(TIMER_1_IRQn_2);
-            break;
-#endif
-#if TIMER_2_EN
-        case TIMER_2:
-            NVIC_SetPriority(TIMER_2_IRQn_1, TIMER_IRQ_PRIO);
-            NVIC_SetPriority(TIMER_2_IRQn_2, TIMER_IRQ_PRIO);
-            NVIC_EnableIRQ(TIMER_2_IRQn_1);
-            NVIC_EnableIRQ(TIMER_2_IRQn_2);
-            break;
-#endif
-#if TIMER_3_EN
-        case TIMER_3:
-            NVIC_SetPriority(TIMER_3_IRQn_1, TIMER_IRQ_PRIO);
-            NVIC_SetPriority(TIMER_3_IRQn_2, TIMER_IRQ_PRIO);
-            NVIC_EnableIRQ(TIMER_3_IRQn_1);
-            NVIC_EnableIRQ(TIMER_3_IRQn_2);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
-        default:
-            return;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_DisableIRQ(TIMER_0_IRQn_1);
-            NVIC_DisableIRQ(TIMER_0_IRQn_2);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_DisableIRQ(TIMER_1_IRQn_1);
-            NVIC_DisableIRQ(TIMER_1_IRQn_2);
-            break;
-#endif
-#if TIMER_2_EN
-        case TIMER_2:
-            NVIC_DisableIRQ(TIMER_2_IRQn_1);
-            NVIC_DisableIRQ(TIMER_2_IRQn_2);
-            break;
-#endif
-#if TIMER_3_EN
-        case TIMER_3:
-            NVIC_DisableIRQ(TIMER_3_IRQn_1);
-            NVIC_DisableIRQ(TIMER_3_IRQn_2);
-            break;
-#endif
-
-        case TIMER_UNDEFINED:
-        default:
-            return;
     }
 }
 

--- a/cpu/cc26x0/periph/timer.c
+++ b/cpu/cc26x0/periph/timer.c
@@ -69,8 +69,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
     /* set the timer speed */
     dev(tim)->TAPR = (RCOSC48M_FREQ / freq) - 1;
-    /* enable global timer interrupt and start the timer */
-    timer_irq_enable(tim);
     dev(tim)->CTL = GPT_CTL_TAEN;
 
     return 0;
@@ -117,16 +115,6 @@ void timer_stop(tim_t tim)
 void timer_start(tim_t tim)
 {
     dev(tim)->CTL = GPT_CTL_TAEN;
-}
-
-void timer_irq_enable(tim_t tim)
-{
-    NVIC_EnableIRQ(GPTIMER_0A_IRQN + (2 * timer_config[tim].num));
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    NVIC_DisableIRQ(GPTIMER_0A_IRQN + (2 * timer_config[tim].num));
 }
 
 /**

--- a/cpu/cc430/periph/timer.c
+++ b/cpu/cc430/periph/timer.c
@@ -108,23 +108,6 @@ void timer_stop(tim_t dev)
     TIMER_BASE->CTL &= ~(CTL_MC_MASK);
 }
 
-void timer_irq_enable(tim_t dev)
-{
-
-    /* TODO: not supported, yet
-     *
-     * Problem here: there is no means, of globally disabling timer interrupts.
-     * We could just enable the interrupts for all CC channels, but this would
-     * mean, that we might enable interrupts for channels, that are not active.
-     * I guess we need to remember the interrupt state of all channels before
-     * disabling and then restore this state when enabling again?! */
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    /* TODO: not supported, yet */
-}
-
 ISR(TIMER_ISR_CC0, isr_timer_a_cc0)
 {
     __enter_isr();

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -130,16 +130,6 @@ void timer_start(tim_t dev)
     timer_config[dev].timer->CMD = TIMER_CMD_START;
 }
 
-void timer_irq_enable(tim_t dev)
-{
-    NVIC_EnableIRQ(timer_config[dev].irqn);
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    NVIC_DisableIRQ(timer_config[dev].irqn);
-}
-
 void timer_reset(tim_t dev)
 {
     timer_config[dev].timer->CNT = 0;

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -117,7 +117,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 
     ROM_TimerIntEnable(timer_base, timer_intbit);
 
-    timer_irq_enable(dev);
     timer_start(dev);
 
     return 0;
@@ -305,64 +304,6 @@ void timer_stop(tim_t dev)
     }
 
     ROM_TimerDisable(timer_base, timer_side);
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    unsigned int timer_intbase;
-
-    if (dev >= TIMER_NUMOF){
-        return;
-    }
-
-    switch(dev){
-#if TIMER_0_EN
-    case TIMER_0:
-        timer_intbase = INT_WTIMER0A;
-        break;
-#endif
-#if TIMER_1_EN
-    case TIMER_1:
-        timer_intbase = INT_WTIMER1A;
-        break;
-#endif
-    default:
-        return; /* unreachable */
-    }
-
-    ROM_IntPrioritySet(timer_intbase, 32);
-    ROM_IntEnable(timer_intbase);
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    unsigned int timer_base;
-    unsigned int timer_intbit = TIMER_TIMA_TIMEOUT;
-    unsigned int timer_intbase;
-
-    if (dev >= TIMER_NUMOF){
-        return;
-    }
-
-    switch(dev){
-#if TIMER_0_EN
-    case TIMER_0:
-        timer_base = WTIMER0_BASE;
-        timer_intbase = INT_WTIMER0A;
-        break;
-#endif
-#if TIMER_1_EN
-    case TIMER_1:
-        timer_base = WTIMER1_BASE;
-        timer_intbase = INT_WTIMER1A;
-        break;
-#endif
-    default:
-        return; /* unreachable */
-    }
-
-    ROM_IntEnable(timer_intbase);
-    ROM_TimerIntDisable(timer_base, timer_intbit);
 }
 
 #if TIMER_0_EN

--- a/cpu/lpc11u34/periph/timer.c
+++ b/cpu/lpc11u34/periph/timer.c
@@ -130,20 +130,6 @@ void timer_stop(tim_t dev)
     }
 }
 
-void timer_irq_enable(tim_t dev)
-{
-    if (dev == TIMER_0) {
-        NVIC_EnableIRQ(TIMER_0_IRQ);
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    if (dev == TIMER_0) {
-        NVIC_DisableIRQ(TIMER_0_IRQ);
-    }
-}
-
 void TIMER_0_ISR(void)
 {
     if (TIMER_0_DEV->IR & MR0_FLAG) {

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -132,20 +132,6 @@ void timer_stop(tim_t dev)
     }
 }
 
-void timer_irq_enable(tim_t dev)
-{
-    if (dev == TIMER_0) {
-        NVIC_EnableIRQ(TIMER_0_IRQ);
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    if (dev == TIMER_0) {
-        NVIC_DisableIRQ(TIMER_0_IRQ);
-    }
-}
-
 #if TIMER_0_EN
 void TIMER_0_ISR(void)
 {

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -175,18 +175,6 @@ void timer_stop(tim_t tim)
     get_dev(tim)->TCR = 0;
 }
 
-void timer_irq_enable(tim_t tim)
-{
-    (void) tim;
-    /* TODO */
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    (void) tim;
-    /* TODO */
-}
-
 static inline void isr_handler(lpc23xx_timer_t *dev, int tim_num)
 {
     for (unsigned i = 0; i < TIMER_CHAN_NUMOF; i++) {

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -108,23 +108,6 @@ void timer_stop(tim_t dev)
     TIMER_BASE->CTL &= ~(TIMER_CTL_MC_MASK);
 }
 
-void timer_irq_enable(tim_t dev)
-{
-
-    /* TODO: not supported, yet
-     *
-     * Problem here: there is no means, of globally disabling timer interrupts.
-     * We could just enable the interrupts for all CC channels, but this would
-     * mean, that we might enable interrupts for channels, that are not active.
-     * I guess we need to remember the interrupt state of all channels before
-     * disabling and then restore this state when enabling again?! */
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    /* TODO: not supported, yet */
-}
-
 ISR(TIMER_ISR_CC0, isr_timer_a_cc0)
 {
     __enter_isr();

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -92,10 +92,8 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     time_null = 0;
     time_null = timer_read(0);
 
-    timer_irq_disable(dev);
     _callback = cb;
     _cb_arg = arg;
-    timer_irq_enable(dev);
 
     return 0;
 }
@@ -153,30 +151,6 @@ int timer_clear(tim_t dev, int channel)
     do_timer_set(0);
 
     return 1;
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    (void)dev;
-    DEBUG("%s\n", __func__);
-
-    if (register_interrupt(SIGALRM, native_isr_timer) != 0) {
-        DEBUG("darn!\n\n");
-    }
-
-    return;
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    (void)dev;
-    DEBUG("%s\n", __func__);
-
-    if (unregister_interrupt(SIGALRM) != 0) {
-        DEBUG("darn!\n\n");
-    }
-
-    return;
 }
 
 void timer_start(tim_t dev)

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -85,8 +85,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     dev(tim)->EVENTS_COMPARE[1] = 0;
     dev(tim)->EVENTS_COMPARE[2] = 0;
 
-    /* enable interrupts */
-    timer_irq_enable(tim);
     /* start the timer */
     dev(tim)->TASKS_START = 1;
 
@@ -140,16 +138,6 @@ void timer_start(tim_t tim)
 void timer_stop(tim_t tim)
 {
     dev(tim)->TASKS_STOP = 1;
-}
-
-void timer_irq_enable(tim_t tim)
-{
-    NVIC_EnableIRQ(timer_config[tim].irqn);
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    NVIC_DisableIRQ(timer_config[tim].irqn);
 }
 
 static inline void irq_handler(int num)

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -117,9 +117,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     /* start channel 1 */
     dev(tim)->TC_CHANNEL[1].TC_CCR = (TC_CCR_CLKEN | TC_CCR_SWTRG);
 
-    /* enable global interrupts for given timer */
-    timer_irq_enable(tim);
-
     return 0;
 }
 
@@ -164,16 +161,6 @@ void timer_start(tim_t tim)
 void timer_stop(tim_t tim)
 {
     dev(tim)->TC_CHANNEL[1].TC_CCR = TC_CCR_CLKDIS;
-}
-
-void timer_irq_enable(tim_t tim)
-{
-    NVIC_EnableIRQ(timer_config[tim].id_ch0);
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    NVIC_DisableIRQ(timer_config[tim].id_ch0);
 }
 
 static inline void isr_handler(tim_t tim)

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -121,9 +121,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     config[dev].cb = cb;
     config[dev].arg = arg;
 
-    /* enable interrupts for given timer */
-    timer_irq_enable(dev);
-
     timer_start(dev);
 
     return 0;
@@ -283,42 +280,6 @@ void timer_start(tim_t dev)
 #if TIMER_1_EN
         case TIMER_1:
             TIMER_1_DEV.CTRLA.bit.ENABLE = 1;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_EnableIRQ(TC3_IRQn);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_EnableIRQ(TC4_IRQn);
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_DisableIRQ(TC3_IRQn);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_DisableIRQ(TC4_IRQn);
             break;
 #endif
         case TIMER_UNDEFINED:

--- a/cpu/saml21/periph/timer.c
+++ b/cpu/saml21/periph/timer.c
@@ -78,9 +78,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     config[dev].cb = cb;
     config[dev].arg = arg;
 
-    /* enable interrupts for given timer */
-    timer_irq_enable(dev);
-
     timer_start(dev);
 
     return 0;
@@ -188,32 +185,6 @@ void timer_start(tim_t dev)
 #if TIMER_0_EN
         case TIMER_0:
             TIMER_0_DEV.CTRLA.bit.ENABLE = 1;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_EnableIRQ(TC0_IRQn);
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_DisableIRQ(TC0_IRQn);
             break;
 #endif
         case TIMER_UNDEFINED:

--- a/cpu/stm32f0/periph/timer.c
+++ b/cpu/stm32f0/periph/timer.c
@@ -80,9 +80,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     timer->PSC = (TIMER_0_FREQ / freq) - 1;
     timer->EGR |= TIM_EGR_UG;
 
-    /* enable the timer's interrupt */
-    timer_irq_enable(dev);
-
     /* start the timer */
     timer_start(dev);
 
@@ -227,42 +224,6 @@ void timer_stop(tim_t dev)
 #if TIMER_1_EN
         case TIMER_1:
             TIMER_1_DEV->CR1 &= ~TIM_CR1_CEN;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_EnableIRQ(TIMER_0_IRQ_CHAN);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_EnableIRQ(TIMER_1_IRQ_CHAN);
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_DisableIRQ(TIMER_0_IRQ_CHAN);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_DisableIRQ(TIMER_1_IRQ_CHAN);
             break;
 #endif
         case TIMER_UNDEFINED:

--- a/cpu/stm32f1/periph/timer.c
+++ b/cpu/stm32f1/periph/timer.c
@@ -60,8 +60,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     /* generate an update event to apply our configuration */
     dev(tim)->EGR = TIM_EGR_UG;
 
-    /* enable the timer's interrupt */
-    timer_irq_enable(tim);
     /* reset the counter and start the timer */
     timer_start(tim);
 
@@ -110,16 +108,6 @@ void timer_start(tim_t tim)
 void timer_stop(tim_t tim)
 {
     dev(tim)->CR1 &= ~(TIM_CR1_CEN);
-}
-
-void timer_irq_enable(tim_t tim)
-{
-    NVIC_EnableIRQ(timer_config[tim].irqn);
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    NVIC_DisableIRQ(timer_config[tim].irqn);
 }
 
 static inline void irq_handler(tim_t tim)

--- a/cpu/stm32f2/periph/timer.c
+++ b/cpu/stm32f2/periph/timer.c
@@ -70,9 +70,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     /* set auto-reload and prescaler values and load new values */
     get_dev(dev)->EGR |= TIM_EGR_UG;
 
-    /* enable the timer's interrupt */
-    timer_irq_enable(dev);
-
     /* start the timer */
     timer_start(dev);
 
@@ -143,16 +140,6 @@ void timer_start(tim_t dev)
 void timer_stop(tim_t dev)
 {
     get_dev(dev)->CR1 &= ~TIM_CR1_CEN;
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    NVIC_EnableIRQ(timer_config[dev].irqn);
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    NVIC_DisableIRQ(timer_config[dev].irqn);
 }
 
 void TIMER_0_ISR(void)

--- a/cpu/stm32f3/periph/timer.c
+++ b/cpu/stm32f3/periph/timer.c
@@ -66,9 +66,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     timer->PSC = (TIMER_0_FREQ / freq) - 1;
     timer->EGR |= TIM_EGR_UG;
 
-    /* enable the timer's interrupt */
-    timer_irq_enable(dev);
-
     /* start the timer */
     timer_start(dev);
 
@@ -191,32 +188,6 @@ void timer_stop(tim_t dev)
 #if TIMER_0_EN
         case TIMER_0:
             TIMER_0_DEV->CR1 &= ~TIM_CR1_CEN;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_EnableIRQ(TIMER_0_IRQ_CHAN);
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_DisableIRQ(TIMER_0_IRQ_CHAN);
             break;
 #endif
         case TIMER_UNDEFINED:

--- a/cpu/stm32f4/periph/timer.c
+++ b/cpu/stm32f4/periph/timer.c
@@ -77,9 +77,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     /* set auto-reload and prescaler values and load new values */
     timer->EGR |= TIM_EGR_UG;
 
-    /* enable the timer's interrupt */
-    timer_irq_enable(dev);
-
     /* start the timer */
     timer_start(dev);
 
@@ -228,42 +225,6 @@ void timer_stop(tim_t dev)
 #if TIMER_1_EN
         case TIMER_1:
             TIMER_1_DEV->CR1 &= ~TIM_CR1_CEN;
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_EnableIRQ(TIMER_0_IRQ_CHAN);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_EnableIRQ(TIMER_1_IRQ_CHAN);
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_DisableIRQ(TIMER_0_IRQ_CHAN);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_DisableIRQ(TIMER_1_IRQ_CHAN);
             break;
 #endif
         case TIMER_UNDEFINED:

--- a/cpu/stm32l1/periph/timer.c
+++ b/cpu/stm32l1/periph/timer.c
@@ -68,8 +68,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     tim->PSC = (CLOCK_CORECLOCK / freq) - 1;
     /* trigger update event to make pre-scaler value effective */
     tim->EGR = TIM_EGR_UG;
-    /* enable interrupts and start the timer */
-    timer_irq_enable(dev);
     timer_start(dev);
     return 0;
 }
@@ -121,16 +119,6 @@ void timer_start(tim_t dev)
 void timer_stop(tim_t dev)
 {
     _tim(dev)->CR1 &= ~(TIM_CR1_CEN);
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    NVIC_EnableIRQ(timer_config[dev].irqn);
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    NVIC_DisableIRQ(timer_config[dev].irqn);
 }
 
 static inline void irq_handler(tim_t num, TIM_TypeDef *tim)

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -166,20 +166,6 @@ void timer_start(tim_t dev);
  */
 void timer_stop(tim_t dev);
 
-/**
- * @brief Enable the interrupts for the given timer
- *
- * @param[in] dev           timer to enable interrupts for
- */
-void timer_irq_enable(tim_t dev);
-
-/**
- * @brief Disable interrupts for the given timer
- *
- * @param[in] dev           the timer to disable interrupts for
- */
-void timer_irq_disable(tim_t dev);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Fixes #5265.

Caveat: these functions are used in OpenWSN, but at the moment, this doesn't compile anyways (see #5390).
