### PR TITLE
boards/nucleo-f303: fix broken stdio uart dev

### DIFF
--- a/boards/nucleo-f303/include/periph_conf.h
+++ b/boards/nucleo-f303/include/periph_conf.h
@@ -76,29 +76,29 @@ extern "C" {
 #define UART_IRQ_PRIO       1
 
 /* UART 0 device configuration */
-#define UART_0_DEV          USART1
-#define UART_0_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
-#define UART_0_CLK          (CLOCK_CORECLOCK / 1)   /* UART clock runs with 72MHz (F_CPU / 1) */
-#define UART_0_IRQ_CHAN     USART1_IRQn
-#define UART_0_ISR          isr_usart1
+#define UART_0_DEV          USART2
+#define UART_0_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
+#define UART_0_CLK          (CLOCK_CORECLOCK / 2)   /* UART clock runs with 36MHz (F_CPU / 2) */
+#define UART_0_IRQ_CHAN     USART2_IRQn
+#define UART_0_ISR          isr_usart2
 /* UART 0 pin configuration */
 #define UART_0_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
 #define UART_0_PORT         GPIOA
-#define UART_0_TX_PIN       9
-#define UART_0_RX_PIN       10
+#define UART_0_TX_PIN       2
+#define UART_0_RX_PIN       3
 #define UART_0_AF           7
 
 /* UART 1 device configuration */
-#define UART_1_DEV          USART2
-#define UART_1_CLKEN()      (RCC->APB1ENR |= RCC_APB1ENR_USART2EN)
-#define UART_1_CLK          (CLOCK_CORECLOCK / 2)   /* UART clock runs with 36MHz (F_CPU / 2) */
-#define UART_1_IRQ_CHAN     USART2_IRQn
-#define UART_1_ISR          isr_usart2
+#define UART_1_DEV          USART1
+#define UART_1_CLKEN()      (RCC->APB2ENR |= RCC_APB2ENR_USART1EN)
+#define UART_1_CLK          (CLOCK_CORECLOCK / 1)   /* UART clock runs with 72MHz (F_CPU / 1) */
+#define UART_1_IRQ_CHAN     USART1_IRQn
+#define UART_1_ISR          isr_usart1
 /* UART 1 pin configuration */
 #define UART_1_PORT_CLKEN() (RCC->AHBENR |= RCC_AHBENR_GPIOAEN)
 #define UART_1_PORT         GPIOA
-#define UART_1_TX_PIN       2
-#define UART_1_RX_PIN       3
+#define UART_1_TX_PIN       9
+#define UART_1_RX_PIN       10
 #define UART_1_AF           7
 
 /* UART 2 device configuration */


### PR DESCRIPTION
This fixes the nucleo-f303 debug uart which was broken.
This partially fix issue #5707.
