### PR TITLE
cpu/stm32f103cb: generalize linkerscript

### DIFF
--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = stm32f1
 export CPU_MODEL = stm32f103cb
 
+# the spark-core uses its own custom linkerscript...
+export LINKER_SCRIPT = stm32f103cb_sparkcore.ld
+
 # set the default port
 export PORT ?= /dev/ttyUSB0
 

--- a/cpu/stm32f1/ldscripts/stm32f103cb.ld
+++ b/cpu/stm32f1/ldscripts/stm32f103cb.ld
@@ -20,7 +20,7 @@
 
 MEMORY
 {
-    rom (rx)    : ORIGIN = 0x08005000, LENGTH = 128K-0x5000
+    rom (rx)    : ORIGIN = 0x08000000, LENGTH = 128K
     ram (xrw)   : ORIGIN = 0x20000000, LENGTH = 20K
     cpuid (r)   : ORIGIN = 0x1ffff7e8, LENGTH = 12
 }

--- a/cpu/stm32f1/ldscripts/stm32f103cb_sparkcore.ld
+++ b/cpu/stm32f1/ldscripts/stm32f103cb_sparkcore.ld
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_stm32f1
+ * @{
+ *
+ * @file
+ * @brief           Spark-core specific memory definitions for the STM32F103CB
+ *
+ * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+MEMORY
+{
+    rom (rx)    : ORIGIN = 0x08005000, LENGTH = 128K-0x5000
+    ram (xrw)   : ORIGIN = 0x20000000, LENGTH = 20K
+    cpuid (r)   : ORIGIN = 0x1ffff7e8, LENGTH = 12
+}
+
+_cpuid_address = ORIGIN(cpuid);
+
+INCLUDE cortexm_base.ld


### PR DESCRIPTION
This was just discovered on the devel list: the linkerscript for the `stm32f103cb` was imported together with the `spark-core` board, and it contained an text section offset specific to this board.

This PR generalizes the existing ld script and adds a `spark-core` specific one.