### PR TITLE
boards/nucleo-f103: set stdio uart to USB port by default

### DIFF
--- a/boards/nucleo-f103/include/board.h
+++ b/boards/nucleo-f103/include/board.h
@@ -28,9 +28,9 @@ extern "C" {
 #endif
 
 /**
- * @brief Use the 2nd UART for STDIO on this board
+ * @brief Use the first UART for STDIO on this board
  */
-#define UART_STDIO_DEV      UART_DEV(1)
+#define UART_STDIO_DEV      UART_DEV(0)
 
 /**
  * @name xtimer configuration


### PR DESCRIPTION
This PR set the default stdio uart to the USB port on the nucleo-f103 (note that this UART is shared with the RX/TX pins of the Arduino compatible connectors of the board).