### PR TITLE
netstats_l2: cc2538 (and at86rf2xx fixes)

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -277,7 +277,9 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 
         rfcore_write_fifo(vector[i].iov_base, vector[i].iov_len);
     }
-
+    #ifdef MODULE_NETSTATS_L2
+            netdev->stats.tx_bytes += pkt_len;
+    #endif
     /* Set first byte of TX FIFO to the packet length */
     rfcore_poke_tx_fifo(0, pkt_len + CC2538_AUTOCRC_LEN);
 
@@ -323,7 +325,10 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
         /* GNRC is expecting len bytes of data */
         pkt_len = len;
     }
-
+    #ifdef MODULE_NETSTATS_L2
+        netdev->stats.rx_count++;
+        netdev->stats.rx_bytes += pkt_len;
+    #endif
     rfcore_read_fifo(buf, pkt_len);
 
     if (info != NULL && RFCORE->XREG_RSSISTATbits.RSSI_VALID) {
@@ -388,6 +393,9 @@ static int _init(netdev2_t *netdev)
     dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;
 #elif MODULE_GNRC
     dev->netdev.proto = GNRC_NETTYPE_UNDEF;
+#endif
+#ifdef MODULE_NETSTATS_L2
+    memset(&netdev->stats, 0, sizeof(netstats_t));
 #endif
 
     return 0;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -148,15 +148,15 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
         at86rf2xx_fb_stop(dev);
         return pkt_len;
     }
-#ifdef MODULE_NETSTATS_L2
-    netdev->stats.rx_count++;
-    netdev->stats.rx_bytes += pkt_len;
-#endif
     /* not enough space in buf */
     if (pkt_len > len) {
         at86rf2xx_fb_stop(dev);
         return -ENOBUFS;
     }
+    #ifdef MODULE_NETSTATS_L2
+        netdev->stats.rx_count++;
+        netdev->stats.rx_bytes += pkt_len;
+    #endif
     /* copy payload */
     at86rf2xx_fb_read(dev, (uint8_t *)buf, pkt_len);
 


### PR DESCRIPTION
add layer2 netstats to `cc2538` and minor correction in `at86rf2xx`.