### PR TITLE
boards/native: set PORT to tap0

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -84,7 +84,7 @@ endif
 export LINKFLAGS += -ffunction-sections
 
 # set the tap interface for term/valgrind
-ifneq (,$(filter netdev2_tap,$(USEMODULE)))
+ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
 	export PORT ?= tap0
 else
 	export PORT =


### PR DESCRIPTION
`PORT` is unset if `netdev2_tap` is not in `USEMODULES`.
But unfortunately, `netdev2_tap` is set by boards/native/Makefile.dep
*after* `PORT` is set, so that `PORT` remains empty.

This commit breaks this circular dependency by checking for
`netdev_default` and `gnrc_netdev_default` instead.

Without this commit, `make term` throws an error for examples that
require a tap interface, when `PORT` is not explicitely given.