### PR TITLE
make: use LLDB if GDB is not available on native platform

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -36,7 +36,11 @@ export OFLAGS =
 endif
 endif
 
-export DEBUGGER ?= $(shell command -v $(PREFIX)gdb gdb lldb | head -n 1)
+ifeq ($(shell uname -s),Darwin)
+export DEBUGGER ?= lldb
+else
+export DEBUGGER ?= gdb
+endif
 export TERMPROG ?= $(ELF)
 export FLASHER = true
 export VALGRIND ?= valgrind

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -36,7 +36,7 @@ export OFLAGS =
 endif
 endif
 
-export DEBUGGER = gdb
+export DEBUGGER ?= $(shell command -v $(PREFIX)gdb gdb lldb | head -n 1)
 export TERMPROG ?= $(ELF)
 export FLASHER = true
 export VALGRIND ?= valgrind
@@ -95,7 +95,11 @@ endif
 export TERMFLAGS := $(PORT) $(TERMFLAGS)
 
 export ASFLAGS =
+ifeq ($(shell basename $(DEBUGGER)),lldb)
+export DEBUGGER_FLAGS = -- $(ELF) $(TERMFLAGS)
+else
 export DEBUGGER_FLAGS = -q --args $(ELF) $(TERMFLAGS)
+endif
 term-valgrind: export VALGRIND_FLAGS ?= \
 	--leak-check=full \
 	--track-origins=yes \


### PR DESCRIPTION
If GDB is not available on native platform (i.e. macOS), then use LLDB instead.
Related: #534

Known problem: It spawns two processes but LLDB kills only one when quitting. We have to `kill -9` it manually.

Another problem: `make TOOLCHAIN=llvm all` results in `error: unknown target triple '-Wall', please use -triple or -arch`. We can, though, build RIOT with `make all` without genuine GCC because `/usr/bin/gcc` mimics GCC and delegates to Clang.
