### PR TITLE
boards/remote: add gpio and saul definitions

### DIFF
--- a/boards/remote-common/Makefile.dep
+++ b/boards/remote-common/Makefile.dep
@@ -4,3 +4,6 @@ ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += gnrc_netdev2
     USEMODULE += netdev2_ieee802154
 endif
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/remote-pa/include/board.h
+++ b/boards/remote-pa/include/board.h
@@ -57,6 +57,13 @@
 /** @} */
 
 /**
+ * @name User button pin definition
+ * @{
+ */
+#define BUTTON_GPIO         GPIO_9_PIN
+/** @} */
+
+/**
  * @name 2.4GHz RF switch controlled by SW
  * @{
  */

--- a/boards/remote-pa/include/gpio_params.h
+++ b/boards/remote-pa/include/gpio_params.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_remote-pa
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    smlng <s@mlng.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(blue)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Button(User)",
+        .pin = BUTTON_GPIO,
+        .mode = GPIO_IN_PU
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/remote-reva/include/board.h
+++ b/boards/remote-reva/include/board.h
@@ -57,6 +57,12 @@
 /** @} */
 
 /**
+ * @name User button pin definition
+ * @{
+ */
+#define BUTTON_GPIO     GPIO_3_PIN
+/** @} */
+/**
  * @name  RF switch controlled by SW
  * @brief Controls which RF interface goes to the RP-SMA external antenna
  *

--- a/boards/remote-reva/include/gpio_params.h
+++ b/boards/remote-reva/include/gpio_params.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_remote-reva
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    smlng <s@mlng.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(blue)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Button(User)",
+        .pin = BUTTON_GPIO,
+        .mode = GPIO_IN_PU
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/remote-revb/include/board.h
+++ b/boards/remote-revb/include/board.h
@@ -57,6 +57,13 @@
 /** @} */
 
 /**
+ * @name User button pin definition
+ * @{
+ */
+#define BUTTON_GPIO     GPIO_3_PIN
+/** @} */
+
+/**
  * @name  RF switch controlled by SW
  * @brief Controls which RF interface goes to the RP-SMA external antenna
  *

--- a/boards/remote-revb/include/gpio_params.h
+++ b/boards/remote-revb/include/gpio_params.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_remote-revb
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    smlng <s@mlng.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(blue)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Button(User)",
+        .pin = BUTTON_GPIO,
+        .mode = GPIO_IN_PU
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
Adds `BUTTON_GPIO` definition to all `remote-*` boards as well SAUL definitions for LEDs and user button. Depends on #5978.