### PR TITLE
sys/arduino: make arduino sketch works on avr based boards

### DIFF
--- a/boards/arduino-common/Makefile.features
+++ b/boards/arduino-common/Makefile.features
@@ -5,6 +5,7 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
+FEATURES_PROVIDED += arduino
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = avr8

--- a/examples/arduino_hello-world/hello-world.sketch
+++ b/examples/arduino_hello-world/hello-world.sketch
@@ -13,6 +13,15 @@
 #define ARDUINO_LED     (0)
 #endif
 
+// For some boards RIOT defines a macro assigning the required baudrate of the
+// serial link. If this macro is not set, the default baudrate is set to
+// 115200.
+#ifdef UART_STDIO_BAUDRATE
+#define SERIAL_BAUDRATE UART_STDIO_BAUDRATE
+#else
+#define SERIAL_BAUDRATE 115200
+#endif
+
 // Assign the default LED pin
 int ledPin = ARDUINO_LED;
 
@@ -26,8 +35,9 @@ void setup(void)
 {
     // configure the LED pin to be output
     pinMode(ledPin, OUTPUT);
-    // configure the first serial port to run with a baudrate of 115200
-    Serial.begin(115200);
+    // configure the first serial port to run with the previously defined
+    // baudrate
+    Serial.begin(SERIAL_BAUDRATE);
     // say hello
     Serial.println("Hello Arduino!");
 }

--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -6,4 +6,4 @@ SRCDIR = $(RIOTBASE)/sys/arduino
 $(shell $(RIOTBASE)/dist/tools/arduino/pre_build.sh $(SRCDIR) $(APPDIR) $(SKETCHES))
 
 # include the Arduino headers
-export INCLUDES += -I$(RIOTBASE)/sys/arduino/include
+INCLUDES += -I$(RIOTBASE)/sys/arduino/include

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -54,7 +54,7 @@ int digitalRead(int pin)
     }
 }
 
-void delay(int msec)
+void delay(unsigned long msec)
 {
     xtimer_usleep(1000 * msec);
 }

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -80,7 +80,7 @@ int digitalRead(int pin);
  *
  * @param[in] msec      number of milliseconds to sleep
  */
-void delay(int msec);
+void delay(unsigned long msec);
 
 #endif /* ARDUINO_H */
 /** @} */

--- a/sys/arduino/include/serialport.hpp
+++ b/sys/arduino/include/serialport.hpp
@@ -84,7 +84,7 @@ public:
      *
      * @param[in] speed     speed in bits per second (baud)
      */
-    void begin(int speed);
+    void begin(long speed);
 
     /**
      * @brief   Disables serial communication, allowing the RX and TX pins to be

--- a/sys/arduino/pre.snip
+++ b/sys/arduino/pre.snip
@@ -1,1 +1,2 @@
 #include "arduino.hpp"
+#include "board.h"

--- a/sys/arduino/serialport.cpp
+++ b/sys/arduino/serialport.cpp
@@ -43,7 +43,7 @@ int SerialPort::available(void)
     return (int)rx_buf.avail;
 }
 
-void SerialPort::begin(int baudrate)
+void SerialPort::begin(long baudrate)
 {
     /* this clears the contents of the ringbuffer... */
     ringbuffer_init(&rx_buf, rx_mem, SERIAL_RX_BUFSIZE);
@@ -92,7 +92,7 @@ size_t SerialPort::print(float val)
 size_t SerialPort::print(float val, int format)
 {
     char buf[64];
-    size_t len = sprintf(buf, "%.*f", format, val);
+    size_t len = sprintf(buf, "%.*f", format, (double)val);
     write(buf, len);
     return len;
 }


### PR DESCRIPTION
This is an attempt to fix #5986.

I made several small changes:
- added the cpp and arduino features in arduino_common boards to avoid a warning message at the beginning of the build
- fixed the implicit conversion warning by using uint32_t instead of int in the RIOT Serial.begin() and sleep() functions of the arduino-like API
- Changed the default baudrate from 115200 to 9600 in the provided example because avr based boards doesn't support 115200 ([see this comment](https://github.com/RIOT-OS/RIOT/blob/master/boards/arduino-common/include/board.h#L36)). This change is debattable as it breaks the default for other boards like arduino-zero, nucleo, etc
