### PR TITLE
saml21: add I2C support

### DIFF
--- a/boards/saml21-xpro/Makefile.features
+++ b/boards/saml21-xpro/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -25,6 +25,52 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+/**
+ * @brief   External oscillator and clock configuration
+ *
+ * For selection of the used CORECLOCK, we have implemented two choices:
+ *
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why we use this option as default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL       (1)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+/* generate the actual used core clock frequency */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
 
 /**
  * @brief GCLK reference speed
@@ -79,7 +125,23 @@ extern "C" {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF          (0)
+#define I2C_NUMOF          (1U)
+#define I2C_0_EN            1
+#define I2C_1_EN            0
+#define I2C_2_EN            0
+#define I2C_3_EN            0
+#define I2C_IRQ_PRIO        1
+
+#define I2C_0_DEV           SERCOM1->I2CM
+#define I2C_0_IRQ           SERCOM1_IRQn
+#define I2C_0_ISR           isr_sercom1
+/* I2C 0 GCLK */
+#define I2C_0_GCLK_ID       SERCOM1_GCLK_ID_CORE
+#define I2C_0_GCLK_ID_SLOW  SERCOM1_GCLK_ID_SLOW
+/* I2C 0 pin configuration */
+#define I2C_0_SDA           GPIO_PIN(PA, 16)
+#define I2C_0_SCL           GPIO_PIN(PA, 17)
+#define I2C_0_MUX           GPIO_MUX_C
 /** @} */
 
 /**

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/ac.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/ac.h
@@ -1,0 +1,600 @@
+/**
+ * \file
+ *
+ * \brief Component description for AC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_AC_COMPONENT_
+#define _SAML21_AC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AC */
+/* ========================================================================== */
+/** \addtogroup SAML21_AC Analog Comparators */
+/*@{*/
+
+#define AC_U2245
+#define REV_AC                      0x100
+
+/* -------- AC_CTRLA : (AC Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLA_OFFSET             0x00         /**< \brief (AC_CTRLA offset) Control A */
+#define AC_CTRLA_RESETVALUE         0x00ul       /**< \brief (AC_CTRLA reset_value) Control A */
+
+#define AC_CTRLA_SWRST_Pos          0            /**< \brief (AC_CTRLA) Software Reset */
+#define AC_CTRLA_SWRST              (0x1ul << AC_CTRLA_SWRST_Pos)
+#define AC_CTRLA_ENABLE_Pos         1            /**< \brief (AC_CTRLA) Enable */
+#define AC_CTRLA_ENABLE             (0x1ul << AC_CTRLA_ENABLE_Pos)
+#define AC_CTRLA_MASK               0x03ul       /**< \brief (AC_CTRLA) MASK Register */
+
+/* -------- AC_CTRLB : (AC Offset: 0x01) ( /W  8) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  START0:1;         /*!< bit:      0  Comparator 0 Start Comparison      */
+    uint8_t  START1:1;         /*!< bit:      1  Comparator 1 Start Comparison      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  START:2;          /*!< bit:  0.. 1  Comparator x Start Comparison      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLB_OFFSET             0x01         /**< \brief (AC_CTRLB offset) Control B */
+#define AC_CTRLB_RESETVALUE         0x00ul       /**< \brief (AC_CTRLB reset_value) Control B */
+
+#define AC_CTRLB_START0_Pos         0            /**< \brief (AC_CTRLB) Comparator 0 Start Comparison */
+#define AC_CTRLB_START0             (1 << AC_CTRLB_START0_Pos)
+#define AC_CTRLB_START1_Pos         1            /**< \brief (AC_CTRLB) Comparator 1 Start Comparison */
+#define AC_CTRLB_START1             (1 << AC_CTRLB_START1_Pos)
+#define AC_CTRLB_START_Pos          0            /**< \brief (AC_CTRLB) Comparator x Start Comparison */
+#define AC_CTRLB_START_Msk          (0x3ul << AC_CTRLB_START_Pos)
+#define AC_CTRLB_START(value)       (AC_CTRLB_START_Msk & ((value) << AC_CTRLB_START_Pos))
+#define AC_CTRLB_MASK               0x03ul       /**< \brief (AC_CTRLB) MASK Register */
+
+/* -------- AC_EVCTRL : (AC Offset: 0x02) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COMPEO0:1;        /*!< bit:      0  Comparator 0 Event Output Enable   */
+    uint16_t COMPEO1:1;        /*!< bit:      1  Comparator 1 Event Output Enable   */
+    uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t WINEO0:1;         /*!< bit:      4  Window 0 Event Output Enable       */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t COMPEI0:1;        /*!< bit:      8  Comparator 0 Event Input Enable    */
+    uint16_t COMPEI1:1;        /*!< bit:      9  Comparator 1 Event Input Enable    */
+    uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t INVEI0:1;         /*!< bit:     12  Comparator 0 Input Event Invert Enable */
+    uint16_t INVEI1:1;         /*!< bit:     13  Comparator 1 Input Event Invert Enable */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t COMPEO:2;         /*!< bit:  0.. 1  Comparator x Event Output Enable   */
+    uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t WINEO:1;          /*!< bit:      4  Window x Event Output Enable       */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t COMPEI:2;         /*!< bit:  8.. 9  Comparator x Event Input Enable    */
+    uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint16_t INVEI:2;          /*!< bit: 12..13  Comparator x Input Event Invert Enable */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} AC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_EVCTRL_OFFSET            0x02         /**< \brief (AC_EVCTRL offset) Event Control */
+#define AC_EVCTRL_RESETVALUE        0x0000ul     /**< \brief (AC_EVCTRL reset_value) Event Control */
+
+#define AC_EVCTRL_COMPEO0_Pos       0            /**< \brief (AC_EVCTRL) Comparator 0 Event Output Enable */
+#define AC_EVCTRL_COMPEO0           (1 << AC_EVCTRL_COMPEO0_Pos)
+#define AC_EVCTRL_COMPEO1_Pos       1            /**< \brief (AC_EVCTRL) Comparator 1 Event Output Enable */
+#define AC_EVCTRL_COMPEO1           (1 << AC_EVCTRL_COMPEO1_Pos)
+#define AC_EVCTRL_COMPEO_Pos        0            /**< \brief (AC_EVCTRL) Comparator x Event Output Enable */
+#define AC_EVCTRL_COMPEO_Msk        (0x3ul << AC_EVCTRL_COMPEO_Pos)
+#define AC_EVCTRL_COMPEO(value)     (AC_EVCTRL_COMPEO_Msk & ((value) << AC_EVCTRL_COMPEO_Pos))
+#define AC_EVCTRL_WINEO0_Pos        4            /**< \brief (AC_EVCTRL) Window 0 Event Output Enable */
+#define AC_EVCTRL_WINEO0            (1 << AC_EVCTRL_WINEO0_Pos)
+#define AC_EVCTRL_WINEO_Pos         4            /**< \brief (AC_EVCTRL) Window x Event Output Enable */
+#define AC_EVCTRL_WINEO_Msk         (0x1ul << AC_EVCTRL_WINEO_Pos)
+#define AC_EVCTRL_WINEO(value)      (AC_EVCTRL_WINEO_Msk & ((value) << AC_EVCTRL_WINEO_Pos))
+#define AC_EVCTRL_COMPEI0_Pos       8            /**< \brief (AC_EVCTRL) Comparator 0 Event Input Enable */
+#define AC_EVCTRL_COMPEI0           (1 << AC_EVCTRL_COMPEI0_Pos)
+#define AC_EVCTRL_COMPEI1_Pos       9            /**< \brief (AC_EVCTRL) Comparator 1 Event Input Enable */
+#define AC_EVCTRL_COMPEI1           (1 << AC_EVCTRL_COMPEI1_Pos)
+#define AC_EVCTRL_COMPEI_Pos        8            /**< \brief (AC_EVCTRL) Comparator x Event Input Enable */
+#define AC_EVCTRL_COMPEI_Msk        (0x3ul << AC_EVCTRL_COMPEI_Pos)
+#define AC_EVCTRL_COMPEI(value)     (AC_EVCTRL_COMPEI_Msk & ((value) << AC_EVCTRL_COMPEI_Pos))
+#define AC_EVCTRL_INVEI0_Pos        12           /**< \brief (AC_EVCTRL) Comparator 0 Input Event Invert Enable */
+#define AC_EVCTRL_INVEI0            (1 << AC_EVCTRL_INVEI0_Pos)
+#define AC_EVCTRL_INVEI1_Pos        13           /**< \brief (AC_EVCTRL) Comparator 1 Input Event Invert Enable */
+#define AC_EVCTRL_INVEI1            (1 << AC_EVCTRL_INVEI1_Pos)
+#define AC_EVCTRL_INVEI_Pos         12           /**< \brief (AC_EVCTRL) Comparator x Input Event Invert Enable */
+#define AC_EVCTRL_INVEI_Msk         (0x3ul << AC_EVCTRL_INVEI_Pos)
+#define AC_EVCTRL_INVEI(value)      (AC_EVCTRL_INVEI_Msk & ((value) << AC_EVCTRL_INVEI_Pos))
+#define AC_EVCTRL_MASK              0x3313ul     /**< \brief (AC_EVCTRL) MASK Register */
+
+/* -------- AC_INTENCLR : (AC Offset: 0x04) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0 Interrupt Enable      */
+    uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1 Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN0:1;           /*!< bit:      4  Window 0 Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN:1;            /*!< bit:      4  Window x Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENCLR_OFFSET          0x04         /**< \brief (AC_INTENCLR offset) Interrupt Enable Clear */
+#define AC_INTENCLR_RESETVALUE      0x00ul       /**< \brief (AC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define AC_INTENCLR_COMP0_Pos       0            /**< \brief (AC_INTENCLR) Comparator 0 Interrupt Enable */
+#define AC_INTENCLR_COMP0           (1 << AC_INTENCLR_COMP0_Pos)
+#define AC_INTENCLR_COMP1_Pos       1            /**< \brief (AC_INTENCLR) Comparator 1 Interrupt Enable */
+#define AC_INTENCLR_COMP1           (1 << AC_INTENCLR_COMP1_Pos)
+#define AC_INTENCLR_COMP_Pos        0            /**< \brief (AC_INTENCLR) Comparator x Interrupt Enable */
+#define AC_INTENCLR_COMP_Msk        (0x3ul << AC_INTENCLR_COMP_Pos)
+#define AC_INTENCLR_COMP(value)     (AC_INTENCLR_COMP_Msk & ((value) << AC_INTENCLR_COMP_Pos))
+#define AC_INTENCLR_WIN0_Pos        4            /**< \brief (AC_INTENCLR) Window 0 Interrupt Enable */
+#define AC_INTENCLR_WIN0            (1 << AC_INTENCLR_WIN0_Pos)
+#define AC_INTENCLR_WIN_Pos         4            /**< \brief (AC_INTENCLR) Window x Interrupt Enable */
+#define AC_INTENCLR_WIN_Msk         (0x1ul << AC_INTENCLR_WIN_Pos)
+#define AC_INTENCLR_WIN(value)      (AC_INTENCLR_WIN_Msk & ((value) << AC_INTENCLR_WIN_Pos))
+#define AC_INTENCLR_MASK            0x13ul       /**< \brief (AC_INTENCLR) MASK Register */
+
+/* -------- AC_INTENSET : (AC Offset: 0x05) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0 Interrupt Enable      */
+    uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1 Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN0:1;           /*!< bit:      4  Window 0 Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN:1;            /*!< bit:      4  Window x Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENSET_OFFSET          0x05         /**< \brief (AC_INTENSET offset) Interrupt Enable Set */
+#define AC_INTENSET_RESETVALUE      0x00ul       /**< \brief (AC_INTENSET reset_value) Interrupt Enable Set */
+
+#define AC_INTENSET_COMP0_Pos       0            /**< \brief (AC_INTENSET) Comparator 0 Interrupt Enable */
+#define AC_INTENSET_COMP0           (1 << AC_INTENSET_COMP0_Pos)
+#define AC_INTENSET_COMP1_Pos       1            /**< \brief (AC_INTENSET) Comparator 1 Interrupt Enable */
+#define AC_INTENSET_COMP1           (1 << AC_INTENSET_COMP1_Pos)
+#define AC_INTENSET_COMP_Pos        0            /**< \brief (AC_INTENSET) Comparator x Interrupt Enable */
+#define AC_INTENSET_COMP_Msk        (0x3ul << AC_INTENSET_COMP_Pos)
+#define AC_INTENSET_COMP(value)     (AC_INTENSET_COMP_Msk & ((value) << AC_INTENSET_COMP_Pos))
+#define AC_INTENSET_WIN0_Pos        4            /**< \brief (AC_INTENSET) Window 0 Interrupt Enable */
+#define AC_INTENSET_WIN0            (1 << AC_INTENSET_WIN0_Pos)
+#define AC_INTENSET_WIN_Pos         4            /**< \brief (AC_INTENSET) Window x Interrupt Enable */
+#define AC_INTENSET_WIN_Msk         (0x1ul << AC_INTENSET_WIN_Pos)
+#define AC_INTENSET_WIN(value)      (AC_INTENSET_WIN_Msk & ((value) << AC_INTENSET_WIN_Pos))
+#define AC_INTENSET_MASK            0x13ul       /**< \brief (AC_INTENSET) MASK Register */
+
+/* -------- AC_INTFLAG : (AC Offset: 0x06) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
+    __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
+    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
+    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
+    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
+    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTFLAG_OFFSET           0x06         /**< \brief (AC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define AC_INTFLAG_RESETVALUE       0x00ul       /**< \brief (AC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define AC_INTFLAG_COMP0_Pos        0            /**< \brief (AC_INTFLAG) Comparator 0 */
+#define AC_INTFLAG_COMP0            (1 << AC_INTFLAG_COMP0_Pos)
+#define AC_INTFLAG_COMP1_Pos        1            /**< \brief (AC_INTFLAG) Comparator 1 */
+#define AC_INTFLAG_COMP1            (1 << AC_INTFLAG_COMP1_Pos)
+#define AC_INTFLAG_COMP_Pos         0            /**< \brief (AC_INTFLAG) Comparator x */
+#define AC_INTFLAG_COMP_Msk         (0x3ul << AC_INTFLAG_COMP_Pos)
+#define AC_INTFLAG_COMP(value)      (AC_INTFLAG_COMP_Msk & ((value) << AC_INTFLAG_COMP_Pos))
+#define AC_INTFLAG_WIN0_Pos         4            /**< \brief (AC_INTFLAG) Window 0 */
+#define AC_INTFLAG_WIN0             (1 << AC_INTFLAG_WIN0_Pos)
+#define AC_INTFLAG_WIN_Pos          4            /**< \brief (AC_INTFLAG) Window x */
+#define AC_INTFLAG_WIN_Msk          (0x1ul << AC_INTFLAG_WIN_Pos)
+#define AC_INTFLAG_WIN(value)       (AC_INTFLAG_WIN_Msk & ((value) << AC_INTFLAG_WIN_Pos))
+#define AC_INTFLAG_MASK             0x13ul       /**< \brief (AC_INTFLAG) MASK Register */
+
+/* -------- AC_STATUSA : (AC Offset: 0x07) (R/   8) Status A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STATE0:1;         /*!< bit:      0  Comparator 0 Current State         */
+    uint8_t  STATE1:1;         /*!< bit:      1  Comparator 1 Current State         */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WSTATE0:2;        /*!< bit:  4.. 5  Window 0 Current State             */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  STATE:2;          /*!< bit:  0.. 1  Comparator x Current State         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSA_OFFSET           0x07         /**< \brief (AC_STATUSA offset) Status A */
+#define AC_STATUSA_RESETVALUE       0x00ul       /**< \brief (AC_STATUSA reset_value) Status A */
+
+#define AC_STATUSA_STATE0_Pos       0            /**< \brief (AC_STATUSA) Comparator 0 Current State */
+#define AC_STATUSA_STATE0           (1 << AC_STATUSA_STATE0_Pos)
+#define AC_STATUSA_STATE1_Pos       1            /**< \brief (AC_STATUSA) Comparator 1 Current State */
+#define AC_STATUSA_STATE1           (1 << AC_STATUSA_STATE1_Pos)
+#define AC_STATUSA_STATE_Pos        0            /**< \brief (AC_STATUSA) Comparator x Current State */
+#define AC_STATUSA_STATE_Msk        (0x3ul << AC_STATUSA_STATE_Pos)
+#define AC_STATUSA_STATE(value)     (AC_STATUSA_STATE_Msk & ((value) << AC_STATUSA_STATE_Pos))
+#define AC_STATUSA_WSTATE0_Pos      4            /**< \brief (AC_STATUSA) Window 0 Current State */
+#define AC_STATUSA_WSTATE0_Msk      (0x3ul << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0(value)   (AC_STATUSA_WSTATE0_Msk & ((value) << AC_STATUSA_WSTATE0_Pos))
+#define   AC_STATUSA_WSTATE0_ABOVE_Val    0x0ul  /**< \brief (AC_STATUSA) Signal is above window */
+#define   AC_STATUSA_WSTATE0_INSIDE_Val   0x1ul  /**< \brief (AC_STATUSA) Signal is inside window */
+#define   AC_STATUSA_WSTATE0_BELOW_Val    0x2ul  /**< \brief (AC_STATUSA) Signal is below window */
+#define AC_STATUSA_WSTATE0_ABOVE    (AC_STATUSA_WSTATE0_ABOVE_Val  << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0_INSIDE   (AC_STATUSA_WSTATE0_INSIDE_Val << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0_BELOW    (AC_STATUSA_WSTATE0_BELOW_Val  << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_MASK             0x33ul       /**< \brief (AC_STATUSA) MASK Register */
+
+/* -------- AC_STATUSB : (AC Offset: 0x08) (R/   8) Status B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY0:1;         /*!< bit:      0  Comparator 0 Ready                 */
+    uint8_t  READY1:1;         /*!< bit:      1  Comparator 1 Ready                 */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  READY:2;          /*!< bit:  0.. 1  Comparator x Ready                 */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSB_OFFSET           0x08         /**< \brief (AC_STATUSB offset) Status B */
+#define AC_STATUSB_RESETVALUE       0x00ul       /**< \brief (AC_STATUSB reset_value) Status B */
+
+#define AC_STATUSB_READY0_Pos       0            /**< \brief (AC_STATUSB) Comparator 0 Ready */
+#define AC_STATUSB_READY0           (1 << AC_STATUSB_READY0_Pos)
+#define AC_STATUSB_READY1_Pos       1            /**< \brief (AC_STATUSB) Comparator 1 Ready */
+#define AC_STATUSB_READY1           (1 << AC_STATUSB_READY1_Pos)
+#define AC_STATUSB_READY_Pos        0            /**< \brief (AC_STATUSB) Comparator x Ready */
+#define AC_STATUSB_READY_Msk        (0x3ul << AC_STATUSB_READY_Pos)
+#define AC_STATUSB_READY(value)     (AC_STATUSB_READY_Msk & ((value) << AC_STATUSB_READY_Pos))
+#define AC_STATUSB_MASK             0x03ul       /**< \brief (AC_STATUSB) MASK Register */
+
+/* -------- AC_DBGCTRL : (AC Offset: 0x09) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Run                          */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_DBGCTRL_OFFSET           0x09         /**< \brief (AC_DBGCTRL offset) Debug Control */
+#define AC_DBGCTRL_RESETVALUE       0x00ul       /**< \brief (AC_DBGCTRL reset_value) Debug Control */
+
+#define AC_DBGCTRL_DBGRUN_Pos       0            /**< \brief (AC_DBGCTRL) Debug Run */
+#define AC_DBGCTRL_DBGRUN           (0x1ul << AC_DBGCTRL_DBGRUN_Pos)
+#define AC_DBGCTRL_MASK             0x01ul       /**< \brief (AC_DBGCTRL) MASK Register */
+
+/* -------- AC_WINCTRL : (AC Offset: 0x0A) (R/W  8) Window Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  WEN0:1;           /*!< bit:      0  Window 0 Mode Enable               */
+    uint8_t  WINTSEL0:2;       /*!< bit:  1.. 2  Window 0 Interrupt Selection       */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_WINCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_WINCTRL_OFFSET           0x0A         /**< \brief (AC_WINCTRL offset) Window Control */
+#define AC_WINCTRL_RESETVALUE       0x00ul       /**< \brief (AC_WINCTRL reset_value) Window Control */
+
+#define AC_WINCTRL_WEN0_Pos         0            /**< \brief (AC_WINCTRL) Window 0 Mode Enable */
+#define AC_WINCTRL_WEN0             (0x1ul << AC_WINCTRL_WEN0_Pos)
+#define AC_WINCTRL_WINTSEL0_Pos     1            /**< \brief (AC_WINCTRL) Window 0 Interrupt Selection */
+#define AC_WINCTRL_WINTSEL0_Msk     (0x3ul << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0(value)  (AC_WINCTRL_WINTSEL0_Msk & ((value) << AC_WINCTRL_WINTSEL0_Pos))
+#define   AC_WINCTRL_WINTSEL0_ABOVE_Val   0x0ul  /**< \brief (AC_WINCTRL) Interrupt on signal above window */
+#define   AC_WINCTRL_WINTSEL0_INSIDE_Val  0x1ul  /**< \brief (AC_WINCTRL) Interrupt on signal inside window */
+#define   AC_WINCTRL_WINTSEL0_BELOW_Val   0x2ul  /**< \brief (AC_WINCTRL) Interrupt on signal below window */
+#define   AC_WINCTRL_WINTSEL0_OUTSIDE_Val 0x3ul  /**< \brief (AC_WINCTRL) Interrupt on signal outside window */
+#define AC_WINCTRL_WINTSEL0_ABOVE   (AC_WINCTRL_WINTSEL0_ABOVE_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_INSIDE  (AC_WINCTRL_WINTSEL0_INSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_BELOW   (AC_WINCTRL_WINTSEL0_BELOW_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_OUTSIDE (AC_WINCTRL_WINTSEL0_OUTSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_MASK             0x07ul       /**< \brief (AC_WINCTRL) MASK Register */
+
+/* -------- AC_SCALER : (AC Offset: 0x0C) (R/W  8) Scaler n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  VALUE:6;          /*!< bit:  0.. 5  Scaler Value                       */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_SCALER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_SCALER_OFFSET            0x0C         /**< \brief (AC_SCALER offset) Scaler n */
+#define AC_SCALER_RESETVALUE        0x00ul       /**< \brief (AC_SCALER reset_value) Scaler n */
+
+#define AC_SCALER_VALUE_Pos         0            /**< \brief (AC_SCALER) Scaler Value */
+#define AC_SCALER_VALUE_Msk         (0x3Ful << AC_SCALER_VALUE_Pos)
+#define AC_SCALER_VALUE(value)      (AC_SCALER_VALUE_Msk & ((value) << AC_SCALER_VALUE_Pos))
+#define AC_SCALER_MASK              0x3Ful       /**< \brief (AC_SCALER) MASK Register */
+
+/* -------- AC_COMPCTRL : (AC Offset: 0x10) (R/W 32) Comparator Control n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t SINGLE:1;         /*!< bit:      2  Single-Shot Mode                   */
+    uint32_t INTSEL:2;         /*!< bit:  3.. 4  Interrupt Selection                */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t MUXNEG:3;         /*!< bit:  8..10  Negative Input Mux Selection       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t MUXPOS:3;         /*!< bit: 12..14  Positive Input Mux Selection       */
+    uint32_t SWAP:1;           /*!< bit:     15  Swap Inputs and Invert             */
+    uint32_t SPEED:2;          /*!< bit: 16..17  Speed Selection                    */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t HYSTEN:1;         /*!< bit:     19  Hysteresis Enable                  */
+    uint32_t HYST:2;           /*!< bit: 20..21  Hysteresis Level                   */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t FLEN:3;           /*!< bit: 24..26  Filter Length                      */
+    uint32_t :1;               /*!< bit:     27  Reserved                           */
+    uint32_t OUT:2;            /*!< bit: 28..29  Output                             */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AC_COMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_COMPCTRL_OFFSET          0x10         /**< \brief (AC_COMPCTRL offset) Comparator Control n */
+#define AC_COMPCTRL_RESETVALUE      0x00000000ul /**< \brief (AC_COMPCTRL reset_value) Comparator Control n */
+
+#define AC_COMPCTRL_ENABLE_Pos      1            /**< \brief (AC_COMPCTRL) Enable */
+#define AC_COMPCTRL_ENABLE          (0x1ul << AC_COMPCTRL_ENABLE_Pos)
+#define AC_COMPCTRL_SINGLE_Pos      2            /**< \brief (AC_COMPCTRL) Single-Shot Mode */
+#define AC_COMPCTRL_SINGLE          (0x1ul << AC_COMPCTRL_SINGLE_Pos)
+#define AC_COMPCTRL_INTSEL_Pos      3            /**< \brief (AC_COMPCTRL) Interrupt Selection */
+#define AC_COMPCTRL_INTSEL_Msk      (0x3ul << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL(value)   (AC_COMPCTRL_INTSEL_Msk & ((value) << AC_COMPCTRL_INTSEL_Pos))
+#define   AC_COMPCTRL_INTSEL_TOGGLE_Val   0x0ul  /**< \brief (AC_COMPCTRL) Interrupt on comparator output toggle */
+#define   AC_COMPCTRL_INTSEL_RISING_Val   0x1ul  /**< \brief (AC_COMPCTRL) Interrupt on comparator output rising */
+#define   AC_COMPCTRL_INTSEL_FALLING_Val  0x2ul  /**< \brief (AC_COMPCTRL) Interrupt on comparator output falling */
+#define   AC_COMPCTRL_INTSEL_EOC_Val      0x3ul  /**< \brief (AC_COMPCTRL) Interrupt on end of comparison (single-shot mode only) */
+#define AC_COMPCTRL_INTSEL_TOGGLE   (AC_COMPCTRL_INTSEL_TOGGLE_Val << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_RISING   (AC_COMPCTRL_INTSEL_RISING_Val << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_FALLING  (AC_COMPCTRL_INTSEL_FALLING_Val << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_EOC      (AC_COMPCTRL_INTSEL_EOC_Val    << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_RUNSTDBY_Pos    6            /**< \brief (AC_COMPCTRL) Run in Standby */
+#define AC_COMPCTRL_RUNSTDBY        (0x1ul << AC_COMPCTRL_RUNSTDBY_Pos)
+#define AC_COMPCTRL_MUXNEG_Pos      8            /**< \brief (AC_COMPCTRL) Negative Input Mux Selection */
+#define AC_COMPCTRL_MUXNEG_Msk      (0x7ul << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG(value)   (AC_COMPCTRL_MUXNEG_Msk & ((value) << AC_COMPCTRL_MUXNEG_Pos))
+#define   AC_COMPCTRL_MUXNEG_PIN0_Val     0x0ul  /**< \brief (AC_COMPCTRL) I/O pin 0 */
+#define   AC_COMPCTRL_MUXNEG_PIN1_Val     0x1ul  /**< \brief (AC_COMPCTRL) I/O pin 1 */
+#define   AC_COMPCTRL_MUXNEG_PIN2_Val     0x2ul  /**< \brief (AC_COMPCTRL) I/O pin 2 */
+#define   AC_COMPCTRL_MUXNEG_PIN3_Val     0x3ul  /**< \brief (AC_COMPCTRL) I/O pin 3 */
+#define   AC_COMPCTRL_MUXNEG_GND_Val      0x4ul  /**< \brief (AC_COMPCTRL) Ground */
+#define   AC_COMPCTRL_MUXNEG_VSCALE_Val   0x5ul  /**< \brief (AC_COMPCTRL) VDD scaler */
+#define   AC_COMPCTRL_MUXNEG_BANDGAP_Val  0x6ul  /**< \brief (AC_COMPCTRL) Internal bandgap voltage */
+#define   AC_COMPCTRL_MUXNEG_DAC_Val      0x7ul  /**< \brief (AC_COMPCTRL) DAC output */
+#define AC_COMPCTRL_MUXNEG_PIN0     (AC_COMPCTRL_MUXNEG_PIN0_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_PIN1     (AC_COMPCTRL_MUXNEG_PIN1_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_PIN2     (AC_COMPCTRL_MUXNEG_PIN2_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_PIN3     (AC_COMPCTRL_MUXNEG_PIN3_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_GND      (AC_COMPCTRL_MUXNEG_GND_Val    << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_VSCALE   (AC_COMPCTRL_MUXNEG_VSCALE_Val << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_BANDGAP  (AC_COMPCTRL_MUXNEG_BANDGAP_Val << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_DAC      (AC_COMPCTRL_MUXNEG_DAC_Val    << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXPOS_Pos      12           /**< \brief (AC_COMPCTRL) Positive Input Mux Selection */
+#define AC_COMPCTRL_MUXPOS_Msk      (0x7ul << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS(value)   (AC_COMPCTRL_MUXPOS_Msk & ((value) << AC_COMPCTRL_MUXPOS_Pos))
+#define   AC_COMPCTRL_MUXPOS_PIN0_Val     0x0ul  /**< \brief (AC_COMPCTRL) I/O pin 0 */
+#define   AC_COMPCTRL_MUXPOS_PIN1_Val     0x1ul  /**< \brief (AC_COMPCTRL) I/O pin 1 */
+#define   AC_COMPCTRL_MUXPOS_PIN2_Val     0x2ul  /**< \brief (AC_COMPCTRL) I/O pin 2 */
+#define   AC_COMPCTRL_MUXPOS_PIN3_Val     0x3ul  /**< \brief (AC_COMPCTRL) I/O pin 3 */
+#define   AC_COMPCTRL_MUXPOS_VSCALE_Val   0x4ul  /**< \brief (AC_COMPCTRL) VDD Scaler */
+#define AC_COMPCTRL_MUXPOS_PIN0     (AC_COMPCTRL_MUXPOS_PIN0_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_PIN1     (AC_COMPCTRL_MUXPOS_PIN1_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_PIN2     (AC_COMPCTRL_MUXPOS_PIN2_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_PIN3     (AC_COMPCTRL_MUXPOS_PIN3_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_VSCALE   (AC_COMPCTRL_MUXPOS_VSCALE_Val << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_SWAP_Pos        15           /**< \brief (AC_COMPCTRL) Swap Inputs and Invert */
+#define AC_COMPCTRL_SWAP            (0x1ul << AC_COMPCTRL_SWAP_Pos)
+#define AC_COMPCTRL_SPEED_Pos       16           /**< \brief (AC_COMPCTRL) Speed Selection */
+#define AC_COMPCTRL_SPEED_Msk       (0x3ul << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_SPEED(value)    (AC_COMPCTRL_SPEED_Msk & ((value) << AC_COMPCTRL_SPEED_Pos))
+#define   AC_COMPCTRL_SPEED_LOW_Val       0x0ul  /**< \brief (AC_COMPCTRL) Low speed */
+#define   AC_COMPCTRL_SPEED_MEDLOW_Val    0x1ul  /**< \brief (AC_COMPCTRL) Medium low speed */
+#define   AC_COMPCTRL_SPEED_MEDHIGH_Val   0x2ul  /**< \brief (AC_COMPCTRL) Medium high speed */
+#define   AC_COMPCTRL_SPEED_HIGH_Val      0x3ul  /**< \brief (AC_COMPCTRL) High speed */
+#define AC_COMPCTRL_SPEED_LOW       (AC_COMPCTRL_SPEED_LOW_Val     << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_SPEED_MEDLOW    (AC_COMPCTRL_SPEED_MEDLOW_Val  << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_SPEED_MEDHIGH   (AC_COMPCTRL_SPEED_MEDHIGH_Val << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_SPEED_HIGH      (AC_COMPCTRL_SPEED_HIGH_Val    << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_HYSTEN_Pos      19           /**< \brief (AC_COMPCTRL) Hysteresis Enable */
+#define AC_COMPCTRL_HYSTEN          (0x1ul << AC_COMPCTRL_HYSTEN_Pos)
+#define AC_COMPCTRL_HYST_Pos        20           /**< \brief (AC_COMPCTRL) Hysteresis Level */
+#define AC_COMPCTRL_HYST_Msk        (0x3ul << AC_COMPCTRL_HYST_Pos)
+#define AC_COMPCTRL_HYST(value)     (AC_COMPCTRL_HYST_Msk & ((value) << AC_COMPCTRL_HYST_Pos))
+#define   AC_COMPCTRL_HYST_HYST50_Val     0x0ul  /**< \brief (AC_COMPCTRL) 50mV */
+#define   AC_COMPCTRL_HYST_HYST70_Val     0x1ul  /**< \brief (AC_COMPCTRL) 70mV */
+#define   AC_COMPCTRL_HYST_HYST90_Val     0x2ul  /**< \brief (AC_COMPCTRL) 90mV */
+#define   AC_COMPCTRL_HYST_HYST110_Val    0x3ul  /**< \brief (AC_COMPCTRL) 110mV */
+#define AC_COMPCTRL_HYST_HYST50     (AC_COMPCTRL_HYST_HYST50_Val   << AC_COMPCTRL_HYST_Pos)
+#define AC_COMPCTRL_HYST_HYST70     (AC_COMPCTRL_HYST_HYST70_Val   << AC_COMPCTRL_HYST_Pos)
+#define AC_COMPCTRL_HYST_HYST90     (AC_COMPCTRL_HYST_HYST90_Val   << AC_COMPCTRL_HYST_Pos)
+#define AC_COMPCTRL_HYST_HYST110    (AC_COMPCTRL_HYST_HYST110_Val  << AC_COMPCTRL_HYST_Pos)
+#define AC_COMPCTRL_FLEN_Pos        24           /**< \brief (AC_COMPCTRL) Filter Length */
+#define AC_COMPCTRL_FLEN_Msk        (0x7ul << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN(value)     (AC_COMPCTRL_FLEN_Msk & ((value) << AC_COMPCTRL_FLEN_Pos))
+#define   AC_COMPCTRL_FLEN_OFF_Val        0x0ul  /**< \brief (AC_COMPCTRL) No filtering */
+#define   AC_COMPCTRL_FLEN_MAJ3_Val       0x1ul  /**< \brief (AC_COMPCTRL) 3-bit majority function (2 of 3) */
+#define   AC_COMPCTRL_FLEN_MAJ5_Val       0x2ul  /**< \brief (AC_COMPCTRL) 5-bit majority function (3 of 5) */
+#define AC_COMPCTRL_FLEN_OFF        (AC_COMPCTRL_FLEN_OFF_Val      << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN_MAJ3       (AC_COMPCTRL_FLEN_MAJ3_Val     << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN_MAJ5       (AC_COMPCTRL_FLEN_MAJ5_Val     << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_OUT_Pos         28           /**< \brief (AC_COMPCTRL) Output */
+#define AC_COMPCTRL_OUT_Msk         (0x3ul << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT(value)      (AC_COMPCTRL_OUT_Msk & ((value) << AC_COMPCTRL_OUT_Pos))
+#define   AC_COMPCTRL_OUT_OFF_Val         0x0ul  /**< \brief (AC_COMPCTRL) The output of COMPn is not routed to the COMPn I/O port */
+#define   AC_COMPCTRL_OUT_ASYNC_Val       0x1ul  /**< \brief (AC_COMPCTRL) The asynchronous output of COMPn is routed to the COMPn I/O port */
+#define   AC_COMPCTRL_OUT_SYNC_Val        0x2ul  /**< \brief (AC_COMPCTRL) The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port */
+#define AC_COMPCTRL_OUT_OFF         (AC_COMPCTRL_OUT_OFF_Val       << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT_ASYNC       (AC_COMPCTRL_OUT_ASYNC_Val     << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT_SYNC        (AC_COMPCTRL_OUT_SYNC_Val      << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_MASK            0x373BF75Eul /**< \brief (AC_COMPCTRL) MASK Register */
+
+/* -------- AC_SYNCBUSY : (AC Offset: 0x20) (R/  32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset Synchronization Busy */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable Synchronization Busy        */
+    uint32_t WINCTRL:1;        /*!< bit:      2  WINCTRL Synchronization Busy       */
+    uint32_t COMPCTRL0:1;      /*!< bit:      3  COMPCTRL 0 Synchronization Busy    */
+    uint32_t COMPCTRL1:1;      /*!< bit:      4  COMPCTRL 1 Synchronization Busy    */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :3;               /*!< bit:  0.. 2  Reserved                           */
+    uint32_t COMPCTRL:2;       /*!< bit:  3.. 4  COMPCTRL x Synchronization Busy    */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_SYNCBUSY_OFFSET          0x20         /**< \brief (AC_SYNCBUSY offset) Synchronization Busy */
+#define AC_SYNCBUSY_RESETVALUE      0x00000000ul /**< \brief (AC_SYNCBUSY reset_value) Synchronization Busy */
+
+#define AC_SYNCBUSY_SWRST_Pos       0            /**< \brief (AC_SYNCBUSY) Software Reset Synchronization Busy */
+#define AC_SYNCBUSY_SWRST           (0x1ul << AC_SYNCBUSY_SWRST_Pos)
+#define AC_SYNCBUSY_ENABLE_Pos      1            /**< \brief (AC_SYNCBUSY) Enable Synchronization Busy */
+#define AC_SYNCBUSY_ENABLE          (0x1ul << AC_SYNCBUSY_ENABLE_Pos)
+#define AC_SYNCBUSY_WINCTRL_Pos     2            /**< \brief (AC_SYNCBUSY) WINCTRL Synchronization Busy */
+#define AC_SYNCBUSY_WINCTRL         (0x1ul << AC_SYNCBUSY_WINCTRL_Pos)
+#define AC_SYNCBUSY_COMPCTRL0_Pos   3            /**< \brief (AC_SYNCBUSY) COMPCTRL 0 Synchronization Busy */
+#define AC_SYNCBUSY_COMPCTRL0       (1 << AC_SYNCBUSY_COMPCTRL0_Pos)
+#define AC_SYNCBUSY_COMPCTRL1_Pos   4            /**< \brief (AC_SYNCBUSY) COMPCTRL 1 Synchronization Busy */
+#define AC_SYNCBUSY_COMPCTRL1       (1 << AC_SYNCBUSY_COMPCTRL1_Pos)
+#define AC_SYNCBUSY_COMPCTRL_Pos    3            /**< \brief (AC_SYNCBUSY) COMPCTRL x Synchronization Busy */
+#define AC_SYNCBUSY_COMPCTRL_Msk    (0x3ul << AC_SYNCBUSY_COMPCTRL_Pos)
+#define AC_SYNCBUSY_COMPCTRL(value) (AC_SYNCBUSY_COMPCTRL_Msk & ((value) << AC_SYNCBUSY_COMPCTRL_Pos))
+#define AC_SYNCBUSY_MASK            0x0000001Ful /**< \brief (AC_SYNCBUSY) MASK Register */
+
+/** \brief AC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO AC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+  __O  AC_CTRLB_Type             CTRLB;       /**< \brief Offset: 0x01 ( /W  8) Control B */
+  __IO AC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x02 (R/W 16) Event Control */
+  __IO AC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x04 (R/W  8) Interrupt Enable Clear */
+  __IO AC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x05 (R/W  8) Interrupt Enable Set */
+  __IO AC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x06 (R/W  8) Interrupt Flag Status and Clear */
+  __I  AC_STATUSA_Type           STATUSA;     /**< \brief Offset: 0x07 (R/   8) Status A */
+  __I  AC_STATUSB_Type           STATUSB;     /**< \brief Offset: 0x08 (R/   8) Status B */
+  __IO AC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x09 (R/W  8) Debug Control */
+  __IO AC_WINCTRL_Type           WINCTRL;     /**< \brief Offset: 0x0A (R/W  8) Window Control */
+       RoReg8                    Reserved1[0x1];
+  __IO AC_SCALER_Type            SCALER[2];   /**< \brief Offset: 0x0C (R/W  8) Scaler n */
+       RoReg8                    Reserved2[0x2];
+  __IO AC_COMPCTRL_Type          COMPCTRL[2]; /**< \brief Offset: 0x10 (R/W 32) Comparator Control n */
+       RoReg8                    Reserved3[0x8];
+  __I  AC_SYNCBUSY_Type          SYNCBUSY;    /**< \brief Offset: 0x20 (R/  32) Synchronization Busy */
+} Ac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_AC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/adc_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/adc_100.h
@@ -1,0 +1,760 @@
+/**
+ * \file
+ *
+ * \brief Component description for ADC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_ADC_COMPONENT_
+#define _SAML21_ADC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ADC */
+/* ========================================================================== */
+/** \addtogroup SAML21_ADC Analog Digital Converter */
+/*@{*/
+
+#define ADC_U2247
+#define REV_ADC                     0x100
+
+/* -------- ADC_CTRLA : (ADC Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint8_t  ONDEMAND:1;       /*!< bit:      7  On Demand Control                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLA_OFFSET            0x00         /**< \brief (ADC_CTRLA offset) Control A */
+#define ADC_CTRLA_RESETVALUE        0x00ul       /**< \brief (ADC_CTRLA reset_value) Control A */
+
+#define ADC_CTRLA_SWRST_Pos         0            /**< \brief (ADC_CTRLA) Software Reset */
+#define ADC_CTRLA_SWRST             (0x1ul << ADC_CTRLA_SWRST_Pos)
+#define ADC_CTRLA_ENABLE_Pos        1            /**< \brief (ADC_CTRLA) Enable */
+#define ADC_CTRLA_ENABLE            (0x1ul << ADC_CTRLA_ENABLE_Pos)
+#define ADC_CTRLA_RUNSTDBY_Pos      6            /**< \brief (ADC_CTRLA) Run during Standby */
+#define ADC_CTRLA_RUNSTDBY          (0x1ul << ADC_CTRLA_RUNSTDBY_Pos)
+#define ADC_CTRLA_ONDEMAND_Pos      7            /**< \brief (ADC_CTRLA) On Demand Control */
+#define ADC_CTRLA_ONDEMAND          (0x1ul << ADC_CTRLA_ONDEMAND_Pos)
+#define ADC_CTRLA_MASK              0xC3ul       /**< \brief (ADC_CTRLA) MASK Register */
+
+/* -------- ADC_CTRLB : (ADC Offset: 0x01) (R/W  8) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PRESCALER:3;      /*!< bit:  0.. 2  Prescaler Configuration            */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLB_OFFSET            0x01         /**< \brief (ADC_CTRLB offset) Control B */
+#define ADC_CTRLB_RESETVALUE        0x00ul       /**< \brief (ADC_CTRLB reset_value) Control B */
+
+#define ADC_CTRLB_PRESCALER_Pos     0            /**< \brief (ADC_CTRLB) Prescaler Configuration */
+#define ADC_CTRLB_PRESCALER_Msk     (0x7ul << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER(value)  (ADC_CTRLB_PRESCALER_Msk & ((value) << ADC_CTRLB_PRESCALER_Pos))
+#define   ADC_CTRLB_PRESCALER_DIV2_Val    0x0ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 2 */
+#define   ADC_CTRLB_PRESCALER_DIV4_Val    0x1ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 4 */
+#define   ADC_CTRLB_PRESCALER_DIV8_Val    0x2ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 8 */
+#define   ADC_CTRLB_PRESCALER_DIV16_Val   0x3ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 16 */
+#define   ADC_CTRLB_PRESCALER_DIV32_Val   0x4ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 32 */
+#define   ADC_CTRLB_PRESCALER_DIV64_Val   0x5ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 64 */
+#define   ADC_CTRLB_PRESCALER_DIV128_Val  0x6ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 128 */
+#define   ADC_CTRLB_PRESCALER_DIV256_Val  0x7ul  /**< \brief (ADC_CTRLB) Peripheral clock divided by 256 */
+#define ADC_CTRLB_PRESCALER_DIV2    (ADC_CTRLB_PRESCALER_DIV2_Val  << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV4    (ADC_CTRLB_PRESCALER_DIV4_Val  << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV8    (ADC_CTRLB_PRESCALER_DIV8_Val  << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV16   (ADC_CTRLB_PRESCALER_DIV16_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV32   (ADC_CTRLB_PRESCALER_DIV32_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV64   (ADC_CTRLB_PRESCALER_DIV64_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV128  (ADC_CTRLB_PRESCALER_DIV128_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV256  (ADC_CTRLB_PRESCALER_DIV256_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_MASK              0x07ul       /**< \brief (ADC_CTRLB) MASK Register */
+
+/* -------- ADC_REFCTRL : (ADC Offset: 0x02) (R/W  8) Reference Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  REFSEL:4;         /*!< bit:  0.. 3  Reference Selection                */
+    uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  REFCOMP:1;        /*!< bit:      7  Reference Buffer Offset Compensation Enable */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_REFCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_REFCTRL_OFFSET          0x02         /**< \brief (ADC_REFCTRL offset) Reference Control */
+#define ADC_REFCTRL_RESETVALUE      0x00ul       /**< \brief (ADC_REFCTRL reset_value) Reference Control */
+
+#define ADC_REFCTRL_REFSEL_Pos      0            /**< \brief (ADC_REFCTRL) Reference Selection */
+#define ADC_REFCTRL_REFSEL_Msk      (0xFul << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL(value)   (ADC_REFCTRL_REFSEL_Msk & ((value) << ADC_REFCTRL_REFSEL_Pos))
+#define   ADC_REFCTRL_REFSEL_INTREF_Val   0x0ul  /**< \brief (ADC_REFCTRL) Internal Bandgap Reference */
+#define   ADC_REFCTRL_REFSEL_INTVCC0_Val  0x1ul  /**< \brief (ADC_REFCTRL) 1/1.6 VDDANA */
+#define   ADC_REFCTRL_REFSEL_INTVCC1_Val  0x2ul  /**< \brief (ADC_REFCTRL) 1/2 VDDANA */
+#define   ADC_REFCTRL_REFSEL_AREFA_Val    0x3ul  /**< \brief (ADC_REFCTRL) External Reference */
+#define   ADC_REFCTRL_REFSEL_AREFB_Val    0x4ul  /**< \brief (ADC_REFCTRL) External Reference */
+#define   ADC_REFCTRL_REFSEL_INTVCC2_Val  0x5ul  /**< \brief (ADC_REFCTRL) VCCANA */
+#define ADC_REFCTRL_REFSEL_INTREF   (ADC_REFCTRL_REFSEL_INTREF_Val << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_INTVCC0  (ADC_REFCTRL_REFSEL_INTVCC0_Val << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_INTVCC1  (ADC_REFCTRL_REFSEL_INTVCC1_Val << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_AREFA    (ADC_REFCTRL_REFSEL_AREFA_Val  << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_AREFB    (ADC_REFCTRL_REFSEL_AREFB_Val  << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_INTVCC2  (ADC_REFCTRL_REFSEL_INTVCC2_Val << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFCOMP_Pos     7            /**< \brief (ADC_REFCTRL) Reference Buffer Offset Compensation Enable */
+#define ADC_REFCTRL_REFCOMP         (0x1ul << ADC_REFCTRL_REFCOMP_Pos)
+#define ADC_REFCTRL_MASK            0x8Ful       /**< \brief (ADC_REFCTRL) MASK Register */
+
+/* -------- ADC_EVCTRL : (ADC Offset: 0x03) (R/W  8) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  FLUSHEI:1;        /*!< bit:      0  Flush Event Input Enable           */
+    uint8_t  STARTEI:1;        /*!< bit:      1  Start Conversion Event Input Enable */
+    uint8_t  FLUSHINV:1;       /*!< bit:      2  Flush Event Invert Enable          */
+    uint8_t  STARTINV:1;       /*!< bit:      3  Satrt Event Invert Enable          */
+    uint8_t  RESRDYEO:1;       /*!< bit:      4  Result Ready Event Out             */
+    uint8_t  WINMONEO:1;       /*!< bit:      5  Window Monitor Event Out           */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_EVCTRL_OFFSET           0x03         /**< \brief (ADC_EVCTRL offset) Event Control */
+#define ADC_EVCTRL_RESETVALUE       0x00ul       /**< \brief (ADC_EVCTRL reset_value) Event Control */
+
+#define ADC_EVCTRL_FLUSHEI_Pos      0            /**< \brief (ADC_EVCTRL) Flush Event Input Enable */
+#define ADC_EVCTRL_FLUSHEI          (0x1ul << ADC_EVCTRL_FLUSHEI_Pos)
+#define ADC_EVCTRL_STARTEI_Pos      1            /**< \brief (ADC_EVCTRL) Start Conversion Event Input Enable */
+#define ADC_EVCTRL_STARTEI          (0x1ul << ADC_EVCTRL_STARTEI_Pos)
+#define ADC_EVCTRL_FLUSHINV_Pos     2            /**< \brief (ADC_EVCTRL) Flush Event Invert Enable */
+#define ADC_EVCTRL_FLUSHINV         (0x1ul << ADC_EVCTRL_FLUSHINV_Pos)
+#define ADC_EVCTRL_STARTINV_Pos     3            /**< \brief (ADC_EVCTRL) Satrt Event Invert Enable */
+#define ADC_EVCTRL_STARTINV         (0x1ul << ADC_EVCTRL_STARTINV_Pos)
+#define ADC_EVCTRL_RESRDYEO_Pos     4            /**< \brief (ADC_EVCTRL) Result Ready Event Out */
+#define ADC_EVCTRL_RESRDYEO         (0x1ul << ADC_EVCTRL_RESRDYEO_Pos)
+#define ADC_EVCTRL_WINMONEO_Pos     5            /**< \brief (ADC_EVCTRL) Window Monitor Event Out */
+#define ADC_EVCTRL_WINMONEO         (0x1ul << ADC_EVCTRL_WINMONEO_Pos)
+#define ADC_EVCTRL_MASK             0x3Ful       /**< \brief (ADC_EVCTRL) MASK Register */
+
+/* -------- ADC_INTENCLR : (ADC Offset: 0x04) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Disable     */
+    uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Disable          */
+    uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Disable   */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENCLR_OFFSET         0x04         /**< \brief (ADC_INTENCLR offset) Interrupt Enable Clear */
+#define ADC_INTENCLR_RESETVALUE     0x00ul       /**< \brief (ADC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define ADC_INTENCLR_RESRDY_Pos     0            /**< \brief (ADC_INTENCLR) Result Ready Interrupt Disable */
+#define ADC_INTENCLR_RESRDY         (0x1ul << ADC_INTENCLR_RESRDY_Pos)
+#define ADC_INTENCLR_OVERRUN_Pos    1            /**< \brief (ADC_INTENCLR) Overrun Interrupt Disable */
+#define ADC_INTENCLR_OVERRUN        (0x1ul << ADC_INTENCLR_OVERRUN_Pos)
+#define ADC_INTENCLR_WINMON_Pos     2            /**< \brief (ADC_INTENCLR) Window Monitor Interrupt Disable */
+#define ADC_INTENCLR_WINMON         (0x1ul << ADC_INTENCLR_WINMON_Pos)
+#define ADC_INTENCLR_MASK           0x07ul       /**< \brief (ADC_INTENCLR) MASK Register */
+
+/* -------- ADC_INTENSET : (ADC Offset: 0x05) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Enable      */
+    uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Enable           */
+    uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Enable    */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENSET_OFFSET         0x05         /**< \brief (ADC_INTENSET offset) Interrupt Enable Set */
+#define ADC_INTENSET_RESETVALUE     0x00ul       /**< \brief (ADC_INTENSET reset_value) Interrupt Enable Set */
+
+#define ADC_INTENSET_RESRDY_Pos     0            /**< \brief (ADC_INTENSET) Result Ready Interrupt Enable */
+#define ADC_INTENSET_RESRDY         (0x1ul << ADC_INTENSET_RESRDY_Pos)
+#define ADC_INTENSET_OVERRUN_Pos    1            /**< \brief (ADC_INTENSET) Overrun Interrupt Enable */
+#define ADC_INTENSET_OVERRUN        (0x1ul << ADC_INTENSET_OVERRUN_Pos)
+#define ADC_INTENSET_WINMON_Pos     2            /**< \brief (ADC_INTENSET) Window Monitor Interrupt Enable */
+#define ADC_INTENSET_WINMON         (0x1ul << ADC_INTENSET_WINMON_Pos)
+#define ADC_INTENSET_MASK           0x07ul       /**< \brief (ADC_INTENSET) MASK Register */
+
+/* -------- ADC_INTFLAG : (ADC Offset: 0x06) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
+    __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
+    __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
+    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTFLAG_OFFSET          0x06         /**< \brief (ADC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define ADC_INTFLAG_RESETVALUE      0x00ul       /**< \brief (ADC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define ADC_INTFLAG_RESRDY_Pos      0            /**< \brief (ADC_INTFLAG) Result Ready Interrupt Flag */
+#define ADC_INTFLAG_RESRDY          (0x1ul << ADC_INTFLAG_RESRDY_Pos)
+#define ADC_INTFLAG_OVERRUN_Pos     1            /**< \brief (ADC_INTFLAG) Overrun Interrupt Flag */
+#define ADC_INTFLAG_OVERRUN         (0x1ul << ADC_INTFLAG_OVERRUN_Pos)
+#define ADC_INTFLAG_WINMON_Pos      2            /**< \brief (ADC_INTFLAG) Window Monitor Interrupt Flag */
+#define ADC_INTFLAG_WINMON          (0x1ul << ADC_INTFLAG_WINMON_Pos)
+#define ADC_INTFLAG_MASK            0x07ul       /**< \brief (ADC_INTFLAG) MASK Register */
+
+/* -------- ADC_SEQSTATUS : (ADC Offset: 0x07) (R/   8) Sequence Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SEQSTATE:5;       /*!< bit:  0.. 4  Sequence State                     */
+    uint8_t  :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint8_t  SEQBUSY:1;        /*!< bit:      7  Sequence Busy                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_SEQSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SEQSTATUS_OFFSET        0x07         /**< \brief (ADC_SEQSTATUS offset) Sequence Status */
+#define ADC_SEQSTATUS_RESETVALUE    0x00ul       /**< \brief (ADC_SEQSTATUS reset_value) Sequence Status */
+
+#define ADC_SEQSTATUS_SEQSTATE_Pos  0            /**< \brief (ADC_SEQSTATUS) Sequence State */
+#define ADC_SEQSTATUS_SEQSTATE_Msk  (0x1Ful << ADC_SEQSTATUS_SEQSTATE_Pos)
+#define ADC_SEQSTATUS_SEQSTATE(value) (ADC_SEQSTATUS_SEQSTATE_Msk & ((value) << ADC_SEQSTATUS_SEQSTATE_Pos))
+#define ADC_SEQSTATUS_SEQBUSY_Pos   7            /**< \brief (ADC_SEQSTATUS) Sequence Busy */
+#define ADC_SEQSTATUS_SEQBUSY       (0x1ul << ADC_SEQSTATUS_SEQBUSY_Pos)
+#define ADC_SEQSTATUS_MASK          0x9Ful       /**< \brief (ADC_SEQSTATUS) MASK Register */
+
+/* -------- ADC_INPUTCTRL : (ADC Offset: 0x08) (R/W 16) Input Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t MUXPOS:5;         /*!< bit:  0.. 4  Positive Mux Input Selection       */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t MUXNEG:5;         /*!< bit:  8..12  Negative Mux Input Selection       */
+    uint16_t :3;               /*!< bit: 13..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_INPUTCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INPUTCTRL_OFFSET        0x08         /**< \brief (ADC_INPUTCTRL offset) Input Control */
+#define ADC_INPUTCTRL_RESETVALUE    0x0000ul     /**< \brief (ADC_INPUTCTRL reset_value) Input Control */
+
+#define ADC_INPUTCTRL_MUXPOS_Pos    0            /**< \brief (ADC_INPUTCTRL) Positive Mux Input Selection */
+#define ADC_INPUTCTRL_MUXPOS_Msk    (0x1Ful << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS(value) (ADC_INPUTCTRL_MUXPOS_Msk & ((value) << ADC_INPUTCTRL_MUXPOS_Pos))
+#define   ADC_INPUTCTRL_MUXPOS_AIN0_Val   0x0ul  /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN1_Val   0x1ul  /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN2_Val   0x2ul  /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN3_Val   0x3ul  /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN4_Val   0x4ul  /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN5_Val   0x5ul  /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN6_Val   0x6ul  /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN7_Val   0x7ul  /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN8_Val   0x8ul  /**< \brief (ADC_INPUTCTRL) ADC AIN8 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN9_Val   0x9ul  /**< \brief (ADC_INPUTCTRL) ADC AIN9 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN10_Val  0xAul  /**< \brief (ADC_INPUTCTRL) ADC AIN10 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN11_Val  0xBul  /**< \brief (ADC_INPUTCTRL) ADC AIN11 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN12_Val  0xCul  /**< \brief (ADC_INPUTCTRL) ADC AIN12 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN13_Val  0xDul  /**< \brief (ADC_INPUTCTRL) ADC AIN13 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN14_Val  0xEul  /**< \brief (ADC_INPUTCTRL) ADC AIN14 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN15_Val  0xFul  /**< \brief (ADC_INPUTCTRL) ADC AIN15 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN16_Val  0x10ul  /**< \brief (ADC_INPUTCTRL) ADC AIN16 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN17_Val  0x11ul  /**< \brief (ADC_INPUTCTRL) ADC AIN17 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN18_Val  0x12ul  /**< \brief (ADC_INPUTCTRL) ADC AIN18 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN19_Val  0x13ul  /**< \brief (ADC_INPUTCTRL) ADC AIN19 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN20_Val  0x14ul  /**< \brief (ADC_INPUTCTRL) ADC AIN20 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN21_Val  0x15ul  /**< \brief (ADC_INPUTCTRL) ADC AIN21 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN22_Val  0x16ul  /**< \brief (ADC_INPUTCTRL) ADC AIN22 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_AIN23_Val  0x17ul  /**< \brief (ADC_INPUTCTRL) ADC AIN23 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_TEMP_Val   0x18ul  /**< \brief (ADC_INPUTCTRL) Temperature Sensor */
+#define   ADC_INPUTCTRL_MUXPOS_BANDGAP_Val 0x19ul  /**< \brief (ADC_INPUTCTRL) Bandgap Voltage */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val 0x1Aul  /**< \brief (ADC_INPUTCTRL) 1/4 Scaled Core Supply */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1Bul  /**< \brief (ADC_INPUTCTRL) 1/4 Scaled I/O Supply */
+#define   ADC_INPUTCTRL_MUXPOS_DAC_Val    0x1Cul  /**< \brief (ADC_INPUTCTRL) DAC Output */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDVBAT_Val 0x1Dul  /**< \brief (ADC_INPUTCTRL) 1/4 Scaled VBAT Supply */
+#define   ADC_INPUTCTRL_MUXPOS_OPAMP01_Val 0x1Eul  /**< \brief (ADC_INPUTCTRL) OPAMP0 or OPAMP1 output */
+#define   ADC_INPUTCTRL_MUXPOS_OPAMP2_Val 0x1Ful  /**< \brief (ADC_INPUTCTRL) OPAMP2 output */
+#define ADC_INPUTCTRL_MUXPOS_AIN0   (ADC_INPUTCTRL_MUXPOS_AIN0_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN1   (ADC_INPUTCTRL_MUXPOS_AIN1_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN2   (ADC_INPUTCTRL_MUXPOS_AIN2_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN3   (ADC_INPUTCTRL_MUXPOS_AIN3_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN4   (ADC_INPUTCTRL_MUXPOS_AIN4_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN5   (ADC_INPUTCTRL_MUXPOS_AIN5_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN6   (ADC_INPUTCTRL_MUXPOS_AIN6_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN7   (ADC_INPUTCTRL_MUXPOS_AIN7_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN8   (ADC_INPUTCTRL_MUXPOS_AIN8_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN9   (ADC_INPUTCTRL_MUXPOS_AIN9_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN10  (ADC_INPUTCTRL_MUXPOS_AIN10_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN11  (ADC_INPUTCTRL_MUXPOS_AIN11_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN12  (ADC_INPUTCTRL_MUXPOS_AIN12_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN13  (ADC_INPUTCTRL_MUXPOS_AIN13_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN14  (ADC_INPUTCTRL_MUXPOS_AIN14_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN15  (ADC_INPUTCTRL_MUXPOS_AIN15_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN16  (ADC_INPUTCTRL_MUXPOS_AIN16_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN17  (ADC_INPUTCTRL_MUXPOS_AIN17_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN18  (ADC_INPUTCTRL_MUXPOS_AIN18_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN19  (ADC_INPUTCTRL_MUXPOS_AIN19_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN20  (ADC_INPUTCTRL_MUXPOS_AIN20_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN21  (ADC_INPUTCTRL_MUXPOS_AIN21_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN22  (ADC_INPUTCTRL_MUXPOS_AIN22_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_AIN23  (ADC_INPUTCTRL_MUXPOS_AIN23_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_TEMP   (ADC_INPUTCTRL_MUXPOS_TEMP_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_BANDGAP (ADC_INPUTCTRL_MUXPOS_BANDGAP_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC (ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC (ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_DAC    (ADC_INPUTCTRL_MUXPOS_DAC_Val  << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_SCALEDVBAT (ADC_INPUTCTRL_MUXPOS_SCALEDVBAT_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_OPAMP01 (ADC_INPUTCTRL_MUXPOS_OPAMP01_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_OPAMP2 (ADC_INPUTCTRL_MUXPOS_OPAMP2_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXNEG_Pos    8            /**< \brief (ADC_INPUTCTRL) Negative Mux Input Selection */
+#define ADC_INPUTCTRL_MUXNEG_Msk    (0x1Ful << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG(value) (ADC_INPUTCTRL_MUXNEG_Msk & ((value) << ADC_INPUTCTRL_MUXNEG_Pos))
+#define   ADC_INPUTCTRL_MUXNEG_AIN0_Val   0x0ul  /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_AIN1_Val   0x1ul  /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_AIN2_Val   0x2ul  /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_AIN3_Val   0x3ul  /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_AIN4_Val   0x4ul  /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_AIN5_Val   0x5ul  /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_AIN6_Val   0x6ul  /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_AIN7_Val   0x7ul  /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
+#define ADC_INPUTCTRL_MUXNEG_AIN0   (ADC_INPUTCTRL_MUXNEG_AIN0_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_AIN1   (ADC_INPUTCTRL_MUXNEG_AIN1_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_AIN2   (ADC_INPUTCTRL_MUXNEG_AIN2_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_AIN3   (ADC_INPUTCTRL_MUXNEG_AIN3_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_AIN4   (ADC_INPUTCTRL_MUXNEG_AIN4_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_AIN5   (ADC_INPUTCTRL_MUXNEG_AIN5_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_AIN6   (ADC_INPUTCTRL_MUXNEG_AIN6_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_AIN7   (ADC_INPUTCTRL_MUXNEG_AIN7_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MASK          0x1F1Ful     /**< \brief (ADC_INPUTCTRL) MASK Register */
+
+/* -------- ADC_CTRLC : (ADC Offset: 0x0A) (R/W 16) Control C -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DIFFMODE:1;       /*!< bit:      0  Differential Mode                  */
+    uint16_t LEFTADJ:1;        /*!< bit:      1  Left-Adjusted Result               */
+    uint16_t FREERUN:1;        /*!< bit:      2  Free Running Mode                  */
+    uint16_t CORREN:1;         /*!< bit:      3  Digital Correction Logic Enable    */
+    uint16_t RESSEL:2;         /*!< bit:  4.. 5  Conversion Result Resolution       */
+    uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t WINMODE:3;        /*!< bit:  8..10  Window Monitor Mode                */
+    uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_CTRLC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLC_OFFSET            0x0A         /**< \brief (ADC_CTRLC offset) Control C */
+#define ADC_CTRLC_RESETVALUE        0x0000ul     /**< \brief (ADC_CTRLC reset_value) Control C */
+
+#define ADC_CTRLC_DIFFMODE_Pos      0            /**< \brief (ADC_CTRLC) Differential Mode */
+#define ADC_CTRLC_DIFFMODE          (0x1ul << ADC_CTRLC_DIFFMODE_Pos)
+#define ADC_CTRLC_LEFTADJ_Pos       1            /**< \brief (ADC_CTRLC) Left-Adjusted Result */
+#define ADC_CTRLC_LEFTADJ           (0x1ul << ADC_CTRLC_LEFTADJ_Pos)
+#define ADC_CTRLC_FREERUN_Pos       2            /**< \brief (ADC_CTRLC) Free Running Mode */
+#define ADC_CTRLC_FREERUN           (0x1ul << ADC_CTRLC_FREERUN_Pos)
+#define ADC_CTRLC_CORREN_Pos        3            /**< \brief (ADC_CTRLC) Digital Correction Logic Enable */
+#define ADC_CTRLC_CORREN            (0x1ul << ADC_CTRLC_CORREN_Pos)
+#define ADC_CTRLC_RESSEL_Pos        4            /**< \brief (ADC_CTRLC) Conversion Result Resolution */
+#define ADC_CTRLC_RESSEL_Msk        (0x3ul << ADC_CTRLC_RESSEL_Pos)
+#define ADC_CTRLC_RESSEL(value)     (ADC_CTRLC_RESSEL_Msk & ((value) << ADC_CTRLC_RESSEL_Pos))
+#define   ADC_CTRLC_RESSEL_12BIT_Val      0x0ul  /**< \brief (ADC_CTRLC) 12-bit result */
+#define   ADC_CTRLC_RESSEL_16BIT_Val      0x1ul  /**< \brief (ADC_CTRLC) For averaging mode output */
+#define   ADC_CTRLC_RESSEL_10BIT_Val      0x2ul  /**< \brief (ADC_CTRLC) 10-bit result */
+#define   ADC_CTRLC_RESSEL_8BIT_Val       0x3ul  /**< \brief (ADC_CTRLC) 8-bit result */
+#define ADC_CTRLC_RESSEL_12BIT      (ADC_CTRLC_RESSEL_12BIT_Val    << ADC_CTRLC_RESSEL_Pos)
+#define ADC_CTRLC_RESSEL_16BIT      (ADC_CTRLC_RESSEL_16BIT_Val    << ADC_CTRLC_RESSEL_Pos)
+#define ADC_CTRLC_RESSEL_10BIT      (ADC_CTRLC_RESSEL_10BIT_Val    << ADC_CTRLC_RESSEL_Pos)
+#define ADC_CTRLC_RESSEL_8BIT       (ADC_CTRLC_RESSEL_8BIT_Val     << ADC_CTRLC_RESSEL_Pos)
+#define ADC_CTRLC_WINMODE_Pos       8            /**< \brief (ADC_CTRLC) Window Monitor Mode */
+#define ADC_CTRLC_WINMODE_Msk       (0x7ul << ADC_CTRLC_WINMODE_Pos)
+#define ADC_CTRLC_WINMODE(value)    (ADC_CTRLC_WINMODE_Msk & ((value) << ADC_CTRLC_WINMODE_Pos))
+#define   ADC_CTRLC_WINMODE_DISABLE_Val   0x0ul  /**< \brief (ADC_CTRLC) No window mode (default) */
+#define   ADC_CTRLC_WINMODE_MODE1_Val     0x1ul  /**< \brief (ADC_CTRLC) RESULT > WINLT */
+#define   ADC_CTRLC_WINMODE_MODE2_Val     0x2ul  /**< \brief (ADC_CTRLC) RESULT < WINUT */
+#define   ADC_CTRLC_WINMODE_MODE3_Val     0x3ul  /**< \brief (ADC_CTRLC) WINLT < RESULT < WINUT */
+#define   ADC_CTRLC_WINMODE_MODE4_Val     0x4ul  /**< \brief (ADC_CTRLC) !(WINLT < RESULT < WINUT) */
+#define ADC_CTRLC_WINMODE_DISABLE   (ADC_CTRLC_WINMODE_DISABLE_Val << ADC_CTRLC_WINMODE_Pos)
+#define ADC_CTRLC_WINMODE_MODE1     (ADC_CTRLC_WINMODE_MODE1_Val   << ADC_CTRLC_WINMODE_Pos)
+#define ADC_CTRLC_WINMODE_MODE2     (ADC_CTRLC_WINMODE_MODE2_Val   << ADC_CTRLC_WINMODE_Pos)
+#define ADC_CTRLC_WINMODE_MODE3     (ADC_CTRLC_WINMODE_MODE3_Val   << ADC_CTRLC_WINMODE_Pos)
+#define ADC_CTRLC_WINMODE_MODE4     (ADC_CTRLC_WINMODE_MODE4_Val   << ADC_CTRLC_WINMODE_Pos)
+#define ADC_CTRLC_MASK              0x073Ful     /**< \brief (ADC_CTRLC) MASK Register */
+
+/* -------- ADC_AVGCTRL : (ADC Offset: 0x0C) (R/W  8) Average Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SAMPLENUM:4;      /*!< bit:  0.. 3  Number of Samples to be Collected  */
+    uint8_t  ADJRES:3;         /*!< bit:  4.. 6  Adjusting Result / Division Coefficient */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_AVGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_AVGCTRL_OFFSET          0x0C         /**< \brief (ADC_AVGCTRL offset) Average Control */
+#define ADC_AVGCTRL_RESETVALUE      0x00ul       /**< \brief (ADC_AVGCTRL reset_value) Average Control */
+
+#define ADC_AVGCTRL_SAMPLENUM_Pos   0            /**< \brief (ADC_AVGCTRL) Number of Samples to be Collected */
+#define ADC_AVGCTRL_SAMPLENUM_Msk   (0xFul << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM(value) (ADC_AVGCTRL_SAMPLENUM_Msk & ((value) << ADC_AVGCTRL_SAMPLENUM_Pos))
+#define   ADC_AVGCTRL_SAMPLENUM_1_Val     0x0ul  /**< \brief (ADC_AVGCTRL) 1 sample */
+#define   ADC_AVGCTRL_SAMPLENUM_2_Val     0x1ul  /**< \brief (ADC_AVGCTRL) 2 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_4_Val     0x2ul  /**< \brief (ADC_AVGCTRL) 4 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_8_Val     0x3ul  /**< \brief (ADC_AVGCTRL) 8 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_16_Val    0x4ul  /**< \brief (ADC_AVGCTRL) 16 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_32_Val    0x5ul  /**< \brief (ADC_AVGCTRL) 32 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_64_Val    0x6ul  /**< \brief (ADC_AVGCTRL) 64 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_128_Val   0x7ul  /**< \brief (ADC_AVGCTRL) 128 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_256_Val   0x8ul  /**< \brief (ADC_AVGCTRL) 256 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_512_Val   0x9ul  /**< \brief (ADC_AVGCTRL) 512 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_1024_Val  0xAul  /**< \brief (ADC_AVGCTRL) 1024 samples */
+#define ADC_AVGCTRL_SAMPLENUM_1     (ADC_AVGCTRL_SAMPLENUM_1_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_2     (ADC_AVGCTRL_SAMPLENUM_2_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_4     (ADC_AVGCTRL_SAMPLENUM_4_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_8     (ADC_AVGCTRL_SAMPLENUM_8_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_16    (ADC_AVGCTRL_SAMPLENUM_16_Val  << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_32    (ADC_AVGCTRL_SAMPLENUM_32_Val  << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_64    (ADC_AVGCTRL_SAMPLENUM_64_Val  << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_128   (ADC_AVGCTRL_SAMPLENUM_128_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_256   (ADC_AVGCTRL_SAMPLENUM_256_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_512   (ADC_AVGCTRL_SAMPLENUM_512_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_1024  (ADC_AVGCTRL_SAMPLENUM_1024_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_ADJRES_Pos      4            /**< \brief (ADC_AVGCTRL) Adjusting Result / Division Coefficient */
+#define ADC_AVGCTRL_ADJRES_Msk      (0x7ul << ADC_AVGCTRL_ADJRES_Pos)
+#define ADC_AVGCTRL_ADJRES(value)   (ADC_AVGCTRL_ADJRES_Msk & ((value) << ADC_AVGCTRL_ADJRES_Pos))
+#define ADC_AVGCTRL_MASK            0x7Ful       /**< \brief (ADC_AVGCTRL) MASK Register */
+
+/* -------- ADC_SAMPCTRL : (ADC Offset: 0x0D) (R/W  8) Sample Time Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SAMPLEN:6;        /*!< bit:  0.. 5  Sampling Time Length               */
+    uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  OFFCOMP:1;        /*!< bit:      7  Comparator Offset Compensation Enable */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_SAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SAMPCTRL_OFFSET         0x0D         /**< \brief (ADC_SAMPCTRL offset) Sample Time Control */
+#define ADC_SAMPCTRL_RESETVALUE     0x00ul       /**< \brief (ADC_SAMPCTRL reset_value) Sample Time Control */
+
+#define ADC_SAMPCTRL_SAMPLEN_Pos    0            /**< \brief (ADC_SAMPCTRL) Sampling Time Length */
+#define ADC_SAMPCTRL_SAMPLEN_Msk    (0x3Ful << ADC_SAMPCTRL_SAMPLEN_Pos)
+#define ADC_SAMPCTRL_SAMPLEN(value) (ADC_SAMPCTRL_SAMPLEN_Msk & ((value) << ADC_SAMPCTRL_SAMPLEN_Pos))
+#define ADC_SAMPCTRL_OFFCOMP_Pos    7            /**< \brief (ADC_SAMPCTRL) Comparator Offset Compensation Enable */
+#define ADC_SAMPCTRL_OFFCOMP        (0x1ul << ADC_SAMPCTRL_OFFCOMP_Pos)
+#define ADC_SAMPCTRL_MASK           0xBFul       /**< \brief (ADC_SAMPCTRL) MASK Register */
+
+/* -------- ADC_WINLT : (ADC Offset: 0x0E) (R/W 16) Window Monitor Lower Threshold -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t WINLT:16;         /*!< bit:  0..15  Window Lower Threshold             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_WINLT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINLT_OFFSET            0x0E         /**< \brief (ADC_WINLT offset) Window Monitor Lower Threshold */
+#define ADC_WINLT_RESETVALUE        0x0000ul     /**< \brief (ADC_WINLT reset_value) Window Monitor Lower Threshold */
+
+#define ADC_WINLT_WINLT_Pos         0            /**< \brief (ADC_WINLT) Window Lower Threshold */
+#define ADC_WINLT_WINLT_Msk         (0xFFFFul << ADC_WINLT_WINLT_Pos)
+#define ADC_WINLT_WINLT(value)      (ADC_WINLT_WINLT_Msk & ((value) << ADC_WINLT_WINLT_Pos))
+#define ADC_WINLT_MASK              0xFFFFul     /**< \brief (ADC_WINLT) MASK Register */
+
+/* -------- ADC_WINUT : (ADC Offset: 0x10) (R/W 16) Window Monitor Upper Threshold -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t WINUT:16;         /*!< bit:  0..15  Window Upper Threshold             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_WINUT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINUT_OFFSET            0x10         /**< \brief (ADC_WINUT offset) Window Monitor Upper Threshold */
+#define ADC_WINUT_RESETVALUE        0x0000ul     /**< \brief (ADC_WINUT reset_value) Window Monitor Upper Threshold */
+
+#define ADC_WINUT_WINUT_Pos         0            /**< \brief (ADC_WINUT) Window Upper Threshold */
+#define ADC_WINUT_WINUT_Msk         (0xFFFFul << ADC_WINUT_WINUT_Pos)
+#define ADC_WINUT_WINUT(value)      (ADC_WINUT_WINUT_Msk & ((value) << ADC_WINUT_WINUT_Pos))
+#define ADC_WINUT_MASK              0xFFFFul     /**< \brief (ADC_WINUT) MASK Register */
+
+/* -------- ADC_GAINCORR : (ADC Offset: 0x12) (R/W 16) Gain Correction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t GAINCORR:12;      /*!< bit:  0..11  Gain Correction Value              */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_GAINCORR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_GAINCORR_OFFSET         0x12         /**< \brief (ADC_GAINCORR offset) Gain Correction */
+#define ADC_GAINCORR_RESETVALUE     0x0000ul     /**< \brief (ADC_GAINCORR reset_value) Gain Correction */
+
+#define ADC_GAINCORR_GAINCORR_Pos   0            /**< \brief (ADC_GAINCORR) Gain Correction Value */
+#define ADC_GAINCORR_GAINCORR_Msk   (0xFFFul << ADC_GAINCORR_GAINCORR_Pos)
+#define ADC_GAINCORR_GAINCORR(value) (ADC_GAINCORR_GAINCORR_Msk & ((value) << ADC_GAINCORR_GAINCORR_Pos))
+#define ADC_GAINCORR_MASK           0x0FFFul     /**< \brief (ADC_GAINCORR) MASK Register */
+
+/* -------- ADC_OFFSETCORR : (ADC Offset: 0x14) (R/W 16) Offset Correction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t OFFSETCORR:12;    /*!< bit:  0..11  Offset Correction Value            */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_OFFSETCORR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_OFFSETCORR_OFFSET       0x14         /**< \brief (ADC_OFFSETCORR offset) Offset Correction */
+#define ADC_OFFSETCORR_RESETVALUE   0x0000ul     /**< \brief (ADC_OFFSETCORR reset_value) Offset Correction */
+
+#define ADC_OFFSETCORR_OFFSETCORR_Pos 0            /**< \brief (ADC_OFFSETCORR) Offset Correction Value */
+#define ADC_OFFSETCORR_OFFSETCORR_Msk (0xFFFul << ADC_OFFSETCORR_OFFSETCORR_Pos)
+#define ADC_OFFSETCORR_OFFSETCORR(value) (ADC_OFFSETCORR_OFFSETCORR_Msk & ((value) << ADC_OFFSETCORR_OFFSETCORR_Pos))
+#define ADC_OFFSETCORR_MASK         0x0FFFul     /**< \brief (ADC_OFFSETCORR) MASK Register */
+
+/* -------- ADC_SWTRIG : (ADC Offset: 0x18) (R/W  8) Software Trigger -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  FLUSH:1;          /*!< bit:      0  ADC Flush                          */
+    uint8_t  START:1;          /*!< bit:      1  Start ADC Conversion               */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_SWTRIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SWTRIG_OFFSET           0x18         /**< \brief (ADC_SWTRIG offset) Software Trigger */
+#define ADC_SWTRIG_RESETVALUE       0x00ul       /**< \brief (ADC_SWTRIG reset_value) Software Trigger */
+
+#define ADC_SWTRIG_FLUSH_Pos        0            /**< \brief (ADC_SWTRIG) ADC Flush */
+#define ADC_SWTRIG_FLUSH            (0x1ul << ADC_SWTRIG_FLUSH_Pos)
+#define ADC_SWTRIG_START_Pos        1            /**< \brief (ADC_SWTRIG) Start ADC Conversion */
+#define ADC_SWTRIG_START            (0x1ul << ADC_SWTRIG_START_Pos)
+#define ADC_SWTRIG_MASK             0x03ul       /**< \brief (ADC_SWTRIG) MASK Register */
+
+/* -------- ADC_DBGCTRL : (ADC Offset: 0x1C) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Run                          */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_DBGCTRL_OFFSET          0x1C         /**< \brief (ADC_DBGCTRL offset) Debug Control */
+#define ADC_DBGCTRL_RESETVALUE      0x00ul       /**< \brief (ADC_DBGCTRL reset_value) Debug Control */
+
+#define ADC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (ADC_DBGCTRL) Debug Run */
+#define ADC_DBGCTRL_DBGRUN          (0x1ul << ADC_DBGCTRL_DBGRUN_Pos)
+#define ADC_DBGCTRL_MASK            0x01ul       /**< \brief (ADC_DBGCTRL) MASK Register */
+
+/* -------- ADC_SYNCBUSY : (ADC Offset: 0x20) (R/  16) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  SWRST Synchronization Busy         */
+    uint16_t ENABLE:1;         /*!< bit:      1  ENABLE Synchronization Busy        */
+    uint16_t AVGCTRL:1;        /*!< bit:      2  AVGCTRL Synchronization Busy       */
+    uint16_t SAMPCTRL:1;       /*!< bit:      3  SAMPCTRL Synchronization Busy      */
+    uint16_t CTRLC:1;          /*!< bit:      4  CTRLC Synchronization Busy         */
+    uint16_t INPUTCTRL:1;      /*!< bit:      5  INPUTCTRL Synchronization Busy     */
+    uint16_t OFFSETCORR:1;     /*!< bit:      6  OFFSETCTRL Synchronization Busy    */
+    uint16_t GAINCORR:1;       /*!< bit:      7  GAINCORR Synchronization Busy      */
+    uint16_t WINLT:1;          /*!< bit:      8  WINLT Synchronization Busy         */
+    uint16_t WINUT:1;          /*!< bit:      9  WINUT Synchronization Busy         */
+    uint16_t SWTRIG:1;         /*!< bit:     10  SWTRG Synchronization Busy         */
+    uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SYNCBUSY_OFFSET         0x20         /**< \brief (ADC_SYNCBUSY offset) Synchronization Busy */
+#define ADC_SYNCBUSY_RESETVALUE     0x0000ul     /**< \brief (ADC_SYNCBUSY reset_value) Synchronization Busy */
+
+#define ADC_SYNCBUSY_SWRST_Pos      0            /**< \brief (ADC_SYNCBUSY) SWRST Synchronization Busy */
+#define ADC_SYNCBUSY_SWRST          (0x1ul << ADC_SYNCBUSY_SWRST_Pos)
+#define ADC_SYNCBUSY_ENABLE_Pos     1            /**< \brief (ADC_SYNCBUSY) ENABLE Synchronization Busy */
+#define ADC_SYNCBUSY_ENABLE         (0x1ul << ADC_SYNCBUSY_ENABLE_Pos)
+#define ADC_SYNCBUSY_AVGCTRL_Pos    2            /**< \brief (ADC_SYNCBUSY) AVGCTRL Synchronization Busy */
+#define ADC_SYNCBUSY_AVGCTRL        (0x1ul << ADC_SYNCBUSY_AVGCTRL_Pos)
+#define ADC_SYNCBUSY_SAMPCTRL_Pos   3            /**< \brief (ADC_SYNCBUSY) SAMPCTRL Synchronization Busy */
+#define ADC_SYNCBUSY_SAMPCTRL       (0x1ul << ADC_SYNCBUSY_SAMPCTRL_Pos)
+#define ADC_SYNCBUSY_CTRLC_Pos      4            /**< \brief (ADC_SYNCBUSY) CTRLC Synchronization Busy */
+#define ADC_SYNCBUSY_CTRLC          (0x1ul << ADC_SYNCBUSY_CTRLC_Pos)
+#define ADC_SYNCBUSY_INPUTCTRL_Pos  5            /**< \brief (ADC_SYNCBUSY) INPUTCTRL Synchronization Busy */
+#define ADC_SYNCBUSY_INPUTCTRL      (0x1ul << ADC_SYNCBUSY_INPUTCTRL_Pos)
+#define ADC_SYNCBUSY_OFFSETCORR_Pos 6            /**< \brief (ADC_SYNCBUSY) OFFSETCTRL Synchronization Busy */
+#define ADC_SYNCBUSY_OFFSETCORR     (0x1ul << ADC_SYNCBUSY_OFFSETCORR_Pos)
+#define ADC_SYNCBUSY_GAINCORR_Pos   7            /**< \brief (ADC_SYNCBUSY) GAINCORR Synchronization Busy */
+#define ADC_SYNCBUSY_GAINCORR       (0x1ul << ADC_SYNCBUSY_GAINCORR_Pos)
+#define ADC_SYNCBUSY_WINLT_Pos      8            /**< \brief (ADC_SYNCBUSY) WINLT Synchronization Busy */
+#define ADC_SYNCBUSY_WINLT          (0x1ul << ADC_SYNCBUSY_WINLT_Pos)
+#define ADC_SYNCBUSY_WINUT_Pos      9            /**< \brief (ADC_SYNCBUSY) WINUT Synchronization Busy */
+#define ADC_SYNCBUSY_WINUT          (0x1ul << ADC_SYNCBUSY_WINUT_Pos)
+#define ADC_SYNCBUSY_SWTRIG_Pos     10           /**< \brief (ADC_SYNCBUSY) SWTRG Synchronization Busy */
+#define ADC_SYNCBUSY_SWTRIG         (0x1ul << ADC_SYNCBUSY_SWTRIG_Pos)
+#define ADC_SYNCBUSY_MASK           0x07FFul     /**< \brief (ADC_SYNCBUSY) MASK Register */
+
+/* -------- ADC_RESULT : (ADC Offset: 0x24) (R/  16) Result -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t RESULT:16;        /*!< bit:  0..15  Result Value                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_RESULT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_RESULT_OFFSET           0x24         /**< \brief (ADC_RESULT offset) Result */
+#define ADC_RESULT_RESETVALUE       0x0000ul     /**< \brief (ADC_RESULT reset_value) Result */
+
+#define ADC_RESULT_RESULT_Pos       0            /**< \brief (ADC_RESULT) Result Value */
+#define ADC_RESULT_RESULT_Msk       (0xFFFFul << ADC_RESULT_RESULT_Pos)
+#define ADC_RESULT_RESULT(value)    (ADC_RESULT_RESULT_Msk & ((value) << ADC_RESULT_RESULT_Pos))
+#define ADC_RESULT_MASK             0xFFFFul     /**< \brief (ADC_RESULT) MASK Register */
+
+/* -------- ADC_SEQCTRL : (ADC Offset: 0x28) (R/W 32) Sequence Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEQEN:32;         /*!< bit:  0..31  Enable Positive Input in the Sequence */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADC_SEQCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SEQCTRL_OFFSET          0x28         /**< \brief (ADC_SEQCTRL offset) Sequence Control */
+#define ADC_SEQCTRL_RESETVALUE      0x00000000ul /**< \brief (ADC_SEQCTRL reset_value) Sequence Control */
+
+#define ADC_SEQCTRL_SEQEN_Pos       0            /**< \brief (ADC_SEQCTRL) Enable Positive Input in the Sequence */
+#define ADC_SEQCTRL_SEQEN_Msk       (0xFFFFFFFFul << ADC_SEQCTRL_SEQEN_Pos)
+#define ADC_SEQCTRL_SEQEN(value)    (ADC_SEQCTRL_SEQEN_Msk & ((value) << ADC_SEQCTRL_SEQEN_Pos))
+#define ADC_SEQCTRL_MASK            0xFFFFFFFFul /**< \brief (ADC_SEQCTRL) MASK Register */
+
+/* -------- ADC_CALIB : (ADC Offset: 0x2C) (R/W 16) Calibration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BIASCOMP:3;       /*!< bit:  0.. 2  Bias Comparator Scaling            */
+    uint16_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint16_t BIASREFBUF:3;     /*!< bit:  8..10  Bias  Reference Buffer Scaling     */
+    uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_CALIB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CALIB_OFFSET            0x2C         /**< \brief (ADC_CALIB offset) Calibration */
+#define ADC_CALIB_RESETVALUE        0x0000ul     /**< \brief (ADC_CALIB reset_value) Calibration */
+
+#define ADC_CALIB_BIASCOMP_Pos      0            /**< \brief (ADC_CALIB) Bias Comparator Scaling */
+#define ADC_CALIB_BIASCOMP_Msk      (0x7ul << ADC_CALIB_BIASCOMP_Pos)
+#define ADC_CALIB_BIASCOMP(value)   (ADC_CALIB_BIASCOMP_Msk & ((value) << ADC_CALIB_BIASCOMP_Pos))
+#define ADC_CALIB_BIASREFBUF_Pos    8            /**< \brief (ADC_CALIB) Bias  Reference Buffer Scaling */
+#define ADC_CALIB_BIASREFBUF_Msk    (0x7ul << ADC_CALIB_BIASREFBUF_Pos)
+#define ADC_CALIB_BIASREFBUF(value) (ADC_CALIB_BIASREFBUF_Msk & ((value) << ADC_CALIB_BIASREFBUF_Pos))
+#define ADC_CALIB_MASK              0x0707ul     /**< \brief (ADC_CALIB) MASK Register */
+
+/** \brief ADC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO ADC_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+  __IO ADC_CTRLB_Type            CTRLB;       /**< \brief Offset: 0x01 (R/W  8) Control B */
+  __IO ADC_REFCTRL_Type          REFCTRL;     /**< \brief Offset: 0x02 (R/W  8) Reference Control */
+  __IO ADC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x03 (R/W  8) Event Control */
+  __IO ADC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x04 (R/W  8) Interrupt Enable Clear */
+  __IO ADC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x05 (R/W  8) Interrupt Enable Set */
+  __IO ADC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x06 (R/W  8) Interrupt Flag Status and Clear */
+  __I  ADC_SEQSTATUS_Type        SEQSTATUS;   /**< \brief Offset: 0x07 (R/   8) Sequence Status */
+  __IO ADC_INPUTCTRL_Type        INPUTCTRL;   /**< \brief Offset: 0x08 (R/W 16) Input Control */
+  __IO ADC_CTRLC_Type            CTRLC;       /**< \brief Offset: 0x0A (R/W 16) Control C */
+  __IO ADC_AVGCTRL_Type          AVGCTRL;     /**< \brief Offset: 0x0C (R/W  8) Average Control */
+  __IO ADC_SAMPCTRL_Type         SAMPCTRL;    /**< \brief Offset: 0x0D (R/W  8) Sample Time Control */
+  __IO ADC_WINLT_Type            WINLT;       /**< \brief Offset: 0x0E (R/W 16) Window Monitor Lower Threshold */
+  __IO ADC_WINUT_Type            WINUT;       /**< \brief Offset: 0x10 (R/W 16) Window Monitor Upper Threshold */
+  __IO ADC_GAINCORR_Type         GAINCORR;    /**< \brief Offset: 0x12 (R/W 16) Gain Correction */
+  __IO ADC_OFFSETCORR_Type       OFFSETCORR;  /**< \brief Offset: 0x14 (R/W 16) Offset Correction */
+       RoReg8                    Reserved1[0x2];
+  __IO ADC_SWTRIG_Type           SWTRIG;      /**< \brief Offset: 0x18 (R/W  8) Software Trigger */
+       RoReg8                    Reserved2[0x3];
+  __IO ADC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x1C (R/W  8) Debug Control */
+       RoReg8                    Reserved3[0x3];
+  __I  ADC_SYNCBUSY_Type         SYNCBUSY;    /**< \brief Offset: 0x20 (R/  16) Synchronization Busy */
+       RoReg8                    Reserved4[0x2];
+  __I  ADC_RESULT_Type           RESULT;      /**< \brief Offset: 0x24 (R/  16) Result */
+       RoReg8                    Reserved5[0x2];
+  __IO ADC_SEQCTRL_Type          SEQCTRL;     /**< \brief Offset: 0x28 (R/W 32) Sequence Control */
+  __IO ADC_CALIB_Type            CALIB;       /**< \brief Offset: 0x2C (R/W 16) Calibration */
+} Adc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_ADC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/aes.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/aes.h
@@ -1,0 +1,347 @@
+/**
+ * \file
+ *
+ * \brief Component description for AES
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_AES_COMPONENT_
+#define _SAML21_AES_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AES */
+/* ========================================================================== */
+/** \addtogroup SAML21_AES Advanced Encryption Standard */
+/*@{*/
+
+#define AES_U2238
+#define REV_AES                     0x100
+
+/* -------- AES_CTRLA : (AES Offset: 0x00) (R/W 32) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t AESMODE:3;        /*!< bit:  2.. 4  AES Modes of operation             */
+    uint32_t CFBS:3;           /*!< bit:  5.. 7  CFB Types                          */
+    uint32_t KEYSIZE:2;        /*!< bit:  8.. 9  Keysize                            */
+    uint32_t CIPHER:1;         /*!< bit:     10  Cipher mode                        */
+    uint32_t STARTMODE:1;      /*!< bit:     11  Start mode                         */
+    uint32_t LOD:1;            /*!< bit:     12  LOD Enable                         */
+    uint32_t KEYGEN:1;         /*!< bit:     13  Last key generation                */
+    uint32_t XORKEY:1;         /*!< bit:     14  Xor Key operation                  */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t CTYPE:4;          /*!< bit: 16..19  Counter measure types              */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AES_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_CTRLA_OFFSET            0x00         /**< \brief (AES_CTRLA offset) Control A */
+#define AES_CTRLA_RESETVALUE        0x00000000ul /**< \brief (AES_CTRLA reset_value) Control A */
+
+#define AES_CTRLA_SWRST_Pos         0            /**< \brief (AES_CTRLA) Software Reset */
+#define AES_CTRLA_SWRST             (0x1ul << AES_CTRLA_SWRST_Pos)
+#define AES_CTRLA_ENABLE_Pos        1            /**< \brief (AES_CTRLA) Enable */
+#define AES_CTRLA_ENABLE            (0x1ul << AES_CTRLA_ENABLE_Pos)
+#define AES_CTRLA_AESMODE_Pos       2            /**< \brief (AES_CTRLA) AES Modes of operation */
+#define AES_CTRLA_AESMODE_Msk       (0x7ul << AES_CTRLA_AESMODE_Pos)
+#define AES_CTRLA_AESMODE(value)    (AES_CTRLA_AESMODE_Msk & ((value) << AES_CTRLA_AESMODE_Pos))
+#define AES_CTRLA_CFBS_Pos          5            /**< \brief (AES_CTRLA) CFB Types */
+#define AES_CTRLA_CFBS_Msk          (0x7ul << AES_CTRLA_CFBS_Pos)
+#define AES_CTRLA_CFBS(value)       (AES_CTRLA_CFBS_Msk & ((value) << AES_CTRLA_CFBS_Pos))
+#define AES_CTRLA_KEYSIZE_Pos       8            /**< \brief (AES_CTRLA) Keysize */
+#define AES_CTRLA_KEYSIZE_Msk       (0x3ul << AES_CTRLA_KEYSIZE_Pos)
+#define AES_CTRLA_KEYSIZE(value)    (AES_CTRLA_KEYSIZE_Msk & ((value) << AES_CTRLA_KEYSIZE_Pos))
+#define AES_CTRLA_CIPHER_Pos        10           /**< \brief (AES_CTRLA) Cipher mode */
+#define AES_CTRLA_CIPHER            (0x1ul << AES_CTRLA_CIPHER_Pos)
+#define AES_CTRLA_STARTMODE_Pos     11           /**< \brief (AES_CTRLA) Start mode */
+#define AES_CTRLA_STARTMODE         (0x1ul << AES_CTRLA_STARTMODE_Pos)
+#define AES_CTRLA_LOD_Pos           12           /**< \brief (AES_CTRLA) LOD Enable */
+#define AES_CTRLA_LOD               (0x1ul << AES_CTRLA_LOD_Pos)
+#define AES_CTRLA_KEYGEN_Pos        13           /**< \brief (AES_CTRLA) Last key generation */
+#define AES_CTRLA_KEYGEN            (0x1ul << AES_CTRLA_KEYGEN_Pos)
+#define AES_CTRLA_XORKEY_Pos        14           /**< \brief (AES_CTRLA) Xor Key operation */
+#define AES_CTRLA_XORKEY            (0x1ul << AES_CTRLA_XORKEY_Pos)
+#define AES_CTRLA_CTYPE_Pos         16           /**< \brief (AES_CTRLA) Counter measure types */
+#define AES_CTRLA_CTYPE_Msk         (0xFul << AES_CTRLA_CTYPE_Pos)
+#define AES_CTRLA_CTYPE(value)      (AES_CTRLA_CTYPE_Msk & ((value) << AES_CTRLA_CTYPE_Pos))
+#define AES_CTRLA_MASK              0x000F7FFFul /**< \brief (AES_CTRLA) MASK Register */
+
+/* -------- AES_CTRLB : (AES Offset: 0x04) (R/W  8) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  START:1;          /*!< bit:      0  Manual Start                       */
+    uint8_t  NEWMSG:1;         /*!< bit:      1  New message                        */
+    uint8_t  EOM:1;            /*!< bit:      2  End of message                     */
+    uint8_t  GFMUL:1;          /*!< bit:      3  GF Multiplication                  */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AES_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_CTRLB_OFFSET            0x04         /**< \brief (AES_CTRLB offset) Control B */
+#define AES_CTRLB_RESETVALUE        0x00ul       /**< \brief (AES_CTRLB reset_value) Control B */
+
+#define AES_CTRLB_START_Pos         0            /**< \brief (AES_CTRLB) Manual Start */
+#define AES_CTRLB_START             (0x1ul << AES_CTRLB_START_Pos)
+#define AES_CTRLB_NEWMSG_Pos        1            /**< \brief (AES_CTRLB) New message */
+#define AES_CTRLB_NEWMSG            (0x1ul << AES_CTRLB_NEWMSG_Pos)
+#define AES_CTRLB_EOM_Pos           2            /**< \brief (AES_CTRLB) End of message */
+#define AES_CTRLB_EOM               (0x1ul << AES_CTRLB_EOM_Pos)
+#define AES_CTRLB_GFMUL_Pos         3            /**< \brief (AES_CTRLB) GF Multiplication */
+#define AES_CTRLB_GFMUL             (0x1ul << AES_CTRLB_GFMUL_Pos)
+#define AES_CTRLB_MASK              0x0Ful       /**< \brief (AES_CTRLB) MASK Register */
+
+/* -------- AES_INTENCLR : (AES Offset: 0x05) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
+    uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AES_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_INTENCLR_OFFSET         0x05         /**< \brief (AES_INTENCLR offset) Interrupt Enable Clear */
+#define AES_INTENCLR_RESETVALUE     0x00ul       /**< \brief (AES_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define AES_INTENCLR_ENCCMP_Pos     0            /**< \brief (AES_INTENCLR) Encryption Complete */
+#define AES_INTENCLR_ENCCMP         (0x1ul << AES_INTENCLR_ENCCMP_Pos)
+#define   AES_INTENCLR_ENCCMP_0_Val       0x0ul  /**< \brief (AES_INTENCLR) 1 (no division) */
+#define   AES_INTENCLR_ENCCMP_1_Val       0x1ul  /**< \brief (AES_INTENCLR) 2 */
+#define   AES_INTENCLR_ENCCMP_2_Val       0x2ul  /**< \brief (AES_INTENCLR) 4 */
+#define   AES_INTENCLR_ENCCMP_3_Val       0x3ul  /**< \brief (AES_INTENCLR) 8 */
+#define AES_INTENCLR_ENCCMP_0       (AES_INTENCLR_ENCCMP_0_Val     << AES_INTENCLR_ENCCMP_Pos)
+#define AES_INTENCLR_ENCCMP_1       (AES_INTENCLR_ENCCMP_1_Val     << AES_INTENCLR_ENCCMP_Pos)
+#define AES_INTENCLR_ENCCMP_2       (AES_INTENCLR_ENCCMP_2_Val     << AES_INTENCLR_ENCCMP_Pos)
+#define AES_INTENCLR_ENCCMP_3       (AES_INTENCLR_ENCCMP_3_Val     << AES_INTENCLR_ENCCMP_Pos)
+#define AES_INTENCLR_GFMCMP_Pos     1            /**< \brief (AES_INTENCLR) GF Multiplication Complete */
+#define AES_INTENCLR_GFMCMP         (0x1ul << AES_INTENCLR_GFMCMP_Pos)
+#define AES_INTENCLR_MASK           0x03ul       /**< \brief (AES_INTENCLR) MASK Register */
+
+/* -------- AES_INTENSET : (AES Offset: 0x06) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
+    uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AES_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_INTENSET_OFFSET         0x06         /**< \brief (AES_INTENSET offset) Interrupt Enable Set */
+#define AES_INTENSET_RESETVALUE     0x00ul       /**< \brief (AES_INTENSET reset_value) Interrupt Enable Set */
+
+#define AES_INTENSET_ENCCMP_Pos     0            /**< \brief (AES_INTENSET) Encryption Complete */
+#define AES_INTENSET_ENCCMP         (0x1ul << AES_INTENSET_ENCCMP_Pos)
+#define AES_INTENSET_GFMCMP_Pos     1            /**< \brief (AES_INTENSET) GF Multiplication Complete */
+#define AES_INTENSET_GFMCMP         (0x1ul << AES_INTENSET_GFMCMP_Pos)
+#define AES_INTENSET_MASK           0x03ul       /**< \brief (AES_INTENSET) MASK Register */
+
+/* -------- AES_INTFLAG : (AES Offset: 0x07) (R/W  8) Interrupt Flag Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
+    __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AES_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_INTFLAG_OFFSET          0x07         /**< \brief (AES_INTFLAG offset) Interrupt Flag Status */
+#define AES_INTFLAG_RESETVALUE      0x00ul       /**< \brief (AES_INTFLAG reset_value) Interrupt Flag Status */
+
+#define AES_INTFLAG_ENCCMP_Pos      0            /**< \brief (AES_INTFLAG) Encryption Complete */
+#define AES_INTFLAG_ENCCMP          (0x1ul << AES_INTFLAG_ENCCMP_Pos)
+#define AES_INTFLAG_GFMCMP_Pos      1            /**< \brief (AES_INTFLAG) GF Multiplication Complete */
+#define AES_INTFLAG_GFMCMP          (0x1ul << AES_INTFLAG_GFMCMP_Pos)
+#define AES_INTFLAG_MASK            0x03ul       /**< \brief (AES_INTFLAG) MASK Register */
+
+/* -------- AES_DATABUFPTR : (AES Offset: 0x08) (R/W  8) Data buffer pointer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  INDATAPTR:2;      /*!< bit:  0.. 1  Input Data Pointer                 */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AES_DATABUFPTR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_DATABUFPTR_OFFSET       0x08         /**< \brief (AES_DATABUFPTR offset) Data buffer pointer */
+#define AES_DATABUFPTR_RESETVALUE   0x00ul       /**< \brief (AES_DATABUFPTR reset_value) Data buffer pointer */
+
+#define AES_DATABUFPTR_INDATAPTR_Pos 0            /**< \brief (AES_DATABUFPTR) Input Data Pointer */
+#define AES_DATABUFPTR_INDATAPTR_Msk (0x3ul << AES_DATABUFPTR_INDATAPTR_Pos)
+#define AES_DATABUFPTR_INDATAPTR(value) (AES_DATABUFPTR_INDATAPTR_Msk & ((value) << AES_DATABUFPTR_INDATAPTR_Pos))
+#define AES_DATABUFPTR_MASK         0x03ul       /**< \brief (AES_DATABUFPTR) MASK Register */
+
+/* -------- AES_DBGCTRL : (AES Offset: 0x09) ( /W  8) Debug control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Run                          */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AES_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_DBGCTRL_OFFSET          0x09         /**< \brief (AES_DBGCTRL offset) Debug control */
+#define AES_DBGCTRL_RESETVALUE      0x00ul       /**< \brief (AES_DBGCTRL reset_value) Debug control */
+
+#define AES_DBGCTRL_DBGRUN_Pos      0            /**< \brief (AES_DBGCTRL) Debug Run */
+#define AES_DBGCTRL_DBGRUN          (0x1ul << AES_DBGCTRL_DBGRUN_Pos)
+#define AES_DBGCTRL_MASK            0x01ul       /**< \brief (AES_DBGCTRL) MASK Register */
+
+/* -------- AES_KEYWORD : (AES Offset: 0x0C) ( /W 32) Keyword n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} AES_KEYWORD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_KEYWORD_OFFSET          0x0C         /**< \brief (AES_KEYWORD offset) Keyword n */
+#define AES_KEYWORD_RESETVALUE      0x00000000ul /**< \brief (AES_KEYWORD reset_value) Keyword n */
+#define AES_KEYWORD_MASK            0xFFFFFFFFul /**< \brief (AES_KEYWORD) MASK Register */
+
+/* -------- AES_INDATA : (AES Offset: 0x38) (R/W 32) Indata -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} AES_INDATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_INDATA_OFFSET           0x38         /**< \brief (AES_INDATA offset) Indata */
+#define AES_INDATA_RESETVALUE       0x00000000ul /**< \brief (AES_INDATA reset_value) Indata */
+#define AES_INDATA_MASK             0xFFFFFFFFul /**< \brief (AES_INDATA) MASK Register */
+
+/* -------- AES_INTVECTV : (AES Offset: 0x3C) ( /W 32) Initialisation Vector n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} AES_INTVECTV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_INTVECTV_OFFSET         0x3C         /**< \brief (AES_INTVECTV offset) Initialisation Vector n */
+#define AES_INTVECTV_RESETVALUE     0x00000000ul /**< \brief (AES_INTVECTV reset_value) Initialisation Vector n */
+#define AES_INTVECTV_MASK           0xFFFFFFFFul /**< \brief (AES_INTVECTV) MASK Register */
+
+/* -------- AES_HASHKEY : (AES Offset: 0x5C) (R/W 32) Hash key n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} AES_HASHKEY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_HASHKEY_OFFSET          0x5C         /**< \brief (AES_HASHKEY offset) Hash key n */
+#define AES_HASHKEY_RESETVALUE      0x00000000ul /**< \brief (AES_HASHKEY reset_value) Hash key n */
+#define AES_HASHKEY_MASK            0xFFFFFFFFul /**< \brief (AES_HASHKEY) MASK Register */
+
+/* -------- AES_GHASH : (AES Offset: 0x6C) (R/W 32) Galois Hash n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} AES_GHASH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_GHASH_OFFSET            0x6C         /**< \brief (AES_GHASH offset) Galois Hash n */
+#define AES_GHASH_RESETVALUE        0x00000000ul /**< \brief (AES_GHASH reset_value) Galois Hash n */
+#define AES_GHASH_MASK              0xFFFFFFFFul /**< \brief (AES_GHASH) MASK Register */
+
+/* -------- AES_CIPLEN : (AES Offset: 0x80) (R/W 32) Cipher Length -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} AES_CIPLEN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_CIPLEN_OFFSET           0x80         /**< \brief (AES_CIPLEN offset) Cipher Length */
+#define AES_CIPLEN_RESETVALUE       0x00000000ul /**< \brief (AES_CIPLEN reset_value) Cipher Length */
+#define AES_CIPLEN_MASK             0xFFFFFFFFul /**< \brief (AES_CIPLEN) MASK Register */
+
+/* -------- AES_RANDSEED : (AES Offset: 0x84) (R/W 32) Random Seed -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} AES_RANDSEED_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AES_RANDSEED_OFFSET         0x84         /**< \brief (AES_RANDSEED offset) Random Seed */
+#define AES_RANDSEED_RESETVALUE     0x00000000ul /**< \brief (AES_RANDSEED reset_value) Random Seed */
+#define AES_RANDSEED_MASK           0xFFFFFFFFul /**< \brief (AES_RANDSEED) MASK Register */
+
+/** \brief AES hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO AES_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x00 (R/W 32) Control A */
+  __IO AES_CTRLB_Type            CTRLB;       /**< \brief Offset: 0x04 (R/W  8) Control B */
+  __IO AES_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x05 (R/W  8) Interrupt Enable Clear */
+  __IO AES_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x06 (R/W  8) Interrupt Enable Set */
+  __IO AES_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x07 (R/W  8) Interrupt Flag Status */
+  __IO AES_DATABUFPTR_Type       DATABUFPTR;  /**< \brief Offset: 0x08 (R/W  8) Data buffer pointer */
+  __O  AES_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x09 ( /W  8) Debug control */
+       RoReg8                    Reserved1[0x2];
+  __O  AES_KEYWORD_Type          KEYWORD[8];  /**< \brief Offset: 0x0C ( /W 32) Keyword n */
+       RoReg8                    Reserved2[0xC];
+  __IO AES_INDATA_Type           INDATA;      /**< \brief Offset: 0x38 (R/W 32) Indata */
+  __O  AES_INTVECTV_Type         INTVECTV[4]; /**< \brief Offset: 0x3C ( /W 32) Initialisation Vector n */
+       RoReg8                    Reserved3[0x10];
+  __IO AES_HASHKEY_Type          HASHKEY[4];  /**< \brief Offset: 0x5C (R/W 32) Hash key n */
+  __IO AES_GHASH_Type            GHASH[4];    /**< \brief Offset: 0x6C (R/W 32) Galois Hash n */
+       RoReg8                    Reserved4[0x4];
+  __IO AES_CIPLEN_Type           CIPLEN;      /**< \brief Offset: 0x80 (R/W 32) Cipher Length */
+  __IO AES_RANDSEED_Type         RANDSEED;    /**< \brief Offset: 0x84 (R/W 32) Random Seed */
+} Aes;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_AES_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/ccl.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/ccl.h
@@ -1,0 +1,202 @@
+/**
+ * \file
+ *
+ * \brief Component description for CCL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_CCL_COMPONENT_
+#define _SAML21_CCL_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR CCL */
+/* ========================================================================== */
+/** \addtogroup SAML21_CCL Configurable Custom Logic */
+/*@{*/
+
+#define CCL_U2225
+#define REV_CCL                     0x100
+
+/* -------- CCL_CTRL : (CCL Offset: 0x0) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} CCL_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCL_CTRL_OFFSET             0x0          /**< \brief (CCL_CTRL offset) Control */
+#define CCL_CTRL_RESETVALUE         0x00ul       /**< \brief (CCL_CTRL reset_value) Control */
+
+#define CCL_CTRL_SWRST_Pos          0            /**< \brief (CCL_CTRL) Software Reset */
+#define CCL_CTRL_SWRST              (0x1ul << CCL_CTRL_SWRST_Pos)
+#define CCL_CTRL_ENABLE_Pos         1            /**< \brief (CCL_CTRL) Enable */
+#define CCL_CTRL_ENABLE             (0x1ul << CCL_CTRL_ENABLE_Pos)
+#define CCL_CTRL_RUNSTDBY_Pos       6            /**< \brief (CCL_CTRL) Run during Standby */
+#define CCL_CTRL_RUNSTDBY           (0x1ul << CCL_CTRL_RUNSTDBY_Pos)
+#define CCL_CTRL_MASK               0x43ul       /**< \brief (CCL_CTRL) MASK Register */
+
+/* -------- CCL_SEQCTRL : (CCL Offset: 0x4) (R/W  8) SEQ Control x -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SEQSEL:4;         /*!< bit:  0.. 3  Sequential Selection               */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} CCL_SEQCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCL_SEQCTRL_OFFSET          0x4          /**< \brief (CCL_SEQCTRL offset) SEQ Control x */
+#define CCL_SEQCTRL_RESETVALUE      0x00ul       /**< \brief (CCL_SEQCTRL reset_value) SEQ Control x */
+
+#define CCL_SEQCTRL_SEQSEL_Pos      0            /**< \brief (CCL_SEQCTRL) Sequential Selection */
+#define CCL_SEQCTRL_SEQSEL_Msk      (0xFul << CCL_SEQCTRL_SEQSEL_Pos)
+#define CCL_SEQCTRL_SEQSEL(value)   (CCL_SEQCTRL_SEQSEL_Msk & ((value) << CCL_SEQCTRL_SEQSEL_Pos))
+#define   CCL_SEQCTRL_SEQSEL_DISABLE_Val  0x0ul  /**< \brief (CCL_SEQCTRL) Sequential logic is disabled */
+#define   CCL_SEQCTRL_SEQSEL_DFF_Val      0x1ul  /**< \brief (CCL_SEQCTRL) D flip flop */
+#define   CCL_SEQCTRL_SEQSEL_JK_Val       0x2ul  /**< \brief (CCL_SEQCTRL) JK flip flop */
+#define   CCL_SEQCTRL_SEQSEL_LATCH_Val    0x3ul  /**< \brief (CCL_SEQCTRL) D latch */
+#define   CCL_SEQCTRL_SEQSEL_RS_Val       0x4ul  /**< \brief (CCL_SEQCTRL) RS latch */
+#define CCL_SEQCTRL_SEQSEL_DISABLE  (CCL_SEQCTRL_SEQSEL_DISABLE_Val << CCL_SEQCTRL_SEQSEL_Pos)
+#define CCL_SEQCTRL_SEQSEL_DFF      (CCL_SEQCTRL_SEQSEL_DFF_Val    << CCL_SEQCTRL_SEQSEL_Pos)
+#define CCL_SEQCTRL_SEQSEL_JK       (CCL_SEQCTRL_SEQSEL_JK_Val     << CCL_SEQCTRL_SEQSEL_Pos)
+#define CCL_SEQCTRL_SEQSEL_LATCH    (CCL_SEQCTRL_SEQSEL_LATCH_Val  << CCL_SEQCTRL_SEQSEL_Pos)
+#define CCL_SEQCTRL_SEQSEL_RS       (CCL_SEQCTRL_SEQSEL_RS_Val     << CCL_SEQCTRL_SEQSEL_Pos)
+#define CCL_SEQCTRL_MASK            0x0Ful       /**< \brief (CCL_SEQCTRL) MASK Register */
+
+/* -------- CCL_LUTCTRL : (CCL Offset: 0x8) (R/W 32) LUT Control x -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  LUT Enable                         */
+    uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint32_t FILTSEL:2;        /*!< bit:  4.. 5  Filter Selection                   */
+    uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t EDGESEL:1;        /*!< bit:      7  Edge Selection                     */
+    uint32_t INSEL0:4;         /*!< bit:  8..11  Input Selection 0                  */
+    uint32_t INSEL1:4;         /*!< bit: 12..15  Input Selection 1                  */
+    uint32_t INSEL2:4;         /*!< bit: 16..19  Input Selection 2                  */
+    uint32_t INVEI:1;          /*!< bit:     20  Input Event Invert                 */
+    uint32_t LUTEI:1;          /*!< bit:     21  Event Input Enable                 */
+    uint32_t LUTEO:1;          /*!< bit:     22  Event Output Enable                */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t TRUTH:8;          /*!< bit: 24..31  Truth Value                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CCL_LUTCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CCL_LUTCTRL_OFFSET          0x8          /**< \brief (CCL_LUTCTRL offset) LUT Control x */
+#define CCL_LUTCTRL_RESETVALUE      0x00000000ul /**< \brief (CCL_LUTCTRL reset_value) LUT Control x */
+
+#define CCL_LUTCTRL_ENABLE_Pos      1            /**< \brief (CCL_LUTCTRL) LUT Enable */
+#define CCL_LUTCTRL_ENABLE          (0x1ul << CCL_LUTCTRL_ENABLE_Pos)
+#define CCL_LUTCTRL_FILTSEL_Pos     4            /**< \brief (CCL_LUTCTRL) Filter Selection */
+#define CCL_LUTCTRL_FILTSEL_Msk     (0x3ul << CCL_LUTCTRL_FILTSEL_Pos)
+#define CCL_LUTCTRL_FILTSEL(value)  (CCL_LUTCTRL_FILTSEL_Msk & ((value) << CCL_LUTCTRL_FILTSEL_Pos))
+#define   CCL_LUTCTRL_FILTSEL_DISABLE_Val 0x0ul  /**< \brief (CCL_LUTCTRL) Filter disabled */
+#define   CCL_LUTCTRL_FILTSEL_SYNCH_Val   0x1ul  /**< \brief (CCL_LUTCTRL) Synchronizer enabled */
+#define   CCL_LUTCTRL_FILTSEL_FILTER_Val  0x2ul  /**< \brief (CCL_LUTCTRL) Filter enabled */
+#define CCL_LUTCTRL_FILTSEL_DISABLE (CCL_LUTCTRL_FILTSEL_DISABLE_Val << CCL_LUTCTRL_FILTSEL_Pos)
+#define CCL_LUTCTRL_FILTSEL_SYNCH   (CCL_LUTCTRL_FILTSEL_SYNCH_Val << CCL_LUTCTRL_FILTSEL_Pos)
+#define CCL_LUTCTRL_FILTSEL_FILTER  (CCL_LUTCTRL_FILTSEL_FILTER_Val << CCL_LUTCTRL_FILTSEL_Pos)
+#define CCL_LUTCTRL_EDGESEL_Pos     7            /**< \brief (CCL_LUTCTRL) Edge Selection */
+#define CCL_LUTCTRL_EDGESEL         (0x1ul << CCL_LUTCTRL_EDGESEL_Pos)
+#define CCL_LUTCTRL_INSEL0_Pos      8            /**< \brief (CCL_LUTCTRL) Input Selection 0 */
+#define CCL_LUTCTRL_INSEL0_Msk      (0xFul << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0(value)   (CCL_LUTCTRL_INSEL0_Msk & ((value) << CCL_LUTCTRL_INSEL0_Pos))
+#define   CCL_LUTCTRL_INSEL0_MASK_Val     0x0ul  /**< \brief (CCL_LUTCTRL) Masked input */
+#define   CCL_LUTCTRL_INSEL0_FEEDBACK_Val 0x1ul  /**< \brief (CCL_LUTCTRL) Feedback input source */
+#define   CCL_LUTCTRL_INSEL0_LINK_Val     0x2ul  /**< \brief (CCL_LUTCTRL) Linked LUT input source */
+#define   CCL_LUTCTRL_INSEL0_EVENT_Val    0x3ul  /**< \brief (CCL_LUTCTRL) Event in put source */
+#define   CCL_LUTCTRL_INSEL0_IO_Val       0x4ul  /**< \brief (CCL_LUTCTRL) I/O pin input source */
+#define   CCL_LUTCTRL_INSEL0_AC_Val       0x5ul  /**< \brief (CCL_LUTCTRL) AC input source */
+#define   CCL_LUTCTRL_INSEL0_TC_Val       0x6ul  /**< \brief (CCL_LUTCTRL) TC input source */
+#define   CCL_LUTCTRL_INSEL0_ALTTC_Val    0x7ul  /**< \brief (CCL_LUTCTRL) Alternate TC input source */
+#define   CCL_LUTCTRL_INSEL0_TCC_Val      0x8ul  /**< \brief (CCL_LUTCTRL) TCC input source */
+#define   CCL_LUTCTRL_INSEL0_SERCOM_Val   0x9ul  /**< \brief (CCL_LUTCTRL) SERCOM inout source */
+#define CCL_LUTCTRL_INSEL0_MASK     (CCL_LUTCTRL_INSEL0_MASK_Val   << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0_FEEDBACK (CCL_LUTCTRL_INSEL0_FEEDBACK_Val << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0_LINK     (CCL_LUTCTRL_INSEL0_LINK_Val   << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0_EVENT    (CCL_LUTCTRL_INSEL0_EVENT_Val  << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0_IO       (CCL_LUTCTRL_INSEL0_IO_Val     << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0_AC       (CCL_LUTCTRL_INSEL0_AC_Val     << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0_TC       (CCL_LUTCTRL_INSEL0_TC_Val     << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0_ALTTC    (CCL_LUTCTRL_INSEL0_ALTTC_Val  << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0_TCC      (CCL_LUTCTRL_INSEL0_TCC_Val    << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL0_SERCOM   (CCL_LUTCTRL_INSEL0_SERCOM_Val << CCL_LUTCTRL_INSEL0_Pos)
+#define CCL_LUTCTRL_INSEL1_Pos      12           /**< \brief (CCL_LUTCTRL) Input Selection 1 */
+#define CCL_LUTCTRL_INSEL1_Msk      (0xFul << CCL_LUTCTRL_INSEL1_Pos)
+#define CCL_LUTCTRL_INSEL1(value)   (CCL_LUTCTRL_INSEL1_Msk & ((value) << CCL_LUTCTRL_INSEL1_Pos))
+#define CCL_LUTCTRL_INSEL2_Pos      16           /**< \brief (CCL_LUTCTRL) Input Selection 2 */
+#define CCL_LUTCTRL_INSEL2_Msk      (0xFul << CCL_LUTCTRL_INSEL2_Pos)
+#define CCL_LUTCTRL_INSEL2(value)   (CCL_LUTCTRL_INSEL2_Msk & ((value) << CCL_LUTCTRL_INSEL2_Pos))
+#define CCL_LUTCTRL_INVEI_Pos       20           /**< \brief (CCL_LUTCTRL) Input Event Invert */
+#define CCL_LUTCTRL_INVEI           (0x1ul << CCL_LUTCTRL_INVEI_Pos)
+#define CCL_LUTCTRL_LUTEI_Pos       21           /**< \brief (CCL_LUTCTRL) Event Input Enable */
+#define CCL_LUTCTRL_LUTEI           (0x1ul << CCL_LUTCTRL_LUTEI_Pos)
+#define CCL_LUTCTRL_LUTEO_Pos       22           /**< \brief (CCL_LUTCTRL) Event Output Enable */
+#define CCL_LUTCTRL_LUTEO           (0x1ul << CCL_LUTCTRL_LUTEO_Pos)
+#define CCL_LUTCTRL_TRUTH_Pos       24           /**< \brief (CCL_LUTCTRL) Truth Value */
+#define CCL_LUTCTRL_TRUTH_Msk       (0xFFul << CCL_LUTCTRL_TRUTH_Pos)
+#define CCL_LUTCTRL_TRUTH(value)    (CCL_LUTCTRL_TRUTH_Msk & ((value) << CCL_LUTCTRL_TRUTH_Pos))
+#define CCL_LUTCTRL_MASK            0xFF7FFFB2ul /**< \brief (CCL_LUTCTRL) MASK Register */
+
+/** \brief CCL hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO CCL_CTRL_Type             CTRL;        /**< \brief Offset: 0x0 (R/W  8) Control */
+       RoReg8                    Reserved1[0x3];
+  __IO CCL_SEQCTRL_Type          SEQCTRL[2];  /**< \brief Offset: 0x4 (R/W  8) SEQ Control x */
+       RoReg8                    Reserved2[0x2];
+  __IO CCL_LUTCTRL_Type          LUTCTRL[4];  /**< \brief Offset: 0x8 (R/W 32) LUT Control x */
+} Ccl;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_CCL_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/dac.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/dac.h
@@ -1,0 +1,471 @@
+/**
+ * \file
+ *
+ * \brief Component description for DAC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_DAC_COMPONENT_
+#define _SAML21_DAC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DAC */
+/* ========================================================================== */
+/** \addtogroup SAML21_DAC Digital-to-Analog Converter */
+/*@{*/
+
+#define DAC_U2244
+#define REV_DAC                     0x100
+
+/* -------- DAC_CTRLA : (DAC Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable DAC Controller              */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLA_OFFSET            0x00         /**< \brief (DAC_CTRLA offset) Control A */
+#define DAC_CTRLA_RESETVALUE        0x00ul       /**< \brief (DAC_CTRLA reset_value) Control A */
+
+#define DAC_CTRLA_SWRST_Pos         0            /**< \brief (DAC_CTRLA) Software Reset */
+#define DAC_CTRLA_SWRST             (0x1ul << DAC_CTRLA_SWRST_Pos)
+#define DAC_CTRLA_ENABLE_Pos        1            /**< \brief (DAC_CTRLA) Enable DAC Controller */
+#define DAC_CTRLA_ENABLE            (0x1ul << DAC_CTRLA_ENABLE_Pos)
+#define DAC_CTRLA_MASK              0x03ul       /**< \brief (DAC_CTRLA) MASK Register */
+
+/* -------- DAC_CTRLB : (DAC Offset: 0x01) (R/W  8) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DIFF:1;           /*!< bit:      0  Differential mode enable           */
+    uint8_t  REFSEL:2;         /*!< bit:  1.. 2  Reference Selection for DAC0/1     */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLB_OFFSET            0x01         /**< \brief (DAC_CTRLB offset) Control B */
+#define DAC_CTRLB_RESETVALUE        0x00ul       /**< \brief (DAC_CTRLB reset_value) Control B */
+
+#define DAC_CTRLB_DIFF_Pos          0            /**< \brief (DAC_CTRLB) Differential mode enable */
+#define DAC_CTRLB_DIFF              (0x1ul << DAC_CTRLB_DIFF_Pos)
+#define DAC_CTRLB_REFSEL_Pos        1            /**< \brief (DAC_CTRLB) Reference Selection for DAC0/1 */
+#define DAC_CTRLB_REFSEL_Msk        (0x3ul << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL(value)     (DAC_CTRLB_REFSEL_Msk & ((value) << DAC_CTRLB_REFSEL_Pos))
+#define   DAC_CTRLB_REFSEL_VREFPU_Val     0x0ul  /**< \brief (DAC_CTRLB) External reference unbuffered */
+#define   DAC_CTRLB_REFSEL_VDDANA_Val     0x1ul  /**< \brief (DAC_CTRLB) Analog supply */
+#define   DAC_CTRLB_REFSEL_VREFPB_Val     0x2ul  /**< \brief (DAC_CTRLB) External reference buffered */
+#define   DAC_CTRLB_REFSEL_INTREF_Val     0x3ul  /**< \brief (DAC_CTRLB) Internal bandgap reference */
+#define DAC_CTRLB_REFSEL_VREFPU     (DAC_CTRLB_REFSEL_VREFPU_Val   << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL_VDDANA     (DAC_CTRLB_REFSEL_VDDANA_Val   << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL_VREFPB     (DAC_CTRLB_REFSEL_VREFPB_Val   << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL_INTREF     (DAC_CTRLB_REFSEL_INTREF_Val   << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_MASK              0x07ul       /**< \brief (DAC_CTRLB) MASK Register */
+
+/* -------- DAC_EVCTRL : (DAC Offset: 0x02) (R/W  8) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STARTEI0:1;       /*!< bit:      0  Start Conversion Event Input DAC 0 */
+    uint8_t  STARTEI1:1;       /*!< bit:      1  Start Conversion Event Input DAC 1 */
+    uint8_t  EMPTYEO0:1;       /*!< bit:      2  Data Buffer Empty Event Output DAC 0 */
+    uint8_t  EMPTYEO1:1;       /*!< bit:      3  Data Buffer Empty Event Output DAC 1 */
+    uint8_t  INVEI0:1;         /*!< bit:      4  Enable Invertion of DAC 0 input event */
+    uint8_t  INVEI1:1;         /*!< bit:      5  Enable Invertion of DAC 1 input event */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  STARTEI:2;        /*!< bit:  0.. 1  Start Conversion Event Input DAC x */
+    uint8_t  EMPTYEO:2;        /*!< bit:  2.. 3  Data Buffer Empty Event Output DAC x */
+    uint8_t  INVEI:2;          /*!< bit:  4.. 5  Enable Invertion of DAC x input event */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_EVCTRL_OFFSET           0x02         /**< \brief (DAC_EVCTRL offset) Event Control */
+#define DAC_EVCTRL_RESETVALUE       0x00ul       /**< \brief (DAC_EVCTRL reset_value) Event Control */
+
+#define DAC_EVCTRL_STARTEI0_Pos     0            /**< \brief (DAC_EVCTRL) Start Conversion Event Input DAC 0 */
+#define DAC_EVCTRL_STARTEI0         (1 << DAC_EVCTRL_STARTEI0_Pos)
+#define DAC_EVCTRL_STARTEI1_Pos     1            /**< \brief (DAC_EVCTRL) Start Conversion Event Input DAC 1 */
+#define DAC_EVCTRL_STARTEI1         (1 << DAC_EVCTRL_STARTEI1_Pos)
+#define DAC_EVCTRL_STARTEI_Pos      0            /**< \brief (DAC_EVCTRL) Start Conversion Event Input DAC x */
+#define DAC_EVCTRL_STARTEI_Msk      (0x3ul << DAC_EVCTRL_STARTEI_Pos)
+#define DAC_EVCTRL_STARTEI(value)   (DAC_EVCTRL_STARTEI_Msk & ((value) << DAC_EVCTRL_STARTEI_Pos))
+#define DAC_EVCTRL_EMPTYEO0_Pos     2            /**< \brief (DAC_EVCTRL) Data Buffer Empty Event Output DAC 0 */
+#define DAC_EVCTRL_EMPTYEO0         (1 << DAC_EVCTRL_EMPTYEO0_Pos)
+#define DAC_EVCTRL_EMPTYEO1_Pos     3            /**< \brief (DAC_EVCTRL) Data Buffer Empty Event Output DAC 1 */
+#define DAC_EVCTRL_EMPTYEO1         (1 << DAC_EVCTRL_EMPTYEO1_Pos)
+#define DAC_EVCTRL_EMPTYEO_Pos      2            /**< \brief (DAC_EVCTRL) Data Buffer Empty Event Output DAC x */
+#define DAC_EVCTRL_EMPTYEO_Msk      (0x3ul << DAC_EVCTRL_EMPTYEO_Pos)
+#define DAC_EVCTRL_EMPTYEO(value)   (DAC_EVCTRL_EMPTYEO_Msk & ((value) << DAC_EVCTRL_EMPTYEO_Pos))
+#define DAC_EVCTRL_INVEI0_Pos       4            /**< \brief (DAC_EVCTRL) Enable Invertion of DAC 0 input event */
+#define DAC_EVCTRL_INVEI0           (1 << DAC_EVCTRL_INVEI0_Pos)
+#define DAC_EVCTRL_INVEI1_Pos       5            /**< \brief (DAC_EVCTRL) Enable Invertion of DAC 1 input event */
+#define DAC_EVCTRL_INVEI1           (1 << DAC_EVCTRL_INVEI1_Pos)
+#define DAC_EVCTRL_INVEI_Pos        4            /**< \brief (DAC_EVCTRL) Enable Invertion of DAC x input event */
+#define DAC_EVCTRL_INVEI_Msk        (0x3ul << DAC_EVCTRL_INVEI_Pos)
+#define DAC_EVCTRL_INVEI(value)     (DAC_EVCTRL_INVEI_Msk & ((value) << DAC_EVCTRL_INVEI_Pos))
+#define DAC_EVCTRL_MASK             0x3Ful       /**< \brief (DAC_EVCTRL) MASK Register */
+
+/* -------- DAC_INTENCLR : (DAC Offset: 0x04) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  UNDERRUN0:1;      /*!< bit:      0  Underrun Interrupt Enable for DAC 0 */
+    uint8_t  UNDERRUN1:1;      /*!< bit:      1  Underrun Interrupt Enable for DAC 1 */
+    uint8_t  EMPTY0:1;         /*!< bit:      2  Data Buffer 0 Empty Interrupt Enable */
+    uint8_t  EMPTY1:1;         /*!< bit:      3  Data Buffer 1 Empty Interrupt Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun Interrupt Enable for DAC x */
+    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENCLR_OFFSET         0x04         /**< \brief (DAC_INTENCLR offset) Interrupt Enable Clear */
+#define DAC_INTENCLR_RESETVALUE     0x00ul       /**< \brief (DAC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define DAC_INTENCLR_UNDERRUN0_Pos  0            /**< \brief (DAC_INTENCLR) Underrun Interrupt Enable for DAC 0 */
+#define DAC_INTENCLR_UNDERRUN0      (1 << DAC_INTENCLR_UNDERRUN0_Pos)
+#define DAC_INTENCLR_UNDERRUN1_Pos  1            /**< \brief (DAC_INTENCLR) Underrun Interrupt Enable for DAC 1 */
+#define DAC_INTENCLR_UNDERRUN1      (1 << DAC_INTENCLR_UNDERRUN1_Pos)
+#define DAC_INTENCLR_UNDERRUN_Pos   0            /**< \brief (DAC_INTENCLR) Underrun Interrupt Enable for DAC x */
+#define DAC_INTENCLR_UNDERRUN_Msk   (0x3ul << DAC_INTENCLR_UNDERRUN_Pos)
+#define DAC_INTENCLR_UNDERRUN(value) (DAC_INTENCLR_UNDERRUN_Msk & ((value) << DAC_INTENCLR_UNDERRUN_Pos))
+#define DAC_INTENCLR_EMPTY0_Pos     2            /**< \brief (DAC_INTENCLR) Data Buffer 0 Empty Interrupt Enable */
+#define DAC_INTENCLR_EMPTY0         (1 << DAC_INTENCLR_EMPTY0_Pos)
+#define DAC_INTENCLR_EMPTY1_Pos     3            /**< \brief (DAC_INTENCLR) Data Buffer 1 Empty Interrupt Enable */
+#define DAC_INTENCLR_EMPTY1         (1 << DAC_INTENCLR_EMPTY1_Pos)
+#define DAC_INTENCLR_EMPTY_Pos      2            /**< \brief (DAC_INTENCLR) Data Buffer x Empty Interrupt Enable */
+#define DAC_INTENCLR_EMPTY_Msk      (0x3ul << DAC_INTENCLR_EMPTY_Pos)
+#define DAC_INTENCLR_EMPTY(value)   (DAC_INTENCLR_EMPTY_Msk & ((value) << DAC_INTENCLR_EMPTY_Pos))
+#define DAC_INTENCLR_MASK           0x0Ful       /**< \brief (DAC_INTENCLR) MASK Register */
+
+/* -------- DAC_INTENSET : (DAC Offset: 0x05) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  UNDERRUN0:1;      /*!< bit:      0  Underrun Interrupt Enable for DAC 0 */
+    uint8_t  UNDERRUN1:1;      /*!< bit:      1  Underrun Interrupt Enable for DAC 1 */
+    uint8_t  EMPTY0:1;         /*!< bit:      2  Data Buffer 0 Empty Interrupt Enable */
+    uint8_t  EMPTY1:1;         /*!< bit:      3  Data Buffer 1 Empty Interrupt Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun Interrupt Enable for DAC x */
+    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENSET_OFFSET         0x05         /**< \brief (DAC_INTENSET offset) Interrupt Enable Set */
+#define DAC_INTENSET_RESETVALUE     0x00ul       /**< \brief (DAC_INTENSET reset_value) Interrupt Enable Set */
+
+#define DAC_INTENSET_UNDERRUN0_Pos  0            /**< \brief (DAC_INTENSET) Underrun Interrupt Enable for DAC 0 */
+#define DAC_INTENSET_UNDERRUN0      (1 << DAC_INTENSET_UNDERRUN0_Pos)
+#define DAC_INTENSET_UNDERRUN1_Pos  1            /**< \brief (DAC_INTENSET) Underrun Interrupt Enable for DAC 1 */
+#define DAC_INTENSET_UNDERRUN1      (1 << DAC_INTENSET_UNDERRUN1_Pos)
+#define DAC_INTENSET_UNDERRUN_Pos   0            /**< \brief (DAC_INTENSET) Underrun Interrupt Enable for DAC x */
+#define DAC_INTENSET_UNDERRUN_Msk   (0x3ul << DAC_INTENSET_UNDERRUN_Pos)
+#define DAC_INTENSET_UNDERRUN(value) (DAC_INTENSET_UNDERRUN_Msk & ((value) << DAC_INTENSET_UNDERRUN_Pos))
+#define DAC_INTENSET_EMPTY0_Pos     2            /**< \brief (DAC_INTENSET) Data Buffer 0 Empty Interrupt Enable */
+#define DAC_INTENSET_EMPTY0         (1 << DAC_INTENSET_EMPTY0_Pos)
+#define DAC_INTENSET_EMPTY1_Pos     3            /**< \brief (DAC_INTENSET) Data Buffer 1 Empty Interrupt Enable */
+#define DAC_INTENSET_EMPTY1         (1 << DAC_INTENSET_EMPTY1_Pos)
+#define DAC_INTENSET_EMPTY_Pos      2            /**< \brief (DAC_INTENSET) Data Buffer x Empty Interrupt Enable */
+#define DAC_INTENSET_EMPTY_Msk      (0x3ul << DAC_INTENSET_EMPTY_Pos)
+#define DAC_INTENSET_EMPTY(value)   (DAC_INTENSET_EMPTY_Msk & ((value) << DAC_INTENSET_EMPTY_Pos))
+#define DAC_INTENSET_MASK           0x0Ful       /**< \brief (DAC_INTENSET) MASK Register */
+
+/* -------- DAC_INTFLAG : (DAC Offset: 0x06) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  UNDERRUN0:1;      /*!< bit:      0  DAC 0 Underrun                     */
+    __I uint8_t  UNDERRUN1:1;      /*!< bit:      1  DAC 1 Underrun                     */
+    __I uint8_t  EMPTY0:1;         /*!< bit:      2  Data Buffer 0 Empty                */
+    __I uint8_t  EMPTY1:1;         /*!< bit:      3  Data Buffer 1 Empty                */
+    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
+    __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
+    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTFLAG_OFFSET          0x06         /**< \brief (DAC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define DAC_INTFLAG_RESETVALUE      0x00ul       /**< \brief (DAC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define DAC_INTFLAG_UNDERRUN0_Pos   0            /**< \brief (DAC_INTFLAG) DAC 0 Underrun */
+#define DAC_INTFLAG_UNDERRUN0       (1 << DAC_INTFLAG_UNDERRUN0_Pos)
+#define DAC_INTFLAG_UNDERRUN1_Pos   1            /**< \brief (DAC_INTFLAG) DAC 1 Underrun */
+#define DAC_INTFLAG_UNDERRUN1       (1 << DAC_INTFLAG_UNDERRUN1_Pos)
+#define DAC_INTFLAG_UNDERRUN_Pos    0            /**< \brief (DAC_INTFLAG) DAC x Underrun */
+#define DAC_INTFLAG_UNDERRUN_Msk    (0x3ul << DAC_INTFLAG_UNDERRUN_Pos)
+#define DAC_INTFLAG_UNDERRUN(value) (DAC_INTFLAG_UNDERRUN_Msk & ((value) << DAC_INTFLAG_UNDERRUN_Pos))
+#define DAC_INTFLAG_EMPTY0_Pos      2            /**< \brief (DAC_INTFLAG) Data Buffer 0 Empty */
+#define DAC_INTFLAG_EMPTY0          (1 << DAC_INTFLAG_EMPTY0_Pos)
+#define DAC_INTFLAG_EMPTY1_Pos      3            /**< \brief (DAC_INTFLAG) Data Buffer 1 Empty */
+#define DAC_INTFLAG_EMPTY1          (1 << DAC_INTFLAG_EMPTY1_Pos)
+#define DAC_INTFLAG_EMPTY_Pos       2            /**< \brief (DAC_INTFLAG) Data Buffer x Empty */
+#define DAC_INTFLAG_EMPTY_Msk       (0x3ul << DAC_INTFLAG_EMPTY_Pos)
+#define DAC_INTFLAG_EMPTY(value)    (DAC_INTFLAG_EMPTY_Msk & ((value) << DAC_INTFLAG_EMPTY_Pos))
+#define DAC_INTFLAG_MASK            0x0Ful       /**< \brief (DAC_INTFLAG) MASK Register */
+
+/* -------- DAC_STATUS : (DAC Offset: 0x07) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY0:1;         /*!< bit:      0  DAC 0 Startup Ready                */
+    uint8_t  READY1:1;         /*!< bit:      1  DAC 1 Startup Ready                */
+    uint8_t  EOC0:1;           /*!< bit:      2  DAC 0 End of Conversion            */
+    uint8_t  EOC1:1;           /*!< bit:      3  DAC 1 End of Conversion            */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  READY:2;          /*!< bit:  0.. 1  DAC x Startup Ready                */
+    uint8_t  EOC:2;            /*!< bit:  2.. 3  DAC x End of Conversion            */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_STATUS_OFFSET           0x07         /**< \brief (DAC_STATUS offset) Status */
+#define DAC_STATUS_RESETVALUE       0x00ul       /**< \brief (DAC_STATUS reset_value) Status */
+
+#define DAC_STATUS_READY0_Pos       0            /**< \brief (DAC_STATUS) DAC 0 Startup Ready */
+#define DAC_STATUS_READY0           (1 << DAC_STATUS_READY0_Pos)
+#define DAC_STATUS_READY1_Pos       1            /**< \brief (DAC_STATUS) DAC 1 Startup Ready */
+#define DAC_STATUS_READY1           (1 << DAC_STATUS_READY1_Pos)
+#define DAC_STATUS_READY_Pos        0            /**< \brief (DAC_STATUS) DAC x Startup Ready */
+#define DAC_STATUS_READY_Msk        (0x3ul << DAC_STATUS_READY_Pos)
+#define DAC_STATUS_READY(value)     (DAC_STATUS_READY_Msk & ((value) << DAC_STATUS_READY_Pos))
+#define DAC_STATUS_EOC0_Pos         2            /**< \brief (DAC_STATUS) DAC 0 End of Conversion */
+#define DAC_STATUS_EOC0             (1 << DAC_STATUS_EOC0_Pos)
+#define DAC_STATUS_EOC1_Pos         3            /**< \brief (DAC_STATUS) DAC 1 End of Conversion */
+#define DAC_STATUS_EOC1             (1 << DAC_STATUS_EOC1_Pos)
+#define DAC_STATUS_EOC_Pos          2            /**< \brief (DAC_STATUS) DAC x End of Conversion */
+#define DAC_STATUS_EOC_Msk          (0x3ul << DAC_STATUS_EOC_Pos)
+#define DAC_STATUS_EOC(value)       (DAC_STATUS_EOC_Msk & ((value) << DAC_STATUS_EOC_Pos))
+#define DAC_STATUS_MASK             0x0Ful       /**< \brief (DAC_STATUS) MASK Register */
+
+/* -------- DAC_SYNCBUSY : (DAC Offset: 0x08) (R/  32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  DAC Enable Status                  */
+    uint32_t DATA0:1;          /*!< bit:      2  Data DAC 0                         */
+    uint32_t DATA1:1;          /*!< bit:      3  Data DAC 1                         */
+    uint32_t DATABUF0:1;       /*!< bit:      4  Data Buffer DAC 0                  */
+    uint32_t DATABUF1:1;       /*!< bit:      5  Data Buffer DAC 1                  */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t DATA:2;           /*!< bit:  2.. 3  Data DAC x                         */
+    uint32_t DATABUF:2;        /*!< bit:  4.. 5  Data Buffer DAC x                  */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DAC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_SYNCBUSY_OFFSET         0x08         /**< \brief (DAC_SYNCBUSY offset) Synchronization Busy */
+#define DAC_SYNCBUSY_RESETVALUE     0x00000000ul /**< \brief (DAC_SYNCBUSY reset_value) Synchronization Busy */
+
+#define DAC_SYNCBUSY_SWRST_Pos      0            /**< \brief (DAC_SYNCBUSY) Software Reset */
+#define DAC_SYNCBUSY_SWRST          (0x1ul << DAC_SYNCBUSY_SWRST_Pos)
+#define DAC_SYNCBUSY_ENABLE_Pos     1            /**< \brief (DAC_SYNCBUSY) DAC Enable Status */
+#define DAC_SYNCBUSY_ENABLE         (0x1ul << DAC_SYNCBUSY_ENABLE_Pos)
+#define DAC_SYNCBUSY_DATA0_Pos      2            /**< \brief (DAC_SYNCBUSY) Data DAC 0 */
+#define DAC_SYNCBUSY_DATA0          (1 << DAC_SYNCBUSY_DATA0_Pos)
+#define DAC_SYNCBUSY_DATA1_Pos      3            /**< \brief (DAC_SYNCBUSY) Data DAC 1 */
+#define DAC_SYNCBUSY_DATA1          (1 << DAC_SYNCBUSY_DATA1_Pos)
+#define DAC_SYNCBUSY_DATA_Pos       2            /**< \brief (DAC_SYNCBUSY) Data DAC x */
+#define DAC_SYNCBUSY_DATA_Msk       (0x3ul << DAC_SYNCBUSY_DATA_Pos)
+#define DAC_SYNCBUSY_DATA(value)    (DAC_SYNCBUSY_DATA_Msk & ((value) << DAC_SYNCBUSY_DATA_Pos))
+#define DAC_SYNCBUSY_DATABUF0_Pos   4            /**< \brief (DAC_SYNCBUSY) Data Buffer DAC 0 */
+#define DAC_SYNCBUSY_DATABUF0       (1 << DAC_SYNCBUSY_DATABUF0_Pos)
+#define DAC_SYNCBUSY_DATABUF1_Pos   5            /**< \brief (DAC_SYNCBUSY) Data Buffer DAC 1 */
+#define DAC_SYNCBUSY_DATABUF1       (1 << DAC_SYNCBUSY_DATABUF1_Pos)
+#define DAC_SYNCBUSY_DATABUF_Pos    4            /**< \brief (DAC_SYNCBUSY) Data Buffer DAC x */
+#define DAC_SYNCBUSY_DATABUF_Msk    (0x3ul << DAC_SYNCBUSY_DATABUF_Pos)
+#define DAC_SYNCBUSY_DATABUF(value) (DAC_SYNCBUSY_DATABUF_Msk & ((value) << DAC_SYNCBUSY_DATABUF_Pos))
+#define DAC_SYNCBUSY_MASK           0x0000003Ful /**< \brief (DAC_SYNCBUSY) MASK Register */
+
+/* -------- DAC_DACCTRL : (DAC Offset: 0x0C) (R/W 16) DACx Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t LEFTADJ:1;        /*!< bit:      0  Left Adjusted Data                 */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable DAC0                        */
+    uint16_t CCTRL:2;          /*!< bit:  2.. 3  Current Control                    */
+    uint16_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint16_t DITHER:1;         /*!< bit:      7  Dithering Mode                     */
+    uint16_t REFRESH:4;        /*!< bit:  8..11  Refresh period                     */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DAC_DACCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DACCTRL_OFFSET          0x0C         /**< \brief (DAC_DACCTRL offset) DACx Control */
+#define DAC_DACCTRL_RESETVALUE      0x0000ul     /**< \brief (DAC_DACCTRL reset_value) DACx Control */
+
+#define DAC_DACCTRL_LEFTADJ_Pos     0            /**< \brief (DAC_DACCTRL) Left Adjusted Data */
+#define DAC_DACCTRL_LEFTADJ         (0x1ul << DAC_DACCTRL_LEFTADJ_Pos)
+#define DAC_DACCTRL_ENABLE_Pos      1            /**< \brief (DAC_DACCTRL) Enable DAC0 */
+#define DAC_DACCTRL_ENABLE          (0x1ul << DAC_DACCTRL_ENABLE_Pos)
+#define DAC_DACCTRL_CCTRL_Pos       2            /**< \brief (DAC_DACCTRL) Current Control */
+#define DAC_DACCTRL_CCTRL_Msk       (0x3ul << DAC_DACCTRL_CCTRL_Pos)
+#define DAC_DACCTRL_CCTRL(value)    (DAC_DACCTRL_CCTRL_Msk & ((value) << DAC_DACCTRL_CCTRL_Pos))
+#define   DAC_DACCTRL_CCTRL_CC12M_Val     0x0ul  /**< \brief (DAC_DACCTRL) 1MHz<GCLK_DAC<12MHz */
+#define   DAC_DACCTRL_CCTRL_CC1M_Val      0x1ul  /**< \brief (DAC_DACCTRL) 100kHz<GCLK_DAC<1MHz */
+#define   DAC_DACCTRL_CCTRL_CC100K_Val    0x2ul  /**< \brief (DAC_DACCTRL) 10kHz<GCLK_DAC<100kHz */
+#define   DAC_DACCTRL_CCTRL_CC10K_Val     0x3ul  /**< \brief (DAC_DACCTRL) GCLK_DAC<100kHz */
+#define DAC_DACCTRL_CCTRL_CC12M     (DAC_DACCTRL_CCTRL_CC12M_Val   << DAC_DACCTRL_CCTRL_Pos)
+#define DAC_DACCTRL_CCTRL_CC1M      (DAC_DACCTRL_CCTRL_CC1M_Val    << DAC_DACCTRL_CCTRL_Pos)
+#define DAC_DACCTRL_CCTRL_CC100K    (DAC_DACCTRL_CCTRL_CC100K_Val  << DAC_DACCTRL_CCTRL_Pos)
+#define DAC_DACCTRL_CCTRL_CC10K     (DAC_DACCTRL_CCTRL_CC10K_Val   << DAC_DACCTRL_CCTRL_Pos)
+#define DAC_DACCTRL_RUNSTDBY_Pos    6            /**< \brief (DAC_DACCTRL) Run in Standby */
+#define DAC_DACCTRL_RUNSTDBY        (0x1ul << DAC_DACCTRL_RUNSTDBY_Pos)
+#define DAC_DACCTRL_DITHER_Pos      7            /**< \brief (DAC_DACCTRL) Dithering Mode */
+#define DAC_DACCTRL_DITHER          (0x1ul << DAC_DACCTRL_DITHER_Pos)
+#define DAC_DACCTRL_REFRESH_Pos     8            /**< \brief (DAC_DACCTRL) Refresh period */
+#define DAC_DACCTRL_REFRESH_Msk     (0xFul << DAC_DACCTRL_REFRESH_Pos)
+#define DAC_DACCTRL_REFRESH(value)  (DAC_DACCTRL_REFRESH_Msk & ((value) << DAC_DACCTRL_REFRESH_Pos))
+#define DAC_DACCTRL_MASK            0x0FCFul     /**< \brief (DAC_DACCTRL) MASK Register */
+
+/* -------- DAC_DATA : (DAC Offset: 0x10) ( /W 16) Data DAC0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATA:16;          /*!< bit:  0..15  DAC0 Data                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DAC_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATA_OFFSET             0x10         /**< \brief (DAC_DATA offset) Data DAC0 */
+#define DAC_DATA_RESETVALUE         0x0000ul     /**< \brief (DAC_DATA reset_value) Data DAC0 */
+
+#define DAC_DATA_DATA_Pos           0            /**< \brief (DAC_DATA) DAC0 Data */
+#define DAC_DATA_DATA_Msk           (0xFFFFul << DAC_DATA_DATA_Pos)
+#define DAC_DATA_DATA(value)        (DAC_DATA_DATA_Msk & ((value) << DAC_DATA_DATA_Pos))
+#define DAC_DATA_MASK               0xFFFFul     /**< \brief (DAC_DATA) MASK Register */
+
+/* -------- DAC_DATABUF : (DAC Offset: 0x14) ( /W 16) Data Buffer DAC0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATABUF:16;       /*!< bit:  0..15  DAC0 Data Buffer                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DAC_DATABUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATABUF_OFFSET          0x14         /**< \brief (DAC_DATABUF offset) Data Buffer DAC0 */
+#define DAC_DATABUF_RESETVALUE      0x0000ul     /**< \brief (DAC_DATABUF reset_value) Data Buffer DAC0 */
+
+#define DAC_DATABUF_DATABUF_Pos     0            /**< \brief (DAC_DATABUF) DAC0 Data Buffer */
+#define DAC_DATABUF_DATABUF_Msk     (0xFFFFul << DAC_DATABUF_DATABUF_Pos)
+#define DAC_DATABUF_DATABUF(value)  (DAC_DATABUF_DATABUF_Msk & ((value) << DAC_DATABUF_DATABUF_Pos))
+#define DAC_DATABUF_MASK            0xFFFFul     /**< \brief (DAC_DATABUF) MASK Register */
+
+/* -------- DAC_DBGCTRL : (DAC Offset: 0x18) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Run                          */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DBGCTRL_OFFSET          0x18         /**< \brief (DAC_DBGCTRL offset) Debug Control */
+#define DAC_DBGCTRL_RESETVALUE      0x00ul       /**< \brief (DAC_DBGCTRL reset_value) Debug Control */
+
+#define DAC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (DAC_DBGCTRL) Debug Run */
+#define DAC_DBGCTRL_DBGRUN          (0x1ul << DAC_DBGCTRL_DBGRUN_Pos)
+#define DAC_DBGCTRL_MASK            0x01ul       /**< \brief (DAC_DBGCTRL) MASK Register */
+
+/** \brief DAC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO DAC_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+  __IO DAC_CTRLB_Type            CTRLB;       /**< \brief Offset: 0x01 (R/W  8) Control B */
+  __IO DAC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x02 (R/W  8) Event Control */
+       RoReg8                    Reserved1[0x1];
+  __IO DAC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x04 (R/W  8) Interrupt Enable Clear */
+  __IO DAC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x05 (R/W  8) Interrupt Enable Set */
+  __IO DAC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x06 (R/W  8) Interrupt Flag Status and Clear */
+  __I  DAC_STATUS_Type           STATUS;      /**< \brief Offset: 0x07 (R/   8) Status */
+  __I  DAC_SYNCBUSY_Type         SYNCBUSY;    /**< \brief Offset: 0x08 (R/  32) Synchronization Busy */
+  __IO DAC_DACCTRL_Type          DACCTRL[2];  /**< \brief Offset: 0x0C (R/W 16) DACx Control */
+  __O  DAC_DATA_Type             DATA[2];     /**< \brief Offset: 0x10 ( /W 16) Data DAC0 */
+  __O  DAC_DATABUF_Type          DATABUF[2];  /**< \brief Offset: 0x14 ( /W 16) Data Buffer DAC0 */
+  __IO DAC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x18 (R/W  8) Debug Control */
+} Dac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_DAC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/dmac.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/dmac.h
@@ -1,0 +1,1083 @@
+/**
+ * \file
+ *
+ * \brief Component description for DMAC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_DMAC_COMPONENT_
+#define _SAML21_DMAC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DMAC */
+/* ========================================================================== */
+/** \addtogroup SAML21_DMAC Direct Memory Access Controller */
+/*@{*/
+
+#define DMAC_U2223
+#define REV_DMAC                    0x200
+
+/* -------- DMAC_CTRL : (DMAC Offset: 0x00) (R/W 16) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t DMAENABLE:1;      /*!< bit:      1  DMA Enable                         */
+    uint16_t CRCENABLE:1;      /*!< bit:      2  CRC Enable                         */
+    uint16_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint16_t LVLEN0:1;         /*!< bit:      8  Priority Level 0 Enable            */
+    uint16_t LVLEN1:1;         /*!< bit:      9  Priority Level 1 Enable            */
+    uint16_t LVLEN2:1;         /*!< bit:     10  Priority Level 2 Enable            */
+    uint16_t LVLEN3:1;         /*!< bit:     11  Priority Level 3 Enable            */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint16_t LVLEN:4;          /*!< bit:  8..11  Priority Level x Enable            */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DMAC_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CTRL_OFFSET            0x00         /**< \brief (DMAC_CTRL offset) Control */
+#define DMAC_CTRL_RESETVALUE        0x0000ul     /**< \brief (DMAC_CTRL reset_value) Control */
+
+#define DMAC_CTRL_SWRST_Pos         0            /**< \brief (DMAC_CTRL) Software Reset */
+#define DMAC_CTRL_SWRST             (0x1ul << DMAC_CTRL_SWRST_Pos)
+#define DMAC_CTRL_DMAENABLE_Pos     1            /**< \brief (DMAC_CTRL) DMA Enable */
+#define DMAC_CTRL_DMAENABLE         (0x1ul << DMAC_CTRL_DMAENABLE_Pos)
+#define DMAC_CTRL_CRCENABLE_Pos     2            /**< \brief (DMAC_CTRL) CRC Enable */
+#define DMAC_CTRL_CRCENABLE         (0x1ul << DMAC_CTRL_CRCENABLE_Pos)
+#define DMAC_CTRL_LVLEN0_Pos        8            /**< \brief (DMAC_CTRL) Priority Level 0 Enable */
+#define DMAC_CTRL_LVLEN0            (1 << DMAC_CTRL_LVLEN0_Pos)
+#define DMAC_CTRL_LVLEN1_Pos        9            /**< \brief (DMAC_CTRL) Priority Level 1 Enable */
+#define DMAC_CTRL_LVLEN1            (1 << DMAC_CTRL_LVLEN1_Pos)
+#define DMAC_CTRL_LVLEN2_Pos        10           /**< \brief (DMAC_CTRL) Priority Level 2 Enable */
+#define DMAC_CTRL_LVLEN2            (1 << DMAC_CTRL_LVLEN2_Pos)
+#define DMAC_CTRL_LVLEN3_Pos        11           /**< \brief (DMAC_CTRL) Priority Level 3 Enable */
+#define DMAC_CTRL_LVLEN3            (1 << DMAC_CTRL_LVLEN3_Pos)
+#define DMAC_CTRL_LVLEN_Pos         8            /**< \brief (DMAC_CTRL) Priority Level x Enable */
+#define DMAC_CTRL_LVLEN_Msk         (0xFul << DMAC_CTRL_LVLEN_Pos)
+#define DMAC_CTRL_LVLEN(value)      (DMAC_CTRL_LVLEN_Msk & ((value) << DMAC_CTRL_LVLEN_Pos))
+#define DMAC_CTRL_MASK              0x0F07ul     /**< \brief (DMAC_CTRL) MASK Register */
+
+/* -------- DMAC_CRCCTRL : (DMAC Offset: 0x02) (R/W 16) CRC Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t CRCBEATSIZE:2;    /*!< bit:  0.. 1  CRC Beat Size                      */
+    uint16_t CRCPOLY:2;        /*!< bit:  2.. 3  CRC Polynomial Type                */
+    uint16_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint16_t CRCSRC:6;         /*!< bit:  8..13  CRC Input Source                   */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DMAC_CRCCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCCTRL_OFFSET         0x02         /**< \brief (DMAC_CRCCTRL offset) CRC Control */
+#define DMAC_CRCCTRL_RESETVALUE     0x0000ul     /**< \brief (DMAC_CRCCTRL reset_value) CRC Control */
+
+#define DMAC_CRCCTRL_CRCBEATSIZE_Pos 0            /**< \brief (DMAC_CRCCTRL) CRC Beat Size */
+#define DMAC_CRCCTRL_CRCBEATSIZE_Msk (0x3ul << DMAC_CRCCTRL_CRCBEATSIZE_Pos)
+#define DMAC_CRCCTRL_CRCBEATSIZE(value) (DMAC_CRCCTRL_CRCBEATSIZE_Msk & ((value) << DMAC_CRCCTRL_CRCBEATSIZE_Pos))
+#define   DMAC_CRCCTRL_CRCBEATSIZE_BYTE_Val 0x0ul  /**< \brief (DMAC_CRCCTRL) 8-bit bus transfer */
+#define   DMAC_CRCCTRL_CRCBEATSIZE_HWORD_Val 0x1ul  /**< \brief (DMAC_CRCCTRL) 16-bit bus transfer */
+#define   DMAC_CRCCTRL_CRCBEATSIZE_WORD_Val 0x2ul  /**< \brief (DMAC_CRCCTRL) 32-bit bus transfer */
+#define DMAC_CRCCTRL_CRCBEATSIZE_BYTE (DMAC_CRCCTRL_CRCBEATSIZE_BYTE_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)
+#define DMAC_CRCCTRL_CRCBEATSIZE_HWORD (DMAC_CRCCTRL_CRCBEATSIZE_HWORD_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)
+#define DMAC_CRCCTRL_CRCBEATSIZE_WORD (DMAC_CRCCTRL_CRCBEATSIZE_WORD_Val << DMAC_CRCCTRL_CRCBEATSIZE_Pos)
+#define DMAC_CRCCTRL_CRCPOLY_Pos    2            /**< \brief (DMAC_CRCCTRL) CRC Polynomial Type */
+#define DMAC_CRCCTRL_CRCPOLY_Msk    (0x3ul << DMAC_CRCCTRL_CRCPOLY_Pos)
+#define DMAC_CRCCTRL_CRCPOLY(value) (DMAC_CRCCTRL_CRCPOLY_Msk & ((value) << DMAC_CRCCTRL_CRCPOLY_Pos))
+#define   DMAC_CRCCTRL_CRCPOLY_CRC16_Val  0x0ul  /**< \brief (DMAC_CRCCTRL) CRC-16 (CRC-CCITT) */
+#define   DMAC_CRCCTRL_CRCPOLY_CRC32_Val  0x1ul  /**< \brief (DMAC_CRCCTRL) CRC32 (IEEE 802.3) */
+#define DMAC_CRCCTRL_CRCPOLY_CRC16  (DMAC_CRCCTRL_CRCPOLY_CRC16_Val << DMAC_CRCCTRL_CRCPOLY_Pos)
+#define DMAC_CRCCTRL_CRCPOLY_CRC32  (DMAC_CRCCTRL_CRCPOLY_CRC32_Val << DMAC_CRCCTRL_CRCPOLY_Pos)
+#define DMAC_CRCCTRL_CRCSRC_Pos     8            /**< \brief (DMAC_CRCCTRL) CRC Input Source */
+#define DMAC_CRCCTRL_CRCSRC_Msk     (0x3Ful << DMAC_CRCCTRL_CRCSRC_Pos)
+#define DMAC_CRCCTRL_CRCSRC(value)  (DMAC_CRCCTRL_CRCSRC_Msk & ((value) << DMAC_CRCCTRL_CRCSRC_Pos))
+#define   DMAC_CRCCTRL_CRCSRC_NOACT_Val   0x0ul  /**< \brief (DMAC_CRCCTRL) No action */
+#define   DMAC_CRCCTRL_CRCSRC_IO_Val      0x1ul  /**< \brief (DMAC_CRCCTRL) I/O interface */
+#define DMAC_CRCCTRL_CRCSRC_NOACT   (DMAC_CRCCTRL_CRCSRC_NOACT_Val << DMAC_CRCCTRL_CRCSRC_Pos)
+#define DMAC_CRCCTRL_CRCSRC_IO      (DMAC_CRCCTRL_CRCSRC_IO_Val    << DMAC_CRCCTRL_CRCSRC_Pos)
+#define DMAC_CRCCTRL_MASK           0x3F0Ful     /**< \brief (DMAC_CRCCTRL) MASK Register */
+
+/* -------- DMAC_CRCDATAIN : (DMAC Offset: 0x04) (R/W 32) CRC Data Input -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CRCDATAIN:32;     /*!< bit:  0..31  CRC Data Input                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_CRCDATAIN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCDATAIN_OFFSET       0x04         /**< \brief (DMAC_CRCDATAIN offset) CRC Data Input */
+#define DMAC_CRCDATAIN_RESETVALUE   0x00000000ul /**< \brief (DMAC_CRCDATAIN reset_value) CRC Data Input */
+
+#define DMAC_CRCDATAIN_CRCDATAIN_Pos 0            /**< \brief (DMAC_CRCDATAIN) CRC Data Input */
+#define DMAC_CRCDATAIN_CRCDATAIN_Msk (0xFFFFFFFFul << DMAC_CRCDATAIN_CRCDATAIN_Pos)
+#define DMAC_CRCDATAIN_CRCDATAIN(value) (DMAC_CRCDATAIN_CRCDATAIN_Msk & ((value) << DMAC_CRCDATAIN_CRCDATAIN_Pos))
+#define DMAC_CRCDATAIN_MASK         0xFFFFFFFFul /**< \brief (DMAC_CRCDATAIN) MASK Register */
+
+/* -------- DMAC_CRCCHKSUM : (DMAC Offset: 0x08) (R/W 32) CRC Checksum -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CRCCHKSUM:32;     /*!< bit:  0..31  CRC Checksum                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_CRCCHKSUM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCCHKSUM_OFFSET       0x08         /**< \brief (DMAC_CRCCHKSUM offset) CRC Checksum */
+#define DMAC_CRCCHKSUM_RESETVALUE   0x00000000ul /**< \brief (DMAC_CRCCHKSUM reset_value) CRC Checksum */
+
+#define DMAC_CRCCHKSUM_CRCCHKSUM_Pos 0            /**< \brief (DMAC_CRCCHKSUM) CRC Checksum */
+#define DMAC_CRCCHKSUM_CRCCHKSUM_Msk (0xFFFFFFFFul << DMAC_CRCCHKSUM_CRCCHKSUM_Pos)
+#define DMAC_CRCCHKSUM_CRCCHKSUM(value) (DMAC_CRCCHKSUM_CRCCHKSUM_Msk & ((value) << DMAC_CRCCHKSUM_CRCCHKSUM_Pos))
+#define DMAC_CRCCHKSUM_MASK         0xFFFFFFFFul /**< \brief (DMAC_CRCCHKSUM) MASK Register */
+
+/* -------- DMAC_CRCSTATUS : (DMAC Offset: 0x0C) (R/W  8) CRC Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CRCBUSY:1;        /*!< bit:      0  CRC Module Busy                    */
+    uint8_t  CRCZERO:1;        /*!< bit:      1  CRC Zero                           */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DMAC_CRCSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CRCSTATUS_OFFSET       0x0C         /**< \brief (DMAC_CRCSTATUS offset) CRC Status */
+#define DMAC_CRCSTATUS_RESETVALUE   0x00ul       /**< \brief (DMAC_CRCSTATUS reset_value) CRC Status */
+
+#define DMAC_CRCSTATUS_CRCBUSY_Pos  0            /**< \brief (DMAC_CRCSTATUS) CRC Module Busy */
+#define DMAC_CRCSTATUS_CRCBUSY      (0x1ul << DMAC_CRCSTATUS_CRCBUSY_Pos)
+#define DMAC_CRCSTATUS_CRCZERO_Pos  1            /**< \brief (DMAC_CRCSTATUS) CRC Zero */
+#define DMAC_CRCSTATUS_CRCZERO      (0x1ul << DMAC_CRCSTATUS_CRCZERO_Pos)
+#define DMAC_CRCSTATUS_MASK         0x03ul       /**< \brief (DMAC_CRCSTATUS) MASK Register */
+
+/* -------- DMAC_DBGCTRL : (DMAC Offset: 0x0D) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Run                          */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DMAC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_DBGCTRL_OFFSET         0x0D         /**< \brief (DMAC_DBGCTRL offset) Debug Control */
+#define DMAC_DBGCTRL_RESETVALUE     0x00ul       /**< \brief (DMAC_DBGCTRL reset_value) Debug Control */
+
+#define DMAC_DBGCTRL_DBGRUN_Pos     0            /**< \brief (DMAC_DBGCTRL) Debug Run */
+#define DMAC_DBGCTRL_DBGRUN         (0x1ul << DMAC_DBGCTRL_DBGRUN_Pos)
+#define DMAC_DBGCTRL_MASK           0x01ul       /**< \brief (DMAC_DBGCTRL) MASK Register */
+
+/* -------- DMAC_SWTRIGCTRL : (DMAC Offset: 0x10) (R/W 32) Software Trigger Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWTRIG0:1;        /*!< bit:      0  Channel 0 Software Trigger         */
+    uint32_t SWTRIG1:1;        /*!< bit:      1  Channel 1 Software Trigger         */
+    uint32_t SWTRIG2:1;        /*!< bit:      2  Channel 2 Software Trigger         */
+    uint32_t SWTRIG3:1;        /*!< bit:      3  Channel 3 Software Trigger         */
+    uint32_t SWTRIG4:1;        /*!< bit:      4  Channel 4 Software Trigger         */
+    uint32_t SWTRIG5:1;        /*!< bit:      5  Channel 5 Software Trigger         */
+    uint32_t SWTRIG6:1;        /*!< bit:      6  Channel 6 Software Trigger         */
+    uint32_t SWTRIG7:1;        /*!< bit:      7  Channel 7 Software Trigger         */
+    uint32_t SWTRIG8:1;        /*!< bit:      8  Channel 8 Software Trigger         */
+    uint32_t SWTRIG9:1;        /*!< bit:      9  Channel 9 Software Trigger         */
+    uint32_t SWTRIG10:1;       /*!< bit:     10  Channel 10 Software Trigger        */
+    uint32_t SWTRIG11:1;       /*!< bit:     11  Channel 11 Software Trigger        */
+    uint32_t SWTRIG12:1;       /*!< bit:     12  Channel 12 Software Trigger        */
+    uint32_t SWTRIG13:1;       /*!< bit:     13  Channel 13 Software Trigger        */
+    uint32_t SWTRIG14:1;       /*!< bit:     14  Channel 14 Software Trigger        */
+    uint32_t SWTRIG15:1;       /*!< bit:     15  Channel 15 Software Trigger        */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t SWTRIG:16;        /*!< bit:  0..15  Channel x Software Trigger         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_SWTRIGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_SWTRIGCTRL_OFFSET      0x10         /**< \brief (DMAC_SWTRIGCTRL offset) Software Trigger Control */
+#define DMAC_SWTRIGCTRL_RESETVALUE  0x00000000ul /**< \brief (DMAC_SWTRIGCTRL reset_value) Software Trigger Control */
+
+#define DMAC_SWTRIGCTRL_SWTRIG0_Pos 0            /**< \brief (DMAC_SWTRIGCTRL) Channel 0 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG0     (1 << DMAC_SWTRIGCTRL_SWTRIG0_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG1_Pos 1            /**< \brief (DMAC_SWTRIGCTRL) Channel 1 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG1     (1 << DMAC_SWTRIGCTRL_SWTRIG1_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG2_Pos 2            /**< \brief (DMAC_SWTRIGCTRL) Channel 2 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG2     (1 << DMAC_SWTRIGCTRL_SWTRIG2_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG3_Pos 3            /**< \brief (DMAC_SWTRIGCTRL) Channel 3 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG3     (1 << DMAC_SWTRIGCTRL_SWTRIG3_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG4_Pos 4            /**< \brief (DMAC_SWTRIGCTRL) Channel 4 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG4     (1 << DMAC_SWTRIGCTRL_SWTRIG4_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG5_Pos 5            /**< \brief (DMAC_SWTRIGCTRL) Channel 5 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG5     (1 << DMAC_SWTRIGCTRL_SWTRIG5_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG6_Pos 6            /**< \brief (DMAC_SWTRIGCTRL) Channel 6 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG6     (1 << DMAC_SWTRIGCTRL_SWTRIG6_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG7_Pos 7            /**< \brief (DMAC_SWTRIGCTRL) Channel 7 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG7     (1 << DMAC_SWTRIGCTRL_SWTRIG7_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG8_Pos 8            /**< \brief (DMAC_SWTRIGCTRL) Channel 8 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG8     (1 << DMAC_SWTRIGCTRL_SWTRIG8_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG9_Pos 9            /**< \brief (DMAC_SWTRIGCTRL) Channel 9 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG9     (1 << DMAC_SWTRIGCTRL_SWTRIG9_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG10_Pos 10           /**< \brief (DMAC_SWTRIGCTRL) Channel 10 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG10    (1 << DMAC_SWTRIGCTRL_SWTRIG10_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG11_Pos 11           /**< \brief (DMAC_SWTRIGCTRL) Channel 11 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG11    (1 << DMAC_SWTRIGCTRL_SWTRIG11_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG12_Pos 12           /**< \brief (DMAC_SWTRIGCTRL) Channel 12 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG12    (1 << DMAC_SWTRIGCTRL_SWTRIG12_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG13_Pos 13           /**< \brief (DMAC_SWTRIGCTRL) Channel 13 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG13    (1 << DMAC_SWTRIGCTRL_SWTRIG13_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG14_Pos 14           /**< \brief (DMAC_SWTRIGCTRL) Channel 14 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG14    (1 << DMAC_SWTRIGCTRL_SWTRIG14_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG15_Pos 15           /**< \brief (DMAC_SWTRIGCTRL) Channel 15 Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG15    (1 << DMAC_SWTRIGCTRL_SWTRIG15_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG_Pos  0            /**< \brief (DMAC_SWTRIGCTRL) Channel x Software Trigger */
+#define DMAC_SWTRIGCTRL_SWTRIG_Msk  (0xFFFFul << DMAC_SWTRIGCTRL_SWTRIG_Pos)
+#define DMAC_SWTRIGCTRL_SWTRIG(value) (DMAC_SWTRIGCTRL_SWTRIG_Msk & ((value) << DMAC_SWTRIGCTRL_SWTRIG_Pos))
+#define DMAC_SWTRIGCTRL_MASK        0x0000FFFFul /**< \brief (DMAC_SWTRIGCTRL) MASK Register */
+
+/* -------- DMAC_PRICTRL0 : (DMAC Offset: 0x14) (R/W 32) Priority Control 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LVLPRI0:4;        /*!< bit:  0.. 3  Level 0 Channel Priority Number    */
+    uint32_t :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint32_t RRLVLEN0:1;       /*!< bit:      7  Level 0 Round-Robin Scheduling Enable */
+    uint32_t LVLPRI1:4;        /*!< bit:  8..11  Level 1 Channel Priority Number    */
+    uint32_t :3;               /*!< bit: 12..14  Reserved                           */
+    uint32_t RRLVLEN1:1;       /*!< bit:     15  Level 1 Round-Robin Scheduling Enable */
+    uint32_t LVLPRI2:4;        /*!< bit: 16..19  Level 2 Channel Priority Number    */
+    uint32_t :3;               /*!< bit: 20..22  Reserved                           */
+    uint32_t RRLVLEN2:1;       /*!< bit:     23  Level 2 Round-Robin Scheduling Enable */
+    uint32_t LVLPRI3:4;        /*!< bit: 24..27  Level 3 Channel Priority Number    */
+    uint32_t :3;               /*!< bit: 28..30  Reserved                           */
+    uint32_t RRLVLEN3:1;       /*!< bit:     31  Level 3 Round-Robin Scheduling Enable */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_PRICTRL0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_PRICTRL0_OFFSET        0x14         /**< \brief (DMAC_PRICTRL0 offset) Priority Control 0 */
+#define DMAC_PRICTRL0_RESETVALUE    0x00000000ul /**< \brief (DMAC_PRICTRL0 reset_value) Priority Control 0 */
+
+#define DMAC_PRICTRL0_LVLPRI0_Pos   0            /**< \brief (DMAC_PRICTRL0) Level 0 Channel Priority Number */
+#define DMAC_PRICTRL0_LVLPRI0_Msk   (0xFul << DMAC_PRICTRL0_LVLPRI0_Pos)
+#define DMAC_PRICTRL0_LVLPRI0(value) (DMAC_PRICTRL0_LVLPRI0_Msk & ((value) << DMAC_PRICTRL0_LVLPRI0_Pos))
+#define DMAC_PRICTRL0_RRLVLEN0_Pos  7            /**< \brief (DMAC_PRICTRL0) Level 0 Round-Robin Scheduling Enable */
+#define DMAC_PRICTRL0_RRLVLEN0      (0x1ul << DMAC_PRICTRL0_RRLVLEN0_Pos)
+#define DMAC_PRICTRL0_LVLPRI1_Pos   8            /**< \brief (DMAC_PRICTRL0) Level 1 Channel Priority Number */
+#define DMAC_PRICTRL0_LVLPRI1_Msk   (0xFul << DMAC_PRICTRL0_LVLPRI1_Pos)
+#define DMAC_PRICTRL0_LVLPRI1(value) (DMAC_PRICTRL0_LVLPRI1_Msk & ((value) << DMAC_PRICTRL0_LVLPRI1_Pos))
+#define DMAC_PRICTRL0_RRLVLEN1_Pos  15           /**< \brief (DMAC_PRICTRL0) Level 1 Round-Robin Scheduling Enable */
+#define DMAC_PRICTRL0_RRLVLEN1      (0x1ul << DMAC_PRICTRL0_RRLVLEN1_Pos)
+#define DMAC_PRICTRL0_LVLPRI2_Pos   16           /**< \brief (DMAC_PRICTRL0) Level 2 Channel Priority Number */
+#define DMAC_PRICTRL0_LVLPRI2_Msk   (0xFul << DMAC_PRICTRL0_LVLPRI2_Pos)
+#define DMAC_PRICTRL0_LVLPRI2(value) (DMAC_PRICTRL0_LVLPRI2_Msk & ((value) << DMAC_PRICTRL0_LVLPRI2_Pos))
+#define DMAC_PRICTRL0_RRLVLEN2_Pos  23           /**< \brief (DMAC_PRICTRL0) Level 2 Round-Robin Scheduling Enable */
+#define DMAC_PRICTRL0_RRLVLEN2      (0x1ul << DMAC_PRICTRL0_RRLVLEN2_Pos)
+#define DMAC_PRICTRL0_LVLPRI3_Pos   24           /**< \brief (DMAC_PRICTRL0) Level 3 Channel Priority Number */
+#define DMAC_PRICTRL0_LVLPRI3_Msk   (0xFul << DMAC_PRICTRL0_LVLPRI3_Pos)
+#define DMAC_PRICTRL0_LVLPRI3(value) (DMAC_PRICTRL0_LVLPRI3_Msk & ((value) << DMAC_PRICTRL0_LVLPRI3_Pos))
+#define DMAC_PRICTRL0_RRLVLEN3_Pos  31           /**< \brief (DMAC_PRICTRL0) Level 3 Round-Robin Scheduling Enable */
+#define DMAC_PRICTRL0_RRLVLEN3      (0x1ul << DMAC_PRICTRL0_RRLVLEN3_Pos)
+#define DMAC_PRICTRL0_MASK          0x8F8F8F8Ful /**< \brief (DMAC_PRICTRL0) MASK Register */
+
+/* -------- DMAC_INTPEND : (DMAC Offset: 0x20) (R/W 16) Interrupt Pending -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t ID:4;             /*!< bit:  0.. 3  Channel ID                         */
+    uint16_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint16_t TERR:1;           /*!< bit:      8  Transfer Error                     */
+    uint16_t TCMPL:1;          /*!< bit:      9  Transfer Complete                  */
+    uint16_t SUSP:1;           /*!< bit:     10  Channel Suspend                    */
+    uint16_t :2;               /*!< bit: 11..12  Reserved                           */
+    uint16_t FERR:1;           /*!< bit:     13  Fetch Error                        */
+    uint16_t BUSY:1;           /*!< bit:     14  Busy                               */
+    uint16_t PEND:1;           /*!< bit:     15  Pending                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DMAC_INTPEND_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_INTPEND_OFFSET         0x20         /**< \brief (DMAC_INTPEND offset) Interrupt Pending */
+#define DMAC_INTPEND_RESETVALUE     0x0000ul     /**< \brief (DMAC_INTPEND reset_value) Interrupt Pending */
+
+#define DMAC_INTPEND_ID_Pos         0            /**< \brief (DMAC_INTPEND) Channel ID */
+#define DMAC_INTPEND_ID_Msk         (0xFul << DMAC_INTPEND_ID_Pos)
+#define DMAC_INTPEND_ID(value)      (DMAC_INTPEND_ID_Msk & ((value) << DMAC_INTPEND_ID_Pos))
+#define DMAC_INTPEND_TERR_Pos       8            /**< \brief (DMAC_INTPEND) Transfer Error */
+#define DMAC_INTPEND_TERR           (0x1ul << DMAC_INTPEND_TERR_Pos)
+#define DMAC_INTPEND_TCMPL_Pos      9            /**< \brief (DMAC_INTPEND) Transfer Complete */
+#define DMAC_INTPEND_TCMPL          (0x1ul << DMAC_INTPEND_TCMPL_Pos)
+#define DMAC_INTPEND_SUSP_Pos       10           /**< \brief (DMAC_INTPEND) Channel Suspend */
+#define DMAC_INTPEND_SUSP           (0x1ul << DMAC_INTPEND_SUSP_Pos)
+#define DMAC_INTPEND_FERR_Pos       13           /**< \brief (DMAC_INTPEND) Fetch Error */
+#define DMAC_INTPEND_FERR           (0x1ul << DMAC_INTPEND_FERR_Pos)
+#define DMAC_INTPEND_BUSY_Pos       14           /**< \brief (DMAC_INTPEND) Busy */
+#define DMAC_INTPEND_BUSY           (0x1ul << DMAC_INTPEND_BUSY_Pos)
+#define DMAC_INTPEND_PEND_Pos       15           /**< \brief (DMAC_INTPEND) Pending */
+#define DMAC_INTPEND_PEND           (0x1ul << DMAC_INTPEND_PEND_Pos)
+#define DMAC_INTPEND_MASK           0xE70Ful     /**< \brief (DMAC_INTPEND) MASK Register */
+
+/* -------- DMAC_INTSTATUS : (DMAC Offset: 0x24) (R/  32) Interrupt Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHINT0:1;         /*!< bit:      0  Channel 0 Pending Interrupt        */
+    uint32_t CHINT1:1;         /*!< bit:      1  Channel 1 Pending Interrupt        */
+    uint32_t CHINT2:1;         /*!< bit:      2  Channel 2 Pending Interrupt        */
+    uint32_t CHINT3:1;         /*!< bit:      3  Channel 3 Pending Interrupt        */
+    uint32_t CHINT4:1;         /*!< bit:      4  Channel 4 Pending Interrupt        */
+    uint32_t CHINT5:1;         /*!< bit:      5  Channel 5 Pending Interrupt        */
+    uint32_t CHINT6:1;         /*!< bit:      6  Channel 6 Pending Interrupt        */
+    uint32_t CHINT7:1;         /*!< bit:      7  Channel 7 Pending Interrupt        */
+    uint32_t CHINT8:1;         /*!< bit:      8  Channel 8 Pending Interrupt        */
+    uint32_t CHINT9:1;         /*!< bit:      9  Channel 9 Pending Interrupt        */
+    uint32_t CHINT10:1;        /*!< bit:     10  Channel 10 Pending Interrupt       */
+    uint32_t CHINT11:1;        /*!< bit:     11  Channel 11 Pending Interrupt       */
+    uint32_t CHINT12:1;        /*!< bit:     12  Channel 12 Pending Interrupt       */
+    uint32_t CHINT13:1;        /*!< bit:     13  Channel 13 Pending Interrupt       */
+    uint32_t CHINT14:1;        /*!< bit:     14  Channel 14 Pending Interrupt       */
+    uint32_t CHINT15:1;        /*!< bit:     15  Channel 15 Pending Interrupt       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t CHINT:16;         /*!< bit:  0..15  Channel x Pending Interrupt        */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_INTSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_INTSTATUS_OFFSET       0x24         /**< \brief (DMAC_INTSTATUS offset) Interrupt Status */
+#define DMAC_INTSTATUS_RESETVALUE   0x00000000ul /**< \brief (DMAC_INTSTATUS reset_value) Interrupt Status */
+
+#define DMAC_INTSTATUS_CHINT0_Pos   0            /**< \brief (DMAC_INTSTATUS) Channel 0 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT0       (1 << DMAC_INTSTATUS_CHINT0_Pos)
+#define DMAC_INTSTATUS_CHINT1_Pos   1            /**< \brief (DMAC_INTSTATUS) Channel 1 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT1       (1 << DMAC_INTSTATUS_CHINT1_Pos)
+#define DMAC_INTSTATUS_CHINT2_Pos   2            /**< \brief (DMAC_INTSTATUS) Channel 2 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT2       (1 << DMAC_INTSTATUS_CHINT2_Pos)
+#define DMAC_INTSTATUS_CHINT3_Pos   3            /**< \brief (DMAC_INTSTATUS) Channel 3 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT3       (1 << DMAC_INTSTATUS_CHINT3_Pos)
+#define DMAC_INTSTATUS_CHINT4_Pos   4            /**< \brief (DMAC_INTSTATUS) Channel 4 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT4       (1 << DMAC_INTSTATUS_CHINT4_Pos)
+#define DMAC_INTSTATUS_CHINT5_Pos   5            /**< \brief (DMAC_INTSTATUS) Channel 5 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT5       (1 << DMAC_INTSTATUS_CHINT5_Pos)
+#define DMAC_INTSTATUS_CHINT6_Pos   6            /**< \brief (DMAC_INTSTATUS) Channel 6 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT6       (1 << DMAC_INTSTATUS_CHINT6_Pos)
+#define DMAC_INTSTATUS_CHINT7_Pos   7            /**< \brief (DMAC_INTSTATUS) Channel 7 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT7       (1 << DMAC_INTSTATUS_CHINT7_Pos)
+#define DMAC_INTSTATUS_CHINT8_Pos   8            /**< \brief (DMAC_INTSTATUS) Channel 8 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT8       (1 << DMAC_INTSTATUS_CHINT8_Pos)
+#define DMAC_INTSTATUS_CHINT9_Pos   9            /**< \brief (DMAC_INTSTATUS) Channel 9 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT9       (1 << DMAC_INTSTATUS_CHINT9_Pos)
+#define DMAC_INTSTATUS_CHINT10_Pos  10           /**< \brief (DMAC_INTSTATUS) Channel 10 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT10      (1 << DMAC_INTSTATUS_CHINT10_Pos)
+#define DMAC_INTSTATUS_CHINT11_Pos  11           /**< \brief (DMAC_INTSTATUS) Channel 11 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT11      (1 << DMAC_INTSTATUS_CHINT11_Pos)
+#define DMAC_INTSTATUS_CHINT12_Pos  12           /**< \brief (DMAC_INTSTATUS) Channel 12 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT12      (1 << DMAC_INTSTATUS_CHINT12_Pos)
+#define DMAC_INTSTATUS_CHINT13_Pos  13           /**< \brief (DMAC_INTSTATUS) Channel 13 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT13      (1 << DMAC_INTSTATUS_CHINT13_Pos)
+#define DMAC_INTSTATUS_CHINT14_Pos  14           /**< \brief (DMAC_INTSTATUS) Channel 14 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT14      (1 << DMAC_INTSTATUS_CHINT14_Pos)
+#define DMAC_INTSTATUS_CHINT15_Pos  15           /**< \brief (DMAC_INTSTATUS) Channel 15 Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT15      (1 << DMAC_INTSTATUS_CHINT15_Pos)
+#define DMAC_INTSTATUS_CHINT_Pos    0            /**< \brief (DMAC_INTSTATUS) Channel x Pending Interrupt */
+#define DMAC_INTSTATUS_CHINT_Msk    (0xFFFFul << DMAC_INTSTATUS_CHINT_Pos)
+#define DMAC_INTSTATUS_CHINT(value) (DMAC_INTSTATUS_CHINT_Msk & ((value) << DMAC_INTSTATUS_CHINT_Pos))
+#define DMAC_INTSTATUS_MASK         0x0000FFFFul /**< \brief (DMAC_INTSTATUS) MASK Register */
+
+/* -------- DMAC_BUSYCH : (DMAC Offset: 0x28) (R/  32) Busy Channels -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BUSYCH0:1;        /*!< bit:      0  Busy Channel 0                     */
+    uint32_t BUSYCH1:1;        /*!< bit:      1  Busy Channel 1                     */
+    uint32_t BUSYCH2:1;        /*!< bit:      2  Busy Channel 2                     */
+    uint32_t BUSYCH3:1;        /*!< bit:      3  Busy Channel 3                     */
+    uint32_t BUSYCH4:1;        /*!< bit:      4  Busy Channel 4                     */
+    uint32_t BUSYCH5:1;        /*!< bit:      5  Busy Channel 5                     */
+    uint32_t BUSYCH6:1;        /*!< bit:      6  Busy Channel 6                     */
+    uint32_t BUSYCH7:1;        /*!< bit:      7  Busy Channel 7                     */
+    uint32_t BUSYCH8:1;        /*!< bit:      8  Busy Channel 8                     */
+    uint32_t BUSYCH9:1;        /*!< bit:      9  Busy Channel 9                     */
+    uint32_t BUSYCH10:1;       /*!< bit:     10  Busy Channel 10                    */
+    uint32_t BUSYCH11:1;       /*!< bit:     11  Busy Channel 11                    */
+    uint32_t BUSYCH12:1;       /*!< bit:     12  Busy Channel 12                    */
+    uint32_t BUSYCH13:1;       /*!< bit:     13  Busy Channel 13                    */
+    uint32_t BUSYCH14:1;       /*!< bit:     14  Busy Channel 14                    */
+    uint32_t BUSYCH15:1;       /*!< bit:     15  Busy Channel 15                    */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t BUSYCH:16;        /*!< bit:  0..15  Busy Channel x                     */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_BUSYCH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BUSYCH_OFFSET          0x28         /**< \brief (DMAC_BUSYCH offset) Busy Channels */
+#define DMAC_BUSYCH_RESETVALUE      0x00000000ul /**< \brief (DMAC_BUSYCH reset_value) Busy Channels */
+
+#define DMAC_BUSYCH_BUSYCH0_Pos     0            /**< \brief (DMAC_BUSYCH) Busy Channel 0 */
+#define DMAC_BUSYCH_BUSYCH0         (1 << DMAC_BUSYCH_BUSYCH0_Pos)
+#define DMAC_BUSYCH_BUSYCH1_Pos     1            /**< \brief (DMAC_BUSYCH) Busy Channel 1 */
+#define DMAC_BUSYCH_BUSYCH1         (1 << DMAC_BUSYCH_BUSYCH1_Pos)
+#define DMAC_BUSYCH_BUSYCH2_Pos     2            /**< \brief (DMAC_BUSYCH) Busy Channel 2 */
+#define DMAC_BUSYCH_BUSYCH2         (1 << DMAC_BUSYCH_BUSYCH2_Pos)
+#define DMAC_BUSYCH_BUSYCH3_Pos     3            /**< \brief (DMAC_BUSYCH) Busy Channel 3 */
+#define DMAC_BUSYCH_BUSYCH3         (1 << DMAC_BUSYCH_BUSYCH3_Pos)
+#define DMAC_BUSYCH_BUSYCH4_Pos     4            /**< \brief (DMAC_BUSYCH) Busy Channel 4 */
+#define DMAC_BUSYCH_BUSYCH4         (1 << DMAC_BUSYCH_BUSYCH4_Pos)
+#define DMAC_BUSYCH_BUSYCH5_Pos     5            /**< \brief (DMAC_BUSYCH) Busy Channel 5 */
+#define DMAC_BUSYCH_BUSYCH5         (1 << DMAC_BUSYCH_BUSYCH5_Pos)
+#define DMAC_BUSYCH_BUSYCH6_Pos     6            /**< \brief (DMAC_BUSYCH) Busy Channel 6 */
+#define DMAC_BUSYCH_BUSYCH6         (1 << DMAC_BUSYCH_BUSYCH6_Pos)
+#define DMAC_BUSYCH_BUSYCH7_Pos     7            /**< \brief (DMAC_BUSYCH) Busy Channel 7 */
+#define DMAC_BUSYCH_BUSYCH7         (1 << DMAC_BUSYCH_BUSYCH7_Pos)
+#define DMAC_BUSYCH_BUSYCH8_Pos     8            /**< \brief (DMAC_BUSYCH) Busy Channel 8 */
+#define DMAC_BUSYCH_BUSYCH8         (1 << DMAC_BUSYCH_BUSYCH8_Pos)
+#define DMAC_BUSYCH_BUSYCH9_Pos     9            /**< \brief (DMAC_BUSYCH) Busy Channel 9 */
+#define DMAC_BUSYCH_BUSYCH9         (1 << DMAC_BUSYCH_BUSYCH9_Pos)
+#define DMAC_BUSYCH_BUSYCH10_Pos    10           /**< \brief (DMAC_BUSYCH) Busy Channel 10 */
+#define DMAC_BUSYCH_BUSYCH10        (1 << DMAC_BUSYCH_BUSYCH10_Pos)
+#define DMAC_BUSYCH_BUSYCH11_Pos    11           /**< \brief (DMAC_BUSYCH) Busy Channel 11 */
+#define DMAC_BUSYCH_BUSYCH11        (1 << DMAC_BUSYCH_BUSYCH11_Pos)
+#define DMAC_BUSYCH_BUSYCH12_Pos    12           /**< \brief (DMAC_BUSYCH) Busy Channel 12 */
+#define DMAC_BUSYCH_BUSYCH12        (1 << DMAC_BUSYCH_BUSYCH12_Pos)
+#define DMAC_BUSYCH_BUSYCH13_Pos    13           /**< \brief (DMAC_BUSYCH) Busy Channel 13 */
+#define DMAC_BUSYCH_BUSYCH13        (1 << DMAC_BUSYCH_BUSYCH13_Pos)
+#define DMAC_BUSYCH_BUSYCH14_Pos    14           /**< \brief (DMAC_BUSYCH) Busy Channel 14 */
+#define DMAC_BUSYCH_BUSYCH14        (1 << DMAC_BUSYCH_BUSYCH14_Pos)
+#define DMAC_BUSYCH_BUSYCH15_Pos    15           /**< \brief (DMAC_BUSYCH) Busy Channel 15 */
+#define DMAC_BUSYCH_BUSYCH15        (1 << DMAC_BUSYCH_BUSYCH15_Pos)
+#define DMAC_BUSYCH_BUSYCH_Pos      0            /**< \brief (DMAC_BUSYCH) Busy Channel x */
+#define DMAC_BUSYCH_BUSYCH_Msk      (0xFFFFul << DMAC_BUSYCH_BUSYCH_Pos)
+#define DMAC_BUSYCH_BUSYCH(value)   (DMAC_BUSYCH_BUSYCH_Msk & ((value) << DMAC_BUSYCH_BUSYCH_Pos))
+#define DMAC_BUSYCH_MASK            0x0000FFFFul /**< \brief (DMAC_BUSYCH) MASK Register */
+
+/* -------- DMAC_PENDCH : (DMAC Offset: 0x2C) (R/  32) Pending Channels -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PENDCH0:1;        /*!< bit:      0  Pending Channel 0                  */
+    uint32_t PENDCH1:1;        /*!< bit:      1  Pending Channel 1                  */
+    uint32_t PENDCH2:1;        /*!< bit:      2  Pending Channel 2                  */
+    uint32_t PENDCH3:1;        /*!< bit:      3  Pending Channel 3                  */
+    uint32_t PENDCH4:1;        /*!< bit:      4  Pending Channel 4                  */
+    uint32_t PENDCH5:1;        /*!< bit:      5  Pending Channel 5                  */
+    uint32_t PENDCH6:1;        /*!< bit:      6  Pending Channel 6                  */
+    uint32_t PENDCH7:1;        /*!< bit:      7  Pending Channel 7                  */
+    uint32_t PENDCH8:1;        /*!< bit:      8  Pending Channel 8                  */
+    uint32_t PENDCH9:1;        /*!< bit:      9  Pending Channel 9                  */
+    uint32_t PENDCH10:1;       /*!< bit:     10  Pending Channel 10                 */
+    uint32_t PENDCH11:1;       /*!< bit:     11  Pending Channel 11                 */
+    uint32_t PENDCH12:1;       /*!< bit:     12  Pending Channel 12                 */
+    uint32_t PENDCH13:1;       /*!< bit:     13  Pending Channel 13                 */
+    uint32_t PENDCH14:1;       /*!< bit:     14  Pending Channel 14                 */
+    uint32_t PENDCH15:1;       /*!< bit:     15  Pending Channel 15                 */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t PENDCH:16;        /*!< bit:  0..15  Pending Channel x                  */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_PENDCH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_PENDCH_OFFSET          0x2C         /**< \brief (DMAC_PENDCH offset) Pending Channels */
+#define DMAC_PENDCH_RESETVALUE      0x00000000ul /**< \brief (DMAC_PENDCH reset_value) Pending Channels */
+
+#define DMAC_PENDCH_PENDCH0_Pos     0            /**< \brief (DMAC_PENDCH) Pending Channel 0 */
+#define DMAC_PENDCH_PENDCH0         (1 << DMAC_PENDCH_PENDCH0_Pos)
+#define DMAC_PENDCH_PENDCH1_Pos     1            /**< \brief (DMAC_PENDCH) Pending Channel 1 */
+#define DMAC_PENDCH_PENDCH1         (1 << DMAC_PENDCH_PENDCH1_Pos)
+#define DMAC_PENDCH_PENDCH2_Pos     2            /**< \brief (DMAC_PENDCH) Pending Channel 2 */
+#define DMAC_PENDCH_PENDCH2         (1 << DMAC_PENDCH_PENDCH2_Pos)
+#define DMAC_PENDCH_PENDCH3_Pos     3            /**< \brief (DMAC_PENDCH) Pending Channel 3 */
+#define DMAC_PENDCH_PENDCH3         (1 << DMAC_PENDCH_PENDCH3_Pos)
+#define DMAC_PENDCH_PENDCH4_Pos     4            /**< \brief (DMAC_PENDCH) Pending Channel 4 */
+#define DMAC_PENDCH_PENDCH4         (1 << DMAC_PENDCH_PENDCH4_Pos)
+#define DMAC_PENDCH_PENDCH5_Pos     5            /**< \brief (DMAC_PENDCH) Pending Channel 5 */
+#define DMAC_PENDCH_PENDCH5         (1 << DMAC_PENDCH_PENDCH5_Pos)
+#define DMAC_PENDCH_PENDCH6_Pos     6            /**< \brief (DMAC_PENDCH) Pending Channel 6 */
+#define DMAC_PENDCH_PENDCH6         (1 << DMAC_PENDCH_PENDCH6_Pos)
+#define DMAC_PENDCH_PENDCH7_Pos     7            /**< \brief (DMAC_PENDCH) Pending Channel 7 */
+#define DMAC_PENDCH_PENDCH7         (1 << DMAC_PENDCH_PENDCH7_Pos)
+#define DMAC_PENDCH_PENDCH8_Pos     8            /**< \brief (DMAC_PENDCH) Pending Channel 8 */
+#define DMAC_PENDCH_PENDCH8         (1 << DMAC_PENDCH_PENDCH8_Pos)
+#define DMAC_PENDCH_PENDCH9_Pos     9            /**< \brief (DMAC_PENDCH) Pending Channel 9 */
+#define DMAC_PENDCH_PENDCH9         (1 << DMAC_PENDCH_PENDCH9_Pos)
+#define DMAC_PENDCH_PENDCH10_Pos    10           /**< \brief (DMAC_PENDCH) Pending Channel 10 */
+#define DMAC_PENDCH_PENDCH10        (1 << DMAC_PENDCH_PENDCH10_Pos)
+#define DMAC_PENDCH_PENDCH11_Pos    11           /**< \brief (DMAC_PENDCH) Pending Channel 11 */
+#define DMAC_PENDCH_PENDCH11        (1 << DMAC_PENDCH_PENDCH11_Pos)
+#define DMAC_PENDCH_PENDCH12_Pos    12           /**< \brief (DMAC_PENDCH) Pending Channel 12 */
+#define DMAC_PENDCH_PENDCH12        (1 << DMAC_PENDCH_PENDCH12_Pos)
+#define DMAC_PENDCH_PENDCH13_Pos    13           /**< \brief (DMAC_PENDCH) Pending Channel 13 */
+#define DMAC_PENDCH_PENDCH13        (1 << DMAC_PENDCH_PENDCH13_Pos)
+#define DMAC_PENDCH_PENDCH14_Pos    14           /**< \brief (DMAC_PENDCH) Pending Channel 14 */
+#define DMAC_PENDCH_PENDCH14        (1 << DMAC_PENDCH_PENDCH14_Pos)
+#define DMAC_PENDCH_PENDCH15_Pos    15           /**< \brief (DMAC_PENDCH) Pending Channel 15 */
+#define DMAC_PENDCH_PENDCH15        (1 << DMAC_PENDCH_PENDCH15_Pos)
+#define DMAC_PENDCH_PENDCH_Pos      0            /**< \brief (DMAC_PENDCH) Pending Channel x */
+#define DMAC_PENDCH_PENDCH_Msk      (0xFFFFul << DMAC_PENDCH_PENDCH_Pos)
+#define DMAC_PENDCH_PENDCH(value)   (DMAC_PENDCH_PENDCH_Msk & ((value) << DMAC_PENDCH_PENDCH_Pos))
+#define DMAC_PENDCH_MASK            0x0000FFFFul /**< \brief (DMAC_PENDCH) MASK Register */
+
+/* -------- DMAC_ACTIVE : (DMAC Offset: 0x30) (R/  32) Active Channel and Levels -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LVLEX0:1;         /*!< bit:      0  Level 0 Channel Trigger Request Executing */
+    uint32_t LVLEX1:1;         /*!< bit:      1  Level 1 Channel Trigger Request Executing */
+    uint32_t LVLEX2:1;         /*!< bit:      2  Level 2 Channel Trigger Request Executing */
+    uint32_t LVLEX3:1;         /*!< bit:      3  Level 3 Channel Trigger Request Executing */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t ID:5;             /*!< bit:  8..12  Active Channel ID                  */
+    uint32_t :2;               /*!< bit: 13..14  Reserved                           */
+    uint32_t ABUSY:1;          /*!< bit:     15  Active Channel Busy                */
+    uint32_t BTCNT:16;         /*!< bit: 16..31  Active Channel Block Transfer Count */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t LVLEX:4;          /*!< bit:  0.. 3  Level x Channel Trigger Request Executing */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_ACTIVE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_ACTIVE_OFFSET          0x30         /**< \brief (DMAC_ACTIVE offset) Active Channel and Levels */
+#define DMAC_ACTIVE_RESETVALUE      0x00000000ul /**< \brief (DMAC_ACTIVE reset_value) Active Channel and Levels */
+
+#define DMAC_ACTIVE_LVLEX0_Pos      0            /**< \brief (DMAC_ACTIVE) Level 0 Channel Trigger Request Executing */
+#define DMAC_ACTIVE_LVLEX0          (1 << DMAC_ACTIVE_LVLEX0_Pos)
+#define DMAC_ACTIVE_LVLEX1_Pos      1            /**< \brief (DMAC_ACTIVE) Level 1 Channel Trigger Request Executing */
+#define DMAC_ACTIVE_LVLEX1          (1 << DMAC_ACTIVE_LVLEX1_Pos)
+#define DMAC_ACTIVE_LVLEX2_Pos      2            /**< \brief (DMAC_ACTIVE) Level 2 Channel Trigger Request Executing */
+#define DMAC_ACTIVE_LVLEX2          (1 << DMAC_ACTIVE_LVLEX2_Pos)
+#define DMAC_ACTIVE_LVLEX3_Pos      3            /**< \brief (DMAC_ACTIVE) Level 3 Channel Trigger Request Executing */
+#define DMAC_ACTIVE_LVLEX3          (1 << DMAC_ACTIVE_LVLEX3_Pos)
+#define DMAC_ACTIVE_LVLEX_Pos       0            /**< \brief (DMAC_ACTIVE) Level x Channel Trigger Request Executing */
+#define DMAC_ACTIVE_LVLEX_Msk       (0xFul << DMAC_ACTIVE_LVLEX_Pos)
+#define DMAC_ACTIVE_LVLEX(value)    (DMAC_ACTIVE_LVLEX_Msk & ((value) << DMAC_ACTIVE_LVLEX_Pos))
+#define DMAC_ACTIVE_ID_Pos          8            /**< \brief (DMAC_ACTIVE) Active Channel ID */
+#define DMAC_ACTIVE_ID_Msk          (0x1Ful << DMAC_ACTIVE_ID_Pos)
+#define DMAC_ACTIVE_ID(value)       (DMAC_ACTIVE_ID_Msk & ((value) << DMAC_ACTIVE_ID_Pos))
+#define DMAC_ACTIVE_ABUSY_Pos       15           /**< \brief (DMAC_ACTIVE) Active Channel Busy */
+#define DMAC_ACTIVE_ABUSY           (0x1ul << DMAC_ACTIVE_ABUSY_Pos)
+#define DMAC_ACTIVE_BTCNT_Pos       16           /**< \brief (DMAC_ACTIVE) Active Channel Block Transfer Count */
+#define DMAC_ACTIVE_BTCNT_Msk       (0xFFFFul << DMAC_ACTIVE_BTCNT_Pos)
+#define DMAC_ACTIVE_BTCNT(value)    (DMAC_ACTIVE_BTCNT_Msk & ((value) << DMAC_ACTIVE_BTCNT_Pos))
+#define DMAC_ACTIVE_MASK            0xFFFF9F0Ful /**< \brief (DMAC_ACTIVE) MASK Register */
+
+/* -------- DMAC_BASEADDR : (DMAC Offset: 0x34) (R/W 32) Descriptor Memory Section Base Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BASEADDR:32;      /*!< bit:  0..31  Descriptor Memory Base Address     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_BASEADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BASEADDR_OFFSET        0x34         /**< \brief (DMAC_BASEADDR offset) Descriptor Memory Section Base Address */
+#define DMAC_BASEADDR_RESETVALUE    0x00000000ul /**< \brief (DMAC_BASEADDR reset_value) Descriptor Memory Section Base Address */
+
+#define DMAC_BASEADDR_BASEADDR_Pos  0            /**< \brief (DMAC_BASEADDR) Descriptor Memory Base Address */
+#define DMAC_BASEADDR_BASEADDR_Msk  (0xFFFFFFFFul << DMAC_BASEADDR_BASEADDR_Pos)
+#define DMAC_BASEADDR_BASEADDR(value) (DMAC_BASEADDR_BASEADDR_Msk & ((value) << DMAC_BASEADDR_BASEADDR_Pos))
+#define DMAC_BASEADDR_MASK          0xFFFFFFFFul /**< \brief (DMAC_BASEADDR) MASK Register */
+
+/* -------- DMAC_WRBADDR : (DMAC Offset: 0x38) (R/W 32) Write-Back Memory Section Base Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WRBADDR:32;       /*!< bit:  0..31  Write-Back Memory Base Address     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_WRBADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_WRBADDR_OFFSET         0x38         /**< \brief (DMAC_WRBADDR offset) Write-Back Memory Section Base Address */
+#define DMAC_WRBADDR_RESETVALUE     0x00000000ul /**< \brief (DMAC_WRBADDR reset_value) Write-Back Memory Section Base Address */
+
+#define DMAC_WRBADDR_WRBADDR_Pos    0            /**< \brief (DMAC_WRBADDR) Write-Back Memory Base Address */
+#define DMAC_WRBADDR_WRBADDR_Msk    (0xFFFFFFFFul << DMAC_WRBADDR_WRBADDR_Pos)
+#define DMAC_WRBADDR_WRBADDR(value) (DMAC_WRBADDR_WRBADDR_Msk & ((value) << DMAC_WRBADDR_WRBADDR_Pos))
+#define DMAC_WRBADDR_MASK           0xFFFFFFFFul /**< \brief (DMAC_WRBADDR) MASK Register */
+
+/* -------- DMAC_CHID : (DMAC Offset: 0x3F) (R/W  8) Channel ID -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ID:4;             /*!< bit:  0.. 3  Channel ID                         */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DMAC_CHID_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHID_OFFSET            0x3F         /**< \brief (DMAC_CHID offset) Channel ID */
+#define DMAC_CHID_RESETVALUE        0x00ul       /**< \brief (DMAC_CHID reset_value) Channel ID */
+
+#define DMAC_CHID_ID_Pos            0            /**< \brief (DMAC_CHID) Channel ID */
+#define DMAC_CHID_ID_Msk            (0xFul << DMAC_CHID_ID_Pos)
+#define DMAC_CHID_ID(value)         (DMAC_CHID_ID_Msk & ((value) << DMAC_CHID_ID_Pos))
+#define DMAC_CHID_MASK              0x0Ful       /**< \brief (DMAC_CHID) MASK Register */
+
+/* -------- DMAC_CHCTRLA : (DMAC Offset: 0x40) (R/W  8) Channel Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Channel Software Reset             */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Channel Enable                     */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      6  Channel run in standby             */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DMAC_CHCTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHCTRLA_OFFSET         0x40         /**< \brief (DMAC_CHCTRLA offset) Channel Control A */
+#define DMAC_CHCTRLA_RESETVALUE     0x00ul       /**< \brief (DMAC_CHCTRLA reset_value) Channel Control A */
+
+#define DMAC_CHCTRLA_SWRST_Pos      0            /**< \brief (DMAC_CHCTRLA) Channel Software Reset */
+#define DMAC_CHCTRLA_SWRST          (0x1ul << DMAC_CHCTRLA_SWRST_Pos)
+#define DMAC_CHCTRLA_ENABLE_Pos     1            /**< \brief (DMAC_CHCTRLA) Channel Enable */
+#define DMAC_CHCTRLA_ENABLE         (0x1ul << DMAC_CHCTRLA_ENABLE_Pos)
+#define DMAC_CHCTRLA_RUNSTDBY_Pos   6            /**< \brief (DMAC_CHCTRLA) Channel run in standby */
+#define DMAC_CHCTRLA_RUNSTDBY       (0x1ul << DMAC_CHCTRLA_RUNSTDBY_Pos)
+#define DMAC_CHCTRLA_MASK           0x43ul       /**< \brief (DMAC_CHCTRLA) MASK Register */
+
+/* -------- DMAC_CHCTRLB : (DMAC Offset: 0x44) (R/W 32) Channel Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EVACT:3;          /*!< bit:  0.. 2  Event Input Action                 */
+    uint32_t EVIE:1;           /*!< bit:      3  Channel Event Input Enable         */
+    uint32_t EVOE:1;           /*!< bit:      4  Channel Event Output Enable        */
+    uint32_t LVL:2;            /*!< bit:  5.. 6  Channel Arbitration Level          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t TRIGSRC:6;        /*!< bit:  8..13  Trigger Source                     */
+    uint32_t :8;               /*!< bit: 14..21  Reserved                           */
+    uint32_t TRIGACT:2;        /*!< bit: 22..23  Trigger Action                     */
+    uint32_t CMD:2;            /*!< bit: 24..25  Software Command                   */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_CHCTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHCTRLB_OFFSET         0x44         /**< \brief (DMAC_CHCTRLB offset) Channel Control B */
+#define DMAC_CHCTRLB_RESETVALUE     0x00000000ul /**< \brief (DMAC_CHCTRLB reset_value) Channel Control B */
+
+#define DMAC_CHCTRLB_EVACT_Pos      0            /**< \brief (DMAC_CHCTRLB) Event Input Action */
+#define DMAC_CHCTRLB_EVACT_Msk      (0x7ul << DMAC_CHCTRLB_EVACT_Pos)
+#define DMAC_CHCTRLB_EVACT(value)   (DMAC_CHCTRLB_EVACT_Msk & ((value) << DMAC_CHCTRLB_EVACT_Pos))
+#define   DMAC_CHCTRLB_EVACT_NOACT_Val    0x0ul  /**< \brief (DMAC_CHCTRLB) No action */
+#define   DMAC_CHCTRLB_EVACT_TRIG_Val     0x1ul  /**< \brief (DMAC_CHCTRLB) Transfer and periodic transfer trigger */
+#define   DMAC_CHCTRLB_EVACT_CTRIG_Val    0x2ul  /**< \brief (DMAC_CHCTRLB) Conditional transfer trigger */
+#define   DMAC_CHCTRLB_EVACT_CBLOCK_Val   0x3ul  /**< \brief (DMAC_CHCTRLB) Conditional block transfer */
+#define   DMAC_CHCTRLB_EVACT_SUSPEND_Val  0x4ul  /**< \brief (DMAC_CHCTRLB) Channel suspend operation */
+#define   DMAC_CHCTRLB_EVACT_RESUME_Val   0x5ul  /**< \brief (DMAC_CHCTRLB) Channel resume operation */
+#define   DMAC_CHCTRLB_EVACT_SSKIP_Val    0x6ul  /**< \brief (DMAC_CHCTRLB) Skip next block suspend action */
+#define DMAC_CHCTRLB_EVACT_NOACT    (DMAC_CHCTRLB_EVACT_NOACT_Val  << DMAC_CHCTRLB_EVACT_Pos)
+#define DMAC_CHCTRLB_EVACT_TRIG     (DMAC_CHCTRLB_EVACT_TRIG_Val   << DMAC_CHCTRLB_EVACT_Pos)
+#define DMAC_CHCTRLB_EVACT_CTRIG    (DMAC_CHCTRLB_EVACT_CTRIG_Val  << DMAC_CHCTRLB_EVACT_Pos)
+#define DMAC_CHCTRLB_EVACT_CBLOCK   (DMAC_CHCTRLB_EVACT_CBLOCK_Val << DMAC_CHCTRLB_EVACT_Pos)
+#define DMAC_CHCTRLB_EVACT_SUSPEND  (DMAC_CHCTRLB_EVACT_SUSPEND_Val << DMAC_CHCTRLB_EVACT_Pos)
+#define DMAC_CHCTRLB_EVACT_RESUME   (DMAC_CHCTRLB_EVACT_RESUME_Val << DMAC_CHCTRLB_EVACT_Pos)
+#define DMAC_CHCTRLB_EVACT_SSKIP    (DMAC_CHCTRLB_EVACT_SSKIP_Val  << DMAC_CHCTRLB_EVACT_Pos)
+#define DMAC_CHCTRLB_EVIE_Pos       3            /**< \brief (DMAC_CHCTRLB) Channel Event Input Enable */
+#define DMAC_CHCTRLB_EVIE           (0x1ul << DMAC_CHCTRLB_EVIE_Pos)
+#define DMAC_CHCTRLB_EVOE_Pos       4            /**< \brief (DMAC_CHCTRLB) Channel Event Output Enable */
+#define DMAC_CHCTRLB_EVOE           (0x1ul << DMAC_CHCTRLB_EVOE_Pos)
+#define DMAC_CHCTRLB_LVL_Pos        5            /**< \brief (DMAC_CHCTRLB) Channel Arbitration Level */
+#define DMAC_CHCTRLB_LVL_Msk        (0x3ul << DMAC_CHCTRLB_LVL_Pos)
+#define DMAC_CHCTRLB_LVL(value)     (DMAC_CHCTRLB_LVL_Msk & ((value) << DMAC_CHCTRLB_LVL_Pos))
+#define DMAC_CHCTRLB_TRIGSRC_Pos    8            /**< \brief (DMAC_CHCTRLB) Trigger Source */
+#define DMAC_CHCTRLB_TRIGSRC_Msk    (0x3Ful << DMAC_CHCTRLB_TRIGSRC_Pos)
+#define DMAC_CHCTRLB_TRIGSRC(value) (DMAC_CHCTRLB_TRIGSRC_Msk & ((value) << DMAC_CHCTRLB_TRIGSRC_Pos))
+#define   DMAC_CHCTRLB_TRIGSRC_DISABLE_Val 0x0ul  /**< \brief (DMAC_CHCTRLB) Only software/event triggers */
+#define DMAC_CHCTRLB_TRIGSRC_DISABLE (DMAC_CHCTRLB_TRIGSRC_DISABLE_Val << DMAC_CHCTRLB_TRIGSRC_Pos)
+#define DMAC_CHCTRLB_TRIGACT_Pos    22           /**< \brief (DMAC_CHCTRLB) Trigger Action */
+#define DMAC_CHCTRLB_TRIGACT_Msk    (0x3ul << DMAC_CHCTRLB_TRIGACT_Pos)
+#define DMAC_CHCTRLB_TRIGACT(value) (DMAC_CHCTRLB_TRIGACT_Msk & ((value) << DMAC_CHCTRLB_TRIGACT_Pos))
+#define   DMAC_CHCTRLB_TRIGACT_BLOCK_Val  0x0ul  /**< \brief (DMAC_CHCTRLB) One trigger required for each block transfer */
+#define   DMAC_CHCTRLB_TRIGACT_BEAT_Val   0x2ul  /**< \brief (DMAC_CHCTRLB) One trigger required for each beat transfer */
+#define   DMAC_CHCTRLB_TRIGACT_TRANSACTION_Val 0x3ul  /**< \brief (DMAC_CHCTRLB) One trigger required for each transaction */
+#define DMAC_CHCTRLB_TRIGACT_BLOCK  (DMAC_CHCTRLB_TRIGACT_BLOCK_Val << DMAC_CHCTRLB_TRIGACT_Pos)
+#define DMAC_CHCTRLB_TRIGACT_BEAT   (DMAC_CHCTRLB_TRIGACT_BEAT_Val << DMAC_CHCTRLB_TRIGACT_Pos)
+#define DMAC_CHCTRLB_TRIGACT_TRANSACTION (DMAC_CHCTRLB_TRIGACT_TRANSACTION_Val << DMAC_CHCTRLB_TRIGACT_Pos)
+#define DMAC_CHCTRLB_CMD_Pos        24           /**< \brief (DMAC_CHCTRLB) Software Command */
+#define DMAC_CHCTRLB_CMD_Msk        (0x3ul << DMAC_CHCTRLB_CMD_Pos)
+#define DMAC_CHCTRLB_CMD(value)     (DMAC_CHCTRLB_CMD_Msk & ((value) << DMAC_CHCTRLB_CMD_Pos))
+#define   DMAC_CHCTRLB_CMD_NOACT_Val      0x0ul  /**< \brief (DMAC_CHCTRLB) No action */
+#define   DMAC_CHCTRLB_CMD_SUSPEND_Val    0x1ul  /**< \brief (DMAC_CHCTRLB) Channel suspend operation */
+#define   DMAC_CHCTRLB_CMD_RESUME_Val     0x2ul  /**< \brief (DMAC_CHCTRLB) Channel resume operation */
+#define DMAC_CHCTRLB_CMD_NOACT      (DMAC_CHCTRLB_CMD_NOACT_Val    << DMAC_CHCTRLB_CMD_Pos)
+#define DMAC_CHCTRLB_CMD_SUSPEND    (DMAC_CHCTRLB_CMD_SUSPEND_Val  << DMAC_CHCTRLB_CMD_Pos)
+#define DMAC_CHCTRLB_CMD_RESUME     (DMAC_CHCTRLB_CMD_RESUME_Val   << DMAC_CHCTRLB_CMD_Pos)
+#define DMAC_CHCTRLB_MASK           0x03C03F7Ful /**< \brief (DMAC_CHCTRLB) MASK Register */
+
+/* -------- DMAC_CHINTENCLR : (DMAC Offset: 0x4C) (R/W  8) Channel Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error Interrupt Enable */
+    uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete Interrupt Enable */
+    uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend Interrupt Enable   */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DMAC_CHINTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHINTENCLR_OFFSET      0x4C         /**< \brief (DMAC_CHINTENCLR offset) Channel Interrupt Enable Clear */
+#define DMAC_CHINTENCLR_RESETVALUE  0x00ul       /**< \brief (DMAC_CHINTENCLR reset_value) Channel Interrupt Enable Clear */
+
+#define DMAC_CHINTENCLR_TERR_Pos    0            /**< \brief (DMAC_CHINTENCLR) Channel Transfer Error Interrupt Enable */
+#define DMAC_CHINTENCLR_TERR        (0x1ul << DMAC_CHINTENCLR_TERR_Pos)
+#define DMAC_CHINTENCLR_TCMPL_Pos   1            /**< \brief (DMAC_CHINTENCLR) Channel Transfer Complete Interrupt Enable */
+#define DMAC_CHINTENCLR_TCMPL       (0x1ul << DMAC_CHINTENCLR_TCMPL_Pos)
+#define DMAC_CHINTENCLR_SUSP_Pos    2            /**< \brief (DMAC_CHINTENCLR) Channel Suspend Interrupt Enable */
+#define DMAC_CHINTENCLR_SUSP        (0x1ul << DMAC_CHINTENCLR_SUSP_Pos)
+#define DMAC_CHINTENCLR_MASK        0x07ul       /**< \brief (DMAC_CHINTENCLR) MASK Register */
+
+/* -------- DMAC_CHINTENSET : (DMAC Offset: 0x4D) (R/W  8) Channel Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error Interrupt Enable */
+    uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete Interrupt Enable */
+    uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend Interrupt Enable   */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DMAC_CHINTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHINTENSET_OFFSET      0x4D         /**< \brief (DMAC_CHINTENSET offset) Channel Interrupt Enable Set */
+#define DMAC_CHINTENSET_RESETVALUE  0x00ul       /**< \brief (DMAC_CHINTENSET reset_value) Channel Interrupt Enable Set */
+
+#define DMAC_CHINTENSET_TERR_Pos    0            /**< \brief (DMAC_CHINTENSET) Channel Transfer Error Interrupt Enable */
+#define DMAC_CHINTENSET_TERR        (0x1ul << DMAC_CHINTENSET_TERR_Pos)
+#define DMAC_CHINTENSET_TCMPL_Pos   1            /**< \brief (DMAC_CHINTENSET) Channel Transfer Complete Interrupt Enable */
+#define DMAC_CHINTENSET_TCMPL       (0x1ul << DMAC_CHINTENSET_TCMPL_Pos)
+#define DMAC_CHINTENSET_SUSP_Pos    2            /**< \brief (DMAC_CHINTENSET) Channel Suspend Interrupt Enable */
+#define DMAC_CHINTENSET_SUSP        (0x1ul << DMAC_CHINTENSET_SUSP_Pos)
+#define DMAC_CHINTENSET_MASK        0x07ul       /**< \brief (DMAC_CHINTENSET) MASK Register */
+
+/* -------- DMAC_CHINTFLAG : (DMAC Offset: 0x4E) (R/W  8) Channel Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
+    __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
+    __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
+    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DMAC_CHINTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHINTFLAG_OFFSET       0x4E         /**< \brief (DMAC_CHINTFLAG offset) Channel Interrupt Flag Status and Clear */
+#define DMAC_CHINTFLAG_RESETVALUE   0x00ul       /**< \brief (DMAC_CHINTFLAG reset_value) Channel Interrupt Flag Status and Clear */
+
+#define DMAC_CHINTFLAG_TERR_Pos     0            /**< \brief (DMAC_CHINTFLAG) Channel Transfer Error */
+#define DMAC_CHINTFLAG_TERR         (0x1ul << DMAC_CHINTFLAG_TERR_Pos)
+#define DMAC_CHINTFLAG_TCMPL_Pos    1            /**< \brief (DMAC_CHINTFLAG) Channel Transfer Complete */
+#define DMAC_CHINTFLAG_TCMPL        (0x1ul << DMAC_CHINTFLAG_TCMPL_Pos)
+#define DMAC_CHINTFLAG_SUSP_Pos     2            /**< \brief (DMAC_CHINTFLAG) Channel Suspend */
+#define DMAC_CHINTFLAG_SUSP         (0x1ul << DMAC_CHINTFLAG_SUSP_Pos)
+#define DMAC_CHINTFLAG_MASK         0x07ul       /**< \brief (DMAC_CHINTFLAG) MASK Register */
+
+/* -------- DMAC_CHSTATUS : (DMAC Offset: 0x4F) (R/   8) Channel Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PEND:1;           /*!< bit:      0  Channel Pending                    */
+    uint8_t  BUSY:1;           /*!< bit:      1  Channel Busy                       */
+    uint8_t  FERR:1;           /*!< bit:      2  Channel Fetch Error                */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DMAC_CHSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_CHSTATUS_OFFSET        0x4F         /**< \brief (DMAC_CHSTATUS offset) Channel Status */
+#define DMAC_CHSTATUS_RESETVALUE    0x00ul       /**< \brief (DMAC_CHSTATUS reset_value) Channel Status */
+
+#define DMAC_CHSTATUS_PEND_Pos      0            /**< \brief (DMAC_CHSTATUS) Channel Pending */
+#define DMAC_CHSTATUS_PEND          (0x1ul << DMAC_CHSTATUS_PEND_Pos)
+#define DMAC_CHSTATUS_BUSY_Pos      1            /**< \brief (DMAC_CHSTATUS) Channel Busy */
+#define DMAC_CHSTATUS_BUSY          (0x1ul << DMAC_CHSTATUS_BUSY_Pos)
+#define DMAC_CHSTATUS_FERR_Pos      2            /**< \brief (DMAC_CHSTATUS) Channel Fetch Error */
+#define DMAC_CHSTATUS_FERR          (0x1ul << DMAC_CHSTATUS_FERR_Pos)
+#define DMAC_CHSTATUS_MASK          0x07ul       /**< \brief (DMAC_CHSTATUS) MASK Register */
+
+/* -------- DMAC_BTCTRL : (DMAC Offset: 0x00) (R/W 16) Block Transfer Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t VALID:1;          /*!< bit:      0  Descriptor Valid                   */
+    uint16_t EVOSEL:2;         /*!< bit:  1.. 2  Event Output Selection             */
+    uint16_t BLOCKACT:2;       /*!< bit:  3.. 4  Block Action                       */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t BEATSIZE:2;       /*!< bit:  8.. 9  Beat Size                          */
+    uint16_t SRCINC:1;         /*!< bit:     10  Source Address Increment Enable    */
+    uint16_t DSTINC:1;         /*!< bit:     11  Destination Address Increment Enable */
+    uint16_t STEPSEL:1;        /*!< bit:     12  Step Selection                     */
+    uint16_t STEPSIZE:3;       /*!< bit: 13..15  Address Increment Step Size        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DMAC_BTCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BTCTRL_OFFSET          0x00         /**< \brief (DMAC_BTCTRL offset) Block Transfer Control */
+#define DMAC_BTCTRL_RESETVALUE      0x0000ul     /**< \brief (DMAC_BTCTRL reset_value) Block Transfer Control */
+
+#define DMAC_BTCTRL_VALID_Pos       0            /**< \brief (DMAC_BTCTRL) Descriptor Valid */
+#define DMAC_BTCTRL_VALID           (0x1ul << DMAC_BTCTRL_VALID_Pos)
+#define DMAC_BTCTRL_EVOSEL_Pos      1            /**< \brief (DMAC_BTCTRL) Event Output Selection */
+#define DMAC_BTCTRL_EVOSEL_Msk      (0x3ul << DMAC_BTCTRL_EVOSEL_Pos)
+#define DMAC_BTCTRL_EVOSEL(value)   (DMAC_BTCTRL_EVOSEL_Msk & ((value) << DMAC_BTCTRL_EVOSEL_Pos))
+#define   DMAC_BTCTRL_EVOSEL_DISABLE_Val  0x0ul  /**< \brief (DMAC_BTCTRL) Event generation disabled */
+#define   DMAC_BTCTRL_EVOSEL_BLOCK_Val    0x1ul  /**< \brief (DMAC_BTCTRL) Event strobe when block transfer complete */
+#define   DMAC_BTCTRL_EVOSEL_BEAT_Val     0x3ul  /**< \brief (DMAC_BTCTRL) Event strobe when beat transfer complete */
+#define DMAC_BTCTRL_EVOSEL_DISABLE  (DMAC_BTCTRL_EVOSEL_DISABLE_Val << DMAC_BTCTRL_EVOSEL_Pos)
+#define DMAC_BTCTRL_EVOSEL_BLOCK    (DMAC_BTCTRL_EVOSEL_BLOCK_Val  << DMAC_BTCTRL_EVOSEL_Pos)
+#define DMAC_BTCTRL_EVOSEL_BEAT     (DMAC_BTCTRL_EVOSEL_BEAT_Val   << DMAC_BTCTRL_EVOSEL_Pos)
+#define DMAC_BTCTRL_BLOCKACT_Pos    3            /**< \brief (DMAC_BTCTRL) Block Action */
+#define DMAC_BTCTRL_BLOCKACT_Msk    (0x3ul << DMAC_BTCTRL_BLOCKACT_Pos)
+#define DMAC_BTCTRL_BLOCKACT(value) (DMAC_BTCTRL_BLOCKACT_Msk & ((value) << DMAC_BTCTRL_BLOCKACT_Pos))
+#define   DMAC_BTCTRL_BLOCKACT_NOACT_Val  0x0ul  /**< \brief (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction */
+#define   DMAC_BTCTRL_BLOCKACT_INT_Val    0x1ul  /**< \brief (DMAC_BTCTRL) Channel will be disabled if it is the last block transfer in the transaction and block interrupt */
+#define   DMAC_BTCTRL_BLOCKACT_SUSPEND_Val 0x2ul  /**< \brief (DMAC_BTCTRL) Channel suspend operation is completed */
+#define   DMAC_BTCTRL_BLOCKACT_BOTH_Val   0x3ul  /**< \brief (DMAC_BTCTRL) Both channel suspend operation and block interrupt */
+#define DMAC_BTCTRL_BLOCKACT_NOACT  (DMAC_BTCTRL_BLOCKACT_NOACT_Val << DMAC_BTCTRL_BLOCKACT_Pos)
+#define DMAC_BTCTRL_BLOCKACT_INT    (DMAC_BTCTRL_BLOCKACT_INT_Val  << DMAC_BTCTRL_BLOCKACT_Pos)
+#define DMAC_BTCTRL_BLOCKACT_SUSPEND (DMAC_BTCTRL_BLOCKACT_SUSPEND_Val << DMAC_BTCTRL_BLOCKACT_Pos)
+#define DMAC_BTCTRL_BLOCKACT_BOTH   (DMAC_BTCTRL_BLOCKACT_BOTH_Val << DMAC_BTCTRL_BLOCKACT_Pos)
+#define DMAC_BTCTRL_BEATSIZE_Pos    8            /**< \brief (DMAC_BTCTRL) Beat Size */
+#define DMAC_BTCTRL_BEATSIZE_Msk    (0x3ul << DMAC_BTCTRL_BEATSIZE_Pos)
+#define DMAC_BTCTRL_BEATSIZE(value) (DMAC_BTCTRL_BEATSIZE_Msk & ((value) << DMAC_BTCTRL_BEATSIZE_Pos))
+#define   DMAC_BTCTRL_BEATSIZE_BYTE_Val   0x0ul  /**< \brief (DMAC_BTCTRL) 8-bit bus transfer */
+#define   DMAC_BTCTRL_BEATSIZE_HWORD_Val  0x1ul  /**< \brief (DMAC_BTCTRL) 16-bit bus transfer */
+#define   DMAC_BTCTRL_BEATSIZE_WORD_Val   0x2ul  /**< \brief (DMAC_BTCTRL) 32-bit bus transfer */
+#define DMAC_BTCTRL_BEATSIZE_BYTE   (DMAC_BTCTRL_BEATSIZE_BYTE_Val << DMAC_BTCTRL_BEATSIZE_Pos)
+#define DMAC_BTCTRL_BEATSIZE_HWORD  (DMAC_BTCTRL_BEATSIZE_HWORD_Val << DMAC_BTCTRL_BEATSIZE_Pos)
+#define DMAC_BTCTRL_BEATSIZE_WORD   (DMAC_BTCTRL_BEATSIZE_WORD_Val << DMAC_BTCTRL_BEATSIZE_Pos)
+#define DMAC_BTCTRL_SRCINC_Pos      10           /**< \brief (DMAC_BTCTRL) Source Address Increment Enable */
+#define DMAC_BTCTRL_SRCINC          (0x1ul << DMAC_BTCTRL_SRCINC_Pos)
+#define DMAC_BTCTRL_DSTINC_Pos      11           /**< \brief (DMAC_BTCTRL) Destination Address Increment Enable */
+#define DMAC_BTCTRL_DSTINC          (0x1ul << DMAC_BTCTRL_DSTINC_Pos)
+#define DMAC_BTCTRL_STEPSEL_Pos     12           /**< \brief (DMAC_BTCTRL) Step Selection */
+#define DMAC_BTCTRL_STEPSEL         (0x1ul << DMAC_BTCTRL_STEPSEL_Pos)
+#define   DMAC_BTCTRL_STEPSEL_DST_Val     0x0ul  /**< \brief (DMAC_BTCTRL) Step size settings apply to the destination address */
+#define   DMAC_BTCTRL_STEPSEL_SRC_Val     0x1ul  /**< \brief (DMAC_BTCTRL) Step size settings apply to the source address */
+#define DMAC_BTCTRL_STEPSEL_DST     (DMAC_BTCTRL_STEPSEL_DST_Val   << DMAC_BTCTRL_STEPSEL_Pos)
+#define DMAC_BTCTRL_STEPSEL_SRC     (DMAC_BTCTRL_STEPSEL_SRC_Val   << DMAC_BTCTRL_STEPSEL_Pos)
+#define DMAC_BTCTRL_STEPSIZE_Pos    13           /**< \brief (DMAC_BTCTRL) Address Increment Step Size */
+#define DMAC_BTCTRL_STEPSIZE_Msk    (0x7ul << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_STEPSIZE(value) (DMAC_BTCTRL_STEPSIZE_Msk & ((value) << DMAC_BTCTRL_STEPSIZE_Pos))
+#define   DMAC_BTCTRL_STEPSIZE_X1_Val     0x0ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 1 */
+#define   DMAC_BTCTRL_STEPSIZE_X2_Val     0x1ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 2 */
+#define   DMAC_BTCTRL_STEPSIZE_X4_Val     0x2ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 4 */
+#define   DMAC_BTCTRL_STEPSIZE_X8_Val     0x3ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 8 */
+#define   DMAC_BTCTRL_STEPSIZE_X16_Val    0x4ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 16 */
+#define   DMAC_BTCTRL_STEPSIZE_X32_Val    0x5ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 32 */
+#define   DMAC_BTCTRL_STEPSIZE_X64_Val    0x6ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 64 */
+#define   DMAC_BTCTRL_STEPSIZE_X128_Val   0x7ul  /**< \brief (DMAC_BTCTRL) Next ADDR = ADDR + (BEATSIZE+1) * 128 */
+#define DMAC_BTCTRL_STEPSIZE_X1     (DMAC_BTCTRL_STEPSIZE_X1_Val   << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_STEPSIZE_X2     (DMAC_BTCTRL_STEPSIZE_X2_Val   << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_STEPSIZE_X4     (DMAC_BTCTRL_STEPSIZE_X4_Val   << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_STEPSIZE_X8     (DMAC_BTCTRL_STEPSIZE_X8_Val   << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_STEPSIZE_X16    (DMAC_BTCTRL_STEPSIZE_X16_Val  << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_STEPSIZE_X32    (DMAC_BTCTRL_STEPSIZE_X32_Val  << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_STEPSIZE_X64    (DMAC_BTCTRL_STEPSIZE_X64_Val  << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_STEPSIZE_X128   (DMAC_BTCTRL_STEPSIZE_X128_Val << DMAC_BTCTRL_STEPSIZE_Pos)
+#define DMAC_BTCTRL_MASK            0xFF1Ful     /**< \brief (DMAC_BTCTRL) MASK Register */
+
+/* -------- DMAC_BTCNT : (DMAC Offset: 0x02) (R/W 16) Block Transfer Count -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BTCNT:16;         /*!< bit:  0..15  Block Transfer Count               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DMAC_BTCNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_BTCNT_OFFSET           0x02         /**< \brief (DMAC_BTCNT offset) Block Transfer Count */
+
+#define DMAC_BTCNT_BTCNT_Pos        0            /**< \brief (DMAC_BTCNT) Block Transfer Count */
+#define DMAC_BTCNT_BTCNT_Msk        (0xFFFFul << DMAC_BTCNT_BTCNT_Pos)
+#define DMAC_BTCNT_BTCNT(value)     (DMAC_BTCNT_BTCNT_Msk & ((value) << DMAC_BTCNT_BTCNT_Pos))
+#define DMAC_BTCNT_MASK             0xFFFFul     /**< \brief (DMAC_BTCNT) MASK Register */
+
+/* -------- DMAC_SRCADDR : (DMAC Offset: 0x04) (R/W 32) Block Transfer Source Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SRCADDR:32;       /*!< bit:  0..31  Transfer Source Address            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_SRCADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_SRCADDR_OFFSET         0x04         /**< \brief (DMAC_SRCADDR offset) Block Transfer Source Address */
+
+#define DMAC_SRCADDR_SRCADDR_Pos    0            /**< \brief (DMAC_SRCADDR) Transfer Source Address */
+#define DMAC_SRCADDR_SRCADDR_Msk    (0xFFFFFFFFul << DMAC_SRCADDR_SRCADDR_Pos)
+#define DMAC_SRCADDR_SRCADDR(value) (DMAC_SRCADDR_SRCADDR_Msk & ((value) << DMAC_SRCADDR_SRCADDR_Pos))
+#define DMAC_SRCADDR_MASK           0xFFFFFFFFul /**< \brief (DMAC_SRCADDR) MASK Register */
+
+/* -------- DMAC_DSTADDR : (DMAC Offset: 0x08) (R/W 32) Block Transfer Destination Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DSTADDR:32;       /*!< bit:  0..31  Transfer Destination Address       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_DSTADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_DSTADDR_OFFSET         0x08         /**< \brief (DMAC_DSTADDR offset) Block Transfer Destination Address */
+
+#define DMAC_DSTADDR_DSTADDR_Pos    0            /**< \brief (DMAC_DSTADDR) Transfer Destination Address */
+#define DMAC_DSTADDR_DSTADDR_Msk    (0xFFFFFFFFul << DMAC_DSTADDR_DSTADDR_Pos)
+#define DMAC_DSTADDR_DSTADDR(value) (DMAC_DSTADDR_DSTADDR_Msk & ((value) << DMAC_DSTADDR_DSTADDR_Pos))
+#define DMAC_DSTADDR_MASK           0xFFFFFFFFul /**< \brief (DMAC_DSTADDR) MASK Register */
+
+/* -------- DMAC_DESCADDR : (DMAC Offset: 0x0C) (R/W 32) Next Descriptor Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DESCADDR:32;      /*!< bit:  0..31  Next Descriptor Address            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DMAC_DESCADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DMAC_DESCADDR_OFFSET        0x0C         /**< \brief (DMAC_DESCADDR offset) Next Descriptor Address */
+
+#define DMAC_DESCADDR_DESCADDR_Pos  0            /**< \brief (DMAC_DESCADDR) Next Descriptor Address */
+#define DMAC_DESCADDR_DESCADDR_Msk  (0xFFFFFFFFul << DMAC_DESCADDR_DESCADDR_Pos)
+#define DMAC_DESCADDR_DESCADDR(value) (DMAC_DESCADDR_DESCADDR_Msk & ((value) << DMAC_DESCADDR_DESCADDR_Pos))
+#define DMAC_DESCADDR_MASK          0xFFFFFFFFul /**< \brief (DMAC_DESCADDR) MASK Register */
+
+/** \brief DMAC APB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO DMAC_CTRL_Type            CTRL;        /**< \brief Offset: 0x00 (R/W 16) Control */
+  __IO DMAC_CRCCTRL_Type         CRCCTRL;     /**< \brief Offset: 0x02 (R/W 16) CRC Control */
+  __IO DMAC_CRCDATAIN_Type       CRCDATAIN;   /**< \brief Offset: 0x04 (R/W 32) CRC Data Input */
+  __IO DMAC_CRCCHKSUM_Type       CRCCHKSUM;   /**< \brief Offset: 0x08 (R/W 32) CRC Checksum */
+  __IO DMAC_CRCSTATUS_Type       CRCSTATUS;   /**< \brief Offset: 0x0C (R/W  8) CRC Status */
+  __IO DMAC_DBGCTRL_Type         DBGCTRL;     /**< \brief Offset: 0x0D (R/W  8) Debug Control */
+       RoReg8                    Reserved1[0x2];
+  __IO DMAC_SWTRIGCTRL_Type      SWTRIGCTRL;  /**< \brief Offset: 0x10 (R/W 32) Software Trigger Control */
+  __IO DMAC_PRICTRL0_Type        PRICTRL0;    /**< \brief Offset: 0x14 (R/W 32) Priority Control 0 */
+       RoReg8                    Reserved2[0x8];
+  __IO DMAC_INTPEND_Type         INTPEND;     /**< \brief Offset: 0x20 (R/W 16) Interrupt Pending */
+       RoReg8                    Reserved3[0x2];
+  __I  DMAC_INTSTATUS_Type       INTSTATUS;   /**< \brief Offset: 0x24 (R/  32) Interrupt Status */
+  __I  DMAC_BUSYCH_Type          BUSYCH;      /**< \brief Offset: 0x28 (R/  32) Busy Channels */
+  __I  DMAC_PENDCH_Type          PENDCH;      /**< \brief Offset: 0x2C (R/  32) Pending Channels */
+  __I  DMAC_ACTIVE_Type          ACTIVE;      /**< \brief Offset: 0x30 (R/  32) Active Channel and Levels */
+  __IO DMAC_BASEADDR_Type        BASEADDR;    /**< \brief Offset: 0x34 (R/W 32) Descriptor Memory Section Base Address */
+  __IO DMAC_WRBADDR_Type         WRBADDR;     /**< \brief Offset: 0x38 (R/W 32) Write-Back Memory Section Base Address */
+       RoReg8                    Reserved4[0x3];
+  __IO DMAC_CHID_Type            CHID;        /**< \brief Offset: 0x3F (R/W  8) Channel ID */
+  __IO DMAC_CHCTRLA_Type         CHCTRLA;     /**< \brief Offset: 0x40 (R/W  8) Channel Control A */
+       RoReg8                    Reserved5[0x3];
+  __IO DMAC_CHCTRLB_Type         CHCTRLB;     /**< \brief Offset: 0x44 (R/W 32) Channel Control B */
+       RoReg8                    Reserved6[0x4];
+  __IO DMAC_CHINTENCLR_Type      CHINTENCLR;  /**< \brief Offset: 0x4C (R/W  8) Channel Interrupt Enable Clear */
+  __IO DMAC_CHINTENSET_Type      CHINTENSET;  /**< \brief Offset: 0x4D (R/W  8) Channel Interrupt Enable Set */
+  __IO DMAC_CHINTFLAG_Type       CHINTFLAG;   /**< \brief Offset: 0x4E (R/W  8) Channel Interrupt Flag Status and Clear */
+  __I  DMAC_CHSTATUS_Type        CHSTATUS;    /**< \brief Offset: 0x4F (R/   8) Channel Status */
+} Dmac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief DMAC Descriptor SRAM registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO DMAC_BTCTRL_Type          BTCTRL;      /**< \brief Offset: 0x00 (R/W 16) Block Transfer Control */
+  __IO DMAC_BTCNT_Type           BTCNT;       /**< \brief Offset: 0x02 (R/W 16) Block Transfer Count */
+  __IO DMAC_SRCADDR_Type         SRCADDR;     /**< \brief Offset: 0x04 (R/W 32) Block Transfer Source Address */
+  __IO DMAC_DSTADDR_Type         DSTADDR;     /**< \brief Offset: 0x08 (R/W 32) Block Transfer Destination Address */
+  __IO DMAC_DESCADDR_Type        DESCADDR;    /**< \brief Offset: 0x0C (R/W 32) Next Descriptor Address */
+} DmacDescriptor
+#ifdef __GNUC__
+  __attribute__ ((aligned (8)))
+#endif
+;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __GNUC__
+ #define SECTION_DMAC_DESCRIPTOR      __attribute__ ((section(".lpram")))
+#elif defined(__ICCARM__)
+ #define SECTION_DMAC_DESCRIPTOR      @".lpram"
+#endif
+
+/*@}*/
+
+#endif /* _SAML21_DMAC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/dsu.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/dsu.h
@@ -1,0 +1,627 @@
+/**
+ * \file
+ *
+ * \brief Component description for DSU
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_DSU_COMPONENT_
+#define _SAML21_DSU_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DSU */
+/* ========================================================================== */
+/** \addtogroup SAML21_DSU Device Service Unit */
+/*@{*/
+
+#define DSU_U2209
+#define REV_DSU                     0x240
+
+/* -------- DSU_CTRL : (DSU Offset: 0x0000) ( /W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  CRC:1;            /*!< bit:      2  32-bit Cyclic Redundancy Code      */
+    uint8_t  MBIST:1;          /*!< bit:      3  Memory built-in self-test          */
+    uint8_t  CE:1;             /*!< bit:      4  Chip-Erase                         */
+    uint8_t  :1;               /*!< bit:      5  Reserved                           */
+    uint8_t  ARR:1;            /*!< bit:      6  Auxiliary Row Read                 */
+    uint8_t  SMSA:1;           /*!< bit:      7  Start Memory Stream Access         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DSU_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CTRL_OFFSET             0x0000       /**< \brief (DSU_CTRL offset) Control */
+#define DSU_CTRL_RESETVALUE         0x00ul       /**< \brief (DSU_CTRL reset_value) Control */
+
+#define DSU_CTRL_SWRST_Pos          0            /**< \brief (DSU_CTRL) Software Reset */
+#define DSU_CTRL_SWRST              (0x1ul << DSU_CTRL_SWRST_Pos)
+#define DSU_CTRL_CRC_Pos            2            /**< \brief (DSU_CTRL) 32-bit Cyclic Redundancy Code */
+#define DSU_CTRL_CRC                (0x1ul << DSU_CTRL_CRC_Pos)
+#define DSU_CTRL_MBIST_Pos          3            /**< \brief (DSU_CTRL) Memory built-in self-test */
+#define DSU_CTRL_MBIST              (0x1ul << DSU_CTRL_MBIST_Pos)
+#define DSU_CTRL_CE_Pos             4            /**< \brief (DSU_CTRL) Chip-Erase */
+#define DSU_CTRL_CE                 (0x1ul << DSU_CTRL_CE_Pos)
+#define DSU_CTRL_ARR_Pos            6            /**< \brief (DSU_CTRL) Auxiliary Row Read */
+#define DSU_CTRL_ARR                (0x1ul << DSU_CTRL_ARR_Pos)
+#define DSU_CTRL_SMSA_Pos           7            /**< \brief (DSU_CTRL) Start Memory Stream Access */
+#define DSU_CTRL_SMSA               (0x1ul << DSU_CTRL_SMSA_Pos)
+#define DSU_CTRL_MASK               0xDDul       /**< \brief (DSU_CTRL) MASK Register */
+
+/* -------- DSU_STATUSA : (DSU Offset: 0x0001) (R/W  8) Status A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DONE:1;           /*!< bit:      0  Done                               */
+    uint8_t  CRSTEXT:1;        /*!< bit:      1  CPU Reset Phase Extension          */
+    uint8_t  BERR:1;           /*!< bit:      2  Bus Error                          */
+    uint8_t  FAIL:1;           /*!< bit:      3  Failure                            */
+    uint8_t  PERR:1;           /*!< bit:      4  Protection Error                   */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DSU_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSA_OFFSET          0x0001       /**< \brief (DSU_STATUSA offset) Status A */
+#define DSU_STATUSA_RESETVALUE      0x00ul       /**< \brief (DSU_STATUSA reset_value) Status A */
+
+#define DSU_STATUSA_DONE_Pos        0            /**< \brief (DSU_STATUSA) Done */
+#define DSU_STATUSA_DONE            (0x1ul << DSU_STATUSA_DONE_Pos)
+#define DSU_STATUSA_CRSTEXT_Pos     1            /**< \brief (DSU_STATUSA) CPU Reset Phase Extension */
+#define DSU_STATUSA_CRSTEXT         (0x1ul << DSU_STATUSA_CRSTEXT_Pos)
+#define DSU_STATUSA_BERR_Pos        2            /**< \brief (DSU_STATUSA) Bus Error */
+#define DSU_STATUSA_BERR            (0x1ul << DSU_STATUSA_BERR_Pos)
+#define DSU_STATUSA_FAIL_Pos        3            /**< \brief (DSU_STATUSA) Failure */
+#define DSU_STATUSA_FAIL            (0x1ul << DSU_STATUSA_FAIL_Pos)
+#define DSU_STATUSA_PERR_Pos        4            /**< \brief (DSU_STATUSA) Protection Error */
+#define DSU_STATUSA_PERR            (0x1ul << DSU_STATUSA_PERR_Pos)
+#define DSU_STATUSA_MASK            0x1Ful       /**< \brief (DSU_STATUSA) MASK Register */
+
+/* -------- DSU_STATUSB : (DSU Offset: 0x0002) (R/   8) Status B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PROT:1;           /*!< bit:      0  Protected                          */
+    uint8_t  DBGPRES:1;        /*!< bit:      1  Debugger Present                   */
+    uint8_t  DCCD0:1;          /*!< bit:      2  Debug Communication Channel 0 Dirty */
+    uint8_t  DCCD1:1;          /*!< bit:      3  Debug Communication Channel 1 Dirty */
+    uint8_t  HPE:1;            /*!< bit:      4  Hot-Plugging Enable                */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint8_t  DCCD:2;           /*!< bit:  2.. 3  Debug Communication Channel x Dirty */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DSU_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSB_OFFSET          0x0002       /**< \brief (DSU_STATUSB offset) Status B */
+#define DSU_STATUSB_RESETVALUE      0x00ul       /**< \brief (DSU_STATUSB reset_value) Status B */
+
+#define DSU_STATUSB_PROT_Pos        0            /**< \brief (DSU_STATUSB) Protected */
+#define DSU_STATUSB_PROT            (0x1ul << DSU_STATUSB_PROT_Pos)
+#define DSU_STATUSB_DBGPRES_Pos     1            /**< \brief (DSU_STATUSB) Debugger Present */
+#define DSU_STATUSB_DBGPRES         (0x1ul << DSU_STATUSB_DBGPRES_Pos)
+#define DSU_STATUSB_DCCD0_Pos       2            /**< \brief (DSU_STATUSB) Debug Communication Channel 0 Dirty */
+#define DSU_STATUSB_DCCD0           (1 << DSU_STATUSB_DCCD0_Pos)
+#define DSU_STATUSB_DCCD1_Pos       3            /**< \brief (DSU_STATUSB) Debug Communication Channel 1 Dirty */
+#define DSU_STATUSB_DCCD1           (1 << DSU_STATUSB_DCCD1_Pos)
+#define DSU_STATUSB_DCCD_Pos        2            /**< \brief (DSU_STATUSB) Debug Communication Channel x Dirty */
+#define DSU_STATUSB_DCCD_Msk        (0x3ul << DSU_STATUSB_DCCD_Pos)
+#define DSU_STATUSB_DCCD(value)     (DSU_STATUSB_DCCD_Msk & ((value) << DSU_STATUSB_DCCD_Pos))
+#define DSU_STATUSB_HPE_Pos         4            /**< \brief (DSU_STATUSB) Hot-Plugging Enable */
+#define DSU_STATUSB_HPE             (0x1ul << DSU_STATUSB_HPE_Pos)
+#define DSU_STATUSB_MASK            0x1Ful       /**< \brief (DSU_STATUSB) MASK Register */
+
+/* -------- DSU_ADDR : (DSU Offset: 0x0004) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t AMOD:2;           /*!< bit:  0.. 1  Access Mode                        */
+    uint32_t ADDR:30;          /*!< bit:  2..31  Address                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ADDR_OFFSET             0x0004       /**< \brief (DSU_ADDR offset) Address */
+#define DSU_ADDR_RESETVALUE         0x00000000ul /**< \brief (DSU_ADDR reset_value) Address */
+
+#define DSU_ADDR_AMOD_Pos           0            /**< \brief (DSU_ADDR) Access Mode */
+#define DSU_ADDR_AMOD_Msk           (0x3ul << DSU_ADDR_AMOD_Pos)
+#define DSU_ADDR_AMOD(value)        (DSU_ADDR_AMOD_Msk & ((value) << DSU_ADDR_AMOD_Pos))
+#define DSU_ADDR_ADDR_Pos           2            /**< \brief (DSU_ADDR) Address */
+#define DSU_ADDR_ADDR_Msk           (0x3FFFFFFFul << DSU_ADDR_ADDR_Pos)
+#define DSU_ADDR_ADDR(value)        (DSU_ADDR_ADDR_Msk & ((value) << DSU_ADDR_ADDR_Pos))
+#define DSU_ADDR_MASK               0xFFFFFFFFul /**< \brief (DSU_ADDR) MASK Register */
+
+/* -------- DSU_LENGTH : (DSU Offset: 0x0008) (R/W 32) Length -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t LENGTH:30;        /*!< bit:  2..31  Length                             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_LENGTH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_LENGTH_OFFSET           0x0008       /**< \brief (DSU_LENGTH offset) Length */
+#define DSU_LENGTH_RESETVALUE       0x00000000ul /**< \brief (DSU_LENGTH reset_value) Length */
+
+#define DSU_LENGTH_LENGTH_Pos       2            /**< \brief (DSU_LENGTH) Length */
+#define DSU_LENGTH_LENGTH_Msk       (0x3FFFFFFFul << DSU_LENGTH_LENGTH_Pos)
+#define DSU_LENGTH_LENGTH(value)    (DSU_LENGTH_LENGTH_Msk & ((value) << DSU_LENGTH_LENGTH_Pos))
+#define DSU_LENGTH_MASK             0xFFFFFFFCul /**< \brief (DSU_LENGTH) MASK Register */
+
+/* -------- DSU_DATA : (DSU Offset: 0x000C) (R/W 32) Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DATA_OFFSET             0x000C       /**< \brief (DSU_DATA offset) Data */
+#define DSU_DATA_RESETVALUE         0x00000000ul /**< \brief (DSU_DATA reset_value) Data */
+
+#define DSU_DATA_DATA_Pos           0            /**< \brief (DSU_DATA) Data */
+#define DSU_DATA_DATA_Msk           (0xFFFFFFFFul << DSU_DATA_DATA_Pos)
+#define DSU_DATA_DATA(value)        (DSU_DATA_DATA_Msk & ((value) << DSU_DATA_DATA_Pos))
+#define DSU_DATA_MASK               0xFFFFFFFFul /**< \brief (DSU_DATA) MASK Register */
+
+/* -------- DSU_DCC : (DSU Offset: 0x0010) (R/W 32) Debug Communication Channel n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DCC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCC_OFFSET              0x0010       /**< \brief (DSU_DCC offset) Debug Communication Channel n */
+#define DSU_DCC_RESETVALUE          0x00000000ul /**< \brief (DSU_DCC reset_value) Debug Communication Channel n */
+
+#define DSU_DCC_DATA_Pos            0            /**< \brief (DSU_DCC) Data */
+#define DSU_DCC_DATA_Msk            (0xFFFFFFFFul << DSU_DCC_DATA_Pos)
+#define DSU_DCC_DATA(value)         (DSU_DCC_DATA_Msk & ((value) << DSU_DCC_DATA_Pos))
+#define DSU_DCC_MASK                0xFFFFFFFFul /**< \brief (DSU_DCC) MASK Register */
+
+/* -------- DSU_DID : (DSU Offset: 0x0018) (R/  32) Device Identification -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DEVSEL:8;         /*!< bit:  0.. 7  Device Select                      */
+    uint32_t REVISION:4;       /*!< bit:  8..11  Revision Number                    */
+    uint32_t DIE:4;            /*!< bit: 12..15  Die Number                         */
+    uint32_t SERIES:6;         /*!< bit: 16..21  Series                             */
+    uint32_t :1;               /*!< bit:     22  Reserved                           */
+    uint32_t FAMILY:5;         /*!< bit: 23..27  Family                             */
+    uint32_t PROCESSOR:4;      /*!< bit: 28..31  Processor                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DID_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DID_OFFSET              0x0018       /**< \brief (DSU_DID offset) Device Identification */
+
+#define DSU_DID_DEVSEL_Pos          0            /**< \brief (DSU_DID) Device Select */
+#define DSU_DID_DEVSEL_Msk          (0xFFul << DSU_DID_DEVSEL_Pos)
+#define DSU_DID_DEVSEL(value)       (DSU_DID_DEVSEL_Msk & ((value) << DSU_DID_DEVSEL_Pos))
+#define DSU_DID_REVISION_Pos        8            /**< \brief (DSU_DID) Revision Number */
+#define DSU_DID_REVISION_Msk        (0xFul << DSU_DID_REVISION_Pos)
+#define DSU_DID_REVISION(value)     (DSU_DID_REVISION_Msk & ((value) << DSU_DID_REVISION_Pos))
+#define DSU_DID_DIE_Pos             12           /**< \brief (DSU_DID) Die Number */
+#define DSU_DID_DIE_Msk             (0xFul << DSU_DID_DIE_Pos)
+#define DSU_DID_DIE(value)          (DSU_DID_DIE_Msk & ((value) << DSU_DID_DIE_Pos))
+#define DSU_DID_SERIES_Pos          16           /**< \brief (DSU_DID) Series */
+#define DSU_DID_SERIES_Msk          (0x3Ful << DSU_DID_SERIES_Pos)
+#define DSU_DID_SERIES(value)       (DSU_DID_SERIES_Msk & ((value) << DSU_DID_SERIES_Pos))
+#define   DSU_DID_SERIES_0_Val            0x0ul  /**< \brief (DSU_DID) Cortex-M0+ processor, basic feature set */
+#define   DSU_DID_SERIES_1_Val            0x1ul  /**< \brief (DSU_DID) Cortex-M0+ processor, USB */
+#define DSU_DID_SERIES_0            (DSU_DID_SERIES_0_Val          << DSU_DID_SERIES_Pos)
+#define DSU_DID_SERIES_1            (DSU_DID_SERIES_1_Val          << DSU_DID_SERIES_Pos)
+#define DSU_DID_FAMILY_Pos          23           /**< \brief (DSU_DID) Family */
+#define DSU_DID_FAMILY_Msk          (0x1Ful << DSU_DID_FAMILY_Pos)
+#define DSU_DID_FAMILY(value)       (DSU_DID_FAMILY_Msk & ((value) << DSU_DID_FAMILY_Pos))
+#define   DSU_DID_FAMILY_0_Val            0x0ul  /**< \brief (DSU_DID) General purpose microcontroller */
+#define   DSU_DID_FAMILY_1_Val            0x1ul  /**< \brief (DSU_DID) PicoPower */
+#define DSU_DID_FAMILY_0            (DSU_DID_FAMILY_0_Val          << DSU_DID_FAMILY_Pos)
+#define DSU_DID_FAMILY_1            (DSU_DID_FAMILY_1_Val          << DSU_DID_FAMILY_Pos)
+#define DSU_DID_PROCESSOR_Pos       28           /**< \brief (DSU_DID) Processor */
+#define DSU_DID_PROCESSOR_Msk       (0xFul << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR(value)    (DSU_DID_PROCESSOR_Msk & ((value) << DSU_DID_PROCESSOR_Pos))
+#define   DSU_DID_PROCESSOR_0_Val         0x0ul  /**< \brief (DSU_DID) Cortex-M0 */
+#define   DSU_DID_PROCESSOR_1_Val         0x1ul  /**< \brief (DSU_DID) Cortex-M0+ */
+#define   DSU_DID_PROCESSOR_2_Val         0x2ul  /**< \brief (DSU_DID) Cortex-M3 */
+#define   DSU_DID_PROCESSOR_3_Val         0x3ul  /**< \brief (DSU_DID) Cortex-M4 */
+#define DSU_DID_PROCESSOR_0         (DSU_DID_PROCESSOR_0_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_1         (DSU_DID_PROCESSOR_1_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_2         (DSU_DID_PROCESSOR_2_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_3         (DSU_DID_PROCESSOR_3_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_MASK                0xFFBFFFFFul /**< \brief (DSU_DID) MASK Register */
+
+/* -------- DSU_DCFG : (DSU Offset: 0x00F0) (R/W 32) Device Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DCFG:32;          /*!< bit:  0..31  Device Configuration               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCFG_OFFSET             0x00F0       /**< \brief (DSU_DCFG offset) Device Configuration */
+#define DSU_DCFG_RESETVALUE         0x00000000ul /**< \brief (DSU_DCFG reset_value) Device Configuration */
+
+#define DSU_DCFG_DCFG_Pos           0            /**< \brief (DSU_DCFG) Device Configuration */
+#define DSU_DCFG_DCFG_Msk           (0xFFFFFFFFul << DSU_DCFG_DCFG_Pos)
+#define DSU_DCFG_DCFG(value)        (DSU_DCFG_DCFG_Msk & ((value) << DSU_DCFG_DCFG_Pos))
+#define DSU_DCFG_MASK               0xFFFFFFFFul /**< \brief (DSU_DCFG) MASK Register */
+
+/* -------- DSU_ENTRY : (DSU Offset: 0x1000) (R/  32) Coresight ROM Table Entry n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EPRES:1;          /*!< bit:      0  Entry Present                      */
+    uint32_t FMT:1;            /*!< bit:      1  Format                             */
+    uint32_t :10;              /*!< bit:  2..11  Reserved                           */
+    uint32_t ADDOFF:20;        /*!< bit: 12..31  Address Offset                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_ENTRY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ENTRY_OFFSET            0x1000       /**< \brief (DSU_ENTRY offset) Coresight ROM Table Entry n */
+
+#define DSU_ENTRY_EPRES_Pos         0            /**< \brief (DSU_ENTRY) Entry Present */
+#define DSU_ENTRY_EPRES             (0x1ul << DSU_ENTRY_EPRES_Pos)
+#define DSU_ENTRY_FMT_Pos           1            /**< \brief (DSU_ENTRY) Format */
+#define DSU_ENTRY_FMT               (0x1ul << DSU_ENTRY_FMT_Pos)
+#define DSU_ENTRY_ADDOFF_Pos        12           /**< \brief (DSU_ENTRY) Address Offset */
+#define DSU_ENTRY_ADDOFF_Msk        (0xFFFFFul << DSU_ENTRY_ADDOFF_Pos)
+#define DSU_ENTRY_ADDOFF(value)     (DSU_ENTRY_ADDOFF_Msk & ((value) << DSU_ENTRY_ADDOFF_Pos))
+#define DSU_ENTRY_MASK              0xFFFFF003ul /**< \brief (DSU_ENTRY) MASK Register */
+
+/* -------- DSU_END : (DSU Offset: 0x1008) (R/  32) Coresight ROM Table End -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t END:32;           /*!< bit:  0..31  End Marker                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_END_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_END_OFFSET              0x1008       /**< \brief (DSU_END offset) Coresight ROM Table End */
+#define DSU_END_RESETVALUE          0x00000000ul /**< \brief (DSU_END reset_value) Coresight ROM Table End */
+
+#define DSU_END_END_Pos             0            /**< \brief (DSU_END) End Marker */
+#define DSU_END_END_Msk             (0xFFFFFFFFul << DSU_END_END_Pos)
+#define DSU_END_END(value)          (DSU_END_END_Msk & ((value) << DSU_END_END_Pos))
+#define DSU_END_MASK                0xFFFFFFFFul /**< \brief (DSU_END) MASK Register */
+
+/* -------- DSU_MEMTYPE : (DSU Offset: 0x1FCC) (R/  32) Coresight ROM Table Memory Type -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SMEMP:1;          /*!< bit:      0  System Memory Present              */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_MEMTYPE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_MEMTYPE_OFFSET          0x1FCC       /**< \brief (DSU_MEMTYPE offset) Coresight ROM Table Memory Type */
+#define DSU_MEMTYPE_RESETVALUE      0x00000000ul /**< \brief (DSU_MEMTYPE reset_value) Coresight ROM Table Memory Type */
+
+#define DSU_MEMTYPE_SMEMP_Pos       0            /**< \brief (DSU_MEMTYPE) System Memory Present */
+#define DSU_MEMTYPE_SMEMP           (0x1ul << DSU_MEMTYPE_SMEMP_Pos)
+#define DSU_MEMTYPE_MASK            0x00000001ul /**< \brief (DSU_MEMTYPE) MASK Register */
+
+/* -------- DSU_PID4 : (DSU Offset: 0x1FD0) (R/  32) Peripheral Identification 4 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t JEPCC:4;          /*!< bit:  0.. 3  JEP-106 Continuation Code          */
+    uint32_t FKBC:4;           /*!< bit:  4.. 7  4KB count                          */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID4_OFFSET             0x1FD0       /**< \brief (DSU_PID4 offset) Peripheral Identification 4 */
+#define DSU_PID4_RESETVALUE         0x00000000ul /**< \brief (DSU_PID4 reset_value) Peripheral Identification 4 */
+
+#define DSU_PID4_JEPCC_Pos          0            /**< \brief (DSU_PID4) JEP-106 Continuation Code */
+#define DSU_PID4_JEPCC_Msk          (0xFul << DSU_PID4_JEPCC_Pos)
+#define DSU_PID4_JEPCC(value)       (DSU_PID4_JEPCC_Msk & ((value) << DSU_PID4_JEPCC_Pos))
+#define DSU_PID4_FKBC_Pos           4            /**< \brief (DSU_PID4) 4KB count */
+#define DSU_PID4_FKBC_Msk           (0xFul << DSU_PID4_FKBC_Pos)
+#define DSU_PID4_FKBC(value)        (DSU_PID4_FKBC_Msk & ((value) << DSU_PID4_FKBC_Pos))
+#define DSU_PID4_MASK               0x000000FFul /**< \brief (DSU_PID4) MASK Register */
+
+/* -------- DSU_PID5 : (DSU Offset: 0x1FD4) (R/  32) Peripheral Identification 5 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID5_OFFSET             0x1FD4       /**< \brief (DSU_PID5 offset) Peripheral Identification 5 */
+#define DSU_PID5_MASK               0x00000000ul /**< \brief (DSU_PID5) MASK Register */
+
+/* -------- DSU_PID6 : (DSU Offset: 0x1FD8) (R/  32) Peripheral Identification 6 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID6_OFFSET             0x1FD8       /**< \brief (DSU_PID6 offset) Peripheral Identification 6 */
+#define DSU_PID6_MASK               0x00000000ul /**< \brief (DSU_PID6) MASK Register */
+
+/* -------- DSU_PID7 : (DSU Offset: 0x1FDC) (R/  32) Peripheral Identification 7 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID7_OFFSET             0x1FDC       /**< \brief (DSU_PID7 offset) Peripheral Identification 7 */
+#define DSU_PID7_MASK               0x00000000ul /**< \brief (DSU_PID7) MASK Register */
+
+/* -------- DSU_PID0 : (DSU Offset: 0x1FE0) (R/  32) Peripheral Identification 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PARTNBL:8;        /*!< bit:  0.. 7  Part Number Low                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID0_OFFSET             0x1FE0       /**< \brief (DSU_PID0 offset) Peripheral Identification 0 */
+#define DSU_PID0_RESETVALUE         0x00000000ul /**< \brief (DSU_PID0 reset_value) Peripheral Identification 0 */
+
+#define DSU_PID0_PARTNBL_Pos        0            /**< \brief (DSU_PID0) Part Number Low */
+#define DSU_PID0_PARTNBL_Msk        (0xFFul << DSU_PID0_PARTNBL_Pos)
+#define DSU_PID0_PARTNBL(value)     (DSU_PID0_PARTNBL_Msk & ((value) << DSU_PID0_PARTNBL_Pos))
+#define DSU_PID0_MASK               0x000000FFul /**< \brief (DSU_PID0) MASK Register */
+
+/* -------- DSU_PID1 : (DSU Offset: 0x1FE4) (R/  32) Peripheral Identification 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PARTNBH:4;        /*!< bit:  0.. 3  Part Number High                   */
+    uint32_t JEPIDCL:4;        /*!< bit:  4.. 7  Low part of the JEP-106 Identity Code */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID1_OFFSET             0x1FE4       /**< \brief (DSU_PID1 offset) Peripheral Identification 1 */
+#define DSU_PID1_RESETVALUE         0x000000FCul /**< \brief (DSU_PID1 reset_value) Peripheral Identification 1 */
+
+#define DSU_PID1_PARTNBH_Pos        0            /**< \brief (DSU_PID1) Part Number High */
+#define DSU_PID1_PARTNBH_Msk        (0xFul << DSU_PID1_PARTNBH_Pos)
+#define DSU_PID1_PARTNBH(value)     (DSU_PID1_PARTNBH_Msk & ((value) << DSU_PID1_PARTNBH_Pos))
+#define DSU_PID1_JEPIDCL_Pos        4            /**< \brief (DSU_PID1) Low part of the JEP-106 Identity Code */
+#define DSU_PID1_JEPIDCL_Msk        (0xFul << DSU_PID1_JEPIDCL_Pos)
+#define DSU_PID1_JEPIDCL(value)     (DSU_PID1_JEPIDCL_Msk & ((value) << DSU_PID1_JEPIDCL_Pos))
+#define DSU_PID1_MASK               0x000000FFul /**< \brief (DSU_PID1) MASK Register */
+
+/* -------- DSU_PID2 : (DSU Offset: 0x1FE8) (R/  32) Peripheral Identification 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t JEPIDCH:3;        /*!< bit:  0.. 2  JEP-106 Identity Code High         */
+    uint32_t JEPU:1;           /*!< bit:      3  JEP-106 Identity Code is used      */
+    uint32_t REVISION:4;       /*!< bit:  4.. 7  Revision Number                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID2_OFFSET             0x1FE8       /**< \brief (DSU_PID2 offset) Peripheral Identification 2 */
+#define DSU_PID2_RESETVALUE         0x00000009ul /**< \brief (DSU_PID2 reset_value) Peripheral Identification 2 */
+
+#define DSU_PID2_JEPIDCH_Pos        0            /**< \brief (DSU_PID2) JEP-106 Identity Code High */
+#define DSU_PID2_JEPIDCH_Msk        (0x7ul << DSU_PID2_JEPIDCH_Pos)
+#define DSU_PID2_JEPIDCH(value)     (DSU_PID2_JEPIDCH_Msk & ((value) << DSU_PID2_JEPIDCH_Pos))
+#define DSU_PID2_JEPU_Pos           3            /**< \brief (DSU_PID2) JEP-106 Identity Code is used */
+#define DSU_PID2_JEPU               (0x1ul << DSU_PID2_JEPU_Pos)
+#define DSU_PID2_REVISION_Pos       4            /**< \brief (DSU_PID2) Revision Number */
+#define DSU_PID2_REVISION_Msk       (0xFul << DSU_PID2_REVISION_Pos)
+#define DSU_PID2_REVISION(value)    (DSU_PID2_REVISION_Msk & ((value) << DSU_PID2_REVISION_Pos))
+#define DSU_PID2_MASK               0x000000FFul /**< \brief (DSU_PID2) MASK Register */
+
+/* -------- DSU_PID3 : (DSU Offset: 0x1FEC) (R/  32) Peripheral Identification 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CUSMOD:4;         /*!< bit:  0.. 3  ARM CUSMOD                         */
+    uint32_t REVAND:4;         /*!< bit:  4.. 7  Revision Number                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID3_OFFSET             0x1FEC       /**< \brief (DSU_PID3 offset) Peripheral Identification 3 */
+#define DSU_PID3_RESETVALUE         0x00000000ul /**< \brief (DSU_PID3 reset_value) Peripheral Identification 3 */
+
+#define DSU_PID3_CUSMOD_Pos         0            /**< \brief (DSU_PID3) ARM CUSMOD */
+#define DSU_PID3_CUSMOD_Msk         (0xFul << DSU_PID3_CUSMOD_Pos)
+#define DSU_PID3_CUSMOD(value)      (DSU_PID3_CUSMOD_Msk & ((value) << DSU_PID3_CUSMOD_Pos))
+#define DSU_PID3_REVAND_Pos         4            /**< \brief (DSU_PID3) Revision Number */
+#define DSU_PID3_REVAND_Msk         (0xFul << DSU_PID3_REVAND_Pos)
+#define DSU_PID3_REVAND(value)      (DSU_PID3_REVAND_Msk & ((value) << DSU_PID3_REVAND_Pos))
+#define DSU_PID3_MASK               0x000000FFul /**< \brief (DSU_PID3) MASK Register */
+
+/* -------- DSU_CID0 : (DSU Offset: 0x1FF0) (R/  32) Component Identification 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLEB0:8;     /*!< bit:  0.. 7  Preamble Byte 0                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID0_OFFSET             0x1FF0       /**< \brief (DSU_CID0 offset) Component Identification 0 */
+#define DSU_CID0_RESETVALUE         0x00000000ul /**< \brief (DSU_CID0 reset_value) Component Identification 0 */
+
+#define DSU_CID0_PREAMBLEB0_Pos     0            /**< \brief (DSU_CID0) Preamble Byte 0 */
+#define DSU_CID0_PREAMBLEB0_Msk     (0xFFul << DSU_CID0_PREAMBLEB0_Pos)
+#define DSU_CID0_PREAMBLEB0(value)  (DSU_CID0_PREAMBLEB0_Msk & ((value) << DSU_CID0_PREAMBLEB0_Pos))
+#define DSU_CID0_MASK               0x000000FFul /**< \brief (DSU_CID0) MASK Register */
+
+/* -------- DSU_CID1 : (DSU Offset: 0x1FF4) (R/  32) Component Identification 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLE:4;       /*!< bit:  0.. 3  Preamble                           */
+    uint32_t CCLASS:4;         /*!< bit:  4.. 7  Component Class                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID1_OFFSET             0x1FF4       /**< \brief (DSU_CID1 offset) Component Identification 1 */
+#define DSU_CID1_RESETVALUE         0x00000000ul /**< \brief (DSU_CID1 reset_value) Component Identification 1 */
+
+#define DSU_CID1_PREAMBLE_Pos       0            /**< \brief (DSU_CID1) Preamble */
+#define DSU_CID1_PREAMBLE_Msk       (0xFul << DSU_CID1_PREAMBLE_Pos)
+#define DSU_CID1_PREAMBLE(value)    (DSU_CID1_PREAMBLE_Msk & ((value) << DSU_CID1_PREAMBLE_Pos))
+#define DSU_CID1_CCLASS_Pos         4            /**< \brief (DSU_CID1) Component Class */
+#define DSU_CID1_CCLASS_Msk         (0xFul << DSU_CID1_CCLASS_Pos)
+#define DSU_CID1_CCLASS(value)      (DSU_CID1_CCLASS_Msk & ((value) << DSU_CID1_CCLASS_Pos))
+#define DSU_CID1_MASK               0x000000FFul /**< \brief (DSU_CID1) MASK Register */
+
+/* -------- DSU_CID2 : (DSU Offset: 0x1FF8) (R/  32) Component Identification 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLEB2:8;     /*!< bit:  0.. 7  Preamble Byte 2                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID2_OFFSET             0x1FF8       /**< \brief (DSU_CID2 offset) Component Identification 2 */
+#define DSU_CID2_RESETVALUE         0x00000000ul /**< \brief (DSU_CID2 reset_value) Component Identification 2 */
+
+#define DSU_CID2_PREAMBLEB2_Pos     0            /**< \brief (DSU_CID2) Preamble Byte 2 */
+#define DSU_CID2_PREAMBLEB2_Msk     (0xFFul << DSU_CID2_PREAMBLEB2_Pos)
+#define DSU_CID2_PREAMBLEB2(value)  (DSU_CID2_PREAMBLEB2_Msk & ((value) << DSU_CID2_PREAMBLEB2_Pos))
+#define DSU_CID2_MASK               0x000000FFul /**< \brief (DSU_CID2) MASK Register */
+
+/* -------- DSU_CID3 : (DSU Offset: 0x1FFC) (R/  32) Component Identification 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLEB3:8;     /*!< bit:  0.. 7  Preamble Byte 3                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID3_OFFSET             0x1FFC       /**< \brief (DSU_CID3 offset) Component Identification 3 */
+#define DSU_CID3_RESETVALUE         0x00000000ul /**< \brief (DSU_CID3 reset_value) Component Identification 3 */
+
+#define DSU_CID3_PREAMBLEB3_Pos     0            /**< \brief (DSU_CID3) Preamble Byte 3 */
+#define DSU_CID3_PREAMBLEB3_Msk     (0xFFul << DSU_CID3_PREAMBLEB3_Pos)
+#define DSU_CID3_PREAMBLEB3(value)  (DSU_CID3_PREAMBLEB3_Msk & ((value) << DSU_CID3_PREAMBLEB3_Pos))
+#define DSU_CID3_MASK               0x000000FFul /**< \brief (DSU_CID3) MASK Register */
+
+/** \brief DSU hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __O  DSU_CTRL_Type             CTRL;        /**< \brief Offset: 0x0000 ( /W  8) Control */
+  __IO DSU_STATUSA_Type          STATUSA;     /**< \brief Offset: 0x0001 (R/W  8) Status A */
+  __I  DSU_STATUSB_Type          STATUSB;     /**< \brief Offset: 0x0002 (R/   8) Status B */
+       RoReg8                    Reserved1[0x1];
+  __IO DSU_ADDR_Type             ADDR;        /**< \brief Offset: 0x0004 (R/W 32) Address */
+  __IO DSU_LENGTH_Type           LENGTH;      /**< \brief Offset: 0x0008 (R/W 32) Length */
+  __IO DSU_DATA_Type             DATA;        /**< \brief Offset: 0x000C (R/W 32) Data */
+  __IO DSU_DCC_Type              DCC[2];      /**< \brief Offset: 0x0010 (R/W 32) Debug Communication Channel n */
+  __I  DSU_DID_Type              DID;         /**< \brief Offset: 0x0018 (R/  32) Device Identification */
+       RoReg8                    Reserved2[0xD4];
+  __IO DSU_DCFG_Type             DCFG[2];     /**< \brief Offset: 0x00F0 (R/W 32) Device Configuration */
+       RoReg8                    Reserved3[0xF08];
+  __I  DSU_ENTRY_Type            ENTRY[2];    /**< \brief Offset: 0x1000 (R/  32) Coresight ROM Table Entry n */
+  __I  DSU_END_Type              END;         /**< \brief Offset: 0x1008 (R/  32) Coresight ROM Table End */
+       RoReg8                    Reserved4[0xFC0];
+  __I  DSU_MEMTYPE_Type          MEMTYPE;     /**< \brief Offset: 0x1FCC (R/  32) Coresight ROM Table Memory Type */
+  __I  DSU_PID4_Type             PID4;        /**< \brief Offset: 0x1FD0 (R/  32) Peripheral Identification 4 */
+  __I  DSU_PID5_Type             PID5;        /**< \brief Offset: 0x1FD4 (R/  32) Peripheral Identification 5 */
+  __I  DSU_PID6_Type             PID6;        /**< \brief Offset: 0x1FD8 (R/  32) Peripheral Identification 6 */
+  __I  DSU_PID7_Type             PID7;        /**< \brief Offset: 0x1FDC (R/  32) Peripheral Identification 7 */
+  __I  DSU_PID0_Type             PID0;        /**< \brief Offset: 0x1FE0 (R/  32) Peripheral Identification 0 */
+  __I  DSU_PID1_Type             PID1;        /**< \brief Offset: 0x1FE4 (R/  32) Peripheral Identification 1 */
+  __I  DSU_PID2_Type             PID2;        /**< \brief Offset: 0x1FE8 (R/  32) Peripheral Identification 2 */
+  __I  DSU_PID3_Type             PID3;        /**< \brief Offset: 0x1FEC (R/  32) Peripheral Identification 3 */
+  __I  DSU_CID0_Type             CID0;        /**< \brief Offset: 0x1FF0 (R/  32) Component Identification 0 */
+  __I  DSU_CID1_Type             CID1;        /**< \brief Offset: 0x1FF4 (R/  32) Component Identification 1 */
+  __I  DSU_CID2_Type             CID2;        /**< \brief Offset: 0x1FF8 (R/  32) Component Identification 2 */
+  __I  DSU_CID3_Type             CID3;        /**< \brief Offset: 0x1FFC (R/  32) Component Identification 3 */
+} Dsu;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_DSU_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/eic_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/eic_100.h
@@ -1,0 +1,414 @@
+/**
+ * \file
+ *
+ * \brief Component description for EIC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_EIC_COMPONENT_
+#define _SAML21_EIC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EIC */
+/* ========================================================================== */
+/** \addtogroup SAML21_EIC External Interrupt Controller */
+/*@{*/
+
+#define EIC_U2254
+#define REV_EIC                     0x100
+
+/* -------- EIC_CTRLA : (EIC Offset: 0x00) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  CKSEL:1;          /*!< bit:      4  Clock Selection                    */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CTRLA_OFFSET            0x00         /**< \brief (EIC_CTRLA offset) Control */
+#define EIC_CTRLA_RESETVALUE        0x00ul       /**< \brief (EIC_CTRLA reset_value) Control */
+
+#define EIC_CTRLA_SWRST_Pos         0            /**< \brief (EIC_CTRLA) Software Reset */
+#define EIC_CTRLA_SWRST             (0x1ul << EIC_CTRLA_SWRST_Pos)
+#define EIC_CTRLA_ENABLE_Pos        1            /**< \brief (EIC_CTRLA) Enable */
+#define EIC_CTRLA_ENABLE            (0x1ul << EIC_CTRLA_ENABLE_Pos)
+#define EIC_CTRLA_CKSEL_Pos         4            /**< \brief (EIC_CTRLA) Clock Selection */
+#define EIC_CTRLA_CKSEL             (0x1ul << EIC_CTRLA_CKSEL_Pos)
+#define EIC_CTRLA_MASK              0x13ul       /**< \brief (EIC_CTRLA) MASK Register */
+
+/* -------- EIC_NMICTRL : (EIC Offset: 0x01) (R/W  8) NMI Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  NMISENSE:3;       /*!< bit:  0.. 2  NMI Input Sense Configuration      */
+    uint8_t  NMIFILTEN:1;      /*!< bit:      3  NMI Filter Enable                  */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_NMICTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMICTRL_OFFSET          0x01         /**< \brief (EIC_NMICTRL offset) NMI Control */
+#define EIC_NMICTRL_RESETVALUE      0x00ul       /**< \brief (EIC_NMICTRL reset_value) NMI Control */
+
+#define EIC_NMICTRL_NMISENSE_Pos    0            /**< \brief (EIC_NMICTRL) NMI Input Sense Configuration */
+#define EIC_NMICTRL_NMISENSE_Msk    (0x7ul << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE(value) (EIC_NMICTRL_NMISENSE_Msk & ((value) << EIC_NMICTRL_NMISENSE_Pos))
+#define   EIC_NMICTRL_NMISENSE_NONE_Val   0x0ul  /**< \brief (EIC_NMICTRL) No detection */
+#define   EIC_NMICTRL_NMISENSE_RISE_Val   0x1ul  /**< \brief (EIC_NMICTRL) Rising edge detection */
+#define   EIC_NMICTRL_NMISENSE_FALL_Val   0x2ul  /**< \brief (EIC_NMICTRL) Falling edge detection */
+#define   EIC_NMICTRL_NMISENSE_BOTH_Val   0x3ul  /**< \brief (EIC_NMICTRL) Both edges detection */
+#define   EIC_NMICTRL_NMISENSE_HIGH_Val   0x4ul  /**< \brief (EIC_NMICTRL) High level detection */
+#define   EIC_NMICTRL_NMISENSE_LOW_Val    0x5ul  /**< \brief (EIC_NMICTRL) Low level detection */
+#define EIC_NMICTRL_NMISENSE_NONE   (EIC_NMICTRL_NMISENSE_NONE_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_RISE   (EIC_NMICTRL_NMISENSE_RISE_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_FALL   (EIC_NMICTRL_NMISENSE_FALL_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_BOTH   (EIC_NMICTRL_NMISENSE_BOTH_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_HIGH   (EIC_NMICTRL_NMISENSE_HIGH_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_LOW    (EIC_NMICTRL_NMISENSE_LOW_Val  << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMIFILTEN_Pos   3            /**< \brief (EIC_NMICTRL) NMI Filter Enable */
+#define EIC_NMICTRL_NMIFILTEN       (0x1ul << EIC_NMICTRL_NMIFILTEN_Pos)
+#define EIC_NMICTRL_MASK            0x0Ful       /**< \brief (EIC_NMICTRL) MASK Register */
+
+/* -------- EIC_NMIFLAG : (EIC Offset: 0x02) (R/W 16) NMI Interrupt Flag -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t NMI:1;            /*!< bit:      0  NMI Interrupt Flag                 */
+    uint16_t :15;              /*!< bit:  1..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} EIC_NMIFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMIFLAG_OFFSET          0x02         /**< \brief (EIC_NMIFLAG offset) NMI Interrupt Flag */
+#define EIC_NMIFLAG_RESETVALUE      0x0000ul     /**< \brief (EIC_NMIFLAG reset_value) NMI Interrupt Flag */
+
+#define EIC_NMIFLAG_NMI_Pos         0            /**< \brief (EIC_NMIFLAG) NMI Interrupt Flag */
+#define EIC_NMIFLAG_NMI             (0x1ul << EIC_NMIFLAG_NMI_Pos)
+#define EIC_NMIFLAG_MASK            0x0001ul     /**< \brief (EIC_NMIFLAG) MASK Register */
+
+/* -------- EIC_SYNCBUSY : (EIC Offset: 0x04) (R/  32) Syncbusy register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software reset synchronisation     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable synchronisation             */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_SYNCBUSY_OFFSET         0x04         /**< \brief (EIC_SYNCBUSY offset) Syncbusy register */
+#define EIC_SYNCBUSY_RESETVALUE     0x00000000ul /**< \brief (EIC_SYNCBUSY reset_value) Syncbusy register */
+
+#define EIC_SYNCBUSY_SWRST_Pos      0            /**< \brief (EIC_SYNCBUSY) Software reset synchronisation */
+#define EIC_SYNCBUSY_SWRST          (0x1ul << EIC_SYNCBUSY_SWRST_Pos)
+#define EIC_SYNCBUSY_ENABLE_Pos     1            /**< \brief (EIC_SYNCBUSY) Enable synchronisation */
+#define EIC_SYNCBUSY_ENABLE         (0x1ul << EIC_SYNCBUSY_ENABLE_Pos)
+#define EIC_SYNCBUSY_MASK           0x00000003ul /**< \brief (EIC_SYNCBUSY) MASK Register */
+
+/* -------- EIC_EVCTRL : (EIC Offset: 0x08) (R/W 32) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINTEO:16;      /*!< bit:  0..15  External Interrupt Event Output Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_EVCTRL_OFFSET           0x08         /**< \brief (EIC_EVCTRL offset) Event Control */
+#define EIC_EVCTRL_RESETVALUE       0x00000000ul /**< \brief (EIC_EVCTRL reset_value) Event Control */
+
+#define EIC_EVCTRL_EXTINTEO_Pos     0            /**< \brief (EIC_EVCTRL) External Interrupt Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO_Msk     (0xFFFFul << EIC_EVCTRL_EXTINTEO_Pos)
+#define EIC_EVCTRL_EXTINTEO(value)  (EIC_EVCTRL_EXTINTEO_Msk & ((value) << EIC_EVCTRL_EXTINTEO_Pos))
+#define EIC_EVCTRL_MASK             0x0000FFFFul /**< \brief (EIC_EVCTRL) MASK Register */
+
+/* -------- EIC_INTENCLR : (EIC Offset: 0x0C) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Disable         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENCLR_OFFSET         0x0C         /**< \brief (EIC_INTENCLR offset) Interrupt Enable Clear */
+#define EIC_INTENCLR_RESETVALUE     0x00000000ul /**< \brief (EIC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define EIC_INTENCLR_EXTINT_Pos     0            /**< \brief (EIC_INTENCLR) External Interrupt Disable */
+#define EIC_INTENCLR_EXTINT_Msk     (0xFFFFul << EIC_INTENCLR_EXTINT_Pos)
+#define EIC_INTENCLR_EXTINT(value)  (EIC_INTENCLR_EXTINT_Msk & ((value) << EIC_INTENCLR_EXTINT_Pos))
+#define EIC_INTENCLR_MASK           0x0000FFFFul /**< \brief (EIC_INTENCLR) MASK Register */
+
+/* -------- EIC_INTENSET : (EIC Offset: 0x10) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Disable         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENSET_OFFSET         0x10         /**< \brief (EIC_INTENSET offset) Interrupt Enable Set */
+#define EIC_INTENSET_RESETVALUE     0x00000000ul /**< \brief (EIC_INTENSET reset_value) Interrupt Enable Set */
+
+#define EIC_INTENSET_EXTINT_Pos     0            /**< \brief (EIC_INTENSET) External Interrupt Disable */
+#define EIC_INTENSET_EXTINT_Msk     (0xFFFFul << EIC_INTENSET_EXTINT_Pos)
+#define EIC_INTENSET_EXTINT(value)  (EIC_INTENSET_EXTINT_Msk & ((value) << EIC_INTENSET_EXTINT_Pos))
+#define EIC_INTENSET_MASK           0x0000FFFFul /**< \brief (EIC_INTENSET) MASK Register */
+
+/* -------- EIC_INTFLAG : (EIC Offset: 0x14) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
+    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTFLAG_OFFSET          0x14         /**< \brief (EIC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define EIC_INTFLAG_RESETVALUE      0x00000000ul /**< \brief (EIC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define EIC_INTFLAG_EXTINT_Pos      0            /**< \brief (EIC_INTFLAG) External Interrupt Flag */
+#define EIC_INTFLAG_EXTINT_Msk      (0xFFFFul << EIC_INTFLAG_EXTINT_Pos)
+#define EIC_INTFLAG_EXTINT(value)   (EIC_INTFLAG_EXTINT_Msk & ((value) << EIC_INTFLAG_EXTINT_Pos))
+#define EIC_INTFLAG_MASK            0x0000FFFFul /**< \brief (EIC_INTFLAG) MASK Register */
+
+/* -------- EIC_CONFIG : (EIC Offset: 0x1C) (R/W 32) Configuration n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SENSE0:3;         /*!< bit:  0.. 2  Input Sense Configuration 0        */
+    uint32_t FILTEN0:1;        /*!< bit:      3  Filter Enable 0                    */
+    uint32_t SENSE1:3;         /*!< bit:  4.. 6  Input Sense Configuration 1        */
+    uint32_t FILTEN1:1;        /*!< bit:      7  Filter Enable 1                    */
+    uint32_t SENSE2:3;         /*!< bit:  8..10  Input Sense Configuration 2        */
+    uint32_t FILTEN2:1;        /*!< bit:     11  Filter Enable 2                    */
+    uint32_t SENSE3:3;         /*!< bit: 12..14  Input Sense Configuration 3        */
+    uint32_t FILTEN3:1;        /*!< bit:     15  Filter Enable 3                    */
+    uint32_t SENSE4:3;         /*!< bit: 16..18  Input Sense Configuration 4        */
+    uint32_t FILTEN4:1;        /*!< bit:     19  Filter Enable 4                    */
+    uint32_t SENSE5:3;         /*!< bit: 20..22  Input Sense Configuration 5        */
+    uint32_t FILTEN5:1;        /*!< bit:     23  Filter Enable 5                    */
+    uint32_t SENSE6:3;         /*!< bit: 24..26  Input Sense Configuration 6        */
+    uint32_t FILTEN6:1;        /*!< bit:     27  Filter Enable 6                    */
+    uint32_t SENSE7:3;         /*!< bit: 28..30  Input Sense Configuration 7        */
+    uint32_t FILTEN7:1;        /*!< bit:     31  Filter Enable 7                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CONFIG_OFFSET           0x1C         /**< \brief (EIC_CONFIG offset) Configuration n */
+#define EIC_CONFIG_RESETVALUE       0x00000000ul /**< \brief (EIC_CONFIG reset_value) Configuration n */
+
+#define EIC_CONFIG_SENSE0_Pos       0            /**< \brief (EIC_CONFIG) Input Sense Configuration 0 */
+#define EIC_CONFIG_SENSE0_Msk       (0x7ul << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0(value)    (EIC_CONFIG_SENSE0_Msk & ((value) << EIC_CONFIG_SENSE0_Pos))
+#define   EIC_CONFIG_SENSE0_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE0_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE0_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE0_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE0_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE0_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE0_NONE      (EIC_CONFIG_SENSE0_NONE_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_RISE      (EIC_CONFIG_SENSE0_RISE_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_FALL      (EIC_CONFIG_SENSE0_FALL_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_BOTH      (EIC_CONFIG_SENSE0_BOTH_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_HIGH      (EIC_CONFIG_SENSE0_HIGH_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_LOW       (EIC_CONFIG_SENSE0_LOW_Val     << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_FILTEN0_Pos      3            /**< \brief (EIC_CONFIG) Filter Enable 0 */
+#define EIC_CONFIG_FILTEN0          (0x1ul << EIC_CONFIG_FILTEN0_Pos)
+#define EIC_CONFIG_SENSE1_Pos       4            /**< \brief (EIC_CONFIG) Input Sense Configuration 1 */
+#define EIC_CONFIG_SENSE1_Msk       (0x7ul << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1(value)    (EIC_CONFIG_SENSE1_Msk & ((value) << EIC_CONFIG_SENSE1_Pos))
+#define   EIC_CONFIG_SENSE1_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE1_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE1_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE1_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE1_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE1_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE1_NONE      (EIC_CONFIG_SENSE1_NONE_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_RISE      (EIC_CONFIG_SENSE1_RISE_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_FALL      (EIC_CONFIG_SENSE1_FALL_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_BOTH      (EIC_CONFIG_SENSE1_BOTH_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_HIGH      (EIC_CONFIG_SENSE1_HIGH_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_LOW       (EIC_CONFIG_SENSE1_LOW_Val     << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_FILTEN1_Pos      7            /**< \brief (EIC_CONFIG) Filter Enable 1 */
+#define EIC_CONFIG_FILTEN1          (0x1ul << EIC_CONFIG_FILTEN1_Pos)
+#define EIC_CONFIG_SENSE2_Pos       8            /**< \brief (EIC_CONFIG) Input Sense Configuration 2 */
+#define EIC_CONFIG_SENSE2_Msk       (0x7ul << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2(value)    (EIC_CONFIG_SENSE2_Msk & ((value) << EIC_CONFIG_SENSE2_Pos))
+#define   EIC_CONFIG_SENSE2_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE2_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE2_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE2_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE2_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE2_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE2_NONE      (EIC_CONFIG_SENSE2_NONE_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_RISE      (EIC_CONFIG_SENSE2_RISE_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_FALL      (EIC_CONFIG_SENSE2_FALL_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_BOTH      (EIC_CONFIG_SENSE2_BOTH_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_HIGH      (EIC_CONFIG_SENSE2_HIGH_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_LOW       (EIC_CONFIG_SENSE2_LOW_Val     << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_FILTEN2_Pos      11           /**< \brief (EIC_CONFIG) Filter Enable 2 */
+#define EIC_CONFIG_FILTEN2          (0x1ul << EIC_CONFIG_FILTEN2_Pos)
+#define EIC_CONFIG_SENSE3_Pos       12           /**< \brief (EIC_CONFIG) Input Sense Configuration 3 */
+#define EIC_CONFIG_SENSE3_Msk       (0x7ul << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3(value)    (EIC_CONFIG_SENSE3_Msk & ((value) << EIC_CONFIG_SENSE3_Pos))
+#define   EIC_CONFIG_SENSE3_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE3_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE3_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE3_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE3_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE3_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE3_NONE      (EIC_CONFIG_SENSE3_NONE_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_RISE      (EIC_CONFIG_SENSE3_RISE_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_FALL      (EIC_CONFIG_SENSE3_FALL_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_BOTH      (EIC_CONFIG_SENSE3_BOTH_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_HIGH      (EIC_CONFIG_SENSE3_HIGH_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_LOW       (EIC_CONFIG_SENSE3_LOW_Val     << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_FILTEN3_Pos      15           /**< \brief (EIC_CONFIG) Filter Enable 3 */
+#define EIC_CONFIG_FILTEN3          (0x1ul << EIC_CONFIG_FILTEN3_Pos)
+#define EIC_CONFIG_SENSE4_Pos       16           /**< \brief (EIC_CONFIG) Input Sense Configuration 4 */
+#define EIC_CONFIG_SENSE4_Msk       (0x7ul << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4(value)    (EIC_CONFIG_SENSE4_Msk & ((value) << EIC_CONFIG_SENSE4_Pos))
+#define   EIC_CONFIG_SENSE4_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE4_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE4_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE4_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE4_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE4_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE4_NONE      (EIC_CONFIG_SENSE4_NONE_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_RISE      (EIC_CONFIG_SENSE4_RISE_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_FALL      (EIC_CONFIG_SENSE4_FALL_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_BOTH      (EIC_CONFIG_SENSE4_BOTH_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_HIGH      (EIC_CONFIG_SENSE4_HIGH_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_LOW       (EIC_CONFIG_SENSE4_LOW_Val     << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_FILTEN4_Pos      19           /**< \brief (EIC_CONFIG) Filter Enable 4 */
+#define EIC_CONFIG_FILTEN4          (0x1ul << EIC_CONFIG_FILTEN4_Pos)
+#define EIC_CONFIG_SENSE5_Pos       20           /**< \brief (EIC_CONFIG) Input Sense Configuration 5 */
+#define EIC_CONFIG_SENSE5_Msk       (0x7ul << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5(value)    (EIC_CONFIG_SENSE5_Msk & ((value) << EIC_CONFIG_SENSE5_Pos))
+#define   EIC_CONFIG_SENSE5_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE5_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE5_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE5_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE5_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE5_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE5_NONE      (EIC_CONFIG_SENSE5_NONE_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_RISE      (EIC_CONFIG_SENSE5_RISE_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_FALL      (EIC_CONFIG_SENSE5_FALL_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_BOTH      (EIC_CONFIG_SENSE5_BOTH_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_HIGH      (EIC_CONFIG_SENSE5_HIGH_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_LOW       (EIC_CONFIG_SENSE5_LOW_Val     << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_FILTEN5_Pos      23           /**< \brief (EIC_CONFIG) Filter Enable 5 */
+#define EIC_CONFIG_FILTEN5          (0x1ul << EIC_CONFIG_FILTEN5_Pos)
+#define EIC_CONFIG_SENSE6_Pos       24           /**< \brief (EIC_CONFIG) Input Sense Configuration 6 */
+#define EIC_CONFIG_SENSE6_Msk       (0x7ul << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6(value)    (EIC_CONFIG_SENSE6_Msk & ((value) << EIC_CONFIG_SENSE6_Pos))
+#define   EIC_CONFIG_SENSE6_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE6_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE6_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE6_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE6_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE6_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE6_NONE      (EIC_CONFIG_SENSE6_NONE_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_RISE      (EIC_CONFIG_SENSE6_RISE_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_FALL      (EIC_CONFIG_SENSE6_FALL_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_BOTH      (EIC_CONFIG_SENSE6_BOTH_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_HIGH      (EIC_CONFIG_SENSE6_HIGH_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_LOW       (EIC_CONFIG_SENSE6_LOW_Val     << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_FILTEN6_Pos      27           /**< \brief (EIC_CONFIG) Filter Enable 6 */
+#define EIC_CONFIG_FILTEN6          (0x1ul << EIC_CONFIG_FILTEN6_Pos)
+#define EIC_CONFIG_SENSE7_Pos       28           /**< \brief (EIC_CONFIG) Input Sense Configuration 7 */
+#define EIC_CONFIG_SENSE7_Msk       (0x7ul << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7(value)    (EIC_CONFIG_SENSE7_Msk & ((value) << EIC_CONFIG_SENSE7_Pos))
+#define   EIC_CONFIG_SENSE7_NONE_Val      0x0ul  /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE7_RISE_Val      0x1ul  /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE7_FALL_Val      0x2ul  /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE7_BOTH_Val      0x3ul  /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE7_HIGH_Val      0x4ul  /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE7_LOW_Val       0x5ul  /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE7_NONE      (EIC_CONFIG_SENSE7_NONE_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_RISE      (EIC_CONFIG_SENSE7_RISE_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_FALL      (EIC_CONFIG_SENSE7_FALL_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_BOTH      (EIC_CONFIG_SENSE7_BOTH_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_HIGH      (EIC_CONFIG_SENSE7_HIGH_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_LOW       (EIC_CONFIG_SENSE7_LOW_Val     << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_FILTEN7_Pos      31           /**< \brief (EIC_CONFIG) Filter Enable 7 */
+#define EIC_CONFIG_FILTEN7          (0x1ul << EIC_CONFIG_FILTEN7_Pos)
+#define EIC_CONFIG_MASK             0xFFFFFFFFul /**< \brief (EIC_CONFIG) MASK Register */
+
+/** \brief EIC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO EIC_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control */
+  __IO EIC_NMICTRL_Type          NMICTRL;     /**< \brief Offset: 0x01 (R/W  8) NMI Control */
+  __IO EIC_NMIFLAG_Type          NMIFLAG;     /**< \brief Offset: 0x02 (R/W 16) NMI Interrupt Flag */
+  __I  EIC_SYNCBUSY_Type         SYNCBUSY;    /**< \brief Offset: 0x04 (R/  32) Syncbusy register */
+  __IO EIC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x08 (R/W 32) Event Control */
+  __IO EIC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x0C (R/W 32) Interrupt Enable Clear */
+  __IO EIC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x10 (R/W 32) Interrupt Enable Set */
+  __IO EIC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x14 (R/W 32) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved1[0x4];
+  __IO EIC_CONFIG_Type           CONFIG[2];   /**< \brief Offset: 0x1C (R/W 32) Configuration n */
+} Eic;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_EIC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/evsys.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/evsys.h
@@ -1,0 +1,618 @@
+/**
+ * \file
+ *
+ * \brief Component description for EVSYS
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_EVSYS_COMPONENT_
+#define _SAML21_EVSYS_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EVSYS */
+/* ========================================================================== */
+/** \addtogroup SAML21_EVSYS Event System Interface */
+/*@{*/
+
+#define EVSYS_U2256
+#define REV_EVSYS                   0x100
+
+/* -------- EVSYS_CTRLA : (EVSYS Offset: 0x00) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EVSYS_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CTRLA_OFFSET          0x00         /**< \brief (EVSYS_CTRLA offset) Control */
+#define EVSYS_CTRLA_RESETVALUE      0x00ul       /**< \brief (EVSYS_CTRLA reset_value) Control */
+
+#define EVSYS_CTRLA_SWRST_Pos       0            /**< \brief (EVSYS_CTRLA) Software Reset */
+#define EVSYS_CTRLA_SWRST           (0x1ul << EVSYS_CTRLA_SWRST_Pos)
+#define EVSYS_CTRLA_MASK            0x01ul       /**< \brief (EVSYS_CTRLA) MASK Register */
+
+/* -------- EVSYS_CHSTATUS : (EVSYS Offset: 0x0C) (R/  32) Channel Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t USRRDY0:1;        /*!< bit:      0  Channel 0 User Ready               */
+    uint32_t USRRDY1:1;        /*!< bit:      1  Channel 1 User Ready               */
+    uint32_t USRRDY2:1;        /*!< bit:      2  Channel 2 User Ready               */
+    uint32_t USRRDY3:1;        /*!< bit:      3  Channel 3 User Ready               */
+    uint32_t USRRDY4:1;        /*!< bit:      4  Channel 4 User Ready               */
+    uint32_t USRRDY5:1;        /*!< bit:      5  Channel 5 User Ready               */
+    uint32_t USRRDY6:1;        /*!< bit:      6  Channel 6 User Ready               */
+    uint32_t USRRDY7:1;        /*!< bit:      7  Channel 7 User Ready               */
+    uint32_t USRRDY8:1;        /*!< bit:      8  Channel 8 User Ready               */
+    uint32_t USRRDY9:1;        /*!< bit:      9  Channel 9 User Ready               */
+    uint32_t USRRDY10:1;       /*!< bit:     10  Channel 10 User Ready              */
+    uint32_t USRRDY11:1;       /*!< bit:     11  Channel 11 User Ready              */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t CHBUSY0:1;        /*!< bit:     16  Channel 0 Busy                     */
+    uint32_t CHBUSY1:1;        /*!< bit:     17  Channel 1 Busy                     */
+    uint32_t CHBUSY2:1;        /*!< bit:     18  Channel 2 Busy                     */
+    uint32_t CHBUSY3:1;        /*!< bit:     19  Channel 3 Busy                     */
+    uint32_t CHBUSY4:1;        /*!< bit:     20  Channel 4 Busy                     */
+    uint32_t CHBUSY5:1;        /*!< bit:     21  Channel 5 Busy                     */
+    uint32_t CHBUSY6:1;        /*!< bit:     22  Channel 6 Busy                     */
+    uint32_t CHBUSY7:1;        /*!< bit:     23  Channel 7 Busy                     */
+    uint32_t CHBUSY8:1;        /*!< bit:     24  Channel 8 Busy                     */
+    uint32_t CHBUSY9:1;        /*!< bit:     25  Channel 9 Busy                     */
+    uint32_t CHBUSY10:1;       /*!< bit:     26  Channel 10 Busy                    */
+    uint32_t CHBUSY11:1;       /*!< bit:     27  Channel 11 Busy                    */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t USRRDY:12;        /*!< bit:  0..11  Channel x User Ready               */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t CHBUSY:12;        /*!< bit: 16..27  Channel x Busy                     */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_CHSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHSTATUS_OFFSET       0x0C         /**< \brief (EVSYS_CHSTATUS offset) Channel Status */
+#define EVSYS_CHSTATUS_RESETVALUE   0x00000000ul /**< \brief (EVSYS_CHSTATUS reset_value) Channel Status */
+
+#define EVSYS_CHSTATUS_USRRDY0_Pos  0            /**< \brief (EVSYS_CHSTATUS) Channel 0 User Ready */
+#define EVSYS_CHSTATUS_USRRDY0      (1 << EVSYS_CHSTATUS_USRRDY0_Pos)
+#define EVSYS_CHSTATUS_USRRDY1_Pos  1            /**< \brief (EVSYS_CHSTATUS) Channel 1 User Ready */
+#define EVSYS_CHSTATUS_USRRDY1      (1 << EVSYS_CHSTATUS_USRRDY1_Pos)
+#define EVSYS_CHSTATUS_USRRDY2_Pos  2            /**< \brief (EVSYS_CHSTATUS) Channel 2 User Ready */
+#define EVSYS_CHSTATUS_USRRDY2      (1 << EVSYS_CHSTATUS_USRRDY2_Pos)
+#define EVSYS_CHSTATUS_USRRDY3_Pos  3            /**< \brief (EVSYS_CHSTATUS) Channel 3 User Ready */
+#define EVSYS_CHSTATUS_USRRDY3      (1 << EVSYS_CHSTATUS_USRRDY3_Pos)
+#define EVSYS_CHSTATUS_USRRDY4_Pos  4            /**< \brief (EVSYS_CHSTATUS) Channel 4 User Ready */
+#define EVSYS_CHSTATUS_USRRDY4      (1 << EVSYS_CHSTATUS_USRRDY4_Pos)
+#define EVSYS_CHSTATUS_USRRDY5_Pos  5            /**< \brief (EVSYS_CHSTATUS) Channel 5 User Ready */
+#define EVSYS_CHSTATUS_USRRDY5      (1 << EVSYS_CHSTATUS_USRRDY5_Pos)
+#define EVSYS_CHSTATUS_USRRDY6_Pos  6            /**< \brief (EVSYS_CHSTATUS) Channel 6 User Ready */
+#define EVSYS_CHSTATUS_USRRDY6      (1 << EVSYS_CHSTATUS_USRRDY6_Pos)
+#define EVSYS_CHSTATUS_USRRDY7_Pos  7            /**< \brief (EVSYS_CHSTATUS) Channel 7 User Ready */
+#define EVSYS_CHSTATUS_USRRDY7      (1 << EVSYS_CHSTATUS_USRRDY7_Pos)
+#define EVSYS_CHSTATUS_USRRDY8_Pos  8            /**< \brief (EVSYS_CHSTATUS) Channel 8 User Ready */
+#define EVSYS_CHSTATUS_USRRDY8      (1 << EVSYS_CHSTATUS_USRRDY8_Pos)
+#define EVSYS_CHSTATUS_USRRDY9_Pos  9            /**< \brief (EVSYS_CHSTATUS) Channel 9 User Ready */
+#define EVSYS_CHSTATUS_USRRDY9      (1 << EVSYS_CHSTATUS_USRRDY9_Pos)
+#define EVSYS_CHSTATUS_USRRDY10_Pos 10           /**< \brief (EVSYS_CHSTATUS) Channel 10 User Ready */
+#define EVSYS_CHSTATUS_USRRDY10     (1 << EVSYS_CHSTATUS_USRRDY10_Pos)
+#define EVSYS_CHSTATUS_USRRDY11_Pos 11           /**< \brief (EVSYS_CHSTATUS) Channel 11 User Ready */
+#define EVSYS_CHSTATUS_USRRDY11     (1 << EVSYS_CHSTATUS_USRRDY11_Pos)
+#define EVSYS_CHSTATUS_USRRDY_Pos   0            /**< \brief (EVSYS_CHSTATUS) Channel x User Ready */
+#define EVSYS_CHSTATUS_USRRDY_Msk   (0xFFFul << EVSYS_CHSTATUS_USRRDY_Pos)
+#define EVSYS_CHSTATUS_USRRDY(value) (EVSYS_CHSTATUS_USRRDY_Msk & ((value) << EVSYS_CHSTATUS_USRRDY_Pos))
+#define EVSYS_CHSTATUS_CHBUSY0_Pos  16           /**< \brief (EVSYS_CHSTATUS) Channel 0 Busy */
+#define EVSYS_CHSTATUS_CHBUSY0      (1 << EVSYS_CHSTATUS_CHBUSY0_Pos)
+#define EVSYS_CHSTATUS_CHBUSY1_Pos  17           /**< \brief (EVSYS_CHSTATUS) Channel 1 Busy */
+#define EVSYS_CHSTATUS_CHBUSY1      (1 << EVSYS_CHSTATUS_CHBUSY1_Pos)
+#define EVSYS_CHSTATUS_CHBUSY2_Pos  18           /**< \brief (EVSYS_CHSTATUS) Channel 2 Busy */
+#define EVSYS_CHSTATUS_CHBUSY2      (1 << EVSYS_CHSTATUS_CHBUSY2_Pos)
+#define EVSYS_CHSTATUS_CHBUSY3_Pos  19           /**< \brief (EVSYS_CHSTATUS) Channel 3 Busy */
+#define EVSYS_CHSTATUS_CHBUSY3      (1 << EVSYS_CHSTATUS_CHBUSY3_Pos)
+#define EVSYS_CHSTATUS_CHBUSY4_Pos  20           /**< \brief (EVSYS_CHSTATUS) Channel 4 Busy */
+#define EVSYS_CHSTATUS_CHBUSY4      (1 << EVSYS_CHSTATUS_CHBUSY4_Pos)
+#define EVSYS_CHSTATUS_CHBUSY5_Pos  21           /**< \brief (EVSYS_CHSTATUS) Channel 5 Busy */
+#define EVSYS_CHSTATUS_CHBUSY5      (1 << EVSYS_CHSTATUS_CHBUSY5_Pos)
+#define EVSYS_CHSTATUS_CHBUSY6_Pos  22           /**< \brief (EVSYS_CHSTATUS) Channel 6 Busy */
+#define EVSYS_CHSTATUS_CHBUSY6      (1 << EVSYS_CHSTATUS_CHBUSY6_Pos)
+#define EVSYS_CHSTATUS_CHBUSY7_Pos  23           /**< \brief (EVSYS_CHSTATUS) Channel 7 Busy */
+#define EVSYS_CHSTATUS_CHBUSY7      (1 << EVSYS_CHSTATUS_CHBUSY7_Pos)
+#define EVSYS_CHSTATUS_CHBUSY8_Pos  24           /**< \brief (EVSYS_CHSTATUS) Channel 8 Busy */
+#define EVSYS_CHSTATUS_CHBUSY8      (1 << EVSYS_CHSTATUS_CHBUSY8_Pos)
+#define EVSYS_CHSTATUS_CHBUSY9_Pos  25           /**< \brief (EVSYS_CHSTATUS) Channel 9 Busy */
+#define EVSYS_CHSTATUS_CHBUSY9      (1 << EVSYS_CHSTATUS_CHBUSY9_Pos)
+#define EVSYS_CHSTATUS_CHBUSY10_Pos 26           /**< \brief (EVSYS_CHSTATUS) Channel 10 Busy */
+#define EVSYS_CHSTATUS_CHBUSY10     (1 << EVSYS_CHSTATUS_CHBUSY10_Pos)
+#define EVSYS_CHSTATUS_CHBUSY11_Pos 27           /**< \brief (EVSYS_CHSTATUS) Channel 11 Busy */
+#define EVSYS_CHSTATUS_CHBUSY11     (1 << EVSYS_CHSTATUS_CHBUSY11_Pos)
+#define EVSYS_CHSTATUS_CHBUSY_Pos   16           /**< \brief (EVSYS_CHSTATUS) Channel x Busy */
+#define EVSYS_CHSTATUS_CHBUSY_Msk   (0xFFFul << EVSYS_CHSTATUS_CHBUSY_Pos)
+#define EVSYS_CHSTATUS_CHBUSY(value) (EVSYS_CHSTATUS_CHBUSY_Msk & ((value) << EVSYS_CHSTATUS_CHBUSY_Pos))
+#define EVSYS_CHSTATUS_MASK         0x0FFF0FFFul /**< \brief (EVSYS_CHSTATUS) MASK Register */
+
+/* -------- EVSYS_INTENCLR : (EVSYS Offset: 0x10) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVR0:1;           /*!< bit:      0  Channel 0 Overrun Interrupt Enable */
+    uint32_t OVR1:1;           /*!< bit:      1  Channel 1 Overrun Interrupt Enable */
+    uint32_t OVR2:1;           /*!< bit:      2  Channel 2 Overrun Interrupt Enable */
+    uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun Interrupt Enable */
+    uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun Interrupt Enable */
+    uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun Interrupt Enable */
+    uint32_t OVR6:1;           /*!< bit:      6  Channel 6 Overrun Interrupt Enable */
+    uint32_t OVR7:1;           /*!< bit:      7  Channel 7 Overrun Interrupt Enable */
+    uint32_t OVR8:1;           /*!< bit:      8  Channel 8 Overrun Interrupt Enable */
+    uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun Interrupt Enable */
+    uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun Interrupt Enable */
+    uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun Interrupt Enable */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection Interrupt Enable */
+    uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection Interrupt Enable */
+    uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection Interrupt Enable */
+    uint32_t EVD3:1;           /*!< bit:     19  Channel 3 Event Detection Interrupt Enable */
+    uint32_t EVD4:1;           /*!< bit:     20  Channel 4 Event Detection Interrupt Enable */
+    uint32_t EVD5:1;           /*!< bit:     21  Channel 5 Event Detection Interrupt Enable */
+    uint32_t EVD6:1;           /*!< bit:     22  Channel 6 Event Detection Interrupt Enable */
+    uint32_t EVD7:1;           /*!< bit:     23  Channel 7 Event Detection Interrupt Enable */
+    uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection Interrupt Enable */
+    uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection Interrupt Enable */
+    uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection Interrupt Enable */
+    uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection Interrupt Enable */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun Interrupt Enable */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection Interrupt Enable */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENCLR_OFFSET       0x10         /**< \brief (EVSYS_INTENCLR offset) Interrupt Enable Clear */
+#define EVSYS_INTENCLR_RESETVALUE   0x00000000ul /**< \brief (EVSYS_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define EVSYS_INTENCLR_OVR0_Pos     0            /**< \brief (EVSYS_INTENCLR) Channel 0 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR0         (1 << EVSYS_INTENCLR_OVR0_Pos)
+#define EVSYS_INTENCLR_OVR1_Pos     1            /**< \brief (EVSYS_INTENCLR) Channel 1 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR1         (1 << EVSYS_INTENCLR_OVR1_Pos)
+#define EVSYS_INTENCLR_OVR2_Pos     2            /**< \brief (EVSYS_INTENCLR) Channel 2 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR2         (1 << EVSYS_INTENCLR_OVR2_Pos)
+#define EVSYS_INTENCLR_OVR3_Pos     3            /**< \brief (EVSYS_INTENCLR) Channel 3 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR3         (1 << EVSYS_INTENCLR_OVR3_Pos)
+#define EVSYS_INTENCLR_OVR4_Pos     4            /**< \brief (EVSYS_INTENCLR) Channel 4 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR4         (1 << EVSYS_INTENCLR_OVR4_Pos)
+#define EVSYS_INTENCLR_OVR5_Pos     5            /**< \brief (EVSYS_INTENCLR) Channel 5 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR5         (1 << EVSYS_INTENCLR_OVR5_Pos)
+#define EVSYS_INTENCLR_OVR6_Pos     6            /**< \brief (EVSYS_INTENCLR) Channel 6 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR6         (1 << EVSYS_INTENCLR_OVR6_Pos)
+#define EVSYS_INTENCLR_OVR7_Pos     7            /**< \brief (EVSYS_INTENCLR) Channel 7 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR7         (1 << EVSYS_INTENCLR_OVR7_Pos)
+#define EVSYS_INTENCLR_OVR8_Pos     8            /**< \brief (EVSYS_INTENCLR) Channel 8 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR8         (1 << EVSYS_INTENCLR_OVR8_Pos)
+#define EVSYS_INTENCLR_OVR9_Pos     9            /**< \brief (EVSYS_INTENCLR) Channel 9 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR9         (1 << EVSYS_INTENCLR_OVR9_Pos)
+#define EVSYS_INTENCLR_OVR10_Pos    10           /**< \brief (EVSYS_INTENCLR) Channel 10 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR10        (1 << EVSYS_INTENCLR_OVR10_Pos)
+#define EVSYS_INTENCLR_OVR11_Pos    11           /**< \brief (EVSYS_INTENCLR) Channel 11 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR11        (1 << EVSYS_INTENCLR_OVR11_Pos)
+#define EVSYS_INTENCLR_OVR_Pos      0            /**< \brief (EVSYS_INTENCLR) Channel x Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR_Msk      (0xFFFul << EVSYS_INTENCLR_OVR_Pos)
+#define EVSYS_INTENCLR_OVR(value)   (EVSYS_INTENCLR_OVR_Msk & ((value) << EVSYS_INTENCLR_OVR_Pos))
+#define EVSYS_INTENCLR_EVD0_Pos     16           /**< \brief (EVSYS_INTENCLR) Channel 0 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD0         (1 << EVSYS_INTENCLR_EVD0_Pos)
+#define EVSYS_INTENCLR_EVD1_Pos     17           /**< \brief (EVSYS_INTENCLR) Channel 1 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD1         (1 << EVSYS_INTENCLR_EVD1_Pos)
+#define EVSYS_INTENCLR_EVD2_Pos     18           /**< \brief (EVSYS_INTENCLR) Channel 2 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD2         (1 << EVSYS_INTENCLR_EVD2_Pos)
+#define EVSYS_INTENCLR_EVD3_Pos     19           /**< \brief (EVSYS_INTENCLR) Channel 3 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD3         (1 << EVSYS_INTENCLR_EVD3_Pos)
+#define EVSYS_INTENCLR_EVD4_Pos     20           /**< \brief (EVSYS_INTENCLR) Channel 4 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD4         (1 << EVSYS_INTENCLR_EVD4_Pos)
+#define EVSYS_INTENCLR_EVD5_Pos     21           /**< \brief (EVSYS_INTENCLR) Channel 5 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD5         (1 << EVSYS_INTENCLR_EVD5_Pos)
+#define EVSYS_INTENCLR_EVD6_Pos     22           /**< \brief (EVSYS_INTENCLR) Channel 6 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD6         (1 << EVSYS_INTENCLR_EVD6_Pos)
+#define EVSYS_INTENCLR_EVD7_Pos     23           /**< \brief (EVSYS_INTENCLR) Channel 7 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD7         (1 << EVSYS_INTENCLR_EVD7_Pos)
+#define EVSYS_INTENCLR_EVD8_Pos     24           /**< \brief (EVSYS_INTENCLR) Channel 8 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD8         (1 << EVSYS_INTENCLR_EVD8_Pos)
+#define EVSYS_INTENCLR_EVD9_Pos     25           /**< \brief (EVSYS_INTENCLR) Channel 9 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD9         (1 << EVSYS_INTENCLR_EVD9_Pos)
+#define EVSYS_INTENCLR_EVD10_Pos    26           /**< \brief (EVSYS_INTENCLR) Channel 10 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD10        (1 << EVSYS_INTENCLR_EVD10_Pos)
+#define EVSYS_INTENCLR_EVD11_Pos    27           /**< \brief (EVSYS_INTENCLR) Channel 11 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD11        (1 << EVSYS_INTENCLR_EVD11_Pos)
+#define EVSYS_INTENCLR_EVD_Pos      16           /**< \brief (EVSYS_INTENCLR) Channel x Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD_Msk      (0xFFFul << EVSYS_INTENCLR_EVD_Pos)
+#define EVSYS_INTENCLR_EVD(value)   (EVSYS_INTENCLR_EVD_Msk & ((value) << EVSYS_INTENCLR_EVD_Pos))
+#define EVSYS_INTENCLR_MASK         0x0FFF0FFFul /**< \brief (EVSYS_INTENCLR) MASK Register */
+
+/* -------- EVSYS_INTENSET : (EVSYS Offset: 0x14) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVR0:1;           /*!< bit:      0  Channel 0 Overrun Interrupt Enable */
+    uint32_t OVR1:1;           /*!< bit:      1  Channel 1 Overrun Interrupt Enable */
+    uint32_t OVR2:1;           /*!< bit:      2  Channel 2 Overrun Interrupt Enable */
+    uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun Interrupt Enable */
+    uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun Interrupt Enable */
+    uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun Interrupt Enable */
+    uint32_t OVR6:1;           /*!< bit:      6  Channel 6 Overrun Interrupt Enable */
+    uint32_t OVR7:1;           /*!< bit:      7  Channel 7 Overrun Interrupt Enable */
+    uint32_t OVR8:1;           /*!< bit:      8  Channel 8 Overrun Interrupt Enable */
+    uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun Interrupt Enable */
+    uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun Interrupt Enable */
+    uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun Interrupt Enable */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection Interrupt Enable */
+    uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection Interrupt Enable */
+    uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection Interrupt Enable */
+    uint32_t EVD3:1;           /*!< bit:     19  Channel 3 Event Detection Interrupt Enable */
+    uint32_t EVD4:1;           /*!< bit:     20  Channel 4 Event Detection Interrupt Enable */
+    uint32_t EVD5:1;           /*!< bit:     21  Channel 5 Event Detection Interrupt Enable */
+    uint32_t EVD6:1;           /*!< bit:     22  Channel 6 Event Detection Interrupt Enable */
+    uint32_t EVD7:1;           /*!< bit:     23  Channel 7 Event Detection Interrupt Enable */
+    uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection Interrupt Enable */
+    uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection Interrupt Enable */
+    uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection Interrupt Enable */
+    uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection Interrupt Enable */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun Interrupt Enable */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection Interrupt Enable */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENSET_OFFSET       0x14         /**< \brief (EVSYS_INTENSET offset) Interrupt Enable Set */
+#define EVSYS_INTENSET_RESETVALUE   0x00000000ul /**< \brief (EVSYS_INTENSET reset_value) Interrupt Enable Set */
+
+#define EVSYS_INTENSET_OVR0_Pos     0            /**< \brief (EVSYS_INTENSET) Channel 0 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR0         (1 << EVSYS_INTENSET_OVR0_Pos)
+#define EVSYS_INTENSET_OVR1_Pos     1            /**< \brief (EVSYS_INTENSET) Channel 1 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR1         (1 << EVSYS_INTENSET_OVR1_Pos)
+#define EVSYS_INTENSET_OVR2_Pos     2            /**< \brief (EVSYS_INTENSET) Channel 2 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR2         (1 << EVSYS_INTENSET_OVR2_Pos)
+#define EVSYS_INTENSET_OVR3_Pos     3            /**< \brief (EVSYS_INTENSET) Channel 3 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR3         (1 << EVSYS_INTENSET_OVR3_Pos)
+#define EVSYS_INTENSET_OVR4_Pos     4            /**< \brief (EVSYS_INTENSET) Channel 4 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR4         (1 << EVSYS_INTENSET_OVR4_Pos)
+#define EVSYS_INTENSET_OVR5_Pos     5            /**< \brief (EVSYS_INTENSET) Channel 5 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR5         (1 << EVSYS_INTENSET_OVR5_Pos)
+#define EVSYS_INTENSET_OVR6_Pos     6            /**< \brief (EVSYS_INTENSET) Channel 6 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR6         (1 << EVSYS_INTENSET_OVR6_Pos)
+#define EVSYS_INTENSET_OVR7_Pos     7            /**< \brief (EVSYS_INTENSET) Channel 7 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR7         (1 << EVSYS_INTENSET_OVR7_Pos)
+#define EVSYS_INTENSET_OVR8_Pos     8            /**< \brief (EVSYS_INTENSET) Channel 8 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR8         (1 << EVSYS_INTENSET_OVR8_Pos)
+#define EVSYS_INTENSET_OVR9_Pos     9            /**< \brief (EVSYS_INTENSET) Channel 9 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR9         (1 << EVSYS_INTENSET_OVR9_Pos)
+#define EVSYS_INTENSET_OVR10_Pos    10           /**< \brief (EVSYS_INTENSET) Channel 10 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR10        (1 << EVSYS_INTENSET_OVR10_Pos)
+#define EVSYS_INTENSET_OVR11_Pos    11           /**< \brief (EVSYS_INTENSET) Channel 11 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR11        (1 << EVSYS_INTENSET_OVR11_Pos)
+#define EVSYS_INTENSET_OVR_Pos      0            /**< \brief (EVSYS_INTENSET) Channel x Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR_Msk      (0xFFFul << EVSYS_INTENSET_OVR_Pos)
+#define EVSYS_INTENSET_OVR(value)   (EVSYS_INTENSET_OVR_Msk & ((value) << EVSYS_INTENSET_OVR_Pos))
+#define EVSYS_INTENSET_EVD0_Pos     16           /**< \brief (EVSYS_INTENSET) Channel 0 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD0         (1 << EVSYS_INTENSET_EVD0_Pos)
+#define EVSYS_INTENSET_EVD1_Pos     17           /**< \brief (EVSYS_INTENSET) Channel 1 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD1         (1 << EVSYS_INTENSET_EVD1_Pos)
+#define EVSYS_INTENSET_EVD2_Pos     18           /**< \brief (EVSYS_INTENSET) Channel 2 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD2         (1 << EVSYS_INTENSET_EVD2_Pos)
+#define EVSYS_INTENSET_EVD3_Pos     19           /**< \brief (EVSYS_INTENSET) Channel 3 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD3         (1 << EVSYS_INTENSET_EVD3_Pos)
+#define EVSYS_INTENSET_EVD4_Pos     20           /**< \brief (EVSYS_INTENSET) Channel 4 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD4         (1 << EVSYS_INTENSET_EVD4_Pos)
+#define EVSYS_INTENSET_EVD5_Pos     21           /**< \brief (EVSYS_INTENSET) Channel 5 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD5         (1 << EVSYS_INTENSET_EVD5_Pos)
+#define EVSYS_INTENSET_EVD6_Pos     22           /**< \brief (EVSYS_INTENSET) Channel 6 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD6         (1 << EVSYS_INTENSET_EVD6_Pos)
+#define EVSYS_INTENSET_EVD7_Pos     23           /**< \brief (EVSYS_INTENSET) Channel 7 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD7         (1 << EVSYS_INTENSET_EVD7_Pos)
+#define EVSYS_INTENSET_EVD8_Pos     24           /**< \brief (EVSYS_INTENSET) Channel 8 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD8         (1 << EVSYS_INTENSET_EVD8_Pos)
+#define EVSYS_INTENSET_EVD9_Pos     25           /**< \brief (EVSYS_INTENSET) Channel 9 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD9         (1 << EVSYS_INTENSET_EVD9_Pos)
+#define EVSYS_INTENSET_EVD10_Pos    26           /**< \brief (EVSYS_INTENSET) Channel 10 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD10        (1 << EVSYS_INTENSET_EVD10_Pos)
+#define EVSYS_INTENSET_EVD11_Pos    27           /**< \brief (EVSYS_INTENSET) Channel 11 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD11        (1 << EVSYS_INTENSET_EVD11_Pos)
+#define EVSYS_INTENSET_EVD_Pos      16           /**< \brief (EVSYS_INTENSET) Channel x Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD_Msk      (0xFFFul << EVSYS_INTENSET_EVD_Pos)
+#define EVSYS_INTENSET_EVD(value)   (EVSYS_INTENSET_EVD_Msk & ((value) << EVSYS_INTENSET_EVD_Pos))
+#define EVSYS_INTENSET_MASK         0x0FFF0FFFul /**< \brief (EVSYS_INTENSET) MASK Register */
+
+/* -------- EVSYS_INTFLAG : (EVSYS Offset: 0x18) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t OVR0:1;           /*!< bit:      0  Channel 0 Overrun                  */
+    __I uint32_t OVR1:1;           /*!< bit:      1  Channel 1 Overrun                  */
+    __I uint32_t OVR2:1;           /*!< bit:      2  Channel 2 Overrun                  */
+    __I uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun                  */
+    __I uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun                  */
+    __I uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun                  */
+    __I uint32_t OVR6:1;           /*!< bit:      6  Channel 6 Overrun                  */
+    __I uint32_t OVR7:1;           /*!< bit:      7  Channel 7 Overrun                  */
+    __I uint32_t OVR8:1;           /*!< bit:      8  Channel 8 Overrun                  */
+    __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
+    __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
+    __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
+    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
+    __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
+    __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
+    __I uint32_t EVD3:1;           /*!< bit:     19  Channel 3 Event Detection          */
+    __I uint32_t EVD4:1;           /*!< bit:     20  Channel 4 Event Detection          */
+    __I uint32_t EVD5:1;           /*!< bit:     21  Channel 5 Event Detection          */
+    __I uint32_t EVD6:1;           /*!< bit:     22  Channel 6 Event Detection          */
+    __I uint32_t EVD7:1;           /*!< bit:     23  Channel 7 Event Detection          */
+    __I uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection          */
+    __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
+    __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
+    __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
+    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
+    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
+    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTFLAG_OFFSET        0x18         /**< \brief (EVSYS_INTFLAG offset) Interrupt Flag Status and Clear */
+#define EVSYS_INTFLAG_RESETVALUE    0x00000000ul /**< \brief (EVSYS_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define EVSYS_INTFLAG_OVR0_Pos      0            /**< \brief (EVSYS_INTFLAG) Channel 0 Overrun */
+#define EVSYS_INTFLAG_OVR0          (1 << EVSYS_INTFLAG_OVR0_Pos)
+#define EVSYS_INTFLAG_OVR1_Pos      1            /**< \brief (EVSYS_INTFLAG) Channel 1 Overrun */
+#define EVSYS_INTFLAG_OVR1          (1 << EVSYS_INTFLAG_OVR1_Pos)
+#define EVSYS_INTFLAG_OVR2_Pos      2            /**< \brief (EVSYS_INTFLAG) Channel 2 Overrun */
+#define EVSYS_INTFLAG_OVR2          (1 << EVSYS_INTFLAG_OVR2_Pos)
+#define EVSYS_INTFLAG_OVR3_Pos      3            /**< \brief (EVSYS_INTFLAG) Channel 3 Overrun */
+#define EVSYS_INTFLAG_OVR3          (1 << EVSYS_INTFLAG_OVR3_Pos)
+#define EVSYS_INTFLAG_OVR4_Pos      4            /**< \brief (EVSYS_INTFLAG) Channel 4 Overrun */
+#define EVSYS_INTFLAG_OVR4          (1 << EVSYS_INTFLAG_OVR4_Pos)
+#define EVSYS_INTFLAG_OVR5_Pos      5            /**< \brief (EVSYS_INTFLAG) Channel 5 Overrun */
+#define EVSYS_INTFLAG_OVR5          (1 << EVSYS_INTFLAG_OVR5_Pos)
+#define EVSYS_INTFLAG_OVR6_Pos      6            /**< \brief (EVSYS_INTFLAG) Channel 6 Overrun */
+#define EVSYS_INTFLAG_OVR6          (1 << EVSYS_INTFLAG_OVR6_Pos)
+#define EVSYS_INTFLAG_OVR7_Pos      7            /**< \brief (EVSYS_INTFLAG) Channel 7 Overrun */
+#define EVSYS_INTFLAG_OVR7          (1 << EVSYS_INTFLAG_OVR7_Pos)
+#define EVSYS_INTFLAG_OVR8_Pos      8            /**< \brief (EVSYS_INTFLAG) Channel 8 Overrun */
+#define EVSYS_INTFLAG_OVR8          (1 << EVSYS_INTFLAG_OVR8_Pos)
+#define EVSYS_INTFLAG_OVR9_Pos      9            /**< \brief (EVSYS_INTFLAG) Channel 9 Overrun */
+#define EVSYS_INTFLAG_OVR9          (1 << EVSYS_INTFLAG_OVR9_Pos)
+#define EVSYS_INTFLAG_OVR10_Pos     10           /**< \brief (EVSYS_INTFLAG) Channel 10 Overrun */
+#define EVSYS_INTFLAG_OVR10         (1 << EVSYS_INTFLAG_OVR10_Pos)
+#define EVSYS_INTFLAG_OVR11_Pos     11           /**< \brief (EVSYS_INTFLAG) Channel 11 Overrun */
+#define EVSYS_INTFLAG_OVR11         (1 << EVSYS_INTFLAG_OVR11_Pos)
+#define EVSYS_INTFLAG_OVR_Pos       0            /**< \brief (EVSYS_INTFLAG) Channel x Overrun */
+#define EVSYS_INTFLAG_OVR_Msk       (0xFFFul << EVSYS_INTFLAG_OVR_Pos)
+#define EVSYS_INTFLAG_OVR(value)    (EVSYS_INTFLAG_OVR_Msk & ((value) << EVSYS_INTFLAG_OVR_Pos))
+#define EVSYS_INTFLAG_EVD0_Pos      16           /**< \brief (EVSYS_INTFLAG) Channel 0 Event Detection */
+#define EVSYS_INTFLAG_EVD0          (1 << EVSYS_INTFLAG_EVD0_Pos)
+#define EVSYS_INTFLAG_EVD1_Pos      17           /**< \brief (EVSYS_INTFLAG) Channel 1 Event Detection */
+#define EVSYS_INTFLAG_EVD1          (1 << EVSYS_INTFLAG_EVD1_Pos)
+#define EVSYS_INTFLAG_EVD2_Pos      18           /**< \brief (EVSYS_INTFLAG) Channel 2 Event Detection */
+#define EVSYS_INTFLAG_EVD2          (1 << EVSYS_INTFLAG_EVD2_Pos)
+#define EVSYS_INTFLAG_EVD3_Pos      19           /**< \brief (EVSYS_INTFLAG) Channel 3 Event Detection */
+#define EVSYS_INTFLAG_EVD3          (1 << EVSYS_INTFLAG_EVD3_Pos)
+#define EVSYS_INTFLAG_EVD4_Pos      20           /**< \brief (EVSYS_INTFLAG) Channel 4 Event Detection */
+#define EVSYS_INTFLAG_EVD4          (1 << EVSYS_INTFLAG_EVD4_Pos)
+#define EVSYS_INTFLAG_EVD5_Pos      21           /**< \brief (EVSYS_INTFLAG) Channel 5 Event Detection */
+#define EVSYS_INTFLAG_EVD5          (1 << EVSYS_INTFLAG_EVD5_Pos)
+#define EVSYS_INTFLAG_EVD6_Pos      22           /**< \brief (EVSYS_INTFLAG) Channel 6 Event Detection */
+#define EVSYS_INTFLAG_EVD6          (1 << EVSYS_INTFLAG_EVD6_Pos)
+#define EVSYS_INTFLAG_EVD7_Pos      23           /**< \brief (EVSYS_INTFLAG) Channel 7 Event Detection */
+#define EVSYS_INTFLAG_EVD7          (1 << EVSYS_INTFLAG_EVD7_Pos)
+#define EVSYS_INTFLAG_EVD8_Pos      24           /**< \brief (EVSYS_INTFLAG) Channel 8 Event Detection */
+#define EVSYS_INTFLAG_EVD8          (1 << EVSYS_INTFLAG_EVD8_Pos)
+#define EVSYS_INTFLAG_EVD9_Pos      25           /**< \brief (EVSYS_INTFLAG) Channel 9 Event Detection */
+#define EVSYS_INTFLAG_EVD9          (1 << EVSYS_INTFLAG_EVD9_Pos)
+#define EVSYS_INTFLAG_EVD10_Pos     26           /**< \brief (EVSYS_INTFLAG) Channel 10 Event Detection */
+#define EVSYS_INTFLAG_EVD10         (1 << EVSYS_INTFLAG_EVD10_Pos)
+#define EVSYS_INTFLAG_EVD11_Pos     27           /**< \brief (EVSYS_INTFLAG) Channel 11 Event Detection */
+#define EVSYS_INTFLAG_EVD11         (1 << EVSYS_INTFLAG_EVD11_Pos)
+#define EVSYS_INTFLAG_EVD_Pos       16           /**< \brief (EVSYS_INTFLAG) Channel x Event Detection */
+#define EVSYS_INTFLAG_EVD_Msk       (0xFFFul << EVSYS_INTFLAG_EVD_Pos)
+#define EVSYS_INTFLAG_EVD(value)    (EVSYS_INTFLAG_EVD_Msk & ((value) << EVSYS_INTFLAG_EVD_Pos))
+#define EVSYS_INTFLAG_MASK          0x0FFF0FFFul /**< \brief (EVSYS_INTFLAG) MASK Register */
+
+/* -------- EVSYS_SWEVT : (EVSYS Offset: 0x1C) ( /W 32) Software Event -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHANNEL0:1;       /*!< bit:      0  Channel 0 Software Selection       */
+    uint32_t CHANNEL1:1;       /*!< bit:      1  Channel 1 Software Selection       */
+    uint32_t CHANNEL2:1;       /*!< bit:      2  Channel 2 Software Selection       */
+    uint32_t CHANNEL3:1;       /*!< bit:      3  Channel 3 Software Selection       */
+    uint32_t CHANNEL4:1;       /*!< bit:      4  Channel 4 Software Selection       */
+    uint32_t CHANNEL5:1;       /*!< bit:      5  Channel 5 Software Selection       */
+    uint32_t CHANNEL6:1;       /*!< bit:      6  Channel 6 Software Selection       */
+    uint32_t CHANNEL7:1;       /*!< bit:      7  Channel 7 Software Selection       */
+    uint32_t CHANNEL8:1;       /*!< bit:      8  Channel 8 Software Selection       */
+    uint32_t CHANNEL9:1;       /*!< bit:      9  Channel 9 Software Selection       */
+    uint32_t CHANNEL10:1;      /*!< bit:     10  Channel 10 Software Selection      */
+    uint32_t CHANNEL11:1;      /*!< bit:     11  Channel 11 Software Selection      */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t CHANNEL:12;       /*!< bit:  0..11  Channel x Software Selection       */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_SWEVT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_SWEVT_OFFSET          0x1C         /**< \brief (EVSYS_SWEVT offset) Software Event */
+#define EVSYS_SWEVT_RESETVALUE      0x00000000ul /**< \brief (EVSYS_SWEVT reset_value) Software Event */
+
+#define EVSYS_SWEVT_CHANNEL0_Pos    0            /**< \brief (EVSYS_SWEVT) Channel 0 Software Selection */
+#define EVSYS_SWEVT_CHANNEL0        (1 << EVSYS_SWEVT_CHANNEL0_Pos)
+#define EVSYS_SWEVT_CHANNEL1_Pos    1            /**< \brief (EVSYS_SWEVT) Channel 1 Software Selection */
+#define EVSYS_SWEVT_CHANNEL1        (1 << EVSYS_SWEVT_CHANNEL1_Pos)
+#define EVSYS_SWEVT_CHANNEL2_Pos    2            /**< \brief (EVSYS_SWEVT) Channel 2 Software Selection */
+#define EVSYS_SWEVT_CHANNEL2        (1 << EVSYS_SWEVT_CHANNEL2_Pos)
+#define EVSYS_SWEVT_CHANNEL3_Pos    3            /**< \brief (EVSYS_SWEVT) Channel 3 Software Selection */
+#define EVSYS_SWEVT_CHANNEL3        (1 << EVSYS_SWEVT_CHANNEL3_Pos)
+#define EVSYS_SWEVT_CHANNEL4_Pos    4            /**< \brief (EVSYS_SWEVT) Channel 4 Software Selection */
+#define EVSYS_SWEVT_CHANNEL4        (1 << EVSYS_SWEVT_CHANNEL4_Pos)
+#define EVSYS_SWEVT_CHANNEL5_Pos    5            /**< \brief (EVSYS_SWEVT) Channel 5 Software Selection */
+#define EVSYS_SWEVT_CHANNEL5        (1 << EVSYS_SWEVT_CHANNEL5_Pos)
+#define EVSYS_SWEVT_CHANNEL6_Pos    6            /**< \brief (EVSYS_SWEVT) Channel 6 Software Selection */
+#define EVSYS_SWEVT_CHANNEL6        (1 << EVSYS_SWEVT_CHANNEL6_Pos)
+#define EVSYS_SWEVT_CHANNEL7_Pos    7            /**< \brief (EVSYS_SWEVT) Channel 7 Software Selection */
+#define EVSYS_SWEVT_CHANNEL7        (1 << EVSYS_SWEVT_CHANNEL7_Pos)
+#define EVSYS_SWEVT_CHANNEL8_Pos    8            /**< \brief (EVSYS_SWEVT) Channel 8 Software Selection */
+#define EVSYS_SWEVT_CHANNEL8        (1 << EVSYS_SWEVT_CHANNEL8_Pos)
+#define EVSYS_SWEVT_CHANNEL9_Pos    9            /**< \brief (EVSYS_SWEVT) Channel 9 Software Selection */
+#define EVSYS_SWEVT_CHANNEL9        (1 << EVSYS_SWEVT_CHANNEL9_Pos)
+#define EVSYS_SWEVT_CHANNEL10_Pos   10           /**< \brief (EVSYS_SWEVT) Channel 10 Software Selection */
+#define EVSYS_SWEVT_CHANNEL10       (1 << EVSYS_SWEVT_CHANNEL10_Pos)
+#define EVSYS_SWEVT_CHANNEL11_Pos   11           /**< \brief (EVSYS_SWEVT) Channel 11 Software Selection */
+#define EVSYS_SWEVT_CHANNEL11       (1 << EVSYS_SWEVT_CHANNEL11_Pos)
+#define EVSYS_SWEVT_CHANNEL_Pos     0            /**< \brief (EVSYS_SWEVT) Channel x Software Selection */
+#define EVSYS_SWEVT_CHANNEL_Msk     (0xFFFul << EVSYS_SWEVT_CHANNEL_Pos)
+#define EVSYS_SWEVT_CHANNEL(value)  (EVSYS_SWEVT_CHANNEL_Msk & ((value) << EVSYS_SWEVT_CHANNEL_Pos))
+#define EVSYS_SWEVT_MASK            0x00000FFFul /**< \brief (EVSYS_SWEVT) MASK Register */
+
+/* -------- EVSYS_CHANNEL : (EVSYS Offset: 0x20) (R/W 32) Channel n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EVGEN:7;          /*!< bit:  0.. 6  Event Generator Selection          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PATH:2;           /*!< bit:  8.. 9  Path Selection                     */
+    uint32_t EDGSEL:2;         /*!< bit: 10..11  Edge Detection Selection           */
+    uint32_t :2;               /*!< bit: 12..13  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:     14  Run in standby                     */
+    uint32_t ONDEMAND:1;       /*!< bit:     15  Generic Clock On Demand            */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_CHANNEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHANNEL_OFFSET        0x20         /**< \brief (EVSYS_CHANNEL offset) Channel n */
+#define EVSYS_CHANNEL_RESETVALUE    0x00008000ul /**< \brief (EVSYS_CHANNEL reset_value) Channel n */
+
+#define EVSYS_CHANNEL_EVGEN_Pos     0            /**< \brief (EVSYS_CHANNEL) Event Generator Selection */
+#define EVSYS_CHANNEL_EVGEN_Msk     (0x7Ful << EVSYS_CHANNEL_EVGEN_Pos)
+#define EVSYS_CHANNEL_EVGEN(value)  (EVSYS_CHANNEL_EVGEN_Msk & ((value) << EVSYS_CHANNEL_EVGEN_Pos))
+#define EVSYS_CHANNEL_PATH_Pos      8            /**< \brief (EVSYS_CHANNEL) Path Selection */
+#define EVSYS_CHANNEL_PATH_Msk      (0x3ul << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH(value)   (EVSYS_CHANNEL_PATH_Msk & ((value) << EVSYS_CHANNEL_PATH_Pos))
+#define   EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val 0x0ul  /**< \brief (EVSYS_CHANNEL) Synchronous path */
+#define   EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val 0x1ul  /**< \brief (EVSYS_CHANNEL) Resynchronized path */
+#define   EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val 0x2ul  /**< \brief (EVSYS_CHANNEL) Asynchronous path */
+#define EVSYS_CHANNEL_PATH_SYNCHRONOUS (EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH_RESYNCHRONIZED (EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH_ASYNCHRONOUS (EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_EDGSEL_Pos    10           /**< \brief (EVSYS_CHANNEL) Edge Detection Selection */
+#define EVSYS_CHANNEL_EDGSEL_Msk    (0x3ul << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL(value) (EVSYS_CHANNEL_EDGSEL_Msk & ((value) << EVSYS_CHANNEL_EDGSEL_Pos))
+#define   EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val 0x0ul  /**< \brief (EVSYS_CHANNEL) No event output when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val 0x1ul  /**< \brief (EVSYS_CHANNEL) Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val 0x2ul  /**< \brief (EVSYS_CHANNEL) Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val 0x3ul  /**< \brief (EVSYS_CHANNEL) Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path */
+#define EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT (EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_RISING_EDGE (EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_FALLING_EDGE (EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_BOTH_EDGES (EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_RUNSTDBY_Pos  14           /**< \brief (EVSYS_CHANNEL) Run in standby */
+#define EVSYS_CHANNEL_RUNSTDBY      (0x1ul << EVSYS_CHANNEL_RUNSTDBY_Pos)
+#define EVSYS_CHANNEL_ONDEMAND_Pos  15           /**< \brief (EVSYS_CHANNEL) Generic Clock On Demand */
+#define EVSYS_CHANNEL_ONDEMAND      (0x1ul << EVSYS_CHANNEL_ONDEMAND_Pos)
+#define EVSYS_CHANNEL_MASK          0x0000CF7Ful /**< \brief (EVSYS_CHANNEL) MASK Register */
+
+/* -------- EVSYS_USER : (EVSYS Offset: 0x80) (R/W 32) User Multiplexer n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHANNEL:5;        /*!< bit:  0.. 4  Channel Event Selection            */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_USER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_USER_OFFSET           0x80         /**< \brief (EVSYS_USER offset) User Multiplexer n */
+#define EVSYS_USER_RESETVALUE       0x00000000ul /**< \brief (EVSYS_USER reset_value) User Multiplexer n */
+
+#define EVSYS_USER_CHANNEL_Pos      0            /**< \brief (EVSYS_USER) Channel Event Selection */
+#define EVSYS_USER_CHANNEL_Msk      (0x1Ful << EVSYS_USER_CHANNEL_Pos)
+#define EVSYS_USER_CHANNEL(value)   (EVSYS_USER_CHANNEL_Msk & ((value) << EVSYS_USER_CHANNEL_Pos))
+#define EVSYS_USER_MASK             0x0000001Ful /**< \brief (EVSYS_USER) MASK Register */
+
+/** \brief EVSYS hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO EVSYS_CTRLA_Type          CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control */
+       RoReg8                    Reserved1[0xB];
+  __I  EVSYS_CHSTATUS_Type       CHSTATUS;    /**< \brief Offset: 0x0C (R/  32) Channel Status */
+  __IO EVSYS_INTENCLR_Type       INTENCLR;    /**< \brief Offset: 0x10 (R/W 32) Interrupt Enable Clear */
+  __IO EVSYS_INTENSET_Type       INTENSET;    /**< \brief Offset: 0x14 (R/W 32) Interrupt Enable Set */
+  __IO EVSYS_INTFLAG_Type        INTFLAG;     /**< \brief Offset: 0x18 (R/W 32) Interrupt Flag Status and Clear */
+  __O  EVSYS_SWEVT_Type          SWEVT;       /**< \brief Offset: 0x1C ( /W 32) Software Event */
+  __IO EVSYS_CHANNEL_Type        CHANNEL[12]; /**< \brief Offset: 0x20 (R/W 32) Channel n */
+       RoReg8                    Reserved2[0x30];
+  __IO EVSYS_USER_Type           USER[45];    /**< \brief Offset: 0x80 (R/W 32) User Multiplexer n */
+} Evsys;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_EVSYS_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/gclk_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/gclk_100.h
@@ -1,0 +1,232 @@
+/**
+ * \file
+ *
+ * \brief Component description for GCLK
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_GCLK_COMPONENT_
+#define _SAML21_GCLK_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GCLK */
+/* ========================================================================== */
+/** \addtogroup SAML21_GCLK Generic Clock Generator */
+/*@{*/
+
+#define GCLK_U2122
+#define REV_GCLK                    0x100
+
+/* -------- GCLK_CTRLA : (GCLK Offset: 0x00) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} GCLK_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_CTRLA_OFFSET           0x00         /**< \brief (GCLK_CTRLA offset) Control */
+#define GCLK_CTRLA_RESETVALUE       0x00ul       /**< \brief (GCLK_CTRLA reset_value) Control */
+
+#define GCLK_CTRLA_SWRST_Pos        0            /**< \brief (GCLK_CTRLA) Software Reset */
+#define GCLK_CTRLA_SWRST            (0x1ul << GCLK_CTRLA_SWRST_Pos)
+#define GCLK_CTRLA_MASK             0x01ul       /**< \brief (GCLK_CTRLA) MASK Register */
+
+/* -------- GCLK_SYNCBUSY : (GCLK Offset: 0x04) (R/  32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset Synchroniation Busy bit */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t GENCTRL:9;        /*!< bit:  2..10  Generic Clock Generator Control Synchronization Busy bits */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GCLK_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_SYNCBUSY_OFFSET        0x04         /**< \brief (GCLK_SYNCBUSY offset) Synchronization Busy */
+#define GCLK_SYNCBUSY_RESETVALUE    0x00000000ul /**< \brief (GCLK_SYNCBUSY reset_value) Synchronization Busy */
+
+#define GCLK_SYNCBUSY_SWRST_Pos     0            /**< \brief (GCLK_SYNCBUSY) Software Reset Synchroniation Busy bit */
+#define GCLK_SYNCBUSY_SWRST         (0x1ul << GCLK_SYNCBUSY_SWRST_Pos)
+#define GCLK_SYNCBUSY_GENCTRL_Pos   2            /**< \brief (GCLK_SYNCBUSY) Generic Clock Generator Control Synchronization Busy bits */
+#define GCLK_SYNCBUSY_GENCTRL_Msk   (0x1FFul << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_GENCTRL(value) (GCLK_SYNCBUSY_GENCTRL_Msk & ((value) << GCLK_SYNCBUSY_GENCTRL_Pos))
+#define   GCLK_SYNCBUSY_GENCTRL_GCLK0_Val 0x0ul  /**< \brief (GCLK_SYNCBUSY) Generic clock generator 0 */
+#define   GCLK_SYNCBUSY_GENCTRL_GCLK1_Val 0x1ul  /**< \brief (GCLK_SYNCBUSY) Generic clock generator 1 */
+#define   GCLK_SYNCBUSY_GENCTRL_GCLK2_Val 0x2ul  /**< \brief (GCLK_SYNCBUSY) Generic clock generator 2 */
+#define   GCLK_SYNCBUSY_GENCTRL_GCLK3_Val 0x3ul  /**< \brief (GCLK_SYNCBUSY) Generic clock generator 3 */
+#define   GCLK_SYNCBUSY_GENCTRL_GCLK4_Val 0x4ul  /**< \brief (GCLK_SYNCBUSY) Generic clock generator 4 */
+#define   GCLK_SYNCBUSY_GENCTRL_GCLK5_Val 0x5ul  /**< \brief (GCLK_SYNCBUSY) Generic clock generator 5 */
+#define   GCLK_SYNCBUSY_GENCTRL_GCLK6_Val 0x6ul  /**< \brief (GCLK_SYNCBUSY) Generic clock generator 6 */
+#define   GCLK_SYNCBUSY_GENCTRL_GCLK7_Val 0x7ul  /**< \brief (GCLK_SYNCBUSY) Generic clock generator 7 */
+#define   GCLK_SYNCBUSY_GENCTRL_GCLK8_Val 0x8ul  /**< \brief (GCLK_SYNCBUSY) Generic clock generator 8 */
+#define GCLK_SYNCBUSY_GENCTRL_GCLK0 (GCLK_SYNCBUSY_GENCTRL_GCLK0_Val << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_GENCTRL_GCLK1 (GCLK_SYNCBUSY_GENCTRL_GCLK1_Val << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_GENCTRL_GCLK2 (GCLK_SYNCBUSY_GENCTRL_GCLK2_Val << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_GENCTRL_GCLK3 (GCLK_SYNCBUSY_GENCTRL_GCLK3_Val << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_GENCTRL_GCLK4 (GCLK_SYNCBUSY_GENCTRL_GCLK4_Val << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_GENCTRL_GCLK5 (GCLK_SYNCBUSY_GENCTRL_GCLK5_Val << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_GENCTRL_GCLK6 (GCLK_SYNCBUSY_GENCTRL_GCLK6_Val << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_GENCTRL_GCLK7 (GCLK_SYNCBUSY_GENCTRL_GCLK7_Val << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_GENCTRL_GCLK8 (GCLK_SYNCBUSY_GENCTRL_GCLK8_Val << GCLK_SYNCBUSY_GENCTRL_Pos)
+#define GCLK_SYNCBUSY_MASK          0x000007FDul /**< \brief (GCLK_SYNCBUSY) MASK Register */
+
+/* -------- GCLK_GENCTRL : (GCLK Offset: 0x20) (R/W 32) Generic Clock Generator Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SRC:5;            /*!< bit:  0.. 4  Source Select                      */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t GENEN:1;          /*!< bit:      8  Generic Clock Generator Enable     */
+    uint32_t IDC:1;            /*!< bit:      9  Improve Duty Cycle                 */
+    uint32_t OOV:1;            /*!< bit:     10  Output Off Value                   */
+    uint32_t OE:1;             /*!< bit:     11  Output Enable                      */
+    uint32_t DIVSEL:1;         /*!< bit:     12  Divide Selection                   */
+    uint32_t RUNSTDBY:1;       /*!< bit:     13  Run in Standby                     */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t DIV:16;           /*!< bit: 16..31  Division Factor                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GCLK_GENCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_GENCTRL_OFFSET         0x20         /**< \brief (GCLK_GENCTRL offset) Generic Clock Generator Control */
+#define GCLK_GENCTRL_RESETVALUE     0x00000000ul /**< \brief (GCLK_GENCTRL reset_value) Generic Clock Generator Control */
+
+#define GCLK_GENCTRL_SRC_Pos        0            /**< \brief (GCLK_GENCTRL) Source Select */
+#define GCLK_GENCTRL_SRC_Msk        (0x1Ful << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC(value)     (GCLK_GENCTRL_SRC_Msk & ((value) << GCLK_GENCTRL_SRC_Pos))
+#define   GCLK_GENCTRL_SRC_XOSC_Val       0x0ul  /**< \brief (GCLK_GENCTRL) XOSC oscillator output */
+#define   GCLK_GENCTRL_SRC_GCLKIN_Val     0x1ul  /**< \brief (GCLK_GENCTRL) Generator input pad */
+#define   GCLK_GENCTRL_SRC_GCLKGEN1_Val   0x2ul  /**< \brief (GCLK_GENCTRL) Generic clock generator 1 output */
+#define   GCLK_GENCTRL_SRC_OSCULP32K_Val  0x3ul  /**< \brief (GCLK_GENCTRL) OSCULP32K oscillator output */
+#define   GCLK_GENCTRL_SRC_OSC32K_Val     0x4ul  /**< \brief (GCLK_GENCTRL) OSC32K oscillator output */
+#define   GCLK_GENCTRL_SRC_XOSC32K_Val    0x5ul  /**< \brief (GCLK_GENCTRL) XOSC32K oscillator output */
+#define   GCLK_GENCTRL_SRC_OSC16M_Val     0x6ul  /**< \brief (GCLK_GENCTRL) OSC16M oscillator output */
+#define   GCLK_GENCTRL_SRC_DFLL48M_Val    0x7ul  /**< \brief (GCLK_GENCTRL) DFLL48M output */
+#define   GCLK_GENCTRL_SRC_DPLL96M_Val    0x8ul  /**< \brief (GCLK_GENCTRL) DPLL96M output */
+#define GCLK_GENCTRL_SRC_XOSC       (GCLK_GENCTRL_SRC_XOSC_Val     << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_GCLKIN     (GCLK_GENCTRL_SRC_GCLKIN_Val   << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_GCLKGEN1   (GCLK_GENCTRL_SRC_GCLKGEN1_Val << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_OSCULP32K  (GCLK_GENCTRL_SRC_OSCULP32K_Val << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_OSC32K     (GCLK_GENCTRL_SRC_OSC32K_Val   << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_XOSC32K    (GCLK_GENCTRL_SRC_XOSC32K_Val  << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_OSC16M     (GCLK_GENCTRL_SRC_OSC16M_Val   << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_DFLL48M    (GCLK_GENCTRL_SRC_DFLL48M_Val  << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_DPLL96M    (GCLK_GENCTRL_SRC_DPLL96M_Val  << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_GENEN_Pos      8            /**< \brief (GCLK_GENCTRL) Generic Clock Generator Enable */
+#define GCLK_GENCTRL_GENEN          (0x1ul << GCLK_GENCTRL_GENEN_Pos)
+#define GCLK_GENCTRL_IDC_Pos        9            /**< \brief (GCLK_GENCTRL) Improve Duty Cycle */
+#define GCLK_GENCTRL_IDC            (0x1ul << GCLK_GENCTRL_IDC_Pos)
+#define GCLK_GENCTRL_OOV_Pos        10           /**< \brief (GCLK_GENCTRL) Output Off Value */
+#define GCLK_GENCTRL_OOV            (0x1ul << GCLK_GENCTRL_OOV_Pos)
+#define GCLK_GENCTRL_OE_Pos         11           /**< \brief (GCLK_GENCTRL) Output Enable */
+#define GCLK_GENCTRL_OE             (0x1ul << GCLK_GENCTRL_OE_Pos)
+#define GCLK_GENCTRL_DIVSEL_Pos     12           /**< \brief (GCLK_GENCTRL) Divide Selection */
+#define GCLK_GENCTRL_DIVSEL         (0x1ul << GCLK_GENCTRL_DIVSEL_Pos)
+#define GCLK_GENCTRL_RUNSTDBY_Pos   13           /**< \brief (GCLK_GENCTRL) Run in Standby */
+#define GCLK_GENCTRL_RUNSTDBY       (0x1ul << GCLK_GENCTRL_RUNSTDBY_Pos)
+#define GCLK_GENCTRL_DIV_Pos        16           /**< \brief (GCLK_GENCTRL) Division Factor */
+#define GCLK_GENCTRL_DIV_Msk        (0xFFFFul << GCLK_GENCTRL_DIV_Pos)
+#define GCLK_GENCTRL_DIV(value)     (GCLK_GENCTRL_DIV_Msk & ((value) << GCLK_GENCTRL_DIV_Pos))
+#define GCLK_GENCTRL_MASK           0xFFFF3F1Ful /**< \brief (GCLK_GENCTRL) MASK Register */
+
+/* -------- GCLK_PCHCTRL : (GCLK Offset: 0x80) (R/W 32) Peripheral Clock Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t GEN:4;            /*!< bit:  0.. 3  Generic Clock Generator            */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t CHEN:1;           /*!< bit:      6  Channel Enable                     */
+    uint32_t WRTLOCK:1;        /*!< bit:      7  Write Lock                         */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GCLK_PCHCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_PCHCTRL_OFFSET         0x80         /**< \brief (GCLK_PCHCTRL offset) Peripheral Clock Control */
+#define GCLK_PCHCTRL_RESETVALUE     0x00000000ul /**< \brief (GCLK_PCHCTRL reset_value) Peripheral Clock Control */
+
+#define GCLK_PCHCTRL_GEN_Pos        0            /**< \brief (GCLK_PCHCTRL) Generic Clock Generator */
+#define GCLK_PCHCTRL_GEN_Msk        (0xFul << GCLK_PCHCTRL_GEN_Pos)
+#define GCLK_PCHCTRL_GEN(value)     (GCLK_PCHCTRL_GEN_Msk & ((value) << GCLK_PCHCTRL_GEN_Pos))
+#define   GCLK_PCHCTRL_GEN_GCLK0_Val      0x0ul  /**< \brief (GCLK_PCHCTRL) Generic clock generator 0 */
+#define   GCLK_PCHCTRL_GEN_GCLK1_Val      0x1ul  /**< \brief (GCLK_PCHCTRL) Generic clock generator 1 */
+#define   GCLK_PCHCTRL_GEN_GCLK2_Val      0x2ul  /**< \brief (GCLK_PCHCTRL) Generic clock generator 2 */
+#define   GCLK_PCHCTRL_GEN_GCLK3_Val      0x3ul  /**< \brief (GCLK_PCHCTRL) Generic clock generator 3 */
+#define   GCLK_PCHCTRL_GEN_GCLK4_Val      0x4ul  /**< \brief (GCLK_PCHCTRL) Generic clock generator 4 */
+#define   GCLK_PCHCTRL_GEN_GCLK5_Val      0x5ul  /**< \brief (GCLK_PCHCTRL) Generic clock generator 5 */
+#define   GCLK_PCHCTRL_GEN_GCLK6_Val      0x6ul  /**< \brief (GCLK_PCHCTRL) Generic clock generator 6 */
+#define   GCLK_PCHCTRL_GEN_GCLK7_Val      0x7ul  /**< \brief (GCLK_PCHCTRL) Generic clock generator 7 */
+#define GCLK_PCHCTRL_GEN_GCLK0      (GCLK_PCHCTRL_GEN_GCLK0_Val    << GCLK_PCHCTRL_GEN_Pos)
+#define GCLK_PCHCTRL_GEN_GCLK1      (GCLK_PCHCTRL_GEN_GCLK1_Val    << GCLK_PCHCTRL_GEN_Pos)
+#define GCLK_PCHCTRL_GEN_GCLK2      (GCLK_PCHCTRL_GEN_GCLK2_Val    << GCLK_PCHCTRL_GEN_Pos)
+#define GCLK_PCHCTRL_GEN_GCLK3      (GCLK_PCHCTRL_GEN_GCLK3_Val    << GCLK_PCHCTRL_GEN_Pos)
+#define GCLK_PCHCTRL_GEN_GCLK4      (GCLK_PCHCTRL_GEN_GCLK4_Val    << GCLK_PCHCTRL_GEN_Pos)
+#define GCLK_PCHCTRL_GEN_GCLK5      (GCLK_PCHCTRL_GEN_GCLK5_Val    << GCLK_PCHCTRL_GEN_Pos)
+#define GCLK_PCHCTRL_GEN_GCLK6      (GCLK_PCHCTRL_GEN_GCLK6_Val    << GCLK_PCHCTRL_GEN_Pos)
+#define GCLK_PCHCTRL_GEN_GCLK7      (GCLK_PCHCTRL_GEN_GCLK7_Val    << GCLK_PCHCTRL_GEN_Pos)
+#define GCLK_PCHCTRL_CHEN_Pos       6            /**< \brief (GCLK_PCHCTRL) Channel Enable */
+#define GCLK_PCHCTRL_CHEN           (0x1ul << GCLK_PCHCTRL_CHEN_Pos)
+#define GCLK_PCHCTRL_WRTLOCK_Pos    7            /**< \brief (GCLK_PCHCTRL) Write Lock */
+#define GCLK_PCHCTRL_WRTLOCK        (0x1ul << GCLK_PCHCTRL_WRTLOCK_Pos)
+#define GCLK_PCHCTRL_MASK           0x000000CFul /**< \brief (GCLK_PCHCTRL) MASK Register */
+
+/** \brief GCLK hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO GCLK_CTRLA_Type           CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control */
+       RoReg8                    Reserved1[0x3];
+  __I  GCLK_SYNCBUSY_Type        SYNCBUSY;    /**< \brief Offset: 0x04 (R/  32) Synchronization Busy */
+       RoReg8                    Reserved2[0x18];
+  __IO GCLK_GENCTRL_Type         GENCTRL[9];  /**< \brief Offset: 0x20 (R/W 32) Generic Clock Generator Control */
+       RoReg8                    Reserved3[0x3C];
+  __IO GCLK_PCHCTRL_Type         PCHCTRL[36]; /**< \brief Offset: 0x80 (R/W 32) Peripheral Clock Control */
+} Gclk;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_GCLK_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/mclk_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/mclk_100.h
@@ -1,0 +1,526 @@
+/**
+ * \file
+ *
+ * \brief Component description for MCLK
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_MCLK_COMPONENT_
+#define _SAML21_MCLK_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MCLK */
+/* ========================================================================== */
+/** \addtogroup SAML21_MCLK Main Clock */
+/*@{*/
+
+#define MCLK_U2234
+#define REV_MCLK                    0x100
+
+/* -------- MCLK_CTRLA : (MCLK Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint8_t  CFDEN:1;          /*!< bit:      2  Clock Failure Detector Enable      */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  EMCLK:1;          /*!< bit:      4  Emergency Clock Select             */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} MCLK_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_CTRLA_OFFSET           0x00         /**< \brief (MCLK_CTRLA offset) Control A */
+#define MCLK_CTRLA_RESETVALUE       0x00ul       /**< \brief (MCLK_CTRLA reset_value) Control A */
+
+#define MCLK_CTRLA_CFDEN_Pos        2            /**< \brief (MCLK_CTRLA) Clock Failure Detector Enable */
+#define MCLK_CTRLA_CFDEN            (0x1ul << MCLK_CTRLA_CFDEN_Pos)
+#define MCLK_CTRLA_EMCLK_Pos        4            /**< \brief (MCLK_CTRLA) Emergency Clock Select */
+#define MCLK_CTRLA_EMCLK            (0x1ul << MCLK_CTRLA_EMCLK_Pos)
+#define MCLK_CTRLA_MASK             0x14ul       /**< \brief (MCLK_CTRLA) MASK Register */
+
+/* -------- MCLK_INTENCLR : (MCLK Offset: 0x01) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready Interrupt Enable       */
+    uint8_t  CFD:1;            /*!< bit:      1  Clock Failure Detector Interrupt Enable */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} MCLK_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_INTENCLR_OFFSET        0x01         /**< \brief (MCLK_INTENCLR offset) Interrupt Enable Clear */
+#define MCLK_INTENCLR_RESETVALUE    0x00ul       /**< \brief (MCLK_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define MCLK_INTENCLR_CKRDY_Pos     0            /**< \brief (MCLK_INTENCLR) Clock Ready Interrupt Enable */
+#define MCLK_INTENCLR_CKRDY         (0x1ul << MCLK_INTENCLR_CKRDY_Pos)
+#define MCLK_INTENCLR_CFD_Pos       1            /**< \brief (MCLK_INTENCLR) Clock Failure Detector Interrupt Enable */
+#define MCLK_INTENCLR_CFD           (0x1ul << MCLK_INTENCLR_CFD_Pos)
+#define MCLK_INTENCLR_MASK          0x03ul       /**< \brief (MCLK_INTENCLR) MASK Register */
+
+/* -------- MCLK_INTENSET : (MCLK Offset: 0x02) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready Interrupt Enable       */
+    uint8_t  CFD:1;            /*!< bit:      1  Clock Failure Detector Interrupt Enable */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} MCLK_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_INTENSET_OFFSET        0x02         /**< \brief (MCLK_INTENSET offset) Interrupt Enable Set */
+#define MCLK_INTENSET_RESETVALUE    0x00ul       /**< \brief (MCLK_INTENSET reset_value) Interrupt Enable Set */
+
+#define MCLK_INTENSET_CKRDY_Pos     0            /**< \brief (MCLK_INTENSET) Clock Ready Interrupt Enable */
+#define MCLK_INTENSET_CKRDY         (0x1ul << MCLK_INTENSET_CKRDY_Pos)
+#define MCLK_INTENSET_CFD_Pos       1            /**< \brief (MCLK_INTENSET) Clock Failure Detector Interrupt Enable */
+#define MCLK_INTENSET_CFD           (0x1ul << MCLK_INTENSET_CFD_Pos)
+#define MCLK_INTENSET_MASK          0x03ul       /**< \brief (MCLK_INTENSET) MASK Register */
+
+/* -------- MCLK_INTFLAG : (MCLK Offset: 0x03) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
+    __I uint8_t  CFD:1;            /*!< bit:      1  Clock Failure Detector             */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} MCLK_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_INTFLAG_OFFSET         0x03         /**< \brief (MCLK_INTFLAG offset) Interrupt Flag Status and Clear */
+#define MCLK_INTFLAG_RESETVALUE     0x01ul       /**< \brief (MCLK_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define MCLK_INTFLAG_CKRDY_Pos      0            /**< \brief (MCLK_INTFLAG) Clock Ready */
+#define MCLK_INTFLAG_CKRDY          (0x1ul << MCLK_INTFLAG_CKRDY_Pos)
+#define MCLK_INTFLAG_CFD_Pos        1            /**< \brief (MCLK_INTFLAG) Clock Failure Detector */
+#define MCLK_INTFLAG_CFD            (0x1ul << MCLK_INTFLAG_CFD_Pos)
+#define MCLK_INTFLAG_MASK           0x03ul       /**< \brief (MCLK_INTFLAG) MASK Register */
+
+/* -------- MCLK_CPUDIV : (MCLK Offset: 0x04) (R/W  8) CPU Clock Division -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CPUDIV:8;         /*!< bit:  0.. 7  CPU Clock Division Factor          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} MCLK_CPUDIV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_CPUDIV_OFFSET          0x04         /**< \brief (MCLK_CPUDIV offset) CPU Clock Division */
+#define MCLK_CPUDIV_RESETVALUE      0x01ul       /**< \brief (MCLK_CPUDIV reset_value) CPU Clock Division */
+
+#define MCLK_CPUDIV_CPUDIV_Pos      0            /**< \brief (MCLK_CPUDIV) CPU Clock Division Factor */
+#define MCLK_CPUDIV_CPUDIV_Msk      (0xFFul << MCLK_CPUDIV_CPUDIV_Pos)
+#define MCLK_CPUDIV_CPUDIV(value)   (MCLK_CPUDIV_CPUDIV_Msk & ((value) << MCLK_CPUDIV_CPUDIV_Pos))
+#define   MCLK_CPUDIV_CPUDIV_DIV1_Val     0x1ul  /**< \brief (MCLK_CPUDIV) Divide by 1 */
+#define   MCLK_CPUDIV_CPUDIV_DIV2_Val     0x2ul  /**< \brief (MCLK_CPUDIV) Divide by 2 */
+#define   MCLK_CPUDIV_CPUDIV_DIV4_Val     0x4ul  /**< \brief (MCLK_CPUDIV) Divide by 4 */
+#define   MCLK_CPUDIV_CPUDIV_DIV8_Val     0x8ul  /**< \brief (MCLK_CPUDIV) Divide by 8 */
+#define   MCLK_CPUDIV_CPUDIV_DIV16_Val    0x10ul  /**< \brief (MCLK_CPUDIV) Divide by 16 */
+#define   MCLK_CPUDIV_CPUDIV_DIV32_Val    0x20ul  /**< \brief (MCLK_CPUDIV) Divide by 32 */
+#define   MCLK_CPUDIV_CPUDIV_DIV64_Val    0x40ul  /**< \brief (MCLK_CPUDIV) Divide by 64 */
+#define   MCLK_CPUDIV_CPUDIV_DIV128_Val   0x80ul  /**< \brief (MCLK_CPUDIV) Divide by 128 */
+#define MCLK_CPUDIV_CPUDIV_DIV1     (MCLK_CPUDIV_CPUDIV_DIV1_Val   << MCLK_CPUDIV_CPUDIV_Pos)
+#define MCLK_CPUDIV_CPUDIV_DIV2     (MCLK_CPUDIV_CPUDIV_DIV2_Val   << MCLK_CPUDIV_CPUDIV_Pos)
+#define MCLK_CPUDIV_CPUDIV_DIV4     (MCLK_CPUDIV_CPUDIV_DIV4_Val   << MCLK_CPUDIV_CPUDIV_Pos)
+#define MCLK_CPUDIV_CPUDIV_DIV8     (MCLK_CPUDIV_CPUDIV_DIV8_Val   << MCLK_CPUDIV_CPUDIV_Pos)
+#define MCLK_CPUDIV_CPUDIV_DIV16    (MCLK_CPUDIV_CPUDIV_DIV16_Val  << MCLK_CPUDIV_CPUDIV_Pos)
+#define MCLK_CPUDIV_CPUDIV_DIV32    (MCLK_CPUDIV_CPUDIV_DIV32_Val  << MCLK_CPUDIV_CPUDIV_Pos)
+#define MCLK_CPUDIV_CPUDIV_DIV64    (MCLK_CPUDIV_CPUDIV_DIV64_Val  << MCLK_CPUDIV_CPUDIV_Pos)
+#define MCLK_CPUDIV_CPUDIV_DIV128   (MCLK_CPUDIV_CPUDIV_DIV128_Val << MCLK_CPUDIV_CPUDIV_Pos)
+#define MCLK_CPUDIV_MASK            0xFFul       /**< \brief (MCLK_CPUDIV) MASK Register */
+
+/* -------- MCLK_LPDIV : (MCLK Offset: 0x05) (R/W  8) Low-Power Clock Division -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  LPDIV:8;          /*!< bit:  0.. 7  Low-Power Clock Division Factor    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} MCLK_LPDIV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_LPDIV_OFFSET           0x05         /**< \brief (MCLK_LPDIV offset) Low-Power Clock Division */
+#define MCLK_LPDIV_RESETVALUE       0x01ul       /**< \brief (MCLK_LPDIV reset_value) Low-Power Clock Division */
+
+#define MCLK_LPDIV_LPDIV_Pos        0            /**< \brief (MCLK_LPDIV) Low-Power Clock Division Factor */
+#define MCLK_LPDIV_LPDIV_Msk        (0xFFul << MCLK_LPDIV_LPDIV_Pos)
+#define MCLK_LPDIV_LPDIV(value)     (MCLK_LPDIV_LPDIV_Msk & ((value) << MCLK_LPDIV_LPDIV_Pos))
+#define   MCLK_LPDIV_LPDIV_DIV1_Val       0x1ul  /**< \brief (MCLK_LPDIV) Divide by 1 */
+#define   MCLK_LPDIV_LPDIV_DIV2_Val       0x2ul  /**< \brief (MCLK_LPDIV) Divide by 2 */
+#define   MCLK_LPDIV_LPDIV_DIV4_Val       0x4ul  /**< \brief (MCLK_LPDIV) Divide by 4 */
+#define   MCLK_LPDIV_LPDIV_DIV8_Val       0x8ul  /**< \brief (MCLK_LPDIV) Divide by 8 */
+#define   MCLK_LPDIV_LPDIV_DIV16_Val      0x10ul  /**< \brief (MCLK_LPDIV) Divide by 16 */
+#define   MCLK_LPDIV_LPDIV_DIV32_Val      0x20ul  /**< \brief (MCLK_LPDIV) Divide by 32 */
+#define   MCLK_LPDIV_LPDIV_DIV64_Val      0x40ul  /**< \brief (MCLK_LPDIV) Divide by 64 */
+#define   MCLK_LPDIV_LPDIV_DIV128_Val     0x80ul  /**< \brief (MCLK_LPDIV) Divide by 128 */
+#define MCLK_LPDIV_LPDIV_DIV1       (MCLK_LPDIV_LPDIV_DIV1_Val     << MCLK_LPDIV_LPDIV_Pos)
+#define MCLK_LPDIV_LPDIV_DIV2       (MCLK_LPDIV_LPDIV_DIV2_Val     << MCLK_LPDIV_LPDIV_Pos)
+#define MCLK_LPDIV_LPDIV_DIV4       (MCLK_LPDIV_LPDIV_DIV4_Val     << MCLK_LPDIV_LPDIV_Pos)
+#define MCLK_LPDIV_LPDIV_DIV8       (MCLK_LPDIV_LPDIV_DIV8_Val     << MCLK_LPDIV_LPDIV_Pos)
+#define MCLK_LPDIV_LPDIV_DIV16      (MCLK_LPDIV_LPDIV_DIV16_Val    << MCLK_LPDIV_LPDIV_Pos)
+#define MCLK_LPDIV_LPDIV_DIV32      (MCLK_LPDIV_LPDIV_DIV32_Val    << MCLK_LPDIV_LPDIV_Pos)
+#define MCLK_LPDIV_LPDIV_DIV64      (MCLK_LPDIV_LPDIV_DIV64_Val    << MCLK_LPDIV_LPDIV_Pos)
+#define MCLK_LPDIV_LPDIV_DIV128     (MCLK_LPDIV_LPDIV_DIV128_Val   << MCLK_LPDIV_LPDIV_Pos)
+#define MCLK_LPDIV_MASK             0xFFul       /**< \brief (MCLK_LPDIV) MASK Register */
+
+/* -------- MCLK_BUPDIV : (MCLK Offset: 0x06) (R/W  8) Backup Clock Division -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  BUPDIV:8;         /*!< bit:  0.. 7  Backup Clock Division Factor       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} MCLK_BUPDIV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_BUPDIV_OFFSET          0x06         /**< \brief (MCLK_BUPDIV offset) Backup Clock Division */
+#define MCLK_BUPDIV_RESETVALUE      0x01ul       /**< \brief (MCLK_BUPDIV reset_value) Backup Clock Division */
+
+#define MCLK_BUPDIV_BUPDIV_Pos      0            /**< \brief (MCLK_BUPDIV) Backup Clock Division Factor */
+#define MCLK_BUPDIV_BUPDIV_Msk      (0xFFul << MCLK_BUPDIV_BUPDIV_Pos)
+#define MCLK_BUPDIV_BUPDIV(value)   (MCLK_BUPDIV_BUPDIV_Msk & ((value) << MCLK_BUPDIV_BUPDIV_Pos))
+#define   MCLK_BUPDIV_BUPDIV_DIV1_Val     0x1ul  /**< \brief (MCLK_BUPDIV) Divide by 1 */
+#define   MCLK_BUPDIV_BUPDIV_DIV2_Val     0x2ul  /**< \brief (MCLK_BUPDIV) Divide by 2 */
+#define   MCLK_BUPDIV_BUPDIV_DIV4_Val     0x4ul  /**< \brief (MCLK_BUPDIV) Divide by 4 */
+#define   MCLK_BUPDIV_BUPDIV_DIV8_Val     0x8ul  /**< \brief (MCLK_BUPDIV) Divide by 8 */
+#define   MCLK_BUPDIV_BUPDIV_DIV16_Val    0x10ul  /**< \brief (MCLK_BUPDIV) Divide by 16 */
+#define   MCLK_BUPDIV_BUPDIV_DIV32_Val    0x20ul  /**< \brief (MCLK_BUPDIV) Divide by 32 */
+#define   MCLK_BUPDIV_BUPDIV_DIV64_Val    0x40ul  /**< \brief (MCLK_BUPDIV) Divide by 64 */
+#define   MCLK_BUPDIV_BUPDIV_DIV128_Val   0x80ul  /**< \brief (MCLK_BUPDIV) Divide by 128 */
+#define MCLK_BUPDIV_BUPDIV_DIV1     (MCLK_BUPDIV_BUPDIV_DIV1_Val   << MCLK_BUPDIV_BUPDIV_Pos)
+#define MCLK_BUPDIV_BUPDIV_DIV2     (MCLK_BUPDIV_BUPDIV_DIV2_Val   << MCLK_BUPDIV_BUPDIV_Pos)
+#define MCLK_BUPDIV_BUPDIV_DIV4     (MCLK_BUPDIV_BUPDIV_DIV4_Val   << MCLK_BUPDIV_BUPDIV_Pos)
+#define MCLK_BUPDIV_BUPDIV_DIV8     (MCLK_BUPDIV_BUPDIV_DIV8_Val   << MCLK_BUPDIV_BUPDIV_Pos)
+#define MCLK_BUPDIV_BUPDIV_DIV16    (MCLK_BUPDIV_BUPDIV_DIV16_Val  << MCLK_BUPDIV_BUPDIV_Pos)
+#define MCLK_BUPDIV_BUPDIV_DIV32    (MCLK_BUPDIV_BUPDIV_DIV32_Val  << MCLK_BUPDIV_BUPDIV_Pos)
+#define MCLK_BUPDIV_BUPDIV_DIV64    (MCLK_BUPDIV_BUPDIV_DIV64_Val  << MCLK_BUPDIV_BUPDIV_Pos)
+#define MCLK_BUPDIV_BUPDIV_DIV128   (MCLK_BUPDIV_BUPDIV_DIV128_Val << MCLK_BUPDIV_BUPDIV_Pos)
+#define MCLK_BUPDIV_MASK            0xFFul       /**< \brief (MCLK_BUPDIV) MASK Register */
+
+/* -------- MCLK_AHBMASK : (MCLK Offset: 0x10) (R/W 32) AHB Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t HPB0_:1;          /*!< bit:      0  HPB0 AHB Clock Mask                */
+    uint32_t HPB1_:1;          /*!< bit:      1  HPB1 AHB Clock Mask                */
+    uint32_t HPB2_:1;          /*!< bit:      2  HPB2 AHB Clock Mask                */
+    uint32_t HPB3_:1;          /*!< bit:      3  HPB3 AHB Clock Mask                */
+    uint32_t HPB4_:1;          /*!< bit:      4  HPB4 AHB Clock Mask                */
+    uint32_t DSU_:1;           /*!< bit:      5  DSU AHB Clock Mask                 */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t NVMCTRL_:1;       /*!< bit:      8  NVMCTRL AHB Clock Mask             */
+    uint32_t HMCRAMCHS_:1;     /*!< bit:      9  HMCRAMCHS AHB Clock Mask           */
+    uint32_t HMCRAMCLP_:1;     /*!< bit:     10  HMCRAMCLP AHB Clock Mask           */
+    uint32_t DMAC_:1;          /*!< bit:     11  DMAC AHB Clock Mask                */
+    uint32_t USB_:1;           /*!< bit:     12  USB AHB Clock Mask                 */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t PAC_:1;           /*!< bit:     14  PAC AHB Clock Mask                 */
+    uint32_t NVMCTRL_PICACHU_:1; /*!< bit:     15  NVMCTRL_PICACHU AHB Clock Mask     */
+    uint32_t L2HBRIDGES_H_:1;  /*!< bit:     16  L2HBRIDGES_H AHB Clock Mask        */
+    uint32_t H2LBRIDGES_H_:1;  /*!< bit:     17  H2LBRIDGES_H AHB Clock Mask        */
+    uint32_t HMCRAMCHS_AHBSETUPKEEPER_:1; /*!< bit:     18  HMCRAMCHS_AHBSETUPKEEPER AHB Clock Mask */
+    uint32_t HMCRAMCHS_HMATRIXLP2HMCRAMCHSBRIDGE_:1; /*!< bit:     19  HMCRAMCHS_HMATRIXLP2HMCRAMCHSBRIDGE AHB Clock Mask */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} MCLK_AHBMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_AHBMASK_OFFSET         0x10         /**< \brief (MCLK_AHBMASK offset) AHB Mask */
+#define MCLK_AHBMASK_RESETVALUE     0x000FFFFFul /**< \brief (MCLK_AHBMASK reset_value) AHB Mask */
+
+#define MCLK_AHBMASK_HPB0_Pos       0            /**< \brief (MCLK_AHBMASK) HPB0 AHB Clock Mask */
+#define MCLK_AHBMASK_HPB0           (0x1ul << MCLK_AHBMASK_HPB0_Pos)
+#define MCLK_AHBMASK_HPB1_Pos       1            /**< \brief (MCLK_AHBMASK) HPB1 AHB Clock Mask */
+#define MCLK_AHBMASK_HPB1           (0x1ul << MCLK_AHBMASK_HPB1_Pos)
+#define MCLK_AHBMASK_HPB2_Pos       2            /**< \brief (MCLK_AHBMASK) HPB2 AHB Clock Mask */
+#define MCLK_AHBMASK_HPB2           (0x1ul << MCLK_AHBMASK_HPB2_Pos)
+#define MCLK_AHBMASK_HPB3_Pos       3            /**< \brief (MCLK_AHBMASK) HPB3 AHB Clock Mask */
+#define MCLK_AHBMASK_HPB3           (0x1ul << MCLK_AHBMASK_HPB3_Pos)
+#define MCLK_AHBMASK_HPB4_Pos       4            /**< \brief (MCLK_AHBMASK) HPB4 AHB Clock Mask */
+#define MCLK_AHBMASK_HPB4           (0x1ul << MCLK_AHBMASK_HPB4_Pos)
+#define MCLK_AHBMASK_DSU_Pos        5            /**< \brief (MCLK_AHBMASK) DSU AHB Clock Mask */
+#define MCLK_AHBMASK_DSU            (0x1ul << MCLK_AHBMASK_DSU_Pos)
+#define MCLK_AHBMASK_NVMCTRL_Pos    8            /**< \brief (MCLK_AHBMASK) NVMCTRL AHB Clock Mask */
+#define MCLK_AHBMASK_NVMCTRL        (0x1ul << MCLK_AHBMASK_NVMCTRL_Pos)
+#define MCLK_AHBMASK_HMCRAMCHS_Pos  9            /**< \brief (MCLK_AHBMASK) HMCRAMCHS AHB Clock Mask */
+#define MCLK_AHBMASK_HMCRAMCHS      (0x1ul << MCLK_AHBMASK_HMCRAMCHS_Pos)
+#define MCLK_AHBMASK_HMCRAMCLP_Pos  10           /**< \brief (MCLK_AHBMASK) HMCRAMCLP AHB Clock Mask */
+#define MCLK_AHBMASK_HMCRAMCLP      (0x1ul << MCLK_AHBMASK_HMCRAMCLP_Pos)
+#define MCLK_AHBMASK_DMAC_Pos       11           /**< \brief (MCLK_AHBMASK) DMAC AHB Clock Mask */
+#define MCLK_AHBMASK_DMAC           (0x1ul << MCLK_AHBMASK_DMAC_Pos)
+#define MCLK_AHBMASK_USB_Pos        12           /**< \brief (MCLK_AHBMASK) USB AHB Clock Mask */
+#define MCLK_AHBMASK_USB            (0x1ul << MCLK_AHBMASK_USB_Pos)
+#define MCLK_AHBMASK_PAC_Pos        14           /**< \brief (MCLK_AHBMASK) PAC AHB Clock Mask */
+#define MCLK_AHBMASK_PAC            (0x1ul << MCLK_AHBMASK_PAC_Pos)
+#define MCLK_AHBMASK_NVMCTRL_PICACHU_Pos 15           /**< \brief (MCLK_AHBMASK) NVMCTRL_PICACHU AHB Clock Mask */
+#define MCLK_AHBMASK_NVMCTRL_PICACHU (0x1ul << MCLK_AHBMASK_NVMCTRL_PICACHU_Pos)
+#define MCLK_AHBMASK_L2HBRIDGES_H_Pos 16           /**< \brief (MCLK_AHBMASK) L2HBRIDGES_H AHB Clock Mask */
+#define MCLK_AHBMASK_L2HBRIDGES_H   (0x1ul << MCLK_AHBMASK_L2HBRIDGES_H_Pos)
+#define MCLK_AHBMASK_H2LBRIDGES_H_Pos 17           /**< \brief (MCLK_AHBMASK) H2LBRIDGES_H AHB Clock Mask */
+#define MCLK_AHBMASK_H2LBRIDGES_H   (0x1ul << MCLK_AHBMASK_H2LBRIDGES_H_Pos)
+#define MCLK_AHBMASK_HMCRAMCHS_AHBSETUPKEEPER_Pos 18           /**< \brief (MCLK_AHBMASK) HMCRAMCHS_AHBSETUPKEEPER AHB Clock Mask */
+#define MCLK_AHBMASK_HMCRAMCHS_AHBSETUPKEEPER (0x1ul << MCLK_AHBMASK_HMCRAMCHS_AHBSETUPKEEPER_Pos)
+#define MCLK_AHBMASK_HMCRAMCHS_HMATRIXLP2HMCRAMCHSBRIDGE_Pos 19           /**< \brief (MCLK_AHBMASK) HMCRAMCHS_HMATRIXLP2HMCRAMCHSBRIDGE AHB Clock Mask */
+#define MCLK_AHBMASK_HMCRAMCHS_HMATRIXLP2HMCRAMCHSBRIDGE (0x1ul << MCLK_AHBMASK_HMCRAMCHS_HMATRIXLP2HMCRAMCHSBRIDGE_Pos)
+#define MCLK_AHBMASK_MASK           0x000FDF3Ful /**< \brief (MCLK_AHBMASK) MASK Register */
+
+/* -------- MCLK_APBAMASK : (MCLK Offset: 0x14) (R/W 32) APBA Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PM_:1;            /*!< bit:      0  PM APB Clock Enable                */
+    uint32_t MCLK_:1;          /*!< bit:      1  MCLK APB Clock Enable              */
+    uint32_t RSTC_:1;          /*!< bit:      2  RSTC APB Clock Enable              */
+    uint32_t OSCCTRL_:1;       /*!< bit:      3  OSCCTRL APB Clock Enable           */
+    uint32_t OSC32KCTRL_:1;    /*!< bit:      4  OSC32KCTRL APB Clock Enable        */
+    uint32_t SUPC_:1;          /*!< bit:      5  SUPC APB Clock Enable              */
+    uint32_t GCLK_:1;          /*!< bit:      6  GCLK APB Clock Enable              */
+    uint32_t WDT_:1;           /*!< bit:      7  WDT APB Clock Enable               */
+    uint32_t RTC_:1;           /*!< bit:      8  RTC APB Clock Enable               */
+    uint32_t EIC_:1;           /*!< bit:      9  EIC APB Clock Enable               */
+    uint32_t PORT_:1;          /*!< bit:     10  PORT APB Clock Enable              */
+    uint32_t TAL_:1;           /*!< bit:     11  TAL APB Clock Enable               */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} MCLK_APBAMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBAMASK_OFFSET        0x14         /**< \brief (MCLK_APBAMASK offset) APBA Mask */
+#define MCLK_APBAMASK_RESETVALUE    0x00001FFFul /**< \brief (MCLK_APBAMASK reset_value) APBA Mask */
+
+#define MCLK_APBAMASK_PM_Pos        0            /**< \brief (MCLK_APBAMASK) PM APB Clock Enable */
+#define MCLK_APBAMASK_PM            (0x1ul << MCLK_APBAMASK_PM_Pos)
+#define MCLK_APBAMASK_MCLK_Pos      1            /**< \brief (MCLK_APBAMASK) MCLK APB Clock Enable */
+#define MCLK_APBAMASK_MCLK          (0x1ul << MCLK_APBAMASK_MCLK_Pos)
+#define MCLK_APBAMASK_RSTC_Pos      2            /**< \brief (MCLK_APBAMASK) RSTC APB Clock Enable */
+#define MCLK_APBAMASK_RSTC          (0x1ul << MCLK_APBAMASK_RSTC_Pos)
+#define MCLK_APBAMASK_OSCCTRL_Pos   3            /**< \brief (MCLK_APBAMASK) OSCCTRL APB Clock Enable */
+#define MCLK_APBAMASK_OSCCTRL       (0x1ul << MCLK_APBAMASK_OSCCTRL_Pos)
+#define MCLK_APBAMASK_OSC32KCTRL_Pos 4            /**< \brief (MCLK_APBAMASK) OSC32KCTRL APB Clock Enable */
+#define MCLK_APBAMASK_OSC32KCTRL    (0x1ul << MCLK_APBAMASK_OSC32KCTRL_Pos)
+#define MCLK_APBAMASK_SUPC_Pos      5            /**< \brief (MCLK_APBAMASK) SUPC APB Clock Enable */
+#define MCLK_APBAMASK_SUPC          (0x1ul << MCLK_APBAMASK_SUPC_Pos)
+#define MCLK_APBAMASK_GCLK_Pos      6            /**< \brief (MCLK_APBAMASK) GCLK APB Clock Enable */
+#define MCLK_APBAMASK_GCLK          (0x1ul << MCLK_APBAMASK_GCLK_Pos)
+#define MCLK_APBAMASK_WDT_Pos       7            /**< \brief (MCLK_APBAMASK) WDT APB Clock Enable */
+#define MCLK_APBAMASK_WDT           (0x1ul << MCLK_APBAMASK_WDT_Pos)
+#define MCLK_APBAMASK_RTC_Pos       8            /**< \brief (MCLK_APBAMASK) RTC APB Clock Enable */
+#define MCLK_APBAMASK_RTC           (0x1ul << MCLK_APBAMASK_RTC_Pos)
+#define MCLK_APBAMASK_EIC_Pos       9            /**< \brief (MCLK_APBAMASK) EIC APB Clock Enable */
+#define MCLK_APBAMASK_EIC           (0x1ul << MCLK_APBAMASK_EIC_Pos)
+#define MCLK_APBAMASK_PORT_Pos      10           /**< \brief (MCLK_APBAMASK) PORT APB Clock Enable */
+#define MCLK_APBAMASK_PORT          (0x1ul << MCLK_APBAMASK_PORT_Pos)
+#define MCLK_APBAMASK_TAL_Pos       11           /**< \brief (MCLK_APBAMASK) TAL APB Clock Enable */
+#define MCLK_APBAMASK_TAL           (0x1ul << MCLK_APBAMASK_TAL_Pos)
+#define MCLK_APBAMASK_MASK          0x00000FFFul /**< \brief (MCLK_APBAMASK) MASK Register */
+
+/* -------- MCLK_APBBMASK : (MCLK Offset: 0x18) (R/W 32) APBB Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t USB_:1;           /*!< bit:      0  USB APB Clock Enable               */
+    uint32_t DSU_:1;           /*!< bit:      1  DSU APB Clock Enable               */
+    uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL APB Clock Enable           */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} MCLK_APBBMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBBMASK_OFFSET        0x18         /**< \brief (MCLK_APBBMASK offset) APBB Mask */
+#define MCLK_APBBMASK_RESETVALUE    0x00000007ul /**< \brief (MCLK_APBBMASK reset_value) APBB Mask */
+
+#define MCLK_APBBMASK_USB_Pos       0            /**< \brief (MCLK_APBBMASK) USB APB Clock Enable */
+#define MCLK_APBBMASK_USB           (0x1ul << MCLK_APBBMASK_USB_Pos)
+#define MCLK_APBBMASK_DSU_Pos       1            /**< \brief (MCLK_APBBMASK) DSU APB Clock Enable */
+#define MCLK_APBBMASK_DSU           (0x1ul << MCLK_APBBMASK_DSU_Pos)
+#define MCLK_APBBMASK_NVMCTRL_Pos   2            /**< \brief (MCLK_APBBMASK) NVMCTRL APB Clock Enable */
+#define MCLK_APBBMASK_NVMCTRL       (0x1ul << MCLK_APBBMASK_NVMCTRL_Pos)
+#define MCLK_APBBMASK_MASK          0x00000007ul /**< \brief (MCLK_APBBMASK) MASK Register */
+
+/* -------- MCLK_APBCMASK : (MCLK Offset: 0x1C) (R/W 32) APBC Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SERCOM0_:1;       /*!< bit:      0  SERCOM0 APB Clock Enable           */
+    uint32_t SERCOM1_:1;       /*!< bit:      1  SERCOM1 APB Clock Enable           */
+    uint32_t SERCOM2_:1;       /*!< bit:      2  SERCOM2 APB Clock Enable           */
+    uint32_t SERCOM3_:1;       /*!< bit:      3  SERCOM3 APB Clock Enable           */
+    uint32_t SERCOM4_:1;       /*!< bit:      4  SERCOM4 APB Clock Enable           */
+    uint32_t TCC0_:1;          /*!< bit:      5  TCC0 APB Clock Enable              */
+    uint32_t TCC1_:1;          /*!< bit:      6  TCC1 APB Clock Enable              */
+    uint32_t TCC2_:1;          /*!< bit:      7  TCC2 APB Clock Enable              */
+    uint32_t TC0_:1;           /*!< bit:      8  TC0 APB Clock Enable               */
+    uint32_t TC1_:1;           /*!< bit:      9  TC1 APB Clock Enable               */
+    uint32_t TC2_:1;           /*!< bit:     10  TC2 APB Clock Enable               */
+    uint32_t TC3_:1;           /*!< bit:     11  TC3 APB Clock Enable               */
+    uint32_t DAC_:1;           /*!< bit:     12  DAC APB Clock Enable               */
+    uint32_t AES_:1;           /*!< bit:     13  AES APB Clock Enable               */
+    uint32_t TRNG_:1;          /*!< bit:     14  TRNG APB Clock Enable              */
+    uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} MCLK_APBCMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBCMASK_OFFSET        0x1C         /**< \brief (MCLK_APBCMASK offset) APBC Mask */
+#define MCLK_APBCMASK_RESETVALUE    0x00007FFFul /**< \brief (MCLK_APBCMASK reset_value) APBC Mask */
+
+#define MCLK_APBCMASK_SERCOM0_Pos   0            /**< \brief (MCLK_APBCMASK) SERCOM0 APB Clock Enable */
+#define MCLK_APBCMASK_SERCOM0       (0x1ul << MCLK_APBCMASK_SERCOM0_Pos)
+#define MCLK_APBCMASK_SERCOM1_Pos   1            /**< \brief (MCLK_APBCMASK) SERCOM1 APB Clock Enable */
+#define MCLK_APBCMASK_SERCOM1       (0x1ul << MCLK_APBCMASK_SERCOM1_Pos)
+#define MCLK_APBCMASK_SERCOM2_Pos   2            /**< \brief (MCLK_APBCMASK) SERCOM2 APB Clock Enable */
+#define MCLK_APBCMASK_SERCOM2       (0x1ul << MCLK_APBCMASK_SERCOM2_Pos)
+#define MCLK_APBCMASK_SERCOM3_Pos   3            /**< \brief (MCLK_APBCMASK) SERCOM3 APB Clock Enable */
+#define MCLK_APBCMASK_SERCOM3       (0x1ul << MCLK_APBCMASK_SERCOM3_Pos)
+#define MCLK_APBCMASK_SERCOM4_Pos   4            /**< \brief (MCLK_APBCMASK) SERCOM4 APB Clock Enable */
+#define MCLK_APBCMASK_SERCOM4       (0x1ul << MCLK_APBCMASK_SERCOM4_Pos)
+#define MCLK_APBCMASK_TCC0_Pos      5            /**< \brief (MCLK_APBCMASK) TCC0 APB Clock Enable */
+#define MCLK_APBCMASK_TCC0          (0x1ul << MCLK_APBCMASK_TCC0_Pos)
+#define MCLK_APBCMASK_TCC1_Pos      6            /**< \brief (MCLK_APBCMASK) TCC1 APB Clock Enable */
+#define MCLK_APBCMASK_TCC1          (0x1ul << MCLK_APBCMASK_TCC1_Pos)
+#define MCLK_APBCMASK_TCC2_Pos      7            /**< \brief (MCLK_APBCMASK) TCC2 APB Clock Enable */
+#define MCLK_APBCMASK_TCC2          (0x1ul << MCLK_APBCMASK_TCC2_Pos)
+#define MCLK_APBCMASK_TC0_Pos       8            /**< \brief (MCLK_APBCMASK) TC0 APB Clock Enable */
+#define MCLK_APBCMASK_TC0           (0x1ul << MCLK_APBCMASK_TC0_Pos)
+#define MCLK_APBCMASK_TC1_Pos       9            /**< \brief (MCLK_APBCMASK) TC1 APB Clock Enable */
+#define MCLK_APBCMASK_TC1           (0x1ul << MCLK_APBCMASK_TC1_Pos)
+#define MCLK_APBCMASK_TC2_Pos       10           /**< \brief (MCLK_APBCMASK) TC2 APB Clock Enable */
+#define MCLK_APBCMASK_TC2           (0x1ul << MCLK_APBCMASK_TC2_Pos)
+#define MCLK_APBCMASK_TC3_Pos       11           /**< \brief (MCLK_APBCMASK) TC3 APB Clock Enable */
+#define MCLK_APBCMASK_TC3           (0x1ul << MCLK_APBCMASK_TC3_Pos)
+#define MCLK_APBCMASK_DAC_Pos       12           /**< \brief (MCLK_APBCMASK) DAC APB Clock Enable */
+#define MCLK_APBCMASK_DAC           (0x1ul << MCLK_APBCMASK_DAC_Pos)
+#define MCLK_APBCMASK_AES_Pos       13           /**< \brief (MCLK_APBCMASK) AES APB Clock Enable */
+#define MCLK_APBCMASK_AES           (0x1ul << MCLK_APBCMASK_AES_Pos)
+#define MCLK_APBCMASK_TRNG_Pos      14           /**< \brief (MCLK_APBCMASK) TRNG APB Clock Enable */
+#define MCLK_APBCMASK_TRNG          (0x1ul << MCLK_APBCMASK_TRNG_Pos)
+#define MCLK_APBCMASK_MASK          0x00007FFFul /**< \brief (MCLK_APBCMASK) MASK Register */
+
+/* -------- MCLK_APBDMASK : (MCLK Offset: 0x20) (R/W 32) APBD Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EVSYS_:1;         /*!< bit:      0  EVSYS APB Clock Enable             */
+    uint32_t SERCOM5_:1;       /*!< bit:      1  SERCOM5 APB Clock Enable           */
+    uint32_t TC4_:1;           /*!< bit:      2  TC4 APB Clock Enable               */
+    uint32_t ADC_:1;           /*!< bit:      3  ADC APB Clock Enable               */
+    uint32_t AC_:1;            /*!< bit:      4  AC APB Clock Enable                */
+    uint32_t PTC_:1;           /*!< bit:      5  PTC APB Clock Enable               */
+    uint32_t OPAMP_:1;         /*!< bit:      6  OPAMP APB Clock Enable             */
+    uint32_t CCL_:1;           /*!< bit:      7  CCL APB Clock Enable               */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} MCLK_APBDMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBDMASK_OFFSET        0x20         /**< \brief (MCLK_APBDMASK offset) APBD Mask */
+#define MCLK_APBDMASK_RESETVALUE    0x000000FFul /**< \brief (MCLK_APBDMASK reset_value) APBD Mask */
+
+#define MCLK_APBDMASK_EVSYS_Pos     0            /**< \brief (MCLK_APBDMASK) EVSYS APB Clock Enable */
+#define MCLK_APBDMASK_EVSYS         (0x1ul << MCLK_APBDMASK_EVSYS_Pos)
+#define MCLK_APBDMASK_SERCOM5_Pos   1            /**< \brief (MCLK_APBDMASK) SERCOM5 APB Clock Enable */
+#define MCLK_APBDMASK_SERCOM5       (0x1ul << MCLK_APBDMASK_SERCOM5_Pos)
+#define MCLK_APBDMASK_TC4_Pos       2            /**< \brief (MCLK_APBDMASK) TC4 APB Clock Enable */
+#define MCLK_APBDMASK_TC4           (0x1ul << MCLK_APBDMASK_TC4_Pos)
+#define MCLK_APBDMASK_ADC_Pos       3            /**< \brief (MCLK_APBDMASK) ADC APB Clock Enable */
+#define MCLK_APBDMASK_ADC           (0x1ul << MCLK_APBDMASK_ADC_Pos)
+#define MCLK_APBDMASK_AC_Pos        4            /**< \brief (MCLK_APBDMASK) AC APB Clock Enable */
+#define MCLK_APBDMASK_AC            (0x1ul << MCLK_APBDMASK_AC_Pos)
+#define MCLK_APBDMASK_PTC_Pos       5            /**< \brief (MCLK_APBDMASK) PTC APB Clock Enable */
+#define MCLK_APBDMASK_PTC           (0x1ul << MCLK_APBDMASK_PTC_Pos)
+#define MCLK_APBDMASK_OPAMP_Pos     6            /**< \brief (MCLK_APBDMASK) OPAMP APB Clock Enable */
+#define MCLK_APBDMASK_OPAMP         (0x1ul << MCLK_APBDMASK_OPAMP_Pos)
+#define MCLK_APBDMASK_CCL_Pos       7            /**< \brief (MCLK_APBDMASK) CCL APB Clock Enable */
+#define MCLK_APBDMASK_CCL           (0x1ul << MCLK_APBDMASK_CCL_Pos)
+#define MCLK_APBDMASK_MASK          0x000000FFul /**< \brief (MCLK_APBDMASK) MASK Register */
+
+/* -------- MCLK_APBEMASK : (MCLK Offset: 0x24) (R/W 32) APBE Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PAC_:1;           /*!< bit:      0  PAC APB Clock Enable               */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} MCLK_APBEMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCLK_APBEMASK_OFFSET        0x24         /**< \brief (MCLK_APBEMASK offset) APBE Mask */
+#define MCLK_APBEMASK_RESETVALUE    0x00000009ul /**< \brief (MCLK_APBEMASK reset_value) APBE Mask */
+
+#define MCLK_APBEMASK_PAC_Pos       0            /**< \brief (MCLK_APBEMASK) PAC APB Clock Enable */
+#define MCLK_APBEMASK_PAC           (0x1ul << MCLK_APBEMASK_PAC_Pos)
+#define MCLK_APBEMASK_MASK          0x00000001ul /**< \brief (MCLK_APBEMASK) MASK Register */
+
+/** \brief MCLK hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO MCLK_CTRLA_Type           CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+  __IO MCLK_INTENCLR_Type        INTENCLR;    /**< \brief Offset: 0x01 (R/W  8) Interrupt Enable Clear */
+  __IO MCLK_INTENSET_Type        INTENSET;    /**< \brief Offset: 0x02 (R/W  8) Interrupt Enable Set */
+  __IO MCLK_INTFLAG_Type         INTFLAG;     /**< \brief Offset: 0x03 (R/W  8) Interrupt Flag Status and Clear */
+  __IO MCLK_CPUDIV_Type          CPUDIV;      /**< \brief Offset: 0x04 (R/W  8) CPU Clock Division */
+  __IO MCLK_LPDIV_Type           LPDIV;       /**< \brief Offset: 0x05 (R/W  8) Low-Power Clock Division */
+  __IO MCLK_BUPDIV_Type          BUPDIV;      /**< \brief Offset: 0x06 (R/W  8) Backup Clock Division */
+       RoReg8                    Reserved1[0x9];
+  __IO MCLK_AHBMASK_Type         AHBMASK;     /**< \brief Offset: 0x10 (R/W 32) AHB Mask */
+  __IO MCLK_APBAMASK_Type        APBAMASK;    /**< \brief Offset: 0x14 (R/W 32) APBA Mask */
+  __IO MCLK_APBBMASK_Type        APBBMASK;    /**< \brief Offset: 0x18 (R/W 32) APBB Mask */
+  __IO MCLK_APBCMASK_Type        APBCMASK;    /**< \brief Offset: 0x1C (R/W 32) APBC Mask */
+  __IO MCLK_APBDMASK_Type        APBDMASK;    /**< \brief Offset: 0x20 (R/W 32) APBD Mask */
+  __IO MCLK_APBEMASK_Type        APBEMASK;    /**< \brief Offset: 0x24 (R/W 32) APBE Mask */
+} Mclk;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_MCLK_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/mtb.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/mtb.h
@@ -1,0 +1,396 @@
+/**
+ * \file
+ *
+ * \brief Component description for MTB
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_MTB_COMPONENT_
+#define _SAML21_MTB_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR MTB */
+/* ========================================================================== */
+/** \addtogroup SAML21_MTB Cortex-M0+ Micro-Trace Buffer */
+/*@{*/
+
+#define MTB_U2002
+#define REV_MTB                     0x100
+
+/* -------- MTB_POSITION : (MTB Offset: 0x000) (R/W 32) MTB Position -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t WRAP:1;           /*!< bit:      2  Pointer Value Wraps                */
+    uint32_t POINTER:29;       /*!< bit:  3..31  Trace Packet Location Pointer      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_POSITION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_POSITION_OFFSET         0x000        /**< \brief (MTB_POSITION offset) MTB Position */
+
+#define MTB_POSITION_WRAP_Pos       2            /**< \brief (MTB_POSITION) Pointer Value Wraps */
+#define MTB_POSITION_WRAP           (0x1ul << MTB_POSITION_WRAP_Pos)
+#define MTB_POSITION_POINTER_Pos    3            /**< \brief (MTB_POSITION) Trace Packet Location Pointer */
+#define MTB_POSITION_POINTER_Msk    (0x1FFFFFFFul << MTB_POSITION_POINTER_Pos)
+#define MTB_POSITION_POINTER(value) (MTB_POSITION_POINTER_Msk & ((value) << MTB_POSITION_POINTER_Pos))
+#define MTB_POSITION_MASK           0xFFFFFFFCul /**< \brief (MTB_POSITION) MASK Register */
+
+/* -------- MTB_MASTER : (MTB Offset: 0x004) (R/W 32) MTB Master -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MASK:5;           /*!< bit:  0.. 4  Maximum Value of the Trace Buffer in SRAM */
+    uint32_t TSTARTEN:1;       /*!< bit:      5  Trace Start Input Enable           */
+    uint32_t TSTOPEN:1;        /*!< bit:      6  Trace Stop Input Enable            */
+    uint32_t SFRWPRIV:1;       /*!< bit:      7  Special Function Register Write Privilege */
+    uint32_t RAMPRIV:1;        /*!< bit:      8  SRAM Privilege                     */
+    uint32_t HALTREQ:1;        /*!< bit:      9  Halt Request                       */
+    uint32_t :21;              /*!< bit: 10..30  Reserved                           */
+    uint32_t EN:1;             /*!< bit:     31  Main Trace Enable                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_MASTER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_MASTER_OFFSET           0x004        /**< \brief (MTB_MASTER offset) MTB Master */
+#define MTB_MASTER_RESETVALUE       0x00000000ul /**< \brief (MTB_MASTER reset_value) MTB Master */
+
+#define MTB_MASTER_MASK_Pos         0            /**< \brief (MTB_MASTER) Maximum Value of the Trace Buffer in SRAM */
+#define MTB_MASTER_MASK_Msk         (0x1Ful << MTB_MASTER_MASK_Pos)
+#define MTB_MASTER_MASK(value)      (MTB_MASTER_MASK_Msk & ((value) << MTB_MASTER_MASK_Pos))
+#define MTB_MASTER_TSTARTEN_Pos     5            /**< \brief (MTB_MASTER) Trace Start Input Enable */
+#define MTB_MASTER_TSTARTEN         (0x1ul << MTB_MASTER_TSTARTEN_Pos)
+#define MTB_MASTER_TSTOPEN_Pos      6            /**< \brief (MTB_MASTER) Trace Stop Input Enable */
+#define MTB_MASTER_TSTOPEN          (0x1ul << MTB_MASTER_TSTOPEN_Pos)
+#define MTB_MASTER_SFRWPRIV_Pos     7            /**< \brief (MTB_MASTER) Special Function Register Write Privilege */
+#define MTB_MASTER_SFRWPRIV         (0x1ul << MTB_MASTER_SFRWPRIV_Pos)
+#define MTB_MASTER_RAMPRIV_Pos      8            /**< \brief (MTB_MASTER) SRAM Privilege */
+#define MTB_MASTER_RAMPRIV          (0x1ul << MTB_MASTER_RAMPRIV_Pos)
+#define MTB_MASTER_HALTREQ_Pos      9            /**< \brief (MTB_MASTER) Halt Request */
+#define MTB_MASTER_HALTREQ          (0x1ul << MTB_MASTER_HALTREQ_Pos)
+#define MTB_MASTER_EN_Pos           31           /**< \brief (MTB_MASTER) Main Trace Enable */
+#define MTB_MASTER_EN               (0x1ul << MTB_MASTER_EN_Pos)
+#define MTB_MASTER_MASK_            0x800003FFul /**< \brief (MTB_MASTER) MASK Register */
+
+/* -------- MTB_FLOW : (MTB Offset: 0x008) (R/W 32) MTB Flow -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t AUTOSTOP:1;       /*!< bit:      0  Auto Stop Tracing                  */
+    uint32_t AUTOHALT:1;       /*!< bit:      1  Auto Halt Request                  */
+    uint32_t :1;               /*!< bit:      2  Reserved                           */
+    uint32_t WATERMARK:29;     /*!< bit:  3..31  Watermark value                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_FLOW_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_FLOW_OFFSET             0x008        /**< \brief (MTB_FLOW offset) MTB Flow */
+#define MTB_FLOW_RESETVALUE         0x00000000ul /**< \brief (MTB_FLOW reset_value) MTB Flow */
+
+#define MTB_FLOW_AUTOSTOP_Pos       0            /**< \brief (MTB_FLOW) Auto Stop Tracing */
+#define MTB_FLOW_AUTOSTOP           (0x1ul << MTB_FLOW_AUTOSTOP_Pos)
+#define MTB_FLOW_AUTOHALT_Pos       1            /**< \brief (MTB_FLOW) Auto Halt Request */
+#define MTB_FLOW_AUTOHALT           (0x1ul << MTB_FLOW_AUTOHALT_Pos)
+#define MTB_FLOW_WATERMARK_Pos      3            /**< \brief (MTB_FLOW) Watermark value */
+#define MTB_FLOW_WATERMARK_Msk      (0x1FFFFFFFul << MTB_FLOW_WATERMARK_Pos)
+#define MTB_FLOW_WATERMARK(value)   (MTB_FLOW_WATERMARK_Msk & ((value) << MTB_FLOW_WATERMARK_Pos))
+#define MTB_FLOW_MASK               0xFFFFFFFBul /**< \brief (MTB_FLOW) MASK Register */
+
+/* -------- MTB_BASE : (MTB Offset: 0x00C) (R/  32) MTB Base -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_BASE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_BASE_OFFSET             0x00C        /**< \brief (MTB_BASE offset) MTB Base */
+#define MTB_BASE_MASK               0xFFFFFFFFul /**< \brief (MTB_BASE) MASK Register */
+
+/* -------- MTB_ITCTRL : (MTB Offset: 0xF00) (R/W 32) MTB Integration Mode Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_ITCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_ITCTRL_OFFSET           0xF00        /**< \brief (MTB_ITCTRL offset) MTB Integration Mode Control */
+#define MTB_ITCTRL_MASK             0xFFFFFFFFul /**< \brief (MTB_ITCTRL) MASK Register */
+
+/* -------- MTB_CLAIMSET : (MTB Offset: 0xFA0) (R/W 32) MTB Claim Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_CLAIMSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_CLAIMSET_OFFSET         0xFA0        /**< \brief (MTB_CLAIMSET offset) MTB Claim Set */
+#define MTB_CLAIMSET_MASK           0xFFFFFFFFul /**< \brief (MTB_CLAIMSET) MASK Register */
+
+/* -------- MTB_CLAIMCLR : (MTB Offset: 0xFA4) (R/W 32) MTB Claim Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_CLAIMCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_CLAIMCLR_OFFSET         0xFA4        /**< \brief (MTB_CLAIMCLR offset) MTB Claim Clear */
+#define MTB_CLAIMCLR_MASK           0xFFFFFFFFul /**< \brief (MTB_CLAIMCLR) MASK Register */
+
+/* -------- MTB_LOCKACCESS : (MTB Offset: 0xFB0) (R/W 32) MTB Lock Access -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_LOCKACCESS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_LOCKACCESS_OFFSET       0xFB0        /**< \brief (MTB_LOCKACCESS offset) MTB Lock Access */
+#define MTB_LOCKACCESS_MASK         0xFFFFFFFFul /**< \brief (MTB_LOCKACCESS) MASK Register */
+
+/* -------- MTB_LOCKSTATUS : (MTB Offset: 0xFB4) (R/  32) MTB Lock Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_LOCKSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_LOCKSTATUS_OFFSET       0xFB4        /**< \brief (MTB_LOCKSTATUS offset) MTB Lock Status */
+#define MTB_LOCKSTATUS_MASK         0xFFFFFFFFul /**< \brief (MTB_LOCKSTATUS) MASK Register */
+
+/* -------- MTB_AUTHSTATUS : (MTB Offset: 0xFB8) (R/  32) MTB Authentication Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_AUTHSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_AUTHSTATUS_OFFSET       0xFB8        /**< \brief (MTB_AUTHSTATUS offset) MTB Authentication Status */
+#define MTB_AUTHSTATUS_MASK         0xFFFFFFFFul /**< \brief (MTB_AUTHSTATUS) MASK Register */
+
+/* -------- MTB_DEVARCH : (MTB Offset: 0xFBC) (R/  32) MTB Device Architecture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_DEVARCH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_DEVARCH_OFFSET          0xFBC        /**< \brief (MTB_DEVARCH offset) MTB Device Architecture */
+#define MTB_DEVARCH_MASK            0xFFFFFFFFul /**< \brief (MTB_DEVARCH) MASK Register */
+
+/* -------- MTB_DEVID : (MTB Offset: 0xFC8) (R/  32) MTB Device Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_DEVID_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_DEVID_OFFSET            0xFC8        /**< \brief (MTB_DEVID offset) MTB Device Configuration */
+#define MTB_DEVID_MASK              0xFFFFFFFFul /**< \brief (MTB_DEVID) MASK Register */
+
+/* -------- MTB_DEVTYPE : (MTB Offset: 0xFCC) (R/  32) MTB Device Type -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_DEVTYPE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_DEVTYPE_OFFSET          0xFCC        /**< \brief (MTB_DEVTYPE offset) MTB Device Type */
+#define MTB_DEVTYPE_MASK            0xFFFFFFFFul /**< \brief (MTB_DEVTYPE) MASK Register */
+
+/* -------- MTB_PID4 : (MTB Offset: 0xFD0) (R/  32) Peripheral Identification 4 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_PID4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_PID4_OFFSET             0xFD0        /**< \brief (MTB_PID4 offset) Peripheral Identification 4 */
+#define MTB_PID4_MASK               0xFFFFFFFFul /**< \brief (MTB_PID4) MASK Register */
+
+/* -------- MTB_PID5 : (MTB Offset: 0xFD4) (R/  32) Peripheral Identification 5 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_PID5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_PID5_OFFSET             0xFD4        /**< \brief (MTB_PID5 offset) Peripheral Identification 5 */
+#define MTB_PID5_MASK               0xFFFFFFFFul /**< \brief (MTB_PID5) MASK Register */
+
+/* -------- MTB_PID6 : (MTB Offset: 0xFD8) (R/  32) Peripheral Identification 6 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_PID6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_PID6_OFFSET             0xFD8        /**< \brief (MTB_PID6 offset) Peripheral Identification 6 */
+#define MTB_PID6_MASK               0xFFFFFFFFul /**< \brief (MTB_PID6) MASK Register */
+
+/* -------- MTB_PID7 : (MTB Offset: 0xFDC) (R/  32) Peripheral Identification 7 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_PID7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_PID7_OFFSET             0xFDC        /**< \brief (MTB_PID7 offset) Peripheral Identification 7 */
+#define MTB_PID7_MASK               0xFFFFFFFFul /**< \brief (MTB_PID7) MASK Register */
+
+/* -------- MTB_PID0 : (MTB Offset: 0xFE0) (R/  32) Peripheral Identification 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_PID0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_PID0_OFFSET             0xFE0        /**< \brief (MTB_PID0 offset) Peripheral Identification 0 */
+#define MTB_PID0_MASK               0xFFFFFFFFul /**< \brief (MTB_PID0) MASK Register */
+
+/* -------- MTB_PID1 : (MTB Offset: 0xFE4) (R/  32) Peripheral Identification 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_PID1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_PID1_OFFSET             0xFE4        /**< \brief (MTB_PID1 offset) Peripheral Identification 1 */
+#define MTB_PID1_MASK               0xFFFFFFFFul /**< \brief (MTB_PID1) MASK Register */
+
+/* -------- MTB_PID2 : (MTB Offset: 0xFE8) (R/  32) Peripheral Identification 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_PID2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_PID2_OFFSET             0xFE8        /**< \brief (MTB_PID2 offset) Peripheral Identification 2 */
+#define MTB_PID2_MASK               0xFFFFFFFFul /**< \brief (MTB_PID2) MASK Register */
+
+/* -------- MTB_PID3 : (MTB Offset: 0xFEC) (R/  32) Peripheral Identification 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_PID3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_PID3_OFFSET             0xFEC        /**< \brief (MTB_PID3 offset) Peripheral Identification 3 */
+#define MTB_PID3_MASK               0xFFFFFFFFul /**< \brief (MTB_PID3) MASK Register */
+
+/* -------- MTB_CID0 : (MTB Offset: 0xFF0) (R/  32) Component Identification 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_CID0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_CID0_OFFSET             0xFF0        /**< \brief (MTB_CID0 offset) Component Identification 0 */
+#define MTB_CID0_MASK               0xFFFFFFFFul /**< \brief (MTB_CID0) MASK Register */
+
+/* -------- MTB_CID1 : (MTB Offset: 0xFF4) (R/  32) Component Identification 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_CID1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_CID1_OFFSET             0xFF4        /**< \brief (MTB_CID1 offset) Component Identification 1 */
+#define MTB_CID1_MASK               0xFFFFFFFFul /**< \brief (MTB_CID1) MASK Register */
+
+/* -------- MTB_CID2 : (MTB Offset: 0xFF8) (R/  32) Component Identification 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_CID2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_CID2_OFFSET             0xFF8        /**< \brief (MTB_CID2 offset) Component Identification 2 */
+#define MTB_CID2_MASK               0xFFFFFFFFul /**< \brief (MTB_CID2) MASK Register */
+
+/* -------- MTB_CID3 : (MTB Offset: 0xFFC) (R/  32) Component Identification 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} MTB_CID3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MTB_CID3_OFFSET             0xFFC        /**< \brief (MTB_CID3 offset) Component Identification 3 */
+#define MTB_CID3_MASK               0xFFFFFFFFul /**< \brief (MTB_CID3) MASK Register */
+
+/** \brief MTB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO MTB_POSITION_Type         POSITION;    /**< \brief Offset: 0x000 (R/W 32) MTB Position */
+  __IO MTB_MASTER_Type           MASTER;      /**< \brief Offset: 0x004 (R/W 32) MTB Master */
+  __IO MTB_FLOW_Type             FLOW;        /**< \brief Offset: 0x008 (R/W 32) MTB Flow */
+  __I  MTB_BASE_Type             BASE;        /**< \brief Offset: 0x00C (R/  32) MTB Base */
+       RoReg8                    Reserved1[0xEF0];
+  __IO MTB_ITCTRL_Type           ITCTRL;      /**< \brief Offset: 0xF00 (R/W 32) MTB Integration Mode Control */
+       RoReg8                    Reserved2[0x9C];
+  __IO MTB_CLAIMSET_Type         CLAIMSET;    /**< \brief Offset: 0xFA0 (R/W 32) MTB Claim Set */
+  __IO MTB_CLAIMCLR_Type         CLAIMCLR;    /**< \brief Offset: 0xFA4 (R/W 32) MTB Claim Clear */
+       RoReg8                    Reserved3[0x8];
+  __IO MTB_LOCKACCESS_Type       LOCKACCESS;  /**< \brief Offset: 0xFB0 (R/W 32) MTB Lock Access */
+  __I  MTB_LOCKSTATUS_Type       LOCKSTATUS;  /**< \brief Offset: 0xFB4 (R/  32) MTB Lock Status */
+  __I  MTB_AUTHSTATUS_Type       AUTHSTATUS;  /**< \brief Offset: 0xFB8 (R/  32) MTB Authentication Status */
+  __I  MTB_DEVARCH_Type          DEVARCH;     /**< \brief Offset: 0xFBC (R/  32) MTB Device Architecture */
+       RoReg8                    Reserved4[0x8];
+  __I  MTB_DEVID_Type            DEVID;       /**< \brief Offset: 0xFC8 (R/  32) MTB Device Configuration */
+  __I  MTB_DEVTYPE_Type          DEVTYPE;     /**< \brief Offset: 0xFCC (R/  32) MTB Device Type */
+  __I  MTB_PID4_Type             PID4;        /**< \brief Offset: 0xFD0 (R/  32) Peripheral Identification 4 */
+  __I  MTB_PID5_Type             PID5;        /**< \brief Offset: 0xFD4 (R/  32) Peripheral Identification 5 */
+  __I  MTB_PID6_Type             PID6;        /**< \brief Offset: 0xFD8 (R/  32) Peripheral Identification 6 */
+  __I  MTB_PID7_Type             PID7;        /**< \brief Offset: 0xFDC (R/  32) Peripheral Identification 7 */
+  __I  MTB_PID0_Type             PID0;        /**< \brief Offset: 0xFE0 (R/  32) Peripheral Identification 0 */
+  __I  MTB_PID1_Type             PID1;        /**< \brief Offset: 0xFE4 (R/  32) Peripheral Identification 1 */
+  __I  MTB_PID2_Type             PID2;        /**< \brief Offset: 0xFE8 (R/  32) Peripheral Identification 2 */
+  __I  MTB_PID3_Type             PID3;        /**< \brief Offset: 0xFEC (R/  32) Peripheral Identification 3 */
+  __I  MTB_CID0_Type             CID0;        /**< \brief Offset: 0xFF0 (R/  32) Component Identification 0 */
+  __I  MTB_CID1_Type             CID1;        /**< \brief Offset: 0xFF4 (R/  32) Component Identification 1 */
+  __I  MTB_CID2_Type             CID2;        /**< \brief Offset: 0xFF8 (R/  32) Component Identification 2 */
+  __I  MTB_CID3_Type             CID3;        /**< \brief Offset: 0xFFC (R/  32) Component Identification 3 */
+} Mtb;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_MTB_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/nvmctrl_301.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/nvmctrl_301.h
@@ -1,0 +1,584 @@
+/**
+ * \file
+ *
+ * \brief Component description for NVMCTRL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_NVMCTRL_COMPONENT_
+#define _SAML21_NVMCTRL_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR NVMCTRL */
+/* ========================================================================== */
+/** \addtogroup SAML21_NVMCTRL Non-Volatile Memory Controller */
+/*@{*/
+
+#define NVMCTRL_U2207
+#define REV_NVMCTRL                 0x301
+
+/* -------- NVMCTRL_CTRLA : (NVMCTRL Offset: 0x00) (R/W 16) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t CMD:7;            /*!< bit:  0.. 6  Command                            */
+    uint16_t :1;               /*!< bit:      7  Reserved                           */
+    uint16_t CMDEX:8;          /*!< bit:  8..15  Command Execution                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLA_OFFSET        0x00         /**< \brief (NVMCTRL_CTRLA offset) Control A */
+#define NVMCTRL_CTRLA_RESETVALUE    0x0000ul     /**< \brief (NVMCTRL_CTRLA reset_value) Control A */
+
+#define NVMCTRL_CTRLA_CMD_Pos       0            /**< \brief (NVMCTRL_CTRLA) Command */
+#define NVMCTRL_CTRLA_CMD_Msk       (0x7Ful << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD(value)    (NVMCTRL_CTRLA_CMD_Msk & ((value) << NVMCTRL_CTRLA_CMD_Pos))
+#define   NVMCTRL_CTRLA_CMD_ER_Val        0x2ul  /**< \brief (NVMCTRL_CTRLA) Erase Row - Erases the row addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_WP_Val        0x4ul  /**< \brief (NVMCTRL_CTRLA) Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_EAR_Val       0x5ul  /**< \brief (NVMCTRL_CTRLA) Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
+#define   NVMCTRL_CTRLA_CMD_WAP_Val       0x6ul  /**< \brief (NVMCTRL_CTRLA) Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
+#define   NVMCTRL_CTRLA_CMD_SF_Val        0xAul  /**< \brief (NVMCTRL_CTRLA) Security Flow Command */
+#define   NVMCTRL_CTRLA_CMD_WL_Val        0xFul  /**< \brief (NVMCTRL_CTRLA) Write lockbits */
+#define   NVMCTRL_CTRLA_CMD_RWWEEER_Val   0x1Aul  /**< \brief (NVMCTRL_CTRLA) RWW EEPROM area Erase Row - Erases the row addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_RWWEEWP_Val   0x1Cul  /**< \brief (NVMCTRL_CTRLA) RWW EEPROM Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_LR_Val        0x40ul  /**< \brief (NVMCTRL_CTRLA) Lock Region - Locks the region containing the address location in the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_UR_Val        0x41ul  /**< \brief (NVMCTRL_CTRLA) Unlock Region - Unlocks the region containing the address location in the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_SPRM_Val      0x42ul  /**< \brief (NVMCTRL_CTRLA) Sets the power reduction mode. */
+#define   NVMCTRL_CTRLA_CMD_CPRM_Val      0x43ul  /**< \brief (NVMCTRL_CTRLA) Clears the power reduction mode. */
+#define   NVMCTRL_CTRLA_CMD_PBC_Val       0x44ul  /**< \brief (NVMCTRL_CTRLA) Page Buffer Clear - Clears the page buffer. */
+#define   NVMCTRL_CTRLA_CMD_SSB_Val       0x45ul  /**< \brief (NVMCTRL_CTRLA) Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row. */
+#define   NVMCTRL_CTRLA_CMD_INVALL_Val    0x46ul  /**< \brief (NVMCTRL_CTRLA) Invalidate all cache lines. */
+#define NVMCTRL_CTRLA_CMD_ER        (NVMCTRL_CTRLA_CMD_ER_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_WP        (NVMCTRL_CTRLA_CMD_WP_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_EAR       (NVMCTRL_CTRLA_CMD_EAR_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_WAP       (NVMCTRL_CTRLA_CMD_WAP_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_SF        (NVMCTRL_CTRLA_CMD_SF_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_WL        (NVMCTRL_CTRLA_CMD_WL_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_RWWEEER   (NVMCTRL_CTRLA_CMD_RWWEEER_Val << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_RWWEEWP   (NVMCTRL_CTRLA_CMD_RWWEEWP_Val << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_LR        (NVMCTRL_CTRLA_CMD_LR_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_UR        (NVMCTRL_CTRLA_CMD_UR_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_SPRM      (NVMCTRL_CTRLA_CMD_SPRM_Val    << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_CPRM      (NVMCTRL_CTRLA_CMD_CPRM_Val    << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_PBC       (NVMCTRL_CTRLA_CMD_PBC_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_SSB       (NVMCTRL_CTRLA_CMD_SSB_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_INVALL    (NVMCTRL_CTRLA_CMD_INVALL_Val  << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMDEX_Pos     8            /**< \brief (NVMCTRL_CTRLA) Command Execution */
+#define NVMCTRL_CTRLA_CMDEX_Msk     (0xFFul << NVMCTRL_CTRLA_CMDEX_Pos)
+#define NVMCTRL_CTRLA_CMDEX(value)  (NVMCTRL_CTRLA_CMDEX_Msk & ((value) << NVMCTRL_CTRLA_CMDEX_Pos))
+#define   NVMCTRL_CTRLA_CMDEX_KEY_Val     0xA5ul  /**< \brief (NVMCTRL_CTRLA) Execution Key */
+#define NVMCTRL_CTRLA_CMDEX_KEY     (NVMCTRL_CTRLA_CMDEX_KEY_Val   << NVMCTRL_CTRLA_CMDEX_Pos)
+#define NVMCTRL_CTRLA_MASK          0xFF7Ful     /**< \brief (NVMCTRL_CTRLA) MASK Register */
+
+/* -------- NVMCTRL_CTRLB : (NVMCTRL Offset: 0x04) (R/W 32) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t RWS:4;            /*!< bit:  1.. 4  NVM Read Wait States               */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t MANW:1;           /*!< bit:      7  Manual Write                       */
+    uint32_t SLEEPPRM:2;       /*!< bit:  8.. 9  Power Reduction Mode during Sleep  */
+    uint32_t :1;               /*!< bit:     10  Reserved                           */
+    uint32_t FWUP:1;           /*!< bit:     11  fast wake-up                       */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t READMODE:2;       /*!< bit: 16..17  NVMCTRL Read Mode                  */
+    uint32_t CACHEDIS:1;       /*!< bit:     18  Cache Disable                      */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLB_OFFSET        0x04         /**< \brief (NVMCTRL_CTRLB offset) Control B */
+#define NVMCTRL_CTRLB_RESETVALUE    0x00000000ul /**< \brief (NVMCTRL_CTRLB reset_value) Control B */
+
+#define NVMCTRL_CTRLB_RWS_Pos       1            /**< \brief (NVMCTRL_CTRLB) NVM Read Wait States */
+#define NVMCTRL_CTRLB_RWS_Msk       (0xFul << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS(value)    (NVMCTRL_CTRLB_RWS_Msk & ((value) << NVMCTRL_CTRLB_RWS_Pos))
+#define   NVMCTRL_CTRLB_RWS_SINGLE_Val    0x0ul  /**< \brief (NVMCTRL_CTRLB) Single Auto Wait State */
+#define   NVMCTRL_CTRLB_RWS_HALF_Val      0x1ul  /**< \brief (NVMCTRL_CTRLB) Half Auto Wait State */
+#define   NVMCTRL_CTRLB_RWS_DUAL_Val      0x2ul  /**< \brief (NVMCTRL_CTRLB) Dual Auto Wait State */
+#define NVMCTRL_CTRLB_RWS_SINGLE    (NVMCTRL_CTRLB_RWS_SINGLE_Val  << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS_HALF      (NVMCTRL_CTRLB_RWS_HALF_Val    << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS_DUAL      (NVMCTRL_CTRLB_RWS_DUAL_Val    << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_MANW_Pos      7            /**< \brief (NVMCTRL_CTRLB) Manual Write */
+#define NVMCTRL_CTRLB_MANW          (0x1ul << NVMCTRL_CTRLB_MANW_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_Pos  8            /**< \brief (NVMCTRL_CTRLB) Power Reduction Mode during Sleep */
+#define NVMCTRL_CTRLB_SLEEPPRM_Msk  (0x3ul << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM(value) (NVMCTRL_CTRLB_SLEEPPRM_Msk & ((value) << NVMCTRL_CTRLB_SLEEPPRM_Pos))
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val 0x0ul  /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access. */
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val 0x1ul  /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep. */
+#define   NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val 0x3ul  /**< \brief (NVMCTRL_CTRLB) Auto power reduction disabled. */
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS (NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT (NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_DISABLED (NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_FWUP_Pos      11           /**< \brief (NVMCTRL_CTRLB) fast wake-up */
+#define NVMCTRL_CTRLB_FWUP          (0x1ul << NVMCTRL_CTRLB_FWUP_Pos)
+#define NVMCTRL_CTRLB_READMODE_Pos  16           /**< \brief (NVMCTRL_CTRLB) NVMCTRL Read Mode */
+#define NVMCTRL_CTRLB_READMODE_Msk  (0x3ul << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE(value) (NVMCTRL_CTRLB_READMODE_Msk & ((value) << NVMCTRL_CTRLB_READMODE_Pos))
+#define   NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val 0x0ul  /**< \brief (NVMCTRL_CTRLB) The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance. */
+#define   NVMCTRL_CTRLB_READMODE_LOW_POWER_Val 0x1ul  /**< \brief (NVMCTRL_CTRLB) Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time. */
+#define   NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val 0x2ul  /**< \brief (NVMCTRL_CTRLB) The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings. */
+#define NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY (NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE_LOW_POWER (NVMCTRL_CTRLB_READMODE_LOW_POWER_Val << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE_DETERMINISTIC (NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_CACHEDIS_Pos  18           /**< \brief (NVMCTRL_CTRLB) Cache Disable */
+#define NVMCTRL_CTRLB_CACHEDIS      (0x1ul << NVMCTRL_CTRLB_CACHEDIS_Pos)
+#define NVMCTRL_CTRLB_MASK          0x00070B9Eul /**< \brief (NVMCTRL_CTRLB) MASK Register */
+
+/* -------- NVMCTRL_PARAM : (NVMCTRL Offset: 0x08) (R/W 32) NVM Parameter -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NVMP:16;          /*!< bit:  0..15  NVM Pages                          */
+    uint32_t PSZ:3;            /*!< bit: 16..18  Page Size                          */
+    uint32_t :1;               /*!< bit:     19  Reserved                           */
+    uint32_t RWWEEP:12;        /*!< bit: 20..31  RWW EEPROM Pages                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_PARAM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_PARAM_OFFSET        0x08         /**< \brief (NVMCTRL_PARAM offset) NVM Parameter */
+#define NVMCTRL_PARAM_RESETVALUE    0x00000000ul /**< \brief (NVMCTRL_PARAM reset_value) NVM Parameter */
+
+#define NVMCTRL_PARAM_NVMP_Pos      0            /**< \brief (NVMCTRL_PARAM) NVM Pages */
+#define NVMCTRL_PARAM_NVMP_Msk      (0xFFFFul << NVMCTRL_PARAM_NVMP_Pos)
+#define NVMCTRL_PARAM_NVMP(value)   (NVMCTRL_PARAM_NVMP_Msk & ((value) << NVMCTRL_PARAM_NVMP_Pos))
+#define NVMCTRL_PARAM_PSZ_Pos       16           /**< \brief (NVMCTRL_PARAM) Page Size */
+#define NVMCTRL_PARAM_PSZ_Msk       (0x7ul << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ(value)    (NVMCTRL_PARAM_PSZ_Msk & ((value) << NVMCTRL_PARAM_PSZ_Pos))
+#define   NVMCTRL_PARAM_PSZ_8_Val         0x0ul  /**< \brief (NVMCTRL_PARAM) 8 bytes */
+#define   NVMCTRL_PARAM_PSZ_16_Val        0x1ul  /**< \brief (NVMCTRL_PARAM) 16 bytes */
+#define   NVMCTRL_PARAM_PSZ_32_Val        0x2ul  /**< \brief (NVMCTRL_PARAM) 32 bytes */
+#define   NVMCTRL_PARAM_PSZ_64_Val        0x3ul  /**< \brief (NVMCTRL_PARAM) 64 bytes */
+#define   NVMCTRL_PARAM_PSZ_128_Val       0x4ul  /**< \brief (NVMCTRL_PARAM) 128 bytes */
+#define   NVMCTRL_PARAM_PSZ_256_Val       0x5ul  /**< \brief (NVMCTRL_PARAM) 256 bytes */
+#define   NVMCTRL_PARAM_PSZ_512_Val       0x6ul  /**< \brief (NVMCTRL_PARAM) 512 bytes */
+#define   NVMCTRL_PARAM_PSZ_1024_Val      0x7ul  /**< \brief (NVMCTRL_PARAM) 1024 bytes */
+#define NVMCTRL_PARAM_PSZ_8         (NVMCTRL_PARAM_PSZ_8_Val       << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_16        (NVMCTRL_PARAM_PSZ_16_Val      << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_32        (NVMCTRL_PARAM_PSZ_32_Val      << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_64        (NVMCTRL_PARAM_PSZ_64_Val      << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_128       (NVMCTRL_PARAM_PSZ_128_Val     << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_256       (NVMCTRL_PARAM_PSZ_256_Val     << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_512       (NVMCTRL_PARAM_PSZ_512_Val     << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_1024      (NVMCTRL_PARAM_PSZ_1024_Val    << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_RWWEEP_Pos    20           /**< \brief (NVMCTRL_PARAM) RWW EEPROM Pages */
+#define NVMCTRL_PARAM_RWWEEP_Msk    (0xFFFul << NVMCTRL_PARAM_RWWEEP_Pos)
+#define NVMCTRL_PARAM_RWWEEP(value) (NVMCTRL_PARAM_RWWEEP_Msk & ((value) << NVMCTRL_PARAM_RWWEEP_Pos))
+#define NVMCTRL_PARAM_MASK          0xFFF7FFFFul /**< \brief (NVMCTRL_PARAM) MASK Register */
+
+/* -------- NVMCTRL_INTENCLR : (NVMCTRL Offset: 0x0C) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY:1;          /*!< bit:      0  NVM Ready Interrupt Enable         */
+    uint8_t  ERROR:1;          /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} NVMCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENCLR_OFFSET     0x0C         /**< \brief (NVMCTRL_INTENCLR offset) Interrupt Enable Clear */
+#define NVMCTRL_INTENCLR_RESETVALUE 0x00ul       /**< \brief (NVMCTRL_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define NVMCTRL_INTENCLR_READY_Pos  0            /**< \brief (NVMCTRL_INTENCLR) NVM Ready Interrupt Enable */
+#define NVMCTRL_INTENCLR_READY      (0x1ul << NVMCTRL_INTENCLR_READY_Pos)
+#define NVMCTRL_INTENCLR_ERROR_Pos  1            /**< \brief (NVMCTRL_INTENCLR) Error Interrupt Enable */
+#define NVMCTRL_INTENCLR_ERROR      (0x1ul << NVMCTRL_INTENCLR_ERROR_Pos)
+#define NVMCTRL_INTENCLR_MASK       0x03ul       /**< \brief (NVMCTRL_INTENCLR) MASK Register */
+
+/* -------- NVMCTRL_INTENSET : (NVMCTRL Offset: 0x10) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY:1;          /*!< bit:      0  NVM Ready Interrupt Enable         */
+    uint8_t  ERROR:1;          /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} NVMCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENSET_OFFSET     0x10         /**< \brief (NVMCTRL_INTENSET offset) Interrupt Enable Set */
+#define NVMCTRL_INTENSET_RESETVALUE 0x00ul       /**< \brief (NVMCTRL_INTENSET reset_value) Interrupt Enable Set */
+
+#define NVMCTRL_INTENSET_READY_Pos  0            /**< \brief (NVMCTRL_INTENSET) NVM Ready Interrupt Enable */
+#define NVMCTRL_INTENSET_READY      (0x1ul << NVMCTRL_INTENSET_READY_Pos)
+#define NVMCTRL_INTENSET_ERROR_Pos  1            /**< \brief (NVMCTRL_INTENSET) Error Interrupt Enable */
+#define NVMCTRL_INTENSET_ERROR      (0x1ul << NVMCTRL_INTENSET_ERROR_Pos)
+#define NVMCTRL_INTENSET_MASK       0x03ul       /**< \brief (NVMCTRL_INTENSET) MASK Register */
+
+/* -------- NVMCTRL_INTFLAG : (NVMCTRL Offset: 0x14) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
+    __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} NVMCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTFLAG_OFFSET      0x14         /**< \brief (NVMCTRL_INTFLAG offset) Interrupt Flag Status and Clear */
+#define NVMCTRL_INTFLAG_RESETVALUE  0x00ul       /**< \brief (NVMCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define NVMCTRL_INTFLAG_READY_Pos   0            /**< \brief (NVMCTRL_INTFLAG) NVM Ready */
+#define NVMCTRL_INTFLAG_READY       (0x1ul << NVMCTRL_INTFLAG_READY_Pos)
+#define NVMCTRL_INTFLAG_ERROR_Pos   1            /**< \brief (NVMCTRL_INTFLAG) Error */
+#define NVMCTRL_INTFLAG_ERROR       (0x1ul << NVMCTRL_INTFLAG_ERROR_Pos)
+#define NVMCTRL_INTFLAG_MASK        0x03ul       /**< \brief (NVMCTRL_INTFLAG) MASK Register */
+
+/* -------- NVMCTRL_STATUS : (NVMCTRL Offset: 0x18) (R/W 16) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PRM:1;            /*!< bit:      0  Power Reduction Mode               */
+    uint16_t LOAD:1;           /*!< bit:      1  NVM Page Buffer Active Loading     */
+    uint16_t PROGE:1;          /*!< bit:      2  Programming Error Status           */
+    uint16_t LOCKE:1;          /*!< bit:      3  Lock Error Status                  */
+    uint16_t NVME:1;           /*!< bit:      4  NVM Error                          */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t SB:1;             /*!< bit:      8  Security Bit Status                */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_STATUS_OFFSET       0x18         /**< \brief (NVMCTRL_STATUS offset) Status */
+#define NVMCTRL_STATUS_RESETVALUE   0x0000ul     /**< \brief (NVMCTRL_STATUS reset_value) Status */
+
+#define NVMCTRL_STATUS_PRM_Pos      0            /**< \brief (NVMCTRL_STATUS) Power Reduction Mode */
+#define NVMCTRL_STATUS_PRM          (0x1ul << NVMCTRL_STATUS_PRM_Pos)
+#define NVMCTRL_STATUS_LOAD_Pos     1            /**< \brief (NVMCTRL_STATUS) NVM Page Buffer Active Loading */
+#define NVMCTRL_STATUS_LOAD         (0x1ul << NVMCTRL_STATUS_LOAD_Pos)
+#define NVMCTRL_STATUS_PROGE_Pos    2            /**< \brief (NVMCTRL_STATUS) Programming Error Status */
+#define NVMCTRL_STATUS_PROGE        (0x1ul << NVMCTRL_STATUS_PROGE_Pos)
+#define NVMCTRL_STATUS_LOCKE_Pos    3            /**< \brief (NVMCTRL_STATUS) Lock Error Status */
+#define NVMCTRL_STATUS_LOCKE        (0x1ul << NVMCTRL_STATUS_LOCKE_Pos)
+#define NVMCTRL_STATUS_NVME_Pos     4            /**< \brief (NVMCTRL_STATUS) NVM Error */
+#define NVMCTRL_STATUS_NVME         (0x1ul << NVMCTRL_STATUS_NVME_Pos)
+#define NVMCTRL_STATUS_SB_Pos       8            /**< \brief (NVMCTRL_STATUS) Security Bit Status */
+#define NVMCTRL_STATUS_SB           (0x1ul << NVMCTRL_STATUS_SB_Pos)
+#define NVMCTRL_STATUS_MASK         0x011Ful     /**< \brief (NVMCTRL_STATUS) MASK Register */
+
+/* -------- NVMCTRL_ADDR : (NVMCTRL Offset: 0x1C) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:22;          /*!< bit:  0..21  NVM Address                        */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_ADDR_OFFSET         0x1C         /**< \brief (NVMCTRL_ADDR offset) Address */
+#define NVMCTRL_ADDR_RESETVALUE     0x00000000ul /**< \brief (NVMCTRL_ADDR reset_value) Address */
+
+#define NVMCTRL_ADDR_ADDR_Pos       0            /**< \brief (NVMCTRL_ADDR) NVM Address */
+#define NVMCTRL_ADDR_ADDR_Msk       (0x3FFFFFul << NVMCTRL_ADDR_ADDR_Pos)
+#define NVMCTRL_ADDR_ADDR(value)    (NVMCTRL_ADDR_ADDR_Msk & ((value) << NVMCTRL_ADDR_ADDR_Pos))
+#define NVMCTRL_ADDR_MASK           0x003FFFFFul /**< \brief (NVMCTRL_ADDR) MASK Register */
+
+/* -------- NVMCTRL_LOCK : (NVMCTRL Offset: 0x20) (R/W 16) Lock Section -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t LOCK:16;          /*!< bit:  0..15  Region Lock Bits                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_LOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_LOCK_OFFSET         0x20         /**< \brief (NVMCTRL_LOCK offset) Lock Section */
+#define NVMCTRL_LOCK_RESETVALUE     0x0000ul     /**< \brief (NVMCTRL_LOCK reset_value) Lock Section */
+
+#define NVMCTRL_LOCK_LOCK_Pos       0            /**< \brief (NVMCTRL_LOCK) Region Lock Bits */
+#define NVMCTRL_LOCK_LOCK_Msk       (0xFFFFul << NVMCTRL_LOCK_LOCK_Pos)
+#define NVMCTRL_LOCK_LOCK(value)    (NVMCTRL_LOCK_LOCK_Msk & ((value) << NVMCTRL_LOCK_LOCK_Pos))
+#define NVMCTRL_LOCK_MASK           0xFFFFul     /**< \brief (NVMCTRL_LOCK) MASK Register */
+
+/** \brief NVMCTRL APB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO NVMCTRL_CTRLA_Type        CTRLA;       /**< \brief Offset: 0x00 (R/W 16) Control A */
+       RoReg8                    Reserved1[0x2];
+  __IO NVMCTRL_CTRLB_Type        CTRLB;       /**< \brief Offset: 0x04 (R/W 32) Control B */
+  __IO NVMCTRL_PARAM_Type        PARAM;       /**< \brief Offset: 0x08 (R/W 32) NVM Parameter */
+  __IO NVMCTRL_INTENCLR_Type     INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) Interrupt Enable Clear */
+       RoReg8                    Reserved2[0x3];
+  __IO NVMCTRL_INTENSET_Type     INTENSET;    /**< \brief Offset: 0x10 (R/W  8) Interrupt Enable Set */
+       RoReg8                    Reserved3[0x3];
+  __IO NVMCTRL_INTFLAG_Type      INTFLAG;     /**< \brief Offset: 0x14 (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved4[0x3];
+  __IO NVMCTRL_STATUS_Type       STATUS;      /**< \brief Offset: 0x18 (R/W 16) Status */
+       RoReg8                    Reserved5[0x2];
+  __IO NVMCTRL_ADDR_Type         ADDR;        /**< \brief Offset: 0x1C (R/W 32) Address */
+  __IO NVMCTRL_LOCK_Type         LOCK;        /**< \brief Offset: 0x20 (R/W 16) Lock Section */
+} Nvmctrl;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __GNUC__
+ #define SECTION_NVMCTRL_CAL          __attribute__ ((section(".flash")))
+#elif defined(__ICCARM__)
+ #define SECTION_NVMCTRL_CAL          @".flash"
+#endif
+
+#ifdef __GNUC__
+ #define SECTION_NVMCTRL_LOCKBIT      __attribute__ ((section(".flash")))
+#elif defined(__ICCARM__)
+ #define SECTION_NVMCTRL_LOCKBIT      @".flash"
+#endif
+
+#ifdef __GNUC__
+ #define SECTION_NVMCTRL_OTP1         __attribute__ ((section(".flash")))
+#elif defined(__ICCARM__)
+ #define SECTION_NVMCTRL_OTP1         @".flash"
+#endif
+
+#ifdef __GNUC__
+ #define SECTION_NVMCTRL_OTP2         __attribute__ ((section(".flash")))
+#elif defined(__ICCARM__)
+ #define SECTION_NVMCTRL_OTP2         @".flash"
+#endif
+
+#ifdef __GNUC__
+ #define SECTION_NVMCTRL_OTP3         __attribute__ ((section(".flash")))
+#elif defined(__ICCARM__)
+ #define SECTION_NVMCTRL_OTP3         @".flash"
+#endif
+
+#ifdef __GNUC__
+ #define SECTION_NVMCTRL_OTP4         __attribute__ ((section(".flash")))
+#elif defined(__ICCARM__)
+ #define SECTION_NVMCTRL_OTP4         @".flash"
+#endif
+
+#ifdef __GNUC__
+ #define SECTION_NVMCTRL_OTP5         __attribute__ ((section(".flash")))
+#elif defined(__ICCARM__)
+ #define SECTION_NVMCTRL_OTP5         @".flash"
+#endif
+
+#ifdef __GNUC__
+ #define SECTION_NVMCTRL_TEMP_LOG     __attribute__ ((section(".flash")))
+#elif defined(__ICCARM__)
+ #define SECTION_NVMCTRL_TEMP_LOG     @".flash"
+#endif
+
+#ifdef __GNUC__
+ #define SECTION_NVMCTRL_USER         __attribute__ ((section(".flash")))
+#elif defined(__ICCARM__)
+ #define SECTION_NVMCTRL_USER         @".flash"
+#endif
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR NON-VOLATILE FUSES */
+/* ************************************************************************** */
+/** \addtogroup fuses_api Peripheral Software API */
+/*@{*/
+
+
+#define ADC_FUSES_BIASCOMP_ADDR     NVMCTRL_OTP5
+#define ADC_FUSES_BIASCOMP_Pos      3            /**< \brief (NVMCTRL_OTP5) ADC Comparator Scaling */
+#define ADC_FUSES_BIASCOMP_Msk      (0x7ul << ADC_FUSES_BIASCOMP_Pos)
+#define ADC_FUSES_BIASCOMP(value)   (ADC_FUSES_BIASCOMP_Msk & ((value) << ADC_FUSES_BIASCOMP_Pos))
+
+#define ADC_FUSES_BIASREFBUF_ADDR   NVMCTRL_OTP5
+#define ADC_FUSES_BIASREFBUF_Pos    0            /**< \brief (NVMCTRL_OTP5) ADC Bias Reference Buffer Scaling */
+#define ADC_FUSES_BIASREFBUF_Msk    (0x7ul << ADC_FUSES_BIASREFBUF_Pos)
+#define ADC_FUSES_BIASREFBUF(value) (ADC_FUSES_BIASREFBUF_Msk & ((value) << ADC_FUSES_BIASREFBUF_Pos))
+
+#define FUSES_BOD12_DIS_ADDR        NVMCTRL_USER
+#define FUSES_BOD12_DIS_Pos         23           /**< \brief (NVMCTRL_USER) BOD12 Disable */
+#define FUSES_BOD12_DIS_Msk         (0x1ul << FUSES_BOD12_DIS_Pos)
+
+#define FUSES_BOD12_HYST_ADDR       (NVMCTRL_USER + 4)
+#define FUSES_BOD12_HYST_Pos        10           /**< \brief (NVMCTRL_USER) BOD12 Hysteresis */
+#define FUSES_BOD12_HYST_Msk        (0x1ul << FUSES_BOD12_HYST_Pos)
+
+#define FUSES_BOD33USERLEVEL_ADDR   NVMCTRL_USER
+#define FUSES_BOD33USERLEVEL_Pos    8            /**< \brief (NVMCTRL_USER) BOD33 User Level */
+#define FUSES_BOD33USERLEVEL_Msk    (0x3Ful << FUSES_BOD33USERLEVEL_Pos)
+#define FUSES_BOD33USERLEVEL(value) (FUSES_BOD33USERLEVEL_Msk & ((value) << FUSES_BOD33USERLEVEL_Pos))
+
+#define FUSES_BOD33_ACTION_ADDR     NVMCTRL_USER
+#define FUSES_BOD33_ACTION_Pos      15           /**< \brief (NVMCTRL_USER) BOD33 Action */
+#define FUSES_BOD33_ACTION_Msk      (0x3ul << FUSES_BOD33_ACTION_Pos)
+#define FUSES_BOD33_ACTION(value)   (FUSES_BOD33_ACTION_Msk & ((value) << FUSES_BOD33_ACTION_Pos))
+
+#define FUSES_BOD33_DIS_ADDR        NVMCTRL_USER
+#define FUSES_BOD33_DIS_Pos         14           /**< \brief (NVMCTRL_USER) BOD33 Disable */
+#define FUSES_BOD33_DIS_Msk         (0x1ul << FUSES_BOD33_DIS_Pos)
+
+#define FUSES_BOD33_HYST_ADDR       (NVMCTRL_USER + 4)
+#define FUSES_BOD33_HYST_Pos        9            /**< \brief (NVMCTRL_USER) BOD33 Hysteresis */
+#define FUSES_BOD33_HYST_Msk        (0x1ul << FUSES_BOD33_HYST_Pos)
+
+#define FUSES_HOT_ADC_VAL_ADDR      (NVMCTRL_TEMP_LOG + 4)
+#define FUSES_HOT_ADC_VAL_Pos       20           /**< \brief (NVMCTRL_TEMP_LOG) 12-bit ADC conversion at hot temperature */
+#define FUSES_HOT_ADC_VAL_Msk       (0xFFFul << FUSES_HOT_ADC_VAL_Pos)
+#define FUSES_HOT_ADC_VAL(value)    (FUSES_HOT_ADC_VAL_Msk & ((value) << FUSES_HOT_ADC_VAL_Pos))
+
+#define FUSES_HOT_INT1V_VAL_ADDR    (NVMCTRL_TEMP_LOG + 4)
+#define FUSES_HOT_INT1V_VAL_Pos     0            /**< \brief (NVMCTRL_TEMP_LOG) 2's complement of the internal 1V reference drift at hot temperature (versus a 1.0 centered value) */
+#define FUSES_HOT_INT1V_VAL_Msk     (0xFFul << FUSES_HOT_INT1V_VAL_Pos)
+#define FUSES_HOT_INT1V_VAL(value)  (FUSES_HOT_INT1V_VAL_Msk & ((value) << FUSES_HOT_INT1V_VAL_Pos))
+
+#define FUSES_HOT_TEMP_VAL_DEC_ADDR NVMCTRL_TEMP_LOG
+#define FUSES_HOT_TEMP_VAL_DEC_Pos  20           /**< \brief (NVMCTRL_TEMP_LOG) Decimal part of hot temperature */
+#define FUSES_HOT_TEMP_VAL_DEC_Msk  (0xFul << FUSES_HOT_TEMP_VAL_DEC_Pos)
+#define FUSES_HOT_TEMP_VAL_DEC(value) (FUSES_HOT_TEMP_VAL_DEC_Msk & ((value) << FUSES_HOT_TEMP_VAL_DEC_Pos))
+
+#define FUSES_HOT_TEMP_VAL_INT_ADDR NVMCTRL_TEMP_LOG
+#define FUSES_HOT_TEMP_VAL_INT_Pos  12           /**< \brief (NVMCTRL_TEMP_LOG) Integer part of hot temperature in oC */
+#define FUSES_HOT_TEMP_VAL_INT_Msk  (0xFFul << FUSES_HOT_TEMP_VAL_INT_Pos)
+#define FUSES_HOT_TEMP_VAL_INT(value) (FUSES_HOT_TEMP_VAL_INT_Msk & ((value) << FUSES_HOT_TEMP_VAL_INT_Pos))
+
+#define FUSES_ROOM_ADC_VAL_ADDR     (NVMCTRL_TEMP_LOG + 4)
+#define FUSES_ROOM_ADC_VAL_Pos      8            /**< \brief (NVMCTRL_TEMP_LOG) 12-bit ADC conversion at room temperature */
+#define FUSES_ROOM_ADC_VAL_Msk      (0xFFFul << FUSES_ROOM_ADC_VAL_Pos)
+#define FUSES_ROOM_ADC_VAL(value)   (FUSES_ROOM_ADC_VAL_Msk & ((value) << FUSES_ROOM_ADC_VAL_Pos))
+
+#define FUSES_ROOM_INT1V_VAL_ADDR   NVMCTRL_TEMP_LOG
+#define FUSES_ROOM_INT1V_VAL_Pos    24           /**< \brief (NVMCTRL_TEMP_LOG) 2's complement of the internal 1V reference drift at room temperature (versus a 1.0 centered value) */
+#define FUSES_ROOM_INT1V_VAL_Msk    (0xFFul << FUSES_ROOM_INT1V_VAL_Pos)
+#define FUSES_ROOM_INT1V_VAL(value) (FUSES_ROOM_INT1V_VAL_Msk & ((value) << FUSES_ROOM_INT1V_VAL_Pos))
+
+#define FUSES_ROOM_TEMP_VAL_DEC_ADDR NVMCTRL_TEMP_LOG
+#define FUSES_ROOM_TEMP_VAL_DEC_Pos 8            /**< \brief (NVMCTRL_TEMP_LOG) Decimal part of room temperature */
+#define FUSES_ROOM_TEMP_VAL_DEC_Msk (0xFul << FUSES_ROOM_TEMP_VAL_DEC_Pos)
+#define FUSES_ROOM_TEMP_VAL_DEC(value) (FUSES_ROOM_TEMP_VAL_DEC_Msk & ((value) << FUSES_ROOM_TEMP_VAL_DEC_Pos))
+
+#define FUSES_ROOM_TEMP_VAL_INT_ADDR NVMCTRL_TEMP_LOG
+#define FUSES_ROOM_TEMP_VAL_INT_Pos 0            /**< \brief (NVMCTRL_TEMP_LOG) Integer part of room temperature in oC */
+#define FUSES_ROOM_TEMP_VAL_INT_Msk (0xFFul << FUSES_ROOM_TEMP_VAL_INT_Pos)
+#define FUSES_ROOM_TEMP_VAL_INT(value) (FUSES_ROOM_TEMP_VAL_INT_Msk & ((value) << FUSES_ROOM_TEMP_VAL_INT_Pos))
+
+#define NVMCTRL_FUSES_BOOTPROT_ADDR NVMCTRL_USER
+#define NVMCTRL_FUSES_BOOTPROT_Pos  0            /**< \brief (NVMCTRL_USER) Bootloader Size */
+#define NVMCTRL_FUSES_BOOTPROT_Msk  (0x7ul << NVMCTRL_FUSES_BOOTPROT_Pos)
+#define NVMCTRL_FUSES_BOOTPROT(value) (NVMCTRL_FUSES_BOOTPROT_Msk & ((value) << NVMCTRL_FUSES_BOOTPROT_Pos))
+
+#define NVMCTRL_FUSES_EEPROM_SIZE_ADDR NVMCTRL_USER
+#define NVMCTRL_FUSES_EEPROM_SIZE_Pos 4            /**< \brief (NVMCTRL_USER) EEPROM Size */
+#define NVMCTRL_FUSES_EEPROM_SIZE_Msk (0x7ul << NVMCTRL_FUSES_EEPROM_SIZE_Pos)
+#define NVMCTRL_FUSES_EEPROM_SIZE(value) (NVMCTRL_FUSES_EEPROM_SIZE_Msk & ((value) << NVMCTRL_FUSES_EEPROM_SIZE_Pos))
+
+#define NVMCTRL_FUSES_NVMP_ADDR     NVMCTRL_OTP1
+#define NVMCTRL_FUSES_NVMP_Pos      16           /**< \brief (NVMCTRL_OTP1) Number of NVM Pages */
+#define NVMCTRL_FUSES_NVMP_Msk      (0x1FFFul << NVMCTRL_FUSES_NVMP_Pos)
+#define NVMCTRL_FUSES_NVMP(value)   (NVMCTRL_FUSES_NVMP_Msk & ((value) << NVMCTRL_FUSES_NVMP_Pos))
+
+#define NVMCTRL_FUSES_NVM_LOCK_ADDR NVMCTRL_OTP1
+#define NVMCTRL_FUSES_NVM_LOCK_Pos  0            /**< \brief (NVMCTRL_OTP1) NVM Lock */
+#define NVMCTRL_FUSES_NVM_LOCK_Msk  (0xFFul << NVMCTRL_FUSES_NVM_LOCK_Pos)
+#define NVMCTRL_FUSES_NVM_LOCK(value) (NVMCTRL_FUSES_NVM_LOCK_Msk & ((value) << NVMCTRL_FUSES_NVM_LOCK_Pos))
+
+#define NVMCTRL_FUSES_PSZ_ADDR      NVMCTRL_OTP1
+#define NVMCTRL_FUSES_PSZ_Pos       8            /**< \brief (NVMCTRL_OTP1) NVM Page Size */
+#define NVMCTRL_FUSES_PSZ_Msk       (0x3ul << NVMCTRL_FUSES_PSZ_Pos)
+#define NVMCTRL_FUSES_PSZ(value)    (NVMCTRL_FUSES_PSZ_Msk & ((value) << NVMCTRL_FUSES_PSZ_Pos))
+
+#define NVMCTRL_FUSES_REGION_LOCKS_ADDR (NVMCTRL_USER + 4)
+#define NVMCTRL_FUSES_REGION_LOCKS_Pos 16           /**< \brief (NVMCTRL_USER) NVM Region Locks */
+#define NVMCTRL_FUSES_REGION_LOCKS_Msk (0xFFFFul << NVMCTRL_FUSES_REGION_LOCKS_Pos)
+#define NVMCTRL_FUSES_REGION_LOCKS(value) (NVMCTRL_FUSES_REGION_LOCKS_Msk & ((value) << NVMCTRL_FUSES_REGION_LOCKS_Pos))
+
+#define NVMCTRL_FUSES_RWWEEP_ADDR   (NVMCTRL_OTP1 + 4)
+#define NVMCTRL_FUSES_RWWEEP_Pos    0            /**< \brief (NVMCTRL_OTP1) Number of RWW EEPROM Pages */
+#define NVMCTRL_FUSES_RWWEEP_Msk    (0xFFul << NVMCTRL_FUSES_RWWEEP_Pos)
+#define NVMCTRL_FUSES_RWWEEP(value) (NVMCTRL_FUSES_RWWEEP_Msk & ((value) << NVMCTRL_FUSES_RWWEEP_Pos))
+
+#define USB_FUSES_TRANSN_ADDR       NVMCTRL_OTP5
+#define USB_FUSES_TRANSN_Pos        13           /**< \brief (NVMCTRL_OTP5) USB pad Transn calibration */
+#define USB_FUSES_TRANSN_Msk        (0x1Ful << USB_FUSES_TRANSN_Pos)
+#define USB_FUSES_TRANSN(value)     (USB_FUSES_TRANSN_Msk & ((value) << USB_FUSES_TRANSN_Pos))
+
+#define USB_FUSES_TRANSP_ADDR       NVMCTRL_OTP5
+#define USB_FUSES_TRANSP_Pos        18           /**< \brief (NVMCTRL_OTP5) USB pad Transp calibration */
+#define USB_FUSES_TRANSP_Msk        (0x1Ful << USB_FUSES_TRANSP_Pos)
+#define USB_FUSES_TRANSP(value)     (USB_FUSES_TRANSP_Msk & ((value) << USB_FUSES_TRANSP_Pos))
+
+#define USB_FUSES_TRIM_ADDR         NVMCTRL_OTP5
+#define USB_FUSES_TRIM_Pos          23           /**< \brief (NVMCTRL_OTP5) USB pad Trim calibration */
+#define USB_FUSES_TRIM_Msk          (0x7ul << USB_FUSES_TRIM_Pos)
+#define USB_FUSES_TRIM(value)       (USB_FUSES_TRIM_Msk & ((value) << USB_FUSES_TRIM_Pos))
+
+#define WDT_FUSES_ALWAYSON_ADDR     NVMCTRL_USER
+#define WDT_FUSES_ALWAYSON_Pos      27           /**< \brief (NVMCTRL_USER) WDT Always On */
+#define WDT_FUSES_ALWAYSON_Msk      (0x1ul << WDT_FUSES_ALWAYSON_Pos)
+
+#define WDT_FUSES_ENABLE_ADDR       NVMCTRL_USER
+#define WDT_FUSES_ENABLE_Pos        26           /**< \brief (NVMCTRL_USER) WDT Enable */
+#define WDT_FUSES_ENABLE_Msk        (0x1ul << WDT_FUSES_ENABLE_Pos)
+
+#define WDT_FUSES_EWOFFSET_ADDR     (NVMCTRL_USER + 4)
+#define WDT_FUSES_EWOFFSET_Pos      4            /**< \brief (NVMCTRL_USER) WDT Early Warning Offset */
+#define WDT_FUSES_EWOFFSET_Msk      (0xFul << WDT_FUSES_EWOFFSET_Pos)
+#define WDT_FUSES_EWOFFSET(value)   (WDT_FUSES_EWOFFSET_Msk & ((value) << WDT_FUSES_EWOFFSET_Pos))
+
+#define WDT_FUSES_PER_ADDR          NVMCTRL_USER
+#define WDT_FUSES_PER_Pos           28           /**< \brief (NVMCTRL_USER) WDT Period */
+#define WDT_FUSES_PER_Msk           (0xFul << WDT_FUSES_PER_Pos)
+#define WDT_FUSES_PER(value)        (WDT_FUSES_PER_Msk & ((value) << WDT_FUSES_PER_Pos))
+
+#define WDT_FUSES_WEN_ADDR          (NVMCTRL_USER + 4)
+#define WDT_FUSES_WEN_Pos           8            /**< \brief (NVMCTRL_USER) WDT Window Mode Enable */
+#define WDT_FUSES_WEN_Msk           (0x1ul << WDT_FUSES_WEN_Pos)
+
+#define WDT_FUSES_WINDOW_ADDR       (NVMCTRL_USER + 4)
+#define WDT_FUSES_WINDOW_Pos        0            /**< \brief (NVMCTRL_USER) WDT Window */
+#define WDT_FUSES_WINDOW_Msk        (0xFul << WDT_FUSES_WINDOW_Pos)
+#define WDT_FUSES_WINDOW(value)     (WDT_FUSES_WINDOW_Msk & ((value) << WDT_FUSES_WINDOW_Pos))
+
+/*@}*/
+
+#endif /* _SAML21_NVMCTRL_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/opamp.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/opamp.h
@@ -1,0 +1,176 @@
+/**
+ * \file
+ *
+ * \brief Component description for OPAMP
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_OPAMP_COMPONENT_
+#define _SAML21_OPAMP_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR OPAMP */
+/* ========================================================================== */
+/** \addtogroup SAML21_OPAMP Operational Amplifier */
+/*@{*/
+
+#define OPAMP_U2237
+#define REV_OPAMP                   0x100
+
+/* -------- OPAMP_CTRLA : (OPAMP Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  LPMUX:1;          /*!< bit:      7  Low-Power Mux                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} OPAMP_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_CTRLA_OFFSET          0x00         /**< \brief (OPAMP_CTRLA offset) Control A */
+#define OPAMP_CTRLA_RESETVALUE      0x00ul       /**< \brief (OPAMP_CTRLA reset_value) Control A */
+
+#define OPAMP_CTRLA_SWRST_Pos       0            /**< \brief (OPAMP_CTRLA) Software Reset */
+#define OPAMP_CTRLA_SWRST           (0x1ul << OPAMP_CTRLA_SWRST_Pos)
+#define OPAMP_CTRLA_ENABLE_Pos      1            /**< \brief (OPAMP_CTRLA) Enable */
+#define OPAMP_CTRLA_ENABLE          (0x1ul << OPAMP_CTRLA_ENABLE_Pos)
+#define OPAMP_CTRLA_LPMUX_Pos       7            /**< \brief (OPAMP_CTRLA) Low-Power Mux */
+#define OPAMP_CTRLA_LPMUX           (0x1ul << OPAMP_CTRLA_LPMUX_Pos)
+#define OPAMP_CTRLA_MASK            0x83ul       /**< \brief (OPAMP_CTRLA) MASK Register */
+
+/* -------- OPAMP_STATUS : (OPAMP Offset: 0x02) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY0:1;         /*!< bit:      0  OPAMP 0 Ready                      */
+    uint8_t  READY1:1;         /*!< bit:      1  OPAMP 1 Ready                      */
+    uint8_t  READY2:1;         /*!< bit:      2  OPAMP 2 Ready                      */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} OPAMP_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_STATUS_OFFSET         0x02         /**< \brief (OPAMP_STATUS offset) Status */
+#define OPAMP_STATUS_RESETVALUE     0x00ul       /**< \brief (OPAMP_STATUS reset_value) Status */
+
+#define OPAMP_STATUS_READY0_Pos     0            /**< \brief (OPAMP_STATUS) OPAMP 0 Ready */
+#define OPAMP_STATUS_READY0         (0x1ul << OPAMP_STATUS_READY0_Pos)
+#define OPAMP_STATUS_READY1_Pos     1            /**< \brief (OPAMP_STATUS) OPAMP 1 Ready */
+#define OPAMP_STATUS_READY1         (0x1ul << OPAMP_STATUS_READY1_Pos)
+#define OPAMP_STATUS_READY2_Pos     2            /**< \brief (OPAMP_STATUS) OPAMP 2 Ready */
+#define OPAMP_STATUS_READY2         (0x1ul << OPAMP_STATUS_READY2_Pos)
+#define OPAMP_STATUS_MASK           0x07ul       /**< \brief (OPAMP_STATUS) MASK Register */
+
+/* -------- OPAMP_OPAMPCTRL : (OPAMP Offset: 0x04) (R/W 32) OPAMP Control n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Operational Amplifier Enable       */
+    uint32_t ANAOUT:1;         /*!< bit:      2  Analog Output                      */
+    uint32_t BIAS:2;           /*!< bit:  3.. 4  Bias Selection                     */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint32_t ONDEMAND:1;       /*!< bit:      7  On Demand Control                  */
+    uint32_t RES2OUT:1;        /*!< bit:      8  Resistor ladder To Output          */
+    uint32_t RES2VCC:1;        /*!< bit:      9  Resistor ladder To VCC             */
+    uint32_t RES1EN:1;         /*!< bit:     10  Resistor 1 Enable                  */
+    uint32_t RES1MUX:2;        /*!< bit: 11..12  Resistor 1 Mux                     */
+    uint32_t POTMUX:3;         /*!< bit: 13..15  Potentiometer Selection            */
+    uint32_t MUXPOS:3;         /*!< bit: 16..18  Positive Input Mux Selection       */
+    uint32_t :1;               /*!< bit:     19  Reserved                           */
+    uint32_t MUXNEG:3;         /*!< bit: 20..22  Negative Input Mux Selection       */
+    uint32_t :9;               /*!< bit: 23..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OPAMP_OPAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OPAMP_OPAMPCTRL_OFFSET      0x04         /**< \brief (OPAMP_OPAMPCTRL offset) OPAMP Control n */
+#define OPAMP_OPAMPCTRL_RESETVALUE  0x00000000ul /**< \brief (OPAMP_OPAMPCTRL reset_value) OPAMP Control n */
+
+#define OPAMP_OPAMPCTRL_ENABLE_Pos  1            /**< \brief (OPAMP_OPAMPCTRL) Operational Amplifier Enable */
+#define OPAMP_OPAMPCTRL_ENABLE      (0x1ul << OPAMP_OPAMPCTRL_ENABLE_Pos)
+#define OPAMP_OPAMPCTRL_ANAOUT_Pos  2            /**< \brief (OPAMP_OPAMPCTRL) Analog Output */
+#define OPAMP_OPAMPCTRL_ANAOUT      (0x1ul << OPAMP_OPAMPCTRL_ANAOUT_Pos)
+#define OPAMP_OPAMPCTRL_BIAS_Pos    3            /**< \brief (OPAMP_OPAMPCTRL) Bias Selection */
+#define OPAMP_OPAMPCTRL_BIAS_Msk    (0x3ul << OPAMP_OPAMPCTRL_BIAS_Pos)
+#define OPAMP_OPAMPCTRL_BIAS(value) (OPAMP_OPAMPCTRL_BIAS_Msk & ((value) << OPAMP_OPAMPCTRL_BIAS_Pos))
+#define OPAMP_OPAMPCTRL_RUNSTDBY_Pos 6            /**< \brief (OPAMP_OPAMPCTRL) Run in Standby */
+#define OPAMP_OPAMPCTRL_RUNSTDBY    (0x1ul << OPAMP_OPAMPCTRL_RUNSTDBY_Pos)
+#define OPAMP_OPAMPCTRL_ONDEMAND_Pos 7            /**< \brief (OPAMP_OPAMPCTRL) On Demand Control */
+#define OPAMP_OPAMPCTRL_ONDEMAND    (0x1ul << OPAMP_OPAMPCTRL_ONDEMAND_Pos)
+#define OPAMP_OPAMPCTRL_RES2OUT_Pos 8            /**< \brief (OPAMP_OPAMPCTRL) Resistor ladder To Output */
+#define OPAMP_OPAMPCTRL_RES2OUT     (0x1ul << OPAMP_OPAMPCTRL_RES2OUT_Pos)
+#define OPAMP_OPAMPCTRL_RES2VCC_Pos 9            /**< \brief (OPAMP_OPAMPCTRL) Resistor ladder To VCC */
+#define OPAMP_OPAMPCTRL_RES2VCC     (0x1ul << OPAMP_OPAMPCTRL_RES2VCC_Pos)
+#define OPAMP_OPAMPCTRL_RES1EN_Pos  10           /**< \brief (OPAMP_OPAMPCTRL) Resistor 1 Enable */
+#define OPAMP_OPAMPCTRL_RES1EN      (0x1ul << OPAMP_OPAMPCTRL_RES1EN_Pos)
+#define OPAMP_OPAMPCTRL_RES1MUX_Pos 11           /**< \brief (OPAMP_OPAMPCTRL) Resistor 1 Mux */
+#define OPAMP_OPAMPCTRL_RES1MUX_Msk (0x3ul << OPAMP_OPAMPCTRL_RES1MUX_Pos)
+#define OPAMP_OPAMPCTRL_RES1MUX(value) (OPAMP_OPAMPCTRL_RES1MUX_Msk & ((value) << OPAMP_OPAMPCTRL_RES1MUX_Pos))
+#define OPAMP_OPAMPCTRL_POTMUX_Pos  13           /**< \brief (OPAMP_OPAMPCTRL) Potentiometer Selection */
+#define OPAMP_OPAMPCTRL_POTMUX_Msk  (0x7ul << OPAMP_OPAMPCTRL_POTMUX_Pos)
+#define OPAMP_OPAMPCTRL_POTMUX(value) (OPAMP_OPAMPCTRL_POTMUX_Msk & ((value) << OPAMP_OPAMPCTRL_POTMUX_Pos))
+#define OPAMP_OPAMPCTRL_MUXPOS_Pos  16           /**< \brief (OPAMP_OPAMPCTRL) Positive Input Mux Selection */
+#define OPAMP_OPAMPCTRL_MUXPOS_Msk  (0x7ul << OPAMP_OPAMPCTRL_MUXPOS_Pos)
+#define OPAMP_OPAMPCTRL_MUXPOS(value) (OPAMP_OPAMPCTRL_MUXPOS_Msk & ((value) << OPAMP_OPAMPCTRL_MUXPOS_Pos))
+#define OPAMP_OPAMPCTRL_MUXNEG_Pos  20           /**< \brief (OPAMP_OPAMPCTRL) Negative Input Mux Selection */
+#define OPAMP_OPAMPCTRL_MUXNEG_Msk  (0x7ul << OPAMP_OPAMPCTRL_MUXNEG_Pos)
+#define OPAMP_OPAMPCTRL_MUXNEG(value) (OPAMP_OPAMPCTRL_MUXNEG_Msk & ((value) << OPAMP_OPAMPCTRL_MUXNEG_Pos))
+#define OPAMP_OPAMPCTRL_MASK        0x0077FFDEul /**< \brief (OPAMP_OPAMPCTRL) MASK Register */
+
+/** \brief OPAMP hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO OPAMP_CTRLA_Type          CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+       RoReg8                    Reserved1[0x1];
+  __I  OPAMP_STATUS_Type         STATUS;      /**< \brief Offset: 0x02 (R/   8) Status */
+       RoReg8                    Reserved2[0x1];
+  __IO OPAMP_OPAMPCTRL_Type      OPAMPCTRL[3]; /**< \brief Offset: 0x04 (R/W 32) OPAMP Control n */
+} Opamp;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_OPAMP_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/osc32kctrl.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/osc32kctrl.h
@@ -1,0 +1,298 @@
+/**
+ * \file
+ *
+ * \brief Component description for OSC32KCTRL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_OSC32KCTRL_COMPONENT_
+#define _SAML21_OSC32KCTRL_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR OSC32KCTRL */
+/* ========================================================================== */
+/** \addtogroup SAML21_OSC32KCTRL 32k Oscillators Control */
+/*@{*/
+
+#define OSC32KCTRL_U2246
+#define REV_OSC32KCTRL              0x100
+
+/* -------- OSC32KCTRL_INTENCLR : (OSC32KCTRL Offset: 0x00) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready Interrupt Enable     */
+    uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready Interrupt Enable      */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSC32KCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_INTENCLR_OFFSET  0x00         /**< \brief (OSC32KCTRL_INTENCLR offset) Interrupt Enable Clear */
+#define OSC32KCTRL_INTENCLR_RESETVALUE 0x00000000ul /**< \brief (OSC32KCTRL_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define OSC32KCTRL_INTENCLR_XOSC32KRDY_Pos 0            /**< \brief (OSC32KCTRL_INTENCLR) XOSC32K Ready Interrupt Enable */
+#define OSC32KCTRL_INTENCLR_XOSC32KRDY (0x1ul << OSC32KCTRL_INTENCLR_XOSC32KRDY_Pos)
+#define OSC32KCTRL_INTENCLR_OSC32KRDY_Pos 1            /**< \brief (OSC32KCTRL_INTENCLR) OSC32K Ready Interrupt Enable */
+#define OSC32KCTRL_INTENCLR_OSC32KRDY (0x1ul << OSC32KCTRL_INTENCLR_OSC32KRDY_Pos)
+#define OSC32KCTRL_INTENCLR_MASK    0x00000003ul /**< \brief (OSC32KCTRL_INTENCLR) MASK Register */
+
+/* -------- OSC32KCTRL_INTENSET : (OSC32KCTRL Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready Interrupt Enable     */
+    uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready Interrupt Enable      */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSC32KCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_INTENSET_OFFSET  0x04         /**< \brief (OSC32KCTRL_INTENSET offset) Interrupt Enable Set */
+#define OSC32KCTRL_INTENSET_RESETVALUE 0x00000000ul /**< \brief (OSC32KCTRL_INTENSET reset_value) Interrupt Enable Set */
+
+#define OSC32KCTRL_INTENSET_XOSC32KRDY_Pos 0            /**< \brief (OSC32KCTRL_INTENSET) XOSC32K Ready Interrupt Enable */
+#define OSC32KCTRL_INTENSET_XOSC32KRDY (0x1ul << OSC32KCTRL_INTENSET_XOSC32KRDY_Pos)
+#define OSC32KCTRL_INTENSET_OSC32KRDY_Pos 1            /**< \brief (OSC32KCTRL_INTENSET) OSC32K Ready Interrupt Enable */
+#define OSC32KCTRL_INTENSET_OSC32KRDY (0x1ul << OSC32KCTRL_INTENSET_OSC32KRDY_Pos)
+#define OSC32KCTRL_INTENSET_MASK    0x00000003ul /**< \brief (OSC32KCTRL_INTENSET) MASK Register */
+
+/* -------- OSC32KCTRL_INTFLAG : (OSC32KCTRL Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
+    __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
+    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSC32KCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_INTFLAG_OFFSET   0x08         /**< \brief (OSC32KCTRL_INTFLAG offset) Interrupt Flag Status and Clear */
+#define OSC32KCTRL_INTFLAG_RESETVALUE 0x00000000ul /**< \brief (OSC32KCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define OSC32KCTRL_INTFLAG_XOSC32KRDY_Pos 0            /**< \brief (OSC32KCTRL_INTFLAG) XOSC32K Ready */
+#define OSC32KCTRL_INTFLAG_XOSC32KRDY (0x1ul << OSC32KCTRL_INTFLAG_XOSC32KRDY_Pos)
+#define OSC32KCTRL_INTFLAG_OSC32KRDY_Pos 1            /**< \brief (OSC32KCTRL_INTFLAG) OSC32K Ready */
+#define OSC32KCTRL_INTFLAG_OSC32KRDY (0x1ul << OSC32KCTRL_INTFLAG_OSC32KRDY_Pos)
+#define OSC32KCTRL_INTFLAG_MASK     0x00000003ul /**< \brief (OSC32KCTRL_INTFLAG) MASK Register */
+
+/* -------- OSC32KCTRL_STATUS : (OSC32KCTRL Offset: 0x0C) (R/  32) Power and Clocks Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
+    uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSC32KCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_STATUS_OFFSET    0x0C         /**< \brief (OSC32KCTRL_STATUS offset) Power and Clocks Status */
+#define OSC32KCTRL_STATUS_RESETVALUE 0x00000000ul /**< \brief (OSC32KCTRL_STATUS reset_value) Power and Clocks Status */
+
+#define OSC32KCTRL_STATUS_XOSC32KRDY_Pos 0            /**< \brief (OSC32KCTRL_STATUS) XOSC32K Ready */
+#define OSC32KCTRL_STATUS_XOSC32KRDY (0x1ul << OSC32KCTRL_STATUS_XOSC32KRDY_Pos)
+#define OSC32KCTRL_STATUS_OSC32KRDY_Pos 1            /**< \brief (OSC32KCTRL_STATUS) OSC32K Ready */
+#define OSC32KCTRL_STATUS_OSC32KRDY (0x1ul << OSC32KCTRL_STATUS_OSC32KRDY_Pos)
+#define OSC32KCTRL_STATUS_MASK      0x00000003ul /**< \brief (OSC32KCTRL_STATUS) MASK Register */
+
+/* -------- OSC32KCTRL_RTCCTRL : (OSC32KCTRL Offset: 0x10) (R/W 32) Clock selection -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RTCSEL:3;         /*!< bit:  0.. 2  RTC Clock Selection                */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSC32KCTRL_RTCCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_RTCCTRL_OFFSET   0x10         /**< \brief (OSC32KCTRL_RTCCTRL offset) Clock selection */
+#define OSC32KCTRL_RTCCTRL_RESETVALUE 0x00000000ul /**< \brief (OSC32KCTRL_RTCCTRL reset_value) Clock selection */
+
+#define OSC32KCTRL_RTCCTRL_RTCSEL_Pos 0            /**< \brief (OSC32KCTRL_RTCCTRL) RTC Clock Selection */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_Msk (0x7ul << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)
+#define OSC32KCTRL_RTCCTRL_RTCSEL(value) (OSC32KCTRL_RTCCTRL_RTCSEL_Msk & ((value) << OSC32KCTRL_RTCCTRL_RTCSEL_Pos))
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K_Val 0x0ul  /**< \brief (OSC32KCTRL_RTCCTRL) 1.024kHz from 32kHz internal ULP oscillator */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K_Val 0x1ul  /**< \brief (OSC32KCTRL_RTCCTRL) 32.768kHz from 32kHz internal ULP oscillator */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K_Val 0x2ul  /**< \brief (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K_Val 0x3ul  /**< \brief (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz internal oscillator */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K_Val 0x4ul  /**< \brief (OSC32KCTRL_RTCCTRL) 1.024kHz from 32.768kHz internal oscillator */
+#define   OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K_Val 0x5ul  /**< \brief (OSC32KCTRL_RTCCTRL) 32.768kHz from 32.768kHz external crystal oscillator */
+#define OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K (OSC32KCTRL_RTCCTRL_RTCSEL_ULP1K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)
+#define OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K (OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)
+#define OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K (OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)
+#define OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K (OSC32KCTRL_RTCCTRL_RTCSEL_OSC32K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)
+#define OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K (OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)
+#define OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K (OSC32KCTRL_RTCCTRL_RTCSEL_XOSC32K_Val << OSC32KCTRL_RTCCTRL_RTCSEL_Pos)
+#define OSC32KCTRL_RTCCTRL_MASK     0x00000007ul /**< \brief (OSC32KCTRL_RTCCTRL) MASK Register */
+
+/* -------- OSC32KCTRL_XOSC32K : (OSC32KCTRL Offset: 0x14) (R/W 32) 32kHz External Crystal Oscillator (XOSC32K) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Oscillator Enable                  */
+    uint32_t XTALEN:1;         /*!< bit:      2  Crystal Oscillator Enable          */
+    uint32_t EN32K:1;          /*!< bit:      3  32kHz Output Enable                */
+    uint32_t EN1K:1;           /*!< bit:      4  1kHz Output Enable                 */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint32_t ONDEMAND:1;       /*!< bit:      7  On Demand Control                  */
+    uint32_t STARTUP:3;        /*!< bit:  8..10  Oscillator Start-Up Time           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t WRTLOCK:1;        /*!< bit:     12  Write Lock                         */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSC32KCTRL_XOSC32K_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_XOSC32K_OFFSET   0x14         /**< \brief (OSC32KCTRL_XOSC32K offset) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define OSC32KCTRL_XOSC32K_RESETVALUE 0x00000080ul /**< \brief (OSC32KCTRL_XOSC32K reset_value) 32kHz External Crystal Oscillator (XOSC32K) Control */
+
+#define OSC32KCTRL_XOSC32K_ENABLE_Pos 1            /**< \brief (OSC32KCTRL_XOSC32K) Oscillator Enable */
+#define OSC32KCTRL_XOSC32K_ENABLE   (0x1ul << OSC32KCTRL_XOSC32K_ENABLE_Pos)
+#define OSC32KCTRL_XOSC32K_XTALEN_Pos 2            /**< \brief (OSC32KCTRL_XOSC32K) Crystal Oscillator Enable */
+#define OSC32KCTRL_XOSC32K_XTALEN   (0x1ul << OSC32KCTRL_XOSC32K_XTALEN_Pos)
+#define OSC32KCTRL_XOSC32K_EN32K_Pos 3            /**< \brief (OSC32KCTRL_XOSC32K) 32kHz Output Enable */
+#define OSC32KCTRL_XOSC32K_EN32K    (0x1ul << OSC32KCTRL_XOSC32K_EN32K_Pos)
+#define OSC32KCTRL_XOSC32K_EN1K_Pos 4            /**< \brief (OSC32KCTRL_XOSC32K) 1kHz Output Enable */
+#define OSC32KCTRL_XOSC32K_EN1K     (0x1ul << OSC32KCTRL_XOSC32K_EN1K_Pos)
+#define OSC32KCTRL_XOSC32K_RUNSTDBY_Pos 6            /**< \brief (OSC32KCTRL_XOSC32K) Run in Standby */
+#define OSC32KCTRL_XOSC32K_RUNSTDBY (0x1ul << OSC32KCTRL_XOSC32K_RUNSTDBY_Pos)
+#define OSC32KCTRL_XOSC32K_ONDEMAND_Pos 7            /**< \brief (OSC32KCTRL_XOSC32K) On Demand Control */
+#define OSC32KCTRL_XOSC32K_ONDEMAND (0x1ul << OSC32KCTRL_XOSC32K_ONDEMAND_Pos)
+#define OSC32KCTRL_XOSC32K_STARTUP_Pos 8            /**< \brief (OSC32KCTRL_XOSC32K) Oscillator Start-Up Time */
+#define OSC32KCTRL_XOSC32K_STARTUP_Msk (0x7ul << OSC32KCTRL_XOSC32K_STARTUP_Pos)
+#define OSC32KCTRL_XOSC32K_STARTUP(value) (OSC32KCTRL_XOSC32K_STARTUP_Msk & ((value) << OSC32KCTRL_XOSC32K_STARTUP_Pos))
+#define OSC32KCTRL_XOSC32K_WRTLOCK_Pos 12           /**< \brief (OSC32KCTRL_XOSC32K) Write Lock */
+#define OSC32KCTRL_XOSC32K_WRTLOCK  (0x1ul << OSC32KCTRL_XOSC32K_WRTLOCK_Pos)
+#define OSC32KCTRL_XOSC32K_MASK     0x000017DEul /**< \brief (OSC32KCTRL_XOSC32K) MASK Register */
+
+/* -------- OSC32KCTRL_OSC32K : (OSC32KCTRL Offset: 0x18) (R/W 32) 32kHz Internal Oscillator (OSC32K) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Oscillator Enable                  */
+    uint32_t EN32K:1;          /*!< bit:      2  32kHz Output Enable                */
+    uint32_t EN1K:1;           /*!< bit:      3  1kHz Output Enable                 */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint32_t ONDEMAND:1;       /*!< bit:      7  On Demand Control                  */
+    uint32_t STARTUP:3;        /*!< bit:  8..10  Oscillator Start-Up Time           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t WRTLOCK:1;        /*!< bit:     12  Write Lock                         */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t CALIB:7;          /*!< bit: 16..22  Oscillator Calibration             */
+    uint32_t :9;               /*!< bit: 23..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSC32KCTRL_OSC32K_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_OSC32K_OFFSET    0x18         /**< \brief (OSC32KCTRL_OSC32K offset) 32kHz Internal Oscillator (OSC32K) Control */
+#define OSC32KCTRL_OSC32K_RESETVALUE 0x003F0080ul /**< \brief (OSC32KCTRL_OSC32K reset_value) 32kHz Internal Oscillator (OSC32K) Control */
+
+#define OSC32KCTRL_OSC32K_ENABLE_Pos 1            /**< \brief (OSC32KCTRL_OSC32K) Oscillator Enable */
+#define OSC32KCTRL_OSC32K_ENABLE    (0x1ul << OSC32KCTRL_OSC32K_ENABLE_Pos)
+#define OSC32KCTRL_OSC32K_EN32K_Pos 2            /**< \brief (OSC32KCTRL_OSC32K) 32kHz Output Enable */
+#define OSC32KCTRL_OSC32K_EN32K     (0x1ul << OSC32KCTRL_OSC32K_EN32K_Pos)
+#define OSC32KCTRL_OSC32K_EN1K_Pos  3            /**< \brief (OSC32KCTRL_OSC32K) 1kHz Output Enable */
+#define OSC32KCTRL_OSC32K_EN1K      (0x1ul << OSC32KCTRL_OSC32K_EN1K_Pos)
+#define OSC32KCTRL_OSC32K_RUNSTDBY_Pos 6            /**< \brief (OSC32KCTRL_OSC32K) Run in Standby */
+#define OSC32KCTRL_OSC32K_RUNSTDBY  (0x1ul << OSC32KCTRL_OSC32K_RUNSTDBY_Pos)
+#define OSC32KCTRL_OSC32K_ONDEMAND_Pos 7            /**< \brief (OSC32KCTRL_OSC32K) On Demand Control */
+#define OSC32KCTRL_OSC32K_ONDEMAND  (0x1ul << OSC32KCTRL_OSC32K_ONDEMAND_Pos)
+#define OSC32KCTRL_OSC32K_STARTUP_Pos 8            /**< \brief (OSC32KCTRL_OSC32K) Oscillator Start-Up Time */
+#define OSC32KCTRL_OSC32K_STARTUP_Msk (0x7ul << OSC32KCTRL_OSC32K_STARTUP_Pos)
+#define OSC32KCTRL_OSC32K_STARTUP(value) (OSC32KCTRL_OSC32K_STARTUP_Msk & ((value) << OSC32KCTRL_OSC32K_STARTUP_Pos))
+#define OSC32KCTRL_OSC32K_WRTLOCK_Pos 12           /**< \brief (OSC32KCTRL_OSC32K) Write Lock */
+#define OSC32KCTRL_OSC32K_WRTLOCK   (0x1ul << OSC32KCTRL_OSC32K_WRTLOCK_Pos)
+#define OSC32KCTRL_OSC32K_CALIB_Pos 16           /**< \brief (OSC32KCTRL_OSC32K) Oscillator Calibration */
+#define OSC32KCTRL_OSC32K_CALIB_Msk (0x7Ful << OSC32KCTRL_OSC32K_CALIB_Pos)
+#define OSC32KCTRL_OSC32K_CALIB(value) (OSC32KCTRL_OSC32K_CALIB_Msk & ((value) << OSC32KCTRL_OSC32K_CALIB_Pos))
+#define OSC32KCTRL_OSC32K_MASK      0x007F17CEul /**< \brief (OSC32KCTRL_OSC32K) MASK Register */
+
+/* -------- OSC32KCTRL_OSCULP32K : (OSC32KCTRL Offset: 0x1C) (R/W 32) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t CALIB:5;          /*!< bit:  8..12  Oscillator Calibration             */
+    uint32_t :2;               /*!< bit: 13..14  Reserved                           */
+    uint32_t WRTLOCK:1;        /*!< bit:     15  Write Lock                         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSC32KCTRL_OSCULP32K_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSC32KCTRL_OSCULP32K_OFFSET 0x1C         /**< \brief (OSC32KCTRL_OSCULP32K offset) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+
+#define OSC32KCTRL_OSCULP32K_CALIB_Pos 8            /**< \brief (OSC32KCTRL_OSCULP32K) Oscillator Calibration */
+#define OSC32KCTRL_OSCULP32K_CALIB_Msk (0x1Ful << OSC32KCTRL_OSCULP32K_CALIB_Pos)
+#define OSC32KCTRL_OSCULP32K_CALIB(value) (OSC32KCTRL_OSCULP32K_CALIB_Msk & ((value) << OSC32KCTRL_OSCULP32K_CALIB_Pos))
+#define OSC32KCTRL_OSCULP32K_WRTLOCK_Pos 15           /**< \brief (OSC32KCTRL_OSCULP32K) Write Lock */
+#define OSC32KCTRL_OSCULP32K_WRTLOCK (0x1ul << OSC32KCTRL_OSCULP32K_WRTLOCK_Pos)
+#define OSC32KCTRL_OSCULP32K_MASK   0x00009F00ul /**< \brief (OSC32KCTRL_OSCULP32K) MASK Register */
+
+/** \brief OSC32KCTRL hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO OSC32KCTRL_INTENCLR_Type  INTENCLR;    /**< \brief Offset: 0x00 (R/W 32) Interrupt Enable Clear */
+  __IO OSC32KCTRL_INTENSET_Type  INTENSET;    /**< \brief Offset: 0x04 (R/W 32) Interrupt Enable Set */
+  __IO OSC32KCTRL_INTFLAG_Type   INTFLAG;     /**< \brief Offset: 0x08 (R/W 32) Interrupt Flag Status and Clear */
+  __I  OSC32KCTRL_STATUS_Type    STATUS;      /**< \brief Offset: 0x0C (R/  32) Power and Clocks Status */
+  __IO OSC32KCTRL_RTCCTRL_Type   RTCCTRL;     /**< \brief Offset: 0x10 (R/W 32) Clock selection */
+  __IO OSC32KCTRL_XOSC32K_Type   XOSC32K;     /**< \brief Offset: 0x14 (R/W 32) 32kHz External Crystal Oscillator (XOSC32K) Control */
+  __IO OSC32KCTRL_OSC32K_Type    OSC32K;      /**< \brief Offset: 0x18 (R/W 32) 32kHz Internal Oscillator (OSC32K) Control */
+  __IO OSC32KCTRL_OSCULP32K_Type OSCULP32K;   /**< \brief Offset: 0x1C (R/W 32) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+} Osc32kctrl;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_OSC32KCTRL_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/oscctrl.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/oscctrl.h
@@ -1,0 +1,649 @@
+/**
+ * \file
+ *
+ * \brief Component description for OSCCTRL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_OSCCTRL_COMPONENT_
+#define _SAML21_OSCCTRL_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR OSCCTRL */
+/* ========================================================================== */
+/** \addtogroup SAML21_OSCCTRL Oscillators Control */
+/*@{*/
+
+#define OSCCTRL_U2119
+#define REV_OSCCTRL                 0x100
+
+/* -------- OSCCTRL_INTENCLR : (OSCCTRL Offset: 0x00) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready Interrupt Enable        */
+    uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready Interrupt Enable      */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready Interrupt Enable        */
+    uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds Interrupt Enable */
+    uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine Interrupt Enable    */
+    uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse Interrupt Enable  */
+    uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped Interrupt Enable */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise Interrupt Enable    */
+    uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall Interrupt Enable    */
+    uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Time Out Interrupt Enable     */
+    uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready Interrupt Enable  */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_INTENCLR_OFFSET     0x00         /**< \brief (OSCCTRL_INTENCLR offset) Interrupt Enable Clear */
+#define OSCCTRL_INTENCLR_RESETVALUE 0x00000000ul /**< \brief (OSCCTRL_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define OSCCTRL_INTENCLR_XOSCRDY_Pos 0            /**< \brief (OSCCTRL_INTENCLR) XOSC Ready Interrupt Enable */
+#define OSCCTRL_INTENCLR_XOSCRDY    (0x1ul << OSCCTRL_INTENCLR_XOSCRDY_Pos)
+#define OSCCTRL_INTENCLR_OSC16MRDY_Pos 4            /**< \brief (OSCCTRL_INTENCLR) OSC16M Ready Interrupt Enable */
+#define OSCCTRL_INTENCLR_OSC16MRDY  (0x1ul << OSCCTRL_INTENCLR_OSC16MRDY_Pos)
+#define OSCCTRL_INTENCLR_DFLLRDY_Pos 8            /**< \brief (OSCCTRL_INTENCLR) DFLL Ready Interrupt Enable */
+#define OSCCTRL_INTENCLR_DFLLRDY    (0x1ul << OSCCTRL_INTENCLR_DFLLRDY_Pos)
+#define OSCCTRL_INTENCLR_DFLLOOB_Pos 9            /**< \brief (OSCCTRL_INTENCLR) DFLL Out Of Bounds Interrupt Enable */
+#define OSCCTRL_INTENCLR_DFLLOOB    (0x1ul << OSCCTRL_INTENCLR_DFLLOOB_Pos)
+#define OSCCTRL_INTENCLR_DFLLLCKF_Pos 10           /**< \brief (OSCCTRL_INTENCLR) DFLL Lock Fine Interrupt Enable */
+#define OSCCTRL_INTENCLR_DFLLLCKF   (0x1ul << OSCCTRL_INTENCLR_DFLLLCKF_Pos)
+#define OSCCTRL_INTENCLR_DFLLLCKC_Pos 11           /**< \brief (OSCCTRL_INTENCLR) DFLL Lock Coarse Interrupt Enable */
+#define OSCCTRL_INTENCLR_DFLLLCKC   (0x1ul << OSCCTRL_INTENCLR_DFLLLCKC_Pos)
+#define OSCCTRL_INTENCLR_DFLLRCS_Pos 12           /**< \brief (OSCCTRL_INTENCLR) DFLL Reference Clock Stopped Interrupt Enable */
+#define OSCCTRL_INTENCLR_DFLLRCS    (0x1ul << OSCCTRL_INTENCLR_DFLLRCS_Pos)
+#define OSCCTRL_INTENCLR_DPLLLCKR_Pos 16           /**< \brief (OSCCTRL_INTENCLR) DPLL Lock Rise Interrupt Enable */
+#define OSCCTRL_INTENCLR_DPLLLCKR   (0x1ul << OSCCTRL_INTENCLR_DPLLLCKR_Pos)
+#define OSCCTRL_INTENCLR_DPLLLCKF_Pos 17           /**< \brief (OSCCTRL_INTENCLR) DPLL Lock Fall Interrupt Enable */
+#define OSCCTRL_INTENCLR_DPLLLCKF   (0x1ul << OSCCTRL_INTENCLR_DPLLLCKF_Pos)
+#define OSCCTRL_INTENCLR_DPLLLTO_Pos 18           /**< \brief (OSCCTRL_INTENCLR) DPLL Time Out Interrupt Enable */
+#define OSCCTRL_INTENCLR_DPLLLTO    (0x1ul << OSCCTRL_INTENCLR_DPLLLTO_Pos)
+#define OSCCTRL_INTENCLR_DPLLLDRTO_Pos 19           /**< \brief (OSCCTRL_INTENCLR) DPLL Ratio Ready Interrupt Enable */
+#define OSCCTRL_INTENCLR_DPLLLDRTO  (0x1ul << OSCCTRL_INTENCLR_DPLLLDRTO_Pos)
+#define OSCCTRL_INTENCLR_MASK       0x000F1F11ul /**< \brief (OSCCTRL_INTENCLR) MASK Register */
+
+/* -------- OSCCTRL_INTENSET : (OSCCTRL Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready Interrupt Enable        */
+    uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready Interrupt Enable      */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready Interrupt Enable        */
+    uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds Interrupt Enable */
+    uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine Interrupt Enable    */
+    uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse Interrupt Enable  */
+    uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped Interrupt Enable */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise Interrupt Enable    */
+    uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall Interrupt Enable    */
+    uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Time Out Interrupt Enable     */
+    uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready Interrupt Enable  */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_INTENSET_OFFSET     0x04         /**< \brief (OSCCTRL_INTENSET offset) Interrupt Enable Set */
+#define OSCCTRL_INTENSET_RESETVALUE 0x00000000ul /**< \brief (OSCCTRL_INTENSET reset_value) Interrupt Enable Set */
+
+#define OSCCTRL_INTENSET_XOSCRDY_Pos 0            /**< \brief (OSCCTRL_INTENSET) XOSC Ready Interrupt Enable */
+#define OSCCTRL_INTENSET_XOSCRDY    (0x1ul << OSCCTRL_INTENSET_XOSCRDY_Pos)
+#define OSCCTRL_INTENSET_OSC16MRDY_Pos 4            /**< \brief (OSCCTRL_INTENSET) OSC16M Ready Interrupt Enable */
+#define OSCCTRL_INTENSET_OSC16MRDY  (0x1ul << OSCCTRL_INTENSET_OSC16MRDY_Pos)
+#define OSCCTRL_INTENSET_DFLLRDY_Pos 8            /**< \brief (OSCCTRL_INTENSET) DFLL Ready Interrupt Enable */
+#define OSCCTRL_INTENSET_DFLLRDY    (0x1ul << OSCCTRL_INTENSET_DFLLRDY_Pos)
+#define OSCCTRL_INTENSET_DFLLOOB_Pos 9            /**< \brief (OSCCTRL_INTENSET) DFLL Out Of Bounds Interrupt Enable */
+#define OSCCTRL_INTENSET_DFLLOOB    (0x1ul << OSCCTRL_INTENSET_DFLLOOB_Pos)
+#define OSCCTRL_INTENSET_DFLLLCKF_Pos 10           /**< \brief (OSCCTRL_INTENSET) DFLL Lock Fine Interrupt Enable */
+#define OSCCTRL_INTENSET_DFLLLCKF   (0x1ul << OSCCTRL_INTENSET_DFLLLCKF_Pos)
+#define OSCCTRL_INTENSET_DFLLLCKC_Pos 11           /**< \brief (OSCCTRL_INTENSET) DFLL Lock Coarse Interrupt Enable */
+#define OSCCTRL_INTENSET_DFLLLCKC   (0x1ul << OSCCTRL_INTENSET_DFLLLCKC_Pos)
+#define OSCCTRL_INTENSET_DFLLRCS_Pos 12           /**< \brief (OSCCTRL_INTENSET) DFLL Reference Clock Stopped Interrupt Enable */
+#define OSCCTRL_INTENSET_DFLLRCS    (0x1ul << OSCCTRL_INTENSET_DFLLRCS_Pos)
+#define OSCCTRL_INTENSET_DPLLLCKR_Pos 16           /**< \brief (OSCCTRL_INTENSET) DPLL Lock Rise Interrupt Enable */
+#define OSCCTRL_INTENSET_DPLLLCKR   (0x1ul << OSCCTRL_INTENSET_DPLLLCKR_Pos)
+#define OSCCTRL_INTENSET_DPLLLCKF_Pos 17           /**< \brief (OSCCTRL_INTENSET) DPLL Lock Fall Interrupt Enable */
+#define OSCCTRL_INTENSET_DPLLLCKF   (0x1ul << OSCCTRL_INTENSET_DPLLLCKF_Pos)
+#define OSCCTRL_INTENSET_DPLLLTO_Pos 18           /**< \brief (OSCCTRL_INTENSET) DPLL Time Out Interrupt Enable */
+#define OSCCTRL_INTENSET_DPLLLTO    (0x1ul << OSCCTRL_INTENSET_DPLLLTO_Pos)
+#define OSCCTRL_INTENSET_DPLLLDRTO_Pos 19           /**< \brief (OSCCTRL_INTENSET) DPLL Ratio Ready Interrupt Enable */
+#define OSCCTRL_INTENSET_DPLLLDRTO  (0x1ul << OSCCTRL_INTENSET_DPLLLDRTO_Pos)
+#define OSCCTRL_INTENSET_MASK       0x000F1F11ul /**< \brief (OSCCTRL_INTENSET) MASK Register */
+
+/* -------- OSCCTRL_INTFLAG : (OSCCTRL Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    __I uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    __I uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready                       */
+    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
+    __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
+    __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
+    __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
+    __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
+    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    __I uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise                     */
+    __I uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall                     */
+    __I uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Timeout                       */
+    __I uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready                   */
+    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_INTFLAG_OFFSET      0x08         /**< \brief (OSCCTRL_INTFLAG offset) Interrupt Flag Status and Clear */
+#define OSCCTRL_INTFLAG_RESETVALUE  0x00000000ul /**< \brief (OSCCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define OSCCTRL_INTFLAG_XOSCRDY_Pos 0            /**< \brief (OSCCTRL_INTFLAG) XOSC Ready */
+#define OSCCTRL_INTFLAG_XOSCRDY     (0x1ul << OSCCTRL_INTFLAG_XOSCRDY_Pos)
+#define OSCCTRL_INTFLAG_OSC16MRDY_Pos 4            /**< \brief (OSCCTRL_INTFLAG) OSC16M Ready */
+#define OSCCTRL_INTFLAG_OSC16MRDY   (0x1ul << OSCCTRL_INTFLAG_OSC16MRDY_Pos)
+#define OSCCTRL_INTFLAG_DFLLRDY_Pos 8            /**< \brief (OSCCTRL_INTFLAG) DFLL Ready */
+#define OSCCTRL_INTFLAG_DFLLRDY     (0x1ul << OSCCTRL_INTFLAG_DFLLRDY_Pos)
+#define OSCCTRL_INTFLAG_DFLLOOB_Pos 9            /**< \brief (OSCCTRL_INTFLAG) DFLL Out Of Bounds */
+#define OSCCTRL_INTFLAG_DFLLOOB     (0x1ul << OSCCTRL_INTFLAG_DFLLOOB_Pos)
+#define OSCCTRL_INTFLAG_DFLLLCKF_Pos 10           /**< \brief (OSCCTRL_INTFLAG) DFLL Lock Fine */
+#define OSCCTRL_INTFLAG_DFLLLCKF    (0x1ul << OSCCTRL_INTFLAG_DFLLLCKF_Pos)
+#define OSCCTRL_INTFLAG_DFLLLCKC_Pos 11           /**< \brief (OSCCTRL_INTFLAG) DFLL Lock Coarse */
+#define OSCCTRL_INTFLAG_DFLLLCKC    (0x1ul << OSCCTRL_INTFLAG_DFLLLCKC_Pos)
+#define OSCCTRL_INTFLAG_DFLLRCS_Pos 12           /**< \brief (OSCCTRL_INTFLAG) DFLL Reference Clock Stopped */
+#define OSCCTRL_INTFLAG_DFLLRCS     (0x1ul << OSCCTRL_INTFLAG_DFLLRCS_Pos)
+#define OSCCTRL_INTFLAG_DPLLLCKR_Pos 16           /**< \brief (OSCCTRL_INTFLAG) DPLL Lock Rise */
+#define OSCCTRL_INTFLAG_DPLLLCKR    (0x1ul << OSCCTRL_INTFLAG_DPLLLCKR_Pos)
+#define OSCCTRL_INTFLAG_DPLLLCKF_Pos 17           /**< \brief (OSCCTRL_INTFLAG) DPLL Lock Fall */
+#define OSCCTRL_INTFLAG_DPLLLCKF    (0x1ul << OSCCTRL_INTFLAG_DPLLLCKF_Pos)
+#define OSCCTRL_INTFLAG_DPLLLTO_Pos 18           /**< \brief (OSCCTRL_INTFLAG) DPLL Timeout */
+#define OSCCTRL_INTFLAG_DPLLLTO     (0x1ul << OSCCTRL_INTFLAG_DPLLLTO_Pos)
+#define OSCCTRL_INTFLAG_DPLLLDRTO_Pos 19           /**< \brief (OSCCTRL_INTFLAG) DPLL Ratio Ready */
+#define OSCCTRL_INTFLAG_DPLLLDRTO   (0x1ul << OSCCTRL_INTFLAG_DPLLLDRTO_Pos)
+#define OSCCTRL_INTFLAG_MASK        0x000F1F11ul /**< \brief (OSCCTRL_INTFLAG) MASK Register */
+
+/* -------- OSCCTRL_STATUS : (OSCCTRL Offset: 0x0C) (R/  32) Power and Clocks Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready                       */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
+    uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
+    uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
+    uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
+    uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise                     */
+    uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall                     */
+    uint32_t DPLLTO:1;         /*!< bit:     18  DPLL Timeout                       */
+    uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready                   */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_STATUS_OFFSET       0x0C         /**< \brief (OSCCTRL_STATUS offset) Power and Clocks Status */
+#define OSCCTRL_STATUS_RESETVALUE   0x00000000ul /**< \brief (OSCCTRL_STATUS reset_value) Power and Clocks Status */
+
+#define OSCCTRL_STATUS_XOSCRDY_Pos  0            /**< \brief (OSCCTRL_STATUS) XOSC Ready */
+#define OSCCTRL_STATUS_XOSCRDY      (0x1ul << OSCCTRL_STATUS_XOSCRDY_Pos)
+#define OSCCTRL_STATUS_OSC16MRDY_Pos 4            /**< \brief (OSCCTRL_STATUS) OSC16M Ready */
+#define OSCCTRL_STATUS_OSC16MRDY    (0x1ul << OSCCTRL_STATUS_OSC16MRDY_Pos)
+#define OSCCTRL_STATUS_DFLLRDY_Pos  8            /**< \brief (OSCCTRL_STATUS) DFLL Ready */
+#define OSCCTRL_STATUS_DFLLRDY      (0x1ul << OSCCTRL_STATUS_DFLLRDY_Pos)
+#define OSCCTRL_STATUS_DFLLOOB_Pos  9            /**< \brief (OSCCTRL_STATUS) DFLL Out Of Bounds */
+#define OSCCTRL_STATUS_DFLLOOB      (0x1ul << OSCCTRL_STATUS_DFLLOOB_Pos)
+#define OSCCTRL_STATUS_DFLLLCKF_Pos 10           /**< \brief (OSCCTRL_STATUS) DFLL Lock Fine */
+#define OSCCTRL_STATUS_DFLLLCKF     (0x1ul << OSCCTRL_STATUS_DFLLLCKF_Pos)
+#define OSCCTRL_STATUS_DFLLLCKC_Pos 11           /**< \brief (OSCCTRL_STATUS) DFLL Lock Coarse */
+#define OSCCTRL_STATUS_DFLLLCKC     (0x1ul << OSCCTRL_STATUS_DFLLLCKC_Pos)
+#define OSCCTRL_STATUS_DFLLRCS_Pos  12           /**< \brief (OSCCTRL_STATUS) DFLL Reference Clock Stopped */
+#define OSCCTRL_STATUS_DFLLRCS      (0x1ul << OSCCTRL_STATUS_DFLLRCS_Pos)
+#define OSCCTRL_STATUS_DPLLLCKR_Pos 16           /**< \brief (OSCCTRL_STATUS) DPLL Lock Rise */
+#define OSCCTRL_STATUS_DPLLLCKR     (0x1ul << OSCCTRL_STATUS_DPLLLCKR_Pos)
+#define OSCCTRL_STATUS_DPLLLCKF_Pos 17           /**< \brief (OSCCTRL_STATUS) DPLL Lock Fall */
+#define OSCCTRL_STATUS_DPLLLCKF     (0x1ul << OSCCTRL_STATUS_DPLLLCKF_Pos)
+#define OSCCTRL_STATUS_DPLLTO_Pos   18           /**< \brief (OSCCTRL_STATUS) DPLL Timeout */
+#define OSCCTRL_STATUS_DPLLTO       (0x1ul << OSCCTRL_STATUS_DPLLTO_Pos)
+#define OSCCTRL_STATUS_DPLLLDRTO_Pos 19           /**< \brief (OSCCTRL_STATUS) DPLL Ratio Ready */
+#define OSCCTRL_STATUS_DPLLLDRTO    (0x1ul << OSCCTRL_STATUS_DPLLLDRTO_Pos)
+#define OSCCTRL_STATUS_MASK         0x000F1F11ul /**< \brief (OSCCTRL_STATUS) MASK Register */
+
+/* -------- OSCCTRL_XOSCCTRL : (OSCCTRL Offset: 0x10) (R/W 16) External Multipurpose Crystal Oscillator (XOSC) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :1;               /*!< bit:      0  Reserved                           */
+    uint16_t ENABLE:1;         /*!< bit:      1  Oscillator Enable                  */
+    uint16_t XTALEN:1;         /*!< bit:      2  Crystal Oscillator Enable          */
+    uint16_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint16_t ONDEMAND:1;       /*!< bit:      7  On Demand Control                  */
+    uint16_t GAIN:3;           /*!< bit:  8..10  Oscillator Gain                    */
+    uint16_t AMPGC:1;          /*!< bit:     11  Automatic Amplitude Gain Control   */
+    uint16_t STARTUP:4;        /*!< bit: 12..15  Start-Up Time                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_XOSCCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_XOSCCTRL_OFFSET     0x10         /**< \brief (OSCCTRL_XOSCCTRL offset) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define OSCCTRL_XOSCCTRL_RESETVALUE 0x0080ul     /**< \brief (OSCCTRL_XOSCCTRL reset_value) External Multipurpose Crystal Oscillator (XOSC) Control */
+
+#define OSCCTRL_XOSCCTRL_ENABLE_Pos 1            /**< \brief (OSCCTRL_XOSCCTRL) Oscillator Enable */
+#define OSCCTRL_XOSCCTRL_ENABLE     (0x1ul << OSCCTRL_XOSCCTRL_ENABLE_Pos)
+#define OSCCTRL_XOSCCTRL_XTALEN_Pos 2            /**< \brief (OSCCTRL_XOSCCTRL) Crystal Oscillator Enable */
+#define OSCCTRL_XOSCCTRL_XTALEN     (0x1ul << OSCCTRL_XOSCCTRL_XTALEN_Pos)
+#define OSCCTRL_XOSCCTRL_RUNSTDBY_Pos 6            /**< \brief (OSCCTRL_XOSCCTRL) Run in Standby */
+#define OSCCTRL_XOSCCTRL_RUNSTDBY   (0x1ul << OSCCTRL_XOSCCTRL_RUNSTDBY_Pos)
+#define OSCCTRL_XOSCCTRL_ONDEMAND_Pos 7            /**< \brief (OSCCTRL_XOSCCTRL) On Demand Control */
+#define OSCCTRL_XOSCCTRL_ONDEMAND   (0x1ul << OSCCTRL_XOSCCTRL_ONDEMAND_Pos)
+#define OSCCTRL_XOSCCTRL_GAIN_Pos   8            /**< \brief (OSCCTRL_XOSCCTRL) Oscillator Gain */
+#define OSCCTRL_XOSCCTRL_GAIN_Msk   (0x7ul << OSCCTRL_XOSCCTRL_GAIN_Pos)
+#define OSCCTRL_XOSCCTRL_GAIN(value) (OSCCTRL_XOSCCTRL_GAIN_Msk & ((value) << OSCCTRL_XOSCCTRL_GAIN_Pos))
+#define OSCCTRL_XOSCCTRL_AMPGC_Pos  11           /**< \brief (OSCCTRL_XOSCCTRL) Automatic Amplitude Gain Control */
+#define OSCCTRL_XOSCCTRL_AMPGC      (0x1ul << OSCCTRL_XOSCCTRL_AMPGC_Pos)
+#define OSCCTRL_XOSCCTRL_STARTUP_Pos 12           /**< \brief (OSCCTRL_XOSCCTRL) Start-Up Time */
+#define OSCCTRL_XOSCCTRL_STARTUP_Msk (0xFul << OSCCTRL_XOSCCTRL_STARTUP_Pos)
+#define OSCCTRL_XOSCCTRL_STARTUP(value) (OSCCTRL_XOSCCTRL_STARTUP_Msk & ((value) << OSCCTRL_XOSCCTRL_STARTUP_Pos))
+#define OSCCTRL_XOSCCTRL_MASK       0xFFC6ul     /**< \brief (OSCCTRL_XOSCCTRL) MASK Register */
+
+/* -------- OSCCTRL_OSC16MCTRL : (OSCCTRL Offset: 0x14) (R/W  8) 16MHz Internal Oscillator (OSC16M) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :1;               /*!< bit:      0  Reserved                           */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Oscillator Enable                  */
+    uint8_t  FSEL:2;           /*!< bit:  2.. 3  Oscillator Frequency Select        */
+    uint8_t  :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint8_t  ONDEMAND:1;       /*!< bit:      7  On Demand Control                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} OSCCTRL_OSC16MCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_OSC16MCTRL_OFFSET   0x14         /**< \brief (OSCCTRL_OSC16MCTRL offset) 16MHz Internal Oscillator (OSC16M) Control */
+#define OSCCTRL_OSC16MCTRL_RESETVALUE 0x82ul       /**< \brief (OSCCTRL_OSC16MCTRL reset_value) 16MHz Internal Oscillator (OSC16M) Control */
+
+#define OSCCTRL_OSC16MCTRL_ENABLE_Pos 1            /**< \brief (OSCCTRL_OSC16MCTRL) Oscillator Enable */
+#define OSCCTRL_OSC16MCTRL_ENABLE   (0x1ul << OSCCTRL_OSC16MCTRL_ENABLE_Pos)
+#define OSCCTRL_OSC16MCTRL_FSEL_Pos 2            /**< \brief (OSCCTRL_OSC16MCTRL) Oscillator Frequency Select */
+#define OSCCTRL_OSC16MCTRL_FSEL_Msk (0x3ul << OSCCTRL_OSC16MCTRL_FSEL_Pos)
+#define OSCCTRL_OSC16MCTRL_FSEL(value) (OSCCTRL_OSC16MCTRL_FSEL_Msk & ((value) << OSCCTRL_OSC16MCTRL_FSEL_Pos))
+#define   OSCCTRL_OSC16MCTRL_FSEL_4_Val   0x0ul  /**< \brief (OSCCTRL_OSC16MCTRL) 4MHz */
+#define   OSCCTRL_OSC16MCTRL_FSEL_8_Val   0x1ul  /**< \brief (OSCCTRL_OSC16MCTRL) 8MHz */
+#define   OSCCTRL_OSC16MCTRL_FSEL_12_Val  0x2ul  /**< \brief (OSCCTRL_OSC16MCTRL) 12MHz */
+#define   OSCCTRL_OSC16MCTRL_FSEL_16_Val  0x3ul  /**< \brief (OSCCTRL_OSC16MCTRL) 16MHz */
+#define OSCCTRL_OSC16MCTRL_FSEL_4   (OSCCTRL_OSC16MCTRL_FSEL_4_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)
+#define OSCCTRL_OSC16MCTRL_FSEL_8   (OSCCTRL_OSC16MCTRL_FSEL_8_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)
+#define OSCCTRL_OSC16MCTRL_FSEL_12  (OSCCTRL_OSC16MCTRL_FSEL_12_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)
+#define OSCCTRL_OSC16MCTRL_FSEL_16  (OSCCTRL_OSC16MCTRL_FSEL_16_Val << OSCCTRL_OSC16MCTRL_FSEL_Pos)
+#define OSCCTRL_OSC16MCTRL_RUNSTDBY_Pos 6            /**< \brief (OSCCTRL_OSC16MCTRL) Run in Standby */
+#define OSCCTRL_OSC16MCTRL_RUNSTDBY (0x1ul << OSCCTRL_OSC16MCTRL_RUNSTDBY_Pos)
+#define OSCCTRL_OSC16MCTRL_ONDEMAND_Pos 7            /**< \brief (OSCCTRL_OSC16MCTRL) On Demand Control */
+#define OSCCTRL_OSC16MCTRL_ONDEMAND (0x1ul << OSCCTRL_OSC16MCTRL_ONDEMAND_Pos)
+#define OSCCTRL_OSC16MCTRL_MASK     0xCEul       /**< \brief (OSCCTRL_OSC16MCTRL) MASK Register */
+
+/* -------- OSCCTRL_DFLLCTRL : (OSCCTRL Offset: 0x18) (R/W 16) DFLL48M Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :1;               /*!< bit:      0  Reserved                           */
+    uint16_t ENABLE:1;         /*!< bit:      1  DFLL Enable                        */
+    uint16_t MODE:1;           /*!< bit:      2  Operating Mode Selection           */
+    uint16_t STABLE:1;         /*!< bit:      3  Stable DFLL Frequency              */
+    uint16_t LLAW:1;           /*!< bit:      4  Lose Lock After Wake               */
+    uint16_t USBCRM:1;         /*!< bit:      5  USB Clock Recovery Mode            */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint16_t ONDEMAND:1;       /*!< bit:      7  On Demand Control                  */
+    uint16_t CCDIS:1;          /*!< bit:      8  Chill Cycle Disable                */
+    uint16_t QLDIS:1;          /*!< bit:      9  Quick Lock Disable                 */
+    uint16_t BPLCKC:1;         /*!< bit:     10  Bypass Coarse Lock                 */
+    uint16_t WAITLOCK:1;       /*!< bit:     11  Wait Lock                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_DFLLCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLCTRL_OFFSET     0x18         /**< \brief (OSCCTRL_DFLLCTRL offset) DFLL48M Control */
+#define OSCCTRL_DFLLCTRL_RESETVALUE 0x0080ul     /**< \brief (OSCCTRL_DFLLCTRL reset_value) DFLL48M Control */
+
+#define OSCCTRL_DFLLCTRL_ENABLE_Pos 1            /**< \brief (OSCCTRL_DFLLCTRL) DFLL Enable */
+#define OSCCTRL_DFLLCTRL_ENABLE     (0x1ul << OSCCTRL_DFLLCTRL_ENABLE_Pos)
+#define OSCCTRL_DFLLCTRL_MODE_Pos   2            /**< \brief (OSCCTRL_DFLLCTRL) Operating Mode Selection */
+#define OSCCTRL_DFLLCTRL_MODE       (0x1ul << OSCCTRL_DFLLCTRL_MODE_Pos)
+#define OSCCTRL_DFLLCTRL_STABLE_Pos 3            /**< \brief (OSCCTRL_DFLLCTRL) Stable DFLL Frequency */
+#define OSCCTRL_DFLLCTRL_STABLE     (0x1ul << OSCCTRL_DFLLCTRL_STABLE_Pos)
+#define OSCCTRL_DFLLCTRL_LLAW_Pos   4            /**< \brief (OSCCTRL_DFLLCTRL) Lose Lock After Wake */
+#define OSCCTRL_DFLLCTRL_LLAW       (0x1ul << OSCCTRL_DFLLCTRL_LLAW_Pos)
+#define OSCCTRL_DFLLCTRL_USBCRM_Pos 5            /**< \brief (OSCCTRL_DFLLCTRL) USB Clock Recovery Mode */
+#define OSCCTRL_DFLLCTRL_USBCRM     (0x1ul << OSCCTRL_DFLLCTRL_USBCRM_Pos)
+#define OSCCTRL_DFLLCTRL_RUNSTDBY_Pos 6            /**< \brief (OSCCTRL_DFLLCTRL) Run in Standby */
+#define OSCCTRL_DFLLCTRL_RUNSTDBY   (0x1ul << OSCCTRL_DFLLCTRL_RUNSTDBY_Pos)
+#define OSCCTRL_DFLLCTRL_ONDEMAND_Pos 7            /**< \brief (OSCCTRL_DFLLCTRL) On Demand Control */
+#define OSCCTRL_DFLLCTRL_ONDEMAND   (0x1ul << OSCCTRL_DFLLCTRL_ONDEMAND_Pos)
+#define OSCCTRL_DFLLCTRL_CCDIS_Pos  8            /**< \brief (OSCCTRL_DFLLCTRL) Chill Cycle Disable */
+#define OSCCTRL_DFLLCTRL_CCDIS      (0x1ul << OSCCTRL_DFLLCTRL_CCDIS_Pos)
+#define OSCCTRL_DFLLCTRL_QLDIS_Pos  9            /**< \brief (OSCCTRL_DFLLCTRL) Quick Lock Disable */
+#define OSCCTRL_DFLLCTRL_QLDIS      (0x1ul << OSCCTRL_DFLLCTRL_QLDIS_Pos)
+#define OSCCTRL_DFLLCTRL_BPLCKC_Pos 10           /**< \brief (OSCCTRL_DFLLCTRL) Bypass Coarse Lock */
+#define OSCCTRL_DFLLCTRL_BPLCKC     (0x1ul << OSCCTRL_DFLLCTRL_BPLCKC_Pos)
+#define OSCCTRL_DFLLCTRL_WAITLOCK_Pos 11           /**< \brief (OSCCTRL_DFLLCTRL) Wait Lock */
+#define OSCCTRL_DFLLCTRL_WAITLOCK   (0x1ul << OSCCTRL_DFLLCTRL_WAITLOCK_Pos)
+#define OSCCTRL_DFLLCTRL_MASK       0x0FFEul     /**< \brief (OSCCTRL_DFLLCTRL) MASK Register */
+
+/* -------- OSCCTRL_DFLLVAL : (OSCCTRL Offset: 0x1C) (R/W 32) DFLL48M Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FINE:10;          /*!< bit:  0.. 9  Fine Value                         */
+    uint32_t COARSE:6;         /*!< bit: 10..15  Coarse Value                       */
+    uint32_t DIFF:16;          /*!< bit: 16..31  Multiplication Ratio Difference    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_DFLLVAL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLVAL_OFFSET      0x1C         /**< \brief (OSCCTRL_DFLLVAL offset) DFLL48M Value */
+#define OSCCTRL_DFLLVAL_RESETVALUE  0x00000000ul /**< \brief (OSCCTRL_DFLLVAL reset_value) DFLL48M Value */
+
+#define OSCCTRL_DFLLVAL_FINE_Pos    0            /**< \brief (OSCCTRL_DFLLVAL) Fine Value */
+#define OSCCTRL_DFLLVAL_FINE_Msk    (0x3FFul << OSCCTRL_DFLLVAL_FINE_Pos)
+#define OSCCTRL_DFLLVAL_FINE(value) (OSCCTRL_DFLLVAL_FINE_Msk & ((value) << OSCCTRL_DFLLVAL_FINE_Pos))
+#define OSCCTRL_DFLLVAL_COARSE_Pos  10           /**< \brief (OSCCTRL_DFLLVAL) Coarse Value */
+#define OSCCTRL_DFLLVAL_COARSE_Msk  (0x3Ful << OSCCTRL_DFLLVAL_COARSE_Pos)
+#define OSCCTRL_DFLLVAL_COARSE(value) (OSCCTRL_DFLLVAL_COARSE_Msk & ((value) << OSCCTRL_DFLLVAL_COARSE_Pos))
+#define OSCCTRL_DFLLVAL_DIFF_Pos    16           /**< \brief (OSCCTRL_DFLLVAL) Multiplication Ratio Difference */
+#define OSCCTRL_DFLLVAL_DIFF_Msk    (0xFFFFul << OSCCTRL_DFLLVAL_DIFF_Pos)
+#define OSCCTRL_DFLLVAL_DIFF(value) (OSCCTRL_DFLLVAL_DIFF_Msk & ((value) << OSCCTRL_DFLLVAL_DIFF_Pos))
+#define OSCCTRL_DFLLVAL_MASK        0xFFFFFFFFul /**< \brief (OSCCTRL_DFLLVAL) MASK Register */
+
+/* -------- OSCCTRL_DFLLMUL : (OSCCTRL Offset: 0x20) (R/W 32) DFLL48M Multiplier -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MUL:16;           /*!< bit:  0..15  DFLL Multiply Factor               */
+    uint32_t FSTEP:10;         /*!< bit: 16..25  Fine Maximum Step                  */
+    uint32_t CSTEP:6;          /*!< bit: 26..31  Coarse Maximum Step                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_DFLLMUL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLMUL_OFFSET      0x20         /**< \brief (OSCCTRL_DFLLMUL offset) DFLL48M Multiplier */
+#define OSCCTRL_DFLLMUL_RESETVALUE  0x00000000ul /**< \brief (OSCCTRL_DFLLMUL reset_value) DFLL48M Multiplier */
+
+#define OSCCTRL_DFLLMUL_MUL_Pos     0            /**< \brief (OSCCTRL_DFLLMUL) DFLL Multiply Factor */
+#define OSCCTRL_DFLLMUL_MUL_Msk     (0xFFFFul << OSCCTRL_DFLLMUL_MUL_Pos)
+#define OSCCTRL_DFLLMUL_MUL(value)  (OSCCTRL_DFLLMUL_MUL_Msk & ((value) << OSCCTRL_DFLLMUL_MUL_Pos))
+#define OSCCTRL_DFLLMUL_FSTEP_Pos   16           /**< \brief (OSCCTRL_DFLLMUL) Fine Maximum Step */
+#define OSCCTRL_DFLLMUL_FSTEP_Msk   (0x3FFul << OSCCTRL_DFLLMUL_FSTEP_Pos)
+#define OSCCTRL_DFLLMUL_FSTEP(value) (OSCCTRL_DFLLMUL_FSTEP_Msk & ((value) << OSCCTRL_DFLLMUL_FSTEP_Pos))
+#define OSCCTRL_DFLLMUL_CSTEP_Pos   26           /**< \brief (OSCCTRL_DFLLMUL) Coarse Maximum Step */
+#define OSCCTRL_DFLLMUL_CSTEP_Msk   (0x3Ful << OSCCTRL_DFLLMUL_CSTEP_Pos)
+#define OSCCTRL_DFLLMUL_CSTEP(value) (OSCCTRL_DFLLMUL_CSTEP_Msk & ((value) << OSCCTRL_DFLLMUL_CSTEP_Pos))
+#define OSCCTRL_DFLLMUL_MASK        0xFFFFFFFFul /**< \brief (OSCCTRL_DFLLMUL) MASK Register */
+
+/* -------- OSCCTRL_DFLLSYNC : (OSCCTRL Offset: 0x24) (R/W  8) DFLL48M Synchronization -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  READREQ:1;        /*!< bit:      7  Read Request                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} OSCCTRL_DFLLSYNC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DFLLSYNC_OFFSET     0x24         /**< \brief (OSCCTRL_DFLLSYNC offset) DFLL48M Synchronization */
+#define OSCCTRL_DFLLSYNC_RESETVALUE 0x00ul       /**< \brief (OSCCTRL_DFLLSYNC reset_value) DFLL48M Synchronization */
+
+#define OSCCTRL_DFLLSYNC_READREQ_Pos 7            /**< \brief (OSCCTRL_DFLLSYNC) Read Request */
+#define OSCCTRL_DFLLSYNC_READREQ    (0x1ul << OSCCTRL_DFLLSYNC_READREQ_Pos)
+#define OSCCTRL_DFLLSYNC_MASK       0x80ul       /**< \brief (OSCCTRL_DFLLSYNC) MASK Register */
+
+/* -------- OSCCTRL_DPLLCTRLA : (OSCCTRL Offset: 0x28) (R/W  8) DPLL Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :1;               /*!< bit:      0  Reserved                           */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint8_t  ONDEMAND:1;       /*!< bit:      7  On Demand                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} OSCCTRL_DPLLCTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLCTRLA_OFFSET    0x28         /**< \brief (OSCCTRL_DPLLCTRLA offset) DPLL Control */
+#define OSCCTRL_DPLLCTRLA_RESETVALUE 0x80ul       /**< \brief (OSCCTRL_DPLLCTRLA reset_value) DPLL Control */
+
+#define OSCCTRL_DPLLCTRLA_ENABLE_Pos 1            /**< \brief (OSCCTRL_DPLLCTRLA) Enable */
+#define OSCCTRL_DPLLCTRLA_ENABLE    (0x1ul << OSCCTRL_DPLLCTRLA_ENABLE_Pos)
+#define OSCCTRL_DPLLCTRLA_RUNSTDBY_Pos 6            /**< \brief (OSCCTRL_DPLLCTRLA) Run in Standby */
+#define OSCCTRL_DPLLCTRLA_RUNSTDBY  (0x1ul << OSCCTRL_DPLLCTRLA_RUNSTDBY_Pos)
+#define OSCCTRL_DPLLCTRLA_ONDEMAND_Pos 7            /**< \brief (OSCCTRL_DPLLCTRLA) On Demand */
+#define OSCCTRL_DPLLCTRLA_ONDEMAND  (0x1ul << OSCCTRL_DPLLCTRLA_ONDEMAND_Pos)
+#define OSCCTRL_DPLLCTRLA_MASK      0xC2ul       /**< \brief (OSCCTRL_DPLLCTRLA) MASK Register */
+
+/* -------- OSCCTRL_DPLLRATIO : (OSCCTRL Offset: 0x2C) (R/W 32) DPLL Ratio Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LDR:12;           /*!< bit:  0..11  Loop Divider Ratio                 */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t LDRFRAC:4;        /*!< bit: 16..19  Loop Divider Ratio Fractional Part */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_DPLLRATIO_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLRATIO_OFFSET    0x2C         /**< \brief (OSCCTRL_DPLLRATIO offset) DPLL Ratio Control */
+#define OSCCTRL_DPLLRATIO_RESETVALUE 0x00000000ul /**< \brief (OSCCTRL_DPLLRATIO reset_value) DPLL Ratio Control */
+
+#define OSCCTRL_DPLLRATIO_LDR_Pos   0            /**< \brief (OSCCTRL_DPLLRATIO) Loop Divider Ratio */
+#define OSCCTRL_DPLLRATIO_LDR_Msk   (0xFFFul << OSCCTRL_DPLLRATIO_LDR_Pos)
+#define OSCCTRL_DPLLRATIO_LDR(value) (OSCCTRL_DPLLRATIO_LDR_Msk & ((value) << OSCCTRL_DPLLRATIO_LDR_Pos))
+#define OSCCTRL_DPLLRATIO_LDRFRAC_Pos 16           /**< \brief (OSCCTRL_DPLLRATIO) Loop Divider Ratio Fractional Part */
+#define OSCCTRL_DPLLRATIO_LDRFRAC_Msk (0xFul << OSCCTRL_DPLLRATIO_LDRFRAC_Pos)
+#define OSCCTRL_DPLLRATIO_LDRFRAC(value) (OSCCTRL_DPLLRATIO_LDRFRAC_Msk & ((value) << OSCCTRL_DPLLRATIO_LDRFRAC_Pos))
+#define OSCCTRL_DPLLRATIO_MASK      0x000F0FFFul /**< \brief (OSCCTRL_DPLLRATIO) MASK Register */
+
+/* -------- OSCCTRL_DPLLCTRLB : (OSCCTRL Offset: 0x30) (R/W 32) Digital Core Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FILTER:2;         /*!< bit:  0.. 1  Proportional Integral Filter Selection */
+    uint32_t LPEN:1;           /*!< bit:      2  Low-Power Enable                   */
+    uint32_t WUF:1;            /*!< bit:      3  Wake Up Fast                       */
+    uint32_t REFCLK:2;         /*!< bit:  4.. 5  Reference Clock Selection          */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t LTIME:3;          /*!< bit:  8..10  Lock Time                          */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t LBYPASS:1;        /*!< bit:     12  Lock Bypass                        */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t DIV:11;           /*!< bit: 16..26  Clock Divider                      */
+    uint32_t :5;               /*!< bit: 27..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} OSCCTRL_DPLLCTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLCTRLB_OFFSET    0x30         /**< \brief (OSCCTRL_DPLLCTRLB offset) Digital Core Configuration */
+#define OSCCTRL_DPLLCTRLB_RESETVALUE 0x00000000ul /**< \brief (OSCCTRL_DPLLCTRLB reset_value) Digital Core Configuration */
+
+#define OSCCTRL_DPLLCTRLB_FILTER_Pos 0            /**< \brief (OSCCTRL_DPLLCTRLB) Proportional Integral Filter Selection */
+#define OSCCTRL_DPLLCTRLB_FILTER_Msk (0x3ul << OSCCTRL_DPLLCTRLB_FILTER_Pos)
+#define OSCCTRL_DPLLCTRLB_FILTER(value) (OSCCTRL_DPLLCTRLB_FILTER_Msk & ((value) << OSCCTRL_DPLLCTRLB_FILTER_Pos))
+#define OSCCTRL_DPLLCTRLB_LPEN_Pos  2            /**< \brief (OSCCTRL_DPLLCTRLB) Low-Power Enable */
+#define OSCCTRL_DPLLCTRLB_LPEN      (0x1ul << OSCCTRL_DPLLCTRLB_LPEN_Pos)
+#define OSCCTRL_DPLLCTRLB_WUF_Pos   3            /**< \brief (OSCCTRL_DPLLCTRLB) Wake Up Fast */
+#define OSCCTRL_DPLLCTRLB_WUF       (0x1ul << OSCCTRL_DPLLCTRLB_WUF_Pos)
+#define OSCCTRL_DPLLCTRLB_REFCLK_Pos 4            /**< \brief (OSCCTRL_DPLLCTRLB) Reference Clock Selection */
+#define OSCCTRL_DPLLCTRLB_REFCLK_Msk (0x3ul << OSCCTRL_DPLLCTRLB_REFCLK_Pos)
+#define OSCCTRL_DPLLCTRLB_REFCLK(value) (OSCCTRL_DPLLCTRLB_REFCLK_Msk & ((value) << OSCCTRL_DPLLCTRLB_REFCLK_Pos))
+#define OSCCTRL_DPLLCTRLB_LTIME_Pos 8            /**< \brief (OSCCTRL_DPLLCTRLB) Lock Time */
+#define OSCCTRL_DPLLCTRLB_LTIME_Msk (0x7ul << OSCCTRL_DPLLCTRLB_LTIME_Pos)
+#define OSCCTRL_DPLLCTRLB_LTIME(value) (OSCCTRL_DPLLCTRLB_LTIME_Msk & ((value) << OSCCTRL_DPLLCTRLB_LTIME_Pos))
+#define OSCCTRL_DPLLCTRLB_LBYPASS_Pos 12           /**< \brief (OSCCTRL_DPLLCTRLB) Lock Bypass */
+#define OSCCTRL_DPLLCTRLB_LBYPASS   (0x1ul << OSCCTRL_DPLLCTRLB_LBYPASS_Pos)
+#define OSCCTRL_DPLLCTRLB_DIV_Pos   16           /**< \brief (OSCCTRL_DPLLCTRLB) Clock Divider */
+#define OSCCTRL_DPLLCTRLB_DIV_Msk   (0x7FFul << OSCCTRL_DPLLCTRLB_DIV_Pos)
+#define OSCCTRL_DPLLCTRLB_DIV(value) (OSCCTRL_DPLLCTRLB_DIV_Msk & ((value) << OSCCTRL_DPLLCTRLB_DIV_Pos))
+#define OSCCTRL_DPLLCTRLB_MASK      0x07FF173Ful /**< \brief (OSCCTRL_DPLLCTRLB) MASK Register */
+
+/* -------- OSCCTRL_DPLLPRESC : (OSCCTRL Offset: 0x34) (R/W  8) DPLL Prescaler -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PRESC:2;          /*!< bit:  0.. 1  Output Clock Prescaler             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} OSCCTRL_DPLLPRESC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLPRESC_OFFSET    0x34         /**< \brief (OSCCTRL_DPLLPRESC offset) DPLL Prescaler */
+#define OSCCTRL_DPLLPRESC_RESETVALUE 0x00ul       /**< \brief (OSCCTRL_DPLLPRESC reset_value) DPLL Prescaler */
+
+#define OSCCTRL_DPLLPRESC_PRESC_Pos 0            /**< \brief (OSCCTRL_DPLLPRESC) Output Clock Prescaler */
+#define OSCCTRL_DPLLPRESC_PRESC_Msk (0x3ul << OSCCTRL_DPLLPRESC_PRESC_Pos)
+#define OSCCTRL_DPLLPRESC_PRESC(value) (OSCCTRL_DPLLPRESC_PRESC_Msk & ((value) << OSCCTRL_DPLLPRESC_PRESC_Pos))
+#define   OSCCTRL_DPLLPRESC_PRESC_DIV1_Val 0x0ul  /**< \brief (OSCCTRL_DPLLPRESC) DPLL output is divided by 1 */
+#define   OSCCTRL_DPLLPRESC_PRESC_DIV2_Val 0x1ul  /**< \brief (OSCCTRL_DPLLPRESC) DPLL output is divided by 2 */
+#define   OSCCTRL_DPLLPRESC_PRESC_DIV4_Val 0x2ul  /**< \brief (OSCCTRL_DPLLPRESC) DPLL output is divided by 4 */
+#define OSCCTRL_DPLLPRESC_PRESC_DIV1 (OSCCTRL_DPLLPRESC_PRESC_DIV1_Val << OSCCTRL_DPLLPRESC_PRESC_Pos)
+#define OSCCTRL_DPLLPRESC_PRESC_DIV2 (OSCCTRL_DPLLPRESC_PRESC_DIV2_Val << OSCCTRL_DPLLPRESC_PRESC_Pos)
+#define OSCCTRL_DPLLPRESC_PRESC_DIV4 (OSCCTRL_DPLLPRESC_PRESC_DIV4_Val << OSCCTRL_DPLLPRESC_PRESC_Pos)
+#define OSCCTRL_DPLLPRESC_MASK      0x03ul       /**< \brief (OSCCTRL_DPLLPRESC) MASK Register */
+
+/* -------- OSCCTRL_DPLLSYNCBUSY : (OSCCTRL Offset: 0x38) (R/   8) DPLL Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :1;               /*!< bit:      0  Reserved                           */
+    uint8_t  ENABLE:1;         /*!< bit:      1  DPLL Enable Synchronization Status */
+    uint8_t  DPLLRATIO:1;      /*!< bit:      2  DPLL Ratio Synchronization Status  */
+    uint8_t  DPLLPRESC:1;      /*!< bit:      3  DPLL Prescaler Synchronization Status */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} OSCCTRL_DPLLSYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLSYNCBUSY_OFFSET 0x38         /**< \brief (OSCCTRL_DPLLSYNCBUSY offset) DPLL Synchronization Busy */
+#define OSCCTRL_DPLLSYNCBUSY_RESETVALUE 0x00ul       /**< \brief (OSCCTRL_DPLLSYNCBUSY reset_value) DPLL Synchronization Busy */
+
+#define OSCCTRL_DPLLSYNCBUSY_ENABLE_Pos 1            /**< \brief (OSCCTRL_DPLLSYNCBUSY) DPLL Enable Synchronization Status */
+#define OSCCTRL_DPLLSYNCBUSY_ENABLE (0x1ul << OSCCTRL_DPLLSYNCBUSY_ENABLE_Pos)
+#define OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Pos 2            /**< \brief (OSCCTRL_DPLLSYNCBUSY) DPLL Ratio Synchronization Status */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLRATIO (0x1ul << OSCCTRL_DPLLSYNCBUSY_DPLLRATIO_Pos)
+#define OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Pos 3            /**< \brief (OSCCTRL_DPLLSYNCBUSY) DPLL Prescaler Synchronization Status */
+#define OSCCTRL_DPLLSYNCBUSY_DPLLPRESC (0x1ul << OSCCTRL_DPLLSYNCBUSY_DPLLPRESC_Pos)
+#define OSCCTRL_DPLLSYNCBUSY_MASK   0x0Eul       /**< \brief (OSCCTRL_DPLLSYNCBUSY) MASK Register */
+
+/* -------- OSCCTRL_DPLLSTATUS : (OSCCTRL Offset: 0x3C) (R/   8) DPLL Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  LOCK:1;           /*!< bit:      0  DPLL Lock Status                   */
+    uint8_t  CLKRDY:1;         /*!< bit:      1  DPLL Clock Ready                   */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} OSCCTRL_DPLLSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define OSCCTRL_DPLLSTATUS_OFFSET   0x3C         /**< \brief (OSCCTRL_DPLLSTATUS offset) DPLL Status */
+#define OSCCTRL_DPLLSTATUS_RESETVALUE 0x00ul       /**< \brief (OSCCTRL_DPLLSTATUS reset_value) DPLL Status */
+
+#define OSCCTRL_DPLLSTATUS_LOCK_Pos 0            /**< \brief (OSCCTRL_DPLLSTATUS) DPLL Lock Status */
+#define OSCCTRL_DPLLSTATUS_LOCK     (0x1ul << OSCCTRL_DPLLSTATUS_LOCK_Pos)
+#define OSCCTRL_DPLLSTATUS_CLKRDY_Pos 1            /**< \brief (OSCCTRL_DPLLSTATUS) DPLL Clock Ready */
+#define OSCCTRL_DPLLSTATUS_CLKRDY   (0x1ul << OSCCTRL_DPLLSTATUS_CLKRDY_Pos)
+#define OSCCTRL_DPLLSTATUS_MASK     0x03ul       /**< \brief (OSCCTRL_DPLLSTATUS) MASK Register */
+
+/** \brief OSCCTRL hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO OSCCTRL_INTENCLR_Type     INTENCLR;    /**< \brief Offset: 0x00 (R/W 32) Interrupt Enable Clear */
+  __IO OSCCTRL_INTENSET_Type     INTENSET;    /**< \brief Offset: 0x04 (R/W 32) Interrupt Enable Set */
+  __IO OSCCTRL_INTFLAG_Type      INTFLAG;     /**< \brief Offset: 0x08 (R/W 32) Interrupt Flag Status and Clear */
+  __I  OSCCTRL_STATUS_Type       STATUS;      /**< \brief Offset: 0x0C (R/  32) Power and Clocks Status */
+  __IO OSCCTRL_XOSCCTRL_Type     XOSCCTRL;    /**< \brief Offset: 0x10 (R/W 16) External Multipurpose Crystal Oscillator (XOSC) Control */
+       RoReg8                    Reserved1[0x2];
+  __IO OSCCTRL_OSC16MCTRL_Type   OSC16MCTRL;  /**< \brief Offset: 0x14 (R/W  8) 16MHz Internal Oscillator (OSC16M) Control */
+       RoReg8                    Reserved2[0x3];
+  __IO OSCCTRL_DFLLCTRL_Type     DFLLCTRL;    /**< \brief Offset: 0x18 (R/W 16) DFLL48M Control */
+       RoReg8                    Reserved3[0x2];
+  __IO OSCCTRL_DFLLVAL_Type      DFLLVAL;     /**< \brief Offset: 0x1C (R/W 32) DFLL48M Value */
+  __IO OSCCTRL_DFLLMUL_Type      DFLLMUL;     /**< \brief Offset: 0x20 (R/W 32) DFLL48M Multiplier */
+  __IO OSCCTRL_DFLLSYNC_Type     DFLLSYNC;    /**< \brief Offset: 0x24 (R/W  8) DFLL48M Synchronization */
+       RoReg8                    Reserved4[0x3];
+  __IO OSCCTRL_DPLLCTRLA_Type    DPLLCTRLA;   /**< \brief Offset: 0x28 (R/W  8) DPLL Control */
+       RoReg8                    Reserved5[0x3];
+  __IO OSCCTRL_DPLLRATIO_Type    DPLLRATIO;   /**< \brief Offset: 0x2C (R/W 32) DPLL Ratio Control */
+  __IO OSCCTRL_DPLLCTRLB_Type    DPLLCTRLB;   /**< \brief Offset: 0x30 (R/W 32) Digital Core Configuration */
+  __IO OSCCTRL_DPLLPRESC_Type    DPLLPRESC;   /**< \brief Offset: 0x34 (R/W  8) DPLL Prescaler */
+       RoReg8                    Reserved6[0x3];
+  __I  OSCCTRL_DPLLSYNCBUSY_Type DPLLSYNCBUSY; /**< \brief Offset: 0x38 (R/   8) DPLL Synchronization Busy */
+       RoReg8                    Reserved7[0x3];
+  __I  OSCCTRL_DPLLSTATUS_Type   DPLLSTATUS;  /**< \brief Offset: 0x3C (R/   8) DPLL Status */
+} Oscctrl;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_OSCCTRL_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/pac_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/pac_100.h
@@ -1,0 +1,622 @@
+/**
+ * \file
+ *
+ * \brief Component description for PAC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_PAC_COMPONENT_
+#define _SAML21_PAC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PAC */
+/* ========================================================================== */
+/** \addtogroup SAML21_PAC Peripheral Access Controller */
+/*@{*/
+
+#define PAC_U2120
+#define REV_PAC                     0x100
+
+/* -------- PAC_WRCTRL : (PAC Offset: 0x00) (R/W 32) Write control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PERID:16;         /*!< bit:  0..15  Peripheral identifier              */
+    uint32_t KEY:8;            /*!< bit: 16..23  Peripheral access control key      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_WRCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_WRCTRL_OFFSET           0x00         /**< \brief (PAC_WRCTRL offset) Write control */
+#define PAC_WRCTRL_RESETVALUE       0x00000000ul /**< \brief (PAC_WRCTRL reset_value) Write control */
+
+#define PAC_WRCTRL_PERID_Pos        0            /**< \brief (PAC_WRCTRL) Peripheral identifier */
+#define PAC_WRCTRL_PERID_Msk        (0xFFFFul << PAC_WRCTRL_PERID_Pos)
+#define PAC_WRCTRL_PERID(value)     (PAC_WRCTRL_PERID_Msk & ((value) << PAC_WRCTRL_PERID_Pos))
+#define PAC_WRCTRL_KEY_Pos          16           /**< \brief (PAC_WRCTRL) Peripheral access control key */
+#define PAC_WRCTRL_KEY_Msk          (0xFFul << PAC_WRCTRL_KEY_Pos)
+#define PAC_WRCTRL_KEY(value)       (PAC_WRCTRL_KEY_Msk & ((value) << PAC_WRCTRL_KEY_Pos))
+#define   PAC_WRCTRL_KEY_OFF_Val          0x0ul  /**< \brief (PAC_WRCTRL) No action */
+#define   PAC_WRCTRL_KEY_CLR_Val          0x1ul  /**< \brief (PAC_WRCTRL) Clear protection */
+#define   PAC_WRCTRL_KEY_SET_Val          0x2ul  /**< \brief (PAC_WRCTRL) Set protection */
+#define   PAC_WRCTRL_KEY_SETLCK_Val       0x3ul  /**< \brief (PAC_WRCTRL) Set and lock protection */
+#define PAC_WRCTRL_KEY_OFF          (PAC_WRCTRL_KEY_OFF_Val        << PAC_WRCTRL_KEY_Pos)
+#define PAC_WRCTRL_KEY_CLR          (PAC_WRCTRL_KEY_CLR_Val        << PAC_WRCTRL_KEY_Pos)
+#define PAC_WRCTRL_KEY_SET          (PAC_WRCTRL_KEY_SET_Val        << PAC_WRCTRL_KEY_Pos)
+#define PAC_WRCTRL_KEY_SETLCK       (PAC_WRCTRL_KEY_SETLCK_Val     << PAC_WRCTRL_KEY_Pos)
+#define PAC_WRCTRL_MASK             0x00FFFFFFul /**< \brief (PAC_WRCTRL) MASK Register */
+
+/* -------- PAC_EVCTRL : (PAC Offset: 0x04) (R/W  8) Event control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ERREO:1;          /*!< bit:      0  Peripheral acess error event output */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PAC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_EVCTRL_OFFSET           0x04         /**< \brief (PAC_EVCTRL offset) Event control */
+#define PAC_EVCTRL_RESETVALUE       0x00ul       /**< \brief (PAC_EVCTRL reset_value) Event control */
+
+#define PAC_EVCTRL_ERREO_Pos        0            /**< \brief (PAC_EVCTRL) Peripheral acess error event output */
+#define PAC_EVCTRL_ERREO            (0x1ul << PAC_EVCTRL_ERREO_Pos)
+#define PAC_EVCTRL_MASK             0x01ul       /**< \brief (PAC_EVCTRL) MASK Register */
+
+/* -------- PAC_INTENCLR : (PAC Offset: 0x08) (R/W  8) Interrupt enable clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ERR:1;            /*!< bit:      0  Peripheral access error interrupt disable */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PAC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTENCLR_OFFSET         0x08         /**< \brief (PAC_INTENCLR offset) Interrupt enable clear */
+#define PAC_INTENCLR_RESETVALUE     0x00ul       /**< \brief (PAC_INTENCLR reset_value) Interrupt enable clear */
+
+#define PAC_INTENCLR_ERR_Pos        0            /**< \brief (PAC_INTENCLR) Peripheral access error interrupt disable */
+#define PAC_INTENCLR_ERR            (0x1ul << PAC_INTENCLR_ERR_Pos)
+#define PAC_INTENCLR_MASK           0x01ul       /**< \brief (PAC_INTENCLR) MASK Register */
+
+/* -------- PAC_INTENSET : (PAC Offset: 0x09) (R/W  8) Interrupt enable set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ERR:1;            /*!< bit:      0  Peripheral access error interrupt enable */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PAC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTENSET_OFFSET         0x09         /**< \brief (PAC_INTENSET offset) Interrupt enable set */
+#define PAC_INTENSET_RESETVALUE     0x00ul       /**< \brief (PAC_INTENSET reset_value) Interrupt enable set */
+
+#define PAC_INTENSET_ERR_Pos        0            /**< \brief (PAC_INTENSET) Peripheral access error interrupt enable */
+#define PAC_INTENSET_ERR            (0x1ul << PAC_INTENSET_ERR_Pos)
+#define PAC_INTENSET_MASK           0x01ul       /**< \brief (PAC_INTENSET) MASK Register */
+
+/* -------- PAC_INTFLAGAHB : (PAC Offset: 0x10) (R/W 32) Bridge interrupt flag status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t FLASH_:1;         /*!< bit:      0  FLASH                              */
+    __I uint32_t HSRAMCM0P_:1;     /*!< bit:      1  HSRAMCM0P                          */
+    __I uint32_t HSRAMDSU_:1;      /*!< bit:      2  HSRAMDSU                           */
+    __I uint32_t HPB1_:1;          /*!< bit:      3  HPB1                               */
+    __I uint32_t H2LBRIDGES_:1;    /*!< bit:      4  H2LBRIDGES                         */
+    __I uint32_t :11;              /*!< bit:  5..15  Reserved                           */
+    __I uint32_t HPB0_:1;          /*!< bit:     16  HPB0                               */
+    __I uint32_t HPB2_:1;          /*!< bit:     17  HPB2                               */
+    __I uint32_t HPB3_:1;          /*!< bit:     18  HPB3                               */
+    __I uint32_t HPB4_:1;          /*!< bit:     19  HPB4                               */
+    __I uint32_t :1;               /*!< bit:     20  Reserved                           */
+    __I uint32_t LPRAMHS_:1;       /*!< bit:     21  LPRAMHS                            */
+    __I uint32_t LPRAMPICOP_:1;    /*!< bit:     22  LPRAMPICOP                         */
+    __I uint32_t LPRAMDMAC_:1;     /*!< bit:     23  LPRAMDMAC                          */
+    __I uint32_t L2HBRIDGES_:1;    /*!< bit:     24  L2HBRIDGES                         */
+    __I uint32_t HSRAMLP_:1;       /*!< bit:     25  HSRAMLP                            */
+    __I uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_INTFLAGAHB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGAHB_OFFSET       0x10         /**< \brief (PAC_INTFLAGAHB offset) Bridge interrupt flag status */
+#define PAC_INTFLAGAHB_RESETVALUE   0x00000000ul /**< \brief (PAC_INTFLAGAHB reset_value) Bridge interrupt flag status */
+
+#define PAC_INTFLAGAHB_FLASH_Pos    0            /**< \brief (PAC_INTFLAGAHB) FLASH */
+#define PAC_INTFLAGAHB_FLASH        (0x1ul << PAC_INTFLAGAHB_FLASH_Pos)
+#define PAC_INTFLAGAHB_HSRAMCM0P_Pos 1            /**< \brief (PAC_INTFLAGAHB) HSRAMCM0P */
+#define PAC_INTFLAGAHB_HSRAMCM0P    (0x1ul << PAC_INTFLAGAHB_HSRAMCM0P_Pos)
+#define PAC_INTFLAGAHB_HSRAMDSU_Pos 2            /**< \brief (PAC_INTFLAGAHB) HSRAMDSU */
+#define PAC_INTFLAGAHB_HSRAMDSU     (0x1ul << PAC_INTFLAGAHB_HSRAMDSU_Pos)
+#define PAC_INTFLAGAHB_HPB1_Pos     3            /**< \brief (PAC_INTFLAGAHB) HPB1 */
+#define PAC_INTFLAGAHB_HPB1         (0x1ul << PAC_INTFLAGAHB_HPB1_Pos)
+#define PAC_INTFLAGAHB_H2LBRIDGES_Pos 4            /**< \brief (PAC_INTFLAGAHB) H2LBRIDGES */
+#define PAC_INTFLAGAHB_H2LBRIDGES   (0x1ul << PAC_INTFLAGAHB_H2LBRIDGES_Pos)
+#define PAC_INTFLAGAHB_HPB0_Pos     16           /**< \brief (PAC_INTFLAGAHB) HPB0 */
+#define PAC_INTFLAGAHB_HPB0         (0x1ul << PAC_INTFLAGAHB_HPB0_Pos)
+#define PAC_INTFLAGAHB_HPB2_Pos     17           /**< \brief (PAC_INTFLAGAHB) HPB2 */
+#define PAC_INTFLAGAHB_HPB2         (0x1ul << PAC_INTFLAGAHB_HPB2_Pos)
+#define PAC_INTFLAGAHB_HPB3_Pos     18           /**< \brief (PAC_INTFLAGAHB) HPB3 */
+#define PAC_INTFLAGAHB_HPB3         (0x1ul << PAC_INTFLAGAHB_HPB3_Pos)
+#define PAC_INTFLAGAHB_HPB4_Pos     19           /**< \brief (PAC_INTFLAGAHB) HPB4 */
+#define PAC_INTFLAGAHB_HPB4         (0x1ul << PAC_INTFLAGAHB_HPB4_Pos)
+#define PAC_INTFLAGAHB_LPRAMHS_Pos  21           /**< \brief (PAC_INTFLAGAHB) LPRAMHS */
+#define PAC_INTFLAGAHB_LPRAMHS      (0x1ul << PAC_INTFLAGAHB_LPRAMHS_Pos)
+#define PAC_INTFLAGAHB_LPRAMPICOP_Pos 22           /**< \brief (PAC_INTFLAGAHB) LPRAMPICOP */
+#define PAC_INTFLAGAHB_LPRAMPICOP   (0x1ul << PAC_INTFLAGAHB_LPRAMPICOP_Pos)
+#define PAC_INTFLAGAHB_LPRAMDMAC_Pos 23           /**< \brief (PAC_INTFLAGAHB) LPRAMDMAC */
+#define PAC_INTFLAGAHB_LPRAMDMAC    (0x1ul << PAC_INTFLAGAHB_LPRAMDMAC_Pos)
+#define PAC_INTFLAGAHB_L2HBRIDGES_Pos 24           /**< \brief (PAC_INTFLAGAHB) L2HBRIDGES */
+#define PAC_INTFLAGAHB_L2HBRIDGES   (0x1ul << PAC_INTFLAGAHB_L2HBRIDGES_Pos)
+#define PAC_INTFLAGAHB_HSRAMLP_Pos  25           /**< \brief (PAC_INTFLAGAHB) HSRAMLP */
+#define PAC_INTFLAGAHB_HSRAMLP      (0x1ul << PAC_INTFLAGAHB_HSRAMLP_Pos)
+#define PAC_INTFLAGAHB_MASK         0x03EF001Ful /**< \brief (PAC_INTFLAGAHB) MASK Register */
+
+/* -------- PAC_INTFLAGA : (PAC Offset: 0x14) (R/W 32) Peripheral interrupt flag status - Bridge A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t PM_:1;            /*!< bit:      0  PM                                 */
+    __I uint32_t MCLK_:1;          /*!< bit:      1  MCLK                               */
+    __I uint32_t RSTC_:1;          /*!< bit:      2  RSTC                               */
+    __I uint32_t OSCCTRL_:1;       /*!< bit:      3  OSCCTRL                            */
+    __I uint32_t OSC32KCTRL_:1;    /*!< bit:      4  OSC32KCTRL                         */
+    __I uint32_t SUPC_:1;          /*!< bit:      5  SUPC                               */
+    __I uint32_t GCLK_:1;          /*!< bit:      6  GCLK                               */
+    __I uint32_t WDT_:1;           /*!< bit:      7  WDT                                */
+    __I uint32_t RTC_:1;           /*!< bit:      8  RTC                                */
+    __I uint32_t EIC_:1;           /*!< bit:      9  EIC                                */
+    __I uint32_t PORT_:1;          /*!< bit:     10  PORT                               */
+    __I uint32_t TAL_:1;           /*!< bit:     11  TAL                                */
+    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_INTFLAGA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGA_OFFSET         0x14         /**< \brief (PAC_INTFLAGA offset) Peripheral interrupt flag status - Bridge A */
+#define PAC_INTFLAGA_RESETVALUE     0x00000000ul /**< \brief (PAC_INTFLAGA reset_value) Peripheral interrupt flag status - Bridge A */
+
+#define PAC_INTFLAGA_PM_Pos         0            /**< \brief (PAC_INTFLAGA) PM */
+#define PAC_INTFLAGA_PM             (0x1ul << PAC_INTFLAGA_PM_Pos)
+#define PAC_INTFLAGA_MCLK_Pos       1            /**< \brief (PAC_INTFLAGA) MCLK */
+#define PAC_INTFLAGA_MCLK           (0x1ul << PAC_INTFLAGA_MCLK_Pos)
+#define PAC_INTFLAGA_RSTC_Pos       2            /**< \brief (PAC_INTFLAGA) RSTC */
+#define PAC_INTFLAGA_RSTC           (0x1ul << PAC_INTFLAGA_RSTC_Pos)
+#define PAC_INTFLAGA_OSCCTRL_Pos    3            /**< \brief (PAC_INTFLAGA) OSCCTRL */
+#define PAC_INTFLAGA_OSCCTRL        (0x1ul << PAC_INTFLAGA_OSCCTRL_Pos)
+#define PAC_INTFLAGA_OSC32KCTRL_Pos 4            /**< \brief (PAC_INTFLAGA) OSC32KCTRL */
+#define PAC_INTFLAGA_OSC32KCTRL     (0x1ul << PAC_INTFLAGA_OSC32KCTRL_Pos)
+#define PAC_INTFLAGA_SUPC_Pos       5            /**< \brief (PAC_INTFLAGA) SUPC */
+#define PAC_INTFLAGA_SUPC           (0x1ul << PAC_INTFLAGA_SUPC_Pos)
+#define PAC_INTFLAGA_GCLK_Pos       6            /**< \brief (PAC_INTFLAGA) GCLK */
+#define PAC_INTFLAGA_GCLK           (0x1ul << PAC_INTFLAGA_GCLK_Pos)
+#define PAC_INTFLAGA_WDT_Pos        7            /**< \brief (PAC_INTFLAGA) WDT */
+#define PAC_INTFLAGA_WDT            (0x1ul << PAC_INTFLAGA_WDT_Pos)
+#define PAC_INTFLAGA_RTC_Pos        8            /**< \brief (PAC_INTFLAGA) RTC */
+#define PAC_INTFLAGA_RTC            (0x1ul << PAC_INTFLAGA_RTC_Pos)
+#define PAC_INTFLAGA_EIC_Pos        9            /**< \brief (PAC_INTFLAGA) EIC */
+#define PAC_INTFLAGA_EIC            (0x1ul << PAC_INTFLAGA_EIC_Pos)
+#define PAC_INTFLAGA_PORT_Pos       10           /**< \brief (PAC_INTFLAGA) PORT */
+#define PAC_INTFLAGA_PORT           (0x1ul << PAC_INTFLAGA_PORT_Pos)
+#define PAC_INTFLAGA_TAL_Pos        11           /**< \brief (PAC_INTFLAGA) TAL */
+#define PAC_INTFLAGA_TAL            (0x1ul << PAC_INTFLAGA_TAL_Pos)
+#define PAC_INTFLAGA_MASK           0x00000FFFul /**< \brief (PAC_INTFLAGA) MASK Register */
+
+/* -------- PAC_INTFLAGB : (PAC Offset: 0x18) (R/W 32) Peripheral interrupt flag status - Bridge B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t USB_:1;           /*!< bit:      0  USB                                */
+    __I uint32_t DSU_:1;           /*!< bit:      1  DSU                                */
+    __I uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL                            */
+    __I uint32_t MTB_:1;           /*!< bit:      3  MTB                                */
+    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_INTFLAGB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGB_OFFSET         0x18         /**< \brief (PAC_INTFLAGB offset) Peripheral interrupt flag status - Bridge B */
+#define PAC_INTFLAGB_RESETVALUE     0x00000000ul /**< \brief (PAC_INTFLAGB reset_value) Peripheral interrupt flag status - Bridge B */
+
+#define PAC_INTFLAGB_USB_Pos        0            /**< \brief (PAC_INTFLAGB) USB */
+#define PAC_INTFLAGB_USB            (0x1ul << PAC_INTFLAGB_USB_Pos)
+#define PAC_INTFLAGB_DSU_Pos        1            /**< \brief (PAC_INTFLAGB) DSU */
+#define PAC_INTFLAGB_DSU            (0x1ul << PAC_INTFLAGB_DSU_Pos)
+#define PAC_INTFLAGB_NVMCTRL_Pos    2            /**< \brief (PAC_INTFLAGB) NVMCTRL */
+#define PAC_INTFLAGB_NVMCTRL        (0x1ul << PAC_INTFLAGB_NVMCTRL_Pos)
+#define PAC_INTFLAGB_MTB_Pos        3            /**< \brief (PAC_INTFLAGB) MTB */
+#define PAC_INTFLAGB_MTB            (0x1ul << PAC_INTFLAGB_MTB_Pos)
+#define PAC_INTFLAGB_MASK           0x0000000Ful /**< \brief (PAC_INTFLAGB) MASK Register */
+
+/* -------- PAC_INTFLAGC : (PAC Offset: 0x1C) (R/W 32) Peripheral interrupt flag status - Bridge C -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t SERCOM0_:1;       /*!< bit:      0  SERCOM0                            */
+    __I uint32_t SERCOM1_:1;       /*!< bit:      1  SERCOM1                            */
+    __I uint32_t SERCOM2_:1;       /*!< bit:      2  SERCOM2                            */
+    __I uint32_t SERCOM3_:1;       /*!< bit:      3  SERCOM3                            */
+    __I uint32_t SERCOM4_:1;       /*!< bit:      4  SERCOM4                            */
+    __I uint32_t TCC0_:1;          /*!< bit:      5  TCC0                               */
+    __I uint32_t TCC1_:1;          /*!< bit:      6  TCC1                               */
+    __I uint32_t TCC2_:1;          /*!< bit:      7  TCC2                               */
+    __I uint32_t TC0_:1;           /*!< bit:      8  TC0                                */
+    __I uint32_t TC1_:1;           /*!< bit:      9  TC1                                */
+    __I uint32_t TC2_:1;           /*!< bit:     10  TC2                                */
+    __I uint32_t TC3_:1;           /*!< bit:     11  TC3                                */
+    __I uint32_t DAC_:1;           /*!< bit:     12  DAC                                */
+    __I uint32_t AES_:1;           /*!< bit:     13  AES                                */
+    __I uint32_t TRNG_:1;          /*!< bit:     14  TRNG                               */
+    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_INTFLAGC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGC_OFFSET         0x1C         /**< \brief (PAC_INTFLAGC offset) Peripheral interrupt flag status - Bridge C */
+#define PAC_INTFLAGC_RESETVALUE     0x00000000ul /**< \brief (PAC_INTFLAGC reset_value) Peripheral interrupt flag status - Bridge C */
+
+#define PAC_INTFLAGC_SERCOM0_Pos    0            /**< \brief (PAC_INTFLAGC) SERCOM0 */
+#define PAC_INTFLAGC_SERCOM0        (0x1ul << PAC_INTFLAGC_SERCOM0_Pos)
+#define PAC_INTFLAGC_SERCOM1_Pos    1            /**< \brief (PAC_INTFLAGC) SERCOM1 */
+#define PAC_INTFLAGC_SERCOM1        (0x1ul << PAC_INTFLAGC_SERCOM1_Pos)
+#define PAC_INTFLAGC_SERCOM2_Pos    2            /**< \brief (PAC_INTFLAGC) SERCOM2 */
+#define PAC_INTFLAGC_SERCOM2        (0x1ul << PAC_INTFLAGC_SERCOM2_Pos)
+#define PAC_INTFLAGC_SERCOM3_Pos    3            /**< \brief (PAC_INTFLAGC) SERCOM3 */
+#define PAC_INTFLAGC_SERCOM3        (0x1ul << PAC_INTFLAGC_SERCOM3_Pos)
+#define PAC_INTFLAGC_SERCOM4_Pos    4            /**< \brief (PAC_INTFLAGC) SERCOM4 */
+#define PAC_INTFLAGC_SERCOM4        (0x1ul << PAC_INTFLAGC_SERCOM4_Pos)
+#define PAC_INTFLAGC_TCC0_Pos       5            /**< \brief (PAC_INTFLAGC) TCC0 */
+#define PAC_INTFLAGC_TCC0           (0x1ul << PAC_INTFLAGC_TCC0_Pos)
+#define PAC_INTFLAGC_TCC1_Pos       6            /**< \brief (PAC_INTFLAGC) TCC1 */
+#define PAC_INTFLAGC_TCC1           (0x1ul << PAC_INTFLAGC_TCC1_Pos)
+#define PAC_INTFLAGC_TCC2_Pos       7            /**< \brief (PAC_INTFLAGC) TCC2 */
+#define PAC_INTFLAGC_TCC2           (0x1ul << PAC_INTFLAGC_TCC2_Pos)
+#define PAC_INTFLAGC_TC0_Pos        8            /**< \brief (PAC_INTFLAGC) TC0 */
+#define PAC_INTFLAGC_TC0            (0x1ul << PAC_INTFLAGC_TC0_Pos)
+#define PAC_INTFLAGC_TC1_Pos        9            /**< \brief (PAC_INTFLAGC) TC1 */
+#define PAC_INTFLAGC_TC1            (0x1ul << PAC_INTFLAGC_TC1_Pos)
+#define PAC_INTFLAGC_TC2_Pos        10           /**< \brief (PAC_INTFLAGC) TC2 */
+#define PAC_INTFLAGC_TC2            (0x1ul << PAC_INTFLAGC_TC2_Pos)
+#define PAC_INTFLAGC_TC3_Pos        11           /**< \brief (PAC_INTFLAGC) TC3 */
+#define PAC_INTFLAGC_TC3            (0x1ul << PAC_INTFLAGC_TC3_Pos)
+#define PAC_INTFLAGC_DAC_Pos        12           /**< \brief (PAC_INTFLAGC) DAC */
+#define PAC_INTFLAGC_DAC            (0x1ul << PAC_INTFLAGC_DAC_Pos)
+#define PAC_INTFLAGC_AES_Pos        13           /**< \brief (PAC_INTFLAGC) AES */
+#define PAC_INTFLAGC_AES            (0x1ul << PAC_INTFLAGC_AES_Pos)
+#define PAC_INTFLAGC_TRNG_Pos       14           /**< \brief (PAC_INTFLAGC) TRNG */
+#define PAC_INTFLAGC_TRNG           (0x1ul << PAC_INTFLAGC_TRNG_Pos)
+#define PAC_INTFLAGC_MASK           0x00007FFFul /**< \brief (PAC_INTFLAGC) MASK Register */
+
+/* -------- PAC_INTFLAGD : (PAC Offset: 0x20) (R/W 32) Peripheral interrupt flag status - Bridge D -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t EVSYS_:1;         /*!< bit:      0  EVSYS                              */
+    __I uint32_t SERCOM5_:1;       /*!< bit:      1  SERCOM5                            */
+    __I uint32_t TC4_:1;           /*!< bit:      2  TC4                                */
+    __I uint32_t ADC_:1;           /*!< bit:      3  ADC                                */
+    __I uint32_t AC_:1;            /*!< bit:      4  AC                                 */
+    __I uint32_t PTC_:1;           /*!< bit:      5  PTC                                */
+    __I uint32_t OPAMP_:1;         /*!< bit:      6  OPAMP                              */
+    __I uint32_t CCL_:1;           /*!< bit:      7  CCL                                */
+    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_INTFLAGD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGD_OFFSET         0x20         /**< \brief (PAC_INTFLAGD offset) Peripheral interrupt flag status - Bridge D */
+#define PAC_INTFLAGD_RESETVALUE     0x00000000ul /**< \brief (PAC_INTFLAGD reset_value) Peripheral interrupt flag status - Bridge D */
+
+#define PAC_INTFLAGD_EVSYS_Pos      0            /**< \brief (PAC_INTFLAGD) EVSYS */
+#define PAC_INTFLAGD_EVSYS          (0x1ul << PAC_INTFLAGD_EVSYS_Pos)
+#define PAC_INTFLAGD_SERCOM5_Pos    1            /**< \brief (PAC_INTFLAGD) SERCOM5 */
+#define PAC_INTFLAGD_SERCOM5        (0x1ul << PAC_INTFLAGD_SERCOM5_Pos)
+#define PAC_INTFLAGD_TC4_Pos        2            /**< \brief (PAC_INTFLAGD) TC4 */
+#define PAC_INTFLAGD_TC4            (0x1ul << PAC_INTFLAGD_TC4_Pos)
+#define PAC_INTFLAGD_ADC_Pos        3            /**< \brief (PAC_INTFLAGD) ADC */
+#define PAC_INTFLAGD_ADC            (0x1ul << PAC_INTFLAGD_ADC_Pos)
+#define PAC_INTFLAGD_AC_Pos         4            /**< \brief (PAC_INTFLAGD) AC */
+#define PAC_INTFLAGD_AC             (0x1ul << PAC_INTFLAGD_AC_Pos)
+#define PAC_INTFLAGD_PTC_Pos        5            /**< \brief (PAC_INTFLAGD) PTC */
+#define PAC_INTFLAGD_PTC            (0x1ul << PAC_INTFLAGD_PTC_Pos)
+#define PAC_INTFLAGD_OPAMP_Pos      6            /**< \brief (PAC_INTFLAGD) OPAMP */
+#define PAC_INTFLAGD_OPAMP          (0x1ul << PAC_INTFLAGD_OPAMP_Pos)
+#define PAC_INTFLAGD_CCL_Pos        7            /**< \brief (PAC_INTFLAGD) CCL */
+#define PAC_INTFLAGD_CCL            (0x1ul << PAC_INTFLAGD_CCL_Pos)
+#define PAC_INTFLAGD_MASK           0x000000FFul /**< \brief (PAC_INTFLAGD) MASK Register */
+
+/* -------- PAC_INTFLAGE : (PAC Offset: 0x24) (R/W 32) Peripheral interrupt flag status - Bridge E -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t PAC_:1;           /*!< bit:      0  PAC                                */
+    __I uint32_t DMAC_:1;          /*!< bit:      1  DMAC                               */
+    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_INTFLAGE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_INTFLAGE_OFFSET         0x24         /**< \brief (PAC_INTFLAGE offset) Peripheral interrupt flag status - Bridge E */
+#define PAC_INTFLAGE_RESETVALUE     0x00000000ul /**< \brief (PAC_INTFLAGE reset_value) Peripheral interrupt flag status - Bridge E */
+
+#define PAC_INTFLAGE_PAC_Pos        0            /**< \brief (PAC_INTFLAGE) PAC */
+#define PAC_INTFLAGE_PAC            (0x1ul << PAC_INTFLAGE_PAC_Pos)
+#define PAC_INTFLAGE_DMAC_Pos       1            /**< \brief (PAC_INTFLAGE) DMAC */
+#define PAC_INTFLAGE_DMAC           (0x1ul << PAC_INTFLAGE_DMAC_Pos)
+#define PAC_INTFLAGE_MASK           0x00000003ul /**< \brief (PAC_INTFLAGE) MASK Register */
+
+/* -------- PAC_STATUSA : (PAC Offset: 0x34) (R/  32) Peripheral write protection status - Bridge A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PM_:1;            /*!< bit:      0  PM APB Protect Enable              */
+    uint32_t MCLK_:1;          /*!< bit:      1  MCLK APB Protect Enable            */
+    uint32_t RSTC_:1;          /*!< bit:      2  RSTC APB Protect Enable            */
+    uint32_t OSCCTRL_:1;       /*!< bit:      3  OSCCTRL APB Protect Enable         */
+    uint32_t OSC32KCTRL_:1;    /*!< bit:      4  OSC32KCTRL APB Protect Enable      */
+    uint32_t SUPC_:1;          /*!< bit:      5  SUPC APB Protect Enable            */
+    uint32_t GCLK_:1;          /*!< bit:      6  GCLK APB Protect Enable            */
+    uint32_t WDT_:1;           /*!< bit:      7  WDT APB Protect Enable             */
+    uint32_t RTC_:1;           /*!< bit:      8  RTC APB Protect Enable             */
+    uint32_t EIC_:1;           /*!< bit:      9  EIC APB Protect Enable             */
+    uint32_t PORT_:1;          /*!< bit:     10  PORT APB Protect Enable            */
+    uint32_t TAL_:1;           /*!< bit:     11  TAL APB Protect Enable             */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSA_OFFSET          0x34         /**< \brief (PAC_STATUSA offset) Peripheral write protection status - Bridge A */
+#define PAC_STATUSA_RESETVALUE      0x00001000ul /**< \brief (PAC_STATUSA reset_value) Peripheral write protection status - Bridge A */
+
+#define PAC_STATUSA_PM_Pos          0            /**< \brief (PAC_STATUSA) PM APB Protect Enable */
+#define PAC_STATUSA_PM              (0x1ul << PAC_STATUSA_PM_Pos)
+#define PAC_STATUSA_MCLK_Pos        1            /**< \brief (PAC_STATUSA) MCLK APB Protect Enable */
+#define PAC_STATUSA_MCLK            (0x1ul << PAC_STATUSA_MCLK_Pos)
+#define PAC_STATUSA_RSTC_Pos        2            /**< \brief (PAC_STATUSA) RSTC APB Protect Enable */
+#define PAC_STATUSA_RSTC            (0x1ul << PAC_STATUSA_RSTC_Pos)
+#define PAC_STATUSA_OSCCTRL_Pos     3            /**< \brief (PAC_STATUSA) OSCCTRL APB Protect Enable */
+#define PAC_STATUSA_OSCCTRL         (0x1ul << PAC_STATUSA_OSCCTRL_Pos)
+#define PAC_STATUSA_OSC32KCTRL_Pos  4            /**< \brief (PAC_STATUSA) OSC32KCTRL APB Protect Enable */
+#define PAC_STATUSA_OSC32KCTRL      (0x1ul << PAC_STATUSA_OSC32KCTRL_Pos)
+#define PAC_STATUSA_SUPC_Pos        5            /**< \brief (PAC_STATUSA) SUPC APB Protect Enable */
+#define PAC_STATUSA_SUPC            (0x1ul << PAC_STATUSA_SUPC_Pos)
+#define PAC_STATUSA_GCLK_Pos        6            /**< \brief (PAC_STATUSA) GCLK APB Protect Enable */
+#define PAC_STATUSA_GCLK            (0x1ul << PAC_STATUSA_GCLK_Pos)
+#define PAC_STATUSA_WDT_Pos         7            /**< \brief (PAC_STATUSA) WDT APB Protect Enable */
+#define PAC_STATUSA_WDT             (0x1ul << PAC_STATUSA_WDT_Pos)
+#define PAC_STATUSA_RTC_Pos         8            /**< \brief (PAC_STATUSA) RTC APB Protect Enable */
+#define PAC_STATUSA_RTC             (0x1ul << PAC_STATUSA_RTC_Pos)
+#define PAC_STATUSA_EIC_Pos         9            /**< \brief (PAC_STATUSA) EIC APB Protect Enable */
+#define PAC_STATUSA_EIC             (0x1ul << PAC_STATUSA_EIC_Pos)
+#define PAC_STATUSA_PORT_Pos        10           /**< \brief (PAC_STATUSA) PORT APB Protect Enable */
+#define PAC_STATUSA_PORT            (0x1ul << PAC_STATUSA_PORT_Pos)
+#define PAC_STATUSA_TAL_Pos         11           /**< \brief (PAC_STATUSA) TAL APB Protect Enable */
+#define PAC_STATUSA_TAL             (0x1ul << PAC_STATUSA_TAL_Pos)
+#define PAC_STATUSA_MASK            0x00000FFFul /**< \brief (PAC_STATUSA) MASK Register */
+
+/* -------- PAC_STATUSB : (PAC Offset: 0x38) (R/  32) Peripheral write protection status - Bridge B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t USB_:1;           /*!< bit:      0  USB APB Protect Enable             */
+    uint32_t DSU_:1;           /*!< bit:      1  DSU APB Protect Enable             */
+    uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL APB Protect Enable         */
+    uint32_t MTB_:1;           /*!< bit:      3  MTB APB Protect Enable             */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSB_OFFSET          0x38         /**< \brief (PAC_STATUSB offset) Peripheral write protection status - Bridge B */
+#define PAC_STATUSB_RESETVALUE      0x00000022ul /**< \brief (PAC_STATUSB reset_value) Peripheral write protection status - Bridge B */
+
+#define PAC_STATUSB_USB_Pos         0            /**< \brief (PAC_STATUSB) USB APB Protect Enable */
+#define PAC_STATUSB_USB             (0x1ul << PAC_STATUSB_USB_Pos)
+#define PAC_STATUSB_DSU_Pos         1            /**< \brief (PAC_STATUSB) DSU APB Protect Enable */
+#define PAC_STATUSB_DSU             (0x1ul << PAC_STATUSB_DSU_Pos)
+#define PAC_STATUSB_NVMCTRL_Pos     2            /**< \brief (PAC_STATUSB) NVMCTRL APB Protect Enable */
+#define PAC_STATUSB_NVMCTRL         (0x1ul << PAC_STATUSB_NVMCTRL_Pos)
+#define PAC_STATUSB_MTB_Pos         3            /**< \brief (PAC_STATUSB) MTB APB Protect Enable */
+#define PAC_STATUSB_MTB             (0x1ul << PAC_STATUSB_MTB_Pos)
+#define PAC_STATUSB_MASK            0x0000000Ful /**< \brief (PAC_STATUSB) MASK Register */
+
+/* -------- PAC_STATUSC : (PAC Offset: 0x3C) (R/  32) Peripheral write protection status - Bridge C -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SERCOM0_:1;       /*!< bit:      0  SERCOM0 APB Protect Enable         */
+    uint32_t SERCOM1_:1;       /*!< bit:      1  SERCOM1 APB Protect Enable         */
+    uint32_t SERCOM2_:1;       /*!< bit:      2  SERCOM2 APB Protect Enable         */
+    uint32_t SERCOM3_:1;       /*!< bit:      3  SERCOM3 APB Protect Enable         */
+    uint32_t SERCOM4_:1;       /*!< bit:      4  SERCOM4 APB Protect Enable         */
+    uint32_t TCC0_:1;          /*!< bit:      5  TCC0 APB Protect Enable            */
+    uint32_t TCC1_:1;          /*!< bit:      6  TCC1 APB Protect Enable            */
+    uint32_t TCC2_:1;          /*!< bit:      7  TCC2 APB Protect Enable            */
+    uint32_t TC0_:1;           /*!< bit:      8  TC0 APB Protect Enable             */
+    uint32_t TC1_:1;           /*!< bit:      9  TC1 APB Protect Enable             */
+    uint32_t TC2_:1;           /*!< bit:     10  TC2 APB Protect Enable             */
+    uint32_t TC3_:1;           /*!< bit:     11  TC3 APB Protect Enable             */
+    uint32_t DAC_:1;           /*!< bit:     12  DAC APB Protect Enable             */
+    uint32_t AES_:1;           /*!< bit:     13  AES APB Protect Enable             */
+    uint32_t TRNG_:1;          /*!< bit:     14  TRNG APB Protect Enable            */
+    uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_STATUSC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSC_OFFSET          0x3C         /**< \brief (PAC_STATUSC offset) Peripheral write protection status - Bridge C */
+#define PAC_STATUSC_RESETVALUE      0x00000000ul /**< \brief (PAC_STATUSC reset_value) Peripheral write protection status - Bridge C */
+
+#define PAC_STATUSC_SERCOM0_Pos     0            /**< \brief (PAC_STATUSC) SERCOM0 APB Protect Enable */
+#define PAC_STATUSC_SERCOM0         (0x1ul << PAC_STATUSC_SERCOM0_Pos)
+#define PAC_STATUSC_SERCOM1_Pos     1            /**< \brief (PAC_STATUSC) SERCOM1 APB Protect Enable */
+#define PAC_STATUSC_SERCOM1         (0x1ul << PAC_STATUSC_SERCOM1_Pos)
+#define PAC_STATUSC_SERCOM2_Pos     2            /**< \brief (PAC_STATUSC) SERCOM2 APB Protect Enable */
+#define PAC_STATUSC_SERCOM2         (0x1ul << PAC_STATUSC_SERCOM2_Pos)
+#define PAC_STATUSC_SERCOM3_Pos     3            /**< \brief (PAC_STATUSC) SERCOM3 APB Protect Enable */
+#define PAC_STATUSC_SERCOM3         (0x1ul << PAC_STATUSC_SERCOM3_Pos)
+#define PAC_STATUSC_SERCOM4_Pos     4            /**< \brief (PAC_STATUSC) SERCOM4 APB Protect Enable */
+#define PAC_STATUSC_SERCOM4         (0x1ul << PAC_STATUSC_SERCOM4_Pos)
+#define PAC_STATUSC_TCC0_Pos        5            /**< \brief (PAC_STATUSC) TCC0 APB Protect Enable */
+#define PAC_STATUSC_TCC0            (0x1ul << PAC_STATUSC_TCC0_Pos)
+#define PAC_STATUSC_TCC1_Pos        6            /**< \brief (PAC_STATUSC) TCC1 APB Protect Enable */
+#define PAC_STATUSC_TCC1            (0x1ul << PAC_STATUSC_TCC1_Pos)
+#define PAC_STATUSC_TCC2_Pos        7            /**< \brief (PAC_STATUSC) TCC2 APB Protect Enable */
+#define PAC_STATUSC_TCC2            (0x1ul << PAC_STATUSC_TCC2_Pos)
+#define PAC_STATUSC_TC0_Pos         8            /**< \brief (PAC_STATUSC) TC0 APB Protect Enable */
+#define PAC_STATUSC_TC0             (0x1ul << PAC_STATUSC_TC0_Pos)
+#define PAC_STATUSC_TC1_Pos         9            /**< \brief (PAC_STATUSC) TC1 APB Protect Enable */
+#define PAC_STATUSC_TC1             (0x1ul << PAC_STATUSC_TC1_Pos)
+#define PAC_STATUSC_TC2_Pos         10           /**< \brief (PAC_STATUSC) TC2 APB Protect Enable */
+#define PAC_STATUSC_TC2             (0x1ul << PAC_STATUSC_TC2_Pos)
+#define PAC_STATUSC_TC3_Pos         11           /**< \brief (PAC_STATUSC) TC3 APB Protect Enable */
+#define PAC_STATUSC_TC3             (0x1ul << PAC_STATUSC_TC3_Pos)
+#define PAC_STATUSC_DAC_Pos         12           /**< \brief (PAC_STATUSC) DAC APB Protect Enable */
+#define PAC_STATUSC_DAC             (0x1ul << PAC_STATUSC_DAC_Pos)
+#define PAC_STATUSC_AES_Pos         13           /**< \brief (PAC_STATUSC) AES APB Protect Enable */
+#define PAC_STATUSC_AES             (0x1ul << PAC_STATUSC_AES_Pos)
+#define PAC_STATUSC_TRNG_Pos        14           /**< \brief (PAC_STATUSC) TRNG APB Protect Enable */
+#define PAC_STATUSC_TRNG            (0x1ul << PAC_STATUSC_TRNG_Pos)
+#define PAC_STATUSC_MASK            0x00007FFFul /**< \brief (PAC_STATUSC) MASK Register */
+
+/* -------- PAC_STATUSD : (PAC Offset: 0x40) (R/  32) Peripheral write protection status - Bridge D -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EVSYS_:1;         /*!< bit:      0  EVSYS APB Protect Enable           */
+    uint32_t SERCOM5_:1;       /*!< bit:      1  SERCOM5 APB Protect Enable         */
+    uint32_t TC4_:1;           /*!< bit:      2  TC4 APB Protect Enable             */
+    uint32_t ADC_:1;           /*!< bit:      3  ADC APB Protect Enable             */
+    uint32_t AC_:1;            /*!< bit:      4  AC APB Protect Enable              */
+    uint32_t PTC_:1;           /*!< bit:      5  PTC APB Protect Enable             */
+    uint32_t OPAMP_:1;         /*!< bit:      6  OPAMP APB Protect Enable           */
+    uint32_t CCL_:1;           /*!< bit:      7  CCL APB Protect Enable             */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_STATUSD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSD_OFFSET          0x40         /**< \brief (PAC_STATUSD offset) Peripheral write protection status - Bridge D */
+#define PAC_STATUSD_RESETVALUE      0x00000000ul /**< \brief (PAC_STATUSD reset_value) Peripheral write protection status - Bridge D */
+
+#define PAC_STATUSD_EVSYS_Pos       0            /**< \brief (PAC_STATUSD) EVSYS APB Protect Enable */
+#define PAC_STATUSD_EVSYS           (0x1ul << PAC_STATUSD_EVSYS_Pos)
+#define PAC_STATUSD_SERCOM5_Pos     1            /**< \brief (PAC_STATUSD) SERCOM5 APB Protect Enable */
+#define PAC_STATUSD_SERCOM5         (0x1ul << PAC_STATUSD_SERCOM5_Pos)
+#define PAC_STATUSD_TC4_Pos         2            /**< \brief (PAC_STATUSD) TC4 APB Protect Enable */
+#define PAC_STATUSD_TC4             (0x1ul << PAC_STATUSD_TC4_Pos)
+#define PAC_STATUSD_ADC_Pos         3            /**< \brief (PAC_STATUSD) ADC APB Protect Enable */
+#define PAC_STATUSD_ADC             (0x1ul << PAC_STATUSD_ADC_Pos)
+#define PAC_STATUSD_AC_Pos          4            /**< \brief (PAC_STATUSD) AC APB Protect Enable */
+#define PAC_STATUSD_AC              (0x1ul << PAC_STATUSD_AC_Pos)
+#define PAC_STATUSD_PTC_Pos         5            /**< \brief (PAC_STATUSD) PTC APB Protect Enable */
+#define PAC_STATUSD_PTC             (0x1ul << PAC_STATUSD_PTC_Pos)
+#define PAC_STATUSD_OPAMP_Pos       6            /**< \brief (PAC_STATUSD) OPAMP APB Protect Enable */
+#define PAC_STATUSD_OPAMP           (0x1ul << PAC_STATUSD_OPAMP_Pos)
+#define PAC_STATUSD_CCL_Pos         7            /**< \brief (PAC_STATUSD) CCL APB Protect Enable */
+#define PAC_STATUSD_CCL             (0x1ul << PAC_STATUSD_CCL_Pos)
+#define PAC_STATUSD_MASK            0x000000FFul /**< \brief (PAC_STATUSD) MASK Register */
+
+/* -------- PAC_STATUSE : (PAC Offset: 0x44) (R/  32) Peripheral write protection status - Bridge E -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PAC_:1;           /*!< bit:      0  PAC APB Protect Enable             */
+    uint32_t DMAC_:1;          /*!< bit:      1  DMAC APB Protect Enable            */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_STATUSE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_STATUSE_OFFSET          0x44         /**< \brief (PAC_STATUSE offset) Peripheral write protection status - Bridge E */
+#define PAC_STATUSE_RESETVALUE      0x00000000ul /**< \brief (PAC_STATUSE reset_value) Peripheral write protection status - Bridge E */
+
+#define PAC_STATUSE_PAC_Pos         0            /**< \brief (PAC_STATUSE) PAC APB Protect Enable */
+#define PAC_STATUSE_PAC             (0x1ul << PAC_STATUSE_PAC_Pos)
+#define PAC_STATUSE_DMAC_Pos        1            /**< \brief (PAC_STATUSE) DMAC APB Protect Enable */
+#define PAC_STATUSE_DMAC            (0x1ul << PAC_STATUSE_DMAC_Pos)
+#define PAC_STATUSE_MASK            0x00000003ul /**< \brief (PAC_STATUSE) MASK Register */
+
+/** \brief PAC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO PAC_WRCTRL_Type           WRCTRL;      /**< \brief Offset: 0x00 (R/W 32) Write control */
+  __IO PAC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x04 (R/W  8) Event control */
+       RoReg8                    Reserved1[0x3];
+  __IO PAC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x08 (R/W  8) Interrupt enable clear */
+  __IO PAC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x09 (R/W  8) Interrupt enable set */
+       RoReg8                    Reserved2[0x6];
+  __IO PAC_INTFLAGAHB_Type       INTFLAGAHB;  /**< \brief Offset: 0x10 (R/W 32) Bridge interrupt flag status */
+  __IO PAC_INTFLAGA_Type         INTFLAGA;    /**< \brief Offset: 0x14 (R/W 32) Peripheral interrupt flag status - Bridge A */
+  __IO PAC_INTFLAGB_Type         INTFLAGB;    /**< \brief Offset: 0x18 (R/W 32) Peripheral interrupt flag status - Bridge B */
+  __IO PAC_INTFLAGC_Type         INTFLAGC;    /**< \brief Offset: 0x1C (R/W 32) Peripheral interrupt flag status - Bridge C */
+  __IO PAC_INTFLAGD_Type         INTFLAGD;    /**< \brief Offset: 0x20 (R/W 32) Peripheral interrupt flag status - Bridge D */
+  __IO PAC_INTFLAGE_Type         INTFLAGE;    /**< \brief Offset: 0x24 (R/W 32) Peripheral interrupt flag status - Bridge E */
+       RoReg8                    Reserved3[0xC];
+  __I  PAC_STATUSA_Type          STATUSA;     /**< \brief Offset: 0x34 (R/  32) Peripheral write protection status - Bridge A */
+  __I  PAC_STATUSB_Type          STATUSB;     /**< \brief Offset: 0x38 (R/  32) Peripheral write protection status - Bridge B */
+  __I  PAC_STATUSC_Type          STATUSC;     /**< \brief Offset: 0x3C (R/  32) Peripheral write protection status - Bridge C */
+  __I  PAC_STATUSD_Type          STATUSD;     /**< \brief Offset: 0x40 (R/  32) Peripheral write protection status - Bridge D */
+  __I  PAC_STATUSE_Type          STATUSE;     /**< \brief Offset: 0x44 (R/  32) Peripheral write protection status - Bridge E */
+} Pac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_PAC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/pm_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/pm_100.h
@@ -1,0 +1,286 @@
+/**
+ * \file
+ *
+ * \brief Component description for PM
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_PM_COMPONENT_
+#define _SAML21_PM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PM */
+/* ========================================================================== */
+/** \addtogroup SAML21_PM Power Manager */
+/*@{*/
+
+#define PM_U2240
+#define REV_PM                      0x100
+
+/* -------- PM_CTRLA : (PM Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint8_t  IORET:1;          /*!< bit:      2  I/O Retention                      */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_CTRLA_OFFSET             0x00         /**< \brief (PM_CTRLA offset) Control A */
+#define PM_CTRLA_RESETVALUE         0x00ul       /**< \brief (PM_CTRLA reset_value) Control A */
+
+#define PM_CTRLA_IORET_Pos          2            /**< \brief (PM_CTRLA) I/O Retention */
+#define PM_CTRLA_IORET              (0x1ul << PM_CTRLA_IORET_Pos)
+#define PM_CTRLA_MASK               0x04ul       /**< \brief (PM_CTRLA) MASK Register */
+
+/* -------- PM_SLEEPCFG : (PM Offset: 0x01) (R/W  8) Sleep Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SLEEPMODE:3;      /*!< bit:  0.. 2  Sleep Mode                         */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_SLEEPCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_SLEEPCFG_OFFSET          0x01         /**< \brief (PM_SLEEPCFG offset) Sleep Configuration */
+#define PM_SLEEPCFG_RESETVALUE      0x00ul       /**< \brief (PM_SLEEPCFG reset_value) Sleep Configuration */
+
+#define PM_SLEEPCFG_SLEEPMODE_Pos   0            /**< \brief (PM_SLEEPCFG) Sleep Mode */
+#define PM_SLEEPCFG_SLEEPMODE_Msk   (0x7ul << PM_SLEEPCFG_SLEEPMODE_Pos)
+#define PM_SLEEPCFG_SLEEPMODE(value) (PM_SLEEPCFG_SLEEPMODE_Msk & ((value) << PM_SLEEPCFG_SLEEPMODE_Pos))
+#define   PM_SLEEPCFG_SLEEPMODE_IDLE0_Val 0x0ul  /**< \brief (PM_SLEEPCFG) CPU clock is OFF */
+#define   PM_SLEEPCFG_SLEEPMODE_IDLE1_Val 0x1ul  /**< \brief (PM_SLEEPCFG) AHB clock is OFF */
+#define   PM_SLEEPCFG_SLEEPMODE_IDLE2_Val 0x2ul  /**< \brief (PM_SLEEPCFG) APB clock are OFF */
+#define   PM_SLEEPCFG_SLEEPMODE_STANDBY_Val 0x4ul  /**< \brief (PM_SLEEPCFG) All Clocks are OFF */
+#define   PM_SLEEPCFG_SLEEPMODE_BACKUP_Val 0x5ul  /**< \brief (PM_SLEEPCFG) Only Backup domain is powered ON */
+#define   PM_SLEEPCFG_SLEEPMODE_OFF_Val   0x6ul  /**< \brief (PM_SLEEPCFG) All power domains are powered OFF */
+#define PM_SLEEPCFG_SLEEPMODE_IDLE0 (PM_SLEEPCFG_SLEEPMODE_IDLE0_Val << PM_SLEEPCFG_SLEEPMODE_Pos)
+#define PM_SLEEPCFG_SLEEPMODE_IDLE1 (PM_SLEEPCFG_SLEEPMODE_IDLE1_Val << PM_SLEEPCFG_SLEEPMODE_Pos)
+#define PM_SLEEPCFG_SLEEPMODE_IDLE2 (PM_SLEEPCFG_SLEEPMODE_IDLE2_Val << PM_SLEEPCFG_SLEEPMODE_Pos)
+#define PM_SLEEPCFG_SLEEPMODE_STANDBY (PM_SLEEPCFG_SLEEPMODE_STANDBY_Val << PM_SLEEPCFG_SLEEPMODE_Pos)
+#define PM_SLEEPCFG_SLEEPMODE_BACKUP (PM_SLEEPCFG_SLEEPMODE_BACKUP_Val << PM_SLEEPCFG_SLEEPMODE_Pos)
+#define PM_SLEEPCFG_SLEEPMODE_OFF   (PM_SLEEPCFG_SLEEPMODE_OFF_Val << PM_SLEEPCFG_SLEEPMODE_Pos)
+#define PM_SLEEPCFG_MASK            0x07ul       /**< \brief (PM_SLEEPCFG) MASK Register */
+
+/* -------- PM_PLCFG : (PM Offset: 0x02) (R/W  8) Performance Level Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PLSEL:2;          /*!< bit:  0.. 1  Performance Level Select           */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_PLCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PLCFG_OFFSET             0x02         /**< \brief (PM_PLCFG offset) Performance Level Configuration */
+#define PM_PLCFG_RESETVALUE         0x00ul       /**< \brief (PM_PLCFG reset_value) Performance Level Configuration */
+
+#define PM_PLCFG_PLSEL_Pos          0            /**< \brief (PM_PLCFG) Performance Level Select */
+#define PM_PLCFG_PLSEL_Msk          (0x3ul << PM_PLCFG_PLSEL_Pos)
+#define PM_PLCFG_PLSEL(value)       (PM_PLCFG_PLSEL_Msk & ((value) << PM_PLCFG_PLSEL_Pos))
+#define   PM_PLCFG_PLSEL_PL0_Val          0x0ul  /**< \brief (PM_PLCFG) Performance Level 0 */
+#define   PM_PLCFG_PLSEL_PL1_Val          0x1ul  /**< \brief (PM_PLCFG) Performance Level 1 */
+#define   PM_PLCFG_PLSEL_PL2_Val          0x2ul  /**< \brief (PM_PLCFG) Performance Level 2 */
+#define PM_PLCFG_PLSEL_PL0          (PM_PLCFG_PLSEL_PL0_Val        << PM_PLCFG_PLSEL_Pos)
+#define PM_PLCFG_PLSEL_PL1          (PM_PLCFG_PLSEL_PL1_Val        << PM_PLCFG_PLSEL_Pos)
+#define PM_PLCFG_PLSEL_PL2          (PM_PLCFG_PLSEL_PL2_Val        << PM_PLCFG_PLSEL_Pos)
+#define PM_PLCFG_MASK               0x03ul       /**< \brief (PM_PLCFG) MASK Register */
+
+/* -------- PM_INTENCLR : (PM Offset: 0x04) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Interrupt Enable */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENCLR_OFFSET          0x04         /**< \brief (PM_INTENCLR offset) Interrupt Enable Clear */
+#define PM_INTENCLR_RESETVALUE      0x00ul       /**< \brief (PM_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define PM_INTENCLR_PLRDY_Pos       0            /**< \brief (PM_INTENCLR) Performance Level Interrupt Enable */
+#define PM_INTENCLR_PLRDY           (0x1ul << PM_INTENCLR_PLRDY_Pos)
+#define PM_INTENCLR_MASK            0x01ul       /**< \brief (PM_INTENCLR) MASK Register */
+
+/* -------- PM_INTENSET : (PM Offset: 0x05) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Ready interrupt Enable */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENSET_OFFSET          0x05         /**< \brief (PM_INTENSET offset) Interrupt Enable Set */
+#define PM_INTENSET_RESETVALUE      0x00ul       /**< \brief (PM_INTENSET reset_value) Interrupt Enable Set */
+
+#define PM_INTENSET_PLRDY_Pos       0            /**< \brief (PM_INTENSET) Performance Level Ready interrupt Enable */
+#define PM_INTENSET_PLRDY           (0x1ul << PM_INTENSET_PLRDY_Pos)
+#define PM_INTENSET_MASK            0x01ul       /**< \brief (PM_INTENSET) MASK Register */
+
+/* -------- PM_INTFLAG : (PM Offset: 0x06) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Ready            */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTFLAG_OFFSET           0x06         /**< \brief (PM_INTFLAG offset) Interrupt Flag Status and Clear */
+#define PM_INTFLAG_RESETVALUE       0x00ul       /**< \brief (PM_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define PM_INTFLAG_PLRDY_Pos        0            /**< \brief (PM_INTFLAG) Performance Level Ready */
+#define PM_INTFLAG_PLRDY            (0x1ul << PM_INTFLAG_PLRDY_Pos)
+#define PM_INTFLAG_MASK             0x01ul       /**< \brief (PM_INTFLAG) MASK Register */
+
+/* -------- PM_STDBYCFG : (PM Offset: 0x08) (R/W 16) Standby Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PDCFG:2;          /*!< bit:  0.. 1  Power Domain Configuration         */
+    uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t DPGPD0:1;         /*!< bit:      4  Dynamic Power Gating for PD0       */
+    uint16_t DPGPD1:1;         /*!< bit:      5  Dynamic Power Gating for PD1       */
+    uint16_t :1;               /*!< bit:      6  Reserved                           */
+    uint16_t AVREGSD:1;        /*!< bit:      7  Automatic VREG Switching Disable   */
+    uint16_t LINKPD:2;         /*!< bit:  8.. 9  Linked Power Domain                */
+    uint16_t BBIASHS:2;        /*!< bit: 10..11  Back Bias for HMCRAMCHS            */
+    uint16_t BBIASLP:2;        /*!< bit: 12..13  Back Bias for HMCRAMCLP            */
+    uint16_t BBIASPP:2;        /*!< bit: 14..15  Back Bias for PicoPram             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} PM_STDBYCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_STDBYCFG_OFFSET          0x08         /**< \brief (PM_STDBYCFG offset) Standby Configuration */
+#define PM_STDBYCFG_RESETVALUE      0x0000ul     /**< \brief (PM_STDBYCFG reset_value) Standby Configuration */
+
+#define PM_STDBYCFG_PDCFG_Pos       0            /**< \brief (PM_STDBYCFG) Power Domain Configuration */
+#define PM_STDBYCFG_PDCFG_Msk       (0x3ul << PM_STDBYCFG_PDCFG_Pos)
+#define PM_STDBYCFG_PDCFG(value)    (PM_STDBYCFG_PDCFG_Msk & ((value) << PM_STDBYCFG_PDCFG_Pos))
+#define   PM_STDBYCFG_PDCFG_DEFAULT_Val   0x0ul  /**< \brief (PM_STDBYCFG) All power domains switching is handled by hardware. */
+#define   PM_STDBYCFG_PDCFG_PD0_Val       0x1ul  /**< \brief (PM_STDBYCFG) PD0 is forced ACTIVE. PD1 and PD2 power domains switching is handled by hardware. */
+#define   PM_STDBYCFG_PDCFG_PD01_Val      0x2ul  /**< \brief (PM_STDBYCFG) PD0 and PD1 are forced ACTIVE. PD2 power domain switching is handled by hardware. */
+#define   PM_STDBYCFG_PDCFG_PD012_Val     0x3ul  /**< \brief (PM_STDBYCFG) All power domains are forced ACTIVE. */
+#define PM_STDBYCFG_PDCFG_DEFAULT   (PM_STDBYCFG_PDCFG_DEFAULT_Val << PM_STDBYCFG_PDCFG_Pos)
+#define PM_STDBYCFG_PDCFG_PD0       (PM_STDBYCFG_PDCFG_PD0_Val     << PM_STDBYCFG_PDCFG_Pos)
+#define PM_STDBYCFG_PDCFG_PD01      (PM_STDBYCFG_PDCFG_PD01_Val    << PM_STDBYCFG_PDCFG_Pos)
+#define PM_STDBYCFG_PDCFG_PD012     (PM_STDBYCFG_PDCFG_PD012_Val   << PM_STDBYCFG_PDCFG_Pos)
+#define PM_STDBYCFG_DPGPD0_Pos      4            /**< \brief (PM_STDBYCFG) Dynamic Power Gating for PD0 */
+#define PM_STDBYCFG_DPGPD0          (0x1ul << PM_STDBYCFG_DPGPD0_Pos)
+#define PM_STDBYCFG_DPGPD1_Pos      5            /**< \brief (PM_STDBYCFG) Dynamic Power Gating for PD1 */
+#define PM_STDBYCFG_DPGPD1          (0x1ul << PM_STDBYCFG_DPGPD1_Pos)
+#define PM_STDBYCFG_AVREGSD_Pos     7            /**< \brief (PM_STDBYCFG) Automatic VREG Switching Disable */
+#define PM_STDBYCFG_AVREGSD         (0x1ul << PM_STDBYCFG_AVREGSD_Pos)
+#define PM_STDBYCFG_LINKPD_Pos      8            /**< \brief (PM_STDBYCFG) Linked Power Domain */
+#define PM_STDBYCFG_LINKPD_Msk      (0x3ul << PM_STDBYCFG_LINKPD_Pos)
+#define PM_STDBYCFG_LINKPD(value)   (PM_STDBYCFG_LINKPD_Msk & ((value) << PM_STDBYCFG_LINKPD_Pos))
+#define   PM_STDBYCFG_LINKPD_DEFAULT_Val  0x0ul  /**< \brief (PM_STDBYCFG) Power domains are not linked */
+#define   PM_STDBYCFG_LINKPD_PD01_Val     0x1ul  /**< \brief (PM_STDBYCFG) PD0 and PD1 power domains are linked */
+#define   PM_STDBYCFG_LINKPD_PD12_Val     0x2ul  /**< \brief (PM_STDBYCFG) PD1 and PD2 power domains are linked */
+#define   PM_STDBYCFG_LINKPD_PD012_Val    0x3ul  /**< \brief (PM_STDBYCFG) All power domains are linked */
+#define PM_STDBYCFG_LINKPD_DEFAULT  (PM_STDBYCFG_LINKPD_DEFAULT_Val << PM_STDBYCFG_LINKPD_Pos)
+#define PM_STDBYCFG_LINKPD_PD01     (PM_STDBYCFG_LINKPD_PD01_Val   << PM_STDBYCFG_LINKPD_Pos)
+#define PM_STDBYCFG_LINKPD_PD12     (PM_STDBYCFG_LINKPD_PD12_Val   << PM_STDBYCFG_LINKPD_Pos)
+#define PM_STDBYCFG_LINKPD_PD012    (PM_STDBYCFG_LINKPD_PD012_Val  << PM_STDBYCFG_LINKPD_Pos)
+#define PM_STDBYCFG_BBIASHS_Pos     10           /**< \brief (PM_STDBYCFG) Back Bias for HMCRAMCHS */
+#define PM_STDBYCFG_BBIASHS_Msk     (0x3ul << PM_STDBYCFG_BBIASHS_Pos)
+#define PM_STDBYCFG_BBIASHS(value)  (PM_STDBYCFG_BBIASHS_Msk & ((value) << PM_STDBYCFG_BBIASHS_Pos))
+#define PM_STDBYCFG_BBIASLP_Pos     12           /**< \brief (PM_STDBYCFG) Back Bias for HMCRAMCLP */
+#define PM_STDBYCFG_BBIASLP_Msk     (0x3ul << PM_STDBYCFG_BBIASLP_Pos)
+#define PM_STDBYCFG_BBIASLP(value)  (PM_STDBYCFG_BBIASLP_Msk & ((value) << PM_STDBYCFG_BBIASLP_Pos))
+#define PM_STDBYCFG_BBIASPP_Pos     14           /**< \brief (PM_STDBYCFG) Back Bias for PicoPram */
+#define PM_STDBYCFG_BBIASPP_Msk     (0x3ul << PM_STDBYCFG_BBIASPP_Pos)
+#define PM_STDBYCFG_BBIASPP(value)  (PM_STDBYCFG_BBIASPP_Msk & ((value) << PM_STDBYCFG_BBIASPP_Pos))
+#define PM_STDBYCFG_MASK            0xFFB3ul     /**< \brief (PM_STDBYCFG) MASK Register */
+
+/* -------- PM_PWSAKDLY : (PM Offset: 0x0C) (R/W  8) Power Switch Acknowledge Delay -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DLYVAL:7;         /*!< bit:  0.. 6  Delay Value                        */
+    uint8_t  IGNACK:1;         /*!< bit:      7  Ignore Acknowledge                 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_PWSAKDLY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PWSAKDLY_OFFSET          0x0C         /**< \brief (PM_PWSAKDLY offset) Power Switch Acknowledge Delay */
+#define PM_PWSAKDLY_RESETVALUE      0x00ul       /**< \brief (PM_PWSAKDLY reset_value) Power Switch Acknowledge Delay */
+
+#define PM_PWSAKDLY_DLYVAL_Pos      0            /**< \brief (PM_PWSAKDLY) Delay Value */
+#define PM_PWSAKDLY_DLYVAL_Msk      (0x7Ful << PM_PWSAKDLY_DLYVAL_Pos)
+#define PM_PWSAKDLY_DLYVAL(value)   (PM_PWSAKDLY_DLYVAL_Msk & ((value) << PM_PWSAKDLY_DLYVAL_Pos))
+#define PM_PWSAKDLY_IGNACK_Pos      7            /**< \brief (PM_PWSAKDLY) Ignore Acknowledge */
+#define PM_PWSAKDLY_IGNACK          (0x1ul << PM_PWSAKDLY_IGNACK_Pos)
+#define PM_PWSAKDLY_MASK            0xFFul       /**< \brief (PM_PWSAKDLY) MASK Register */
+
+/** \brief PM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO PM_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+  __IO PM_SLEEPCFG_Type          SLEEPCFG;    /**< \brief Offset: 0x01 (R/W  8) Sleep Configuration */
+  __IO PM_PLCFG_Type             PLCFG;       /**< \brief Offset: 0x02 (R/W  8) Performance Level Configuration */
+       RoReg8                    Reserved1[0x1];
+  __IO PM_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x04 (R/W  8) Interrupt Enable Clear */
+  __IO PM_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x05 (R/W  8) Interrupt Enable Set */
+  __IO PM_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x06 (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved2[0x1];
+  __IO PM_STDBYCFG_Type          STDBYCFG;    /**< \brief Offset: 0x08 (R/W 16) Standby Configuration */
+       RoReg8                    Reserved3[0x2];
+  __IO PM_PWSAKDLY_Type          PWSAKDLY;    /**< \brief Offset: 0x0C (R/W  8) Power Switch Acknowledge Delay */
+} Pm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_PM_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/port.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/port.h
@@ -1,0 +1,421 @@
+/**
+ * \file
+ *
+ * \brief Component description for PORT
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_PORT_COMPONENT_
+#define _SAML21_PORT_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PORT */
+/* ========================================================================== */
+/** \addtogroup SAML21_PORT Port Module */
+/*@{*/
+
+#define PORT_U2210
+#define REV_PORT                    0x200
+
+/* -------- PORT_DIR : (PORT Offset: 0x00) (R/W 32) GROUP Data Direction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIR:32;           /*!< bit:  0..31  Port Data Direction                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIR_OFFSET             0x00         /**< \brief (PORT_DIR offset) Data Direction */
+#define PORT_DIR_RESETVALUE         0x00000000ul /**< \brief (PORT_DIR reset_value) Data Direction */
+
+#define PORT_DIR_DIR_Pos            0            /**< \brief (PORT_DIR) Port Data Direction */
+#define PORT_DIR_DIR_Msk            (0xFFFFFFFFul << PORT_DIR_DIR_Pos)
+#define PORT_DIR_DIR(value)         (PORT_DIR_DIR_Msk & ((value) << PORT_DIR_DIR_Pos))
+#define PORT_DIR_MASK               0xFFFFFFFFul /**< \brief (PORT_DIR) MASK Register */
+
+/* -------- PORT_DIRCLR : (PORT Offset: 0x04) (R/W 32) GROUP Data Direction Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIRCLR:32;        /*!< bit:  0..31  Port Data Direction Clear          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRCLR_OFFSET          0x04         /**< \brief (PORT_DIRCLR offset) Data Direction Clear */
+#define PORT_DIRCLR_RESETVALUE      0x00000000ul /**< \brief (PORT_DIRCLR reset_value) Data Direction Clear */
+
+#define PORT_DIRCLR_DIRCLR_Pos      0            /**< \brief (PORT_DIRCLR) Port Data Direction Clear */
+#define PORT_DIRCLR_DIRCLR_Msk      (0xFFFFFFFFul << PORT_DIRCLR_DIRCLR_Pos)
+#define PORT_DIRCLR_DIRCLR(value)   (PORT_DIRCLR_DIRCLR_Msk & ((value) << PORT_DIRCLR_DIRCLR_Pos))
+#define PORT_DIRCLR_MASK            0xFFFFFFFFul /**< \brief (PORT_DIRCLR) MASK Register */
+
+/* -------- PORT_DIRSET : (PORT Offset: 0x08) (R/W 32) GROUP Data Direction Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIRSET:32;        /*!< bit:  0..31  Port Data Direction Set            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRSET_OFFSET          0x08         /**< \brief (PORT_DIRSET offset) Data Direction Set */
+#define PORT_DIRSET_RESETVALUE      0x00000000ul /**< \brief (PORT_DIRSET reset_value) Data Direction Set */
+
+#define PORT_DIRSET_DIRSET_Pos      0            /**< \brief (PORT_DIRSET) Port Data Direction Set */
+#define PORT_DIRSET_DIRSET_Msk      (0xFFFFFFFFul << PORT_DIRSET_DIRSET_Pos)
+#define PORT_DIRSET_DIRSET(value)   (PORT_DIRSET_DIRSET_Msk & ((value) << PORT_DIRSET_DIRSET_Pos))
+#define PORT_DIRSET_MASK            0xFFFFFFFFul /**< \brief (PORT_DIRSET) MASK Register */
+
+/* -------- PORT_DIRTGL : (PORT Offset: 0x0C) (R/W 32) GROUP Data Direction Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIRTGL:32;        /*!< bit:  0..31  Port Data Direction Toggle         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRTGL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRTGL_OFFSET          0x0C         /**< \brief (PORT_DIRTGL offset) Data Direction Toggle */
+#define PORT_DIRTGL_RESETVALUE      0x00000000ul /**< \brief (PORT_DIRTGL reset_value) Data Direction Toggle */
+
+#define PORT_DIRTGL_DIRTGL_Pos      0            /**< \brief (PORT_DIRTGL) Port Data Direction Toggle */
+#define PORT_DIRTGL_DIRTGL_Msk      (0xFFFFFFFFul << PORT_DIRTGL_DIRTGL_Pos)
+#define PORT_DIRTGL_DIRTGL(value)   (PORT_DIRTGL_DIRTGL_Msk & ((value) << PORT_DIRTGL_DIRTGL_Pos))
+#define PORT_DIRTGL_MASK            0xFFFFFFFFul /**< \brief (PORT_DIRTGL) MASK Register */
+
+/* -------- PORT_OUT : (PORT Offset: 0x10) (R/W 32) GROUP Data Output Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUT:32;           /*!< bit:  0..31  Port Data Output Value             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUT_OFFSET             0x10         /**< \brief (PORT_OUT offset) Data Output Value */
+#define PORT_OUT_RESETVALUE         0x00000000ul /**< \brief (PORT_OUT reset_value) Data Output Value */
+
+#define PORT_OUT_OUT_Pos            0            /**< \brief (PORT_OUT) Port Data Output Value */
+#define PORT_OUT_OUT_Msk            (0xFFFFFFFFul << PORT_OUT_OUT_Pos)
+#define PORT_OUT_OUT(value)         (PORT_OUT_OUT_Msk & ((value) << PORT_OUT_OUT_Pos))
+#define PORT_OUT_MASK               0xFFFFFFFFul /**< \brief (PORT_OUT) MASK Register */
+
+/* -------- PORT_OUTCLR : (PORT Offset: 0x14) (R/W 32) GROUP Data Output Value Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTCLR:32;        /*!< bit:  0..31  Port Data Output Value Clear       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTCLR_OFFSET          0x14         /**< \brief (PORT_OUTCLR offset) Data Output Value Clear */
+#define PORT_OUTCLR_RESETVALUE      0x00000000ul /**< \brief (PORT_OUTCLR reset_value) Data Output Value Clear */
+
+#define PORT_OUTCLR_OUTCLR_Pos      0            /**< \brief (PORT_OUTCLR) Port Data Output Value Clear */
+#define PORT_OUTCLR_OUTCLR_Msk      (0xFFFFFFFFul << PORT_OUTCLR_OUTCLR_Pos)
+#define PORT_OUTCLR_OUTCLR(value)   (PORT_OUTCLR_OUTCLR_Msk & ((value) << PORT_OUTCLR_OUTCLR_Pos))
+#define PORT_OUTCLR_MASK            0xFFFFFFFFul /**< \brief (PORT_OUTCLR) MASK Register */
+
+/* -------- PORT_OUTSET : (PORT Offset: 0x18) (R/W 32) GROUP Data Output Value Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTSET:32;        /*!< bit:  0..31  Port Data Output Value Set         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTSET_OFFSET          0x18         /**< \brief (PORT_OUTSET offset) Data Output Value Set */
+#define PORT_OUTSET_RESETVALUE      0x00000000ul /**< \brief (PORT_OUTSET reset_value) Data Output Value Set */
+
+#define PORT_OUTSET_OUTSET_Pos      0            /**< \brief (PORT_OUTSET) Port Data Output Value Set */
+#define PORT_OUTSET_OUTSET_Msk      (0xFFFFFFFFul << PORT_OUTSET_OUTSET_Pos)
+#define PORT_OUTSET_OUTSET(value)   (PORT_OUTSET_OUTSET_Msk & ((value) << PORT_OUTSET_OUTSET_Pos))
+#define PORT_OUTSET_MASK            0xFFFFFFFFul /**< \brief (PORT_OUTSET) MASK Register */
+
+/* -------- PORT_OUTTGL : (PORT Offset: 0x1C) (R/W 32) GROUP Data Output Value Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTTGL:32;        /*!< bit:  0..31  Port Data Output Value Toggle      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTTGL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTTGL_OFFSET          0x1C         /**< \brief (PORT_OUTTGL offset) Data Output Value Toggle */
+#define PORT_OUTTGL_RESETVALUE      0x00000000ul /**< \brief (PORT_OUTTGL reset_value) Data Output Value Toggle */
+
+#define PORT_OUTTGL_OUTTGL_Pos      0            /**< \brief (PORT_OUTTGL) Port Data Output Value Toggle */
+#define PORT_OUTTGL_OUTTGL_Msk      (0xFFFFFFFFul << PORT_OUTTGL_OUTTGL_Pos)
+#define PORT_OUTTGL_OUTTGL(value)   (PORT_OUTTGL_OUTTGL_Msk & ((value) << PORT_OUTTGL_OUTTGL_Pos))
+#define PORT_OUTTGL_MASK            0xFFFFFFFFul /**< \brief (PORT_OUTTGL) MASK Register */
+
+/* -------- PORT_IN : (PORT Offset: 0x20) (R/  32) GROUP Data Input Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IN:32;            /*!< bit:  0..31  Port Data Input Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_IN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_IN_OFFSET              0x20         /**< \brief (PORT_IN offset) Data Input Value */
+#define PORT_IN_RESETVALUE          0x00000000ul /**< \brief (PORT_IN reset_value) Data Input Value */
+
+#define PORT_IN_IN_Pos              0            /**< \brief (PORT_IN) Port Data Input Value */
+#define PORT_IN_IN_Msk              (0xFFFFFFFFul << PORT_IN_IN_Pos)
+#define PORT_IN_IN(value)           (PORT_IN_IN_Msk & ((value) << PORT_IN_IN_Pos))
+#define PORT_IN_MASK                0xFFFFFFFFul /**< \brief (PORT_IN) MASK Register */
+
+/* -------- PORT_CTRL : (PORT Offset: 0x24) (R/W 32) GROUP Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SAMPLING:32;      /*!< bit:  0..31  Input Sampling Mode                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_CTRL_OFFSET            0x24         /**< \brief (PORT_CTRL offset) Control */
+#define PORT_CTRL_RESETVALUE        0x00000000ul /**< \brief (PORT_CTRL reset_value) Control */
+
+#define PORT_CTRL_SAMPLING_Pos      0            /**< \brief (PORT_CTRL) Input Sampling Mode */
+#define PORT_CTRL_SAMPLING_Msk      (0xFFFFFFFFul << PORT_CTRL_SAMPLING_Pos)
+#define PORT_CTRL_SAMPLING(value)   (PORT_CTRL_SAMPLING_Msk & ((value) << PORT_CTRL_SAMPLING_Pos))
+#define PORT_CTRL_MASK              0xFFFFFFFFul /**< \brief (PORT_CTRL) MASK Register */
+
+/* -------- PORT_WRCONFIG : (PORT Offset: 0x28) ( /W 32) GROUP Write Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PINMASK:16;       /*!< bit:  0..15  Pin Mask for Multiple Pin Configuration */
+    uint32_t PMUXEN:1;         /*!< bit:     16  Select Peripheral Multiplexer      */
+    uint32_t INEN:1;           /*!< bit:     17  Input Enable                       */
+    uint32_t PULLEN:1;         /*!< bit:     18  Pull Enable                        */
+    uint32_t :3;               /*!< bit: 19..21  Reserved                           */
+    uint32_t DRVSTR:1;         /*!< bit:     22  Output Driver Strength Selection   */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t PMUX:4;           /*!< bit: 24..27  Peripheral Multiplexing Template   */
+    uint32_t WRPMUX:1;         /*!< bit:     28  Write PMUX Registers               */
+    uint32_t :1;               /*!< bit:     29  Reserved                           */
+    uint32_t WRPINCFG:1;       /*!< bit:     30  Write PINCFG Registers             */
+    uint32_t HWSEL:1;          /*!< bit:     31  Half-Word Select                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_WRCONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_WRCONFIG_OFFSET        0x28         /**< \brief (PORT_WRCONFIG offset) Write Configuration */
+#define PORT_WRCONFIG_RESETVALUE    0x00000000ul /**< \brief (PORT_WRCONFIG reset_value) Write Configuration */
+
+#define PORT_WRCONFIG_PINMASK_Pos   0            /**< \brief (PORT_WRCONFIG) Pin Mask for Multiple Pin Configuration */
+#define PORT_WRCONFIG_PINMASK_Msk   (0xFFFFul << PORT_WRCONFIG_PINMASK_Pos)
+#define PORT_WRCONFIG_PINMASK(value) (PORT_WRCONFIG_PINMASK_Msk & ((value) << PORT_WRCONFIG_PINMASK_Pos))
+#define PORT_WRCONFIG_PMUXEN_Pos    16           /**< \brief (PORT_WRCONFIG) Select Peripheral Multiplexer */
+#define PORT_WRCONFIG_PMUXEN        (0x1ul << PORT_WRCONFIG_PMUXEN_Pos)
+#define PORT_WRCONFIG_INEN_Pos      17           /**< \brief (PORT_WRCONFIG) Input Enable */
+#define PORT_WRCONFIG_INEN          (0x1ul << PORT_WRCONFIG_INEN_Pos)
+#define PORT_WRCONFIG_PULLEN_Pos    18           /**< \brief (PORT_WRCONFIG) Pull Enable */
+#define PORT_WRCONFIG_PULLEN        (0x1ul << PORT_WRCONFIG_PULLEN_Pos)
+#define PORT_WRCONFIG_DRVSTR_Pos    22           /**< \brief (PORT_WRCONFIG) Output Driver Strength Selection */
+#define PORT_WRCONFIG_DRVSTR        (0x1ul << PORT_WRCONFIG_DRVSTR_Pos)
+#define PORT_WRCONFIG_PMUX_Pos      24           /**< \brief (PORT_WRCONFIG) Peripheral Multiplexing Template */
+#define PORT_WRCONFIG_PMUX_Msk      (0xFul << PORT_WRCONFIG_PMUX_Pos)
+#define PORT_WRCONFIG_PMUX(value)   (PORT_WRCONFIG_PMUX_Msk & ((value) << PORT_WRCONFIG_PMUX_Pos))
+#define PORT_WRCONFIG_WRPMUX_Pos    28           /**< \brief (PORT_WRCONFIG) Write PMUX Registers */
+#define PORT_WRCONFIG_WRPMUX        (0x1ul << PORT_WRCONFIG_WRPMUX_Pos)
+#define PORT_WRCONFIG_WRPINCFG_Pos  30           /**< \brief (PORT_WRCONFIG) Write PINCFG Registers */
+#define PORT_WRCONFIG_WRPINCFG      (0x1ul << PORT_WRCONFIG_WRPINCFG_Pos)
+#define PORT_WRCONFIG_HWSEL_Pos     31           /**< \brief (PORT_WRCONFIG) Half-Word Select */
+#define PORT_WRCONFIG_HWSEL         (0x1ul << PORT_WRCONFIG_HWSEL_Pos)
+#define PORT_WRCONFIG_MASK          0xDF47FFFFul /**< \brief (PORT_WRCONFIG) MASK Register */
+
+/* -------- PORT_EVCTRL : (PORT Offset: 0x2C) (R/W 32) GROUP Event Input Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PID0:5;           /*!< bit:  0.. 4  Port Event Pin Identifier 0        */
+    uint32_t EVACT0:2;         /*!< bit:  5.. 6  Port Event Action 0                */
+    uint32_t PORTEI0:1;        /*!< bit:      7  Port Event Enable Input 0          */
+    uint32_t PID1:5;           /*!< bit:  8..12  Port Event Pin Identifier 1        */
+    uint32_t EVACT1:2;         /*!< bit: 13..14  Port Event Action 1                */
+    uint32_t PORTEI1:1;        /*!< bit:     15  Port Event Enable Input 1          */
+    uint32_t PID2:5;           /*!< bit: 16..20  Port Event Pin Identifier 2        */
+    uint32_t EVACT2:2;         /*!< bit: 21..22  Port Event Action 2                */
+    uint32_t PORTEI2:1;        /*!< bit:     23  Port Event Enable Input 2          */
+    uint32_t PID3:5;           /*!< bit: 24..28  Port Event Pin Identifier 3        */
+    uint32_t EVACT3:2;         /*!< bit: 29..30  Port Event Action 3                */
+    uint32_t PORTEI3:1;        /*!< bit:     31  Port Event Enable Input 3          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_EVCTRL_OFFSET          0x2C         /**< \brief (PORT_EVCTRL offset) Event Input Control */
+#define PORT_EVCTRL_RESETVALUE      0x00000000ul /**< \brief (PORT_EVCTRL reset_value) Event Input Control */
+
+#define PORT_EVCTRL_PID0_Pos        0            /**< \brief (PORT_EVCTRL) Port Event Pin Identifier 0 */
+#define PORT_EVCTRL_PID0_Msk        (0x1Ful << PORT_EVCTRL_PID0_Pos)
+#define PORT_EVCTRL_PID0(value)     (PORT_EVCTRL_PID0_Msk & ((value) << PORT_EVCTRL_PID0_Pos))
+#define PORT_EVCTRL_EVACT0_Pos      5            /**< \brief (PORT_EVCTRL) Port Event Action 0 */
+#define PORT_EVCTRL_EVACT0_Msk      (0x3ul << PORT_EVCTRL_EVACT0_Pos)
+#define PORT_EVCTRL_EVACT0(value)   (PORT_EVCTRL_EVACT0_Msk & ((value) << PORT_EVCTRL_EVACT0_Pos))
+#define PORT_EVCTRL_PORTEI0_Pos     7            /**< \brief (PORT_EVCTRL) Port Event Enable Input 0 */
+#define PORT_EVCTRL_PORTEI0         (0x1ul << PORT_EVCTRL_PORTEI0_Pos)
+#define PORT_EVCTRL_PID1_Pos        8            /**< \brief (PORT_EVCTRL) Port Event Pin Identifier 1 */
+#define PORT_EVCTRL_PID1_Msk        (0x1Ful << PORT_EVCTRL_PID1_Pos)
+#define PORT_EVCTRL_PID1(value)     (PORT_EVCTRL_PID1_Msk & ((value) << PORT_EVCTRL_PID1_Pos))
+#define PORT_EVCTRL_EVACT1_Pos      13           /**< \brief (PORT_EVCTRL) Port Event Action 1 */
+#define PORT_EVCTRL_EVACT1_Msk      (0x3ul << PORT_EVCTRL_EVACT1_Pos)
+#define PORT_EVCTRL_EVACT1(value)   (PORT_EVCTRL_EVACT1_Msk & ((value) << PORT_EVCTRL_EVACT1_Pos))
+#define PORT_EVCTRL_PORTEI1_Pos     15           /**< \brief (PORT_EVCTRL) Port Event Enable Input 1 */
+#define PORT_EVCTRL_PORTEI1         (0x1ul << PORT_EVCTRL_PORTEI1_Pos)
+#define PORT_EVCTRL_PID2_Pos        16           /**< \brief (PORT_EVCTRL) Port Event Pin Identifier 2 */
+#define PORT_EVCTRL_PID2_Msk        (0x1Ful << PORT_EVCTRL_PID2_Pos)
+#define PORT_EVCTRL_PID2(value)     (PORT_EVCTRL_PID2_Msk & ((value) << PORT_EVCTRL_PID2_Pos))
+#define PORT_EVCTRL_EVACT2_Pos      21           /**< \brief (PORT_EVCTRL) Port Event Action 2 */
+#define PORT_EVCTRL_EVACT2_Msk      (0x3ul << PORT_EVCTRL_EVACT2_Pos)
+#define PORT_EVCTRL_EVACT2(value)   (PORT_EVCTRL_EVACT2_Msk & ((value) << PORT_EVCTRL_EVACT2_Pos))
+#define PORT_EVCTRL_PORTEI2_Pos     23           /**< \brief (PORT_EVCTRL) Port Event Enable Input 2 */
+#define PORT_EVCTRL_PORTEI2         (0x1ul << PORT_EVCTRL_PORTEI2_Pos)
+#define PORT_EVCTRL_PID3_Pos        24           /**< \brief (PORT_EVCTRL) Port Event Pin Identifier 3 */
+#define PORT_EVCTRL_PID3_Msk        (0x1Ful << PORT_EVCTRL_PID3_Pos)
+#define PORT_EVCTRL_PID3(value)     (PORT_EVCTRL_PID3_Msk & ((value) << PORT_EVCTRL_PID3_Pos))
+#define PORT_EVCTRL_EVACT3_Pos      29           /**< \brief (PORT_EVCTRL) Port Event Action 3 */
+#define PORT_EVCTRL_EVACT3_Msk      (0x3ul << PORT_EVCTRL_EVACT3_Pos)
+#define PORT_EVCTRL_EVACT3(value)   (PORT_EVCTRL_EVACT3_Msk & ((value) << PORT_EVCTRL_EVACT3_Pos))
+#define PORT_EVCTRL_PORTEI3_Pos     31           /**< \brief (PORT_EVCTRL) Port Event Enable Input 3 */
+#define PORT_EVCTRL_PORTEI3         (0x1ul << PORT_EVCTRL_PORTEI3_Pos)
+#define PORT_EVCTRL_MASK            0xFFFFFFFFul /**< \brief (PORT_EVCTRL) MASK Register */
+
+/* -------- PORT_PMUX : (PORT Offset: 0x30) (R/W  8) GROUP Peripheral Multiplexing n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PMUXE:4;          /*!< bit:  0.. 3  Peripheral Multiplexing for Even-Numbered Pin */
+    uint8_t  PMUXO:4;          /*!< bit:  4.. 7  Peripheral Multiplexing for Odd-Numbered Pin */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PORT_PMUX_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PMUX_OFFSET            0x30         /**< \brief (PORT_PMUX offset) Peripheral Multiplexing n */
+#define PORT_PMUX_RESETVALUE        0x00ul       /**< \brief (PORT_PMUX reset_value) Peripheral Multiplexing n */
+
+#define PORT_PMUX_PMUXE_Pos         0            /**< \brief (PORT_PMUX) Peripheral Multiplexing for Even-Numbered Pin */
+#define PORT_PMUX_PMUXE_Msk         (0xFul << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE(value)      (PORT_PMUX_PMUXE_Msk & ((value) << PORT_PMUX_PMUXE_Pos))
+#define PORT_PMUX_PMUXO_Pos         4            /**< \brief (PORT_PMUX) Peripheral Multiplexing for Odd-Numbered Pin */
+#define PORT_PMUX_PMUXO_Msk         (0xFul << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO(value)      (PORT_PMUX_PMUXO_Msk & ((value) << PORT_PMUX_PMUXO_Pos))
+#define PORT_PMUX_MASK              0xFFul       /**< \brief (PORT_PMUX) MASK Register */
+
+/* -------- PORT_PINCFG : (PORT Offset: 0x40) (R/W  8) GROUP Pin Configuration n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PMUXEN:1;         /*!< bit:      0  Select Peripheral Multiplexer      */
+    uint8_t  INEN:1;           /*!< bit:      1  Input Enable                       */
+    uint8_t  PULLEN:1;         /*!< bit:      2  Pull Enable                        */
+    uint8_t  :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint8_t  DRVSTR:1;         /*!< bit:      6  Output Driver Strength Selection   */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PORT_PINCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PINCFG_OFFSET          0x40         /**< \brief (PORT_PINCFG offset) Pin Configuration n */
+#define PORT_PINCFG_RESETVALUE      0x00ul       /**< \brief (PORT_PINCFG reset_value) Pin Configuration n */
+
+#define PORT_PINCFG_PMUXEN_Pos      0            /**< \brief (PORT_PINCFG) Select Peripheral Multiplexer */
+#define PORT_PINCFG_PMUXEN          (0x1ul << PORT_PINCFG_PMUXEN_Pos)
+#define PORT_PINCFG_INEN_Pos        1            /**< \brief (PORT_PINCFG) Input Enable */
+#define PORT_PINCFG_INEN            (0x1ul << PORT_PINCFG_INEN_Pos)
+#define PORT_PINCFG_PULLEN_Pos      2            /**< \brief (PORT_PINCFG) Pull Enable */
+#define PORT_PINCFG_PULLEN          (0x1ul << PORT_PINCFG_PULLEN_Pos)
+#define PORT_PINCFG_DRVSTR_Pos      6            /**< \brief (PORT_PINCFG) Output Driver Strength Selection */
+#define PORT_PINCFG_DRVSTR          (0x1ul << PORT_PINCFG_DRVSTR_Pos)
+#define PORT_PINCFG_MASK            0x47ul       /**< \brief (PORT_PINCFG) MASK Register */
+
+/** \brief PortGroup hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO PORT_DIR_Type             DIR;         /**< \brief Offset: 0x00 (R/W 32) Data Direction */
+  __IO PORT_DIRCLR_Type          DIRCLR;      /**< \brief Offset: 0x04 (R/W 32) Data Direction Clear */
+  __IO PORT_DIRSET_Type          DIRSET;      /**< \brief Offset: 0x08 (R/W 32) Data Direction Set */
+  __IO PORT_DIRTGL_Type          DIRTGL;      /**< \brief Offset: 0x0C (R/W 32) Data Direction Toggle */
+  __IO PORT_OUT_Type             OUT;         /**< \brief Offset: 0x10 (R/W 32) Data Output Value */
+  __IO PORT_OUTCLR_Type          OUTCLR;      /**< \brief Offset: 0x14 (R/W 32) Data Output Value Clear */
+  __IO PORT_OUTSET_Type          OUTSET;      /**< \brief Offset: 0x18 (R/W 32) Data Output Value Set */
+  __IO PORT_OUTTGL_Type          OUTTGL;      /**< \brief Offset: 0x1C (R/W 32) Data Output Value Toggle */
+  __I  PORT_IN_Type              IN;          /**< \brief Offset: 0x20 (R/  32) Data Input Value */
+  __IO PORT_CTRL_Type            CTRL;        /**< \brief Offset: 0x24 (R/W 32) Control */
+  __O  PORT_WRCONFIG_Type        WRCONFIG;    /**< \brief Offset: 0x28 ( /W 32) Write Configuration */
+  __IO PORT_EVCTRL_Type          EVCTRL;      /**< \brief Offset: 0x2C (R/W 32) Event Input Control */
+  __IO PORT_PMUX_Type            PMUX[16];    /**< \brief Offset: 0x30 (R/W  8) Peripheral Multiplexing n */
+  __IO PORT_PINCFG_Type          PINCFG[32];  /**< \brief Offset: 0x40 (R/W  8) Pin Configuration n */
+       RoReg8                    Reserved1[0x20];
+} PortGroup;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief PORT hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+       PortGroup                 Group[2];    /**< \brief Offset: 0x00 PortGroup groups [GROUPS] */
+} Port;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#define SECTION_PORT_IOBUS
+
+/*@}*/
+
+#endif /* _SAML21_PORT_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/rstc_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/rstc_100.h
@@ -1,0 +1,220 @@
+/**
+ * \file
+ *
+ * \brief Component description for RSTC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_RSTC_COMPONENT_
+#define _SAML21_RSTC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RSTC */
+/* ========================================================================== */
+/** \addtogroup SAML21_RSTC Reset Controller */
+/*@{*/
+
+#define RSTC_U2239
+#define REV_RSTC                    0x100
+
+/* -------- RSTC_RCAUSE : (RSTC Offset: 0x00) (R/   8) Reset Cause -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  POR:1;            /*!< bit:      0  Power On Reset                     */
+    uint8_t  BOD12:1;          /*!< bit:      1  Brown Out 12 Detector Reset        */
+    uint8_t  BOD33:1;          /*!< bit:      2  Brown Out 33 Detector Reset        */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  EXT:1;            /*!< bit:      4  External Reset                     */
+    uint8_t  WDT:1;            /*!< bit:      5  Watchdog Reset                     */
+    uint8_t  SYST:1;           /*!< bit:      6  System Reset Request               */
+    uint8_t  BACKUP:1;         /*!< bit:      7  Backup Reset                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RSTC_RCAUSE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_RCAUSE_OFFSET          0x00         /**< \brief (RSTC_RCAUSE offset) Reset Cause */
+
+#define RSTC_RCAUSE_POR_Pos         0            /**< \brief (RSTC_RCAUSE) Power On Reset */
+#define RSTC_RCAUSE_POR             (0x1ul << RSTC_RCAUSE_POR_Pos)
+#define RSTC_RCAUSE_BOD12_Pos       1            /**< \brief (RSTC_RCAUSE) Brown Out 12 Detector Reset */
+#define RSTC_RCAUSE_BOD12           (0x1ul << RSTC_RCAUSE_BOD12_Pos)
+#define RSTC_RCAUSE_BOD33_Pos       2            /**< \brief (RSTC_RCAUSE) Brown Out 33 Detector Reset */
+#define RSTC_RCAUSE_BOD33           (0x1ul << RSTC_RCAUSE_BOD33_Pos)
+#define RSTC_RCAUSE_EXT_Pos         4            /**< \brief (RSTC_RCAUSE) External Reset */
+#define RSTC_RCAUSE_EXT             (0x1ul << RSTC_RCAUSE_EXT_Pos)
+#define RSTC_RCAUSE_WDT_Pos         5            /**< \brief (RSTC_RCAUSE) Watchdog Reset */
+#define RSTC_RCAUSE_WDT             (0x1ul << RSTC_RCAUSE_WDT_Pos)
+#define RSTC_RCAUSE_SYST_Pos        6            /**< \brief (RSTC_RCAUSE) System Reset Request */
+#define RSTC_RCAUSE_SYST            (0x1ul << RSTC_RCAUSE_SYST_Pos)
+#define RSTC_RCAUSE_BACKUP_Pos      7            /**< \brief (RSTC_RCAUSE) Backup Reset */
+#define RSTC_RCAUSE_BACKUP          (0x1ul << RSTC_RCAUSE_BACKUP_Pos)
+#define RSTC_RCAUSE_MASK            0xF7ul       /**< \brief (RSTC_RCAUSE) MASK Register */
+
+/* -------- RSTC_BKUPEXIT : (RSTC Offset: 0x02) (R/   8) Backup Exit Source -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EXTWAKE:1;        /*!< bit:      0  External Wakeup                    */
+    uint8_t  RTC:1;            /*!< bit:      1  Real Timer Counter Interrupt       */
+    uint8_t  BBPS:1;           /*!< bit:      2  Battery Backup Power Switch        */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RSTC_BKUPEXIT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_BKUPEXIT_OFFSET        0x02         /**< \brief (RSTC_BKUPEXIT offset) Backup Exit Source */
+
+#define RSTC_BKUPEXIT_EXTWAKE_Pos   0            /**< \brief (RSTC_BKUPEXIT) External Wakeup */
+#define RSTC_BKUPEXIT_EXTWAKE       (0x1ul << RSTC_BKUPEXIT_EXTWAKE_Pos)
+#define RSTC_BKUPEXIT_RTC_Pos       1            /**< \brief (RSTC_BKUPEXIT) Real Timer Counter Interrupt */
+#define RSTC_BKUPEXIT_RTC           (0x1ul << RSTC_BKUPEXIT_RTC_Pos)
+#define RSTC_BKUPEXIT_BBPS_Pos      2            /**< \brief (RSTC_BKUPEXIT) Battery Backup Power Switch */
+#define RSTC_BKUPEXIT_BBPS          (0x1ul << RSTC_BKUPEXIT_BBPS_Pos)
+#define RSTC_BKUPEXIT_MASK          0x07ul       /**< \brief (RSTC_BKUPEXIT) MASK Register */
+
+/* -------- RSTC_WKDBCONF : (RSTC Offset: 0x04) (R/W  8) Wakeup Debounce Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  WKDBCNT:5;        /*!< bit:  0.. 4  Wakeup Debounce Counter            */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RSTC_WKDBCONF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_WKDBCONF_OFFSET        0x04         /**< \brief (RSTC_WKDBCONF offset) Wakeup Debounce Configuration */
+#define RSTC_WKDBCONF_RESETVALUE    0x00ul       /**< \brief (RSTC_WKDBCONF reset_value) Wakeup Debounce Configuration */
+
+#define RSTC_WKDBCONF_WKDBCNT_Pos   0            /**< \brief (RSTC_WKDBCONF) Wakeup Debounce Counter */
+#define RSTC_WKDBCONF_WKDBCNT_Msk   (0x1Ful << RSTC_WKDBCONF_WKDBCNT_Pos)
+#define RSTC_WKDBCONF_WKDBCNT(value) (RSTC_WKDBCONF_WKDBCNT_Msk & ((value) << RSTC_WKDBCONF_WKDBCNT_Pos))
+#define   RSTC_WKDBCONF_WKDBCNT_OFF_Val   0x0ul  /**< \brief (RSTC_WKDBCONF) No debouncing.Input pin is low or high level sensitive depending on its WKPOLx bit. */
+#define   RSTC_WKDBCONF_WKDBCNT_2CK32_Val 0x1ul  /**< \brief (RSTC_WKDBCONF) Input pin shall be active for at least two 32kHz clock period. */
+#define   RSTC_WKDBCONF_WKDBCNT_3CK32_Val 0x2ul  /**< \brief (RSTC_WKDBCONF) Input pin shall be active for at least three 32kHz clock period. */
+#define   RSTC_WKDBCONF_WKDBCNT_32CK32_Val 0x3ul  /**< \brief (RSTC_WKDBCONF) Input pin shall be active for at least 32 32kHz clock period. */
+#define   RSTC_WKDBCONF_WKDBCNT_512CK32_Val 0x4ul  /**< \brief (RSTC_WKDBCONF) Input pin shall be active for at least 512 32kHz clock period. */
+#define   RSTC_WKDBCONF_WKDBCNT_4096CK32_Val 0x5ul  /**< \brief (RSTC_WKDBCONF) Input pin shall be active for at least 4096 32kHz clock period. */
+#define   RSTC_WKDBCONF_WKDBCNT_32768CK32_Val 0x6ul  /**< \brief (RSTC_WKDBCONF) Input pin shall be active for at least 32768 32kHz clock period. */
+#define RSTC_WKDBCONF_WKDBCNT_OFF   (RSTC_WKDBCONF_WKDBCNT_OFF_Val << RSTC_WKDBCONF_WKDBCNT_Pos)
+#define RSTC_WKDBCONF_WKDBCNT_2CK32 (RSTC_WKDBCONF_WKDBCNT_2CK32_Val << RSTC_WKDBCONF_WKDBCNT_Pos)
+#define RSTC_WKDBCONF_WKDBCNT_3CK32 (RSTC_WKDBCONF_WKDBCNT_3CK32_Val << RSTC_WKDBCONF_WKDBCNT_Pos)
+#define RSTC_WKDBCONF_WKDBCNT_32CK32 (RSTC_WKDBCONF_WKDBCNT_32CK32_Val << RSTC_WKDBCONF_WKDBCNT_Pos)
+#define RSTC_WKDBCONF_WKDBCNT_512CK32 (RSTC_WKDBCONF_WKDBCNT_512CK32_Val << RSTC_WKDBCONF_WKDBCNT_Pos)
+#define RSTC_WKDBCONF_WKDBCNT_4096CK32 (RSTC_WKDBCONF_WKDBCNT_4096CK32_Val << RSTC_WKDBCONF_WKDBCNT_Pos)
+#define RSTC_WKDBCONF_WKDBCNT_32768CK32 (RSTC_WKDBCONF_WKDBCNT_32768CK32_Val << RSTC_WKDBCONF_WKDBCNT_Pos)
+#define RSTC_WKDBCONF_MASK          0x1Ful       /**< \brief (RSTC_WKDBCONF) MASK Register */
+
+/* -------- RSTC_WKPOL : (RSTC Offset: 0x08) (R/W 16) Wakeup Polarity -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t WKPOL:16;         /*!< bit:  0..15  Wakeup Polarity                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RSTC_WKPOL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_WKPOL_OFFSET           0x08         /**< \brief (RSTC_WKPOL offset) Wakeup Polarity */
+#define RSTC_WKPOL_RESETVALUE       0x0000ul     /**< \brief (RSTC_WKPOL reset_value) Wakeup Polarity */
+
+#define RSTC_WKPOL_WKPOL_Pos        0            /**< \brief (RSTC_WKPOL) Wakeup Polarity */
+#define RSTC_WKPOL_WKPOL_Msk        (0xFFFFul << RSTC_WKPOL_WKPOL_Pos)
+#define RSTC_WKPOL_WKPOL(value)     (RSTC_WKPOL_WKPOL_Msk & ((value) << RSTC_WKPOL_WKPOL_Pos))
+#define RSTC_WKPOL_MASK             0xFFFFul     /**< \brief (RSTC_WKPOL) MASK Register */
+
+/* -------- RSTC_WKEN : (RSTC Offset: 0x0C) (R/W 16) Wakeup Enable -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t WKEN:16;          /*!< bit:  0..15  Wakeup Enable                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RSTC_WKEN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_WKEN_OFFSET            0x0C         /**< \brief (RSTC_WKEN offset) Wakeup Enable */
+#define RSTC_WKEN_RESETVALUE        0x0000ul     /**< \brief (RSTC_WKEN reset_value) Wakeup Enable */
+
+#define RSTC_WKEN_WKEN_Pos          0            /**< \brief (RSTC_WKEN) Wakeup Enable */
+#define RSTC_WKEN_WKEN_Msk          (0xFFFFul << RSTC_WKEN_WKEN_Pos)
+#define RSTC_WKEN_WKEN(value)       (RSTC_WKEN_WKEN_Msk & ((value) << RSTC_WKEN_WKEN_Pos))
+#define RSTC_WKEN_MASK              0xFFFFul     /**< \brief (RSTC_WKEN) MASK Register */
+
+/* -------- RSTC_WKCAUSE : (RSTC Offset: 0x10) (R/W 16) Wakeup Cause -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t WKCAUSE:16;       /*!< bit:  0..15  Wakeup Cause                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RSTC_WKCAUSE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RSTC_WKCAUSE_OFFSET         0x10         /**< \brief (RSTC_WKCAUSE offset) Wakeup Cause */
+#define RSTC_WKCAUSE_RESETVALUE     0x0000ul     /**< \brief (RSTC_WKCAUSE reset_value) Wakeup Cause */
+
+#define RSTC_WKCAUSE_WKCAUSE_Pos    0            /**< \brief (RSTC_WKCAUSE) Wakeup Cause */
+#define RSTC_WKCAUSE_WKCAUSE_Msk    (0xFFFFul << RSTC_WKCAUSE_WKCAUSE_Pos)
+#define RSTC_WKCAUSE_WKCAUSE(value) (RSTC_WKCAUSE_WKCAUSE_Msk & ((value) << RSTC_WKCAUSE_WKCAUSE_Pos))
+#define RSTC_WKCAUSE_MASK           0xFFFFul     /**< \brief (RSTC_WKCAUSE) MASK Register */
+
+/** \brief RSTC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __I  RSTC_RCAUSE_Type          RCAUSE;      /**< \brief Offset: 0x00 (R/   8) Reset Cause */
+       RoReg8                    Reserved1[0x1];
+  __I  RSTC_BKUPEXIT_Type        BKUPEXIT;    /**< \brief Offset: 0x02 (R/   8) Backup Exit Source */
+       RoReg8                    Reserved2[0x1];
+  __IO RSTC_WKDBCONF_Type        WKDBCONF;    /**< \brief Offset: 0x04 (R/W  8) Wakeup Debounce Configuration */
+       RoReg8                    Reserved3[0x3];
+  __IO RSTC_WKPOL_Type           WKPOL;       /**< \brief Offset: 0x08 (R/W 16) Wakeup Polarity */
+       RoReg8                    Reserved4[0x2];
+  __IO RSTC_WKEN_Type            WKEN;        /**< \brief Offset: 0x0C (R/W 16) Wakeup Enable */
+       RoReg8                    Reserved5[0x2];
+  __IO RSTC_WKCAUSE_Type         WKCAUSE;     /**< \brief Offset: 0x10 (R/W 16) Wakeup Cause */
+} Rstc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_RSTC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/rtc_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/rtc_100.h
@@ -1,0 +1,1399 @@
+/**
+ * \file
+ *
+ * \brief Component description for RTC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_RTC_COMPONENT_
+#define _SAML21_RTC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RTC */
+/* ========================================================================== */
+/** \addtogroup SAML21_RTC Real-Time Counter */
+/*@{*/
+
+#define RTC_U2250
+#define REV_RTC                     0x100
+
+/* -------- RTC_MODE0_CTRLA : (RTC Offset: 0x00) (R/W 16) MODE0 MODE0 Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  Operating Mode                     */
+    uint16_t :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint16_t MATCHCLR:1;       /*!< bit:      7  Clear on Match                     */
+    uint16_t PRESCALER:4;      /*!< bit:  8..11  Prescaler                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_CTRLA_OFFSET      0x00         /**< \brief (RTC_MODE0_CTRLA offset) MODE0 Control A */
+#define RTC_MODE0_CTRLA_RESETVALUE  0x0000ul     /**< \brief (RTC_MODE0_CTRLA reset_value) MODE0 Control A */
+
+#define RTC_MODE0_CTRLA_SWRST_Pos   0            /**< \brief (RTC_MODE0_CTRLA) Software Reset */
+#define RTC_MODE0_CTRLA_SWRST       (0x1ul << RTC_MODE0_CTRLA_SWRST_Pos)
+#define RTC_MODE0_CTRLA_ENABLE_Pos  1            /**< \brief (RTC_MODE0_CTRLA) Enable */
+#define RTC_MODE0_CTRLA_ENABLE      (0x1ul << RTC_MODE0_CTRLA_ENABLE_Pos)
+#define RTC_MODE0_CTRLA_MODE_Pos    2            /**< \brief (RTC_MODE0_CTRLA) Operating Mode */
+#define RTC_MODE0_CTRLA_MODE_Msk    (0x3ul << RTC_MODE0_CTRLA_MODE_Pos)
+#define RTC_MODE0_CTRLA_MODE(value) (RTC_MODE0_CTRLA_MODE_Msk & ((value) << RTC_MODE0_CTRLA_MODE_Pos))
+#define   RTC_MODE0_CTRLA_MODE_COUNT32_Val 0x0ul  /**< \brief (RTC_MODE0_CTRLA) Mode 0: 32-bit Counter */
+#define   RTC_MODE0_CTRLA_MODE_COUNT16_Val 0x1ul  /**< \brief (RTC_MODE0_CTRLA) Mode 1: 16-bit Counter */
+#define   RTC_MODE0_CTRLA_MODE_CLOCK_Val  0x2ul  /**< \brief (RTC_MODE0_CTRLA) Mode 2: Clock/Calendar */
+#define RTC_MODE0_CTRLA_MODE_COUNT32 (RTC_MODE0_CTRLA_MODE_COUNT32_Val << RTC_MODE0_CTRLA_MODE_Pos)
+#define RTC_MODE0_CTRLA_MODE_COUNT16 (RTC_MODE0_CTRLA_MODE_COUNT16_Val << RTC_MODE0_CTRLA_MODE_Pos)
+#define RTC_MODE0_CTRLA_MODE_CLOCK  (RTC_MODE0_CTRLA_MODE_CLOCK_Val << RTC_MODE0_CTRLA_MODE_Pos)
+#define RTC_MODE0_CTRLA_MATCHCLR_Pos 7            /**< \brief (RTC_MODE0_CTRLA) Clear on Match */
+#define RTC_MODE0_CTRLA_MATCHCLR    (0x1ul << RTC_MODE0_CTRLA_MATCHCLR_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_Pos 8            /**< \brief (RTC_MODE0_CTRLA) Prescaler */
+#define RTC_MODE0_CTRLA_PRESCALER_Msk (0xFul << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER(value) (RTC_MODE0_CTRLA_PRESCALER_Msk & ((value) << RTC_MODE0_CTRLA_PRESCALER_Pos))
+#define   RTC_MODE0_CTRLA_PRESCALER_OFF_Val 0x0ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV1_Val 0x1ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV2_Val 0x2ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV4_Val 0x3ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV8_Val 0x4ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV16_Val 0x5ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV32_Val 0x6ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV64_Val 0x7ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV128_Val 0x8ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV256_Val 0x9ul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV512_Val 0xAul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE0_CTRLA_PRESCALER_DIV1024_Val 0xBul  /**< \brief (RTC_MODE0_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define RTC_MODE0_CTRLA_PRESCALER_OFF (RTC_MODE0_CTRLA_PRESCALER_OFF_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV1 (RTC_MODE0_CTRLA_PRESCALER_DIV1_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV2 (RTC_MODE0_CTRLA_PRESCALER_DIV2_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV4 (RTC_MODE0_CTRLA_PRESCALER_DIV4_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV8 (RTC_MODE0_CTRLA_PRESCALER_DIV8_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV16 (RTC_MODE0_CTRLA_PRESCALER_DIV16_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV32 (RTC_MODE0_CTRLA_PRESCALER_DIV32_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV64 (RTC_MODE0_CTRLA_PRESCALER_DIV64_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV128 (RTC_MODE0_CTRLA_PRESCALER_DIV128_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV256 (RTC_MODE0_CTRLA_PRESCALER_DIV256_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV512 (RTC_MODE0_CTRLA_PRESCALER_DIV512_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_PRESCALER_DIV1024 (RTC_MODE0_CTRLA_PRESCALER_DIV1024_Val << RTC_MODE0_CTRLA_PRESCALER_Pos)
+#define RTC_MODE0_CTRLA_MASK        0x0F8Ful     /**< \brief (RTC_MODE0_CTRLA) MASK Register */
+
+/* -------- RTC_MODE1_CTRLA : (RTC Offset: 0x00) (R/W 16) MODE1 MODE1 Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  Operating Mode                     */
+    uint16_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint16_t PRESCALER:4;      /*!< bit:  8..11  Prescaler                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_CTRLA_OFFSET      0x00         /**< \brief (RTC_MODE1_CTRLA offset) MODE1 Control A */
+#define RTC_MODE1_CTRLA_RESETVALUE  0x0000ul     /**< \brief (RTC_MODE1_CTRLA reset_value) MODE1 Control A */
+
+#define RTC_MODE1_CTRLA_SWRST_Pos   0            /**< \brief (RTC_MODE1_CTRLA) Software Reset */
+#define RTC_MODE1_CTRLA_SWRST       (0x1ul << RTC_MODE1_CTRLA_SWRST_Pos)
+#define RTC_MODE1_CTRLA_ENABLE_Pos  1            /**< \brief (RTC_MODE1_CTRLA) Enable */
+#define RTC_MODE1_CTRLA_ENABLE      (0x1ul << RTC_MODE1_CTRLA_ENABLE_Pos)
+#define RTC_MODE1_CTRLA_MODE_Pos    2            /**< \brief (RTC_MODE1_CTRLA) Operating Mode */
+#define RTC_MODE1_CTRLA_MODE_Msk    (0x3ul << RTC_MODE1_CTRLA_MODE_Pos)
+#define RTC_MODE1_CTRLA_MODE(value) (RTC_MODE1_CTRLA_MODE_Msk & ((value) << RTC_MODE1_CTRLA_MODE_Pos))
+#define   RTC_MODE1_CTRLA_MODE_COUNT32_Val 0x0ul  /**< \brief (RTC_MODE1_CTRLA) Mode 0: 32-bit Counter */
+#define   RTC_MODE1_CTRLA_MODE_COUNT16_Val 0x1ul  /**< \brief (RTC_MODE1_CTRLA) Mode 1: 16-bit Counter */
+#define   RTC_MODE1_CTRLA_MODE_CLOCK_Val  0x2ul  /**< \brief (RTC_MODE1_CTRLA) Mode 2: Clock/Calendar */
+#define RTC_MODE1_CTRLA_MODE_COUNT32 (RTC_MODE1_CTRLA_MODE_COUNT32_Val << RTC_MODE1_CTRLA_MODE_Pos)
+#define RTC_MODE1_CTRLA_MODE_COUNT16 (RTC_MODE1_CTRLA_MODE_COUNT16_Val << RTC_MODE1_CTRLA_MODE_Pos)
+#define RTC_MODE1_CTRLA_MODE_CLOCK  (RTC_MODE1_CTRLA_MODE_CLOCK_Val << RTC_MODE1_CTRLA_MODE_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_Pos 8            /**< \brief (RTC_MODE1_CTRLA) Prescaler */
+#define RTC_MODE1_CTRLA_PRESCALER_Msk (0xFul << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER(value) (RTC_MODE1_CTRLA_PRESCALER_Msk & ((value) << RTC_MODE1_CTRLA_PRESCALER_Pos))
+#define   RTC_MODE1_CTRLA_PRESCALER_OFF_Val 0x0ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV1_Val 0x1ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV2_Val 0x2ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV4_Val 0x3ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV8_Val 0x4ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV16_Val 0x5ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV32_Val 0x6ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV64_Val 0x7ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV128_Val 0x8ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV256_Val 0x9ul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV512_Val 0xAul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE1_CTRLA_PRESCALER_DIV1024_Val 0xBul  /**< \brief (RTC_MODE1_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define RTC_MODE1_CTRLA_PRESCALER_OFF (RTC_MODE1_CTRLA_PRESCALER_OFF_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV1 (RTC_MODE1_CTRLA_PRESCALER_DIV1_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV2 (RTC_MODE1_CTRLA_PRESCALER_DIV2_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV4 (RTC_MODE1_CTRLA_PRESCALER_DIV4_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV8 (RTC_MODE1_CTRLA_PRESCALER_DIV8_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV16 (RTC_MODE1_CTRLA_PRESCALER_DIV16_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV32 (RTC_MODE1_CTRLA_PRESCALER_DIV32_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV64 (RTC_MODE1_CTRLA_PRESCALER_DIV64_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV128 (RTC_MODE1_CTRLA_PRESCALER_DIV128_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV256 (RTC_MODE1_CTRLA_PRESCALER_DIV256_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV512 (RTC_MODE1_CTRLA_PRESCALER_DIV512_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_PRESCALER_DIV1024 (RTC_MODE1_CTRLA_PRESCALER_DIV1024_Val << RTC_MODE1_CTRLA_PRESCALER_Pos)
+#define RTC_MODE1_CTRLA_MASK        0x0F0Ful     /**< \brief (RTC_MODE1_CTRLA) MASK Register */
+
+/* -------- RTC_MODE2_CTRLA : (RTC Offset: 0x00) (R/W 16) MODE2 MODE2 Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  Operating Mode                     */
+    uint16_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint16_t CLKREP:1;         /*!< bit:      6  Clock Representation               */
+    uint16_t MATCHCLR:1;       /*!< bit:      7  Clear on Match                     */
+    uint16_t PRESCALER:4;      /*!< bit:  8..11  Prescaler                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CTRLA_OFFSET      0x00         /**< \brief (RTC_MODE2_CTRLA offset) MODE2 Control A */
+#define RTC_MODE2_CTRLA_RESETVALUE  0x0000ul     /**< \brief (RTC_MODE2_CTRLA reset_value) MODE2 Control A */
+
+#define RTC_MODE2_CTRLA_SWRST_Pos   0            /**< \brief (RTC_MODE2_CTRLA) Software Reset */
+#define RTC_MODE2_CTRLA_SWRST       (0x1ul << RTC_MODE2_CTRLA_SWRST_Pos)
+#define RTC_MODE2_CTRLA_ENABLE_Pos  1            /**< \brief (RTC_MODE2_CTRLA) Enable */
+#define RTC_MODE2_CTRLA_ENABLE      (0x1ul << RTC_MODE2_CTRLA_ENABLE_Pos)
+#define RTC_MODE2_CTRLA_MODE_Pos    2            /**< \brief (RTC_MODE2_CTRLA) Operating Mode */
+#define RTC_MODE2_CTRLA_MODE_Msk    (0x3ul << RTC_MODE2_CTRLA_MODE_Pos)
+#define RTC_MODE2_CTRLA_MODE(value) (RTC_MODE2_CTRLA_MODE_Msk & ((value) << RTC_MODE2_CTRLA_MODE_Pos))
+#define   RTC_MODE2_CTRLA_MODE_COUNT32_Val 0x0ul  /**< \brief (RTC_MODE2_CTRLA) Mode 0: 32-bit Counter */
+#define   RTC_MODE2_CTRLA_MODE_COUNT16_Val 0x1ul  /**< \brief (RTC_MODE2_CTRLA) Mode 1: 16-bit Counter */
+#define   RTC_MODE2_CTRLA_MODE_CLOCK_Val  0x2ul  /**< \brief (RTC_MODE2_CTRLA) Mode 2: Clock/Calendar */
+#define RTC_MODE2_CTRLA_MODE_COUNT32 (RTC_MODE2_CTRLA_MODE_COUNT32_Val << RTC_MODE2_CTRLA_MODE_Pos)
+#define RTC_MODE2_CTRLA_MODE_COUNT16 (RTC_MODE2_CTRLA_MODE_COUNT16_Val << RTC_MODE2_CTRLA_MODE_Pos)
+#define RTC_MODE2_CTRLA_MODE_CLOCK  (RTC_MODE2_CTRLA_MODE_CLOCK_Val << RTC_MODE2_CTRLA_MODE_Pos)
+#define RTC_MODE2_CTRLA_CLKREP_Pos  6            /**< \brief (RTC_MODE2_CTRLA) Clock Representation */
+#define RTC_MODE2_CTRLA_CLKREP      (0x1ul << RTC_MODE2_CTRLA_CLKREP_Pos)
+#define RTC_MODE2_CTRLA_MATCHCLR_Pos 7            /**< \brief (RTC_MODE2_CTRLA) Clear on Match */
+#define RTC_MODE2_CTRLA_MATCHCLR    (0x1ul << RTC_MODE2_CTRLA_MATCHCLR_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_Pos 8            /**< \brief (RTC_MODE2_CTRLA) Prescaler */
+#define RTC_MODE2_CTRLA_PRESCALER_Msk (0xFul << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER(value) (RTC_MODE2_CTRLA_PRESCALER_Msk & ((value) << RTC_MODE2_CTRLA_PRESCALER_Pos))
+#define   RTC_MODE2_CTRLA_PRESCALER_OFF_Val 0x0ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV1_Val 0x1ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV2_Val 0x2ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV4_Val 0x3ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV8_Val 0x4ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV16_Val 0x5ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV32_Val 0x6ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV64_Val 0x7ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV128_Val 0x8ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV256_Val 0x9ul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV512_Val 0xAul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE2_CTRLA_PRESCALER_DIV1024_Val 0xBul  /**< \brief (RTC_MODE2_CTRLA) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define RTC_MODE2_CTRLA_PRESCALER_OFF (RTC_MODE2_CTRLA_PRESCALER_OFF_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV1 (RTC_MODE2_CTRLA_PRESCALER_DIV1_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV2 (RTC_MODE2_CTRLA_PRESCALER_DIV2_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV4 (RTC_MODE2_CTRLA_PRESCALER_DIV4_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV8 (RTC_MODE2_CTRLA_PRESCALER_DIV8_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV16 (RTC_MODE2_CTRLA_PRESCALER_DIV16_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV32 (RTC_MODE2_CTRLA_PRESCALER_DIV32_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV64 (RTC_MODE2_CTRLA_PRESCALER_DIV64_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV128 (RTC_MODE2_CTRLA_PRESCALER_DIV128_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV256 (RTC_MODE2_CTRLA_PRESCALER_DIV256_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV512 (RTC_MODE2_CTRLA_PRESCALER_DIV512_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_PRESCALER_DIV1024 (RTC_MODE2_CTRLA_PRESCALER_DIV1024_Val << RTC_MODE2_CTRLA_PRESCALER_Pos)
+#define RTC_MODE2_CTRLA_MASK        0x0FCFul     /**< \brief (RTC_MODE2_CTRLA) MASK Register */
+
+/* -------- RTC_MODE0_EVCTRL : (RTC Offset: 0x04) (R/W 32) MODE0 MODE0 Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PEREO0:1;         /*!< bit:      0  Periodic Interval 0 Event Output Enable */
+    uint32_t PEREO1:1;         /*!< bit:      1  Periodic Interval 1 Event Output Enable */
+    uint32_t PEREO2:1;         /*!< bit:      2  Periodic Interval 2 Event Output Enable */
+    uint32_t PEREO3:1;         /*!< bit:      3  Periodic Interval 3 Event Output Enable */
+    uint32_t PEREO4:1;         /*!< bit:      4  Periodic Interval 4 Event Output Enable */
+    uint32_t PEREO5:1;         /*!< bit:      5  Periodic Interval 5 Event Output Enable */
+    uint32_t PEREO6:1;         /*!< bit:      6  Periodic Interval 6 Event Output Enable */
+    uint32_t PEREO7:1;         /*!< bit:      7  Periodic Interval 7 Event Output Enable */
+    uint32_t CMPEO0:1;         /*!< bit:      8  Compare 0 Event Output Enable      */
+    uint32_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint32_t OVFEO:1;          /*!< bit:     15  Overflow Event Output Enable       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t PEREO:8;          /*!< bit:  0.. 7  Periodic Interval x Event Output Enable */
+    uint32_t CMPEO:1;          /*!< bit:      8  Compare x Event Output Enable      */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE0_EVCTRL offset) MODE0 Event Control */
+#define RTC_MODE0_EVCTRL_RESETVALUE 0x00000000ul /**< \brief (RTC_MODE0_EVCTRL reset_value) MODE0 Event Control */
+
+#define RTC_MODE0_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 0 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO0     (1 << RTC_MODE0_EVCTRL_PEREO0_Pos)
+#define RTC_MODE0_EVCTRL_PEREO1_Pos 1            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 1 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO1     (1 << RTC_MODE0_EVCTRL_PEREO1_Pos)
+#define RTC_MODE0_EVCTRL_PEREO2_Pos 2            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 2 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO2     (1 << RTC_MODE0_EVCTRL_PEREO2_Pos)
+#define RTC_MODE0_EVCTRL_PEREO3_Pos 3            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 3 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO3     (1 << RTC_MODE0_EVCTRL_PEREO3_Pos)
+#define RTC_MODE0_EVCTRL_PEREO4_Pos 4            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 4 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO4     (1 << RTC_MODE0_EVCTRL_PEREO4_Pos)
+#define RTC_MODE0_EVCTRL_PEREO5_Pos 5            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 5 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO5     (1 << RTC_MODE0_EVCTRL_PEREO5_Pos)
+#define RTC_MODE0_EVCTRL_PEREO6_Pos 6            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 6 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO6     (1 << RTC_MODE0_EVCTRL_PEREO6_Pos)
+#define RTC_MODE0_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 7 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO7     (1 << RTC_MODE0_EVCTRL_PEREO7_Pos)
+#define RTC_MODE0_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval x Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO_Msk  (0xFFul << RTC_MODE0_EVCTRL_PEREO_Pos)
+#define RTC_MODE0_EVCTRL_PEREO(value) (RTC_MODE0_EVCTRL_PEREO_Msk & ((value) << RTC_MODE0_EVCTRL_PEREO_Pos))
+#define RTC_MODE0_EVCTRL_CMPEO0_Pos 8            /**< \brief (RTC_MODE0_EVCTRL) Compare 0 Event Output Enable */
+#define RTC_MODE0_EVCTRL_CMPEO0     (1 << RTC_MODE0_EVCTRL_CMPEO0_Pos)
+#define RTC_MODE0_EVCTRL_CMPEO_Pos  8            /**< \brief (RTC_MODE0_EVCTRL) Compare x Event Output Enable */
+#define RTC_MODE0_EVCTRL_CMPEO_Msk  (0x1ul << RTC_MODE0_EVCTRL_CMPEO_Pos)
+#define RTC_MODE0_EVCTRL_CMPEO(value) (RTC_MODE0_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE0_EVCTRL_CMPEO_Pos))
+#define RTC_MODE0_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE0_EVCTRL) Overflow Event Output Enable */
+#define RTC_MODE0_EVCTRL_OVFEO      (0x1ul << RTC_MODE0_EVCTRL_OVFEO_Pos)
+#define RTC_MODE0_EVCTRL_MASK       0x000081FFul /**< \brief (RTC_MODE0_EVCTRL) MASK Register */
+
+/* -------- RTC_MODE1_EVCTRL : (RTC Offset: 0x04) (R/W 32) MODE1 MODE1 Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PEREO0:1;         /*!< bit:      0  Periodic Interval 0 Event Output Enable */
+    uint32_t PEREO1:1;         /*!< bit:      1  Periodic Interval 1 Event Output Enable */
+    uint32_t PEREO2:1;         /*!< bit:      2  Periodic Interval 2 Event Output Enable */
+    uint32_t PEREO3:1;         /*!< bit:      3  Periodic Interval 3 Event Output Enable */
+    uint32_t PEREO4:1;         /*!< bit:      4  Periodic Interval 4 Event Output Enable */
+    uint32_t PEREO5:1;         /*!< bit:      5  Periodic Interval 5 Event Output Enable */
+    uint32_t PEREO6:1;         /*!< bit:      6  Periodic Interval 6 Event Output Enable */
+    uint32_t PEREO7:1;         /*!< bit:      7  Periodic Interval 7 Event Output Enable */
+    uint32_t CMPEO0:1;         /*!< bit:      8  Compare 0 Event Output Enable      */
+    uint32_t CMPEO1:1;         /*!< bit:      9  Compare 1 Event Output Enable      */
+    uint32_t :5;               /*!< bit: 10..14  Reserved                           */
+    uint32_t OVFEO:1;          /*!< bit:     15  Overflow Event Output Enable       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t PEREO:8;          /*!< bit:  0.. 7  Periodic Interval x Event Output Enable */
+    uint32_t CMPEO:2;          /*!< bit:  8.. 9  Compare x Event Output Enable      */
+    uint32_t :22;              /*!< bit: 10..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE1_EVCTRL offset) MODE1 Event Control */
+#define RTC_MODE1_EVCTRL_RESETVALUE 0x00000000ul /**< \brief (RTC_MODE1_EVCTRL reset_value) MODE1 Event Control */
+
+#define RTC_MODE1_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 0 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO0     (1 << RTC_MODE1_EVCTRL_PEREO0_Pos)
+#define RTC_MODE1_EVCTRL_PEREO1_Pos 1            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 1 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO1     (1 << RTC_MODE1_EVCTRL_PEREO1_Pos)
+#define RTC_MODE1_EVCTRL_PEREO2_Pos 2            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 2 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO2     (1 << RTC_MODE1_EVCTRL_PEREO2_Pos)
+#define RTC_MODE1_EVCTRL_PEREO3_Pos 3            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 3 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO3     (1 << RTC_MODE1_EVCTRL_PEREO3_Pos)
+#define RTC_MODE1_EVCTRL_PEREO4_Pos 4            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 4 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO4     (1 << RTC_MODE1_EVCTRL_PEREO4_Pos)
+#define RTC_MODE1_EVCTRL_PEREO5_Pos 5            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 5 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO5     (1 << RTC_MODE1_EVCTRL_PEREO5_Pos)
+#define RTC_MODE1_EVCTRL_PEREO6_Pos 6            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 6 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO6     (1 << RTC_MODE1_EVCTRL_PEREO6_Pos)
+#define RTC_MODE1_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 7 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO7     (1 << RTC_MODE1_EVCTRL_PEREO7_Pos)
+#define RTC_MODE1_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval x Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO_Msk  (0xFFul << RTC_MODE1_EVCTRL_PEREO_Pos)
+#define RTC_MODE1_EVCTRL_PEREO(value) (RTC_MODE1_EVCTRL_PEREO_Msk & ((value) << RTC_MODE1_EVCTRL_PEREO_Pos))
+#define RTC_MODE1_EVCTRL_CMPEO0_Pos 8            /**< \brief (RTC_MODE1_EVCTRL) Compare 0 Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO0     (1 << RTC_MODE1_EVCTRL_CMPEO0_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO1_Pos 9            /**< \brief (RTC_MODE1_EVCTRL) Compare 1 Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO1     (1 << RTC_MODE1_EVCTRL_CMPEO1_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO_Pos  8            /**< \brief (RTC_MODE1_EVCTRL) Compare x Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO_Msk  (0x3ul << RTC_MODE1_EVCTRL_CMPEO_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO(value) (RTC_MODE1_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE1_EVCTRL_CMPEO_Pos))
+#define RTC_MODE1_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE1_EVCTRL) Overflow Event Output Enable */
+#define RTC_MODE1_EVCTRL_OVFEO      (0x1ul << RTC_MODE1_EVCTRL_OVFEO_Pos)
+#define RTC_MODE1_EVCTRL_MASK       0x000083FFul /**< \brief (RTC_MODE1_EVCTRL) MASK Register */
+
+/* -------- RTC_MODE2_EVCTRL : (RTC Offset: 0x04) (R/W 32) MODE2 MODE2 Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PEREO0:1;         /*!< bit:      0  Periodic Interval 0 Event Output Enable */
+    uint32_t PEREO1:1;         /*!< bit:      1  Periodic Interval 1 Event Output Enable */
+    uint32_t PEREO2:1;         /*!< bit:      2  Periodic Interval 2 Event Output Enable */
+    uint32_t PEREO3:1;         /*!< bit:      3  Periodic Interval 3 Event Output Enable */
+    uint32_t PEREO4:1;         /*!< bit:      4  Periodic Interval 4 Event Output Enable */
+    uint32_t PEREO5:1;         /*!< bit:      5  Periodic Interval 5 Event Output Enable */
+    uint32_t PEREO6:1;         /*!< bit:      6  Periodic Interval 6 Event Output Enable */
+    uint32_t PEREO7:1;         /*!< bit:      7  Periodic Interval 7 Event Output Enable */
+    uint32_t ALARMEO0:1;       /*!< bit:      8  Alarm 0 Event Output Enable        */
+    uint32_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint32_t OVFEO:1;          /*!< bit:     15  Overflow Event Output Enable       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t PEREO:8;          /*!< bit:  0.. 7  Periodic Interval x Event Output Enable */
+    uint32_t ALARMEO:1;        /*!< bit:      8  Alarm x Event Output Enable        */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE2_EVCTRL offset) MODE2 Event Control */
+#define RTC_MODE2_EVCTRL_RESETVALUE 0x00000000ul /**< \brief (RTC_MODE2_EVCTRL reset_value) MODE2 Event Control */
+
+#define RTC_MODE2_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 0 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO0     (1 << RTC_MODE2_EVCTRL_PEREO0_Pos)
+#define RTC_MODE2_EVCTRL_PEREO1_Pos 1            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 1 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO1     (1 << RTC_MODE2_EVCTRL_PEREO1_Pos)
+#define RTC_MODE2_EVCTRL_PEREO2_Pos 2            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 2 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO2     (1 << RTC_MODE2_EVCTRL_PEREO2_Pos)
+#define RTC_MODE2_EVCTRL_PEREO3_Pos 3            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 3 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO3     (1 << RTC_MODE2_EVCTRL_PEREO3_Pos)
+#define RTC_MODE2_EVCTRL_PEREO4_Pos 4            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 4 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO4     (1 << RTC_MODE2_EVCTRL_PEREO4_Pos)
+#define RTC_MODE2_EVCTRL_PEREO5_Pos 5            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 5 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO5     (1 << RTC_MODE2_EVCTRL_PEREO5_Pos)
+#define RTC_MODE2_EVCTRL_PEREO6_Pos 6            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 6 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO6     (1 << RTC_MODE2_EVCTRL_PEREO6_Pos)
+#define RTC_MODE2_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 7 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO7     (1 << RTC_MODE2_EVCTRL_PEREO7_Pos)
+#define RTC_MODE2_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval x Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO_Msk  (0xFFul << RTC_MODE2_EVCTRL_PEREO_Pos)
+#define RTC_MODE2_EVCTRL_PEREO(value) (RTC_MODE2_EVCTRL_PEREO_Msk & ((value) << RTC_MODE2_EVCTRL_PEREO_Pos))
+#define RTC_MODE2_EVCTRL_ALARMEO0_Pos 8            /**< \brief (RTC_MODE2_EVCTRL) Alarm 0 Event Output Enable */
+#define RTC_MODE2_EVCTRL_ALARMEO0   (1 << RTC_MODE2_EVCTRL_ALARMEO0_Pos)
+#define RTC_MODE2_EVCTRL_ALARMEO_Pos 8            /**< \brief (RTC_MODE2_EVCTRL) Alarm x Event Output Enable */
+#define RTC_MODE2_EVCTRL_ALARMEO_Msk (0x1ul << RTC_MODE2_EVCTRL_ALARMEO_Pos)
+#define RTC_MODE2_EVCTRL_ALARMEO(value) (RTC_MODE2_EVCTRL_ALARMEO_Msk & ((value) << RTC_MODE2_EVCTRL_ALARMEO_Pos))
+#define RTC_MODE2_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE2_EVCTRL) Overflow Event Output Enable */
+#define RTC_MODE2_EVCTRL_OVFEO      (0x1ul << RTC_MODE2_EVCTRL_OVFEO_Pos)
+#define RTC_MODE2_EVCTRL_MASK       0x000081FFul /**< \brief (RTC_MODE2_EVCTRL) MASK Register */
+
+/* -------- RTC_MODE0_INTENCLR : (RTC Offset: 0x08) (R/W 16) MODE0 MODE0 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PER0:1;           /*!< bit:      0  Periodic Interval 0 Interrupt Enable */
+    uint16_t PER1:1;           /*!< bit:      1  Periodic Interval 1 Interrupt Enable */
+    uint16_t PER2:1;           /*!< bit:      2  Periodic Interval 2 Interrupt Enable */
+    uint16_t PER3:1;           /*!< bit:      3  Periodic Interval 3 Interrupt Enable */
+    uint16_t PER4:1;           /*!< bit:      4  Periodic Interval 4 Interrupt Enable */
+    uint16_t PER5:1;           /*!< bit:      5  Periodic Interval 5 Interrupt Enable */
+    uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6 Interrupt Enable */
+    uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7 Interrupt Enable */
+    uint16_t CMP0:1;           /*!< bit:      8  Compare 0 Interrupt Enable         */
+    uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t OVF:1;            /*!< bit:     15  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x Interrupt Enable */
+    uint16_t CMP:1;            /*!< bit:      8  Compare x Interrupt Enable         */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENCLR_OFFSET   0x08         /**< \brief (RTC_MODE0_INTENCLR offset) MODE0 Interrupt Enable Clear */
+#define RTC_MODE0_INTENCLR_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE0_INTENCLR reset_value) MODE0 Interrupt Enable Clear */
+
+#define RTC_MODE0_INTENCLR_PER0_Pos 0            /**< \brief (RTC_MODE0_INTENCLR) Periodic Interval 0 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER0     (1 << RTC_MODE0_INTENCLR_PER0_Pos)
+#define RTC_MODE0_INTENCLR_PER1_Pos 1            /**< \brief (RTC_MODE0_INTENCLR) Periodic Interval 1 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER1     (1 << RTC_MODE0_INTENCLR_PER1_Pos)
+#define RTC_MODE0_INTENCLR_PER2_Pos 2            /**< \brief (RTC_MODE0_INTENCLR) Periodic Interval 2 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER2     (1 << RTC_MODE0_INTENCLR_PER2_Pos)
+#define RTC_MODE0_INTENCLR_PER3_Pos 3            /**< \brief (RTC_MODE0_INTENCLR) Periodic Interval 3 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER3     (1 << RTC_MODE0_INTENCLR_PER3_Pos)
+#define RTC_MODE0_INTENCLR_PER4_Pos 4            /**< \brief (RTC_MODE0_INTENCLR) Periodic Interval 4 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER4     (1 << RTC_MODE0_INTENCLR_PER4_Pos)
+#define RTC_MODE0_INTENCLR_PER5_Pos 5            /**< \brief (RTC_MODE0_INTENCLR) Periodic Interval 5 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER5     (1 << RTC_MODE0_INTENCLR_PER5_Pos)
+#define RTC_MODE0_INTENCLR_PER6_Pos 6            /**< \brief (RTC_MODE0_INTENCLR) Periodic Interval 6 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER6     (1 << RTC_MODE0_INTENCLR_PER6_Pos)
+#define RTC_MODE0_INTENCLR_PER7_Pos 7            /**< \brief (RTC_MODE0_INTENCLR) Periodic Interval 7 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER7     (1 << RTC_MODE0_INTENCLR_PER7_Pos)
+#define RTC_MODE0_INTENCLR_PER_Pos  0            /**< \brief (RTC_MODE0_INTENCLR) Periodic Interval x Interrupt Enable */
+#define RTC_MODE0_INTENCLR_PER_Msk  (0xFFul << RTC_MODE0_INTENCLR_PER_Pos)
+#define RTC_MODE0_INTENCLR_PER(value) (RTC_MODE0_INTENCLR_PER_Msk & ((value) << RTC_MODE0_INTENCLR_PER_Pos))
+#define RTC_MODE0_INTENCLR_CMP0_Pos 8            /**< \brief (RTC_MODE0_INTENCLR) Compare 0 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_CMP0     (1 << RTC_MODE0_INTENCLR_CMP0_Pos)
+#define RTC_MODE0_INTENCLR_CMP_Pos  8            /**< \brief (RTC_MODE0_INTENCLR) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENCLR_CMP_Msk  (0x1ul << RTC_MODE0_INTENCLR_CMP_Pos)
+#define RTC_MODE0_INTENCLR_CMP(value) (RTC_MODE0_INTENCLR_CMP_Msk & ((value) << RTC_MODE0_INTENCLR_CMP_Pos))
+#define RTC_MODE0_INTENCLR_OVF_Pos  15           /**< \brief (RTC_MODE0_INTENCLR) Overflow Interrupt Enable */
+#define RTC_MODE0_INTENCLR_OVF      (0x1ul << RTC_MODE0_INTENCLR_OVF_Pos)
+#define RTC_MODE0_INTENCLR_MASK     0x81FFul     /**< \brief (RTC_MODE0_INTENCLR) MASK Register */
+
+/* -------- RTC_MODE1_INTENCLR : (RTC Offset: 0x08) (R/W 16) MODE1 MODE1 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PER0:1;           /*!< bit:      0  Periodic Interval 0 Interrupt Enable */
+    uint16_t PER1:1;           /*!< bit:      1  Periodic Interval 1 Interrupt Enable */
+    uint16_t PER2:1;           /*!< bit:      2  Periodic Interval 2 Interrupt Enable */
+    uint16_t PER3:1;           /*!< bit:      3  Periodic Interval 3 Interrupt Enable */
+    uint16_t PER4:1;           /*!< bit:      4  Periodic Interval 4 Interrupt Enable */
+    uint16_t PER5:1;           /*!< bit:      5  Periodic Interval 5 Interrupt Enable */
+    uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6 Interrupt Enable */
+    uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7 Interrupt Enable */
+    uint16_t CMP0:1;           /*!< bit:      8  Compare 0 Interrupt Enable         */
+    uint16_t CMP1:1;           /*!< bit:      9  Compare 1 Interrupt Enable         */
+    uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    uint16_t OVF:1;            /*!< bit:     15  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x Interrupt Enable */
+    uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x Interrupt Enable         */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENCLR_OFFSET   0x08         /**< \brief (RTC_MODE1_INTENCLR offset) MODE1 Interrupt Enable Clear */
+#define RTC_MODE1_INTENCLR_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE1_INTENCLR reset_value) MODE1 Interrupt Enable Clear */
+
+#define RTC_MODE1_INTENCLR_PER0_Pos 0            /**< \brief (RTC_MODE1_INTENCLR) Periodic Interval 0 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER0     (1 << RTC_MODE1_INTENCLR_PER0_Pos)
+#define RTC_MODE1_INTENCLR_PER1_Pos 1            /**< \brief (RTC_MODE1_INTENCLR) Periodic Interval 1 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER1     (1 << RTC_MODE1_INTENCLR_PER1_Pos)
+#define RTC_MODE1_INTENCLR_PER2_Pos 2            /**< \brief (RTC_MODE1_INTENCLR) Periodic Interval 2 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER2     (1 << RTC_MODE1_INTENCLR_PER2_Pos)
+#define RTC_MODE1_INTENCLR_PER3_Pos 3            /**< \brief (RTC_MODE1_INTENCLR) Periodic Interval 3 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER3     (1 << RTC_MODE1_INTENCLR_PER3_Pos)
+#define RTC_MODE1_INTENCLR_PER4_Pos 4            /**< \brief (RTC_MODE1_INTENCLR) Periodic Interval 4 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER4     (1 << RTC_MODE1_INTENCLR_PER4_Pos)
+#define RTC_MODE1_INTENCLR_PER5_Pos 5            /**< \brief (RTC_MODE1_INTENCLR) Periodic Interval 5 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER5     (1 << RTC_MODE1_INTENCLR_PER5_Pos)
+#define RTC_MODE1_INTENCLR_PER6_Pos 6            /**< \brief (RTC_MODE1_INTENCLR) Periodic Interval 6 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER6     (1 << RTC_MODE1_INTENCLR_PER6_Pos)
+#define RTC_MODE1_INTENCLR_PER7_Pos 7            /**< \brief (RTC_MODE1_INTENCLR) Periodic Interval 7 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER7     (1 << RTC_MODE1_INTENCLR_PER7_Pos)
+#define RTC_MODE1_INTENCLR_PER_Pos  0            /**< \brief (RTC_MODE1_INTENCLR) Periodic Interval x Interrupt Enable */
+#define RTC_MODE1_INTENCLR_PER_Msk  (0xFFul << RTC_MODE1_INTENCLR_PER_Pos)
+#define RTC_MODE1_INTENCLR_PER(value) (RTC_MODE1_INTENCLR_PER_Msk & ((value) << RTC_MODE1_INTENCLR_PER_Pos))
+#define RTC_MODE1_INTENCLR_CMP0_Pos 8            /**< \brief (RTC_MODE1_INTENCLR) Compare 0 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP0     (1 << RTC_MODE1_INTENCLR_CMP0_Pos)
+#define RTC_MODE1_INTENCLR_CMP1_Pos 9            /**< \brief (RTC_MODE1_INTENCLR) Compare 1 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP1     (1 << RTC_MODE1_INTENCLR_CMP1_Pos)
+#define RTC_MODE1_INTENCLR_CMP_Pos  8            /**< \brief (RTC_MODE1_INTENCLR) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP_Msk  (0x3ul << RTC_MODE1_INTENCLR_CMP_Pos)
+#define RTC_MODE1_INTENCLR_CMP(value) (RTC_MODE1_INTENCLR_CMP_Msk & ((value) << RTC_MODE1_INTENCLR_CMP_Pos))
+#define RTC_MODE1_INTENCLR_OVF_Pos  15           /**< \brief (RTC_MODE1_INTENCLR) Overflow Interrupt Enable */
+#define RTC_MODE1_INTENCLR_OVF      (0x1ul << RTC_MODE1_INTENCLR_OVF_Pos)
+#define RTC_MODE1_INTENCLR_MASK     0x83FFul     /**< \brief (RTC_MODE1_INTENCLR) MASK Register */
+
+/* -------- RTC_MODE2_INTENCLR : (RTC Offset: 0x08) (R/W 16) MODE2 MODE2 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PER0:1;           /*!< bit:      0  Periodic Interval 0 Interrupt Enable */
+    uint16_t PER1:1;           /*!< bit:      1  Periodic Interval 1 Interrupt Enable */
+    uint16_t PER2:1;           /*!< bit:      2  Periodic Interval 2 Interrupt Enable */
+    uint16_t PER3:1;           /*!< bit:      3  Periodic Interval 3 Interrupt Enable */
+    uint16_t PER4:1;           /*!< bit:      4  Periodic Interval 4 Interrupt Enable */
+    uint16_t PER5:1;           /*!< bit:      5  Periodic Interval 5 Interrupt Enable */
+    uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6 Interrupt Enable */
+    uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7 Interrupt Enable */
+    uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0 Interrupt Enable           */
+    uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t OVF:1;            /*!< bit:     15  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x Interrupt Enable */
+    uint16_t ALARM:1;          /*!< bit:      8  Alarm x Interrupt Enable           */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENCLR_OFFSET   0x08         /**< \brief (RTC_MODE2_INTENCLR offset) MODE2 Interrupt Enable Clear */
+#define RTC_MODE2_INTENCLR_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE2_INTENCLR reset_value) MODE2 Interrupt Enable Clear */
+
+#define RTC_MODE2_INTENCLR_PER0_Pos 0            /**< \brief (RTC_MODE2_INTENCLR) Periodic Interval 0 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER0     (1 << RTC_MODE2_INTENCLR_PER0_Pos)
+#define RTC_MODE2_INTENCLR_PER1_Pos 1            /**< \brief (RTC_MODE2_INTENCLR) Periodic Interval 1 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER1     (1 << RTC_MODE2_INTENCLR_PER1_Pos)
+#define RTC_MODE2_INTENCLR_PER2_Pos 2            /**< \brief (RTC_MODE2_INTENCLR) Periodic Interval 2 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER2     (1 << RTC_MODE2_INTENCLR_PER2_Pos)
+#define RTC_MODE2_INTENCLR_PER3_Pos 3            /**< \brief (RTC_MODE2_INTENCLR) Periodic Interval 3 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER3     (1 << RTC_MODE2_INTENCLR_PER3_Pos)
+#define RTC_MODE2_INTENCLR_PER4_Pos 4            /**< \brief (RTC_MODE2_INTENCLR) Periodic Interval 4 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER4     (1 << RTC_MODE2_INTENCLR_PER4_Pos)
+#define RTC_MODE2_INTENCLR_PER5_Pos 5            /**< \brief (RTC_MODE2_INTENCLR) Periodic Interval 5 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER5     (1 << RTC_MODE2_INTENCLR_PER5_Pos)
+#define RTC_MODE2_INTENCLR_PER6_Pos 6            /**< \brief (RTC_MODE2_INTENCLR) Periodic Interval 6 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER6     (1 << RTC_MODE2_INTENCLR_PER6_Pos)
+#define RTC_MODE2_INTENCLR_PER7_Pos 7            /**< \brief (RTC_MODE2_INTENCLR) Periodic Interval 7 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER7     (1 << RTC_MODE2_INTENCLR_PER7_Pos)
+#define RTC_MODE2_INTENCLR_PER_Pos  0            /**< \brief (RTC_MODE2_INTENCLR) Periodic Interval x Interrupt Enable */
+#define RTC_MODE2_INTENCLR_PER_Msk  (0xFFul << RTC_MODE2_INTENCLR_PER_Pos)
+#define RTC_MODE2_INTENCLR_PER(value) (RTC_MODE2_INTENCLR_PER_Msk & ((value) << RTC_MODE2_INTENCLR_PER_Pos))
+#define RTC_MODE2_INTENCLR_ALARM0_Pos 8            /**< \brief (RTC_MODE2_INTENCLR) Alarm 0 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_ALARM0   (1 << RTC_MODE2_INTENCLR_ALARM0_Pos)
+#define RTC_MODE2_INTENCLR_ALARM_Pos 8            /**< \brief (RTC_MODE2_INTENCLR) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENCLR_ALARM_Msk (0x1ul << RTC_MODE2_INTENCLR_ALARM_Pos)
+#define RTC_MODE2_INTENCLR_ALARM(value) (RTC_MODE2_INTENCLR_ALARM_Msk & ((value) << RTC_MODE2_INTENCLR_ALARM_Pos))
+#define RTC_MODE2_INTENCLR_OVF_Pos  15           /**< \brief (RTC_MODE2_INTENCLR) Overflow Interrupt Enable */
+#define RTC_MODE2_INTENCLR_OVF      (0x1ul << RTC_MODE2_INTENCLR_OVF_Pos)
+#define RTC_MODE2_INTENCLR_MASK     0x81FFul     /**< \brief (RTC_MODE2_INTENCLR) MASK Register */
+
+/* -------- RTC_MODE0_INTENSET : (RTC Offset: 0x0A) (R/W 16) MODE0 MODE0 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PER0:1;           /*!< bit:      0  Periodic Interval 0 Interrupt Enable */
+    uint16_t PER1:1;           /*!< bit:      1  Periodic Interval 1 Interrupt Enable */
+    uint16_t PER2:1;           /*!< bit:      2  Periodic Interval 2 Interrupt Enable */
+    uint16_t PER3:1;           /*!< bit:      3  Periodic Interval 3 Interrupt Enable */
+    uint16_t PER4:1;           /*!< bit:      4  Periodic Interval 4 Interrupt Enable */
+    uint16_t PER5:1;           /*!< bit:      5  Periodic Interval 5 Interrupt Enable */
+    uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6 Interrupt Enable */
+    uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7 Interrupt Enable */
+    uint16_t CMP0:1;           /*!< bit:      8  Compare 0 Interrupt Enable         */
+    uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t OVF:1;            /*!< bit:     15  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x Interrupt Enable */
+    uint16_t CMP:1;            /*!< bit:      8  Compare x Interrupt Enable         */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENSET_OFFSET   0x0A         /**< \brief (RTC_MODE0_INTENSET offset) MODE0 Interrupt Enable Set */
+#define RTC_MODE0_INTENSET_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE0_INTENSET reset_value) MODE0 Interrupt Enable Set */
+
+#define RTC_MODE0_INTENSET_PER0_Pos 0            /**< \brief (RTC_MODE0_INTENSET) Periodic Interval 0 Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER0     (1 << RTC_MODE0_INTENSET_PER0_Pos)
+#define RTC_MODE0_INTENSET_PER1_Pos 1            /**< \brief (RTC_MODE0_INTENSET) Periodic Interval 1 Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER1     (1 << RTC_MODE0_INTENSET_PER1_Pos)
+#define RTC_MODE0_INTENSET_PER2_Pos 2            /**< \brief (RTC_MODE0_INTENSET) Periodic Interval 2 Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER2     (1 << RTC_MODE0_INTENSET_PER2_Pos)
+#define RTC_MODE0_INTENSET_PER3_Pos 3            /**< \brief (RTC_MODE0_INTENSET) Periodic Interval 3 Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER3     (1 << RTC_MODE0_INTENSET_PER3_Pos)
+#define RTC_MODE0_INTENSET_PER4_Pos 4            /**< \brief (RTC_MODE0_INTENSET) Periodic Interval 4 Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER4     (1 << RTC_MODE0_INTENSET_PER4_Pos)
+#define RTC_MODE0_INTENSET_PER5_Pos 5            /**< \brief (RTC_MODE0_INTENSET) Periodic Interval 5 Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER5     (1 << RTC_MODE0_INTENSET_PER5_Pos)
+#define RTC_MODE0_INTENSET_PER6_Pos 6            /**< \brief (RTC_MODE0_INTENSET) Periodic Interval 6 Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER6     (1 << RTC_MODE0_INTENSET_PER6_Pos)
+#define RTC_MODE0_INTENSET_PER7_Pos 7            /**< \brief (RTC_MODE0_INTENSET) Periodic Interval 7 Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER7     (1 << RTC_MODE0_INTENSET_PER7_Pos)
+#define RTC_MODE0_INTENSET_PER_Pos  0            /**< \brief (RTC_MODE0_INTENSET) Periodic Interval x Interrupt Enable */
+#define RTC_MODE0_INTENSET_PER_Msk  (0xFFul << RTC_MODE0_INTENSET_PER_Pos)
+#define RTC_MODE0_INTENSET_PER(value) (RTC_MODE0_INTENSET_PER_Msk & ((value) << RTC_MODE0_INTENSET_PER_Pos))
+#define RTC_MODE0_INTENSET_CMP0_Pos 8            /**< \brief (RTC_MODE0_INTENSET) Compare 0 Interrupt Enable */
+#define RTC_MODE0_INTENSET_CMP0     (1 << RTC_MODE0_INTENSET_CMP0_Pos)
+#define RTC_MODE0_INTENSET_CMP_Pos  8            /**< \brief (RTC_MODE0_INTENSET) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENSET_CMP_Msk  (0x1ul << RTC_MODE0_INTENSET_CMP_Pos)
+#define RTC_MODE0_INTENSET_CMP(value) (RTC_MODE0_INTENSET_CMP_Msk & ((value) << RTC_MODE0_INTENSET_CMP_Pos))
+#define RTC_MODE0_INTENSET_OVF_Pos  15           /**< \brief (RTC_MODE0_INTENSET) Overflow Interrupt Enable */
+#define RTC_MODE0_INTENSET_OVF      (0x1ul << RTC_MODE0_INTENSET_OVF_Pos)
+#define RTC_MODE0_INTENSET_MASK     0x81FFul     /**< \brief (RTC_MODE0_INTENSET) MASK Register */
+
+/* -------- RTC_MODE1_INTENSET : (RTC Offset: 0x0A) (R/W 16) MODE1 MODE1 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PER0:1;           /*!< bit:      0  Periodic Interval 0 Interrupt Enable */
+    uint16_t PER1:1;           /*!< bit:      1  Periodic Interval 1 Interrupt Enable */
+    uint16_t PER2:1;           /*!< bit:      2  Periodic Interval 2 Interrupt Enable */
+    uint16_t PER3:1;           /*!< bit:      3  Periodic Interval 3 Interrupt Enable */
+    uint16_t PER4:1;           /*!< bit:      4  Periodic Interval 4 Interrupt Enable */
+    uint16_t PER5:1;           /*!< bit:      5  Periodic Interval 5 Interrupt Enable */
+    uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6 Interrupt Enable */
+    uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7 Interrupt Enable */
+    uint16_t CMP0:1;           /*!< bit:      8  Compare 0 Interrupt Enable         */
+    uint16_t CMP1:1;           /*!< bit:      9  Compare 1 Interrupt Enable         */
+    uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    uint16_t OVF:1;            /*!< bit:     15  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x Interrupt Enable */
+    uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x Interrupt Enable         */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENSET_OFFSET   0x0A         /**< \brief (RTC_MODE1_INTENSET offset) MODE1 Interrupt Enable Set */
+#define RTC_MODE1_INTENSET_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE1_INTENSET reset_value) MODE1 Interrupt Enable Set */
+
+#define RTC_MODE1_INTENSET_PER0_Pos 0            /**< \brief (RTC_MODE1_INTENSET) Periodic Interval 0 Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER0     (1 << RTC_MODE1_INTENSET_PER0_Pos)
+#define RTC_MODE1_INTENSET_PER1_Pos 1            /**< \brief (RTC_MODE1_INTENSET) Periodic Interval 1 Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER1     (1 << RTC_MODE1_INTENSET_PER1_Pos)
+#define RTC_MODE1_INTENSET_PER2_Pos 2            /**< \brief (RTC_MODE1_INTENSET) Periodic Interval 2 Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER2     (1 << RTC_MODE1_INTENSET_PER2_Pos)
+#define RTC_MODE1_INTENSET_PER3_Pos 3            /**< \brief (RTC_MODE1_INTENSET) Periodic Interval 3 Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER3     (1 << RTC_MODE1_INTENSET_PER3_Pos)
+#define RTC_MODE1_INTENSET_PER4_Pos 4            /**< \brief (RTC_MODE1_INTENSET) Periodic Interval 4 Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER4     (1 << RTC_MODE1_INTENSET_PER4_Pos)
+#define RTC_MODE1_INTENSET_PER5_Pos 5            /**< \brief (RTC_MODE1_INTENSET) Periodic Interval 5 Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER5     (1 << RTC_MODE1_INTENSET_PER5_Pos)
+#define RTC_MODE1_INTENSET_PER6_Pos 6            /**< \brief (RTC_MODE1_INTENSET) Periodic Interval 6 Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER6     (1 << RTC_MODE1_INTENSET_PER6_Pos)
+#define RTC_MODE1_INTENSET_PER7_Pos 7            /**< \brief (RTC_MODE1_INTENSET) Periodic Interval 7 Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER7     (1 << RTC_MODE1_INTENSET_PER7_Pos)
+#define RTC_MODE1_INTENSET_PER_Pos  0            /**< \brief (RTC_MODE1_INTENSET) Periodic Interval x Interrupt Enable */
+#define RTC_MODE1_INTENSET_PER_Msk  (0xFFul << RTC_MODE1_INTENSET_PER_Pos)
+#define RTC_MODE1_INTENSET_PER(value) (RTC_MODE1_INTENSET_PER_Msk & ((value) << RTC_MODE1_INTENSET_PER_Pos))
+#define RTC_MODE1_INTENSET_CMP0_Pos 8            /**< \brief (RTC_MODE1_INTENSET) Compare 0 Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP0     (1 << RTC_MODE1_INTENSET_CMP0_Pos)
+#define RTC_MODE1_INTENSET_CMP1_Pos 9            /**< \brief (RTC_MODE1_INTENSET) Compare 1 Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP1     (1 << RTC_MODE1_INTENSET_CMP1_Pos)
+#define RTC_MODE1_INTENSET_CMP_Pos  8            /**< \brief (RTC_MODE1_INTENSET) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP_Msk  (0x3ul << RTC_MODE1_INTENSET_CMP_Pos)
+#define RTC_MODE1_INTENSET_CMP(value) (RTC_MODE1_INTENSET_CMP_Msk & ((value) << RTC_MODE1_INTENSET_CMP_Pos))
+#define RTC_MODE1_INTENSET_OVF_Pos  15           /**< \brief (RTC_MODE1_INTENSET) Overflow Interrupt Enable */
+#define RTC_MODE1_INTENSET_OVF      (0x1ul << RTC_MODE1_INTENSET_OVF_Pos)
+#define RTC_MODE1_INTENSET_MASK     0x83FFul     /**< \brief (RTC_MODE1_INTENSET) MASK Register */
+
+/* -------- RTC_MODE2_INTENSET : (RTC Offset: 0x0A) (R/W 16) MODE2 MODE2 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PER0:1;           /*!< bit:      0  Periodic Interval 0 Enable         */
+    uint16_t PER1:1;           /*!< bit:      1  Periodic Interval 1 Enable         */
+    uint16_t PER2:1;           /*!< bit:      2  Periodic Interval 2 Enable         */
+    uint16_t PER3:1;           /*!< bit:      3  Periodic Interval 3 Enable         */
+    uint16_t PER4:1;           /*!< bit:      4  Periodic Interval 4 Enable         */
+    uint16_t PER5:1;           /*!< bit:      5  Periodic Interval 5 Enable         */
+    uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6 Enable         */
+    uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7 Enable         */
+    uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0 Interrupt Enable           */
+    uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t OVF:1;            /*!< bit:     15  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x Enable         */
+    uint16_t ALARM:1;          /*!< bit:      8  Alarm x Interrupt Enable           */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENSET_OFFSET   0x0A         /**< \brief (RTC_MODE2_INTENSET offset) MODE2 Interrupt Enable Set */
+#define RTC_MODE2_INTENSET_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE2_INTENSET reset_value) MODE2 Interrupt Enable Set */
+
+#define RTC_MODE2_INTENSET_PER0_Pos 0            /**< \brief (RTC_MODE2_INTENSET) Periodic Interval 0 Enable */
+#define RTC_MODE2_INTENSET_PER0     (1 << RTC_MODE2_INTENSET_PER0_Pos)
+#define RTC_MODE2_INTENSET_PER1_Pos 1            /**< \brief (RTC_MODE2_INTENSET) Periodic Interval 1 Enable */
+#define RTC_MODE2_INTENSET_PER1     (1 << RTC_MODE2_INTENSET_PER1_Pos)
+#define RTC_MODE2_INTENSET_PER2_Pos 2            /**< \brief (RTC_MODE2_INTENSET) Periodic Interval 2 Enable */
+#define RTC_MODE2_INTENSET_PER2     (1 << RTC_MODE2_INTENSET_PER2_Pos)
+#define RTC_MODE2_INTENSET_PER3_Pos 3            /**< \brief (RTC_MODE2_INTENSET) Periodic Interval 3 Enable */
+#define RTC_MODE2_INTENSET_PER3     (1 << RTC_MODE2_INTENSET_PER3_Pos)
+#define RTC_MODE2_INTENSET_PER4_Pos 4            /**< \brief (RTC_MODE2_INTENSET) Periodic Interval 4 Enable */
+#define RTC_MODE2_INTENSET_PER4     (1 << RTC_MODE2_INTENSET_PER4_Pos)
+#define RTC_MODE2_INTENSET_PER5_Pos 5            /**< \brief (RTC_MODE2_INTENSET) Periodic Interval 5 Enable */
+#define RTC_MODE2_INTENSET_PER5     (1 << RTC_MODE2_INTENSET_PER5_Pos)
+#define RTC_MODE2_INTENSET_PER6_Pos 6            /**< \brief (RTC_MODE2_INTENSET) Periodic Interval 6 Enable */
+#define RTC_MODE2_INTENSET_PER6     (1 << RTC_MODE2_INTENSET_PER6_Pos)
+#define RTC_MODE2_INTENSET_PER7_Pos 7            /**< \brief (RTC_MODE2_INTENSET) Periodic Interval 7 Enable */
+#define RTC_MODE2_INTENSET_PER7     (1 << RTC_MODE2_INTENSET_PER7_Pos)
+#define RTC_MODE2_INTENSET_PER_Pos  0            /**< \brief (RTC_MODE2_INTENSET) Periodic Interval x Enable */
+#define RTC_MODE2_INTENSET_PER_Msk  (0xFFul << RTC_MODE2_INTENSET_PER_Pos)
+#define RTC_MODE2_INTENSET_PER(value) (RTC_MODE2_INTENSET_PER_Msk & ((value) << RTC_MODE2_INTENSET_PER_Pos))
+#define RTC_MODE2_INTENSET_ALARM0_Pos 8            /**< \brief (RTC_MODE2_INTENSET) Alarm 0 Interrupt Enable */
+#define RTC_MODE2_INTENSET_ALARM0   (1 << RTC_MODE2_INTENSET_ALARM0_Pos)
+#define RTC_MODE2_INTENSET_ALARM_Pos 8            /**< \brief (RTC_MODE2_INTENSET) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENSET_ALARM_Msk (0x1ul << RTC_MODE2_INTENSET_ALARM_Pos)
+#define RTC_MODE2_INTENSET_ALARM(value) (RTC_MODE2_INTENSET_ALARM_Msk & ((value) << RTC_MODE2_INTENSET_ALARM_Pos))
+#define RTC_MODE2_INTENSET_OVF_Pos  15           /**< \brief (RTC_MODE2_INTENSET) Overflow Interrupt Enable */
+#define RTC_MODE2_INTENSET_OVF      (0x1ul << RTC_MODE2_INTENSET_OVF_Pos)
+#define RTC_MODE2_INTENSET_MASK     0x81FFul     /**< \brief (RTC_MODE2_INTENSET) MASK Register */
+
+/* -------- RTC_MODE0_INTFLAG : (RTC Offset: 0x0C) (R/W 16) MODE0 MODE0 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t PER0:1;           /*!< bit:      0  Periodic Interval 0                */
+    __I uint16_t PER1:1;           /*!< bit:      1  Periodic Interval 1                */
+    __I uint16_t PER2:1;           /*!< bit:      2  Periodic Interval 2                */
+    __I uint16_t PER3:1;           /*!< bit:      3  Periodic Interval 3                */
+    __I uint16_t PER4:1;           /*!< bit:      4  Periodic Interval 4                */
+    __I uint16_t PER5:1;           /*!< bit:      5  Periodic Interval 5                */
+    __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
+    __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
+    __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
+    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
+    __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
+    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTFLAG_OFFSET    0x0C         /**< \brief (RTC_MODE0_INTFLAG offset) MODE0 Interrupt Flag Status and Clear */
+#define RTC_MODE0_INTFLAG_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE0_INTFLAG reset_value) MODE0 Interrupt Flag Status and Clear */
+
+#define RTC_MODE0_INTFLAG_PER0_Pos  0            /**< \brief (RTC_MODE0_INTFLAG) Periodic Interval 0 */
+#define RTC_MODE0_INTFLAG_PER0      (1 << RTC_MODE0_INTFLAG_PER0_Pos)
+#define RTC_MODE0_INTFLAG_PER1_Pos  1            /**< \brief (RTC_MODE0_INTFLAG) Periodic Interval 1 */
+#define RTC_MODE0_INTFLAG_PER1      (1 << RTC_MODE0_INTFLAG_PER1_Pos)
+#define RTC_MODE0_INTFLAG_PER2_Pos  2            /**< \brief (RTC_MODE0_INTFLAG) Periodic Interval 2 */
+#define RTC_MODE0_INTFLAG_PER2      (1 << RTC_MODE0_INTFLAG_PER2_Pos)
+#define RTC_MODE0_INTFLAG_PER3_Pos  3            /**< \brief (RTC_MODE0_INTFLAG) Periodic Interval 3 */
+#define RTC_MODE0_INTFLAG_PER3      (1 << RTC_MODE0_INTFLAG_PER3_Pos)
+#define RTC_MODE0_INTFLAG_PER4_Pos  4            /**< \brief (RTC_MODE0_INTFLAG) Periodic Interval 4 */
+#define RTC_MODE0_INTFLAG_PER4      (1 << RTC_MODE0_INTFLAG_PER4_Pos)
+#define RTC_MODE0_INTFLAG_PER5_Pos  5            /**< \brief (RTC_MODE0_INTFLAG) Periodic Interval 5 */
+#define RTC_MODE0_INTFLAG_PER5      (1 << RTC_MODE0_INTFLAG_PER5_Pos)
+#define RTC_MODE0_INTFLAG_PER6_Pos  6            /**< \brief (RTC_MODE0_INTFLAG) Periodic Interval 6 */
+#define RTC_MODE0_INTFLAG_PER6      (1 << RTC_MODE0_INTFLAG_PER6_Pos)
+#define RTC_MODE0_INTFLAG_PER7_Pos  7            /**< \brief (RTC_MODE0_INTFLAG) Periodic Interval 7 */
+#define RTC_MODE0_INTFLAG_PER7      (1 << RTC_MODE0_INTFLAG_PER7_Pos)
+#define RTC_MODE0_INTFLAG_PER_Pos   0            /**< \brief (RTC_MODE0_INTFLAG) Periodic Interval x */
+#define RTC_MODE0_INTFLAG_PER_Msk   (0xFFul << RTC_MODE0_INTFLAG_PER_Pos)
+#define RTC_MODE0_INTFLAG_PER(value) (RTC_MODE0_INTFLAG_PER_Msk & ((value) << RTC_MODE0_INTFLAG_PER_Pos))
+#define RTC_MODE0_INTFLAG_CMP0_Pos  8            /**< \brief (RTC_MODE0_INTFLAG) Compare 0 */
+#define RTC_MODE0_INTFLAG_CMP0      (1 << RTC_MODE0_INTFLAG_CMP0_Pos)
+#define RTC_MODE0_INTFLAG_CMP_Pos   8            /**< \brief (RTC_MODE0_INTFLAG) Compare x */
+#define RTC_MODE0_INTFLAG_CMP_Msk   (0x1ul << RTC_MODE0_INTFLAG_CMP_Pos)
+#define RTC_MODE0_INTFLAG_CMP(value) (RTC_MODE0_INTFLAG_CMP_Msk & ((value) << RTC_MODE0_INTFLAG_CMP_Pos))
+#define RTC_MODE0_INTFLAG_OVF_Pos   15           /**< \brief (RTC_MODE0_INTFLAG) Overflow */
+#define RTC_MODE0_INTFLAG_OVF       (0x1ul << RTC_MODE0_INTFLAG_OVF_Pos)
+#define RTC_MODE0_INTFLAG_MASK      0x81FFul     /**< \brief (RTC_MODE0_INTFLAG) MASK Register */
+
+/* -------- RTC_MODE1_INTFLAG : (RTC Offset: 0x0C) (R/W 16) MODE1 MODE1 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t PER0:1;           /*!< bit:      0  Periodic Interval 0                */
+    __I uint16_t PER1:1;           /*!< bit:      1  Periodic Interval 1                */
+    __I uint16_t PER2:1;           /*!< bit:      2  Periodic Interval 2                */
+    __I uint16_t PER3:1;           /*!< bit:      3  Periodic Interval 3                */
+    __I uint16_t PER4:1;           /*!< bit:      4  Periodic Interval 4                */
+    __I uint16_t PER5:1;           /*!< bit:      5  Periodic Interval 5                */
+    __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
+    __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
+    __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
+    __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
+    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
+    __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
+    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTFLAG_OFFSET    0x0C         /**< \brief (RTC_MODE1_INTFLAG offset) MODE1 Interrupt Flag Status and Clear */
+#define RTC_MODE1_INTFLAG_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE1_INTFLAG reset_value) MODE1 Interrupt Flag Status and Clear */
+
+#define RTC_MODE1_INTFLAG_PER0_Pos  0            /**< \brief (RTC_MODE1_INTFLAG) Periodic Interval 0 */
+#define RTC_MODE1_INTFLAG_PER0      (1 << RTC_MODE1_INTFLAG_PER0_Pos)
+#define RTC_MODE1_INTFLAG_PER1_Pos  1            /**< \brief (RTC_MODE1_INTFLAG) Periodic Interval 1 */
+#define RTC_MODE1_INTFLAG_PER1      (1 << RTC_MODE1_INTFLAG_PER1_Pos)
+#define RTC_MODE1_INTFLAG_PER2_Pos  2            /**< \brief (RTC_MODE1_INTFLAG) Periodic Interval 2 */
+#define RTC_MODE1_INTFLAG_PER2      (1 << RTC_MODE1_INTFLAG_PER2_Pos)
+#define RTC_MODE1_INTFLAG_PER3_Pos  3            /**< \brief (RTC_MODE1_INTFLAG) Periodic Interval 3 */
+#define RTC_MODE1_INTFLAG_PER3      (1 << RTC_MODE1_INTFLAG_PER3_Pos)
+#define RTC_MODE1_INTFLAG_PER4_Pos  4            /**< \brief (RTC_MODE1_INTFLAG) Periodic Interval 4 */
+#define RTC_MODE1_INTFLAG_PER4      (1 << RTC_MODE1_INTFLAG_PER4_Pos)
+#define RTC_MODE1_INTFLAG_PER5_Pos  5            /**< \brief (RTC_MODE1_INTFLAG) Periodic Interval 5 */
+#define RTC_MODE1_INTFLAG_PER5      (1 << RTC_MODE1_INTFLAG_PER5_Pos)
+#define RTC_MODE1_INTFLAG_PER6_Pos  6            /**< \brief (RTC_MODE1_INTFLAG) Periodic Interval 6 */
+#define RTC_MODE1_INTFLAG_PER6      (1 << RTC_MODE1_INTFLAG_PER6_Pos)
+#define RTC_MODE1_INTFLAG_PER7_Pos  7            /**< \brief (RTC_MODE1_INTFLAG) Periodic Interval 7 */
+#define RTC_MODE1_INTFLAG_PER7      (1 << RTC_MODE1_INTFLAG_PER7_Pos)
+#define RTC_MODE1_INTFLAG_PER_Pos   0            /**< \brief (RTC_MODE1_INTFLAG) Periodic Interval x */
+#define RTC_MODE1_INTFLAG_PER_Msk   (0xFFul << RTC_MODE1_INTFLAG_PER_Pos)
+#define RTC_MODE1_INTFLAG_PER(value) (RTC_MODE1_INTFLAG_PER_Msk & ((value) << RTC_MODE1_INTFLAG_PER_Pos))
+#define RTC_MODE1_INTFLAG_CMP0_Pos  8            /**< \brief (RTC_MODE1_INTFLAG) Compare 0 */
+#define RTC_MODE1_INTFLAG_CMP0      (1 << RTC_MODE1_INTFLAG_CMP0_Pos)
+#define RTC_MODE1_INTFLAG_CMP1_Pos  9            /**< \brief (RTC_MODE1_INTFLAG) Compare 1 */
+#define RTC_MODE1_INTFLAG_CMP1      (1 << RTC_MODE1_INTFLAG_CMP1_Pos)
+#define RTC_MODE1_INTFLAG_CMP_Pos   8            /**< \brief (RTC_MODE1_INTFLAG) Compare x */
+#define RTC_MODE1_INTFLAG_CMP_Msk   (0x3ul << RTC_MODE1_INTFLAG_CMP_Pos)
+#define RTC_MODE1_INTFLAG_CMP(value) (RTC_MODE1_INTFLAG_CMP_Msk & ((value) << RTC_MODE1_INTFLAG_CMP_Pos))
+#define RTC_MODE1_INTFLAG_OVF_Pos   15           /**< \brief (RTC_MODE1_INTFLAG) Overflow */
+#define RTC_MODE1_INTFLAG_OVF       (0x1ul << RTC_MODE1_INTFLAG_OVF_Pos)
+#define RTC_MODE1_INTFLAG_MASK      0x83FFul     /**< \brief (RTC_MODE1_INTFLAG) MASK Register */
+
+/* -------- RTC_MODE2_INTFLAG : (RTC Offset: 0x0C) (R/W 16) MODE2 MODE2 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t PER0:1;           /*!< bit:      0  Periodic Interval 0                */
+    __I uint16_t PER1:1;           /*!< bit:      1  Periodic Interval 1                */
+    __I uint16_t PER2:1;           /*!< bit:      2  Periodic Interval 2                */
+    __I uint16_t PER3:1;           /*!< bit:      3  Periodic Interval 3                */
+    __I uint16_t PER4:1;           /*!< bit:      4  Periodic Interval 4                */
+    __I uint16_t PER5:1;           /*!< bit:      5  Periodic Interval 5                */
+    __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
+    __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
+    __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
+    __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
+    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTFLAG_OFFSET    0x0C         /**< \brief (RTC_MODE2_INTFLAG offset) MODE2 Interrupt Flag Status and Clear */
+#define RTC_MODE2_INTFLAG_RESETVALUE 0x0000ul     /**< \brief (RTC_MODE2_INTFLAG reset_value) MODE2 Interrupt Flag Status and Clear */
+
+#define RTC_MODE2_INTFLAG_PER0_Pos  0            /**< \brief (RTC_MODE2_INTFLAG) Periodic Interval 0 */
+#define RTC_MODE2_INTFLAG_PER0      (1 << RTC_MODE2_INTFLAG_PER0_Pos)
+#define RTC_MODE2_INTFLAG_PER1_Pos  1            /**< \brief (RTC_MODE2_INTFLAG) Periodic Interval 1 */
+#define RTC_MODE2_INTFLAG_PER1      (1 << RTC_MODE2_INTFLAG_PER1_Pos)
+#define RTC_MODE2_INTFLAG_PER2_Pos  2            /**< \brief (RTC_MODE2_INTFLAG) Periodic Interval 2 */
+#define RTC_MODE2_INTFLAG_PER2      (1 << RTC_MODE2_INTFLAG_PER2_Pos)
+#define RTC_MODE2_INTFLAG_PER3_Pos  3            /**< \brief (RTC_MODE2_INTFLAG) Periodic Interval 3 */
+#define RTC_MODE2_INTFLAG_PER3      (1 << RTC_MODE2_INTFLAG_PER3_Pos)
+#define RTC_MODE2_INTFLAG_PER4_Pos  4            /**< \brief (RTC_MODE2_INTFLAG) Periodic Interval 4 */
+#define RTC_MODE2_INTFLAG_PER4      (1 << RTC_MODE2_INTFLAG_PER4_Pos)
+#define RTC_MODE2_INTFLAG_PER5_Pos  5            /**< \brief (RTC_MODE2_INTFLAG) Periodic Interval 5 */
+#define RTC_MODE2_INTFLAG_PER5      (1 << RTC_MODE2_INTFLAG_PER5_Pos)
+#define RTC_MODE2_INTFLAG_PER6_Pos  6            /**< \brief (RTC_MODE2_INTFLAG) Periodic Interval 6 */
+#define RTC_MODE2_INTFLAG_PER6      (1 << RTC_MODE2_INTFLAG_PER6_Pos)
+#define RTC_MODE2_INTFLAG_PER7_Pos  7            /**< \brief (RTC_MODE2_INTFLAG) Periodic Interval 7 */
+#define RTC_MODE2_INTFLAG_PER7      (1 << RTC_MODE2_INTFLAG_PER7_Pos)
+#define RTC_MODE2_INTFLAG_PER_Pos   0            /**< \brief (RTC_MODE2_INTFLAG) Periodic Interval x */
+#define RTC_MODE2_INTFLAG_PER_Msk   (0xFFul << RTC_MODE2_INTFLAG_PER_Pos)
+#define RTC_MODE2_INTFLAG_PER(value) (RTC_MODE2_INTFLAG_PER_Msk & ((value) << RTC_MODE2_INTFLAG_PER_Pos))
+#define RTC_MODE2_INTFLAG_ALARM0_Pos 8            /**< \brief (RTC_MODE2_INTFLAG) Alarm 0 */
+#define RTC_MODE2_INTFLAG_ALARM0    (1 << RTC_MODE2_INTFLAG_ALARM0_Pos)
+#define RTC_MODE2_INTFLAG_ALARM_Pos 8            /**< \brief (RTC_MODE2_INTFLAG) Alarm x */
+#define RTC_MODE2_INTFLAG_ALARM_Msk (0x1ul << RTC_MODE2_INTFLAG_ALARM_Pos)
+#define RTC_MODE2_INTFLAG_ALARM(value) (RTC_MODE2_INTFLAG_ALARM_Msk & ((value) << RTC_MODE2_INTFLAG_ALARM_Pos))
+#define RTC_MODE2_INTFLAG_OVF_Pos   15           /**< \brief (RTC_MODE2_INTFLAG) Overflow */
+#define RTC_MODE2_INTFLAG_OVF       (0x1ul << RTC_MODE2_INTFLAG_OVF_Pos)
+#define RTC_MODE2_INTFLAG_MASK      0x81FFul     /**< \brief (RTC_MODE2_INTFLAG) MASK Register */
+
+/* -------- RTC_DBGCTRL : (RTC Offset: 0x0E) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Run During Debug                   */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_DBGCTRL_OFFSET          0x0E         /**< \brief (RTC_DBGCTRL offset) Debug Control */
+#define RTC_DBGCTRL_RESETVALUE      0x00ul       /**< \brief (RTC_DBGCTRL reset_value) Debug Control */
+
+#define RTC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (RTC_DBGCTRL) Run During Debug */
+#define RTC_DBGCTRL_DBGRUN          (0x1ul << RTC_DBGCTRL_DBGRUN_Pos)
+#define RTC_DBGCTRL_MASK            0x01ul       /**< \brief (RTC_DBGCTRL) MASK Register */
+
+/* -------- RTC_MODE0_SYNCBUSY : (RTC Offset: 0x10) (R/  32) MODE0 MODE0 Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset Busy                */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable Bit Busy                    */
+    uint32_t FREQCORR:1;       /*!< bit:      2  FREQCORR Register Busy             */
+    uint32_t COUNT:1;          /*!< bit:      3  COUNT Register Busy                */
+    uint32_t :1;               /*!< bit:      4  Reserved                           */
+    uint32_t COMP0:1;          /*!< bit:      5  COMP 0 Register Busy               */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :5;               /*!< bit:  0.. 4  Reserved                           */
+    uint32_t COMP:1;           /*!< bit:      5  COMP x Register Busy               */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_SYNCBUSY_OFFSET   0x10         /**< \brief (RTC_MODE0_SYNCBUSY offset) MODE0 Synchronization Busy Status */
+#define RTC_MODE0_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (RTC_MODE0_SYNCBUSY reset_value) MODE0 Synchronization Busy Status */
+
+#define RTC_MODE0_SYNCBUSY_SWRST_Pos 0            /**< \brief (RTC_MODE0_SYNCBUSY) Software Reset Busy */
+#define RTC_MODE0_SYNCBUSY_SWRST    (0x1ul << RTC_MODE0_SYNCBUSY_SWRST_Pos)
+#define RTC_MODE0_SYNCBUSY_ENABLE_Pos 1            /**< \brief (RTC_MODE0_SYNCBUSY) Enable Bit Busy */
+#define RTC_MODE0_SYNCBUSY_ENABLE   (0x1ul << RTC_MODE0_SYNCBUSY_ENABLE_Pos)
+#define RTC_MODE0_SYNCBUSY_FREQCORR_Pos 2            /**< \brief (RTC_MODE0_SYNCBUSY) FREQCORR Register Busy */
+#define RTC_MODE0_SYNCBUSY_FREQCORR (0x1ul << RTC_MODE0_SYNCBUSY_FREQCORR_Pos)
+#define RTC_MODE0_SYNCBUSY_COUNT_Pos 3            /**< \brief (RTC_MODE0_SYNCBUSY) COUNT Register Busy */
+#define RTC_MODE0_SYNCBUSY_COUNT    (0x1ul << RTC_MODE0_SYNCBUSY_COUNT_Pos)
+#define RTC_MODE0_SYNCBUSY_COMP0_Pos 5            /**< \brief (RTC_MODE0_SYNCBUSY) COMP 0 Register Busy */
+#define RTC_MODE0_SYNCBUSY_COMP0    (1 << RTC_MODE0_SYNCBUSY_COMP0_Pos)
+#define RTC_MODE0_SYNCBUSY_COMP_Pos 5            /**< \brief (RTC_MODE0_SYNCBUSY) COMP x Register Busy */
+#define RTC_MODE0_SYNCBUSY_COMP_Msk (0x1ul << RTC_MODE0_SYNCBUSY_COMP_Pos)
+#define RTC_MODE0_SYNCBUSY_COMP(value) (RTC_MODE0_SYNCBUSY_COMP_Msk & ((value) << RTC_MODE0_SYNCBUSY_COMP_Pos))
+#define RTC_MODE0_SYNCBUSY_MASK     0x0000002Ful /**< \brief (RTC_MODE0_SYNCBUSY) MASK Register */
+
+/* -------- RTC_MODE1_SYNCBUSY : (RTC Offset: 0x10) (R/  32) MODE1 MODE1 Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset Bit Busy            */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable Bit Busy                    */
+    uint32_t FREQCORR:1;       /*!< bit:      2  FREQCORR Register Busy             */
+    uint32_t COUNT:1;          /*!< bit:      3  COUNT Register Busy                */
+    uint32_t PER:1;            /*!< bit:      4  PER Register Busy                  */
+    uint32_t COMP0:1;          /*!< bit:      5  COMP 0 Register Busy               */
+    uint32_t COMP1:1;          /*!< bit:      6  COMP 1 Register Busy               */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :5;               /*!< bit:  0.. 4  Reserved                           */
+    uint32_t COMP:2;           /*!< bit:  5.. 6  COMP x Register Busy               */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_SYNCBUSY_OFFSET   0x10         /**< \brief (RTC_MODE1_SYNCBUSY offset) MODE1 Synchronization Busy Status */
+#define RTC_MODE1_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (RTC_MODE1_SYNCBUSY reset_value) MODE1 Synchronization Busy Status */
+
+#define RTC_MODE1_SYNCBUSY_SWRST_Pos 0            /**< \brief (RTC_MODE1_SYNCBUSY) Software Reset Bit Busy */
+#define RTC_MODE1_SYNCBUSY_SWRST    (0x1ul << RTC_MODE1_SYNCBUSY_SWRST_Pos)
+#define RTC_MODE1_SYNCBUSY_ENABLE_Pos 1            /**< \brief (RTC_MODE1_SYNCBUSY) Enable Bit Busy */
+#define RTC_MODE1_SYNCBUSY_ENABLE   (0x1ul << RTC_MODE1_SYNCBUSY_ENABLE_Pos)
+#define RTC_MODE1_SYNCBUSY_FREQCORR_Pos 2            /**< \brief (RTC_MODE1_SYNCBUSY) FREQCORR Register Busy */
+#define RTC_MODE1_SYNCBUSY_FREQCORR (0x1ul << RTC_MODE1_SYNCBUSY_FREQCORR_Pos)
+#define RTC_MODE1_SYNCBUSY_COUNT_Pos 3            /**< \brief (RTC_MODE1_SYNCBUSY) COUNT Register Busy */
+#define RTC_MODE1_SYNCBUSY_COUNT    (0x1ul << RTC_MODE1_SYNCBUSY_COUNT_Pos)
+#define RTC_MODE1_SYNCBUSY_PER_Pos  4            /**< \brief (RTC_MODE1_SYNCBUSY) PER Register Busy */
+#define RTC_MODE1_SYNCBUSY_PER      (0x1ul << RTC_MODE1_SYNCBUSY_PER_Pos)
+#define RTC_MODE1_SYNCBUSY_COMP0_Pos 5            /**< \brief (RTC_MODE1_SYNCBUSY) COMP 0 Register Busy */
+#define RTC_MODE1_SYNCBUSY_COMP0    (1 << RTC_MODE1_SYNCBUSY_COMP0_Pos)
+#define RTC_MODE1_SYNCBUSY_COMP1_Pos 6            /**< \brief (RTC_MODE1_SYNCBUSY) COMP 1 Register Busy */
+#define RTC_MODE1_SYNCBUSY_COMP1    (1 << RTC_MODE1_SYNCBUSY_COMP1_Pos)
+#define RTC_MODE1_SYNCBUSY_COMP_Pos 5            /**< \brief (RTC_MODE1_SYNCBUSY) COMP x Register Busy */
+#define RTC_MODE1_SYNCBUSY_COMP_Msk (0x3ul << RTC_MODE1_SYNCBUSY_COMP_Pos)
+#define RTC_MODE1_SYNCBUSY_COMP(value) (RTC_MODE1_SYNCBUSY_COMP_Msk & ((value) << RTC_MODE1_SYNCBUSY_COMP_Pos))
+#define RTC_MODE1_SYNCBUSY_MASK     0x0000007Ful /**< \brief (RTC_MODE1_SYNCBUSY) MASK Register */
+
+/* -------- RTC_MODE2_SYNCBUSY : (RTC Offset: 0x10) (R/  32) MODE2 MODE2 Synchronization Busy Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset Bit Busy            */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable Bit Busy                    */
+    uint32_t FREQCORR:1;       /*!< bit:      2  FREQCORR Register Busy             */
+    uint32_t CLOCK:1;          /*!< bit:      3  CLOCK Register Busy                */
+    uint32_t :1;               /*!< bit:      4  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      5  ALARM 0 Register Busy              */
+    uint32_t :5;               /*!< bit:  6..10  Reserved                           */
+    uint32_t MASK0:1;          /*!< bit:     11  MASK 0 Register Busy               */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :5;               /*!< bit:  0.. 4  Reserved                           */
+    uint32_t ALARM:1;          /*!< bit:      5  ALARM x Register Busy              */
+    uint32_t :5;               /*!< bit:  6..10  Reserved                           */
+    uint32_t MASK:1;           /*!< bit:     11  MASK x Register Busy               */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_SYNCBUSY_OFFSET   0x10         /**< \brief (RTC_MODE2_SYNCBUSY offset) MODE2 Synchronization Busy Status */
+#define RTC_MODE2_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (RTC_MODE2_SYNCBUSY reset_value) MODE2 Synchronization Busy Status */
+
+#define RTC_MODE2_SYNCBUSY_SWRST_Pos 0            /**< \brief (RTC_MODE2_SYNCBUSY) Software Reset Bit Busy */
+#define RTC_MODE2_SYNCBUSY_SWRST    (0x1ul << RTC_MODE2_SYNCBUSY_SWRST_Pos)
+#define RTC_MODE2_SYNCBUSY_ENABLE_Pos 1            /**< \brief (RTC_MODE2_SYNCBUSY) Enable Bit Busy */
+#define RTC_MODE2_SYNCBUSY_ENABLE   (0x1ul << RTC_MODE2_SYNCBUSY_ENABLE_Pos)
+#define RTC_MODE2_SYNCBUSY_FREQCORR_Pos 2            /**< \brief (RTC_MODE2_SYNCBUSY) FREQCORR Register Busy */
+#define RTC_MODE2_SYNCBUSY_FREQCORR (0x1ul << RTC_MODE2_SYNCBUSY_FREQCORR_Pos)
+#define RTC_MODE2_SYNCBUSY_CLOCK_Pos 3            /**< \brief (RTC_MODE2_SYNCBUSY) CLOCK Register Busy */
+#define RTC_MODE2_SYNCBUSY_CLOCK    (0x1ul << RTC_MODE2_SYNCBUSY_CLOCK_Pos)
+#define RTC_MODE2_SYNCBUSY_ALARM0_Pos 5            /**< \brief (RTC_MODE2_SYNCBUSY) ALARM 0 Register Busy */
+#define RTC_MODE2_SYNCBUSY_ALARM0   (1 << RTC_MODE2_SYNCBUSY_ALARM0_Pos)
+#define RTC_MODE2_SYNCBUSY_ALARM_Pos 5            /**< \brief (RTC_MODE2_SYNCBUSY) ALARM x Register Busy */
+#define RTC_MODE2_SYNCBUSY_ALARM_Msk (0x1ul << RTC_MODE2_SYNCBUSY_ALARM_Pos)
+#define RTC_MODE2_SYNCBUSY_ALARM(value) (RTC_MODE2_SYNCBUSY_ALARM_Msk & ((value) << RTC_MODE2_SYNCBUSY_ALARM_Pos))
+#define RTC_MODE2_SYNCBUSY_MASK0_Pos 11           /**< \brief (RTC_MODE2_SYNCBUSY) MASK 0 Register Busy */
+#define RTC_MODE2_SYNCBUSY_MASK0    (1 << RTC_MODE2_SYNCBUSY_MASK0_Pos)
+#define RTC_MODE2_SYNCBUSY_MASK_Pos 11           /**< \brief (RTC_MODE2_SYNCBUSY) MASK x Register Busy */
+#define RTC_MODE2_SYNCBUSY_MASK_Msk (0x1ul << RTC_MODE2_SYNCBUSY_MASK_Pos)
+#define RTC_MODE2_SYNCBUSY_MASK(value) (RTC_MODE2_SYNCBUSY_MASK_Msk & ((value) << RTC_MODE2_SYNCBUSY_MASK_Pos))
+#define RTC_MODE2_SYNCBUSY_MASK_    0x0000082Ful /**< \brief (RTC_MODE2_SYNCBUSY) MASK Register */
+
+/* -------- RTC_FREQCORR : (RTC Offset: 0x14) (R/W  8) Frequency Correction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  VALUE:7;          /*!< bit:  0.. 6  Correction Value                   */
+    uint8_t  SIGN:1;           /*!< bit:      7  Correction Sign                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_FREQCORR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_FREQCORR_OFFSET         0x14         /**< \brief (RTC_FREQCORR offset) Frequency Correction */
+#define RTC_FREQCORR_RESETVALUE     0x00ul       /**< \brief (RTC_FREQCORR reset_value) Frequency Correction */
+
+#define RTC_FREQCORR_VALUE_Pos      0            /**< \brief (RTC_FREQCORR) Correction Value */
+#define RTC_FREQCORR_VALUE_Msk      (0x7Ful << RTC_FREQCORR_VALUE_Pos)
+#define RTC_FREQCORR_VALUE(value)   (RTC_FREQCORR_VALUE_Msk & ((value) << RTC_FREQCORR_VALUE_Pos))
+#define RTC_FREQCORR_SIGN_Pos       7            /**< \brief (RTC_FREQCORR) Correction Sign */
+#define RTC_FREQCORR_SIGN           (0x1ul << RTC_FREQCORR_SIGN_Pos)
+#define RTC_FREQCORR_MASK           0xFFul       /**< \brief (RTC_FREQCORR) MASK Register */
+
+/* -------- RTC_MODE0_COUNT : (RTC Offset: 0x18) (R/W 32) MODE0 MODE0 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COUNT:32;         /*!< bit:  0..31  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COUNT_OFFSET      0x18         /**< \brief (RTC_MODE0_COUNT offset) MODE0 Counter Value */
+#define RTC_MODE0_COUNT_RESETVALUE  0x00000000ul /**< \brief (RTC_MODE0_COUNT reset_value) MODE0 Counter Value */
+
+#define RTC_MODE0_COUNT_COUNT_Pos   0            /**< \brief (RTC_MODE0_COUNT) Counter Value */
+#define RTC_MODE0_COUNT_COUNT_Msk   (0xFFFFFFFFul << RTC_MODE0_COUNT_COUNT_Pos)
+#define RTC_MODE0_COUNT_COUNT(value) (RTC_MODE0_COUNT_COUNT_Msk & ((value) << RTC_MODE0_COUNT_COUNT_Pos))
+#define RTC_MODE0_COUNT_MASK        0xFFFFFFFFul /**< \brief (RTC_MODE0_COUNT) MASK Register */
+
+/* -------- RTC_MODE1_COUNT : (RTC Offset: 0x18) (R/W 16) MODE1 MODE1 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COUNT:16;         /*!< bit:  0..15  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COUNT_OFFSET      0x18         /**< \brief (RTC_MODE1_COUNT offset) MODE1 Counter Value */
+#define RTC_MODE1_COUNT_RESETVALUE  0x0000ul     /**< \brief (RTC_MODE1_COUNT reset_value) MODE1 Counter Value */
+
+#define RTC_MODE1_COUNT_COUNT_Pos   0            /**< \brief (RTC_MODE1_COUNT) Counter Value */
+#define RTC_MODE1_COUNT_COUNT_Msk   (0xFFFFul << RTC_MODE1_COUNT_COUNT_Pos)
+#define RTC_MODE1_COUNT_COUNT(value) (RTC_MODE1_COUNT_COUNT_Msk & ((value) << RTC_MODE1_COUNT_COUNT_Pos))
+#define RTC_MODE1_COUNT_MASK        0xFFFFul     /**< \brief (RTC_MODE1_COUNT) MASK Register */
+
+/* -------- RTC_MODE2_CLOCK : (RTC Offset: 0x18) (R/W 32) MODE2 MODE2 Clock Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SECOND:6;         /*!< bit:  0.. 5  Second                             */
+    uint32_t MINUTE:6;         /*!< bit:  6..11  Minute                             */
+    uint32_t HOUR:5;           /*!< bit: 12..16  Hour                               */
+    uint32_t DAY:5;            /*!< bit: 17..21  Day                                */
+    uint32_t MONTH:4;          /*!< bit: 22..25  Month                              */
+    uint32_t YEAR:6;           /*!< bit: 26..31  Year                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_CLOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CLOCK_OFFSET      0x18         /**< \brief (RTC_MODE2_CLOCK offset) MODE2 Clock Value */
+#define RTC_MODE2_CLOCK_RESETVALUE  0x00000000ul /**< \brief (RTC_MODE2_CLOCK reset_value) MODE2 Clock Value */
+
+#define RTC_MODE2_CLOCK_SECOND_Pos  0            /**< \brief (RTC_MODE2_CLOCK) Second */
+#define RTC_MODE2_CLOCK_SECOND_Msk  (0x3Ful << RTC_MODE2_CLOCK_SECOND_Pos)
+#define RTC_MODE2_CLOCK_SECOND(value) (RTC_MODE2_CLOCK_SECOND_Msk & ((value) << RTC_MODE2_CLOCK_SECOND_Pos))
+#define RTC_MODE2_CLOCK_MINUTE_Pos  6            /**< \brief (RTC_MODE2_CLOCK) Minute */
+#define RTC_MODE2_CLOCK_MINUTE_Msk  (0x3Ful << RTC_MODE2_CLOCK_MINUTE_Pos)
+#define RTC_MODE2_CLOCK_MINUTE(value) (RTC_MODE2_CLOCK_MINUTE_Msk & ((value) << RTC_MODE2_CLOCK_MINUTE_Pos))
+#define RTC_MODE2_CLOCK_HOUR_Pos    12           /**< \brief (RTC_MODE2_CLOCK) Hour */
+#define RTC_MODE2_CLOCK_HOUR_Msk    (0x1Ful << RTC_MODE2_CLOCK_HOUR_Pos)
+#define RTC_MODE2_CLOCK_HOUR(value) (RTC_MODE2_CLOCK_HOUR_Msk & ((value) << RTC_MODE2_CLOCK_HOUR_Pos))
+#define RTC_MODE2_CLOCK_DAY_Pos     17           /**< \brief (RTC_MODE2_CLOCK) Day */
+#define RTC_MODE2_CLOCK_DAY_Msk     (0x1Ful << RTC_MODE2_CLOCK_DAY_Pos)
+#define RTC_MODE2_CLOCK_DAY(value)  (RTC_MODE2_CLOCK_DAY_Msk & ((value) << RTC_MODE2_CLOCK_DAY_Pos))
+#define RTC_MODE2_CLOCK_MONTH_Pos   22           /**< \brief (RTC_MODE2_CLOCK) Month */
+#define RTC_MODE2_CLOCK_MONTH_Msk   (0xFul << RTC_MODE2_CLOCK_MONTH_Pos)
+#define RTC_MODE2_CLOCK_MONTH(value) (RTC_MODE2_CLOCK_MONTH_Msk & ((value) << RTC_MODE2_CLOCK_MONTH_Pos))
+#define RTC_MODE2_CLOCK_YEAR_Pos    26           /**< \brief (RTC_MODE2_CLOCK) Year */
+#define RTC_MODE2_CLOCK_YEAR_Msk    (0x3Ful << RTC_MODE2_CLOCK_YEAR_Pos)
+#define RTC_MODE2_CLOCK_YEAR(value) (RTC_MODE2_CLOCK_YEAR_Msk & ((value) << RTC_MODE2_CLOCK_YEAR_Pos))
+#define RTC_MODE2_CLOCK_MASK        0xFFFFFFFFul /**< \brief (RTC_MODE2_CLOCK) MASK Register */
+
+/* -------- RTC_MODE1_PER : (RTC Offset: 0x1C) (R/W 16) MODE1 MODE1 Counter Period -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PER:16;           /*!< bit:  0..15  Counter Period                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_PER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_PER_OFFSET        0x1C         /**< \brief (RTC_MODE1_PER offset) MODE1 Counter Period */
+#define RTC_MODE1_PER_RESETVALUE    0x0000ul     /**< \brief (RTC_MODE1_PER reset_value) MODE1 Counter Period */
+
+#define RTC_MODE1_PER_PER_Pos       0            /**< \brief (RTC_MODE1_PER) Counter Period */
+#define RTC_MODE1_PER_PER_Msk       (0xFFFFul << RTC_MODE1_PER_PER_Pos)
+#define RTC_MODE1_PER_PER(value)    (RTC_MODE1_PER_PER_Msk & ((value) << RTC_MODE1_PER_PER_Pos))
+#define RTC_MODE1_PER_MASK          0xFFFFul     /**< \brief (RTC_MODE1_PER) MASK Register */
+
+/* -------- RTC_MODE0_COMP : (RTC Offset: 0x20) (R/W 32) MODE0 MODE0 Compare n Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COMP:32;          /*!< bit:  0..31  Compare Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_COMP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COMP_OFFSET       0x20         /**< \brief (RTC_MODE0_COMP offset) MODE0 Compare n Value */
+#define RTC_MODE0_COMP_RESETVALUE   0x00000000ul /**< \brief (RTC_MODE0_COMP reset_value) MODE0 Compare n Value */
+
+#define RTC_MODE0_COMP_COMP_Pos     0            /**< \brief (RTC_MODE0_COMP) Compare Value */
+#define RTC_MODE0_COMP_COMP_Msk     (0xFFFFFFFFul << RTC_MODE0_COMP_COMP_Pos)
+#define RTC_MODE0_COMP_COMP(value)  (RTC_MODE0_COMP_COMP_Msk & ((value) << RTC_MODE0_COMP_COMP_Pos))
+#define RTC_MODE0_COMP_MASK         0xFFFFFFFFul /**< \brief (RTC_MODE0_COMP) MASK Register */
+
+/* -------- RTC_MODE1_COMP : (RTC Offset: 0x20) (R/W 16) MODE1 MODE1 Compare n Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COMP:16;          /*!< bit:  0..15  Compare Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_COMP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COMP_OFFSET       0x20         /**< \brief (RTC_MODE1_COMP offset) MODE1 Compare n Value */
+#define RTC_MODE1_COMP_RESETVALUE   0x0000ul     /**< \brief (RTC_MODE1_COMP reset_value) MODE1 Compare n Value */
+
+#define RTC_MODE1_COMP_COMP_Pos     0            /**< \brief (RTC_MODE1_COMP) Compare Value */
+#define RTC_MODE1_COMP_COMP_Msk     (0xFFFFul << RTC_MODE1_COMP_COMP_Pos)
+#define RTC_MODE1_COMP_COMP(value)  (RTC_MODE1_COMP_COMP_Msk & ((value) << RTC_MODE1_COMP_COMP_Pos))
+#define RTC_MODE1_COMP_MASK         0xFFFFul     /**< \brief (RTC_MODE1_COMP) MASK Register */
+
+/* -------- RTC_MODE2_ALARM : (RTC Offset: 0x20) (R/W 32) MODE2 MODE2_ALARM Alarm n Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SECOND:6;         /*!< bit:  0.. 5  Second                             */
+    uint32_t MINUTE:6;         /*!< bit:  6..11  Minute                             */
+    uint32_t HOUR:5;           /*!< bit: 12..16  Hour                               */
+    uint32_t DAY:5;            /*!< bit: 17..21  Day                                */
+    uint32_t MONTH:4;          /*!< bit: 22..25  Month                              */
+    uint32_t YEAR:6;           /*!< bit: 26..31  Year                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_ALARM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_ALARM_OFFSET      0x20         /**< \brief (RTC_MODE2_ALARM offset) MODE2_ALARM Alarm n Value */
+#define RTC_MODE2_ALARM_RESETVALUE  0x00000000ul /**< \brief (RTC_MODE2_ALARM reset_value) MODE2_ALARM Alarm n Value */
+
+#define RTC_MODE2_ALARM_SECOND_Pos  0            /**< \brief (RTC_MODE2_ALARM) Second */
+#define RTC_MODE2_ALARM_SECOND_Msk  (0x3Ful << RTC_MODE2_ALARM_SECOND_Pos)
+#define RTC_MODE2_ALARM_SECOND(value) (RTC_MODE2_ALARM_SECOND_Msk & ((value) << RTC_MODE2_ALARM_SECOND_Pos))
+#define RTC_MODE2_ALARM_MINUTE_Pos  6            /**< \brief (RTC_MODE2_ALARM) Minute */
+#define RTC_MODE2_ALARM_MINUTE_Msk  (0x3Ful << RTC_MODE2_ALARM_MINUTE_Pos)
+#define RTC_MODE2_ALARM_MINUTE(value) (RTC_MODE2_ALARM_MINUTE_Msk & ((value) << RTC_MODE2_ALARM_MINUTE_Pos))
+#define RTC_MODE2_ALARM_HOUR_Pos    12           /**< \brief (RTC_MODE2_ALARM) Hour */
+#define RTC_MODE2_ALARM_HOUR_Msk    (0x1Ful << RTC_MODE2_ALARM_HOUR_Pos)
+#define RTC_MODE2_ALARM_HOUR(value) (RTC_MODE2_ALARM_HOUR_Msk & ((value) << RTC_MODE2_ALARM_HOUR_Pos))
+#define RTC_MODE2_ALARM_DAY_Pos     17           /**< \brief (RTC_MODE2_ALARM) Day */
+#define RTC_MODE2_ALARM_DAY_Msk     (0x1Ful << RTC_MODE2_ALARM_DAY_Pos)
+#define RTC_MODE2_ALARM_DAY(value)  (RTC_MODE2_ALARM_DAY_Msk & ((value) << RTC_MODE2_ALARM_DAY_Pos))
+#define RTC_MODE2_ALARM_MONTH_Pos   22           /**< \brief (RTC_MODE2_ALARM) Month */
+#define RTC_MODE2_ALARM_MONTH_Msk   (0xFul << RTC_MODE2_ALARM_MONTH_Pos)
+#define RTC_MODE2_ALARM_MONTH(value) (RTC_MODE2_ALARM_MONTH_Msk & ((value) << RTC_MODE2_ALARM_MONTH_Pos))
+#define RTC_MODE2_ALARM_YEAR_Pos    26           /**< \brief (RTC_MODE2_ALARM) Year */
+#define RTC_MODE2_ALARM_YEAR_Msk    (0x3Ful << RTC_MODE2_ALARM_YEAR_Pos)
+#define RTC_MODE2_ALARM_YEAR(value) (RTC_MODE2_ALARM_YEAR_Msk & ((value) << RTC_MODE2_ALARM_YEAR_Pos))
+#define RTC_MODE2_ALARM_MASK        0xFFFFFFFFul /**< \brief (RTC_MODE2_ALARM) MASK Register */
+
+/* -------- RTC_MODE2_MASK : (RTC Offset: 0x24) (R/W  8) MODE2 MODE2_ALARM Alarm n Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SEL:3;            /*!< bit:  0.. 2  Alarm Mask Selection               */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE2_MASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_MASK_OFFSET       0x24         /**< \brief (RTC_MODE2_MASK offset) MODE2_ALARM Alarm n Mask */
+#define RTC_MODE2_MASK_RESETVALUE   0x00ul       /**< \brief (RTC_MODE2_MASK reset_value) MODE2_ALARM Alarm n Mask */
+
+#define RTC_MODE2_MASK_SEL_Pos      0            /**< \brief (RTC_MODE2_MASK) Alarm Mask Selection */
+#define RTC_MODE2_MASK_SEL_Msk      (0x7ul << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL(value)   (RTC_MODE2_MASK_SEL_Msk & ((value) << RTC_MODE2_MASK_SEL_Pos))
+#define   RTC_MODE2_MASK_SEL_OFF_Val      0x0ul  /**< \brief (RTC_MODE2_MASK) Alarm Disabled */
+#define   RTC_MODE2_MASK_SEL_SS_Val       0x1ul  /**< \brief (RTC_MODE2_MASK) Match seconds only */
+#define   RTC_MODE2_MASK_SEL_MMSS_Val     0x2ul  /**< \brief (RTC_MODE2_MASK) Match seconds and minutes only */
+#define   RTC_MODE2_MASK_SEL_HHMMSS_Val   0x3ul  /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, and hours only */
+#define   RTC_MODE2_MASK_SEL_DDHHMMSS_Val 0x4ul  /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, and days only */
+#define   RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val 0x5ul  /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, and months only */
+#define   RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val 0x6ul  /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, months, and years */
+#define RTC_MODE2_MASK_SEL_OFF      (RTC_MODE2_MASK_SEL_OFF_Val    << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_SS       (RTC_MODE2_MASK_SEL_SS_Val     << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_MMSS     (RTC_MODE2_MASK_SEL_MMSS_Val   << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_HHMMSS   (RTC_MODE2_MASK_SEL_HHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_DDHHMMSS (RTC_MODE2_MASK_SEL_DDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_MMDDHHMMSS (RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_YYMMDDHHMMSS (RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_MASK         0x07ul       /**< \brief (RTC_MODE2_MASK) MASK Register */
+
+/* -------- RTC_GP : (RTC Offset: 0x40) (R/W 32) General Purpose -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_GP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_GP_OFFSET               0x40         /**< \brief (RTC_GP offset) General Purpose */
+#define RTC_GP_RESETVALUE           0x00000000ul /**< \brief (RTC_GP reset_value) General Purpose */
+#define RTC_GP_MASK                 0xFFFFFFFFul /**< \brief (RTC_GP) MASK Register */
+
+/** \brief RtcMode2Alarm hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO RTC_MODE2_ALARM_Type      ALARM;       /**< \brief Offset: 0x00 (R/W 32) MODE2_ALARM Alarm n Value */
+  __IO RTC_MODE2_MASK_Type       MASK;        /**< \brief Offset: 0x04 (R/W  8) MODE2_ALARM Alarm n Mask */
+       RoReg8                    Reserved1[0x3];
+} RtcMode2Alarm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief RTC_MODE0 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 32-bit Counter with Single 32-bit Compare */
+  __IO RTC_MODE0_CTRLA_Type      CTRLA;       /**< \brief Offset: 0x00 (R/W 16) MODE0 Control A */
+       RoReg8                    Reserved1[0x2];
+  __IO RTC_MODE0_EVCTRL_Type     EVCTRL;      /**< \brief Offset: 0x04 (R/W 32) MODE0 Event Control */
+  __IO RTC_MODE0_INTENCLR_Type   INTENCLR;    /**< \brief Offset: 0x08 (R/W 16) MODE0 Interrupt Enable Clear */
+  __IO RTC_MODE0_INTENSET_Type   INTENSET;    /**< \brief Offset: 0x0A (R/W 16) MODE0 Interrupt Enable Set */
+  __IO RTC_MODE0_INTFLAG_Type    INTFLAG;     /**< \brief Offset: 0x0C (R/W 16) MODE0 Interrupt Flag Status and Clear */
+  __IO RTC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x0E (R/W  8) Debug Control */
+       RoReg8                    Reserved2[0x1];
+  __I  RTC_MODE0_SYNCBUSY_Type   SYNCBUSY;    /**< \brief Offset: 0x10 (R/  32) MODE0 Synchronization Busy Status */
+  __IO RTC_FREQCORR_Type         FREQCORR;    /**< \brief Offset: 0x14 (R/W  8) Frequency Correction */
+       RoReg8                    Reserved3[0x3];
+  __IO RTC_MODE0_COUNT_Type      COUNT;       /**< \brief Offset: 0x18 (R/W 32) MODE0 Counter Value */
+       RoReg8                    Reserved4[0x4];
+  __IO RTC_MODE0_COMP_Type       COMP[1];     /**< \brief Offset: 0x20 (R/W 32) MODE0 Compare n Value */
+       RoReg8                    Reserved5[0x1C];
+  __IO RTC_GP_Type               GP[4];       /**< \brief Offset: 0x40 (R/W 32) General Purpose */
+} RtcMode0;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief RTC_MODE1 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 16-bit Counter with Two 16-bit Compares */
+  __IO RTC_MODE1_CTRLA_Type      CTRLA;       /**< \brief Offset: 0x00 (R/W 16) MODE1 Control A */
+       RoReg8                    Reserved1[0x2];
+  __IO RTC_MODE1_EVCTRL_Type     EVCTRL;      /**< \brief Offset: 0x04 (R/W 32) MODE1 Event Control */
+  __IO RTC_MODE1_INTENCLR_Type   INTENCLR;    /**< \brief Offset: 0x08 (R/W 16) MODE1 Interrupt Enable Clear */
+  __IO RTC_MODE1_INTENSET_Type   INTENSET;    /**< \brief Offset: 0x0A (R/W 16) MODE1 Interrupt Enable Set */
+  __IO RTC_MODE1_INTFLAG_Type    INTFLAG;     /**< \brief Offset: 0x0C (R/W 16) MODE1 Interrupt Flag Status and Clear */
+  __IO RTC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x0E (R/W  8) Debug Control */
+       RoReg8                    Reserved2[0x1];
+  __I  RTC_MODE1_SYNCBUSY_Type   SYNCBUSY;    /**< \brief Offset: 0x10 (R/  32) MODE1 Synchronization Busy Status */
+  __IO RTC_FREQCORR_Type         FREQCORR;    /**< \brief Offset: 0x14 (R/W  8) Frequency Correction */
+       RoReg8                    Reserved3[0x3];
+  __IO RTC_MODE1_COUNT_Type      COUNT;       /**< \brief Offset: 0x18 (R/W 16) MODE1 Counter Value */
+       RoReg8                    Reserved4[0x2];
+  __IO RTC_MODE1_PER_Type        PER;         /**< \brief Offset: 0x1C (R/W 16) MODE1 Counter Period */
+       RoReg8                    Reserved5[0x2];
+  __IO RTC_MODE1_COMP_Type       COMP[2];     /**< \brief Offset: 0x20 (R/W 16) MODE1 Compare n Value */
+       RoReg8                    Reserved6[0x1C];
+  __IO RTC_GP_Type               GP[4];       /**< \brief Offset: 0x40 (R/W 32) General Purpose */
+} RtcMode1;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief RTC_MODE2 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* Clock/Calendar with Alarm */
+  __IO RTC_MODE2_CTRLA_Type      CTRLA;       /**< \brief Offset: 0x00 (R/W 16) MODE2 Control A */
+       RoReg8                    Reserved1[0x2];
+  __IO RTC_MODE2_EVCTRL_Type     EVCTRL;      /**< \brief Offset: 0x04 (R/W 32) MODE2 Event Control */
+  __IO RTC_MODE2_INTENCLR_Type   INTENCLR;    /**< \brief Offset: 0x08 (R/W 16) MODE2 Interrupt Enable Clear */
+  __IO RTC_MODE2_INTENSET_Type   INTENSET;    /**< \brief Offset: 0x0A (R/W 16) MODE2 Interrupt Enable Set */
+  __IO RTC_MODE2_INTFLAG_Type    INTFLAG;     /**< \brief Offset: 0x0C (R/W 16) MODE2 Interrupt Flag Status and Clear */
+  __IO RTC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x0E (R/W  8) Debug Control */
+       RoReg8                    Reserved2[0x1];
+  __I  RTC_MODE2_SYNCBUSY_Type   SYNCBUSY;    /**< \brief Offset: 0x10 (R/  32) MODE2 Synchronization Busy Status */
+  __IO RTC_FREQCORR_Type         FREQCORR;    /**< \brief Offset: 0x14 (R/W  8) Frequency Correction */
+       RoReg8                    Reserved3[0x3];
+  __IO RTC_MODE2_CLOCK_Type      CLOCK;       /**< \brief Offset: 0x18 (R/W 32) MODE2 Clock Value */
+       RoReg8                    Reserved4[0x4];
+       RtcMode2Alarm             Mode2Alarm[1]; /**< \brief Offset: 0x20 RtcMode2Alarm groups [ALARM_NUM] */
+       RoReg8                    Reserved5[0x18];
+  __IO RTC_GP_Type               GP[4];       /**< \brief Offset: 0x40 (R/W 32) General Purpose */
+} RtcMode2;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       RtcMode0                  MODE0;       /**< \brief Offset: 0x00 32-bit Counter with Single 32-bit Compare */
+       RtcMode1                  MODE1;       /**< \brief Offset: 0x00 16-bit Counter with Two 16-bit Compares */
+       RtcMode2                  MODE2;       /**< \brief Offset: 0x00 Clock/Calendar with Alarm */
+} Rtc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_RTC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/sercom.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/sercom.h
@@ -1,0 +1,1460 @@
+/**
+ * \file
+ *
+ * \brief Component description for SERCOM
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_SERCOM_COMPONENT_
+#define _SAML21_SERCOM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SERCOM */
+/* ========================================================================== */
+/** \addtogroup SAML21_SERCOM Serial Communication Interface */
+/*@{*/
+
+#define SERCOM_U2201
+#define REV_SERCOM                  0x210
+
+/* -------- SERCOM_I2CM_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CM I2CM Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run in Standby                     */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t PINOUT:1;         /*!< bit:     16  Pin Usage                          */
+    uint32_t :3;               /*!< bit: 17..19  Reserved                           */
+    uint32_t SDAHOLD:2;        /*!< bit: 20..21  SDA Hold Time                      */
+    uint32_t MEXTTOEN:1;       /*!< bit:     22  Master SCL Low Extend Timeout      */
+    uint32_t SEXTTOEN:1;       /*!< bit:     23  Slave SCL Low Extend Timeout       */
+    uint32_t SPEED:2;          /*!< bit: 24..25  Transfer Speed                     */
+    uint32_t :1;               /*!< bit:     26  Reserved                           */
+    uint32_t SCLSM:1;          /*!< bit:     27  SCL Clock Stretch Mode             */
+    uint32_t INACTOUT:2;       /*!< bit: 28..29  Inactive Time-Out                  */
+    uint32_t LOWTOUTEN:1;      /*!< bit:     30  SCL Low Timeout Enable             */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLA_OFFSET    0x00         /**< \brief (SERCOM_I2CM_CTRLA offset) I2CM Control A */
+#define SERCOM_I2CM_CTRLA_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_CTRLA reset_value) I2CM Control A */
+
+#define SERCOM_I2CM_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_I2CM_CTRLA) Software Reset */
+#define SERCOM_I2CM_CTRLA_SWRST     (0x1ul << SERCOM_I2CM_CTRLA_SWRST_Pos)
+#define SERCOM_I2CM_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_I2CM_CTRLA) Enable */
+#define SERCOM_I2CM_CTRLA_ENABLE    (0x1ul << SERCOM_I2CM_CTRLA_ENABLE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_Pos  2            /**< \brief (SERCOM_I2CM_CTRLA) Operating Mode */
+#define SERCOM_I2CM_CTRLA_MODE_Msk  (0x7ul << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE(value) (SERCOM_I2CM_CTRLA_MODE_Msk & ((value) << SERCOM_I2CM_CTRLA_MODE_Pos))
+#define SERCOM_I2CM_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_I2CM_CTRLA) Run in Standby */
+#define SERCOM_I2CM_CTRLA_RUNSTDBY  (0x1ul << SERCOM_I2CM_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_I2CM_CTRLA_PINOUT_Pos 16           /**< \brief (SERCOM_I2CM_CTRLA) Pin Usage */
+#define SERCOM_I2CM_CTRLA_PINOUT    (0x1ul << SERCOM_I2CM_CTRLA_PINOUT_Pos)
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Pos 20           /**< \brief (SERCOM_I2CM_CTRLA) SDA Hold Time */
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Msk (0x3ul << SERCOM_I2CM_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CM_CTRLA_SDAHOLD(value) (SERCOM_I2CM_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos))
+#define SERCOM_I2CM_CTRLA_MEXTTOEN_Pos 22           /**< \brief (SERCOM_I2CM_CTRLA) Master SCL Low Extend Timeout */
+#define SERCOM_I2CM_CTRLA_MEXTTOEN  (0x1ul << SERCOM_I2CM_CTRLA_MEXTTOEN_Pos)
+#define SERCOM_I2CM_CTRLA_SEXTTOEN_Pos 23           /**< \brief (SERCOM_I2CM_CTRLA) Slave SCL Low Extend Timeout */
+#define SERCOM_I2CM_CTRLA_SEXTTOEN  (0x1ul << SERCOM_I2CM_CTRLA_SEXTTOEN_Pos)
+#define SERCOM_I2CM_CTRLA_SPEED_Pos 24           /**< \brief (SERCOM_I2CM_CTRLA) Transfer Speed */
+#define SERCOM_I2CM_CTRLA_SPEED_Msk (0x3ul << SERCOM_I2CM_CTRLA_SPEED_Pos)
+#define SERCOM_I2CM_CTRLA_SPEED(value) (SERCOM_I2CM_CTRLA_SPEED_Msk & ((value) << SERCOM_I2CM_CTRLA_SPEED_Pos))
+#define SERCOM_I2CM_CTRLA_SCLSM_Pos 27           /**< \brief (SERCOM_I2CM_CTRLA) SCL Clock Stretch Mode */
+#define SERCOM_I2CM_CTRLA_SCLSM     (0x1ul << SERCOM_I2CM_CTRLA_SCLSM_Pos)
+#define SERCOM_I2CM_CTRLA_INACTOUT_Pos 28           /**< \brief (SERCOM_I2CM_CTRLA) Inactive Time-Out */
+#define SERCOM_I2CM_CTRLA_INACTOUT_Msk (0x3ul << SERCOM_I2CM_CTRLA_INACTOUT_Pos)
+#define SERCOM_I2CM_CTRLA_INACTOUT(value) (SERCOM_I2CM_CTRLA_INACTOUT_Msk & ((value) << SERCOM_I2CM_CTRLA_INACTOUT_Pos))
+#define SERCOM_I2CM_CTRLA_LOWTOUTEN_Pos 30           /**< \brief (SERCOM_I2CM_CTRLA) SCL Low Timeout Enable */
+#define SERCOM_I2CM_CTRLA_LOWTOUTEN (0x1ul << SERCOM_I2CM_CTRLA_LOWTOUTEN_Pos)
+#define SERCOM_I2CM_CTRLA_MASK      0x7BF1009Ful /**< \brief (SERCOM_I2CM_CTRLA) MASK Register */
+
+/* -------- SERCOM_I2CS_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CS I2CS Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run during Standby                 */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t PINOUT:1;         /*!< bit:     16  Pin Usage                          */
+    uint32_t :3;               /*!< bit: 17..19  Reserved                           */
+    uint32_t SDAHOLD:2;        /*!< bit: 20..21  SDA Hold Time                      */
+    uint32_t :1;               /*!< bit:     22  Reserved                           */
+    uint32_t SEXTTOEN:1;       /*!< bit:     23  Slave SCL Low Extend Timeout       */
+    uint32_t SPEED:2;          /*!< bit: 24..25  Transfer Speed                     */
+    uint32_t :1;               /*!< bit:     26  Reserved                           */
+    uint32_t SCLSM:1;          /*!< bit:     27  SCL Clock Stretch Mode             */
+    uint32_t :2;               /*!< bit: 28..29  Reserved                           */
+    uint32_t LOWTOUTEN:1;      /*!< bit:     30  SCL Low Timeout Enable             */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLA_OFFSET    0x00         /**< \brief (SERCOM_I2CS_CTRLA offset) I2CS Control A */
+#define SERCOM_I2CS_CTRLA_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CS_CTRLA reset_value) I2CS Control A */
+
+#define SERCOM_I2CS_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_I2CS_CTRLA) Software Reset */
+#define SERCOM_I2CS_CTRLA_SWRST     (0x1ul << SERCOM_I2CS_CTRLA_SWRST_Pos)
+#define SERCOM_I2CS_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_I2CS_CTRLA) Enable */
+#define SERCOM_I2CS_CTRLA_ENABLE    (0x1ul << SERCOM_I2CS_CTRLA_ENABLE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_Pos  2            /**< \brief (SERCOM_I2CS_CTRLA) Operating Mode */
+#define SERCOM_I2CS_CTRLA_MODE_Msk  (0x7ul << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE(value) (SERCOM_I2CS_CTRLA_MODE_Msk & ((value) << SERCOM_I2CS_CTRLA_MODE_Pos))
+#define SERCOM_I2CS_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_I2CS_CTRLA) Run during Standby */
+#define SERCOM_I2CS_CTRLA_RUNSTDBY  (0x1ul << SERCOM_I2CS_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_I2CS_CTRLA_PINOUT_Pos 16           /**< \brief (SERCOM_I2CS_CTRLA) Pin Usage */
+#define SERCOM_I2CS_CTRLA_PINOUT    (0x1ul << SERCOM_I2CS_CTRLA_PINOUT_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Pos 20           /**< \brief (SERCOM_I2CS_CTRLA) SDA Hold Time */
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Msk (0x3ul << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD(value) (SERCOM_I2CS_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos))
+#define SERCOM_I2CS_CTRLA_SEXTTOEN_Pos 23           /**< \brief (SERCOM_I2CS_CTRLA) Slave SCL Low Extend Timeout */
+#define SERCOM_I2CS_CTRLA_SEXTTOEN  (0x1ul << SERCOM_I2CS_CTRLA_SEXTTOEN_Pos)
+#define SERCOM_I2CS_CTRLA_SPEED_Pos 24           /**< \brief (SERCOM_I2CS_CTRLA) Transfer Speed */
+#define SERCOM_I2CS_CTRLA_SPEED_Msk (0x3ul << SERCOM_I2CS_CTRLA_SPEED_Pos)
+#define SERCOM_I2CS_CTRLA_SPEED(value) (SERCOM_I2CS_CTRLA_SPEED_Msk & ((value) << SERCOM_I2CS_CTRLA_SPEED_Pos))
+#define SERCOM_I2CS_CTRLA_SCLSM_Pos 27           /**< \brief (SERCOM_I2CS_CTRLA) SCL Clock Stretch Mode */
+#define SERCOM_I2CS_CTRLA_SCLSM     (0x1ul << SERCOM_I2CS_CTRLA_SCLSM_Pos)
+#define SERCOM_I2CS_CTRLA_LOWTOUTEN_Pos 30           /**< \brief (SERCOM_I2CS_CTRLA) SCL Low Timeout Enable */
+#define SERCOM_I2CS_CTRLA_LOWTOUTEN (0x1ul << SERCOM_I2CS_CTRLA_LOWTOUTEN_Pos)
+#define SERCOM_I2CS_CTRLA_MASK      0x4BB1009Ful /**< \brief (SERCOM_I2CS_CTRLA) MASK Register */
+
+/* -------- SERCOM_SPI_CTRLA : (SERCOM Offset: 0x00) (R/W 32) SPI SPI Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run during Standby                 */
+    uint32_t IBON:1;           /*!< bit:      8  Immediate Buffer Overflow Notification */
+    uint32_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t DOPO:2;           /*!< bit: 16..17  Data Out Pinout                    */
+    uint32_t :2;               /*!< bit: 18..19  Reserved                           */
+    uint32_t DIPO:2;           /*!< bit: 20..21  Data In Pinout                     */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t FORM:4;           /*!< bit: 24..27  Frame Format                       */
+    uint32_t CPHA:1;           /*!< bit:     28  Clock Phase                        */
+    uint32_t CPOL:1;           /*!< bit:     29  Clock Polarity                     */
+    uint32_t DORD:1;           /*!< bit:     30  Data Order                         */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLA_OFFSET     0x00         /**< \brief (SERCOM_SPI_CTRLA offset) SPI Control A */
+#define SERCOM_SPI_CTRLA_RESETVALUE 0x00000000ul /**< \brief (SERCOM_SPI_CTRLA reset_value) SPI Control A */
+
+#define SERCOM_SPI_CTRLA_SWRST_Pos  0            /**< \brief (SERCOM_SPI_CTRLA) Software Reset */
+#define SERCOM_SPI_CTRLA_SWRST      (0x1ul << SERCOM_SPI_CTRLA_SWRST_Pos)
+#define SERCOM_SPI_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_SPI_CTRLA) Enable */
+#define SERCOM_SPI_CTRLA_ENABLE     (0x1ul << SERCOM_SPI_CTRLA_ENABLE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_Pos   2            /**< \brief (SERCOM_SPI_CTRLA) Operating Mode */
+#define SERCOM_SPI_CTRLA_MODE_Msk   (0x7ul << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE(value) (SERCOM_SPI_CTRLA_MODE_Msk & ((value) << SERCOM_SPI_CTRLA_MODE_Pos))
+#define SERCOM_SPI_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_SPI_CTRLA) Run during Standby */
+#define SERCOM_SPI_CTRLA_RUNSTDBY   (0x1ul << SERCOM_SPI_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_SPI_CTRLA_IBON_Pos   8            /**< \brief (SERCOM_SPI_CTRLA) Immediate Buffer Overflow Notification */
+#define SERCOM_SPI_CTRLA_IBON       (0x1ul << SERCOM_SPI_CTRLA_IBON_Pos)
+#define SERCOM_SPI_CTRLA_DOPO_Pos   16           /**< \brief (SERCOM_SPI_CTRLA) Data Out Pinout */
+#define SERCOM_SPI_CTRLA_DOPO_Msk   (0x3ul << SERCOM_SPI_CTRLA_DOPO_Pos)
+#define SERCOM_SPI_CTRLA_DOPO(value) (SERCOM_SPI_CTRLA_DOPO_Msk & ((value) << SERCOM_SPI_CTRLA_DOPO_Pos))
+#define SERCOM_SPI_CTRLA_DIPO_Pos   20           /**< \brief (SERCOM_SPI_CTRLA) Data In Pinout */
+#define SERCOM_SPI_CTRLA_DIPO_Msk   (0x3ul << SERCOM_SPI_CTRLA_DIPO_Pos)
+#define SERCOM_SPI_CTRLA_DIPO(value) (SERCOM_SPI_CTRLA_DIPO_Msk & ((value) << SERCOM_SPI_CTRLA_DIPO_Pos))
+#define SERCOM_SPI_CTRLA_FORM_Pos   24           /**< \brief (SERCOM_SPI_CTRLA) Frame Format */
+#define SERCOM_SPI_CTRLA_FORM_Msk   (0xFul << SERCOM_SPI_CTRLA_FORM_Pos)
+#define SERCOM_SPI_CTRLA_FORM(value) (SERCOM_SPI_CTRLA_FORM_Msk & ((value) << SERCOM_SPI_CTRLA_FORM_Pos))
+#define SERCOM_SPI_CTRLA_CPHA_Pos   28           /**< \brief (SERCOM_SPI_CTRLA) Clock Phase */
+#define SERCOM_SPI_CTRLA_CPHA       (0x1ul << SERCOM_SPI_CTRLA_CPHA_Pos)
+#define SERCOM_SPI_CTRLA_CPOL_Pos   29           /**< \brief (SERCOM_SPI_CTRLA) Clock Polarity */
+#define SERCOM_SPI_CTRLA_CPOL       (0x1ul << SERCOM_SPI_CTRLA_CPOL_Pos)
+#define SERCOM_SPI_CTRLA_DORD_Pos   30           /**< \brief (SERCOM_SPI_CTRLA) Data Order */
+#define SERCOM_SPI_CTRLA_DORD       (0x1ul << SERCOM_SPI_CTRLA_DORD_Pos)
+#define SERCOM_SPI_CTRLA_MASK       0x7F33019Ful /**< \brief (SERCOM_SPI_CTRLA) MASK Register */
+
+/* -------- SERCOM_USART_CTRLA : (SERCOM Offset: 0x00) (R/W 32) USART USART Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run during Standby                 */
+    uint32_t IBON:1;           /*!< bit:      8  Immediate Buffer Overflow Notification */
+    uint32_t :4;               /*!< bit:  9..12  Reserved                           */
+    uint32_t SAMPR:3;          /*!< bit: 13..15  Sample                             */
+    uint32_t TXPO:2;           /*!< bit: 16..17  Transmit Data Pinout               */
+    uint32_t :2;               /*!< bit: 18..19  Reserved                           */
+    uint32_t RXPO:2;           /*!< bit: 20..21  Receive Data Pinout                */
+    uint32_t SAMPA:2;          /*!< bit: 22..23  Sample Adjustment                  */
+    uint32_t FORM:4;           /*!< bit: 24..27  Frame Format                       */
+    uint32_t CMODE:1;          /*!< bit:     28  Communication Mode                 */
+    uint32_t CPOL:1;           /*!< bit:     29  Clock Polarity                     */
+    uint32_t DORD:1;           /*!< bit:     30  Data Order                         */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLA_OFFSET   0x00         /**< \brief (SERCOM_USART_CTRLA offset) USART Control A */
+#define SERCOM_USART_CTRLA_RESETVALUE 0x00000000ul /**< \brief (SERCOM_USART_CTRLA reset_value) USART Control A */
+
+#define SERCOM_USART_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_USART_CTRLA) Software Reset */
+#define SERCOM_USART_CTRLA_SWRST    (0x1ul << SERCOM_USART_CTRLA_SWRST_Pos)
+#define SERCOM_USART_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_USART_CTRLA) Enable */
+#define SERCOM_USART_CTRLA_ENABLE   (0x1ul << SERCOM_USART_CTRLA_ENABLE_Pos)
+#define SERCOM_USART_CTRLA_MODE_Pos 2            /**< \brief (SERCOM_USART_CTRLA) Operating Mode */
+#define SERCOM_USART_CTRLA_MODE_Msk (0x7ul << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE(value) (SERCOM_USART_CTRLA_MODE_Msk & ((value) << SERCOM_USART_CTRLA_MODE_Pos))
+#define SERCOM_USART_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_USART_CTRLA) Run during Standby */
+#define SERCOM_USART_CTRLA_RUNSTDBY (0x1ul << SERCOM_USART_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_USART_CTRLA_IBON_Pos 8            /**< \brief (SERCOM_USART_CTRLA) Immediate Buffer Overflow Notification */
+#define SERCOM_USART_CTRLA_IBON     (0x1ul << SERCOM_USART_CTRLA_IBON_Pos)
+#define SERCOM_USART_CTRLA_SAMPR_Pos 13           /**< \brief (SERCOM_USART_CTRLA) Sample */
+#define SERCOM_USART_CTRLA_SAMPR_Msk (0x7ul << SERCOM_USART_CTRLA_SAMPR_Pos)
+#define SERCOM_USART_CTRLA_SAMPR(value) (SERCOM_USART_CTRLA_SAMPR_Msk & ((value) << SERCOM_USART_CTRLA_SAMPR_Pos))
+#define SERCOM_USART_CTRLA_TXPO_Pos 16           /**< \brief (SERCOM_USART_CTRLA) Transmit Data Pinout */
+#define SERCOM_USART_CTRLA_TXPO_Msk (0x3ul << SERCOM_USART_CTRLA_TXPO_Pos)
+#define SERCOM_USART_CTRLA_TXPO(value) (SERCOM_USART_CTRLA_TXPO_Msk & ((value) << SERCOM_USART_CTRLA_TXPO_Pos))
+#define SERCOM_USART_CTRLA_RXPO_Pos 20           /**< \brief (SERCOM_USART_CTRLA) Receive Data Pinout */
+#define SERCOM_USART_CTRLA_RXPO_Msk (0x3ul << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO(value) (SERCOM_USART_CTRLA_RXPO_Msk & ((value) << SERCOM_USART_CTRLA_RXPO_Pos))
+#define SERCOM_USART_CTRLA_SAMPA_Pos 22           /**< \brief (SERCOM_USART_CTRLA) Sample Adjustment */
+#define SERCOM_USART_CTRLA_SAMPA_Msk (0x3ul << SERCOM_USART_CTRLA_SAMPA_Pos)
+#define SERCOM_USART_CTRLA_SAMPA(value) (SERCOM_USART_CTRLA_SAMPA_Msk & ((value) << SERCOM_USART_CTRLA_SAMPA_Pos))
+#define SERCOM_USART_CTRLA_FORM_Pos 24           /**< \brief (SERCOM_USART_CTRLA) Frame Format */
+#define SERCOM_USART_CTRLA_FORM_Msk (0xFul << SERCOM_USART_CTRLA_FORM_Pos)
+#define SERCOM_USART_CTRLA_FORM(value) (SERCOM_USART_CTRLA_FORM_Msk & ((value) << SERCOM_USART_CTRLA_FORM_Pos))
+#define SERCOM_USART_CTRLA_CMODE_Pos 28           /**< \brief (SERCOM_USART_CTRLA) Communication Mode */
+#define SERCOM_USART_CTRLA_CMODE    (0x1ul << SERCOM_USART_CTRLA_CMODE_Pos)
+#define SERCOM_USART_CTRLA_CPOL_Pos 29           /**< \brief (SERCOM_USART_CTRLA) Clock Polarity */
+#define SERCOM_USART_CTRLA_CPOL     (0x1ul << SERCOM_USART_CTRLA_CPOL_Pos)
+#define SERCOM_USART_CTRLA_DORD_Pos 30           /**< \brief (SERCOM_USART_CTRLA) Data Order */
+#define SERCOM_USART_CTRLA_DORD     (0x1ul << SERCOM_USART_CTRLA_DORD_Pos)
+#define SERCOM_USART_CTRLA_MASK     0x7FF3E19Ful /**< \brief (SERCOM_USART_CTRLA) MASK Register */
+
+/* -------- SERCOM_I2CM_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CM I2CM Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t SMEN:1;           /*!< bit:      8  Smart Mode Enable                  */
+    uint32_t QCEN:1;           /*!< bit:      9  Quick Command Enable               */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t CMD:2;            /*!< bit: 16..17  Command                            */
+    uint32_t ACKACT:1;         /*!< bit:     18  Acknowledge Action                 */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLB_OFFSET    0x04         /**< \brief (SERCOM_I2CM_CTRLB offset) I2CM Control B */
+#define SERCOM_I2CM_CTRLB_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_CTRLB reset_value) I2CM Control B */
+
+#define SERCOM_I2CM_CTRLB_SMEN_Pos  8            /**< \brief (SERCOM_I2CM_CTRLB) Smart Mode Enable */
+#define SERCOM_I2CM_CTRLB_SMEN      (0x1ul << SERCOM_I2CM_CTRLB_SMEN_Pos)
+#define SERCOM_I2CM_CTRLB_QCEN_Pos  9            /**< \brief (SERCOM_I2CM_CTRLB) Quick Command Enable */
+#define SERCOM_I2CM_CTRLB_QCEN      (0x1ul << SERCOM_I2CM_CTRLB_QCEN_Pos)
+#define SERCOM_I2CM_CTRLB_CMD_Pos   16           /**< \brief (SERCOM_I2CM_CTRLB) Command */
+#define SERCOM_I2CM_CTRLB_CMD_Msk   (0x3ul << SERCOM_I2CM_CTRLB_CMD_Pos)
+#define SERCOM_I2CM_CTRLB_CMD(value) (SERCOM_I2CM_CTRLB_CMD_Msk & ((value) << SERCOM_I2CM_CTRLB_CMD_Pos))
+#define SERCOM_I2CM_CTRLB_ACKACT_Pos 18           /**< \brief (SERCOM_I2CM_CTRLB) Acknowledge Action */
+#define SERCOM_I2CM_CTRLB_ACKACT    (0x1ul << SERCOM_I2CM_CTRLB_ACKACT_Pos)
+#define SERCOM_I2CM_CTRLB_MASK      0x00070300ul /**< \brief (SERCOM_I2CM_CTRLB) MASK Register */
+
+/* -------- SERCOM_I2CS_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CS I2CS Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t SMEN:1;           /*!< bit:      8  Smart Mode Enable                  */
+    uint32_t GCMD:1;           /*!< bit:      9  PMBus Group Command                */
+    uint32_t AACKEN:1;         /*!< bit:     10  Automatic Address Acknowledge      */
+    uint32_t :3;               /*!< bit: 11..13  Reserved                           */
+    uint32_t AMODE:2;          /*!< bit: 14..15  Address Mode                       */
+    uint32_t CMD:2;            /*!< bit: 16..17  Command                            */
+    uint32_t ACKACT:1;         /*!< bit:     18  Acknowledge Action                 */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLB_OFFSET    0x04         /**< \brief (SERCOM_I2CS_CTRLB offset) I2CS Control B */
+#define SERCOM_I2CS_CTRLB_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CS_CTRLB reset_value) I2CS Control B */
+
+#define SERCOM_I2CS_CTRLB_SMEN_Pos  8            /**< \brief (SERCOM_I2CS_CTRLB) Smart Mode Enable */
+#define SERCOM_I2CS_CTRLB_SMEN      (0x1ul << SERCOM_I2CS_CTRLB_SMEN_Pos)
+#define SERCOM_I2CS_CTRLB_GCMD_Pos  9            /**< \brief (SERCOM_I2CS_CTRLB) PMBus Group Command */
+#define SERCOM_I2CS_CTRLB_GCMD      (0x1ul << SERCOM_I2CS_CTRLB_GCMD_Pos)
+#define SERCOM_I2CS_CTRLB_AACKEN_Pos 10           /**< \brief (SERCOM_I2CS_CTRLB) Automatic Address Acknowledge */
+#define SERCOM_I2CS_CTRLB_AACKEN    (0x1ul << SERCOM_I2CS_CTRLB_AACKEN_Pos)
+#define SERCOM_I2CS_CTRLB_AMODE_Pos 14           /**< \brief (SERCOM_I2CS_CTRLB) Address Mode */
+#define SERCOM_I2CS_CTRLB_AMODE_Msk (0x3ul << SERCOM_I2CS_CTRLB_AMODE_Pos)
+#define SERCOM_I2CS_CTRLB_AMODE(value) (SERCOM_I2CS_CTRLB_AMODE_Msk & ((value) << SERCOM_I2CS_CTRLB_AMODE_Pos))
+#define SERCOM_I2CS_CTRLB_CMD_Pos   16           /**< \brief (SERCOM_I2CS_CTRLB) Command */
+#define SERCOM_I2CS_CTRLB_CMD_Msk   (0x3ul << SERCOM_I2CS_CTRLB_CMD_Pos)
+#define SERCOM_I2CS_CTRLB_CMD(value) (SERCOM_I2CS_CTRLB_CMD_Msk & ((value) << SERCOM_I2CS_CTRLB_CMD_Pos))
+#define SERCOM_I2CS_CTRLB_ACKACT_Pos 18           /**< \brief (SERCOM_I2CS_CTRLB) Acknowledge Action */
+#define SERCOM_I2CS_CTRLB_ACKACT    (0x1ul << SERCOM_I2CS_CTRLB_ACKACT_Pos)
+#define SERCOM_I2CS_CTRLB_MASK      0x0007C700ul /**< \brief (SERCOM_I2CS_CTRLB) MASK Register */
+
+/* -------- SERCOM_SPI_CTRLB : (SERCOM Offset: 0x04) (R/W 32) SPI SPI Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHSIZE:3;         /*!< bit:  0.. 2  Character Size                     */
+    uint32_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint32_t PLOADEN:1;        /*!< bit:      6  Data Preload Enable                */
+    uint32_t :2;               /*!< bit:  7.. 8  Reserved                           */
+    uint32_t SSDE:1;           /*!< bit:      9  Slave Select Low Detect Enable     */
+    uint32_t :3;               /*!< bit: 10..12  Reserved                           */
+    uint32_t MSSEN:1;          /*!< bit:     13  Master Slave Select Enable         */
+    uint32_t AMODE:2;          /*!< bit: 14..15  Address Mode                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t RXEN:1;           /*!< bit:     17  Receiver Enable                    */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLB_OFFSET     0x04         /**< \brief (SERCOM_SPI_CTRLB offset) SPI Control B */
+#define SERCOM_SPI_CTRLB_RESETVALUE 0x00000000ul /**< \brief (SERCOM_SPI_CTRLB reset_value) SPI Control B */
+
+#define SERCOM_SPI_CTRLB_CHSIZE_Pos 0            /**< \brief (SERCOM_SPI_CTRLB) Character Size */
+#define SERCOM_SPI_CTRLB_CHSIZE_Msk (0x7ul << SERCOM_SPI_CTRLB_CHSIZE_Pos)
+#define SERCOM_SPI_CTRLB_CHSIZE(value) (SERCOM_SPI_CTRLB_CHSIZE_Msk & ((value) << SERCOM_SPI_CTRLB_CHSIZE_Pos))
+#define SERCOM_SPI_CTRLB_PLOADEN_Pos 6            /**< \brief (SERCOM_SPI_CTRLB) Data Preload Enable */
+#define SERCOM_SPI_CTRLB_PLOADEN    (0x1ul << SERCOM_SPI_CTRLB_PLOADEN_Pos)
+#define SERCOM_SPI_CTRLB_SSDE_Pos   9            /**< \brief (SERCOM_SPI_CTRLB) Slave Select Low Detect Enable */
+#define SERCOM_SPI_CTRLB_SSDE       (0x1ul << SERCOM_SPI_CTRLB_SSDE_Pos)
+#define SERCOM_SPI_CTRLB_MSSEN_Pos  13           /**< \brief (SERCOM_SPI_CTRLB) Master Slave Select Enable */
+#define SERCOM_SPI_CTRLB_MSSEN      (0x1ul << SERCOM_SPI_CTRLB_MSSEN_Pos)
+#define SERCOM_SPI_CTRLB_AMODE_Pos  14           /**< \brief (SERCOM_SPI_CTRLB) Address Mode */
+#define SERCOM_SPI_CTRLB_AMODE_Msk  (0x3ul << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_AMODE(value) (SERCOM_SPI_CTRLB_AMODE_Msk & ((value) << SERCOM_SPI_CTRLB_AMODE_Pos))
+#define SERCOM_SPI_CTRLB_RXEN_Pos   17           /**< \brief (SERCOM_SPI_CTRLB) Receiver Enable */
+#define SERCOM_SPI_CTRLB_RXEN       (0x1ul << SERCOM_SPI_CTRLB_RXEN_Pos)
+#define SERCOM_SPI_CTRLB_MASK       0x0002E247ul /**< \brief (SERCOM_SPI_CTRLB) MASK Register */
+
+/* -------- SERCOM_USART_CTRLB : (SERCOM Offset: 0x04) (R/W 32) USART USART Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHSIZE:3;         /*!< bit:  0.. 2  Character Size                     */
+    uint32_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint32_t SBMODE:1;         /*!< bit:      6  Stop Bit Mode                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t COLDEN:1;         /*!< bit:      8  Collision Detection Enable         */
+    uint32_t SFDE:1;           /*!< bit:      9  Start of Frame Detection Enable    */
+    uint32_t ENC:1;            /*!< bit:     10  Encoding Format                    */
+    uint32_t :2;               /*!< bit: 11..12  Reserved                           */
+    uint32_t PMODE:1;          /*!< bit:     13  Parity Mode                        */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t TXEN:1;           /*!< bit:     16  Transmitter Enable                 */
+    uint32_t RXEN:1;           /*!< bit:     17  Receiver Enable                    */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLB_OFFSET   0x04         /**< \brief (SERCOM_USART_CTRLB offset) USART Control B */
+#define SERCOM_USART_CTRLB_RESETVALUE 0x00000000ul /**< \brief (SERCOM_USART_CTRLB reset_value) USART Control B */
+
+#define SERCOM_USART_CTRLB_CHSIZE_Pos 0            /**< \brief (SERCOM_USART_CTRLB) Character Size */
+#define SERCOM_USART_CTRLB_CHSIZE_Msk (0x7ul << SERCOM_USART_CTRLB_CHSIZE_Pos)
+#define SERCOM_USART_CTRLB_CHSIZE(value) (SERCOM_USART_CTRLB_CHSIZE_Msk & ((value) << SERCOM_USART_CTRLB_CHSIZE_Pos))
+#define SERCOM_USART_CTRLB_SBMODE_Pos 6            /**< \brief (SERCOM_USART_CTRLB) Stop Bit Mode */
+#define SERCOM_USART_CTRLB_SBMODE   (0x1ul << SERCOM_USART_CTRLB_SBMODE_Pos)
+#define SERCOM_USART_CTRLB_COLDEN_Pos 8            /**< \brief (SERCOM_USART_CTRLB) Collision Detection Enable */
+#define SERCOM_USART_CTRLB_COLDEN   (0x1ul << SERCOM_USART_CTRLB_COLDEN_Pos)
+#define SERCOM_USART_CTRLB_SFDE_Pos 9            /**< \brief (SERCOM_USART_CTRLB) Start of Frame Detection Enable */
+#define SERCOM_USART_CTRLB_SFDE     (0x1ul << SERCOM_USART_CTRLB_SFDE_Pos)
+#define SERCOM_USART_CTRLB_ENC_Pos  10           /**< \brief (SERCOM_USART_CTRLB) Encoding Format */
+#define SERCOM_USART_CTRLB_ENC      (0x1ul << SERCOM_USART_CTRLB_ENC_Pos)
+#define SERCOM_USART_CTRLB_PMODE_Pos 13           /**< \brief (SERCOM_USART_CTRLB) Parity Mode */
+#define SERCOM_USART_CTRLB_PMODE    (0x1ul << SERCOM_USART_CTRLB_PMODE_Pos)
+#define SERCOM_USART_CTRLB_TXEN_Pos 16           /**< \brief (SERCOM_USART_CTRLB) Transmitter Enable */
+#define SERCOM_USART_CTRLB_TXEN     (0x1ul << SERCOM_USART_CTRLB_TXEN_Pos)
+#define SERCOM_USART_CTRLB_RXEN_Pos 17           /**< \brief (SERCOM_USART_CTRLB) Receiver Enable */
+#define SERCOM_USART_CTRLB_RXEN     (0x1ul << SERCOM_USART_CTRLB_RXEN_Pos)
+#define SERCOM_USART_CTRLB_MASK     0x00032747ul /**< \brief (SERCOM_USART_CTRLB) MASK Register */
+
+/* -------- SERCOM_I2CM_BAUD : (SERCOM Offset: 0x0C) (R/W 32) I2CM I2CM Baud Rate -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BAUD:8;           /*!< bit:  0.. 7  Baud Rate Value                    */
+    uint32_t BAUDLOW:8;        /*!< bit:  8..15  Baud Rate Value Low                */
+    uint32_t HSBAUD:8;         /*!< bit: 16..23  High Speed Baud Rate Value         */
+    uint32_t HSBAUDLOW:8;      /*!< bit: 24..31  High Speed Baud Rate Value Low     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_BAUD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_BAUD_OFFSET     0x0C         /**< \brief (SERCOM_I2CM_BAUD offset) I2CM Baud Rate */
+#define SERCOM_I2CM_BAUD_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_BAUD reset_value) I2CM Baud Rate */
+
+#define SERCOM_I2CM_BAUD_BAUD_Pos   0            /**< \brief (SERCOM_I2CM_BAUD) Baud Rate Value */
+#define SERCOM_I2CM_BAUD_BAUD_Msk   (0xFFul << SERCOM_I2CM_BAUD_BAUD_Pos)
+#define SERCOM_I2CM_BAUD_BAUD(value) (SERCOM_I2CM_BAUD_BAUD_Msk & ((value) << SERCOM_I2CM_BAUD_BAUD_Pos))
+#define SERCOM_I2CM_BAUD_BAUDLOW_Pos 8            /**< \brief (SERCOM_I2CM_BAUD) Baud Rate Value Low */
+#define SERCOM_I2CM_BAUD_BAUDLOW_Msk (0xFFul << SERCOM_I2CM_BAUD_BAUDLOW_Pos)
+#define SERCOM_I2CM_BAUD_BAUDLOW(value) (SERCOM_I2CM_BAUD_BAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_BAUDLOW_Pos))
+#define SERCOM_I2CM_BAUD_HSBAUD_Pos 16           /**< \brief (SERCOM_I2CM_BAUD) High Speed Baud Rate Value */
+#define SERCOM_I2CM_BAUD_HSBAUD_Msk (0xFFul << SERCOM_I2CM_BAUD_HSBAUD_Pos)
+#define SERCOM_I2CM_BAUD_HSBAUD(value) (SERCOM_I2CM_BAUD_HSBAUD_Msk & ((value) << SERCOM_I2CM_BAUD_HSBAUD_Pos))
+#define SERCOM_I2CM_BAUD_HSBAUDLOW_Pos 24           /**< \brief (SERCOM_I2CM_BAUD) High Speed Baud Rate Value Low */
+#define SERCOM_I2CM_BAUD_HSBAUDLOW_Msk (0xFFul << SERCOM_I2CM_BAUD_HSBAUDLOW_Pos)
+#define SERCOM_I2CM_BAUD_HSBAUDLOW(value) (SERCOM_I2CM_BAUD_HSBAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_HSBAUDLOW_Pos))
+#define SERCOM_I2CM_BAUD_MASK       0xFFFFFFFFul /**< \brief (SERCOM_I2CM_BAUD) MASK Register */
+
+/* -------- SERCOM_SPI_BAUD : (SERCOM Offset: 0x0C) (R/W  8) SPI SPI Baud Rate -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  BAUD:8;           /*!< bit:  0.. 7  Baud Rate Value                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_BAUD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_BAUD_OFFSET      0x0C         /**< \brief (SERCOM_SPI_BAUD offset) SPI Baud Rate */
+#define SERCOM_SPI_BAUD_RESETVALUE  0x00ul       /**< \brief (SERCOM_SPI_BAUD reset_value) SPI Baud Rate */
+
+#define SERCOM_SPI_BAUD_BAUD_Pos    0            /**< \brief (SERCOM_SPI_BAUD) Baud Rate Value */
+#define SERCOM_SPI_BAUD_BAUD_Msk    (0xFFul << SERCOM_SPI_BAUD_BAUD_Pos)
+#define SERCOM_SPI_BAUD_BAUD(value) (SERCOM_SPI_BAUD_BAUD_Msk & ((value) << SERCOM_SPI_BAUD_BAUD_Pos))
+#define SERCOM_SPI_BAUD_MASK        0xFFul       /**< \brief (SERCOM_SPI_BAUD) MASK Register */
+
+/* -------- SERCOM_USART_BAUD : (SERCOM Offset: 0x0C) (R/W 16) USART USART Baud Rate -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BAUD:16;          /*!< bit:  0..15  Baud Rate Value                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct { // FRAC mode
+    uint16_t BAUD:13;          /*!< bit:  0..12  Baud Rate Value                    */
+    uint16_t FP:3;             /*!< bit: 13..15  Fractional Part                    */
+  } FRAC;                      /*!< Structure used for FRAC                         */
+  struct { // FRACFP mode
+    uint16_t BAUD:13;          /*!< bit:  0..12  Baud Rate Value                    */
+    uint16_t FP:3;             /*!< bit: 13..15  Fractional Part                    */
+  } FRACFP;                    /*!< Structure used for FRACFP                       */
+  struct { // USARTFP mode
+    uint16_t BAUD:16;          /*!< bit:  0..15  Baud Rate Value                    */
+  } USARTFP;                   /*!< Structure used for USARTFP                      */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_BAUD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_BAUD_OFFSET    0x0C         /**< \brief (SERCOM_USART_BAUD offset) USART Baud Rate */
+#define SERCOM_USART_BAUD_RESETVALUE 0x0000ul     /**< \brief (SERCOM_USART_BAUD reset_value) USART Baud Rate */
+
+#define SERCOM_USART_BAUD_BAUD_Pos  0            /**< \brief (SERCOM_USART_BAUD) Baud Rate Value */
+#define SERCOM_USART_BAUD_BAUD_Msk  (0xFFFFul << SERCOM_USART_BAUD_BAUD_Pos)
+#define SERCOM_USART_BAUD_BAUD(value) (SERCOM_USART_BAUD_BAUD_Msk & ((value) << SERCOM_USART_BAUD_BAUD_Pos))
+#define SERCOM_USART_BAUD_MASK      0xFFFFul     /**< \brief (SERCOM_USART_BAUD) MASK Register */
+
+// FRAC mode
+#define SERCOM_USART_BAUD_FRAC_BAUD_Pos 0            /**< \brief (SERCOM_USART_BAUD_FRAC) Baud Rate Value */
+#define SERCOM_USART_BAUD_FRAC_BAUD_Msk (0x1FFFul << SERCOM_USART_BAUD_FRAC_BAUD_Pos)
+#define SERCOM_USART_BAUD_FRAC_BAUD(value) (SERCOM_USART_BAUD_FRAC_BAUD_Msk & ((value) << SERCOM_USART_BAUD_FRAC_BAUD_Pos))
+#define SERCOM_USART_BAUD_FRAC_FP_Pos 13           /**< \brief (SERCOM_USART_BAUD_FRAC) Fractional Part */
+#define SERCOM_USART_BAUD_FRAC_FP_Msk (0x7ul << SERCOM_USART_BAUD_FRAC_FP_Pos)
+#define SERCOM_USART_BAUD_FRAC_FP(value) (SERCOM_USART_BAUD_FRAC_FP_Msk & ((value) << SERCOM_USART_BAUD_FRAC_FP_Pos))
+#define SERCOM_USART_BAUD_FRAC_MASK 0xFFFFul     /**< \brief (SERCOM_USART_BAUD_FRAC) MASK Register */
+
+// FRACFP mode
+#define SERCOM_USART_BAUD_FRACFP_BAUD_Pos 0            /**< \brief (SERCOM_USART_BAUD_FRACFP) Baud Rate Value */
+#define SERCOM_USART_BAUD_FRACFP_BAUD_Msk (0x1FFFul << SERCOM_USART_BAUD_FRACFP_BAUD_Pos)
+#define SERCOM_USART_BAUD_FRACFP_BAUD(value) (SERCOM_USART_BAUD_FRACFP_BAUD_Msk & ((value) << SERCOM_USART_BAUD_FRACFP_BAUD_Pos))
+#define SERCOM_USART_BAUD_FRACFP_FP_Pos 13           /**< \brief (SERCOM_USART_BAUD_FRACFP) Fractional Part */
+#define SERCOM_USART_BAUD_FRACFP_FP_Msk (0x7ul << SERCOM_USART_BAUD_FRACFP_FP_Pos)
+#define SERCOM_USART_BAUD_FRACFP_FP(value) (SERCOM_USART_BAUD_FRACFP_FP_Msk & ((value) << SERCOM_USART_BAUD_FRACFP_FP_Pos))
+#define SERCOM_USART_BAUD_FRACFP_MASK 0xFFFFul     /**< \brief (SERCOM_USART_BAUD_FRACFP) MASK Register */
+
+// USARTFP mode
+#define SERCOM_USART_BAUD_USARTFP_BAUD_Pos 0            /**< \brief (SERCOM_USART_BAUD_USARTFP) Baud Rate Value */
+#define SERCOM_USART_BAUD_USARTFP_BAUD_Msk (0xFFFFul << SERCOM_USART_BAUD_USARTFP_BAUD_Pos)
+#define SERCOM_USART_BAUD_USARTFP_BAUD(value) (SERCOM_USART_BAUD_USARTFP_BAUD_Msk & ((value) << SERCOM_USART_BAUD_USARTFP_BAUD_Pos))
+#define SERCOM_USART_BAUD_USARTFP_MASK 0xFFFFul     /**< \brief (SERCOM_USART_BAUD_USARTFP) MASK Register */
+
+/* -------- SERCOM_USART_RXPL : (SERCOM Offset: 0x0E) (R/W  8) USART USART Receive Pulse Length -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  RXPL:8;           /*!< bit:  0.. 7  Receive Pulse Length               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_RXPL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_RXPL_OFFSET    0x0E         /**< \brief (SERCOM_USART_RXPL offset) USART Receive Pulse Length */
+#define SERCOM_USART_RXPL_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_RXPL reset_value) USART Receive Pulse Length */
+
+#define SERCOM_USART_RXPL_RXPL_Pos  0            /**< \brief (SERCOM_USART_RXPL) Receive Pulse Length */
+#define SERCOM_USART_RXPL_RXPL_Msk  (0xFFul << SERCOM_USART_RXPL_RXPL_Pos)
+#define SERCOM_USART_RXPL_RXPL(value) (SERCOM_USART_RXPL_RXPL_Msk & ((value) << SERCOM_USART_RXPL_RXPL_Pos))
+#define SERCOM_USART_RXPL_MASK      0xFFul       /**< \brief (SERCOM_USART_RXPL) MASK Register */
+
+/* -------- SERCOM_I2CM_INTENCLR : (SERCOM Offset: 0x14) (R/W  8) I2CM I2CM Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt Disable    */
+    uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt Disable     */
+    uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt Disable   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENCLR_OFFSET 0x14         /**< \brief (SERCOM_I2CM_INTENCLR offset) I2CM Interrupt Enable Clear */
+#define SERCOM_I2CM_INTENCLR_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_INTENCLR reset_value) I2CM Interrupt Enable Clear */
+
+#define SERCOM_I2CM_INTENCLR_MB_Pos 0            /**< \brief (SERCOM_I2CM_INTENCLR) Master On Bus Interrupt Disable */
+#define SERCOM_I2CM_INTENCLR_MB     (0x1ul << SERCOM_I2CM_INTENCLR_MB_Pos)
+#define SERCOM_I2CM_INTENCLR_SB_Pos 1            /**< \brief (SERCOM_I2CM_INTENCLR) Slave On Bus Interrupt Disable */
+#define SERCOM_I2CM_INTENCLR_SB     (0x1ul << SERCOM_I2CM_INTENCLR_SB_Pos)
+#define SERCOM_I2CM_INTENCLR_ERROR_Pos 7            /**< \brief (SERCOM_I2CM_INTENCLR) Combined Error Interrupt Disable */
+#define SERCOM_I2CM_INTENCLR_ERROR  (0x1ul << SERCOM_I2CM_INTENCLR_ERROR_Pos)
+#define SERCOM_I2CM_INTENCLR_MASK   0x83ul       /**< \brief (SERCOM_I2CM_INTENCLR) MASK Register */
+
+/* -------- SERCOM_I2CS_INTENCLR : (SERCOM Offset: 0x14) (R/W  8) I2CS I2CS Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt Disable    */
+    uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt Disable    */
+    uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt Disable             */
+    uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt Disable   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENCLR_OFFSET 0x14         /**< \brief (SERCOM_I2CS_INTENCLR offset) I2CS Interrupt Enable Clear */
+#define SERCOM_I2CS_INTENCLR_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CS_INTENCLR reset_value) I2CS Interrupt Enable Clear */
+
+#define SERCOM_I2CS_INTENCLR_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTENCLR) Stop Received Interrupt Disable */
+#define SERCOM_I2CS_INTENCLR_PREC   (0x1ul << SERCOM_I2CS_INTENCLR_PREC_Pos)
+#define SERCOM_I2CS_INTENCLR_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTENCLR) Address Match Interrupt Disable */
+#define SERCOM_I2CS_INTENCLR_AMATCH (0x1ul << SERCOM_I2CS_INTENCLR_AMATCH_Pos)
+#define SERCOM_I2CS_INTENCLR_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTENCLR) Data Interrupt Disable */
+#define SERCOM_I2CS_INTENCLR_DRDY   (0x1ul << SERCOM_I2CS_INTENCLR_DRDY_Pos)
+#define SERCOM_I2CS_INTENCLR_ERROR_Pos 7            /**< \brief (SERCOM_I2CS_INTENCLR) Combined Error Interrupt Disable */
+#define SERCOM_I2CS_INTENCLR_ERROR  (0x1ul << SERCOM_I2CS_INTENCLR_ERROR_Pos)
+#define SERCOM_I2CS_INTENCLR_MASK   0x87ul       /**< \brief (SERCOM_I2CS_INTENCLR) MASK Register */
+
+/* -------- SERCOM_SPI_INTENCLR : (SERCOM Offset: 0x14) (R/W  8) SPI SPI Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Disable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Disable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Disable */
+    uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Disable */
+    uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt Disable   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENCLR_OFFSET  0x14         /**< \brief (SERCOM_SPI_INTENCLR offset) SPI Interrupt Enable Clear */
+#define SERCOM_SPI_INTENCLR_RESETVALUE 0x00ul       /**< \brief (SERCOM_SPI_INTENCLR reset_value) SPI Interrupt Enable Clear */
+
+#define SERCOM_SPI_INTENCLR_DRE_Pos 0            /**< \brief (SERCOM_SPI_INTENCLR) Data Register Empty Interrupt Disable */
+#define SERCOM_SPI_INTENCLR_DRE     (0x1ul << SERCOM_SPI_INTENCLR_DRE_Pos)
+#define SERCOM_SPI_INTENCLR_TXC_Pos 1            /**< \brief (SERCOM_SPI_INTENCLR) Transmit Complete Interrupt Disable */
+#define SERCOM_SPI_INTENCLR_TXC     (0x1ul << SERCOM_SPI_INTENCLR_TXC_Pos)
+#define SERCOM_SPI_INTENCLR_RXC_Pos 2            /**< \brief (SERCOM_SPI_INTENCLR) Receive Complete Interrupt Disable */
+#define SERCOM_SPI_INTENCLR_RXC     (0x1ul << SERCOM_SPI_INTENCLR_RXC_Pos)
+#define SERCOM_SPI_INTENCLR_SSL_Pos 3            /**< \brief (SERCOM_SPI_INTENCLR) Slave Select Low Interrupt Disable */
+#define SERCOM_SPI_INTENCLR_SSL     (0x1ul << SERCOM_SPI_INTENCLR_SSL_Pos)
+#define SERCOM_SPI_INTENCLR_ERROR_Pos 7            /**< \brief (SERCOM_SPI_INTENCLR) Combined Error Interrupt Disable */
+#define SERCOM_SPI_INTENCLR_ERROR   (0x1ul << SERCOM_SPI_INTENCLR_ERROR_Pos)
+#define SERCOM_SPI_INTENCLR_MASK    0x8Ful       /**< \brief (SERCOM_SPI_INTENCLR) MASK Register */
+
+/* -------- SERCOM_USART_INTENCLR : (SERCOM Offset: 0x14) (R/W  8) USART USART Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Disable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Disable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Disable */
+    uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt Disable    */
+    uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt Disable */
+    uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt Disable   */
+    uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt Disable   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENCLR_OFFSET 0x14         /**< \brief (SERCOM_USART_INTENCLR offset) USART Interrupt Enable Clear */
+#define SERCOM_USART_INTENCLR_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_INTENCLR reset_value) USART Interrupt Enable Clear */
+
+#define SERCOM_USART_INTENCLR_DRE_Pos 0            /**< \brief (SERCOM_USART_INTENCLR) Data Register Empty Interrupt Disable */
+#define SERCOM_USART_INTENCLR_DRE   (0x1ul << SERCOM_USART_INTENCLR_DRE_Pos)
+#define SERCOM_USART_INTENCLR_TXC_Pos 1            /**< \brief (SERCOM_USART_INTENCLR) Transmit Complete Interrupt Disable */
+#define SERCOM_USART_INTENCLR_TXC   (0x1ul << SERCOM_USART_INTENCLR_TXC_Pos)
+#define SERCOM_USART_INTENCLR_RXC_Pos 2            /**< \brief (SERCOM_USART_INTENCLR) Receive Complete Interrupt Disable */
+#define SERCOM_USART_INTENCLR_RXC   (0x1ul << SERCOM_USART_INTENCLR_RXC_Pos)
+#define SERCOM_USART_INTENCLR_RXS_Pos 3            /**< \brief (SERCOM_USART_INTENCLR) Receive Start Interrupt Disable */
+#define SERCOM_USART_INTENCLR_RXS   (0x1ul << SERCOM_USART_INTENCLR_RXS_Pos)
+#define SERCOM_USART_INTENCLR_CTSIC_Pos 4            /**< \brief (SERCOM_USART_INTENCLR) Clear To Send Input Change Interrupt Disable */
+#define SERCOM_USART_INTENCLR_CTSIC (0x1ul << SERCOM_USART_INTENCLR_CTSIC_Pos)
+#define SERCOM_USART_INTENCLR_RXBRK_Pos 5            /**< \brief (SERCOM_USART_INTENCLR) Break Received Interrupt Disable */
+#define SERCOM_USART_INTENCLR_RXBRK (0x1ul << SERCOM_USART_INTENCLR_RXBRK_Pos)
+#define SERCOM_USART_INTENCLR_ERROR_Pos 7            /**< \brief (SERCOM_USART_INTENCLR) Combined Error Interrupt Disable */
+#define SERCOM_USART_INTENCLR_ERROR (0x1ul << SERCOM_USART_INTENCLR_ERROR_Pos)
+#define SERCOM_USART_INTENCLR_MASK  0xBFul       /**< \brief (SERCOM_USART_INTENCLR) MASK Register */
+
+/* -------- SERCOM_I2CM_INTENSET : (SERCOM Offset: 0x16) (R/W  8) I2CM I2CM Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt Enable     */
+    uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt Enable      */
+    uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt Enable    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENSET_OFFSET 0x16         /**< \brief (SERCOM_I2CM_INTENSET offset) I2CM Interrupt Enable Set */
+#define SERCOM_I2CM_INTENSET_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_INTENSET reset_value) I2CM Interrupt Enable Set */
+
+#define SERCOM_I2CM_INTENSET_MB_Pos 0            /**< \brief (SERCOM_I2CM_INTENSET) Master On Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENSET_MB     (0x1ul << SERCOM_I2CM_INTENSET_MB_Pos)
+#define SERCOM_I2CM_INTENSET_SB_Pos 1            /**< \brief (SERCOM_I2CM_INTENSET) Slave On Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENSET_SB     (0x1ul << SERCOM_I2CM_INTENSET_SB_Pos)
+#define SERCOM_I2CM_INTENSET_ERROR_Pos 7            /**< \brief (SERCOM_I2CM_INTENSET) Combined Error Interrupt Enable */
+#define SERCOM_I2CM_INTENSET_ERROR  (0x1ul << SERCOM_I2CM_INTENSET_ERROR_Pos)
+#define SERCOM_I2CM_INTENSET_MASK   0x83ul       /**< \brief (SERCOM_I2CM_INTENSET) MASK Register */
+
+/* -------- SERCOM_I2CS_INTENSET : (SERCOM Offset: 0x16) (R/W  8) I2CS I2CS Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt Enable     */
+    uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt Enable     */
+    uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt Enable              */
+    uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt Enable    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENSET_OFFSET 0x16         /**< \brief (SERCOM_I2CS_INTENSET offset) I2CS Interrupt Enable Set */
+#define SERCOM_I2CS_INTENSET_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CS_INTENSET reset_value) I2CS Interrupt Enable Set */
+
+#define SERCOM_I2CS_INTENSET_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTENSET) Stop Received Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_PREC   (0x1ul << SERCOM_I2CS_INTENSET_PREC_Pos)
+#define SERCOM_I2CS_INTENSET_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTENSET) Address Match Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_AMATCH (0x1ul << SERCOM_I2CS_INTENSET_AMATCH_Pos)
+#define SERCOM_I2CS_INTENSET_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTENSET) Data Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_DRDY   (0x1ul << SERCOM_I2CS_INTENSET_DRDY_Pos)
+#define SERCOM_I2CS_INTENSET_ERROR_Pos 7            /**< \brief (SERCOM_I2CS_INTENSET) Combined Error Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_ERROR  (0x1ul << SERCOM_I2CS_INTENSET_ERROR_Pos)
+#define SERCOM_I2CS_INTENSET_MASK   0x87ul       /**< \brief (SERCOM_I2CS_INTENSET) MASK Register */
+
+/* -------- SERCOM_SPI_INTENSET : (SERCOM Offset: 0x16) (R/W  8) SPI SPI Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Enable  */
+    uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt Enable    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENSET_OFFSET  0x16         /**< \brief (SERCOM_SPI_INTENSET offset) SPI Interrupt Enable Set */
+#define SERCOM_SPI_INTENSET_RESETVALUE 0x00ul       /**< \brief (SERCOM_SPI_INTENSET reset_value) SPI Interrupt Enable Set */
+
+#define SERCOM_SPI_INTENSET_DRE_Pos 0            /**< \brief (SERCOM_SPI_INTENSET) Data Register Empty Interrupt Enable */
+#define SERCOM_SPI_INTENSET_DRE     (0x1ul << SERCOM_SPI_INTENSET_DRE_Pos)
+#define SERCOM_SPI_INTENSET_TXC_Pos 1            /**< \brief (SERCOM_SPI_INTENSET) Transmit Complete Interrupt Enable */
+#define SERCOM_SPI_INTENSET_TXC     (0x1ul << SERCOM_SPI_INTENSET_TXC_Pos)
+#define SERCOM_SPI_INTENSET_RXC_Pos 2            /**< \brief (SERCOM_SPI_INTENSET) Receive Complete Interrupt Enable */
+#define SERCOM_SPI_INTENSET_RXC     (0x1ul << SERCOM_SPI_INTENSET_RXC_Pos)
+#define SERCOM_SPI_INTENSET_SSL_Pos 3            /**< \brief (SERCOM_SPI_INTENSET) Slave Select Low Interrupt Enable */
+#define SERCOM_SPI_INTENSET_SSL     (0x1ul << SERCOM_SPI_INTENSET_SSL_Pos)
+#define SERCOM_SPI_INTENSET_ERROR_Pos 7            /**< \brief (SERCOM_SPI_INTENSET) Combined Error Interrupt Enable */
+#define SERCOM_SPI_INTENSET_ERROR   (0x1ul << SERCOM_SPI_INTENSET_ERROR_Pos)
+#define SERCOM_SPI_INTENSET_MASK    0x8Ful       /**< \brief (SERCOM_SPI_INTENSET) MASK Register */
+
+/* -------- SERCOM_USART_INTENSET : (SERCOM Offset: 0x16) (R/W  8) USART USART Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt Enable     */
+    uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt Enable */
+    uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt Enable    */
+    uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt Enable    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENSET_OFFSET 0x16         /**< \brief (SERCOM_USART_INTENSET offset) USART Interrupt Enable Set */
+#define SERCOM_USART_INTENSET_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_INTENSET reset_value) USART Interrupt Enable Set */
+
+#define SERCOM_USART_INTENSET_DRE_Pos 0            /**< \brief (SERCOM_USART_INTENSET) Data Register Empty Interrupt Enable */
+#define SERCOM_USART_INTENSET_DRE   (0x1ul << SERCOM_USART_INTENSET_DRE_Pos)
+#define SERCOM_USART_INTENSET_TXC_Pos 1            /**< \brief (SERCOM_USART_INTENSET) Transmit Complete Interrupt Enable */
+#define SERCOM_USART_INTENSET_TXC   (0x1ul << SERCOM_USART_INTENSET_TXC_Pos)
+#define SERCOM_USART_INTENSET_RXC_Pos 2            /**< \brief (SERCOM_USART_INTENSET) Receive Complete Interrupt Enable */
+#define SERCOM_USART_INTENSET_RXC   (0x1ul << SERCOM_USART_INTENSET_RXC_Pos)
+#define SERCOM_USART_INTENSET_RXS_Pos 3            /**< \brief (SERCOM_USART_INTENSET) Receive Start Interrupt Enable */
+#define SERCOM_USART_INTENSET_RXS   (0x1ul << SERCOM_USART_INTENSET_RXS_Pos)
+#define SERCOM_USART_INTENSET_CTSIC_Pos 4            /**< \brief (SERCOM_USART_INTENSET) Clear To Send Input Change Interrupt Enable */
+#define SERCOM_USART_INTENSET_CTSIC (0x1ul << SERCOM_USART_INTENSET_CTSIC_Pos)
+#define SERCOM_USART_INTENSET_RXBRK_Pos 5            /**< \brief (SERCOM_USART_INTENSET) Break Received Interrupt Enable */
+#define SERCOM_USART_INTENSET_RXBRK (0x1ul << SERCOM_USART_INTENSET_RXBRK_Pos)
+#define SERCOM_USART_INTENSET_ERROR_Pos 7            /**< \brief (SERCOM_USART_INTENSET) Combined Error Interrupt Enable */
+#define SERCOM_USART_INTENSET_ERROR (0x1ul << SERCOM_USART_INTENSET_ERROR_Pos)
+#define SERCOM_USART_INTENSET_MASK  0xBFul       /**< \brief (SERCOM_USART_INTENSET) MASK Register */
+
+/* -------- SERCOM_I2CM_INTFLAG : (SERCOM Offset: 0x18) (R/W  8) I2CM I2CM Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
+    __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
+    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTFLAG_OFFSET  0x18         /**< \brief (SERCOM_I2CM_INTFLAG offset) I2CM Interrupt Flag Status and Clear */
+#define SERCOM_I2CM_INTFLAG_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_INTFLAG reset_value) I2CM Interrupt Flag Status and Clear */
+
+#define SERCOM_I2CM_INTFLAG_MB_Pos  0            /**< \brief (SERCOM_I2CM_INTFLAG) Master On Bus Interrupt */
+#define SERCOM_I2CM_INTFLAG_MB      (0x1ul << SERCOM_I2CM_INTFLAG_MB_Pos)
+#define SERCOM_I2CM_INTFLAG_SB_Pos  1            /**< \brief (SERCOM_I2CM_INTFLAG) Slave On Bus Interrupt */
+#define SERCOM_I2CM_INTFLAG_SB      (0x1ul << SERCOM_I2CM_INTFLAG_SB_Pos)
+#define SERCOM_I2CM_INTFLAG_ERROR_Pos 7            /**< \brief (SERCOM_I2CM_INTFLAG) Combined Error Interrupt */
+#define SERCOM_I2CM_INTFLAG_ERROR   (0x1ul << SERCOM_I2CM_INTFLAG_ERROR_Pos)
+#define SERCOM_I2CM_INTFLAG_MASK    0x83ul       /**< \brief (SERCOM_I2CM_INTFLAG) MASK Register */
+
+/* -------- SERCOM_I2CS_INTFLAG : (SERCOM Offset: 0x18) (R/W  8) I2CS I2CS Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
+    __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
+    __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
+    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTFLAG_OFFSET  0x18         /**< \brief (SERCOM_I2CS_INTFLAG offset) I2CS Interrupt Flag Status and Clear */
+#define SERCOM_I2CS_INTFLAG_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CS_INTFLAG reset_value) I2CS Interrupt Flag Status and Clear */
+
+#define SERCOM_I2CS_INTFLAG_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTFLAG) Stop Received Interrupt */
+#define SERCOM_I2CS_INTFLAG_PREC    (0x1ul << SERCOM_I2CS_INTFLAG_PREC_Pos)
+#define SERCOM_I2CS_INTFLAG_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTFLAG) Address Match Interrupt */
+#define SERCOM_I2CS_INTFLAG_AMATCH  (0x1ul << SERCOM_I2CS_INTFLAG_AMATCH_Pos)
+#define SERCOM_I2CS_INTFLAG_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTFLAG) Data Interrupt */
+#define SERCOM_I2CS_INTFLAG_DRDY    (0x1ul << SERCOM_I2CS_INTFLAG_DRDY_Pos)
+#define SERCOM_I2CS_INTFLAG_ERROR_Pos 7            /**< \brief (SERCOM_I2CS_INTFLAG) Combined Error Interrupt */
+#define SERCOM_I2CS_INTFLAG_ERROR   (0x1ul << SERCOM_I2CS_INTFLAG_ERROR_Pos)
+#define SERCOM_I2CS_INTFLAG_MASK    0x87ul       /**< \brief (SERCOM_I2CS_INTFLAG) MASK Register */
+
+/* -------- SERCOM_SPI_INTFLAG : (SERCOM Offset: 0x18) (R/W  8) SPI SPI Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt      */
+    __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
+    __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
+    __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
+    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTFLAG_OFFSET   0x18         /**< \brief (SERCOM_SPI_INTFLAG offset) SPI Interrupt Flag Status and Clear */
+#define SERCOM_SPI_INTFLAG_RESETVALUE 0x00ul       /**< \brief (SERCOM_SPI_INTFLAG reset_value) SPI Interrupt Flag Status and Clear */
+
+#define SERCOM_SPI_INTFLAG_DRE_Pos  0            /**< \brief (SERCOM_SPI_INTFLAG) Data Register Empty Interrupt */
+#define SERCOM_SPI_INTFLAG_DRE      (0x1ul << SERCOM_SPI_INTFLAG_DRE_Pos)
+#define SERCOM_SPI_INTFLAG_TXC_Pos  1            /**< \brief (SERCOM_SPI_INTFLAG) Transmit Complete Interrupt */
+#define SERCOM_SPI_INTFLAG_TXC      (0x1ul << SERCOM_SPI_INTFLAG_TXC_Pos)
+#define SERCOM_SPI_INTFLAG_RXC_Pos  2            /**< \brief (SERCOM_SPI_INTFLAG) Receive Complete Interrupt */
+#define SERCOM_SPI_INTFLAG_RXC      (0x1ul << SERCOM_SPI_INTFLAG_RXC_Pos)
+#define SERCOM_SPI_INTFLAG_SSL_Pos  3            /**< \brief (SERCOM_SPI_INTFLAG) Slave Select Low Interrupt Flag */
+#define SERCOM_SPI_INTFLAG_SSL      (0x1ul << SERCOM_SPI_INTFLAG_SSL_Pos)
+#define SERCOM_SPI_INTFLAG_ERROR_Pos 7            /**< \brief (SERCOM_SPI_INTFLAG) Combined Error Interrupt */
+#define SERCOM_SPI_INTFLAG_ERROR    (0x1ul << SERCOM_SPI_INTFLAG_ERROR_Pos)
+#define SERCOM_SPI_INTFLAG_MASK     0x8Ful       /**< \brief (SERCOM_SPI_INTFLAG) MASK Register */
+
+/* -------- SERCOM_USART_INTFLAG : (SERCOM Offset: 0x18) (R/W  8) USART USART Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt      */
+    __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
+    __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
+    __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
+    __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
+    __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
+    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTFLAG_OFFSET 0x18         /**< \brief (SERCOM_USART_INTFLAG offset) USART Interrupt Flag Status and Clear */
+#define SERCOM_USART_INTFLAG_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_INTFLAG reset_value) USART Interrupt Flag Status and Clear */
+
+#define SERCOM_USART_INTFLAG_DRE_Pos 0            /**< \brief (SERCOM_USART_INTFLAG) Data Register Empty Interrupt */
+#define SERCOM_USART_INTFLAG_DRE    (0x1ul << SERCOM_USART_INTFLAG_DRE_Pos)
+#define SERCOM_USART_INTFLAG_TXC_Pos 1            /**< \brief (SERCOM_USART_INTFLAG) Transmit Complete Interrupt */
+#define SERCOM_USART_INTFLAG_TXC    (0x1ul << SERCOM_USART_INTFLAG_TXC_Pos)
+#define SERCOM_USART_INTFLAG_RXC_Pos 2            /**< \brief (SERCOM_USART_INTFLAG) Receive Complete Interrupt */
+#define SERCOM_USART_INTFLAG_RXC    (0x1ul << SERCOM_USART_INTFLAG_RXC_Pos)
+#define SERCOM_USART_INTFLAG_RXS_Pos 3            /**< \brief (SERCOM_USART_INTFLAG) Receive Start Interrupt */
+#define SERCOM_USART_INTFLAG_RXS    (0x1ul << SERCOM_USART_INTFLAG_RXS_Pos)
+#define SERCOM_USART_INTFLAG_CTSIC_Pos 4            /**< \brief (SERCOM_USART_INTFLAG) Clear To Send Input Change Interrupt */
+#define SERCOM_USART_INTFLAG_CTSIC  (0x1ul << SERCOM_USART_INTFLAG_CTSIC_Pos)
+#define SERCOM_USART_INTFLAG_RXBRK_Pos 5            /**< \brief (SERCOM_USART_INTFLAG) Break Received Interrupt */
+#define SERCOM_USART_INTFLAG_RXBRK  (0x1ul << SERCOM_USART_INTFLAG_RXBRK_Pos)
+#define SERCOM_USART_INTFLAG_ERROR_Pos 7            /**< \brief (SERCOM_USART_INTFLAG) Combined Error Interrupt */
+#define SERCOM_USART_INTFLAG_ERROR  (0x1ul << SERCOM_USART_INTFLAG_ERROR_Pos)
+#define SERCOM_USART_INTFLAG_MASK   0xBFul       /**< \brief (SERCOM_USART_INTFLAG) MASK Register */
+
+/* -------- SERCOM_I2CM_STATUS : (SERCOM Offset: 0x1A) (R/W 16) I2CM I2CM Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BUSERR:1;         /*!< bit:      0  Bus Error                          */
+    uint16_t ARBLOST:1;        /*!< bit:      1  Arbitration Lost                   */
+    uint16_t RXNACK:1;         /*!< bit:      2  Received Not Acknowledge           */
+    uint16_t :1;               /*!< bit:      3  Reserved                           */
+    uint16_t BUSSTATE:2;       /*!< bit:  4.. 5  Bus State                          */
+    uint16_t LOWTOUT:1;        /*!< bit:      6  SCL Low Timeout                    */
+    uint16_t CLKHOLD:1;        /*!< bit:      7  Clock Hold                         */
+    uint16_t MEXTTOUT:1;       /*!< bit:      8  Master SCL Low Extend Timeout      */
+    uint16_t SEXTTOUT:1;       /*!< bit:      9  Slave SCL Low Extend Timeout       */
+    uint16_t LENERR:1;         /*!< bit:     10  Length Error                       */
+    uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_STATUS_OFFSET   0x1A         /**< \brief (SERCOM_I2CM_STATUS offset) I2CM Status */
+#define SERCOM_I2CM_STATUS_RESETVALUE 0x0000ul     /**< \brief (SERCOM_I2CM_STATUS reset_value) I2CM Status */
+
+#define SERCOM_I2CM_STATUS_BUSERR_Pos 0            /**< \brief (SERCOM_I2CM_STATUS) Bus Error */
+#define SERCOM_I2CM_STATUS_BUSERR   (0x1ul << SERCOM_I2CM_STATUS_BUSERR_Pos)
+#define SERCOM_I2CM_STATUS_ARBLOST_Pos 1            /**< \brief (SERCOM_I2CM_STATUS) Arbitration Lost */
+#define SERCOM_I2CM_STATUS_ARBLOST  (0x1ul << SERCOM_I2CM_STATUS_ARBLOST_Pos)
+#define SERCOM_I2CM_STATUS_RXNACK_Pos 2            /**< \brief (SERCOM_I2CM_STATUS) Received Not Acknowledge */
+#define SERCOM_I2CM_STATUS_RXNACK   (0x1ul << SERCOM_I2CM_STATUS_RXNACK_Pos)
+#define SERCOM_I2CM_STATUS_BUSSTATE_Pos 4            /**< \brief (SERCOM_I2CM_STATUS) Bus State */
+#define SERCOM_I2CM_STATUS_BUSSTATE_Msk (0x3ul << SERCOM_I2CM_STATUS_BUSSTATE_Pos)
+#define SERCOM_I2CM_STATUS_BUSSTATE(value) (SERCOM_I2CM_STATUS_BUSSTATE_Msk & ((value) << SERCOM_I2CM_STATUS_BUSSTATE_Pos))
+#define SERCOM_I2CM_STATUS_LOWTOUT_Pos 6            /**< \brief (SERCOM_I2CM_STATUS) SCL Low Timeout */
+#define SERCOM_I2CM_STATUS_LOWTOUT  (0x1ul << SERCOM_I2CM_STATUS_LOWTOUT_Pos)
+#define SERCOM_I2CM_STATUS_CLKHOLD_Pos 7            /**< \brief (SERCOM_I2CM_STATUS) Clock Hold */
+#define SERCOM_I2CM_STATUS_CLKHOLD  (0x1ul << SERCOM_I2CM_STATUS_CLKHOLD_Pos)
+#define SERCOM_I2CM_STATUS_MEXTTOUT_Pos 8            /**< \brief (SERCOM_I2CM_STATUS) Master SCL Low Extend Timeout */
+#define SERCOM_I2CM_STATUS_MEXTTOUT (0x1ul << SERCOM_I2CM_STATUS_MEXTTOUT_Pos)
+#define SERCOM_I2CM_STATUS_SEXTTOUT_Pos 9            /**< \brief (SERCOM_I2CM_STATUS) Slave SCL Low Extend Timeout */
+#define SERCOM_I2CM_STATUS_SEXTTOUT (0x1ul << SERCOM_I2CM_STATUS_SEXTTOUT_Pos)
+#define SERCOM_I2CM_STATUS_LENERR_Pos 10           /**< \brief (SERCOM_I2CM_STATUS) Length Error */
+#define SERCOM_I2CM_STATUS_LENERR   (0x1ul << SERCOM_I2CM_STATUS_LENERR_Pos)
+#define SERCOM_I2CM_STATUS_MASK     0x07F7ul     /**< \brief (SERCOM_I2CM_STATUS) MASK Register */
+
+/* -------- SERCOM_I2CS_STATUS : (SERCOM Offset: 0x1A) (R/W 16) I2CS I2CS Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BUSERR:1;         /*!< bit:      0  Bus Error                          */
+    uint16_t COLL:1;           /*!< bit:      1  Transmit Collision                 */
+    uint16_t RXNACK:1;         /*!< bit:      2  Received Not Acknowledge           */
+    uint16_t DIR:1;            /*!< bit:      3  Read/Write Direction               */
+    uint16_t SR:1;             /*!< bit:      4  Repeated Start                     */
+    uint16_t :1;               /*!< bit:      5  Reserved                           */
+    uint16_t LOWTOUT:1;        /*!< bit:      6  SCL Low Timeout                    */
+    uint16_t CLKHOLD:1;        /*!< bit:      7  Clock Hold                         */
+    uint16_t :1;               /*!< bit:      8  Reserved                           */
+    uint16_t SEXTTOUT:1;       /*!< bit:      9  Slave SCL Low Extend Timeout       */
+    uint16_t HS:1;             /*!< bit:     10  High Speed                         */
+    uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_STATUS_OFFSET   0x1A         /**< \brief (SERCOM_I2CS_STATUS offset) I2CS Status */
+#define SERCOM_I2CS_STATUS_RESETVALUE 0x0000ul     /**< \brief (SERCOM_I2CS_STATUS reset_value) I2CS Status */
+
+#define SERCOM_I2CS_STATUS_BUSERR_Pos 0            /**< \brief (SERCOM_I2CS_STATUS) Bus Error */
+#define SERCOM_I2CS_STATUS_BUSERR   (0x1ul << SERCOM_I2CS_STATUS_BUSERR_Pos)
+#define SERCOM_I2CS_STATUS_COLL_Pos 1            /**< \brief (SERCOM_I2CS_STATUS) Transmit Collision */
+#define SERCOM_I2CS_STATUS_COLL     (0x1ul << SERCOM_I2CS_STATUS_COLL_Pos)
+#define SERCOM_I2CS_STATUS_RXNACK_Pos 2            /**< \brief (SERCOM_I2CS_STATUS) Received Not Acknowledge */
+#define SERCOM_I2CS_STATUS_RXNACK   (0x1ul << SERCOM_I2CS_STATUS_RXNACK_Pos)
+#define SERCOM_I2CS_STATUS_DIR_Pos  3            /**< \brief (SERCOM_I2CS_STATUS) Read/Write Direction */
+#define SERCOM_I2CS_STATUS_DIR      (0x1ul << SERCOM_I2CS_STATUS_DIR_Pos)
+#define SERCOM_I2CS_STATUS_SR_Pos   4            /**< \brief (SERCOM_I2CS_STATUS) Repeated Start */
+#define SERCOM_I2CS_STATUS_SR       (0x1ul << SERCOM_I2CS_STATUS_SR_Pos)
+#define SERCOM_I2CS_STATUS_LOWTOUT_Pos 6            /**< \brief (SERCOM_I2CS_STATUS) SCL Low Timeout */
+#define SERCOM_I2CS_STATUS_LOWTOUT  (0x1ul << SERCOM_I2CS_STATUS_LOWTOUT_Pos)
+#define SERCOM_I2CS_STATUS_CLKHOLD_Pos 7            /**< \brief (SERCOM_I2CS_STATUS) Clock Hold */
+#define SERCOM_I2CS_STATUS_CLKHOLD  (0x1ul << SERCOM_I2CS_STATUS_CLKHOLD_Pos)
+#define SERCOM_I2CS_STATUS_SEXTTOUT_Pos 9            /**< \brief (SERCOM_I2CS_STATUS) Slave SCL Low Extend Timeout */
+#define SERCOM_I2CS_STATUS_SEXTTOUT (0x1ul << SERCOM_I2CS_STATUS_SEXTTOUT_Pos)
+#define SERCOM_I2CS_STATUS_HS_Pos   10           /**< \brief (SERCOM_I2CS_STATUS) High Speed */
+#define SERCOM_I2CS_STATUS_HS       (0x1ul << SERCOM_I2CS_STATUS_HS_Pos)
+#define SERCOM_I2CS_STATUS_MASK     0x06DFul     /**< \brief (SERCOM_I2CS_STATUS) MASK Register */
+
+/* -------- SERCOM_SPI_STATUS : (SERCOM Offset: 0x1A) (R/W 16) SPI SPI Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t BUFOVF:1;         /*!< bit:      2  Buffer Overflow                    */
+    uint16_t :13;              /*!< bit:  3..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_STATUS_OFFSET    0x1A         /**< \brief (SERCOM_SPI_STATUS offset) SPI Status */
+#define SERCOM_SPI_STATUS_RESETVALUE 0x0000ul     /**< \brief (SERCOM_SPI_STATUS reset_value) SPI Status */
+
+#define SERCOM_SPI_STATUS_BUFOVF_Pos 2            /**< \brief (SERCOM_SPI_STATUS) Buffer Overflow */
+#define SERCOM_SPI_STATUS_BUFOVF    (0x1ul << SERCOM_SPI_STATUS_BUFOVF_Pos)
+#define SERCOM_SPI_STATUS_MASK      0x0004ul     /**< \brief (SERCOM_SPI_STATUS) MASK Register */
+
+/* -------- SERCOM_USART_STATUS : (SERCOM Offset: 0x1A) (R/W 16) USART USART Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PERR:1;           /*!< bit:      0  Parity Error                       */
+    uint16_t FERR:1;           /*!< bit:      1  Frame Error                        */
+    uint16_t BUFOVF:1;         /*!< bit:      2  Buffer Overflow                    */
+    uint16_t CTS:1;            /*!< bit:      3  Clear To Send                      */
+    uint16_t ISF:1;            /*!< bit:      4  Inconsistent Sync Field            */
+    uint16_t COLL:1;           /*!< bit:      5  Collision Detected                 */
+    uint16_t :10;              /*!< bit:  6..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_STATUS_OFFSET  0x1A         /**< \brief (SERCOM_USART_STATUS offset) USART Status */
+#define SERCOM_USART_STATUS_RESETVALUE 0x0000ul     /**< \brief (SERCOM_USART_STATUS reset_value) USART Status */
+
+#define SERCOM_USART_STATUS_PERR_Pos 0            /**< \brief (SERCOM_USART_STATUS) Parity Error */
+#define SERCOM_USART_STATUS_PERR    (0x1ul << SERCOM_USART_STATUS_PERR_Pos)
+#define SERCOM_USART_STATUS_FERR_Pos 1            /**< \brief (SERCOM_USART_STATUS) Frame Error */
+#define SERCOM_USART_STATUS_FERR    (0x1ul << SERCOM_USART_STATUS_FERR_Pos)
+#define SERCOM_USART_STATUS_BUFOVF_Pos 2            /**< \brief (SERCOM_USART_STATUS) Buffer Overflow */
+#define SERCOM_USART_STATUS_BUFOVF  (0x1ul << SERCOM_USART_STATUS_BUFOVF_Pos)
+#define SERCOM_USART_STATUS_CTS_Pos 3            /**< \brief (SERCOM_USART_STATUS) Clear To Send */
+#define SERCOM_USART_STATUS_CTS     (0x1ul << SERCOM_USART_STATUS_CTS_Pos)
+#define SERCOM_USART_STATUS_ISF_Pos 4            /**< \brief (SERCOM_USART_STATUS) Inconsistent Sync Field */
+#define SERCOM_USART_STATUS_ISF     (0x1ul << SERCOM_USART_STATUS_ISF_Pos)
+#define SERCOM_USART_STATUS_COLL_Pos 5            /**< \brief (SERCOM_USART_STATUS) Collision Detected */
+#define SERCOM_USART_STATUS_COLL    (0x1ul << SERCOM_USART_STATUS_COLL_Pos)
+#define SERCOM_USART_STATUS_MASK    0x003Ful     /**< \brief (SERCOM_USART_STATUS) MASK Register */
+
+/* -------- SERCOM_I2CM_SYNCBUSY : (SERCOM Offset: 0x1C) (R/  32) I2CM I2CM Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset Synchronization Busy */
+    uint32_t ENABLE:1;         /*!< bit:      1  SERCOM Enable Synchronization Busy */
+    uint32_t SYSOP:1;          /*!< bit:      2  System Operation Synchronization Busy */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_SYNCBUSY_OFFSET 0x1C         /**< \brief (SERCOM_I2CM_SYNCBUSY offset) I2CM Synchronization Busy */
+#define SERCOM_I2CM_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_SYNCBUSY reset_value) I2CM Synchronization Busy */
+
+#define SERCOM_I2CM_SYNCBUSY_SWRST_Pos 0            /**< \brief (SERCOM_I2CM_SYNCBUSY) Software Reset Synchronization Busy */
+#define SERCOM_I2CM_SYNCBUSY_SWRST  (0x1ul << SERCOM_I2CM_SYNCBUSY_SWRST_Pos)
+#define SERCOM_I2CM_SYNCBUSY_ENABLE_Pos 1            /**< \brief (SERCOM_I2CM_SYNCBUSY) SERCOM Enable Synchronization Busy */
+#define SERCOM_I2CM_SYNCBUSY_ENABLE (0x1ul << SERCOM_I2CM_SYNCBUSY_ENABLE_Pos)
+#define SERCOM_I2CM_SYNCBUSY_SYSOP_Pos 2            /**< \brief (SERCOM_I2CM_SYNCBUSY) System Operation Synchronization Busy */
+#define SERCOM_I2CM_SYNCBUSY_SYSOP  (0x1ul << SERCOM_I2CM_SYNCBUSY_SYSOP_Pos)
+#define SERCOM_I2CM_SYNCBUSY_MASK   0x00000007ul /**< \brief (SERCOM_I2CM_SYNCBUSY) MASK Register */
+
+/* -------- SERCOM_I2CS_SYNCBUSY : (SERCOM Offset: 0x1C) (R/  32) I2CS I2CS Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset Synchronization Busy */
+    uint32_t ENABLE:1;         /*!< bit:      1  SERCOM Enable Synchronization Busy */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_SYNCBUSY_OFFSET 0x1C         /**< \brief (SERCOM_I2CS_SYNCBUSY offset) I2CS Synchronization Busy */
+#define SERCOM_I2CS_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CS_SYNCBUSY reset_value) I2CS Synchronization Busy */
+
+#define SERCOM_I2CS_SYNCBUSY_SWRST_Pos 0            /**< \brief (SERCOM_I2CS_SYNCBUSY) Software Reset Synchronization Busy */
+#define SERCOM_I2CS_SYNCBUSY_SWRST  (0x1ul << SERCOM_I2CS_SYNCBUSY_SWRST_Pos)
+#define SERCOM_I2CS_SYNCBUSY_ENABLE_Pos 1            /**< \brief (SERCOM_I2CS_SYNCBUSY) SERCOM Enable Synchronization Busy */
+#define SERCOM_I2CS_SYNCBUSY_ENABLE (0x1ul << SERCOM_I2CS_SYNCBUSY_ENABLE_Pos)
+#define SERCOM_I2CS_SYNCBUSY_MASK   0x00000003ul /**< \brief (SERCOM_I2CS_SYNCBUSY) MASK Register */
+
+/* -------- SERCOM_SPI_SYNCBUSY : (SERCOM Offset: 0x1C) (R/  32) SPI SPI Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset Synchronization Busy */
+    uint32_t ENABLE:1;         /*!< bit:      1  SERCOM Enable Synchronization Busy */
+    uint32_t CTRLB:1;          /*!< bit:      2  CTRLB Synchronization Busy         */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_SYNCBUSY_OFFSET  0x1C         /**< \brief (SERCOM_SPI_SYNCBUSY offset) SPI Synchronization Busy */
+#define SERCOM_SPI_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (SERCOM_SPI_SYNCBUSY reset_value) SPI Synchronization Busy */
+
+#define SERCOM_SPI_SYNCBUSY_SWRST_Pos 0            /**< \brief (SERCOM_SPI_SYNCBUSY) Software Reset Synchronization Busy */
+#define SERCOM_SPI_SYNCBUSY_SWRST   (0x1ul << SERCOM_SPI_SYNCBUSY_SWRST_Pos)
+#define SERCOM_SPI_SYNCBUSY_ENABLE_Pos 1            /**< \brief (SERCOM_SPI_SYNCBUSY) SERCOM Enable Synchronization Busy */
+#define SERCOM_SPI_SYNCBUSY_ENABLE  (0x1ul << SERCOM_SPI_SYNCBUSY_ENABLE_Pos)
+#define SERCOM_SPI_SYNCBUSY_CTRLB_Pos 2            /**< \brief (SERCOM_SPI_SYNCBUSY) CTRLB Synchronization Busy */
+#define SERCOM_SPI_SYNCBUSY_CTRLB   (0x1ul << SERCOM_SPI_SYNCBUSY_CTRLB_Pos)
+#define SERCOM_SPI_SYNCBUSY_MASK    0x00000007ul /**< \brief (SERCOM_SPI_SYNCBUSY) MASK Register */
+
+/* -------- SERCOM_USART_SYNCBUSY : (SERCOM Offset: 0x1C) (R/  32) USART USART Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset Synchronization Busy */
+    uint32_t ENABLE:1;         /*!< bit:      1  SERCOM Enable Synchronization Busy */
+    uint32_t CTRLB:1;          /*!< bit:      2  CTRLB Synchronization Busy         */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_SYNCBUSY_OFFSET 0x1C         /**< \brief (SERCOM_USART_SYNCBUSY offset) USART Synchronization Busy */
+#define SERCOM_USART_SYNCBUSY_RESETVALUE 0x00000000ul /**< \brief (SERCOM_USART_SYNCBUSY reset_value) USART Synchronization Busy */
+
+#define SERCOM_USART_SYNCBUSY_SWRST_Pos 0            /**< \brief (SERCOM_USART_SYNCBUSY) Software Reset Synchronization Busy */
+#define SERCOM_USART_SYNCBUSY_SWRST (0x1ul << SERCOM_USART_SYNCBUSY_SWRST_Pos)
+#define SERCOM_USART_SYNCBUSY_ENABLE_Pos 1            /**< \brief (SERCOM_USART_SYNCBUSY) SERCOM Enable Synchronization Busy */
+#define SERCOM_USART_SYNCBUSY_ENABLE (0x1ul << SERCOM_USART_SYNCBUSY_ENABLE_Pos)
+#define SERCOM_USART_SYNCBUSY_CTRLB_Pos 2            /**< \brief (SERCOM_USART_SYNCBUSY) CTRLB Synchronization Busy */
+#define SERCOM_USART_SYNCBUSY_CTRLB (0x1ul << SERCOM_USART_SYNCBUSY_CTRLB_Pos)
+#define SERCOM_USART_SYNCBUSY_MASK  0x00000007ul /**< \brief (SERCOM_USART_SYNCBUSY) MASK Register */
+
+/* -------- SERCOM_I2CM_ADDR : (SERCOM Offset: 0x24) (R/W 32) I2CM I2CM Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:11;          /*!< bit:  0..10  Address Value                      */
+    uint32_t :2;               /*!< bit: 11..12  Reserved                           */
+    uint32_t LENEN:1;          /*!< bit:     13  Length Enable                      */
+    uint32_t HS:1;             /*!< bit:     14  High Speed Mode                    */
+    uint32_t TENBITEN:1;       /*!< bit:     15  Ten Bit Addressing Enable          */
+    uint32_t LEN:8;            /*!< bit: 16..23  Length                             */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_ADDR_OFFSET     0x24         /**< \brief (SERCOM_I2CM_ADDR offset) I2CM Address */
+#define SERCOM_I2CM_ADDR_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CM_ADDR reset_value) I2CM Address */
+
+#define SERCOM_I2CM_ADDR_ADDR_Pos   0            /**< \brief (SERCOM_I2CM_ADDR) Address Value */
+#define SERCOM_I2CM_ADDR_ADDR_Msk   (0x7FFul << SERCOM_I2CM_ADDR_ADDR_Pos)
+#define SERCOM_I2CM_ADDR_ADDR(value) (SERCOM_I2CM_ADDR_ADDR_Msk & ((value) << SERCOM_I2CM_ADDR_ADDR_Pos))
+#define SERCOM_I2CM_ADDR_LENEN_Pos  13           /**< \brief (SERCOM_I2CM_ADDR) Length Enable */
+#define SERCOM_I2CM_ADDR_LENEN      (0x1ul << SERCOM_I2CM_ADDR_LENEN_Pos)
+#define SERCOM_I2CM_ADDR_HS_Pos     14           /**< \brief (SERCOM_I2CM_ADDR) High Speed Mode */
+#define SERCOM_I2CM_ADDR_HS         (0x1ul << SERCOM_I2CM_ADDR_HS_Pos)
+#define SERCOM_I2CM_ADDR_TENBITEN_Pos 15           /**< \brief (SERCOM_I2CM_ADDR) Ten Bit Addressing Enable */
+#define SERCOM_I2CM_ADDR_TENBITEN   (0x1ul << SERCOM_I2CM_ADDR_TENBITEN_Pos)
+#define SERCOM_I2CM_ADDR_LEN_Pos    16           /**< \brief (SERCOM_I2CM_ADDR) Length */
+#define SERCOM_I2CM_ADDR_LEN_Msk    (0xFFul << SERCOM_I2CM_ADDR_LEN_Pos)
+#define SERCOM_I2CM_ADDR_LEN(value) (SERCOM_I2CM_ADDR_LEN_Msk & ((value) << SERCOM_I2CM_ADDR_LEN_Pos))
+#define SERCOM_I2CM_ADDR_MASK       0x00FFE7FFul /**< \brief (SERCOM_I2CM_ADDR) MASK Register */
+
+/* -------- SERCOM_I2CS_ADDR : (SERCOM Offset: 0x24) (R/W 32) I2CS I2CS Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t GENCEN:1;         /*!< bit:      0  General Call Address Enable        */
+    uint32_t ADDR:10;          /*!< bit:  1..10  Address Value                      */
+    uint32_t :4;               /*!< bit: 11..14  Reserved                           */
+    uint32_t TENBITEN:1;       /*!< bit:     15  Ten Bit Addressing Enable          */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t ADDRMASK:10;      /*!< bit: 17..26  Address Mask                       */
+    uint32_t :5;               /*!< bit: 27..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_ADDR_OFFSET     0x24         /**< \brief (SERCOM_I2CS_ADDR offset) I2CS Address */
+#define SERCOM_I2CS_ADDR_RESETVALUE 0x00000000ul /**< \brief (SERCOM_I2CS_ADDR reset_value) I2CS Address */
+
+#define SERCOM_I2CS_ADDR_GENCEN_Pos 0            /**< \brief (SERCOM_I2CS_ADDR) General Call Address Enable */
+#define SERCOM_I2CS_ADDR_GENCEN     (0x1ul << SERCOM_I2CS_ADDR_GENCEN_Pos)
+#define SERCOM_I2CS_ADDR_ADDR_Pos   1            /**< \brief (SERCOM_I2CS_ADDR) Address Value */
+#define SERCOM_I2CS_ADDR_ADDR_Msk   (0x3FFul << SERCOM_I2CS_ADDR_ADDR_Pos)
+#define SERCOM_I2CS_ADDR_ADDR(value) (SERCOM_I2CS_ADDR_ADDR_Msk & ((value) << SERCOM_I2CS_ADDR_ADDR_Pos))
+#define SERCOM_I2CS_ADDR_TENBITEN_Pos 15           /**< \brief (SERCOM_I2CS_ADDR) Ten Bit Addressing Enable */
+#define SERCOM_I2CS_ADDR_TENBITEN   (0x1ul << SERCOM_I2CS_ADDR_TENBITEN_Pos)
+#define SERCOM_I2CS_ADDR_ADDRMASK_Pos 17           /**< \brief (SERCOM_I2CS_ADDR) Address Mask */
+#define SERCOM_I2CS_ADDR_ADDRMASK_Msk (0x3FFul << SERCOM_I2CS_ADDR_ADDRMASK_Pos)
+#define SERCOM_I2CS_ADDR_ADDRMASK(value) (SERCOM_I2CS_ADDR_ADDRMASK_Msk & ((value) << SERCOM_I2CS_ADDR_ADDRMASK_Pos))
+#define SERCOM_I2CS_ADDR_MASK       0x07FE87FFul /**< \brief (SERCOM_I2CS_ADDR) MASK Register */
+
+/* -------- SERCOM_SPI_ADDR : (SERCOM Offset: 0x24) (R/W 32) SPI SPI Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:8;           /*!< bit:  0.. 7  Address Value                      */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t ADDRMASK:8;       /*!< bit: 16..23  Address Mask                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_ADDR_OFFSET      0x24         /**< \brief (SERCOM_SPI_ADDR offset) SPI Address */
+#define SERCOM_SPI_ADDR_RESETVALUE  0x00000000ul /**< \brief (SERCOM_SPI_ADDR reset_value) SPI Address */
+
+#define SERCOM_SPI_ADDR_ADDR_Pos    0            /**< \brief (SERCOM_SPI_ADDR) Address Value */
+#define SERCOM_SPI_ADDR_ADDR_Msk    (0xFFul << SERCOM_SPI_ADDR_ADDR_Pos)
+#define SERCOM_SPI_ADDR_ADDR(value) (SERCOM_SPI_ADDR_ADDR_Msk & ((value) << SERCOM_SPI_ADDR_ADDR_Pos))
+#define SERCOM_SPI_ADDR_ADDRMASK_Pos 16           /**< \brief (SERCOM_SPI_ADDR) Address Mask */
+#define SERCOM_SPI_ADDR_ADDRMASK_Msk (0xFFul << SERCOM_SPI_ADDR_ADDRMASK_Pos)
+#define SERCOM_SPI_ADDR_ADDRMASK(value) (SERCOM_SPI_ADDR_ADDRMASK_Msk & ((value) << SERCOM_SPI_ADDR_ADDRMASK_Pos))
+#define SERCOM_SPI_ADDR_MASK        0x00FF00FFul /**< \brief (SERCOM_SPI_ADDR) MASK Register */
+
+/* -------- SERCOM_I2CM_DATA : (SERCOM Offset: 0x28) (R/W  8) I2CM I2CM Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DATA:8;           /*!< bit:  0.. 7  Data Value                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DATA_OFFSET     0x28         /**< \brief (SERCOM_I2CM_DATA offset) I2CM Data */
+#define SERCOM_I2CM_DATA_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_DATA reset_value) I2CM Data */
+
+#define SERCOM_I2CM_DATA_DATA_Pos   0            /**< \brief (SERCOM_I2CM_DATA) Data Value */
+#define SERCOM_I2CM_DATA_DATA_Msk   (0xFFul << SERCOM_I2CM_DATA_DATA_Pos)
+#define SERCOM_I2CM_DATA_DATA(value) (SERCOM_I2CM_DATA_DATA_Msk & ((value) << SERCOM_I2CM_DATA_DATA_Pos))
+#define SERCOM_I2CM_DATA_MASK       0xFFul       /**< \brief (SERCOM_I2CM_DATA) MASK Register */
+
+/* -------- SERCOM_I2CS_DATA : (SERCOM Offset: 0x28) (R/W  8) I2CS I2CS Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DATA:8;           /*!< bit:  0.. 7  Data Value                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_DATA_OFFSET     0x28         /**< \brief (SERCOM_I2CS_DATA offset) I2CS Data */
+#define SERCOM_I2CS_DATA_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CS_DATA reset_value) I2CS Data */
+
+#define SERCOM_I2CS_DATA_DATA_Pos   0            /**< \brief (SERCOM_I2CS_DATA) Data Value */
+#define SERCOM_I2CS_DATA_DATA_Msk   (0xFFul << SERCOM_I2CS_DATA_DATA_Pos)
+#define SERCOM_I2CS_DATA_DATA(value) (SERCOM_I2CS_DATA_DATA_Msk & ((value) << SERCOM_I2CS_DATA_DATA_Pos))
+#define SERCOM_I2CS_DATA_MASK       0xFFul       /**< \brief (SERCOM_I2CS_DATA) MASK Register */
+
+/* -------- SERCOM_SPI_DATA : (SERCOM Offset: 0x28) (R/W 32) SPI SPI Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:9;           /*!< bit:  0.. 8  Data Value                         */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DATA_OFFSET      0x28         /**< \brief (SERCOM_SPI_DATA offset) SPI Data */
+#define SERCOM_SPI_DATA_RESETVALUE  0x00000000ul /**< \brief (SERCOM_SPI_DATA reset_value) SPI Data */
+
+#define SERCOM_SPI_DATA_DATA_Pos    0            /**< \brief (SERCOM_SPI_DATA) Data Value */
+#define SERCOM_SPI_DATA_DATA_Msk    (0x1FFul << SERCOM_SPI_DATA_DATA_Pos)
+#define SERCOM_SPI_DATA_DATA(value) (SERCOM_SPI_DATA_DATA_Msk & ((value) << SERCOM_SPI_DATA_DATA_Pos))
+#define SERCOM_SPI_DATA_MASK        0x000001FFul /**< \brief (SERCOM_SPI_DATA) MASK Register */
+
+/* -------- SERCOM_USART_DATA : (SERCOM Offset: 0x28) (R/W 16) USART USART Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATA:9;           /*!< bit:  0.. 8  Data Value                         */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DATA_OFFSET    0x28         /**< \brief (SERCOM_USART_DATA offset) USART Data */
+#define SERCOM_USART_DATA_RESETVALUE 0x0000ul     /**< \brief (SERCOM_USART_DATA reset_value) USART Data */
+
+#define SERCOM_USART_DATA_DATA_Pos  0            /**< \brief (SERCOM_USART_DATA) Data Value */
+#define SERCOM_USART_DATA_DATA_Msk  (0x1FFul << SERCOM_USART_DATA_DATA_Pos)
+#define SERCOM_USART_DATA_DATA(value) (SERCOM_USART_DATA_DATA_Msk & ((value) << SERCOM_USART_DATA_DATA_Pos))
+#define SERCOM_USART_DATA_MASK      0x01FFul     /**< \brief (SERCOM_USART_DATA) MASK Register */
+
+/* -------- SERCOM_I2CM_DBGCTRL : (SERCOM Offset: 0x30) (R/W  8) I2CM I2CM Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGSTOP:1;        /*!< bit:      0  Debug Mode                         */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DBGCTRL_OFFSET  0x30         /**< \brief (SERCOM_I2CM_DBGCTRL offset) I2CM Debug Control */
+#define SERCOM_I2CM_DBGCTRL_RESETVALUE 0x00ul       /**< \brief (SERCOM_I2CM_DBGCTRL reset_value) I2CM Debug Control */
+
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_I2CM_DBGCTRL) Debug Mode */
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP (0x1ul << SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_I2CM_DBGCTRL_MASK    0x01ul       /**< \brief (SERCOM_I2CM_DBGCTRL) MASK Register */
+
+/* -------- SERCOM_SPI_DBGCTRL : (SERCOM Offset: 0x30) (R/W  8) SPI SPI Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGSTOP:1;        /*!< bit:      0  Debug Mode                         */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DBGCTRL_OFFSET   0x30         /**< \brief (SERCOM_SPI_DBGCTRL offset) SPI Debug Control */
+#define SERCOM_SPI_DBGCTRL_RESETVALUE 0x00ul       /**< \brief (SERCOM_SPI_DBGCTRL reset_value) SPI Debug Control */
+
+#define SERCOM_SPI_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_SPI_DBGCTRL) Debug Mode */
+#define SERCOM_SPI_DBGCTRL_DBGSTOP  (0x1ul << SERCOM_SPI_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_SPI_DBGCTRL_MASK     0x01ul       /**< \brief (SERCOM_SPI_DBGCTRL) MASK Register */
+
+/* -------- SERCOM_USART_DBGCTRL : (SERCOM Offset: 0x30) (R/W  8) USART USART Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGSTOP:1;        /*!< bit:      0  Debug Mode                         */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DBGCTRL_OFFSET 0x30         /**< \brief (SERCOM_USART_DBGCTRL offset) USART Debug Control */
+#define SERCOM_USART_DBGCTRL_RESETVALUE 0x00ul       /**< \brief (SERCOM_USART_DBGCTRL reset_value) USART Debug Control */
+
+#define SERCOM_USART_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_USART_DBGCTRL) Debug Mode */
+#define SERCOM_USART_DBGCTRL_DBGSTOP (0x1ul << SERCOM_USART_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_USART_DBGCTRL_MASK   0x01ul       /**< \brief (SERCOM_USART_DBGCTRL) MASK Register */
+
+/** \brief SERCOM_I2CM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* I2C Master Mode */
+  __IO SERCOM_I2CM_CTRLA_Type    CTRLA;       /**< \brief Offset: 0x00 (R/W 32) I2CM Control A */
+  __IO SERCOM_I2CM_CTRLB_Type    CTRLB;       /**< \brief Offset: 0x04 (R/W 32) I2CM Control B */
+       RoReg8                    Reserved1[0x4];
+  __IO SERCOM_I2CM_BAUD_Type     BAUD;        /**< \brief Offset: 0x0C (R/W 32) I2CM Baud Rate */
+       RoReg8                    Reserved2[0x4];
+  __IO SERCOM_I2CM_INTENCLR_Type INTENCLR;    /**< \brief Offset: 0x14 (R/W  8) I2CM Interrupt Enable Clear */
+       RoReg8                    Reserved3[0x1];
+  __IO SERCOM_I2CM_INTENSET_Type INTENSET;    /**< \brief Offset: 0x16 (R/W  8) I2CM Interrupt Enable Set */
+       RoReg8                    Reserved4[0x1];
+  __IO SERCOM_I2CM_INTFLAG_Type  INTFLAG;     /**< \brief Offset: 0x18 (R/W  8) I2CM Interrupt Flag Status and Clear */
+       RoReg8                    Reserved5[0x1];
+  __IO SERCOM_I2CM_STATUS_Type   STATUS;      /**< \brief Offset: 0x1A (R/W 16) I2CM Status */
+  __I  SERCOM_I2CM_SYNCBUSY_Type SYNCBUSY;    /**< \brief Offset: 0x1C (R/  32) I2CM Synchronization Busy */
+       RoReg8                    Reserved6[0x4];
+  __IO SERCOM_I2CM_ADDR_Type     ADDR;        /**< \brief Offset: 0x24 (R/W 32) I2CM Address */
+  __IO SERCOM_I2CM_DATA_Type     DATA;        /**< \brief Offset: 0x28 (R/W  8) I2CM Data */
+       RoReg8                    Reserved7[0x7];
+  __IO SERCOM_I2CM_DBGCTRL_Type  DBGCTRL;     /**< \brief Offset: 0x30 (R/W  8) I2CM Debug Control */
+} SercomI2cm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SERCOM_I2CS hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* I2C Slave Mode */
+  __IO SERCOM_I2CS_CTRLA_Type    CTRLA;       /**< \brief Offset: 0x00 (R/W 32) I2CS Control A */
+  __IO SERCOM_I2CS_CTRLB_Type    CTRLB;       /**< \brief Offset: 0x04 (R/W 32) I2CS Control B */
+       RoReg8                    Reserved1[0xC];
+  __IO SERCOM_I2CS_INTENCLR_Type INTENCLR;    /**< \brief Offset: 0x14 (R/W  8) I2CS Interrupt Enable Clear */
+       RoReg8                    Reserved2[0x1];
+  __IO SERCOM_I2CS_INTENSET_Type INTENSET;    /**< \brief Offset: 0x16 (R/W  8) I2CS Interrupt Enable Set */
+       RoReg8                    Reserved3[0x1];
+  __IO SERCOM_I2CS_INTFLAG_Type  INTFLAG;     /**< \brief Offset: 0x18 (R/W  8) I2CS Interrupt Flag Status and Clear */
+       RoReg8                    Reserved4[0x1];
+  __IO SERCOM_I2CS_STATUS_Type   STATUS;      /**< \brief Offset: 0x1A (R/W 16) I2CS Status */
+  __I  SERCOM_I2CS_SYNCBUSY_Type SYNCBUSY;    /**< \brief Offset: 0x1C (R/  32) I2CS Synchronization Busy */
+       RoReg8                    Reserved5[0x4];
+  __IO SERCOM_I2CS_ADDR_Type     ADDR;        /**< \brief Offset: 0x24 (R/W 32) I2CS Address */
+  __IO SERCOM_I2CS_DATA_Type     DATA;        /**< \brief Offset: 0x28 (R/W  8) I2CS Data */
+} SercomI2cs;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SERCOM_SPI hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* SPI Mode */
+  __IO SERCOM_SPI_CTRLA_Type     CTRLA;       /**< \brief Offset: 0x00 (R/W 32) SPI Control A */
+  __IO SERCOM_SPI_CTRLB_Type     CTRLB;       /**< \brief Offset: 0x04 (R/W 32) SPI Control B */
+       RoReg8                    Reserved1[0x4];
+  __IO SERCOM_SPI_BAUD_Type      BAUD;        /**< \brief Offset: 0x0C (R/W  8) SPI Baud Rate */
+       RoReg8                    Reserved2[0x7];
+  __IO SERCOM_SPI_INTENCLR_Type  INTENCLR;    /**< \brief Offset: 0x14 (R/W  8) SPI Interrupt Enable Clear */
+       RoReg8                    Reserved3[0x1];
+  __IO SERCOM_SPI_INTENSET_Type  INTENSET;    /**< \brief Offset: 0x16 (R/W  8) SPI Interrupt Enable Set */
+       RoReg8                    Reserved4[0x1];
+  __IO SERCOM_SPI_INTFLAG_Type   INTFLAG;     /**< \brief Offset: 0x18 (R/W  8) SPI Interrupt Flag Status and Clear */
+       RoReg8                    Reserved5[0x1];
+  __IO SERCOM_SPI_STATUS_Type    STATUS;      /**< \brief Offset: 0x1A (R/W 16) SPI Status */
+  __I  SERCOM_SPI_SYNCBUSY_Type  SYNCBUSY;    /**< \brief Offset: 0x1C (R/  32) SPI Synchronization Busy */
+       RoReg8                    Reserved6[0x4];
+  __IO SERCOM_SPI_ADDR_Type      ADDR;        /**< \brief Offset: 0x24 (R/W 32) SPI Address */
+  __IO SERCOM_SPI_DATA_Type      DATA;        /**< \brief Offset: 0x28 (R/W 32) SPI Data */
+       RoReg8                    Reserved7[0x4];
+  __IO SERCOM_SPI_DBGCTRL_Type   DBGCTRL;     /**< \brief Offset: 0x30 (R/W  8) SPI Debug Control */
+} SercomSpi;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SERCOM_USART hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* USART Mode */
+  __IO SERCOM_USART_CTRLA_Type   CTRLA;       /**< \brief Offset: 0x00 (R/W 32) USART Control A */
+  __IO SERCOM_USART_CTRLB_Type   CTRLB;       /**< \brief Offset: 0x04 (R/W 32) USART Control B */
+       RoReg8                    Reserved1[0x4];
+  __IO SERCOM_USART_BAUD_Type    BAUD;        /**< \brief Offset: 0x0C (R/W 16) USART Baud Rate */
+  __IO SERCOM_USART_RXPL_Type    RXPL;        /**< \brief Offset: 0x0E (R/W  8) USART Receive Pulse Length */
+       RoReg8                    Reserved2[0x5];
+  __IO SERCOM_USART_INTENCLR_Type INTENCLR;    /**< \brief Offset: 0x14 (R/W  8) USART Interrupt Enable Clear */
+       RoReg8                    Reserved3[0x1];
+  __IO SERCOM_USART_INTENSET_Type INTENSET;    /**< \brief Offset: 0x16 (R/W  8) USART Interrupt Enable Set */
+       RoReg8                    Reserved4[0x1];
+  __IO SERCOM_USART_INTFLAG_Type INTFLAG;     /**< \brief Offset: 0x18 (R/W  8) USART Interrupt Flag Status and Clear */
+       RoReg8                    Reserved5[0x1];
+  __IO SERCOM_USART_STATUS_Type  STATUS;      /**< \brief Offset: 0x1A (R/W 16) USART Status */
+  __I  SERCOM_USART_SYNCBUSY_Type SYNCBUSY;    /**< \brief Offset: 0x1C (R/  32) USART Synchronization Busy */
+       RoReg8                    Reserved6[0x8];
+  __IO SERCOM_USART_DATA_Type    DATA;        /**< \brief Offset: 0x28 (R/W 16) USART Data */
+       RoReg8                    Reserved7[0x6];
+  __IO SERCOM_USART_DBGCTRL_Type DBGCTRL;     /**< \brief Offset: 0x30 (R/W  8) USART Debug Control */
+} SercomUsart;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       SercomI2cm                I2CM;        /**< \brief Offset: 0x00 I2C Master Mode */
+       SercomI2cs                I2CS;        /**< \brief Offset: 0x00 I2C Slave Mode */
+       SercomSpi                 SPI;         /**< \brief Offset: 0x00 SPI Mode */
+       SercomUsart               USART;       /**< \brief Offset: 0x00 USART Mode */
+} Sercom;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_SERCOM_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/supc_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/supc_100.h
@@ -1,0 +1,607 @@
+/**
+ * \file
+ *
+ * \brief Component description for SUPC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_SUPC_COMPONENT_
+#define _SAML21_SUPC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SUPC */
+/* ========================================================================== */
+/** \addtogroup SAML21_SUPC Supply Controller */
+/*@{*/
+
+#define SUPC_U2117
+#define REV_SUPC                    0x100
+
+/* -------- SUPC_INTENCLR : (SUPC Offset: 0x00) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BOD33RDY:1;       /*!< bit:      0  BOD33 Ready                        */
+    uint32_t BOD33DET:1;       /*!< bit:      1  BOD33 Detection                    */
+    uint32_t B33SRDY:1;        /*!< bit:      2  BOD33 Synchronization Ready        */
+    uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
+    uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
+    uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
+    uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
+    uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_INTENCLR_OFFSET        0x00         /**< \brief (SUPC_INTENCLR offset) Interrupt Enable Clear */
+#define SUPC_INTENCLR_RESETVALUE    0x00000000ul /**< \brief (SUPC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define SUPC_INTENCLR_BOD33RDY_Pos  0            /**< \brief (SUPC_INTENCLR) BOD33 Ready */
+#define SUPC_INTENCLR_BOD33RDY      (0x1ul << SUPC_INTENCLR_BOD33RDY_Pos)
+#define SUPC_INTENCLR_BOD33DET_Pos  1            /**< \brief (SUPC_INTENCLR) BOD33 Detection */
+#define SUPC_INTENCLR_BOD33DET      (0x1ul << SUPC_INTENCLR_BOD33DET_Pos)
+#define SUPC_INTENCLR_B33SRDY_Pos   2            /**< \brief (SUPC_INTENCLR) BOD33 Synchronization Ready */
+#define SUPC_INTENCLR_B33SRDY       (0x1ul << SUPC_INTENCLR_B33SRDY_Pos)
+#define SUPC_INTENCLR_BOD12RDY_Pos  3            /**< \brief (SUPC_INTENCLR) BOD12 Ready */
+#define SUPC_INTENCLR_BOD12RDY      (0x1ul << SUPC_INTENCLR_BOD12RDY_Pos)
+#define SUPC_INTENCLR_BOD12DET_Pos  4            /**< \brief (SUPC_INTENCLR) BOD12 Detection */
+#define SUPC_INTENCLR_BOD12DET      (0x1ul << SUPC_INTENCLR_BOD12DET_Pos)
+#define SUPC_INTENCLR_B12SRDY_Pos   5            /**< \brief (SUPC_INTENCLR) BOD12 Synchronization Ready */
+#define SUPC_INTENCLR_B12SRDY       (0x1ul << SUPC_INTENCLR_B12SRDY_Pos)
+#define SUPC_INTENCLR_VREGRDY_Pos   8            /**< \brief (SUPC_INTENCLR) Voltage Regulator Ready */
+#define SUPC_INTENCLR_VREGRDY       (0x1ul << SUPC_INTENCLR_VREGRDY_Pos)
+#define SUPC_INTENCLR_APWSRDY_Pos   9            /**< \brief (SUPC_INTENCLR) Automatic Power Switch Ready */
+#define SUPC_INTENCLR_APWSRDY       (0x1ul << SUPC_INTENCLR_APWSRDY_Pos)
+#define SUPC_INTENCLR_VCORERDY_Pos  10           /**< \brief (SUPC_INTENCLR) VDDCORE Ready */
+#define SUPC_INTENCLR_VCORERDY      (0x1ul << SUPC_INTENCLR_VCORERDY_Pos)
+#define SUPC_INTENCLR_MASK          0x0000073Ful /**< \brief (SUPC_INTENCLR) MASK Register */
+
+/* -------- SUPC_INTENSET : (SUPC Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BOD33RDY:1;       /*!< bit:      0  BOD33 Ready                        */
+    uint32_t BOD33DET:1;       /*!< bit:      1  BOD33 Detection                    */
+    uint32_t B33SRDY:1;        /*!< bit:      2  BOD33 Synchronization Ready        */
+    uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
+    uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
+    uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
+    uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
+    uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_INTENSET_OFFSET        0x04         /**< \brief (SUPC_INTENSET offset) Interrupt Enable Set */
+#define SUPC_INTENSET_RESETVALUE    0x00000000ul /**< \brief (SUPC_INTENSET reset_value) Interrupt Enable Set */
+
+#define SUPC_INTENSET_BOD33RDY_Pos  0            /**< \brief (SUPC_INTENSET) BOD33 Ready */
+#define SUPC_INTENSET_BOD33RDY      (0x1ul << SUPC_INTENSET_BOD33RDY_Pos)
+#define SUPC_INTENSET_BOD33DET_Pos  1            /**< \brief (SUPC_INTENSET) BOD33 Detection */
+#define SUPC_INTENSET_BOD33DET      (0x1ul << SUPC_INTENSET_BOD33DET_Pos)
+#define SUPC_INTENSET_B33SRDY_Pos   2            /**< \brief (SUPC_INTENSET) BOD33 Synchronization Ready */
+#define SUPC_INTENSET_B33SRDY       (0x1ul << SUPC_INTENSET_B33SRDY_Pos)
+#define SUPC_INTENSET_BOD12RDY_Pos  3            /**< \brief (SUPC_INTENSET) BOD12 Ready */
+#define SUPC_INTENSET_BOD12RDY      (0x1ul << SUPC_INTENSET_BOD12RDY_Pos)
+#define SUPC_INTENSET_BOD12DET_Pos  4            /**< \brief (SUPC_INTENSET) BOD12 Detection */
+#define SUPC_INTENSET_BOD12DET      (0x1ul << SUPC_INTENSET_BOD12DET_Pos)
+#define SUPC_INTENSET_B12SRDY_Pos   5            /**< \brief (SUPC_INTENSET) BOD12 Synchronization Ready */
+#define SUPC_INTENSET_B12SRDY       (0x1ul << SUPC_INTENSET_B12SRDY_Pos)
+#define SUPC_INTENSET_VREGRDY_Pos   8            /**< \brief (SUPC_INTENSET) Voltage Regulator Ready */
+#define SUPC_INTENSET_VREGRDY       (0x1ul << SUPC_INTENSET_VREGRDY_Pos)
+#define SUPC_INTENSET_APWSRDY_Pos   9            /**< \brief (SUPC_INTENSET) Automatic Power Switch Ready */
+#define SUPC_INTENSET_APWSRDY       (0x1ul << SUPC_INTENSET_APWSRDY_Pos)
+#define SUPC_INTENSET_VCORERDY_Pos  10           /**< \brief (SUPC_INTENSET) VDDCORE Ready */
+#define SUPC_INTENSET_VCORERDY      (0x1ul << SUPC_INTENSET_VCORERDY_Pos)
+#define SUPC_INTENSET_MASK          0x0000073Ful /**< \brief (SUPC_INTENSET) MASK Register */
+
+/* -------- SUPC_INTFLAG : (SUPC Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t BOD33RDY:1;       /*!< bit:      0  BOD33 Ready                        */
+    __I uint32_t BOD33DET:1;       /*!< bit:      1  BOD33 Detection                    */
+    __I uint32_t B33SRDY:1;        /*!< bit:      2  BOD33 Synchronization Ready        */
+    __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
+    __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
+    __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
+    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
+    __I uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
+    __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
+    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_INTFLAG_OFFSET         0x08         /**< \brief (SUPC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define SUPC_INTFLAG_RESETVALUE     0x00000000ul /**< \brief (SUPC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define SUPC_INTFLAG_BOD33RDY_Pos   0            /**< \brief (SUPC_INTFLAG) BOD33 Ready */
+#define SUPC_INTFLAG_BOD33RDY       (0x1ul << SUPC_INTFLAG_BOD33RDY_Pos)
+#define SUPC_INTFLAG_BOD33DET_Pos   1            /**< \brief (SUPC_INTFLAG) BOD33 Detection */
+#define SUPC_INTFLAG_BOD33DET       (0x1ul << SUPC_INTFLAG_BOD33DET_Pos)
+#define SUPC_INTFLAG_B33SRDY_Pos    2            /**< \brief (SUPC_INTFLAG) BOD33 Synchronization Ready */
+#define SUPC_INTFLAG_B33SRDY        (0x1ul << SUPC_INTFLAG_B33SRDY_Pos)
+#define SUPC_INTFLAG_BOD12RDY_Pos   3            /**< \brief (SUPC_INTFLAG) BOD12 Ready */
+#define SUPC_INTFLAG_BOD12RDY       (0x1ul << SUPC_INTFLAG_BOD12RDY_Pos)
+#define SUPC_INTFLAG_BOD12DET_Pos   4            /**< \brief (SUPC_INTFLAG) BOD12 Detection */
+#define SUPC_INTFLAG_BOD12DET       (0x1ul << SUPC_INTFLAG_BOD12DET_Pos)
+#define SUPC_INTFLAG_B12SRDY_Pos    5            /**< \brief (SUPC_INTFLAG) BOD12 Synchronization Ready */
+#define SUPC_INTFLAG_B12SRDY        (0x1ul << SUPC_INTFLAG_B12SRDY_Pos)
+#define SUPC_INTFLAG_VREGRDY_Pos    8            /**< \brief (SUPC_INTFLAG) Voltage Regulator Ready */
+#define SUPC_INTFLAG_VREGRDY        (0x1ul << SUPC_INTFLAG_VREGRDY_Pos)
+#define SUPC_INTFLAG_APWSRDY_Pos    9            /**< \brief (SUPC_INTFLAG) Automatic Power Switch Ready */
+#define SUPC_INTFLAG_APWSRDY        (0x1ul << SUPC_INTFLAG_APWSRDY_Pos)
+#define SUPC_INTFLAG_VCORERDY_Pos   10           /**< \brief (SUPC_INTFLAG) VDDCORE Ready */
+#define SUPC_INTFLAG_VCORERDY       (0x1ul << SUPC_INTFLAG_VCORERDY_Pos)
+#define SUPC_INTFLAG_MASK           0x0000073Ful /**< \brief (SUPC_INTFLAG) MASK Register */
+
+/* -------- SUPC_STATUS : (SUPC Offset: 0x0C) (R/  32) Power and Clocks Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BOD33RDY:1;       /*!< bit:      0  BOD33 Ready                        */
+    uint32_t BOD33DET:1;       /*!< bit:      1  BOD33 Detection                    */
+    uint32_t B33SRDY:1;        /*!< bit:      2  BOD33 Synchronization Ready        */
+    uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
+    uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
+    uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
+    uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
+    uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
+    uint32_t BBPS:1;           /*!< bit:     11  Battery Backup Power Switch        */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_STATUS_OFFSET          0x0C         /**< \brief (SUPC_STATUS offset) Power and Clocks Status */
+#define SUPC_STATUS_RESETVALUE      0x00000000ul /**< \brief (SUPC_STATUS reset_value) Power and Clocks Status */
+
+#define SUPC_STATUS_BOD33RDY_Pos    0            /**< \brief (SUPC_STATUS) BOD33 Ready */
+#define SUPC_STATUS_BOD33RDY        (0x1ul << SUPC_STATUS_BOD33RDY_Pos)
+#define SUPC_STATUS_BOD33DET_Pos    1            /**< \brief (SUPC_STATUS) BOD33 Detection */
+#define SUPC_STATUS_BOD33DET        (0x1ul << SUPC_STATUS_BOD33DET_Pos)
+#define SUPC_STATUS_B33SRDY_Pos     2            /**< \brief (SUPC_STATUS) BOD33 Synchronization Ready */
+#define SUPC_STATUS_B33SRDY         (0x1ul << SUPC_STATUS_B33SRDY_Pos)
+#define SUPC_STATUS_BOD12RDY_Pos    3            /**< \brief (SUPC_STATUS) BOD12 Ready */
+#define SUPC_STATUS_BOD12RDY        (0x1ul << SUPC_STATUS_BOD12RDY_Pos)
+#define SUPC_STATUS_BOD12DET_Pos    4            /**< \brief (SUPC_STATUS) BOD12 Detection */
+#define SUPC_STATUS_BOD12DET        (0x1ul << SUPC_STATUS_BOD12DET_Pos)
+#define SUPC_STATUS_B12SRDY_Pos     5            /**< \brief (SUPC_STATUS) BOD12 Synchronization Ready */
+#define SUPC_STATUS_B12SRDY         (0x1ul << SUPC_STATUS_B12SRDY_Pos)
+#define SUPC_STATUS_VREGRDY_Pos     8            /**< \brief (SUPC_STATUS) Voltage Regulator Ready */
+#define SUPC_STATUS_VREGRDY         (0x1ul << SUPC_STATUS_VREGRDY_Pos)
+#define SUPC_STATUS_APWSRDY_Pos     9            /**< \brief (SUPC_STATUS) Automatic Power Switch Ready */
+#define SUPC_STATUS_APWSRDY         (0x1ul << SUPC_STATUS_APWSRDY_Pos)
+#define SUPC_STATUS_VCORERDY_Pos    10           /**< \brief (SUPC_STATUS) VDDCORE Ready */
+#define SUPC_STATUS_VCORERDY        (0x1ul << SUPC_STATUS_VCORERDY_Pos)
+#define SUPC_STATUS_BBPS_Pos        11           /**< \brief (SUPC_STATUS) Battery Backup Power Switch */
+#define SUPC_STATUS_BBPS            (0x1ul << SUPC_STATUS_BBPS_Pos)
+#define SUPC_STATUS_MASK            0x00000F3Ful /**< \brief (SUPC_STATUS) MASK Register */
+
+/* -------- SUPC_BOD33 : (SUPC Offset: 0x10) (R/W 32) BOD33 Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t HYST:1;           /*!< bit:      2  Hysteresis Enable                  */
+    uint32_t ACTION:2;         /*!< bit:  3.. 4  Action when Threshold Crossed      */
+    uint32_t STDBYCFG:1;       /*!< bit:      5  Configuration in Standby mode      */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t RUNBKUP:1;        /*!< bit:      7  Configuration in Backup mode       */
+    uint32_t ACTCFG:1;         /*!< bit:      8  Configuration in Active mode       */
+    uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t VMON:1;           /*!< bit:     10  Voltage Monitored in active and standby mode */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t PSEL:4;           /*!< bit: 12..15  Prescaler Select                   */
+    uint32_t LEVEL:6;          /*!< bit: 16..21  Threshold Level for VDD            */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t BKUPLEVEL:6;      /*!< bit: 24..29  Threshold Level in backup sleep mode or for VBAT */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_BOD33_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_BOD33_OFFSET           0x10         /**< \brief (SUPC_BOD33 offset) BOD33 Control */
+#define SUPC_BOD33_RESETVALUE       0x00000000ul /**< \brief (SUPC_BOD33 reset_value) BOD33 Control */
+
+#define SUPC_BOD33_ENABLE_Pos       1            /**< \brief (SUPC_BOD33) Enable */
+#define SUPC_BOD33_ENABLE           (0x1ul << SUPC_BOD33_ENABLE_Pos)
+#define SUPC_BOD33_HYST_Pos         2            /**< \brief (SUPC_BOD33) Hysteresis Enable */
+#define SUPC_BOD33_HYST             (0x1ul << SUPC_BOD33_HYST_Pos)
+#define SUPC_BOD33_ACTION_Pos       3            /**< \brief (SUPC_BOD33) Action when Threshold Crossed */
+#define SUPC_BOD33_ACTION_Msk       (0x3ul << SUPC_BOD33_ACTION_Pos)
+#define SUPC_BOD33_ACTION(value)    (SUPC_BOD33_ACTION_Msk & ((value) << SUPC_BOD33_ACTION_Pos))
+#define   SUPC_BOD33_ACTION_NONE_Val      0x0ul  /**< \brief (SUPC_BOD33) No action */
+#define   SUPC_BOD33_ACTION_RESET_Val     0x1ul  /**< \brief (SUPC_BOD33) The BOD33 generates a reset */
+#define   SUPC_BOD33_ACTION_INT_Val       0x2ul  /**< \brief (SUPC_BOD33) The BOD33 generates an interrupt */
+#define   SUPC_BOD33_ACTION_BKUP_Val      0x3ul  /**< \brief (SUPC_BOD33) The BOD33 puts the device in backup sleep mode if VMON=0 */
+#define SUPC_BOD33_ACTION_NONE      (SUPC_BOD33_ACTION_NONE_Val    << SUPC_BOD33_ACTION_Pos)
+#define SUPC_BOD33_ACTION_RESET     (SUPC_BOD33_ACTION_RESET_Val   << SUPC_BOD33_ACTION_Pos)
+#define SUPC_BOD33_ACTION_INT       (SUPC_BOD33_ACTION_INT_Val     << SUPC_BOD33_ACTION_Pos)
+#define SUPC_BOD33_ACTION_BKUP      (SUPC_BOD33_ACTION_BKUP_Val    << SUPC_BOD33_ACTION_Pos)
+#define SUPC_BOD33_STDBYCFG_Pos     5            /**< \brief (SUPC_BOD33) Configuration in Standby mode */
+#define SUPC_BOD33_STDBYCFG         (0x1ul << SUPC_BOD33_STDBYCFG_Pos)
+#define SUPC_BOD33_RUNSTDBY_Pos     6            /**< \brief (SUPC_BOD33) Run during Standby */
+#define SUPC_BOD33_RUNSTDBY         (0x1ul << SUPC_BOD33_RUNSTDBY_Pos)
+#define SUPC_BOD33_RUNBKUP_Pos      7            /**< \brief (SUPC_BOD33) Configuration in Backup mode */
+#define SUPC_BOD33_RUNBKUP          (0x1ul << SUPC_BOD33_RUNBKUP_Pos)
+#define SUPC_BOD33_ACTCFG_Pos       8            /**< \brief (SUPC_BOD33) Configuration in Active mode */
+#define SUPC_BOD33_ACTCFG           (0x1ul << SUPC_BOD33_ACTCFG_Pos)
+#define SUPC_BOD33_VMON_Pos         10           /**< \brief (SUPC_BOD33) Voltage Monitored in active and standby mode */
+#define SUPC_BOD33_VMON             (0x1ul << SUPC_BOD33_VMON_Pos)
+#define SUPC_BOD33_PSEL_Pos         12           /**< \brief (SUPC_BOD33) Prescaler Select */
+#define SUPC_BOD33_PSEL_Msk         (0xFul << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL(value)      (SUPC_BOD33_PSEL_Msk & ((value) << SUPC_BOD33_PSEL_Pos))
+#define   SUPC_BOD33_PSEL_DIV2_Val        0x0ul  /**< \brief (SUPC_BOD33) Divide clock by 2 */
+#define   SUPC_BOD33_PSEL_DIV4_Val        0x1ul  /**< \brief (SUPC_BOD33) Divide clock by 4 */
+#define   SUPC_BOD33_PSEL_DIV8_Val        0x2ul  /**< \brief (SUPC_BOD33) Divide clock by 8 */
+#define   SUPC_BOD33_PSEL_DIV16_Val       0x3ul  /**< \brief (SUPC_BOD33) Divide clock by 16 */
+#define   SUPC_BOD33_PSEL_DIV32_Val       0x4ul  /**< \brief (SUPC_BOD33) Divide clock by 32 */
+#define   SUPC_BOD33_PSEL_DIV64_Val       0x5ul  /**< \brief (SUPC_BOD33) Divide clock by 64 */
+#define   SUPC_BOD33_PSEL_DIV128_Val      0x6ul  /**< \brief (SUPC_BOD33) Divide clock by 128 */
+#define   SUPC_BOD33_PSEL_DIV256_Val      0x7ul  /**< \brief (SUPC_BOD33) Divide clock by 256 */
+#define   SUPC_BOD33_PSEL_DIV512_Val      0x8ul  /**< \brief (SUPC_BOD33) Divide clock by 512 */
+#define   SUPC_BOD33_PSEL_DIV1024_Val     0x9ul  /**< \brief (SUPC_BOD33) Divide clock by 1024 */
+#define   SUPC_BOD33_PSEL_DIV2048_Val     0xAul  /**< \brief (SUPC_BOD33) Divide clock by 2048 */
+#define   SUPC_BOD33_PSEL_DIV4096_Val     0xBul  /**< \brief (SUPC_BOD33) Divide clock by 4096 */
+#define   SUPC_BOD33_PSEL_DIV8192_Val     0xCul  /**< \brief (SUPC_BOD33) Divide clock by 8192 */
+#define   SUPC_BOD33_PSEL_DIV16384_Val    0xDul  /**< \brief (SUPC_BOD33) Divide clock by 16384 */
+#define   SUPC_BOD33_PSEL_DIV32768_Val    0xEul  /**< \brief (SUPC_BOD33) Divide clock by 32768 */
+#define   SUPC_BOD33_PSEL_DIV65536_Val    0xFul  /**< \brief (SUPC_BOD33) Divide clock by 65536 */
+#define SUPC_BOD33_PSEL_DIV2        (SUPC_BOD33_PSEL_DIV2_Val      << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV4        (SUPC_BOD33_PSEL_DIV4_Val      << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV8        (SUPC_BOD33_PSEL_DIV8_Val      << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV16       (SUPC_BOD33_PSEL_DIV16_Val     << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV32       (SUPC_BOD33_PSEL_DIV32_Val     << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV64       (SUPC_BOD33_PSEL_DIV64_Val     << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV128      (SUPC_BOD33_PSEL_DIV128_Val    << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV256      (SUPC_BOD33_PSEL_DIV256_Val    << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV512      (SUPC_BOD33_PSEL_DIV512_Val    << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV1024     (SUPC_BOD33_PSEL_DIV1024_Val   << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV2048     (SUPC_BOD33_PSEL_DIV2048_Val   << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV4096     (SUPC_BOD33_PSEL_DIV4096_Val   << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV8192     (SUPC_BOD33_PSEL_DIV8192_Val   << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV16384    (SUPC_BOD33_PSEL_DIV16384_Val  << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV32768    (SUPC_BOD33_PSEL_DIV32768_Val  << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_PSEL_DIV65536    (SUPC_BOD33_PSEL_DIV65536_Val  << SUPC_BOD33_PSEL_Pos)
+#define SUPC_BOD33_LEVEL_Pos        16           /**< \brief (SUPC_BOD33) Threshold Level for VDD */
+#define SUPC_BOD33_LEVEL_Msk        (0x3Ful << SUPC_BOD33_LEVEL_Pos)
+#define SUPC_BOD33_LEVEL(value)     (SUPC_BOD33_LEVEL_Msk & ((value) << SUPC_BOD33_LEVEL_Pos))
+#define SUPC_BOD33_BKUPLEVEL_Pos    24           /**< \brief (SUPC_BOD33) Threshold Level in backup sleep mode or for VBAT */
+#define SUPC_BOD33_BKUPLEVEL_Msk    (0x3Ful << SUPC_BOD33_BKUPLEVEL_Pos)
+#define SUPC_BOD33_BKUPLEVEL(value) (SUPC_BOD33_BKUPLEVEL_Msk & ((value) << SUPC_BOD33_BKUPLEVEL_Pos))
+#define SUPC_BOD33_MASK             0x3F3FF5FEul /**< \brief (SUPC_BOD33) MASK Register */
+
+/* -------- SUPC_BOD12 : (SUPC Offset: 0x14) (R/W 32) BOD12 Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t HYST:1;           /*!< bit:      2  Hysteresis Enable                  */
+    uint32_t ACTION:2;         /*!< bit:  3.. 4  Action when Threshold Crossed      */
+    uint32_t STDBYCFG:1;       /*!< bit:      5  Configuration in Standby mode      */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t ACTCFG:1;         /*!< bit:      8  Configuration in Active mode       */
+    uint32_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint32_t PSEL:4;           /*!< bit: 12..15  Prescaler Select                   */
+    uint32_t LEVEL:6;          /*!< bit: 16..21  Threshold Level                    */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_BOD12_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_BOD12_OFFSET           0x14         /**< \brief (SUPC_BOD12 offset) BOD12 Control */
+#define SUPC_BOD12_RESETVALUE       0x00000000ul /**< \brief (SUPC_BOD12 reset_value) BOD12 Control */
+
+#define SUPC_BOD12_ENABLE_Pos       1            /**< \brief (SUPC_BOD12) Enable */
+#define SUPC_BOD12_ENABLE           (0x1ul << SUPC_BOD12_ENABLE_Pos)
+#define SUPC_BOD12_HYST_Pos         2            /**< \brief (SUPC_BOD12) Hysteresis Enable */
+#define SUPC_BOD12_HYST             (0x1ul << SUPC_BOD12_HYST_Pos)
+#define SUPC_BOD12_ACTION_Pos       3            /**< \brief (SUPC_BOD12) Action when Threshold Crossed */
+#define SUPC_BOD12_ACTION_Msk       (0x3ul << SUPC_BOD12_ACTION_Pos)
+#define SUPC_BOD12_ACTION(value)    (SUPC_BOD12_ACTION_Msk & ((value) << SUPC_BOD12_ACTION_Pos))
+#define   SUPC_BOD12_ACTION_NONE_Val      0x0ul  /**< \brief (SUPC_BOD12) No action */
+#define   SUPC_BOD12_ACTION_RESET_Val     0x1ul  /**< \brief (SUPC_BOD12) The BOD12 generates a reset */
+#define   SUPC_BOD12_ACTION_INT_Val       0x2ul  /**< \brief (SUPC_BOD12) The BOD12 generates an interrupt */
+#define SUPC_BOD12_ACTION_NONE      (SUPC_BOD12_ACTION_NONE_Val    << SUPC_BOD12_ACTION_Pos)
+#define SUPC_BOD12_ACTION_RESET     (SUPC_BOD12_ACTION_RESET_Val   << SUPC_BOD12_ACTION_Pos)
+#define SUPC_BOD12_ACTION_INT       (SUPC_BOD12_ACTION_INT_Val     << SUPC_BOD12_ACTION_Pos)
+#define SUPC_BOD12_STDBYCFG_Pos     5            /**< \brief (SUPC_BOD12) Configuration in Standby mode */
+#define SUPC_BOD12_STDBYCFG         (0x1ul << SUPC_BOD12_STDBYCFG_Pos)
+#define SUPC_BOD12_RUNSTDBY_Pos     6            /**< \brief (SUPC_BOD12) Run during Standby */
+#define SUPC_BOD12_RUNSTDBY         (0x1ul << SUPC_BOD12_RUNSTDBY_Pos)
+#define SUPC_BOD12_ACTCFG_Pos       8            /**< \brief (SUPC_BOD12) Configuration in Active mode */
+#define SUPC_BOD12_ACTCFG           (0x1ul << SUPC_BOD12_ACTCFG_Pos)
+#define SUPC_BOD12_PSEL_Pos         12           /**< \brief (SUPC_BOD12) Prescaler Select */
+#define SUPC_BOD12_PSEL_Msk         (0xFul << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL(value)      (SUPC_BOD12_PSEL_Msk & ((value) << SUPC_BOD12_PSEL_Pos))
+#define   SUPC_BOD12_PSEL_DIV2_Val        0x0ul  /**< \brief (SUPC_BOD12) Divide clock by 2 */
+#define   SUPC_BOD12_PSEL_DIV4_Val        0x1ul  /**< \brief (SUPC_BOD12) Divide clock by 4 */
+#define   SUPC_BOD12_PSEL_DIV8_Val        0x2ul  /**< \brief (SUPC_BOD12) Divide clock by 8 */
+#define   SUPC_BOD12_PSEL_DIV16_Val       0x3ul  /**< \brief (SUPC_BOD12) Divide clock by 16 */
+#define   SUPC_BOD12_PSEL_DIV32_Val       0x4ul  /**< \brief (SUPC_BOD12) Divide clock by 32 */
+#define   SUPC_BOD12_PSEL_DIV64_Val       0x5ul  /**< \brief (SUPC_BOD12) Divide clock by 64 */
+#define   SUPC_BOD12_PSEL_DIV128_Val      0x6ul  /**< \brief (SUPC_BOD12) Divide clock by 128 */
+#define   SUPC_BOD12_PSEL_DIV256_Val      0x7ul  /**< \brief (SUPC_BOD12) Divide clock by 256 */
+#define   SUPC_BOD12_PSEL_DIV512_Val      0x8ul  /**< \brief (SUPC_BOD12) Divide clock by 512 */
+#define   SUPC_BOD12_PSEL_DIV1024_Val     0x9ul  /**< \brief (SUPC_BOD12) Divide clock by 1024 */
+#define   SUPC_BOD12_PSEL_DIV2048_Val     0xAul  /**< \brief (SUPC_BOD12) Divide clock by 2048 */
+#define   SUPC_BOD12_PSEL_DIV4096_Val     0xBul  /**< \brief (SUPC_BOD12) Divide clock by 4096 */
+#define   SUPC_BOD12_PSEL_DIV8192_Val     0xCul  /**< \brief (SUPC_BOD12) Divide clock by 8192 */
+#define   SUPC_BOD12_PSEL_DIV16384_Val    0xDul  /**< \brief (SUPC_BOD12) Divide clock by 16384 */
+#define   SUPC_BOD12_PSEL_DIV32768_Val    0xEul  /**< \brief (SUPC_BOD12) Divide clock by 32768 */
+#define   SUPC_BOD12_PSEL_DIV65536_Val    0xFul  /**< \brief (SUPC_BOD12) Divide clock by 65536 */
+#define SUPC_BOD12_PSEL_DIV2        (SUPC_BOD12_PSEL_DIV2_Val      << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV4        (SUPC_BOD12_PSEL_DIV4_Val      << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV8        (SUPC_BOD12_PSEL_DIV8_Val      << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV16       (SUPC_BOD12_PSEL_DIV16_Val     << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV32       (SUPC_BOD12_PSEL_DIV32_Val     << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV64       (SUPC_BOD12_PSEL_DIV64_Val     << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV128      (SUPC_BOD12_PSEL_DIV128_Val    << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV256      (SUPC_BOD12_PSEL_DIV256_Val    << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV512      (SUPC_BOD12_PSEL_DIV512_Val    << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV1024     (SUPC_BOD12_PSEL_DIV1024_Val   << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV2048     (SUPC_BOD12_PSEL_DIV2048_Val   << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV4096     (SUPC_BOD12_PSEL_DIV4096_Val   << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV8192     (SUPC_BOD12_PSEL_DIV8192_Val   << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV16384    (SUPC_BOD12_PSEL_DIV16384_Val  << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV32768    (SUPC_BOD12_PSEL_DIV32768_Val  << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_PSEL_DIV65536    (SUPC_BOD12_PSEL_DIV65536_Val  << SUPC_BOD12_PSEL_Pos)
+#define SUPC_BOD12_LEVEL_Pos        16           /**< \brief (SUPC_BOD12) Threshold Level */
+#define SUPC_BOD12_LEVEL_Msk        (0x3Ful << SUPC_BOD12_LEVEL_Pos)
+#define SUPC_BOD12_LEVEL(value)     (SUPC_BOD12_LEVEL_Msk & ((value) << SUPC_BOD12_LEVEL_Pos))
+#define SUPC_BOD12_MASK             0x003FF17Eul /**< \brief (SUPC_BOD12) MASK Register */
+
+/* -------- SUPC_VREG : (SUPC Offset: 0x18) (R/W 32) VREG Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t SEL:2;            /*!< bit:  2.. 3  Voltage Regulator Selection in active mode */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t :9;               /*!< bit:  7..15  Reserved                           */
+    uint32_t VSVSTEP:4;        /*!< bit: 16..19  Voltage Scaling Voltage Step       */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t VSPER:8;          /*!< bit: 24..31  Voltage Scaling Period             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_VREG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_VREG_OFFSET            0x18         /**< \brief (SUPC_VREG offset) VREG Control */
+#define SUPC_VREG_RESETVALUE        0x00000000ul /**< \brief (SUPC_VREG reset_value) VREG Control */
+
+#define SUPC_VREG_ENABLE_Pos        1            /**< \brief (SUPC_VREG) Enable */
+#define SUPC_VREG_ENABLE            (0x1ul << SUPC_VREG_ENABLE_Pos)
+#define SUPC_VREG_SEL_Pos           2            /**< \brief (SUPC_VREG) Voltage Regulator Selection in active mode */
+#define SUPC_VREG_SEL_Msk           (0x3ul << SUPC_VREG_SEL_Pos)
+#define SUPC_VREG_SEL(value)        (SUPC_VREG_SEL_Msk & ((value) << SUPC_VREG_SEL_Pos))
+#define   SUPC_VREG_SEL_LDO_Val           0x0ul  /**< \brief (SUPC_VREG) LDO selection */
+#define   SUPC_VREG_SEL_BUCK_Val          0x1ul  /**< \brief (SUPC_VREG) Buck selection */
+#define   SUPC_VREG_SEL_SCVREG_Val        0x2ul  /**< \brief (SUPC_VREG) Switched Cap selection */
+#define SUPC_VREG_SEL_LDO           (SUPC_VREG_SEL_LDO_Val         << SUPC_VREG_SEL_Pos)
+#define SUPC_VREG_SEL_BUCK          (SUPC_VREG_SEL_BUCK_Val        << SUPC_VREG_SEL_Pos)
+#define SUPC_VREG_SEL_SCVREG        (SUPC_VREG_SEL_SCVREG_Val      << SUPC_VREG_SEL_Pos)
+#define SUPC_VREG_RUNSTDBY_Pos      6            /**< \brief (SUPC_VREG) Run during Standby */
+#define SUPC_VREG_RUNSTDBY          (0x1ul << SUPC_VREG_RUNSTDBY_Pos)
+#define SUPC_VREG_VSVSTEP_Pos       16           /**< \brief (SUPC_VREG) Voltage Scaling Voltage Step */
+#define SUPC_VREG_VSVSTEP_Msk       (0xFul << SUPC_VREG_VSVSTEP_Pos)
+#define SUPC_VREG_VSVSTEP(value)    (SUPC_VREG_VSVSTEP_Msk & ((value) << SUPC_VREG_VSVSTEP_Pos))
+#define SUPC_VREG_VSPER_Pos         24           /**< \brief (SUPC_VREG) Voltage Scaling Period */
+#define SUPC_VREG_VSPER_Msk         (0xFFul << SUPC_VREG_VSPER_Pos)
+#define SUPC_VREG_VSPER(value)      (SUPC_VREG_VSPER_Msk & ((value) << SUPC_VREG_VSPER_Pos))
+#define SUPC_VREG_MASK              0xFF0F004Eul /**< \brief (SUPC_VREG) MASK Register */
+
+/* -------- SUPC_VREF : (SUPC Offset: 0x1C) (R/W 32) VREF Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t TSEN:1;           /*!< bit:      1  Temperature Sensor Output Enable   */
+    uint32_t VREFOE:1;         /*!< bit:      2  Voltage Reference Output Enable    */
+    uint32_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t ONDEMAND:1;       /*!< bit:      7  On Demand Contrl                   */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t SEL:4;            /*!< bit: 16..19  Voltage Reference Selection        */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_VREF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_VREF_OFFSET            0x1C         /**< \brief (SUPC_VREF offset) VREF Control */
+#define SUPC_VREF_RESETVALUE        0x00000000ul /**< \brief (SUPC_VREF reset_value) VREF Control */
+
+#define SUPC_VREF_TSEN_Pos          1            /**< \brief (SUPC_VREF) Temperature Sensor Output Enable */
+#define SUPC_VREF_TSEN              (0x1ul << SUPC_VREF_TSEN_Pos)
+#define SUPC_VREF_VREFOE_Pos        2            /**< \brief (SUPC_VREF) Voltage Reference Output Enable */
+#define SUPC_VREF_VREFOE            (0x1ul << SUPC_VREF_VREFOE_Pos)
+#define SUPC_VREF_RUNSTDBY_Pos      6            /**< \brief (SUPC_VREF) Run during Standby */
+#define SUPC_VREF_RUNSTDBY          (0x1ul << SUPC_VREF_RUNSTDBY_Pos)
+#define SUPC_VREF_ONDEMAND_Pos      7            /**< \brief (SUPC_VREF) On Demand Contrl */
+#define SUPC_VREF_ONDEMAND          (0x1ul << SUPC_VREF_ONDEMAND_Pos)
+#define SUPC_VREF_SEL_Pos           16           /**< \brief (SUPC_VREF) Voltage Reference Selection */
+#define SUPC_VREF_SEL_Msk           (0xFul << SUPC_VREF_SEL_Pos)
+#define SUPC_VREF_SEL(value)        (SUPC_VREF_SEL_Msk & ((value) << SUPC_VREF_SEL_Pos))
+#define   SUPC_VREF_SEL_1V0_Val           0x0ul  /**< \brief (SUPC_VREF) 1.0V voltage reference typical value */
+#define   SUPC_VREF_SEL_1V1_Val           0x1ul  /**< \brief (SUPC_VREF) 1.1V voltage reference typical value */
+#define   SUPC_VREF_SEL_1V2_Val           0x2ul  /**< \brief (SUPC_VREF) 1.2V voltage reference typical value */
+#define   SUPC_VREF_SEL_1V25_Val          0x3ul  /**< \brief (SUPC_VREF) 1.25V voltage reference typical value */
+#define   SUPC_VREF_SEL_2V0_Val           0x4ul  /**< \brief (SUPC_VREF) 2.0V voltage reference typical value */
+#define   SUPC_VREF_SEL_2V2_Val           0x5ul  /**< \brief (SUPC_VREF) 2.2V voltage reference typical value */
+#define   SUPC_VREF_SEL_2V4_Val           0x6ul  /**< \brief (SUPC_VREF) 2.4V voltage reference typical value */
+#define   SUPC_VREF_SEL_2V5_Val           0x7ul  /**< \brief (SUPC_VREF) 2.5V voltage reference typical value */
+#define SUPC_VREF_SEL_1V0           (SUPC_VREF_SEL_1V0_Val         << SUPC_VREF_SEL_Pos)
+#define SUPC_VREF_SEL_1V1           (SUPC_VREF_SEL_1V1_Val         << SUPC_VREF_SEL_Pos)
+#define SUPC_VREF_SEL_1V2           (SUPC_VREF_SEL_1V2_Val         << SUPC_VREF_SEL_Pos)
+#define SUPC_VREF_SEL_1V25          (SUPC_VREF_SEL_1V25_Val        << SUPC_VREF_SEL_Pos)
+#define SUPC_VREF_SEL_2V0           (SUPC_VREF_SEL_2V0_Val         << SUPC_VREF_SEL_Pos)
+#define SUPC_VREF_SEL_2V2           (SUPC_VREF_SEL_2V2_Val         << SUPC_VREF_SEL_Pos)
+#define SUPC_VREF_SEL_2V4           (SUPC_VREF_SEL_2V4_Val         << SUPC_VREF_SEL_Pos)
+#define SUPC_VREF_SEL_2V5           (SUPC_VREF_SEL_2V5_Val         << SUPC_VREF_SEL_Pos)
+#define SUPC_VREF_MASK              0x000F00C6ul /**< \brief (SUPC_VREF) MASK Register */
+
+/* -------- SUPC_BBPS : (SUPC Offset: 0x20) (R/W 32) Battery Backup Power Switch -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CONF:2;           /*!< bit:  0.. 1  Battery Backup Configuration       */
+    uint32_t WAKEEN:1;         /*!< bit:      2  Wake Enable                        */
+    uint32_t PSOKEN:1;         /*!< bit:      3  Power Supply OK Enable             */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_BBPS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_BBPS_OFFSET            0x20         /**< \brief (SUPC_BBPS offset) Battery Backup Power Switch */
+#define SUPC_BBPS_RESETVALUE        0x00000000ul /**< \brief (SUPC_BBPS reset_value) Battery Backup Power Switch */
+
+#define SUPC_BBPS_CONF_Pos          0            /**< \brief (SUPC_BBPS) Battery Backup Configuration */
+#define SUPC_BBPS_CONF_Msk          (0x3ul << SUPC_BBPS_CONF_Pos)
+#define SUPC_BBPS_CONF(value)       (SUPC_BBPS_CONF_Msk & ((value) << SUPC_BBPS_CONF_Pos))
+#define   SUPC_BBPS_CONF_NONE_Val         0x0ul  /**< \brief (SUPC_BBPS) The backup domain is always supplied by main power */
+#define   SUPC_BBPS_CONF_APWS_Val         0x1ul  /**< \brief (SUPC_BBPS) The power switch is handled by the automatic power switch */
+#define   SUPC_BBPS_CONF_FORCED_Val       0x2ul  /**< \brief (SUPC_BBPS) The backup domain is always supplied by battery backup power */
+#define   SUPC_BBPS_CONF_BOD33_Val        0x3ul  /**< \brief (SUPC_BBPS) The power switch is handled by the BOD33 */
+#define SUPC_BBPS_CONF_NONE         (SUPC_BBPS_CONF_NONE_Val       << SUPC_BBPS_CONF_Pos)
+#define SUPC_BBPS_CONF_APWS         (SUPC_BBPS_CONF_APWS_Val       << SUPC_BBPS_CONF_Pos)
+#define SUPC_BBPS_CONF_FORCED       (SUPC_BBPS_CONF_FORCED_Val     << SUPC_BBPS_CONF_Pos)
+#define SUPC_BBPS_CONF_BOD33        (SUPC_BBPS_CONF_BOD33_Val      << SUPC_BBPS_CONF_Pos)
+#define SUPC_BBPS_WAKEEN_Pos        2            /**< \brief (SUPC_BBPS) Wake Enable */
+#define SUPC_BBPS_WAKEEN            (0x1ul << SUPC_BBPS_WAKEEN_Pos)
+#define SUPC_BBPS_PSOKEN_Pos        3            /**< \brief (SUPC_BBPS) Power Supply OK Enable */
+#define SUPC_BBPS_PSOKEN            (0x1ul << SUPC_BBPS_PSOKEN_Pos)
+#define SUPC_BBPS_MASK              0x0000000Ful /**< \brief (SUPC_BBPS) MASK Register */
+
+/* -------- SUPC_BKOUT : (SUPC Offset: 0x24) (R/W 32) Backup Output Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:2;             /*!< bit:  0.. 1  Enable Output                      */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t CLR:2;            /*!< bit:  8.. 9  Clear Output                       */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t SET:2;            /*!< bit: 16..17  Set Output                         */
+    uint32_t :6;               /*!< bit: 18..23  Reserved                           */
+    uint32_t RTCTGL:2;         /*!< bit: 24..25  RTC Toggle Output                  */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_BKOUT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_BKOUT_OFFSET           0x24         /**< \brief (SUPC_BKOUT offset) Backup Output Control */
+#define SUPC_BKOUT_RESETVALUE       0x00000000ul /**< \brief (SUPC_BKOUT reset_value) Backup Output Control */
+
+#define SUPC_BKOUT_EN_Pos           0            /**< \brief (SUPC_BKOUT) Enable Output */
+#define SUPC_BKOUT_EN_Msk           (0x3ul << SUPC_BKOUT_EN_Pos)
+#define SUPC_BKOUT_EN(value)        (SUPC_BKOUT_EN_Msk & ((value) << SUPC_BKOUT_EN_Pos))
+#define SUPC_BKOUT_CLR_Pos          8            /**< \brief (SUPC_BKOUT) Clear Output */
+#define SUPC_BKOUT_CLR_Msk          (0x3ul << SUPC_BKOUT_CLR_Pos)
+#define SUPC_BKOUT_CLR(value)       (SUPC_BKOUT_CLR_Msk & ((value) << SUPC_BKOUT_CLR_Pos))
+#define SUPC_BKOUT_SET_Pos          16           /**< \brief (SUPC_BKOUT) Set Output */
+#define SUPC_BKOUT_SET_Msk          (0x3ul << SUPC_BKOUT_SET_Pos)
+#define SUPC_BKOUT_SET(value)       (SUPC_BKOUT_SET_Msk & ((value) << SUPC_BKOUT_SET_Pos))
+#define SUPC_BKOUT_RTCTGL_Pos       24           /**< \brief (SUPC_BKOUT) RTC Toggle Output */
+#define SUPC_BKOUT_RTCTGL_Msk       (0x3ul << SUPC_BKOUT_RTCTGL_Pos)
+#define SUPC_BKOUT_RTCTGL(value)    (SUPC_BKOUT_RTCTGL_Msk & ((value) << SUPC_BKOUT_RTCTGL_Pos))
+#define SUPC_BKOUT_MASK             0x03030303ul /**< \brief (SUPC_BKOUT) MASK Register */
+
+/* -------- SUPC_BKIN : (SUPC Offset: 0x28) (R/  32) Backup Input Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BKIN:8;           /*!< bit:  0.. 7  Backup Input Value                 */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SUPC_BKIN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SUPC_BKIN_OFFSET            0x28         /**< \brief (SUPC_BKIN offset) Backup Input Control */
+#define SUPC_BKIN_RESETVALUE        0x00000000ul /**< \brief (SUPC_BKIN reset_value) Backup Input Control */
+
+#define SUPC_BKIN_BKIN_Pos          0            /**< \brief (SUPC_BKIN) Backup Input Value */
+#define SUPC_BKIN_BKIN_Msk          (0xFFul << SUPC_BKIN_BKIN_Pos)
+#define SUPC_BKIN_BKIN(value)       (SUPC_BKIN_BKIN_Msk & ((value) << SUPC_BKIN_BKIN_Pos))
+#define SUPC_BKIN_MASK              0x000000FFul /**< \brief (SUPC_BKIN) MASK Register */
+
+/** \brief SUPC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO SUPC_INTENCLR_Type        INTENCLR;    /**< \brief Offset: 0x00 (R/W 32) Interrupt Enable Clear */
+  __IO SUPC_INTENSET_Type        INTENSET;    /**< \brief Offset: 0x04 (R/W 32) Interrupt Enable Set */
+  __IO SUPC_INTFLAG_Type         INTFLAG;     /**< \brief Offset: 0x08 (R/W 32) Interrupt Flag Status and Clear */
+  __I  SUPC_STATUS_Type          STATUS;      /**< \brief Offset: 0x0C (R/  32) Power and Clocks Status */
+  __IO SUPC_BOD33_Type           BOD33;       /**< \brief Offset: 0x10 (R/W 32) BOD33 Control */
+  __IO SUPC_BOD12_Type           BOD12;       /**< \brief Offset: 0x14 (R/W 32) BOD12 Control */
+  __IO SUPC_VREG_Type            VREG;        /**< \brief Offset: 0x18 (R/W 32) VREG Control */
+  __IO SUPC_VREF_Type            VREF;        /**< \brief Offset: 0x1C (R/W 32) VREF Control */
+  __IO SUPC_BBPS_Type            BBPS;        /**< \brief Offset: 0x20 (R/W 32) Battery Backup Power Switch */
+  __IO SUPC_BKOUT_Type           BKOUT;       /**< \brief Offset: 0x24 (R/W 32) Backup Output Control */
+  __I  SUPC_BKIN_Type            BKIN;        /**< \brief Offset: 0x28 (R/  32) Backup Input Control */
+} Supc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_SUPC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/tal.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/tal.h
@@ -1,0 +1,901 @@
+/**
+ * \file
+ *
+ * \brief Component description for TAL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TAL_COMPONENT_
+#define _SAML21_TAL_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TAL */
+/* ========================================================================== */
+/** \addtogroup SAML21_TAL Trigger Allocator */
+/*@{*/
+
+#define TAL_U2253
+#define REV_TAL                     0x100
+
+/* -------- TAL_CTRLA : (TAL Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_CTRLA_OFFSET            0x00         /**< \brief (TAL_CTRLA offset) Control A */
+#define TAL_CTRLA_RESETVALUE        0x00ul       /**< \brief (TAL_CTRLA reset_value) Control A */
+
+#define TAL_CTRLA_SWRST_Pos         0            /**< \brief (TAL_CTRLA) Software Reset */
+#define TAL_CTRLA_SWRST             (0x1ul << TAL_CTRLA_SWRST_Pos)
+#define TAL_CTRLA_ENABLE_Pos        1            /**< \brief (TAL_CTRLA) Enable */
+#define TAL_CTRLA_ENABLE            (0x1ul << TAL_CTRLA_ENABLE_Pos)
+#define TAL_CTRLA_MASK              0x03ul       /**< \brief (TAL_CTRLA) MASK Register */
+
+/* -------- TAL_RSTCTRL : (TAL Offset: 0x04) (R/W  8) Reset Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_RSTCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_RSTCTRL_OFFSET          0x04         /**< \brief (TAL_RSTCTRL offset) Reset Control */
+#define TAL_RSTCTRL_RESETVALUE      0x00ul       /**< \brief (TAL_RSTCTRL reset_value) Reset Control */
+#define TAL_RSTCTRL_MASK            0x00ul       /**< \brief (TAL_RSTCTRL) MASK Register */
+
+/* -------- TAL_EXTCTRL : (TAL Offset: 0x05) (R/W  8) External Break Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ENABLE:1;         /*!< bit:      0  Enable BRK Pin                     */
+    uint8_t  INV:1;            /*!< bit:      1  Invert BRK Pin                     */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_EXTCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_EXTCTRL_OFFSET          0x05         /**< \brief (TAL_EXTCTRL offset) External Break Control */
+#define TAL_EXTCTRL_RESETVALUE      0x00ul       /**< \brief (TAL_EXTCTRL reset_value) External Break Control */
+
+#define TAL_EXTCTRL_ENABLE_Pos      0            /**< \brief (TAL_EXTCTRL) Enable BRK Pin */
+#define TAL_EXTCTRL_ENABLE          (0x1ul << TAL_EXTCTRL_ENABLE_Pos)
+#define TAL_EXTCTRL_INV_Pos         1            /**< \brief (TAL_EXTCTRL) Invert BRK Pin */
+#define TAL_EXTCTRL_INV             (0x1ul << TAL_EXTCTRL_INV_Pos)
+#define TAL_EXTCTRL_MASK            0x03ul       /**< \brief (TAL_EXTCTRL) MASK Register */
+
+/* -------- TAL_EVCTRL : (TAL Offset: 0x06) (R/W  8) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  BRKEI:1;          /*!< bit:      0  Break Input Event Enable           */
+    uint8_t  BRKEO:1;          /*!< bit:      1  Break Output Event Enable          */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_EVCTRL_OFFSET           0x06         /**< \brief (TAL_EVCTRL offset) Event Control */
+#define TAL_EVCTRL_RESETVALUE       0x00ul       /**< \brief (TAL_EVCTRL reset_value) Event Control */
+
+#define TAL_EVCTRL_BRKEI_Pos        0            /**< \brief (TAL_EVCTRL) Break Input Event Enable */
+#define TAL_EVCTRL_BRKEI            (0x1ul << TAL_EVCTRL_BRKEI_Pos)
+#define TAL_EVCTRL_BRKEO_Pos        1            /**< \brief (TAL_EVCTRL) Break Output Event Enable */
+#define TAL_EVCTRL_BRKEO            (0x1ul << TAL_EVCTRL_BRKEO_Pos)
+#define TAL_EVCTRL_MASK             0x03ul       /**< \brief (TAL_EVCTRL) MASK Register */
+
+/* -------- TAL_INTENCLR : (TAL Offset: 0x08) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  BRK:1;            /*!< bit:      0  Break Interrupt Enable             */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_INTENCLR_OFFSET         0x08         /**< \brief (TAL_INTENCLR offset) Interrupt Enable Clear */
+#define TAL_INTENCLR_RESETVALUE     0x00ul       /**< \brief (TAL_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define TAL_INTENCLR_BRK_Pos        0            /**< \brief (TAL_INTENCLR) Break Interrupt Enable */
+#define TAL_INTENCLR_BRK            (0x1ul << TAL_INTENCLR_BRK_Pos)
+#define TAL_INTENCLR_MASK           0x01ul       /**< \brief (TAL_INTENCLR) MASK Register */
+
+/* -------- TAL_INTENSET : (TAL Offset: 0x09) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  BRK:1;            /*!< bit:      0  Break Interrupt Enable             */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_INTENSET_OFFSET         0x09         /**< \brief (TAL_INTENSET offset) Interrupt Enable Set */
+#define TAL_INTENSET_RESETVALUE     0x00ul       /**< \brief (TAL_INTENSET reset_value) Interrupt Enable Set */
+
+#define TAL_INTENSET_BRK_Pos        0            /**< \brief (TAL_INTENSET) Break Interrupt Enable */
+#define TAL_INTENSET_BRK            (0x1ul << TAL_INTENSET_BRK_Pos)
+#define TAL_INTENSET_MASK           0x01ul       /**< \brief (TAL_INTENSET) MASK Register */
+
+/* -------- TAL_INTFLAG : (TAL Offset: 0x0A) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  BRK:1;            /*!< bit:      0  Break                              */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_INTFLAG_OFFSET          0x0A         /**< \brief (TAL_INTFLAG offset) Interrupt Flag Status and Clear */
+#define TAL_INTFLAG_RESETVALUE      0x00ul       /**< \brief (TAL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define TAL_INTFLAG_BRK_Pos         0            /**< \brief (TAL_INTFLAG) Break */
+#define TAL_INTFLAG_BRK             (0x1ul << TAL_INTFLAG_BRK_Pos)
+#define TAL_INTFLAG_MASK            0x01ul       /**< \brief (TAL_INTFLAG) MASK Register */
+
+/* -------- TAL_GLOBMASK : (TAL Offset: 0x0B) (R/W  8) Global Break Requests Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CM0P:1;           /*!< bit:      0  CM0P Break Master                  */
+    uint8_t  PPP:1;            /*!< bit:      1  PPP Break Master                   */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  EVBRK:1;          /*!< bit:      6  Event Break Master                 */
+    uint8_t  EXTBRK:1;         /*!< bit:      7  External Break Master              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_GLOBMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_GLOBMASK_OFFSET         0x0B         /**< \brief (TAL_GLOBMASK offset) Global Break Requests Mask */
+#define TAL_GLOBMASK_RESETVALUE     0x00ul       /**< \brief (TAL_GLOBMASK reset_value) Global Break Requests Mask */
+
+#define TAL_GLOBMASK_CM0P_Pos       0            /**< \brief (TAL_GLOBMASK) CM0P Break Master */
+#define TAL_GLOBMASK_CM0P           (0x1ul << TAL_GLOBMASK_CM0P_Pos)
+#define TAL_GLOBMASK_PPP_Pos        1            /**< \brief (TAL_GLOBMASK) PPP Break Master */
+#define TAL_GLOBMASK_PPP            (0x1ul << TAL_GLOBMASK_PPP_Pos)
+#define TAL_GLOBMASK_EVBRK_Pos      6            /**< \brief (TAL_GLOBMASK) Event Break Master */
+#define TAL_GLOBMASK_EVBRK          (0x1ul << TAL_GLOBMASK_EVBRK_Pos)
+#define TAL_GLOBMASK_EXTBRK_Pos     7            /**< \brief (TAL_GLOBMASK) External Break Master */
+#define TAL_GLOBMASK_EXTBRK         (0x1ul << TAL_GLOBMASK_EXTBRK_Pos)
+#define TAL_GLOBMASK_MASK           0xC3ul       /**< \brief (TAL_GLOBMASK) MASK Register */
+
+/* -------- TAL_HALT : (TAL Offset: 0x0C) ( /W  8) Debug Halt Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CM0P:1;           /*!< bit:      0  CM0P Break Master                  */
+    uint8_t  PPP:1;            /*!< bit:      1  PPP Break Master                   */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  EVBRK:1;          /*!< bit:      6  Event Break Master                 */
+    uint8_t  EXTBRK:1;         /*!< bit:      7  External Break Master              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_HALT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_HALT_OFFSET             0x0C         /**< \brief (TAL_HALT offset) Debug Halt Request */
+#define TAL_HALT_RESETVALUE         0x00ul       /**< \brief (TAL_HALT reset_value) Debug Halt Request */
+
+#define TAL_HALT_CM0P_Pos           0            /**< \brief (TAL_HALT) CM0P Break Master */
+#define TAL_HALT_CM0P               (0x1ul << TAL_HALT_CM0P_Pos)
+#define TAL_HALT_PPP_Pos            1            /**< \brief (TAL_HALT) PPP Break Master */
+#define TAL_HALT_PPP                (0x1ul << TAL_HALT_PPP_Pos)
+#define TAL_HALT_EVBRK_Pos          6            /**< \brief (TAL_HALT) Event Break Master */
+#define TAL_HALT_EVBRK              (0x1ul << TAL_HALT_EVBRK_Pos)
+#define TAL_HALT_EXTBRK_Pos         7            /**< \brief (TAL_HALT) External Break Master */
+#define TAL_HALT_EXTBRK             (0x1ul << TAL_HALT_EXTBRK_Pos)
+#define TAL_HALT_MASK               0xC3ul       /**< \brief (TAL_HALT) MASK Register */
+
+/* -------- TAL_RESTART : (TAL Offset: 0x0D) ( /W  8) Debug Restart Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CM0P:1;           /*!< bit:      0  CM0P Break Master                  */
+    uint8_t  PPP:1;            /*!< bit:      1  PPP Break Master                   */
+    uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  EXTBRK:1;         /*!< bit:      7  External Break Master              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_RESTART_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_RESTART_OFFSET          0x0D         /**< \brief (TAL_RESTART offset) Debug Restart Request */
+#define TAL_RESTART_RESETVALUE      0x00ul       /**< \brief (TAL_RESTART reset_value) Debug Restart Request */
+
+#define TAL_RESTART_CM0P_Pos        0            /**< \brief (TAL_RESTART) CM0P Break Master */
+#define TAL_RESTART_CM0P            (0x1ul << TAL_RESTART_CM0P_Pos)
+#define TAL_RESTART_PPP_Pos         1            /**< \brief (TAL_RESTART) PPP Break Master */
+#define TAL_RESTART_PPP             (0x1ul << TAL_RESTART_PPP_Pos)
+#define TAL_RESTART_EXTBRK_Pos      7            /**< \brief (TAL_RESTART) External Break Master */
+#define TAL_RESTART_EXTBRK          (0x1ul << TAL_RESTART_EXTBRK_Pos)
+#define TAL_RESTART_MASK            0x83ul       /**< \brief (TAL_RESTART) MASK Register */
+
+/* -------- TAL_BRKSTATUS : (TAL Offset: 0x0E) (R/  16) Break Request Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t CM0P:2;           /*!< bit:  0.. 1  CM0P Break Request                 */
+    uint16_t PPP:2;            /*!< bit:  2.. 3  PPP Break Request                  */
+    uint16_t :8;               /*!< bit:  4..11  Reserved                           */
+    uint16_t EVBRK:2;          /*!< bit: 12..13  Event Break Request                */
+    uint16_t EXTBRK:2;         /*!< bit: 14..15  External Break Request             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TAL_BRKSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_BRKSTATUS_OFFSET        0x0E         /**< \brief (TAL_BRKSTATUS offset) Break Request Status */
+#define TAL_BRKSTATUS_RESETVALUE    0x0000ul     /**< \brief (TAL_BRKSTATUS reset_value) Break Request Status */
+
+#define TAL_BRKSTATUS_CM0P_Pos      0            /**< \brief (TAL_BRKSTATUS) CM0P Break Request */
+#define TAL_BRKSTATUS_CM0P_Msk      (0x3ul << TAL_BRKSTATUS_CM0P_Pos)
+#define TAL_BRKSTATUS_CM0P(value)   (TAL_BRKSTATUS_CM0P_Msk & ((value) << TAL_BRKSTATUS_CM0P_Pos))
+#define TAL_BRKSTATUS_PPP_Pos       2            /**< \brief (TAL_BRKSTATUS) PPP Break Request */
+#define TAL_BRKSTATUS_PPP_Msk       (0x3ul << TAL_BRKSTATUS_PPP_Pos)
+#define TAL_BRKSTATUS_PPP(value)    (TAL_BRKSTATUS_PPP_Msk & ((value) << TAL_BRKSTATUS_PPP_Pos))
+#define TAL_BRKSTATUS_EVBRK_Pos     12           /**< \brief (TAL_BRKSTATUS) Event Break Request */
+#define TAL_BRKSTATUS_EVBRK_Msk     (0x3ul << TAL_BRKSTATUS_EVBRK_Pos)
+#define TAL_BRKSTATUS_EVBRK(value)  (TAL_BRKSTATUS_EVBRK_Msk & ((value) << TAL_BRKSTATUS_EVBRK_Pos))
+#define TAL_BRKSTATUS_EXTBRK_Pos    14           /**< \brief (TAL_BRKSTATUS) External Break Request */
+#define TAL_BRKSTATUS_EXTBRK_Msk    (0x3ul << TAL_BRKSTATUS_EXTBRK_Pos)
+#define TAL_BRKSTATUS_EXTBRK(value) (TAL_BRKSTATUS_EXTBRK_Msk & ((value) << TAL_BRKSTATUS_EXTBRK_Pos))
+#define TAL_BRKSTATUS_MASK          0xF00Ful     /**< \brief (TAL_BRKSTATUS) MASK Register */
+
+/* -------- TAL_CTICTRLA : (TAL Offset: 0x10) (R/W  8) CTIS Cross-Trigger Interface n Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ACTION:2;         /*!< bit:  0.. 1  Action when global break issued    */
+    uint8_t  RESTART:1;        /*!< bit:      2  Action when global restart issued  */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_CTICTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_CTICTRLA_OFFSET         0x10         /**< \brief (TAL_CTICTRLA offset) Cross-Trigger Interface n Control A */
+#define TAL_CTICTRLA_RESETVALUE     0x00ul       /**< \brief (TAL_CTICTRLA reset_value) Cross-Trigger Interface n Control A */
+
+#define TAL_CTICTRLA_ACTION_Pos     0            /**< \brief (TAL_CTICTRLA) Action when global break issued */
+#define TAL_CTICTRLA_ACTION_Msk     (0x3ul << TAL_CTICTRLA_ACTION_Pos)
+#define TAL_CTICTRLA_ACTION(value)  (TAL_CTICTRLA_ACTION_Msk & ((value) << TAL_CTICTRLA_ACTION_Pos))
+#define   TAL_CTICTRLA_ACTION_BREAK_Val   0x0ul  /**< \brief (TAL_CTICTRLA) Break when requested */
+#define   TAL_CTICTRLA_ACTION_INTERRUPT_Val 0x1ul  /**< \brief (TAL_CTICTRLA) Trigger DBG interrupt instead of break */
+#define   TAL_CTICTRLA_ACTION_IGNORE_Val  0x2ul  /**< \brief (TAL_CTICTRLA) Ignore break request */
+#define TAL_CTICTRLA_ACTION_BREAK   (TAL_CTICTRLA_ACTION_BREAK_Val << TAL_CTICTRLA_ACTION_Pos)
+#define TAL_CTICTRLA_ACTION_INTERRUPT (TAL_CTICTRLA_ACTION_INTERRUPT_Val << TAL_CTICTRLA_ACTION_Pos)
+#define TAL_CTICTRLA_ACTION_IGNORE  (TAL_CTICTRLA_ACTION_IGNORE_Val << TAL_CTICTRLA_ACTION_Pos)
+#define TAL_CTICTRLA_RESTART_Pos    2            /**< \brief (TAL_CTICTRLA) Action when global restart issued */
+#define TAL_CTICTRLA_RESTART        (0x1ul << TAL_CTICTRLA_RESTART_Pos)
+#define TAL_CTICTRLA_MASK           0x07ul       /**< \brief (TAL_CTICTRLA) MASK Register */
+
+/* -------- TAL_CTIMASK : (TAL Offset: 0x11) (R/W  8) CTIS Cross-Trigger Interface n Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CM0P:1;           /*!< bit:      0  CM0P Break Master                  */
+    uint8_t  PPP:1;            /*!< bit:      1  PPP Break Master                   */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  EVBRK:1;          /*!< bit:      6  Event Break Master                 */
+    uint8_t  EXTBRK:1;         /*!< bit:      7  External Break Master              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_CTIMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_CTIMASK_OFFSET          0x11         /**< \brief (TAL_CTIMASK offset) Cross-Trigger Interface n Mask */
+#define TAL_CTIMASK_RESETVALUE      0x00ul       /**< \brief (TAL_CTIMASK reset_value) Cross-Trigger Interface n Mask */
+
+#define TAL_CTIMASK_CM0P_Pos        0            /**< \brief (TAL_CTIMASK) CM0P Break Master */
+#define TAL_CTIMASK_CM0P            (0x1ul << TAL_CTIMASK_CM0P_Pos)
+#define TAL_CTIMASK_PPP_Pos         1            /**< \brief (TAL_CTIMASK) PPP Break Master */
+#define TAL_CTIMASK_PPP             (0x1ul << TAL_CTIMASK_PPP_Pos)
+#define TAL_CTIMASK_EVBRK_Pos       6            /**< \brief (TAL_CTIMASK) Event Break Master */
+#define TAL_CTIMASK_EVBRK           (0x1ul << TAL_CTIMASK_EVBRK_Pos)
+#define TAL_CTIMASK_EXTBRK_Pos      7            /**< \brief (TAL_CTIMASK) External Break Master */
+#define TAL_CTIMASK_EXTBRK          (0x1ul << TAL_CTIMASK_EXTBRK_Pos)
+#define TAL_CTIMASK_MASK            0xC3ul       /**< \brief (TAL_CTIMASK) MASK Register */
+
+/* -------- TAL_INTSTATUS : (TAL Offset: 0x20) (R/   8) Interrupt n Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  IRQ0:1;           /*!< bit:      0  Interrupt Status for Interrupt Request 0 within Interrupt n */
+    uint8_t  IRQ1:1;           /*!< bit:      1  Interrupt Status for Interrupt Request 1 within Interrupt n */
+    uint8_t  IRQ2:1;           /*!< bit:      2  Interrupt Status for Interrupt Request 2 within Interrupt n */
+    uint8_t  IRQ3:1;           /*!< bit:      3  Interrupt Status for Interrupt Request 3 within Interrupt n */
+    uint8_t  IRQ4:1;           /*!< bit:      4  Interrupt Status for Interrupt Request 4 within Interrupt n */
+    uint8_t  IRQ5:1;           /*!< bit:      5  Interrupt Status for Interrupt Request 5 within Interrupt n */
+    uint8_t  IRQ6:1;           /*!< bit:      6  Interrupt Status for Interrupt Request 6 within Interrupt n */
+    uint8_t  IRQ7:1;           /*!< bit:      7  Interrupt Status for Interrupt Request 7 within Interrupt n */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  IRQ:8;            /*!< bit:  0.. 7  Interrupt Status for Interrupt Request x within Interrupt n */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TAL_INTSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_INTSTATUS_OFFSET        0x20         /**< \brief (TAL_INTSTATUS offset) Interrupt n Status */
+#define TAL_INTSTATUS_RESETVALUE    0x00ul       /**< \brief (TAL_INTSTATUS reset_value) Interrupt n Status */
+
+#define TAL_INTSTATUS_IRQ0_Pos      0            /**< \brief (TAL_INTSTATUS) Interrupt Status for Interrupt Request 0 within Interrupt n */
+#define TAL_INTSTATUS_IRQ0          (1 << TAL_INTSTATUS_IRQ0_Pos)
+#define TAL_INTSTATUS_IRQ1_Pos      1            /**< \brief (TAL_INTSTATUS) Interrupt Status for Interrupt Request 1 within Interrupt n */
+#define TAL_INTSTATUS_IRQ1          (1 << TAL_INTSTATUS_IRQ1_Pos)
+#define TAL_INTSTATUS_IRQ2_Pos      2            /**< \brief (TAL_INTSTATUS) Interrupt Status for Interrupt Request 2 within Interrupt n */
+#define TAL_INTSTATUS_IRQ2          (1 << TAL_INTSTATUS_IRQ2_Pos)
+#define TAL_INTSTATUS_IRQ3_Pos      3            /**< \brief (TAL_INTSTATUS) Interrupt Status for Interrupt Request 3 within Interrupt n */
+#define TAL_INTSTATUS_IRQ3          (1 << TAL_INTSTATUS_IRQ3_Pos)
+#define TAL_INTSTATUS_IRQ4_Pos      4            /**< \brief (TAL_INTSTATUS) Interrupt Status for Interrupt Request 4 within Interrupt n */
+#define TAL_INTSTATUS_IRQ4          (1 << TAL_INTSTATUS_IRQ4_Pos)
+#define TAL_INTSTATUS_IRQ5_Pos      5            /**< \brief (TAL_INTSTATUS) Interrupt Status for Interrupt Request 5 within Interrupt n */
+#define TAL_INTSTATUS_IRQ5          (1 << TAL_INTSTATUS_IRQ5_Pos)
+#define TAL_INTSTATUS_IRQ6_Pos      6            /**< \brief (TAL_INTSTATUS) Interrupt Status for Interrupt Request 6 within Interrupt n */
+#define TAL_INTSTATUS_IRQ6          (1 << TAL_INTSTATUS_IRQ6_Pos)
+#define TAL_INTSTATUS_IRQ7_Pos      7            /**< \brief (TAL_INTSTATUS) Interrupt Status for Interrupt Request 7 within Interrupt n */
+#define TAL_INTSTATUS_IRQ7          (1 << TAL_INTSTATUS_IRQ7_Pos)
+#define TAL_INTSTATUS_IRQ_Pos       0            /**< \brief (TAL_INTSTATUS) Interrupt Status for Interrupt Request x within Interrupt n */
+#define TAL_INTSTATUS_IRQ_Msk       (0xFFul << TAL_INTSTATUS_IRQ_Pos)
+#define TAL_INTSTATUS_IRQ(value)    (TAL_INTSTATUS_IRQ_Msk & ((value) << TAL_INTSTATUS_IRQ_Pos))
+#define TAL_INTSTATUS_MASK          0xFFul       /**< \brief (TAL_INTSTATUS) MASK Register */
+
+/* -------- TAL_DMACPUSEL0 : (TAL Offset: 0x40) (R/W 32) DMA Channel Interrupts CPU Select 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CH0:1;            /*!< bit:      0  DMA Channel 0 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t CH1:1;            /*!< bit:      2  DMA Channel 1 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t CH2:1;            /*!< bit:      4  DMA Channel 2 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t CH3:1;            /*!< bit:      6  DMA Channel 3 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t CH4:1;            /*!< bit:      8  DMA Channel 4 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t CH5:1;            /*!< bit:     10  DMA Channel 5 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t CH6:1;            /*!< bit:     12  DMA Channel 6 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t CH7:1;            /*!< bit:     14  DMA Channel 7 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t CH8:1;            /*!< bit:     16  DMA Channel 8 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     17  Reserved                           */
+    uint32_t CH9:1;            /*!< bit:     18  DMA Channel 9 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     19  Reserved                           */
+    uint32_t CH10:1;           /*!< bit:     20  DMA Channel 10 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     21  Reserved                           */
+    uint32_t CH11:1;           /*!< bit:     22  DMA Channel 11 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t CH12:1;           /*!< bit:     24  DMA Channel 12 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     25  Reserved                           */
+    uint32_t CH13:1;           /*!< bit:     26  DMA Channel 13 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     27  Reserved                           */
+    uint32_t CH14:1;           /*!< bit:     28  DMA Channel 14 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     29  Reserved                           */
+    uint32_t CH15:1;           /*!< bit:     30  DMA Channel 15 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TAL_DMACPUSEL0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_DMACPUSEL0_OFFSET       0x40         /**< \brief (TAL_DMACPUSEL0 offset) DMA Channel Interrupts CPU Select 0 */
+#define TAL_DMACPUSEL0_RESETVALUE   0x00000000ul /**< \brief (TAL_DMACPUSEL0 reset_value) DMA Channel Interrupts CPU Select 0 */
+
+#define TAL_DMACPUSEL0_CH0_Pos      0            /**< \brief (TAL_DMACPUSEL0) DMA Channel 0 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH0_Msk      (0x1ul << TAL_DMACPUSEL0_CH0_Pos)
+#define TAL_DMACPUSEL0_CH0(value)   (TAL_DMACPUSEL0_CH0_Msk & ((value) << TAL_DMACPUSEL0_CH0_Pos))
+#define TAL_DMACPUSEL0_CH1_Pos      2            /**< \brief (TAL_DMACPUSEL0) DMA Channel 1 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH1_Msk      (0x1ul << TAL_DMACPUSEL0_CH1_Pos)
+#define TAL_DMACPUSEL0_CH1(value)   (TAL_DMACPUSEL0_CH1_Msk & ((value) << TAL_DMACPUSEL0_CH1_Pos))
+#define TAL_DMACPUSEL0_CH2_Pos      4            /**< \brief (TAL_DMACPUSEL0) DMA Channel 2 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH2_Msk      (0x1ul << TAL_DMACPUSEL0_CH2_Pos)
+#define TAL_DMACPUSEL0_CH2(value)   (TAL_DMACPUSEL0_CH2_Msk & ((value) << TAL_DMACPUSEL0_CH2_Pos))
+#define TAL_DMACPUSEL0_CH3_Pos      6            /**< \brief (TAL_DMACPUSEL0) DMA Channel 3 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH3_Msk      (0x1ul << TAL_DMACPUSEL0_CH3_Pos)
+#define TAL_DMACPUSEL0_CH3(value)   (TAL_DMACPUSEL0_CH3_Msk & ((value) << TAL_DMACPUSEL0_CH3_Pos))
+#define TAL_DMACPUSEL0_CH4_Pos      8            /**< \brief (TAL_DMACPUSEL0) DMA Channel 4 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH4_Msk      (0x1ul << TAL_DMACPUSEL0_CH4_Pos)
+#define TAL_DMACPUSEL0_CH4(value)   (TAL_DMACPUSEL0_CH4_Msk & ((value) << TAL_DMACPUSEL0_CH4_Pos))
+#define TAL_DMACPUSEL0_CH5_Pos      10           /**< \brief (TAL_DMACPUSEL0) DMA Channel 5 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH5_Msk      (0x1ul << TAL_DMACPUSEL0_CH5_Pos)
+#define TAL_DMACPUSEL0_CH5(value)   (TAL_DMACPUSEL0_CH5_Msk & ((value) << TAL_DMACPUSEL0_CH5_Pos))
+#define TAL_DMACPUSEL0_CH6_Pos      12           /**< \brief (TAL_DMACPUSEL0) DMA Channel 6 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH6_Msk      (0x1ul << TAL_DMACPUSEL0_CH6_Pos)
+#define TAL_DMACPUSEL0_CH6(value)   (TAL_DMACPUSEL0_CH6_Msk & ((value) << TAL_DMACPUSEL0_CH6_Pos))
+#define TAL_DMACPUSEL0_CH7_Pos      14           /**< \brief (TAL_DMACPUSEL0) DMA Channel 7 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH7_Msk      (0x1ul << TAL_DMACPUSEL0_CH7_Pos)
+#define TAL_DMACPUSEL0_CH7(value)   (TAL_DMACPUSEL0_CH7_Msk & ((value) << TAL_DMACPUSEL0_CH7_Pos))
+#define TAL_DMACPUSEL0_CH8_Pos      16           /**< \brief (TAL_DMACPUSEL0) DMA Channel 8 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH8_Msk      (0x1ul << TAL_DMACPUSEL0_CH8_Pos)
+#define TAL_DMACPUSEL0_CH8(value)   (TAL_DMACPUSEL0_CH8_Msk & ((value) << TAL_DMACPUSEL0_CH8_Pos))
+#define TAL_DMACPUSEL0_CH9_Pos      18           /**< \brief (TAL_DMACPUSEL0) DMA Channel 9 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH9_Msk      (0x1ul << TAL_DMACPUSEL0_CH9_Pos)
+#define TAL_DMACPUSEL0_CH9(value)   (TAL_DMACPUSEL0_CH9_Msk & ((value) << TAL_DMACPUSEL0_CH9_Pos))
+#define TAL_DMACPUSEL0_CH10_Pos     20           /**< \brief (TAL_DMACPUSEL0) DMA Channel 10 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH10_Msk     (0x1ul << TAL_DMACPUSEL0_CH10_Pos)
+#define TAL_DMACPUSEL0_CH10(value)  (TAL_DMACPUSEL0_CH10_Msk & ((value) << TAL_DMACPUSEL0_CH10_Pos))
+#define TAL_DMACPUSEL0_CH11_Pos     22           /**< \brief (TAL_DMACPUSEL0) DMA Channel 11 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH11_Msk     (0x1ul << TAL_DMACPUSEL0_CH11_Pos)
+#define TAL_DMACPUSEL0_CH11(value)  (TAL_DMACPUSEL0_CH11_Msk & ((value) << TAL_DMACPUSEL0_CH11_Pos))
+#define TAL_DMACPUSEL0_CH12_Pos     24           /**< \brief (TAL_DMACPUSEL0) DMA Channel 12 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH12_Msk     (0x1ul << TAL_DMACPUSEL0_CH12_Pos)
+#define TAL_DMACPUSEL0_CH12(value)  (TAL_DMACPUSEL0_CH12_Msk & ((value) << TAL_DMACPUSEL0_CH12_Pos))
+#define TAL_DMACPUSEL0_CH13_Pos     26           /**< \brief (TAL_DMACPUSEL0) DMA Channel 13 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH13_Msk     (0x1ul << TAL_DMACPUSEL0_CH13_Pos)
+#define TAL_DMACPUSEL0_CH13(value)  (TAL_DMACPUSEL0_CH13_Msk & ((value) << TAL_DMACPUSEL0_CH13_Pos))
+#define TAL_DMACPUSEL0_CH14_Pos     28           /**< \brief (TAL_DMACPUSEL0) DMA Channel 14 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH14_Msk     (0x1ul << TAL_DMACPUSEL0_CH14_Pos)
+#define TAL_DMACPUSEL0_CH14(value)  (TAL_DMACPUSEL0_CH14_Msk & ((value) << TAL_DMACPUSEL0_CH14_Pos))
+#define TAL_DMACPUSEL0_CH15_Pos     30           /**< \brief (TAL_DMACPUSEL0) DMA Channel 15 Interrupt CPU Select */
+#define TAL_DMACPUSEL0_CH15_Msk     (0x1ul << TAL_DMACPUSEL0_CH15_Pos)
+#define TAL_DMACPUSEL0_CH15(value)  (TAL_DMACPUSEL0_CH15_Msk & ((value) << TAL_DMACPUSEL0_CH15_Pos))
+#define TAL_DMACPUSEL0_MASK         0x55555555ul /**< \brief (TAL_DMACPUSEL0) MASK Register */
+
+/* -------- TAL_EVCPUSEL0 : (TAL Offset: 0x48) (R/W 32) EVSYS Channel Interrupts CPU Select 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CH0:1;            /*!< bit:      0  Event Channel 0 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t CH1:1;            /*!< bit:      2  Event Channel 1 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t CH2:1;            /*!< bit:      4  Event Channel 2 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t CH3:1;            /*!< bit:      6  Event Channel 3 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t CH4:1;            /*!< bit:      8  Event Channel 4 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t CH5:1;            /*!< bit:     10  Event Channel 5 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t CH6:1;            /*!< bit:     12  Event Channel 6 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t CH7:1;            /*!< bit:     14  Event Channel 7 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t CH8:1;            /*!< bit:     16  Event Channel 8 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     17  Reserved                           */
+    uint32_t CH9:1;            /*!< bit:     18  Event Channel 9 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     19  Reserved                           */
+    uint32_t CH10:1;           /*!< bit:     20  Event Channel 10 Interrupt CPU Select */
+    uint32_t :1;               /*!< bit:     21  Reserved                           */
+    uint32_t CH11:1;           /*!< bit:     22  Event Channel 11 Interrupt CPU Select */
+    uint32_t :9;               /*!< bit: 23..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TAL_EVCPUSEL0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_EVCPUSEL0_OFFSET        0x48         /**< \brief (TAL_EVCPUSEL0 offset) EVSYS Channel Interrupts CPU Select 0 */
+#define TAL_EVCPUSEL0_RESETVALUE    0x00000000ul /**< \brief (TAL_EVCPUSEL0 reset_value) EVSYS Channel Interrupts CPU Select 0 */
+
+#define TAL_EVCPUSEL0_CH0_Pos       0            /**< \brief (TAL_EVCPUSEL0) Event Channel 0 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH0_Msk       (0x1ul << TAL_EVCPUSEL0_CH0_Pos)
+#define TAL_EVCPUSEL0_CH0(value)    (TAL_EVCPUSEL0_CH0_Msk & ((value) << TAL_EVCPUSEL0_CH0_Pos))
+#define TAL_EVCPUSEL0_CH1_Pos       2            /**< \brief (TAL_EVCPUSEL0) Event Channel 1 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH1_Msk       (0x1ul << TAL_EVCPUSEL0_CH1_Pos)
+#define TAL_EVCPUSEL0_CH1(value)    (TAL_EVCPUSEL0_CH1_Msk & ((value) << TAL_EVCPUSEL0_CH1_Pos))
+#define TAL_EVCPUSEL0_CH2_Pos       4            /**< \brief (TAL_EVCPUSEL0) Event Channel 2 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH2_Msk       (0x1ul << TAL_EVCPUSEL0_CH2_Pos)
+#define TAL_EVCPUSEL0_CH2(value)    (TAL_EVCPUSEL0_CH2_Msk & ((value) << TAL_EVCPUSEL0_CH2_Pos))
+#define TAL_EVCPUSEL0_CH3_Pos       6            /**< \brief (TAL_EVCPUSEL0) Event Channel 3 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH3_Msk       (0x1ul << TAL_EVCPUSEL0_CH3_Pos)
+#define TAL_EVCPUSEL0_CH3(value)    (TAL_EVCPUSEL0_CH3_Msk & ((value) << TAL_EVCPUSEL0_CH3_Pos))
+#define TAL_EVCPUSEL0_CH4_Pos       8            /**< \brief (TAL_EVCPUSEL0) Event Channel 4 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH4_Msk       (0x1ul << TAL_EVCPUSEL0_CH4_Pos)
+#define TAL_EVCPUSEL0_CH4(value)    (TAL_EVCPUSEL0_CH4_Msk & ((value) << TAL_EVCPUSEL0_CH4_Pos))
+#define TAL_EVCPUSEL0_CH5_Pos       10           /**< \brief (TAL_EVCPUSEL0) Event Channel 5 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH5_Msk       (0x1ul << TAL_EVCPUSEL0_CH5_Pos)
+#define TAL_EVCPUSEL0_CH5(value)    (TAL_EVCPUSEL0_CH5_Msk & ((value) << TAL_EVCPUSEL0_CH5_Pos))
+#define TAL_EVCPUSEL0_CH6_Pos       12           /**< \brief (TAL_EVCPUSEL0) Event Channel 6 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH6_Msk       (0x1ul << TAL_EVCPUSEL0_CH6_Pos)
+#define TAL_EVCPUSEL0_CH6(value)    (TAL_EVCPUSEL0_CH6_Msk & ((value) << TAL_EVCPUSEL0_CH6_Pos))
+#define TAL_EVCPUSEL0_CH7_Pos       14           /**< \brief (TAL_EVCPUSEL0) Event Channel 7 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH7_Msk       (0x1ul << TAL_EVCPUSEL0_CH7_Pos)
+#define TAL_EVCPUSEL0_CH7(value)    (TAL_EVCPUSEL0_CH7_Msk & ((value) << TAL_EVCPUSEL0_CH7_Pos))
+#define TAL_EVCPUSEL0_CH8_Pos       16           /**< \brief (TAL_EVCPUSEL0) Event Channel 8 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH8_Msk       (0x1ul << TAL_EVCPUSEL0_CH8_Pos)
+#define TAL_EVCPUSEL0_CH8(value)    (TAL_EVCPUSEL0_CH8_Msk & ((value) << TAL_EVCPUSEL0_CH8_Pos))
+#define TAL_EVCPUSEL0_CH9_Pos       18           /**< \brief (TAL_EVCPUSEL0) Event Channel 9 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH9_Msk       (0x1ul << TAL_EVCPUSEL0_CH9_Pos)
+#define TAL_EVCPUSEL0_CH9(value)    (TAL_EVCPUSEL0_CH9_Msk & ((value) << TAL_EVCPUSEL0_CH9_Pos))
+#define TAL_EVCPUSEL0_CH10_Pos      20           /**< \brief (TAL_EVCPUSEL0) Event Channel 10 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH10_Msk      (0x1ul << TAL_EVCPUSEL0_CH10_Pos)
+#define TAL_EVCPUSEL0_CH10(value)   (TAL_EVCPUSEL0_CH10_Msk & ((value) << TAL_EVCPUSEL0_CH10_Pos))
+#define TAL_EVCPUSEL0_CH11_Pos      22           /**< \brief (TAL_EVCPUSEL0) Event Channel 11 Interrupt CPU Select */
+#define TAL_EVCPUSEL0_CH11_Msk      (0x1ul << TAL_EVCPUSEL0_CH11_Pos)
+#define TAL_EVCPUSEL0_CH11(value)   (TAL_EVCPUSEL0_CH11_Msk & ((value) << TAL_EVCPUSEL0_CH11_Pos))
+#define TAL_EVCPUSEL0_MASK          0x00555555ul /**< \brief (TAL_EVCPUSEL0) MASK Register */
+
+/* -------- TAL_EICCPUSEL0 : (TAL Offset: 0x50) (R/W 32) EIC External Interrupts CPU Select 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINT0:1;        /*!< bit:      0  External Interrupt 0 CPU Select    */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t EXTINT1:1;        /*!< bit:      2  External Interrupt 1 CPU Select    */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t EXTINT2:1;        /*!< bit:      4  External Interrupt 2 CPU Select    */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t EXTINT3:1;        /*!< bit:      6  External Interrupt 3 CPU Select    */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t EXTINT4:1;        /*!< bit:      8  External Interrupt 4 CPU Select    */
+    uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t EXTINT5:1;        /*!< bit:     10  External Interrupt 5 CPU Select    */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t EXTINT6:1;        /*!< bit:     12  External Interrupt 6 CPU Select    */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t EXTINT7:1;        /*!< bit:     14  External Interrupt 7 CPU Select    */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t EXTINT8:1;        /*!< bit:     16  External Interrupt 8 CPU Select    */
+    uint32_t :1;               /*!< bit:     17  Reserved                           */
+    uint32_t EXTINT9:1;        /*!< bit:     18  External Interrupt 9 CPU Select    */
+    uint32_t :1;               /*!< bit:     19  Reserved                           */
+    uint32_t EXTINT10:1;       /*!< bit:     20  External Interrupt 10 CPU Select   */
+    uint32_t :1;               /*!< bit:     21  Reserved                           */
+    uint32_t EXTINT11:1;       /*!< bit:     22  External Interrupt 11 CPU Select   */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t EXTINT12:1;       /*!< bit:     24  External Interrupt 12 CPU Select   */
+    uint32_t :1;               /*!< bit:     25  Reserved                           */
+    uint32_t EXTINT13:1;       /*!< bit:     26  External Interrupt 13 CPU Select   */
+    uint32_t :1;               /*!< bit:     27  Reserved                           */
+    uint32_t EXTINT14:1;       /*!< bit:     28  External Interrupt 14 CPU Select   */
+    uint32_t :1;               /*!< bit:     29  Reserved                           */
+    uint32_t EXTINT15:1;       /*!< bit:     30  External Interrupt 15 CPU Select   */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TAL_EICCPUSEL0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_EICCPUSEL0_OFFSET       0x50         /**< \brief (TAL_EICCPUSEL0 offset) EIC External Interrupts CPU Select 0 */
+#define TAL_EICCPUSEL0_RESETVALUE   0x00000000ul /**< \brief (TAL_EICCPUSEL0 reset_value) EIC External Interrupts CPU Select 0 */
+
+#define TAL_EICCPUSEL0_EXTINT0_Pos  0            /**< \brief (TAL_EICCPUSEL0) External Interrupt 0 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT0_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT0_Pos)
+#define TAL_EICCPUSEL0_EXTINT0(value) (TAL_EICCPUSEL0_EXTINT0_Msk & ((value) << TAL_EICCPUSEL0_EXTINT0_Pos))
+#define TAL_EICCPUSEL0_EXTINT1_Pos  2            /**< \brief (TAL_EICCPUSEL0) External Interrupt 1 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT1_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT1_Pos)
+#define TAL_EICCPUSEL0_EXTINT1(value) (TAL_EICCPUSEL0_EXTINT1_Msk & ((value) << TAL_EICCPUSEL0_EXTINT1_Pos))
+#define TAL_EICCPUSEL0_EXTINT2_Pos  4            /**< \brief (TAL_EICCPUSEL0) External Interrupt 2 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT2_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT2_Pos)
+#define TAL_EICCPUSEL0_EXTINT2(value) (TAL_EICCPUSEL0_EXTINT2_Msk & ((value) << TAL_EICCPUSEL0_EXTINT2_Pos))
+#define TAL_EICCPUSEL0_EXTINT3_Pos  6            /**< \brief (TAL_EICCPUSEL0) External Interrupt 3 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT3_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT3_Pos)
+#define TAL_EICCPUSEL0_EXTINT3(value) (TAL_EICCPUSEL0_EXTINT3_Msk & ((value) << TAL_EICCPUSEL0_EXTINT3_Pos))
+#define TAL_EICCPUSEL0_EXTINT4_Pos  8            /**< \brief (TAL_EICCPUSEL0) External Interrupt 4 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT4_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT4_Pos)
+#define TAL_EICCPUSEL0_EXTINT4(value) (TAL_EICCPUSEL0_EXTINT4_Msk & ((value) << TAL_EICCPUSEL0_EXTINT4_Pos))
+#define TAL_EICCPUSEL0_EXTINT5_Pos  10           /**< \brief (TAL_EICCPUSEL0) External Interrupt 5 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT5_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT5_Pos)
+#define TAL_EICCPUSEL0_EXTINT5(value) (TAL_EICCPUSEL0_EXTINT5_Msk & ((value) << TAL_EICCPUSEL0_EXTINT5_Pos))
+#define TAL_EICCPUSEL0_EXTINT6_Pos  12           /**< \brief (TAL_EICCPUSEL0) External Interrupt 6 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT6_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT6_Pos)
+#define TAL_EICCPUSEL0_EXTINT6(value) (TAL_EICCPUSEL0_EXTINT6_Msk & ((value) << TAL_EICCPUSEL0_EXTINT6_Pos))
+#define TAL_EICCPUSEL0_EXTINT7_Pos  14           /**< \brief (TAL_EICCPUSEL0) External Interrupt 7 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT7_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT7_Pos)
+#define TAL_EICCPUSEL0_EXTINT7(value) (TAL_EICCPUSEL0_EXTINT7_Msk & ((value) << TAL_EICCPUSEL0_EXTINT7_Pos))
+#define TAL_EICCPUSEL0_EXTINT8_Pos  16           /**< \brief (TAL_EICCPUSEL0) External Interrupt 8 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT8_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT8_Pos)
+#define TAL_EICCPUSEL0_EXTINT8(value) (TAL_EICCPUSEL0_EXTINT8_Msk & ((value) << TAL_EICCPUSEL0_EXTINT8_Pos))
+#define TAL_EICCPUSEL0_EXTINT9_Pos  18           /**< \brief (TAL_EICCPUSEL0) External Interrupt 9 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT9_Msk  (0x1ul << TAL_EICCPUSEL0_EXTINT9_Pos)
+#define TAL_EICCPUSEL0_EXTINT9(value) (TAL_EICCPUSEL0_EXTINT9_Msk & ((value) << TAL_EICCPUSEL0_EXTINT9_Pos))
+#define TAL_EICCPUSEL0_EXTINT10_Pos 20           /**< \brief (TAL_EICCPUSEL0) External Interrupt 10 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT10_Msk (0x1ul << TAL_EICCPUSEL0_EXTINT10_Pos)
+#define TAL_EICCPUSEL0_EXTINT10(value) (TAL_EICCPUSEL0_EXTINT10_Msk & ((value) << TAL_EICCPUSEL0_EXTINT10_Pos))
+#define TAL_EICCPUSEL0_EXTINT11_Pos 22           /**< \brief (TAL_EICCPUSEL0) External Interrupt 11 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT11_Msk (0x1ul << TAL_EICCPUSEL0_EXTINT11_Pos)
+#define TAL_EICCPUSEL0_EXTINT11(value) (TAL_EICCPUSEL0_EXTINT11_Msk & ((value) << TAL_EICCPUSEL0_EXTINT11_Pos))
+#define TAL_EICCPUSEL0_EXTINT12_Pos 24           /**< \brief (TAL_EICCPUSEL0) External Interrupt 12 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT12_Msk (0x1ul << TAL_EICCPUSEL0_EXTINT12_Pos)
+#define TAL_EICCPUSEL0_EXTINT12(value) (TAL_EICCPUSEL0_EXTINT12_Msk & ((value) << TAL_EICCPUSEL0_EXTINT12_Pos))
+#define TAL_EICCPUSEL0_EXTINT13_Pos 26           /**< \brief (TAL_EICCPUSEL0) External Interrupt 13 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT13_Msk (0x1ul << TAL_EICCPUSEL0_EXTINT13_Pos)
+#define TAL_EICCPUSEL0_EXTINT13(value) (TAL_EICCPUSEL0_EXTINT13_Msk & ((value) << TAL_EICCPUSEL0_EXTINT13_Pos))
+#define TAL_EICCPUSEL0_EXTINT14_Pos 28           /**< \brief (TAL_EICCPUSEL0) External Interrupt 14 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT14_Msk (0x1ul << TAL_EICCPUSEL0_EXTINT14_Pos)
+#define TAL_EICCPUSEL0_EXTINT14(value) (TAL_EICCPUSEL0_EXTINT14_Msk & ((value) << TAL_EICCPUSEL0_EXTINT14_Pos))
+#define TAL_EICCPUSEL0_EXTINT15_Pos 30           /**< \brief (TAL_EICCPUSEL0) External Interrupt 15 CPU Select */
+#define TAL_EICCPUSEL0_EXTINT15_Msk (0x1ul << TAL_EICCPUSEL0_EXTINT15_Pos)
+#define TAL_EICCPUSEL0_EXTINT15(value) (TAL_EICCPUSEL0_EXTINT15_Msk & ((value) << TAL_EICCPUSEL0_EXTINT15_Pos))
+#define TAL_EICCPUSEL0_MASK         0x55555555ul /**< \brief (TAL_EICCPUSEL0) MASK Register */
+
+/* -------- TAL_INTCPUSEL0 : (TAL Offset: 0x58) (R/W 32) Interrupts CPU Select 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SYSTEM:1;         /*!< bit:      0  SYSTEM Interrupt CPU Select        */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t WDT:1;            /*!< bit:      2  WDT Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t RTC:1;            /*!< bit:      4  RTC Interrupt CPU Select           */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t NVMCTRL:1;        /*!< bit:      8  NVMCTRL Interrupt CPU Select       */
+    uint32_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint32_t USB:1;            /*!< bit:     12  USB Interrupt CPU Select           */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t SERCOM0:1;        /*!< bit:     16  SERCOM0 Interrupt CPU Select       */
+    uint32_t :1;               /*!< bit:     17  Reserved                           */
+    uint32_t SERCOM1:1;        /*!< bit:     18  SERCOM1 Interrupt CPU Select       */
+    uint32_t :1;               /*!< bit:     19  Reserved                           */
+    uint32_t SERCOM2:1;        /*!< bit:     20  SERCOM2 Interrupt CPU Select       */
+    uint32_t :1;               /*!< bit:     21  Reserved                           */
+    uint32_t SERCOM3:1;        /*!< bit:     22  SERCOM3 Interrupt CPU Select       */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t SERCOM4:1;        /*!< bit:     24  SERCOM4 Interrupt CPU Select       */
+    uint32_t :1;               /*!< bit:     25  Reserved                           */
+    uint32_t SERCOM5:1;        /*!< bit:     26  SERCOM5 Interrupt CPU Select       */
+    uint32_t :1;               /*!< bit:     27  Reserved                           */
+    uint32_t TCC0:1;           /*!< bit:     28  TCC0 Interrupt CPU Select          */
+    uint32_t :1;               /*!< bit:     29  Reserved                           */
+    uint32_t TCC1:1;           /*!< bit:     30  TCC1 Interrupt CPU Select          */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TAL_INTCPUSEL0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_INTCPUSEL0_OFFSET       0x58         /**< \brief (TAL_INTCPUSEL0 offset) Interrupts CPU Select 0 */
+#define TAL_INTCPUSEL0_RESETVALUE   0x00000000ul /**< \brief (TAL_INTCPUSEL0 reset_value) Interrupts CPU Select 0 */
+
+#define TAL_INTCPUSEL0_SYSTEM_Pos   0            /**< \brief (TAL_INTCPUSEL0) SYSTEM Interrupt CPU Select */
+#define TAL_INTCPUSEL0_SYSTEM_Msk   (0x1ul << TAL_INTCPUSEL0_SYSTEM_Pos)
+#define TAL_INTCPUSEL0_SYSTEM(value) (TAL_INTCPUSEL0_SYSTEM_Msk & ((value) << TAL_INTCPUSEL0_SYSTEM_Pos))
+#define TAL_INTCPUSEL0_WDT_Pos      2            /**< \brief (TAL_INTCPUSEL0) WDT Interrupt CPU Select */
+#define TAL_INTCPUSEL0_WDT_Msk      (0x1ul << TAL_INTCPUSEL0_WDT_Pos)
+#define TAL_INTCPUSEL0_WDT(value)   (TAL_INTCPUSEL0_WDT_Msk & ((value) << TAL_INTCPUSEL0_WDT_Pos))
+#define TAL_INTCPUSEL0_RTC_Pos      4            /**< \brief (TAL_INTCPUSEL0) RTC Interrupt CPU Select */
+#define TAL_INTCPUSEL0_RTC_Msk      (0x1ul << TAL_INTCPUSEL0_RTC_Pos)
+#define TAL_INTCPUSEL0_RTC(value)   (TAL_INTCPUSEL0_RTC_Msk & ((value) << TAL_INTCPUSEL0_RTC_Pos))
+#define TAL_INTCPUSEL0_NVMCTRL_Pos  8            /**< \brief (TAL_INTCPUSEL0) NVMCTRL Interrupt CPU Select */
+#define TAL_INTCPUSEL0_NVMCTRL_Msk  (0x1ul << TAL_INTCPUSEL0_NVMCTRL_Pos)
+#define TAL_INTCPUSEL0_NVMCTRL(value) (TAL_INTCPUSEL0_NVMCTRL_Msk & ((value) << TAL_INTCPUSEL0_NVMCTRL_Pos))
+#define TAL_INTCPUSEL0_USB_Pos      12           /**< \brief (TAL_INTCPUSEL0) USB Interrupt CPU Select */
+#define TAL_INTCPUSEL0_USB_Msk      (0x1ul << TAL_INTCPUSEL0_USB_Pos)
+#define TAL_INTCPUSEL0_USB(value)   (TAL_INTCPUSEL0_USB_Msk & ((value) << TAL_INTCPUSEL0_USB_Pos))
+#define TAL_INTCPUSEL0_SERCOM0_Pos  16           /**< \brief (TAL_INTCPUSEL0) SERCOM0 Interrupt CPU Select */
+#define TAL_INTCPUSEL0_SERCOM0_Msk  (0x1ul << TAL_INTCPUSEL0_SERCOM0_Pos)
+#define TAL_INTCPUSEL0_SERCOM0(value) (TAL_INTCPUSEL0_SERCOM0_Msk & ((value) << TAL_INTCPUSEL0_SERCOM0_Pos))
+#define TAL_INTCPUSEL0_SERCOM1_Pos  18           /**< \brief (TAL_INTCPUSEL0) SERCOM1 Interrupt CPU Select */
+#define TAL_INTCPUSEL0_SERCOM1_Msk  (0x1ul << TAL_INTCPUSEL0_SERCOM1_Pos)
+#define TAL_INTCPUSEL0_SERCOM1(value) (TAL_INTCPUSEL0_SERCOM1_Msk & ((value) << TAL_INTCPUSEL0_SERCOM1_Pos))
+#define TAL_INTCPUSEL0_SERCOM2_Pos  20           /**< \brief (TAL_INTCPUSEL0) SERCOM2 Interrupt CPU Select */
+#define TAL_INTCPUSEL0_SERCOM2_Msk  (0x1ul << TAL_INTCPUSEL0_SERCOM2_Pos)
+#define TAL_INTCPUSEL0_SERCOM2(value) (TAL_INTCPUSEL0_SERCOM2_Msk & ((value) << TAL_INTCPUSEL0_SERCOM2_Pos))
+#define TAL_INTCPUSEL0_SERCOM3_Pos  22           /**< \brief (TAL_INTCPUSEL0) SERCOM3 Interrupt CPU Select */
+#define TAL_INTCPUSEL0_SERCOM3_Msk  (0x1ul << TAL_INTCPUSEL0_SERCOM3_Pos)
+#define TAL_INTCPUSEL0_SERCOM3(value) (TAL_INTCPUSEL0_SERCOM3_Msk & ((value) << TAL_INTCPUSEL0_SERCOM3_Pos))
+#define TAL_INTCPUSEL0_SERCOM4_Pos  24           /**< \brief (TAL_INTCPUSEL0) SERCOM4 Interrupt CPU Select */
+#define TAL_INTCPUSEL0_SERCOM4_Msk  (0x1ul << TAL_INTCPUSEL0_SERCOM4_Pos)
+#define TAL_INTCPUSEL0_SERCOM4(value) (TAL_INTCPUSEL0_SERCOM4_Msk & ((value) << TAL_INTCPUSEL0_SERCOM4_Pos))
+#define TAL_INTCPUSEL0_SERCOM5_Pos  26           /**< \brief (TAL_INTCPUSEL0) SERCOM5 Interrupt CPU Select */
+#define TAL_INTCPUSEL0_SERCOM5_Msk  (0x1ul << TAL_INTCPUSEL0_SERCOM5_Pos)
+#define TAL_INTCPUSEL0_SERCOM5(value) (TAL_INTCPUSEL0_SERCOM5_Msk & ((value) << TAL_INTCPUSEL0_SERCOM5_Pos))
+#define TAL_INTCPUSEL0_TCC0_Pos     28           /**< \brief (TAL_INTCPUSEL0) TCC0 Interrupt CPU Select */
+#define TAL_INTCPUSEL0_TCC0_Msk     (0x1ul << TAL_INTCPUSEL0_TCC0_Pos)
+#define TAL_INTCPUSEL0_TCC0(value)  (TAL_INTCPUSEL0_TCC0_Msk & ((value) << TAL_INTCPUSEL0_TCC0_Pos))
+#define TAL_INTCPUSEL0_TCC1_Pos     30           /**< \brief (TAL_INTCPUSEL0) TCC1 Interrupt CPU Select */
+#define TAL_INTCPUSEL0_TCC1_Msk     (0x1ul << TAL_INTCPUSEL0_TCC1_Pos)
+#define TAL_INTCPUSEL0_TCC1(value)  (TAL_INTCPUSEL0_TCC1_Msk & ((value) << TAL_INTCPUSEL0_TCC1_Pos))
+#define TAL_INTCPUSEL0_MASK         0x55551115ul /**< \brief (TAL_INTCPUSEL0) MASK Register */
+
+/* -------- TAL_INTCPUSEL1 : (TAL Offset: 0x5C) (R/W 32) Interrupts CPU Select 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TCC2:1;           /*!< bit:      0  TCC2 Interrupt CPU Select          */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t TC0:1;            /*!< bit:      2  TC0 Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t TC1:1;            /*!< bit:      4  TC1 Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t TC2:1;            /*!< bit:      6  TC2 Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t TC3:1;            /*!< bit:      8  TC3 Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t TC4:1;            /*!< bit:     10  TC4 Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t ADC:1;            /*!< bit:     12  ADC Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t AC:1;             /*!< bit:     14  AC Interrupt CPU Select            */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t DAC:1;            /*!< bit:     16  DAC Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:     17  Reserved                           */
+    uint32_t PTC:1;            /*!< bit:     18  PTC Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:     19  Reserved                           */
+    uint32_t AES:1;            /*!< bit:     20  AES Interrupt CPU Select           */
+    uint32_t :1;               /*!< bit:     21  Reserved                           */
+    uint32_t TRNG:1;           /*!< bit:     22  TRNG Interrupt CPU Select          */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t PICOP:1;          /*!< bit:     24  PICOP Interrupt CPU Select         */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TAL_INTCPUSEL1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_INTCPUSEL1_OFFSET       0x5C         /**< \brief (TAL_INTCPUSEL1 offset) Interrupts CPU Select 1 */
+#define TAL_INTCPUSEL1_RESETVALUE   0x00000000ul /**< \brief (TAL_INTCPUSEL1 reset_value) Interrupts CPU Select 1 */
+
+#define TAL_INTCPUSEL1_TCC2_Pos     0            /**< \brief (TAL_INTCPUSEL1) TCC2 Interrupt CPU Select */
+#define TAL_INTCPUSEL1_TCC2_Msk     (0x1ul << TAL_INTCPUSEL1_TCC2_Pos)
+#define TAL_INTCPUSEL1_TCC2(value)  (TAL_INTCPUSEL1_TCC2_Msk & ((value) << TAL_INTCPUSEL1_TCC2_Pos))
+#define TAL_INTCPUSEL1_TC0_Pos      2            /**< \brief (TAL_INTCPUSEL1) TC0 Interrupt CPU Select */
+#define TAL_INTCPUSEL1_TC0_Msk      (0x1ul << TAL_INTCPUSEL1_TC0_Pos)
+#define TAL_INTCPUSEL1_TC0(value)   (TAL_INTCPUSEL1_TC0_Msk & ((value) << TAL_INTCPUSEL1_TC0_Pos))
+#define TAL_INTCPUSEL1_TC1_Pos      4            /**< \brief (TAL_INTCPUSEL1) TC1 Interrupt CPU Select */
+#define TAL_INTCPUSEL1_TC1_Msk      (0x1ul << TAL_INTCPUSEL1_TC1_Pos)
+#define TAL_INTCPUSEL1_TC1(value)   (TAL_INTCPUSEL1_TC1_Msk & ((value) << TAL_INTCPUSEL1_TC1_Pos))
+#define TAL_INTCPUSEL1_TC2_Pos      6            /**< \brief (TAL_INTCPUSEL1) TC2 Interrupt CPU Select */
+#define TAL_INTCPUSEL1_TC2_Msk      (0x1ul << TAL_INTCPUSEL1_TC2_Pos)
+#define TAL_INTCPUSEL1_TC2(value)   (TAL_INTCPUSEL1_TC2_Msk & ((value) << TAL_INTCPUSEL1_TC2_Pos))
+#define TAL_INTCPUSEL1_TC3_Pos      8            /**< \brief (TAL_INTCPUSEL1) TC3 Interrupt CPU Select */
+#define TAL_INTCPUSEL1_TC3_Msk      (0x1ul << TAL_INTCPUSEL1_TC3_Pos)
+#define TAL_INTCPUSEL1_TC3(value)   (TAL_INTCPUSEL1_TC3_Msk & ((value) << TAL_INTCPUSEL1_TC3_Pos))
+#define TAL_INTCPUSEL1_TC4_Pos      10           /**< \brief (TAL_INTCPUSEL1) TC4 Interrupt CPU Select */
+#define TAL_INTCPUSEL1_TC4_Msk      (0x1ul << TAL_INTCPUSEL1_TC4_Pos)
+#define TAL_INTCPUSEL1_TC4(value)   (TAL_INTCPUSEL1_TC4_Msk & ((value) << TAL_INTCPUSEL1_TC4_Pos))
+#define TAL_INTCPUSEL1_ADC_Pos      12           /**< \brief (TAL_INTCPUSEL1) ADC Interrupt CPU Select */
+#define TAL_INTCPUSEL1_ADC_Msk      (0x1ul << TAL_INTCPUSEL1_ADC_Pos)
+#define TAL_INTCPUSEL1_ADC(value)   (TAL_INTCPUSEL1_ADC_Msk & ((value) << TAL_INTCPUSEL1_ADC_Pos))
+#define TAL_INTCPUSEL1_AC_Pos       14           /**< \brief (TAL_INTCPUSEL1) AC Interrupt CPU Select */
+#define TAL_INTCPUSEL1_AC_Msk       (0x1ul << TAL_INTCPUSEL1_AC_Pos)
+#define TAL_INTCPUSEL1_AC(value)    (TAL_INTCPUSEL1_AC_Msk & ((value) << TAL_INTCPUSEL1_AC_Pos))
+#define TAL_INTCPUSEL1_DAC_Pos      16           /**< \brief (TAL_INTCPUSEL1) DAC Interrupt CPU Select */
+#define TAL_INTCPUSEL1_DAC_Msk      (0x1ul << TAL_INTCPUSEL1_DAC_Pos)
+#define TAL_INTCPUSEL1_DAC(value)   (TAL_INTCPUSEL1_DAC_Msk & ((value) << TAL_INTCPUSEL1_DAC_Pos))
+#define TAL_INTCPUSEL1_PTC_Pos      18           /**< \brief (TAL_INTCPUSEL1) PTC Interrupt CPU Select */
+#define TAL_INTCPUSEL1_PTC_Msk      (0x1ul << TAL_INTCPUSEL1_PTC_Pos)
+#define TAL_INTCPUSEL1_PTC(value)   (TAL_INTCPUSEL1_PTC_Msk & ((value) << TAL_INTCPUSEL1_PTC_Pos))
+#define TAL_INTCPUSEL1_AES_Pos      20           /**< \brief (TAL_INTCPUSEL1) AES Interrupt CPU Select */
+#define TAL_INTCPUSEL1_AES_Msk      (0x1ul << TAL_INTCPUSEL1_AES_Pos)
+#define TAL_INTCPUSEL1_AES(value)   (TAL_INTCPUSEL1_AES_Msk & ((value) << TAL_INTCPUSEL1_AES_Pos))
+#define TAL_INTCPUSEL1_TRNG_Pos     22           /**< \brief (TAL_INTCPUSEL1) TRNG Interrupt CPU Select */
+#define TAL_INTCPUSEL1_TRNG_Msk     (0x1ul << TAL_INTCPUSEL1_TRNG_Pos)
+#define TAL_INTCPUSEL1_TRNG(value)  (TAL_INTCPUSEL1_TRNG_Msk & ((value) << TAL_INTCPUSEL1_TRNG_Pos))
+#define TAL_INTCPUSEL1_PICOP_Pos    24           /**< \brief (TAL_INTCPUSEL1) PICOP Interrupt CPU Select */
+#define TAL_INTCPUSEL1_PICOP_Msk    (0x1ul << TAL_INTCPUSEL1_PICOP_Pos)
+#define TAL_INTCPUSEL1_PICOP(value) (TAL_INTCPUSEL1_PICOP_Msk & ((value) << TAL_INTCPUSEL1_PICOP_Pos))
+#define TAL_INTCPUSEL1_MASK         0x01555555ul /**< \brief (TAL_INTCPUSEL1) MASK Register */
+
+/* -------- TAL_IRQTRIG : (TAL Offset: 0x60) (R/W 16) Interrupt Trigger -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t ENABLE:1;         /*!< bit:      0  Trigger Enable                     */
+    uint16_t IRQNUM:5;         /*!< bit:  1.. 5  Interrupt Request Number           */
+    uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t OVERRIDE:8;       /*!< bit:  8..15  Interrupt Request Override Value   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TAL_IRQTRIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_IRQTRIG_OFFSET          0x60         /**< \brief (TAL_IRQTRIG offset) Interrupt Trigger */
+#define TAL_IRQTRIG_RESETVALUE      0x0000ul     /**< \brief (TAL_IRQTRIG reset_value) Interrupt Trigger */
+
+#define TAL_IRQTRIG_ENABLE_Pos      0            /**< \brief (TAL_IRQTRIG) Trigger Enable */
+#define TAL_IRQTRIG_ENABLE          (0x1ul << TAL_IRQTRIG_ENABLE_Pos)
+#define TAL_IRQTRIG_IRQNUM_Pos      1            /**< \brief (TAL_IRQTRIG) Interrupt Request Number */
+#define TAL_IRQTRIG_IRQNUM_Msk      (0x1Ful << TAL_IRQTRIG_IRQNUM_Pos)
+#define TAL_IRQTRIG_IRQNUM(value)   (TAL_IRQTRIG_IRQNUM_Msk & ((value) << TAL_IRQTRIG_IRQNUM_Pos))
+#define TAL_IRQTRIG_OVERRIDE_Pos    8            /**< \brief (TAL_IRQTRIG) Interrupt Request Override Value */
+#define TAL_IRQTRIG_OVERRIDE_Msk    (0xFFul << TAL_IRQTRIG_OVERRIDE_Pos)
+#define TAL_IRQTRIG_OVERRIDE(value) (TAL_IRQTRIG_OVERRIDE_Msk & ((value) << TAL_IRQTRIG_OVERRIDE_Pos))
+#define TAL_IRQTRIG_MASK            0xFF3Ful     /**< \brief (TAL_IRQTRIG) MASK Register */
+
+/* -------- TAL_CPUIRQS : (TAL Offset: 0x64) (R/  32) Interrupt Status for CPU n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CPUIRQS:29;       /*!< bit:  0..28  Interrupt Requests for CPU n       */
+    uint32_t :3;               /*!< bit: 29..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TAL_CPUIRQS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TAL_CPUIRQS_OFFSET          0x64         /**< \brief (TAL_CPUIRQS offset) Interrupt Status for CPU n */
+#define TAL_CPUIRQS_RESETVALUE      0x00000000ul /**< \brief (TAL_CPUIRQS reset_value) Interrupt Status for CPU n */
+
+#define TAL_CPUIRQS_CPUIRQS_Pos     0            /**< \brief (TAL_CPUIRQS) Interrupt Requests for CPU n */
+#define TAL_CPUIRQS_CPUIRQS_Msk     (0x1FFFFFFFul << TAL_CPUIRQS_CPUIRQS_Pos)
+#define TAL_CPUIRQS_CPUIRQS(value)  (TAL_CPUIRQS_CPUIRQS_Msk & ((value) << TAL_CPUIRQS_CPUIRQS_Pos))
+#define TAL_CPUIRQS_MASK            0x1FFFFFFFul /**< \brief (TAL_CPUIRQS) MASK Register */
+
+/** \brief TalCtis hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO TAL_CTICTRLA_Type         CTICTRLA;    /**< \brief Offset: 0x00 (R/W  8) Cross-Trigger Interface n Control A */
+  __IO TAL_CTIMASK_Type          CTIMASK;     /**< \brief Offset: 0x01 (R/W  8) Cross-Trigger Interface n Mask */
+} TalCtis;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief TAL hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO TAL_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+       RoReg8                    Reserved1[0x3];
+  __IO TAL_RSTCTRL_Type          RSTCTRL;     /**< \brief Offset: 0x04 (R/W  8) Reset Control */
+  __IO TAL_EXTCTRL_Type          EXTCTRL;     /**< \brief Offset: 0x05 (R/W  8) External Break Control */
+  __IO TAL_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x06 (R/W  8) Event Control */
+       RoReg8                    Reserved2[0x1];
+  __IO TAL_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x08 (R/W  8) Interrupt Enable Clear */
+  __IO TAL_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x09 (R/W  8) Interrupt Enable Set */
+  __IO TAL_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x0A (R/W  8) Interrupt Flag Status and Clear */
+  __IO TAL_GLOBMASK_Type         GLOBMASK;    /**< \brief Offset: 0x0B (R/W  8) Global Break Requests Mask */
+  __O  TAL_HALT_Type             HALT;        /**< \brief Offset: 0x0C ( /W  8) Debug Halt Request */
+  __O  TAL_RESTART_Type          RESTART;     /**< \brief Offset: 0x0D ( /W  8) Debug Restart Request */
+  __I  TAL_BRKSTATUS_Type        BRKSTATUS;   /**< \brief Offset: 0x0E (R/  16) Break Request Status */
+       TalCtis                   Ctis[4];     /**< \brief Offset: 0x10 TalCtis groups [CTI_NUM] */
+       RoReg8                    Reserved3[0x8];
+  __I  TAL_INTSTATUS_Type        INTSTATUS[29]; /**< \brief Offset: 0x20 (R/   8) Interrupt n Status */
+       RoReg8                    Reserved4[0x3];
+  __IO TAL_DMACPUSEL0_Type       DMACPUSEL0;  /**< \brief Offset: 0x40 (R/W 32) DMA Channel Interrupts CPU Select 0 */
+       RoReg8                    Reserved5[0x4];
+  __IO TAL_EVCPUSEL0_Type        EVCPUSEL0;   /**< \brief Offset: 0x48 (R/W 32) EVSYS Channel Interrupts CPU Select 0 */
+       RoReg8                    Reserved6[0x4];
+  __IO TAL_EICCPUSEL0_Type       EICCPUSEL0;  /**< \brief Offset: 0x50 (R/W 32) EIC External Interrupts CPU Select 0 */
+       RoReg8                    Reserved7[0x4];
+  __IO TAL_INTCPUSEL0_Type       INTCPUSEL0;  /**< \brief Offset: 0x58 (R/W 32) Interrupts CPU Select 0 */
+  __IO TAL_INTCPUSEL1_Type       INTCPUSEL1;  /**< \brief Offset: 0x5C (R/W 32) Interrupts CPU Select 1 */
+  __IO TAL_IRQTRIG_Type          IRQTRIG;     /**< \brief Offset: 0x60 (R/W 16) Interrupt Trigger */
+       RoReg8                    Reserved8[0x2];
+  __I  TAL_CPUIRQS_Type          CPUIRQS[2];  /**< \brief Offset: 0x64 (R/  32) Interrupt Status for CPU n */
+} Tal;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_TAL_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/tc_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/tc_100.h
@@ -1,0 +1,823 @@
+/**
+ * \file
+ *
+ * \brief Component description for TC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TC_COMPONENT_
+#define _SAML21_TC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TC */
+/* ========================================================================== */
+/** \addtogroup SAML21_TC Basic Timer Counter */
+/*@{*/
+
+#define TC_U2249
+#define REV_TC                      0x100
+
+/* -------- TC_CTRLA : (TC Offset: 0x00) (R/W 32) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:2;           /*!< bit:  2.. 3  Timer Counter Mode                 */
+    uint32_t PRESCSYNC:2;      /*!< bit:  4.. 5  Prescaler and Counter Synchronization */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t ONDEMAND:1;       /*!< bit:      7  Clock On Demand                    */
+    uint32_t PRESCALER:3;      /*!< bit:  8..10  Prescaler                          */
+    uint32_t ALOCK:1;          /*!< bit:     11  Auto Lock                          */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t CAPTEN0:1;        /*!< bit:     16  Capture Channel 0 Enable           */
+    uint32_t CAPTEN1:1;        /*!< bit:     17  Capture Channel 1 Enable           */
+    uint32_t :2;               /*!< bit: 18..19  Reserved                           */
+    uint32_t COPEN0:1;         /*!< bit:     20  Capture On Pin 0 Enable            */
+    uint32_t COPEN1:1;         /*!< bit:     21  Capture On Pin 1 Enable            */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t CAPTEN:2;         /*!< bit: 16..17  Capture Channel x Enable           */
+    uint32_t :2;               /*!< bit: 18..19  Reserved                           */
+    uint32_t COPEN:2;          /*!< bit: 20..21  Capture On Pin x Enable            */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLA_OFFSET             0x00         /**< \brief (TC_CTRLA offset) Control A */
+#define TC_CTRLA_RESETVALUE         0x00000000ul /**< \brief (TC_CTRLA reset_value) Control A */
+
+#define TC_CTRLA_SWRST_Pos          0            /**< \brief (TC_CTRLA) Software Reset */
+#define TC_CTRLA_SWRST              (0x1ul << TC_CTRLA_SWRST_Pos)
+#define TC_CTRLA_ENABLE_Pos         1            /**< \brief (TC_CTRLA) Enable */
+#define TC_CTRLA_ENABLE             (0x1ul << TC_CTRLA_ENABLE_Pos)
+#define TC_CTRLA_MODE_Pos           2            /**< \brief (TC_CTRLA) Timer Counter Mode */
+#define TC_CTRLA_MODE_Msk           (0x3ul << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE(value)        (TC_CTRLA_MODE_Msk & ((value) << TC_CTRLA_MODE_Pos))
+#define   TC_CTRLA_MODE_COUNT16_Val       0x0ul  /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_MODE_COUNT8_Val        0x1ul  /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_MODE_COUNT32_Val       0x2ul  /**< \brief (TC_CTRLA)  */
+#define TC_CTRLA_MODE_COUNT16       (TC_CTRLA_MODE_COUNT16_Val     << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE_COUNT8        (TC_CTRLA_MODE_COUNT8_Val      << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE_COUNT32       (TC_CTRLA_MODE_COUNT32_Val     << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_PRESCSYNC_Pos      4            /**< \brief (TC_CTRLA) Prescaler and Counter Synchronization */
+#define TC_CTRLA_PRESCSYNC_Msk      (0x3ul << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC(value)   (TC_CTRLA_PRESCSYNC_Msk & ((value) << TC_CTRLA_PRESCSYNC_Pos))
+#define   TC_CTRLA_PRESCSYNC_GCLK_Val     0x0ul  /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_PRESCSYNC_PRESC_Val    0x1ul  /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_PRESCSYNC_RESYNC_Val   0x2ul  /**< \brief (TC_CTRLA)  */
+#define TC_CTRLA_PRESCSYNC_GCLK     (TC_CTRLA_PRESCSYNC_GCLK_Val   << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC_PRESC    (TC_CTRLA_PRESCSYNC_PRESC_Val  << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC_RESYNC   (TC_CTRLA_PRESCSYNC_RESYNC_Val << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_RUNSTDBY_Pos       6            /**< \brief (TC_CTRLA) Run during Standby */
+#define TC_CTRLA_RUNSTDBY           (0x1ul << TC_CTRLA_RUNSTDBY_Pos)
+#define TC_CTRLA_ONDEMAND_Pos       7            /**< \brief (TC_CTRLA) Clock On Demand */
+#define TC_CTRLA_ONDEMAND           (0x1ul << TC_CTRLA_ONDEMAND_Pos)
+#define TC_CTRLA_PRESCALER_Pos      8            /**< \brief (TC_CTRLA) Prescaler */
+#define TC_CTRLA_PRESCALER_Msk      (0x7ul << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER(value)   (TC_CTRLA_PRESCALER_Msk & ((value) << TC_CTRLA_PRESCALER_Pos))
+#define TC_CTRLA_ALOCK_Pos          11           /**< \brief (TC_CTRLA) Auto Lock */
+#define TC_CTRLA_ALOCK              (0x1ul << TC_CTRLA_ALOCK_Pos)
+#define TC_CTRLA_CAPTEN0_Pos        16           /**< \brief (TC_CTRLA) Capture Channel 0 Enable */
+#define TC_CTRLA_CAPTEN0            (1 << TC_CTRLA_CAPTEN0_Pos)
+#define TC_CTRLA_CAPTEN1_Pos        17           /**< \brief (TC_CTRLA) Capture Channel 1 Enable */
+#define TC_CTRLA_CAPTEN1            (1 << TC_CTRLA_CAPTEN1_Pos)
+#define TC_CTRLA_CAPTEN_Pos         16           /**< \brief (TC_CTRLA) Capture Channel x Enable */
+#define TC_CTRLA_CAPTEN_Msk         (0x3ul << TC_CTRLA_CAPTEN_Pos)
+#define TC_CTRLA_CAPTEN(value)      (TC_CTRLA_CAPTEN_Msk & ((value) << TC_CTRLA_CAPTEN_Pos))
+#define TC_CTRLA_COPEN0_Pos         20           /**< \brief (TC_CTRLA) Capture On Pin 0 Enable */
+#define TC_CTRLA_COPEN0             (1 << TC_CTRLA_COPEN0_Pos)
+#define TC_CTRLA_COPEN1_Pos         21           /**< \brief (TC_CTRLA) Capture On Pin 1 Enable */
+#define TC_CTRLA_COPEN1             (1 << TC_CTRLA_COPEN1_Pos)
+#define TC_CTRLA_COPEN_Pos          20           /**< \brief (TC_CTRLA) Capture On Pin x Enable */
+#define TC_CTRLA_COPEN_Msk          (0x3ul << TC_CTRLA_COPEN_Pos)
+#define TC_CTRLA_COPEN(value)       (TC_CTRLA_COPEN_Msk & ((value) << TC_CTRLA_COPEN_Pos))
+#define TC_CTRLA_MASK               0x00330FFFul /**< \brief (TC_CTRLA) MASK Register */
+
+/* -------- TC_CTRLBCLR : (TC Offset: 0x04) (R/W  8) Control B Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DIR:1;            /*!< bit:      0  Counter Direction                  */
+    uint8_t  LUPD:1;           /*!< bit:      1  Lock Update                        */
+    uint8_t  ONESHOT:1;        /*!< bit:      2  One-Shot on Counter                */
+    uint8_t  :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint8_t  CMD:3;            /*!< bit:  5.. 7  Command                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_CTRLBCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBCLR_OFFSET          0x04         /**< \brief (TC_CTRLBCLR offset) Control B Clear */
+#define TC_CTRLBCLR_RESETVALUE      0x00ul       /**< \brief (TC_CTRLBCLR reset_value) Control B Clear */
+
+#define TC_CTRLBCLR_DIR_Pos         0            /**< \brief (TC_CTRLBCLR) Counter Direction */
+#define TC_CTRLBCLR_DIR             (0x1ul << TC_CTRLBCLR_DIR_Pos)
+#define TC_CTRLBCLR_LUPD_Pos        1            /**< \brief (TC_CTRLBCLR) Lock Update */
+#define TC_CTRLBCLR_LUPD            (0x1ul << TC_CTRLBCLR_LUPD_Pos)
+#define TC_CTRLBCLR_ONESHOT_Pos     2            /**< \brief (TC_CTRLBCLR) One-Shot on Counter */
+#define TC_CTRLBCLR_ONESHOT         (0x1ul << TC_CTRLBCLR_ONESHOT_Pos)
+#define TC_CTRLBCLR_CMD_Pos         5            /**< \brief (TC_CTRLBCLR) Command */
+#define TC_CTRLBCLR_CMD_Msk         (0x7ul << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD(value)      (TC_CTRLBCLR_CMD_Msk & ((value) << TC_CTRLBCLR_CMD_Pos))
+#define   TC_CTRLBCLR_CMD_NONE_Val        0x0ul  /**< \brief (TC_CTRLBCLR)  */
+#define   TC_CTRLBCLR_CMD_RETRIGGER_Val   0x1ul  /**< \brief (TC_CTRLBCLR)  */
+#define   TC_CTRLBCLR_CMD_STOP_Val        0x2ul  /**< \brief (TC_CTRLBCLR)  */
+#define   TC_CTRLBCLR_CMD_UPDATE_Val      0x3ul  /**< \brief (TC_CTRLBCLR)  */
+#define   TC_CTRLBCLR_CMD_READSYNC_Val    0x4ul  /**< \brief (TC_CTRLBCLR)  */
+#define TC_CTRLBCLR_CMD_NONE        (TC_CTRLBCLR_CMD_NONE_Val      << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD_RETRIGGER   (TC_CTRLBCLR_CMD_RETRIGGER_Val << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD_STOP        (TC_CTRLBCLR_CMD_STOP_Val      << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD_UPDATE      (TC_CTRLBCLR_CMD_UPDATE_Val    << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD_READSYNC    (TC_CTRLBCLR_CMD_READSYNC_Val  << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_MASK            0xE7ul       /**< \brief (TC_CTRLBCLR) MASK Register */
+
+/* -------- TC_CTRLBSET : (TC Offset: 0x05) (R/W  8) Control B Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DIR:1;            /*!< bit:      0  Counter Direction                  */
+    uint8_t  LUPD:1;           /*!< bit:      1  Lock Update                        */
+    uint8_t  ONESHOT:1;        /*!< bit:      2  One-Shot on Counter                */
+    uint8_t  :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint8_t  CMD:3;            /*!< bit:  5.. 7  Command                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_CTRLBSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBSET_OFFSET          0x05         /**< \brief (TC_CTRLBSET offset) Control B Set */
+#define TC_CTRLBSET_RESETVALUE      0x00ul       /**< \brief (TC_CTRLBSET reset_value) Control B Set */
+
+#define TC_CTRLBSET_DIR_Pos         0            /**< \brief (TC_CTRLBSET) Counter Direction */
+#define TC_CTRLBSET_DIR             (0x1ul << TC_CTRLBSET_DIR_Pos)
+#define TC_CTRLBSET_LUPD_Pos        1            /**< \brief (TC_CTRLBSET) Lock Update */
+#define TC_CTRLBSET_LUPD            (0x1ul << TC_CTRLBSET_LUPD_Pos)
+#define TC_CTRLBSET_ONESHOT_Pos     2            /**< \brief (TC_CTRLBSET) One-Shot on Counter */
+#define TC_CTRLBSET_ONESHOT         (0x1ul << TC_CTRLBSET_ONESHOT_Pos)
+#define TC_CTRLBSET_CMD_Pos         5            /**< \brief (TC_CTRLBSET) Command */
+#define TC_CTRLBSET_CMD_Msk         (0x7ul << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD(value)      (TC_CTRLBSET_CMD_Msk & ((value) << TC_CTRLBSET_CMD_Pos))
+#define   TC_CTRLBSET_CMD_NONE_Val        0x0ul  /**< \brief (TC_CTRLBSET)  */
+#define   TC_CTRLBSET_CMD_RETRIGGER_Val   0x1ul  /**< \brief (TC_CTRLBSET)  */
+#define   TC_CTRLBSET_CMD_STOP_Val        0x2ul  /**< \brief (TC_CTRLBSET)  */
+#define   TC_CTRLBSET_CMD_UPDATE_Val      0x3ul  /**< \brief (TC_CTRLBSET)  */
+#define   TC_CTRLBSET_CMD_READSYNC_Val    0x4ul  /**< \brief (TC_CTRLBSET)  */
+#define TC_CTRLBSET_CMD_NONE        (TC_CTRLBSET_CMD_NONE_Val      << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD_RETRIGGER   (TC_CTRLBSET_CMD_RETRIGGER_Val << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD_STOP        (TC_CTRLBSET_CMD_STOP_Val      << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD_UPDATE      (TC_CTRLBSET_CMD_UPDATE_Val    << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD_READSYNC    (TC_CTRLBSET_CMD_READSYNC_Val  << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_MASK            0xE7ul       /**< \brief (TC_CTRLBSET) MASK Register */
+
+/* -------- TC_EVCTRL : (TC Offset: 0x06) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t EVACT:3;          /*!< bit:  0.. 2  Event Action                       */
+    uint16_t :1;               /*!< bit:      3  Reserved                           */
+    uint16_t TCINV:1;          /*!< bit:      4  TC Event Input Polarity            */
+    uint16_t TCEI:1;           /*!< bit:      5  TC Event Enable                    */
+    uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t OVFEO:1;          /*!< bit:      8  Event Output Enable                */
+    uint16_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint16_t MCEO0:1;          /*!< bit:     12  MC Event Output Enable 0           */
+    uint16_t MCEO1:1;          /*!< bit:     13  MC Event Output Enable 1           */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t :12;              /*!< bit:  0..11  Reserved                           */
+    uint16_t MCEO:2;           /*!< bit: 12..13  MC Event Output Enable x           */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_EVCTRL_OFFSET            0x06         /**< \brief (TC_EVCTRL offset) Event Control */
+#define TC_EVCTRL_RESETVALUE        0x0000ul     /**< \brief (TC_EVCTRL reset_value) Event Control */
+
+#define TC_EVCTRL_EVACT_Pos         0            /**< \brief (TC_EVCTRL) Event Action */
+#define TC_EVCTRL_EVACT_Msk         (0x7ul << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT(value)      (TC_EVCTRL_EVACT_Msk & ((value) << TC_EVCTRL_EVACT_Pos))
+#define   TC_EVCTRL_EVACT_OFF_Val         0x0ul  /**< \brief (TC_EVCTRL)  */
+#define   TC_EVCTRL_EVACT_RETRIGGER_Val   0x1ul  /**< \brief (TC_EVCTRL)  */
+#define   TC_EVCTRL_EVACT_COUNT_Val       0x2ul  /**< \brief (TC_EVCTRL)  */
+#define   TC_EVCTRL_EVACT_START_Val       0x3ul  /**< \brief (TC_EVCTRL)  */
+#define   TC_EVCTRL_EVACT_STAMP_Val       0x4ul  /**< \brief (TC_EVCTRL)  */
+#define   TC_EVCTRL_EVACT_PPW_Val         0x5ul  /**< \brief (TC_EVCTRL)  */
+#define   TC_EVCTRL_EVACT_PWP_Val         0x6ul  /**< \brief (TC_EVCTRL)  */
+#define   TC_EVCTRL_EVACT_PW_Val          0x7ul  /**< \brief (TC_EVCTRL)  */
+#define TC_EVCTRL_EVACT_OFF         (TC_EVCTRL_EVACT_OFF_Val       << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_RETRIGGER   (TC_EVCTRL_EVACT_RETRIGGER_Val << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_COUNT       (TC_EVCTRL_EVACT_COUNT_Val     << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_START       (TC_EVCTRL_EVACT_START_Val     << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_STAMP       (TC_EVCTRL_EVACT_STAMP_Val     << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_PPW         (TC_EVCTRL_EVACT_PPW_Val       << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_PWP         (TC_EVCTRL_EVACT_PWP_Val       << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_PW          (TC_EVCTRL_EVACT_PW_Val        << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_TCINV_Pos         4            /**< \brief (TC_EVCTRL) TC Event Input Polarity */
+#define TC_EVCTRL_TCINV             (0x1ul << TC_EVCTRL_TCINV_Pos)
+#define TC_EVCTRL_TCEI_Pos          5            /**< \brief (TC_EVCTRL) TC Event Enable */
+#define TC_EVCTRL_TCEI              (0x1ul << TC_EVCTRL_TCEI_Pos)
+#define TC_EVCTRL_OVFEO_Pos         8            /**< \brief (TC_EVCTRL) Event Output Enable */
+#define TC_EVCTRL_OVFEO             (0x1ul << TC_EVCTRL_OVFEO_Pos)
+#define TC_EVCTRL_MCEO0_Pos         12           /**< \brief (TC_EVCTRL) MC Event Output Enable 0 */
+#define TC_EVCTRL_MCEO0             (1 << TC_EVCTRL_MCEO0_Pos)
+#define TC_EVCTRL_MCEO1_Pos         13           /**< \brief (TC_EVCTRL) MC Event Output Enable 1 */
+#define TC_EVCTRL_MCEO1             (1 << TC_EVCTRL_MCEO1_Pos)
+#define TC_EVCTRL_MCEO_Pos          12           /**< \brief (TC_EVCTRL) MC Event Output Enable x */
+#define TC_EVCTRL_MCEO_Msk          (0x3ul << TC_EVCTRL_MCEO_Pos)
+#define TC_EVCTRL_MCEO(value)       (TC_EVCTRL_MCEO_Msk & ((value) << TC_EVCTRL_MCEO_Pos))
+#define TC_EVCTRL_MASK              0x3137ul     /**< \brief (TC_EVCTRL) MASK Register */
+
+/* -------- TC_INTENCLR : (TC Offset: 0x08) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Disable              */
+    uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Disable              */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Disable 0             */
+    uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Disable 1             */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Disable x             */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENCLR_OFFSET          0x08         /**< \brief (TC_INTENCLR offset) Interrupt Enable Clear */
+#define TC_INTENCLR_RESETVALUE      0x00ul       /**< \brief (TC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define TC_INTENCLR_OVF_Pos         0            /**< \brief (TC_INTENCLR) OVF Interrupt Disable */
+#define TC_INTENCLR_OVF             (0x1ul << TC_INTENCLR_OVF_Pos)
+#define TC_INTENCLR_ERR_Pos         1            /**< \brief (TC_INTENCLR) ERR Interrupt Disable */
+#define TC_INTENCLR_ERR             (0x1ul << TC_INTENCLR_ERR_Pos)
+#define TC_INTENCLR_MC0_Pos         4            /**< \brief (TC_INTENCLR) MC Interrupt Disable 0 */
+#define TC_INTENCLR_MC0             (1 << TC_INTENCLR_MC0_Pos)
+#define TC_INTENCLR_MC1_Pos         5            /**< \brief (TC_INTENCLR) MC Interrupt Disable 1 */
+#define TC_INTENCLR_MC1             (1 << TC_INTENCLR_MC1_Pos)
+#define TC_INTENCLR_MC_Pos          4            /**< \brief (TC_INTENCLR) MC Interrupt Disable x */
+#define TC_INTENCLR_MC_Msk          (0x3ul << TC_INTENCLR_MC_Pos)
+#define TC_INTENCLR_MC(value)       (TC_INTENCLR_MC_Msk & ((value) << TC_INTENCLR_MC_Pos))
+#define TC_INTENCLR_MASK            0x33ul       /**< \brief (TC_INTENCLR) MASK Register */
+
+/* -------- TC_INTENSET : (TC Offset: 0x09) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Enable               */
+    uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Enable               */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Enable 0              */
+    uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Enable 1              */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Enable x              */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENSET_OFFSET          0x09         /**< \brief (TC_INTENSET offset) Interrupt Enable Set */
+#define TC_INTENSET_RESETVALUE      0x00ul       /**< \brief (TC_INTENSET reset_value) Interrupt Enable Set */
+
+#define TC_INTENSET_OVF_Pos         0            /**< \brief (TC_INTENSET) OVF Interrupt Enable */
+#define TC_INTENSET_OVF             (0x1ul << TC_INTENSET_OVF_Pos)
+#define TC_INTENSET_ERR_Pos         1            /**< \brief (TC_INTENSET) ERR Interrupt Enable */
+#define TC_INTENSET_ERR             (0x1ul << TC_INTENSET_ERR_Pos)
+#define TC_INTENSET_MC0_Pos         4            /**< \brief (TC_INTENSET) MC Interrupt Enable 0 */
+#define TC_INTENSET_MC0             (1 << TC_INTENSET_MC0_Pos)
+#define TC_INTENSET_MC1_Pos         5            /**< \brief (TC_INTENSET) MC Interrupt Enable 1 */
+#define TC_INTENSET_MC1             (1 << TC_INTENSET_MC1_Pos)
+#define TC_INTENSET_MC_Pos          4            /**< \brief (TC_INTENSET) MC Interrupt Enable x */
+#define TC_INTENSET_MC_Msk          (0x3ul << TC_INTENSET_MC_Pos)
+#define TC_INTENSET_MC(value)       (TC_INTENSET_MC_Msk & ((value) << TC_INTENSET_MC_Pos))
+#define TC_INTENSET_MASK            0x33ul       /**< \brief (TC_INTENSET) MASK Register */
+
+/* -------- TC_INTFLAG : (TC Offset: 0x0A) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
+    __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
+    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
+    __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
+    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
+    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTFLAG_OFFSET           0x0A         /**< \brief (TC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define TC_INTFLAG_RESETVALUE       0x00ul       /**< \brief (TC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define TC_INTFLAG_OVF_Pos          0            /**< \brief (TC_INTFLAG) OVF Interrupt Flag */
+#define TC_INTFLAG_OVF              (0x1ul << TC_INTFLAG_OVF_Pos)
+#define TC_INTFLAG_ERR_Pos          1            /**< \brief (TC_INTFLAG) ERR Interrupt Flag */
+#define TC_INTFLAG_ERR              (0x1ul << TC_INTFLAG_ERR_Pos)
+#define TC_INTFLAG_MC0_Pos          4            /**< \brief (TC_INTFLAG) MC Interrupt Flag 0 */
+#define TC_INTFLAG_MC0              (1 << TC_INTFLAG_MC0_Pos)
+#define TC_INTFLAG_MC1_Pos          5            /**< \brief (TC_INTFLAG) MC Interrupt Flag 1 */
+#define TC_INTFLAG_MC1              (1 << TC_INTFLAG_MC1_Pos)
+#define TC_INTFLAG_MC_Pos           4            /**< \brief (TC_INTFLAG) MC Interrupt Flag x */
+#define TC_INTFLAG_MC_Msk           (0x3ul << TC_INTFLAG_MC_Pos)
+#define TC_INTFLAG_MC(value)        (TC_INTFLAG_MC_Msk & ((value) << TC_INTFLAG_MC_Pos))
+#define TC_INTFLAG_MASK             0x33ul       /**< \brief (TC_INTFLAG) MASK Register */
+
+/* -------- TC_STATUS : (TC Offset: 0x0B) (R/W  8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STOP:1;           /*!< bit:      0  Stop Status Flag                   */
+    uint8_t  SLAVE:1;          /*!< bit:      1  Slave Status Flag                  */
+    uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  PERBUFV:1;        /*!< bit:      3  Synchronization Busy Status        */
+    uint8_t  CCBUFV0:1;        /*!< bit:      4  Compare channel buffer 0 valid     */
+    uint8_t  CCBUFV1:1;        /*!< bit:      5  Compare channel buffer 1 valid     */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  CCBUFV:2;         /*!< bit:  4.. 5  Compare channel buffer x valid     */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_STATUS_OFFSET            0x0B         /**< \brief (TC_STATUS offset) Status */
+#define TC_STATUS_RESETVALUE        0x01ul       /**< \brief (TC_STATUS reset_value) Status */
+
+#define TC_STATUS_STOP_Pos          0            /**< \brief (TC_STATUS) Stop Status Flag */
+#define TC_STATUS_STOP              (0x1ul << TC_STATUS_STOP_Pos)
+#define TC_STATUS_SLAVE_Pos         1            /**< \brief (TC_STATUS) Slave Status Flag */
+#define TC_STATUS_SLAVE             (0x1ul << TC_STATUS_SLAVE_Pos)
+#define TC_STATUS_PERBUFV_Pos       3            /**< \brief (TC_STATUS) Synchronization Busy Status */
+#define TC_STATUS_PERBUFV           (0x1ul << TC_STATUS_PERBUFV_Pos)
+#define TC_STATUS_CCBUFV0_Pos       4            /**< \brief (TC_STATUS) Compare channel buffer 0 valid */
+#define TC_STATUS_CCBUFV0           (1 << TC_STATUS_CCBUFV0_Pos)
+#define TC_STATUS_CCBUFV1_Pos       5            /**< \brief (TC_STATUS) Compare channel buffer 1 valid */
+#define TC_STATUS_CCBUFV1           (1 << TC_STATUS_CCBUFV1_Pos)
+#define TC_STATUS_CCBUFV_Pos        4            /**< \brief (TC_STATUS) Compare channel buffer x valid */
+#define TC_STATUS_CCBUFV_Msk        (0x3ul << TC_STATUS_CCBUFV_Pos)
+#define TC_STATUS_CCBUFV(value)     (TC_STATUS_CCBUFV_Msk & ((value) << TC_STATUS_CCBUFV_Pos))
+#define TC_STATUS_MASK              0x3Bul       /**< \brief (TC_STATUS) MASK Register */
+
+/* -------- TC_WAVE : (TC Offset: 0x0C) (R/W  8) Waveform Generation Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  WAVEGEN:2;        /*!< bit:  0.. 1  Waveform Generation Mode           */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_WAVE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_WAVE_OFFSET              0x0C         /**< \brief (TC_WAVE offset) Waveform Generation Control */
+#define TC_WAVE_RESETVALUE          0x00ul       /**< \brief (TC_WAVE reset_value) Waveform Generation Control */
+
+#define TC_WAVE_WAVEGEN_Pos         0            /**< \brief (TC_WAVE) Waveform Generation Mode */
+#define TC_WAVE_WAVEGEN_Msk         (0x3ul << TC_WAVE_WAVEGEN_Pos)
+#define TC_WAVE_WAVEGEN(value)      (TC_WAVE_WAVEGEN_Msk & ((value) << TC_WAVE_WAVEGEN_Pos))
+#define   TC_WAVE_WAVEGEN_NFRQ_Val        0x0ul  /**< \brief (TC_WAVE)  */
+#define   TC_WAVE_WAVEGEN_MFRQ_Val        0x1ul  /**< \brief (TC_WAVE)  */
+#define   TC_WAVE_WAVEGEN_NPWM_Val        0x2ul  /**< \brief (TC_WAVE)  */
+#define   TC_WAVE_WAVEGEN_MPWM_Val        0x3ul  /**< \brief (TC_WAVE)  */
+#define TC_WAVE_WAVEGEN_NFRQ        (TC_WAVE_WAVEGEN_NFRQ_Val      << TC_WAVE_WAVEGEN_Pos)
+#define TC_WAVE_WAVEGEN_MFRQ        (TC_WAVE_WAVEGEN_MFRQ_Val      << TC_WAVE_WAVEGEN_Pos)
+#define TC_WAVE_WAVEGEN_NPWM        (TC_WAVE_WAVEGEN_NPWM_Val      << TC_WAVE_WAVEGEN_Pos)
+#define TC_WAVE_WAVEGEN_MPWM        (TC_WAVE_WAVEGEN_MPWM_Val      << TC_WAVE_WAVEGEN_Pos)
+#define TC_WAVE_MASK                0x03ul       /**< \brief (TC_WAVE) MASK Register */
+
+/* -------- TC_DRVCTRL : (TC Offset: 0x0D) (R/W  8) Control C -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  INVEN0:1;         /*!< bit:      0  Output Waveform Invert Enable 0    */
+    uint8_t  INVEN1:1;         /*!< bit:      1  Output Waveform Invert Enable 1    */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  INVEN:2;          /*!< bit:  0.. 1  Output Waveform Invert Enable x    */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_DRVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_DRVCTRL_OFFSET           0x0D         /**< \brief (TC_DRVCTRL offset) Control C */
+#define TC_DRVCTRL_RESETVALUE       0x00ul       /**< \brief (TC_DRVCTRL reset_value) Control C */
+
+#define TC_DRVCTRL_INVEN0_Pos       0            /**< \brief (TC_DRVCTRL) Output Waveform Invert Enable 0 */
+#define TC_DRVCTRL_INVEN0           (1 << TC_DRVCTRL_INVEN0_Pos)
+#define TC_DRVCTRL_INVEN1_Pos       1            /**< \brief (TC_DRVCTRL) Output Waveform Invert Enable 1 */
+#define TC_DRVCTRL_INVEN1           (1 << TC_DRVCTRL_INVEN1_Pos)
+#define TC_DRVCTRL_INVEN_Pos        0            /**< \brief (TC_DRVCTRL) Output Waveform Invert Enable x */
+#define TC_DRVCTRL_INVEN_Msk        (0x3ul << TC_DRVCTRL_INVEN_Pos)
+#define TC_DRVCTRL_INVEN(value)     (TC_DRVCTRL_INVEN_Msk & ((value) << TC_DRVCTRL_INVEN_Pos))
+#define TC_DRVCTRL_MASK             0x03ul       /**< \brief (TC_DRVCTRL) MASK Register */
+
+/* -------- TC_DBGCTRL : (TC Offset: 0x0F) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Run During Debug                   */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_DBGCTRL_OFFSET           0x0F         /**< \brief (TC_DBGCTRL offset) Debug Control */
+#define TC_DBGCTRL_RESETVALUE       0x00ul       /**< \brief (TC_DBGCTRL reset_value) Debug Control */
+
+#define TC_DBGCTRL_DBGRUN_Pos       0            /**< \brief (TC_DBGCTRL) Run During Debug */
+#define TC_DBGCTRL_DBGRUN           (0x1ul << TC_DBGCTRL_DBGRUN_Pos)
+#define TC_DBGCTRL_MASK             0x01ul       /**< \brief (TC_DBGCTRL) MASK Register */
+
+/* -------- TC_SYNCBUSY : (TC Offset: 0x10) (R/  32) Synchronization Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  swrst                              */
+    uint32_t ENABLE:1;         /*!< bit:      1  enable                             */
+    uint32_t CTRLB:1;          /*!< bit:      2  CTRLB                              */
+    uint32_t STATUS:1;         /*!< bit:      3  STATUS                             */
+    uint32_t COUNT:1;          /*!< bit:      4  Counter                            */
+    uint32_t PER:1;            /*!< bit:      5  Period                             */
+    uint32_t CC0:1;            /*!< bit:      6  Compare Channel 0                  */
+    uint32_t CC1:1;            /*!< bit:      7  Compare Channel 1                  */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :6;               /*!< bit:  0.. 5  Reserved                           */
+    uint32_t CC:2;             /*!< bit:  6.. 7  Compare Channel x                  */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_SYNCBUSY_OFFSET          0x10         /**< \brief (TC_SYNCBUSY offset) Synchronization Status */
+#define TC_SYNCBUSY_RESETVALUE      0x00000000ul /**< \brief (TC_SYNCBUSY reset_value) Synchronization Status */
+
+#define TC_SYNCBUSY_SWRST_Pos       0            /**< \brief (TC_SYNCBUSY) swrst */
+#define TC_SYNCBUSY_SWRST           (0x1ul << TC_SYNCBUSY_SWRST_Pos)
+#define TC_SYNCBUSY_ENABLE_Pos      1            /**< \brief (TC_SYNCBUSY) enable */
+#define TC_SYNCBUSY_ENABLE          (0x1ul << TC_SYNCBUSY_ENABLE_Pos)
+#define TC_SYNCBUSY_CTRLB_Pos       2            /**< \brief (TC_SYNCBUSY) CTRLB */
+#define TC_SYNCBUSY_CTRLB           (0x1ul << TC_SYNCBUSY_CTRLB_Pos)
+#define TC_SYNCBUSY_STATUS_Pos      3            /**< \brief (TC_SYNCBUSY) STATUS */
+#define TC_SYNCBUSY_STATUS          (0x1ul << TC_SYNCBUSY_STATUS_Pos)
+#define TC_SYNCBUSY_COUNT_Pos       4            /**< \brief (TC_SYNCBUSY) Counter */
+#define TC_SYNCBUSY_COUNT           (0x1ul << TC_SYNCBUSY_COUNT_Pos)
+#define TC_SYNCBUSY_PER_Pos         5            /**< \brief (TC_SYNCBUSY) Period */
+#define TC_SYNCBUSY_PER             (0x1ul << TC_SYNCBUSY_PER_Pos)
+#define TC_SYNCBUSY_CC0_Pos         6            /**< \brief (TC_SYNCBUSY) Compare Channel 0 */
+#define TC_SYNCBUSY_CC0             (1 << TC_SYNCBUSY_CC0_Pos)
+#define TC_SYNCBUSY_CC1_Pos         7            /**< \brief (TC_SYNCBUSY) Compare Channel 1 */
+#define TC_SYNCBUSY_CC1             (1 << TC_SYNCBUSY_CC1_Pos)
+#define TC_SYNCBUSY_CC_Pos          6            /**< \brief (TC_SYNCBUSY) Compare Channel x */
+#define TC_SYNCBUSY_CC_Msk          (0x3ul << TC_SYNCBUSY_CC_Pos)
+#define TC_SYNCBUSY_CC(value)       (TC_SYNCBUSY_CC_Msk & ((value) << TC_SYNCBUSY_CC_Pos))
+#define TC_SYNCBUSY_MASK            0x000000FFul /**< \brief (TC_SYNCBUSY) MASK Register */
+
+/* -------- TC_COUNT16_COUNT : (TC Offset: 0x14) (R/W 16) COUNT16 COUNT16 Count -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COUNT:16;         /*!< bit:  0..15  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_COUNT16_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_COUNT_OFFSET     0x14         /**< \brief (TC_COUNT16_COUNT offset) COUNT16 Count */
+#define TC_COUNT16_COUNT_RESETVALUE 0x0000ul     /**< \brief (TC_COUNT16_COUNT reset_value) COUNT16 Count */
+
+#define TC_COUNT16_COUNT_COUNT_Pos  0            /**< \brief (TC_COUNT16_COUNT) Counter Value */
+#define TC_COUNT16_COUNT_COUNT_Msk  (0xFFFFul << TC_COUNT16_COUNT_COUNT_Pos)
+#define TC_COUNT16_COUNT_COUNT(value) (TC_COUNT16_COUNT_COUNT_Msk & ((value) << TC_COUNT16_COUNT_COUNT_Pos))
+#define TC_COUNT16_COUNT_MASK       0xFFFFul     /**< \brief (TC_COUNT16_COUNT) MASK Register */
+
+/* -------- TC_COUNT32_COUNT : (TC Offset: 0x14) (R/W 32) COUNT32 COUNT32 Count -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COUNT:32;         /*!< bit:  0..31  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_COUNT32_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_COUNT_OFFSET     0x14         /**< \brief (TC_COUNT32_COUNT offset) COUNT32 Count */
+#define TC_COUNT32_COUNT_RESETVALUE 0x00000000ul /**< \brief (TC_COUNT32_COUNT reset_value) COUNT32 Count */
+
+#define TC_COUNT32_COUNT_COUNT_Pos  0            /**< \brief (TC_COUNT32_COUNT) Counter Value */
+#define TC_COUNT32_COUNT_COUNT_Msk  (0xFFFFFFFFul << TC_COUNT32_COUNT_COUNT_Pos)
+#define TC_COUNT32_COUNT_COUNT(value) (TC_COUNT32_COUNT_COUNT_Msk & ((value) << TC_COUNT32_COUNT_COUNT_Pos))
+#define TC_COUNT32_COUNT_MASK       0xFFFFFFFFul /**< \brief (TC_COUNT32_COUNT) MASK Register */
+
+/* -------- TC_COUNT8_COUNT : (TC Offset: 0x14) (R/W  8) COUNT8 COUNT8 Count -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  COUNT:8;          /*!< bit:  0.. 7  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_COUNT_OFFSET      0x14         /**< \brief (TC_COUNT8_COUNT offset) COUNT8 Count */
+#define TC_COUNT8_COUNT_RESETVALUE  0x00ul       /**< \brief (TC_COUNT8_COUNT reset_value) COUNT8 Count */
+
+#define TC_COUNT8_COUNT_COUNT_Pos   0            /**< \brief (TC_COUNT8_COUNT) Counter Value */
+#define TC_COUNT8_COUNT_COUNT_Msk   (0xFFul << TC_COUNT8_COUNT_COUNT_Pos)
+#define TC_COUNT8_COUNT_COUNT(value) (TC_COUNT8_COUNT_COUNT_Msk & ((value) << TC_COUNT8_COUNT_COUNT_Pos))
+#define TC_COUNT8_COUNT_MASK        0xFFul       /**< \brief (TC_COUNT8_COUNT) MASK Register */
+
+/* -------- TC_COUNT8_PER : (TC Offset: 0x1B) (R/W  8) COUNT8 COUNT8 Period -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PER:8;            /*!< bit:  0.. 7  Period Value                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_PER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_PER_OFFSET        0x1B         /**< \brief (TC_COUNT8_PER offset) COUNT8 Period */
+#define TC_COUNT8_PER_RESETVALUE    0xFFul       /**< \brief (TC_COUNT8_PER reset_value) COUNT8 Period */
+
+#define TC_COUNT8_PER_PER_Pos       0            /**< \brief (TC_COUNT8_PER) Period Value */
+#define TC_COUNT8_PER_PER_Msk       (0xFFul << TC_COUNT8_PER_PER_Pos)
+#define TC_COUNT8_PER_PER(value)    (TC_COUNT8_PER_PER_Msk & ((value) << TC_COUNT8_PER_PER_Pos))
+#define TC_COUNT8_PER_MASK          0xFFul       /**< \brief (TC_COUNT8_PER) MASK Register */
+
+/* -------- TC_COUNT16_CC : (TC Offset: 0x1C) (R/W 16) COUNT16 COUNT16 Compare and Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t CC:16;            /*!< bit:  0..15  Counter/Compare Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_COUNT16_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_CC_OFFSET        0x1C         /**< \brief (TC_COUNT16_CC offset) COUNT16 Compare and Capture */
+#define TC_COUNT16_CC_RESETVALUE    0x0000ul     /**< \brief (TC_COUNT16_CC reset_value) COUNT16 Compare and Capture */
+
+#define TC_COUNT16_CC_CC_Pos        0            /**< \brief (TC_COUNT16_CC) Counter/Compare Value */
+#define TC_COUNT16_CC_CC_Msk        (0xFFFFul << TC_COUNT16_CC_CC_Pos)
+#define TC_COUNT16_CC_CC(value)     (TC_COUNT16_CC_CC_Msk & ((value) << TC_COUNT16_CC_CC_Pos))
+#define TC_COUNT16_CC_MASK          0xFFFFul     /**< \brief (TC_COUNT16_CC) MASK Register */
+
+/* -------- TC_COUNT32_CC : (TC Offset: 0x1C) (R/W 32) COUNT32 COUNT32 Compare and Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CC:32;            /*!< bit:  0..31  Counter/Compare Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_COUNT32_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_CC_OFFSET        0x1C         /**< \brief (TC_COUNT32_CC offset) COUNT32 Compare and Capture */
+#define TC_COUNT32_CC_RESETVALUE    0x00000000ul /**< \brief (TC_COUNT32_CC reset_value) COUNT32 Compare and Capture */
+
+#define TC_COUNT32_CC_CC_Pos        0            /**< \brief (TC_COUNT32_CC) Counter/Compare Value */
+#define TC_COUNT32_CC_CC_Msk        (0xFFFFFFFFul << TC_COUNT32_CC_CC_Pos)
+#define TC_COUNT32_CC_CC(value)     (TC_COUNT32_CC_CC_Msk & ((value) << TC_COUNT32_CC_CC_Pos))
+#define TC_COUNT32_CC_MASK          0xFFFFFFFFul /**< \brief (TC_COUNT32_CC) MASK Register */
+
+/* -------- TC_COUNT8_CC : (TC Offset: 0x1C) (R/W  8) COUNT8 COUNT8 Compare and Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CC:8;             /*!< bit:  0.. 7  Counter/Compare Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_CC_OFFSET         0x1C         /**< \brief (TC_COUNT8_CC offset) COUNT8 Compare and Capture */
+#define TC_COUNT8_CC_RESETVALUE     0x00ul       /**< \brief (TC_COUNT8_CC reset_value) COUNT8 Compare and Capture */
+
+#define TC_COUNT8_CC_CC_Pos         0            /**< \brief (TC_COUNT8_CC) Counter/Compare Value */
+#define TC_COUNT8_CC_CC_Msk         (0xFFul << TC_COUNT8_CC_CC_Pos)
+#define TC_COUNT8_CC_CC(value)      (TC_COUNT8_CC_CC_Msk & ((value) << TC_COUNT8_CC_CC_Pos))
+#define TC_COUNT8_CC_MASK           0xFFul       /**< \brief (TC_COUNT8_CC) MASK Register */
+
+/* -------- TC_COUNT8_PERBUF : (TC Offset: 0x2F) (R/W  8) COUNT8 COUNT8 Period Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PERB:8;           /*!< bit:  0.. 7  Period Buffer Value                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_PERBUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_PERBUF_OFFSET     0x2F         /**< \brief (TC_COUNT8_PERBUF offset) COUNT8 Period Buffer */
+#define TC_COUNT8_PERBUF_RESETVALUE 0xFFul       /**< \brief (TC_COUNT8_PERBUF reset_value) COUNT8 Period Buffer */
+
+#define TC_COUNT8_PERBUF_PERB_Pos   0            /**< \brief (TC_COUNT8_PERBUF) Period Buffer Value */
+#define TC_COUNT8_PERBUF_PERB_Msk   (0xFFul << TC_COUNT8_PERBUF_PERB_Pos)
+#define TC_COUNT8_PERBUF_PERB(value) (TC_COUNT8_PERBUF_PERB_Msk & ((value) << TC_COUNT8_PERBUF_PERB_Pos))
+#define TC_COUNT8_PERBUF_MASK       0xFFul       /**< \brief (TC_COUNT8_PERBUF) MASK Register */
+
+/* -------- TC_COUNT16_CCBUF : (TC Offset: 0x30) (R/W 16) COUNT16 COUNT16 Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t CCBUF:16;         /*!< bit:  0..15  Counter/Compare Buffer Value       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_COUNT16_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_CCBUF_OFFSET     0x30         /**< \brief (TC_COUNT16_CCBUF offset) COUNT16 Compare and Capture Buffer */
+#define TC_COUNT16_CCBUF_RESETVALUE 0x0000ul     /**< \brief (TC_COUNT16_CCBUF reset_value) COUNT16 Compare and Capture Buffer */
+
+#define TC_COUNT16_CCBUF_CCBUF_Pos  0            /**< \brief (TC_COUNT16_CCBUF) Counter/Compare Buffer Value */
+#define TC_COUNT16_CCBUF_CCBUF_Msk  (0xFFFFul << TC_COUNT16_CCBUF_CCBUF_Pos)
+#define TC_COUNT16_CCBUF_CCBUF(value) (TC_COUNT16_CCBUF_CCBUF_Msk & ((value) << TC_COUNT16_CCBUF_CCBUF_Pos))
+#define TC_COUNT16_CCBUF_MASK       0xFFFFul     /**< \brief (TC_COUNT16_CCBUF) MASK Register */
+
+/* -------- TC_COUNT32_CCBUF : (TC Offset: 0x30) (R/W 32) COUNT32 COUNT32 Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CCBUF:32;         /*!< bit:  0..31  Counter/Compare Buffer Value       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_COUNT32_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_CCBUF_OFFSET     0x30         /**< \brief (TC_COUNT32_CCBUF offset) COUNT32 Compare and Capture Buffer */
+#define TC_COUNT32_CCBUF_RESETVALUE 0x00000000ul /**< \brief (TC_COUNT32_CCBUF reset_value) COUNT32 Compare and Capture Buffer */
+
+#define TC_COUNT32_CCBUF_CCBUF_Pos  0            /**< \brief (TC_COUNT32_CCBUF) Counter/Compare Buffer Value */
+#define TC_COUNT32_CCBUF_CCBUF_Msk  (0xFFFFFFFFul << TC_COUNT32_CCBUF_CCBUF_Pos)
+#define TC_COUNT32_CCBUF_CCBUF(value) (TC_COUNT32_CCBUF_CCBUF_Msk & ((value) << TC_COUNT32_CCBUF_CCBUF_Pos))
+#define TC_COUNT32_CCBUF_MASK       0xFFFFFFFFul /**< \brief (TC_COUNT32_CCBUF) MASK Register */
+
+/* -------- TC_COUNT8_CCBUF : (TC Offset: 0x30) (R/W  8) COUNT8 COUNT8 Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CCBUF:8;          /*!< bit:  0.. 7  Counter/Compare Buffer Value       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_CCBUF_OFFSET      0x30         /**< \brief (TC_COUNT8_CCBUF offset) COUNT8 Compare and Capture Buffer */
+#define TC_COUNT8_CCBUF_RESETVALUE  0x00ul       /**< \brief (TC_COUNT8_CCBUF reset_value) COUNT8 Compare and Capture Buffer */
+
+#define TC_COUNT8_CCBUF_CCBUF_Pos   0            /**< \brief (TC_COUNT8_CCBUF) Counter/Compare Buffer Value */
+#define TC_COUNT8_CCBUF_CCBUF_Msk   (0xFFul << TC_COUNT8_CCBUF_CCBUF_Pos)
+#define TC_COUNT8_CCBUF_CCBUF(value) (TC_COUNT8_CCBUF_CCBUF_Msk & ((value) << TC_COUNT8_CCBUF_CCBUF_Pos))
+#define TC_COUNT8_CCBUF_MASK        0xFFul       /**< \brief (TC_COUNT8_CCBUF) MASK Register */
+
+/** \brief TC_COUNT8 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 8-bit Counter Mode */
+  __IO TC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W 32) Control A */
+  __IO TC_CTRLBCLR_Type          CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TC_CTRLBSET_Type          CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+  __IO TC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x06 (R/W 16) Event Control */
+  __IO TC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x08 (R/W  8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x09 (R/W  8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x0A (R/W  8) Interrupt Flag Status and Clear */
+  __IO TC_STATUS_Type            STATUS;      /**< \brief Offset: 0x0B (R/W  8) Status */
+  __IO TC_WAVE_Type              WAVE;        /**< \brief Offset: 0x0C (R/W  8) Waveform Generation Control */
+  __IO TC_DRVCTRL_Type           DRVCTRL;     /**< \brief Offset: 0x0D (R/W  8) Control C */
+       RoReg8                    Reserved1[0x1];
+  __IO TC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x0F (R/W  8) Debug Control */
+  __I  TC_SYNCBUSY_Type          SYNCBUSY;    /**< \brief Offset: 0x10 (R/  32) Synchronization Status */
+  __IO TC_COUNT8_COUNT_Type      COUNT;       /**< \brief Offset: 0x14 (R/W  8) COUNT8 Count */
+       RoReg8                    Reserved2[0x6];
+  __IO TC_COUNT8_PER_Type        PER;         /**< \brief Offset: 0x1B (R/W  8) COUNT8 Period */
+  __IO TC_COUNT8_CC_Type         CC[2];       /**< \brief Offset: 0x1C (R/W  8) COUNT8 Compare and Capture */
+       RoReg8                    Reserved3[0x11];
+  __IO TC_COUNT8_PERBUF_Type     PERBUF;      /**< \brief Offset: 0x2F (R/W  8) COUNT8 Period Buffer */
+  __IO TC_COUNT8_CCBUF_Type      CCBUF[2];    /**< \brief Offset: 0x30 (R/W  8) COUNT8 Compare and Capture Buffer */
+} TcCount8;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief TC_COUNT16 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 16-bit Counter Mode */
+  __IO TC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W 32) Control A */
+  __IO TC_CTRLBCLR_Type          CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TC_CTRLBSET_Type          CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+  __IO TC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x06 (R/W 16) Event Control */
+  __IO TC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x08 (R/W  8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x09 (R/W  8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x0A (R/W  8) Interrupt Flag Status and Clear */
+  __IO TC_STATUS_Type            STATUS;      /**< \brief Offset: 0x0B (R/W  8) Status */
+  __IO TC_WAVE_Type              WAVE;        /**< \brief Offset: 0x0C (R/W  8) Waveform Generation Control */
+  __IO TC_DRVCTRL_Type           DRVCTRL;     /**< \brief Offset: 0x0D (R/W  8) Control C */
+       RoReg8                    Reserved1[0x1];
+  __IO TC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x0F (R/W  8) Debug Control */
+  __I  TC_SYNCBUSY_Type          SYNCBUSY;    /**< \brief Offset: 0x10 (R/  32) Synchronization Status */
+  __IO TC_COUNT16_COUNT_Type     COUNT;       /**< \brief Offset: 0x14 (R/W 16) COUNT16 Count */
+       RoReg8                    Reserved2[0x6];
+  __IO TC_COUNT16_CC_Type        CC[2];       /**< \brief Offset: 0x1C (R/W 16) COUNT16 Compare and Capture */
+       RoReg8                    Reserved3[0x10];
+  __IO TC_COUNT16_CCBUF_Type     CCBUF[2];    /**< \brief Offset: 0x30 (R/W 16) COUNT16 Compare and Capture Buffer */
+} TcCount16;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief TC_COUNT32 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 32-bit Counter Mode */
+  __IO TC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W 32) Control A */
+  __IO TC_CTRLBCLR_Type          CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TC_CTRLBSET_Type          CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+  __IO TC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x06 (R/W 16) Event Control */
+  __IO TC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x08 (R/W  8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x09 (R/W  8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x0A (R/W  8) Interrupt Flag Status and Clear */
+  __IO TC_STATUS_Type            STATUS;      /**< \brief Offset: 0x0B (R/W  8) Status */
+  __IO TC_WAVE_Type              WAVE;        /**< \brief Offset: 0x0C (R/W  8) Waveform Generation Control */
+  __IO TC_DRVCTRL_Type           DRVCTRL;     /**< \brief Offset: 0x0D (R/W  8) Control C */
+       RoReg8                    Reserved1[0x1];
+  __IO TC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x0F (R/W  8) Debug Control */
+  __I  TC_SYNCBUSY_Type          SYNCBUSY;    /**< \brief Offset: 0x10 (R/  32) Synchronization Status */
+  __IO TC_COUNT32_COUNT_Type     COUNT;       /**< \brief Offset: 0x14 (R/W 32) COUNT32 Count */
+       RoReg8                    Reserved2[0x4];
+  __IO TC_COUNT32_CC_Type        CC[2];       /**< \brief Offset: 0x1C (R/W 32) COUNT32 Compare and Capture */
+       RoReg8                    Reserved3[0xC];
+  __IO TC_COUNT32_CCBUF_Type     CCBUF[2];    /**< \brief Offset: 0x30 (R/W 32) COUNT32 Compare and Capture Buffer */
+} TcCount32;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       TcCount8                  COUNT8;      /**< \brief Offset: 0x00 8-bit Counter Mode */
+       TcCount16                 COUNT16;     /**< \brief Offset: 0x00 16-bit Counter Mode */
+       TcCount32                 COUNT32;     /**< \brief Offset: 0x00 32-bit Counter Mode */
+} Tc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_TC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/tcc_200.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/tcc_200.h
@@ -1,0 +1,1810 @@
+/**
+ * \file
+ *
+ * \brief Component description for TCC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TCC_COMPONENT_
+#define _SAML21_TCC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TCC */
+/* ========================================================================== */
+/** \addtogroup SAML21_TCC Timer Counter Control */
+/*@{*/
+
+#define TCC_U2213
+#define REV_TCC                     0x200
+
+/* -------- TCC_CTRLA : (TCC Offset: 0x00) (R/W 32) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t :3;               /*!< bit:  2.. 4  Reserved                           */
+    uint32_t RESOLUTION:2;     /*!< bit:  5.. 6  Enhanced Resolution                */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PRESCALER:3;      /*!< bit:  8..10  Prescaler                          */
+    uint32_t RUNSTDBY:1;       /*!< bit:     11  Run in Standby                     */
+    uint32_t PRESCSYNC:2;      /*!< bit: 12..13  Prescaler and Counter Synchronization Selection */
+    uint32_t ALOCK:1;          /*!< bit:     14  Auto Lock                          */
+    uint32_t MSYNC:1;          /*!< bit:     15  Master Synchronization (only for TCC Slave Instance) */
+    uint32_t :8;               /*!< bit: 16..23  Reserved                           */
+    uint32_t CPTEN0:1;         /*!< bit:     24  Capture Channel 0 Enable           */
+    uint32_t CPTEN1:1;         /*!< bit:     25  Capture Channel 1 Enable           */
+    uint32_t CPTEN2:1;         /*!< bit:     26  Capture Channel 2 Enable           */
+    uint32_t CPTEN3:1;         /*!< bit:     27  Capture Channel 3 Enable           */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :24;              /*!< bit:  0..23  Reserved                           */
+    uint32_t CPTEN:4;          /*!< bit: 24..27  Capture Channel x Enable           */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_CTRLA_OFFSET            0x00         /**< \brief (TCC_CTRLA offset) Control A */
+#define TCC_CTRLA_RESETVALUE        0x00000000ul /**< \brief (TCC_CTRLA reset_value) Control A */
+
+#define TCC_CTRLA_SWRST_Pos         0            /**< \brief (TCC_CTRLA) Software Reset */
+#define TCC_CTRLA_SWRST             (0x1ul << TCC_CTRLA_SWRST_Pos)
+#define TCC_CTRLA_ENABLE_Pos        1            /**< \brief (TCC_CTRLA) Enable */
+#define TCC_CTRLA_ENABLE            (0x1ul << TCC_CTRLA_ENABLE_Pos)
+#define TCC_CTRLA_RESOLUTION_Pos    5            /**< \brief (TCC_CTRLA) Enhanced Resolution */
+#define TCC_CTRLA_RESOLUTION_Msk    (0x3ul << TCC_CTRLA_RESOLUTION_Pos)
+#define TCC_CTRLA_RESOLUTION(value) (TCC_CTRLA_RESOLUTION_Msk & ((value) << TCC_CTRLA_RESOLUTION_Pos))
+#define   TCC_CTRLA_RESOLUTION_NONE_Val   0x0ul  /**< \brief (TCC_CTRLA) Dithering is disabled */
+#define   TCC_CTRLA_RESOLUTION_DITH4_Val  0x1ul  /**< \brief (TCC_CTRLA) Dithering is done every 16 PWM frames */
+#define   TCC_CTRLA_RESOLUTION_DITH5_Val  0x2ul  /**< \brief (TCC_CTRLA) Dithering is done every 32 PWM frames */
+#define   TCC_CTRLA_RESOLUTION_DITH6_Val  0x3ul  /**< \brief (TCC_CTRLA) Dithering is done every 64 PWM frames */
+#define TCC_CTRLA_RESOLUTION_NONE   (TCC_CTRLA_RESOLUTION_NONE_Val << TCC_CTRLA_RESOLUTION_Pos)
+#define TCC_CTRLA_RESOLUTION_DITH4  (TCC_CTRLA_RESOLUTION_DITH4_Val << TCC_CTRLA_RESOLUTION_Pos)
+#define TCC_CTRLA_RESOLUTION_DITH5  (TCC_CTRLA_RESOLUTION_DITH5_Val << TCC_CTRLA_RESOLUTION_Pos)
+#define TCC_CTRLA_RESOLUTION_DITH6  (TCC_CTRLA_RESOLUTION_DITH6_Val << TCC_CTRLA_RESOLUTION_Pos)
+#define TCC_CTRLA_PRESCALER_Pos     8            /**< \brief (TCC_CTRLA) Prescaler */
+#define TCC_CTRLA_PRESCALER_Msk     (0x7ul << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_PRESCALER(value)  (TCC_CTRLA_PRESCALER_Msk & ((value) << TCC_CTRLA_PRESCALER_Pos))
+#define   TCC_CTRLA_PRESCALER_DIV1_Val    0x0ul  /**< \brief (TCC_CTRLA) No division */
+#define   TCC_CTRLA_PRESCALER_DIV2_Val    0x1ul  /**< \brief (TCC_CTRLA) Divide by 2 */
+#define   TCC_CTRLA_PRESCALER_DIV4_Val    0x2ul  /**< \brief (TCC_CTRLA) Divide by 4 */
+#define   TCC_CTRLA_PRESCALER_DIV8_Val    0x3ul  /**< \brief (TCC_CTRLA) Divide by 8 */
+#define   TCC_CTRLA_PRESCALER_DIV16_Val   0x4ul  /**< \brief (TCC_CTRLA) Divide by 16 */
+#define   TCC_CTRLA_PRESCALER_DIV64_Val   0x5ul  /**< \brief (TCC_CTRLA) Divide by 64 */
+#define   TCC_CTRLA_PRESCALER_DIV256_Val  0x6ul  /**< \brief (TCC_CTRLA) Divide by 256 */
+#define   TCC_CTRLA_PRESCALER_DIV1024_Val 0x7ul  /**< \brief (TCC_CTRLA) Divide by 1024 */
+#define TCC_CTRLA_PRESCALER_DIV1    (TCC_CTRLA_PRESCALER_DIV1_Val  << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_PRESCALER_DIV2    (TCC_CTRLA_PRESCALER_DIV2_Val  << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_PRESCALER_DIV4    (TCC_CTRLA_PRESCALER_DIV4_Val  << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_PRESCALER_DIV8    (TCC_CTRLA_PRESCALER_DIV8_Val  << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_PRESCALER_DIV16   (TCC_CTRLA_PRESCALER_DIV16_Val << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_PRESCALER_DIV64   (TCC_CTRLA_PRESCALER_DIV64_Val << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_PRESCALER_DIV256  (TCC_CTRLA_PRESCALER_DIV256_Val << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_PRESCALER_DIV1024 (TCC_CTRLA_PRESCALER_DIV1024_Val << TCC_CTRLA_PRESCALER_Pos)
+#define TCC_CTRLA_RUNSTDBY_Pos      11           /**< \brief (TCC_CTRLA) Run in Standby */
+#define TCC_CTRLA_RUNSTDBY          (0x1ul << TCC_CTRLA_RUNSTDBY_Pos)
+#define TCC_CTRLA_PRESCSYNC_Pos     12           /**< \brief (TCC_CTRLA) Prescaler and Counter Synchronization Selection */
+#define TCC_CTRLA_PRESCSYNC_Msk     (0x3ul << TCC_CTRLA_PRESCSYNC_Pos)
+#define TCC_CTRLA_PRESCSYNC(value)  (TCC_CTRLA_PRESCSYNC_Msk & ((value) << TCC_CTRLA_PRESCSYNC_Pos))
+#define   TCC_CTRLA_PRESCSYNC_GCLK_Val    0x0ul  /**< \brief (TCC_CTRLA) Reload or reset counter on next GCLK */
+#define   TCC_CTRLA_PRESCSYNC_PRESC_Val   0x1ul  /**< \brief (TCC_CTRLA) Reload or reset counter on next prescaler clock */
+#define   TCC_CTRLA_PRESCSYNC_RESYNC_Val  0x2ul  /**< \brief (TCC_CTRLA) Reload or reset counter on next GCLK and reset prescaler counter */
+#define TCC_CTRLA_PRESCSYNC_GCLK    (TCC_CTRLA_PRESCSYNC_GCLK_Val  << TCC_CTRLA_PRESCSYNC_Pos)
+#define TCC_CTRLA_PRESCSYNC_PRESC   (TCC_CTRLA_PRESCSYNC_PRESC_Val << TCC_CTRLA_PRESCSYNC_Pos)
+#define TCC_CTRLA_PRESCSYNC_RESYNC  (TCC_CTRLA_PRESCSYNC_RESYNC_Val << TCC_CTRLA_PRESCSYNC_Pos)
+#define TCC_CTRLA_ALOCK_Pos         14           /**< \brief (TCC_CTRLA) Auto Lock */
+#define TCC_CTRLA_ALOCK             (0x1ul << TCC_CTRLA_ALOCK_Pos)
+#define TCC_CTRLA_MSYNC_Pos         15           /**< \brief (TCC_CTRLA) Master Synchronization (only for TCC Slave Instance) */
+#define TCC_CTRLA_MSYNC             (0x1ul << TCC_CTRLA_MSYNC_Pos)
+#define TCC_CTRLA_CPTEN0_Pos        24           /**< \brief (TCC_CTRLA) Capture Channel 0 Enable */
+#define TCC_CTRLA_CPTEN0            (1 << TCC_CTRLA_CPTEN0_Pos)
+#define TCC_CTRLA_CPTEN1_Pos        25           /**< \brief (TCC_CTRLA) Capture Channel 1 Enable */
+#define TCC_CTRLA_CPTEN1            (1 << TCC_CTRLA_CPTEN1_Pos)
+#define TCC_CTRLA_CPTEN2_Pos        26           /**< \brief (TCC_CTRLA) Capture Channel 2 Enable */
+#define TCC_CTRLA_CPTEN2            (1 << TCC_CTRLA_CPTEN2_Pos)
+#define TCC_CTRLA_CPTEN3_Pos        27           /**< \brief (TCC_CTRLA) Capture Channel 3 Enable */
+#define TCC_CTRLA_CPTEN3            (1 << TCC_CTRLA_CPTEN3_Pos)
+#define TCC_CTRLA_CPTEN_Pos         24           /**< \brief (TCC_CTRLA) Capture Channel x Enable */
+#define TCC_CTRLA_CPTEN_Msk         (0xFul << TCC_CTRLA_CPTEN_Pos)
+#define TCC_CTRLA_CPTEN(value)      (TCC_CTRLA_CPTEN_Msk & ((value) << TCC_CTRLA_CPTEN_Pos))
+#define TCC_CTRLA_MASK              0x0F00FF63ul /**< \brief (TCC_CTRLA) MASK Register */
+
+/* -------- TCC_CTRLBCLR : (TCC Offset: 0x04) (R/W  8) Control B Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DIR:1;            /*!< bit:      0  Counter Direction                  */
+    uint8_t  LUPD:1;           /*!< bit:      1  Lock Update                        */
+    uint8_t  ONESHOT:1;        /*!< bit:      2  One-Shot                           */
+    uint8_t  IDXCMD:2;         /*!< bit:  3.. 4  Ramp Index Command                 */
+    uint8_t  CMD:3;            /*!< bit:  5.. 7  TCC Command                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TCC_CTRLBCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_CTRLBCLR_OFFSET         0x04         /**< \brief (TCC_CTRLBCLR offset) Control B Clear */
+#define TCC_CTRLBCLR_RESETVALUE     0x00ul       /**< \brief (TCC_CTRLBCLR reset_value) Control B Clear */
+
+#define TCC_CTRLBCLR_DIR_Pos        0            /**< \brief (TCC_CTRLBCLR) Counter Direction */
+#define TCC_CTRLBCLR_DIR            (0x1ul << TCC_CTRLBCLR_DIR_Pos)
+#define TCC_CTRLBCLR_LUPD_Pos       1            /**< \brief (TCC_CTRLBCLR) Lock Update */
+#define TCC_CTRLBCLR_LUPD           (0x1ul << TCC_CTRLBCLR_LUPD_Pos)
+#define TCC_CTRLBCLR_ONESHOT_Pos    2            /**< \brief (TCC_CTRLBCLR) One-Shot */
+#define TCC_CTRLBCLR_ONESHOT        (0x1ul << TCC_CTRLBCLR_ONESHOT_Pos)
+#define TCC_CTRLBCLR_IDXCMD_Pos     3            /**< \brief (TCC_CTRLBCLR) Ramp Index Command */
+#define TCC_CTRLBCLR_IDXCMD_Msk     (0x3ul << TCC_CTRLBCLR_IDXCMD_Pos)
+#define TCC_CTRLBCLR_IDXCMD(value)  (TCC_CTRLBCLR_IDXCMD_Msk & ((value) << TCC_CTRLBCLR_IDXCMD_Pos))
+#define   TCC_CTRLBCLR_IDXCMD_DISABLE_Val 0x0ul  /**< \brief (TCC_CTRLBCLR) Command disabled: Index toggles between cycles A and B */
+#define   TCC_CTRLBCLR_IDXCMD_SET_Val     0x1ul  /**< \brief (TCC_CTRLBCLR) Set index: cycle B will be forced in the next cycle */
+#define   TCC_CTRLBCLR_IDXCMD_CLEAR_Val   0x2ul  /**< \brief (TCC_CTRLBCLR) Clear index: cycle A will be forced in the next cycle */
+#define   TCC_CTRLBCLR_IDXCMD_HOLD_Val    0x3ul  /**< \brief (TCC_CTRLBCLR) Hold index: the next cycle will be the same as the current cycle */
+#define TCC_CTRLBCLR_IDXCMD_DISABLE (TCC_CTRLBCLR_IDXCMD_DISABLE_Val << TCC_CTRLBCLR_IDXCMD_Pos)
+#define TCC_CTRLBCLR_IDXCMD_SET     (TCC_CTRLBCLR_IDXCMD_SET_Val   << TCC_CTRLBCLR_IDXCMD_Pos)
+#define TCC_CTRLBCLR_IDXCMD_CLEAR   (TCC_CTRLBCLR_IDXCMD_CLEAR_Val << TCC_CTRLBCLR_IDXCMD_Pos)
+#define TCC_CTRLBCLR_IDXCMD_HOLD    (TCC_CTRLBCLR_IDXCMD_HOLD_Val  << TCC_CTRLBCLR_IDXCMD_Pos)
+#define TCC_CTRLBCLR_CMD_Pos        5            /**< \brief (TCC_CTRLBCLR) TCC Command */
+#define TCC_CTRLBCLR_CMD_Msk        (0x7ul << TCC_CTRLBCLR_CMD_Pos)
+#define TCC_CTRLBCLR_CMD(value)     (TCC_CTRLBCLR_CMD_Msk & ((value) << TCC_CTRLBCLR_CMD_Pos))
+#define   TCC_CTRLBCLR_CMD_NONE_Val       0x0ul  /**< \brief (TCC_CTRLBCLR) No action */
+#define   TCC_CTRLBCLR_CMD_RETRIGGER_Val  0x1ul  /**< \brief (TCC_CTRLBCLR) Clear start, restart or retrigger */
+#define   TCC_CTRLBCLR_CMD_STOP_Val       0x2ul  /**< \brief (TCC_CTRLBCLR) Force stop */
+#define   TCC_CTRLBCLR_CMD_UPDATE_Val     0x3ul  /**< \brief (TCC_CTRLBCLR) Force update or double buffered registers */
+#define   TCC_CTRLBCLR_CMD_READSYNC_Val   0x4ul  /**< \brief (TCC_CTRLBCLR) Force COUNT read synchronization */
+#define TCC_CTRLBCLR_CMD_NONE       (TCC_CTRLBCLR_CMD_NONE_Val     << TCC_CTRLBCLR_CMD_Pos)
+#define TCC_CTRLBCLR_CMD_RETRIGGER  (TCC_CTRLBCLR_CMD_RETRIGGER_Val << TCC_CTRLBCLR_CMD_Pos)
+#define TCC_CTRLBCLR_CMD_STOP       (TCC_CTRLBCLR_CMD_STOP_Val     << TCC_CTRLBCLR_CMD_Pos)
+#define TCC_CTRLBCLR_CMD_UPDATE     (TCC_CTRLBCLR_CMD_UPDATE_Val   << TCC_CTRLBCLR_CMD_Pos)
+#define TCC_CTRLBCLR_CMD_READSYNC   (TCC_CTRLBCLR_CMD_READSYNC_Val << TCC_CTRLBCLR_CMD_Pos)
+#define TCC_CTRLBCLR_MASK           0xFFul       /**< \brief (TCC_CTRLBCLR) MASK Register */
+
+/* -------- TCC_CTRLBSET : (TCC Offset: 0x05) (R/W  8) Control B Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DIR:1;            /*!< bit:      0  Counter Direction                  */
+    uint8_t  LUPD:1;           /*!< bit:      1  Lock Update                        */
+    uint8_t  ONESHOT:1;        /*!< bit:      2  One-Shot                           */
+    uint8_t  IDXCMD:2;         /*!< bit:  3.. 4  Ramp Index Command                 */
+    uint8_t  CMD:3;            /*!< bit:  5.. 7  TCC Command                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TCC_CTRLBSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_CTRLBSET_OFFSET         0x05         /**< \brief (TCC_CTRLBSET offset) Control B Set */
+#define TCC_CTRLBSET_RESETVALUE     0x00ul       /**< \brief (TCC_CTRLBSET reset_value) Control B Set */
+
+#define TCC_CTRLBSET_DIR_Pos        0            /**< \brief (TCC_CTRLBSET) Counter Direction */
+#define TCC_CTRLBSET_DIR            (0x1ul << TCC_CTRLBSET_DIR_Pos)
+#define TCC_CTRLBSET_LUPD_Pos       1            /**< \brief (TCC_CTRLBSET) Lock Update */
+#define TCC_CTRLBSET_LUPD           (0x1ul << TCC_CTRLBSET_LUPD_Pos)
+#define TCC_CTRLBSET_ONESHOT_Pos    2            /**< \brief (TCC_CTRLBSET) One-Shot */
+#define TCC_CTRLBSET_ONESHOT        (0x1ul << TCC_CTRLBSET_ONESHOT_Pos)
+#define TCC_CTRLBSET_IDXCMD_Pos     3            /**< \brief (TCC_CTRLBSET) Ramp Index Command */
+#define TCC_CTRLBSET_IDXCMD_Msk     (0x3ul << TCC_CTRLBSET_IDXCMD_Pos)
+#define TCC_CTRLBSET_IDXCMD(value)  (TCC_CTRLBSET_IDXCMD_Msk & ((value) << TCC_CTRLBSET_IDXCMD_Pos))
+#define   TCC_CTRLBSET_IDXCMD_DISABLE_Val 0x0ul  /**< \brief (TCC_CTRLBSET) Command disabled: Index toggles between cycles A and B */
+#define   TCC_CTRLBSET_IDXCMD_SET_Val     0x1ul  /**< \brief (TCC_CTRLBSET) Set index: cycle B will be forced in the next cycle */
+#define   TCC_CTRLBSET_IDXCMD_CLEAR_Val   0x2ul  /**< \brief (TCC_CTRLBSET) Clear index: cycle A will be forced in the next cycle */
+#define   TCC_CTRLBSET_IDXCMD_HOLD_Val    0x3ul  /**< \brief (TCC_CTRLBSET) Hold index: the next cycle will be the same as the current cycle */
+#define TCC_CTRLBSET_IDXCMD_DISABLE (TCC_CTRLBSET_IDXCMD_DISABLE_Val << TCC_CTRLBSET_IDXCMD_Pos)
+#define TCC_CTRLBSET_IDXCMD_SET     (TCC_CTRLBSET_IDXCMD_SET_Val   << TCC_CTRLBSET_IDXCMD_Pos)
+#define TCC_CTRLBSET_IDXCMD_CLEAR   (TCC_CTRLBSET_IDXCMD_CLEAR_Val << TCC_CTRLBSET_IDXCMD_Pos)
+#define TCC_CTRLBSET_IDXCMD_HOLD    (TCC_CTRLBSET_IDXCMD_HOLD_Val  << TCC_CTRLBSET_IDXCMD_Pos)
+#define TCC_CTRLBSET_CMD_Pos        5            /**< \brief (TCC_CTRLBSET) TCC Command */
+#define TCC_CTRLBSET_CMD_Msk        (0x7ul << TCC_CTRLBSET_CMD_Pos)
+#define TCC_CTRLBSET_CMD(value)     (TCC_CTRLBSET_CMD_Msk & ((value) << TCC_CTRLBSET_CMD_Pos))
+#define   TCC_CTRLBSET_CMD_NONE_Val       0x0ul  /**< \brief (TCC_CTRLBSET) No action */
+#define   TCC_CTRLBSET_CMD_RETRIGGER_Val  0x1ul  /**< \brief (TCC_CTRLBSET) Clear start, restart or retrigger */
+#define   TCC_CTRLBSET_CMD_STOP_Val       0x2ul  /**< \brief (TCC_CTRLBSET) Force stop */
+#define   TCC_CTRLBSET_CMD_UPDATE_Val     0x3ul  /**< \brief (TCC_CTRLBSET) Force update or double buffered registers */
+#define   TCC_CTRLBSET_CMD_READSYNC_Val   0x4ul  /**< \brief (TCC_CTRLBSET) Force COUNT read synchronization */
+#define TCC_CTRLBSET_CMD_NONE       (TCC_CTRLBSET_CMD_NONE_Val     << TCC_CTRLBSET_CMD_Pos)
+#define TCC_CTRLBSET_CMD_RETRIGGER  (TCC_CTRLBSET_CMD_RETRIGGER_Val << TCC_CTRLBSET_CMD_Pos)
+#define TCC_CTRLBSET_CMD_STOP       (TCC_CTRLBSET_CMD_STOP_Val     << TCC_CTRLBSET_CMD_Pos)
+#define TCC_CTRLBSET_CMD_UPDATE     (TCC_CTRLBSET_CMD_UPDATE_Val   << TCC_CTRLBSET_CMD_Pos)
+#define TCC_CTRLBSET_CMD_READSYNC   (TCC_CTRLBSET_CMD_READSYNC_Val << TCC_CTRLBSET_CMD_Pos)
+#define TCC_CTRLBSET_MASK           0xFFul       /**< \brief (TCC_CTRLBSET) MASK Register */
+
+/* -------- TCC_SYNCBUSY : (TCC Offset: 0x08) (R/  32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Swrst Busy                         */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable Busy                        */
+    uint32_t CTRLB:1;          /*!< bit:      2  Ctrlb Busy                         */
+    uint32_t STATUS:1;         /*!< bit:      3  Status Busy                        */
+    uint32_t COUNT:1;          /*!< bit:      4  Count Busy                         */
+    uint32_t PATT:1;           /*!< bit:      5  Pattern Busy                       */
+    uint32_t WAVE:1;           /*!< bit:      6  Wave Busy                          */
+    uint32_t PER:1;            /*!< bit:      7  Period Busy                        */
+    uint32_t CC0:1;            /*!< bit:      8  Compare Channel 0 Busy             */
+    uint32_t CC1:1;            /*!< bit:      9  Compare Channel 1 Busy             */
+    uint32_t CC2:1;            /*!< bit:     10  Compare Channel 2 Busy             */
+    uint32_t CC3:1;            /*!< bit:     11  Compare Channel 3 Busy             */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t CC:4;             /*!< bit:  8..11  Compare Channel x Busy             */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_SYNCBUSY_OFFSET         0x08         /**< \brief (TCC_SYNCBUSY offset) Synchronization Busy */
+#define TCC_SYNCBUSY_RESETVALUE     0x00000000ul /**< \brief (TCC_SYNCBUSY reset_value) Synchronization Busy */
+
+#define TCC_SYNCBUSY_SWRST_Pos      0            /**< \brief (TCC_SYNCBUSY) Swrst Busy */
+#define TCC_SYNCBUSY_SWRST          (0x1ul << TCC_SYNCBUSY_SWRST_Pos)
+#define TCC_SYNCBUSY_ENABLE_Pos     1            /**< \brief (TCC_SYNCBUSY) Enable Busy */
+#define TCC_SYNCBUSY_ENABLE         (0x1ul << TCC_SYNCBUSY_ENABLE_Pos)
+#define TCC_SYNCBUSY_CTRLB_Pos      2            /**< \brief (TCC_SYNCBUSY) Ctrlb Busy */
+#define TCC_SYNCBUSY_CTRLB          (0x1ul << TCC_SYNCBUSY_CTRLB_Pos)
+#define TCC_SYNCBUSY_STATUS_Pos     3            /**< \brief (TCC_SYNCBUSY) Status Busy */
+#define TCC_SYNCBUSY_STATUS         (0x1ul << TCC_SYNCBUSY_STATUS_Pos)
+#define TCC_SYNCBUSY_COUNT_Pos      4            /**< \brief (TCC_SYNCBUSY) Count Busy */
+#define TCC_SYNCBUSY_COUNT          (0x1ul << TCC_SYNCBUSY_COUNT_Pos)
+#define TCC_SYNCBUSY_PATT_Pos       5            /**< \brief (TCC_SYNCBUSY) Pattern Busy */
+#define TCC_SYNCBUSY_PATT           (0x1ul << TCC_SYNCBUSY_PATT_Pos)
+#define TCC_SYNCBUSY_WAVE_Pos       6            /**< \brief (TCC_SYNCBUSY) Wave Busy */
+#define TCC_SYNCBUSY_WAVE           (0x1ul << TCC_SYNCBUSY_WAVE_Pos)
+#define TCC_SYNCBUSY_PER_Pos        7            /**< \brief (TCC_SYNCBUSY) Period Busy */
+#define TCC_SYNCBUSY_PER            (0x1ul << TCC_SYNCBUSY_PER_Pos)
+#define TCC_SYNCBUSY_CC0_Pos        8            /**< \brief (TCC_SYNCBUSY) Compare Channel 0 Busy */
+#define TCC_SYNCBUSY_CC0            (1 << TCC_SYNCBUSY_CC0_Pos)
+#define TCC_SYNCBUSY_CC1_Pos        9            /**< \brief (TCC_SYNCBUSY) Compare Channel 1 Busy */
+#define TCC_SYNCBUSY_CC1            (1 << TCC_SYNCBUSY_CC1_Pos)
+#define TCC_SYNCBUSY_CC2_Pos        10           /**< \brief (TCC_SYNCBUSY) Compare Channel 2 Busy */
+#define TCC_SYNCBUSY_CC2            (1 << TCC_SYNCBUSY_CC2_Pos)
+#define TCC_SYNCBUSY_CC3_Pos        11           /**< \brief (TCC_SYNCBUSY) Compare Channel 3 Busy */
+#define TCC_SYNCBUSY_CC3            (1 << TCC_SYNCBUSY_CC3_Pos)
+#define TCC_SYNCBUSY_CC_Pos         8            /**< \brief (TCC_SYNCBUSY) Compare Channel x Busy */
+#define TCC_SYNCBUSY_CC_Msk         (0xFul << TCC_SYNCBUSY_CC_Pos)
+#define TCC_SYNCBUSY_CC(value)      (TCC_SYNCBUSY_CC_Msk & ((value) << TCC_SYNCBUSY_CC_Pos))
+#define TCC_SYNCBUSY_MASK           0x00000FFFul /**< \brief (TCC_SYNCBUSY) MASK Register */
+
+/* -------- TCC_FCTRLA : (TCC Offset: 0x0C) (R/W 32) Recoverable Fault A Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SRC:2;            /*!< bit:  0.. 1  Fault A Source                     */
+    uint32_t :1;               /*!< bit:      2  Reserved                           */
+    uint32_t KEEP:1;           /*!< bit:      3  Fault A Keeper                     */
+    uint32_t QUAL:1;           /*!< bit:      4  Fault A Qualification              */
+    uint32_t BLANK:2;          /*!< bit:  5.. 6  Fault A Blanking Mode              */
+    uint32_t RESTART:1;        /*!< bit:      7  Fault A Restart                    */
+    uint32_t HALT:2;           /*!< bit:  8.. 9  Fault A Halt Mode                  */
+    uint32_t CHSEL:2;          /*!< bit: 10..11  Fault A Capture Channel            */
+    uint32_t CAPTURE:3;        /*!< bit: 12..14  Fault A Capture Action             */
+    uint32_t BLANKPRESC:1;     /*!< bit:     15  Fault A Blanking Prescaler         */
+    uint32_t BLANKVAL:8;       /*!< bit: 16..23  Fault A Blanking Time              */
+    uint32_t FILTERVAL:4;      /*!< bit: 24..27  Fault A Filter Value               */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_FCTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_FCTRLA_OFFSET           0x0C         /**< \brief (TCC_FCTRLA offset) Recoverable Fault A Configuration */
+#define TCC_FCTRLA_RESETVALUE       0x00000000ul /**< \brief (TCC_FCTRLA reset_value) Recoverable Fault A Configuration */
+
+#define TCC_FCTRLA_SRC_Pos          0            /**< \brief (TCC_FCTRLA) Fault A Source */
+#define TCC_FCTRLA_SRC_Msk          (0x3ul << TCC_FCTRLA_SRC_Pos)
+#define TCC_FCTRLA_SRC(value)       (TCC_FCTRLA_SRC_Msk & ((value) << TCC_FCTRLA_SRC_Pos))
+#define   TCC_FCTRLA_SRC_DISABLE_Val      0x0ul  /**< \brief (TCC_FCTRLA) Fault input disabled */
+#define   TCC_FCTRLA_SRC_ENABLE_Val       0x1ul  /**< \brief (TCC_FCTRLA) MCEx (x=0,1) event input */
+#define   TCC_FCTRLA_SRC_INVERT_Val       0x2ul  /**< \brief (TCC_FCTRLA) Inverted MCEx (x=0,1) event input */
+#define   TCC_FCTRLA_SRC_ALTFAULT_Val     0x3ul  /**< \brief (TCC_FCTRLA) Alternate fault (A or B) state at the end of the previous period */
+#define TCC_FCTRLA_SRC_DISABLE      (TCC_FCTRLA_SRC_DISABLE_Val    << TCC_FCTRLA_SRC_Pos)
+#define TCC_FCTRLA_SRC_ENABLE       (TCC_FCTRLA_SRC_ENABLE_Val     << TCC_FCTRLA_SRC_Pos)
+#define TCC_FCTRLA_SRC_INVERT       (TCC_FCTRLA_SRC_INVERT_Val     << TCC_FCTRLA_SRC_Pos)
+#define TCC_FCTRLA_SRC_ALTFAULT     (TCC_FCTRLA_SRC_ALTFAULT_Val   << TCC_FCTRLA_SRC_Pos)
+#define TCC_FCTRLA_KEEP_Pos         3            /**< \brief (TCC_FCTRLA) Fault A Keeper */
+#define TCC_FCTRLA_KEEP             (0x1ul << TCC_FCTRLA_KEEP_Pos)
+#define TCC_FCTRLA_QUAL_Pos         4            /**< \brief (TCC_FCTRLA) Fault A Qualification */
+#define TCC_FCTRLA_QUAL             (0x1ul << TCC_FCTRLA_QUAL_Pos)
+#define TCC_FCTRLA_BLANK_Pos        5            /**< \brief (TCC_FCTRLA) Fault A Blanking Mode */
+#define TCC_FCTRLA_BLANK_Msk        (0x3ul << TCC_FCTRLA_BLANK_Pos)
+#define TCC_FCTRLA_BLANK(value)     (TCC_FCTRLA_BLANK_Msk & ((value) << TCC_FCTRLA_BLANK_Pos))
+#define   TCC_FCTRLA_BLANK_START_Val      0x0ul  /**< \brief (TCC_FCTRLA) Blanking applied from start of the ramp */
+#define   TCC_FCTRLA_BLANK_RISE_Val       0x1ul  /**< \brief (TCC_FCTRLA) Blanking applied from rising edge of the output waveform */
+#define   TCC_FCTRLA_BLANK_FALL_Val       0x2ul  /**< \brief (TCC_FCTRLA) Blanking applied from falling edge of the output waveform */
+#define   TCC_FCTRLA_BLANK_BOTH_Val       0x3ul  /**< \brief (TCC_FCTRLA) Blanking applied from each toggle of the output waveform */
+#define TCC_FCTRLA_BLANK_START      (TCC_FCTRLA_BLANK_START_Val    << TCC_FCTRLA_BLANK_Pos)
+#define TCC_FCTRLA_BLANK_RISE       (TCC_FCTRLA_BLANK_RISE_Val     << TCC_FCTRLA_BLANK_Pos)
+#define TCC_FCTRLA_BLANK_FALL       (TCC_FCTRLA_BLANK_FALL_Val     << TCC_FCTRLA_BLANK_Pos)
+#define TCC_FCTRLA_BLANK_BOTH       (TCC_FCTRLA_BLANK_BOTH_Val     << TCC_FCTRLA_BLANK_Pos)
+#define TCC_FCTRLA_RESTART_Pos      7            /**< \brief (TCC_FCTRLA) Fault A Restart */
+#define TCC_FCTRLA_RESTART          (0x1ul << TCC_FCTRLA_RESTART_Pos)
+#define TCC_FCTRLA_HALT_Pos         8            /**< \brief (TCC_FCTRLA) Fault A Halt Mode */
+#define TCC_FCTRLA_HALT_Msk         (0x3ul << TCC_FCTRLA_HALT_Pos)
+#define TCC_FCTRLA_HALT(value)      (TCC_FCTRLA_HALT_Msk & ((value) << TCC_FCTRLA_HALT_Pos))
+#define   TCC_FCTRLA_HALT_DISABLE_Val     0x0ul  /**< \brief (TCC_FCTRLA) Halt action disabled */
+#define   TCC_FCTRLA_HALT_HW_Val          0x1ul  /**< \brief (TCC_FCTRLA) Hardware halt action */
+#define   TCC_FCTRLA_HALT_SW_Val          0x2ul  /**< \brief (TCC_FCTRLA) Software halt action */
+#define   TCC_FCTRLA_HALT_NR_Val          0x3ul  /**< \brief (TCC_FCTRLA) Non-recoverable fault */
+#define TCC_FCTRLA_HALT_DISABLE     (TCC_FCTRLA_HALT_DISABLE_Val   << TCC_FCTRLA_HALT_Pos)
+#define TCC_FCTRLA_HALT_HW          (TCC_FCTRLA_HALT_HW_Val        << TCC_FCTRLA_HALT_Pos)
+#define TCC_FCTRLA_HALT_SW          (TCC_FCTRLA_HALT_SW_Val        << TCC_FCTRLA_HALT_Pos)
+#define TCC_FCTRLA_HALT_NR          (TCC_FCTRLA_HALT_NR_Val        << TCC_FCTRLA_HALT_Pos)
+#define TCC_FCTRLA_CHSEL_Pos        10           /**< \brief (TCC_FCTRLA) Fault A Capture Channel */
+#define TCC_FCTRLA_CHSEL_Msk        (0x3ul << TCC_FCTRLA_CHSEL_Pos)
+#define TCC_FCTRLA_CHSEL(value)     (TCC_FCTRLA_CHSEL_Msk & ((value) << TCC_FCTRLA_CHSEL_Pos))
+#define   TCC_FCTRLA_CHSEL_CC0_Val        0x0ul  /**< \brief (TCC_FCTRLA) Capture value stored in channel 0 */
+#define   TCC_FCTRLA_CHSEL_CC1_Val        0x1ul  /**< \brief (TCC_FCTRLA) Capture value stored in channel 1 */
+#define   TCC_FCTRLA_CHSEL_CC2_Val        0x2ul  /**< \brief (TCC_FCTRLA) Capture value stored in channel 2 */
+#define   TCC_FCTRLA_CHSEL_CC3_Val        0x3ul  /**< \brief (TCC_FCTRLA) Capture value stored in channel 3 */
+#define TCC_FCTRLA_CHSEL_CC0        (TCC_FCTRLA_CHSEL_CC0_Val      << TCC_FCTRLA_CHSEL_Pos)
+#define TCC_FCTRLA_CHSEL_CC1        (TCC_FCTRLA_CHSEL_CC1_Val      << TCC_FCTRLA_CHSEL_Pos)
+#define TCC_FCTRLA_CHSEL_CC2        (TCC_FCTRLA_CHSEL_CC2_Val      << TCC_FCTRLA_CHSEL_Pos)
+#define TCC_FCTRLA_CHSEL_CC3        (TCC_FCTRLA_CHSEL_CC3_Val      << TCC_FCTRLA_CHSEL_Pos)
+#define TCC_FCTRLA_CAPTURE_Pos      12           /**< \brief (TCC_FCTRLA) Fault A Capture Action */
+#define TCC_FCTRLA_CAPTURE_Msk      (0x7ul << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_CAPTURE(value)   (TCC_FCTRLA_CAPTURE_Msk & ((value) << TCC_FCTRLA_CAPTURE_Pos))
+#define   TCC_FCTRLA_CAPTURE_DISABLE_Val  0x0ul  /**< \brief (TCC_FCTRLA) No capture */
+#define   TCC_FCTRLA_CAPTURE_CAPT_Val     0x1ul  /**< \brief (TCC_FCTRLA) Capture on fault */
+#define   TCC_FCTRLA_CAPTURE_CAPTMIN_Val  0x2ul  /**< \brief (TCC_FCTRLA) Minimum capture */
+#define   TCC_FCTRLA_CAPTURE_CAPTMAX_Val  0x3ul  /**< \brief (TCC_FCTRLA) Maximum capture */
+#define   TCC_FCTRLA_CAPTURE_LOCMIN_Val   0x4ul  /**< \brief (TCC_FCTRLA) Minimum local detection */
+#define   TCC_FCTRLA_CAPTURE_LOCMAX_Val   0x5ul  /**< \brief (TCC_FCTRLA) Maximum local detection */
+#define   TCC_FCTRLA_CAPTURE_DERIV0_Val   0x6ul  /**< \brief (TCC_FCTRLA) Minimum and maximum local detection */
+#define   TCC_FCTRLA_CAPTURE_CAPTMARK_Val 0x7ul  /**< \brief (TCC_FCTRLA) Capture with ramp index as MSB value */
+#define TCC_FCTRLA_CAPTURE_DISABLE  (TCC_FCTRLA_CAPTURE_DISABLE_Val << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_CAPTURE_CAPT     (TCC_FCTRLA_CAPTURE_CAPT_Val   << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_CAPTURE_CAPTMIN  (TCC_FCTRLA_CAPTURE_CAPTMIN_Val << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_CAPTURE_CAPTMAX  (TCC_FCTRLA_CAPTURE_CAPTMAX_Val << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_CAPTURE_LOCMIN   (TCC_FCTRLA_CAPTURE_LOCMIN_Val << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_CAPTURE_LOCMAX   (TCC_FCTRLA_CAPTURE_LOCMAX_Val << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_CAPTURE_DERIV0   (TCC_FCTRLA_CAPTURE_DERIV0_Val << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_CAPTURE_CAPTMARK (TCC_FCTRLA_CAPTURE_CAPTMARK_Val << TCC_FCTRLA_CAPTURE_Pos)
+#define TCC_FCTRLA_BLANKPRESC_Pos   15           /**< \brief (TCC_FCTRLA) Fault A Blanking Prescaler */
+#define TCC_FCTRLA_BLANKPRESC       (0x1ul << TCC_FCTRLA_BLANKPRESC_Pos)
+#define TCC_FCTRLA_BLANKVAL_Pos     16           /**< \brief (TCC_FCTRLA) Fault A Blanking Time */
+#define TCC_FCTRLA_BLANKVAL_Msk     (0xFFul << TCC_FCTRLA_BLANKVAL_Pos)
+#define TCC_FCTRLA_BLANKVAL(value)  (TCC_FCTRLA_BLANKVAL_Msk & ((value) << TCC_FCTRLA_BLANKVAL_Pos))
+#define TCC_FCTRLA_FILTERVAL_Pos    24           /**< \brief (TCC_FCTRLA) Fault A Filter Value */
+#define TCC_FCTRLA_FILTERVAL_Msk    (0xFul << TCC_FCTRLA_FILTERVAL_Pos)
+#define TCC_FCTRLA_FILTERVAL(value) (TCC_FCTRLA_FILTERVAL_Msk & ((value) << TCC_FCTRLA_FILTERVAL_Pos))
+#define TCC_FCTRLA_MASK             0x0FFFFFFBul /**< \brief (TCC_FCTRLA) MASK Register */
+
+/* -------- TCC_FCTRLB : (TCC Offset: 0x10) (R/W 32) Recoverable Fault B Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SRC:2;            /*!< bit:  0.. 1  Fault B Source                     */
+    uint32_t :1;               /*!< bit:      2  Reserved                           */
+    uint32_t KEEP:1;           /*!< bit:      3  Fault B Keeper                     */
+    uint32_t QUAL:1;           /*!< bit:      4  Fault B Qualification              */
+    uint32_t BLANK:2;          /*!< bit:  5.. 6  Fault B Blanking Mode              */
+    uint32_t RESTART:1;        /*!< bit:      7  Fault B Restart                    */
+    uint32_t HALT:2;           /*!< bit:  8.. 9  Fault B Halt Mode                  */
+    uint32_t CHSEL:2;          /*!< bit: 10..11  Fault B Capture Channel            */
+    uint32_t CAPTURE:3;        /*!< bit: 12..14  Fault B Capture Action             */
+    uint32_t BLANKPRESC:1;     /*!< bit:     15  Fault B Blanking Prescaler         */
+    uint32_t BLANKVAL:8;       /*!< bit: 16..23  Fault B Blanking Time              */
+    uint32_t FILTERVAL:4;      /*!< bit: 24..27  Fault B Filter Value               */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_FCTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_FCTRLB_OFFSET           0x10         /**< \brief (TCC_FCTRLB offset) Recoverable Fault B Configuration */
+#define TCC_FCTRLB_RESETVALUE       0x00000000ul /**< \brief (TCC_FCTRLB reset_value) Recoverable Fault B Configuration */
+
+#define TCC_FCTRLB_SRC_Pos          0            /**< \brief (TCC_FCTRLB) Fault B Source */
+#define TCC_FCTRLB_SRC_Msk          (0x3ul << TCC_FCTRLB_SRC_Pos)
+#define TCC_FCTRLB_SRC(value)       (TCC_FCTRLB_SRC_Msk & ((value) << TCC_FCTRLB_SRC_Pos))
+#define   TCC_FCTRLB_SRC_DISABLE_Val      0x0ul  /**< \brief (TCC_FCTRLB) Fault input disabled */
+#define   TCC_FCTRLB_SRC_ENABLE_Val       0x1ul  /**< \brief (TCC_FCTRLB) MCEx (x=0,1) event input */
+#define   TCC_FCTRLB_SRC_INVERT_Val       0x2ul  /**< \brief (TCC_FCTRLB) Inverted MCEx (x=0,1) event input */
+#define   TCC_FCTRLB_SRC_ALTFAULT_Val     0x3ul  /**< \brief (TCC_FCTRLB) Alternate fault (A or B) state at the end of the previous period */
+#define TCC_FCTRLB_SRC_DISABLE      (TCC_FCTRLB_SRC_DISABLE_Val    << TCC_FCTRLB_SRC_Pos)
+#define TCC_FCTRLB_SRC_ENABLE       (TCC_FCTRLB_SRC_ENABLE_Val     << TCC_FCTRLB_SRC_Pos)
+#define TCC_FCTRLB_SRC_INVERT       (TCC_FCTRLB_SRC_INVERT_Val     << TCC_FCTRLB_SRC_Pos)
+#define TCC_FCTRLB_SRC_ALTFAULT     (TCC_FCTRLB_SRC_ALTFAULT_Val   << TCC_FCTRLB_SRC_Pos)
+#define TCC_FCTRLB_KEEP_Pos         3            /**< \brief (TCC_FCTRLB) Fault B Keeper */
+#define TCC_FCTRLB_KEEP             (0x1ul << TCC_FCTRLB_KEEP_Pos)
+#define TCC_FCTRLB_QUAL_Pos         4            /**< \brief (TCC_FCTRLB) Fault B Qualification */
+#define TCC_FCTRLB_QUAL             (0x1ul << TCC_FCTRLB_QUAL_Pos)
+#define TCC_FCTRLB_BLANK_Pos        5            /**< \brief (TCC_FCTRLB) Fault B Blanking Mode */
+#define TCC_FCTRLB_BLANK_Msk        (0x3ul << TCC_FCTRLB_BLANK_Pos)
+#define TCC_FCTRLB_BLANK(value)     (TCC_FCTRLB_BLANK_Msk & ((value) << TCC_FCTRLB_BLANK_Pos))
+#define   TCC_FCTRLB_BLANK_START_Val      0x0ul  /**< \brief (TCC_FCTRLB) Blanking applied from start of the ramp */
+#define   TCC_FCTRLB_BLANK_RISE_Val       0x1ul  /**< \brief (TCC_FCTRLB) Blanking applied from rising edge of the output waveform */
+#define   TCC_FCTRLB_BLANK_FALL_Val       0x2ul  /**< \brief (TCC_FCTRLB) Blanking applied from falling edge of the output waveform */
+#define   TCC_FCTRLB_BLANK_BOTH_Val       0x3ul  /**< \brief (TCC_FCTRLB) Blanking applied from each toggle of the output waveform */
+#define TCC_FCTRLB_BLANK_START      (TCC_FCTRLB_BLANK_START_Val    << TCC_FCTRLB_BLANK_Pos)
+#define TCC_FCTRLB_BLANK_RISE       (TCC_FCTRLB_BLANK_RISE_Val     << TCC_FCTRLB_BLANK_Pos)
+#define TCC_FCTRLB_BLANK_FALL       (TCC_FCTRLB_BLANK_FALL_Val     << TCC_FCTRLB_BLANK_Pos)
+#define TCC_FCTRLB_BLANK_BOTH       (TCC_FCTRLB_BLANK_BOTH_Val     << TCC_FCTRLB_BLANK_Pos)
+#define TCC_FCTRLB_RESTART_Pos      7            /**< \brief (TCC_FCTRLB) Fault B Restart */
+#define TCC_FCTRLB_RESTART          (0x1ul << TCC_FCTRLB_RESTART_Pos)
+#define TCC_FCTRLB_HALT_Pos         8            /**< \brief (TCC_FCTRLB) Fault B Halt Mode */
+#define TCC_FCTRLB_HALT_Msk         (0x3ul << TCC_FCTRLB_HALT_Pos)
+#define TCC_FCTRLB_HALT(value)      (TCC_FCTRLB_HALT_Msk & ((value) << TCC_FCTRLB_HALT_Pos))
+#define   TCC_FCTRLB_HALT_DISABLE_Val     0x0ul  /**< \brief (TCC_FCTRLB) Halt action disabled */
+#define   TCC_FCTRLB_HALT_HW_Val          0x1ul  /**< \brief (TCC_FCTRLB) Hardware halt action */
+#define   TCC_FCTRLB_HALT_SW_Val          0x2ul  /**< \brief (TCC_FCTRLB) Software halt action */
+#define   TCC_FCTRLB_HALT_NR_Val          0x3ul  /**< \brief (TCC_FCTRLB) Non-recoverable fault */
+#define TCC_FCTRLB_HALT_DISABLE     (TCC_FCTRLB_HALT_DISABLE_Val   << TCC_FCTRLB_HALT_Pos)
+#define TCC_FCTRLB_HALT_HW          (TCC_FCTRLB_HALT_HW_Val        << TCC_FCTRLB_HALT_Pos)
+#define TCC_FCTRLB_HALT_SW          (TCC_FCTRLB_HALT_SW_Val        << TCC_FCTRLB_HALT_Pos)
+#define TCC_FCTRLB_HALT_NR          (TCC_FCTRLB_HALT_NR_Val        << TCC_FCTRLB_HALT_Pos)
+#define TCC_FCTRLB_CHSEL_Pos        10           /**< \brief (TCC_FCTRLB) Fault B Capture Channel */
+#define TCC_FCTRLB_CHSEL_Msk        (0x3ul << TCC_FCTRLB_CHSEL_Pos)
+#define TCC_FCTRLB_CHSEL(value)     (TCC_FCTRLB_CHSEL_Msk & ((value) << TCC_FCTRLB_CHSEL_Pos))
+#define   TCC_FCTRLB_CHSEL_CC0_Val        0x0ul  /**< \brief (TCC_FCTRLB) Capture value stored in channel 0 */
+#define   TCC_FCTRLB_CHSEL_CC1_Val        0x1ul  /**< \brief (TCC_FCTRLB) Capture value stored in channel 1 */
+#define   TCC_FCTRLB_CHSEL_CC2_Val        0x2ul  /**< \brief (TCC_FCTRLB) Capture value stored in channel 2 */
+#define   TCC_FCTRLB_CHSEL_CC3_Val        0x3ul  /**< \brief (TCC_FCTRLB) Capture value stored in channel 3 */
+#define TCC_FCTRLB_CHSEL_CC0        (TCC_FCTRLB_CHSEL_CC0_Val      << TCC_FCTRLB_CHSEL_Pos)
+#define TCC_FCTRLB_CHSEL_CC1        (TCC_FCTRLB_CHSEL_CC1_Val      << TCC_FCTRLB_CHSEL_Pos)
+#define TCC_FCTRLB_CHSEL_CC2        (TCC_FCTRLB_CHSEL_CC2_Val      << TCC_FCTRLB_CHSEL_Pos)
+#define TCC_FCTRLB_CHSEL_CC3        (TCC_FCTRLB_CHSEL_CC3_Val      << TCC_FCTRLB_CHSEL_Pos)
+#define TCC_FCTRLB_CAPTURE_Pos      12           /**< \brief (TCC_FCTRLB) Fault B Capture Action */
+#define TCC_FCTRLB_CAPTURE_Msk      (0x7ul << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_CAPTURE(value)   (TCC_FCTRLB_CAPTURE_Msk & ((value) << TCC_FCTRLB_CAPTURE_Pos))
+#define   TCC_FCTRLB_CAPTURE_DISABLE_Val  0x0ul  /**< \brief (TCC_FCTRLB) No capture */
+#define   TCC_FCTRLB_CAPTURE_CAPT_Val     0x1ul  /**< \brief (TCC_FCTRLB) Capture on fault */
+#define   TCC_FCTRLB_CAPTURE_CAPTMIN_Val  0x2ul  /**< \brief (TCC_FCTRLB) Minimum capture */
+#define   TCC_FCTRLB_CAPTURE_CAPTMAX_Val  0x3ul  /**< \brief (TCC_FCTRLB) Maximum capture */
+#define   TCC_FCTRLB_CAPTURE_LOCMIN_Val   0x4ul  /**< \brief (TCC_FCTRLB) Minimum local detection */
+#define   TCC_FCTRLB_CAPTURE_LOCMAX_Val   0x5ul  /**< \brief (TCC_FCTRLB) Maximum local detection */
+#define   TCC_FCTRLB_CAPTURE_DERIV0_Val   0x6ul  /**< \brief (TCC_FCTRLB) Minimum and maximum local detection */
+#define   TCC_FCTRLB_CAPTURE_CAPTMARK_Val 0x7ul  /**< \brief (TCC_FCTRLB) Capture with ramp index as MSB value */
+#define TCC_FCTRLB_CAPTURE_DISABLE  (TCC_FCTRLB_CAPTURE_DISABLE_Val << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_CAPTURE_CAPT     (TCC_FCTRLB_CAPTURE_CAPT_Val   << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_CAPTURE_CAPTMIN  (TCC_FCTRLB_CAPTURE_CAPTMIN_Val << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_CAPTURE_CAPTMAX  (TCC_FCTRLB_CAPTURE_CAPTMAX_Val << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_CAPTURE_LOCMIN   (TCC_FCTRLB_CAPTURE_LOCMIN_Val << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_CAPTURE_LOCMAX   (TCC_FCTRLB_CAPTURE_LOCMAX_Val << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_CAPTURE_DERIV0   (TCC_FCTRLB_CAPTURE_DERIV0_Val << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_CAPTURE_CAPTMARK (TCC_FCTRLB_CAPTURE_CAPTMARK_Val << TCC_FCTRLB_CAPTURE_Pos)
+#define TCC_FCTRLB_BLANKPRESC_Pos   15           /**< \brief (TCC_FCTRLB) Fault B Blanking Prescaler */
+#define TCC_FCTRLB_BLANKPRESC       (0x1ul << TCC_FCTRLB_BLANKPRESC_Pos)
+#define TCC_FCTRLB_BLANKVAL_Pos     16           /**< \brief (TCC_FCTRLB) Fault B Blanking Time */
+#define TCC_FCTRLB_BLANKVAL_Msk     (0xFFul << TCC_FCTRLB_BLANKVAL_Pos)
+#define TCC_FCTRLB_BLANKVAL(value)  (TCC_FCTRLB_BLANKVAL_Msk & ((value) << TCC_FCTRLB_BLANKVAL_Pos))
+#define TCC_FCTRLB_FILTERVAL_Pos    24           /**< \brief (TCC_FCTRLB) Fault B Filter Value */
+#define TCC_FCTRLB_FILTERVAL_Msk    (0xFul << TCC_FCTRLB_FILTERVAL_Pos)
+#define TCC_FCTRLB_FILTERVAL(value) (TCC_FCTRLB_FILTERVAL_Msk & ((value) << TCC_FCTRLB_FILTERVAL_Pos))
+#define TCC_FCTRLB_MASK             0x0FFFFFFBul /**< \brief (TCC_FCTRLB) MASK Register */
+
+/* -------- TCC_WEXCTRL : (TCC Offset: 0x14) (R/W 32) Waveform Extension Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OTMX:2;           /*!< bit:  0.. 1  Output Matrix                      */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t DTIEN0:1;         /*!< bit:      8  Dead-time Insertion Generator 0 Enable */
+    uint32_t DTIEN1:1;         /*!< bit:      9  Dead-time Insertion Generator 1 Enable */
+    uint32_t DTIEN2:1;         /*!< bit:     10  Dead-time Insertion Generator 2 Enable */
+    uint32_t DTIEN3:1;         /*!< bit:     11  Dead-time Insertion Generator 3 Enable */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t DTLS:8;           /*!< bit: 16..23  Dead-time Low Side Outputs Value   */
+    uint32_t DTHS:8;           /*!< bit: 24..31  Dead-time High Side Outputs Value  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t DTIEN:4;          /*!< bit:  8..11  Dead-time Insertion Generator x Enable */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_WEXCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_WEXCTRL_OFFSET          0x14         /**< \brief (TCC_WEXCTRL offset) Waveform Extension Configuration */
+#define TCC_WEXCTRL_RESETVALUE      0x00000000ul /**< \brief (TCC_WEXCTRL reset_value) Waveform Extension Configuration */
+
+#define TCC_WEXCTRL_OTMX_Pos        0            /**< \brief (TCC_WEXCTRL) Output Matrix */
+#define TCC_WEXCTRL_OTMX_Msk        (0x3ul << TCC_WEXCTRL_OTMX_Pos)
+#define TCC_WEXCTRL_OTMX(value)     (TCC_WEXCTRL_OTMX_Msk & ((value) << TCC_WEXCTRL_OTMX_Pos))
+#define TCC_WEXCTRL_DTIEN0_Pos      8            /**< \brief (TCC_WEXCTRL) Dead-time Insertion Generator 0 Enable */
+#define TCC_WEXCTRL_DTIEN0          (1 << TCC_WEXCTRL_DTIEN0_Pos)
+#define TCC_WEXCTRL_DTIEN1_Pos      9            /**< \brief (TCC_WEXCTRL) Dead-time Insertion Generator 1 Enable */
+#define TCC_WEXCTRL_DTIEN1          (1 << TCC_WEXCTRL_DTIEN1_Pos)
+#define TCC_WEXCTRL_DTIEN2_Pos      10           /**< \brief (TCC_WEXCTRL) Dead-time Insertion Generator 2 Enable */
+#define TCC_WEXCTRL_DTIEN2          (1 << TCC_WEXCTRL_DTIEN2_Pos)
+#define TCC_WEXCTRL_DTIEN3_Pos      11           /**< \brief (TCC_WEXCTRL) Dead-time Insertion Generator 3 Enable */
+#define TCC_WEXCTRL_DTIEN3          (1 << TCC_WEXCTRL_DTIEN3_Pos)
+#define TCC_WEXCTRL_DTIEN_Pos       8            /**< \brief (TCC_WEXCTRL) Dead-time Insertion Generator x Enable */
+#define TCC_WEXCTRL_DTIEN_Msk       (0xFul << TCC_WEXCTRL_DTIEN_Pos)
+#define TCC_WEXCTRL_DTIEN(value)    (TCC_WEXCTRL_DTIEN_Msk & ((value) << TCC_WEXCTRL_DTIEN_Pos))
+#define TCC_WEXCTRL_DTLS_Pos        16           /**< \brief (TCC_WEXCTRL) Dead-time Low Side Outputs Value */
+#define TCC_WEXCTRL_DTLS_Msk        (0xFFul << TCC_WEXCTRL_DTLS_Pos)
+#define TCC_WEXCTRL_DTLS(value)     (TCC_WEXCTRL_DTLS_Msk & ((value) << TCC_WEXCTRL_DTLS_Pos))
+#define TCC_WEXCTRL_DTHS_Pos        24           /**< \brief (TCC_WEXCTRL) Dead-time High Side Outputs Value */
+#define TCC_WEXCTRL_DTHS_Msk        (0xFFul << TCC_WEXCTRL_DTHS_Pos)
+#define TCC_WEXCTRL_DTHS(value)     (TCC_WEXCTRL_DTHS_Msk & ((value) << TCC_WEXCTRL_DTHS_Pos))
+#define TCC_WEXCTRL_MASK            0xFFFF0F03ul /**< \brief (TCC_WEXCTRL) MASK Register */
+
+/* -------- TCC_DRVCTRL : (TCC Offset: 0x18) (R/W 32) Driver Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NRE0:1;           /*!< bit:      0  Non-Recoverable State 0 Output Enable */
+    uint32_t NRE1:1;           /*!< bit:      1  Non-Recoverable State 1 Output Enable */
+    uint32_t NRE2:1;           /*!< bit:      2  Non-Recoverable State 2 Output Enable */
+    uint32_t NRE3:1;           /*!< bit:      3  Non-Recoverable State 3 Output Enable */
+    uint32_t NRE4:1;           /*!< bit:      4  Non-Recoverable State 4 Output Enable */
+    uint32_t NRE5:1;           /*!< bit:      5  Non-Recoverable State 5 Output Enable */
+    uint32_t NRE6:1;           /*!< bit:      6  Non-Recoverable State 6 Output Enable */
+    uint32_t NRE7:1;           /*!< bit:      7  Non-Recoverable State 7 Output Enable */
+    uint32_t NRV0:1;           /*!< bit:      8  Non-Recoverable State 0 Output Value */
+    uint32_t NRV1:1;           /*!< bit:      9  Non-Recoverable State 1 Output Value */
+    uint32_t NRV2:1;           /*!< bit:     10  Non-Recoverable State 2 Output Value */
+    uint32_t NRV3:1;           /*!< bit:     11  Non-Recoverable State 3 Output Value */
+    uint32_t NRV4:1;           /*!< bit:     12  Non-Recoverable State 4 Output Value */
+    uint32_t NRV5:1;           /*!< bit:     13  Non-Recoverable State 5 Output Value */
+    uint32_t NRV6:1;           /*!< bit:     14  Non-Recoverable State 6 Output Value */
+    uint32_t NRV7:1;           /*!< bit:     15  Non-Recoverable State 7 Output Value */
+    uint32_t INVEN0:1;         /*!< bit:     16  Output Waveform 0 Inversion        */
+    uint32_t INVEN1:1;         /*!< bit:     17  Output Waveform 1 Inversion        */
+    uint32_t INVEN2:1;         /*!< bit:     18  Output Waveform 2 Inversion        */
+    uint32_t INVEN3:1;         /*!< bit:     19  Output Waveform 3 Inversion        */
+    uint32_t INVEN4:1;         /*!< bit:     20  Output Waveform 4 Inversion        */
+    uint32_t INVEN5:1;         /*!< bit:     21  Output Waveform 5 Inversion        */
+    uint32_t INVEN6:1;         /*!< bit:     22  Output Waveform 6 Inversion        */
+    uint32_t INVEN7:1;         /*!< bit:     23  Output Waveform 7 Inversion        */
+    uint32_t FILTERVAL0:4;     /*!< bit: 24..27  Non-Recoverable Fault Input 0 Filter Value */
+    uint32_t FILTERVAL1:4;     /*!< bit: 28..31  Non-Recoverable Fault Input 1 Filter Value */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t NRE:8;            /*!< bit:  0.. 7  Non-Recoverable State x Output Enable */
+    uint32_t NRV:8;            /*!< bit:  8..15  Non-Recoverable State x Output Value */
+    uint32_t INVEN:8;          /*!< bit: 16..23  Output Waveform x Inversion        */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_DRVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_DRVCTRL_OFFSET          0x18         /**< \brief (TCC_DRVCTRL offset) Driver Control */
+#define TCC_DRVCTRL_RESETVALUE      0x00000000ul /**< \brief (TCC_DRVCTRL reset_value) Driver Control */
+
+#define TCC_DRVCTRL_NRE0_Pos        0            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 0 Output Enable */
+#define TCC_DRVCTRL_NRE0            (1 << TCC_DRVCTRL_NRE0_Pos)
+#define TCC_DRVCTRL_NRE1_Pos        1            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 1 Output Enable */
+#define TCC_DRVCTRL_NRE1            (1 << TCC_DRVCTRL_NRE1_Pos)
+#define TCC_DRVCTRL_NRE2_Pos        2            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 2 Output Enable */
+#define TCC_DRVCTRL_NRE2            (1 << TCC_DRVCTRL_NRE2_Pos)
+#define TCC_DRVCTRL_NRE3_Pos        3            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 3 Output Enable */
+#define TCC_DRVCTRL_NRE3            (1 << TCC_DRVCTRL_NRE3_Pos)
+#define TCC_DRVCTRL_NRE4_Pos        4            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 4 Output Enable */
+#define TCC_DRVCTRL_NRE4            (1 << TCC_DRVCTRL_NRE4_Pos)
+#define TCC_DRVCTRL_NRE5_Pos        5            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 5 Output Enable */
+#define TCC_DRVCTRL_NRE5            (1 << TCC_DRVCTRL_NRE5_Pos)
+#define TCC_DRVCTRL_NRE6_Pos        6            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 6 Output Enable */
+#define TCC_DRVCTRL_NRE6            (1 << TCC_DRVCTRL_NRE6_Pos)
+#define TCC_DRVCTRL_NRE7_Pos        7            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 7 Output Enable */
+#define TCC_DRVCTRL_NRE7            (1 << TCC_DRVCTRL_NRE7_Pos)
+#define TCC_DRVCTRL_NRE_Pos         0            /**< \brief (TCC_DRVCTRL) Non-Recoverable State x Output Enable */
+#define TCC_DRVCTRL_NRE_Msk         (0xFFul << TCC_DRVCTRL_NRE_Pos)
+#define TCC_DRVCTRL_NRE(value)      (TCC_DRVCTRL_NRE_Msk & ((value) << TCC_DRVCTRL_NRE_Pos))
+#define TCC_DRVCTRL_NRV0_Pos        8            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 0 Output Value */
+#define TCC_DRVCTRL_NRV0            (1 << TCC_DRVCTRL_NRV0_Pos)
+#define TCC_DRVCTRL_NRV1_Pos        9            /**< \brief (TCC_DRVCTRL) Non-Recoverable State 1 Output Value */
+#define TCC_DRVCTRL_NRV1            (1 << TCC_DRVCTRL_NRV1_Pos)
+#define TCC_DRVCTRL_NRV2_Pos        10           /**< \brief (TCC_DRVCTRL) Non-Recoverable State 2 Output Value */
+#define TCC_DRVCTRL_NRV2            (1 << TCC_DRVCTRL_NRV2_Pos)
+#define TCC_DRVCTRL_NRV3_Pos        11           /**< \brief (TCC_DRVCTRL) Non-Recoverable State 3 Output Value */
+#define TCC_DRVCTRL_NRV3            (1 << TCC_DRVCTRL_NRV3_Pos)
+#define TCC_DRVCTRL_NRV4_Pos        12           /**< \brief (TCC_DRVCTRL) Non-Recoverable State 4 Output Value */
+#define TCC_DRVCTRL_NRV4            (1 << TCC_DRVCTRL_NRV4_Pos)
+#define TCC_DRVCTRL_NRV5_Pos        13           /**< \brief (TCC_DRVCTRL) Non-Recoverable State 5 Output Value */
+#define TCC_DRVCTRL_NRV5            (1 << TCC_DRVCTRL_NRV5_Pos)
+#define TCC_DRVCTRL_NRV6_Pos        14           /**< \brief (TCC_DRVCTRL) Non-Recoverable State 6 Output Value */
+#define TCC_DRVCTRL_NRV6            (1 << TCC_DRVCTRL_NRV6_Pos)
+#define TCC_DRVCTRL_NRV7_Pos        15           /**< \brief (TCC_DRVCTRL) Non-Recoverable State 7 Output Value */
+#define TCC_DRVCTRL_NRV7            (1 << TCC_DRVCTRL_NRV7_Pos)
+#define TCC_DRVCTRL_NRV_Pos         8            /**< \brief (TCC_DRVCTRL) Non-Recoverable State x Output Value */
+#define TCC_DRVCTRL_NRV_Msk         (0xFFul << TCC_DRVCTRL_NRV_Pos)
+#define TCC_DRVCTRL_NRV(value)      (TCC_DRVCTRL_NRV_Msk & ((value) << TCC_DRVCTRL_NRV_Pos))
+#define TCC_DRVCTRL_INVEN0_Pos      16           /**< \brief (TCC_DRVCTRL) Output Waveform 0 Inversion */
+#define TCC_DRVCTRL_INVEN0          (1 << TCC_DRVCTRL_INVEN0_Pos)
+#define TCC_DRVCTRL_INVEN1_Pos      17           /**< \brief (TCC_DRVCTRL) Output Waveform 1 Inversion */
+#define TCC_DRVCTRL_INVEN1          (1 << TCC_DRVCTRL_INVEN1_Pos)
+#define TCC_DRVCTRL_INVEN2_Pos      18           /**< \brief (TCC_DRVCTRL) Output Waveform 2 Inversion */
+#define TCC_DRVCTRL_INVEN2          (1 << TCC_DRVCTRL_INVEN2_Pos)
+#define TCC_DRVCTRL_INVEN3_Pos      19           /**< \brief (TCC_DRVCTRL) Output Waveform 3 Inversion */
+#define TCC_DRVCTRL_INVEN3          (1 << TCC_DRVCTRL_INVEN3_Pos)
+#define TCC_DRVCTRL_INVEN4_Pos      20           /**< \brief (TCC_DRVCTRL) Output Waveform 4 Inversion */
+#define TCC_DRVCTRL_INVEN4          (1 << TCC_DRVCTRL_INVEN4_Pos)
+#define TCC_DRVCTRL_INVEN5_Pos      21           /**< \brief (TCC_DRVCTRL) Output Waveform 5 Inversion */
+#define TCC_DRVCTRL_INVEN5          (1 << TCC_DRVCTRL_INVEN5_Pos)
+#define TCC_DRVCTRL_INVEN6_Pos      22           /**< \brief (TCC_DRVCTRL) Output Waveform 6 Inversion */
+#define TCC_DRVCTRL_INVEN6          (1 << TCC_DRVCTRL_INVEN6_Pos)
+#define TCC_DRVCTRL_INVEN7_Pos      23           /**< \brief (TCC_DRVCTRL) Output Waveform 7 Inversion */
+#define TCC_DRVCTRL_INVEN7          (1 << TCC_DRVCTRL_INVEN7_Pos)
+#define TCC_DRVCTRL_INVEN_Pos       16           /**< \brief (TCC_DRVCTRL) Output Waveform x Inversion */
+#define TCC_DRVCTRL_INVEN_Msk       (0xFFul << TCC_DRVCTRL_INVEN_Pos)
+#define TCC_DRVCTRL_INVEN(value)    (TCC_DRVCTRL_INVEN_Msk & ((value) << TCC_DRVCTRL_INVEN_Pos))
+#define TCC_DRVCTRL_FILTERVAL0_Pos  24           /**< \brief (TCC_DRVCTRL) Non-Recoverable Fault Input 0 Filter Value */
+#define TCC_DRVCTRL_FILTERVAL0_Msk  (0xFul << TCC_DRVCTRL_FILTERVAL0_Pos)
+#define TCC_DRVCTRL_FILTERVAL0(value) (TCC_DRVCTRL_FILTERVAL0_Msk & ((value) << TCC_DRVCTRL_FILTERVAL0_Pos))
+#define TCC_DRVCTRL_FILTERVAL1_Pos  28           /**< \brief (TCC_DRVCTRL) Non-Recoverable Fault Input 1 Filter Value */
+#define TCC_DRVCTRL_FILTERVAL1_Msk  (0xFul << TCC_DRVCTRL_FILTERVAL1_Pos)
+#define TCC_DRVCTRL_FILTERVAL1(value) (TCC_DRVCTRL_FILTERVAL1_Msk & ((value) << TCC_DRVCTRL_FILTERVAL1_Pos))
+#define TCC_DRVCTRL_MASK            0xFFFFFFFFul /**< \brief (TCC_DRVCTRL) MASK Register */
+
+/* -------- TCC_DBGCTRL : (TCC Offset: 0x1E) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Running Mode                 */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  FDDBD:1;          /*!< bit:      2  Fault Detection on Debug Break Detection */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TCC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_DBGCTRL_OFFSET          0x1E         /**< \brief (TCC_DBGCTRL offset) Debug Control */
+#define TCC_DBGCTRL_RESETVALUE      0x00ul       /**< \brief (TCC_DBGCTRL reset_value) Debug Control */
+
+#define TCC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (TCC_DBGCTRL) Debug Running Mode */
+#define TCC_DBGCTRL_DBGRUN          (0x1ul << TCC_DBGCTRL_DBGRUN_Pos)
+#define TCC_DBGCTRL_FDDBD_Pos       2            /**< \brief (TCC_DBGCTRL) Fault Detection on Debug Break Detection */
+#define TCC_DBGCTRL_FDDBD           (0x1ul << TCC_DBGCTRL_FDDBD_Pos)
+#define TCC_DBGCTRL_MASK            0x05ul       /**< \brief (TCC_DBGCTRL) MASK Register */
+
+/* -------- TCC_EVCTRL : (TCC Offset: 0x20) (R/W 32) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EVACT0:3;         /*!< bit:  0.. 2  Timer/counter Input Event0 Action  */
+    uint32_t EVACT1:3;         /*!< bit:  3.. 5  Timer/counter Input Event1 Action  */
+    uint32_t CNTSEL:2;         /*!< bit:  6.. 7  Timer/counter Output Event Mode    */
+    uint32_t OVFEO:1;          /*!< bit:      8  Overflow/Underflow Output Event Enable */
+    uint32_t TRGEO:1;          /*!< bit:      9  Retrigger Output Event Enable      */
+    uint32_t CNTEO:1;          /*!< bit:     10  Timer/counter Output Event Enable  */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t TCINV0:1;         /*!< bit:     12  Inverted Event 0 Input Enable      */
+    uint32_t TCINV1:1;         /*!< bit:     13  Inverted Event 1 Input Enable      */
+    uint32_t TCEI0:1;          /*!< bit:     14  Timer/counter Event 0 Input Enable */
+    uint32_t TCEI1:1;          /*!< bit:     15  Timer/counter Event 1 Input Enable */
+    uint32_t MCEI0:1;          /*!< bit:     16  Match or Capture Channel 0 Event Input Enable */
+    uint32_t MCEI1:1;          /*!< bit:     17  Match or Capture Channel 1 Event Input Enable */
+    uint32_t MCEI2:1;          /*!< bit:     18  Match or Capture Channel 2 Event Input Enable */
+    uint32_t MCEI3:1;          /*!< bit:     19  Match or Capture Channel 3 Event Input Enable */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t MCEO0:1;          /*!< bit:     24  Match or Capture Channel 0 Event Output Enable */
+    uint32_t MCEO1:1;          /*!< bit:     25  Match or Capture Channel 1 Event Output Enable */
+    uint32_t MCEO2:1;          /*!< bit:     26  Match or Capture Channel 2 Event Output Enable */
+    uint32_t MCEO3:1;          /*!< bit:     27  Match or Capture Channel 3 Event Output Enable */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :12;              /*!< bit:  0..11  Reserved                           */
+    uint32_t TCINV:2;          /*!< bit: 12..13  Inverted Event x Input Enable      */
+    uint32_t TCEI:2;           /*!< bit: 14..15  Timer/counter Event x Input Enable */
+    uint32_t MCEI:4;           /*!< bit: 16..19  Match or Capture Channel x Event Input Enable */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t MCEO:4;           /*!< bit: 24..27  Match or Capture Channel x Event Output Enable */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_EVCTRL_OFFSET           0x20         /**< \brief (TCC_EVCTRL offset) Event Control */
+#define TCC_EVCTRL_RESETVALUE       0x00000000ul /**< \brief (TCC_EVCTRL reset_value) Event Control */
+
+#define TCC_EVCTRL_EVACT0_Pos       0            /**< \brief (TCC_EVCTRL) Timer/counter Input Event0 Action */
+#define TCC_EVCTRL_EVACT0_Msk       (0x7ul << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT0(value)    (TCC_EVCTRL_EVACT0_Msk & ((value) << TCC_EVCTRL_EVACT0_Pos))
+#define   TCC_EVCTRL_EVACT0_OFF_Val       0x0ul  /**< \brief (TCC_EVCTRL) Event action disabled */
+#define   TCC_EVCTRL_EVACT0_RETRIGGER_Val 0x1ul  /**< \brief (TCC_EVCTRL) Start, restart or re-trigger counter on event */
+#define   TCC_EVCTRL_EVACT0_COUNTEV_Val   0x2ul  /**< \brief (TCC_EVCTRL) Count on event */
+#define   TCC_EVCTRL_EVACT0_START_Val     0x3ul  /**< \brief (TCC_EVCTRL) Start counter on event */
+#define   TCC_EVCTRL_EVACT0_INC_Val       0x4ul  /**< \brief (TCC_EVCTRL) Increment counter on event */
+#define   TCC_EVCTRL_EVACT0_COUNT_Val     0x5ul  /**< \brief (TCC_EVCTRL) Count on active state of asynchronous event */
+#define   TCC_EVCTRL_EVACT0_STAMP_Val     0x6ul  /**< \brief (TCC_EVCTRL) Stamp capture */
+#define   TCC_EVCTRL_EVACT0_FAULT_Val     0x7ul  /**< \brief (TCC_EVCTRL) Non-recoverable fault */
+#define TCC_EVCTRL_EVACT0_OFF       (TCC_EVCTRL_EVACT0_OFF_Val     << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT0_RETRIGGER (TCC_EVCTRL_EVACT0_RETRIGGER_Val << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT0_COUNTEV   (TCC_EVCTRL_EVACT0_COUNTEV_Val << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT0_START     (TCC_EVCTRL_EVACT0_START_Val   << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT0_INC       (TCC_EVCTRL_EVACT0_INC_Val     << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT0_COUNT     (TCC_EVCTRL_EVACT0_COUNT_Val   << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT0_STAMP     (TCC_EVCTRL_EVACT0_STAMP_Val   << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT0_FAULT     (TCC_EVCTRL_EVACT0_FAULT_Val   << TCC_EVCTRL_EVACT0_Pos)
+#define TCC_EVCTRL_EVACT1_Pos       3            /**< \brief (TCC_EVCTRL) Timer/counter Input Event1 Action */
+#define TCC_EVCTRL_EVACT1_Msk       (0x7ul << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_EVACT1(value)    (TCC_EVCTRL_EVACT1_Msk & ((value) << TCC_EVCTRL_EVACT1_Pos))
+#define   TCC_EVCTRL_EVACT1_OFF_Val       0x0ul  /**< \brief (TCC_EVCTRL) Event action disabled */
+#define   TCC_EVCTRL_EVACT1_RETRIGGER_Val 0x1ul  /**< \brief (TCC_EVCTRL) Re-trigger counter on event */
+#define   TCC_EVCTRL_EVACT1_DIR_Val       0x2ul  /**< \brief (TCC_EVCTRL) Direction control */
+#define   TCC_EVCTRL_EVACT1_STOP_Val      0x3ul  /**< \brief (TCC_EVCTRL) Stop counter on event */
+#define   TCC_EVCTRL_EVACT1_DEC_Val       0x4ul  /**< \brief (TCC_EVCTRL) Decrement counter on event */
+#define   TCC_EVCTRL_EVACT1_PPW_Val       0x5ul  /**< \brief (TCC_EVCTRL) Period capture value in CC0 register, pulse width capture value in CC1 register */
+#define   TCC_EVCTRL_EVACT1_PWP_Val       0x6ul  /**< \brief (TCC_EVCTRL) Period capture value in CC1 register, pulse width capture value in CC0 register */
+#define   TCC_EVCTRL_EVACT1_FAULT_Val     0x7ul  /**< \brief (TCC_EVCTRL) Non-recoverable fault */
+#define TCC_EVCTRL_EVACT1_OFF       (TCC_EVCTRL_EVACT1_OFF_Val     << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_EVACT1_RETRIGGER (TCC_EVCTRL_EVACT1_RETRIGGER_Val << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_EVACT1_DIR       (TCC_EVCTRL_EVACT1_DIR_Val     << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_EVACT1_STOP      (TCC_EVCTRL_EVACT1_STOP_Val    << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_EVACT1_DEC       (TCC_EVCTRL_EVACT1_DEC_Val     << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_EVACT1_PPW       (TCC_EVCTRL_EVACT1_PPW_Val     << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_EVACT1_PWP       (TCC_EVCTRL_EVACT1_PWP_Val     << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_EVACT1_FAULT     (TCC_EVCTRL_EVACT1_FAULT_Val   << TCC_EVCTRL_EVACT1_Pos)
+#define TCC_EVCTRL_CNTSEL_Pos       6            /**< \brief (TCC_EVCTRL) Timer/counter Output Event Mode */
+#define TCC_EVCTRL_CNTSEL_Msk       (0x3ul << TCC_EVCTRL_CNTSEL_Pos)
+#define TCC_EVCTRL_CNTSEL(value)    (TCC_EVCTRL_CNTSEL_Msk & ((value) << TCC_EVCTRL_CNTSEL_Pos))
+#define   TCC_EVCTRL_CNTSEL_START_Val     0x0ul  /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a new counter cycle starts */
+#define   TCC_EVCTRL_CNTSEL_END_Val       0x1ul  /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a counter cycle ends */
+#define   TCC_EVCTRL_CNTSEL_BETWEEN_Val   0x2ul  /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a counter cycle ends, except for the first and last cycles */
+#define   TCC_EVCTRL_CNTSEL_BOUNDARY_Val  0x3ul  /**< \brief (TCC_EVCTRL) An interrupt/event is generated when a new counter cycle starts or a counter cycle ends */
+#define TCC_EVCTRL_CNTSEL_START     (TCC_EVCTRL_CNTSEL_START_Val   << TCC_EVCTRL_CNTSEL_Pos)
+#define TCC_EVCTRL_CNTSEL_END       (TCC_EVCTRL_CNTSEL_END_Val     << TCC_EVCTRL_CNTSEL_Pos)
+#define TCC_EVCTRL_CNTSEL_BETWEEN   (TCC_EVCTRL_CNTSEL_BETWEEN_Val << TCC_EVCTRL_CNTSEL_Pos)
+#define TCC_EVCTRL_CNTSEL_BOUNDARY  (TCC_EVCTRL_CNTSEL_BOUNDARY_Val << TCC_EVCTRL_CNTSEL_Pos)
+#define TCC_EVCTRL_OVFEO_Pos        8            /**< \brief (TCC_EVCTRL) Overflow/Underflow Output Event Enable */
+#define TCC_EVCTRL_OVFEO            (0x1ul << TCC_EVCTRL_OVFEO_Pos)
+#define TCC_EVCTRL_TRGEO_Pos        9            /**< \brief (TCC_EVCTRL) Retrigger Output Event Enable */
+#define TCC_EVCTRL_TRGEO            (0x1ul << TCC_EVCTRL_TRGEO_Pos)
+#define TCC_EVCTRL_CNTEO_Pos        10           /**< \brief (TCC_EVCTRL) Timer/counter Output Event Enable */
+#define TCC_EVCTRL_CNTEO            (0x1ul << TCC_EVCTRL_CNTEO_Pos)
+#define TCC_EVCTRL_TCINV0_Pos       12           /**< \brief (TCC_EVCTRL) Inverted Event 0 Input Enable */
+#define TCC_EVCTRL_TCINV0           (1 << TCC_EVCTRL_TCINV0_Pos)
+#define TCC_EVCTRL_TCINV1_Pos       13           /**< \brief (TCC_EVCTRL) Inverted Event 1 Input Enable */
+#define TCC_EVCTRL_TCINV1           (1 << TCC_EVCTRL_TCINV1_Pos)
+#define TCC_EVCTRL_TCINV_Pos        12           /**< \brief (TCC_EVCTRL) Inverted Event x Input Enable */
+#define TCC_EVCTRL_TCINV_Msk        (0x3ul << TCC_EVCTRL_TCINV_Pos)
+#define TCC_EVCTRL_TCINV(value)     (TCC_EVCTRL_TCINV_Msk & ((value) << TCC_EVCTRL_TCINV_Pos))
+#define TCC_EVCTRL_TCEI0_Pos        14           /**< \brief (TCC_EVCTRL) Timer/counter Event 0 Input Enable */
+#define TCC_EVCTRL_TCEI0            (1 << TCC_EVCTRL_TCEI0_Pos)
+#define TCC_EVCTRL_TCEI1_Pos        15           /**< \brief (TCC_EVCTRL) Timer/counter Event 1 Input Enable */
+#define TCC_EVCTRL_TCEI1            (1 << TCC_EVCTRL_TCEI1_Pos)
+#define TCC_EVCTRL_TCEI_Pos         14           /**< \brief (TCC_EVCTRL) Timer/counter Event x Input Enable */
+#define TCC_EVCTRL_TCEI_Msk         (0x3ul << TCC_EVCTRL_TCEI_Pos)
+#define TCC_EVCTRL_TCEI(value)      (TCC_EVCTRL_TCEI_Msk & ((value) << TCC_EVCTRL_TCEI_Pos))
+#define TCC_EVCTRL_MCEI0_Pos        16           /**< \brief (TCC_EVCTRL) Match or Capture Channel 0 Event Input Enable */
+#define TCC_EVCTRL_MCEI0            (1 << TCC_EVCTRL_MCEI0_Pos)
+#define TCC_EVCTRL_MCEI1_Pos        17           /**< \brief (TCC_EVCTRL) Match or Capture Channel 1 Event Input Enable */
+#define TCC_EVCTRL_MCEI1            (1 << TCC_EVCTRL_MCEI1_Pos)
+#define TCC_EVCTRL_MCEI2_Pos        18           /**< \brief (TCC_EVCTRL) Match or Capture Channel 2 Event Input Enable */
+#define TCC_EVCTRL_MCEI2            (1 << TCC_EVCTRL_MCEI2_Pos)
+#define TCC_EVCTRL_MCEI3_Pos        19           /**< \brief (TCC_EVCTRL) Match or Capture Channel 3 Event Input Enable */
+#define TCC_EVCTRL_MCEI3            (1 << TCC_EVCTRL_MCEI3_Pos)
+#define TCC_EVCTRL_MCEI_Pos         16           /**< \brief (TCC_EVCTRL) Match or Capture Channel x Event Input Enable */
+#define TCC_EVCTRL_MCEI_Msk         (0xFul << TCC_EVCTRL_MCEI_Pos)
+#define TCC_EVCTRL_MCEI(value)      (TCC_EVCTRL_MCEI_Msk & ((value) << TCC_EVCTRL_MCEI_Pos))
+#define TCC_EVCTRL_MCEO0_Pos        24           /**< \brief (TCC_EVCTRL) Match or Capture Channel 0 Event Output Enable */
+#define TCC_EVCTRL_MCEO0            (1 << TCC_EVCTRL_MCEO0_Pos)
+#define TCC_EVCTRL_MCEO1_Pos        25           /**< \brief (TCC_EVCTRL) Match or Capture Channel 1 Event Output Enable */
+#define TCC_EVCTRL_MCEO1            (1 << TCC_EVCTRL_MCEO1_Pos)
+#define TCC_EVCTRL_MCEO2_Pos        26           /**< \brief (TCC_EVCTRL) Match or Capture Channel 2 Event Output Enable */
+#define TCC_EVCTRL_MCEO2            (1 << TCC_EVCTRL_MCEO2_Pos)
+#define TCC_EVCTRL_MCEO3_Pos        27           /**< \brief (TCC_EVCTRL) Match or Capture Channel 3 Event Output Enable */
+#define TCC_EVCTRL_MCEO3            (1 << TCC_EVCTRL_MCEO3_Pos)
+#define TCC_EVCTRL_MCEO_Pos         24           /**< \brief (TCC_EVCTRL) Match or Capture Channel x Event Output Enable */
+#define TCC_EVCTRL_MCEO_Msk         (0xFul << TCC_EVCTRL_MCEO_Pos)
+#define TCC_EVCTRL_MCEO(value)      (TCC_EVCTRL_MCEO_Msk & ((value) << TCC_EVCTRL_MCEO_Pos))
+#define TCC_EVCTRL_MASK             0x0F0FF7FFul /**< \brief (TCC_EVCTRL) MASK Register */
+
+/* -------- TCC_INTENCLR : (TCC Offset: 0x24) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow Interrupt Enable          */
+    uint32_t TRG:1;            /*!< bit:      1  Retrigger Interrupt Enable         */
+    uint32_t CNT:1;            /*!< bit:      2  Counter Interrupt Enable           */
+    uint32_t ERR:1;            /*!< bit:      3  Error Interrupt Enable             */
+    uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault Interrupt Enable */
+    uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault Interrupt Enable */
+    uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A Interrupt Enable */
+    uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B Interrupt Enable */
+    uint32_t FAULT0:1;         /*!< bit:     14  Non-Recoverable Fault 0 Interrupt Enable */
+    uint32_t FAULT1:1;         /*!< bit:     15  Non-Recoverable Fault 1 Interrupt Enable */
+    uint32_t MC0:1;            /*!< bit:     16  Match or Capture Channel 0 Interrupt Enable */
+    uint32_t MC1:1;            /*!< bit:     17  Match or Capture Channel 1 Interrupt Enable */
+    uint32_t MC2:1;            /*!< bit:     18  Match or Capture Channel 2 Interrupt Enable */
+    uint32_t MC3:1;            /*!< bit:     19  Match or Capture Channel 3 Interrupt Enable */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t MC:4;             /*!< bit: 16..19  Match or Capture Channel x Interrupt Enable */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_INTENCLR_OFFSET         0x24         /**< \brief (TCC_INTENCLR offset) Interrupt Enable Clear */
+#define TCC_INTENCLR_RESETVALUE     0x00000000ul /**< \brief (TCC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define TCC_INTENCLR_OVF_Pos        0            /**< \brief (TCC_INTENCLR) Overflow Interrupt Enable */
+#define TCC_INTENCLR_OVF            (0x1ul << TCC_INTENCLR_OVF_Pos)
+#define TCC_INTENCLR_TRG_Pos        1            /**< \brief (TCC_INTENCLR) Retrigger Interrupt Enable */
+#define TCC_INTENCLR_TRG            (0x1ul << TCC_INTENCLR_TRG_Pos)
+#define TCC_INTENCLR_CNT_Pos        2            /**< \brief (TCC_INTENCLR) Counter Interrupt Enable */
+#define TCC_INTENCLR_CNT            (0x1ul << TCC_INTENCLR_CNT_Pos)
+#define TCC_INTENCLR_ERR_Pos        3            /**< \brief (TCC_INTENCLR) Error Interrupt Enable */
+#define TCC_INTENCLR_ERR            (0x1ul << TCC_INTENCLR_ERR_Pos)
+#define TCC_INTENCLR_UFS_Pos        10           /**< \brief (TCC_INTENCLR) Non-Recoverable Update Fault Interrupt Enable */
+#define TCC_INTENCLR_UFS            (0x1ul << TCC_INTENCLR_UFS_Pos)
+#define TCC_INTENCLR_DFS_Pos        11           /**< \brief (TCC_INTENCLR) Non-Recoverable Debug Fault Interrupt Enable */
+#define TCC_INTENCLR_DFS            (0x1ul << TCC_INTENCLR_DFS_Pos)
+#define TCC_INTENCLR_FAULTA_Pos     12           /**< \brief (TCC_INTENCLR) Recoverable Fault A Interrupt Enable */
+#define TCC_INTENCLR_FAULTA         (0x1ul << TCC_INTENCLR_FAULTA_Pos)
+#define TCC_INTENCLR_FAULTB_Pos     13           /**< \brief (TCC_INTENCLR) Recoverable Fault B Interrupt Enable */
+#define TCC_INTENCLR_FAULTB         (0x1ul << TCC_INTENCLR_FAULTB_Pos)
+#define TCC_INTENCLR_FAULT0_Pos     14           /**< \brief (TCC_INTENCLR) Non-Recoverable Fault 0 Interrupt Enable */
+#define TCC_INTENCLR_FAULT0         (0x1ul << TCC_INTENCLR_FAULT0_Pos)
+#define TCC_INTENCLR_FAULT1_Pos     15           /**< \brief (TCC_INTENCLR) Non-Recoverable Fault 1 Interrupt Enable */
+#define TCC_INTENCLR_FAULT1         (0x1ul << TCC_INTENCLR_FAULT1_Pos)
+#define TCC_INTENCLR_MC0_Pos        16           /**< \brief (TCC_INTENCLR) Match or Capture Channel 0 Interrupt Enable */
+#define TCC_INTENCLR_MC0            (1 << TCC_INTENCLR_MC0_Pos)
+#define TCC_INTENCLR_MC1_Pos        17           /**< \brief (TCC_INTENCLR) Match or Capture Channel 1 Interrupt Enable */
+#define TCC_INTENCLR_MC1            (1 << TCC_INTENCLR_MC1_Pos)
+#define TCC_INTENCLR_MC2_Pos        18           /**< \brief (TCC_INTENCLR) Match or Capture Channel 2 Interrupt Enable */
+#define TCC_INTENCLR_MC2            (1 << TCC_INTENCLR_MC2_Pos)
+#define TCC_INTENCLR_MC3_Pos        19           /**< \brief (TCC_INTENCLR) Match or Capture Channel 3 Interrupt Enable */
+#define TCC_INTENCLR_MC3            (1 << TCC_INTENCLR_MC3_Pos)
+#define TCC_INTENCLR_MC_Pos         16           /**< \brief (TCC_INTENCLR) Match or Capture Channel x Interrupt Enable */
+#define TCC_INTENCLR_MC_Msk         (0xFul << TCC_INTENCLR_MC_Pos)
+#define TCC_INTENCLR_MC(value)      (TCC_INTENCLR_MC_Msk & ((value) << TCC_INTENCLR_MC_Pos))
+#define TCC_INTENCLR_MASK           0x000FFC0Ful /**< \brief (TCC_INTENCLR) MASK Register */
+
+/* -------- TCC_INTENSET : (TCC Offset: 0x28) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow Interrupt Enable          */
+    uint32_t TRG:1;            /*!< bit:      1  Retrigger Interrupt Enable         */
+    uint32_t CNT:1;            /*!< bit:      2  Counter Interrupt Enable           */
+    uint32_t ERR:1;            /*!< bit:      3  Error Interrupt Enable             */
+    uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault Interrupt Enable */
+    uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault Interrupt Enable */
+    uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A Interrupt Enable */
+    uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B Interrupt Enable */
+    uint32_t FAULT0:1;         /*!< bit:     14  Non-Recoverable Fault 0 Interrupt Enable */
+    uint32_t FAULT1:1;         /*!< bit:     15  Non-Recoverable Fault 1 Interrupt Enable */
+    uint32_t MC0:1;            /*!< bit:     16  Match or Capture Channel 0 Interrupt Enable */
+    uint32_t MC1:1;            /*!< bit:     17  Match or Capture Channel 1 Interrupt Enable */
+    uint32_t MC2:1;            /*!< bit:     18  Match or Capture Channel 2 Interrupt Enable */
+    uint32_t MC3:1;            /*!< bit:     19  Match or Capture Channel 3 Interrupt Enable */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t MC:4;             /*!< bit: 16..19  Match or Capture Channel x Interrupt Enable */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_INTENSET_OFFSET         0x28         /**< \brief (TCC_INTENSET offset) Interrupt Enable Set */
+#define TCC_INTENSET_RESETVALUE     0x00000000ul /**< \brief (TCC_INTENSET reset_value) Interrupt Enable Set */
+
+#define TCC_INTENSET_OVF_Pos        0            /**< \brief (TCC_INTENSET) Overflow Interrupt Enable */
+#define TCC_INTENSET_OVF            (0x1ul << TCC_INTENSET_OVF_Pos)
+#define TCC_INTENSET_TRG_Pos        1            /**< \brief (TCC_INTENSET) Retrigger Interrupt Enable */
+#define TCC_INTENSET_TRG            (0x1ul << TCC_INTENSET_TRG_Pos)
+#define TCC_INTENSET_CNT_Pos        2            /**< \brief (TCC_INTENSET) Counter Interrupt Enable */
+#define TCC_INTENSET_CNT            (0x1ul << TCC_INTENSET_CNT_Pos)
+#define TCC_INTENSET_ERR_Pos        3            /**< \brief (TCC_INTENSET) Error Interrupt Enable */
+#define TCC_INTENSET_ERR            (0x1ul << TCC_INTENSET_ERR_Pos)
+#define TCC_INTENSET_UFS_Pos        10           /**< \brief (TCC_INTENSET) Non-Recoverable Update Fault Interrupt Enable */
+#define TCC_INTENSET_UFS            (0x1ul << TCC_INTENSET_UFS_Pos)
+#define TCC_INTENSET_DFS_Pos        11           /**< \brief (TCC_INTENSET) Non-Recoverable Debug Fault Interrupt Enable */
+#define TCC_INTENSET_DFS            (0x1ul << TCC_INTENSET_DFS_Pos)
+#define TCC_INTENSET_FAULTA_Pos     12           /**< \brief (TCC_INTENSET) Recoverable Fault A Interrupt Enable */
+#define TCC_INTENSET_FAULTA         (0x1ul << TCC_INTENSET_FAULTA_Pos)
+#define TCC_INTENSET_FAULTB_Pos     13           /**< \brief (TCC_INTENSET) Recoverable Fault B Interrupt Enable */
+#define TCC_INTENSET_FAULTB         (0x1ul << TCC_INTENSET_FAULTB_Pos)
+#define TCC_INTENSET_FAULT0_Pos     14           /**< \brief (TCC_INTENSET) Non-Recoverable Fault 0 Interrupt Enable */
+#define TCC_INTENSET_FAULT0         (0x1ul << TCC_INTENSET_FAULT0_Pos)
+#define TCC_INTENSET_FAULT1_Pos     15           /**< \brief (TCC_INTENSET) Non-Recoverable Fault 1 Interrupt Enable */
+#define TCC_INTENSET_FAULT1         (0x1ul << TCC_INTENSET_FAULT1_Pos)
+#define TCC_INTENSET_MC0_Pos        16           /**< \brief (TCC_INTENSET) Match or Capture Channel 0 Interrupt Enable */
+#define TCC_INTENSET_MC0            (1 << TCC_INTENSET_MC0_Pos)
+#define TCC_INTENSET_MC1_Pos        17           /**< \brief (TCC_INTENSET) Match or Capture Channel 1 Interrupt Enable */
+#define TCC_INTENSET_MC1            (1 << TCC_INTENSET_MC1_Pos)
+#define TCC_INTENSET_MC2_Pos        18           /**< \brief (TCC_INTENSET) Match or Capture Channel 2 Interrupt Enable */
+#define TCC_INTENSET_MC2            (1 << TCC_INTENSET_MC2_Pos)
+#define TCC_INTENSET_MC3_Pos        19           /**< \brief (TCC_INTENSET) Match or Capture Channel 3 Interrupt Enable */
+#define TCC_INTENSET_MC3            (1 << TCC_INTENSET_MC3_Pos)
+#define TCC_INTENSET_MC_Pos         16           /**< \brief (TCC_INTENSET) Match or Capture Channel x Interrupt Enable */
+#define TCC_INTENSET_MC_Msk         (0xFul << TCC_INTENSET_MC_Pos)
+#define TCC_INTENSET_MC(value)      (TCC_INTENSET_MC_Msk & ((value) << TCC_INTENSET_MC_Pos))
+#define TCC_INTENSET_MASK           0x000FFC0Ful /**< \brief (TCC_INTENSET) MASK Register */
+
+/* -------- TCC_INTFLAG : (TCC Offset: 0x2C) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
+    __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
+    __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
+    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
+    __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
+    __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
+    __I uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B                */
+    __I uint32_t FAULT0:1;         /*!< bit:     14  Non-Recoverable Fault 0            */
+    __I uint32_t FAULT1:1;         /*!< bit:     15  Non-Recoverable Fault 1            */
+    __I uint32_t MC0:1;            /*!< bit:     16  Match or Capture 0                 */
+    __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
+    __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
+    __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
+    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
+    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_INTFLAG_OFFSET          0x2C         /**< \brief (TCC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define TCC_INTFLAG_RESETVALUE      0x00000000ul /**< \brief (TCC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define TCC_INTFLAG_OVF_Pos         0            /**< \brief (TCC_INTFLAG) Overflow */
+#define TCC_INTFLAG_OVF             (0x1ul << TCC_INTFLAG_OVF_Pos)
+#define TCC_INTFLAG_TRG_Pos         1            /**< \brief (TCC_INTFLAG) Retrigger */
+#define TCC_INTFLAG_TRG             (0x1ul << TCC_INTFLAG_TRG_Pos)
+#define TCC_INTFLAG_CNT_Pos         2            /**< \brief (TCC_INTFLAG) Counter */
+#define TCC_INTFLAG_CNT             (0x1ul << TCC_INTFLAG_CNT_Pos)
+#define TCC_INTFLAG_ERR_Pos         3            /**< \brief (TCC_INTFLAG) Error */
+#define TCC_INTFLAG_ERR             (0x1ul << TCC_INTFLAG_ERR_Pos)
+#define TCC_INTFLAG_UFS_Pos         10           /**< \brief (TCC_INTFLAG) Non-Recoverable Update Fault */
+#define TCC_INTFLAG_UFS             (0x1ul << TCC_INTFLAG_UFS_Pos)
+#define TCC_INTFLAG_DFS_Pos         11           /**< \brief (TCC_INTFLAG) Non-Recoverable Debug Fault */
+#define TCC_INTFLAG_DFS             (0x1ul << TCC_INTFLAG_DFS_Pos)
+#define TCC_INTFLAG_FAULTA_Pos      12           /**< \brief (TCC_INTFLAG) Recoverable Fault A */
+#define TCC_INTFLAG_FAULTA          (0x1ul << TCC_INTFLAG_FAULTA_Pos)
+#define TCC_INTFLAG_FAULTB_Pos      13           /**< \brief (TCC_INTFLAG) Recoverable Fault B */
+#define TCC_INTFLAG_FAULTB          (0x1ul << TCC_INTFLAG_FAULTB_Pos)
+#define TCC_INTFLAG_FAULT0_Pos      14           /**< \brief (TCC_INTFLAG) Non-Recoverable Fault 0 */
+#define TCC_INTFLAG_FAULT0          (0x1ul << TCC_INTFLAG_FAULT0_Pos)
+#define TCC_INTFLAG_FAULT1_Pos      15           /**< \brief (TCC_INTFLAG) Non-Recoverable Fault 1 */
+#define TCC_INTFLAG_FAULT1          (0x1ul << TCC_INTFLAG_FAULT1_Pos)
+#define TCC_INTFLAG_MC0_Pos         16           /**< \brief (TCC_INTFLAG) Match or Capture 0 */
+#define TCC_INTFLAG_MC0             (1 << TCC_INTFLAG_MC0_Pos)
+#define TCC_INTFLAG_MC1_Pos         17           /**< \brief (TCC_INTFLAG) Match or Capture 1 */
+#define TCC_INTFLAG_MC1             (1 << TCC_INTFLAG_MC1_Pos)
+#define TCC_INTFLAG_MC2_Pos         18           /**< \brief (TCC_INTFLAG) Match or Capture 2 */
+#define TCC_INTFLAG_MC2             (1 << TCC_INTFLAG_MC2_Pos)
+#define TCC_INTFLAG_MC3_Pos         19           /**< \brief (TCC_INTFLAG) Match or Capture 3 */
+#define TCC_INTFLAG_MC3             (1 << TCC_INTFLAG_MC3_Pos)
+#define TCC_INTFLAG_MC_Pos          16           /**< \brief (TCC_INTFLAG) Match or Capture x */
+#define TCC_INTFLAG_MC_Msk          (0xFul << TCC_INTFLAG_MC_Pos)
+#define TCC_INTFLAG_MC(value)       (TCC_INTFLAG_MC_Msk & ((value) << TCC_INTFLAG_MC_Pos))
+#define TCC_INTFLAG_MASK            0x000FFC0Ful /**< \brief (TCC_INTFLAG) MASK Register */
+
+/* -------- TCC_STATUS : (TCC Offset: 0x30) (R/W 32) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t STOP:1;           /*!< bit:      0  Stop                               */
+    uint32_t IDX:1;            /*!< bit:      1  Ramp                               */
+    uint32_t UFS:1;            /*!< bit:      2  Non-recoverable Update Fault State */
+    uint32_t DFS:1;            /*!< bit:      3  Non-Recoverable Debug Fault State  */
+    uint32_t SLAVE:1;          /*!< bit:      4  Slave                              */
+    uint32_t PATTBUFV:1;       /*!< bit:      5  Pattern Buffer Valid               */
+    uint32_t WAVEBUFV:1;       /*!< bit:      6  Wave Buffer Valid                  */
+    uint32_t PERBUFV:1;        /*!< bit:      7  Period Buffer Valid                */
+    uint32_t FAULTAIN:1;       /*!< bit:      8  Recoverable Fault A Input          */
+    uint32_t FAULTBIN:1;       /*!< bit:      9  Recoverable Fault B Input          */
+    uint32_t FAULT0IN:1;       /*!< bit:     10  Non-Recoverable Fault0 Input       */
+    uint32_t FAULT1IN:1;       /*!< bit:     11  Non-Recoverable Fault1 Input       */
+    uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A State          */
+    uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B State          */
+    uint32_t FAULT0:1;         /*!< bit:     14  Non-Recoverable Fault 0 State      */
+    uint32_t FAULT1:1;         /*!< bit:     15  Non-Recoverable Fault 1 State      */
+    uint32_t CCBUFV0:1;        /*!< bit:     16  Compare Channel 0 Buffer Valid     */
+    uint32_t CCBUFV1:1;        /*!< bit:     17  Compare Channel 1 Buffer Valid     */
+    uint32_t CCBUFV2:1;        /*!< bit:     18  Compare Channel 2 Buffer Valid     */
+    uint32_t CCBUFV3:1;        /*!< bit:     19  Compare Channel 3 Buffer Valid     */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t CMP0:1;           /*!< bit:     24  Compare Channel 0 Value            */
+    uint32_t CMP1:1;           /*!< bit:     25  Compare Channel 1 Value            */
+    uint32_t CMP2:1;           /*!< bit:     26  Compare Channel 2 Value            */
+    uint32_t CMP3:1;           /*!< bit:     27  Compare Channel 3 Value            */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t CCBUFV:4;         /*!< bit: 16..19  Compare Channel x Buffer Valid     */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t CMP:4;            /*!< bit: 24..27  Compare Channel x Value            */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_STATUS_OFFSET           0x30         /**< \brief (TCC_STATUS offset) Status */
+#define TCC_STATUS_RESETVALUE       0x00000001ul /**< \brief (TCC_STATUS reset_value) Status */
+
+#define TCC_STATUS_STOP_Pos         0            /**< \brief (TCC_STATUS) Stop */
+#define TCC_STATUS_STOP             (0x1ul << TCC_STATUS_STOP_Pos)
+#define TCC_STATUS_IDX_Pos          1            /**< \brief (TCC_STATUS) Ramp */
+#define TCC_STATUS_IDX              (0x1ul << TCC_STATUS_IDX_Pos)
+#define TCC_STATUS_UFS_Pos          2            /**< \brief (TCC_STATUS) Non-recoverable Update Fault State */
+#define TCC_STATUS_UFS              (0x1ul << TCC_STATUS_UFS_Pos)
+#define TCC_STATUS_DFS_Pos          3            /**< \brief (TCC_STATUS) Non-Recoverable Debug Fault State */
+#define TCC_STATUS_DFS              (0x1ul << TCC_STATUS_DFS_Pos)
+#define TCC_STATUS_SLAVE_Pos        4            /**< \brief (TCC_STATUS) Slave */
+#define TCC_STATUS_SLAVE            (0x1ul << TCC_STATUS_SLAVE_Pos)
+#define TCC_STATUS_PATTBUFV_Pos     5            /**< \brief (TCC_STATUS) Pattern Buffer Valid */
+#define TCC_STATUS_PATTBUFV         (0x1ul << TCC_STATUS_PATTBUFV_Pos)
+#define TCC_STATUS_WAVEBUFV_Pos     6            /**< \brief (TCC_STATUS) Wave Buffer Valid */
+#define TCC_STATUS_WAVEBUFV         (0x1ul << TCC_STATUS_WAVEBUFV_Pos)
+#define TCC_STATUS_PERBUFV_Pos      7            /**< \brief (TCC_STATUS) Period Buffer Valid */
+#define TCC_STATUS_PERBUFV          (0x1ul << TCC_STATUS_PERBUFV_Pos)
+#define TCC_STATUS_FAULTAIN_Pos     8            /**< \brief (TCC_STATUS) Recoverable Fault A Input */
+#define TCC_STATUS_FAULTAIN         (0x1ul << TCC_STATUS_FAULTAIN_Pos)
+#define TCC_STATUS_FAULTBIN_Pos     9            /**< \brief (TCC_STATUS) Recoverable Fault B Input */
+#define TCC_STATUS_FAULTBIN         (0x1ul << TCC_STATUS_FAULTBIN_Pos)
+#define TCC_STATUS_FAULT0IN_Pos     10           /**< \brief (TCC_STATUS) Non-Recoverable Fault0 Input */
+#define TCC_STATUS_FAULT0IN         (0x1ul << TCC_STATUS_FAULT0IN_Pos)
+#define TCC_STATUS_FAULT1IN_Pos     11           /**< \brief (TCC_STATUS) Non-Recoverable Fault1 Input */
+#define TCC_STATUS_FAULT1IN         (0x1ul << TCC_STATUS_FAULT1IN_Pos)
+#define TCC_STATUS_FAULTA_Pos       12           /**< \brief (TCC_STATUS) Recoverable Fault A State */
+#define TCC_STATUS_FAULTA           (0x1ul << TCC_STATUS_FAULTA_Pos)
+#define TCC_STATUS_FAULTB_Pos       13           /**< \brief (TCC_STATUS) Recoverable Fault B State */
+#define TCC_STATUS_FAULTB           (0x1ul << TCC_STATUS_FAULTB_Pos)
+#define TCC_STATUS_FAULT0_Pos       14           /**< \brief (TCC_STATUS) Non-Recoverable Fault 0 State */
+#define TCC_STATUS_FAULT0           (0x1ul << TCC_STATUS_FAULT0_Pos)
+#define TCC_STATUS_FAULT1_Pos       15           /**< \brief (TCC_STATUS) Non-Recoverable Fault 1 State */
+#define TCC_STATUS_FAULT1           (0x1ul << TCC_STATUS_FAULT1_Pos)
+#define TCC_STATUS_CCBUFV0_Pos      16           /**< \brief (TCC_STATUS) Compare Channel 0 Buffer Valid */
+#define TCC_STATUS_CCBUFV0          (1 << TCC_STATUS_CCBUFV0_Pos)
+#define TCC_STATUS_CCBUFV1_Pos      17           /**< \brief (TCC_STATUS) Compare Channel 1 Buffer Valid */
+#define TCC_STATUS_CCBUFV1          (1 << TCC_STATUS_CCBUFV1_Pos)
+#define TCC_STATUS_CCBUFV2_Pos      18           /**< \brief (TCC_STATUS) Compare Channel 2 Buffer Valid */
+#define TCC_STATUS_CCBUFV2          (1 << TCC_STATUS_CCBUFV2_Pos)
+#define TCC_STATUS_CCBUFV3_Pos      19           /**< \brief (TCC_STATUS) Compare Channel 3 Buffer Valid */
+#define TCC_STATUS_CCBUFV3          (1 << TCC_STATUS_CCBUFV3_Pos)
+#define TCC_STATUS_CCBUFV_Pos       16           /**< \brief (TCC_STATUS) Compare Channel x Buffer Valid */
+#define TCC_STATUS_CCBUFV_Msk       (0xFul << TCC_STATUS_CCBUFV_Pos)
+#define TCC_STATUS_CCBUFV(value)    (TCC_STATUS_CCBUFV_Msk & ((value) << TCC_STATUS_CCBUFV_Pos))
+#define TCC_STATUS_CMP0_Pos         24           /**< \brief (TCC_STATUS) Compare Channel 0 Value */
+#define TCC_STATUS_CMP0             (1 << TCC_STATUS_CMP0_Pos)
+#define TCC_STATUS_CMP1_Pos         25           /**< \brief (TCC_STATUS) Compare Channel 1 Value */
+#define TCC_STATUS_CMP1             (1 << TCC_STATUS_CMP1_Pos)
+#define TCC_STATUS_CMP2_Pos         26           /**< \brief (TCC_STATUS) Compare Channel 2 Value */
+#define TCC_STATUS_CMP2             (1 << TCC_STATUS_CMP2_Pos)
+#define TCC_STATUS_CMP3_Pos         27           /**< \brief (TCC_STATUS) Compare Channel 3 Value */
+#define TCC_STATUS_CMP3             (1 << TCC_STATUS_CMP3_Pos)
+#define TCC_STATUS_CMP_Pos          24           /**< \brief (TCC_STATUS) Compare Channel x Value */
+#define TCC_STATUS_CMP_Msk          (0xFul << TCC_STATUS_CMP_Pos)
+#define TCC_STATUS_CMP(value)       (TCC_STATUS_CMP_Msk & ((value) << TCC_STATUS_CMP_Pos))
+#define TCC_STATUS_MASK             0x0F0FFFFFul /**< \brief (TCC_STATUS) MASK Register */
+
+/* -------- TCC_COUNT : (TCC Offset: 0x34) (R/W 32) Count -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // DITH4 mode
+    uint32_t :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint32_t COUNT:20;         /*!< bit:  4..23  Counter Value                      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH4;                     /*!< Structure used for DITH4                        */
+  struct { // DITH5 mode
+    uint32_t :5;               /*!< bit:  0.. 4  Reserved                           */
+    uint32_t COUNT:19;         /*!< bit:  5..23  Counter Value                      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH5;                     /*!< Structure used for DITH5                        */
+  struct { // DITH6 mode
+    uint32_t :6;               /*!< bit:  0.. 5  Reserved                           */
+    uint32_t COUNT:18;         /*!< bit:  6..23  Counter Value                      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH6;                     /*!< Structure used for DITH6                        */
+  struct {
+    uint32_t COUNT:24;         /*!< bit:  0..23  Counter Value                      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_COUNT_OFFSET            0x34         /**< \brief (TCC_COUNT offset) Count */
+#define TCC_COUNT_RESETVALUE        0x00000000ul /**< \brief (TCC_COUNT reset_value) Count */
+
+// DITH4 mode
+#define TCC_COUNT_DITH4_COUNT_Pos   4            /**< \brief (TCC_COUNT_DITH4) Counter Value */
+#define TCC_COUNT_DITH4_COUNT_Msk   (0xFFFFFul << TCC_COUNT_DITH4_COUNT_Pos)
+#define TCC_COUNT_DITH4_COUNT(value) (TCC_COUNT_DITH4_COUNT_Msk & ((value) << TCC_COUNT_DITH4_COUNT_Pos))
+#define TCC_COUNT_DITH4_MASK        0x00FFFFF0ul /**< \brief (TCC_COUNT_DITH4) MASK Register */
+
+// DITH5 mode
+#define TCC_COUNT_DITH5_COUNT_Pos   5            /**< \brief (TCC_COUNT_DITH5) Counter Value */
+#define TCC_COUNT_DITH5_COUNT_Msk   (0x7FFFFul << TCC_COUNT_DITH5_COUNT_Pos)
+#define TCC_COUNT_DITH5_COUNT(value) (TCC_COUNT_DITH5_COUNT_Msk & ((value) << TCC_COUNT_DITH5_COUNT_Pos))
+#define TCC_COUNT_DITH5_MASK        0x00FFFFE0ul /**< \brief (TCC_COUNT_DITH5) MASK Register */
+
+// DITH6 mode
+#define TCC_COUNT_DITH6_COUNT_Pos   6            /**< \brief (TCC_COUNT_DITH6) Counter Value */
+#define TCC_COUNT_DITH6_COUNT_Msk   (0x3FFFFul << TCC_COUNT_DITH6_COUNT_Pos)
+#define TCC_COUNT_DITH6_COUNT(value) (TCC_COUNT_DITH6_COUNT_Msk & ((value) << TCC_COUNT_DITH6_COUNT_Pos))
+#define TCC_COUNT_DITH6_MASK        0x00FFFFC0ul /**< \brief (TCC_COUNT_DITH6) MASK Register */
+
+#define TCC_COUNT_COUNT_Pos         0            /**< \brief (TCC_COUNT) Counter Value */
+#define TCC_COUNT_COUNT_Msk         (0xFFFFFFul << TCC_COUNT_COUNT_Pos)
+#define TCC_COUNT_COUNT(value)      (TCC_COUNT_COUNT_Msk & ((value) << TCC_COUNT_COUNT_Pos))
+#define TCC_COUNT_MASK              0x00FFFFFFul /**< \brief (TCC_COUNT) MASK Register */
+
+/* -------- TCC_PATT : (TCC Offset: 0x38) (R/W 16) Pattern -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PGE0:1;           /*!< bit:      0  Pattern Generator 0 Output Enable  */
+    uint16_t PGE1:1;           /*!< bit:      1  Pattern Generator 1 Output Enable  */
+    uint16_t PGE2:1;           /*!< bit:      2  Pattern Generator 2 Output Enable  */
+    uint16_t PGE3:1;           /*!< bit:      3  Pattern Generator 3 Output Enable  */
+    uint16_t PGE4:1;           /*!< bit:      4  Pattern Generator 4 Output Enable  */
+    uint16_t PGE5:1;           /*!< bit:      5  Pattern Generator 5 Output Enable  */
+    uint16_t PGE6:1;           /*!< bit:      6  Pattern Generator 6 Output Enable  */
+    uint16_t PGE7:1;           /*!< bit:      7  Pattern Generator 7 Output Enable  */
+    uint16_t PGV0:1;           /*!< bit:      8  Pattern Generator 0 Output Value   */
+    uint16_t PGV1:1;           /*!< bit:      9  Pattern Generator 1 Output Value   */
+    uint16_t PGV2:1;           /*!< bit:     10  Pattern Generator 2 Output Value   */
+    uint16_t PGV3:1;           /*!< bit:     11  Pattern Generator 3 Output Value   */
+    uint16_t PGV4:1;           /*!< bit:     12  Pattern Generator 4 Output Value   */
+    uint16_t PGV5:1;           /*!< bit:     13  Pattern Generator 5 Output Value   */
+    uint16_t PGV6:1;           /*!< bit:     14  Pattern Generator 6 Output Value   */
+    uint16_t PGV7:1;           /*!< bit:     15  Pattern Generator 7 Output Value   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PGE:8;            /*!< bit:  0.. 7  Pattern Generator x Output Enable  */
+    uint16_t PGV:8;            /*!< bit:  8..15  Pattern Generator x Output Value   */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TCC_PATT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_PATT_OFFSET             0x38         /**< \brief (TCC_PATT offset) Pattern */
+#define TCC_PATT_RESETVALUE         0x0000ul     /**< \brief (TCC_PATT reset_value) Pattern */
+
+#define TCC_PATT_PGE0_Pos           0            /**< \brief (TCC_PATT) Pattern Generator 0 Output Enable */
+#define TCC_PATT_PGE0               (1 << TCC_PATT_PGE0_Pos)
+#define TCC_PATT_PGE1_Pos           1            /**< \brief (TCC_PATT) Pattern Generator 1 Output Enable */
+#define TCC_PATT_PGE1               (1 << TCC_PATT_PGE1_Pos)
+#define TCC_PATT_PGE2_Pos           2            /**< \brief (TCC_PATT) Pattern Generator 2 Output Enable */
+#define TCC_PATT_PGE2               (1 << TCC_PATT_PGE2_Pos)
+#define TCC_PATT_PGE3_Pos           3            /**< \brief (TCC_PATT) Pattern Generator 3 Output Enable */
+#define TCC_PATT_PGE3               (1 << TCC_PATT_PGE3_Pos)
+#define TCC_PATT_PGE4_Pos           4            /**< \brief (TCC_PATT) Pattern Generator 4 Output Enable */
+#define TCC_PATT_PGE4               (1 << TCC_PATT_PGE4_Pos)
+#define TCC_PATT_PGE5_Pos           5            /**< \brief (TCC_PATT) Pattern Generator 5 Output Enable */
+#define TCC_PATT_PGE5               (1 << TCC_PATT_PGE5_Pos)
+#define TCC_PATT_PGE6_Pos           6            /**< \brief (TCC_PATT) Pattern Generator 6 Output Enable */
+#define TCC_PATT_PGE6               (1 << TCC_PATT_PGE6_Pos)
+#define TCC_PATT_PGE7_Pos           7            /**< \brief (TCC_PATT) Pattern Generator 7 Output Enable */
+#define TCC_PATT_PGE7               (1 << TCC_PATT_PGE7_Pos)
+#define TCC_PATT_PGE_Pos            0            /**< \brief (TCC_PATT) Pattern Generator x Output Enable */
+#define TCC_PATT_PGE_Msk            (0xFFul << TCC_PATT_PGE_Pos)
+#define TCC_PATT_PGE(value)         (TCC_PATT_PGE_Msk & ((value) << TCC_PATT_PGE_Pos))
+#define TCC_PATT_PGV0_Pos           8            /**< \brief (TCC_PATT) Pattern Generator 0 Output Value */
+#define TCC_PATT_PGV0               (1 << TCC_PATT_PGV0_Pos)
+#define TCC_PATT_PGV1_Pos           9            /**< \brief (TCC_PATT) Pattern Generator 1 Output Value */
+#define TCC_PATT_PGV1               (1 << TCC_PATT_PGV1_Pos)
+#define TCC_PATT_PGV2_Pos           10           /**< \brief (TCC_PATT) Pattern Generator 2 Output Value */
+#define TCC_PATT_PGV2               (1 << TCC_PATT_PGV2_Pos)
+#define TCC_PATT_PGV3_Pos           11           /**< \brief (TCC_PATT) Pattern Generator 3 Output Value */
+#define TCC_PATT_PGV3               (1 << TCC_PATT_PGV3_Pos)
+#define TCC_PATT_PGV4_Pos           12           /**< \brief (TCC_PATT) Pattern Generator 4 Output Value */
+#define TCC_PATT_PGV4               (1 << TCC_PATT_PGV4_Pos)
+#define TCC_PATT_PGV5_Pos           13           /**< \brief (TCC_PATT) Pattern Generator 5 Output Value */
+#define TCC_PATT_PGV5               (1 << TCC_PATT_PGV5_Pos)
+#define TCC_PATT_PGV6_Pos           14           /**< \brief (TCC_PATT) Pattern Generator 6 Output Value */
+#define TCC_PATT_PGV6               (1 << TCC_PATT_PGV6_Pos)
+#define TCC_PATT_PGV7_Pos           15           /**< \brief (TCC_PATT) Pattern Generator 7 Output Value */
+#define TCC_PATT_PGV7               (1 << TCC_PATT_PGV7_Pos)
+#define TCC_PATT_PGV_Pos            8            /**< \brief (TCC_PATT) Pattern Generator x Output Value */
+#define TCC_PATT_PGV_Msk            (0xFFul << TCC_PATT_PGV_Pos)
+#define TCC_PATT_PGV(value)         (TCC_PATT_PGV_Msk & ((value) << TCC_PATT_PGV_Pos))
+#define TCC_PATT_MASK               0xFFFFul     /**< \brief (TCC_PATT) MASK Register */
+
+/* -------- TCC_WAVE : (TCC Offset: 0x3C) (R/W 32) Waveform Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WAVEGEN:3;        /*!< bit:  0.. 2  Waveform Generation                */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t RAMP:2;           /*!< bit:  4.. 5  Ramp Mode                          */
+    uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t CIPEREN:1;        /*!< bit:      7  Circular period Enable             */
+    uint32_t CICCEN0:1;        /*!< bit:      8  Circular Channel 0 Enable          */
+    uint32_t CICCEN1:1;        /*!< bit:      9  Circular Channel 1 Enable          */
+    uint32_t CICCEN2:1;        /*!< bit:     10  Circular Channel 2 Enable          */
+    uint32_t CICCEN3:1;        /*!< bit:     11  Circular Channel 3 Enable          */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t POL0:1;           /*!< bit:     16  Channel 0 Polarity                 */
+    uint32_t POL1:1;           /*!< bit:     17  Channel 1 Polarity                 */
+    uint32_t POL2:1;           /*!< bit:     18  Channel 2 Polarity                 */
+    uint32_t POL3:1;           /*!< bit:     19  Channel 3 Polarity                 */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t SWAP0:1;          /*!< bit:     24  Swap DTI Output Pair 0             */
+    uint32_t SWAP1:1;          /*!< bit:     25  Swap DTI Output Pair 1             */
+    uint32_t SWAP2:1;          /*!< bit:     26  Swap DTI Output Pair 2             */
+    uint32_t SWAP3:1;          /*!< bit:     27  Swap DTI Output Pair 3             */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t CICCEN:4;         /*!< bit:  8..11  Circular Channel x Enable          */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t POL:4;            /*!< bit: 16..19  Channel x Polarity                 */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t SWAP:4;           /*!< bit: 24..27  Swap DTI Output Pair x             */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_WAVE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_WAVE_OFFSET             0x3C         /**< \brief (TCC_WAVE offset) Waveform Control */
+#define TCC_WAVE_RESETVALUE         0x00000000ul /**< \brief (TCC_WAVE reset_value) Waveform Control */
+
+#define TCC_WAVE_WAVEGEN_Pos        0            /**< \brief (TCC_WAVE) Waveform Generation */
+#define TCC_WAVE_WAVEGEN_Msk        (0x7ul << TCC_WAVE_WAVEGEN_Pos)
+#define TCC_WAVE_WAVEGEN(value)     (TCC_WAVE_WAVEGEN_Msk & ((value) << TCC_WAVE_WAVEGEN_Pos))
+#define   TCC_WAVE_WAVEGEN_NFRQ_Val       0x0ul  /**< \brief (TCC_WAVE) Normal frequency */
+#define   TCC_WAVE_WAVEGEN_MFRQ_Val       0x1ul  /**< \brief (TCC_WAVE) Match frequency */
+#define   TCC_WAVE_WAVEGEN_NPWM_Val       0x2ul  /**< \brief (TCC_WAVE) Normal PWM */
+#define   TCC_WAVE_WAVEGEN_DSCRITICAL_Val 0x4ul  /**< \brief (TCC_WAVE) Dual-slope critical */
+#define   TCC_WAVE_WAVEGEN_DSBOTTOM_Val   0x5ul  /**< \brief (TCC_WAVE) Dual-slope with interrupt/event condition when COUNT reaches ZERO */
+#define   TCC_WAVE_WAVEGEN_DSBOTH_Val     0x6ul  /**< \brief (TCC_WAVE) Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP */
+#define   TCC_WAVE_WAVEGEN_DSTOP_Val      0x7ul  /**< \brief (TCC_WAVE) Dual-slope with interrupt/event condition when COUNT reaches TOP */
+#define TCC_WAVE_WAVEGEN_NFRQ       (TCC_WAVE_WAVEGEN_NFRQ_Val     << TCC_WAVE_WAVEGEN_Pos)
+#define TCC_WAVE_WAVEGEN_MFRQ       (TCC_WAVE_WAVEGEN_MFRQ_Val     << TCC_WAVE_WAVEGEN_Pos)
+#define TCC_WAVE_WAVEGEN_NPWM       (TCC_WAVE_WAVEGEN_NPWM_Val     << TCC_WAVE_WAVEGEN_Pos)
+#define TCC_WAVE_WAVEGEN_DSCRITICAL (TCC_WAVE_WAVEGEN_DSCRITICAL_Val << TCC_WAVE_WAVEGEN_Pos)
+#define TCC_WAVE_WAVEGEN_DSBOTTOM   (TCC_WAVE_WAVEGEN_DSBOTTOM_Val << TCC_WAVE_WAVEGEN_Pos)
+#define TCC_WAVE_WAVEGEN_DSBOTH     (TCC_WAVE_WAVEGEN_DSBOTH_Val   << TCC_WAVE_WAVEGEN_Pos)
+#define TCC_WAVE_WAVEGEN_DSTOP      (TCC_WAVE_WAVEGEN_DSTOP_Val    << TCC_WAVE_WAVEGEN_Pos)
+#define TCC_WAVE_RAMP_Pos           4            /**< \brief (TCC_WAVE) Ramp Mode */
+#define TCC_WAVE_RAMP_Msk           (0x3ul << TCC_WAVE_RAMP_Pos)
+#define TCC_WAVE_RAMP(value)        (TCC_WAVE_RAMP_Msk & ((value) << TCC_WAVE_RAMP_Pos))
+#define   TCC_WAVE_RAMP_RAMP1_Val         0x0ul  /**< \brief (TCC_WAVE) RAMP1 operation */
+#define   TCC_WAVE_RAMP_RAMP2A_Val        0x1ul  /**< \brief (TCC_WAVE) Alternative RAMP2 operation */
+#define   TCC_WAVE_RAMP_RAMP2_Val         0x2ul  /**< \brief (TCC_WAVE) RAMP2 operation */
+#define   TCC_WAVE_RAMP_RAMP2C_Val        0x3ul  /**< \brief (TCC_WAVE) Critical RAMP2 operation */
+#define TCC_WAVE_RAMP_RAMP1         (TCC_WAVE_RAMP_RAMP1_Val       << TCC_WAVE_RAMP_Pos)
+#define TCC_WAVE_RAMP_RAMP2A        (TCC_WAVE_RAMP_RAMP2A_Val      << TCC_WAVE_RAMP_Pos)
+#define TCC_WAVE_RAMP_RAMP2         (TCC_WAVE_RAMP_RAMP2_Val       << TCC_WAVE_RAMP_Pos)
+#define TCC_WAVE_RAMP_RAMP2C        (TCC_WAVE_RAMP_RAMP2C_Val      << TCC_WAVE_RAMP_Pos)
+#define TCC_WAVE_CIPEREN_Pos        7            /**< \brief (TCC_WAVE) Circular period Enable */
+#define TCC_WAVE_CIPEREN            (0x1ul << TCC_WAVE_CIPEREN_Pos)
+#define TCC_WAVE_CICCEN0_Pos        8            /**< \brief (TCC_WAVE) Circular Channel 0 Enable */
+#define TCC_WAVE_CICCEN0            (1 << TCC_WAVE_CICCEN0_Pos)
+#define TCC_WAVE_CICCEN1_Pos        9            /**< \brief (TCC_WAVE) Circular Channel 1 Enable */
+#define TCC_WAVE_CICCEN1            (1 << TCC_WAVE_CICCEN1_Pos)
+#define TCC_WAVE_CICCEN2_Pos        10           /**< \brief (TCC_WAVE) Circular Channel 2 Enable */
+#define TCC_WAVE_CICCEN2            (1 << TCC_WAVE_CICCEN2_Pos)
+#define TCC_WAVE_CICCEN3_Pos        11           /**< \brief (TCC_WAVE) Circular Channel 3 Enable */
+#define TCC_WAVE_CICCEN3            (1 << TCC_WAVE_CICCEN3_Pos)
+#define TCC_WAVE_CICCEN_Pos         8            /**< \brief (TCC_WAVE) Circular Channel x Enable */
+#define TCC_WAVE_CICCEN_Msk         (0xFul << TCC_WAVE_CICCEN_Pos)
+#define TCC_WAVE_CICCEN(value)      (TCC_WAVE_CICCEN_Msk & ((value) << TCC_WAVE_CICCEN_Pos))
+#define TCC_WAVE_POL0_Pos           16           /**< \brief (TCC_WAVE) Channel 0 Polarity */
+#define TCC_WAVE_POL0               (1 << TCC_WAVE_POL0_Pos)
+#define TCC_WAVE_POL1_Pos           17           /**< \brief (TCC_WAVE) Channel 1 Polarity */
+#define TCC_WAVE_POL1               (1 << TCC_WAVE_POL1_Pos)
+#define TCC_WAVE_POL2_Pos           18           /**< \brief (TCC_WAVE) Channel 2 Polarity */
+#define TCC_WAVE_POL2               (1 << TCC_WAVE_POL2_Pos)
+#define TCC_WAVE_POL3_Pos           19           /**< \brief (TCC_WAVE) Channel 3 Polarity */
+#define TCC_WAVE_POL3               (1 << TCC_WAVE_POL3_Pos)
+#define TCC_WAVE_POL_Pos            16           /**< \brief (TCC_WAVE) Channel x Polarity */
+#define TCC_WAVE_POL_Msk            (0xFul << TCC_WAVE_POL_Pos)
+#define TCC_WAVE_POL(value)         (TCC_WAVE_POL_Msk & ((value) << TCC_WAVE_POL_Pos))
+#define TCC_WAVE_SWAP0_Pos          24           /**< \brief (TCC_WAVE) Swap DTI Output Pair 0 */
+#define TCC_WAVE_SWAP0              (1 << TCC_WAVE_SWAP0_Pos)
+#define TCC_WAVE_SWAP1_Pos          25           /**< \brief (TCC_WAVE) Swap DTI Output Pair 1 */
+#define TCC_WAVE_SWAP1              (1 << TCC_WAVE_SWAP1_Pos)
+#define TCC_WAVE_SWAP2_Pos          26           /**< \brief (TCC_WAVE) Swap DTI Output Pair 2 */
+#define TCC_WAVE_SWAP2              (1 << TCC_WAVE_SWAP2_Pos)
+#define TCC_WAVE_SWAP3_Pos          27           /**< \brief (TCC_WAVE) Swap DTI Output Pair 3 */
+#define TCC_WAVE_SWAP3              (1 << TCC_WAVE_SWAP3_Pos)
+#define TCC_WAVE_SWAP_Pos           24           /**< \brief (TCC_WAVE) Swap DTI Output Pair x */
+#define TCC_WAVE_SWAP_Msk           (0xFul << TCC_WAVE_SWAP_Pos)
+#define TCC_WAVE_SWAP(value)        (TCC_WAVE_SWAP_Msk & ((value) << TCC_WAVE_SWAP_Pos))
+#define TCC_WAVE_MASK               0x0F0F0FB7ul /**< \brief (TCC_WAVE) MASK Register */
+
+/* -------- TCC_PER : (TCC Offset: 0x40) (R/W 32) Period -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // DITH4 mode
+    uint32_t DITHER:4;         /*!< bit:  0.. 3  Dithering Cycle Number             */
+    uint32_t PER:20;           /*!< bit:  4..23  Period Value                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH4;                     /*!< Structure used for DITH4                        */
+  struct { // DITH5 mode
+    uint32_t DITHER:5;         /*!< bit:  0.. 4  Dithering Cycle Number             */
+    uint32_t PER:19;           /*!< bit:  5..23  Period Value                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH5;                     /*!< Structure used for DITH5                        */
+  struct { // DITH6 mode
+    uint32_t DITHER:6;         /*!< bit:  0.. 5  Dithering Cycle Number             */
+    uint32_t PER:18;           /*!< bit:  6..23  Period Value                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH6;                     /*!< Structure used for DITH6                        */
+  struct {
+    uint32_t PER:24;           /*!< bit:  0..23  Period Value                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_PER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_PER_OFFSET              0x40         /**< \brief (TCC_PER offset) Period */
+#define TCC_PER_RESETVALUE          0xFFFFFFFFul /**< \brief (TCC_PER reset_value) Period */
+
+// DITH4 mode
+#define TCC_PER_DITH4_DITHER_Pos    0            /**< \brief (TCC_PER_DITH4) Dithering Cycle Number */
+#define TCC_PER_DITH4_DITHER_Msk    (0xFul << TCC_PER_DITH4_DITHER_Pos)
+#define TCC_PER_DITH4_DITHER(value) (TCC_PER_DITH4_DITHER_Msk & ((value) << TCC_PER_DITH4_DITHER_Pos))
+#define TCC_PER_DITH4_PER_Pos       4            /**< \brief (TCC_PER_DITH4) Period Value */
+#define TCC_PER_DITH4_PER_Msk       (0xFFFFFul << TCC_PER_DITH4_PER_Pos)
+#define TCC_PER_DITH4_PER(value)    (TCC_PER_DITH4_PER_Msk & ((value) << TCC_PER_DITH4_PER_Pos))
+#define TCC_PER_DITH4_MASK          0x00FFFFFFul /**< \brief (TCC_PER_DITH4) MASK Register */
+
+// DITH5 mode
+#define TCC_PER_DITH5_DITHER_Pos    0            /**< \brief (TCC_PER_DITH5) Dithering Cycle Number */
+#define TCC_PER_DITH5_DITHER_Msk    (0x1Ful << TCC_PER_DITH5_DITHER_Pos)
+#define TCC_PER_DITH5_DITHER(value) (TCC_PER_DITH5_DITHER_Msk & ((value) << TCC_PER_DITH5_DITHER_Pos))
+#define TCC_PER_DITH5_PER_Pos       5            /**< \brief (TCC_PER_DITH5) Period Value */
+#define TCC_PER_DITH5_PER_Msk       (0x7FFFFul << TCC_PER_DITH5_PER_Pos)
+#define TCC_PER_DITH5_PER(value)    (TCC_PER_DITH5_PER_Msk & ((value) << TCC_PER_DITH5_PER_Pos))
+#define TCC_PER_DITH5_MASK          0x00FFFFFFul /**< \brief (TCC_PER_DITH5) MASK Register */
+
+// DITH6 mode
+#define TCC_PER_DITH6_DITHER_Pos    0            /**< \brief (TCC_PER_DITH6) Dithering Cycle Number */
+#define TCC_PER_DITH6_DITHER_Msk    (0x3Ful << TCC_PER_DITH6_DITHER_Pos)
+#define TCC_PER_DITH6_DITHER(value) (TCC_PER_DITH6_DITHER_Msk & ((value) << TCC_PER_DITH6_DITHER_Pos))
+#define TCC_PER_DITH6_PER_Pos       6            /**< \brief (TCC_PER_DITH6) Period Value */
+#define TCC_PER_DITH6_PER_Msk       (0x3FFFFul << TCC_PER_DITH6_PER_Pos)
+#define TCC_PER_DITH6_PER(value)    (TCC_PER_DITH6_PER_Msk & ((value) << TCC_PER_DITH6_PER_Pos))
+#define TCC_PER_DITH6_MASK          0x00FFFFFFul /**< \brief (TCC_PER_DITH6) MASK Register */
+
+#define TCC_PER_PER_Pos             0            /**< \brief (TCC_PER) Period Value */
+#define TCC_PER_PER_Msk             (0xFFFFFFul << TCC_PER_PER_Pos)
+#define TCC_PER_PER(value)          (TCC_PER_PER_Msk & ((value) << TCC_PER_PER_Pos))
+#define TCC_PER_MASK                0x00FFFFFFul /**< \brief (TCC_PER) MASK Register */
+
+/* -------- TCC_CC : (TCC Offset: 0x44) (R/W 32) Compare and Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // DITH4 mode
+    uint32_t DITHER:4;         /*!< bit:  0.. 3  Dithering Cycle Number             */
+    uint32_t CC:20;            /*!< bit:  4..23  Channel Compare/Capture Value      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH4;                     /*!< Structure used for DITH4                        */
+  struct { // DITH5 mode
+    uint32_t DITHER:5;         /*!< bit:  0.. 4  Dithering Cycle Number             */
+    uint32_t CC:19;            /*!< bit:  5..23  Channel Compare/Capture Value      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH5;                     /*!< Structure used for DITH5                        */
+  struct { // DITH6 mode
+    uint32_t DITHER:6;         /*!< bit:  0.. 5  Dithering Cycle Number             */
+    uint32_t CC:18;            /*!< bit:  6..23  Channel Compare/Capture Value      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH6;                     /*!< Structure used for DITH6                        */
+  struct {
+    uint32_t CC:24;            /*!< bit:  0..23  Channel Compare/Capture Value      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_CC_OFFSET               0x44         /**< \brief (TCC_CC offset) Compare and Capture */
+#define TCC_CC_RESETVALUE           0x00000000ul /**< \brief (TCC_CC reset_value) Compare and Capture */
+
+// DITH4 mode
+#define TCC_CC_DITH4_DITHER_Pos     0            /**< \brief (TCC_CC_DITH4) Dithering Cycle Number */
+#define TCC_CC_DITH4_DITHER_Msk     (0xFul << TCC_CC_DITH4_DITHER_Pos)
+#define TCC_CC_DITH4_DITHER(value)  (TCC_CC_DITH4_DITHER_Msk & ((value) << TCC_CC_DITH4_DITHER_Pos))
+#define TCC_CC_DITH4_CC_Pos         4            /**< \brief (TCC_CC_DITH4) Channel Compare/Capture Value */
+#define TCC_CC_DITH4_CC_Msk         (0xFFFFFul << TCC_CC_DITH4_CC_Pos)
+#define TCC_CC_DITH4_CC(value)      (TCC_CC_DITH4_CC_Msk & ((value) << TCC_CC_DITH4_CC_Pos))
+#define TCC_CC_DITH4_MASK           0x00FFFFFFul /**< \brief (TCC_CC_DITH4) MASK Register */
+
+// DITH5 mode
+#define TCC_CC_DITH5_DITHER_Pos     0            /**< \brief (TCC_CC_DITH5) Dithering Cycle Number */
+#define TCC_CC_DITH5_DITHER_Msk     (0x1Ful << TCC_CC_DITH5_DITHER_Pos)
+#define TCC_CC_DITH5_DITHER(value)  (TCC_CC_DITH5_DITHER_Msk & ((value) << TCC_CC_DITH5_DITHER_Pos))
+#define TCC_CC_DITH5_CC_Pos         5            /**< \brief (TCC_CC_DITH5) Channel Compare/Capture Value */
+#define TCC_CC_DITH5_CC_Msk         (0x7FFFFul << TCC_CC_DITH5_CC_Pos)
+#define TCC_CC_DITH5_CC(value)      (TCC_CC_DITH5_CC_Msk & ((value) << TCC_CC_DITH5_CC_Pos))
+#define TCC_CC_DITH5_MASK           0x00FFFFFFul /**< \brief (TCC_CC_DITH5) MASK Register */
+
+// DITH6 mode
+#define TCC_CC_DITH6_DITHER_Pos     0            /**< \brief (TCC_CC_DITH6) Dithering Cycle Number */
+#define TCC_CC_DITH6_DITHER_Msk     (0x3Ful << TCC_CC_DITH6_DITHER_Pos)
+#define TCC_CC_DITH6_DITHER(value)  (TCC_CC_DITH6_DITHER_Msk & ((value) << TCC_CC_DITH6_DITHER_Pos))
+#define TCC_CC_DITH6_CC_Pos         6            /**< \brief (TCC_CC_DITH6) Channel Compare/Capture Value */
+#define TCC_CC_DITH6_CC_Msk         (0x3FFFFul << TCC_CC_DITH6_CC_Pos)
+#define TCC_CC_DITH6_CC(value)      (TCC_CC_DITH6_CC_Msk & ((value) << TCC_CC_DITH6_CC_Pos))
+#define TCC_CC_DITH6_MASK           0x00FFFFFFul /**< \brief (TCC_CC_DITH6) MASK Register */
+
+#define TCC_CC_CC_Pos               0            /**< \brief (TCC_CC) Channel Compare/Capture Value */
+#define TCC_CC_CC_Msk               (0xFFFFFFul << TCC_CC_CC_Pos)
+#define TCC_CC_CC(value)            (TCC_CC_CC_Msk & ((value) << TCC_CC_CC_Pos))
+#define TCC_CC_MASK                 0x00FFFFFFul /**< \brief (TCC_CC) MASK Register */
+
+/* -------- TCC_PATTBUF : (TCC Offset: 0x64) (R/W 16) Pattern Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PGEB0:1;          /*!< bit:      0  Pattern Generator 0 Output Enable Buffer */
+    uint16_t PGEB1:1;          /*!< bit:      1  Pattern Generator 1 Output Enable Buffer */
+    uint16_t PGEB2:1;          /*!< bit:      2  Pattern Generator 2 Output Enable Buffer */
+    uint16_t PGEB3:1;          /*!< bit:      3  Pattern Generator 3 Output Enable Buffer */
+    uint16_t PGEB4:1;          /*!< bit:      4  Pattern Generator 4 Output Enable Buffer */
+    uint16_t PGEB5:1;          /*!< bit:      5  Pattern Generator 5 Output Enable Buffer */
+    uint16_t PGEB6:1;          /*!< bit:      6  Pattern Generator 6 Output Enable Buffer */
+    uint16_t PGEB7:1;          /*!< bit:      7  Pattern Generator 7 Output Enable Buffer */
+    uint16_t PGVB0:1;          /*!< bit:      8  Pattern Generator 0 Output Enable  */
+    uint16_t PGVB1:1;          /*!< bit:      9  Pattern Generator 1 Output Enable  */
+    uint16_t PGVB2:1;          /*!< bit:     10  Pattern Generator 2 Output Enable  */
+    uint16_t PGVB3:1;          /*!< bit:     11  Pattern Generator 3 Output Enable  */
+    uint16_t PGVB4:1;          /*!< bit:     12  Pattern Generator 4 Output Enable  */
+    uint16_t PGVB5:1;          /*!< bit:     13  Pattern Generator 5 Output Enable  */
+    uint16_t PGVB6:1;          /*!< bit:     14  Pattern Generator 6 Output Enable  */
+    uint16_t PGVB7:1;          /*!< bit:     15  Pattern Generator 7 Output Enable  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PGEB:8;           /*!< bit:  0.. 7  Pattern Generator x Output Enable Buffer */
+    uint16_t PGVB:8;           /*!< bit:  8..15  Pattern Generator x Output Enable  */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TCC_PATTBUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_PATTBUF_OFFSET          0x64         /**< \brief (TCC_PATTBUF offset) Pattern Buffer */
+#define TCC_PATTBUF_RESETVALUE      0x0000ul     /**< \brief (TCC_PATTBUF reset_value) Pattern Buffer */
+
+#define TCC_PATTBUF_PGEB0_Pos       0            /**< \brief (TCC_PATTBUF) Pattern Generator 0 Output Enable Buffer */
+#define TCC_PATTBUF_PGEB0           (1 << TCC_PATTBUF_PGEB0_Pos)
+#define TCC_PATTBUF_PGEB1_Pos       1            /**< \brief (TCC_PATTBUF) Pattern Generator 1 Output Enable Buffer */
+#define TCC_PATTBUF_PGEB1           (1 << TCC_PATTBUF_PGEB1_Pos)
+#define TCC_PATTBUF_PGEB2_Pos       2            /**< \brief (TCC_PATTBUF) Pattern Generator 2 Output Enable Buffer */
+#define TCC_PATTBUF_PGEB2           (1 << TCC_PATTBUF_PGEB2_Pos)
+#define TCC_PATTBUF_PGEB3_Pos       3            /**< \brief (TCC_PATTBUF) Pattern Generator 3 Output Enable Buffer */
+#define TCC_PATTBUF_PGEB3           (1 << TCC_PATTBUF_PGEB3_Pos)
+#define TCC_PATTBUF_PGEB4_Pos       4            /**< \brief (TCC_PATTBUF) Pattern Generator 4 Output Enable Buffer */
+#define TCC_PATTBUF_PGEB4           (1 << TCC_PATTBUF_PGEB4_Pos)
+#define TCC_PATTBUF_PGEB5_Pos       5            /**< \brief (TCC_PATTBUF) Pattern Generator 5 Output Enable Buffer */
+#define TCC_PATTBUF_PGEB5           (1 << TCC_PATTBUF_PGEB5_Pos)
+#define TCC_PATTBUF_PGEB6_Pos       6            /**< \brief (TCC_PATTBUF) Pattern Generator 6 Output Enable Buffer */
+#define TCC_PATTBUF_PGEB6           (1 << TCC_PATTBUF_PGEB6_Pos)
+#define TCC_PATTBUF_PGEB7_Pos       7            /**< \brief (TCC_PATTBUF) Pattern Generator 7 Output Enable Buffer */
+#define TCC_PATTBUF_PGEB7           (1 << TCC_PATTBUF_PGEB7_Pos)
+#define TCC_PATTBUF_PGEB_Pos        0            /**< \brief (TCC_PATTBUF) Pattern Generator x Output Enable Buffer */
+#define TCC_PATTBUF_PGEB_Msk        (0xFFul << TCC_PATTBUF_PGEB_Pos)
+#define TCC_PATTBUF_PGEB(value)     (TCC_PATTBUF_PGEB_Msk & ((value) << TCC_PATTBUF_PGEB_Pos))
+#define TCC_PATTBUF_PGVB0_Pos       8            /**< \brief (TCC_PATTBUF) Pattern Generator 0 Output Enable */
+#define TCC_PATTBUF_PGVB0           (1 << TCC_PATTBUF_PGVB0_Pos)
+#define TCC_PATTBUF_PGVB1_Pos       9            /**< \brief (TCC_PATTBUF) Pattern Generator 1 Output Enable */
+#define TCC_PATTBUF_PGVB1           (1 << TCC_PATTBUF_PGVB1_Pos)
+#define TCC_PATTBUF_PGVB2_Pos       10           /**< \brief (TCC_PATTBUF) Pattern Generator 2 Output Enable */
+#define TCC_PATTBUF_PGVB2           (1 << TCC_PATTBUF_PGVB2_Pos)
+#define TCC_PATTBUF_PGVB3_Pos       11           /**< \brief (TCC_PATTBUF) Pattern Generator 3 Output Enable */
+#define TCC_PATTBUF_PGVB3           (1 << TCC_PATTBUF_PGVB3_Pos)
+#define TCC_PATTBUF_PGVB4_Pos       12           /**< \brief (TCC_PATTBUF) Pattern Generator 4 Output Enable */
+#define TCC_PATTBUF_PGVB4           (1 << TCC_PATTBUF_PGVB4_Pos)
+#define TCC_PATTBUF_PGVB5_Pos       13           /**< \brief (TCC_PATTBUF) Pattern Generator 5 Output Enable */
+#define TCC_PATTBUF_PGVB5           (1 << TCC_PATTBUF_PGVB5_Pos)
+#define TCC_PATTBUF_PGVB6_Pos       14           /**< \brief (TCC_PATTBUF) Pattern Generator 6 Output Enable */
+#define TCC_PATTBUF_PGVB6           (1 << TCC_PATTBUF_PGVB6_Pos)
+#define TCC_PATTBUF_PGVB7_Pos       15           /**< \brief (TCC_PATTBUF) Pattern Generator 7 Output Enable */
+#define TCC_PATTBUF_PGVB7           (1 << TCC_PATTBUF_PGVB7_Pos)
+#define TCC_PATTBUF_PGVB_Pos        8            /**< \brief (TCC_PATTBUF) Pattern Generator x Output Enable */
+#define TCC_PATTBUF_PGVB_Msk        (0xFFul << TCC_PATTBUF_PGVB_Pos)
+#define TCC_PATTBUF_PGVB(value)     (TCC_PATTBUF_PGVB_Msk & ((value) << TCC_PATTBUF_PGVB_Pos))
+#define TCC_PATTBUF_MASK            0xFFFFul     /**< \brief (TCC_PATTBUF) MASK Register */
+
+/* -------- TCC_WAVEBUF : (TCC Offset: 0x68) (R/W 32) Waveform Control Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WAVEGENB:3;       /*!< bit:  0.. 2  Waveform Generation Buffer         */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t RAMPB:2;          /*!< bit:  4.. 5  Ramp Mode Buffer                   */
+    uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t CIPERENB:1;       /*!< bit:      7  Circular Period Enable Buffer      */
+    uint32_t CICCENB0:1;       /*!< bit:      8  Circular Channel 0 Enable Buffer   */
+    uint32_t CICCENB1:1;       /*!< bit:      9  Circular Channel 1 Enable Buffer   */
+    uint32_t CICCENB2:1;       /*!< bit:     10  Circular Channel 2 Enable Buffer   */
+    uint32_t CICCENB3:1;       /*!< bit:     11  Circular Channel 3 Enable Buffer   */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t POLB0:1;          /*!< bit:     16  Channel 0 Polarity Buffer          */
+    uint32_t POLB1:1;          /*!< bit:     17  Channel 1 Polarity Buffer          */
+    uint32_t POLB2:1;          /*!< bit:     18  Channel 2 Polarity Buffer          */
+    uint32_t POLB3:1;          /*!< bit:     19  Channel 3 Polarity Buffer          */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t SWAPB0:1;         /*!< bit:     24  Swap DTI Output Pair 0 Buffer      */
+    uint32_t SWAPB1:1;         /*!< bit:     25  Swap DTI Output Pair 1 Buffer      */
+    uint32_t SWAPB2:1;         /*!< bit:     26  Swap DTI Output Pair 2 Buffer      */
+    uint32_t SWAPB3:1;         /*!< bit:     27  Swap DTI Output Pair 3 Buffer      */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t CICCENB:4;        /*!< bit:  8..11  Circular Channel x Enable Buffer   */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t POLB:4;           /*!< bit: 16..19  Channel x Polarity Buffer          */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t SWAPB:4;          /*!< bit: 24..27  Swap DTI Output Pair x Buffer      */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_WAVEBUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_WAVEBUF_OFFSET          0x68         /**< \brief (TCC_WAVEBUF offset) Waveform Control Buffer */
+#define TCC_WAVEBUF_RESETVALUE      0x00000000ul /**< \brief (TCC_WAVEBUF reset_value) Waveform Control Buffer */
+
+#define TCC_WAVEBUF_WAVEGENB_Pos    0            /**< \brief (TCC_WAVEBUF) Waveform Generation Buffer */
+#define TCC_WAVEBUF_WAVEGENB_Msk    (0x7ul << TCC_WAVEBUF_WAVEGENB_Pos)
+#define TCC_WAVEBUF_WAVEGENB(value) (TCC_WAVEBUF_WAVEGENB_Msk & ((value) << TCC_WAVEBUF_WAVEGENB_Pos))
+#define   TCC_WAVEBUF_WAVEGENB_NFRQ_Val   0x0ul  /**< \brief (TCC_WAVEBUF) Normal frequency */
+#define   TCC_WAVEBUF_WAVEGENB_MFRQ_Val   0x1ul  /**< \brief (TCC_WAVEBUF) Match frequency */
+#define   TCC_WAVEBUF_WAVEGENB_NPWM_Val   0x2ul  /**< \brief (TCC_WAVEBUF) Normal PWM */
+#define   TCC_WAVEBUF_WAVEGENB_DSCRITICAL_Val 0x4ul  /**< \brief (TCC_WAVEBUF) Dual-slope critical */
+#define   TCC_WAVEBUF_WAVEGENB_DSBOTTOM_Val 0x5ul  /**< \brief (TCC_WAVEBUF) Dual-slope with interrupt/event condition when COUNT reaches ZERO */
+#define   TCC_WAVEBUF_WAVEGENB_DSBOTH_Val 0x6ul  /**< \brief (TCC_WAVEBUF) Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP */
+#define   TCC_WAVEBUF_WAVEGENB_DSTOP_Val  0x7ul  /**< \brief (TCC_WAVEBUF) Dual-slope with interrupt/event condition when COUNT reaches TOP */
+#define TCC_WAVEBUF_WAVEGENB_NFRQ   (TCC_WAVEBUF_WAVEGENB_NFRQ_Val << TCC_WAVEBUF_WAVEGENB_Pos)
+#define TCC_WAVEBUF_WAVEGENB_MFRQ   (TCC_WAVEBUF_WAVEGENB_MFRQ_Val << TCC_WAVEBUF_WAVEGENB_Pos)
+#define TCC_WAVEBUF_WAVEGENB_NPWM   (TCC_WAVEBUF_WAVEGENB_NPWM_Val << TCC_WAVEBUF_WAVEGENB_Pos)
+#define TCC_WAVEBUF_WAVEGENB_DSCRITICAL (TCC_WAVEBUF_WAVEGENB_DSCRITICAL_Val << TCC_WAVEBUF_WAVEGENB_Pos)
+#define TCC_WAVEBUF_WAVEGENB_DSBOTTOM (TCC_WAVEBUF_WAVEGENB_DSBOTTOM_Val << TCC_WAVEBUF_WAVEGENB_Pos)
+#define TCC_WAVEBUF_WAVEGENB_DSBOTH (TCC_WAVEBUF_WAVEGENB_DSBOTH_Val << TCC_WAVEBUF_WAVEGENB_Pos)
+#define TCC_WAVEBUF_WAVEGENB_DSTOP  (TCC_WAVEBUF_WAVEGENB_DSTOP_Val << TCC_WAVEBUF_WAVEGENB_Pos)
+#define TCC_WAVEBUF_RAMPB_Pos       4            /**< \brief (TCC_WAVEBUF) Ramp Mode Buffer */
+#define TCC_WAVEBUF_RAMPB_Msk       (0x3ul << TCC_WAVEBUF_RAMPB_Pos)
+#define TCC_WAVEBUF_RAMPB(value)    (TCC_WAVEBUF_RAMPB_Msk & ((value) << TCC_WAVEBUF_RAMPB_Pos))
+#define TCC_WAVEBUF_CIPERENB_Pos    7            /**< \brief (TCC_WAVEBUF) Circular Period Enable Buffer */
+#define TCC_WAVEBUF_CIPERENB        (0x1ul << TCC_WAVEBUF_CIPERENB_Pos)
+#define TCC_WAVEBUF_CICCENB0_Pos    8            /**< \brief (TCC_WAVEBUF) Circular Channel 0 Enable Buffer */
+#define TCC_WAVEBUF_CICCENB0        (1 << TCC_WAVEBUF_CICCENB0_Pos)
+#define TCC_WAVEBUF_CICCENB1_Pos    9            /**< \brief (TCC_WAVEBUF) Circular Channel 1 Enable Buffer */
+#define TCC_WAVEBUF_CICCENB1        (1 << TCC_WAVEBUF_CICCENB1_Pos)
+#define TCC_WAVEBUF_CICCENB2_Pos    10           /**< \brief (TCC_WAVEBUF) Circular Channel 2 Enable Buffer */
+#define TCC_WAVEBUF_CICCENB2        (1 << TCC_WAVEBUF_CICCENB2_Pos)
+#define TCC_WAVEBUF_CICCENB3_Pos    11           /**< \brief (TCC_WAVEBUF) Circular Channel 3 Enable Buffer */
+#define TCC_WAVEBUF_CICCENB3        (1 << TCC_WAVEBUF_CICCENB3_Pos)
+#define TCC_WAVEBUF_CICCENB_Pos     8            /**< \brief (TCC_WAVEBUF) Circular Channel x Enable Buffer */
+#define TCC_WAVEBUF_CICCENB_Msk     (0xFul << TCC_WAVEBUF_CICCENB_Pos)
+#define TCC_WAVEBUF_CICCENB(value)  (TCC_WAVEBUF_CICCENB_Msk & ((value) << TCC_WAVEBUF_CICCENB_Pos))
+#define TCC_WAVEBUF_POLB0_Pos       16           /**< \brief (TCC_WAVEBUF) Channel 0 Polarity Buffer */
+#define TCC_WAVEBUF_POLB0           (1 << TCC_WAVEBUF_POLB0_Pos)
+#define TCC_WAVEBUF_POLB1_Pos       17           /**< \brief (TCC_WAVEBUF) Channel 1 Polarity Buffer */
+#define TCC_WAVEBUF_POLB1           (1 << TCC_WAVEBUF_POLB1_Pos)
+#define TCC_WAVEBUF_POLB2_Pos       18           /**< \brief (TCC_WAVEBUF) Channel 2 Polarity Buffer */
+#define TCC_WAVEBUF_POLB2           (1 << TCC_WAVEBUF_POLB2_Pos)
+#define TCC_WAVEBUF_POLB3_Pos       19           /**< \brief (TCC_WAVEBUF) Channel 3 Polarity Buffer */
+#define TCC_WAVEBUF_POLB3           (1 << TCC_WAVEBUF_POLB3_Pos)
+#define TCC_WAVEBUF_POLB_Pos        16           /**< \brief (TCC_WAVEBUF) Channel x Polarity Buffer */
+#define TCC_WAVEBUF_POLB_Msk        (0xFul << TCC_WAVEBUF_POLB_Pos)
+#define TCC_WAVEBUF_POLB(value)     (TCC_WAVEBUF_POLB_Msk & ((value) << TCC_WAVEBUF_POLB_Pos))
+#define TCC_WAVEBUF_SWAPB0_Pos      24           /**< \brief (TCC_WAVEBUF) Swap DTI Output Pair 0 Buffer */
+#define TCC_WAVEBUF_SWAPB0          (1 << TCC_WAVEBUF_SWAPB0_Pos)
+#define TCC_WAVEBUF_SWAPB1_Pos      25           /**< \brief (TCC_WAVEBUF) Swap DTI Output Pair 1 Buffer */
+#define TCC_WAVEBUF_SWAPB1          (1 << TCC_WAVEBUF_SWAPB1_Pos)
+#define TCC_WAVEBUF_SWAPB2_Pos      26           /**< \brief (TCC_WAVEBUF) Swap DTI Output Pair 2 Buffer */
+#define TCC_WAVEBUF_SWAPB2          (1 << TCC_WAVEBUF_SWAPB2_Pos)
+#define TCC_WAVEBUF_SWAPB3_Pos      27           /**< \brief (TCC_WAVEBUF) Swap DTI Output Pair 3 Buffer */
+#define TCC_WAVEBUF_SWAPB3          (1 << TCC_WAVEBUF_SWAPB3_Pos)
+#define TCC_WAVEBUF_SWAPB_Pos       24           /**< \brief (TCC_WAVEBUF) Swap DTI Output Pair x Buffer */
+#define TCC_WAVEBUF_SWAPB_Msk       (0xFul << TCC_WAVEBUF_SWAPB_Pos)
+#define TCC_WAVEBUF_SWAPB(value)    (TCC_WAVEBUF_SWAPB_Msk & ((value) << TCC_WAVEBUF_SWAPB_Pos))
+#define TCC_WAVEBUF_MASK            0x0F0F0FB7ul /**< \brief (TCC_WAVEBUF) MASK Register */
+
+/* -------- TCC_PERBUF : (TCC Offset: 0x6C) (R/W 32) Period Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // DITH4 mode
+    uint32_t DITHERBUF:4;      /*!< bit:  0.. 3  Dithering Buffer Cycle Number      */
+    uint32_t PERBUF:20;        /*!< bit:  4..23  Period Buffer Value                */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH4;                     /*!< Structure used for DITH4                        */
+  struct { // DITH5 mode
+    uint32_t DITHERBUF:5;      /*!< bit:  0.. 4  Dithering Buffer Cycle Number      */
+    uint32_t PERBUF:19;        /*!< bit:  5..23  Period Buffer Value                */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH5;                     /*!< Structure used for DITH5                        */
+  struct { // DITH6 mode
+    uint32_t DITHERBUF:6;      /*!< bit:  0.. 5  Dithering Buffer Cycle Number      */
+    uint32_t PERBUF:18;        /*!< bit:  6..23  Period Buffer Value                */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH6;                     /*!< Structure used for DITH6                        */
+  struct {
+    uint32_t PERBUF:24;        /*!< bit:  0..23  Period Buffer Value                */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_PERBUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_PERBUF_OFFSET           0x6C         /**< \brief (TCC_PERBUF offset) Period Buffer */
+#define TCC_PERBUF_RESETVALUE       0xFFFFFFFFul /**< \brief (TCC_PERBUF reset_value) Period Buffer */
+
+// DITH4 mode
+#define TCC_PERBUF_DITH4_DITHERBUF_Pos 0            /**< \brief (TCC_PERBUF_DITH4) Dithering Buffer Cycle Number */
+#define TCC_PERBUF_DITH4_DITHERBUF_Msk (0xFul << TCC_PERBUF_DITH4_DITHERBUF_Pos)
+#define TCC_PERBUF_DITH4_DITHERBUF(value) (TCC_PERBUF_DITH4_DITHERBUF_Msk & ((value) << TCC_PERBUF_DITH4_DITHERBUF_Pos))
+#define TCC_PERBUF_DITH4_PERBUF_Pos 4            /**< \brief (TCC_PERBUF_DITH4) Period Buffer Value */
+#define TCC_PERBUF_DITH4_PERBUF_Msk (0xFFFFFul << TCC_PERBUF_DITH4_PERBUF_Pos)
+#define TCC_PERBUF_DITH4_PERBUF(value) (TCC_PERBUF_DITH4_PERBUF_Msk & ((value) << TCC_PERBUF_DITH4_PERBUF_Pos))
+#define TCC_PERBUF_DITH4_MASK       0x00FFFFFFul /**< \brief (TCC_PERBUF_DITH4) MASK Register */
+
+// DITH5 mode
+#define TCC_PERBUF_DITH5_DITHERBUF_Pos 0            /**< \brief (TCC_PERBUF_DITH5) Dithering Buffer Cycle Number */
+#define TCC_PERBUF_DITH5_DITHERBUF_Msk (0x1Ful << TCC_PERBUF_DITH5_DITHERBUF_Pos)
+#define TCC_PERBUF_DITH5_DITHERBUF(value) (TCC_PERBUF_DITH5_DITHERBUF_Msk & ((value) << TCC_PERBUF_DITH5_DITHERBUF_Pos))
+#define TCC_PERBUF_DITH5_PERBUF_Pos 5            /**< \brief (TCC_PERBUF_DITH5) Period Buffer Value */
+#define TCC_PERBUF_DITH5_PERBUF_Msk (0x7FFFFul << TCC_PERBUF_DITH5_PERBUF_Pos)
+#define TCC_PERBUF_DITH5_PERBUF(value) (TCC_PERBUF_DITH5_PERBUF_Msk & ((value) << TCC_PERBUF_DITH5_PERBUF_Pos))
+#define TCC_PERBUF_DITH5_MASK       0x00FFFFFFul /**< \brief (TCC_PERBUF_DITH5) MASK Register */
+
+// DITH6 mode
+#define TCC_PERBUF_DITH6_DITHERBUF_Pos 0            /**< \brief (TCC_PERBUF_DITH6) Dithering Buffer Cycle Number */
+#define TCC_PERBUF_DITH6_DITHERBUF_Msk (0x3Ful << TCC_PERBUF_DITH6_DITHERBUF_Pos)
+#define TCC_PERBUF_DITH6_DITHERBUF(value) (TCC_PERBUF_DITH6_DITHERBUF_Msk & ((value) << TCC_PERBUF_DITH6_DITHERBUF_Pos))
+#define TCC_PERBUF_DITH6_PERBUF_Pos 6            /**< \brief (TCC_PERBUF_DITH6) Period Buffer Value */
+#define TCC_PERBUF_DITH6_PERBUF_Msk (0x3FFFFul << TCC_PERBUF_DITH6_PERBUF_Pos)
+#define TCC_PERBUF_DITH6_PERBUF(value) (TCC_PERBUF_DITH6_PERBUF_Msk & ((value) << TCC_PERBUF_DITH6_PERBUF_Pos))
+#define TCC_PERBUF_DITH6_MASK       0x00FFFFFFul /**< \brief (TCC_PERBUF_DITH6) MASK Register */
+
+#define TCC_PERBUF_PERBUF_Pos       0            /**< \brief (TCC_PERBUF) Period Buffer Value */
+#define TCC_PERBUF_PERBUF_Msk       (0xFFFFFFul << TCC_PERBUF_PERBUF_Pos)
+#define TCC_PERBUF_PERBUF(value)    (TCC_PERBUF_PERBUF_Msk & ((value) << TCC_PERBUF_PERBUF_Pos))
+#define TCC_PERBUF_MASK             0x00FFFFFFul /**< \brief (TCC_PERBUF) MASK Register */
+
+/* -------- TCC_CCBUF : (TCC Offset: 0x70) (R/W 32) Compare and Capture Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // DITH4 mode
+    uint32_t CCBUF:4;          /*!< bit:  0.. 3  Channel Compare/Capture Buffer Value */
+    uint32_t DITHERBUF:20;     /*!< bit:  4..23  Dithering Buffer Cycle Number      */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH4;                     /*!< Structure used for DITH4                        */
+  struct { // DITH5 mode
+    uint32_t DITHERBUF:5;      /*!< bit:  0.. 4  Dithering Buffer Cycle Number      */
+    uint32_t CCBUF:19;         /*!< bit:  5..23  Channel Compare/Capture Buffer Value */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH5;                     /*!< Structure used for DITH5                        */
+  struct { // DITH6 mode
+    uint32_t DITHERBUF:6;      /*!< bit:  0.. 5  Dithering Buffer Cycle Number      */
+    uint32_t CCBUF:18;         /*!< bit:  6..23  Channel Compare/Capture Buffer Value */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } DITH6;                     /*!< Structure used for DITH6                        */
+  struct {
+    uint32_t CCBUF:24;         /*!< bit:  0..23  Channel Compare/Capture Buffer Value */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TCC_CCBUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TCC_CCBUF_OFFSET            0x70         /**< \brief (TCC_CCBUF offset) Compare and Capture Buffer */
+#define TCC_CCBUF_RESETVALUE        0x00000000ul /**< \brief (TCC_CCBUF reset_value) Compare and Capture Buffer */
+
+// DITH4 mode
+#define TCC_CCBUF_DITH4_CCBUF_Pos   0            /**< \brief (TCC_CCBUF_DITH4) Channel Compare/Capture Buffer Value */
+#define TCC_CCBUF_DITH4_CCBUF_Msk   (0xFul << TCC_CCBUF_DITH4_CCBUF_Pos)
+#define TCC_CCBUF_DITH4_CCBUF(value) (TCC_CCBUF_DITH4_CCBUF_Msk & ((value) << TCC_CCBUF_DITH4_CCBUF_Pos))
+#define TCC_CCBUF_DITH4_DITHERBUF_Pos 4            /**< \brief (TCC_CCBUF_DITH4) Dithering Buffer Cycle Number */
+#define TCC_CCBUF_DITH4_DITHERBUF_Msk (0xFFFFFul << TCC_CCBUF_DITH4_DITHERBUF_Pos)
+#define TCC_CCBUF_DITH4_DITHERBUF(value) (TCC_CCBUF_DITH4_DITHERBUF_Msk & ((value) << TCC_CCBUF_DITH4_DITHERBUF_Pos))
+#define TCC_CCBUF_DITH4_MASK        0x00FFFFFFul /**< \brief (TCC_CCBUF_DITH4) MASK Register */
+
+// DITH5 mode
+#define TCC_CCBUF_DITH5_DITHERBUF_Pos 0            /**< \brief (TCC_CCBUF_DITH5) Dithering Buffer Cycle Number */
+#define TCC_CCBUF_DITH5_DITHERBUF_Msk (0x1Ful << TCC_CCBUF_DITH5_DITHERBUF_Pos)
+#define TCC_CCBUF_DITH5_DITHERBUF(value) (TCC_CCBUF_DITH5_DITHERBUF_Msk & ((value) << TCC_CCBUF_DITH5_DITHERBUF_Pos))
+#define TCC_CCBUF_DITH5_CCBUF_Pos   5            /**< \brief (TCC_CCBUF_DITH5) Channel Compare/Capture Buffer Value */
+#define TCC_CCBUF_DITH5_CCBUF_Msk   (0x7FFFFul << TCC_CCBUF_DITH5_CCBUF_Pos)
+#define TCC_CCBUF_DITH5_CCBUF(value) (TCC_CCBUF_DITH5_CCBUF_Msk & ((value) << TCC_CCBUF_DITH5_CCBUF_Pos))
+#define TCC_CCBUF_DITH5_MASK        0x00FFFFFFul /**< \brief (TCC_CCBUF_DITH5) MASK Register */
+
+// DITH6 mode
+#define TCC_CCBUF_DITH6_DITHERBUF_Pos 0            /**< \brief (TCC_CCBUF_DITH6) Dithering Buffer Cycle Number */
+#define TCC_CCBUF_DITH6_DITHERBUF_Msk (0x3Ful << TCC_CCBUF_DITH6_DITHERBUF_Pos)
+#define TCC_CCBUF_DITH6_DITHERBUF(value) (TCC_CCBUF_DITH6_DITHERBUF_Msk & ((value) << TCC_CCBUF_DITH6_DITHERBUF_Pos))
+#define TCC_CCBUF_DITH6_CCBUF_Pos   6            /**< \brief (TCC_CCBUF_DITH6) Channel Compare/Capture Buffer Value */
+#define TCC_CCBUF_DITH6_CCBUF_Msk   (0x3FFFFul << TCC_CCBUF_DITH6_CCBUF_Pos)
+#define TCC_CCBUF_DITH6_CCBUF(value) (TCC_CCBUF_DITH6_CCBUF_Msk & ((value) << TCC_CCBUF_DITH6_CCBUF_Pos))
+#define TCC_CCBUF_DITH6_MASK        0x00FFFFFFul /**< \brief (TCC_CCBUF_DITH6) MASK Register */
+
+#define TCC_CCBUF_CCBUF_Pos         0            /**< \brief (TCC_CCBUF) Channel Compare/Capture Buffer Value */
+#define TCC_CCBUF_CCBUF_Msk         (0xFFFFFFul << TCC_CCBUF_CCBUF_Pos)
+#define TCC_CCBUF_CCBUF(value)      (TCC_CCBUF_CCBUF_Msk & ((value) << TCC_CCBUF_CCBUF_Pos))
+#define TCC_CCBUF_MASK              0x00FFFFFFul /**< \brief (TCC_CCBUF) MASK Register */
+
+/** \brief TCC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO TCC_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x00 (R/W 32) Control A */
+  __IO TCC_CTRLBCLR_Type         CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TCC_CTRLBSET_Type         CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+       RoReg8                    Reserved1[0x2];
+  __I  TCC_SYNCBUSY_Type         SYNCBUSY;    /**< \brief Offset: 0x08 (R/  32) Synchronization Busy */
+  __IO TCC_FCTRLA_Type           FCTRLA;      /**< \brief Offset: 0x0C (R/W 32) Recoverable Fault A Configuration */
+  __IO TCC_FCTRLB_Type           FCTRLB;      /**< \brief Offset: 0x10 (R/W 32) Recoverable Fault B Configuration */
+  __IO TCC_WEXCTRL_Type          WEXCTRL;     /**< \brief Offset: 0x14 (R/W 32) Waveform Extension Configuration */
+  __IO TCC_DRVCTRL_Type          DRVCTRL;     /**< \brief Offset: 0x18 (R/W 32) Driver Control */
+       RoReg8                    Reserved2[0x2];
+  __IO TCC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x1E (R/W  8) Debug Control */
+       RoReg8                    Reserved3[0x1];
+  __IO TCC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x20 (R/W 32) Event Control */
+  __IO TCC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x24 (R/W 32) Interrupt Enable Clear */
+  __IO TCC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x28 (R/W 32) Interrupt Enable Set */
+  __IO TCC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x2C (R/W 32) Interrupt Flag Status and Clear */
+  __IO TCC_STATUS_Type           STATUS;      /**< \brief Offset: 0x30 (R/W 32) Status */
+  __IO TCC_COUNT_Type            COUNT;       /**< \brief Offset: 0x34 (R/W 32) Count */
+  __IO TCC_PATT_Type             PATT;        /**< \brief Offset: 0x38 (R/W 16) Pattern */
+       RoReg8                    Reserved4[0x2];
+  __IO TCC_WAVE_Type             WAVE;        /**< \brief Offset: 0x3C (R/W 32) Waveform Control */
+  __IO TCC_PER_Type              PER;         /**< \brief Offset: 0x40 (R/W 32) Period */
+  __IO TCC_CC_Type               CC[4];       /**< \brief Offset: 0x44 (R/W 32) Compare and Capture */
+       RoReg8                    Reserved5[0x10];
+  __IO TCC_PATTBUF_Type          PATTBUF;     /**< \brief Offset: 0x64 (R/W 16) Pattern Buffer */
+       RoReg8                    Reserved6[0x2];
+  __IO TCC_WAVEBUF_Type          WAVEBUF;     /**< \brief Offset: 0x68 (R/W 32) Waveform Control Buffer */
+  __IO TCC_PERBUF_Type           PERBUF;      /**< \brief Offset: 0x6C (R/W 32) Period Buffer */
+  __IO TCC_CCBUF_Type            CCBUF[4];    /**< \brief Offset: 0x70 (R/W 32) Compare and Capture Buffer */
+} Tcc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_TCC_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/trng.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/trng.h
@@ -1,0 +1,186 @@
+/**
+ * \file
+ *
+ * \brief Component description for TRNG
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TRNG_COMPONENT_
+#define _SAML21_TRNG_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TRNG */
+/* ========================================================================== */
+/** \addtogroup SAML21_TRNG True Random Generator */
+/*@{*/
+
+#define TRNG_U2242
+#define REV_TRNG                    0x100
+
+/* -------- TRNG_CTRLA : (TRNG Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :1;               /*!< bit:      0  Reserved                           */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      6  Run in Standby                     */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TRNG_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_CTRLA_OFFSET           0x00         /**< \brief (TRNG_CTRLA offset) Control A */
+#define TRNG_CTRLA_RESETVALUE       0x00ul       /**< \brief (TRNG_CTRLA reset_value) Control A */
+
+#define TRNG_CTRLA_ENABLE_Pos       1            /**< \brief (TRNG_CTRLA) Enable */
+#define TRNG_CTRLA_ENABLE           (0x1ul << TRNG_CTRLA_ENABLE_Pos)
+#define TRNG_CTRLA_RUNSTDBY_Pos     6            /**< \brief (TRNG_CTRLA) Run in Standby */
+#define TRNG_CTRLA_RUNSTDBY         (0x1ul << TRNG_CTRLA_RUNSTDBY_Pos)
+#define TRNG_CTRLA_MASK             0x42ul       /**< \brief (TRNG_CTRLA) MASK Register */
+
+/* -------- TRNG_EVCTRL : (TRNG Offset: 0x04) (R/W  8) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DATARDYEO:1;      /*!< bit:      0  Data Ready Event Output            */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TRNG_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_EVCTRL_OFFSET          0x04         /**< \brief (TRNG_EVCTRL offset) Event Control */
+#define TRNG_EVCTRL_RESETVALUE      0x00ul       /**< \brief (TRNG_EVCTRL reset_value) Event Control */
+
+#define TRNG_EVCTRL_DATARDYEO_Pos   0            /**< \brief (TRNG_EVCTRL) Data Ready Event Output */
+#define TRNG_EVCTRL_DATARDYEO       (0x1ul << TRNG_EVCTRL_DATARDYEO_Pos)
+#define TRNG_EVCTRL_MASK            0x01ul       /**< \brief (TRNG_EVCTRL) MASK Register */
+
+/* -------- TRNG_INTENCLR : (TRNG Offset: 0x08) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Enable        */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TRNG_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_INTENCLR_OFFSET        0x08         /**< \brief (TRNG_INTENCLR offset) Interrupt Enable Clear */
+#define TRNG_INTENCLR_RESETVALUE    0x00ul       /**< \brief (TRNG_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define TRNG_INTENCLR_DATARDY_Pos   0            /**< \brief (TRNG_INTENCLR) Data Ready Interrupt Enable */
+#define TRNG_INTENCLR_DATARDY       (0x1ul << TRNG_INTENCLR_DATARDY_Pos)
+#define TRNG_INTENCLR_MASK          0x01ul       /**< \brief (TRNG_INTENCLR) MASK Register */
+
+/* -------- TRNG_INTENSET : (TRNG Offset: 0x09) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Enable        */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TRNG_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_INTENSET_OFFSET        0x09         /**< \brief (TRNG_INTENSET offset) Interrupt Enable Set */
+#define TRNG_INTENSET_RESETVALUE    0x00ul       /**< \brief (TRNG_INTENSET reset_value) Interrupt Enable Set */
+
+#define TRNG_INTENSET_DATARDY_Pos   0            /**< \brief (TRNG_INTENSET) Data Ready Interrupt Enable */
+#define TRNG_INTENSET_DATARDY       (0x1ul << TRNG_INTENSET_DATARDY_Pos)
+#define TRNG_INTENSET_MASK          0x01ul       /**< \brief (TRNG_INTENSET) MASK Register */
+
+/* -------- TRNG_INTFLAG : (TRNG Offset: 0x0A) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TRNG_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_INTFLAG_OFFSET         0x0A         /**< \brief (TRNG_INTFLAG offset) Interrupt Flag Status and Clear */
+#define TRNG_INTFLAG_RESETVALUE     0x00ul       /**< \brief (TRNG_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define TRNG_INTFLAG_DATARDY_Pos    0            /**< \brief (TRNG_INTFLAG) Data Ready Interrupt Flag */
+#define TRNG_INTFLAG_DATARDY        (0x1ul << TRNG_INTFLAG_DATARDY_Pos)
+#define TRNG_INTFLAG_MASK           0x01ul       /**< \brief (TRNG_INTFLAG) MASK Register */
+
+/* -------- TRNG_DATA : (TRNG Offset: 0x20) (R/  32) Output Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Output Data                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TRNG_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_DATA_OFFSET            0x20         /**< \brief (TRNG_DATA offset) Output Data */
+#define TRNG_DATA_RESETVALUE        0x00000000ul /**< \brief (TRNG_DATA reset_value) Output Data */
+
+#define TRNG_DATA_DATA_Pos          0            /**< \brief (TRNG_DATA) Output Data */
+#define TRNG_DATA_DATA_Msk          (0xFFFFFFFFul << TRNG_DATA_DATA_Pos)
+#define TRNG_DATA_DATA(value)       (TRNG_DATA_DATA_Msk & ((value) << TRNG_DATA_DATA_Pos))
+#define TRNG_DATA_MASK              0xFFFFFFFFul /**< \brief (TRNG_DATA) MASK Register */
+
+/** \brief TRNG hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO TRNG_CTRLA_Type           CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+       RoReg8                    Reserved1[0x3];
+  __IO TRNG_EVCTRL_Type          EVCTRL;      /**< \brief Offset: 0x04 (R/W  8) Event Control */
+       RoReg8                    Reserved2[0x3];
+  __IO TRNG_INTENCLR_Type        INTENCLR;    /**< \brief Offset: 0x08 (R/W  8) Interrupt Enable Clear */
+  __IO TRNG_INTENSET_Type        INTENSET;    /**< \brief Offset: 0x09 (R/W  8) Interrupt Enable Set */
+  __IO TRNG_INTFLAG_Type         INTFLAG;     /**< \brief Offset: 0x0A (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved3[0x15];
+  __I  TRNG_DATA_Type            DATA;        /**< \brief Offset: 0x20 (R/  32) Output Data */
+} Trng;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_TRNG_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/usb.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/usb.h
@@ -1,0 +1,1770 @@
+/**
+ * \file
+ *
+ * \brief Component description for USB
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_USB_COMPONENT_
+#define _SAML21_USB_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR USB */
+/* ========================================================================== */
+/** \addtogroup SAML21_USB Universal Serial Bus */
+/*@{*/
+
+#define USB_U2222
+#define REV_USB                     0x110
+
+/* -------- USB_CTRLA : (USB Offset: 0x000) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      2  Run in Standby Mode                */
+    uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  MODE:1;           /*!< bit:      7  Operating Mode                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_CTRLA_OFFSET            0x000        /**< \brief (USB_CTRLA offset) Control A */
+#define USB_CTRLA_RESETVALUE        0x00ul       /**< \brief (USB_CTRLA reset_value) Control A */
+
+#define USB_CTRLA_SWRST_Pos         0            /**< \brief (USB_CTRLA) Software Reset */
+#define USB_CTRLA_SWRST             (0x1ul << USB_CTRLA_SWRST_Pos)
+#define USB_CTRLA_ENABLE_Pos        1            /**< \brief (USB_CTRLA) Enable */
+#define USB_CTRLA_ENABLE            (0x1ul << USB_CTRLA_ENABLE_Pos)
+#define USB_CTRLA_RUNSTDBY_Pos      2            /**< \brief (USB_CTRLA) Run in Standby Mode */
+#define USB_CTRLA_RUNSTDBY          (0x1ul << USB_CTRLA_RUNSTDBY_Pos)
+#define USB_CTRLA_MODE_Pos          7            /**< \brief (USB_CTRLA) Operating Mode */
+#define USB_CTRLA_MODE              (0x1ul << USB_CTRLA_MODE_Pos)
+#define   USB_CTRLA_MODE_DEVICE_Val       0x0ul  /**< \brief (USB_CTRLA) Device Mode */
+#define   USB_CTRLA_MODE_HOST_Val         0x1ul  /**< \brief (USB_CTRLA) Host Mode */
+#define USB_CTRLA_MODE_DEVICE       (USB_CTRLA_MODE_DEVICE_Val     << USB_CTRLA_MODE_Pos)
+#define USB_CTRLA_MODE_HOST         (USB_CTRLA_MODE_HOST_Val       << USB_CTRLA_MODE_Pos)
+#define USB_CTRLA_MASK              0x87ul       /**< \brief (USB_CTRLA) MASK Register */
+
+/* -------- USB_SYNCBUSY : (USB Offset: 0x002) (R/   8) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset Synchronization Busy */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable Synchronization Busy        */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_SYNCBUSY_OFFSET         0x002        /**< \brief (USB_SYNCBUSY offset) Synchronization Busy */
+#define USB_SYNCBUSY_RESETVALUE     0x00ul       /**< \brief (USB_SYNCBUSY reset_value) Synchronization Busy */
+
+#define USB_SYNCBUSY_SWRST_Pos      0            /**< \brief (USB_SYNCBUSY) Software Reset Synchronization Busy */
+#define USB_SYNCBUSY_SWRST          (0x1ul << USB_SYNCBUSY_SWRST_Pos)
+#define USB_SYNCBUSY_ENABLE_Pos     1            /**< \brief (USB_SYNCBUSY) Enable Synchronization Busy */
+#define USB_SYNCBUSY_ENABLE         (0x1ul << USB_SYNCBUSY_ENABLE_Pos)
+#define USB_SYNCBUSY_MASK           0x03ul       /**< \brief (USB_SYNCBUSY) MASK Register */
+
+/* -------- USB_DEVICE_CTRLB : (USB Offset: 0x008) (R/W 16) DEVICE DEVICE Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DETACH:1;         /*!< bit:      0  Detach                             */
+    uint16_t UPRSM:1;          /*!< bit:      1  Upstream Resume                    */
+    uint16_t SPDCONF:2;        /*!< bit:  2.. 3  Speed Configuration                */
+    uint16_t NREPLY:1;         /*!< bit:      4  No Reply                           */
+    uint16_t TSTJ:1;           /*!< bit:      5  Test mode J                        */
+    uint16_t TSTK:1;           /*!< bit:      6  Test mode K                        */
+    uint16_t TSTPCKT:1;        /*!< bit:      7  Test packet mode                   */
+    uint16_t OPMODE2:1;        /*!< bit:      8  Specific Operational Mode          */
+    uint16_t GNAK:1;           /*!< bit:      9  Global NAK                         */
+    uint16_t LPMHDSK:2;        /*!< bit: 10..11  Link Power Management Handshake    */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_DEVICE_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_CTRLB_OFFSET     0x008        /**< \brief (USB_DEVICE_CTRLB offset) DEVICE Control B */
+#define USB_DEVICE_CTRLB_RESETVALUE 0x0001ul     /**< \brief (USB_DEVICE_CTRLB reset_value) DEVICE Control B */
+
+#define USB_DEVICE_CTRLB_DETACH_Pos 0            /**< \brief (USB_DEVICE_CTRLB) Detach */
+#define USB_DEVICE_CTRLB_DETACH     (0x1ul << USB_DEVICE_CTRLB_DETACH_Pos)
+#define USB_DEVICE_CTRLB_UPRSM_Pos  1            /**< \brief (USB_DEVICE_CTRLB) Upstream Resume */
+#define USB_DEVICE_CTRLB_UPRSM      (0x1ul << USB_DEVICE_CTRLB_UPRSM_Pos)
+#define USB_DEVICE_CTRLB_SPDCONF_Pos 2            /**< \brief (USB_DEVICE_CTRLB) Speed Configuration */
+#define USB_DEVICE_CTRLB_SPDCONF_Msk (0x3ul << USB_DEVICE_CTRLB_SPDCONF_Pos)
+#define USB_DEVICE_CTRLB_SPDCONF(value) (USB_DEVICE_CTRLB_SPDCONF_Msk & ((value) << USB_DEVICE_CTRLB_SPDCONF_Pos))
+#define   USB_DEVICE_CTRLB_SPDCONF_FS_Val 0x0ul  /**< \brief (USB_DEVICE_CTRLB) FS : Full Speed */
+#define   USB_DEVICE_CTRLB_SPDCONF_LS_Val 0x1ul  /**< \brief (USB_DEVICE_CTRLB) LS : Low Speed */
+#define   USB_DEVICE_CTRLB_SPDCONF_HS_Val 0x2ul  /**< \brief (USB_DEVICE_CTRLB) HS : High Speed capable */
+#define   USB_DEVICE_CTRLB_SPDCONF_HSTM_Val 0x3ul  /**< \brief (USB_DEVICE_CTRLB) HSTM: High Speed Test Mode (force high-speed mode for test mode) */
+#define USB_DEVICE_CTRLB_SPDCONF_FS (USB_DEVICE_CTRLB_SPDCONF_FS_Val << USB_DEVICE_CTRLB_SPDCONF_Pos)
+#define USB_DEVICE_CTRLB_SPDCONF_LS (USB_DEVICE_CTRLB_SPDCONF_LS_Val << USB_DEVICE_CTRLB_SPDCONF_Pos)
+#define USB_DEVICE_CTRLB_SPDCONF_HS (USB_DEVICE_CTRLB_SPDCONF_HS_Val << USB_DEVICE_CTRLB_SPDCONF_Pos)
+#define USB_DEVICE_CTRLB_SPDCONF_HSTM (USB_DEVICE_CTRLB_SPDCONF_HSTM_Val << USB_DEVICE_CTRLB_SPDCONF_Pos)
+#define USB_DEVICE_CTRLB_NREPLY_Pos 4            /**< \brief (USB_DEVICE_CTRLB) No Reply */
+#define USB_DEVICE_CTRLB_NREPLY     (0x1ul << USB_DEVICE_CTRLB_NREPLY_Pos)
+#define USB_DEVICE_CTRLB_TSTJ_Pos   5            /**< \brief (USB_DEVICE_CTRLB) Test mode J */
+#define USB_DEVICE_CTRLB_TSTJ       (0x1ul << USB_DEVICE_CTRLB_TSTJ_Pos)
+#define USB_DEVICE_CTRLB_TSTK_Pos   6            /**< \brief (USB_DEVICE_CTRLB) Test mode K */
+#define USB_DEVICE_CTRLB_TSTK       (0x1ul << USB_DEVICE_CTRLB_TSTK_Pos)
+#define USB_DEVICE_CTRLB_TSTPCKT_Pos 7            /**< \brief (USB_DEVICE_CTRLB) Test packet mode */
+#define USB_DEVICE_CTRLB_TSTPCKT    (0x1ul << USB_DEVICE_CTRLB_TSTPCKT_Pos)
+#define USB_DEVICE_CTRLB_OPMODE2_Pos 8            /**< \brief (USB_DEVICE_CTRLB) Specific Operational Mode */
+#define USB_DEVICE_CTRLB_OPMODE2    (0x1ul << USB_DEVICE_CTRLB_OPMODE2_Pos)
+#define USB_DEVICE_CTRLB_GNAK_Pos   9            /**< \brief (USB_DEVICE_CTRLB) Global NAK */
+#define USB_DEVICE_CTRLB_GNAK       (0x1ul << USB_DEVICE_CTRLB_GNAK_Pos)
+#define USB_DEVICE_CTRLB_LPMHDSK_Pos 10           /**< \brief (USB_DEVICE_CTRLB) Link Power Management Handshake */
+#define USB_DEVICE_CTRLB_LPMHDSK_Msk (0x3ul << USB_DEVICE_CTRLB_LPMHDSK_Pos)
+#define USB_DEVICE_CTRLB_LPMHDSK(value) (USB_DEVICE_CTRLB_LPMHDSK_Msk & ((value) << USB_DEVICE_CTRLB_LPMHDSK_Pos))
+#define   USB_DEVICE_CTRLB_LPMHDSK_NO_Val 0x0ul  /**< \brief (USB_DEVICE_CTRLB) No handshake. LPM is not supported */
+#define   USB_DEVICE_CTRLB_LPMHDSK_ACK_Val 0x1ul  /**< \brief (USB_DEVICE_CTRLB) ACK */
+#define   USB_DEVICE_CTRLB_LPMHDSK_NYET_Val 0x2ul  /**< \brief (USB_DEVICE_CTRLB) NYET */
+#define   USB_DEVICE_CTRLB_LPMHDSK_STALL_Val 0x3ul  /**< \brief (USB_DEVICE_CTRLB) STALL */
+#define USB_DEVICE_CTRLB_LPMHDSK_NO (USB_DEVICE_CTRLB_LPMHDSK_NO_Val << USB_DEVICE_CTRLB_LPMHDSK_Pos)
+#define USB_DEVICE_CTRLB_LPMHDSK_ACK (USB_DEVICE_CTRLB_LPMHDSK_ACK_Val << USB_DEVICE_CTRLB_LPMHDSK_Pos)
+#define USB_DEVICE_CTRLB_LPMHDSK_NYET (USB_DEVICE_CTRLB_LPMHDSK_NYET_Val << USB_DEVICE_CTRLB_LPMHDSK_Pos)
+#define USB_DEVICE_CTRLB_LPMHDSK_STALL (USB_DEVICE_CTRLB_LPMHDSK_STALL_Val << USB_DEVICE_CTRLB_LPMHDSK_Pos)
+#define USB_DEVICE_CTRLB_MASK       0x0FFFul     /**< \brief (USB_DEVICE_CTRLB) MASK Register */
+
+/* -------- USB_HOST_CTRLB : (USB Offset: 0x008) (R/W 16) HOST HOST Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :1;               /*!< bit:      0  Reserved                           */
+    uint16_t RESUME:1;         /*!< bit:      1  Send USB Resume                    */
+    uint16_t SPDCONF:2;        /*!< bit:  2.. 3  Speed Configuration for Host       */
+    uint16_t AUTORESUME:1;     /*!< bit:      4  Auto Resume Enable                 */
+    uint16_t TSTJ:1;           /*!< bit:      5  Test mode J                        */
+    uint16_t TSTK:1;           /*!< bit:      6  Test mode K                        */
+    uint16_t :1;               /*!< bit:      7  Reserved                           */
+    uint16_t SOFE:1;           /*!< bit:      8  Start of Frame Generation Enable   */
+    uint16_t BUSRESET:1;       /*!< bit:      9  Send USB Reset                     */
+    uint16_t VBUSOK:1;         /*!< bit:     10  VBUS is OK                         */
+    uint16_t L1RESUME:1;       /*!< bit:     11  Send L1 Resume                     */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_HOST_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_CTRLB_OFFSET       0x008        /**< \brief (USB_HOST_CTRLB offset) HOST Control B */
+#define USB_HOST_CTRLB_RESETVALUE   0x0000ul     /**< \brief (USB_HOST_CTRLB reset_value) HOST Control B */
+
+#define USB_HOST_CTRLB_RESUME_Pos   1            /**< \brief (USB_HOST_CTRLB) Send USB Resume */
+#define USB_HOST_CTRLB_RESUME       (0x1ul << USB_HOST_CTRLB_RESUME_Pos)
+#define USB_HOST_CTRLB_SPDCONF_Pos  2            /**< \brief (USB_HOST_CTRLB) Speed Configuration for Host */
+#define USB_HOST_CTRLB_SPDCONF_Msk  (0x3ul << USB_HOST_CTRLB_SPDCONF_Pos)
+#define USB_HOST_CTRLB_SPDCONF(value) (USB_HOST_CTRLB_SPDCONF_Msk & ((value) << USB_HOST_CTRLB_SPDCONF_Pos))
+#define   USB_HOST_CTRLB_SPDCONF_NORMAL_Val 0x0ul  /**< \brief (USB_HOST_CTRLB) Normal mode: the host starts in full-speed mode and performs a high-speed reset to switch to the high speed mode if the downstream peripheral is high-speed capable. */
+#define   USB_HOST_CTRLB_SPDCONF_FS_Val   0x3ul  /**< \brief (USB_HOST_CTRLB) Full-speed: the host remains in full-speed mode whatever is the peripheral speed capability. Relevant in UTMI mode only. */
+#define USB_HOST_CTRLB_SPDCONF_NORMAL (USB_HOST_CTRLB_SPDCONF_NORMAL_Val << USB_HOST_CTRLB_SPDCONF_Pos)
+#define USB_HOST_CTRLB_SPDCONF_FS   (USB_HOST_CTRLB_SPDCONF_FS_Val << USB_HOST_CTRLB_SPDCONF_Pos)
+#define USB_HOST_CTRLB_AUTORESUME_Pos 4            /**< \brief (USB_HOST_CTRLB) Auto Resume Enable */
+#define USB_HOST_CTRLB_AUTORESUME   (0x1ul << USB_HOST_CTRLB_AUTORESUME_Pos)
+#define USB_HOST_CTRLB_TSTJ_Pos     5            /**< \brief (USB_HOST_CTRLB) Test mode J */
+#define USB_HOST_CTRLB_TSTJ         (0x1ul << USB_HOST_CTRLB_TSTJ_Pos)
+#define USB_HOST_CTRLB_TSTK_Pos     6            /**< \brief (USB_HOST_CTRLB) Test mode K */
+#define USB_HOST_CTRLB_TSTK         (0x1ul << USB_HOST_CTRLB_TSTK_Pos)
+#define USB_HOST_CTRLB_SOFE_Pos     8            /**< \brief (USB_HOST_CTRLB) Start of Frame Generation Enable */
+#define USB_HOST_CTRLB_SOFE         (0x1ul << USB_HOST_CTRLB_SOFE_Pos)
+#define USB_HOST_CTRLB_BUSRESET_Pos 9            /**< \brief (USB_HOST_CTRLB) Send USB Reset */
+#define USB_HOST_CTRLB_BUSRESET     (0x1ul << USB_HOST_CTRLB_BUSRESET_Pos)
+#define USB_HOST_CTRLB_VBUSOK_Pos   10           /**< \brief (USB_HOST_CTRLB) VBUS is OK */
+#define USB_HOST_CTRLB_VBUSOK       (0x1ul << USB_HOST_CTRLB_VBUSOK_Pos)
+#define USB_HOST_CTRLB_L1RESUME_Pos 11           /**< \brief (USB_HOST_CTRLB) Send L1 Resume */
+#define USB_HOST_CTRLB_L1RESUME     (0x1ul << USB_HOST_CTRLB_L1RESUME_Pos)
+#define USB_HOST_CTRLB_MASK         0x0F7Eul     /**< \brief (USB_HOST_CTRLB) MASK Register */
+
+/* -------- USB_DEVICE_DADD : (USB Offset: 0x00A) (R/W  8) DEVICE DEVICE Device Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DADD:7;           /*!< bit:  0.. 6  Device Address                     */
+    uint8_t  ADDEN:1;          /*!< bit:      7  Device Address Enable              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_DADD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_DADD_OFFSET      0x00A        /**< \brief (USB_DEVICE_DADD offset) DEVICE Device Address */
+#define USB_DEVICE_DADD_RESETVALUE  0x00ul       /**< \brief (USB_DEVICE_DADD reset_value) DEVICE Device Address */
+
+#define USB_DEVICE_DADD_DADD_Pos    0            /**< \brief (USB_DEVICE_DADD) Device Address */
+#define USB_DEVICE_DADD_DADD_Msk    (0x7Ful << USB_DEVICE_DADD_DADD_Pos)
+#define USB_DEVICE_DADD_DADD(value) (USB_DEVICE_DADD_DADD_Msk & ((value) << USB_DEVICE_DADD_DADD_Pos))
+#define USB_DEVICE_DADD_ADDEN_Pos   7            /**< \brief (USB_DEVICE_DADD) Device Address Enable */
+#define USB_DEVICE_DADD_ADDEN       (0x1ul << USB_DEVICE_DADD_ADDEN_Pos)
+#define USB_DEVICE_DADD_MASK        0xFFul       /**< \brief (USB_DEVICE_DADD) MASK Register */
+
+/* -------- USB_HOST_HSOFC : (USB Offset: 0x00A) (R/W  8) HOST HOST Host Start Of Frame Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  FLENC:4;          /*!< bit:  0.. 3  Frame Length Control               */
+    uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  FLENCE:1;         /*!< bit:      7  Frame Length Control Enable        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_HSOFC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_HSOFC_OFFSET       0x00A        /**< \brief (USB_HOST_HSOFC offset) HOST Host Start Of Frame Control */
+#define USB_HOST_HSOFC_RESETVALUE   0x00ul       /**< \brief (USB_HOST_HSOFC reset_value) HOST Host Start Of Frame Control */
+
+#define USB_HOST_HSOFC_FLENC_Pos    0            /**< \brief (USB_HOST_HSOFC) Frame Length Control */
+#define USB_HOST_HSOFC_FLENC_Msk    (0xFul << USB_HOST_HSOFC_FLENC_Pos)
+#define USB_HOST_HSOFC_FLENC(value) (USB_HOST_HSOFC_FLENC_Msk & ((value) << USB_HOST_HSOFC_FLENC_Pos))
+#define USB_HOST_HSOFC_FLENCE_Pos   7            /**< \brief (USB_HOST_HSOFC) Frame Length Control Enable */
+#define USB_HOST_HSOFC_FLENCE       (0x1ul << USB_HOST_HSOFC_FLENCE_Pos)
+#define USB_HOST_HSOFC_MASK         0x8Ful       /**< \brief (USB_HOST_HSOFC) MASK Register */
+
+/* -------- USB_DEVICE_STATUS : (USB Offset: 0x00C) (R/   8) DEVICE DEVICE Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint8_t  SPEED:2;          /*!< bit:  2.. 3  Speed Status                       */
+    uint8_t  :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint8_t  LINESTATE:2;      /*!< bit:  6.. 7  USB Line State Status              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_STATUS_OFFSET    0x00C        /**< \brief (USB_DEVICE_STATUS offset) DEVICE Status */
+#define USB_DEVICE_STATUS_RESETVALUE 0x40ul       /**< \brief (USB_DEVICE_STATUS reset_value) DEVICE Status */
+
+#define USB_DEVICE_STATUS_SPEED_Pos 2            /**< \brief (USB_DEVICE_STATUS) Speed Status */
+#define USB_DEVICE_STATUS_SPEED_Msk (0x3ul << USB_DEVICE_STATUS_SPEED_Pos)
+#define USB_DEVICE_STATUS_SPEED(value) (USB_DEVICE_STATUS_SPEED_Msk & ((value) << USB_DEVICE_STATUS_SPEED_Pos))
+#define   USB_DEVICE_STATUS_SPEED_FS_Val  0x0ul  /**< \brief (USB_DEVICE_STATUS) Full-speed mode */
+#define   USB_DEVICE_STATUS_SPEED_HS_Val  0x1ul  /**< \brief (USB_DEVICE_STATUS) High-speed mode */
+#define   USB_DEVICE_STATUS_SPEED_LS_Val  0x2ul  /**< \brief (USB_DEVICE_STATUS) Low-speed mode */
+#define USB_DEVICE_STATUS_SPEED_FS  (USB_DEVICE_STATUS_SPEED_FS_Val << USB_DEVICE_STATUS_SPEED_Pos)
+#define USB_DEVICE_STATUS_SPEED_HS  (USB_DEVICE_STATUS_SPEED_HS_Val << USB_DEVICE_STATUS_SPEED_Pos)
+#define USB_DEVICE_STATUS_SPEED_LS  (USB_DEVICE_STATUS_SPEED_LS_Val << USB_DEVICE_STATUS_SPEED_Pos)
+#define USB_DEVICE_STATUS_LINESTATE_Pos 6            /**< \brief (USB_DEVICE_STATUS) USB Line State Status */
+#define USB_DEVICE_STATUS_LINESTATE_Msk (0x3ul << USB_DEVICE_STATUS_LINESTATE_Pos)
+#define USB_DEVICE_STATUS_LINESTATE(value) (USB_DEVICE_STATUS_LINESTATE_Msk & ((value) << USB_DEVICE_STATUS_LINESTATE_Pos))
+#define   USB_DEVICE_STATUS_LINESTATE_0_Val 0x0ul  /**< \brief (USB_DEVICE_STATUS) SE0/RESET */
+#define   USB_DEVICE_STATUS_LINESTATE_1_Val 0x1ul  /**< \brief (USB_DEVICE_STATUS) FS-J or LS-K State */
+#define   USB_DEVICE_STATUS_LINESTATE_2_Val 0x2ul  /**< \brief (USB_DEVICE_STATUS) FS-K or LS-J State */
+#define USB_DEVICE_STATUS_LINESTATE_0 (USB_DEVICE_STATUS_LINESTATE_0_Val << USB_DEVICE_STATUS_LINESTATE_Pos)
+#define USB_DEVICE_STATUS_LINESTATE_1 (USB_DEVICE_STATUS_LINESTATE_1_Val << USB_DEVICE_STATUS_LINESTATE_Pos)
+#define USB_DEVICE_STATUS_LINESTATE_2 (USB_DEVICE_STATUS_LINESTATE_2_Val << USB_DEVICE_STATUS_LINESTATE_Pos)
+#define USB_DEVICE_STATUS_MASK      0xCCul       /**< \brief (USB_DEVICE_STATUS) MASK Register */
+
+/* -------- USB_HOST_STATUS : (USB Offset: 0x00C) (R/W  8) HOST HOST Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint8_t  SPEED:2;          /*!< bit:  2.. 3  Speed Status                       */
+    uint8_t  :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint8_t  LINESTATE:2;      /*!< bit:  6.. 7  USB Line State Status              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_STATUS_OFFSET      0x00C        /**< \brief (USB_HOST_STATUS offset) HOST Status */
+#define USB_HOST_STATUS_RESETVALUE  0x00ul       /**< \brief (USB_HOST_STATUS reset_value) HOST Status */
+
+#define USB_HOST_STATUS_SPEED_Pos   2            /**< \brief (USB_HOST_STATUS) Speed Status */
+#define USB_HOST_STATUS_SPEED_Msk   (0x3ul << USB_HOST_STATUS_SPEED_Pos)
+#define USB_HOST_STATUS_SPEED(value) (USB_HOST_STATUS_SPEED_Msk & ((value) << USB_HOST_STATUS_SPEED_Pos))
+#define USB_HOST_STATUS_LINESTATE_Pos 6            /**< \brief (USB_HOST_STATUS) USB Line State Status */
+#define USB_HOST_STATUS_LINESTATE_Msk (0x3ul << USB_HOST_STATUS_LINESTATE_Pos)
+#define USB_HOST_STATUS_LINESTATE(value) (USB_HOST_STATUS_LINESTATE_Msk & ((value) << USB_HOST_STATUS_LINESTATE_Pos))
+#define USB_HOST_STATUS_MASK        0xCCul       /**< \brief (USB_HOST_STATUS) MASK Register */
+
+/* -------- USB_FSMSTATUS : (USB Offset: 0x00D) (R/   8) Finite State Machine Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  FSMSTATE:6;       /*!< bit:  0.. 5  Fine State Machine Status          */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_FSMSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_FSMSTATUS_OFFSET        0x00D        /**< \brief (USB_FSMSTATUS offset) Finite State Machine Status */
+#define USB_FSMSTATUS_RESETVALUE    0x01ul       /**< \brief (USB_FSMSTATUS reset_value) Finite State Machine Status */
+
+#define USB_FSMSTATUS_FSMSTATE_Pos  0            /**< \brief (USB_FSMSTATUS) Fine State Machine Status */
+#define USB_FSMSTATUS_FSMSTATE_Msk  (0x3Ful << USB_FSMSTATUS_FSMSTATE_Pos)
+#define USB_FSMSTATUS_FSMSTATE(value) (USB_FSMSTATUS_FSMSTATE_Msk & ((value) << USB_FSMSTATUS_FSMSTATE_Pos))
+#define   USB_FSMSTATUS_FSMSTATE_OFF_Val  0x1ul  /**< \brief (USB_FSMSTATUS) OFF (L3). It corresponds to the powered-off, disconnected, and disabled state */
+#define   USB_FSMSTATUS_FSMSTATE_ON_Val   0x2ul  /**< \brief (USB_FSMSTATUS) ON (L0). It corresponds to the Idle and Active states */
+#define   USB_FSMSTATUS_FSMSTATE_SUSPEND_Val 0x4ul  /**< \brief (USB_FSMSTATUS) SUSPEND (L2) */
+#define   USB_FSMSTATUS_FSMSTATE_SLEEP_Val 0x8ul  /**< \brief (USB_FSMSTATUS) SLEEP (L1) */
+#define   USB_FSMSTATUS_FSMSTATE_DNRESUME_Val 0x10ul  /**< \brief (USB_FSMSTATUS) DNRESUME. Down Stream Resume. */
+#define   USB_FSMSTATUS_FSMSTATE_UPRESUME_Val 0x20ul  /**< \brief (USB_FSMSTATUS) UPRESUME. Up Stream Resume. */
+#define   USB_FSMSTATUS_FSMSTATE_RESET_Val 0x40ul  /**< \brief (USB_FSMSTATUS) RESET. USB lines Reset. */
+#define USB_FSMSTATUS_FSMSTATE_OFF  (USB_FSMSTATUS_FSMSTATE_OFF_Val << USB_FSMSTATUS_FSMSTATE_Pos)
+#define USB_FSMSTATUS_FSMSTATE_ON   (USB_FSMSTATUS_FSMSTATE_ON_Val << USB_FSMSTATUS_FSMSTATE_Pos)
+#define USB_FSMSTATUS_FSMSTATE_SUSPEND (USB_FSMSTATUS_FSMSTATE_SUSPEND_Val << USB_FSMSTATUS_FSMSTATE_Pos)
+#define USB_FSMSTATUS_FSMSTATE_SLEEP (USB_FSMSTATUS_FSMSTATE_SLEEP_Val << USB_FSMSTATUS_FSMSTATE_Pos)
+#define USB_FSMSTATUS_FSMSTATE_DNRESUME (USB_FSMSTATUS_FSMSTATE_DNRESUME_Val << USB_FSMSTATUS_FSMSTATE_Pos)
+#define USB_FSMSTATUS_FSMSTATE_UPRESUME (USB_FSMSTATUS_FSMSTATE_UPRESUME_Val << USB_FSMSTATUS_FSMSTATE_Pos)
+#define USB_FSMSTATUS_FSMSTATE_RESET (USB_FSMSTATUS_FSMSTATE_RESET_Val << USB_FSMSTATUS_FSMSTATE_Pos)
+#define USB_FSMSTATUS_MASK          0x3Ful       /**< \brief (USB_FSMSTATUS) MASK Register */
+
+/* -------- USB_DEVICE_FNUM : (USB Offset: 0x010) (R/  16) DEVICE DEVICE Device Frame Number -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t MFNUM:3;          /*!< bit:  0.. 2  Micro Frame Number                 */
+    uint16_t FNUM:11;          /*!< bit:  3..13  Frame Number                       */
+    uint16_t :1;               /*!< bit:     14  Reserved                           */
+    uint16_t FNCERR:1;         /*!< bit:     15  Frame Number CRC Error             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_DEVICE_FNUM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_FNUM_OFFSET      0x010        /**< \brief (USB_DEVICE_FNUM offset) DEVICE Device Frame Number */
+#define USB_DEVICE_FNUM_RESETVALUE  0x0000ul     /**< \brief (USB_DEVICE_FNUM reset_value) DEVICE Device Frame Number */
+
+#define USB_DEVICE_FNUM_MFNUM_Pos   0            /**< \brief (USB_DEVICE_FNUM) Micro Frame Number */
+#define USB_DEVICE_FNUM_MFNUM_Msk   (0x7ul << USB_DEVICE_FNUM_MFNUM_Pos)
+#define USB_DEVICE_FNUM_MFNUM(value) (USB_DEVICE_FNUM_MFNUM_Msk & ((value) << USB_DEVICE_FNUM_MFNUM_Pos))
+#define USB_DEVICE_FNUM_FNUM_Pos    3            /**< \brief (USB_DEVICE_FNUM) Frame Number */
+#define USB_DEVICE_FNUM_FNUM_Msk    (0x7FFul << USB_DEVICE_FNUM_FNUM_Pos)
+#define USB_DEVICE_FNUM_FNUM(value) (USB_DEVICE_FNUM_FNUM_Msk & ((value) << USB_DEVICE_FNUM_FNUM_Pos))
+#define USB_DEVICE_FNUM_FNCERR_Pos  15           /**< \brief (USB_DEVICE_FNUM) Frame Number CRC Error */
+#define USB_DEVICE_FNUM_FNCERR      (0x1ul << USB_DEVICE_FNUM_FNCERR_Pos)
+#define USB_DEVICE_FNUM_MASK        0xBFFFul     /**< \brief (USB_DEVICE_FNUM) MASK Register */
+
+/* -------- USB_HOST_FNUM : (USB Offset: 0x010) (R/W 16) HOST HOST Host Frame Number -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t MFNUM:3;          /*!< bit:  0.. 2  Micro Frame Number                 */
+    uint16_t FNUM:11;          /*!< bit:  3..13  Frame Number                       */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_HOST_FNUM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_FNUM_OFFSET        0x010        /**< \brief (USB_HOST_FNUM offset) HOST Host Frame Number */
+#define USB_HOST_FNUM_RESETVALUE    0x0000ul     /**< \brief (USB_HOST_FNUM reset_value) HOST Host Frame Number */
+
+#define USB_HOST_FNUM_MFNUM_Pos     0            /**< \brief (USB_HOST_FNUM) Micro Frame Number */
+#define USB_HOST_FNUM_MFNUM_Msk     (0x7ul << USB_HOST_FNUM_MFNUM_Pos)
+#define USB_HOST_FNUM_MFNUM(value)  (USB_HOST_FNUM_MFNUM_Msk & ((value) << USB_HOST_FNUM_MFNUM_Pos))
+#define USB_HOST_FNUM_FNUM_Pos      3            /**< \brief (USB_HOST_FNUM) Frame Number */
+#define USB_HOST_FNUM_FNUM_Msk      (0x7FFul << USB_HOST_FNUM_FNUM_Pos)
+#define USB_HOST_FNUM_FNUM(value)   (USB_HOST_FNUM_FNUM_Msk & ((value) << USB_HOST_FNUM_FNUM_Pos))
+#define USB_HOST_FNUM_MASK          0x3FFFul     /**< \brief (USB_HOST_FNUM) MASK Register */
+
+/* -------- USB_HOST_FLENHIGH : (USB Offset: 0x012) (R/   8) HOST HOST Host Frame Length -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  FLENHIGH:8;       /*!< bit:  0.. 7  Frame Length                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_FLENHIGH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_FLENHIGH_OFFSET    0x012        /**< \brief (USB_HOST_FLENHIGH offset) HOST Host Frame Length */
+#define USB_HOST_FLENHIGH_RESETVALUE 0x00ul       /**< \brief (USB_HOST_FLENHIGH reset_value) HOST Host Frame Length */
+
+#define USB_HOST_FLENHIGH_FLENHIGH_Pos 0            /**< \brief (USB_HOST_FLENHIGH) Frame Length */
+#define USB_HOST_FLENHIGH_FLENHIGH_Msk (0xFFul << USB_HOST_FLENHIGH_FLENHIGH_Pos)
+#define USB_HOST_FLENHIGH_FLENHIGH(value) (USB_HOST_FLENHIGH_FLENHIGH_Msk & ((value) << USB_HOST_FLENHIGH_FLENHIGH_Pos))
+#define USB_HOST_FLENHIGH_MASK      0xFFul       /**< \brief (USB_HOST_FLENHIGH) MASK Register */
+
+/* -------- USB_DEVICE_INTENCLR : (USB Offset: 0x014) (R/W 16) DEVICE DEVICE Device Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SUSPEND:1;        /*!< bit:      0  Suspend Interrupt Enable           */
+    uint16_t MSOF:1;           /*!< bit:      1  Micro Start of Frame Interrupt Enable in High Speed Mode */
+    uint16_t SOF:1;            /*!< bit:      2  Start Of Frame Interrupt Enable    */
+    uint16_t EORST:1;          /*!< bit:      3  End of Reset Interrupt Enable      */
+    uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up Interrupt Enable           */
+    uint16_t EORSM:1;          /*!< bit:      5  End Of Resume Interrupt Enable     */
+    uint16_t UPRSM:1;          /*!< bit:      6  Upstream Resume Interrupt Enable   */
+    uint16_t RAMACER:1;        /*!< bit:      7  Ram Access Interrupt Enable        */
+    uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet Interrupt Enable */
+    uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend Interrupt Enable */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_DEVICE_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_INTENCLR_OFFSET  0x014        /**< \brief (USB_DEVICE_INTENCLR offset) DEVICE Device Interrupt Enable Clear */
+#define USB_DEVICE_INTENCLR_RESETVALUE 0x0000ul     /**< \brief (USB_DEVICE_INTENCLR reset_value) DEVICE Device Interrupt Enable Clear */
+
+#define USB_DEVICE_INTENCLR_SUSPEND_Pos 0            /**< \brief (USB_DEVICE_INTENCLR) Suspend Interrupt Enable */
+#define USB_DEVICE_INTENCLR_SUSPEND (0x1ul << USB_DEVICE_INTENCLR_SUSPEND_Pos)
+#define USB_DEVICE_INTENCLR_MSOF_Pos 1            /**< \brief (USB_DEVICE_INTENCLR) Micro Start of Frame Interrupt Enable in High Speed Mode */
+#define USB_DEVICE_INTENCLR_MSOF    (0x1ul << USB_DEVICE_INTENCLR_MSOF_Pos)
+#define USB_DEVICE_INTENCLR_SOF_Pos 2            /**< \brief (USB_DEVICE_INTENCLR) Start Of Frame Interrupt Enable */
+#define USB_DEVICE_INTENCLR_SOF     (0x1ul << USB_DEVICE_INTENCLR_SOF_Pos)
+#define USB_DEVICE_INTENCLR_EORST_Pos 3            /**< \brief (USB_DEVICE_INTENCLR) End of Reset Interrupt Enable */
+#define USB_DEVICE_INTENCLR_EORST   (0x1ul << USB_DEVICE_INTENCLR_EORST_Pos)
+#define USB_DEVICE_INTENCLR_WAKEUP_Pos 4            /**< \brief (USB_DEVICE_INTENCLR) Wake Up Interrupt Enable */
+#define USB_DEVICE_INTENCLR_WAKEUP  (0x1ul << USB_DEVICE_INTENCLR_WAKEUP_Pos)
+#define USB_DEVICE_INTENCLR_EORSM_Pos 5            /**< \brief (USB_DEVICE_INTENCLR) End Of Resume Interrupt Enable */
+#define USB_DEVICE_INTENCLR_EORSM   (0x1ul << USB_DEVICE_INTENCLR_EORSM_Pos)
+#define USB_DEVICE_INTENCLR_UPRSM_Pos 6            /**< \brief (USB_DEVICE_INTENCLR) Upstream Resume Interrupt Enable */
+#define USB_DEVICE_INTENCLR_UPRSM   (0x1ul << USB_DEVICE_INTENCLR_UPRSM_Pos)
+#define USB_DEVICE_INTENCLR_RAMACER_Pos 7            /**< \brief (USB_DEVICE_INTENCLR) Ram Access Interrupt Enable */
+#define USB_DEVICE_INTENCLR_RAMACER (0x1ul << USB_DEVICE_INTENCLR_RAMACER_Pos)
+#define USB_DEVICE_INTENCLR_LPMNYET_Pos 8            /**< \brief (USB_DEVICE_INTENCLR) Link Power Management Not Yet Interrupt Enable */
+#define USB_DEVICE_INTENCLR_LPMNYET (0x1ul << USB_DEVICE_INTENCLR_LPMNYET_Pos)
+#define USB_DEVICE_INTENCLR_LPMSUSP_Pos 9            /**< \brief (USB_DEVICE_INTENCLR) Link Power Management Suspend Interrupt Enable */
+#define USB_DEVICE_INTENCLR_LPMSUSP (0x1ul << USB_DEVICE_INTENCLR_LPMSUSP_Pos)
+#define USB_DEVICE_INTENCLR_MASK    0x03FFul     /**< \brief (USB_DEVICE_INTENCLR) MASK Register */
+
+/* -------- USB_HOST_INTENCLR : (USB Offset: 0x014) (R/W 16) HOST HOST Host Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame Interrupt Disable */
+    uint16_t RST:1;            /*!< bit:      3  BUS Reset Interrupt Disable        */
+    uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up Interrupt Disable          */
+    uint16_t DNRSM:1;          /*!< bit:      5  DownStream to Device Interrupt Disable */
+    uint16_t UPRSM:1;          /*!< bit:      6  Upstream Resume from Device Interrupt Disable */
+    uint16_t RAMACER:1;        /*!< bit:      7  Ram Access Interrupt Disable       */
+    uint16_t DCONN:1;          /*!< bit:      8  Device Connection Interrupt Disable */
+    uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection Interrupt Disable */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_HOST_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_INTENCLR_OFFSET    0x014        /**< \brief (USB_HOST_INTENCLR offset) HOST Host Interrupt Enable Clear */
+#define USB_HOST_INTENCLR_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_INTENCLR reset_value) HOST Host Interrupt Enable Clear */
+
+#define USB_HOST_INTENCLR_HSOF_Pos  2            /**< \brief (USB_HOST_INTENCLR) Host Start Of Frame Interrupt Disable */
+#define USB_HOST_INTENCLR_HSOF      (0x1ul << USB_HOST_INTENCLR_HSOF_Pos)
+#define USB_HOST_INTENCLR_RST_Pos   3            /**< \brief (USB_HOST_INTENCLR) BUS Reset Interrupt Disable */
+#define USB_HOST_INTENCLR_RST       (0x1ul << USB_HOST_INTENCLR_RST_Pos)
+#define USB_HOST_INTENCLR_WAKEUP_Pos 4            /**< \brief (USB_HOST_INTENCLR) Wake Up Interrupt Disable */
+#define USB_HOST_INTENCLR_WAKEUP    (0x1ul << USB_HOST_INTENCLR_WAKEUP_Pos)
+#define USB_HOST_INTENCLR_DNRSM_Pos 5            /**< \brief (USB_HOST_INTENCLR) DownStream to Device Interrupt Disable */
+#define USB_HOST_INTENCLR_DNRSM     (0x1ul << USB_HOST_INTENCLR_DNRSM_Pos)
+#define USB_HOST_INTENCLR_UPRSM_Pos 6            /**< \brief (USB_HOST_INTENCLR) Upstream Resume from Device Interrupt Disable */
+#define USB_HOST_INTENCLR_UPRSM     (0x1ul << USB_HOST_INTENCLR_UPRSM_Pos)
+#define USB_HOST_INTENCLR_RAMACER_Pos 7            /**< \brief (USB_HOST_INTENCLR) Ram Access Interrupt Disable */
+#define USB_HOST_INTENCLR_RAMACER   (0x1ul << USB_HOST_INTENCLR_RAMACER_Pos)
+#define USB_HOST_INTENCLR_DCONN_Pos 8            /**< \brief (USB_HOST_INTENCLR) Device Connection Interrupt Disable */
+#define USB_HOST_INTENCLR_DCONN     (0x1ul << USB_HOST_INTENCLR_DCONN_Pos)
+#define USB_HOST_INTENCLR_DDISC_Pos 9            /**< \brief (USB_HOST_INTENCLR) Device Disconnection Interrupt Disable */
+#define USB_HOST_INTENCLR_DDISC     (0x1ul << USB_HOST_INTENCLR_DDISC_Pos)
+#define USB_HOST_INTENCLR_MASK      0x03FCul     /**< \brief (USB_HOST_INTENCLR) MASK Register */
+
+/* -------- USB_DEVICE_INTENSET : (USB Offset: 0x018) (R/W 16) DEVICE DEVICE Device Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SUSPEND:1;        /*!< bit:      0  Suspend Interrupt Enable           */
+    uint16_t MSOF:1;           /*!< bit:      1  Micro Start of Frame Interrupt Enable in High Speed Mode */
+    uint16_t SOF:1;            /*!< bit:      2  Start Of Frame Interrupt Enable    */
+    uint16_t EORST:1;          /*!< bit:      3  End of Reset Interrupt Enable      */
+    uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up Interrupt Enable           */
+    uint16_t EORSM:1;          /*!< bit:      5  End Of Resume Interrupt Enable     */
+    uint16_t UPRSM:1;          /*!< bit:      6  Upstream Resume Interrupt Enable   */
+    uint16_t RAMACER:1;        /*!< bit:      7  Ram Access Interrupt Enable        */
+    uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet Interrupt Enable */
+    uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend Interrupt Enable */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_DEVICE_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_INTENSET_OFFSET  0x018        /**< \brief (USB_DEVICE_INTENSET offset) DEVICE Device Interrupt Enable Set */
+#define USB_DEVICE_INTENSET_RESETVALUE 0x0000ul     /**< \brief (USB_DEVICE_INTENSET reset_value) DEVICE Device Interrupt Enable Set */
+
+#define USB_DEVICE_INTENSET_SUSPEND_Pos 0            /**< \brief (USB_DEVICE_INTENSET) Suspend Interrupt Enable */
+#define USB_DEVICE_INTENSET_SUSPEND (0x1ul << USB_DEVICE_INTENSET_SUSPEND_Pos)
+#define USB_DEVICE_INTENSET_MSOF_Pos 1            /**< \brief (USB_DEVICE_INTENSET) Micro Start of Frame Interrupt Enable in High Speed Mode */
+#define USB_DEVICE_INTENSET_MSOF    (0x1ul << USB_DEVICE_INTENSET_MSOF_Pos)
+#define USB_DEVICE_INTENSET_SOF_Pos 2            /**< \brief (USB_DEVICE_INTENSET) Start Of Frame Interrupt Enable */
+#define USB_DEVICE_INTENSET_SOF     (0x1ul << USB_DEVICE_INTENSET_SOF_Pos)
+#define USB_DEVICE_INTENSET_EORST_Pos 3            /**< \brief (USB_DEVICE_INTENSET) End of Reset Interrupt Enable */
+#define USB_DEVICE_INTENSET_EORST   (0x1ul << USB_DEVICE_INTENSET_EORST_Pos)
+#define USB_DEVICE_INTENSET_WAKEUP_Pos 4            /**< \brief (USB_DEVICE_INTENSET) Wake Up Interrupt Enable */
+#define USB_DEVICE_INTENSET_WAKEUP  (0x1ul << USB_DEVICE_INTENSET_WAKEUP_Pos)
+#define USB_DEVICE_INTENSET_EORSM_Pos 5            /**< \brief (USB_DEVICE_INTENSET) End Of Resume Interrupt Enable */
+#define USB_DEVICE_INTENSET_EORSM   (0x1ul << USB_DEVICE_INTENSET_EORSM_Pos)
+#define USB_DEVICE_INTENSET_UPRSM_Pos 6            /**< \brief (USB_DEVICE_INTENSET) Upstream Resume Interrupt Enable */
+#define USB_DEVICE_INTENSET_UPRSM   (0x1ul << USB_DEVICE_INTENSET_UPRSM_Pos)
+#define USB_DEVICE_INTENSET_RAMACER_Pos 7            /**< \brief (USB_DEVICE_INTENSET) Ram Access Interrupt Enable */
+#define USB_DEVICE_INTENSET_RAMACER (0x1ul << USB_DEVICE_INTENSET_RAMACER_Pos)
+#define USB_DEVICE_INTENSET_LPMNYET_Pos 8            /**< \brief (USB_DEVICE_INTENSET) Link Power Management Not Yet Interrupt Enable */
+#define USB_DEVICE_INTENSET_LPMNYET (0x1ul << USB_DEVICE_INTENSET_LPMNYET_Pos)
+#define USB_DEVICE_INTENSET_LPMSUSP_Pos 9            /**< \brief (USB_DEVICE_INTENSET) Link Power Management Suspend Interrupt Enable */
+#define USB_DEVICE_INTENSET_LPMSUSP (0x1ul << USB_DEVICE_INTENSET_LPMSUSP_Pos)
+#define USB_DEVICE_INTENSET_MASK    0x03FFul     /**< \brief (USB_DEVICE_INTENSET) MASK Register */
+
+/* -------- USB_HOST_INTENSET : (USB Offset: 0x018) (R/W 16) HOST HOST Host Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame Interrupt Enable */
+    uint16_t RST:1;            /*!< bit:      3  Bus Reset Interrupt Enable         */
+    uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up Interrupt Enable           */
+    uint16_t DNRSM:1;          /*!< bit:      5  DownStream to the Device Interrupt Enable */
+    uint16_t UPRSM:1;          /*!< bit:      6  Upstream Resume fromthe device Interrupt Enable */
+    uint16_t RAMACER:1;        /*!< bit:      7  Ram Access Interrupt Enable        */
+    uint16_t DCONN:1;          /*!< bit:      8  Link Power Management Interrupt Enable */
+    uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection Interrupt Enable */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_HOST_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_INTENSET_OFFSET    0x018        /**< \brief (USB_HOST_INTENSET offset) HOST Host Interrupt Enable Set */
+#define USB_HOST_INTENSET_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_INTENSET reset_value) HOST Host Interrupt Enable Set */
+
+#define USB_HOST_INTENSET_HSOF_Pos  2            /**< \brief (USB_HOST_INTENSET) Host Start Of Frame Interrupt Enable */
+#define USB_HOST_INTENSET_HSOF      (0x1ul << USB_HOST_INTENSET_HSOF_Pos)
+#define USB_HOST_INTENSET_RST_Pos   3            /**< \brief (USB_HOST_INTENSET) Bus Reset Interrupt Enable */
+#define USB_HOST_INTENSET_RST       (0x1ul << USB_HOST_INTENSET_RST_Pos)
+#define USB_HOST_INTENSET_WAKEUP_Pos 4            /**< \brief (USB_HOST_INTENSET) Wake Up Interrupt Enable */
+#define USB_HOST_INTENSET_WAKEUP    (0x1ul << USB_HOST_INTENSET_WAKEUP_Pos)
+#define USB_HOST_INTENSET_DNRSM_Pos 5            /**< \brief (USB_HOST_INTENSET) DownStream to the Device Interrupt Enable */
+#define USB_HOST_INTENSET_DNRSM     (0x1ul << USB_HOST_INTENSET_DNRSM_Pos)
+#define USB_HOST_INTENSET_UPRSM_Pos 6            /**< \brief (USB_HOST_INTENSET) Upstream Resume fromthe device Interrupt Enable */
+#define USB_HOST_INTENSET_UPRSM     (0x1ul << USB_HOST_INTENSET_UPRSM_Pos)
+#define USB_HOST_INTENSET_RAMACER_Pos 7            /**< \brief (USB_HOST_INTENSET) Ram Access Interrupt Enable */
+#define USB_HOST_INTENSET_RAMACER   (0x1ul << USB_HOST_INTENSET_RAMACER_Pos)
+#define USB_HOST_INTENSET_DCONN_Pos 8            /**< \brief (USB_HOST_INTENSET) Link Power Management Interrupt Enable */
+#define USB_HOST_INTENSET_DCONN     (0x1ul << USB_HOST_INTENSET_DCONN_Pos)
+#define USB_HOST_INTENSET_DDISC_Pos 9            /**< \brief (USB_HOST_INTENSET) Device Disconnection Interrupt Enable */
+#define USB_HOST_INTENSET_DDISC     (0x1ul << USB_HOST_INTENSET_DDISC_Pos)
+#define USB_HOST_INTENSET_MASK      0x03FCul     /**< \brief (USB_HOST_INTENSET) MASK Register */
+
+/* -------- USB_DEVICE_INTFLAG : (USB Offset: 0x01C) (R/W 16) DEVICE DEVICE Device Interrupt Flag -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t SUSPEND:1;        /*!< bit:      0  Suspend                            */
+    __I uint16_t MSOF:1;           /*!< bit:      1  Micro Start of Frame in High Speed Mode */
+    __I uint16_t SOF:1;            /*!< bit:      2  Start Of Frame                     */
+    __I uint16_t EORST:1;          /*!< bit:      3  End of Reset                       */
+    __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
+    __I uint16_t EORSM:1;          /*!< bit:      5  End Of Resume                      */
+    __I uint16_t UPRSM:1;          /*!< bit:      6  Upstream Resume                    */
+    __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
+    __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
+    __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
+    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_DEVICE_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_INTFLAG_OFFSET   0x01C        /**< \brief (USB_DEVICE_INTFLAG offset) DEVICE Device Interrupt Flag */
+#define USB_DEVICE_INTFLAG_RESETVALUE 0x0000ul     /**< \brief (USB_DEVICE_INTFLAG reset_value) DEVICE Device Interrupt Flag */
+
+#define USB_DEVICE_INTFLAG_SUSPEND_Pos 0            /**< \brief (USB_DEVICE_INTFLAG) Suspend */
+#define USB_DEVICE_INTFLAG_SUSPEND  (0x1ul << USB_DEVICE_INTFLAG_SUSPEND_Pos)
+#define USB_DEVICE_INTFLAG_MSOF_Pos 1            /**< \brief (USB_DEVICE_INTFLAG) Micro Start of Frame in High Speed Mode */
+#define USB_DEVICE_INTFLAG_MSOF     (0x1ul << USB_DEVICE_INTFLAG_MSOF_Pos)
+#define USB_DEVICE_INTFLAG_SOF_Pos  2            /**< \brief (USB_DEVICE_INTFLAG) Start Of Frame */
+#define USB_DEVICE_INTFLAG_SOF      (0x1ul << USB_DEVICE_INTFLAG_SOF_Pos)
+#define USB_DEVICE_INTFLAG_EORST_Pos 3            /**< \brief (USB_DEVICE_INTFLAG) End of Reset */
+#define USB_DEVICE_INTFLAG_EORST    (0x1ul << USB_DEVICE_INTFLAG_EORST_Pos)
+#define USB_DEVICE_INTFLAG_WAKEUP_Pos 4            /**< \brief (USB_DEVICE_INTFLAG) Wake Up */
+#define USB_DEVICE_INTFLAG_WAKEUP   (0x1ul << USB_DEVICE_INTFLAG_WAKEUP_Pos)
+#define USB_DEVICE_INTFLAG_EORSM_Pos 5            /**< \brief (USB_DEVICE_INTFLAG) End Of Resume */
+#define USB_DEVICE_INTFLAG_EORSM    (0x1ul << USB_DEVICE_INTFLAG_EORSM_Pos)
+#define USB_DEVICE_INTFLAG_UPRSM_Pos 6            /**< \brief (USB_DEVICE_INTFLAG) Upstream Resume */
+#define USB_DEVICE_INTFLAG_UPRSM    (0x1ul << USB_DEVICE_INTFLAG_UPRSM_Pos)
+#define USB_DEVICE_INTFLAG_RAMACER_Pos 7            /**< \brief (USB_DEVICE_INTFLAG) Ram Access */
+#define USB_DEVICE_INTFLAG_RAMACER  (0x1ul << USB_DEVICE_INTFLAG_RAMACER_Pos)
+#define USB_DEVICE_INTFLAG_LPMNYET_Pos 8            /**< \brief (USB_DEVICE_INTFLAG) Link Power Management Not Yet */
+#define USB_DEVICE_INTFLAG_LPMNYET  (0x1ul << USB_DEVICE_INTFLAG_LPMNYET_Pos)
+#define USB_DEVICE_INTFLAG_LPMSUSP_Pos 9            /**< \brief (USB_DEVICE_INTFLAG) Link Power Management Suspend */
+#define USB_DEVICE_INTFLAG_LPMSUSP  (0x1ul << USB_DEVICE_INTFLAG_LPMSUSP_Pos)
+#define USB_DEVICE_INTFLAG_MASK     0x03FFul     /**< \brief (USB_DEVICE_INTFLAG) MASK Register */
+
+/* -------- USB_HOST_INTFLAG : (USB Offset: 0x01C) (R/W 16) HOST HOST Host Interrupt Flag -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
+    __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
+    __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
+    __I uint16_t DNRSM:1;          /*!< bit:      5  Downstream                         */
+    __I uint16_t UPRSM:1;          /*!< bit:      6  Upstream Resume from the Device    */
+    __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
+    __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
+    __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
+    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_HOST_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_INTFLAG_OFFSET     0x01C        /**< \brief (USB_HOST_INTFLAG offset) HOST Host Interrupt Flag */
+#define USB_HOST_INTFLAG_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_INTFLAG reset_value) HOST Host Interrupt Flag */
+
+#define USB_HOST_INTFLAG_HSOF_Pos   2            /**< \brief (USB_HOST_INTFLAG) Host Start Of Frame */
+#define USB_HOST_INTFLAG_HSOF       (0x1ul << USB_HOST_INTFLAG_HSOF_Pos)
+#define USB_HOST_INTFLAG_RST_Pos    3            /**< \brief (USB_HOST_INTFLAG) Bus Reset */
+#define USB_HOST_INTFLAG_RST        (0x1ul << USB_HOST_INTFLAG_RST_Pos)
+#define USB_HOST_INTFLAG_WAKEUP_Pos 4            /**< \brief (USB_HOST_INTFLAG) Wake Up */
+#define USB_HOST_INTFLAG_WAKEUP     (0x1ul << USB_HOST_INTFLAG_WAKEUP_Pos)
+#define USB_HOST_INTFLAG_DNRSM_Pos  5            /**< \brief (USB_HOST_INTFLAG) Downstream */
+#define USB_HOST_INTFLAG_DNRSM      (0x1ul << USB_HOST_INTFLAG_DNRSM_Pos)
+#define USB_HOST_INTFLAG_UPRSM_Pos  6            /**< \brief (USB_HOST_INTFLAG) Upstream Resume from the Device */
+#define USB_HOST_INTFLAG_UPRSM      (0x1ul << USB_HOST_INTFLAG_UPRSM_Pos)
+#define USB_HOST_INTFLAG_RAMACER_Pos 7            /**< \brief (USB_HOST_INTFLAG) Ram Access */
+#define USB_HOST_INTFLAG_RAMACER    (0x1ul << USB_HOST_INTFLAG_RAMACER_Pos)
+#define USB_HOST_INTFLAG_DCONN_Pos  8            /**< \brief (USB_HOST_INTFLAG) Device Connection */
+#define USB_HOST_INTFLAG_DCONN      (0x1ul << USB_HOST_INTFLAG_DCONN_Pos)
+#define USB_HOST_INTFLAG_DDISC_Pos  9            /**< \brief (USB_HOST_INTFLAG) Device Disconnection */
+#define USB_HOST_INTFLAG_DDISC      (0x1ul << USB_HOST_INTFLAG_DDISC_Pos)
+#define USB_HOST_INTFLAG_MASK       0x03FCul     /**< \brief (USB_HOST_INTFLAG) MASK Register */
+
+/* -------- USB_DEVICE_EPINTSMRY : (USB Offset: 0x020) (R/  16) DEVICE DEVICE End Point Interrupt Summary -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t EPINT0:1;         /*!< bit:      0  End Point 0 Interrupt              */
+    uint16_t EPINT1:1;         /*!< bit:      1  End Point 1 Interrupt              */
+    uint16_t EPINT2:1;         /*!< bit:      2  End Point 2 Interrupt              */
+    uint16_t EPINT3:1;         /*!< bit:      3  End Point 3 Interrupt              */
+    uint16_t EPINT4:1;         /*!< bit:      4  End Point 4 Interrupt              */
+    uint16_t EPINT5:1;         /*!< bit:      5  End Point 5 Interrupt              */
+    uint16_t EPINT6:1;         /*!< bit:      6  End Point 6 Interrupt              */
+    uint16_t EPINT7:1;         /*!< bit:      7  End Point 7 Interrupt              */
+    uint16_t :8;               /*!< bit:  8..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t EPINT:8;          /*!< bit:  0.. 7  End Point x Interrupt              */
+    uint16_t :8;               /*!< bit:  8..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_DEVICE_EPINTSMRY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_EPINTSMRY_OFFSET 0x020        /**< \brief (USB_DEVICE_EPINTSMRY offset) DEVICE End Point Interrupt Summary */
+#define USB_DEVICE_EPINTSMRY_RESETVALUE 0x0000ul     /**< \brief (USB_DEVICE_EPINTSMRY reset_value) DEVICE End Point Interrupt Summary */
+
+#define USB_DEVICE_EPINTSMRY_EPINT0_Pos 0            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 0 Interrupt */
+#define USB_DEVICE_EPINTSMRY_EPINT0 (1 << USB_DEVICE_EPINTSMRY_EPINT0_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT1_Pos 1            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 1 Interrupt */
+#define USB_DEVICE_EPINTSMRY_EPINT1 (1 << USB_DEVICE_EPINTSMRY_EPINT1_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT2_Pos 2            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 2 Interrupt */
+#define USB_DEVICE_EPINTSMRY_EPINT2 (1 << USB_DEVICE_EPINTSMRY_EPINT2_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT3_Pos 3            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 3 Interrupt */
+#define USB_DEVICE_EPINTSMRY_EPINT3 (1 << USB_DEVICE_EPINTSMRY_EPINT3_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT4_Pos 4            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 4 Interrupt */
+#define USB_DEVICE_EPINTSMRY_EPINT4 (1 << USB_DEVICE_EPINTSMRY_EPINT4_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT5_Pos 5            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 5 Interrupt */
+#define USB_DEVICE_EPINTSMRY_EPINT5 (1 << USB_DEVICE_EPINTSMRY_EPINT5_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT6_Pos 6            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 6 Interrupt */
+#define USB_DEVICE_EPINTSMRY_EPINT6 (1 << USB_DEVICE_EPINTSMRY_EPINT6_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT7_Pos 7            /**< \brief (USB_DEVICE_EPINTSMRY) End Point 7 Interrupt */
+#define USB_DEVICE_EPINTSMRY_EPINT7 (1 << USB_DEVICE_EPINTSMRY_EPINT7_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT_Pos 0            /**< \brief (USB_DEVICE_EPINTSMRY) End Point x Interrupt */
+#define USB_DEVICE_EPINTSMRY_EPINT_Msk (0xFFul << USB_DEVICE_EPINTSMRY_EPINT_Pos)
+#define USB_DEVICE_EPINTSMRY_EPINT(value) (USB_DEVICE_EPINTSMRY_EPINT_Msk & ((value) << USB_DEVICE_EPINTSMRY_EPINT_Pos))
+#define USB_DEVICE_EPINTSMRY_MASK   0x00FFul     /**< \brief (USB_DEVICE_EPINTSMRY) MASK Register */
+
+/* -------- USB_HOST_PINTSMRY : (USB Offset: 0x020) (R/  16) HOST HOST Pipe Interrupt Summary -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t EPINT0:1;         /*!< bit:      0  Pipe 0 Interrupt                   */
+    uint16_t EPINT1:1;         /*!< bit:      1  Pipe 1 Interrupt                   */
+    uint16_t EPINT2:1;         /*!< bit:      2  Pipe 2 Interrupt                   */
+    uint16_t EPINT3:1;         /*!< bit:      3  Pipe 3 Interrupt                   */
+    uint16_t EPINT4:1;         /*!< bit:      4  Pipe 4 Interrupt                   */
+    uint16_t EPINT5:1;         /*!< bit:      5  Pipe 5 Interrupt                   */
+    uint16_t EPINT6:1;         /*!< bit:      6  Pipe 6 Interrupt                   */
+    uint16_t EPINT7:1;         /*!< bit:      7  Pipe 7 Interrupt                   */
+    uint16_t :8;               /*!< bit:  8..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t EPINT:8;          /*!< bit:  0.. 7  Pipe x Interrupt                   */
+    uint16_t :8;               /*!< bit:  8..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_HOST_PINTSMRY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_PINTSMRY_OFFSET    0x020        /**< \brief (USB_HOST_PINTSMRY offset) HOST Pipe Interrupt Summary */
+#define USB_HOST_PINTSMRY_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_PINTSMRY reset_value) HOST Pipe Interrupt Summary */
+
+#define USB_HOST_PINTSMRY_EPINT0_Pos 0            /**< \brief (USB_HOST_PINTSMRY) Pipe 0 Interrupt */
+#define USB_HOST_PINTSMRY_EPINT0    (1 << USB_HOST_PINTSMRY_EPINT0_Pos)
+#define USB_HOST_PINTSMRY_EPINT1_Pos 1            /**< \brief (USB_HOST_PINTSMRY) Pipe 1 Interrupt */
+#define USB_HOST_PINTSMRY_EPINT1    (1 << USB_HOST_PINTSMRY_EPINT1_Pos)
+#define USB_HOST_PINTSMRY_EPINT2_Pos 2            /**< \brief (USB_HOST_PINTSMRY) Pipe 2 Interrupt */
+#define USB_HOST_PINTSMRY_EPINT2    (1 << USB_HOST_PINTSMRY_EPINT2_Pos)
+#define USB_HOST_PINTSMRY_EPINT3_Pos 3            /**< \brief (USB_HOST_PINTSMRY) Pipe 3 Interrupt */
+#define USB_HOST_PINTSMRY_EPINT3    (1 << USB_HOST_PINTSMRY_EPINT3_Pos)
+#define USB_HOST_PINTSMRY_EPINT4_Pos 4            /**< \brief (USB_HOST_PINTSMRY) Pipe 4 Interrupt */
+#define USB_HOST_PINTSMRY_EPINT4    (1 << USB_HOST_PINTSMRY_EPINT4_Pos)
+#define USB_HOST_PINTSMRY_EPINT5_Pos 5            /**< \brief (USB_HOST_PINTSMRY) Pipe 5 Interrupt */
+#define USB_HOST_PINTSMRY_EPINT5    (1 << USB_HOST_PINTSMRY_EPINT5_Pos)
+#define USB_HOST_PINTSMRY_EPINT6_Pos 6            /**< \brief (USB_HOST_PINTSMRY) Pipe 6 Interrupt */
+#define USB_HOST_PINTSMRY_EPINT6    (1 << USB_HOST_PINTSMRY_EPINT6_Pos)
+#define USB_HOST_PINTSMRY_EPINT7_Pos 7            /**< \brief (USB_HOST_PINTSMRY) Pipe 7 Interrupt */
+#define USB_HOST_PINTSMRY_EPINT7    (1 << USB_HOST_PINTSMRY_EPINT7_Pos)
+#define USB_HOST_PINTSMRY_EPINT_Pos 0            /**< \brief (USB_HOST_PINTSMRY) Pipe x Interrupt */
+#define USB_HOST_PINTSMRY_EPINT_Msk (0xFFul << USB_HOST_PINTSMRY_EPINT_Pos)
+#define USB_HOST_PINTSMRY_EPINT(value) (USB_HOST_PINTSMRY_EPINT_Msk & ((value) << USB_HOST_PINTSMRY_EPINT_Pos))
+#define USB_HOST_PINTSMRY_MASK      0x00FFul     /**< \brief (USB_HOST_PINTSMRY) MASK Register */
+
+/* -------- USB_DESCADD : (USB Offset: 0x024) (R/W 32) Descriptor Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DESCADD:32;       /*!< bit:  0..31  Descriptor Address Value           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USB_DESCADD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DESCADD_OFFSET          0x024        /**< \brief (USB_DESCADD offset) Descriptor Address */
+#define USB_DESCADD_RESETVALUE      0x00000000ul /**< \brief (USB_DESCADD reset_value) Descriptor Address */
+
+#define USB_DESCADD_DESCADD_Pos     0            /**< \brief (USB_DESCADD) Descriptor Address Value */
+#define USB_DESCADD_DESCADD_Msk     (0xFFFFFFFFul << USB_DESCADD_DESCADD_Pos)
+#define USB_DESCADD_DESCADD(value)  (USB_DESCADD_DESCADD_Msk & ((value) << USB_DESCADD_DESCADD_Pos))
+#define USB_DESCADD_MASK            0xFFFFFFFFul /**< \brief (USB_DESCADD) MASK Register */
+
+/* -------- USB_PADCAL : (USB Offset: 0x028) (R/W 16) USB PAD Calibration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t TRANSP:5;         /*!< bit:  0.. 4  USB Pad Transp calibration         */
+    uint16_t :1;               /*!< bit:      5  Reserved                           */
+    uint16_t TRANSN:5;         /*!< bit:  6..10  USB Pad Transn calibration         */
+    uint16_t :1;               /*!< bit:     11  Reserved                           */
+    uint16_t TRIM:3;           /*!< bit: 12..14  USB Pad Trim calibration           */
+    uint16_t :1;               /*!< bit:     15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_PADCAL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_PADCAL_OFFSET           0x028        /**< \brief (USB_PADCAL offset) USB PAD Calibration */
+#define USB_PADCAL_RESETVALUE       0x0000ul     /**< \brief (USB_PADCAL reset_value) USB PAD Calibration */
+
+#define USB_PADCAL_TRANSP_Pos       0            /**< \brief (USB_PADCAL) USB Pad Transp calibration */
+#define USB_PADCAL_TRANSP_Msk       (0x1Ful << USB_PADCAL_TRANSP_Pos)
+#define USB_PADCAL_TRANSP(value)    (USB_PADCAL_TRANSP_Msk & ((value) << USB_PADCAL_TRANSP_Pos))
+#define USB_PADCAL_TRANSN_Pos       6            /**< \brief (USB_PADCAL) USB Pad Transn calibration */
+#define USB_PADCAL_TRANSN_Msk       (0x1Ful << USB_PADCAL_TRANSN_Pos)
+#define USB_PADCAL_TRANSN(value)    (USB_PADCAL_TRANSN_Msk & ((value) << USB_PADCAL_TRANSN_Pos))
+#define USB_PADCAL_TRIM_Pos         12           /**< \brief (USB_PADCAL) USB Pad Trim calibration */
+#define USB_PADCAL_TRIM_Msk         (0x7ul << USB_PADCAL_TRIM_Pos)
+#define USB_PADCAL_TRIM(value)      (USB_PADCAL_TRIM_Msk & ((value) << USB_PADCAL_TRIM_Pos))
+#define USB_PADCAL_MASK             0x77DFul     /**< \brief (USB_PADCAL) MASK Register */
+
+/* -------- USB_DEVICE_EPCFG : (USB Offset: 0x100) (R/W  8) DEVICE DEVICE_ENDPOINT End Point Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EPTYPE0:3;        /*!< bit:  0.. 2  End Point Type0                    */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  EPTYPE1:3;        /*!< bit:  4.. 6  End Point Type1                    */
+    uint8_t  NYETDIS:1;        /*!< bit:      7  NYET Token Disable                 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_EPCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_EPCFG_OFFSET     0x100        /**< \brief (USB_DEVICE_EPCFG offset) DEVICE_ENDPOINT End Point Configuration */
+#define USB_DEVICE_EPCFG_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPCFG reset_value) DEVICE_ENDPOINT End Point Configuration */
+
+#define USB_DEVICE_EPCFG_EPTYPE0_Pos 0            /**< \brief (USB_DEVICE_EPCFG) End Point Type0 */
+#define USB_DEVICE_EPCFG_EPTYPE0_Msk (0x7ul << USB_DEVICE_EPCFG_EPTYPE0_Pos)
+#define USB_DEVICE_EPCFG_EPTYPE0(value) (USB_DEVICE_EPCFG_EPTYPE0_Msk & ((value) << USB_DEVICE_EPCFG_EPTYPE0_Pos))
+#define USB_DEVICE_EPCFG_EPTYPE1_Pos 4            /**< \brief (USB_DEVICE_EPCFG) End Point Type1 */
+#define USB_DEVICE_EPCFG_EPTYPE1_Msk (0x7ul << USB_DEVICE_EPCFG_EPTYPE1_Pos)
+#define USB_DEVICE_EPCFG_EPTYPE1(value) (USB_DEVICE_EPCFG_EPTYPE1_Msk & ((value) << USB_DEVICE_EPCFG_EPTYPE1_Pos))
+#define USB_DEVICE_EPCFG_NYETDIS_Pos 7            /**< \brief (USB_DEVICE_EPCFG) NYET Token Disable */
+#define USB_DEVICE_EPCFG_NYETDIS    (0x1ul << USB_DEVICE_EPCFG_NYETDIS_Pos)
+#define USB_DEVICE_EPCFG_MASK       0xF7ul       /**< \brief (USB_DEVICE_EPCFG) MASK Register */
+
+/* -------- USB_HOST_PCFG : (USB Offset: 0x100) (R/W  8) HOST HOST_PIPE End Point Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PTOKEN:2;         /*!< bit:  0.. 1  Pipe Token                         */
+    uint8_t  BK:1;             /*!< bit:      2  Pipe Bank                          */
+    uint8_t  PTYPE:3;          /*!< bit:  3.. 5  Pipe Type                          */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_PCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_PCFG_OFFSET        0x100        /**< \brief (USB_HOST_PCFG offset) HOST_PIPE End Point Configuration */
+#define USB_HOST_PCFG_RESETVALUE    0x00ul       /**< \brief (USB_HOST_PCFG reset_value) HOST_PIPE End Point Configuration */
+
+#define USB_HOST_PCFG_PTOKEN_Pos    0            /**< \brief (USB_HOST_PCFG) Pipe Token */
+#define USB_HOST_PCFG_PTOKEN_Msk    (0x3ul << USB_HOST_PCFG_PTOKEN_Pos)
+#define USB_HOST_PCFG_PTOKEN(value) (USB_HOST_PCFG_PTOKEN_Msk & ((value) << USB_HOST_PCFG_PTOKEN_Pos))
+#define USB_HOST_PCFG_BK_Pos        2            /**< \brief (USB_HOST_PCFG) Pipe Bank */
+#define USB_HOST_PCFG_BK            (0x1ul << USB_HOST_PCFG_BK_Pos)
+#define USB_HOST_PCFG_PTYPE_Pos     3            /**< \brief (USB_HOST_PCFG) Pipe Type */
+#define USB_HOST_PCFG_PTYPE_Msk     (0x7ul << USB_HOST_PCFG_PTYPE_Pos)
+#define USB_HOST_PCFG_PTYPE(value)  (USB_HOST_PCFG_PTYPE_Msk & ((value) << USB_HOST_PCFG_PTYPE_Pos))
+#define USB_HOST_PCFG_MASK          0x3Ful       /**< \brief (USB_HOST_PCFG) MASK Register */
+
+/* -------- USB_HOST_BINTERVAL : (USB Offset: 0x103) (R/W  8) HOST HOST_PIPE Bus Access Period of Pipe -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  BITINTERVAL:8;    /*!< bit:  0.. 7  Bit Interval                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_BINTERVAL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_BINTERVAL_OFFSET   0x103        /**< \brief (USB_HOST_BINTERVAL offset) HOST_PIPE Bus Access Period of Pipe */
+#define USB_HOST_BINTERVAL_RESETVALUE 0x00ul       /**< \brief (USB_HOST_BINTERVAL reset_value) HOST_PIPE Bus Access Period of Pipe */
+
+#define USB_HOST_BINTERVAL_BITINTERVAL_Pos 0            /**< \brief (USB_HOST_BINTERVAL) Bit Interval */
+#define USB_HOST_BINTERVAL_BITINTERVAL_Msk (0xFFul << USB_HOST_BINTERVAL_BITINTERVAL_Pos)
+#define USB_HOST_BINTERVAL_BITINTERVAL(value) (USB_HOST_BINTERVAL_BITINTERVAL_Msk & ((value) << USB_HOST_BINTERVAL_BITINTERVAL_Pos))
+#define USB_HOST_BINTERVAL_MASK     0xFFul       /**< \brief (USB_HOST_BINTERVAL) MASK Register */
+
+/* -------- USB_DEVICE_EPSTATUSCLR : (USB Offset: 0x104) ( /W  8) DEVICE DEVICE_ENDPOINT End Point Pipe Status Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DTGLOUT:1;        /*!< bit:      0  Data Toggle OUT Clear              */
+    uint8_t  DTGLIN:1;         /*!< bit:      1  Data Toggle IN Clear               */
+    uint8_t  CURBK:1;          /*!< bit:      2  Current Bank Clear                 */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  STALLRQ0:1;       /*!< bit:      4  Stall 0 Request Clear              */
+    uint8_t  STALLRQ1:1;       /*!< bit:      5  Stall 1 Request Clear              */
+    uint8_t  BK0RDY:1;         /*!< bit:      6  Bank 0 Ready Clear                 */
+    uint8_t  BK1RDY:1;         /*!< bit:      7  Bank 1 Ready Clear                 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  STALLRQ:2;        /*!< bit:  4.. 5  Stall x Request Clear              */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_EPSTATUSCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_EPSTATUSCLR_OFFSET 0x104        /**< \brief (USB_DEVICE_EPSTATUSCLR offset) DEVICE_ENDPOINT End Point Pipe Status Clear */
+#define USB_DEVICE_EPSTATUSCLR_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPSTATUSCLR reset_value) DEVICE_ENDPOINT End Point Pipe Status Clear */
+
+#define USB_DEVICE_EPSTATUSCLR_DTGLOUT_Pos 0            /**< \brief (USB_DEVICE_EPSTATUSCLR) Data Toggle OUT Clear */
+#define USB_DEVICE_EPSTATUSCLR_DTGLOUT (0x1ul << USB_DEVICE_EPSTATUSCLR_DTGLOUT_Pos)
+#define USB_DEVICE_EPSTATUSCLR_DTGLIN_Pos 1            /**< \brief (USB_DEVICE_EPSTATUSCLR) Data Toggle IN Clear */
+#define USB_DEVICE_EPSTATUSCLR_DTGLIN (0x1ul << USB_DEVICE_EPSTATUSCLR_DTGLIN_Pos)
+#define USB_DEVICE_EPSTATUSCLR_CURBK_Pos 2            /**< \brief (USB_DEVICE_EPSTATUSCLR) Current Bank Clear */
+#define USB_DEVICE_EPSTATUSCLR_CURBK (0x1ul << USB_DEVICE_EPSTATUSCLR_CURBK_Pos)
+#define USB_DEVICE_EPSTATUSCLR_STALLRQ0_Pos 4            /**< \brief (USB_DEVICE_EPSTATUSCLR) Stall 0 Request Clear */
+#define USB_DEVICE_EPSTATUSCLR_STALLRQ0 (1 << USB_DEVICE_EPSTATUSCLR_STALLRQ0_Pos)
+#define USB_DEVICE_EPSTATUSCLR_STALLRQ1_Pos 5            /**< \brief (USB_DEVICE_EPSTATUSCLR) Stall 1 Request Clear */
+#define USB_DEVICE_EPSTATUSCLR_STALLRQ1 (1 << USB_DEVICE_EPSTATUSCLR_STALLRQ1_Pos)
+#define USB_DEVICE_EPSTATUSCLR_STALLRQ_Pos 4            /**< \brief (USB_DEVICE_EPSTATUSCLR) Stall x Request Clear */
+#define USB_DEVICE_EPSTATUSCLR_STALLRQ_Msk (0x3ul << USB_DEVICE_EPSTATUSCLR_STALLRQ_Pos)
+#define USB_DEVICE_EPSTATUSCLR_STALLRQ(value) (USB_DEVICE_EPSTATUSCLR_STALLRQ_Msk & ((value) << USB_DEVICE_EPSTATUSCLR_STALLRQ_Pos))
+#define USB_DEVICE_EPSTATUSCLR_BK0RDY_Pos 6            /**< \brief (USB_DEVICE_EPSTATUSCLR) Bank 0 Ready Clear */
+#define USB_DEVICE_EPSTATUSCLR_BK0RDY (0x1ul << USB_DEVICE_EPSTATUSCLR_BK0RDY_Pos)
+#define USB_DEVICE_EPSTATUSCLR_BK1RDY_Pos 7            /**< \brief (USB_DEVICE_EPSTATUSCLR) Bank 1 Ready Clear */
+#define USB_DEVICE_EPSTATUSCLR_BK1RDY (0x1ul << USB_DEVICE_EPSTATUSCLR_BK1RDY_Pos)
+#define USB_DEVICE_EPSTATUSCLR_MASK 0xF7ul       /**< \brief (USB_DEVICE_EPSTATUSCLR) MASK Register */
+
+/* -------- USB_HOST_PSTATUSCLR : (USB Offset: 0x104) ( /W  8) HOST HOST_PIPE End Point Pipe Status Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DTGL:1;           /*!< bit:      0  Data Toggle clear                  */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  CURBK:1;          /*!< bit:      2  Curren Bank clear                  */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  PFREEZE:1;        /*!< bit:      4  Pipe Freeze Clear                  */
+    uint8_t  :1;               /*!< bit:      5  Reserved                           */
+    uint8_t  BK0RDY:1;         /*!< bit:      6  Bank 0 Ready Clear                 */
+    uint8_t  BK1RDY:1;         /*!< bit:      7  Bank 1 Ready Clear                 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_PSTATUSCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_PSTATUSCLR_OFFSET  0x104        /**< \brief (USB_HOST_PSTATUSCLR offset) HOST_PIPE End Point Pipe Status Clear */
+#define USB_HOST_PSTATUSCLR_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PSTATUSCLR reset_value) HOST_PIPE End Point Pipe Status Clear */
+
+#define USB_HOST_PSTATUSCLR_DTGL_Pos 0            /**< \brief (USB_HOST_PSTATUSCLR) Data Toggle clear */
+#define USB_HOST_PSTATUSCLR_DTGL    (0x1ul << USB_HOST_PSTATUSCLR_DTGL_Pos)
+#define USB_HOST_PSTATUSCLR_CURBK_Pos 2            /**< \brief (USB_HOST_PSTATUSCLR) Curren Bank clear */
+#define USB_HOST_PSTATUSCLR_CURBK   (0x1ul << USB_HOST_PSTATUSCLR_CURBK_Pos)
+#define USB_HOST_PSTATUSCLR_PFREEZE_Pos 4            /**< \brief (USB_HOST_PSTATUSCLR) Pipe Freeze Clear */
+#define USB_HOST_PSTATUSCLR_PFREEZE (0x1ul << USB_HOST_PSTATUSCLR_PFREEZE_Pos)
+#define USB_HOST_PSTATUSCLR_BK0RDY_Pos 6            /**< \brief (USB_HOST_PSTATUSCLR) Bank 0 Ready Clear */
+#define USB_HOST_PSTATUSCLR_BK0RDY  (0x1ul << USB_HOST_PSTATUSCLR_BK0RDY_Pos)
+#define USB_HOST_PSTATUSCLR_BK1RDY_Pos 7            /**< \brief (USB_HOST_PSTATUSCLR) Bank 1 Ready Clear */
+#define USB_HOST_PSTATUSCLR_BK1RDY  (0x1ul << USB_HOST_PSTATUSCLR_BK1RDY_Pos)
+#define USB_HOST_PSTATUSCLR_MASK    0xD5ul       /**< \brief (USB_HOST_PSTATUSCLR) MASK Register */
+
+/* -------- USB_DEVICE_EPSTATUSSET : (USB Offset: 0x105) ( /W  8) DEVICE DEVICE_ENDPOINT End Point Pipe Status Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DTGLOUT:1;        /*!< bit:      0  Data Toggle OUT Set                */
+    uint8_t  DTGLIN:1;         /*!< bit:      1  Data Toggle IN Set                 */
+    uint8_t  CURBK:1;          /*!< bit:      2  Current Bank Set                   */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  STALLRQ0:1;       /*!< bit:      4  Stall 0 Request Set                */
+    uint8_t  STALLRQ1:1;       /*!< bit:      5  Stall 1 Request Set                */
+    uint8_t  BK0RDY:1;         /*!< bit:      6  Bank 0 Ready Set                   */
+    uint8_t  BK1RDY:1;         /*!< bit:      7  Bank 1 Ready Set                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  STALLRQ:2;        /*!< bit:  4.. 5  Stall x Request Set                */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_EPSTATUSSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_EPSTATUSSET_OFFSET 0x105        /**< \brief (USB_DEVICE_EPSTATUSSET offset) DEVICE_ENDPOINT End Point Pipe Status Set */
+#define USB_DEVICE_EPSTATUSSET_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPSTATUSSET reset_value) DEVICE_ENDPOINT End Point Pipe Status Set */
+
+#define USB_DEVICE_EPSTATUSSET_DTGLOUT_Pos 0            /**< \brief (USB_DEVICE_EPSTATUSSET) Data Toggle OUT Set */
+#define USB_DEVICE_EPSTATUSSET_DTGLOUT (0x1ul << USB_DEVICE_EPSTATUSSET_DTGLOUT_Pos)
+#define USB_DEVICE_EPSTATUSSET_DTGLIN_Pos 1            /**< \brief (USB_DEVICE_EPSTATUSSET) Data Toggle IN Set */
+#define USB_DEVICE_EPSTATUSSET_DTGLIN (0x1ul << USB_DEVICE_EPSTATUSSET_DTGLIN_Pos)
+#define USB_DEVICE_EPSTATUSSET_CURBK_Pos 2            /**< \brief (USB_DEVICE_EPSTATUSSET) Current Bank Set */
+#define USB_DEVICE_EPSTATUSSET_CURBK (0x1ul << USB_DEVICE_EPSTATUSSET_CURBK_Pos)
+#define USB_DEVICE_EPSTATUSSET_STALLRQ0_Pos 4            /**< \brief (USB_DEVICE_EPSTATUSSET) Stall 0 Request Set */
+#define USB_DEVICE_EPSTATUSSET_STALLRQ0 (1 << USB_DEVICE_EPSTATUSSET_STALLRQ0_Pos)
+#define USB_DEVICE_EPSTATUSSET_STALLRQ1_Pos 5            /**< \brief (USB_DEVICE_EPSTATUSSET) Stall 1 Request Set */
+#define USB_DEVICE_EPSTATUSSET_STALLRQ1 (1 << USB_DEVICE_EPSTATUSSET_STALLRQ1_Pos)
+#define USB_DEVICE_EPSTATUSSET_STALLRQ_Pos 4            /**< \brief (USB_DEVICE_EPSTATUSSET) Stall x Request Set */
+#define USB_DEVICE_EPSTATUSSET_STALLRQ_Msk (0x3ul << USB_DEVICE_EPSTATUSSET_STALLRQ_Pos)
+#define USB_DEVICE_EPSTATUSSET_STALLRQ(value) (USB_DEVICE_EPSTATUSSET_STALLRQ_Msk & ((value) << USB_DEVICE_EPSTATUSSET_STALLRQ_Pos))
+#define USB_DEVICE_EPSTATUSSET_BK0RDY_Pos 6            /**< \brief (USB_DEVICE_EPSTATUSSET) Bank 0 Ready Set */
+#define USB_DEVICE_EPSTATUSSET_BK0RDY (0x1ul << USB_DEVICE_EPSTATUSSET_BK0RDY_Pos)
+#define USB_DEVICE_EPSTATUSSET_BK1RDY_Pos 7            /**< \brief (USB_DEVICE_EPSTATUSSET) Bank 1 Ready Set */
+#define USB_DEVICE_EPSTATUSSET_BK1RDY (0x1ul << USB_DEVICE_EPSTATUSSET_BK1RDY_Pos)
+#define USB_DEVICE_EPSTATUSSET_MASK 0xF7ul       /**< \brief (USB_DEVICE_EPSTATUSSET) MASK Register */
+
+/* -------- USB_HOST_PSTATUSSET : (USB Offset: 0x105) ( /W  8) HOST HOST_PIPE End Point Pipe Status Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DTGL:1;           /*!< bit:      0  Data Toggle Set                    */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  CURBK:1;          /*!< bit:      2  Current Bank Set                   */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  PFREEZE:1;        /*!< bit:      4  Pipe Freeze Set                    */
+    uint8_t  :1;               /*!< bit:      5  Reserved                           */
+    uint8_t  BK0RDY:1;         /*!< bit:      6  Bank 0 Ready Set                   */
+    uint8_t  BK1RDY:1;         /*!< bit:      7  Bank 1 Ready Set                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_PSTATUSSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_PSTATUSSET_OFFSET  0x105        /**< \brief (USB_HOST_PSTATUSSET offset) HOST_PIPE End Point Pipe Status Set */
+#define USB_HOST_PSTATUSSET_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PSTATUSSET reset_value) HOST_PIPE End Point Pipe Status Set */
+
+#define USB_HOST_PSTATUSSET_DTGL_Pos 0            /**< \brief (USB_HOST_PSTATUSSET) Data Toggle Set */
+#define USB_HOST_PSTATUSSET_DTGL    (0x1ul << USB_HOST_PSTATUSSET_DTGL_Pos)
+#define USB_HOST_PSTATUSSET_CURBK_Pos 2            /**< \brief (USB_HOST_PSTATUSSET) Current Bank Set */
+#define USB_HOST_PSTATUSSET_CURBK   (0x1ul << USB_HOST_PSTATUSSET_CURBK_Pos)
+#define USB_HOST_PSTATUSSET_PFREEZE_Pos 4            /**< \brief (USB_HOST_PSTATUSSET) Pipe Freeze Set */
+#define USB_HOST_PSTATUSSET_PFREEZE (0x1ul << USB_HOST_PSTATUSSET_PFREEZE_Pos)
+#define USB_HOST_PSTATUSSET_BK0RDY_Pos 6            /**< \brief (USB_HOST_PSTATUSSET) Bank 0 Ready Set */
+#define USB_HOST_PSTATUSSET_BK0RDY  (0x1ul << USB_HOST_PSTATUSSET_BK0RDY_Pos)
+#define USB_HOST_PSTATUSSET_BK1RDY_Pos 7            /**< \brief (USB_HOST_PSTATUSSET) Bank 1 Ready Set */
+#define USB_HOST_PSTATUSSET_BK1RDY  (0x1ul << USB_HOST_PSTATUSSET_BK1RDY_Pos)
+#define USB_HOST_PSTATUSSET_MASK    0xD5ul       /**< \brief (USB_HOST_PSTATUSSET) MASK Register */
+
+/* -------- USB_DEVICE_EPSTATUS : (USB Offset: 0x106) (R/   8) DEVICE DEVICE_ENDPOINT End Point Pipe Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DTGLOUT:1;        /*!< bit:      0  Data Toggle Out                    */
+    uint8_t  DTGLIN:1;         /*!< bit:      1  Data Toggle In                     */
+    uint8_t  CURBK:1;          /*!< bit:      2  Current Bank                       */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  STALLRQ0:1;       /*!< bit:      4  Stall 0 Request                    */
+    uint8_t  STALLRQ1:1;       /*!< bit:      5  Stall 1 Request                    */
+    uint8_t  BK0RDY:1;         /*!< bit:      6  Bank 0 ready                       */
+    uint8_t  BK1RDY:1;         /*!< bit:      7  Bank 1 ready                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  STALLRQ:2;        /*!< bit:  4.. 5  Stall x Request                    */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_EPSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_EPSTATUS_OFFSET  0x106        /**< \brief (USB_DEVICE_EPSTATUS offset) DEVICE_ENDPOINT End Point Pipe Status */
+#define USB_DEVICE_EPSTATUS_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPSTATUS reset_value) DEVICE_ENDPOINT End Point Pipe Status */
+
+#define USB_DEVICE_EPSTATUS_DTGLOUT_Pos 0            /**< \brief (USB_DEVICE_EPSTATUS) Data Toggle Out */
+#define USB_DEVICE_EPSTATUS_DTGLOUT (0x1ul << USB_DEVICE_EPSTATUS_DTGLOUT_Pos)
+#define USB_DEVICE_EPSTATUS_DTGLIN_Pos 1            /**< \brief (USB_DEVICE_EPSTATUS) Data Toggle In */
+#define USB_DEVICE_EPSTATUS_DTGLIN  (0x1ul << USB_DEVICE_EPSTATUS_DTGLIN_Pos)
+#define USB_DEVICE_EPSTATUS_CURBK_Pos 2            /**< \brief (USB_DEVICE_EPSTATUS) Current Bank */
+#define USB_DEVICE_EPSTATUS_CURBK   (0x1ul << USB_DEVICE_EPSTATUS_CURBK_Pos)
+#define USB_DEVICE_EPSTATUS_STALLRQ0_Pos 4            /**< \brief (USB_DEVICE_EPSTATUS) Stall 0 Request */
+#define USB_DEVICE_EPSTATUS_STALLRQ0 (1 << USB_DEVICE_EPSTATUS_STALLRQ0_Pos)
+#define USB_DEVICE_EPSTATUS_STALLRQ1_Pos 5            /**< \brief (USB_DEVICE_EPSTATUS) Stall 1 Request */
+#define USB_DEVICE_EPSTATUS_STALLRQ1 (1 << USB_DEVICE_EPSTATUS_STALLRQ1_Pos)
+#define USB_DEVICE_EPSTATUS_STALLRQ_Pos 4            /**< \brief (USB_DEVICE_EPSTATUS) Stall x Request */
+#define USB_DEVICE_EPSTATUS_STALLRQ_Msk (0x3ul << USB_DEVICE_EPSTATUS_STALLRQ_Pos)
+#define USB_DEVICE_EPSTATUS_STALLRQ(value) (USB_DEVICE_EPSTATUS_STALLRQ_Msk & ((value) << USB_DEVICE_EPSTATUS_STALLRQ_Pos))
+#define USB_DEVICE_EPSTATUS_BK0RDY_Pos 6            /**< \brief (USB_DEVICE_EPSTATUS) Bank 0 ready */
+#define USB_DEVICE_EPSTATUS_BK0RDY  (0x1ul << USB_DEVICE_EPSTATUS_BK0RDY_Pos)
+#define USB_DEVICE_EPSTATUS_BK1RDY_Pos 7            /**< \brief (USB_DEVICE_EPSTATUS) Bank 1 ready */
+#define USB_DEVICE_EPSTATUS_BK1RDY  (0x1ul << USB_DEVICE_EPSTATUS_BK1RDY_Pos)
+#define USB_DEVICE_EPSTATUS_MASK    0xF7ul       /**< \brief (USB_DEVICE_EPSTATUS) MASK Register */
+
+/* -------- USB_HOST_PSTATUS : (USB Offset: 0x106) (R/   8) HOST HOST_PIPE End Point Pipe Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DTGL:1;           /*!< bit:      0  Data Toggle                        */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  CURBK:1;          /*!< bit:      2  Current Bank                       */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  PFREEZE:1;        /*!< bit:      4  Pipe Freeze                        */
+    uint8_t  :1;               /*!< bit:      5  Reserved                           */
+    uint8_t  BK0RDY:1;         /*!< bit:      6  Bank 0 ready                       */
+    uint8_t  BK1RDY:1;         /*!< bit:      7  Bank 1 ready                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_PSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_PSTATUS_OFFSET     0x106        /**< \brief (USB_HOST_PSTATUS offset) HOST_PIPE End Point Pipe Status */
+#define USB_HOST_PSTATUS_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PSTATUS reset_value) HOST_PIPE End Point Pipe Status */
+
+#define USB_HOST_PSTATUS_DTGL_Pos   0            /**< \brief (USB_HOST_PSTATUS) Data Toggle */
+#define USB_HOST_PSTATUS_DTGL       (0x1ul << USB_HOST_PSTATUS_DTGL_Pos)
+#define USB_HOST_PSTATUS_CURBK_Pos  2            /**< \brief (USB_HOST_PSTATUS) Current Bank */
+#define USB_HOST_PSTATUS_CURBK      (0x1ul << USB_HOST_PSTATUS_CURBK_Pos)
+#define USB_HOST_PSTATUS_PFREEZE_Pos 4            /**< \brief (USB_HOST_PSTATUS) Pipe Freeze */
+#define USB_HOST_PSTATUS_PFREEZE    (0x1ul << USB_HOST_PSTATUS_PFREEZE_Pos)
+#define USB_HOST_PSTATUS_BK0RDY_Pos 6            /**< \brief (USB_HOST_PSTATUS) Bank 0 ready */
+#define USB_HOST_PSTATUS_BK0RDY     (0x1ul << USB_HOST_PSTATUS_BK0RDY_Pos)
+#define USB_HOST_PSTATUS_BK1RDY_Pos 7            /**< \brief (USB_HOST_PSTATUS) Bank 1 ready */
+#define USB_HOST_PSTATUS_BK1RDY     (0x1ul << USB_HOST_PSTATUS_BK1RDY_Pos)
+#define USB_HOST_PSTATUS_MASK       0xD5ul       /**< \brief (USB_HOST_PSTATUS) MASK Register */
+
+/* -------- USB_DEVICE_EPINTFLAG : (USB Offset: 0x107) (R/W  8) DEVICE DEVICE_ENDPOINT End Point Interrupt Flag -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  TRCPT0:1;         /*!< bit:      0  Transfer Complete 0                */
+    __I uint8_t  TRCPT1:1;         /*!< bit:      1  Transfer Complete 1                */
+    __I uint8_t  TRFAIL0:1;        /*!< bit:      2  Error Flow 0                       */
+    __I uint8_t  TRFAIL1:1;        /*!< bit:      3  Error Flow 1                       */
+    __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
+    __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
+    __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
+    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
+    __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
+    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
+    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_EPINTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_EPINTFLAG_OFFSET 0x107        /**< \brief (USB_DEVICE_EPINTFLAG offset) DEVICE_ENDPOINT End Point Interrupt Flag */
+#define USB_DEVICE_EPINTFLAG_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPINTFLAG reset_value) DEVICE_ENDPOINT End Point Interrupt Flag */
+
+#define USB_DEVICE_EPINTFLAG_TRCPT0_Pos 0            /**< \brief (USB_DEVICE_EPINTFLAG) Transfer Complete 0 */
+#define USB_DEVICE_EPINTFLAG_TRCPT0 (1 << USB_DEVICE_EPINTFLAG_TRCPT0_Pos)
+#define USB_DEVICE_EPINTFLAG_TRCPT1_Pos 1            /**< \brief (USB_DEVICE_EPINTFLAG) Transfer Complete 1 */
+#define USB_DEVICE_EPINTFLAG_TRCPT1 (1 << USB_DEVICE_EPINTFLAG_TRCPT1_Pos)
+#define USB_DEVICE_EPINTFLAG_TRCPT_Pos 0            /**< \brief (USB_DEVICE_EPINTFLAG) Transfer Complete x */
+#define USB_DEVICE_EPINTFLAG_TRCPT_Msk (0x3ul << USB_DEVICE_EPINTFLAG_TRCPT_Pos)
+#define USB_DEVICE_EPINTFLAG_TRCPT(value) (USB_DEVICE_EPINTFLAG_TRCPT_Msk & ((value) << USB_DEVICE_EPINTFLAG_TRCPT_Pos))
+#define USB_DEVICE_EPINTFLAG_TRFAIL0_Pos 2            /**< \brief (USB_DEVICE_EPINTFLAG) Error Flow 0 */
+#define USB_DEVICE_EPINTFLAG_TRFAIL0 (1 << USB_DEVICE_EPINTFLAG_TRFAIL0_Pos)
+#define USB_DEVICE_EPINTFLAG_TRFAIL1_Pos 3            /**< \brief (USB_DEVICE_EPINTFLAG) Error Flow 1 */
+#define USB_DEVICE_EPINTFLAG_TRFAIL1 (1 << USB_DEVICE_EPINTFLAG_TRFAIL1_Pos)
+#define USB_DEVICE_EPINTFLAG_TRFAIL_Pos 2            /**< \brief (USB_DEVICE_EPINTFLAG) Error Flow x */
+#define USB_DEVICE_EPINTFLAG_TRFAIL_Msk (0x3ul << USB_DEVICE_EPINTFLAG_TRFAIL_Pos)
+#define USB_DEVICE_EPINTFLAG_TRFAIL(value) (USB_DEVICE_EPINTFLAG_TRFAIL_Msk & ((value) << USB_DEVICE_EPINTFLAG_TRFAIL_Pos))
+#define USB_DEVICE_EPINTFLAG_RXSTP_Pos 4            /**< \brief (USB_DEVICE_EPINTFLAG) Received Setup */
+#define USB_DEVICE_EPINTFLAG_RXSTP  (0x1ul << USB_DEVICE_EPINTFLAG_RXSTP_Pos)
+#define USB_DEVICE_EPINTFLAG_STALL0_Pos 5            /**< \brief (USB_DEVICE_EPINTFLAG) Stall 0 In/out */
+#define USB_DEVICE_EPINTFLAG_STALL0 (1 << USB_DEVICE_EPINTFLAG_STALL0_Pos)
+#define USB_DEVICE_EPINTFLAG_STALL1_Pos 6            /**< \brief (USB_DEVICE_EPINTFLAG) Stall 1 In/out */
+#define USB_DEVICE_EPINTFLAG_STALL1 (1 << USB_DEVICE_EPINTFLAG_STALL1_Pos)
+#define USB_DEVICE_EPINTFLAG_STALL_Pos 5            /**< \brief (USB_DEVICE_EPINTFLAG) Stall x In/out */
+#define USB_DEVICE_EPINTFLAG_STALL_Msk (0x3ul << USB_DEVICE_EPINTFLAG_STALL_Pos)
+#define USB_DEVICE_EPINTFLAG_STALL(value) (USB_DEVICE_EPINTFLAG_STALL_Msk & ((value) << USB_DEVICE_EPINTFLAG_STALL_Pos))
+#define USB_DEVICE_EPINTFLAG_MASK   0x7Ful       /**< \brief (USB_DEVICE_EPINTFLAG) MASK Register */
+
+/* -------- USB_HOST_PINTFLAG : (USB Offset: 0x107) (R/W  8) HOST HOST_PIPE Pipe Interrupt Flag -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  TRCPT0:1;         /*!< bit:      0  Transfer Complete 0 Interrupt Flag */
+    __I uint8_t  TRCPT1:1;         /*!< bit:      1  Transfer Complete 1 Interrupt Flag */
+    __I uint8_t  TRFAIL:1;         /*!< bit:      2  Error Flow Interrupt Flag          */
+    __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
+    __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit Setup Interrupt Flag      */
+    __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
+    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_PINTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_PINTFLAG_OFFSET    0x107        /**< \brief (USB_HOST_PINTFLAG offset) HOST_PIPE Pipe Interrupt Flag */
+#define USB_HOST_PINTFLAG_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PINTFLAG reset_value) HOST_PIPE Pipe Interrupt Flag */
+
+#define USB_HOST_PINTFLAG_TRCPT0_Pos 0            /**< \brief (USB_HOST_PINTFLAG) Transfer Complete 0 Interrupt Flag */
+#define USB_HOST_PINTFLAG_TRCPT0    (1 << USB_HOST_PINTFLAG_TRCPT0_Pos)
+#define USB_HOST_PINTFLAG_TRCPT1_Pos 1            /**< \brief (USB_HOST_PINTFLAG) Transfer Complete 1 Interrupt Flag */
+#define USB_HOST_PINTFLAG_TRCPT1    (1 << USB_HOST_PINTFLAG_TRCPT1_Pos)
+#define USB_HOST_PINTFLAG_TRCPT_Pos 0            /**< \brief (USB_HOST_PINTFLAG) Transfer Complete x Interrupt Flag */
+#define USB_HOST_PINTFLAG_TRCPT_Msk (0x3ul << USB_HOST_PINTFLAG_TRCPT_Pos)
+#define USB_HOST_PINTFLAG_TRCPT(value) (USB_HOST_PINTFLAG_TRCPT_Msk & ((value) << USB_HOST_PINTFLAG_TRCPT_Pos))
+#define USB_HOST_PINTFLAG_TRFAIL_Pos 2            /**< \brief (USB_HOST_PINTFLAG) Error Flow Interrupt Flag */
+#define USB_HOST_PINTFLAG_TRFAIL    (0x1ul << USB_HOST_PINTFLAG_TRFAIL_Pos)
+#define USB_HOST_PINTFLAG_PERR_Pos  3            /**< \brief (USB_HOST_PINTFLAG) Pipe Error Interrupt Flag */
+#define USB_HOST_PINTFLAG_PERR      (0x1ul << USB_HOST_PINTFLAG_PERR_Pos)
+#define USB_HOST_PINTFLAG_TXSTP_Pos 4            /**< \brief (USB_HOST_PINTFLAG) Transmit Setup Interrupt Flag */
+#define USB_HOST_PINTFLAG_TXSTP     (0x1ul << USB_HOST_PINTFLAG_TXSTP_Pos)
+#define USB_HOST_PINTFLAG_STALL_Pos 5            /**< \brief (USB_HOST_PINTFLAG) Stall Interrupt Flag */
+#define USB_HOST_PINTFLAG_STALL     (0x1ul << USB_HOST_PINTFLAG_STALL_Pos)
+#define USB_HOST_PINTFLAG_MASK      0x3Ful       /**< \brief (USB_HOST_PINTFLAG) MASK Register */
+
+/* -------- USB_DEVICE_EPINTENCLR : (USB Offset: 0x108) (R/W  8) DEVICE DEVICE_ENDPOINT End Point Interrupt Clear Flag -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  TRCPT0:1;         /*!< bit:      0  Transfer Complete 0 Interrupt Disable */
+    uint8_t  TRCPT1:1;         /*!< bit:      1  Transfer Complete 1 Interrupt Disable */
+    uint8_t  TRFAIL0:1;        /*!< bit:      2  Error Flow 0 Interrupt Disable     */
+    uint8_t  TRFAIL1:1;        /*!< bit:      3  Error Flow 1 Interrupt Disable     */
+    uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup Interrupt Disable   */
+    uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/Out Interrupt Disable   */
+    uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/Out Interrupt Disable   */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Disable */
+    uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x Interrupt Disable     */
+    uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/Out Interrupt Disable   */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_EPINTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_EPINTENCLR_OFFSET 0x108        /**< \brief (USB_DEVICE_EPINTENCLR offset) DEVICE_ENDPOINT End Point Interrupt Clear Flag */
+#define USB_DEVICE_EPINTENCLR_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPINTENCLR reset_value) DEVICE_ENDPOINT End Point Interrupt Clear Flag */
+
+#define USB_DEVICE_EPINTENCLR_TRCPT0_Pos 0            /**< \brief (USB_DEVICE_EPINTENCLR) Transfer Complete 0 Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_TRCPT0 (1 << USB_DEVICE_EPINTENCLR_TRCPT0_Pos)
+#define USB_DEVICE_EPINTENCLR_TRCPT1_Pos 1            /**< \brief (USB_DEVICE_EPINTENCLR) Transfer Complete 1 Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_TRCPT1 (1 << USB_DEVICE_EPINTENCLR_TRCPT1_Pos)
+#define USB_DEVICE_EPINTENCLR_TRCPT_Pos 0            /**< \brief (USB_DEVICE_EPINTENCLR) Transfer Complete x Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_TRCPT_Msk (0x3ul << USB_DEVICE_EPINTENCLR_TRCPT_Pos)
+#define USB_DEVICE_EPINTENCLR_TRCPT(value) (USB_DEVICE_EPINTENCLR_TRCPT_Msk & ((value) << USB_DEVICE_EPINTENCLR_TRCPT_Pos))
+#define USB_DEVICE_EPINTENCLR_TRFAIL0_Pos 2            /**< \brief (USB_DEVICE_EPINTENCLR) Error Flow 0 Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_TRFAIL0 (1 << USB_DEVICE_EPINTENCLR_TRFAIL0_Pos)
+#define USB_DEVICE_EPINTENCLR_TRFAIL1_Pos 3            /**< \brief (USB_DEVICE_EPINTENCLR) Error Flow 1 Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_TRFAIL1 (1 << USB_DEVICE_EPINTENCLR_TRFAIL1_Pos)
+#define USB_DEVICE_EPINTENCLR_TRFAIL_Pos 2            /**< \brief (USB_DEVICE_EPINTENCLR) Error Flow x Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_TRFAIL_Msk (0x3ul << USB_DEVICE_EPINTENCLR_TRFAIL_Pos)
+#define USB_DEVICE_EPINTENCLR_TRFAIL(value) (USB_DEVICE_EPINTENCLR_TRFAIL_Msk & ((value) << USB_DEVICE_EPINTENCLR_TRFAIL_Pos))
+#define USB_DEVICE_EPINTENCLR_RXSTP_Pos 4            /**< \brief (USB_DEVICE_EPINTENCLR) Received Setup Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_RXSTP (0x1ul << USB_DEVICE_EPINTENCLR_RXSTP_Pos)
+#define USB_DEVICE_EPINTENCLR_STALL0_Pos 5            /**< \brief (USB_DEVICE_EPINTENCLR) Stall 0 In/Out Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_STALL0 (1 << USB_DEVICE_EPINTENCLR_STALL0_Pos)
+#define USB_DEVICE_EPINTENCLR_STALL1_Pos 6            /**< \brief (USB_DEVICE_EPINTENCLR) Stall 1 In/Out Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_STALL1 (1 << USB_DEVICE_EPINTENCLR_STALL1_Pos)
+#define USB_DEVICE_EPINTENCLR_STALL_Pos 5            /**< \brief (USB_DEVICE_EPINTENCLR) Stall x In/Out Interrupt Disable */
+#define USB_DEVICE_EPINTENCLR_STALL_Msk (0x3ul << USB_DEVICE_EPINTENCLR_STALL_Pos)
+#define USB_DEVICE_EPINTENCLR_STALL(value) (USB_DEVICE_EPINTENCLR_STALL_Msk & ((value) << USB_DEVICE_EPINTENCLR_STALL_Pos))
+#define USB_DEVICE_EPINTENCLR_MASK  0x7Ful       /**< \brief (USB_DEVICE_EPINTENCLR) MASK Register */
+
+/* -------- USB_HOST_PINTENCLR : (USB Offset: 0x108) (R/W  8) HOST HOST_PIPE Pipe Interrupt Flag Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  TRCPT0:1;         /*!< bit:      0  Transfer Complete 0 Disable        */
+    uint8_t  TRCPT1:1;         /*!< bit:      1  Transfer Complete 1 Disable        */
+    uint8_t  TRFAIL:1;         /*!< bit:      2  Error Flow Interrupt Disable       */
+    uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Disable       */
+    uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Disable  */
+    uint8_t  STALL:1;          /*!< bit:      5  Stall Inetrrupt Disable            */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Disable        */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_PINTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_PINTENCLR_OFFSET   0x108        /**< \brief (USB_HOST_PINTENCLR offset) HOST_PIPE Pipe Interrupt Flag Clear */
+#define USB_HOST_PINTENCLR_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PINTENCLR reset_value) HOST_PIPE Pipe Interrupt Flag Clear */
+
+#define USB_HOST_PINTENCLR_TRCPT0_Pos 0            /**< \brief (USB_HOST_PINTENCLR) Transfer Complete 0 Disable */
+#define USB_HOST_PINTENCLR_TRCPT0   (1 << USB_HOST_PINTENCLR_TRCPT0_Pos)
+#define USB_HOST_PINTENCLR_TRCPT1_Pos 1            /**< \brief (USB_HOST_PINTENCLR) Transfer Complete 1 Disable */
+#define USB_HOST_PINTENCLR_TRCPT1   (1 << USB_HOST_PINTENCLR_TRCPT1_Pos)
+#define USB_HOST_PINTENCLR_TRCPT_Pos 0            /**< \brief (USB_HOST_PINTENCLR) Transfer Complete x Disable */
+#define USB_HOST_PINTENCLR_TRCPT_Msk (0x3ul << USB_HOST_PINTENCLR_TRCPT_Pos)
+#define USB_HOST_PINTENCLR_TRCPT(value) (USB_HOST_PINTENCLR_TRCPT_Msk & ((value) << USB_HOST_PINTENCLR_TRCPT_Pos))
+#define USB_HOST_PINTENCLR_TRFAIL_Pos 2            /**< \brief (USB_HOST_PINTENCLR) Error Flow Interrupt Disable */
+#define USB_HOST_PINTENCLR_TRFAIL   (0x1ul << USB_HOST_PINTENCLR_TRFAIL_Pos)
+#define USB_HOST_PINTENCLR_PERR_Pos 3            /**< \brief (USB_HOST_PINTENCLR) Pipe Error Interrupt Disable */
+#define USB_HOST_PINTENCLR_PERR     (0x1ul << USB_HOST_PINTENCLR_PERR_Pos)
+#define USB_HOST_PINTENCLR_TXSTP_Pos 4            /**< \brief (USB_HOST_PINTENCLR) Transmit  Setup Interrupt Disable */
+#define USB_HOST_PINTENCLR_TXSTP    (0x1ul << USB_HOST_PINTENCLR_TXSTP_Pos)
+#define USB_HOST_PINTENCLR_STALL_Pos 5            /**< \brief (USB_HOST_PINTENCLR) Stall Inetrrupt Disable */
+#define USB_HOST_PINTENCLR_STALL    (0x1ul << USB_HOST_PINTENCLR_STALL_Pos)
+#define USB_HOST_PINTENCLR_MASK     0x3Ful       /**< \brief (USB_HOST_PINTENCLR) MASK Register */
+
+/* -------- USB_DEVICE_EPINTENSET : (USB Offset: 0x109) (R/W  8) DEVICE DEVICE_ENDPOINT End Point Interrupt Set Flag -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  TRCPT0:1;         /*!< bit:      0  Transfer Complete 0 Interrupt Enable */
+    uint8_t  TRCPT1:1;         /*!< bit:      1  Transfer Complete 1 Interrupt Enable */
+    uint8_t  TRFAIL0:1;        /*!< bit:      2  Error Flow 0 Interrupt Enable      */
+    uint8_t  TRFAIL1:1;        /*!< bit:      3  Error Flow 1 Interrupt Enable      */
+    uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup Interrupt Enable    */
+    uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out Interrupt enable    */
+    uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out Interrupt enable    */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Enable */
+    uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x Interrupt Enable      */
+    uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out Interrupt enable    */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_EPINTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_EPINTENSET_OFFSET 0x109        /**< \brief (USB_DEVICE_EPINTENSET offset) DEVICE_ENDPOINT End Point Interrupt Set Flag */
+#define USB_DEVICE_EPINTENSET_RESETVALUE 0x00ul       /**< \brief (USB_DEVICE_EPINTENSET reset_value) DEVICE_ENDPOINT End Point Interrupt Set Flag */
+
+#define USB_DEVICE_EPINTENSET_TRCPT0_Pos 0            /**< \brief (USB_DEVICE_EPINTENSET) Transfer Complete 0 Interrupt Enable */
+#define USB_DEVICE_EPINTENSET_TRCPT0 (1 << USB_DEVICE_EPINTENSET_TRCPT0_Pos)
+#define USB_DEVICE_EPINTENSET_TRCPT1_Pos 1            /**< \brief (USB_DEVICE_EPINTENSET) Transfer Complete 1 Interrupt Enable */
+#define USB_DEVICE_EPINTENSET_TRCPT1 (1 << USB_DEVICE_EPINTENSET_TRCPT1_Pos)
+#define USB_DEVICE_EPINTENSET_TRCPT_Pos 0            /**< \brief (USB_DEVICE_EPINTENSET) Transfer Complete x Interrupt Enable */
+#define USB_DEVICE_EPINTENSET_TRCPT_Msk (0x3ul << USB_DEVICE_EPINTENSET_TRCPT_Pos)
+#define USB_DEVICE_EPINTENSET_TRCPT(value) (USB_DEVICE_EPINTENSET_TRCPT_Msk & ((value) << USB_DEVICE_EPINTENSET_TRCPT_Pos))
+#define USB_DEVICE_EPINTENSET_TRFAIL0_Pos 2            /**< \brief (USB_DEVICE_EPINTENSET) Error Flow 0 Interrupt Enable */
+#define USB_DEVICE_EPINTENSET_TRFAIL0 (1 << USB_DEVICE_EPINTENSET_TRFAIL0_Pos)
+#define USB_DEVICE_EPINTENSET_TRFAIL1_Pos 3            /**< \brief (USB_DEVICE_EPINTENSET) Error Flow 1 Interrupt Enable */
+#define USB_DEVICE_EPINTENSET_TRFAIL1 (1 << USB_DEVICE_EPINTENSET_TRFAIL1_Pos)
+#define USB_DEVICE_EPINTENSET_TRFAIL_Pos 2            /**< \brief (USB_DEVICE_EPINTENSET) Error Flow x Interrupt Enable */
+#define USB_DEVICE_EPINTENSET_TRFAIL_Msk (0x3ul << USB_DEVICE_EPINTENSET_TRFAIL_Pos)
+#define USB_DEVICE_EPINTENSET_TRFAIL(value) (USB_DEVICE_EPINTENSET_TRFAIL_Msk & ((value) << USB_DEVICE_EPINTENSET_TRFAIL_Pos))
+#define USB_DEVICE_EPINTENSET_RXSTP_Pos 4            /**< \brief (USB_DEVICE_EPINTENSET) Received Setup Interrupt Enable */
+#define USB_DEVICE_EPINTENSET_RXSTP (0x1ul << USB_DEVICE_EPINTENSET_RXSTP_Pos)
+#define USB_DEVICE_EPINTENSET_STALL0_Pos 5            /**< \brief (USB_DEVICE_EPINTENSET) Stall 0 In/out Interrupt enable */
+#define USB_DEVICE_EPINTENSET_STALL0 (1 << USB_DEVICE_EPINTENSET_STALL0_Pos)
+#define USB_DEVICE_EPINTENSET_STALL1_Pos 6            /**< \brief (USB_DEVICE_EPINTENSET) Stall 1 In/out Interrupt enable */
+#define USB_DEVICE_EPINTENSET_STALL1 (1 << USB_DEVICE_EPINTENSET_STALL1_Pos)
+#define USB_DEVICE_EPINTENSET_STALL_Pos 5            /**< \brief (USB_DEVICE_EPINTENSET) Stall x In/out Interrupt enable */
+#define USB_DEVICE_EPINTENSET_STALL_Msk (0x3ul << USB_DEVICE_EPINTENSET_STALL_Pos)
+#define USB_DEVICE_EPINTENSET_STALL(value) (USB_DEVICE_EPINTENSET_STALL_Msk & ((value) << USB_DEVICE_EPINTENSET_STALL_Pos))
+#define USB_DEVICE_EPINTENSET_MASK  0x7Ful       /**< \brief (USB_DEVICE_EPINTENSET) MASK Register */
+
+/* -------- USB_HOST_PINTENSET : (USB Offset: 0x109) (R/W  8) HOST HOST_PIPE Pipe Interrupt Flag Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  TRCPT0:1;         /*!< bit:      0  Transfer Complete 0 Interrupt Enable */
+    uint8_t  TRCPT1:1;         /*!< bit:      1  Transfer Complete 1 Interrupt Enable */
+    uint8_t  TRFAIL:1;         /*!< bit:      2  Error Flow Interrupt Enable        */
+    uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Enable        */
+    uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Enable   */
+    uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Enable             */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Enable */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_PINTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_PINTENSET_OFFSET   0x109        /**< \brief (USB_HOST_PINTENSET offset) HOST_PIPE Pipe Interrupt Flag Set */
+#define USB_HOST_PINTENSET_RESETVALUE 0x00ul       /**< \brief (USB_HOST_PINTENSET reset_value) HOST_PIPE Pipe Interrupt Flag Set */
+
+#define USB_HOST_PINTENSET_TRCPT0_Pos 0            /**< \brief (USB_HOST_PINTENSET) Transfer Complete 0 Interrupt Enable */
+#define USB_HOST_PINTENSET_TRCPT0   (1 << USB_HOST_PINTENSET_TRCPT0_Pos)
+#define USB_HOST_PINTENSET_TRCPT1_Pos 1            /**< \brief (USB_HOST_PINTENSET) Transfer Complete 1 Interrupt Enable */
+#define USB_HOST_PINTENSET_TRCPT1   (1 << USB_HOST_PINTENSET_TRCPT1_Pos)
+#define USB_HOST_PINTENSET_TRCPT_Pos 0            /**< \brief (USB_HOST_PINTENSET) Transfer Complete x Interrupt Enable */
+#define USB_HOST_PINTENSET_TRCPT_Msk (0x3ul << USB_HOST_PINTENSET_TRCPT_Pos)
+#define USB_HOST_PINTENSET_TRCPT(value) (USB_HOST_PINTENSET_TRCPT_Msk & ((value) << USB_HOST_PINTENSET_TRCPT_Pos))
+#define USB_HOST_PINTENSET_TRFAIL_Pos 2            /**< \brief (USB_HOST_PINTENSET) Error Flow Interrupt Enable */
+#define USB_HOST_PINTENSET_TRFAIL   (0x1ul << USB_HOST_PINTENSET_TRFAIL_Pos)
+#define USB_HOST_PINTENSET_PERR_Pos 3            /**< \brief (USB_HOST_PINTENSET) Pipe Error Interrupt Enable */
+#define USB_HOST_PINTENSET_PERR     (0x1ul << USB_HOST_PINTENSET_PERR_Pos)
+#define USB_HOST_PINTENSET_TXSTP_Pos 4            /**< \brief (USB_HOST_PINTENSET) Transmit  Setup Interrupt Enable */
+#define USB_HOST_PINTENSET_TXSTP    (0x1ul << USB_HOST_PINTENSET_TXSTP_Pos)
+#define USB_HOST_PINTENSET_STALL_Pos 5            /**< \brief (USB_HOST_PINTENSET) Stall Interrupt Enable */
+#define USB_HOST_PINTENSET_STALL    (0x1ul << USB_HOST_PINTENSET_STALL_Pos)
+#define USB_HOST_PINTENSET_MASK     0x3Ful       /**< \brief (USB_HOST_PINTENSET) MASK Register */
+
+/* -------- USB_DEVICE_ADDR : (USB Offset: 0x000) (R/W 32) DEVICE DEVICE_DESC_BANK Endpoint Bank, Adress of Data Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:32;          /*!< bit:  0..31  Adress of data buffer              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USB_DEVICE_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_ADDR_OFFSET      0x000        /**< \brief (USB_DEVICE_ADDR offset) DEVICE_DESC_BANK Endpoint Bank, Adress of Data Buffer */
+
+#define USB_DEVICE_ADDR_ADDR_Pos    0            /**< \brief (USB_DEVICE_ADDR) Adress of data buffer */
+#define USB_DEVICE_ADDR_ADDR_Msk    (0xFFFFFFFFul << USB_DEVICE_ADDR_ADDR_Pos)
+#define USB_DEVICE_ADDR_ADDR(value) (USB_DEVICE_ADDR_ADDR_Msk & ((value) << USB_DEVICE_ADDR_ADDR_Pos))
+#define USB_DEVICE_ADDR_MASK        0xFFFFFFFFul /**< \brief (USB_DEVICE_ADDR) MASK Register */
+
+/* -------- USB_HOST_ADDR : (USB Offset: 0x000) (R/W 32) HOST HOST_DESC_BANK Host Bank, Adress of Data Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:32;          /*!< bit:  0..31  Adress of data buffer              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USB_HOST_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_ADDR_OFFSET        0x000        /**< \brief (USB_HOST_ADDR offset) HOST_DESC_BANK Host Bank, Adress of Data Buffer */
+
+#define USB_HOST_ADDR_ADDR_Pos      0            /**< \brief (USB_HOST_ADDR) Adress of data buffer */
+#define USB_HOST_ADDR_ADDR_Msk      (0xFFFFFFFFul << USB_HOST_ADDR_ADDR_Pos)
+#define USB_HOST_ADDR_ADDR(value)   (USB_HOST_ADDR_ADDR_Msk & ((value) << USB_HOST_ADDR_ADDR_Pos))
+#define USB_HOST_ADDR_MASK          0xFFFFFFFFul /**< \brief (USB_HOST_ADDR) MASK Register */
+
+/* -------- USB_DEVICE_PCKSIZE : (USB Offset: 0x004) (R/W 32) DEVICE DEVICE_DESC_BANK Endpoint Bank, Packet Size -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BYTE_COUNT:14;    /*!< bit:  0..13  Byte Count                         */
+    uint32_t MULTI_PACKET_SIZE:14; /*!< bit: 14..27  Multi Packet In or Out size        */
+    uint32_t SIZE:3;           /*!< bit: 28..30  Enpoint size                       */
+    uint32_t AUTO_ZLP:1;       /*!< bit:     31  Automatic Zero Length Packet       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USB_DEVICE_PCKSIZE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_PCKSIZE_OFFSET   0x004        /**< \brief (USB_DEVICE_PCKSIZE offset) DEVICE_DESC_BANK Endpoint Bank, Packet Size */
+
+#define USB_DEVICE_PCKSIZE_BYTE_COUNT_Pos 0            /**< \brief (USB_DEVICE_PCKSIZE) Byte Count */
+#define USB_DEVICE_PCKSIZE_BYTE_COUNT_Msk (0x3FFFul << USB_DEVICE_PCKSIZE_BYTE_COUNT_Pos)
+#define USB_DEVICE_PCKSIZE_BYTE_COUNT(value) (USB_DEVICE_PCKSIZE_BYTE_COUNT_Msk & ((value) << USB_DEVICE_PCKSIZE_BYTE_COUNT_Pos))
+#define USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Pos 14           /**< \brief (USB_DEVICE_PCKSIZE) Multi Packet In or Out size */
+#define USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Msk (0x3FFFul << USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Pos)
+#define USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE(value) (USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Msk & ((value) << USB_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Pos))
+#define USB_DEVICE_PCKSIZE_SIZE_Pos 28           /**< \brief (USB_DEVICE_PCKSIZE) Enpoint size */
+#define USB_DEVICE_PCKSIZE_SIZE_Msk (0x7ul << USB_DEVICE_PCKSIZE_SIZE_Pos)
+#define USB_DEVICE_PCKSIZE_SIZE(value) (USB_DEVICE_PCKSIZE_SIZE_Msk & ((value) << USB_DEVICE_PCKSIZE_SIZE_Pos))
+#define USB_DEVICE_PCKSIZE_AUTO_ZLP_Pos 31           /**< \brief (USB_DEVICE_PCKSIZE) Automatic Zero Length Packet */
+#define USB_DEVICE_PCKSIZE_AUTO_ZLP (0x1ul << USB_DEVICE_PCKSIZE_AUTO_ZLP_Pos)
+#define USB_DEVICE_PCKSIZE_MASK     0xFFFFFFFFul /**< \brief (USB_DEVICE_PCKSIZE) MASK Register */
+
+/* -------- USB_HOST_PCKSIZE : (USB Offset: 0x004) (R/W 32) HOST HOST_DESC_BANK Host Bank, Packet Size -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BYTE_COUNT:14;    /*!< bit:  0..13  Byte Count                         */
+    uint32_t MULTI_PACKET_SIZE:14; /*!< bit: 14..27  Multi Packet In or Out size        */
+    uint32_t SIZE:3;           /*!< bit: 28..30  Pipe size                          */
+    uint32_t AUTO_ZLP:1;       /*!< bit:     31  Automatic Zero Length Packet       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USB_HOST_PCKSIZE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_PCKSIZE_OFFSET     0x004        /**< \brief (USB_HOST_PCKSIZE offset) HOST_DESC_BANK Host Bank, Packet Size */
+
+#define USB_HOST_PCKSIZE_BYTE_COUNT_Pos 0            /**< \brief (USB_HOST_PCKSIZE) Byte Count */
+#define USB_HOST_PCKSIZE_BYTE_COUNT_Msk (0x3FFFul << USB_HOST_PCKSIZE_BYTE_COUNT_Pos)
+#define USB_HOST_PCKSIZE_BYTE_COUNT(value) (USB_HOST_PCKSIZE_BYTE_COUNT_Msk & ((value) << USB_HOST_PCKSIZE_BYTE_COUNT_Pos))
+#define USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Pos 14           /**< \brief (USB_HOST_PCKSIZE) Multi Packet In or Out size */
+#define USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Msk (0x3FFFul << USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Pos)
+#define USB_HOST_PCKSIZE_MULTI_PACKET_SIZE(value) (USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Msk & ((value) << USB_HOST_PCKSIZE_MULTI_PACKET_SIZE_Pos))
+#define USB_HOST_PCKSIZE_SIZE_Pos   28           /**< \brief (USB_HOST_PCKSIZE) Pipe size */
+#define USB_HOST_PCKSIZE_SIZE_Msk   (0x7ul << USB_HOST_PCKSIZE_SIZE_Pos)
+#define USB_HOST_PCKSIZE_SIZE(value) (USB_HOST_PCKSIZE_SIZE_Msk & ((value) << USB_HOST_PCKSIZE_SIZE_Pos))
+#define USB_HOST_PCKSIZE_AUTO_ZLP_Pos 31           /**< \brief (USB_HOST_PCKSIZE) Automatic Zero Length Packet */
+#define USB_HOST_PCKSIZE_AUTO_ZLP   (0x1ul << USB_HOST_PCKSIZE_AUTO_ZLP_Pos)
+#define USB_HOST_PCKSIZE_MASK       0xFFFFFFFFul /**< \brief (USB_HOST_PCKSIZE) MASK Register */
+
+/* -------- USB_DEVICE_EXTREG : (USB Offset: 0x008) (R/W 16) DEVICE DEVICE_DESC_BANK Endpoint Bank, Extended -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SUBPID:4;         /*!< bit:  0.. 3  SUBPID field send with extended token */
+    uint16_t VARIABLE:11;      /*!< bit:  4..14  Variable field send with extended token */
+    uint16_t :1;               /*!< bit:     15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_DEVICE_EXTREG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_EXTREG_OFFSET    0x008        /**< \brief (USB_DEVICE_EXTREG offset) DEVICE_DESC_BANK Endpoint Bank, Extended */
+
+#define USB_DEVICE_EXTREG_SUBPID_Pos 0            /**< \brief (USB_DEVICE_EXTREG) SUBPID field send with extended token */
+#define USB_DEVICE_EXTREG_SUBPID_Msk (0xFul << USB_DEVICE_EXTREG_SUBPID_Pos)
+#define USB_DEVICE_EXTREG_SUBPID(value) (USB_DEVICE_EXTREG_SUBPID_Msk & ((value) << USB_DEVICE_EXTREG_SUBPID_Pos))
+#define USB_DEVICE_EXTREG_VARIABLE_Pos 4            /**< \brief (USB_DEVICE_EXTREG) Variable field send with extended token */
+#define USB_DEVICE_EXTREG_VARIABLE_Msk (0x7FFul << USB_DEVICE_EXTREG_VARIABLE_Pos)
+#define USB_DEVICE_EXTREG_VARIABLE(value) (USB_DEVICE_EXTREG_VARIABLE_Msk & ((value) << USB_DEVICE_EXTREG_VARIABLE_Pos))
+#define USB_DEVICE_EXTREG_MASK      0x7FFFul     /**< \brief (USB_DEVICE_EXTREG) MASK Register */
+
+/* -------- USB_HOST_EXTREG : (USB Offset: 0x008) (R/W 16) HOST HOST_DESC_BANK Host Bank, Extended -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SUBPID:4;         /*!< bit:  0.. 3  SUBPID field send with extended token */
+    uint16_t VARIABLE:11;      /*!< bit:  4..14  Variable field send with extended token */
+    uint16_t :1;               /*!< bit:     15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_HOST_EXTREG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_EXTREG_OFFSET      0x008        /**< \brief (USB_HOST_EXTREG offset) HOST_DESC_BANK Host Bank, Extended */
+
+#define USB_HOST_EXTREG_SUBPID_Pos  0            /**< \brief (USB_HOST_EXTREG) SUBPID field send with extended token */
+#define USB_HOST_EXTREG_SUBPID_Msk  (0xFul << USB_HOST_EXTREG_SUBPID_Pos)
+#define USB_HOST_EXTREG_SUBPID(value) (USB_HOST_EXTREG_SUBPID_Msk & ((value) << USB_HOST_EXTREG_SUBPID_Pos))
+#define USB_HOST_EXTREG_VARIABLE_Pos 4            /**< \brief (USB_HOST_EXTREG) Variable field send with extended token */
+#define USB_HOST_EXTREG_VARIABLE_Msk (0x7FFul << USB_HOST_EXTREG_VARIABLE_Pos)
+#define USB_HOST_EXTREG_VARIABLE(value) (USB_HOST_EXTREG_VARIABLE_Msk & ((value) << USB_HOST_EXTREG_VARIABLE_Pos))
+#define USB_HOST_EXTREG_MASK        0x7FFFul     /**< \brief (USB_HOST_EXTREG) MASK Register */
+
+/* -------- USB_DEVICE_STATUS_BK : (USB Offset: 0x00A) (R/W  8) DEVICE DEVICE_DESC_BANK Enpoint Bank, Status of Bank -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CRCERR:1;         /*!< bit:      0  CRC Error Status                   */
+    uint8_t  ERRORFLOW:1;      /*!< bit:      1  Error Flow Status                  */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_DEVICE_STATUS_BK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_DEVICE_STATUS_BK_OFFSET 0x00A        /**< \brief (USB_DEVICE_STATUS_BK offset) DEVICE_DESC_BANK Enpoint Bank, Status of Bank */
+
+#define USB_DEVICE_STATUS_BK_CRCERR_Pos 0            /**< \brief (USB_DEVICE_STATUS_BK) CRC Error Status */
+#define USB_DEVICE_STATUS_BK_CRCERR (0x1ul << USB_DEVICE_STATUS_BK_CRCERR_Pos)
+#define USB_DEVICE_STATUS_BK_ERRORFLOW_Pos 1            /**< \brief (USB_DEVICE_STATUS_BK) Error Flow Status */
+#define USB_DEVICE_STATUS_BK_ERRORFLOW (0x1ul << USB_DEVICE_STATUS_BK_ERRORFLOW_Pos)
+#define USB_DEVICE_STATUS_BK_MASK   0x03ul       /**< \brief (USB_DEVICE_STATUS_BK) MASK Register */
+
+/* -------- USB_HOST_STATUS_BK : (USB Offset: 0x00A) (R/W  8) HOST HOST_DESC_BANK Host Bank, Status of Bank -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CRCERR:1;         /*!< bit:      0  CRC Error Status                   */
+    uint8_t  ERRORFLOW:1;      /*!< bit:      1  Error Flow Status                  */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} USB_HOST_STATUS_BK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_STATUS_BK_OFFSET   0x00A        /**< \brief (USB_HOST_STATUS_BK offset) HOST_DESC_BANK Host Bank, Status of Bank */
+
+#define USB_HOST_STATUS_BK_CRCERR_Pos 0            /**< \brief (USB_HOST_STATUS_BK) CRC Error Status */
+#define USB_HOST_STATUS_BK_CRCERR   (0x1ul << USB_HOST_STATUS_BK_CRCERR_Pos)
+#define USB_HOST_STATUS_BK_ERRORFLOW_Pos 1            /**< \brief (USB_HOST_STATUS_BK) Error Flow Status */
+#define USB_HOST_STATUS_BK_ERRORFLOW (0x1ul << USB_HOST_STATUS_BK_ERRORFLOW_Pos)
+#define USB_HOST_STATUS_BK_MASK     0x03ul       /**< \brief (USB_HOST_STATUS_BK) MASK Register */
+
+/* -------- USB_HOST_CTRL_PIPE : (USB Offset: 0x00C) (R/W 16) HOST HOST_DESC_BANK Host Bank, Host Control Pipe -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PDADDR:7;         /*!< bit:  0.. 6  Pipe Device Adress                 */
+    uint16_t :1;               /*!< bit:      7  Reserved                           */
+    uint16_t PEPNUM:4;         /*!< bit:  8..11  Pipe Endpoint Number               */
+    uint16_t PERMAX:4;         /*!< bit: 12..15  Pipe Error Max Number              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_HOST_CTRL_PIPE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_CTRL_PIPE_OFFSET   0x00C        /**< \brief (USB_HOST_CTRL_PIPE offset) HOST_DESC_BANK Host Bank, Host Control Pipe */
+#define USB_HOST_CTRL_PIPE_RESETVALUE 0x0000ul     /**< \brief (USB_HOST_CTRL_PIPE reset_value) HOST_DESC_BANK Host Bank, Host Control Pipe */
+
+#define USB_HOST_CTRL_PIPE_PDADDR_Pos 0            /**< \brief (USB_HOST_CTRL_PIPE) Pipe Device Adress */
+#define USB_HOST_CTRL_PIPE_PDADDR_Msk (0x7Ful << USB_HOST_CTRL_PIPE_PDADDR_Pos)
+#define USB_HOST_CTRL_PIPE_PDADDR(value) (USB_HOST_CTRL_PIPE_PDADDR_Msk & ((value) << USB_HOST_CTRL_PIPE_PDADDR_Pos))
+#define USB_HOST_CTRL_PIPE_PEPNUM_Pos 8            /**< \brief (USB_HOST_CTRL_PIPE) Pipe Endpoint Number */
+#define USB_HOST_CTRL_PIPE_PEPNUM_Msk (0xFul << USB_HOST_CTRL_PIPE_PEPNUM_Pos)
+#define USB_HOST_CTRL_PIPE_PEPNUM(value) (USB_HOST_CTRL_PIPE_PEPNUM_Msk & ((value) << USB_HOST_CTRL_PIPE_PEPNUM_Pos))
+#define USB_HOST_CTRL_PIPE_PERMAX_Pos 12           /**< \brief (USB_HOST_CTRL_PIPE) Pipe Error Max Number */
+#define USB_HOST_CTRL_PIPE_PERMAX_Msk (0xFul << USB_HOST_CTRL_PIPE_PERMAX_Pos)
+#define USB_HOST_CTRL_PIPE_PERMAX(value) (USB_HOST_CTRL_PIPE_PERMAX_Msk & ((value) << USB_HOST_CTRL_PIPE_PERMAX_Pos))
+#define USB_HOST_CTRL_PIPE_MASK     0xFF7Ful     /**< \brief (USB_HOST_CTRL_PIPE) MASK Register */
+
+/* -------- USB_HOST_STATUS_PIPE : (USB Offset: 0x00E) (R/W 16) HOST HOST_DESC_BANK Host Bank, Host Status Pipe -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DTGLER:1;         /*!< bit:      0  Data Toggle Error                  */
+    uint16_t DAPIDER:1;        /*!< bit:      1  Data PID Error                     */
+    uint16_t PIDER:1;          /*!< bit:      2  PID Error                          */
+    uint16_t TOUTER:1;         /*!< bit:      3  Time Out Error                     */
+    uint16_t CRC16ER:1;        /*!< bit:      4  CRC16 Error                        */
+    uint16_t ERCNT:3;          /*!< bit:  5.. 7  Pipe Error Count                   */
+    uint16_t :8;               /*!< bit:  8..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} USB_HOST_STATUS_PIPE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USB_HOST_STATUS_PIPE_OFFSET 0x00E        /**< \brief (USB_HOST_STATUS_PIPE offset) HOST_DESC_BANK Host Bank, Host Status Pipe */
+
+#define USB_HOST_STATUS_PIPE_DTGLER_Pos 0            /**< \brief (USB_HOST_STATUS_PIPE) Data Toggle Error */
+#define USB_HOST_STATUS_PIPE_DTGLER (0x1ul << USB_HOST_STATUS_PIPE_DTGLER_Pos)
+#define USB_HOST_STATUS_PIPE_DAPIDER_Pos 1            /**< \brief (USB_HOST_STATUS_PIPE) Data PID Error */
+#define USB_HOST_STATUS_PIPE_DAPIDER (0x1ul << USB_HOST_STATUS_PIPE_DAPIDER_Pos)
+#define USB_HOST_STATUS_PIPE_PIDER_Pos 2            /**< \brief (USB_HOST_STATUS_PIPE) PID Error */
+#define USB_HOST_STATUS_PIPE_PIDER  (0x1ul << USB_HOST_STATUS_PIPE_PIDER_Pos)
+#define USB_HOST_STATUS_PIPE_TOUTER_Pos 3            /**< \brief (USB_HOST_STATUS_PIPE) Time Out Error */
+#define USB_HOST_STATUS_PIPE_TOUTER (0x1ul << USB_HOST_STATUS_PIPE_TOUTER_Pos)
+#define USB_HOST_STATUS_PIPE_CRC16ER_Pos 4            /**< \brief (USB_HOST_STATUS_PIPE) CRC16 Error */
+#define USB_HOST_STATUS_PIPE_CRC16ER (0x1ul << USB_HOST_STATUS_PIPE_CRC16ER_Pos)
+#define USB_HOST_STATUS_PIPE_ERCNT_Pos 5            /**< \brief (USB_HOST_STATUS_PIPE) Pipe Error Count */
+#define USB_HOST_STATUS_PIPE_ERCNT_Msk (0x7ul << USB_HOST_STATUS_PIPE_ERCNT_Pos)
+#define USB_HOST_STATUS_PIPE_ERCNT(value) (USB_HOST_STATUS_PIPE_ERCNT_Msk & ((value) << USB_HOST_STATUS_PIPE_ERCNT_Pos))
+#define USB_HOST_STATUS_PIPE_MASK   0x00FFul     /**< \brief (USB_HOST_STATUS_PIPE) MASK Register */
+
+/** \brief UsbDeviceDescBank SRAM registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO USB_DEVICE_ADDR_Type      ADDR;        /**< \brief Offset: 0x000 (R/W 32) DEVICE_DESC_BANK Endpoint Bank, Adress of Data Buffer */
+  __IO USB_DEVICE_PCKSIZE_Type   PCKSIZE;     /**< \brief Offset: 0x004 (R/W 32) DEVICE_DESC_BANK Endpoint Bank, Packet Size */
+  __IO USB_DEVICE_EXTREG_Type    EXTREG;      /**< \brief Offset: 0x008 (R/W 16) DEVICE_DESC_BANK Endpoint Bank, Extended */
+  __IO USB_DEVICE_STATUS_BK_Type STATUS_BK;   /**< \brief Offset: 0x00A (R/W  8) DEVICE_DESC_BANK Enpoint Bank, Status of Bank */
+       RoReg8                    Reserved1[0x5];
+} UsbDeviceDescBank;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief UsbHostDescBank SRAM registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO USB_HOST_ADDR_Type        ADDR;        /**< \brief Offset: 0x000 (R/W 32) HOST_DESC_BANK Host Bank, Adress of Data Buffer */
+  __IO USB_HOST_PCKSIZE_Type     PCKSIZE;     /**< \brief Offset: 0x004 (R/W 32) HOST_DESC_BANK Host Bank, Packet Size */
+  __IO USB_HOST_EXTREG_Type      EXTREG;      /**< \brief Offset: 0x008 (R/W 16) HOST_DESC_BANK Host Bank, Extended */
+  __IO USB_HOST_STATUS_BK_Type   STATUS_BK;   /**< \brief Offset: 0x00A (R/W  8) HOST_DESC_BANK Host Bank, Status of Bank */
+       RoReg8                    Reserved1[0x1];
+  __IO USB_HOST_CTRL_PIPE_Type   CTRL_PIPE;   /**< \brief Offset: 0x00C (R/W 16) HOST_DESC_BANK Host Bank, Host Control Pipe */
+  __IO USB_HOST_STATUS_PIPE_Type STATUS_PIPE; /**< \brief Offset: 0x00E (R/W 16) HOST_DESC_BANK Host Bank, Host Status Pipe */
+} UsbHostDescBank;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief UsbDeviceEndpoint hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO USB_DEVICE_EPCFG_Type     EPCFG;       /**< \brief Offset: 0x000 (R/W  8) DEVICE_ENDPOINT End Point Configuration */
+       RoReg8                    Reserved1[0x3];
+  __O  USB_DEVICE_EPSTATUSCLR_Type EPSTATUSCLR; /**< \brief Offset: 0x004 ( /W  8) DEVICE_ENDPOINT End Point Pipe Status Clear */
+  __O  USB_DEVICE_EPSTATUSSET_Type EPSTATUSSET; /**< \brief Offset: 0x005 ( /W  8) DEVICE_ENDPOINT End Point Pipe Status Set */
+  __I  USB_DEVICE_EPSTATUS_Type  EPSTATUS;    /**< \brief Offset: 0x006 (R/   8) DEVICE_ENDPOINT End Point Pipe Status */
+  __IO USB_DEVICE_EPINTFLAG_Type EPINTFLAG;   /**< \brief Offset: 0x007 (R/W  8) DEVICE_ENDPOINT End Point Interrupt Flag */
+  __IO USB_DEVICE_EPINTENCLR_Type EPINTENCLR;  /**< \brief Offset: 0x008 (R/W  8) DEVICE_ENDPOINT End Point Interrupt Clear Flag */
+  __IO USB_DEVICE_EPINTENSET_Type EPINTENSET;  /**< \brief Offset: 0x009 (R/W  8) DEVICE_ENDPOINT End Point Interrupt Set Flag */
+       RoReg8                    Reserved2[0x16];
+} UsbDeviceEndpoint;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief UsbHostPipe hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO USB_HOST_PCFG_Type        PCFG;        /**< \brief Offset: 0x000 (R/W  8) HOST_PIPE End Point Configuration */
+       RoReg8                    Reserved1[0x2];
+  __IO USB_HOST_BINTERVAL_Type   BINTERVAL;   /**< \brief Offset: 0x003 (R/W  8) HOST_PIPE Bus Access Period of Pipe */
+  __O  USB_HOST_PSTATUSCLR_Type  PSTATUSCLR;  /**< \brief Offset: 0x004 ( /W  8) HOST_PIPE End Point Pipe Status Clear */
+  __O  USB_HOST_PSTATUSSET_Type  PSTATUSSET;  /**< \brief Offset: 0x005 ( /W  8) HOST_PIPE End Point Pipe Status Set */
+  __I  USB_HOST_PSTATUS_Type     PSTATUS;     /**< \brief Offset: 0x006 (R/   8) HOST_PIPE End Point Pipe Status */
+  __IO USB_HOST_PINTFLAG_Type    PINTFLAG;    /**< \brief Offset: 0x007 (R/W  8) HOST_PIPE Pipe Interrupt Flag */
+  __IO USB_HOST_PINTENCLR_Type   PINTENCLR;   /**< \brief Offset: 0x008 (R/W  8) HOST_PIPE Pipe Interrupt Flag Clear */
+  __IO USB_HOST_PINTENSET_Type   PINTENSET;   /**< \brief Offset: 0x009 (R/W  8) HOST_PIPE Pipe Interrupt Flag Set */
+       RoReg8                    Reserved2[0x16];
+} UsbHostPipe;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief USB_DEVICE APB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* USB is Device */
+  __IO USB_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x000 (R/W  8) Control A */
+       RoReg8                    Reserved1[0x1];
+  __I  USB_SYNCBUSY_Type         SYNCBUSY;    /**< \brief Offset: 0x002 (R/   8) Synchronization Busy */
+       RoReg8                    Reserved2[0x5];
+  __IO USB_DEVICE_CTRLB_Type     CTRLB;       /**< \brief Offset: 0x008 (R/W 16) DEVICE Control B */
+  __IO USB_DEVICE_DADD_Type      DADD;        /**< \brief Offset: 0x00A (R/W  8) DEVICE Device Address */
+       RoReg8                    Reserved3[0x1];
+  __I  USB_DEVICE_STATUS_Type    STATUS;      /**< \brief Offset: 0x00C (R/   8) DEVICE Status */
+  __I  USB_FSMSTATUS_Type        FSMSTATUS;   /**< \brief Offset: 0x00D (R/   8) Finite State Machine Status */
+       RoReg8                    Reserved4[0x2];
+  __I  USB_DEVICE_FNUM_Type      FNUM;        /**< \brief Offset: 0x010 (R/  16) DEVICE Device Frame Number */
+       RoReg8                    Reserved5[0x2];
+  __IO USB_DEVICE_INTENCLR_Type  INTENCLR;    /**< \brief Offset: 0x014 (R/W 16) DEVICE Device Interrupt Enable Clear */
+       RoReg8                    Reserved6[0x2];
+  __IO USB_DEVICE_INTENSET_Type  INTENSET;    /**< \brief Offset: 0x018 (R/W 16) DEVICE Device Interrupt Enable Set */
+       RoReg8                    Reserved7[0x2];
+  __IO USB_DEVICE_INTFLAG_Type   INTFLAG;     /**< \brief Offset: 0x01C (R/W 16) DEVICE Device Interrupt Flag */
+       RoReg8                    Reserved8[0x2];
+  __I  USB_DEVICE_EPINTSMRY_Type EPINTSMRY;   /**< \brief Offset: 0x020 (R/  16) DEVICE End Point Interrupt Summary */
+       RoReg8                    Reserved9[0x2];
+  __IO USB_DESCADD_Type          DESCADD;     /**< \brief Offset: 0x024 (R/W 32) Descriptor Address */
+  __IO USB_PADCAL_Type           PADCAL;      /**< \brief Offset: 0x028 (R/W 16) USB PAD Calibration */
+       RoReg8                    Reserved10[0xD6];
+       UsbDeviceEndpoint         DeviceEndpoint[8]; /**< \brief Offset: 0x100 UsbDeviceEndpoint groups [EPT_NUM] */
+} UsbDevice;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief USB_HOST hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* USB is Host */
+  __IO USB_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x000 (R/W  8) Control A */
+       RoReg8                    Reserved1[0x1];
+  __I  USB_SYNCBUSY_Type         SYNCBUSY;    /**< \brief Offset: 0x002 (R/   8) Synchronization Busy */
+       RoReg8                    Reserved2[0x5];
+  __IO USB_HOST_CTRLB_Type       CTRLB;       /**< \brief Offset: 0x008 (R/W 16) HOST Control B */
+  __IO USB_HOST_HSOFC_Type       HSOFC;       /**< \brief Offset: 0x00A (R/W  8) HOST Host Start Of Frame Control */
+       RoReg8                    Reserved3[0x1];
+  __IO USB_HOST_STATUS_Type      STATUS;      /**< \brief Offset: 0x00C (R/W  8) HOST Status */
+  __I  USB_FSMSTATUS_Type        FSMSTATUS;   /**< \brief Offset: 0x00D (R/   8) Finite State Machine Status */
+       RoReg8                    Reserved4[0x2];
+  __IO USB_HOST_FNUM_Type        FNUM;        /**< \brief Offset: 0x010 (R/W 16) HOST Host Frame Number */
+  __I  USB_HOST_FLENHIGH_Type    FLENHIGH;    /**< \brief Offset: 0x012 (R/   8) HOST Host Frame Length */
+       RoReg8                    Reserved5[0x1];
+  __IO USB_HOST_INTENCLR_Type    INTENCLR;    /**< \brief Offset: 0x014 (R/W 16) HOST Host Interrupt Enable Clear */
+       RoReg8                    Reserved6[0x2];
+  __IO USB_HOST_INTENSET_Type    INTENSET;    /**< \brief Offset: 0x018 (R/W 16) HOST Host Interrupt Enable Set */
+       RoReg8                    Reserved7[0x2];
+  __IO USB_HOST_INTFLAG_Type     INTFLAG;     /**< \brief Offset: 0x01C (R/W 16) HOST Host Interrupt Flag */
+       RoReg8                    Reserved8[0x2];
+  __I  USB_HOST_PINTSMRY_Type    PINTSMRY;    /**< \brief Offset: 0x020 (R/  16) HOST Pipe Interrupt Summary */
+       RoReg8                    Reserved9[0x2];
+  __IO USB_DESCADD_Type          DESCADD;     /**< \brief Offset: 0x024 (R/W 32) Descriptor Address */
+  __IO USB_PADCAL_Type           PADCAL;      /**< \brief Offset: 0x028 (R/W 16) USB PAD Calibration */
+       RoReg8                    Reserved10[0xD6];
+       UsbHostPipe               HostPipe[8]; /**< \brief Offset: 0x100 UsbHostPipe groups [EPT_NUM] */
+} UsbHost;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief USB_DEVICE Descriptor SRAM registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* USB is Device */
+       UsbDeviceDescBank         DeviceDescBank[2]; /**< \brief Offset: 0x000 UsbDeviceDescBank groups */
+} UsbDeviceDescriptor;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief USB_HOST Descriptor SRAM registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* USB is Host */
+       UsbHostDescBank           HostDescBank[2]; /**< \brief Offset: 0x000 UsbHostDescBank groups */
+} UsbHostDescriptor;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#ifdef __GNUC__
+ #define SECTION_USB_DESCRIPTOR       __attribute__ ((section(".hsram")))
+#elif defined(__ICCARM__)
+ #define SECTION_USB_DESCRIPTOR       @".hsram"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       UsbDevice                 DEVICE;      /**< \brief Offset: 0x000 USB is Device */
+       UsbHost                   HOST;        /**< \brief Offset: 0x000 USB is Host */
+} Usb;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_USB_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/component/wdt.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/component/wdt.h
@@ -1,0 +1,314 @@
+/**
+ * \file
+ *
+ * \brief Component description for WDT
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_WDT_COMPONENT_
+#define _SAML21_WDT_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR WDT */
+/* ========================================================================== */
+/** \addtogroup SAML21_WDT Watchdog Timer */
+/*@{*/
+
+#define WDT_U2251
+#define REV_WDT                     0x100
+
+/* -------- WDT_CTRLA : (WDT Offset: 0x0) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :1;               /*!< bit:      0  Reserved                           */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  WEN:1;            /*!< bit:      2  Watchdog Timer Window Mode Enable  */
+    uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  ALWAYSON:1;       /*!< bit:      7  Always-On                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CTRLA_OFFSET            0x0          /**< \brief (WDT_CTRLA offset) Control */
+#define WDT_CTRLA_RESETVALUE        0x00ul       /**< \brief (WDT_CTRLA reset_value) Control */
+
+#define WDT_CTRLA_ENABLE_Pos        1            /**< \brief (WDT_CTRLA) Enable */
+#define WDT_CTRLA_ENABLE            (0x1ul << WDT_CTRLA_ENABLE_Pos)
+#define WDT_CTRLA_WEN_Pos           2            /**< \brief (WDT_CTRLA) Watchdog Timer Window Mode Enable */
+#define WDT_CTRLA_WEN               (0x1ul << WDT_CTRLA_WEN_Pos)
+#define WDT_CTRLA_ALWAYSON_Pos      7            /**< \brief (WDT_CTRLA) Always-On */
+#define WDT_CTRLA_ALWAYSON          (0x1ul << WDT_CTRLA_ALWAYSON_Pos)
+#define WDT_CTRLA_MASK              0x86ul       /**< \brief (WDT_CTRLA) MASK Register */
+
+/* -------- WDT_CONFIG : (WDT Offset: 0x1) (R/W  8) Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PER:4;            /*!< bit:  0.. 3  Time-Out Period                    */
+    uint8_t  WINDOW:4;         /*!< bit:  4.. 7  Window Mode Time-Out Period        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CONFIG_OFFSET           0x1          /**< \brief (WDT_CONFIG offset) Configuration */
+#define WDT_CONFIG_RESETVALUE       0xBBul       /**< \brief (WDT_CONFIG reset_value) Configuration */
+
+#define WDT_CONFIG_PER_Pos          0            /**< \brief (WDT_CONFIG) Time-Out Period */
+#define WDT_CONFIG_PER_Msk          (0xFul << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER(value)       (WDT_CONFIG_PER_Msk & ((value) << WDT_CONFIG_PER_Pos))
+#define   WDT_CONFIG_PER_CYC8_Val         0x0ul  /**< \brief (WDT_CONFIG) 8 clock cycles */
+#define   WDT_CONFIG_PER_CYC16_Val        0x1ul  /**< \brief (WDT_CONFIG) 16 clock cycles */
+#define   WDT_CONFIG_PER_CYC32_Val        0x2ul  /**< \brief (WDT_CONFIG) 32 clock cycles */
+#define   WDT_CONFIG_PER_CYC64_Val        0x3ul  /**< \brief (WDT_CONFIG) 64 clock cycles */
+#define   WDT_CONFIG_PER_CYC128_Val       0x4ul  /**< \brief (WDT_CONFIG) 128 clock cycles */
+#define   WDT_CONFIG_PER_CYC256_Val       0x5ul  /**< \brief (WDT_CONFIG) 256 clock cycles */
+#define   WDT_CONFIG_PER_CYC512_Val       0x6ul  /**< \brief (WDT_CONFIG) 512 clock cycles */
+#define   WDT_CONFIG_PER_CYC1024_Val      0x7ul  /**< \brief (WDT_CONFIG) 1024 clock cycles */
+#define   WDT_CONFIG_PER_CYC2048_Val      0x8ul  /**< \brief (WDT_CONFIG) 2048 clock cycles */
+#define   WDT_CONFIG_PER_CYC4096_Val      0x9ul  /**< \brief (WDT_CONFIG) 4096 clock cycles */
+#define   WDT_CONFIG_PER_CYC8192_Val      0xAul  /**< \brief (WDT_CONFIG) 8192 clock cycles */
+#define   WDT_CONFIG_PER_CYC16384_Val     0xBul  /**< \brief (WDT_CONFIG) 16384 clock cycles */
+#define WDT_CONFIG_PER_CYC8         (WDT_CONFIG_PER_CYC8_Val       << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC16        (WDT_CONFIG_PER_CYC16_Val      << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC32        (WDT_CONFIG_PER_CYC32_Val      << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC64        (WDT_CONFIG_PER_CYC64_Val      << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC128       (WDT_CONFIG_PER_CYC128_Val     << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC256       (WDT_CONFIG_PER_CYC256_Val     << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC512       (WDT_CONFIG_PER_CYC512_Val     << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC1024      (WDT_CONFIG_PER_CYC1024_Val    << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC2048      (WDT_CONFIG_PER_CYC2048_Val    << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC4096      (WDT_CONFIG_PER_CYC4096_Val    << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC8192      (WDT_CONFIG_PER_CYC8192_Val    << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC16384     (WDT_CONFIG_PER_CYC16384_Val   << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_WINDOW_Pos       4            /**< \brief (WDT_CONFIG) Window Mode Time-Out Period */
+#define WDT_CONFIG_WINDOW_Msk       (0xFul << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW(value)    (WDT_CONFIG_WINDOW_Msk & ((value) << WDT_CONFIG_WINDOW_Pos))
+#define   WDT_CONFIG_WINDOW_CYC8_Val      0x0ul  /**< \brief (WDT_CONFIG) 8 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC16_Val     0x1ul  /**< \brief (WDT_CONFIG) 16 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC32_Val     0x2ul  /**< \brief (WDT_CONFIG) 32 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC64_Val     0x3ul  /**< \brief (WDT_CONFIG) 64 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC128_Val    0x4ul  /**< \brief (WDT_CONFIG) 128 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC256_Val    0x5ul  /**< \brief (WDT_CONFIG) 256 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC512_Val    0x6ul  /**< \brief (WDT_CONFIG) 512 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC1024_Val   0x7ul  /**< \brief (WDT_CONFIG) 1024 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC2048_Val   0x8ul  /**< \brief (WDT_CONFIG) 2048 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC4096_Val   0x9ul  /**< \brief (WDT_CONFIG) 4096 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC8192_Val   0xAul  /**< \brief (WDT_CONFIG) 8192 clock cycles */
+#define   WDT_CONFIG_WINDOW_CYC16384_Val  0xBul  /**< \brief (WDT_CONFIG) 16384 clock cycles */
+#define WDT_CONFIG_WINDOW_CYC8      (WDT_CONFIG_WINDOW_CYC8_Val    << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC16     (WDT_CONFIG_WINDOW_CYC16_Val   << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC32     (WDT_CONFIG_WINDOW_CYC32_Val   << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC64     (WDT_CONFIG_WINDOW_CYC64_Val   << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC128    (WDT_CONFIG_WINDOW_CYC128_Val  << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC256    (WDT_CONFIG_WINDOW_CYC256_Val  << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC512    (WDT_CONFIG_WINDOW_CYC512_Val  << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC1024   (WDT_CONFIG_WINDOW_CYC1024_Val << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC2048   (WDT_CONFIG_WINDOW_CYC2048_Val << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC4096   (WDT_CONFIG_WINDOW_CYC4096_Val << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC8192   (WDT_CONFIG_WINDOW_CYC8192_Val << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_CYC16384  (WDT_CONFIG_WINDOW_CYC16384_Val << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_MASK             0xFFul       /**< \brief (WDT_CONFIG) MASK Register */
+
+/* -------- WDT_EWCTRL : (WDT Offset: 0x2) (R/W  8) Early Warning Interrupt Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EWOFFSET:4;       /*!< bit:  0.. 3  Early Warning Interrupt Time Offset */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_EWCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_EWCTRL_OFFSET           0x2          /**< \brief (WDT_EWCTRL offset) Early Warning Interrupt Control */
+#define WDT_EWCTRL_RESETVALUE       0x0Bul       /**< \brief (WDT_EWCTRL reset_value) Early Warning Interrupt Control */
+
+#define WDT_EWCTRL_EWOFFSET_Pos     0            /**< \brief (WDT_EWCTRL) Early Warning Interrupt Time Offset */
+#define WDT_EWCTRL_EWOFFSET_Msk     (0xFul << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET(value)  (WDT_EWCTRL_EWOFFSET_Msk & ((value) << WDT_EWCTRL_EWOFFSET_Pos))
+#define   WDT_EWCTRL_EWOFFSET_CYC8_Val    0x0ul  /**< \brief (WDT_EWCTRL) 8 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC16_Val   0x1ul  /**< \brief (WDT_EWCTRL) 16 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC32_Val   0x2ul  /**< \brief (WDT_EWCTRL) 32 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC64_Val   0x3ul  /**< \brief (WDT_EWCTRL) 64 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC128_Val  0x4ul  /**< \brief (WDT_EWCTRL) 128 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC256_Val  0x5ul  /**< \brief (WDT_EWCTRL) 256 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC512_Val  0x6ul  /**< \brief (WDT_EWCTRL) 512 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC1024_Val 0x7ul  /**< \brief (WDT_EWCTRL) 1024 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC2048_Val 0x8ul  /**< \brief (WDT_EWCTRL) 2048 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC4096_Val 0x9ul  /**< \brief (WDT_EWCTRL) 4096 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC8192_Val 0xAul  /**< \brief (WDT_EWCTRL) 8192 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC16384_Val 0xBul  /**< \brief (WDT_EWCTRL) 16384 clock cycles */
+#define WDT_EWCTRL_EWOFFSET_CYC8    (WDT_EWCTRL_EWOFFSET_CYC8_Val  << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC16   (WDT_EWCTRL_EWOFFSET_CYC16_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC32   (WDT_EWCTRL_EWOFFSET_CYC32_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC64   (WDT_EWCTRL_EWOFFSET_CYC64_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC128  (WDT_EWCTRL_EWOFFSET_CYC128_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC256  (WDT_EWCTRL_EWOFFSET_CYC256_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC512  (WDT_EWCTRL_EWOFFSET_CYC512_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC1024 (WDT_EWCTRL_EWOFFSET_CYC1024_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC2048 (WDT_EWCTRL_EWOFFSET_CYC2048_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC4096 (WDT_EWCTRL_EWOFFSET_CYC4096_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC8192 (WDT_EWCTRL_EWOFFSET_CYC8192_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC16384 (WDT_EWCTRL_EWOFFSET_CYC16384_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_MASK             0x0Ful       /**< \brief (WDT_EWCTRL) MASK Register */
+
+/* -------- WDT_INTENCLR : (WDT Offset: 0x4) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EW:1;             /*!< bit:      0  Early Warning Interrupt Enable     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENCLR_OFFSET         0x4          /**< \brief (WDT_INTENCLR offset) Interrupt Enable Clear */
+#define WDT_INTENCLR_RESETVALUE     0x00ul       /**< \brief (WDT_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define WDT_INTENCLR_EW_Pos         0            /**< \brief (WDT_INTENCLR) Early Warning Interrupt Enable */
+#define WDT_INTENCLR_EW             (0x1ul << WDT_INTENCLR_EW_Pos)
+#define WDT_INTENCLR_MASK           0x01ul       /**< \brief (WDT_INTENCLR) MASK Register */
+
+/* -------- WDT_INTENSET : (WDT Offset: 0x5) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EW:1;             /*!< bit:      0  Early Warning Interrupt Enable     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENSET_OFFSET         0x5          /**< \brief (WDT_INTENSET offset) Interrupt Enable Set */
+#define WDT_INTENSET_RESETVALUE     0x00ul       /**< \brief (WDT_INTENSET reset_value) Interrupt Enable Set */
+
+#define WDT_INTENSET_EW_Pos         0            /**< \brief (WDT_INTENSET) Early Warning Interrupt Enable */
+#define WDT_INTENSET_EW             (0x1ul << WDT_INTENSET_EW_Pos)
+#define WDT_INTENSET_MASK           0x01ul       /**< \brief (WDT_INTENSET) MASK Register */
+
+/* -------- WDT_INTFLAG : (WDT Offset: 0x6) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTFLAG_OFFSET          0x6          /**< \brief (WDT_INTFLAG offset) Interrupt Flag Status and Clear */
+#define WDT_INTFLAG_RESETVALUE      0x00ul       /**< \brief (WDT_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define WDT_INTFLAG_EW_Pos          0            /**< \brief (WDT_INTFLAG) Early Warning */
+#define WDT_INTFLAG_EW              (0x1ul << WDT_INTFLAG_EW_Pos)
+#define WDT_INTFLAG_MASK            0x01ul       /**< \brief (WDT_INTFLAG) MASK Register */
+
+/* -------- WDT_SYNCBUSY : (WDT Offset: 0x8) (R/  32) Synchronization Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable Busy                        */
+    uint32_t WEN:1;            /*!< bit:      2  Window Enable Busy                 */
+    uint32_t ALWAYSON:1;       /*!< bit:      3  Always-On Busy                     */
+    uint32_t CLEAR:1;          /*!< bit:      4  Clear Busy                         */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_SYNCBUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_SYNCBUSY_OFFSET         0x8          /**< \brief (WDT_SYNCBUSY offset) Synchronization Busy */
+#define WDT_SYNCBUSY_RESETVALUE     0x00000000ul /**< \brief (WDT_SYNCBUSY reset_value) Synchronization Busy */
+
+#define WDT_SYNCBUSY_ENABLE_Pos     1            /**< \brief (WDT_SYNCBUSY) Enable Busy */
+#define WDT_SYNCBUSY_ENABLE         (0x1ul << WDT_SYNCBUSY_ENABLE_Pos)
+#define WDT_SYNCBUSY_WEN_Pos        2            /**< \brief (WDT_SYNCBUSY) Window Enable Busy */
+#define WDT_SYNCBUSY_WEN            (0x1ul << WDT_SYNCBUSY_WEN_Pos)
+#define WDT_SYNCBUSY_ALWAYSON_Pos   3            /**< \brief (WDT_SYNCBUSY) Always-On Busy */
+#define WDT_SYNCBUSY_ALWAYSON       (0x1ul << WDT_SYNCBUSY_ALWAYSON_Pos)
+#define WDT_SYNCBUSY_CLEAR_Pos      4            /**< \brief (WDT_SYNCBUSY) Clear Busy */
+#define WDT_SYNCBUSY_CLEAR          (0x1ul << WDT_SYNCBUSY_CLEAR_Pos)
+#define WDT_SYNCBUSY_MASK           0x0000001Eul /**< \brief (WDT_SYNCBUSY) MASK Register */
+
+/* -------- WDT_CLEAR : (WDT Offset: 0xC) ( /W  8) Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CLEAR:8;          /*!< bit:  0.. 7  Watchdog Clear                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_CLEAR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CLEAR_OFFSET            0xC          /**< \brief (WDT_CLEAR offset) Clear */
+#define WDT_CLEAR_RESETVALUE        0x00ul       /**< \brief (WDT_CLEAR reset_value) Clear */
+
+#define WDT_CLEAR_CLEAR_Pos         0            /**< \brief (WDT_CLEAR) Watchdog Clear */
+#define WDT_CLEAR_CLEAR_Msk         (0xFFul << WDT_CLEAR_CLEAR_Pos)
+#define WDT_CLEAR_CLEAR(value)      (WDT_CLEAR_CLEAR_Msk & ((value) << WDT_CLEAR_CLEAR_Pos))
+#define   WDT_CLEAR_CLEAR_KEY_Val         0xA5ul  /**< \brief (WDT_CLEAR) Clear Key */
+#define WDT_CLEAR_CLEAR_KEY         (WDT_CLEAR_CLEAR_KEY_Val       << WDT_CLEAR_CLEAR_Pos)
+#define WDT_CLEAR_MASK              0xFFul       /**< \brief (WDT_CLEAR) MASK Register */
+
+/** \brief WDT hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO WDT_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x0 (R/W  8) Control */
+  __IO WDT_CONFIG_Type           CONFIG;      /**< \brief Offset: 0x1 (R/W  8) Configuration */
+  __IO WDT_EWCTRL_Type           EWCTRL;      /**< \brief Offset: 0x2 (R/W  8) Early Warning Interrupt Control */
+       RoReg8                    Reserved1[0x1];
+  __IO WDT_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x4 (R/W  8) Interrupt Enable Clear */
+  __IO WDT_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x5 (R/W  8) Interrupt Enable Set */
+  __IO WDT_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x6 (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved2[0x1];
+  __I  WDT_SYNCBUSY_Type         SYNCBUSY;    /**< \brief Offset: 0x8 (R/  32) Synchronization Busy */
+  __O  WDT_CLEAR_Type            CLEAR;       /**< \brief Offset: 0xC ( /W  8) Clear */
+} Wdt;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAML21_WDT_COMPONENT_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/ac.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/ac.h
@@ -1,0 +1,88 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_AC_INSTANCE_
+#define _SAML21_AC_INSTANCE_
+
+/* ========== Register definition for AC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_AC_CTRLA               (0x43001000U) /**< \brief (AC) Control A */
+#define REG_AC_CTRLB               (0x43001001U) /**< \brief (AC) Control B */
+#define REG_AC_EVCTRL              (0x43001002U) /**< \brief (AC) Event Control */
+#define REG_AC_INTENCLR            (0x43001004U) /**< \brief (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET            (0x43001005U) /**< \brief (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG             (0x43001006U) /**< \brief (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA             (0x43001007U) /**< \brief (AC) Status A */
+#define REG_AC_STATUSB             (0x43001008U) /**< \brief (AC) Status B */
+#define REG_AC_DBGCTRL             (0x43001009U) /**< \brief (AC) Debug Control */
+#define REG_AC_WINCTRL             (0x4300100AU) /**< \brief (AC) Window Control */
+#define REG_AC_SCALER0             (0x4300100CU) /**< \brief (AC) Scaler 0 */
+#define REG_AC_SCALER1             (0x4300100DU) /**< \brief (AC) Scaler 1 */
+#define REG_AC_COMPCTRL0           (0x43001010U) /**< \brief (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1           (0x43001014U) /**< \brief (AC) Comparator Control 1 */
+#define REG_AC_SYNCBUSY            (0x43001020U) /**< \brief (AC) Synchronization Busy */
+#else
+#define REG_AC_CTRLA               (*(RwReg8 *)0x43001000U) /**< \brief (AC) Control A */
+#define REG_AC_CTRLB               (*(WoReg8 *)0x43001001U) /**< \brief (AC) Control B */
+#define REG_AC_EVCTRL              (*(RwReg16*)0x43001002U) /**< \brief (AC) Event Control */
+#define REG_AC_INTENCLR            (*(RwReg8 *)0x43001004U) /**< \brief (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET            (*(RwReg8 *)0x43001005U) /**< \brief (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG             (*(RwReg8 *)0x43001006U) /**< \brief (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA             (*(RoReg8 *)0x43001007U) /**< \brief (AC) Status A */
+#define REG_AC_STATUSB             (*(RoReg8 *)0x43001008U) /**< \brief (AC) Status B */
+#define REG_AC_DBGCTRL             (*(RwReg8 *)0x43001009U) /**< \brief (AC) Debug Control */
+#define REG_AC_WINCTRL             (*(RwReg8 *)0x4300100AU) /**< \brief (AC) Window Control */
+#define REG_AC_SCALER0             (*(RwReg8 *)0x4300100CU) /**< \brief (AC) Scaler 0 */
+#define REG_AC_SCALER1             (*(RwReg8 *)0x4300100DU) /**< \brief (AC) Scaler 1 */
+#define REG_AC_COMPCTRL0           (*(RwReg  *)0x43001010U) /**< \brief (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1           (*(RwReg  *)0x43001014U) /**< \brief (AC) Comparator Control 1 */
+#define REG_AC_SYNCBUSY            (*(RoReg  *)0x43001020U) /**< \brief (AC) Synchronization Busy */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for AC peripheral ========== */
+#define AC_COMPCTRL_MUXNEG_OPAMP    7        // OPAMP selection for MUXNEG
+#define AC_GCLK_ID                  31       // Index of Generic Clock
+#define AC_NUM_CMP                  2        // Number of comparators
+#define AC_PAIRS                    1        // Number of pairs of comparators
+
+#endif /* _SAML21_AC_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/adc_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/adc_100.h
@@ -1,0 +1,103 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ADC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_ADC_INSTANCE_
+#define _SAML21_ADC_INSTANCE_
+
+/* ========== Register definition for ADC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_ADC_CTRLA              (0x43000C00U) /**< \brief (ADC) Control A */
+#define REG_ADC_CTRLB              (0x43000C01U) /**< \brief (ADC) Control B */
+#define REG_ADC_REFCTRL            (0x43000C02U) /**< \brief (ADC) Reference Control */
+#define REG_ADC_EVCTRL             (0x43000C03U) /**< \brief (ADC) Event Control */
+#define REG_ADC_INTENCLR           (0x43000C04U) /**< \brief (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET           (0x43000C05U) /**< \brief (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG            (0x43000C06U) /**< \brief (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_SEQSTATUS          (0x43000C07U) /**< \brief (ADC) Sequence Status */
+#define REG_ADC_INPUTCTRL          (0x43000C08U) /**< \brief (ADC) Input Control */
+#define REG_ADC_CTRLC              (0x43000C0AU) /**< \brief (ADC) Control C */
+#define REG_ADC_AVGCTRL            (0x43000C0CU) /**< \brief (ADC) Average Control */
+#define REG_ADC_SAMPCTRL           (0x43000C0DU) /**< \brief (ADC) Sample Time Control */
+#define REG_ADC_WINLT              (0x43000C0EU) /**< \brief (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT              (0x43000C10U) /**< \brief (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR           (0x43000C12U) /**< \brief (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR         (0x43000C14U) /**< \brief (ADC) Offset Correction */
+#define REG_ADC_SWTRIG             (0x43000C18U) /**< \brief (ADC) Software Trigger */
+#define REG_ADC_DBGCTRL            (0x43000C1CU) /**< \brief (ADC) Debug Control */
+#define REG_ADC_SYNCBUSY           (0x43000C20U) /**< \brief (ADC) Synchronization Busy */
+#define REG_ADC_RESULT             (0x43000C24U) /**< \brief (ADC) Result */
+#define REG_ADC_SEQCTRL            (0x43000C28U) /**< \brief (ADC) Sequence Control */
+#define REG_ADC_CALIB              (0x43000C2CU) /**< \brief (ADC) Calibration */
+#else
+#define REG_ADC_CTRLA              (*(RwReg8 *)0x43000C00U) /**< \brief (ADC) Control A */
+#define REG_ADC_CTRLB              (*(RwReg8 *)0x43000C01U) /**< \brief (ADC) Control B */
+#define REG_ADC_REFCTRL            (*(RwReg8 *)0x43000C02U) /**< \brief (ADC) Reference Control */
+#define REG_ADC_EVCTRL             (*(RwReg8 *)0x43000C03U) /**< \brief (ADC) Event Control */
+#define REG_ADC_INTENCLR           (*(RwReg8 *)0x43000C04U) /**< \brief (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET           (*(RwReg8 *)0x43000C05U) /**< \brief (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG            (*(RwReg8 *)0x43000C06U) /**< \brief (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_SEQSTATUS          (*(RoReg8 *)0x43000C07U) /**< \brief (ADC) Sequence Status */
+#define REG_ADC_INPUTCTRL          (*(RwReg16*)0x43000C08U) /**< \brief (ADC) Input Control */
+#define REG_ADC_CTRLC              (*(RwReg16*)0x43000C0AU) /**< \brief (ADC) Control C */
+#define REG_ADC_AVGCTRL            (*(RwReg8 *)0x43000C0CU) /**< \brief (ADC) Average Control */
+#define REG_ADC_SAMPCTRL           (*(RwReg8 *)0x43000C0DU) /**< \brief (ADC) Sample Time Control */
+#define REG_ADC_WINLT              (*(RwReg16*)0x43000C0EU) /**< \brief (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT              (*(RwReg16*)0x43000C10U) /**< \brief (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR           (*(RwReg16*)0x43000C12U) /**< \brief (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR         (*(RwReg16*)0x43000C14U) /**< \brief (ADC) Offset Correction */
+#define REG_ADC_SWTRIG             (*(RwReg8 *)0x43000C18U) /**< \brief (ADC) Software Trigger */
+#define REG_ADC_DBGCTRL            (*(RwReg8 *)0x43000C1CU) /**< \brief (ADC) Debug Control */
+#define REG_ADC_SYNCBUSY           (*(RoReg16*)0x43000C20U) /**< \brief (ADC) Synchronization Busy */
+#define REG_ADC_RESULT             (*(RoReg16*)0x43000C24U) /**< \brief (ADC) Result */
+#define REG_ADC_SEQCTRL            (*(RwReg  *)0x43000C28U) /**< \brief (ADC) Sequence Control */
+#define REG_ADC_CALIB              (*(RwReg16*)0x43000C2CU) /**< \brief (ADC) Calibration */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for ADC peripheral ========== */
+#define ADC_DMAC_ID_RESRDY          37       // index of DMA RESRDY trigger
+#define ADC_EXTCHANNEL_MSB          19       // Number of external channels
+#define ADC_GCLK_ID                 30       // index of Generic Clock
+#define ADC_RESULT_BITS             16       // Size of RESULT.RESULT bitfield
+#define ADC_RESULT_MSB              15       // Size of Result
+
+#endif /* _SAML21_ADC_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/aes.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/aes.h
@@ -1,0 +1,116 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AES
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_AES_INSTANCE_
+#define _SAML21_AES_INSTANCE_
+
+/* ========== Register definition for AES peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_AES_CTRLA              (0x42003400U) /**< \brief (AES) Control A */
+#define REG_AES_CTRLB              (0x42003404U) /**< \brief (AES) Control B */
+#define REG_AES_INTENCLR           (0x42003405U) /**< \brief (AES) Interrupt Enable Clear */
+#define REG_AES_INTENSET           (0x42003406U) /**< \brief (AES) Interrupt Enable Set */
+#define REG_AES_INTFLAG            (0x42003407U) /**< \brief (AES) Interrupt Flag Status */
+#define REG_AES_DATABUFPTR         (0x42003408U) /**< \brief (AES) Data buffer pointer */
+#define REG_AES_DBGCTRL            (0x42003409U) /**< \brief (AES) Debug control */
+#define REG_AES_KEYWORD0           (0x4200340CU) /**< \brief (AES) Keyword 0 */
+#define REG_AES_KEYWORD1           (0x42003410U) /**< \brief (AES) Keyword 1 */
+#define REG_AES_KEYWORD2           (0x42003414U) /**< \brief (AES) Keyword 2 */
+#define REG_AES_KEYWORD3           (0x42003418U) /**< \brief (AES) Keyword 3 */
+#define REG_AES_KEYWORD4           (0x4200341CU) /**< \brief (AES) Keyword 4 */
+#define REG_AES_KEYWORD5           (0x42003420U) /**< \brief (AES) Keyword 5 */
+#define REG_AES_KEYWORD6           (0x42003424U) /**< \brief (AES) Keyword 6 */
+#define REG_AES_KEYWORD7           (0x42003428U) /**< \brief (AES) Keyword 7 */
+#define REG_AES_INDATA             (0x42003438U) /**< \brief (AES) Indata */
+#define REG_AES_INTVECTV0          (0x4200343CU) /**< \brief (AES) Initialisation Vector 0 */
+#define REG_AES_INTVECTV1          (0x42003440U) /**< \brief (AES) Initialisation Vector 1 */
+#define REG_AES_INTVECTV2          (0x42003444U) /**< \brief (AES) Initialisation Vector 2 */
+#define REG_AES_INTVECTV3          (0x42003448U) /**< \brief (AES) Initialisation Vector 3 */
+#define REG_AES_HASHKEY0           (0x4200345CU) /**< \brief (AES) Hash key 0 */
+#define REG_AES_HASHKEY1           (0x42003460U) /**< \brief (AES) Hash key 1 */
+#define REG_AES_HASHKEY2           (0x42003464U) /**< \brief (AES) Hash key 2 */
+#define REG_AES_HASHKEY3           (0x42003468U) /**< \brief (AES) Hash key 3 */
+#define REG_AES_GHASH0             (0x4200346CU) /**< \brief (AES) Galois Hash 0 */
+#define REG_AES_GHASH1             (0x42003470U) /**< \brief (AES) Galois Hash 1 */
+#define REG_AES_GHASH2             (0x42003474U) /**< \brief (AES) Galois Hash 2 */
+#define REG_AES_GHASH3             (0x42003478U) /**< \brief (AES) Galois Hash 3 */
+#define REG_AES_CIPLEN             (0x42003480U) /**< \brief (AES) Cipher Length */
+#define REG_AES_RANDSEED           (0x42003484U) /**< \brief (AES) Random Seed */
+#else
+#define REG_AES_CTRLA              (*(RwReg  *)0x42003400U) /**< \brief (AES) Control A */
+#define REG_AES_CTRLB              (*(RwReg8 *)0x42003404U) /**< \brief (AES) Control B */
+#define REG_AES_INTENCLR           (*(RwReg8 *)0x42003405U) /**< \brief (AES) Interrupt Enable Clear */
+#define REG_AES_INTENSET           (*(RwReg8 *)0x42003406U) /**< \brief (AES) Interrupt Enable Set */
+#define REG_AES_INTFLAG            (*(RwReg8 *)0x42003407U) /**< \brief (AES) Interrupt Flag Status */
+#define REG_AES_DATABUFPTR         (*(RwReg8 *)0x42003408U) /**< \brief (AES) Data buffer pointer */
+#define REG_AES_DBGCTRL            (*(WoReg8 *)0x42003409U) /**< \brief (AES) Debug control */
+#define REG_AES_KEYWORD0           (*(WoReg  *)0x4200340CU) /**< \brief (AES) Keyword 0 */
+#define REG_AES_KEYWORD1           (*(WoReg  *)0x42003410U) /**< \brief (AES) Keyword 1 */
+#define REG_AES_KEYWORD2           (*(WoReg  *)0x42003414U) /**< \brief (AES) Keyword 2 */
+#define REG_AES_KEYWORD3           (*(WoReg  *)0x42003418U) /**< \brief (AES) Keyword 3 */
+#define REG_AES_KEYWORD4           (*(WoReg  *)0x4200341CU) /**< \brief (AES) Keyword 4 */
+#define REG_AES_KEYWORD5           (*(WoReg  *)0x42003420U) /**< \brief (AES) Keyword 5 */
+#define REG_AES_KEYWORD6           (*(WoReg  *)0x42003424U) /**< \brief (AES) Keyword 6 */
+#define REG_AES_KEYWORD7           (*(WoReg  *)0x42003428U) /**< \brief (AES) Keyword 7 */
+#define REG_AES_INDATA             (*(RwReg  *)0x42003438U) /**< \brief (AES) Indata */
+#define REG_AES_INTVECTV0          (*(WoReg  *)0x4200343CU) /**< \brief (AES) Initialisation Vector 0 */
+#define REG_AES_INTVECTV1          (*(WoReg  *)0x42003440U) /**< \brief (AES) Initialisation Vector 1 */
+#define REG_AES_INTVECTV2          (*(WoReg  *)0x42003444U) /**< \brief (AES) Initialisation Vector 2 */
+#define REG_AES_INTVECTV3          (*(WoReg  *)0x42003448U) /**< \brief (AES) Initialisation Vector 3 */
+#define REG_AES_HASHKEY0           (*(RwReg  *)0x4200345CU) /**< \brief (AES) Hash key 0 */
+#define REG_AES_HASHKEY1           (*(RwReg  *)0x42003460U) /**< \brief (AES) Hash key 1 */
+#define REG_AES_HASHKEY2           (*(RwReg  *)0x42003464U) /**< \brief (AES) Hash key 2 */
+#define REG_AES_HASHKEY3           (*(RwReg  *)0x42003468U) /**< \brief (AES) Hash key 3 */
+#define REG_AES_GHASH0             (*(RwReg  *)0x4200346CU) /**< \brief (AES) Galois Hash 0 */
+#define REG_AES_GHASH1             (*(RwReg  *)0x42003470U) /**< \brief (AES) Galois Hash 1 */
+#define REG_AES_GHASH2             (*(RwReg  *)0x42003474U) /**< \brief (AES) Galois Hash 2 */
+#define REG_AES_GHASH3             (*(RwReg  *)0x42003478U) /**< \brief (AES) Galois Hash 3 */
+#define REG_AES_CIPLEN             (*(RwReg  *)0x42003480U) /**< \brief (AES) Cipher Length */
+#define REG_AES_RANDSEED           (*(RwReg  *)0x42003484U) /**< \brief (AES) Random Seed */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for AES peripheral ========== */
+#define AES_DMAC_ID_RD              45       // DMA DATA Read trigger
+#define AES_DMAC_ID_WR              44       // DMA DATA Write trigger
+
+#endif /* _SAML21_AES_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/ccl.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/ccl.h
@@ -1,0 +1,72 @@
+/**
+ * \file
+ *
+ * \brief Instance description for CCL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_CCL_INSTANCE_
+#define _SAML21_CCL_INSTANCE_
+
+/* ========== Register definition for CCL peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_CCL_CTRL               (0x43001C00U) /**< \brief (CCL) Control */
+#define REG_CCL_SEQCTRL0           (0x43001C04U) /**< \brief (CCL) SEQ Control x 0 */
+#define REG_CCL_SEQCTRL1           (0x43001C05U) /**< \brief (CCL) SEQ Control x 1 */
+#define REG_CCL_LUTCTRL0           (0x43001C08U) /**< \brief (CCL) LUT Control x 0 */
+#define REG_CCL_LUTCTRL1           (0x43001C0CU) /**< \brief (CCL) LUT Control x 1 */
+#define REG_CCL_LUTCTRL2           (0x43001C10U) /**< \brief (CCL) LUT Control x 2 */
+#define REG_CCL_LUTCTRL3           (0x43001C14U) /**< \brief (CCL) LUT Control x 3 */
+#else
+#define REG_CCL_CTRL               (*(RwReg8 *)0x43001C00U) /**< \brief (CCL) Control */
+#define REG_CCL_SEQCTRL0           (*(RwReg8 *)0x43001C04U) /**< \brief (CCL) SEQ Control x 0 */
+#define REG_CCL_SEQCTRL1           (*(RwReg8 *)0x43001C05U) /**< \brief (CCL) SEQ Control x 1 */
+#define REG_CCL_LUTCTRL0           (*(RwReg  *)0x43001C08U) /**< \brief (CCL) LUT Control x 0 */
+#define REG_CCL_LUTCTRL1           (*(RwReg  *)0x43001C0CU) /**< \brief (CCL) LUT Control x 1 */
+#define REG_CCL_LUTCTRL2           (*(RwReg  *)0x43001C10U) /**< \brief (CCL) LUT Control x 2 */
+#define REG_CCL_LUTCTRL3           (*(RwReg  *)0x43001C14U) /**< \brief (CCL) LUT Control x 3 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for CCL peripheral ========== */
+#define CCL_GCLK_ID                 34       // GCLK index for CCL
+#define CCL_IO_NUM                  12       // Numer of input pins
+#define CCL_LUT_NUM                 4        // Number of LUT in a CCL
+#define CCL_SEQ_NUM                 2        // Number of SEQ in a CCL
+
+#endif /* _SAML21_CCL_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/dac.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/dac.h
@@ -1,0 +1,92 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DAC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_DAC_INSTANCE_
+#define _SAML21_DAC_INSTANCE_
+
+/* ========== Register definition for DAC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DAC_CTRLA              (0x42003000U) /**< \brief (DAC) Control A */
+#define REG_DAC_CTRLB              (0x42003001U) /**< \brief (DAC) Control B */
+#define REG_DAC_EVCTRL             (0x42003002U) /**< \brief (DAC) Event Control */
+#define REG_DAC_INTENCLR           (0x42003004U) /**< \brief (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET           (0x42003005U) /**< \brief (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG            (0x42003006U) /**< \brief (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS             (0x42003007U) /**< \brief (DAC) Status */
+#define REG_DAC_SYNCBUSY           (0x42003008U) /**< \brief (DAC) Synchronization Busy */
+#define REG_DAC_DACCTRL0           (0x4200300CU) /**< \brief (DAC) DACx Control 0 */
+#define REG_DAC_DACCTRL1           (0x4200300EU) /**< \brief (DAC) DACx Control 1 */
+#define REG_DAC_DATA0              (0x42003010U) /**< \brief (DAC) Data DAC0 0 */
+#define REG_DAC_DATA1              (0x42003012U) /**< \brief (DAC) Data DAC0 1 */
+#define REG_DAC_DATABUF0           (0x42003014U) /**< \brief (DAC) Data Buffer DAC0 0 */
+#define REG_DAC_DATABUF1           (0x42003016U) /**< \brief (DAC) Data Buffer DAC0 1 */
+#define REG_DAC_DBGCTRL            (0x42003018U) /**< \brief (DAC) Debug Control */
+#else
+#define REG_DAC_CTRLA              (*(RwReg8 *)0x42003000U) /**< \brief (DAC) Control A */
+#define REG_DAC_CTRLB              (*(RwReg8 *)0x42003001U) /**< \brief (DAC) Control B */
+#define REG_DAC_EVCTRL             (*(RwReg8 *)0x42003002U) /**< \brief (DAC) Event Control */
+#define REG_DAC_INTENCLR           (*(RwReg8 *)0x42003004U) /**< \brief (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET           (*(RwReg8 *)0x42003005U) /**< \brief (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG            (*(RwReg8 *)0x42003006U) /**< \brief (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS             (*(RoReg8 *)0x42003007U) /**< \brief (DAC) Status */
+#define REG_DAC_SYNCBUSY           (*(RoReg  *)0x42003008U) /**< \brief (DAC) Synchronization Busy */
+#define REG_DAC_DACCTRL0           (*(RwReg16*)0x4200300CU) /**< \brief (DAC) DACx Control 0 */
+#define REG_DAC_DACCTRL1           (*(RwReg16*)0x4200300EU) /**< \brief (DAC) DACx Control 1 */
+#define REG_DAC_DATA0              (*(WoReg16*)0x42003010U) /**< \brief (DAC) Data DAC0 0 */
+#define REG_DAC_DATA1              (*(WoReg16*)0x42003012U) /**< \brief (DAC) Data DAC0 1 */
+#define REG_DAC_DATABUF0           (*(WoReg16*)0x42003014U) /**< \brief (DAC) Data Buffer DAC0 0 */
+#define REG_DAC_DATABUF1           (*(WoReg16*)0x42003016U) /**< \brief (DAC) Data Buffer DAC0 1 */
+#define REG_DAC_DBGCTRL            (*(RwReg8 *)0x42003018U) /**< \brief (DAC) Debug Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for DAC peripheral ========== */
+#define DAC_DAC_NUM                 2        // Number of DACs
+#define DAC_DATA_SIZE               12       // Number of bits in data
+#define DAC_DMAC_ID_EMPTY_0         38
+#define DAC_DMAC_ID_EMPTY_1         39
+#define DAC_DMAC_ID_EMPTY_LSB       38
+#define DAC_DMAC_ID_EMPTY_MSB       39
+#define DAC_DMAC_ID_EMPTY_SIZE      2
+#define DAC_GCLK_ID                 32       // Index of Generic Clock
+
+#endif /* _SAML21_DAC_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/dmac.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/dmac.h
@@ -1,0 +1,110 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DMAC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_DMAC_INSTANCE_
+#define _SAML21_DMAC_INSTANCE_
+
+/* ========== Register definition for DMAC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DMAC_CTRL              (0x44000400U) /**< \brief (DMAC) Control */
+#define REG_DMAC_CRCCTRL           (0x44000402U) /**< \brief (DMAC) CRC Control */
+#define REG_DMAC_CRCDATAIN         (0x44000404U) /**< \brief (DMAC) CRC Data Input */
+#define REG_DMAC_CRCCHKSUM         (0x44000408U) /**< \brief (DMAC) CRC Checksum */
+#define REG_DMAC_CRCSTATUS         (0x4400040CU) /**< \brief (DMAC) CRC Status */
+#define REG_DMAC_DBGCTRL           (0x4400040DU) /**< \brief (DMAC) Debug Control */
+#define REG_DMAC_SWTRIGCTRL        (0x44000410U) /**< \brief (DMAC) Software Trigger Control */
+#define REG_DMAC_PRICTRL0          (0x44000414U) /**< \brief (DMAC) Priority Control 0 */
+#define REG_DMAC_INTPEND           (0x44000420U) /**< \brief (DMAC) Interrupt Pending */
+#define REG_DMAC_INTSTATUS         (0x44000424U) /**< \brief (DMAC) Interrupt Status */
+#define REG_DMAC_BUSYCH            (0x44000428U) /**< \brief (DMAC) Busy Channels */
+#define REG_DMAC_PENDCH            (0x4400042CU) /**< \brief (DMAC) Pending Channels */
+#define REG_DMAC_ACTIVE            (0x44000430U) /**< \brief (DMAC) Active Channel and Levels */
+#define REG_DMAC_BASEADDR          (0x44000434U) /**< \brief (DMAC) Descriptor Memory Section Base Address */
+#define REG_DMAC_WRBADDR           (0x44000438U) /**< \brief (DMAC) Write-Back Memory Section Base Address */
+#define REG_DMAC_CHID              (0x4400043FU) /**< \brief (DMAC) Channel ID */
+#define REG_DMAC_CHCTRLA           (0x44000440U) /**< \brief (DMAC) Channel Control A */
+#define REG_DMAC_CHCTRLB           (0x44000444U) /**< \brief (DMAC) Channel Control B */
+#define REG_DMAC_CHINTENCLR        (0x4400044CU) /**< \brief (DMAC) Channel Interrupt Enable Clear */
+#define REG_DMAC_CHINTENSET        (0x4400044DU) /**< \brief (DMAC) Channel Interrupt Enable Set */
+#define REG_DMAC_CHINTFLAG         (0x4400044EU) /**< \brief (DMAC) Channel Interrupt Flag Status and Clear */
+#define REG_DMAC_CHSTATUS          (0x4400044FU) /**< \brief (DMAC) Channel Status */
+#else
+#define REG_DMAC_CTRL              (*(RwReg16*)0x44000400U) /**< \brief (DMAC) Control */
+#define REG_DMAC_CRCCTRL           (*(RwReg16*)0x44000402U) /**< \brief (DMAC) CRC Control */
+#define REG_DMAC_CRCDATAIN         (*(RwReg  *)0x44000404U) /**< \brief (DMAC) CRC Data Input */
+#define REG_DMAC_CRCCHKSUM         (*(RwReg  *)0x44000408U) /**< \brief (DMAC) CRC Checksum */
+#define REG_DMAC_CRCSTATUS         (*(RwReg8 *)0x4400040CU) /**< \brief (DMAC) CRC Status */
+#define REG_DMAC_DBGCTRL           (*(RwReg8 *)0x4400040DU) /**< \brief (DMAC) Debug Control */
+#define REG_DMAC_SWTRIGCTRL        (*(RwReg  *)0x44000410U) /**< \brief (DMAC) Software Trigger Control */
+#define REG_DMAC_PRICTRL0          (*(RwReg  *)0x44000414U) /**< \brief (DMAC) Priority Control 0 */
+#define REG_DMAC_INTPEND           (*(RwReg16*)0x44000420U) /**< \brief (DMAC) Interrupt Pending */
+#define REG_DMAC_INTSTATUS         (*(RoReg  *)0x44000424U) /**< \brief (DMAC) Interrupt Status */
+#define REG_DMAC_BUSYCH            (*(RoReg  *)0x44000428U) /**< \brief (DMAC) Busy Channels */
+#define REG_DMAC_PENDCH            (*(RoReg  *)0x4400042CU) /**< \brief (DMAC) Pending Channels */
+#define REG_DMAC_ACTIVE            (*(RoReg  *)0x44000430U) /**< \brief (DMAC) Active Channel and Levels */
+#define REG_DMAC_BASEADDR          (*(RwReg  *)0x44000434U) /**< \brief (DMAC) Descriptor Memory Section Base Address */
+#define REG_DMAC_WRBADDR           (*(RwReg  *)0x44000438U) /**< \brief (DMAC) Write-Back Memory Section Base Address */
+#define REG_DMAC_CHID              (*(RwReg8 *)0x4400043FU) /**< \brief (DMAC) Channel ID */
+#define REG_DMAC_CHCTRLA           (*(RwReg8 *)0x44000440U) /**< \brief (DMAC) Channel Control A */
+#define REG_DMAC_CHCTRLB           (*(RwReg  *)0x44000444U) /**< \brief (DMAC) Channel Control B */
+#define REG_DMAC_CHINTENCLR        (*(RwReg8 *)0x4400044CU) /**< \brief (DMAC) Channel Interrupt Enable Clear */
+#define REG_DMAC_CHINTENSET        (*(RwReg8 *)0x4400044DU) /**< \brief (DMAC) Channel Interrupt Enable Set */
+#define REG_DMAC_CHINTFLAG         (*(RwReg8 *)0x4400044EU) /**< \brief (DMAC) Channel Interrupt Flag Status and Clear */
+#define REG_DMAC_CHSTATUS          (*(RoReg8 *)0x4400044FU) /**< \brief (DMAC) Channel Status */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for DMAC peripheral ========== */
+#define DMAC_CH_BITS                4        // Number of bits to select channel
+#define DMAC_CH_NUM                 16       // Number of channels
+#define DMAC_CLK_AHB_ID             11       // AHB clock index
+#define DMAC_EVIN_NUM               8        // Number of input events
+#define DMAC_EVOUT_NUM              8        // Number of output events
+#define DMAC_LVL_BITS               2        // Number of bit to select level priority
+#define DMAC_LVL_NUM                4        // Enable priority level number
+#define DMAC_QOSCTRL_D_RESETVALUE   2        // QOS dmac ahb interface reset value
+#define DMAC_QOSCTRL_F_RESETVALUE   2        // QOS dmac fetch interface reset value
+#define DMAC_QOSCTRL_WRB_RESETVALUE 2        // QOS dmac write back interface reset value
+#define DMAC_TRIG_BITS              6        // Number of bits to select trigger source
+#define DMAC_TRIG_NUM               46       // Number of peripheral triggers
+
+#endif /* _SAML21_DMAC_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/dsu.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/dsu.h
@@ -1,0 +1,109 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DSU
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_DSU_INSTANCE_
+#define _SAML21_DSU_INSTANCE_
+
+/* ========== Register definition for DSU peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DSU_CTRL               (0x41002000U) /**< \brief (DSU) Control */
+#define REG_DSU_STATUSA            (0x41002001U) /**< \brief (DSU) Status A */
+#define REG_DSU_STATUSB            (0x41002002U) /**< \brief (DSU) Status B */
+#define REG_DSU_ADDR               (0x41002004U) /**< \brief (DSU) Address */
+#define REG_DSU_LENGTH             (0x41002008U) /**< \brief (DSU) Length */
+#define REG_DSU_DATA               (0x4100200CU) /**< \brief (DSU) Data */
+#define REG_DSU_DCC0               (0x41002010U) /**< \brief (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1               (0x41002014U) /**< \brief (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID                (0x41002018U) /**< \brief (DSU) Device Identification */
+#define REG_DSU_DCFG0              (0x410020F0U) /**< \brief (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1              (0x410020F4U) /**< \brief (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0             (0x41003000U) /**< \brief (DSU) Coresight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1             (0x41003004U) /**< \brief (DSU) Coresight ROM Table Entry 1 */
+#define REG_DSU_END                (0x41003008U) /**< \brief (DSU) Coresight ROM Table End */
+#define REG_DSU_MEMTYPE            (0x41003FCCU) /**< \brief (DSU) Coresight ROM Table Memory Type */
+#define REG_DSU_PID4               (0x41003FD0U) /**< \brief (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5               (0x41003FD4U) /**< \brief (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6               (0x41003FD8U) /**< \brief (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7               (0x41003FDCU) /**< \brief (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0               (0x41003FE0U) /**< \brief (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1               (0x41003FE4U) /**< \brief (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2               (0x41003FE8U) /**< \brief (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3               (0x41003FECU) /**< \brief (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0               (0x41003FF0U) /**< \brief (DSU) Component Identification 0 */
+#define REG_DSU_CID1               (0x41003FF4U) /**< \brief (DSU) Component Identification 1 */
+#define REG_DSU_CID2               (0x41003FF8U) /**< \brief (DSU) Component Identification 2 */
+#define REG_DSU_CID3               (0x41003FFCU) /**< \brief (DSU) Component Identification 3 */
+#else
+#define REG_DSU_CTRL               (*(WoReg8 *)0x41002000U) /**< \brief (DSU) Control */
+#define REG_DSU_STATUSA            (*(RwReg8 *)0x41002001U) /**< \brief (DSU) Status A */
+#define REG_DSU_STATUSB            (*(RoReg8 *)0x41002002U) /**< \brief (DSU) Status B */
+#define REG_DSU_ADDR               (*(RwReg  *)0x41002004U) /**< \brief (DSU) Address */
+#define REG_DSU_LENGTH             (*(RwReg  *)0x41002008U) /**< \brief (DSU) Length */
+#define REG_DSU_DATA               (*(RwReg  *)0x4100200CU) /**< \brief (DSU) Data */
+#define REG_DSU_DCC0               (*(RwReg  *)0x41002010U) /**< \brief (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1               (*(RwReg  *)0x41002014U) /**< \brief (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID                (*(RoReg  *)0x41002018U) /**< \brief (DSU) Device Identification */
+#define REG_DSU_DCFG0              (*(RwReg  *)0x410020F0U) /**< \brief (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1              (*(RwReg  *)0x410020F4U) /**< \brief (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0             (*(RoReg  *)0x41003000U) /**< \brief (DSU) Coresight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1             (*(RoReg  *)0x41003004U) /**< \brief (DSU) Coresight ROM Table Entry 1 */
+#define REG_DSU_END                (*(RoReg  *)0x41003008U) /**< \brief (DSU) Coresight ROM Table End */
+#define REG_DSU_MEMTYPE            (*(RoReg  *)0x41003FCCU) /**< \brief (DSU) Coresight ROM Table Memory Type */
+#define REG_DSU_PID4               (*(RoReg  *)0x41003FD0U) /**< \brief (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5               (*(RoReg  *)0x41003FD4U) /**< \brief (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6               (*(RoReg  *)0x41003FD8U) /**< \brief (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7               (*(RoReg  *)0x41003FDCU) /**< \brief (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0               (*(RoReg  *)0x41003FE0U) /**< \brief (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1               (*(RoReg  *)0x41003FE4U) /**< \brief (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2               (*(RoReg  *)0x41003FE8U) /**< \brief (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3               (*(RoReg  *)0x41003FECU) /**< \brief (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0               (*(RoReg  *)0x41003FF0U) /**< \brief (DSU) Component Identification 0 */
+#define REG_DSU_CID1               (*(RoReg  *)0x41003FF4U) /**< \brief (DSU) Component Identification 1 */
+#define REG_DSU_CID2               (*(RoReg  *)0x41003FF8U) /**< \brief (DSU) Component Identification 2 */
+#define REG_DSU_CID3               (*(RoReg  *)0x41003FFCU) /**< \brief (DSU) Component Identification 3 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for DSU peripheral ========== */
+#define DSU_CLK_AHB_ID              5       
+
+#endif /* _SAML21_DSU_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/eic_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/eic_100.h
@@ -1,0 +1,77 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EIC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_EIC_INSTANCE_
+#define _SAML21_EIC_INSTANCE_
+
+/* ========== Register definition for EIC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_EIC_CTRLA              (0x40002400U) /**< \brief (EIC) Control */
+#define REG_EIC_NMICTRL            (0x40002401U) /**< \brief (EIC) NMI Control */
+#define REG_EIC_NMIFLAG            (0x40002402U) /**< \brief (EIC) NMI Interrupt Flag */
+#define REG_EIC_SYNCBUSY           (0x40002404U) /**< \brief (EIC) Syncbusy register */
+#define REG_EIC_EVCTRL             (0x40002408U) /**< \brief (EIC) Event Control */
+#define REG_EIC_INTENCLR           (0x4000240CU) /**< \brief (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET           (0x40002410U) /**< \brief (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG            (0x40002414U) /**< \brief (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_CONFIG0            (0x4000241CU) /**< \brief (EIC) Configuration 0 */
+#define REG_EIC_CONFIG1            (0x40002420U) /**< \brief (EIC) Configuration 1 */
+#else
+#define REG_EIC_CTRLA              (*(RwReg8 *)0x40002400U) /**< \brief (EIC) Control */
+#define REG_EIC_NMICTRL            (*(RwReg8 *)0x40002401U) /**< \brief (EIC) NMI Control */
+#define REG_EIC_NMIFLAG            (*(RwReg16*)0x40002402U) /**< \brief (EIC) NMI Interrupt Flag */
+#define REG_EIC_SYNCBUSY           (*(RoReg  *)0x40002404U) /**< \brief (EIC) Syncbusy register */
+#define REG_EIC_EVCTRL             (*(RwReg  *)0x40002408U) /**< \brief (EIC) Event Control */
+#define REG_EIC_INTENCLR           (*(RwReg  *)0x4000240CU) /**< \brief (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET           (*(RwReg  *)0x40002410U) /**< \brief (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG            (*(RwReg  *)0x40002414U) /**< \brief (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_CONFIG0            (*(RwReg  *)0x4000241CU) /**< \brief (EIC) Configuration 0 */
+#define REG_EIC_CONFIG1            (*(RwReg  *)0x40002420U) /**< \brief (EIC) Configuration 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for EIC peripheral ========== */
+#define EIC_GCLK_ID                 3       
+#define EIC_NUMBER_OF_CONFIG_REGS   2       
+#define EIC_NUMBER_OF_INTERRUPTS    16      
+
+#endif /* _SAML21_EIC_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/evsys.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/evsys.h
@@ -1,0 +1,335 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EVSYS
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_EVSYS_INSTANCE_
+#define _SAML21_EVSYS_INSTANCE_
+
+/* ========== Register definition for EVSYS peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_EVSYS_CTRLA            (0x43000000U) /**< \brief (EVSYS) Control */
+#define REG_EVSYS_CHSTATUS         (0x4300000CU) /**< \brief (EVSYS) Channel Status */
+#define REG_EVSYS_INTENCLR         (0x43000010U) /**< \brief (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET         (0x43000014U) /**< \brief (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG          (0x43000018U) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
+#define REG_EVSYS_SWEVT            (0x4300001CU) /**< \brief (EVSYS) Software Event */
+#define REG_EVSYS_CHANNEL0         (0x43000020U) /**< \brief (EVSYS) Channel 0 */
+#define REG_EVSYS_CHANNEL1         (0x43000024U) /**< \brief (EVSYS) Channel 1 */
+#define REG_EVSYS_CHANNEL2         (0x43000028U) /**< \brief (EVSYS) Channel 2 */
+#define REG_EVSYS_CHANNEL3         (0x4300002CU) /**< \brief (EVSYS) Channel 3 */
+#define REG_EVSYS_CHANNEL4         (0x43000030U) /**< \brief (EVSYS) Channel 4 */
+#define REG_EVSYS_CHANNEL5         (0x43000034U) /**< \brief (EVSYS) Channel 5 */
+#define REG_EVSYS_CHANNEL6         (0x43000038U) /**< \brief (EVSYS) Channel 6 */
+#define REG_EVSYS_CHANNEL7         (0x4300003CU) /**< \brief (EVSYS) Channel 7 */
+#define REG_EVSYS_CHANNEL8         (0x43000040U) /**< \brief (EVSYS) Channel 8 */
+#define REG_EVSYS_CHANNEL9         (0x43000044U) /**< \brief (EVSYS) Channel 9 */
+#define REG_EVSYS_CHANNEL10        (0x43000048U) /**< \brief (EVSYS) Channel 10 */
+#define REG_EVSYS_CHANNEL11        (0x4300004CU) /**< \brief (EVSYS) Channel 11 */
+#define REG_EVSYS_USER0            (0x43000080U) /**< \brief (EVSYS) User Multiplexer 0 */
+#define REG_EVSYS_USER1            (0x43000084U) /**< \brief (EVSYS) User Multiplexer 1 */
+#define REG_EVSYS_USER2            (0x43000088U) /**< \brief (EVSYS) User Multiplexer 2 */
+#define REG_EVSYS_USER3            (0x4300008CU) /**< \brief (EVSYS) User Multiplexer 3 */
+#define REG_EVSYS_USER4            (0x43000090U) /**< \brief (EVSYS) User Multiplexer 4 */
+#define REG_EVSYS_USER5            (0x43000094U) /**< \brief (EVSYS) User Multiplexer 5 */
+#define REG_EVSYS_USER6            (0x43000098U) /**< \brief (EVSYS) User Multiplexer 6 */
+#define REG_EVSYS_USER7            (0x4300009CU) /**< \brief (EVSYS) User Multiplexer 7 */
+#define REG_EVSYS_USER8            (0x430000A0U) /**< \brief (EVSYS) User Multiplexer 8 */
+#define REG_EVSYS_USER9            (0x430000A4U) /**< \brief (EVSYS) User Multiplexer 9 */
+#define REG_EVSYS_USER10           (0x430000A8U) /**< \brief (EVSYS) User Multiplexer 10 */
+#define REG_EVSYS_USER11           (0x430000ACU) /**< \brief (EVSYS) User Multiplexer 11 */
+#define REG_EVSYS_USER12           (0x430000B0U) /**< \brief (EVSYS) User Multiplexer 12 */
+#define REG_EVSYS_USER13           (0x430000B4U) /**< \brief (EVSYS) User Multiplexer 13 */
+#define REG_EVSYS_USER14           (0x430000B8U) /**< \brief (EVSYS) User Multiplexer 14 */
+#define REG_EVSYS_USER15           (0x430000BCU) /**< \brief (EVSYS) User Multiplexer 15 */
+#define REG_EVSYS_USER16           (0x430000C0U) /**< \brief (EVSYS) User Multiplexer 16 */
+#define REG_EVSYS_USER17           (0x430000C4U) /**< \brief (EVSYS) User Multiplexer 17 */
+#define REG_EVSYS_USER18           (0x430000C8U) /**< \brief (EVSYS) User Multiplexer 18 */
+#define REG_EVSYS_USER19           (0x430000CCU) /**< \brief (EVSYS) User Multiplexer 19 */
+#define REG_EVSYS_USER20           (0x430000D0U) /**< \brief (EVSYS) User Multiplexer 20 */
+#define REG_EVSYS_USER21           (0x430000D4U) /**< \brief (EVSYS) User Multiplexer 21 */
+#define REG_EVSYS_USER22           (0x430000D8U) /**< \brief (EVSYS) User Multiplexer 22 */
+#define REG_EVSYS_USER23           (0x430000DCU) /**< \brief (EVSYS) User Multiplexer 23 */
+#define REG_EVSYS_USER24           (0x430000E0U) /**< \brief (EVSYS) User Multiplexer 24 */
+#define REG_EVSYS_USER25           (0x430000E4U) /**< \brief (EVSYS) User Multiplexer 25 */
+#define REG_EVSYS_USER26           (0x430000E8U) /**< \brief (EVSYS) User Multiplexer 26 */
+#define REG_EVSYS_USER27           (0x430000ECU) /**< \brief (EVSYS) User Multiplexer 27 */
+#define REG_EVSYS_USER28           (0x430000F0U) /**< \brief (EVSYS) User Multiplexer 28 */
+#define REG_EVSYS_USER29           (0x430000F4U) /**< \brief (EVSYS) User Multiplexer 29 */
+#define REG_EVSYS_USER30           (0x430000F8U) /**< \brief (EVSYS) User Multiplexer 30 */
+#define REG_EVSYS_USER31           (0x430000FCU) /**< \brief (EVSYS) User Multiplexer 31 */
+#define REG_EVSYS_USER32           (0x43000100U) /**< \brief (EVSYS) User Multiplexer 32 */
+#define REG_EVSYS_USER33           (0x43000104U) /**< \brief (EVSYS) User Multiplexer 33 */
+#define REG_EVSYS_USER34           (0x43000108U) /**< \brief (EVSYS) User Multiplexer 34 */
+#define REG_EVSYS_USER35           (0x4300010CU) /**< \brief (EVSYS) User Multiplexer 35 */
+#define REG_EVSYS_USER36           (0x43000110U) /**< \brief (EVSYS) User Multiplexer 36 */
+#define REG_EVSYS_USER37           (0x43000114U) /**< \brief (EVSYS) User Multiplexer 37 */
+#define REG_EVSYS_USER38           (0x43000118U) /**< \brief (EVSYS) User Multiplexer 38 */
+#define REG_EVSYS_USER39           (0x4300011CU) /**< \brief (EVSYS) User Multiplexer 39 */
+#define REG_EVSYS_USER40           (0x43000120U) /**< \brief (EVSYS) User Multiplexer 40 */
+#define REG_EVSYS_USER41           (0x43000124U) /**< \brief (EVSYS) User Multiplexer 41 */
+#define REG_EVSYS_USER42           (0x43000128U) /**< \brief (EVSYS) User Multiplexer 42 */
+#define REG_EVSYS_USER43           (0x4300012CU) /**< \brief (EVSYS) User Multiplexer 43 */
+#define REG_EVSYS_USER44           (0x43000130U) /**< \brief (EVSYS) User Multiplexer 44 */
+#else
+#define REG_EVSYS_CTRLA            (*(RwReg8 *)0x43000000U) /**< \brief (EVSYS) Control */
+#define REG_EVSYS_CHSTATUS         (*(RoReg  *)0x4300000CU) /**< \brief (EVSYS) Channel Status */
+#define REG_EVSYS_INTENCLR         (*(RwReg  *)0x43000010U) /**< \brief (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET         (*(RwReg  *)0x43000014U) /**< \brief (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG          (*(RwReg  *)0x43000018U) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
+#define REG_EVSYS_SWEVT            (*(WoReg  *)0x4300001CU) /**< \brief (EVSYS) Software Event */
+#define REG_EVSYS_CHANNEL0         (*(RwReg  *)0x43000020U) /**< \brief (EVSYS) Channel 0 */
+#define REG_EVSYS_CHANNEL1         (*(RwReg  *)0x43000024U) /**< \brief (EVSYS) Channel 1 */
+#define REG_EVSYS_CHANNEL2         (*(RwReg  *)0x43000028U) /**< \brief (EVSYS) Channel 2 */
+#define REG_EVSYS_CHANNEL3         (*(RwReg  *)0x4300002CU) /**< \brief (EVSYS) Channel 3 */
+#define REG_EVSYS_CHANNEL4         (*(RwReg  *)0x43000030U) /**< \brief (EVSYS) Channel 4 */
+#define REG_EVSYS_CHANNEL5         (*(RwReg  *)0x43000034U) /**< \brief (EVSYS) Channel 5 */
+#define REG_EVSYS_CHANNEL6         (*(RwReg  *)0x43000038U) /**< \brief (EVSYS) Channel 6 */
+#define REG_EVSYS_CHANNEL7         (*(RwReg  *)0x4300003CU) /**< \brief (EVSYS) Channel 7 */
+#define REG_EVSYS_CHANNEL8         (*(RwReg  *)0x43000040U) /**< \brief (EVSYS) Channel 8 */
+#define REG_EVSYS_CHANNEL9         (*(RwReg  *)0x43000044U) /**< \brief (EVSYS) Channel 9 */
+#define REG_EVSYS_CHANNEL10        (*(RwReg  *)0x43000048U) /**< \brief (EVSYS) Channel 10 */
+#define REG_EVSYS_CHANNEL11        (*(RwReg  *)0x4300004CU) /**< \brief (EVSYS) Channel 11 */
+#define REG_EVSYS_USER0            (*(RwReg  *)0x43000080U) /**< \brief (EVSYS) User Multiplexer 0 */
+#define REG_EVSYS_USER1            (*(RwReg  *)0x43000084U) /**< \brief (EVSYS) User Multiplexer 1 */
+#define REG_EVSYS_USER2            (*(RwReg  *)0x43000088U) /**< \brief (EVSYS) User Multiplexer 2 */
+#define REG_EVSYS_USER3            (*(RwReg  *)0x4300008CU) /**< \brief (EVSYS) User Multiplexer 3 */
+#define REG_EVSYS_USER4            (*(RwReg  *)0x43000090U) /**< \brief (EVSYS) User Multiplexer 4 */
+#define REG_EVSYS_USER5            (*(RwReg  *)0x43000094U) /**< \brief (EVSYS) User Multiplexer 5 */
+#define REG_EVSYS_USER6            (*(RwReg  *)0x43000098U) /**< \brief (EVSYS) User Multiplexer 6 */
+#define REG_EVSYS_USER7            (*(RwReg  *)0x4300009CU) /**< \brief (EVSYS) User Multiplexer 7 */
+#define REG_EVSYS_USER8            (*(RwReg  *)0x430000A0U) /**< \brief (EVSYS) User Multiplexer 8 */
+#define REG_EVSYS_USER9            (*(RwReg  *)0x430000A4U) /**< \brief (EVSYS) User Multiplexer 9 */
+#define REG_EVSYS_USER10           (*(RwReg  *)0x430000A8U) /**< \brief (EVSYS) User Multiplexer 10 */
+#define REG_EVSYS_USER11           (*(RwReg  *)0x430000ACU) /**< \brief (EVSYS) User Multiplexer 11 */
+#define REG_EVSYS_USER12           (*(RwReg  *)0x430000B0U) /**< \brief (EVSYS) User Multiplexer 12 */
+#define REG_EVSYS_USER13           (*(RwReg  *)0x430000B4U) /**< \brief (EVSYS) User Multiplexer 13 */
+#define REG_EVSYS_USER14           (*(RwReg  *)0x430000B8U) /**< \brief (EVSYS) User Multiplexer 14 */
+#define REG_EVSYS_USER15           (*(RwReg  *)0x430000BCU) /**< \brief (EVSYS) User Multiplexer 15 */
+#define REG_EVSYS_USER16           (*(RwReg  *)0x430000C0U) /**< \brief (EVSYS) User Multiplexer 16 */
+#define REG_EVSYS_USER17           (*(RwReg  *)0x430000C4U) /**< \brief (EVSYS) User Multiplexer 17 */
+#define REG_EVSYS_USER18           (*(RwReg  *)0x430000C8U) /**< \brief (EVSYS) User Multiplexer 18 */
+#define REG_EVSYS_USER19           (*(RwReg  *)0x430000CCU) /**< \brief (EVSYS) User Multiplexer 19 */
+#define REG_EVSYS_USER20           (*(RwReg  *)0x430000D0U) /**< \brief (EVSYS) User Multiplexer 20 */
+#define REG_EVSYS_USER21           (*(RwReg  *)0x430000D4U) /**< \brief (EVSYS) User Multiplexer 21 */
+#define REG_EVSYS_USER22           (*(RwReg  *)0x430000D8U) /**< \brief (EVSYS) User Multiplexer 22 */
+#define REG_EVSYS_USER23           (*(RwReg  *)0x430000DCU) /**< \brief (EVSYS) User Multiplexer 23 */
+#define REG_EVSYS_USER24           (*(RwReg  *)0x430000E0U) /**< \brief (EVSYS) User Multiplexer 24 */
+#define REG_EVSYS_USER25           (*(RwReg  *)0x430000E4U) /**< \brief (EVSYS) User Multiplexer 25 */
+#define REG_EVSYS_USER26           (*(RwReg  *)0x430000E8U) /**< \brief (EVSYS) User Multiplexer 26 */
+#define REG_EVSYS_USER27           (*(RwReg  *)0x430000ECU) /**< \brief (EVSYS) User Multiplexer 27 */
+#define REG_EVSYS_USER28           (*(RwReg  *)0x430000F0U) /**< \brief (EVSYS) User Multiplexer 28 */
+#define REG_EVSYS_USER29           (*(RwReg  *)0x430000F4U) /**< \brief (EVSYS) User Multiplexer 29 */
+#define REG_EVSYS_USER30           (*(RwReg  *)0x430000F8U) /**< \brief (EVSYS) User Multiplexer 30 */
+#define REG_EVSYS_USER31           (*(RwReg  *)0x430000FCU) /**< \brief (EVSYS) User Multiplexer 31 */
+#define REG_EVSYS_USER32           (*(RwReg  *)0x43000100U) /**< \brief (EVSYS) User Multiplexer 32 */
+#define REG_EVSYS_USER33           (*(RwReg  *)0x43000104U) /**< \brief (EVSYS) User Multiplexer 33 */
+#define REG_EVSYS_USER34           (*(RwReg  *)0x43000108U) /**< \brief (EVSYS) User Multiplexer 34 */
+#define REG_EVSYS_USER35           (*(RwReg  *)0x4300010CU) /**< \brief (EVSYS) User Multiplexer 35 */
+#define REG_EVSYS_USER36           (*(RwReg  *)0x43000110U) /**< \brief (EVSYS) User Multiplexer 36 */
+#define REG_EVSYS_USER37           (*(RwReg  *)0x43000114U) /**< \brief (EVSYS) User Multiplexer 37 */
+#define REG_EVSYS_USER38           (*(RwReg  *)0x43000118U) /**< \brief (EVSYS) User Multiplexer 38 */
+#define REG_EVSYS_USER39           (*(RwReg  *)0x4300011CU) /**< \brief (EVSYS) User Multiplexer 39 */
+#define REG_EVSYS_USER40           (*(RwReg  *)0x43000120U) /**< \brief (EVSYS) User Multiplexer 40 */
+#define REG_EVSYS_USER41           (*(RwReg  *)0x43000124U) /**< \brief (EVSYS) User Multiplexer 41 */
+#define REG_EVSYS_USER42           (*(RwReg  *)0x43000128U) /**< \brief (EVSYS) User Multiplexer 42 */
+#define REG_EVSYS_USER43           (*(RwReg  *)0x4300012CU) /**< \brief (EVSYS) User Multiplexer 43 */
+#define REG_EVSYS_USER44           (*(RwReg  *)0x43000130U) /**< \brief (EVSYS) User Multiplexer 44 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for EVSYS peripheral ========== */
+#define EVSYS_CHANNELS              12       // Number of Channels
+#define EVSYS_CHANNELS_BITS         4        // Number of bits to select Channel
+#define EVSYS_CHANNELS_MSB          11       // Number of Channels - 1
+#define EVSYS_EXTEVT_NUM            0        // Number of External Event Generators
+#define EVSYS_GCLK_ID_0             5
+#define EVSYS_GCLK_ID_1             6
+#define EVSYS_GCLK_ID_2             7
+#define EVSYS_GCLK_ID_3             8
+#define EVSYS_GCLK_ID_4             9
+#define EVSYS_GCLK_ID_5             10
+#define EVSYS_GCLK_ID_6             11
+#define EVSYS_GCLK_ID_7             12
+#define EVSYS_GCLK_ID_8             13
+#define EVSYS_GCLK_ID_9             14
+#define EVSYS_GCLK_ID_10            15
+#define EVSYS_GCLK_ID_11            16
+#define EVSYS_GCLK_ID_LSB           5
+#define EVSYS_GCLK_ID_MSB           16
+#define EVSYS_GCLK_ID_SIZE          12
+#define EVSYS_GENERATORS            83       // Total Number of Event Generators
+#define EVSYS_GENERATORS_BITS       7        // Number of bits to select Event Generator
+#define EVSYS_USERS                 45       // Total Number of Event Users
+#define EVSYS_USERS_BITS            6        // Number of bits to select Event User
+
+// GENERATORS
+#define EVSYS_ID_GEN_RTC_CMP_0      1
+#define EVSYS_ID_GEN_RTC_CMP_1      2
+#define EVSYS_ID_GEN_RTC_OVF        3
+#define EVSYS_ID_GEN_RTC_PER_0      4
+#define EVSYS_ID_GEN_RTC_PER_1      5
+#define EVSYS_ID_GEN_RTC_PER_2      6
+#define EVSYS_ID_GEN_RTC_PER_3      7
+#define EVSYS_ID_GEN_RTC_PER_4      8
+#define EVSYS_ID_GEN_RTC_PER_5      9
+#define EVSYS_ID_GEN_RTC_PER_6      10
+#define EVSYS_ID_GEN_RTC_PER_7      11
+#define EVSYS_ID_GEN_EIC_EXTINT_0   12
+#define EVSYS_ID_GEN_EIC_EXTINT_1   13
+#define EVSYS_ID_GEN_EIC_EXTINT_2   14
+#define EVSYS_ID_GEN_EIC_EXTINT_3   15
+#define EVSYS_ID_GEN_EIC_EXTINT_4   16
+#define EVSYS_ID_GEN_EIC_EXTINT_5   17
+#define EVSYS_ID_GEN_EIC_EXTINT_6   18
+#define EVSYS_ID_GEN_EIC_EXTINT_7   19
+#define EVSYS_ID_GEN_EIC_EXTINT_8   20
+#define EVSYS_ID_GEN_EIC_EXTINT_9   21
+#define EVSYS_ID_GEN_EIC_EXTINT_10  22
+#define EVSYS_ID_GEN_EIC_EXTINT_11  23
+#define EVSYS_ID_GEN_EIC_EXTINT_12  24
+#define EVSYS_ID_GEN_EIC_EXTINT_13  25
+#define EVSYS_ID_GEN_EIC_EXTINT_14  26
+#define EVSYS_ID_GEN_EIC_EXTINT_15  27
+#define EVSYS_ID_GEN_DMAC_CH_0      28
+#define EVSYS_ID_GEN_DMAC_CH_1      29
+#define EVSYS_ID_GEN_DMAC_CH_2      30
+#define EVSYS_ID_GEN_DMAC_CH_3      31
+#define EVSYS_ID_GEN_DMAC_CH_4      32
+#define EVSYS_ID_GEN_DMAC_CH_5      33
+#define EVSYS_ID_GEN_DMAC_CH_6      34
+#define EVSYS_ID_GEN_DMAC_CH_7      35
+#define EVSYS_ID_GEN_TCC0_OVF       36
+#define EVSYS_ID_GEN_TCC0_TRG       37
+#define EVSYS_ID_GEN_TCC0_CNT       38
+#define EVSYS_ID_GEN_TCC0_MCX_0     39
+#define EVSYS_ID_GEN_TCC0_MCX_1     40
+#define EVSYS_ID_GEN_TCC0_MCX_2     41
+#define EVSYS_ID_GEN_TCC0_MCX_3     42
+#define EVSYS_ID_GEN_TCC1_OVF       43
+#define EVSYS_ID_GEN_TCC1_TRG       44
+#define EVSYS_ID_GEN_TCC1_CNT       45
+#define EVSYS_ID_GEN_TCC1_MCX_0     46
+#define EVSYS_ID_GEN_TCC1_MCX_1     47
+#define EVSYS_ID_GEN_TCC2_OVF       48
+#define EVSYS_ID_GEN_TCC2_TRG       49
+#define EVSYS_ID_GEN_TCC2_CNT       50
+#define EVSYS_ID_GEN_TCC2_MCX_0     51
+#define EVSYS_ID_GEN_TCC2_MCX_1     52
+#define EVSYS_ID_GEN_TC0_OVF        53
+#define EVSYS_ID_GEN_TC0_MCX_0      54
+#define EVSYS_ID_GEN_TC0_MCX_1      55
+#define EVSYS_ID_GEN_TC1_OVF        56
+#define EVSYS_ID_GEN_TC1_MCX_0      57
+#define EVSYS_ID_GEN_TC1_MCX_1      58
+#define EVSYS_ID_GEN_TC2_OVF        59
+#define EVSYS_ID_GEN_TC2_MCX_0      60
+#define EVSYS_ID_GEN_TC2_MCX_1      61
+#define EVSYS_ID_GEN_TC3_OVF        62
+#define EVSYS_ID_GEN_TC3_MCX_0      63
+#define EVSYS_ID_GEN_TC3_MCX_1      64
+#define EVSYS_ID_GEN_TC4_OVF        65
+#define EVSYS_ID_GEN_TC4_MCX_0      66
+#define EVSYS_ID_GEN_TC4_MCX_1      67
+#define EVSYS_ID_GEN_ADC_RESRDY     68
+#define EVSYS_ID_GEN_ADC_WINMON     69
+#define EVSYS_ID_GEN_AC_COMP_0      70
+#define EVSYS_ID_GEN_AC_COMP_1      71
+#define EVSYS_ID_GEN_AC_WIN_0       72
+#define EVSYS_ID_GEN_DAC_EMPTY_0    73
+#define EVSYS_ID_GEN_DAC_EMPTY_1    74
+#define EVSYS_ID_GEN_PTC_EOC        75
+#define EVSYS_ID_GEN_PTC_WCOMP      76
+#define EVSYS_ID_GEN_TRNG_READY     77
+#define EVSYS_ID_GEN_CCL_LUTOUT_0   78
+#define EVSYS_ID_GEN_CCL_LUTOUT_1   79
+#define EVSYS_ID_GEN_CCL_LUTOUT_2   80
+#define EVSYS_ID_GEN_CCL_LUTOUT_3   81
+#define EVSYS_ID_GEN_PAC_ACCERR     82
+#define EVSYS_ID_GEN_TAL_BRK        83
+
+// USERS
+#define EVSYS_ID_USER_PORT_EV_0     0
+#define EVSYS_ID_USER_PORT_EV_1     1
+#define EVSYS_ID_USER_PORT_EV_2     2
+#define EVSYS_ID_USER_PORT_EV_3     3
+#define EVSYS_ID_USER_DMAC_CH_0     4
+#define EVSYS_ID_USER_DMAC_CH_1     5
+#define EVSYS_ID_USER_DMAC_CH_2     6
+#define EVSYS_ID_USER_DMAC_CH_3     7
+#define EVSYS_ID_USER_DMAC_CH_4     8
+#define EVSYS_ID_USER_DMAC_CH_5     9
+#define EVSYS_ID_USER_DMAC_CH_6     10
+#define EVSYS_ID_USER_DMAC_CH_7     11
+#define EVSYS_ID_USER_TCC0_EV_0     12
+#define EVSYS_ID_USER_TCC0_EV_1     13
+#define EVSYS_ID_USER_TCC0_MC_0     14
+#define EVSYS_ID_USER_TCC0_MC_1     15
+#define EVSYS_ID_USER_TCC0_MC_2     16
+#define EVSYS_ID_USER_TCC0_MC_3     17
+#define EVSYS_ID_USER_TCC1_EV_0     18
+#define EVSYS_ID_USER_TCC1_EV_1     19
+#define EVSYS_ID_USER_TCC1_MC_0     20
+#define EVSYS_ID_USER_TCC1_MC_1     21
+#define EVSYS_ID_USER_TCC2_EV_0     22
+#define EVSYS_ID_USER_TCC2_EV_1     23
+#define EVSYS_ID_USER_TCC2_MC_0     24
+#define EVSYS_ID_USER_TCC2_MC_1     25
+#define EVSYS_ID_USER_TC0_EVU       26
+#define EVSYS_ID_USER_TC1_EVU       27
+#define EVSYS_ID_USER_TC2_EVU       28
+#define EVSYS_ID_USER_TC3_EVU       29
+#define EVSYS_ID_USER_TC4_EVU       30
+#define EVSYS_ID_USER_ADC_START     31
+#define EVSYS_ID_USER_ADC_SYNC      32
+#define EVSYS_ID_USER_AC_SOC_0      33
+#define EVSYS_ID_USER_AC_SOC_1      34
+#define EVSYS_ID_USER_DAC_START_0   35
+#define EVSYS_ID_USER_DAC_START_1   36
+#define EVSYS_ID_USER_PTC_STCONV    37
+#define EVSYS_ID_USER_CCL_LUTIN_0   38
+#define EVSYS_ID_USER_CCL_LUTIN_1   39
+#define EVSYS_ID_USER_CCL_LUTIN_2   40
+#define EVSYS_ID_USER_CCL_LUTIN_3   41
+#define EVSYS_ID_USER_TAL_BRK       42
+#define EVSYS_ID_USER_MTB_START     43
+#define EVSYS_ID_USER_MTB_STOP      44
+
+#endif /* _SAML21_EVSYS_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/gclk_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/gclk_100.h
@@ -1,0 +1,163 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GCLK
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_GCLK_INSTANCE_
+#define _SAML21_GCLK_INSTANCE_
+
+/* ========== Register definition for GCLK peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_GCLK_CTRLA             (0x40001800U) /**< \brief (GCLK) Control */
+#define REG_GCLK_SYNCBUSY          (0x40001804U) /**< \brief (GCLK) Synchronization Busy */
+#define REG_GCLK_GENCTRL0          (0x40001820U) /**< \brief (GCLK) Generic Clock Generator Control 0 */
+#define REG_GCLK_GENCTRL1          (0x40001824U) /**< \brief (GCLK) Generic Clock Generator Control 1 */
+#define REG_GCLK_GENCTRL2          (0x40001828U) /**< \brief (GCLK) Generic Clock Generator Control 2 */
+#define REG_GCLK_GENCTRL3          (0x4000182CU) /**< \brief (GCLK) Generic Clock Generator Control 3 */
+#define REG_GCLK_GENCTRL4          (0x40001830U) /**< \brief (GCLK) Generic Clock Generator Control 4 */
+#define REG_GCLK_GENCTRL5          (0x40001834U) /**< \brief (GCLK) Generic Clock Generator Control 5 */
+#define REG_GCLK_GENCTRL6          (0x40001838U) /**< \brief (GCLK) Generic Clock Generator Control 6 */
+#define REG_GCLK_GENCTRL7          (0x4000183CU) /**< \brief (GCLK) Generic Clock Generator Control 7 */
+#define REG_GCLK_GENCTRL8          (0x40001840U) /**< \brief (GCLK) Generic Clock Generator Control 8 */
+#define REG_GCLK_PCHCTRL0          (0x40001880U) /**< \brief (GCLK) Peripheral Clock Control 0 */
+#define REG_GCLK_PCHCTRL1          (0x40001884U) /**< \brief (GCLK) Peripheral Clock Control 1 */
+#define REG_GCLK_PCHCTRL2          (0x40001888U) /**< \brief (GCLK) Peripheral Clock Control 2 */
+#define REG_GCLK_PCHCTRL3          (0x4000188CU) /**< \brief (GCLK) Peripheral Clock Control 3 */
+#define REG_GCLK_PCHCTRL4          (0x40001890U) /**< \brief (GCLK) Peripheral Clock Control 4 */
+#define REG_GCLK_PCHCTRL5          (0x40001894U) /**< \brief (GCLK) Peripheral Clock Control 5 */
+#define REG_GCLK_PCHCTRL6          (0x40001898U) /**< \brief (GCLK) Peripheral Clock Control 6 */
+#define REG_GCLK_PCHCTRL7          (0x4000189CU) /**< \brief (GCLK) Peripheral Clock Control 7 */
+#define REG_GCLK_PCHCTRL8          (0x400018A0U) /**< \brief (GCLK) Peripheral Clock Control 8 */
+#define REG_GCLK_PCHCTRL9          (0x400018A4U) /**< \brief (GCLK) Peripheral Clock Control 9 */
+#define REG_GCLK_PCHCTRL10         (0x400018A8U) /**< \brief (GCLK) Peripheral Clock Control 10 */
+#define REG_GCLK_PCHCTRL11         (0x400018ACU) /**< \brief (GCLK) Peripheral Clock Control 11 */
+#define REG_GCLK_PCHCTRL12         (0x400018B0U) /**< \brief (GCLK) Peripheral Clock Control 12 */
+#define REG_GCLK_PCHCTRL13         (0x400018B4U) /**< \brief (GCLK) Peripheral Clock Control 13 */
+#define REG_GCLK_PCHCTRL14         (0x400018B8U) /**< \brief (GCLK) Peripheral Clock Control 14 */
+#define REG_GCLK_PCHCTRL15         (0x400018BCU) /**< \brief (GCLK) Peripheral Clock Control 15 */
+#define REG_GCLK_PCHCTRL16         (0x400018C0U) /**< \brief (GCLK) Peripheral Clock Control 16 */
+#define REG_GCLK_PCHCTRL17         (0x400018C4U) /**< \brief (GCLK) Peripheral Clock Control 17 */
+#define REG_GCLK_PCHCTRL18         (0x400018C8U) /**< \brief (GCLK) Peripheral Clock Control 18 */
+#define REG_GCLK_PCHCTRL19         (0x400018CCU) /**< \brief (GCLK) Peripheral Clock Control 19 */
+#define REG_GCLK_PCHCTRL20         (0x400018D0U) /**< \brief (GCLK) Peripheral Clock Control 20 */
+#define REG_GCLK_PCHCTRL21         (0x400018D4U) /**< \brief (GCLK) Peripheral Clock Control 21 */
+#define REG_GCLK_PCHCTRL22         (0x400018D8U) /**< \brief (GCLK) Peripheral Clock Control 22 */
+#define REG_GCLK_PCHCTRL23         (0x400018DCU) /**< \brief (GCLK) Peripheral Clock Control 23 */
+#define REG_GCLK_PCHCTRL24         (0x400018E0U) /**< \brief (GCLK) Peripheral Clock Control 24 */
+#define REG_GCLK_PCHCTRL25         (0x400018E4U) /**< \brief (GCLK) Peripheral Clock Control 25 */
+#define REG_GCLK_PCHCTRL26         (0x400018E8U) /**< \brief (GCLK) Peripheral Clock Control 26 */
+#define REG_GCLK_PCHCTRL27         (0x400018ECU) /**< \brief (GCLK) Peripheral Clock Control 27 */
+#define REG_GCLK_PCHCTRL28         (0x400018F0U) /**< \brief (GCLK) Peripheral Clock Control 28 */
+#define REG_GCLK_PCHCTRL29         (0x400018F4U) /**< \brief (GCLK) Peripheral Clock Control 29 */
+#define REG_GCLK_PCHCTRL30         (0x400018F8U) /**< \brief (GCLK) Peripheral Clock Control 30 */
+#define REG_GCLK_PCHCTRL31         (0x400018FCU) /**< \brief (GCLK) Peripheral Clock Control 31 */
+#define REG_GCLK_PCHCTRL32         (0x40001900U) /**< \brief (GCLK) Peripheral Clock Control 32 */
+#define REG_GCLK_PCHCTRL33         (0x40001904U) /**< \brief (GCLK) Peripheral Clock Control 33 */
+#define REG_GCLK_PCHCTRL34         (0x40001908U) /**< \brief (GCLK) Peripheral Clock Control 34 */
+#define REG_GCLK_PCHCTRL35         (0x4000190CU) /**< \brief (GCLK) Peripheral Clock Control 35 */
+#else
+#define REG_GCLK_CTRLA             (*(RwReg8 *)0x40001800U) /**< \brief (GCLK) Control */
+#define REG_GCLK_SYNCBUSY          (*(RoReg  *)0x40001804U) /**< \brief (GCLK) Synchronization Busy */
+#define REG_GCLK_GENCTRL0          (*(RwReg  *)0x40001820U) /**< \brief (GCLK) Generic Clock Generator Control 0 */
+#define REG_GCLK_GENCTRL1          (*(RwReg  *)0x40001824U) /**< \brief (GCLK) Generic Clock Generator Control 1 */
+#define REG_GCLK_GENCTRL2          (*(RwReg  *)0x40001828U) /**< \brief (GCLK) Generic Clock Generator Control 2 */
+#define REG_GCLK_GENCTRL3          (*(RwReg  *)0x4000182CU) /**< \brief (GCLK) Generic Clock Generator Control 3 */
+#define REG_GCLK_GENCTRL4          (*(RwReg  *)0x40001830U) /**< \brief (GCLK) Generic Clock Generator Control 4 */
+#define REG_GCLK_GENCTRL5          (*(RwReg  *)0x40001834U) /**< \brief (GCLK) Generic Clock Generator Control 5 */
+#define REG_GCLK_GENCTRL6          (*(RwReg  *)0x40001838U) /**< \brief (GCLK) Generic Clock Generator Control 6 */
+#define REG_GCLK_GENCTRL7          (*(RwReg  *)0x4000183CU) /**< \brief (GCLK) Generic Clock Generator Control 7 */
+#define REG_GCLK_GENCTRL8          (*(RwReg  *)0x40001840U) /**< \brief (GCLK) Generic Clock Generator Control 8 */
+#define REG_GCLK_PCHCTRL0          (*(RwReg  *)0x40001880U) /**< \brief (GCLK) Peripheral Clock Control 0 */
+#define REG_GCLK_PCHCTRL1          (*(RwReg  *)0x40001884U) /**< \brief (GCLK) Peripheral Clock Control 1 */
+#define REG_GCLK_PCHCTRL2          (*(RwReg  *)0x40001888U) /**< \brief (GCLK) Peripheral Clock Control 2 */
+#define REG_GCLK_PCHCTRL3          (*(RwReg  *)0x4000188CU) /**< \brief (GCLK) Peripheral Clock Control 3 */
+#define REG_GCLK_PCHCTRL4          (*(RwReg  *)0x40001890U) /**< \brief (GCLK) Peripheral Clock Control 4 */
+#define REG_GCLK_PCHCTRL5          (*(RwReg  *)0x40001894U) /**< \brief (GCLK) Peripheral Clock Control 5 */
+#define REG_GCLK_PCHCTRL6          (*(RwReg  *)0x40001898U) /**< \brief (GCLK) Peripheral Clock Control 6 */
+#define REG_GCLK_PCHCTRL7          (*(RwReg  *)0x4000189CU) /**< \brief (GCLK) Peripheral Clock Control 7 */
+#define REG_GCLK_PCHCTRL8          (*(RwReg  *)0x400018A0U) /**< \brief (GCLK) Peripheral Clock Control 8 */
+#define REG_GCLK_PCHCTRL9          (*(RwReg  *)0x400018A4U) /**< \brief (GCLK) Peripheral Clock Control 9 */
+#define REG_GCLK_PCHCTRL10         (*(RwReg  *)0x400018A8U) /**< \brief (GCLK) Peripheral Clock Control 10 */
+#define REG_GCLK_PCHCTRL11         (*(RwReg  *)0x400018ACU) /**< \brief (GCLK) Peripheral Clock Control 11 */
+#define REG_GCLK_PCHCTRL12         (*(RwReg  *)0x400018B0U) /**< \brief (GCLK) Peripheral Clock Control 12 */
+#define REG_GCLK_PCHCTRL13         (*(RwReg  *)0x400018B4U) /**< \brief (GCLK) Peripheral Clock Control 13 */
+#define REG_GCLK_PCHCTRL14         (*(RwReg  *)0x400018B8U) /**< \brief (GCLK) Peripheral Clock Control 14 */
+#define REG_GCLK_PCHCTRL15         (*(RwReg  *)0x400018BCU) /**< \brief (GCLK) Peripheral Clock Control 15 */
+#define REG_GCLK_PCHCTRL16         (*(RwReg  *)0x400018C0U) /**< \brief (GCLK) Peripheral Clock Control 16 */
+#define REG_GCLK_PCHCTRL17         (*(RwReg  *)0x400018C4U) /**< \brief (GCLK) Peripheral Clock Control 17 */
+#define REG_GCLK_PCHCTRL18         (*(RwReg  *)0x400018C8U) /**< \brief (GCLK) Peripheral Clock Control 18 */
+#define REG_GCLK_PCHCTRL19         (*(RwReg  *)0x400018CCU) /**< \brief (GCLK) Peripheral Clock Control 19 */
+#define REG_GCLK_PCHCTRL20         (*(RwReg  *)0x400018D0U) /**< \brief (GCLK) Peripheral Clock Control 20 */
+#define REG_GCLK_PCHCTRL21         (*(RwReg  *)0x400018D4U) /**< \brief (GCLK) Peripheral Clock Control 21 */
+#define REG_GCLK_PCHCTRL22         (*(RwReg  *)0x400018D8U) /**< \brief (GCLK) Peripheral Clock Control 22 */
+#define REG_GCLK_PCHCTRL23         (*(RwReg  *)0x400018DCU) /**< \brief (GCLK) Peripheral Clock Control 23 */
+#define REG_GCLK_PCHCTRL24         (*(RwReg  *)0x400018E0U) /**< \brief (GCLK) Peripheral Clock Control 24 */
+#define REG_GCLK_PCHCTRL25         (*(RwReg  *)0x400018E4U) /**< \brief (GCLK) Peripheral Clock Control 25 */
+#define REG_GCLK_PCHCTRL26         (*(RwReg  *)0x400018E8U) /**< \brief (GCLK) Peripheral Clock Control 26 */
+#define REG_GCLK_PCHCTRL27         (*(RwReg  *)0x400018ECU) /**< \brief (GCLK) Peripheral Clock Control 27 */
+#define REG_GCLK_PCHCTRL28         (*(RwReg  *)0x400018F0U) /**< \brief (GCLK) Peripheral Clock Control 28 */
+#define REG_GCLK_PCHCTRL29         (*(RwReg  *)0x400018F4U) /**< \brief (GCLK) Peripheral Clock Control 29 */
+#define REG_GCLK_PCHCTRL30         (*(RwReg  *)0x400018F8U) /**< \brief (GCLK) Peripheral Clock Control 30 */
+#define REG_GCLK_PCHCTRL31         (*(RwReg  *)0x400018FCU) /**< \brief (GCLK) Peripheral Clock Control 31 */
+#define REG_GCLK_PCHCTRL32         (*(RwReg  *)0x40001900U) /**< \brief (GCLK) Peripheral Clock Control 32 */
+#define REG_GCLK_PCHCTRL33         (*(RwReg  *)0x40001904U) /**< \brief (GCLK) Peripheral Clock Control 33 */
+#define REG_GCLK_PCHCTRL34         (*(RwReg  *)0x40001908U) /**< \brief (GCLK) Peripheral Clock Control 34 */
+#define REG_GCLK_PCHCTRL35         (*(RwReg  *)0x4000190CU) /**< \brief (GCLK) Peripheral Clock Control 35 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for GCLK peripheral ========== */
+#define GCLK_GENDIV_BITS            16      
+#define GCLK_GEN_NUM                9        // Number of Generic Clock Generators
+#define GCLK_GEN_NUM_MSB            8        // Number of Generic Clock Generators - 1
+#define GCLK_GEN_SOURCE_NUM_MSB     8        // Number of Generic Clock Sources - 1
+#define GCLK_NUM                    36       // Number of Generic Clock Users
+#define GCLK_SOURCE_DFLL48M         7       
+#define GCLK_SOURCE_FDPLL           8       
+#define GCLK_SOURCE_GCLKGEN1        2       
+#define GCLK_SOURCE_GCLKIN          1       
+#define GCLK_SOURCE_NUM             9        // Number of Generic Clock Sources
+#define GCLK_SOURCE_OSCULP32K       3       
+#define GCLK_SOURCE_OSC16M          6       
+#define GCLK_SOURCE_OSC32K          4       
+#define GCLK_SOURCE_XOSC            0       
+#define GCLK_SOURCE_XOSC32K         5       
+
+#endif /* _SAML21_GCLK_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/mclk_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/mclk_100.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MCLK
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_MCLK_INSTANCE_
+#define _SAML21_MCLK_INSTANCE_
+
+/* ========== Register definition for MCLK peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_MCLK_CTRLA             (0x40000400U) /**< \brief (MCLK) Control A */
+#define REG_MCLK_INTENCLR          (0x40000401U) /**< \brief (MCLK) Interrupt Enable Clear */
+#define REG_MCLK_INTENSET          (0x40000402U) /**< \brief (MCLK) Interrupt Enable Set */
+#define REG_MCLK_INTFLAG           (0x40000403U) /**< \brief (MCLK) Interrupt Flag Status and Clear */
+#define REG_MCLK_CPUDIV            (0x40000404U) /**< \brief (MCLK) CPU Clock Division */
+#define REG_MCLK_LPDIV             (0x40000405U) /**< \brief (MCLK) Low-Power Clock Division */
+#define REG_MCLK_BUPDIV            (0x40000406U) /**< \brief (MCLK) Backup Clock Division */
+#define REG_MCLK_AHBMASK           (0x40000410U) /**< \brief (MCLK) AHB Mask */
+#define REG_MCLK_APBAMASK          (0x40000414U) /**< \brief (MCLK) APBA Mask */
+#define REG_MCLK_APBBMASK          (0x40000418U) /**< \brief (MCLK) APBB Mask */
+#define REG_MCLK_APBCMASK          (0x4000041CU) /**< \brief (MCLK) APBC Mask */
+#define REG_MCLK_APBDMASK          (0x40000420U) /**< \brief (MCLK) APBD Mask */
+#define REG_MCLK_APBEMASK          (0x40000424U) /**< \brief (MCLK) APBE Mask */
+#else
+#define REG_MCLK_CTRLA             (*(RwReg8 *)0x40000400U) /**< \brief (MCLK) Control A */
+#define REG_MCLK_INTENCLR          (*(RwReg8 *)0x40000401U) /**< \brief (MCLK) Interrupt Enable Clear */
+#define REG_MCLK_INTENSET          (*(RwReg8 *)0x40000402U) /**< \brief (MCLK) Interrupt Enable Set */
+#define REG_MCLK_INTFLAG           (*(RwReg8 *)0x40000403U) /**< \brief (MCLK) Interrupt Flag Status and Clear */
+#define REG_MCLK_CPUDIV            (*(RwReg8 *)0x40000404U) /**< \brief (MCLK) CPU Clock Division */
+#define REG_MCLK_LPDIV             (*(RwReg8 *)0x40000405U) /**< \brief (MCLK) Low-Power Clock Division */
+#define REG_MCLK_BUPDIV            (*(RwReg8 *)0x40000406U) /**< \brief (MCLK) Backup Clock Division */
+#define REG_MCLK_AHBMASK           (*(RwReg  *)0x40000410U) /**< \brief (MCLK) AHB Mask */
+#define REG_MCLK_APBAMASK          (*(RwReg  *)0x40000414U) /**< \brief (MCLK) APBA Mask */
+#define REG_MCLK_APBBMASK          (*(RwReg  *)0x40000418U) /**< \brief (MCLK) APBB Mask */
+#define REG_MCLK_APBCMASK          (*(RwReg  *)0x4000041CU) /**< \brief (MCLK) APBC Mask */
+#define REG_MCLK_APBDMASK          (*(RwReg  *)0x40000420U) /**< \brief (MCLK) APBD Mask */
+#define REG_MCLK_APBEMASK          (*(RwReg  *)0x40000424U) /**< \brief (MCLK) APBE Mask */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for MCLK peripheral ========== */
+#define MCLK_CTRLA_MCSEL_GCLK       1       
+#define MCLK_CTRLA_MCSEL_OSC8M      0       
+#define MCLK_MCLK_CLK_APB_NUM       5       
+#define MCLK_SYSTEM_CLOCK           1000000  // System Clock Frequency at Reset
+
+#endif /* _SAML21_MCLK_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/mtb.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/mtb.h
@@ -1,0 +1,103 @@
+/**
+ * \file
+ *
+ * \brief Instance description for MTB
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_MTB_INSTANCE_
+#define _SAML21_MTB_INSTANCE_
+
+/* ========== Register definition for MTB peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_MTB_POSITION           (0x41006000U) /**< \brief (MTB) MTB Position */
+#define REG_MTB_MASTER             (0x41006004U) /**< \brief (MTB) MTB Master */
+#define REG_MTB_FLOW               (0x41006008U) /**< \brief (MTB) MTB Flow */
+#define REG_MTB_BASE               (0x4100600CU) /**< \brief (MTB) MTB Base */
+#define REG_MTB_ITCTRL             (0x41006F00U) /**< \brief (MTB) MTB Integration Mode Control */
+#define REG_MTB_CLAIMSET           (0x41006FA0U) /**< \brief (MTB) MTB Claim Set */
+#define REG_MTB_CLAIMCLR           (0x41006FA4U) /**< \brief (MTB) MTB Claim Clear */
+#define REG_MTB_LOCKACCESS         (0x41006FB0U) /**< \brief (MTB) MTB Lock Access */
+#define REG_MTB_LOCKSTATUS         (0x41006FB4U) /**< \brief (MTB) MTB Lock Status */
+#define REG_MTB_AUTHSTATUS         (0x41006FB8U) /**< \brief (MTB) MTB Authentication Status */
+#define REG_MTB_DEVARCH            (0x41006FBCU) /**< \brief (MTB) MTB Device Architecture */
+#define REG_MTB_DEVID              (0x41006FC8U) /**< \brief (MTB) MTB Device Configuration */
+#define REG_MTB_DEVTYPE            (0x41006FCCU) /**< \brief (MTB) MTB Device Type */
+#define REG_MTB_PID4               (0x41006FD0U) /**< \brief (MTB) Peripheral Identification 4 */
+#define REG_MTB_PID5               (0x41006FD4U) /**< \brief (MTB) Peripheral Identification 5 */
+#define REG_MTB_PID6               (0x41006FD8U) /**< \brief (MTB) Peripheral Identification 6 */
+#define REG_MTB_PID7               (0x41006FDCU) /**< \brief (MTB) Peripheral Identification 7 */
+#define REG_MTB_PID0               (0x41006FE0U) /**< \brief (MTB) Peripheral Identification 0 */
+#define REG_MTB_PID1               (0x41006FE4U) /**< \brief (MTB) Peripheral Identification 1 */
+#define REG_MTB_PID2               (0x41006FE8U) /**< \brief (MTB) Peripheral Identification 2 */
+#define REG_MTB_PID3               (0x41006FECU) /**< \brief (MTB) Peripheral Identification 3 */
+#define REG_MTB_CID0               (0x41006FF0U) /**< \brief (MTB) Component Identification 0 */
+#define REG_MTB_CID1               (0x41006FF4U) /**< \brief (MTB) Component Identification 1 */
+#define REG_MTB_CID2               (0x41006FF8U) /**< \brief (MTB) Component Identification 2 */
+#define REG_MTB_CID3               (0x41006FFCU) /**< \brief (MTB) Component Identification 3 */
+#else
+#define REG_MTB_POSITION           (*(RwReg  *)0x41006000U) /**< \brief (MTB) MTB Position */
+#define REG_MTB_MASTER             (*(RwReg  *)0x41006004U) /**< \brief (MTB) MTB Master */
+#define REG_MTB_FLOW               (*(RwReg  *)0x41006008U) /**< \brief (MTB) MTB Flow */
+#define REG_MTB_BASE               (*(RoReg  *)0x4100600CU) /**< \brief (MTB) MTB Base */
+#define REG_MTB_ITCTRL             (*(RwReg  *)0x41006F00U) /**< \brief (MTB) MTB Integration Mode Control */
+#define REG_MTB_CLAIMSET           (*(RwReg  *)0x41006FA0U) /**< \brief (MTB) MTB Claim Set */
+#define REG_MTB_CLAIMCLR           (*(RwReg  *)0x41006FA4U) /**< \brief (MTB) MTB Claim Clear */
+#define REG_MTB_LOCKACCESS         (*(RwReg  *)0x41006FB0U) /**< \brief (MTB) MTB Lock Access */
+#define REG_MTB_LOCKSTATUS         (*(RoReg  *)0x41006FB4U) /**< \brief (MTB) MTB Lock Status */
+#define REG_MTB_AUTHSTATUS         (*(RoReg  *)0x41006FB8U) /**< \brief (MTB) MTB Authentication Status */
+#define REG_MTB_DEVARCH            (*(RoReg  *)0x41006FBCU) /**< \brief (MTB) MTB Device Architecture */
+#define REG_MTB_DEVID              (*(RoReg  *)0x41006FC8U) /**< \brief (MTB) MTB Device Configuration */
+#define REG_MTB_DEVTYPE            (*(RoReg  *)0x41006FCCU) /**< \brief (MTB) MTB Device Type */
+#define REG_MTB_PID4               (*(RoReg  *)0x41006FD0U) /**< \brief (MTB) Peripheral Identification 4 */
+#define REG_MTB_PID5               (*(RoReg  *)0x41006FD4U) /**< \brief (MTB) Peripheral Identification 5 */
+#define REG_MTB_PID6               (*(RoReg  *)0x41006FD8U) /**< \brief (MTB) Peripheral Identification 6 */
+#define REG_MTB_PID7               (*(RoReg  *)0x41006FDCU) /**< \brief (MTB) Peripheral Identification 7 */
+#define REG_MTB_PID0               (*(RoReg  *)0x41006FE0U) /**< \brief (MTB) Peripheral Identification 0 */
+#define REG_MTB_PID1               (*(RoReg  *)0x41006FE4U) /**< \brief (MTB) Peripheral Identification 1 */
+#define REG_MTB_PID2               (*(RoReg  *)0x41006FE8U) /**< \brief (MTB) Peripheral Identification 2 */
+#define REG_MTB_PID3               (*(RoReg  *)0x41006FECU) /**< \brief (MTB) Peripheral Identification 3 */
+#define REG_MTB_CID0               (*(RoReg  *)0x41006FF0U) /**< \brief (MTB) Component Identification 0 */
+#define REG_MTB_CID1               (*(RoReg  *)0x41006FF4U) /**< \brief (MTB) Component Identification 1 */
+#define REG_MTB_CID2               (*(RoReg  *)0x41006FF8U) /**< \brief (MTB) Component Identification 2 */
+#define REG_MTB_CID3               (*(RoReg  *)0x41006FFCU) /**< \brief (MTB) Component Identification 3 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAML21_MTB_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/nvmctrl_301.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/nvmctrl_301.h
@@ -1,0 +1,94 @@
+/**
+ * \file
+ *
+ * \brief Instance description for NVMCTRL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_NVMCTRL_INSTANCE_
+#define _SAML21_NVMCTRL_INSTANCE_
+
+/* ========== Register definition for NVMCTRL peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_NVMCTRL_CTRLA          (0x41004000U) /**< \brief (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB          (0x41004004U) /**< \brief (NVMCTRL) Control B */
+#define REG_NVMCTRL_PARAM          (0x41004008U) /**< \brief (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_INTENCLR       (0x4100400CU) /**< \brief (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET       (0x41004010U) /**< \brief (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG        (0x41004014U) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS         (0x41004018U) /**< \brief (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR           (0x4100401CU) /**< \brief (NVMCTRL) Address */
+#define REG_NVMCTRL_LOCK           (0x41004020U) /**< \brief (NVMCTRL) Lock Section */
+#else
+#define REG_NVMCTRL_CTRLA          (*(RwReg16*)0x41004000U) /**< \brief (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB          (*(RwReg  *)0x41004004U) /**< \brief (NVMCTRL) Control B */
+#define REG_NVMCTRL_PARAM          (*(RwReg  *)0x41004008U) /**< \brief (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_INTENCLR       (*(RwReg8 *)0x4100400CU) /**< \brief (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET       (*(RwReg8 *)0x41004010U) /**< \brief (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG        (*(RwReg8 *)0x41004014U) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS         (*(RwReg16*)0x41004018U) /**< \brief (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR           (*(RwReg  *)0x4100401CU) /**< \brief (NVMCTRL) Address */
+#define REG_NVMCTRL_LOCK           (*(RwReg16*)0x41004020U) /**< \brief (NVMCTRL) Lock Section */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for NVMCTRL peripheral ========== */
+#define NVMCTRL_AUX0_ADDRESS        0x00804000
+#define NVMCTRL_AUX1_ADDRESS        0x00806000
+#define NVMCTRL_AUX2_ADDRESS        0x00808000
+#define NVMCTRL_AUX3_ADDRESS        0x0080A000
+#define NVMCTRL_CLK_AHB_ID          8        // Index of AHB Clock in PM.AHBMASK register
+#define NVMCTRL_CLK_AHB_ID_PICACHU  15       // Index of PICACHU AHB Clock
+#define NVMCTRL_FACTORY_WORD_IMPLEMENTED_MASK 0XC0000007FFFFFFFF
+#define NVMCTRL_FLASH_SIZE          262144  
+#define NVMCTRL_GCLK_ID             35       // Index of Generic Clock for test
+#define NVMCTRL_LOCKBIT_ADDRESS     0x00802000
+#define NVMCTRL_PAGE_HW             32      
+#define NVMCTRL_PAGE_SIZE           64      
+#define NVMCTRL_PAGE_W              16      
+#define NVMCTRL_PMSB                3       
+#define NVMCTRL_PSZ_BITS            6       
+#define NVMCTRL_ROW_PAGES           4       
+#define NVMCTRL_ROW_SIZE            256     
+#define NVMCTRL_USER_PAGE_ADDRESS   0x00800000
+#define NVMCTRL_USER_PAGE_OFFSET    0x00800000
+#define NVMCTRL_USER_WORD_IMPLEMENTED_MASK 0XC01FFFFFFFFFFFFF
+#define NVMCTRL_RWWEE_PAGES         128     
+#define NVMCTRL_RWW_EEPROM_ADDR     0x00400000 // Start address of the RWW EEPROM area
+
+#endif /* _SAML21_NVMCTRL_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/opamp.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/opamp.h
@@ -1,0 +1,63 @@
+/**
+ * \file
+ *
+ * \brief Instance description for OPAMP
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_OPAMP_INSTANCE_
+#define _SAML21_OPAMP_INSTANCE_
+
+/* ========== Register definition for OPAMP peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_OPAMP_CTRLA            (0x43001800U) /**< \brief (OPAMP) Control A */
+#define REG_OPAMP_STATUS           (0x43001802U) /**< \brief (OPAMP) Status */
+#define REG_OPAMP_OPAMPCTRL0       (0x43001804U) /**< \brief (OPAMP) OPAMP Control 0 */
+#define REG_OPAMP_OPAMPCTRL1       (0x43001808U) /**< \brief (OPAMP) OPAMP Control 1 */
+#define REG_OPAMP_OPAMPCTRL2       (0x4300180CU) /**< \brief (OPAMP) OPAMP Control 2 */
+#else
+#define REG_OPAMP_CTRLA            (*(RwReg8 *)0x43001800U) /**< \brief (OPAMP) Control A */
+#define REG_OPAMP_STATUS           (*(RoReg8 *)0x43001802U) /**< \brief (OPAMP) Status */
+#define REG_OPAMP_OPAMPCTRL0       (*(RwReg  *)0x43001804U) /**< \brief (OPAMP) OPAMP Control 0 */
+#define REG_OPAMP_OPAMPCTRL1       (*(RwReg  *)0x43001808U) /**< \brief (OPAMP) OPAMP Control 1 */
+#define REG_OPAMP_OPAMPCTRL2       (*(RwReg  *)0x4300180CU) /**< \brief (OPAMP) OPAMP Control 2 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAML21_OPAMP_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/osc32kctrl.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/osc32kctrl.h
@@ -1,0 +1,71 @@
+/**
+ * \file
+ *
+ * \brief Instance description for OSC32KCTRL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_OSC32KCTRL_INSTANCE_
+#define _SAML21_OSC32KCTRL_INSTANCE_
+
+/* ========== Register definition for OSC32KCTRL peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_OSC32KCTRL_INTENCLR    (0x40001000U) /**< \brief (OSC32KCTRL) Interrupt Enable Clear */
+#define REG_OSC32KCTRL_INTENSET    (0x40001004U) /**< \brief (OSC32KCTRL) Interrupt Enable Set */
+#define REG_OSC32KCTRL_INTFLAG     (0x40001008U) /**< \brief (OSC32KCTRL) Interrupt Flag Status and Clear */
+#define REG_OSC32KCTRL_STATUS      (0x4000100CU) /**< \brief (OSC32KCTRL) Power and Clocks Status */
+#define REG_OSC32KCTRL_RTCCTRL     (0x40001010U) /**< \brief (OSC32KCTRL) Clock selection */
+#define REG_OSC32KCTRL_XOSC32K     (0x40001014U) /**< \brief (OSC32KCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define REG_OSC32KCTRL_OSC32K      (0x40001018U) /**< \brief (OSC32KCTRL) 32kHz Internal Oscillator (OSC32K) Control */
+#define REG_OSC32KCTRL_OSCULP32K   (0x4000101CU) /**< \brief (OSC32KCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+#else
+#define REG_OSC32KCTRL_INTENCLR    (*(RwReg  *)0x40001000U) /**< \brief (OSC32KCTRL) Interrupt Enable Clear */
+#define REG_OSC32KCTRL_INTENSET    (*(RwReg  *)0x40001004U) /**< \brief (OSC32KCTRL) Interrupt Enable Set */
+#define REG_OSC32KCTRL_INTFLAG     (*(RwReg  *)0x40001008U) /**< \brief (OSC32KCTRL) Interrupt Flag Status and Clear */
+#define REG_OSC32KCTRL_STATUS      (*(RoReg  *)0x4000100CU) /**< \brief (OSC32KCTRL) Power and Clocks Status */
+#define REG_OSC32KCTRL_RTCCTRL     (*(RwReg  *)0x40001010U) /**< \brief (OSC32KCTRL) Clock selection */
+#define REG_OSC32KCTRL_XOSC32K     (*(RwReg  *)0x40001014U) /**< \brief (OSC32KCTRL) 32kHz External Crystal Oscillator (XOSC32K) Control */
+#define REG_OSC32KCTRL_OSC32K      (*(RwReg  *)0x40001018U) /**< \brief (OSC32KCTRL) 32kHz Internal Oscillator (OSC32K) Control */
+#define REG_OSC32KCTRL_OSCULP32K   (*(RwReg  *)0x4000101CU) /**< \brief (OSC32KCTRL) 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for OSC32KCTRL peripheral ========== */
+#define OSC32KCTRL_OSC32K_COARSE_CALIB_MSB 6       
+
+#endif /* _SAML21_OSC32KCTRL_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/oscctrl.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/oscctrl.h
@@ -1,0 +1,95 @@
+/**
+ * \file
+ *
+ * \brief Instance description for OSCCTRL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_OSCCTRL_INSTANCE_
+#define _SAML21_OSCCTRL_INSTANCE_
+
+/* ========== Register definition for OSCCTRL peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_OSCCTRL_INTENCLR       (0x40000C00U) /**< \brief (OSCCTRL) Interrupt Enable Clear */
+#define REG_OSCCTRL_INTENSET       (0x40000C04U) /**< \brief (OSCCTRL) Interrupt Enable Set */
+#define REG_OSCCTRL_INTFLAG        (0x40000C08U) /**< \brief (OSCCTRL) Interrupt Flag Status and Clear */
+#define REG_OSCCTRL_STATUS         (0x40000C0CU) /**< \brief (OSCCTRL) Power and Clocks Status */
+#define REG_OSCCTRL_XOSCCTRL       (0x40000C10U) /**< \brief (OSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define REG_OSCCTRL_OSC16MCTRL     (0x40000C14U) /**< \brief (OSCCTRL) 16MHz Internal Oscillator (OSC16M) Control */
+#define REG_OSCCTRL_DFLLCTRL       (0x40000C18U) /**< \brief (OSCCTRL) DFLL48M Control */
+#define REG_OSCCTRL_DFLLVAL        (0x40000C1CU) /**< \brief (OSCCTRL) DFLL48M Value */
+#define REG_OSCCTRL_DFLLMUL        (0x40000C20U) /**< \brief (OSCCTRL) DFLL48M Multiplier */
+#define REG_OSCCTRL_DFLLSYNC       (0x40000C24U) /**< \brief (OSCCTRL) DFLL48M Synchronization */
+#define REG_OSCCTRL_DPLLCTRLA      (0x40000C28U) /**< \brief (OSCCTRL) DPLL Control */
+#define REG_OSCCTRL_DPLLRATIO      (0x40000C2CU) /**< \brief (OSCCTRL) DPLL Ratio Control */
+#define REG_OSCCTRL_DPLLCTRLB      (0x40000C30U) /**< \brief (OSCCTRL) Digital Core Configuration */
+#define REG_OSCCTRL_DPLLPRESC      (0x40000C34U) /**< \brief (OSCCTRL) DPLL Prescaler */
+#define REG_OSCCTRL_DPLLSYNCBUSY   (0x40000C38U) /**< \brief (OSCCTRL) DPLL Synchronization Busy */
+#define REG_OSCCTRL_DPLLSTATUS     (0x40000C3CU) /**< \brief (OSCCTRL) DPLL Status */
+#else
+#define REG_OSCCTRL_INTENCLR       (*(RwReg  *)0x40000C00U) /**< \brief (OSCCTRL) Interrupt Enable Clear */
+#define REG_OSCCTRL_INTENSET       (*(RwReg  *)0x40000C04U) /**< \brief (OSCCTRL) Interrupt Enable Set */
+#define REG_OSCCTRL_INTFLAG        (*(RwReg  *)0x40000C08U) /**< \brief (OSCCTRL) Interrupt Flag Status and Clear */
+#define REG_OSCCTRL_STATUS         (*(RoReg  *)0x40000C0CU) /**< \brief (OSCCTRL) Power and Clocks Status */
+#define REG_OSCCTRL_XOSCCTRL       (*(RwReg16*)0x40000C10U) /**< \brief (OSCCTRL) External Multipurpose Crystal Oscillator (XOSC) Control */
+#define REG_OSCCTRL_OSC16MCTRL     (*(RwReg8 *)0x40000C14U) /**< \brief (OSCCTRL) 16MHz Internal Oscillator (OSC16M) Control */
+#define REG_OSCCTRL_DFLLCTRL       (*(RwReg16*)0x40000C18U) /**< \brief (OSCCTRL) DFLL48M Control */
+#define REG_OSCCTRL_DFLLVAL        (*(RwReg  *)0x40000C1CU) /**< \brief (OSCCTRL) DFLL48M Value */
+#define REG_OSCCTRL_DFLLMUL        (*(RwReg  *)0x40000C20U) /**< \brief (OSCCTRL) DFLL48M Multiplier */
+#define REG_OSCCTRL_DFLLSYNC       (*(RwReg8 *)0x40000C24U) /**< \brief (OSCCTRL) DFLL48M Synchronization */
+#define REG_OSCCTRL_DPLLCTRLA      (*(RwReg8 *)0x40000C28U) /**< \brief (OSCCTRL) DPLL Control */
+#define REG_OSCCTRL_DPLLRATIO      (*(RwReg  *)0x40000C2CU) /**< \brief (OSCCTRL) DPLL Ratio Control */
+#define REG_OSCCTRL_DPLLCTRLB      (*(RwReg  *)0x40000C30U) /**< \brief (OSCCTRL) Digital Core Configuration */
+#define REG_OSCCTRL_DPLLPRESC      (*(RwReg8 *)0x40000C34U) /**< \brief (OSCCTRL) DPLL Prescaler */
+#define REG_OSCCTRL_DPLLSYNCBUSY   (*(RoReg8 *)0x40000C38U) /**< \brief (OSCCTRL) DPLL Synchronization Busy */
+#define REG_OSCCTRL_DPLLSTATUS     (*(RoReg8 *)0x40000C3CU) /**< \brief (OSCCTRL) DPLL Status */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for OSCCTRL peripheral ========== */
+#define OSCCTRL_DFLL48M_COARSE_MSB  5       
+#define OSCCTRL_DFLL48M_FINE_MSB    9       
+#define OSCCTRL_GCLK_ID_DFLL48      0        // Index of Generic Clock for DFLL48
+#define OSCCTRL_GCLK_ID_FDPLL       1        // Index of Generic Clock for DPLL
+#define OSCCTRL_GCLK_ID_FDPLL32K    2        // Index of Generic Clock for DPLL 32K
+#define OSCCTRL_DFLL48M_VERSION     0x310   
+#define OSCCTRL_FDPLL_VERSION       0x200   
+#define OSCCTRL_OSC16M_VERSION      0x100   
+#define OSCCTRL_XOSC_VERSION        0x120   
+
+#endif /* _SAML21_OSCCTRL_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/pac_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/pac_100.h
@@ -1,0 +1,87 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PAC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_PAC_INSTANCE_
+#define _SAML21_PAC_INSTANCE_
+
+/* ========== Register definition for PAC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PAC_WRCTRL             (0x44000000U) /**< \brief (PAC) Write control */
+#define REG_PAC_EVCTRL             (0x44000004U) /**< \brief (PAC) Event control */
+#define REG_PAC_INTENCLR           (0x44000008U) /**< \brief (PAC) Interrupt enable clear */
+#define REG_PAC_INTENSET           (0x44000009U) /**< \brief (PAC) Interrupt enable set */
+#define REG_PAC_INTFLAGAHB         (0x44000010U) /**< \brief (PAC) Bridge interrupt flag status */
+#define REG_PAC_INTFLAGA           (0x44000014U) /**< \brief (PAC) Peripheral interrupt flag status - Bridge A */
+#define REG_PAC_INTFLAGB           (0x44000018U) /**< \brief (PAC) Peripheral interrupt flag status - Bridge B */
+#define REG_PAC_INTFLAGC           (0x4400001CU) /**< \brief (PAC) Peripheral interrupt flag status - Bridge C */
+#define REG_PAC_INTFLAGD           (0x44000020U) /**< \brief (PAC) Peripheral interrupt flag status - Bridge D */
+#define REG_PAC_INTFLAGE           (0x44000024U) /**< \brief (PAC) Peripheral interrupt flag status - Bridge E */
+#define REG_PAC_STATUSA            (0x44000034U) /**< \brief (PAC) Peripheral write protection status - Bridge A */
+#define REG_PAC_STATUSB            (0x44000038U) /**< \brief (PAC) Peripheral write protection status - Bridge B */
+#define REG_PAC_STATUSC            (0x4400003CU) /**< \brief (PAC) Peripheral write protection status - Bridge C */
+#define REG_PAC_STATUSD            (0x44000040U) /**< \brief (PAC) Peripheral write protection status - Bridge D */
+#define REG_PAC_STATUSE            (0x44000044U) /**< \brief (PAC) Peripheral write protection status - Bridge E */
+#else
+#define REG_PAC_WRCTRL             (*(RwReg  *)0x44000000U) /**< \brief (PAC) Write control */
+#define REG_PAC_EVCTRL             (*(RwReg8 *)0x44000004U) /**< \brief (PAC) Event control */
+#define REG_PAC_INTENCLR           (*(RwReg8 *)0x44000008U) /**< \brief (PAC) Interrupt enable clear */
+#define REG_PAC_INTENSET           (*(RwReg8 *)0x44000009U) /**< \brief (PAC) Interrupt enable set */
+#define REG_PAC_INTFLAGAHB         (*(RwReg  *)0x44000010U) /**< \brief (PAC) Bridge interrupt flag status */
+#define REG_PAC_INTFLAGA           (*(RwReg  *)0x44000014U) /**< \brief (PAC) Peripheral interrupt flag status - Bridge A */
+#define REG_PAC_INTFLAGB           (*(RwReg  *)0x44000018U) /**< \brief (PAC) Peripheral interrupt flag status - Bridge B */
+#define REG_PAC_INTFLAGC           (*(RwReg  *)0x4400001CU) /**< \brief (PAC) Peripheral interrupt flag status - Bridge C */
+#define REG_PAC_INTFLAGD           (*(RwReg  *)0x44000020U) /**< \brief (PAC) Peripheral interrupt flag status - Bridge D */
+#define REG_PAC_INTFLAGE           (*(RwReg  *)0x44000024U) /**< \brief (PAC) Peripheral interrupt flag status - Bridge E */
+#define REG_PAC_STATUSA            (*(RoReg  *)0x44000034U) /**< \brief (PAC) Peripheral write protection status - Bridge A */
+#define REG_PAC_STATUSB            (*(RoReg  *)0x44000038U) /**< \brief (PAC) Peripheral write protection status - Bridge B */
+#define REG_PAC_STATUSC            (*(RoReg  *)0x4400003CU) /**< \brief (PAC) Peripheral write protection status - Bridge C */
+#define REG_PAC_STATUSD            (*(RoReg  *)0x44000040U) /**< \brief (PAC) Peripheral write protection status - Bridge D */
+#define REG_PAC_STATUSE            (*(RoReg  *)0x44000044U) /**< \brief (PAC) Peripheral write protection status - Bridge E */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PAC peripheral ========== */
+#define PAC_CLK_AHB_ID              14       // AHB clock index
+#define PAC_HPB_NUM                 5        // Number of bridges AHB/APB
+#define PAC_INTFLAG_NUM             6        // Number of intflag registers
+
+#endif /* _SAML21_PAC_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/pm_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/pm_100.h
@@ -1,0 +1,71 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PM
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_PM_INSTANCE_
+#define _SAML21_PM_INSTANCE_
+
+/* ========== Register definition for PM peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PM_CTRLA               (0x40000000U) /**< \brief (PM) Control A */
+#define REG_PM_SLEEPCFG            (0x40000001U) /**< \brief (PM) Sleep Configuration */
+#define REG_PM_PLCFG               (0x40000002U) /**< \brief (PM) Performance Level Configuration */
+#define REG_PM_INTENCLR            (0x40000004U) /**< \brief (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET            (0x40000005U) /**< \brief (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG             (0x40000006U) /**< \brief (PM) Interrupt Flag Status and Clear */
+#define REG_PM_STDBYCFG            (0x40000008U) /**< \brief (PM) Standby Configuration */
+#define REG_PM_PWSAKDLY            (0x4000000CU) /**< \brief (PM) Power Switch Acknowledge Delay */
+#else
+#define REG_PM_CTRLA               (*(RwReg8 *)0x40000000U) /**< \brief (PM) Control A */
+#define REG_PM_SLEEPCFG            (*(RwReg8 *)0x40000001U) /**< \brief (PM) Sleep Configuration */
+#define REG_PM_PLCFG               (*(RwReg8 *)0x40000002U) /**< \brief (PM) Performance Level Configuration */
+#define REG_PM_INTENCLR            (*(RwReg8 *)0x40000004U) /**< \brief (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET            (*(RwReg8 *)0x40000005U) /**< \brief (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG             (*(RwReg8 *)0x40000006U) /**< \brief (PM) Interrupt Flag Status and Clear */
+#define REG_PM_STDBYCFG            (*(RwReg16*)0x40000008U) /**< \brief (PM) Standby Configuration */
+#define REG_PM_PWSAKDLY            (*(RwReg8 *)0x4000000CU) /**< \brief (PM) Power Switch Acknowledge Delay */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PM peripheral ========== */
+#define PM_PD_NUM                   3        // Number of switchable Power Domain
+
+#endif /* _SAML21_PM_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/port.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/port.h
@@ -1,0 +1,141 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PORT
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_PORT_INSTANCE_
+#define _SAML21_PORT_INSTANCE_
+
+/* ========== Register definition for PORT peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PORT_DIR0              (0x40002800U) /**< \brief (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0           (0x40002804U) /**< \brief (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0           (0x40002808U) /**< \brief (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0           (0x4000280CU) /**< \brief (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0              (0x40002810U) /**< \brief (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0           (0x40002814U) /**< \brief (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0           (0x40002818U) /**< \brief (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0           (0x4000281CU) /**< \brief (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0               (0x40002820U) /**< \brief (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0             (0x40002824U) /**< \brief (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0         (0x40002828U) /**< \brief (PORT) Write Configuration 0 */
+#define REG_PORT_EVCTRL0           (0x4000282CU) /**< \brief (PORT) Event Input Control 0 */
+#define REG_PORT_PMUX0             (0x40002830U) /**< \brief (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0           (0x40002840U) /**< \brief (PORT) Pin Configuration 0 */
+#define REG_PORT_DIR1              (0x40002880U) /**< \brief (PORT) Data Direction 1 */
+#define REG_PORT_DIRCLR1           (0x40002884U) /**< \brief (PORT) Data Direction Clear 1 */
+#define REG_PORT_DIRSET1           (0x40002888U) /**< \brief (PORT) Data Direction Set 1 */
+#define REG_PORT_DIRTGL1           (0x4000288CU) /**< \brief (PORT) Data Direction Toggle 1 */
+#define REG_PORT_OUT1              (0x40002890U) /**< \brief (PORT) Data Output Value 1 */
+#define REG_PORT_OUTCLR1           (0x40002894U) /**< \brief (PORT) Data Output Value Clear 1 */
+#define REG_PORT_OUTSET1           (0x40002898U) /**< \brief (PORT) Data Output Value Set 1 */
+#define REG_PORT_OUTTGL1           (0x4000289CU) /**< \brief (PORT) Data Output Value Toggle 1 */
+#define REG_PORT_IN1               (0x400028A0U) /**< \brief (PORT) Data Input Value 1 */
+#define REG_PORT_CTRL1             (0x400028A4U) /**< \brief (PORT) Control 1 */
+#define REG_PORT_WRCONFIG1         (0x400028A8U) /**< \brief (PORT) Write Configuration 1 */
+#define REG_PORT_EVCTRL1           (0x400028ACU) /**< \brief (PORT) Event Input Control 1 */
+#define REG_PORT_PMUX1             (0x400028B0U) /**< \brief (PORT) Peripheral Multiplexing 1 */
+#define REG_PORT_PINCFG1           (0x400028C0U) /**< \brief (PORT) Pin Configuration 1 */
+#else
+#define REG_PORT_DIR0              (*(RwReg  *)0x40002800U) /**< \brief (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0           (*(RwReg  *)0x40002804U) /**< \brief (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0           (*(RwReg  *)0x40002808U) /**< \brief (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0           (*(RwReg  *)0x4000280CU) /**< \brief (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0              (*(RwReg  *)0x40002810U) /**< \brief (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0           (*(RwReg  *)0x40002814U) /**< \brief (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0           (*(RwReg  *)0x40002818U) /**< \brief (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0           (*(RwReg  *)0x4000281CU) /**< \brief (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0               (*(RoReg  *)0x40002820U) /**< \brief (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0             (*(RwReg  *)0x40002824U) /**< \brief (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0         (*(WoReg  *)0x40002828U) /**< \brief (PORT) Write Configuration 0 */
+#define REG_PORT_EVCTRL0           (*(RwReg  *)0x4000282CU) /**< \brief (PORT) Event Input Control 0 */
+#define REG_PORT_PMUX0             (*(RwReg  *)0x40002830U) /**< \brief (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0           (*(RwReg  *)0x40002840U) /**< \brief (PORT) Pin Configuration 0 */
+#define REG_PORT_DIR1              (*(RwReg  *)0x40002880U) /**< \brief (PORT) Data Direction 1 */
+#define REG_PORT_DIRCLR1           (*(RwReg  *)0x40002884U) /**< \brief (PORT) Data Direction Clear 1 */
+#define REG_PORT_DIRSET1           (*(RwReg  *)0x40002888U) /**< \brief (PORT) Data Direction Set 1 */
+#define REG_PORT_DIRTGL1           (*(RwReg  *)0x4000288CU) /**< \brief (PORT) Data Direction Toggle 1 */
+#define REG_PORT_OUT1              (*(RwReg  *)0x40002890U) /**< \brief (PORT) Data Output Value 1 */
+#define REG_PORT_OUTCLR1           (*(RwReg  *)0x40002894U) /**< \brief (PORT) Data Output Value Clear 1 */
+#define REG_PORT_OUTSET1           (*(RwReg  *)0x40002898U) /**< \brief (PORT) Data Output Value Set 1 */
+#define REG_PORT_OUTTGL1           (*(RwReg  *)0x4000289CU) /**< \brief (PORT) Data Output Value Toggle 1 */
+#define REG_PORT_IN1               (*(RoReg  *)0x400028A0U) /**< \brief (PORT) Data Input Value 1 */
+#define REG_PORT_CTRL1             (*(RwReg  *)0x400028A4U) /**< \brief (PORT) Control 1 */
+#define REG_PORT_WRCONFIG1         (*(WoReg  *)0x400028A8U) /**< \brief (PORT) Write Configuration 1 */
+#define REG_PORT_EVCTRL1           (*(RwReg  *)0x400028ACU) /**< \brief (PORT) Event Input Control 1 */
+#define REG_PORT_PMUX1             (*(RwReg  *)0x400028B0U) /**< \brief (PORT) Peripheral Multiplexing 1 */
+#define REG_PORT_PINCFG1           (*(RwReg  *)0x400028C0U) /**< \brief (PORT) Pin Configuration 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PORT peripheral ========== */
+#define PORT_BITS                   84      
+#define PORT_DIR_DEFAULT_VAL        { 0x00000000, 0x00000000, 0x00000000 }
+#define PORT_DIR_IMPLEMENTED        { 0xDBFFFFFF, 0xC0C3FFFF, 0x000D0000 }
+#define PORT_DRVSTR                 1        // DRVSTR supported?
+#define PORT_DRVSTR_DEFAULT_VAL     { 0x00000000, 0x00000000, 0x00000000 }
+#define PORT_DRVSTR_IMPLEMENTED     { 0xD8FFFFFF, 0xC0C3FFFF, 0x000D0000 }
+#define PORT_EVENT_IMPLEMENTED      { 0xCBFFFFFF, 0xC0C3FFFF, 0x00000000 }
+#define PORT_EV_NUM                 4       
+#define PORT_INEN_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define PORT_INEN_IMPLEMENTED       { 0xDBFFFFFF, 0xC0C3FFFF, 0x000D0000 }
+#define PORT_ODRAIN                 0        // ODRAIN supported?
+#define PORT_ODRAIN_DEFAULT_VAL     { 0x00000000, 0x00000000, 0x00000000 }
+#define PORT_ODRAIN_IMPLEMENTED     { 0x00000000, 0x00000000, 0x00000000 }
+#define PORT_OUT_DEFAULT_VAL        { 0x00000000, 0x00000000, 0x00000000 }
+#define PORT_OUT_IMPLEMENTED        { 0xDBFFFFFF, 0xC0C3FFFF, 0x000D0000 }
+#define PORT_PIN_IMPLEMENTED        { 0xDBFFFFFF, 0xC0C3FFFF, 0x000D0000 }
+#define PORT_PMUXBIT0_DEFAULT_VAL   { 0x00000000, 0x00000000, 0x000D0000 }
+#define PORT_PMUXBIT0_IMPLEMENTED   { 0xDBFFFFFF, 0xC0C3FFFF, 0x00000000 }
+#define PORT_PMUXBIT1_DEFAULT_VAL   { 0x40000000, 0x00000000, 0x00000000 }
+#define PORT_PMUXBIT1_IMPLEMENTED   { 0xDBFFFFF3, 0xC0C3FF0F, 0x00000000 }
+#define PORT_PMUXBIT2_DEFAULT_VAL   { 0x40000000, 0x00000000, 0x000D0000 }
+#define PORT_PMUXBIT2_IMPLEMENTED   { 0xDBFFFFF3, 0xC0C3FF0F, 0x00000000 }
+#define PORT_PMUXBIT3_DEFAULT_VAL   { 0x00000000, 0x00000000, 0x00000000 }
+#define PORT_PMUXBIT3_IMPLEMENTED   { 0xC3CF0FF0, 0x00C3CFC7, 0x00000000 }
+#define PORT_PMUXEN_DEFAULT_VAL     { 0x40000000, 0x00000000, 0x00000000 }
+#define PORT_PMUXEN_IMPLEMENTED     { 0xDBFFFFFF, 0xC0C3FFFF, 0x000D0000 }
+#define PORT_PULLEN_DEFAULT_VAL     { 0x00000000, 0x00000000, 0x00000000 }
+#define PORT_PULLEN_IMPLEMENTED     { 0xDBFFFFFF, 0xC0C3FFFF, 0x000D0000 }
+#define PORT_SLEWLIM                0        // SLEWLIM supported?
+#define PORT_SLEWLIM_DEFAULT_VAL    { 0x00000000, 0x00000000, 0x00000000 }
+#define PORT_SLEWLIM_IMPLEMENTED    { 0x00000000, 0x00000000, 0x00000000 }
+
+#endif /* _SAML21_PORT_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/rstc_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/rstc_100.h
@@ -1,0 +1,67 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RSTC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_RSTC_INSTANCE_
+#define _SAML21_RSTC_INSTANCE_
+
+/* ========== Register definition for RSTC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_RSTC_RCAUSE            (0x40000800U) /**< \brief (RSTC) Reset Cause */
+#define REG_RSTC_BKUPEXIT          (0x40000802U) /**< \brief (RSTC) Backup Exit Source */
+#define REG_RSTC_WKDBCONF          (0x40000804U) /**< \brief (RSTC) Wakeup Debounce Configuration */
+#define REG_RSTC_WKPOL             (0x40000808U) /**< \brief (RSTC) Wakeup Polarity */
+#define REG_RSTC_WKEN              (0x4000080CU) /**< \brief (RSTC) Wakeup Enable */
+#define REG_RSTC_WKCAUSE           (0x40000810U) /**< \brief (RSTC) Wakeup Cause */
+#else
+#define REG_RSTC_RCAUSE            (*(RoReg8 *)0x40000800U) /**< \brief (RSTC) Reset Cause */
+#define REG_RSTC_BKUPEXIT          (*(RoReg8 *)0x40000802U) /**< \brief (RSTC) Backup Exit Source */
+#define REG_RSTC_WKDBCONF          (*(RwReg8 *)0x40000804U) /**< \brief (RSTC) Wakeup Debounce Configuration */
+#define REG_RSTC_WKPOL             (*(RwReg16*)0x40000808U) /**< \brief (RSTC) Wakeup Polarity */
+#define REG_RSTC_WKEN              (*(RwReg16*)0x4000080CU) /**< \brief (RSTC) Wakeup Enable */
+#define REG_RSTC_WKCAUSE           (*(RwReg16*)0x40000810U) /**< \brief (RSTC) Wakeup Cause */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for RSTC peripheral ========== */
+#define RSTC_NUMBER_OF_EXTWAKE      16       // number of external wakeup line
+
+#endif /* _SAML21_RSTC_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/rtc_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/rtc_100.h
@@ -1,0 +1,125 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RTC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_RTC_INSTANCE_
+#define _SAML21_RTC_INSTANCE_
+
+/* ========== Register definition for RTC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_RTC_DBGCTRL            (0x4000200EU) /**< \brief (RTC) Debug Control */
+#define REG_RTC_FREQCORR           (0x40002014U) /**< \brief (RTC) Frequency Correction */
+#define REG_RTC_GP0                (0x40002040U) /**< \brief (RTC) General Purpose 0 */
+#define REG_RTC_GP1                (0x40002044U) /**< \brief (RTC) General Purpose 1 */
+#define REG_RTC_GP2                (0x40002048U) /**< \brief (RTC) General Purpose 2 */
+#define REG_RTC_GP3                (0x4000204CU) /**< \brief (RTC) General Purpose 3 */
+#define REG_RTC_MODE0_CTRLA        (0x40002000U) /**< \brief (RTC) MODE0 Control A */
+#define REG_RTC_MODE0_EVCTRL       (0x40002004U) /**< \brief (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR     (0x40002008U) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET     (0x4000200AU) /**< \brief (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG      (0x4000200CU) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_SYNCBUSY     (0x40002010U) /**< \brief (RTC) MODE0 Synchronization Busy Status */
+#define REG_RTC_MODE0_COUNT        (0x40002018U) /**< \brief (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP0        (0x40002020U) /**< \brief (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE1_CTRLA        (0x40002000U) /**< \brief (RTC) MODE1 Control A */
+#define REG_RTC_MODE1_EVCTRL       (0x40002004U) /**< \brief (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR     (0x40002008U) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET     (0x4000200AU) /**< \brief (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG      (0x4000200CU) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_SYNCBUSY     (0x40002010U) /**< \brief (RTC) MODE1 Synchronization Busy Status */
+#define REG_RTC_MODE1_COUNT        (0x40002018U) /**< \brief (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER          (0x4000201CU) /**< \brief (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP0        (0x40002020U) /**< \brief (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1        (0x40002022U) /**< \brief (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE2_CTRLA        (0x40002000U) /**< \brief (RTC) MODE2 Control A */
+#define REG_RTC_MODE2_EVCTRL       (0x40002004U) /**< \brief (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR     (0x40002008U) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET     (0x4000200AU) /**< \brief (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG      (0x4000200CU) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_SYNCBUSY     (0x40002010U) /**< \brief (RTC) MODE2 Synchronization Busy Status */
+#define REG_RTC_MODE2_CLOCK        (0x40002018U) /**< \brief (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_ALARM_ALARM0 (0x40002020U) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_ALARM_MASK0  (0x40002024U) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
+#else
+#define REG_RTC_DBGCTRL            (*(RwReg8 *)0x4000200EU) /**< \brief (RTC) Debug Control */
+#define REG_RTC_FREQCORR           (*(RwReg8 *)0x40002014U) /**< \brief (RTC) Frequency Correction */
+#define REG_RTC_GP0                (*(RwReg  *)0x40002040U) /**< \brief (RTC) General Purpose 0 */
+#define REG_RTC_GP1                (*(RwReg  *)0x40002044U) /**< \brief (RTC) General Purpose 1 */
+#define REG_RTC_GP2                (*(RwReg  *)0x40002048U) /**< \brief (RTC) General Purpose 2 */
+#define REG_RTC_GP3                (*(RwReg  *)0x4000204CU) /**< \brief (RTC) General Purpose 3 */
+#define REG_RTC_MODE0_CTRLA        (*(RwReg16*)0x40002000U) /**< \brief (RTC) MODE0 Control A */
+#define REG_RTC_MODE0_EVCTRL       (*(RwReg  *)0x40002004U) /**< \brief (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR     (*(RwReg16*)0x40002008U) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET     (*(RwReg16*)0x4000200AU) /**< \brief (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG      (*(RwReg16*)0x4000200CU) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_SYNCBUSY     (*(RoReg  *)0x40002010U) /**< \brief (RTC) MODE0 Synchronization Busy Status */
+#define REG_RTC_MODE0_COUNT        (*(RwReg  *)0x40002018U) /**< \brief (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP0        (*(RwReg  *)0x40002020U) /**< \brief (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE1_CTRLA        (*(RwReg16*)0x40002000U) /**< \brief (RTC) MODE1 Control A */
+#define REG_RTC_MODE1_EVCTRL       (*(RwReg  *)0x40002004U) /**< \brief (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR     (*(RwReg16*)0x40002008U) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET     (*(RwReg16*)0x4000200AU) /**< \brief (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG      (*(RwReg16*)0x4000200CU) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_SYNCBUSY     (*(RoReg  *)0x40002010U) /**< \brief (RTC) MODE1 Synchronization Busy Status */
+#define REG_RTC_MODE1_COUNT        (*(RwReg16*)0x40002018U) /**< \brief (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER          (*(RwReg16*)0x4000201CU) /**< \brief (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP0        (*(RwReg16*)0x40002020U) /**< \brief (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1        (*(RwReg16*)0x40002022U) /**< \brief (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE2_CTRLA        (*(RwReg16*)0x40002000U) /**< \brief (RTC) MODE2 Control A */
+#define REG_RTC_MODE2_EVCTRL       (*(RwReg  *)0x40002004U) /**< \brief (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR     (*(RwReg16*)0x40002008U) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET     (*(RwReg16*)0x4000200AU) /**< \brief (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG      (*(RwReg16*)0x4000200CU) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_SYNCBUSY     (*(RoReg  *)0x40002010U) /**< \brief (RTC) MODE2 Synchronization Busy Status */
+#define REG_RTC_MODE2_CLOCK        (*(RwReg  *)0x40002018U) /**< \brief (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_ALARM_ALARM0 (*(RwReg  *)0x40002020U) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_ALARM_MASK0  (*(RwReg  *)0x40002024U) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for RTC peripheral ========== */
+#define RTC_ALARM_NUM               1        // Number of Alarms
+#define RTC_COMP16_NUM              2        // Number of 16-bit Comparators
+#define RTC_COMP32_NUM              1        // Number of 32-bit Comparators
+#define RTC_GPR_NUM                 4        // Number of General-Purpose Registers
+#define RTC_PER_NUM                 8        // Number of Periodic Intervals
+
+#endif /* _SAML21_RTC_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom0.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom0.h
@@ -1,0 +1,144 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM0
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_SERCOM0_INSTANCE_
+#define _SAML21_SERCOM0_INSTANCE_
+
+/* ========== Register definition for SERCOM0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM0_I2CM_CTRLA     (0x42000000U) /**< \brief (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB     (0x42000004U) /**< \brief (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_BAUD      (0x4200000CU) /**< \brief (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR  (0x42000014U) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET  (0x42000016U) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG   (0x42000018U) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS    (0x4200001AU) /**< \brief (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_SYNCBUSY  (0x4200001CU) /**< \brief (SERCOM0) I2CM Synchronization Busy */
+#define REG_SERCOM0_I2CM_ADDR      (0x42000024U) /**< \brief (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA      (0x42000028U) /**< \brief (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CM_DBGCTRL   (0x42000030U) /**< \brief (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CS_CTRLA     (0x42000000U) /**< \brief (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB     (0x42000004U) /**< \brief (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR  (0x42000014U) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET  (0x42000016U) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG   (0x42000018U) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS    (0x4200001AU) /**< \brief (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_SYNCBUSY  (0x4200001CU) /**< \brief (SERCOM0) I2CS Synchronization Busy */
+#define REG_SERCOM0_I2CS_ADDR      (0x42000024U) /**< \brief (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA      (0x42000028U) /**< \brief (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA      (0x42000000U) /**< \brief (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB      (0x42000004U) /**< \brief (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_BAUD       (0x4200000CU) /**< \brief (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR   (0x42000014U) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET   (0x42000016U) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG    (0x42000018U) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS     (0x4200001AU) /**< \brief (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_SYNCBUSY   (0x4200001CU) /**< \brief (SERCOM0) SPI Synchronization Busy */
+#define REG_SERCOM0_SPI_ADDR       (0x42000024U) /**< \brief (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA       (0x42000028U) /**< \brief (SERCOM0) SPI Data */
+#define REG_SERCOM0_SPI_DBGCTRL    (0x42000030U) /**< \brief (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_USART_CTRLA    (0x42000000U) /**< \brief (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB    (0x42000004U) /**< \brief (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_BAUD     (0x4200000CU) /**< \brief (SERCOM0) USART Baud Rate */
+#define REG_SERCOM0_USART_RXPL     (0x4200000EU) /**< \brief (SERCOM0) USART Receive Pulse Length */
+#define REG_SERCOM0_USART_INTENCLR (0x42000014U) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (0x42000016U) /**< \brief (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG  (0x42000018U) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS   (0x4200001AU) /**< \brief (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_SYNCBUSY (0x4200001CU) /**< \brief (SERCOM0) USART Synchronization Busy */
+#define REG_SERCOM0_USART_DATA     (0x42000028U) /**< \brief (SERCOM0) USART Data */
+#define REG_SERCOM0_USART_DBGCTRL  (0x42000030U) /**< \brief (SERCOM0) USART Debug Control */
+#else
+#define REG_SERCOM0_I2CM_CTRLA     (*(RwReg  *)0x42000000U) /**< \brief (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB     (*(RwReg  *)0x42000004U) /**< \brief (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_BAUD      (*(RwReg  *)0x4200000CU) /**< \brief (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR  (*(RwReg8 *)0x42000014U) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET  (*(RwReg8 *)0x42000016U) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG   (*(RwReg8 *)0x42000018U) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS    (*(RwReg16*)0x4200001AU) /**< \brief (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_SYNCBUSY  (*(RoReg  *)0x4200001CU) /**< \brief (SERCOM0) I2CM Synchronization Busy */
+#define REG_SERCOM0_I2CM_ADDR      (*(RwReg  *)0x42000024U) /**< \brief (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA      (*(RwReg8 *)0x42000028U) /**< \brief (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CM_DBGCTRL   (*(RwReg8 *)0x42000030U) /**< \brief (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CS_CTRLA     (*(RwReg  *)0x42000000U) /**< \brief (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB     (*(RwReg  *)0x42000004U) /**< \brief (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR  (*(RwReg8 *)0x42000014U) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET  (*(RwReg8 *)0x42000016U) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG   (*(RwReg8 *)0x42000018U) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS    (*(RwReg16*)0x4200001AU) /**< \brief (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_SYNCBUSY  (*(RoReg  *)0x4200001CU) /**< \brief (SERCOM0) I2CS Synchronization Busy */
+#define REG_SERCOM0_I2CS_ADDR      (*(RwReg  *)0x42000024U) /**< \brief (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA      (*(RwReg8 *)0x42000028U) /**< \brief (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA      (*(RwReg  *)0x42000000U) /**< \brief (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB      (*(RwReg  *)0x42000004U) /**< \brief (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_BAUD       (*(RwReg8 *)0x4200000CU) /**< \brief (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR   (*(RwReg8 *)0x42000014U) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET   (*(RwReg8 *)0x42000016U) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG    (*(RwReg8 *)0x42000018U) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS     (*(RwReg16*)0x4200001AU) /**< \brief (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_SYNCBUSY   (*(RoReg  *)0x4200001CU) /**< \brief (SERCOM0) SPI Synchronization Busy */
+#define REG_SERCOM0_SPI_ADDR       (*(RwReg  *)0x42000024U) /**< \brief (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA       (*(RwReg  *)0x42000028U) /**< \brief (SERCOM0) SPI Data */
+#define REG_SERCOM0_SPI_DBGCTRL    (*(RwReg8 *)0x42000030U) /**< \brief (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_USART_CTRLA    (*(RwReg  *)0x42000000U) /**< \brief (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB    (*(RwReg  *)0x42000004U) /**< \brief (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_BAUD     (*(RwReg16*)0x4200000CU) /**< \brief (SERCOM0) USART Baud Rate */
+#define REG_SERCOM0_USART_RXPL     (*(RwReg8 *)0x4200000EU) /**< \brief (SERCOM0) USART Receive Pulse Length */
+#define REG_SERCOM0_USART_INTENCLR (*(RwReg8 *)0x42000014U) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (*(RwReg8 *)0x42000016U) /**< \brief (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG  (*(RwReg8 *)0x42000018U) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS   (*(RwReg16*)0x4200001AU) /**< \brief (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_SYNCBUSY (*(RoReg  *)0x4200001CU) /**< \brief (SERCOM0) USART Synchronization Busy */
+#define REG_SERCOM0_USART_DATA     (*(RwReg16*)0x42000028U) /**< \brief (SERCOM0) USART Data */
+#define REG_SERCOM0_USART_DBGCTRL  (*(RwReg8 *)0x42000030U) /**< \brief (SERCOM0) USART Debug Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM0 peripheral ========== */
+#define SERCOM0_DMAC_ID_RX          1        // Index of DMA RX trigger
+#define SERCOM0_DMAC_ID_TX          2        // Index of DMA TX trigger
+#define SERCOM0_GCLK_ID_CORE        18      
+#define SERCOM0_GCLK_ID_SLOW        17      
+#define SERCOM0_INT_MSB             6       
+#define SERCOM0_PMSB                3       
+
+#endif /* _SAML21_SERCOM0_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom1.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom1.h
@@ -1,0 +1,144 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM1
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_SERCOM1_INSTANCE_
+#define _SAML21_SERCOM1_INSTANCE_
+
+/* ========== Register definition for SERCOM1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM1_I2CM_CTRLA     (0x42000400U) /**< \brief (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB     (0x42000404U) /**< \brief (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_BAUD      (0x4200040CU) /**< \brief (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR  (0x42000414U) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET  (0x42000416U) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG   (0x42000418U) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS    (0x4200041AU) /**< \brief (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_SYNCBUSY  (0x4200041CU) /**< \brief (SERCOM1) I2CM Synchronization Busy */
+#define REG_SERCOM1_I2CM_ADDR      (0x42000424U) /**< \brief (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA      (0x42000428U) /**< \brief (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CM_DBGCTRL   (0x42000430U) /**< \brief (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CS_CTRLA     (0x42000400U) /**< \brief (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB     (0x42000404U) /**< \brief (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR  (0x42000414U) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET  (0x42000416U) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG   (0x42000418U) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS    (0x4200041AU) /**< \brief (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_SYNCBUSY  (0x4200041CU) /**< \brief (SERCOM1) I2CS Synchronization Busy */
+#define REG_SERCOM1_I2CS_ADDR      (0x42000424U) /**< \brief (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA      (0x42000428U) /**< \brief (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA      (0x42000400U) /**< \brief (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB      (0x42000404U) /**< \brief (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_BAUD       (0x4200040CU) /**< \brief (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR   (0x42000414U) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET   (0x42000416U) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG    (0x42000418U) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS     (0x4200041AU) /**< \brief (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_SYNCBUSY   (0x4200041CU) /**< \brief (SERCOM1) SPI Synchronization Busy */
+#define REG_SERCOM1_SPI_ADDR       (0x42000424U) /**< \brief (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA       (0x42000428U) /**< \brief (SERCOM1) SPI Data */
+#define REG_SERCOM1_SPI_DBGCTRL    (0x42000430U) /**< \brief (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_USART_CTRLA    (0x42000400U) /**< \brief (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB    (0x42000404U) /**< \brief (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_BAUD     (0x4200040CU) /**< \brief (SERCOM1) USART Baud Rate */
+#define REG_SERCOM1_USART_RXPL     (0x4200040EU) /**< \brief (SERCOM1) USART Receive Pulse Length */
+#define REG_SERCOM1_USART_INTENCLR (0x42000414U) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (0x42000416U) /**< \brief (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG  (0x42000418U) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS   (0x4200041AU) /**< \brief (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_SYNCBUSY (0x4200041CU) /**< \brief (SERCOM1) USART Synchronization Busy */
+#define REG_SERCOM1_USART_DATA     (0x42000428U) /**< \brief (SERCOM1) USART Data */
+#define REG_SERCOM1_USART_DBGCTRL  (0x42000430U) /**< \brief (SERCOM1) USART Debug Control */
+#else
+#define REG_SERCOM1_I2CM_CTRLA     (*(RwReg  *)0x42000400U) /**< \brief (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB     (*(RwReg  *)0x42000404U) /**< \brief (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_BAUD      (*(RwReg  *)0x4200040CU) /**< \brief (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR  (*(RwReg8 *)0x42000414U) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET  (*(RwReg8 *)0x42000416U) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG   (*(RwReg8 *)0x42000418U) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS    (*(RwReg16*)0x4200041AU) /**< \brief (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_SYNCBUSY  (*(RoReg  *)0x4200041CU) /**< \brief (SERCOM1) I2CM Synchronization Busy */
+#define REG_SERCOM1_I2CM_ADDR      (*(RwReg  *)0x42000424U) /**< \brief (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA      (*(RwReg8 *)0x42000428U) /**< \brief (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CM_DBGCTRL   (*(RwReg8 *)0x42000430U) /**< \brief (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CS_CTRLA     (*(RwReg  *)0x42000400U) /**< \brief (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB     (*(RwReg  *)0x42000404U) /**< \brief (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR  (*(RwReg8 *)0x42000414U) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET  (*(RwReg8 *)0x42000416U) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG   (*(RwReg8 *)0x42000418U) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS    (*(RwReg16*)0x4200041AU) /**< \brief (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_SYNCBUSY  (*(RoReg  *)0x4200041CU) /**< \brief (SERCOM1) I2CS Synchronization Busy */
+#define REG_SERCOM1_I2CS_ADDR      (*(RwReg  *)0x42000424U) /**< \brief (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA      (*(RwReg8 *)0x42000428U) /**< \brief (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA      (*(RwReg  *)0x42000400U) /**< \brief (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB      (*(RwReg  *)0x42000404U) /**< \brief (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_BAUD       (*(RwReg8 *)0x4200040CU) /**< \brief (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR   (*(RwReg8 *)0x42000414U) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET   (*(RwReg8 *)0x42000416U) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG    (*(RwReg8 *)0x42000418U) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS     (*(RwReg16*)0x4200041AU) /**< \brief (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_SYNCBUSY   (*(RoReg  *)0x4200041CU) /**< \brief (SERCOM1) SPI Synchronization Busy */
+#define REG_SERCOM1_SPI_ADDR       (*(RwReg  *)0x42000424U) /**< \brief (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA       (*(RwReg  *)0x42000428U) /**< \brief (SERCOM1) SPI Data */
+#define REG_SERCOM1_SPI_DBGCTRL    (*(RwReg8 *)0x42000430U) /**< \brief (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_USART_CTRLA    (*(RwReg  *)0x42000400U) /**< \brief (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB    (*(RwReg  *)0x42000404U) /**< \brief (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_BAUD     (*(RwReg16*)0x4200040CU) /**< \brief (SERCOM1) USART Baud Rate */
+#define REG_SERCOM1_USART_RXPL     (*(RwReg8 *)0x4200040EU) /**< \brief (SERCOM1) USART Receive Pulse Length */
+#define REG_SERCOM1_USART_INTENCLR (*(RwReg8 *)0x42000414U) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (*(RwReg8 *)0x42000416U) /**< \brief (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG  (*(RwReg8 *)0x42000418U) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS   (*(RwReg16*)0x4200041AU) /**< \brief (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_SYNCBUSY (*(RoReg  *)0x4200041CU) /**< \brief (SERCOM1) USART Synchronization Busy */
+#define REG_SERCOM1_USART_DATA     (*(RwReg16*)0x42000428U) /**< \brief (SERCOM1) USART Data */
+#define REG_SERCOM1_USART_DBGCTRL  (*(RwReg8 *)0x42000430U) /**< \brief (SERCOM1) USART Debug Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM1 peripheral ========== */
+#define SERCOM1_DMAC_ID_RX          3        // Index of DMA RX trigger
+#define SERCOM1_DMAC_ID_TX          4        // Index of DMA TX trigger
+#define SERCOM1_GCLK_ID_CORE        19      
+#define SERCOM1_GCLK_ID_SLOW        17      
+#define SERCOM1_INT_MSB             6       
+#define SERCOM1_PMSB                3       
+
+#endif /* _SAML21_SERCOM1_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom2.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom2.h
@@ -1,0 +1,144 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM2
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_SERCOM2_INSTANCE_
+#define _SAML21_SERCOM2_INSTANCE_
+
+/* ========== Register definition for SERCOM2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM2_I2CM_CTRLA     (0x42000800U) /**< \brief (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB     (0x42000804U) /**< \brief (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_BAUD      (0x4200080CU) /**< \brief (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR  (0x42000814U) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET  (0x42000816U) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG   (0x42000818U) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS    (0x4200081AU) /**< \brief (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_SYNCBUSY  (0x4200081CU) /**< \brief (SERCOM2) I2CM Synchronization Busy */
+#define REG_SERCOM2_I2CM_ADDR      (0x42000824U) /**< \brief (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA      (0x42000828U) /**< \brief (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CM_DBGCTRL   (0x42000830U) /**< \brief (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CS_CTRLA     (0x42000800U) /**< \brief (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB     (0x42000804U) /**< \brief (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR  (0x42000814U) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET  (0x42000816U) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG   (0x42000818U) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS    (0x4200081AU) /**< \brief (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_SYNCBUSY  (0x4200081CU) /**< \brief (SERCOM2) I2CS Synchronization Busy */
+#define REG_SERCOM2_I2CS_ADDR      (0x42000824U) /**< \brief (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA      (0x42000828U) /**< \brief (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA      (0x42000800U) /**< \brief (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB      (0x42000804U) /**< \brief (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_BAUD       (0x4200080CU) /**< \brief (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR   (0x42000814U) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET   (0x42000816U) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG    (0x42000818U) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS     (0x4200081AU) /**< \brief (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_SYNCBUSY   (0x4200081CU) /**< \brief (SERCOM2) SPI Synchronization Busy */
+#define REG_SERCOM2_SPI_ADDR       (0x42000824U) /**< \brief (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA       (0x42000828U) /**< \brief (SERCOM2) SPI Data */
+#define REG_SERCOM2_SPI_DBGCTRL    (0x42000830U) /**< \brief (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_USART_CTRLA    (0x42000800U) /**< \brief (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB    (0x42000804U) /**< \brief (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_BAUD     (0x4200080CU) /**< \brief (SERCOM2) USART Baud Rate */
+#define REG_SERCOM2_USART_RXPL     (0x4200080EU) /**< \brief (SERCOM2) USART Receive Pulse Length */
+#define REG_SERCOM2_USART_INTENCLR (0x42000814U) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (0x42000816U) /**< \brief (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG  (0x42000818U) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS   (0x4200081AU) /**< \brief (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_SYNCBUSY (0x4200081CU) /**< \brief (SERCOM2) USART Synchronization Busy */
+#define REG_SERCOM2_USART_DATA     (0x42000828U) /**< \brief (SERCOM2) USART Data */
+#define REG_SERCOM2_USART_DBGCTRL  (0x42000830U) /**< \brief (SERCOM2) USART Debug Control */
+#else
+#define REG_SERCOM2_I2CM_CTRLA     (*(RwReg  *)0x42000800U) /**< \brief (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB     (*(RwReg  *)0x42000804U) /**< \brief (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_BAUD      (*(RwReg  *)0x4200080CU) /**< \brief (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR  (*(RwReg8 *)0x42000814U) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET  (*(RwReg8 *)0x42000816U) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG   (*(RwReg8 *)0x42000818U) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS    (*(RwReg16*)0x4200081AU) /**< \brief (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_SYNCBUSY  (*(RoReg  *)0x4200081CU) /**< \brief (SERCOM2) I2CM Synchronization Busy */
+#define REG_SERCOM2_I2CM_ADDR      (*(RwReg  *)0x42000824U) /**< \brief (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA      (*(RwReg8 *)0x42000828U) /**< \brief (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CM_DBGCTRL   (*(RwReg8 *)0x42000830U) /**< \brief (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CS_CTRLA     (*(RwReg  *)0x42000800U) /**< \brief (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB     (*(RwReg  *)0x42000804U) /**< \brief (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR  (*(RwReg8 *)0x42000814U) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET  (*(RwReg8 *)0x42000816U) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG   (*(RwReg8 *)0x42000818U) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS    (*(RwReg16*)0x4200081AU) /**< \brief (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_SYNCBUSY  (*(RoReg  *)0x4200081CU) /**< \brief (SERCOM2) I2CS Synchronization Busy */
+#define REG_SERCOM2_I2CS_ADDR      (*(RwReg  *)0x42000824U) /**< \brief (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA      (*(RwReg8 *)0x42000828U) /**< \brief (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA      (*(RwReg  *)0x42000800U) /**< \brief (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB      (*(RwReg  *)0x42000804U) /**< \brief (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_BAUD       (*(RwReg8 *)0x4200080CU) /**< \brief (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR   (*(RwReg8 *)0x42000814U) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET   (*(RwReg8 *)0x42000816U) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG    (*(RwReg8 *)0x42000818U) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS     (*(RwReg16*)0x4200081AU) /**< \brief (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_SYNCBUSY   (*(RoReg  *)0x4200081CU) /**< \brief (SERCOM2) SPI Synchronization Busy */
+#define REG_SERCOM2_SPI_ADDR       (*(RwReg  *)0x42000824U) /**< \brief (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA       (*(RwReg  *)0x42000828U) /**< \brief (SERCOM2) SPI Data */
+#define REG_SERCOM2_SPI_DBGCTRL    (*(RwReg8 *)0x42000830U) /**< \brief (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_USART_CTRLA    (*(RwReg  *)0x42000800U) /**< \brief (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB    (*(RwReg  *)0x42000804U) /**< \brief (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_BAUD     (*(RwReg16*)0x4200080CU) /**< \brief (SERCOM2) USART Baud Rate */
+#define REG_SERCOM2_USART_RXPL     (*(RwReg8 *)0x4200080EU) /**< \brief (SERCOM2) USART Receive Pulse Length */
+#define REG_SERCOM2_USART_INTENCLR (*(RwReg8 *)0x42000814U) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (*(RwReg8 *)0x42000816U) /**< \brief (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG  (*(RwReg8 *)0x42000818U) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS   (*(RwReg16*)0x4200081AU) /**< \brief (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_SYNCBUSY (*(RoReg  *)0x4200081CU) /**< \brief (SERCOM2) USART Synchronization Busy */
+#define REG_SERCOM2_USART_DATA     (*(RwReg16*)0x42000828U) /**< \brief (SERCOM2) USART Data */
+#define REG_SERCOM2_USART_DBGCTRL  (*(RwReg8 *)0x42000830U) /**< \brief (SERCOM2) USART Debug Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM2 peripheral ========== */
+#define SERCOM2_DMAC_ID_RX          5        // Index of DMA RX trigger
+#define SERCOM2_DMAC_ID_TX          6        // Index of DMA TX trigger
+#define SERCOM2_GCLK_ID_CORE        20      
+#define SERCOM2_GCLK_ID_SLOW        17      
+#define SERCOM2_INT_MSB             6       
+#define SERCOM2_PMSB                3       
+
+#endif /* _SAML21_SERCOM2_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom3.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom3.h
@@ -1,0 +1,144 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM3
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_SERCOM3_INSTANCE_
+#define _SAML21_SERCOM3_INSTANCE_
+
+/* ========== Register definition for SERCOM3 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM3_I2CM_CTRLA     (0x42000C00U) /**< \brief (SERCOM3) I2CM Control A */
+#define REG_SERCOM3_I2CM_CTRLB     (0x42000C04U) /**< \brief (SERCOM3) I2CM Control B */
+#define REG_SERCOM3_I2CM_BAUD      (0x42000C0CU) /**< \brief (SERCOM3) I2CM Baud Rate */
+#define REG_SERCOM3_I2CM_INTENCLR  (0x42000C14U) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
+#define REG_SERCOM3_I2CM_INTENSET  (0x42000C16U) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
+#define REG_SERCOM3_I2CM_INTFLAG   (0x42000C18U) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CM_STATUS    (0x42000C1AU) /**< \brief (SERCOM3) I2CM Status */
+#define REG_SERCOM3_I2CM_SYNCBUSY  (0x42000C1CU) /**< \brief (SERCOM3) I2CM Synchronization Busy */
+#define REG_SERCOM3_I2CM_ADDR      (0x42000C24U) /**< \brief (SERCOM3) I2CM Address */
+#define REG_SERCOM3_I2CM_DATA      (0x42000C28U) /**< \brief (SERCOM3) I2CM Data */
+#define REG_SERCOM3_I2CM_DBGCTRL   (0x42000C30U) /**< \brief (SERCOM3) I2CM Debug Control */
+#define REG_SERCOM3_I2CS_CTRLA     (0x42000C00U) /**< \brief (SERCOM3) I2CS Control A */
+#define REG_SERCOM3_I2CS_CTRLB     (0x42000C04U) /**< \brief (SERCOM3) I2CS Control B */
+#define REG_SERCOM3_I2CS_INTENCLR  (0x42000C14U) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
+#define REG_SERCOM3_I2CS_INTENSET  (0x42000C16U) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
+#define REG_SERCOM3_I2CS_INTFLAG   (0x42000C18U) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CS_STATUS    (0x42000C1AU) /**< \brief (SERCOM3) I2CS Status */
+#define REG_SERCOM3_I2CS_SYNCBUSY  (0x42000C1CU) /**< \brief (SERCOM3) I2CS Synchronization Busy */
+#define REG_SERCOM3_I2CS_ADDR      (0x42000C24U) /**< \brief (SERCOM3) I2CS Address */
+#define REG_SERCOM3_I2CS_DATA      (0x42000C28U) /**< \brief (SERCOM3) I2CS Data */
+#define REG_SERCOM3_SPI_CTRLA      (0x42000C00U) /**< \brief (SERCOM3) SPI Control A */
+#define REG_SERCOM3_SPI_CTRLB      (0x42000C04U) /**< \brief (SERCOM3) SPI Control B */
+#define REG_SERCOM3_SPI_BAUD       (0x42000C0CU) /**< \brief (SERCOM3) SPI Baud Rate */
+#define REG_SERCOM3_SPI_INTENCLR   (0x42000C14U) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
+#define REG_SERCOM3_SPI_INTENSET   (0x42000C16U) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
+#define REG_SERCOM3_SPI_INTFLAG    (0x42000C18U) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM3_SPI_STATUS     (0x42000C1AU) /**< \brief (SERCOM3) SPI Status */
+#define REG_SERCOM3_SPI_SYNCBUSY   (0x42000C1CU) /**< \brief (SERCOM3) SPI Synchronization Busy */
+#define REG_SERCOM3_SPI_ADDR       (0x42000C24U) /**< \brief (SERCOM3) SPI Address */
+#define REG_SERCOM3_SPI_DATA       (0x42000C28U) /**< \brief (SERCOM3) SPI Data */
+#define REG_SERCOM3_SPI_DBGCTRL    (0x42000C30U) /**< \brief (SERCOM3) SPI Debug Control */
+#define REG_SERCOM3_USART_CTRLA    (0x42000C00U) /**< \brief (SERCOM3) USART Control A */
+#define REG_SERCOM3_USART_CTRLB    (0x42000C04U) /**< \brief (SERCOM3) USART Control B */
+#define REG_SERCOM3_USART_BAUD     (0x42000C0CU) /**< \brief (SERCOM3) USART Baud Rate */
+#define REG_SERCOM3_USART_RXPL     (0x42000C0EU) /**< \brief (SERCOM3) USART Receive Pulse Length */
+#define REG_SERCOM3_USART_INTENCLR (0x42000C14U) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
+#define REG_SERCOM3_USART_INTENSET (0x42000C16U) /**< \brief (SERCOM3) USART Interrupt Enable Set */
+#define REG_SERCOM3_USART_INTFLAG  (0x42000C18U) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM3_USART_STATUS   (0x42000C1AU) /**< \brief (SERCOM3) USART Status */
+#define REG_SERCOM3_USART_SYNCBUSY (0x42000C1CU) /**< \brief (SERCOM3) USART Synchronization Busy */
+#define REG_SERCOM3_USART_DATA     (0x42000C28U) /**< \brief (SERCOM3) USART Data */
+#define REG_SERCOM3_USART_DBGCTRL  (0x42000C30U) /**< \brief (SERCOM3) USART Debug Control */
+#else
+#define REG_SERCOM3_I2CM_CTRLA     (*(RwReg  *)0x42000C00U) /**< \brief (SERCOM3) I2CM Control A */
+#define REG_SERCOM3_I2CM_CTRLB     (*(RwReg  *)0x42000C04U) /**< \brief (SERCOM3) I2CM Control B */
+#define REG_SERCOM3_I2CM_BAUD      (*(RwReg  *)0x42000C0CU) /**< \brief (SERCOM3) I2CM Baud Rate */
+#define REG_SERCOM3_I2CM_INTENCLR  (*(RwReg8 *)0x42000C14U) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
+#define REG_SERCOM3_I2CM_INTENSET  (*(RwReg8 *)0x42000C16U) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
+#define REG_SERCOM3_I2CM_INTFLAG   (*(RwReg8 *)0x42000C18U) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CM_STATUS    (*(RwReg16*)0x42000C1AU) /**< \brief (SERCOM3) I2CM Status */
+#define REG_SERCOM3_I2CM_SYNCBUSY  (*(RoReg  *)0x42000C1CU) /**< \brief (SERCOM3) I2CM Synchronization Busy */
+#define REG_SERCOM3_I2CM_ADDR      (*(RwReg  *)0x42000C24U) /**< \brief (SERCOM3) I2CM Address */
+#define REG_SERCOM3_I2CM_DATA      (*(RwReg8 *)0x42000C28U) /**< \brief (SERCOM3) I2CM Data */
+#define REG_SERCOM3_I2CM_DBGCTRL   (*(RwReg8 *)0x42000C30U) /**< \brief (SERCOM3) I2CM Debug Control */
+#define REG_SERCOM3_I2CS_CTRLA     (*(RwReg  *)0x42000C00U) /**< \brief (SERCOM3) I2CS Control A */
+#define REG_SERCOM3_I2CS_CTRLB     (*(RwReg  *)0x42000C04U) /**< \brief (SERCOM3) I2CS Control B */
+#define REG_SERCOM3_I2CS_INTENCLR  (*(RwReg8 *)0x42000C14U) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
+#define REG_SERCOM3_I2CS_INTENSET  (*(RwReg8 *)0x42000C16U) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
+#define REG_SERCOM3_I2CS_INTFLAG   (*(RwReg8 *)0x42000C18U) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CS_STATUS    (*(RwReg16*)0x42000C1AU) /**< \brief (SERCOM3) I2CS Status */
+#define REG_SERCOM3_I2CS_SYNCBUSY  (*(RoReg  *)0x42000C1CU) /**< \brief (SERCOM3) I2CS Synchronization Busy */
+#define REG_SERCOM3_I2CS_ADDR      (*(RwReg  *)0x42000C24U) /**< \brief (SERCOM3) I2CS Address */
+#define REG_SERCOM3_I2CS_DATA      (*(RwReg8 *)0x42000C28U) /**< \brief (SERCOM3) I2CS Data */
+#define REG_SERCOM3_SPI_CTRLA      (*(RwReg  *)0x42000C00U) /**< \brief (SERCOM3) SPI Control A */
+#define REG_SERCOM3_SPI_CTRLB      (*(RwReg  *)0x42000C04U) /**< \brief (SERCOM3) SPI Control B */
+#define REG_SERCOM3_SPI_BAUD       (*(RwReg8 *)0x42000C0CU) /**< \brief (SERCOM3) SPI Baud Rate */
+#define REG_SERCOM3_SPI_INTENCLR   (*(RwReg8 *)0x42000C14U) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
+#define REG_SERCOM3_SPI_INTENSET   (*(RwReg8 *)0x42000C16U) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
+#define REG_SERCOM3_SPI_INTFLAG    (*(RwReg8 *)0x42000C18U) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM3_SPI_STATUS     (*(RwReg16*)0x42000C1AU) /**< \brief (SERCOM3) SPI Status */
+#define REG_SERCOM3_SPI_SYNCBUSY   (*(RoReg  *)0x42000C1CU) /**< \brief (SERCOM3) SPI Synchronization Busy */
+#define REG_SERCOM3_SPI_ADDR       (*(RwReg  *)0x42000C24U) /**< \brief (SERCOM3) SPI Address */
+#define REG_SERCOM3_SPI_DATA       (*(RwReg  *)0x42000C28U) /**< \brief (SERCOM3) SPI Data */
+#define REG_SERCOM3_SPI_DBGCTRL    (*(RwReg8 *)0x42000C30U) /**< \brief (SERCOM3) SPI Debug Control */
+#define REG_SERCOM3_USART_CTRLA    (*(RwReg  *)0x42000C00U) /**< \brief (SERCOM3) USART Control A */
+#define REG_SERCOM3_USART_CTRLB    (*(RwReg  *)0x42000C04U) /**< \brief (SERCOM3) USART Control B */
+#define REG_SERCOM3_USART_BAUD     (*(RwReg16*)0x42000C0CU) /**< \brief (SERCOM3) USART Baud Rate */
+#define REG_SERCOM3_USART_RXPL     (*(RwReg8 *)0x42000C0EU) /**< \brief (SERCOM3) USART Receive Pulse Length */
+#define REG_SERCOM3_USART_INTENCLR (*(RwReg8 *)0x42000C14U) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
+#define REG_SERCOM3_USART_INTENSET (*(RwReg8 *)0x42000C16U) /**< \brief (SERCOM3) USART Interrupt Enable Set */
+#define REG_SERCOM3_USART_INTFLAG  (*(RwReg8 *)0x42000C18U) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM3_USART_STATUS   (*(RwReg16*)0x42000C1AU) /**< \brief (SERCOM3) USART Status */
+#define REG_SERCOM3_USART_SYNCBUSY (*(RoReg  *)0x42000C1CU) /**< \brief (SERCOM3) USART Synchronization Busy */
+#define REG_SERCOM3_USART_DATA     (*(RwReg16*)0x42000C28U) /**< \brief (SERCOM3) USART Data */
+#define REG_SERCOM3_USART_DBGCTRL  (*(RwReg8 *)0x42000C30U) /**< \brief (SERCOM3) USART Debug Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM3 peripheral ========== */
+#define SERCOM3_DMAC_ID_RX          7        // Index of DMA RX trigger
+#define SERCOM3_DMAC_ID_TX          8        // Index of DMA TX trigger
+#define SERCOM3_GCLK_ID_CORE        21      
+#define SERCOM3_GCLK_ID_SLOW        17      
+#define SERCOM3_INT_MSB             6       
+#define SERCOM3_PMSB                3       
+
+#endif /* _SAML21_SERCOM3_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom4.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom4.h
@@ -1,0 +1,144 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM4
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_SERCOM4_INSTANCE_
+#define _SAML21_SERCOM4_INSTANCE_
+
+/* ========== Register definition for SERCOM4 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM4_I2CM_CTRLA     (0x42001000U) /**< \brief (SERCOM4) I2CM Control A */
+#define REG_SERCOM4_I2CM_CTRLB     (0x42001004U) /**< \brief (SERCOM4) I2CM Control B */
+#define REG_SERCOM4_I2CM_BAUD      (0x4200100CU) /**< \brief (SERCOM4) I2CM Baud Rate */
+#define REG_SERCOM4_I2CM_INTENCLR  (0x42001014U) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
+#define REG_SERCOM4_I2CM_INTENSET  (0x42001016U) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
+#define REG_SERCOM4_I2CM_INTFLAG   (0x42001018U) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CM_STATUS    (0x4200101AU) /**< \brief (SERCOM4) I2CM Status */
+#define REG_SERCOM4_I2CM_SYNCBUSY  (0x4200101CU) /**< \brief (SERCOM4) I2CM Synchronization Busy */
+#define REG_SERCOM4_I2CM_ADDR      (0x42001024U) /**< \brief (SERCOM4) I2CM Address */
+#define REG_SERCOM4_I2CM_DATA      (0x42001028U) /**< \brief (SERCOM4) I2CM Data */
+#define REG_SERCOM4_I2CM_DBGCTRL   (0x42001030U) /**< \brief (SERCOM4) I2CM Debug Control */
+#define REG_SERCOM4_I2CS_CTRLA     (0x42001000U) /**< \brief (SERCOM4) I2CS Control A */
+#define REG_SERCOM4_I2CS_CTRLB     (0x42001004U) /**< \brief (SERCOM4) I2CS Control B */
+#define REG_SERCOM4_I2CS_INTENCLR  (0x42001014U) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
+#define REG_SERCOM4_I2CS_INTENSET  (0x42001016U) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
+#define REG_SERCOM4_I2CS_INTFLAG   (0x42001018U) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CS_STATUS    (0x4200101AU) /**< \brief (SERCOM4) I2CS Status */
+#define REG_SERCOM4_I2CS_SYNCBUSY  (0x4200101CU) /**< \brief (SERCOM4) I2CS Synchronization Busy */
+#define REG_SERCOM4_I2CS_ADDR      (0x42001024U) /**< \brief (SERCOM4) I2CS Address */
+#define REG_SERCOM4_I2CS_DATA      (0x42001028U) /**< \brief (SERCOM4) I2CS Data */
+#define REG_SERCOM4_SPI_CTRLA      (0x42001000U) /**< \brief (SERCOM4) SPI Control A */
+#define REG_SERCOM4_SPI_CTRLB      (0x42001004U) /**< \brief (SERCOM4) SPI Control B */
+#define REG_SERCOM4_SPI_BAUD       (0x4200100CU) /**< \brief (SERCOM4) SPI Baud Rate */
+#define REG_SERCOM4_SPI_INTENCLR   (0x42001014U) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
+#define REG_SERCOM4_SPI_INTENSET   (0x42001016U) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
+#define REG_SERCOM4_SPI_INTFLAG    (0x42001018U) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM4_SPI_STATUS     (0x4200101AU) /**< \brief (SERCOM4) SPI Status */
+#define REG_SERCOM4_SPI_SYNCBUSY   (0x4200101CU) /**< \brief (SERCOM4) SPI Synchronization Busy */
+#define REG_SERCOM4_SPI_ADDR       (0x42001024U) /**< \brief (SERCOM4) SPI Address */
+#define REG_SERCOM4_SPI_DATA       (0x42001028U) /**< \brief (SERCOM4) SPI Data */
+#define REG_SERCOM4_SPI_DBGCTRL    (0x42001030U) /**< \brief (SERCOM4) SPI Debug Control */
+#define REG_SERCOM4_USART_CTRLA    (0x42001000U) /**< \brief (SERCOM4) USART Control A */
+#define REG_SERCOM4_USART_CTRLB    (0x42001004U) /**< \brief (SERCOM4) USART Control B */
+#define REG_SERCOM4_USART_BAUD     (0x4200100CU) /**< \brief (SERCOM4) USART Baud Rate */
+#define REG_SERCOM4_USART_RXPL     (0x4200100EU) /**< \brief (SERCOM4) USART Receive Pulse Length */
+#define REG_SERCOM4_USART_INTENCLR (0x42001014U) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
+#define REG_SERCOM4_USART_INTENSET (0x42001016U) /**< \brief (SERCOM4) USART Interrupt Enable Set */
+#define REG_SERCOM4_USART_INTFLAG  (0x42001018U) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM4_USART_STATUS   (0x4200101AU) /**< \brief (SERCOM4) USART Status */
+#define REG_SERCOM4_USART_SYNCBUSY (0x4200101CU) /**< \brief (SERCOM4) USART Synchronization Busy */
+#define REG_SERCOM4_USART_DATA     (0x42001028U) /**< \brief (SERCOM4) USART Data */
+#define REG_SERCOM4_USART_DBGCTRL  (0x42001030U) /**< \brief (SERCOM4) USART Debug Control */
+#else
+#define REG_SERCOM4_I2CM_CTRLA     (*(RwReg  *)0x42001000U) /**< \brief (SERCOM4) I2CM Control A */
+#define REG_SERCOM4_I2CM_CTRLB     (*(RwReg  *)0x42001004U) /**< \brief (SERCOM4) I2CM Control B */
+#define REG_SERCOM4_I2CM_BAUD      (*(RwReg  *)0x4200100CU) /**< \brief (SERCOM4) I2CM Baud Rate */
+#define REG_SERCOM4_I2CM_INTENCLR  (*(RwReg8 *)0x42001014U) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
+#define REG_SERCOM4_I2CM_INTENSET  (*(RwReg8 *)0x42001016U) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
+#define REG_SERCOM4_I2CM_INTFLAG   (*(RwReg8 *)0x42001018U) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CM_STATUS    (*(RwReg16*)0x4200101AU) /**< \brief (SERCOM4) I2CM Status */
+#define REG_SERCOM4_I2CM_SYNCBUSY  (*(RoReg  *)0x4200101CU) /**< \brief (SERCOM4) I2CM Synchronization Busy */
+#define REG_SERCOM4_I2CM_ADDR      (*(RwReg  *)0x42001024U) /**< \brief (SERCOM4) I2CM Address */
+#define REG_SERCOM4_I2CM_DATA      (*(RwReg8 *)0x42001028U) /**< \brief (SERCOM4) I2CM Data */
+#define REG_SERCOM4_I2CM_DBGCTRL   (*(RwReg8 *)0x42001030U) /**< \brief (SERCOM4) I2CM Debug Control */
+#define REG_SERCOM4_I2CS_CTRLA     (*(RwReg  *)0x42001000U) /**< \brief (SERCOM4) I2CS Control A */
+#define REG_SERCOM4_I2CS_CTRLB     (*(RwReg  *)0x42001004U) /**< \brief (SERCOM4) I2CS Control B */
+#define REG_SERCOM4_I2CS_INTENCLR  (*(RwReg8 *)0x42001014U) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
+#define REG_SERCOM4_I2CS_INTENSET  (*(RwReg8 *)0x42001016U) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
+#define REG_SERCOM4_I2CS_INTFLAG   (*(RwReg8 *)0x42001018U) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CS_STATUS    (*(RwReg16*)0x4200101AU) /**< \brief (SERCOM4) I2CS Status */
+#define REG_SERCOM4_I2CS_SYNCBUSY  (*(RoReg  *)0x4200101CU) /**< \brief (SERCOM4) I2CS Synchronization Busy */
+#define REG_SERCOM4_I2CS_ADDR      (*(RwReg  *)0x42001024U) /**< \brief (SERCOM4) I2CS Address */
+#define REG_SERCOM4_I2CS_DATA      (*(RwReg8 *)0x42001028U) /**< \brief (SERCOM4) I2CS Data */
+#define REG_SERCOM4_SPI_CTRLA      (*(RwReg  *)0x42001000U) /**< \brief (SERCOM4) SPI Control A */
+#define REG_SERCOM4_SPI_CTRLB      (*(RwReg  *)0x42001004U) /**< \brief (SERCOM4) SPI Control B */
+#define REG_SERCOM4_SPI_BAUD       (*(RwReg8 *)0x4200100CU) /**< \brief (SERCOM4) SPI Baud Rate */
+#define REG_SERCOM4_SPI_INTENCLR   (*(RwReg8 *)0x42001014U) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
+#define REG_SERCOM4_SPI_INTENSET   (*(RwReg8 *)0x42001016U) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
+#define REG_SERCOM4_SPI_INTFLAG    (*(RwReg8 *)0x42001018U) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM4_SPI_STATUS     (*(RwReg16*)0x4200101AU) /**< \brief (SERCOM4) SPI Status */
+#define REG_SERCOM4_SPI_SYNCBUSY   (*(RoReg  *)0x4200101CU) /**< \brief (SERCOM4) SPI Synchronization Busy */
+#define REG_SERCOM4_SPI_ADDR       (*(RwReg  *)0x42001024U) /**< \brief (SERCOM4) SPI Address */
+#define REG_SERCOM4_SPI_DATA       (*(RwReg  *)0x42001028U) /**< \brief (SERCOM4) SPI Data */
+#define REG_SERCOM4_SPI_DBGCTRL    (*(RwReg8 *)0x42001030U) /**< \brief (SERCOM4) SPI Debug Control */
+#define REG_SERCOM4_USART_CTRLA    (*(RwReg  *)0x42001000U) /**< \brief (SERCOM4) USART Control A */
+#define REG_SERCOM4_USART_CTRLB    (*(RwReg  *)0x42001004U) /**< \brief (SERCOM4) USART Control B */
+#define REG_SERCOM4_USART_BAUD     (*(RwReg16*)0x4200100CU) /**< \brief (SERCOM4) USART Baud Rate */
+#define REG_SERCOM4_USART_RXPL     (*(RwReg8 *)0x4200100EU) /**< \brief (SERCOM4) USART Receive Pulse Length */
+#define REG_SERCOM4_USART_INTENCLR (*(RwReg8 *)0x42001014U) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
+#define REG_SERCOM4_USART_INTENSET (*(RwReg8 *)0x42001016U) /**< \brief (SERCOM4) USART Interrupt Enable Set */
+#define REG_SERCOM4_USART_INTFLAG  (*(RwReg8 *)0x42001018U) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM4_USART_STATUS   (*(RwReg16*)0x4200101AU) /**< \brief (SERCOM4) USART Status */
+#define REG_SERCOM4_USART_SYNCBUSY (*(RoReg  *)0x4200101CU) /**< \brief (SERCOM4) USART Synchronization Busy */
+#define REG_SERCOM4_USART_DATA     (*(RwReg16*)0x42001028U) /**< \brief (SERCOM4) USART Data */
+#define REG_SERCOM4_USART_DBGCTRL  (*(RwReg8 *)0x42001030U) /**< \brief (SERCOM4) USART Debug Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM4 peripheral ========== */
+#define SERCOM4_DMAC_ID_RX          9        // Index of DMA RX trigger
+#define SERCOM4_DMAC_ID_TX          10       // Index of DMA TX trigger
+#define SERCOM4_GCLK_ID_CORE        22      
+#define SERCOM4_GCLK_ID_SLOW        17      
+#define SERCOM4_INT_MSB             6       
+#define SERCOM4_PMSB                3       
+
+#endif /* _SAML21_SERCOM4_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom5.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/sercom5.h
@@ -1,0 +1,144 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM5
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_SERCOM5_INSTANCE_
+#define _SAML21_SERCOM5_INSTANCE_
+
+/* ========== Register definition for SERCOM5 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM5_I2CM_CTRLA     (0x43000400U) /**< \brief (SERCOM5) I2CM Control A */
+#define REG_SERCOM5_I2CM_CTRLB     (0x43000404U) /**< \brief (SERCOM5) I2CM Control B */
+#define REG_SERCOM5_I2CM_BAUD      (0x4300040CU) /**< \brief (SERCOM5) I2CM Baud Rate */
+#define REG_SERCOM5_I2CM_INTENCLR  (0x43000414U) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
+#define REG_SERCOM5_I2CM_INTENSET  (0x43000416U) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
+#define REG_SERCOM5_I2CM_INTFLAG   (0x43000418U) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CM_STATUS    (0x4300041AU) /**< \brief (SERCOM5) I2CM Status */
+#define REG_SERCOM5_I2CM_SYNCBUSY  (0x4300041CU) /**< \brief (SERCOM5) I2CM Synchronization Busy */
+#define REG_SERCOM5_I2CM_ADDR      (0x43000424U) /**< \brief (SERCOM5) I2CM Address */
+#define REG_SERCOM5_I2CM_DATA      (0x43000428U) /**< \brief (SERCOM5) I2CM Data */
+#define REG_SERCOM5_I2CM_DBGCTRL   (0x43000430U) /**< \brief (SERCOM5) I2CM Debug Control */
+#define REG_SERCOM5_I2CS_CTRLA     (0x43000400U) /**< \brief (SERCOM5) I2CS Control A */
+#define REG_SERCOM5_I2CS_CTRLB     (0x43000404U) /**< \brief (SERCOM5) I2CS Control B */
+#define REG_SERCOM5_I2CS_INTENCLR  (0x43000414U) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
+#define REG_SERCOM5_I2CS_INTENSET  (0x43000416U) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
+#define REG_SERCOM5_I2CS_INTFLAG   (0x43000418U) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CS_STATUS    (0x4300041AU) /**< \brief (SERCOM5) I2CS Status */
+#define REG_SERCOM5_I2CS_SYNCBUSY  (0x4300041CU) /**< \brief (SERCOM5) I2CS Synchronization Busy */
+#define REG_SERCOM5_I2CS_ADDR      (0x43000424U) /**< \brief (SERCOM5) I2CS Address */
+#define REG_SERCOM5_I2CS_DATA      (0x43000428U) /**< \brief (SERCOM5) I2CS Data */
+#define REG_SERCOM5_SPI_CTRLA      (0x43000400U) /**< \brief (SERCOM5) SPI Control A */
+#define REG_SERCOM5_SPI_CTRLB      (0x43000404U) /**< \brief (SERCOM5) SPI Control B */
+#define REG_SERCOM5_SPI_BAUD       (0x4300040CU) /**< \brief (SERCOM5) SPI Baud Rate */
+#define REG_SERCOM5_SPI_INTENCLR   (0x43000414U) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
+#define REG_SERCOM5_SPI_INTENSET   (0x43000416U) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
+#define REG_SERCOM5_SPI_INTFLAG    (0x43000418U) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM5_SPI_STATUS     (0x4300041AU) /**< \brief (SERCOM5) SPI Status */
+#define REG_SERCOM5_SPI_SYNCBUSY   (0x4300041CU) /**< \brief (SERCOM5) SPI Synchronization Busy */
+#define REG_SERCOM5_SPI_ADDR       (0x43000424U) /**< \brief (SERCOM5) SPI Address */
+#define REG_SERCOM5_SPI_DATA       (0x43000428U) /**< \brief (SERCOM5) SPI Data */
+#define REG_SERCOM5_SPI_DBGCTRL    (0x43000430U) /**< \brief (SERCOM5) SPI Debug Control */
+#define REG_SERCOM5_USART_CTRLA    (0x43000400U) /**< \brief (SERCOM5) USART Control A */
+#define REG_SERCOM5_USART_CTRLB    (0x43000404U) /**< \brief (SERCOM5) USART Control B */
+#define REG_SERCOM5_USART_BAUD     (0x4300040CU) /**< \brief (SERCOM5) USART Baud Rate */
+#define REG_SERCOM5_USART_RXPL     (0x4300040EU) /**< \brief (SERCOM5) USART Receive Pulse Length */
+#define REG_SERCOM5_USART_INTENCLR (0x43000414U) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
+#define REG_SERCOM5_USART_INTENSET (0x43000416U) /**< \brief (SERCOM5) USART Interrupt Enable Set */
+#define REG_SERCOM5_USART_INTFLAG  (0x43000418U) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM5_USART_STATUS   (0x4300041AU) /**< \brief (SERCOM5) USART Status */
+#define REG_SERCOM5_USART_SYNCBUSY (0x4300041CU) /**< \brief (SERCOM5) USART Synchronization Busy */
+#define REG_SERCOM5_USART_DATA     (0x43000428U) /**< \brief (SERCOM5) USART Data */
+#define REG_SERCOM5_USART_DBGCTRL  (0x43000430U) /**< \brief (SERCOM5) USART Debug Control */
+#else
+#define REG_SERCOM5_I2CM_CTRLA     (*(RwReg  *)0x43000400U) /**< \brief (SERCOM5) I2CM Control A */
+#define REG_SERCOM5_I2CM_CTRLB     (*(RwReg  *)0x43000404U) /**< \brief (SERCOM5) I2CM Control B */
+#define REG_SERCOM5_I2CM_BAUD      (*(RwReg  *)0x4300040CU) /**< \brief (SERCOM5) I2CM Baud Rate */
+#define REG_SERCOM5_I2CM_INTENCLR  (*(RwReg8 *)0x43000414U) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
+#define REG_SERCOM5_I2CM_INTENSET  (*(RwReg8 *)0x43000416U) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
+#define REG_SERCOM5_I2CM_INTFLAG   (*(RwReg8 *)0x43000418U) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CM_STATUS    (*(RwReg16*)0x4300041AU) /**< \brief (SERCOM5) I2CM Status */
+#define REG_SERCOM5_I2CM_SYNCBUSY  (*(RoReg  *)0x4300041CU) /**< \brief (SERCOM5) I2CM Synchronization Busy */
+#define REG_SERCOM5_I2CM_ADDR      (*(RwReg  *)0x43000424U) /**< \brief (SERCOM5) I2CM Address */
+#define REG_SERCOM5_I2CM_DATA      (*(RwReg8 *)0x43000428U) /**< \brief (SERCOM5) I2CM Data */
+#define REG_SERCOM5_I2CM_DBGCTRL   (*(RwReg8 *)0x43000430U) /**< \brief (SERCOM5) I2CM Debug Control */
+#define REG_SERCOM5_I2CS_CTRLA     (*(RwReg  *)0x43000400U) /**< \brief (SERCOM5) I2CS Control A */
+#define REG_SERCOM5_I2CS_CTRLB     (*(RwReg  *)0x43000404U) /**< \brief (SERCOM5) I2CS Control B */
+#define REG_SERCOM5_I2CS_INTENCLR  (*(RwReg8 *)0x43000414U) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
+#define REG_SERCOM5_I2CS_INTENSET  (*(RwReg8 *)0x43000416U) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
+#define REG_SERCOM5_I2CS_INTFLAG   (*(RwReg8 *)0x43000418U) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CS_STATUS    (*(RwReg16*)0x4300041AU) /**< \brief (SERCOM5) I2CS Status */
+#define REG_SERCOM5_I2CS_SYNCBUSY  (*(RoReg  *)0x4300041CU) /**< \brief (SERCOM5) I2CS Synchronization Busy */
+#define REG_SERCOM5_I2CS_ADDR      (*(RwReg  *)0x43000424U) /**< \brief (SERCOM5) I2CS Address */
+#define REG_SERCOM5_I2CS_DATA      (*(RwReg8 *)0x43000428U) /**< \brief (SERCOM5) I2CS Data */
+#define REG_SERCOM5_SPI_CTRLA      (*(RwReg  *)0x43000400U) /**< \brief (SERCOM5) SPI Control A */
+#define REG_SERCOM5_SPI_CTRLB      (*(RwReg  *)0x43000404U) /**< \brief (SERCOM5) SPI Control B */
+#define REG_SERCOM5_SPI_BAUD       (*(RwReg8 *)0x4300040CU) /**< \brief (SERCOM5) SPI Baud Rate */
+#define REG_SERCOM5_SPI_INTENCLR   (*(RwReg8 *)0x43000414U) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
+#define REG_SERCOM5_SPI_INTENSET   (*(RwReg8 *)0x43000416U) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
+#define REG_SERCOM5_SPI_INTFLAG    (*(RwReg8 *)0x43000418U) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM5_SPI_STATUS     (*(RwReg16*)0x4300041AU) /**< \brief (SERCOM5) SPI Status */
+#define REG_SERCOM5_SPI_SYNCBUSY   (*(RoReg  *)0x4300041CU) /**< \brief (SERCOM5) SPI Synchronization Busy */
+#define REG_SERCOM5_SPI_ADDR       (*(RwReg  *)0x43000424U) /**< \brief (SERCOM5) SPI Address */
+#define REG_SERCOM5_SPI_DATA       (*(RwReg  *)0x43000428U) /**< \brief (SERCOM5) SPI Data */
+#define REG_SERCOM5_SPI_DBGCTRL    (*(RwReg8 *)0x43000430U) /**< \brief (SERCOM5) SPI Debug Control */
+#define REG_SERCOM5_USART_CTRLA    (*(RwReg  *)0x43000400U) /**< \brief (SERCOM5) USART Control A */
+#define REG_SERCOM5_USART_CTRLB    (*(RwReg  *)0x43000404U) /**< \brief (SERCOM5) USART Control B */
+#define REG_SERCOM5_USART_BAUD     (*(RwReg16*)0x4300040CU) /**< \brief (SERCOM5) USART Baud Rate */
+#define REG_SERCOM5_USART_RXPL     (*(RwReg8 *)0x4300040EU) /**< \brief (SERCOM5) USART Receive Pulse Length */
+#define REG_SERCOM5_USART_INTENCLR (*(RwReg8 *)0x43000414U) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
+#define REG_SERCOM5_USART_INTENSET (*(RwReg8 *)0x43000416U) /**< \brief (SERCOM5) USART Interrupt Enable Set */
+#define REG_SERCOM5_USART_INTFLAG  (*(RwReg8 *)0x43000418U) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM5_USART_STATUS   (*(RwReg16*)0x4300041AU) /**< \brief (SERCOM5) USART Status */
+#define REG_SERCOM5_USART_SYNCBUSY (*(RoReg  *)0x4300041CU) /**< \brief (SERCOM5) USART Synchronization Busy */
+#define REG_SERCOM5_USART_DATA     (*(RwReg16*)0x43000428U) /**< \brief (SERCOM5) USART Data */
+#define REG_SERCOM5_USART_DBGCTRL  (*(RwReg8 *)0x43000430U) /**< \brief (SERCOM5) USART Debug Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM5 peripheral ========== */
+#define SERCOM5_DMAC_ID_RX                   // Index of DMA RX trigger
+#define SERCOM5_DMAC_ID_TX                   // Index of DMA TX trigger
+#define SERCOM5_GCLK_ID_CORE        24      
+#define SERCOM5_GCLK_ID_SLOW        23      
+#define SERCOM5_INT_MSB             3       
+#define SERCOM5_PMSB                3       
+
+#endif /* _SAML21_SERCOM5_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/supc_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/supc_100.h
@@ -1,0 +1,79 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SUPC
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_SUPC_INSTANCE_
+#define _SAML21_SUPC_INSTANCE_
+
+/* ========== Register definition for SUPC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SUPC_INTENCLR          (0x40001400U) /**< \brief (SUPC) Interrupt Enable Clear */
+#define REG_SUPC_INTENSET          (0x40001404U) /**< \brief (SUPC) Interrupt Enable Set */
+#define REG_SUPC_INTFLAG           (0x40001408U) /**< \brief (SUPC) Interrupt Flag Status and Clear */
+#define REG_SUPC_STATUS            (0x4000140CU) /**< \brief (SUPC) Power and Clocks Status */
+#define REG_SUPC_BOD33             (0x40001410U) /**< \brief (SUPC) BOD33 Control */
+#define REG_SUPC_BOD12             (0x40001414U) /**< \brief (SUPC) BOD12 Control */
+#define REG_SUPC_VREG              (0x40001418U) /**< \brief (SUPC) VREG Control */
+#define REG_SUPC_VREF              (0x4000141CU) /**< \brief (SUPC) VREF Control */
+#define REG_SUPC_BBPS              (0x40001420U) /**< \brief (SUPC) Battery Backup Power Switch */
+#define REG_SUPC_BKOUT             (0x40001424U) /**< \brief (SUPC) Backup Output Control */
+#define REG_SUPC_BKIN              (0x40001428U) /**< \brief (SUPC) Backup Input Control */
+#else
+#define REG_SUPC_INTENCLR          (*(RwReg  *)0x40001400U) /**< \brief (SUPC) Interrupt Enable Clear */
+#define REG_SUPC_INTENSET          (*(RwReg  *)0x40001404U) /**< \brief (SUPC) Interrupt Enable Set */
+#define REG_SUPC_INTFLAG           (*(RwReg  *)0x40001408U) /**< \brief (SUPC) Interrupt Flag Status and Clear */
+#define REG_SUPC_STATUS            (*(RoReg  *)0x4000140CU) /**< \brief (SUPC) Power and Clocks Status */
+#define REG_SUPC_BOD33             (*(RwReg  *)0x40001410U) /**< \brief (SUPC) BOD33 Control */
+#define REG_SUPC_BOD12             (*(RwReg  *)0x40001414U) /**< \brief (SUPC) BOD12 Control */
+#define REG_SUPC_VREG              (*(RwReg  *)0x40001418U) /**< \brief (SUPC) VREG Control */
+#define REG_SUPC_VREF              (*(RwReg  *)0x4000141CU) /**< \brief (SUPC) VREF Control */
+#define REG_SUPC_BBPS              (*(RwReg  *)0x40001420U) /**< \brief (SUPC) Battery Backup Power Switch */
+#define REG_SUPC_BKOUT             (*(RwReg  *)0x40001424U) /**< \brief (SUPC) Backup Output Control */
+#define REG_SUPC_BKIN              (*(RoReg  *)0x40001428U) /**< \brief (SUPC) Backup Input Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SUPC peripheral ========== */
+#define SUPC_BOD12_CALIB_MSB        5       
+#define SUPC_BOD33_CALIB_MSB        5       
+#define SUPC_SUPC_OUT_NUM_MSB       1        // MSB of backup output pad Number
+
+#endif /* _SAML21_SUPC_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/tal.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/tal.h
@@ -1,0 +1,172 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TAL
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TAL_INSTANCE_
+#define _SAML21_TAL_INSTANCE_
+
+/* ========== Register definition for TAL peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TAL_CTRLA              (0x40002C00U) /**< \brief (TAL) Control A */
+#define REG_TAL_RSTCTRL            (0x40002C04U) /**< \brief (TAL) Reset Control */
+#define REG_TAL_EXTCTRL            (0x40002C05U) /**< \brief (TAL) External Break Control */
+#define REG_TAL_EVCTRL             (0x40002C06U) /**< \brief (TAL) Event Control */
+#define REG_TAL_INTENCLR           (0x40002C08U) /**< \brief (TAL) Interrupt Enable Clear */
+#define REG_TAL_INTENSET           (0x40002C09U) /**< \brief (TAL) Interrupt Enable Set */
+#define REG_TAL_INTFLAG            (0x40002C0AU) /**< \brief (TAL) Interrupt Flag Status and Clear */
+#define REG_TAL_GLOBMASK           (0x40002C0BU) /**< \brief (TAL) Global Break Requests Mask */
+#define REG_TAL_HALT               (0x40002C0CU) /**< \brief (TAL) Debug Halt Request */
+#define REG_TAL_RESTART            (0x40002C0DU) /**< \brief (TAL) Debug Restart Request */
+#define REG_TAL_BRKSTATUS          (0x40002C0EU) /**< \brief (TAL) Break Request Status */
+#define REG_TAL_CTICTRLA0          (0x40002C10U) /**< \brief (TAL) Cross-Trigger Interface 0 Control A */
+#define REG_TAL_CTIMASK0           (0x40002C11U) /**< \brief (TAL) Cross-Trigger Interface 0 Mask */
+#define REG_TAL_CTICTRLA1          (0x40002C12U) /**< \brief (TAL) Cross-Trigger Interface 1 Control A */
+#define REG_TAL_CTIMASK1           (0x40002C13U) /**< \brief (TAL) Cross-Trigger Interface 1 Mask */
+#define REG_TAL_CTICTRLA2          (0x40002C14U) /**< \brief (TAL) Cross-Trigger Interface 2 Control A */
+#define REG_TAL_CTIMASK2           (0x40002C15U) /**< \brief (TAL) Cross-Trigger Interface 2 Mask */
+#define REG_TAL_CTICTRLA3          (0x40002C16U) /**< \brief (TAL) Cross-Trigger Interface 3 Control A */
+#define REG_TAL_CTIMASK3           (0x40002C17U) /**< \brief (TAL) Cross-Trigger Interface 3 Mask */
+#define REG_TAL_INTSTATUS0         (0x40002C20U) /**< \brief (TAL) Interrupt 0 Status */
+#define REG_TAL_INTSTATUS1         (0x40002C21U) /**< \brief (TAL) Interrupt 1 Status */
+#define REG_TAL_INTSTATUS2         (0x40002C22U) /**< \brief (TAL) Interrupt 2 Status */
+#define REG_TAL_INTSTATUS3         (0x40002C23U) /**< \brief (TAL) Interrupt 3 Status */
+#define REG_TAL_INTSTATUS4         (0x40002C24U) /**< \brief (TAL) Interrupt 4 Status */
+#define REG_TAL_INTSTATUS5         (0x40002C25U) /**< \brief (TAL) Interrupt 5 Status */
+#define REG_TAL_INTSTATUS6         (0x40002C26U) /**< \brief (TAL) Interrupt 6 Status */
+#define REG_TAL_INTSTATUS7         (0x40002C27U) /**< \brief (TAL) Interrupt 7 Status */
+#define REG_TAL_INTSTATUS8         (0x40002C28U) /**< \brief (TAL) Interrupt 8 Status */
+#define REG_TAL_INTSTATUS9         (0x40002C29U) /**< \brief (TAL) Interrupt 9 Status */
+#define REG_TAL_INTSTATUS10        (0x40002C2AU) /**< \brief (TAL) Interrupt 10 Status */
+#define REG_TAL_INTSTATUS11        (0x40002C2BU) /**< \brief (TAL) Interrupt 11 Status */
+#define REG_TAL_INTSTATUS12        (0x40002C2CU) /**< \brief (TAL) Interrupt 12 Status */
+#define REG_TAL_INTSTATUS13        (0x40002C2DU) /**< \brief (TAL) Interrupt 13 Status */
+#define REG_TAL_INTSTATUS14        (0x40002C2EU) /**< \brief (TAL) Interrupt 14 Status */
+#define REG_TAL_INTSTATUS15        (0x40002C2FU) /**< \brief (TAL) Interrupt 15 Status */
+#define REG_TAL_INTSTATUS16        (0x40002C30U) /**< \brief (TAL) Interrupt 16 Status */
+#define REG_TAL_INTSTATUS17        (0x40002C31U) /**< \brief (TAL) Interrupt 17 Status */
+#define REG_TAL_INTSTATUS18        (0x40002C32U) /**< \brief (TAL) Interrupt 18 Status */
+#define REG_TAL_INTSTATUS19        (0x40002C33U) /**< \brief (TAL) Interrupt 19 Status */
+#define REG_TAL_INTSTATUS20        (0x40002C34U) /**< \brief (TAL) Interrupt 20 Status */
+#define REG_TAL_INTSTATUS21        (0x40002C35U) /**< \brief (TAL) Interrupt 21 Status */
+#define REG_TAL_INTSTATUS22        (0x40002C36U) /**< \brief (TAL) Interrupt 22 Status */
+#define REG_TAL_INTSTATUS23        (0x40002C37U) /**< \brief (TAL) Interrupt 23 Status */
+#define REG_TAL_INTSTATUS24        (0x40002C38U) /**< \brief (TAL) Interrupt 24 Status */
+#define REG_TAL_INTSTATUS25        (0x40002C39U) /**< \brief (TAL) Interrupt 25 Status */
+#define REG_TAL_INTSTATUS26        (0x40002C3AU) /**< \brief (TAL) Interrupt 26 Status */
+#define REG_TAL_INTSTATUS27        (0x40002C3BU) /**< \brief (TAL) Interrupt 27 Status */
+#define REG_TAL_INTSTATUS28        (0x40002C3CU) /**< \brief (TAL) Interrupt 28 Status */
+#define REG_TAL_DMACPUSEL0         (0x40002C40U) /**< \brief (TAL) DMA Channel Interrupts CPU Select 0 */
+#define REG_TAL_EVCPUSEL0          (0x40002C48U) /**< \brief (TAL) EVSYS Channel Interrupts CPU Select 0 */
+#define REG_TAL_EICCPUSEL0         (0x40002C50U) /**< \brief (TAL) EIC External Interrupts CPU Select 0 */
+#define REG_TAL_INTCPUSEL0         (0x40002C58U) /**< \brief (TAL) Interrupts CPU Select 0 */
+#define REG_TAL_INTCPUSEL1         (0x40002C5CU) /**< \brief (TAL) Interrupts CPU Select 1 */
+#define REG_TAL_IRQTRIG            (0x40002C60U) /**< \brief (TAL) Interrupt Trigger */
+#define REG_TAL_CPUIRQS0           (0x40002C64U) /**< \brief (TAL) Interrupt Status for CPU 0 */
+#define REG_TAL_CPUIRQS1           (0x40002C68U) /**< \brief (TAL) Interrupt Status for CPU 1 */
+#else
+#define REG_TAL_CTRLA              (*(RwReg8 *)0x40002C00U) /**< \brief (TAL) Control A */
+#define REG_TAL_RSTCTRL            (*(RwReg8 *)0x40002C04U) /**< \brief (TAL) Reset Control */
+#define REG_TAL_EXTCTRL            (*(RwReg8 *)0x40002C05U) /**< \brief (TAL) External Break Control */
+#define REG_TAL_EVCTRL             (*(RwReg8 *)0x40002C06U) /**< \brief (TAL) Event Control */
+#define REG_TAL_INTENCLR           (*(RwReg8 *)0x40002C08U) /**< \brief (TAL) Interrupt Enable Clear */
+#define REG_TAL_INTENSET           (*(RwReg8 *)0x40002C09U) /**< \brief (TAL) Interrupt Enable Set */
+#define REG_TAL_INTFLAG            (*(RwReg8 *)0x40002C0AU) /**< \brief (TAL) Interrupt Flag Status and Clear */
+#define REG_TAL_GLOBMASK           (*(RwReg8 *)0x40002C0BU) /**< \brief (TAL) Global Break Requests Mask */
+#define REG_TAL_HALT               (*(WoReg8 *)0x40002C0CU) /**< \brief (TAL) Debug Halt Request */
+#define REG_TAL_RESTART            (*(WoReg8 *)0x40002C0DU) /**< \brief (TAL) Debug Restart Request */
+#define REG_TAL_BRKSTATUS          (*(RoReg16*)0x40002C0EU) /**< \brief (TAL) Break Request Status */
+#define REG_TAL_CTICTRLA0          (*(RwReg8 *)0x40002C10U) /**< \brief (TAL) Cross-Trigger Interface 0 Control A */
+#define REG_TAL_CTIMASK0           (*(RwReg8 *)0x40002C11U) /**< \brief (TAL) Cross-Trigger Interface 0 Mask */
+#define REG_TAL_CTICTRLA1          (*(RwReg8 *)0x40002C12U) /**< \brief (TAL) Cross-Trigger Interface 1 Control A */
+#define REG_TAL_CTIMASK1           (*(RwReg8 *)0x40002C13U) /**< \brief (TAL) Cross-Trigger Interface 1 Mask */
+#define REG_TAL_CTICTRLA2          (*(RwReg8 *)0x40002C14U) /**< \brief (TAL) Cross-Trigger Interface 2 Control A */
+#define REG_TAL_CTIMASK2           (*(RwReg8 *)0x40002C15U) /**< \brief (TAL) Cross-Trigger Interface 2 Mask */
+#define REG_TAL_CTICTRLA3          (*(RwReg8 *)0x40002C16U) /**< \brief (TAL) Cross-Trigger Interface 3 Control A */
+#define REG_TAL_CTIMASK3           (*(RwReg8 *)0x40002C17U) /**< \brief (TAL) Cross-Trigger Interface 3 Mask */
+#define REG_TAL_INTSTATUS0         (*(RoReg8 *)0x40002C20U) /**< \brief (TAL) Interrupt 0 Status */
+#define REG_TAL_INTSTATUS1         (*(RoReg8 *)0x40002C21U) /**< \brief (TAL) Interrupt 1 Status */
+#define REG_TAL_INTSTATUS2         (*(RoReg8 *)0x40002C22U) /**< \brief (TAL) Interrupt 2 Status */
+#define REG_TAL_INTSTATUS3         (*(RoReg8 *)0x40002C23U) /**< \brief (TAL) Interrupt 3 Status */
+#define REG_TAL_INTSTATUS4         (*(RoReg8 *)0x40002C24U) /**< \brief (TAL) Interrupt 4 Status */
+#define REG_TAL_INTSTATUS5         (*(RoReg8 *)0x40002C25U) /**< \brief (TAL) Interrupt 5 Status */
+#define REG_TAL_INTSTATUS6         (*(RoReg8 *)0x40002C26U) /**< \brief (TAL) Interrupt 6 Status */
+#define REG_TAL_INTSTATUS7         (*(RoReg8 *)0x40002C27U) /**< \brief (TAL) Interrupt 7 Status */
+#define REG_TAL_INTSTATUS8         (*(RoReg8 *)0x40002C28U) /**< \brief (TAL) Interrupt 8 Status */
+#define REG_TAL_INTSTATUS9         (*(RoReg8 *)0x40002C29U) /**< \brief (TAL) Interrupt 9 Status */
+#define REG_TAL_INTSTATUS10        (*(RoReg8 *)0x40002C2AU) /**< \brief (TAL) Interrupt 10 Status */
+#define REG_TAL_INTSTATUS11        (*(RoReg8 *)0x40002C2BU) /**< \brief (TAL) Interrupt 11 Status */
+#define REG_TAL_INTSTATUS12        (*(RoReg8 *)0x40002C2CU) /**< \brief (TAL) Interrupt 12 Status */
+#define REG_TAL_INTSTATUS13        (*(RoReg8 *)0x40002C2DU) /**< \brief (TAL) Interrupt 13 Status */
+#define REG_TAL_INTSTATUS14        (*(RoReg8 *)0x40002C2EU) /**< \brief (TAL) Interrupt 14 Status */
+#define REG_TAL_INTSTATUS15        (*(RoReg8 *)0x40002C2FU) /**< \brief (TAL) Interrupt 15 Status */
+#define REG_TAL_INTSTATUS16        (*(RoReg8 *)0x40002C30U) /**< \brief (TAL) Interrupt 16 Status */
+#define REG_TAL_INTSTATUS17        (*(RoReg8 *)0x40002C31U) /**< \brief (TAL) Interrupt 17 Status */
+#define REG_TAL_INTSTATUS18        (*(RoReg8 *)0x40002C32U) /**< \brief (TAL) Interrupt 18 Status */
+#define REG_TAL_INTSTATUS19        (*(RoReg8 *)0x40002C33U) /**< \brief (TAL) Interrupt 19 Status */
+#define REG_TAL_INTSTATUS20        (*(RoReg8 *)0x40002C34U) /**< \brief (TAL) Interrupt 20 Status */
+#define REG_TAL_INTSTATUS21        (*(RoReg8 *)0x40002C35U) /**< \brief (TAL) Interrupt 21 Status */
+#define REG_TAL_INTSTATUS22        (*(RoReg8 *)0x40002C36U) /**< \brief (TAL) Interrupt 22 Status */
+#define REG_TAL_INTSTATUS23        (*(RoReg8 *)0x40002C37U) /**< \brief (TAL) Interrupt 23 Status */
+#define REG_TAL_INTSTATUS24        (*(RoReg8 *)0x40002C38U) /**< \brief (TAL) Interrupt 24 Status */
+#define REG_TAL_INTSTATUS25        (*(RoReg8 *)0x40002C39U) /**< \brief (TAL) Interrupt 25 Status */
+#define REG_TAL_INTSTATUS26        (*(RoReg8 *)0x40002C3AU) /**< \brief (TAL) Interrupt 26 Status */
+#define REG_TAL_INTSTATUS27        (*(RoReg8 *)0x40002C3BU) /**< \brief (TAL) Interrupt 27 Status */
+#define REG_TAL_INTSTATUS28        (*(RoReg8 *)0x40002C3CU) /**< \brief (TAL) Interrupt 28 Status */
+#define REG_TAL_DMACPUSEL0         (*(RwReg  *)0x40002C40U) /**< \brief (TAL) DMA Channel Interrupts CPU Select 0 */
+#define REG_TAL_EVCPUSEL0          (*(RwReg  *)0x40002C48U) /**< \brief (TAL) EVSYS Channel Interrupts CPU Select 0 */
+#define REG_TAL_EICCPUSEL0         (*(RwReg  *)0x40002C50U) /**< \brief (TAL) EIC External Interrupts CPU Select 0 */
+#define REG_TAL_INTCPUSEL0         (*(RwReg  *)0x40002C58U) /**< \brief (TAL) Interrupts CPU Select 0 */
+#define REG_TAL_INTCPUSEL1         (*(RwReg  *)0x40002C5CU) /**< \brief (TAL) Interrupts CPU Select 1 */
+#define REG_TAL_IRQTRIG            (*(RwReg16*)0x40002C60U) /**< \brief (TAL) Interrupt Trigger */
+#define REG_TAL_CPUIRQS0           (*(RoReg  *)0x40002C64U) /**< \brief (TAL) Interrupt Status for CPU 0 */
+#define REG_TAL_CPUIRQS1           (*(RoReg  *)0x40002C68U) /**< \brief (TAL) Interrupt Status for CPU 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TAL peripheral ========== */
+#define TAL_CPU_NUM                 2        // Number of CPUs
+#define TAL_CTI_NUM                 4        // Number of Cross-Trigger Interfaces
+#define TAL_DMA_CH_NUM              16       // Number of DMAC Channels
+#define TAL_EV_CH_NUM               12       // Number of EVSYS Channels
+#define TAL_EXTINT_NUM              16       // Number of EIC External Interrrupts
+#define TAL_INT_NUM                 29       // Number of Interrupt Requests
+
+#endif /* _SAML21_TAL_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/tc0_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/tc0_100.h
@@ -1,0 +1,123 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC0
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TC0_INSTANCE_
+#define _SAML21_TC0_INSTANCE_
+
+/* ========== Register definition for TC0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC0_CTRLA              (0x42002000U) /**< \brief (TC0) Control A */
+#define REG_TC0_CTRLBCLR           (0x42002004U) /**< \brief (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET           (0x42002005U) /**< \brief (TC0) Control B Set */
+#define REG_TC0_EVCTRL             (0x42002006U) /**< \brief (TC0) Event Control */
+#define REG_TC0_INTENCLR           (0x42002008U) /**< \brief (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET           (0x42002009U) /**< \brief (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG            (0x4200200AU) /**< \brief (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS             (0x4200200BU) /**< \brief (TC0) Status */
+#define REG_TC0_WAVE               (0x4200200CU) /**< \brief (TC0) Waveform Generation Control */
+#define REG_TC0_DRVCTRL            (0x4200200DU) /**< \brief (TC0) Control C */
+#define REG_TC0_DBGCTRL            (0x4200200FU) /**< \brief (TC0) Debug Control */
+#define REG_TC0_SYNCBUSY           (0x42002010U) /**< \brief (TC0) Synchronization Status */
+#define REG_TC0_COUNT16_COUNT      (0x42002014U) /**< \brief (TC0) COUNT16 Count */
+#define REG_TC0_COUNT16_CC0        (0x4200201CU) /**< \brief (TC0) COUNT16 Compare and Capture 0 */
+#define REG_TC0_COUNT16_CC1        (0x4200201EU) /**< \brief (TC0) COUNT16 Compare and Capture 1 */
+#define REG_TC0_COUNT16_CCBUF0     (0x42002030U) /**< \brief (TC0) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT16_CCBUF1     (0x42002032U) /**< \brief (TC0) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT32_COUNT      (0x42002014U) /**< \brief (TC0) COUNT32 Count */
+#define REG_TC0_COUNT32_CC0        (0x4200201CU) /**< \brief (TC0) COUNT32 Compare and Capture 0 */
+#define REG_TC0_COUNT32_CC1        (0x42002020U) /**< \brief (TC0) COUNT32 Compare and Capture 1 */
+#define REG_TC0_COUNT32_CCBUF0     (0x42002030U) /**< \brief (TC0) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT32_CCBUF1     (0x42002034U) /**< \brief (TC0) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT8_COUNT       (0x42002014U) /**< \brief (TC0) COUNT8 Count */
+#define REG_TC0_COUNT8_PER         (0x4200201BU) /**< \brief (TC0) COUNT8 Period */
+#define REG_TC0_COUNT8_CC0         (0x4200201CU) /**< \brief (TC0) COUNT8 Compare and Capture 0 */
+#define REG_TC0_COUNT8_CC1         (0x4200201DU) /**< \brief (TC0) COUNT8 Compare and Capture 1 */
+#define REG_TC0_COUNT8_PERBUF      (0x4200202FU) /**< \brief (TC0) COUNT8 Period Buffer */
+#define REG_TC0_COUNT8_CCBUF0      (0x42002030U) /**< \brief (TC0) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT8_CCBUF1      (0x42002031U) /**< \brief (TC0) COUNT8 Compare and Capture Buffer 1 */
+#else
+#define REG_TC0_CTRLA              (*(RwReg  *)0x42002000U) /**< \brief (TC0) Control A */
+#define REG_TC0_CTRLBCLR           (*(RwReg8 *)0x42002004U) /**< \brief (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET           (*(RwReg8 *)0x42002005U) /**< \brief (TC0) Control B Set */
+#define REG_TC0_EVCTRL             (*(RwReg16*)0x42002006U) /**< \brief (TC0) Event Control */
+#define REG_TC0_INTENCLR           (*(RwReg8 *)0x42002008U) /**< \brief (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET           (*(RwReg8 *)0x42002009U) /**< \brief (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG            (*(RwReg8 *)0x4200200AU) /**< \brief (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS             (*(RwReg8 *)0x4200200BU) /**< \brief (TC0) Status */
+#define REG_TC0_WAVE               (*(RwReg8 *)0x4200200CU) /**< \brief (TC0) Waveform Generation Control */
+#define REG_TC0_DRVCTRL            (*(RwReg8 *)0x4200200DU) /**< \brief (TC0) Control C */
+#define REG_TC0_DBGCTRL            (*(RwReg8 *)0x4200200FU) /**< \brief (TC0) Debug Control */
+#define REG_TC0_SYNCBUSY           (*(RoReg  *)0x42002010U) /**< \brief (TC0) Synchronization Status */
+#define REG_TC0_COUNT16_COUNT      (*(RwReg16*)0x42002014U) /**< \brief (TC0) COUNT16 Count */
+#define REG_TC0_COUNT16_CC0        (*(RwReg16*)0x4200201CU) /**< \brief (TC0) COUNT16 Compare and Capture 0 */
+#define REG_TC0_COUNT16_CC1        (*(RwReg16*)0x4200201EU) /**< \brief (TC0) COUNT16 Compare and Capture 1 */
+#define REG_TC0_COUNT16_CCBUF0     (*(RwReg16*)0x42002030U) /**< \brief (TC0) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT16_CCBUF1     (*(RwReg16*)0x42002032U) /**< \brief (TC0) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT32_COUNT      (*(RwReg  *)0x42002014U) /**< \brief (TC0) COUNT32 Count */
+#define REG_TC0_COUNT32_CC0        (*(RwReg  *)0x4200201CU) /**< \brief (TC0) COUNT32 Compare and Capture 0 */
+#define REG_TC0_COUNT32_CC1        (*(RwReg  *)0x42002020U) /**< \brief (TC0) COUNT32 Compare and Capture 1 */
+#define REG_TC0_COUNT32_CCBUF0     (*(RwReg  *)0x42002030U) /**< \brief (TC0) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT32_CCBUF1     (*(RwReg  *)0x42002034U) /**< \brief (TC0) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC0_COUNT8_COUNT       (*(RwReg8 *)0x42002014U) /**< \brief (TC0) COUNT8 Count */
+#define REG_TC0_COUNT8_PER         (*(RwReg8 *)0x4200201BU) /**< \brief (TC0) COUNT8 Period */
+#define REG_TC0_COUNT8_CC0         (*(RwReg8 *)0x4200201CU) /**< \brief (TC0) COUNT8 Compare and Capture 0 */
+#define REG_TC0_COUNT8_CC1         (*(RwReg8 *)0x4200201DU) /**< \brief (TC0) COUNT8 Compare and Capture 1 */
+#define REG_TC0_COUNT8_PERBUF      (*(RwReg8 *)0x4200202FU) /**< \brief (TC0) COUNT8 Period Buffer */
+#define REG_TC0_COUNT8_CCBUF0      (*(RwReg8 *)0x42002030U) /**< \brief (TC0) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC0_COUNT8_CCBUF1      (*(RwReg8 *)0x42002031U) /**< \brief (TC0) COUNT8 Compare and Capture Buffer 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC0 peripheral ========== */
+#define TC0_CC_NUM                  2       
+#define TC0_DMAC_ID_MC_0            23
+#define TC0_DMAC_ID_MC_1            24
+#define TC0_DMAC_ID_MC_LSB          23
+#define TC0_DMAC_ID_MC_MSB          24
+#define TC0_DMAC_ID_MC_SIZE         2
+#define TC0_DMAC_ID_OVF             22       // Indexes of DMA Overflow trigger
+#define TC0_EXT                     0       
+#define TC0_GCLK_ID                 27      
+#define TC0_MASTER                  1       
+#define TC0_OW_NUM                  2       
+
+#endif /* _SAML21_TC0_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/tc1_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/tc1_100.h
@@ -1,0 +1,123 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC1
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TC1_INSTANCE_
+#define _SAML21_TC1_INSTANCE_
+
+/* ========== Register definition for TC1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC1_CTRLA              (0x42002400U) /**< \brief (TC1) Control A */
+#define REG_TC1_CTRLBCLR           (0x42002404U) /**< \brief (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET           (0x42002405U) /**< \brief (TC1) Control B Set */
+#define REG_TC1_EVCTRL             (0x42002406U) /**< \brief (TC1) Event Control */
+#define REG_TC1_INTENCLR           (0x42002408U) /**< \brief (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET           (0x42002409U) /**< \brief (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG            (0x4200240AU) /**< \brief (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS             (0x4200240BU) /**< \brief (TC1) Status */
+#define REG_TC1_WAVE               (0x4200240CU) /**< \brief (TC1) Waveform Generation Control */
+#define REG_TC1_DRVCTRL            (0x4200240DU) /**< \brief (TC1) Control C */
+#define REG_TC1_DBGCTRL            (0x4200240FU) /**< \brief (TC1) Debug Control */
+#define REG_TC1_SYNCBUSY           (0x42002410U) /**< \brief (TC1) Synchronization Status */
+#define REG_TC1_COUNT16_COUNT      (0x42002414U) /**< \brief (TC1) COUNT16 Count */
+#define REG_TC1_COUNT16_CC0        (0x4200241CU) /**< \brief (TC1) COUNT16 Compare and Capture 0 */
+#define REG_TC1_COUNT16_CC1        (0x4200241EU) /**< \brief (TC1) COUNT16 Compare and Capture 1 */
+#define REG_TC1_COUNT16_CCBUF0     (0x42002430U) /**< \brief (TC1) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT16_CCBUF1     (0x42002432U) /**< \brief (TC1) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT32_COUNT      (0x42002414U) /**< \brief (TC1) COUNT32 Count */
+#define REG_TC1_COUNT32_CC0        (0x4200241CU) /**< \brief (TC1) COUNT32 Compare and Capture 0 */
+#define REG_TC1_COUNT32_CC1        (0x42002420U) /**< \brief (TC1) COUNT32 Compare and Capture 1 */
+#define REG_TC1_COUNT32_CCBUF0     (0x42002430U) /**< \brief (TC1) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT32_CCBUF1     (0x42002434U) /**< \brief (TC1) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT8_COUNT       (0x42002414U) /**< \brief (TC1) COUNT8 Count */
+#define REG_TC1_COUNT8_PER         (0x4200241BU) /**< \brief (TC1) COUNT8 Period */
+#define REG_TC1_COUNT8_CC0         (0x4200241CU) /**< \brief (TC1) COUNT8 Compare and Capture 0 */
+#define REG_TC1_COUNT8_CC1         (0x4200241DU) /**< \brief (TC1) COUNT8 Compare and Capture 1 */
+#define REG_TC1_COUNT8_PERBUF      (0x4200242FU) /**< \brief (TC1) COUNT8 Period Buffer */
+#define REG_TC1_COUNT8_CCBUF0      (0x42002430U) /**< \brief (TC1) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT8_CCBUF1      (0x42002431U) /**< \brief (TC1) COUNT8 Compare and Capture Buffer 1 */
+#else
+#define REG_TC1_CTRLA              (*(RwReg  *)0x42002400U) /**< \brief (TC1) Control A */
+#define REG_TC1_CTRLBCLR           (*(RwReg8 *)0x42002404U) /**< \brief (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET           (*(RwReg8 *)0x42002405U) /**< \brief (TC1) Control B Set */
+#define REG_TC1_EVCTRL             (*(RwReg16*)0x42002406U) /**< \brief (TC1) Event Control */
+#define REG_TC1_INTENCLR           (*(RwReg8 *)0x42002408U) /**< \brief (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET           (*(RwReg8 *)0x42002409U) /**< \brief (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG            (*(RwReg8 *)0x4200240AU) /**< \brief (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS             (*(RwReg8 *)0x4200240BU) /**< \brief (TC1) Status */
+#define REG_TC1_WAVE               (*(RwReg8 *)0x4200240CU) /**< \brief (TC1) Waveform Generation Control */
+#define REG_TC1_DRVCTRL            (*(RwReg8 *)0x4200240DU) /**< \brief (TC1) Control C */
+#define REG_TC1_DBGCTRL            (*(RwReg8 *)0x4200240FU) /**< \brief (TC1) Debug Control */
+#define REG_TC1_SYNCBUSY           (*(RoReg  *)0x42002410U) /**< \brief (TC1) Synchronization Status */
+#define REG_TC1_COUNT16_COUNT      (*(RwReg16*)0x42002414U) /**< \brief (TC1) COUNT16 Count */
+#define REG_TC1_COUNT16_CC0        (*(RwReg16*)0x4200241CU) /**< \brief (TC1) COUNT16 Compare and Capture 0 */
+#define REG_TC1_COUNT16_CC1        (*(RwReg16*)0x4200241EU) /**< \brief (TC1) COUNT16 Compare and Capture 1 */
+#define REG_TC1_COUNT16_CCBUF0     (*(RwReg16*)0x42002430U) /**< \brief (TC1) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT16_CCBUF1     (*(RwReg16*)0x42002432U) /**< \brief (TC1) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT32_COUNT      (*(RwReg  *)0x42002414U) /**< \brief (TC1) COUNT32 Count */
+#define REG_TC1_COUNT32_CC0        (*(RwReg  *)0x4200241CU) /**< \brief (TC1) COUNT32 Compare and Capture 0 */
+#define REG_TC1_COUNT32_CC1        (*(RwReg  *)0x42002420U) /**< \brief (TC1) COUNT32 Compare and Capture 1 */
+#define REG_TC1_COUNT32_CCBUF0     (*(RwReg  *)0x42002430U) /**< \brief (TC1) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT32_CCBUF1     (*(RwReg  *)0x42002434U) /**< \brief (TC1) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC1_COUNT8_COUNT       (*(RwReg8 *)0x42002414U) /**< \brief (TC1) COUNT8 Count */
+#define REG_TC1_COUNT8_PER         (*(RwReg8 *)0x4200241BU) /**< \brief (TC1) COUNT8 Period */
+#define REG_TC1_COUNT8_CC0         (*(RwReg8 *)0x4200241CU) /**< \brief (TC1) COUNT8 Compare and Capture 0 */
+#define REG_TC1_COUNT8_CC1         (*(RwReg8 *)0x4200241DU) /**< \brief (TC1) COUNT8 Compare and Capture 1 */
+#define REG_TC1_COUNT8_PERBUF      (*(RwReg8 *)0x4200242FU) /**< \brief (TC1) COUNT8 Period Buffer */
+#define REG_TC1_COUNT8_CCBUF0      (*(RwReg8 *)0x42002430U) /**< \brief (TC1) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC1_COUNT8_CCBUF1      (*(RwReg8 *)0x42002431U) /**< \brief (TC1) COUNT8 Compare and Capture Buffer 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC1 peripheral ========== */
+#define TC1_CC_NUM                  2       
+#define TC1_DMAC_ID_MC_0            26
+#define TC1_DMAC_ID_MC_1            27
+#define TC1_DMAC_ID_MC_LSB          26
+#define TC1_DMAC_ID_MC_MSB          27
+#define TC1_DMAC_ID_MC_SIZE         2
+#define TC1_DMAC_ID_OVF             25       // Indexes of DMA Overflow trigger
+#define TC1_EXT                     0       
+#define TC1_GCLK_ID                 27      
+#define TC1_MASTER                  0       
+#define TC1_OW_NUM                  2       
+
+#endif /* _SAML21_TC1_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/tc2_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/tc2_100.h
@@ -1,0 +1,123 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC2
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TC2_INSTANCE_
+#define _SAML21_TC2_INSTANCE_
+
+/* ========== Register definition for TC2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC2_CTRLA              (0x42002800U) /**< \brief (TC2) Control A */
+#define REG_TC2_CTRLBCLR           (0x42002804U) /**< \brief (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET           (0x42002805U) /**< \brief (TC2) Control B Set */
+#define REG_TC2_EVCTRL             (0x42002806U) /**< \brief (TC2) Event Control */
+#define REG_TC2_INTENCLR           (0x42002808U) /**< \brief (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET           (0x42002809U) /**< \brief (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG            (0x4200280AU) /**< \brief (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS             (0x4200280BU) /**< \brief (TC2) Status */
+#define REG_TC2_WAVE               (0x4200280CU) /**< \brief (TC2) Waveform Generation Control */
+#define REG_TC2_DRVCTRL            (0x4200280DU) /**< \brief (TC2) Control C */
+#define REG_TC2_DBGCTRL            (0x4200280FU) /**< \brief (TC2) Debug Control */
+#define REG_TC2_SYNCBUSY           (0x42002810U) /**< \brief (TC2) Synchronization Status */
+#define REG_TC2_COUNT16_COUNT      (0x42002814U) /**< \brief (TC2) COUNT16 Count */
+#define REG_TC2_COUNT16_CC0        (0x4200281CU) /**< \brief (TC2) COUNT16 Compare and Capture 0 */
+#define REG_TC2_COUNT16_CC1        (0x4200281EU) /**< \brief (TC2) COUNT16 Compare and Capture 1 */
+#define REG_TC2_COUNT16_CCBUF0     (0x42002830U) /**< \brief (TC2) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT16_CCBUF1     (0x42002832U) /**< \brief (TC2) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT32_COUNT      (0x42002814U) /**< \brief (TC2) COUNT32 Count */
+#define REG_TC2_COUNT32_CC0        (0x4200281CU) /**< \brief (TC2) COUNT32 Compare and Capture 0 */
+#define REG_TC2_COUNT32_CC1        (0x42002820U) /**< \brief (TC2) COUNT32 Compare and Capture 1 */
+#define REG_TC2_COUNT32_CCBUF0     (0x42002830U) /**< \brief (TC2) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT32_CCBUF1     (0x42002834U) /**< \brief (TC2) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT8_COUNT       (0x42002814U) /**< \brief (TC2) COUNT8 Count */
+#define REG_TC2_COUNT8_PER         (0x4200281BU) /**< \brief (TC2) COUNT8 Period */
+#define REG_TC2_COUNT8_CC0         (0x4200281CU) /**< \brief (TC2) COUNT8 Compare and Capture 0 */
+#define REG_TC2_COUNT8_CC1         (0x4200281DU) /**< \brief (TC2) COUNT8 Compare and Capture 1 */
+#define REG_TC2_COUNT8_PERBUF      (0x4200282FU) /**< \brief (TC2) COUNT8 Period Buffer */
+#define REG_TC2_COUNT8_CCBUF0      (0x42002830U) /**< \brief (TC2) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT8_CCBUF1      (0x42002831U) /**< \brief (TC2) COUNT8 Compare and Capture Buffer 1 */
+#else
+#define REG_TC2_CTRLA              (*(RwReg  *)0x42002800U) /**< \brief (TC2) Control A */
+#define REG_TC2_CTRLBCLR           (*(RwReg8 *)0x42002804U) /**< \brief (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET           (*(RwReg8 *)0x42002805U) /**< \brief (TC2) Control B Set */
+#define REG_TC2_EVCTRL             (*(RwReg16*)0x42002806U) /**< \brief (TC2) Event Control */
+#define REG_TC2_INTENCLR           (*(RwReg8 *)0x42002808U) /**< \brief (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET           (*(RwReg8 *)0x42002809U) /**< \brief (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG            (*(RwReg8 *)0x4200280AU) /**< \brief (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS             (*(RwReg8 *)0x4200280BU) /**< \brief (TC2) Status */
+#define REG_TC2_WAVE               (*(RwReg8 *)0x4200280CU) /**< \brief (TC2) Waveform Generation Control */
+#define REG_TC2_DRVCTRL            (*(RwReg8 *)0x4200280DU) /**< \brief (TC2) Control C */
+#define REG_TC2_DBGCTRL            (*(RwReg8 *)0x4200280FU) /**< \brief (TC2) Debug Control */
+#define REG_TC2_SYNCBUSY           (*(RoReg  *)0x42002810U) /**< \brief (TC2) Synchronization Status */
+#define REG_TC2_COUNT16_COUNT      (*(RwReg16*)0x42002814U) /**< \brief (TC2) COUNT16 Count */
+#define REG_TC2_COUNT16_CC0        (*(RwReg16*)0x4200281CU) /**< \brief (TC2) COUNT16 Compare and Capture 0 */
+#define REG_TC2_COUNT16_CC1        (*(RwReg16*)0x4200281EU) /**< \brief (TC2) COUNT16 Compare and Capture 1 */
+#define REG_TC2_COUNT16_CCBUF0     (*(RwReg16*)0x42002830U) /**< \brief (TC2) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT16_CCBUF1     (*(RwReg16*)0x42002832U) /**< \brief (TC2) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT32_COUNT      (*(RwReg  *)0x42002814U) /**< \brief (TC2) COUNT32 Count */
+#define REG_TC2_COUNT32_CC0        (*(RwReg  *)0x4200281CU) /**< \brief (TC2) COUNT32 Compare and Capture 0 */
+#define REG_TC2_COUNT32_CC1        (*(RwReg  *)0x42002820U) /**< \brief (TC2) COUNT32 Compare and Capture 1 */
+#define REG_TC2_COUNT32_CCBUF0     (*(RwReg  *)0x42002830U) /**< \brief (TC2) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT32_CCBUF1     (*(RwReg  *)0x42002834U) /**< \brief (TC2) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC2_COUNT8_COUNT       (*(RwReg8 *)0x42002814U) /**< \brief (TC2) COUNT8 Count */
+#define REG_TC2_COUNT8_PER         (*(RwReg8 *)0x4200281BU) /**< \brief (TC2) COUNT8 Period */
+#define REG_TC2_COUNT8_CC0         (*(RwReg8 *)0x4200281CU) /**< \brief (TC2) COUNT8 Compare and Capture 0 */
+#define REG_TC2_COUNT8_CC1         (*(RwReg8 *)0x4200281DU) /**< \brief (TC2) COUNT8 Compare and Capture 1 */
+#define REG_TC2_COUNT8_PERBUF      (*(RwReg8 *)0x4200282FU) /**< \brief (TC2) COUNT8 Period Buffer */
+#define REG_TC2_COUNT8_CCBUF0      (*(RwReg8 *)0x42002830U) /**< \brief (TC2) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC2_COUNT8_CCBUF1      (*(RwReg8 *)0x42002831U) /**< \brief (TC2) COUNT8 Compare and Capture Buffer 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC2 peripheral ========== */
+#define TC2_CC_NUM                  2       
+#define TC2_DMAC_ID_MC_0            29
+#define TC2_DMAC_ID_MC_1            30
+#define TC2_DMAC_ID_MC_LSB          29
+#define TC2_DMAC_ID_MC_MSB          30
+#define TC2_DMAC_ID_MC_SIZE         2
+#define TC2_DMAC_ID_OVF             28       // Indexes of DMA Overflow trigger
+#define TC2_EXT                     0       
+#define TC2_GCLK_ID                 28      
+#define TC2_MASTER                  1       
+#define TC2_OW_NUM                  2       
+
+#endif /* _SAML21_TC2_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/tc3_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/tc3_100.h
@@ -1,0 +1,123 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC3
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TC3_INSTANCE_
+#define _SAML21_TC3_INSTANCE_
+
+/* ========== Register definition for TC3 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC3_CTRLA              (0x42002C00U) /**< \brief (TC3) Control A */
+#define REG_TC3_CTRLBCLR           (0x42002C04U) /**< \brief (TC3) Control B Clear */
+#define REG_TC3_CTRLBSET           (0x42002C05U) /**< \brief (TC3) Control B Set */
+#define REG_TC3_EVCTRL             (0x42002C06U) /**< \brief (TC3) Event Control */
+#define REG_TC3_INTENCLR           (0x42002C08U) /**< \brief (TC3) Interrupt Enable Clear */
+#define REG_TC3_INTENSET           (0x42002C09U) /**< \brief (TC3) Interrupt Enable Set */
+#define REG_TC3_INTFLAG            (0x42002C0AU) /**< \brief (TC3) Interrupt Flag Status and Clear */
+#define REG_TC3_STATUS             (0x42002C0BU) /**< \brief (TC3) Status */
+#define REG_TC3_WAVE               (0x42002C0CU) /**< \brief (TC3) Waveform Generation Control */
+#define REG_TC3_DRVCTRL            (0x42002C0DU) /**< \brief (TC3) Control C */
+#define REG_TC3_DBGCTRL            (0x42002C0FU) /**< \brief (TC3) Debug Control */
+#define REG_TC3_SYNCBUSY           (0x42002C10U) /**< \brief (TC3) Synchronization Status */
+#define REG_TC3_COUNT16_COUNT      (0x42002C14U) /**< \brief (TC3) COUNT16 Count */
+#define REG_TC3_COUNT16_CC0        (0x42002C1CU) /**< \brief (TC3) COUNT16 Compare and Capture 0 */
+#define REG_TC3_COUNT16_CC1        (0x42002C1EU) /**< \brief (TC3) COUNT16 Compare and Capture 1 */
+#define REG_TC3_COUNT16_CCBUF0     (0x42002C30U) /**< \brief (TC3) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC3_COUNT16_CCBUF1     (0x42002C32U) /**< \brief (TC3) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC3_COUNT32_COUNT      (0x42002C14U) /**< \brief (TC3) COUNT32 Count */
+#define REG_TC3_COUNT32_CC0        (0x42002C1CU) /**< \brief (TC3) COUNT32 Compare and Capture 0 */
+#define REG_TC3_COUNT32_CC1        (0x42002C20U) /**< \brief (TC3) COUNT32 Compare and Capture 1 */
+#define REG_TC3_COUNT32_CCBUF0     (0x42002C30U) /**< \brief (TC3) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC3_COUNT32_CCBUF1     (0x42002C34U) /**< \brief (TC3) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC3_COUNT8_COUNT       (0x42002C14U) /**< \brief (TC3) COUNT8 Count */
+#define REG_TC3_COUNT8_PER         (0x42002C1BU) /**< \brief (TC3) COUNT8 Period */
+#define REG_TC3_COUNT8_CC0         (0x42002C1CU) /**< \brief (TC3) COUNT8 Compare and Capture 0 */
+#define REG_TC3_COUNT8_CC1         (0x42002C1DU) /**< \brief (TC3) COUNT8 Compare and Capture 1 */
+#define REG_TC3_COUNT8_PERBUF      (0x42002C2FU) /**< \brief (TC3) COUNT8 Period Buffer */
+#define REG_TC3_COUNT8_CCBUF0      (0x42002C30U) /**< \brief (TC3) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC3_COUNT8_CCBUF1      (0x42002C31U) /**< \brief (TC3) COUNT8 Compare and Capture Buffer 1 */
+#else
+#define REG_TC3_CTRLA              (*(RwReg  *)0x42002C00U) /**< \brief (TC3) Control A */
+#define REG_TC3_CTRLBCLR           (*(RwReg8 *)0x42002C04U) /**< \brief (TC3) Control B Clear */
+#define REG_TC3_CTRLBSET           (*(RwReg8 *)0x42002C05U) /**< \brief (TC3) Control B Set */
+#define REG_TC3_EVCTRL             (*(RwReg16*)0x42002C06U) /**< \brief (TC3) Event Control */
+#define REG_TC3_INTENCLR           (*(RwReg8 *)0x42002C08U) /**< \brief (TC3) Interrupt Enable Clear */
+#define REG_TC3_INTENSET           (*(RwReg8 *)0x42002C09U) /**< \brief (TC3) Interrupt Enable Set */
+#define REG_TC3_INTFLAG            (*(RwReg8 *)0x42002C0AU) /**< \brief (TC3) Interrupt Flag Status and Clear */
+#define REG_TC3_STATUS             (*(RwReg8 *)0x42002C0BU) /**< \brief (TC3) Status */
+#define REG_TC3_WAVE               (*(RwReg8 *)0x42002C0CU) /**< \brief (TC3) Waveform Generation Control */
+#define REG_TC3_DRVCTRL            (*(RwReg8 *)0x42002C0DU) /**< \brief (TC3) Control C */
+#define REG_TC3_DBGCTRL            (*(RwReg8 *)0x42002C0FU) /**< \brief (TC3) Debug Control */
+#define REG_TC3_SYNCBUSY           (*(RoReg  *)0x42002C10U) /**< \brief (TC3) Synchronization Status */
+#define REG_TC3_COUNT16_COUNT      (*(RwReg16*)0x42002C14U) /**< \brief (TC3) COUNT16 Count */
+#define REG_TC3_COUNT16_CC0        (*(RwReg16*)0x42002C1CU) /**< \brief (TC3) COUNT16 Compare and Capture 0 */
+#define REG_TC3_COUNT16_CC1        (*(RwReg16*)0x42002C1EU) /**< \brief (TC3) COUNT16 Compare and Capture 1 */
+#define REG_TC3_COUNT16_CCBUF0     (*(RwReg16*)0x42002C30U) /**< \brief (TC3) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC3_COUNT16_CCBUF1     (*(RwReg16*)0x42002C32U) /**< \brief (TC3) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC3_COUNT32_COUNT      (*(RwReg  *)0x42002C14U) /**< \brief (TC3) COUNT32 Count */
+#define REG_TC3_COUNT32_CC0        (*(RwReg  *)0x42002C1CU) /**< \brief (TC3) COUNT32 Compare and Capture 0 */
+#define REG_TC3_COUNT32_CC1        (*(RwReg  *)0x42002C20U) /**< \brief (TC3) COUNT32 Compare and Capture 1 */
+#define REG_TC3_COUNT32_CCBUF0     (*(RwReg  *)0x42002C30U) /**< \brief (TC3) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC3_COUNT32_CCBUF1     (*(RwReg  *)0x42002C34U) /**< \brief (TC3) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC3_COUNT8_COUNT       (*(RwReg8 *)0x42002C14U) /**< \brief (TC3) COUNT8 Count */
+#define REG_TC3_COUNT8_PER         (*(RwReg8 *)0x42002C1BU) /**< \brief (TC3) COUNT8 Period */
+#define REG_TC3_COUNT8_CC0         (*(RwReg8 *)0x42002C1CU) /**< \brief (TC3) COUNT8 Compare and Capture 0 */
+#define REG_TC3_COUNT8_CC1         (*(RwReg8 *)0x42002C1DU) /**< \brief (TC3) COUNT8 Compare and Capture 1 */
+#define REG_TC3_COUNT8_PERBUF      (*(RwReg8 *)0x42002C2FU) /**< \brief (TC3) COUNT8 Period Buffer */
+#define REG_TC3_COUNT8_CCBUF0      (*(RwReg8 *)0x42002C30U) /**< \brief (TC3) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC3_COUNT8_CCBUF1      (*(RwReg8 *)0x42002C31U) /**< \brief (TC3) COUNT8 Compare and Capture Buffer 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC3 peripheral ========== */
+#define TC3_CC_NUM                  2       
+#define TC3_DMAC_ID_MC_0            32
+#define TC3_DMAC_ID_MC_1            33
+#define TC3_DMAC_ID_MC_LSB          32
+#define TC3_DMAC_ID_MC_MSB          33
+#define TC3_DMAC_ID_MC_SIZE         2
+#define TC3_DMAC_ID_OVF             31       // Indexes of DMA Overflow trigger
+#define TC3_EXT                     0       
+#define TC3_GCLK_ID                 28      
+#define TC3_MASTER                  0       
+#define TC3_OW_NUM                  2       
+
+#endif /* _SAML21_TC3_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/tc4_100.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/tc4_100.h
@@ -1,0 +1,123 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC4
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TC4_INSTANCE_
+#define _SAML21_TC4_INSTANCE_
+
+/* ========== Register definition for TC4 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC4_CTRLA              (0x43000800U) /**< \brief (TC4) Control A */
+#define REG_TC4_CTRLBCLR           (0x43000804U) /**< \brief (TC4) Control B Clear */
+#define REG_TC4_CTRLBSET           (0x43000805U) /**< \brief (TC4) Control B Set */
+#define REG_TC4_EVCTRL             (0x43000806U) /**< \brief (TC4) Event Control */
+#define REG_TC4_INTENCLR           (0x43000808U) /**< \brief (TC4) Interrupt Enable Clear */
+#define REG_TC4_INTENSET           (0x43000809U) /**< \brief (TC4) Interrupt Enable Set */
+#define REG_TC4_INTFLAG            (0x4300080AU) /**< \brief (TC4) Interrupt Flag Status and Clear */
+#define REG_TC4_STATUS             (0x4300080BU) /**< \brief (TC4) Status */
+#define REG_TC4_WAVE               (0x4300080CU) /**< \brief (TC4) Waveform Generation Control */
+#define REG_TC4_DRVCTRL            (0x4300080DU) /**< \brief (TC4) Control C */
+#define REG_TC4_DBGCTRL            (0x4300080FU) /**< \brief (TC4) Debug Control */
+#define REG_TC4_SYNCBUSY           (0x43000810U) /**< \brief (TC4) Synchronization Status */
+#define REG_TC4_COUNT16_COUNT      (0x43000814U) /**< \brief (TC4) COUNT16 Count */
+#define REG_TC4_COUNT16_CC0        (0x4300081CU) /**< \brief (TC4) COUNT16 Compare and Capture 0 */
+#define REG_TC4_COUNT16_CC1        (0x4300081EU) /**< \brief (TC4) COUNT16 Compare and Capture 1 */
+#define REG_TC4_COUNT16_CCBUF0     (0x43000830U) /**< \brief (TC4) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC4_COUNT16_CCBUF1     (0x43000832U) /**< \brief (TC4) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC4_COUNT32_COUNT      (0x43000814U) /**< \brief (TC4) COUNT32 Count */
+#define REG_TC4_COUNT32_CC0        (0x4300081CU) /**< \brief (TC4) COUNT32 Compare and Capture 0 */
+#define REG_TC4_COUNT32_CC1        (0x43000820U) /**< \brief (TC4) COUNT32 Compare and Capture 1 */
+#define REG_TC4_COUNT32_CCBUF0     (0x43000830U) /**< \brief (TC4) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC4_COUNT32_CCBUF1     (0x43000834U) /**< \brief (TC4) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC4_COUNT8_COUNT       (0x43000814U) /**< \brief (TC4) COUNT8 Count */
+#define REG_TC4_COUNT8_PER         (0x4300081BU) /**< \brief (TC4) COUNT8 Period */
+#define REG_TC4_COUNT8_CC0         (0x4300081CU) /**< \brief (TC4) COUNT8 Compare and Capture 0 */
+#define REG_TC4_COUNT8_CC1         (0x4300081DU) /**< \brief (TC4) COUNT8 Compare and Capture 1 */
+#define REG_TC4_COUNT8_PERBUF      (0x4300082FU) /**< \brief (TC4) COUNT8 Period Buffer */
+#define REG_TC4_COUNT8_CCBUF0      (0x43000830U) /**< \brief (TC4) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC4_COUNT8_CCBUF1      (0x43000831U) /**< \brief (TC4) COUNT8 Compare and Capture Buffer 1 */
+#else
+#define REG_TC4_CTRLA              (*(RwReg  *)0x43000800U) /**< \brief (TC4) Control A */
+#define REG_TC4_CTRLBCLR           (*(RwReg8 *)0x43000804U) /**< \brief (TC4) Control B Clear */
+#define REG_TC4_CTRLBSET           (*(RwReg8 *)0x43000805U) /**< \brief (TC4) Control B Set */
+#define REG_TC4_EVCTRL             (*(RwReg16*)0x43000806U) /**< \brief (TC4) Event Control */
+#define REG_TC4_INTENCLR           (*(RwReg8 *)0x43000808U) /**< \brief (TC4) Interrupt Enable Clear */
+#define REG_TC4_INTENSET           (*(RwReg8 *)0x43000809U) /**< \brief (TC4) Interrupt Enable Set */
+#define REG_TC4_INTFLAG            (*(RwReg8 *)0x4300080AU) /**< \brief (TC4) Interrupt Flag Status and Clear */
+#define REG_TC4_STATUS             (*(RwReg8 *)0x4300080BU) /**< \brief (TC4) Status */
+#define REG_TC4_WAVE               (*(RwReg8 *)0x4300080CU) /**< \brief (TC4) Waveform Generation Control */
+#define REG_TC4_DRVCTRL            (*(RwReg8 *)0x4300080DU) /**< \brief (TC4) Control C */
+#define REG_TC4_DBGCTRL            (*(RwReg8 *)0x4300080FU) /**< \brief (TC4) Debug Control */
+#define REG_TC4_SYNCBUSY           (*(RoReg  *)0x43000810U) /**< \brief (TC4) Synchronization Status */
+#define REG_TC4_COUNT16_COUNT      (*(RwReg16*)0x43000814U) /**< \brief (TC4) COUNT16 Count */
+#define REG_TC4_COUNT16_CC0        (*(RwReg16*)0x4300081CU) /**< \brief (TC4) COUNT16 Compare and Capture 0 */
+#define REG_TC4_COUNT16_CC1        (*(RwReg16*)0x4300081EU) /**< \brief (TC4) COUNT16 Compare and Capture 1 */
+#define REG_TC4_COUNT16_CCBUF0     (*(RwReg16*)0x43000830U) /**< \brief (TC4) COUNT16 Compare and Capture Buffer 0 */
+#define REG_TC4_COUNT16_CCBUF1     (*(RwReg16*)0x43000832U) /**< \brief (TC4) COUNT16 Compare and Capture Buffer 1 */
+#define REG_TC4_COUNT32_COUNT      (*(RwReg  *)0x43000814U) /**< \brief (TC4) COUNT32 Count */
+#define REG_TC4_COUNT32_CC0        (*(RwReg  *)0x4300081CU) /**< \brief (TC4) COUNT32 Compare and Capture 0 */
+#define REG_TC4_COUNT32_CC1        (*(RwReg  *)0x43000820U) /**< \brief (TC4) COUNT32 Compare and Capture 1 */
+#define REG_TC4_COUNT32_CCBUF0     (*(RwReg  *)0x43000830U) /**< \brief (TC4) COUNT32 Compare and Capture Buffer 0 */
+#define REG_TC4_COUNT32_CCBUF1     (*(RwReg  *)0x43000834U) /**< \brief (TC4) COUNT32 Compare and Capture Buffer 1 */
+#define REG_TC4_COUNT8_COUNT       (*(RwReg8 *)0x43000814U) /**< \brief (TC4) COUNT8 Count */
+#define REG_TC4_COUNT8_PER         (*(RwReg8 *)0x4300081BU) /**< \brief (TC4) COUNT8 Period */
+#define REG_TC4_COUNT8_CC0         (*(RwReg8 *)0x4300081CU) /**< \brief (TC4) COUNT8 Compare and Capture 0 */
+#define REG_TC4_COUNT8_CC1         (*(RwReg8 *)0x4300081DU) /**< \brief (TC4) COUNT8 Compare and Capture 1 */
+#define REG_TC4_COUNT8_PERBUF      (*(RwReg8 *)0x4300082FU) /**< \brief (TC4) COUNT8 Period Buffer */
+#define REG_TC4_COUNT8_CCBUF0      (*(RwReg8 *)0x43000830U) /**< \brief (TC4) COUNT8 Compare and Capture Buffer 0 */
+#define REG_TC4_COUNT8_CCBUF1      (*(RwReg8 *)0x43000831U) /**< \brief (TC4) COUNT8 Compare and Capture Buffer 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC4 peripheral ========== */
+#define TC4_CC_NUM                  2       
+#define TC4_DMAC_ID_MC_0            35
+#define TC4_DMAC_ID_MC_1            36
+#define TC4_DMAC_ID_MC_LSB          35
+#define TC4_DMAC_ID_MC_MSB          36
+#define TC4_DMAC_ID_MC_SIZE         2
+#define TC4_DMAC_ID_OVF             34       // Indexes of DMA Overflow trigger
+#define TC4_EXT                     0       
+#define TC4_GCLK_ID                 29      
+#define TC4_MASTER                  0       
+#define TC4_OW_NUM                  2       
+
+#endif /* _SAML21_TC4_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/tcc0_200.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/tcc0_200.h
@@ -1,0 +1,131 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TCC0
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TCC0_INSTANCE_
+#define _SAML21_TCC0_INSTANCE_
+
+/* ========== Register definition for TCC0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TCC0_CTRLA             (0x42001400U) /**< \brief (TCC0) Control A */
+#define REG_TCC0_CTRLBCLR          (0x42001404U) /**< \brief (TCC0) Control B Clear */
+#define REG_TCC0_CTRLBSET          (0x42001405U) /**< \brief (TCC0) Control B Set */
+#define REG_TCC0_SYNCBUSY          (0x42001408U) /**< \brief (TCC0) Synchronization Busy */
+#define REG_TCC0_FCTRLA            (0x4200140CU) /**< \brief (TCC0) Recoverable Fault A Configuration */
+#define REG_TCC0_FCTRLB            (0x42001410U) /**< \brief (TCC0) Recoverable Fault B Configuration */
+#define REG_TCC0_WEXCTRL           (0x42001414U) /**< \brief (TCC0) Waveform Extension Configuration */
+#define REG_TCC0_DRVCTRL           (0x42001418U) /**< \brief (TCC0) Driver Control */
+#define REG_TCC0_DBGCTRL           (0x4200141EU) /**< \brief (TCC0) Debug Control */
+#define REG_TCC0_EVCTRL            (0x42001420U) /**< \brief (TCC0) Event Control */
+#define REG_TCC0_INTENCLR          (0x42001424U) /**< \brief (TCC0) Interrupt Enable Clear */
+#define REG_TCC0_INTENSET          (0x42001428U) /**< \brief (TCC0) Interrupt Enable Set */
+#define REG_TCC0_INTFLAG           (0x4200142CU) /**< \brief (TCC0) Interrupt Flag Status and Clear */
+#define REG_TCC0_STATUS            (0x42001430U) /**< \brief (TCC0) Status */
+#define REG_TCC0_COUNT             (0x42001434U) /**< \brief (TCC0) Count */
+#define REG_TCC0_PATT              (0x42001438U) /**< \brief (TCC0) Pattern */
+#define REG_TCC0_WAVE              (0x4200143CU) /**< \brief (TCC0) Waveform Control */
+#define REG_TCC0_PER               (0x42001440U) /**< \brief (TCC0) Period */
+#define REG_TCC0_CC0               (0x42001444U) /**< \brief (TCC0) Compare and Capture 0 */
+#define REG_TCC0_CC1               (0x42001448U) /**< \brief (TCC0) Compare and Capture 1 */
+#define REG_TCC0_CC2               (0x4200144CU) /**< \brief (TCC0) Compare and Capture 2 */
+#define REG_TCC0_CC3               (0x42001450U) /**< \brief (TCC0) Compare and Capture 3 */
+#define REG_TCC0_PATTBUF           (0x42001464U) /**< \brief (TCC0) Pattern Buffer */
+#define REG_TCC0_WAVEBUF           (0x42001468U) /**< \brief (TCC0) Waveform Control Buffer */
+#define REG_TCC0_PERBUF            (0x4200146CU) /**< \brief (TCC0) Period Buffer */
+#define REG_TCC0_CCBUF0            (0x42001470U) /**< \brief (TCC0) Compare and Capture Buffer 0 */
+#define REG_TCC0_CCBUF1            (0x42001474U) /**< \brief (TCC0) Compare and Capture Buffer 1 */
+#define REG_TCC0_CCBUF2            (0x42001478U) /**< \brief (TCC0) Compare and Capture Buffer 2 */
+#define REG_TCC0_CCBUF3            (0x4200147CU) /**< \brief (TCC0) Compare and Capture Buffer 3 */
+#else
+#define REG_TCC0_CTRLA             (*(RwReg  *)0x42001400U) /**< \brief (TCC0) Control A */
+#define REG_TCC0_CTRLBCLR          (*(RwReg8 *)0x42001404U) /**< \brief (TCC0) Control B Clear */
+#define REG_TCC0_CTRLBSET          (*(RwReg8 *)0x42001405U) /**< \brief (TCC0) Control B Set */
+#define REG_TCC0_SYNCBUSY          (*(RoReg  *)0x42001408U) /**< \brief (TCC0) Synchronization Busy */
+#define REG_TCC0_FCTRLA            (*(RwReg  *)0x4200140CU) /**< \brief (TCC0) Recoverable Fault A Configuration */
+#define REG_TCC0_FCTRLB            (*(RwReg  *)0x42001410U) /**< \brief (TCC0) Recoverable Fault B Configuration */
+#define REG_TCC0_WEXCTRL           (*(RwReg  *)0x42001414U) /**< \brief (TCC0) Waveform Extension Configuration */
+#define REG_TCC0_DRVCTRL           (*(RwReg  *)0x42001418U) /**< \brief (TCC0) Driver Control */
+#define REG_TCC0_DBGCTRL           (*(RwReg8 *)0x4200141EU) /**< \brief (TCC0) Debug Control */
+#define REG_TCC0_EVCTRL            (*(RwReg  *)0x42001420U) /**< \brief (TCC0) Event Control */
+#define REG_TCC0_INTENCLR          (*(RwReg  *)0x42001424U) /**< \brief (TCC0) Interrupt Enable Clear */
+#define REG_TCC0_INTENSET          (*(RwReg  *)0x42001428U) /**< \brief (TCC0) Interrupt Enable Set */
+#define REG_TCC0_INTFLAG           (*(RwReg  *)0x4200142CU) /**< \brief (TCC0) Interrupt Flag Status and Clear */
+#define REG_TCC0_STATUS            (*(RwReg  *)0x42001430U) /**< \brief (TCC0) Status */
+#define REG_TCC0_COUNT             (*(RwReg  *)0x42001434U) /**< \brief (TCC0) Count */
+#define REG_TCC0_PATT              (*(RwReg16*)0x42001438U) /**< \brief (TCC0) Pattern */
+#define REG_TCC0_WAVE              (*(RwReg  *)0x4200143CU) /**< \brief (TCC0) Waveform Control */
+#define REG_TCC0_PER               (*(RwReg  *)0x42001440U) /**< \brief (TCC0) Period */
+#define REG_TCC0_CC0               (*(RwReg  *)0x42001444U) /**< \brief (TCC0) Compare and Capture 0 */
+#define REG_TCC0_CC1               (*(RwReg  *)0x42001448U) /**< \brief (TCC0) Compare and Capture 1 */
+#define REG_TCC0_CC2               (*(RwReg  *)0x4200144CU) /**< \brief (TCC0) Compare and Capture 2 */
+#define REG_TCC0_CC3               (*(RwReg  *)0x42001450U) /**< \brief (TCC0) Compare and Capture 3 */
+#define REG_TCC0_PATTBUF           (*(RwReg16*)0x42001464U) /**< \brief (TCC0) Pattern Buffer */
+#define REG_TCC0_WAVEBUF           (*(RwReg  *)0x42001468U) /**< \brief (TCC0) Waveform Control Buffer */
+#define REG_TCC0_PERBUF            (*(RwReg  *)0x4200146CU) /**< \brief (TCC0) Period Buffer */
+#define REG_TCC0_CCBUF0            (*(RwReg  *)0x42001470U) /**< \brief (TCC0) Compare and Capture Buffer 0 */
+#define REG_TCC0_CCBUF1            (*(RwReg  *)0x42001474U) /**< \brief (TCC0) Compare and Capture Buffer 1 */
+#define REG_TCC0_CCBUF2            (*(RwReg  *)0x42001478U) /**< \brief (TCC0) Compare and Capture Buffer 2 */
+#define REG_TCC0_CCBUF3            (*(RwReg  *)0x4200147CU) /**< \brief (TCC0) Compare and Capture Buffer 3 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TCC0 peripheral ========== */
+#define TCC0_CC_NUM                 4        // Number of Compare/Capture units
+#define TCC0_DITHERING              1        // Dithering feature implemented
+#define TCC0_DMAC_ID_MC_0           12
+#define TCC0_DMAC_ID_MC_1           13
+#define TCC0_DMAC_ID_MC_2           14
+#define TCC0_DMAC_ID_MC_3           15
+#define TCC0_DMAC_ID_MC_LSB         12
+#define TCC0_DMAC_ID_MC_MSB         15
+#define TCC0_DMAC_ID_MC_SIZE        4
+#define TCC0_DMAC_ID_OVF            11       // DMA overflow/underflow/retrigger trigger
+#define TCC0_DTI                    1        // Dead-Time-Insertion feature implemented
+#define TCC0_EXT                    31       // Coding of implemented extended features
+#define TCC0_GCLK_ID                25       // Index of Generic Clock
+#define TCC0_OTMX                   1        // Output Matrix feature implemented
+#define TCC0_OW_NUM                 8        // Number of Output Waveforms
+#define TCC0_PG                     1        // Pattern Generation feature implemented
+#define TCC0_SIZE                   24      
+#define TCC0_SWAP                   1        // DTI outputs swap feature implemented
+#define TCC0_TYPE                   1        // TCC type 0 : NA, 1 : Master, 2 : Slave
+
+#endif /* _SAML21_TCC0_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/tcc1_200.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/tcc1_200.h
@@ -1,0 +1,119 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TCC1
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TCC1_INSTANCE_
+#define _SAML21_TCC1_INSTANCE_
+
+/* ========== Register definition for TCC1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TCC1_CTRLA             (0x42001800U) /**< \brief (TCC1) Control A */
+#define REG_TCC1_CTRLBCLR          (0x42001804U) /**< \brief (TCC1) Control B Clear */
+#define REG_TCC1_CTRLBSET          (0x42001805U) /**< \brief (TCC1) Control B Set */
+#define REG_TCC1_SYNCBUSY          (0x42001808U) /**< \brief (TCC1) Synchronization Busy */
+#define REG_TCC1_FCTRLA            (0x4200180CU) /**< \brief (TCC1) Recoverable Fault A Configuration */
+#define REG_TCC1_FCTRLB            (0x42001810U) /**< \brief (TCC1) Recoverable Fault B Configuration */
+#define REG_TCC1_DRVCTRL           (0x42001818U) /**< \brief (TCC1) Driver Control */
+#define REG_TCC1_DBGCTRL           (0x4200181EU) /**< \brief (TCC1) Debug Control */
+#define REG_TCC1_EVCTRL            (0x42001820U) /**< \brief (TCC1) Event Control */
+#define REG_TCC1_INTENCLR          (0x42001824U) /**< \brief (TCC1) Interrupt Enable Clear */
+#define REG_TCC1_INTENSET          (0x42001828U) /**< \brief (TCC1) Interrupt Enable Set */
+#define REG_TCC1_INTFLAG           (0x4200182CU) /**< \brief (TCC1) Interrupt Flag Status and Clear */
+#define REG_TCC1_STATUS            (0x42001830U) /**< \brief (TCC1) Status */
+#define REG_TCC1_COUNT             (0x42001834U) /**< \brief (TCC1) Count */
+#define REG_TCC1_PATT              (0x42001838U) /**< \brief (TCC1) Pattern */
+#define REG_TCC1_WAVE              (0x4200183CU) /**< \brief (TCC1) Waveform Control */
+#define REG_TCC1_PER               (0x42001840U) /**< \brief (TCC1) Period */
+#define REG_TCC1_CC0               (0x42001844U) /**< \brief (TCC1) Compare and Capture 0 */
+#define REG_TCC1_CC1               (0x42001848U) /**< \brief (TCC1) Compare and Capture 1 */
+#define REG_TCC1_PATTBUF           (0x42001864U) /**< \brief (TCC1) Pattern Buffer */
+#define REG_TCC1_WAVEBUF           (0x42001868U) /**< \brief (TCC1) Waveform Control Buffer */
+#define REG_TCC1_PERBUF            (0x4200186CU) /**< \brief (TCC1) Period Buffer */
+#define REG_TCC1_CCBUF0            (0x42001870U) /**< \brief (TCC1) Compare and Capture Buffer 0 */
+#define REG_TCC1_CCBUF1            (0x42001874U) /**< \brief (TCC1) Compare and Capture Buffer 1 */
+#else
+#define REG_TCC1_CTRLA             (*(RwReg  *)0x42001800U) /**< \brief (TCC1) Control A */
+#define REG_TCC1_CTRLBCLR          (*(RwReg8 *)0x42001804U) /**< \brief (TCC1) Control B Clear */
+#define REG_TCC1_CTRLBSET          (*(RwReg8 *)0x42001805U) /**< \brief (TCC1) Control B Set */
+#define REG_TCC1_SYNCBUSY          (*(RoReg  *)0x42001808U) /**< \brief (TCC1) Synchronization Busy */
+#define REG_TCC1_FCTRLA            (*(RwReg  *)0x4200180CU) /**< \brief (TCC1) Recoverable Fault A Configuration */
+#define REG_TCC1_FCTRLB            (*(RwReg  *)0x42001810U) /**< \brief (TCC1) Recoverable Fault B Configuration */
+#define REG_TCC1_DRVCTRL           (*(RwReg  *)0x42001818U) /**< \brief (TCC1) Driver Control */
+#define REG_TCC1_DBGCTRL           (*(RwReg8 *)0x4200181EU) /**< \brief (TCC1) Debug Control */
+#define REG_TCC1_EVCTRL            (*(RwReg  *)0x42001820U) /**< \brief (TCC1) Event Control */
+#define REG_TCC1_INTENCLR          (*(RwReg  *)0x42001824U) /**< \brief (TCC1) Interrupt Enable Clear */
+#define REG_TCC1_INTENSET          (*(RwReg  *)0x42001828U) /**< \brief (TCC1) Interrupt Enable Set */
+#define REG_TCC1_INTFLAG           (*(RwReg  *)0x4200182CU) /**< \brief (TCC1) Interrupt Flag Status and Clear */
+#define REG_TCC1_STATUS            (*(RwReg  *)0x42001830U) /**< \brief (TCC1) Status */
+#define REG_TCC1_COUNT             (*(RwReg  *)0x42001834U) /**< \brief (TCC1) Count */
+#define REG_TCC1_PATT              (*(RwReg16*)0x42001838U) /**< \brief (TCC1) Pattern */
+#define REG_TCC1_WAVE              (*(RwReg  *)0x4200183CU) /**< \brief (TCC1) Waveform Control */
+#define REG_TCC1_PER               (*(RwReg  *)0x42001840U) /**< \brief (TCC1) Period */
+#define REG_TCC1_CC0               (*(RwReg  *)0x42001844U) /**< \brief (TCC1) Compare and Capture 0 */
+#define REG_TCC1_CC1               (*(RwReg  *)0x42001848U) /**< \brief (TCC1) Compare and Capture 1 */
+#define REG_TCC1_PATTBUF           (*(RwReg16*)0x42001864U) /**< \brief (TCC1) Pattern Buffer */
+#define REG_TCC1_WAVEBUF           (*(RwReg  *)0x42001868U) /**< \brief (TCC1) Waveform Control Buffer */
+#define REG_TCC1_PERBUF            (*(RwReg  *)0x4200186CU) /**< \brief (TCC1) Period Buffer */
+#define REG_TCC1_CCBUF0            (*(RwReg  *)0x42001870U) /**< \brief (TCC1) Compare and Capture Buffer 0 */
+#define REG_TCC1_CCBUF1            (*(RwReg  *)0x42001874U) /**< \brief (TCC1) Compare and Capture Buffer 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TCC1 peripheral ========== */
+#define TCC1_CC_NUM                 2        // Number of Compare/Capture units
+#define TCC1_DITHERING              1        // Dithering feature implemented
+#define TCC1_DMAC_ID_MC_0           17
+#define TCC1_DMAC_ID_MC_1           18
+#define TCC1_DMAC_ID_MC_LSB         17
+#define TCC1_DMAC_ID_MC_MSB         18
+#define TCC1_DMAC_ID_MC_SIZE        2
+#define TCC1_DMAC_ID_OVF            16       // DMA overflow/underflow/retrigger trigger
+#define TCC1_DTI                    0        // Dead-Time-Insertion feature implemented
+#define TCC1_EXT                    24       // Coding of implemented extended features
+#define TCC1_GCLK_ID                25       // Index of Generic Clock
+#define TCC1_OTMX                   0        // Output Matrix feature implemented
+#define TCC1_OW_NUM                 4        // Number of Output Waveforms
+#define TCC1_PG                     1        // Pattern Generation feature implemented
+#define TCC1_SIZE                   24      
+#define TCC1_SWAP                   0        // DTI outputs swap feature implemented
+#define TCC1_TYPE                   2        // TCC type 0 : NA, 1 : Master, 2 : Slave
+
+#endif /* _SAML21_TCC1_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/tcc2_200.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/tcc2_200.h
@@ -1,0 +1,115 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TCC2
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TCC2_INSTANCE_
+#define _SAML21_TCC2_INSTANCE_
+
+/* ========== Register definition for TCC2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TCC2_CTRLA             (0x42001C00U) /**< \brief (TCC2) Control A */
+#define REG_TCC2_CTRLBCLR          (0x42001C04U) /**< \brief (TCC2) Control B Clear */
+#define REG_TCC2_CTRLBSET          (0x42001C05U) /**< \brief (TCC2) Control B Set */
+#define REG_TCC2_SYNCBUSY          (0x42001C08U) /**< \brief (TCC2) Synchronization Busy */
+#define REG_TCC2_FCTRLA            (0x42001C0CU) /**< \brief (TCC2) Recoverable Fault A Configuration */
+#define REG_TCC2_FCTRLB            (0x42001C10U) /**< \brief (TCC2) Recoverable Fault B Configuration */
+#define REG_TCC2_DRVCTRL           (0x42001C18U) /**< \brief (TCC2) Driver Control */
+#define REG_TCC2_DBGCTRL           (0x42001C1EU) /**< \brief (TCC2) Debug Control */
+#define REG_TCC2_EVCTRL            (0x42001C20U) /**< \brief (TCC2) Event Control */
+#define REG_TCC2_INTENCLR          (0x42001C24U) /**< \brief (TCC2) Interrupt Enable Clear */
+#define REG_TCC2_INTENSET          (0x42001C28U) /**< \brief (TCC2) Interrupt Enable Set */
+#define REG_TCC2_INTFLAG           (0x42001C2CU) /**< \brief (TCC2) Interrupt Flag Status and Clear */
+#define REG_TCC2_STATUS            (0x42001C30U) /**< \brief (TCC2) Status */
+#define REG_TCC2_COUNT             (0x42001C34U) /**< \brief (TCC2) Count */
+#define REG_TCC2_WAVE              (0x42001C3CU) /**< \brief (TCC2) Waveform Control */
+#define REG_TCC2_PER               (0x42001C40U) /**< \brief (TCC2) Period */
+#define REG_TCC2_CC0               (0x42001C44U) /**< \brief (TCC2) Compare and Capture 0 */
+#define REG_TCC2_CC1               (0x42001C48U) /**< \brief (TCC2) Compare and Capture 1 */
+#define REG_TCC2_WAVEBUF           (0x42001C68U) /**< \brief (TCC2) Waveform Control Buffer */
+#define REG_TCC2_PERBUF            (0x42001C6CU) /**< \brief (TCC2) Period Buffer */
+#define REG_TCC2_CCBUF0            (0x42001C70U) /**< \brief (TCC2) Compare and Capture Buffer 0 */
+#define REG_TCC2_CCBUF1            (0x42001C74U) /**< \brief (TCC2) Compare and Capture Buffer 1 */
+#else
+#define REG_TCC2_CTRLA             (*(RwReg  *)0x42001C00U) /**< \brief (TCC2) Control A */
+#define REG_TCC2_CTRLBCLR          (*(RwReg8 *)0x42001C04U) /**< \brief (TCC2) Control B Clear */
+#define REG_TCC2_CTRLBSET          (*(RwReg8 *)0x42001C05U) /**< \brief (TCC2) Control B Set */
+#define REG_TCC2_SYNCBUSY          (*(RoReg  *)0x42001C08U) /**< \brief (TCC2) Synchronization Busy */
+#define REG_TCC2_FCTRLA            (*(RwReg  *)0x42001C0CU) /**< \brief (TCC2) Recoverable Fault A Configuration */
+#define REG_TCC2_FCTRLB            (*(RwReg  *)0x42001C10U) /**< \brief (TCC2) Recoverable Fault B Configuration */
+#define REG_TCC2_DRVCTRL           (*(RwReg  *)0x42001C18U) /**< \brief (TCC2) Driver Control */
+#define REG_TCC2_DBGCTRL           (*(RwReg8 *)0x42001C1EU) /**< \brief (TCC2) Debug Control */
+#define REG_TCC2_EVCTRL            (*(RwReg  *)0x42001C20U) /**< \brief (TCC2) Event Control */
+#define REG_TCC2_INTENCLR          (*(RwReg  *)0x42001C24U) /**< \brief (TCC2) Interrupt Enable Clear */
+#define REG_TCC2_INTENSET          (*(RwReg  *)0x42001C28U) /**< \brief (TCC2) Interrupt Enable Set */
+#define REG_TCC2_INTFLAG           (*(RwReg  *)0x42001C2CU) /**< \brief (TCC2) Interrupt Flag Status and Clear */
+#define REG_TCC2_STATUS            (*(RwReg  *)0x42001C30U) /**< \brief (TCC2) Status */
+#define REG_TCC2_COUNT             (*(RwReg  *)0x42001C34U) /**< \brief (TCC2) Count */
+#define REG_TCC2_WAVE              (*(RwReg  *)0x42001C3CU) /**< \brief (TCC2) Waveform Control */
+#define REG_TCC2_PER               (*(RwReg  *)0x42001C40U) /**< \brief (TCC2) Period */
+#define REG_TCC2_CC0               (*(RwReg  *)0x42001C44U) /**< \brief (TCC2) Compare and Capture 0 */
+#define REG_TCC2_CC1               (*(RwReg  *)0x42001C48U) /**< \brief (TCC2) Compare and Capture 1 */
+#define REG_TCC2_WAVEBUF           (*(RwReg  *)0x42001C68U) /**< \brief (TCC2) Waveform Control Buffer */
+#define REG_TCC2_PERBUF            (*(RwReg  *)0x42001C6CU) /**< \brief (TCC2) Period Buffer */
+#define REG_TCC2_CCBUF0            (*(RwReg  *)0x42001C70U) /**< \brief (TCC2) Compare and Capture Buffer 0 */
+#define REG_TCC2_CCBUF1            (*(RwReg  *)0x42001C74U) /**< \brief (TCC2) Compare and Capture Buffer 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TCC2 peripheral ========== */
+#define TCC2_CC_NUM                 2        // Number of Compare/Capture units
+#define TCC2_DITHERING              0        // Dithering feature implemented
+#define TCC2_DMAC_ID_MC_0           20
+#define TCC2_DMAC_ID_MC_1           21
+#define TCC2_DMAC_ID_MC_LSB         20
+#define TCC2_DMAC_ID_MC_MSB         21
+#define TCC2_DMAC_ID_MC_SIZE        2
+#define TCC2_DMAC_ID_OVF            19       // DMA overflow/underflow/retrigger trigger
+#define TCC2_DTI                    0        // Dead-Time-Insertion feature implemented
+#define TCC2_EXT                    0        // Coding of implemented extended features
+#define TCC2_GCLK_ID                26       // Index of Generic Clock
+#define TCC2_OTMX                   0        // Output Matrix feature implemented
+#define TCC2_OW_NUM                 2        // Number of Output Waveforms
+#define TCC2_PG                     0        // Pattern Generation feature implemented
+#define TCC2_SIZE                   16      
+#define TCC2_SWAP                   0        // DTI outputs swap feature implemented
+#define TCC2_TYPE                   0        // TCC type 0 : NA, 1 : Master, 2 : Slave
+
+#endif /* _SAML21_TCC2_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/trng.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/trng.h
@@ -1,0 +1,65 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TRNG
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_TRNG_INSTANCE_
+#define _SAML21_TRNG_INSTANCE_
+
+/* ========== Register definition for TRNG peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TRNG_CTRLA             (0x42003800U) /**< \brief (TRNG) Control A */
+#define REG_TRNG_EVCTRL            (0x42003804U) /**< \brief (TRNG) Event Control */
+#define REG_TRNG_INTENCLR          (0x42003808U) /**< \brief (TRNG) Interrupt Enable Clear */
+#define REG_TRNG_INTENSET          (0x42003809U) /**< \brief (TRNG) Interrupt Enable Set */
+#define REG_TRNG_INTFLAG           (0x4200380AU) /**< \brief (TRNG) Interrupt Flag Status and Clear */
+#define REG_TRNG_DATA              (0x42003820U) /**< \brief (TRNG) Output Data */
+#else
+#define REG_TRNG_CTRLA             (*(RwReg8 *)0x42003800U) /**< \brief (TRNG) Control A */
+#define REG_TRNG_EVCTRL            (*(RwReg8 *)0x42003804U) /**< \brief (TRNG) Event Control */
+#define REG_TRNG_INTENCLR          (*(RwReg8 *)0x42003808U) /**< \brief (TRNG) Interrupt Enable Clear */
+#define REG_TRNG_INTENSET          (*(RwReg8 *)0x42003809U) /**< \brief (TRNG) Interrupt Enable Set */
+#define REG_TRNG_INTFLAG           (*(RwReg8 *)0x4200380AU) /**< \brief (TRNG) Interrupt Flag Status and Clear */
+#define REG_TRNG_DATA              (*(RoReg  *)0x42003820U) /**< \brief (TRNG) Output Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAML21_TRNG_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/usb.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/usb.h
@@ -1,0 +1,342 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USB
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_USB_INSTANCE_
+#define _SAML21_USB_INSTANCE_
+
+/* ========== Register definition for USB peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_USB_CTRLA              (0x41000000U) /**< \brief (USB) Control A */
+#define REG_USB_SYNCBUSY           (0x41000002U) /**< \brief (USB) Synchronization Busy */
+#define REG_USB_FSMSTATUS          (0x4100000DU) /**< \brief (USB) Finite State Machine Status */
+#define REG_USB_DESCADD            (0x41000024U) /**< \brief (USB) Descriptor Address */
+#define REG_USB_PADCAL             (0x41000028U) /**< \brief (USB) USB PAD Calibration */
+#define REG_USB_DEVICE_CTRLB       (0x41000008U) /**< \brief (USB) DEVICE Control B */
+#define REG_USB_DEVICE_DADD        (0x4100000AU) /**< \brief (USB) DEVICE Device Address */
+#define REG_USB_DEVICE_STATUS      (0x4100000CU) /**< \brief (USB) DEVICE Status */
+#define REG_USB_DEVICE_FNUM        (0x41000010U) /**< \brief (USB) DEVICE Device Frame Number */
+#define REG_USB_DEVICE_INTENCLR    (0x41000014U) /**< \brief (USB) DEVICE Device Interrupt Enable Clear */
+#define REG_USB_DEVICE_INTENSET    (0x41000018U) /**< \brief (USB) DEVICE Device Interrupt Enable Set */
+#define REG_USB_DEVICE_INTFLAG     (0x4100001CU) /**< \brief (USB) DEVICE Device Interrupt Flag */
+#define REG_USB_DEVICE_EPINTSMRY   (0x41000020U) /**< \brief (USB) DEVICE End Point Interrupt Summary */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG0 (0x41000100U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR0 (0x41000104U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET0 (0x41000105U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS0 (0x41000106U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG0 (0x41000107U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR0 (0x41000108U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET0 (0x41000109U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG1 (0x41000120U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR1 (0x41000124U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET1 (0x41000125U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS1 (0x41000126U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG1 (0x41000127U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR1 (0x41000128U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET1 (0x41000129U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG2 (0x41000140U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR2 (0x41000144U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET2 (0x41000145U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS2 (0x41000146U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG2 (0x41000147U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR2 (0x41000148U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET2 (0x41000149U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG3 (0x41000160U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR3 (0x41000164U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET3 (0x41000165U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS3 (0x41000166U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG3 (0x41000167U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR3 (0x41000168U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET3 (0x41000169U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG4 (0x41000180U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR4 (0x41000184U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET4 (0x41000185U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS4 (0x41000186U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG4 (0x41000187U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR4 (0x41000188U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET4 (0x41000189U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG5 (0x410001A0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR5 (0x410001A4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET5 (0x410001A5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS5 (0x410001A6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG5 (0x410001A7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR5 (0x410001A8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET5 (0x410001A9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG6 (0x410001C0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR6 (0x410001C4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET6 (0x410001C5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS6 (0x410001C6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG6 (0x410001C7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR6 (0x410001C8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET6 (0x410001C9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG7 (0x410001E0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR7 (0x410001E4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET7 (0x410001E5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS7 (0x410001E6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG7 (0x410001E7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR7 (0x410001E8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET7 (0x410001E9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 7 */
+#define REG_USB_HOST_CTRLB         (0x41000008U) /**< \brief (USB) HOST Control B */
+#define REG_USB_HOST_HSOFC         (0x4100000AU) /**< \brief (USB) HOST Host Start Of Frame Control */
+#define REG_USB_HOST_STATUS        (0x4100000CU) /**< \brief (USB) HOST Status */
+#define REG_USB_HOST_FNUM          (0x41000010U) /**< \brief (USB) HOST Host Frame Number */
+#define REG_USB_HOST_FLENHIGH      (0x41000012U) /**< \brief (USB) HOST Host Frame Length */
+#define REG_USB_HOST_INTENCLR      (0x41000014U) /**< \brief (USB) HOST Host Interrupt Enable Clear */
+#define REG_USB_HOST_INTENSET      (0x41000018U) /**< \brief (USB) HOST Host Interrupt Enable Set */
+#define REG_USB_HOST_INTFLAG       (0x4100001CU) /**< \brief (USB) HOST Host Interrupt Flag */
+#define REG_USB_HOST_PINTSMRY      (0x41000020U) /**< \brief (USB) HOST Pipe Interrupt Summary */
+#define REG_USB_HOST_PIPE_PCFG0    (0x41000100U) /**< \brief (USB) HOST_PIPE End Point Configuration 0 */
+#define REG_USB_HOST_PIPE_BINTERVAL0 (0x41000103U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 0 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR0 (0x41000104U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 0 */
+#define REG_USB_HOST_PIPE_PSTATUSSET0 (0x41000105U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 0 */
+#define REG_USB_HOST_PIPE_PSTATUS0 (0x41000106U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 0 */
+#define REG_USB_HOST_PIPE_PINTFLAG0 (0x41000107U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 0 */
+#define REG_USB_HOST_PIPE_PINTENCLR0 (0x41000108U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 0 */
+#define REG_USB_HOST_PIPE_PINTENSET0 (0x41000109U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 0 */
+#define REG_USB_HOST_PIPE_PCFG1    (0x41000120U) /**< \brief (USB) HOST_PIPE End Point Configuration 1 */
+#define REG_USB_HOST_PIPE_BINTERVAL1 (0x41000123U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 1 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR1 (0x41000124U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 1 */
+#define REG_USB_HOST_PIPE_PSTATUSSET1 (0x41000125U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 1 */
+#define REG_USB_HOST_PIPE_PSTATUS1 (0x41000126U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 1 */
+#define REG_USB_HOST_PIPE_PINTFLAG1 (0x41000127U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 1 */
+#define REG_USB_HOST_PIPE_PINTENCLR1 (0x41000128U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 1 */
+#define REG_USB_HOST_PIPE_PINTENSET1 (0x41000129U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 1 */
+#define REG_USB_HOST_PIPE_PCFG2    (0x41000140U) /**< \brief (USB) HOST_PIPE End Point Configuration 2 */
+#define REG_USB_HOST_PIPE_BINTERVAL2 (0x41000143U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 2 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR2 (0x41000144U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 2 */
+#define REG_USB_HOST_PIPE_PSTATUSSET2 (0x41000145U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 2 */
+#define REG_USB_HOST_PIPE_PSTATUS2 (0x41000146U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 2 */
+#define REG_USB_HOST_PIPE_PINTFLAG2 (0x41000147U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 2 */
+#define REG_USB_HOST_PIPE_PINTENCLR2 (0x41000148U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 2 */
+#define REG_USB_HOST_PIPE_PINTENSET2 (0x41000149U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 2 */
+#define REG_USB_HOST_PIPE_PCFG3    (0x41000160U) /**< \brief (USB) HOST_PIPE End Point Configuration 3 */
+#define REG_USB_HOST_PIPE_BINTERVAL3 (0x41000163U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 3 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR3 (0x41000164U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 3 */
+#define REG_USB_HOST_PIPE_PSTATUSSET3 (0x41000165U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 3 */
+#define REG_USB_HOST_PIPE_PSTATUS3 (0x41000166U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 3 */
+#define REG_USB_HOST_PIPE_PINTFLAG3 (0x41000167U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 3 */
+#define REG_USB_HOST_PIPE_PINTENCLR3 (0x41000168U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 3 */
+#define REG_USB_HOST_PIPE_PINTENSET3 (0x41000169U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 3 */
+#define REG_USB_HOST_PIPE_PCFG4    (0x41000180U) /**< \brief (USB) HOST_PIPE End Point Configuration 4 */
+#define REG_USB_HOST_PIPE_BINTERVAL4 (0x41000183U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 4 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR4 (0x41000184U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 4 */
+#define REG_USB_HOST_PIPE_PSTATUSSET4 (0x41000185U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 4 */
+#define REG_USB_HOST_PIPE_PSTATUS4 (0x41000186U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 4 */
+#define REG_USB_HOST_PIPE_PINTFLAG4 (0x41000187U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 4 */
+#define REG_USB_HOST_PIPE_PINTENCLR4 (0x41000188U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 4 */
+#define REG_USB_HOST_PIPE_PINTENSET4 (0x41000189U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 4 */
+#define REG_USB_HOST_PIPE_PCFG5    (0x410001A0U) /**< \brief (USB) HOST_PIPE End Point Configuration 5 */
+#define REG_USB_HOST_PIPE_BINTERVAL5 (0x410001A3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 5 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR5 (0x410001A4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 5 */
+#define REG_USB_HOST_PIPE_PSTATUSSET5 (0x410001A5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 5 */
+#define REG_USB_HOST_PIPE_PSTATUS5 (0x410001A6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 5 */
+#define REG_USB_HOST_PIPE_PINTFLAG5 (0x410001A7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 5 */
+#define REG_USB_HOST_PIPE_PINTENCLR5 (0x410001A8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 5 */
+#define REG_USB_HOST_PIPE_PINTENSET5 (0x410001A9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 5 */
+#define REG_USB_HOST_PIPE_PCFG6    (0x410001C0U) /**< \brief (USB) HOST_PIPE End Point Configuration 6 */
+#define REG_USB_HOST_PIPE_BINTERVAL6 (0x410001C3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 6 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR6 (0x410001C4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 6 */
+#define REG_USB_HOST_PIPE_PSTATUSSET6 (0x410001C5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 6 */
+#define REG_USB_HOST_PIPE_PSTATUS6 (0x410001C6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 6 */
+#define REG_USB_HOST_PIPE_PINTFLAG6 (0x410001C7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 6 */
+#define REG_USB_HOST_PIPE_PINTENCLR6 (0x410001C8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 6 */
+#define REG_USB_HOST_PIPE_PINTENSET6 (0x410001C9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 6 */
+#define REG_USB_HOST_PIPE_PCFG7    (0x410001E0U) /**< \brief (USB) HOST_PIPE End Point Configuration 7 */
+#define REG_USB_HOST_PIPE_BINTERVAL7 (0x410001E3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 7 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR7 (0x410001E4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 7 */
+#define REG_USB_HOST_PIPE_PSTATUSSET7 (0x410001E5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 7 */
+#define REG_USB_HOST_PIPE_PSTATUS7 (0x410001E6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 7 */
+#define REG_USB_HOST_PIPE_PINTFLAG7 (0x410001E7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 7 */
+#define REG_USB_HOST_PIPE_PINTENCLR7 (0x410001E8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 7 */
+#define REG_USB_HOST_PIPE_PINTENSET7 (0x410001E9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 7 */
+#else
+#define REG_USB_CTRLA              (*(RwReg8 *)0x41000000U) /**< \brief (USB) Control A */
+#define REG_USB_SYNCBUSY           (*(RoReg8 *)0x41000002U) /**< \brief (USB) Synchronization Busy */
+#define REG_USB_FSMSTATUS          (*(RoReg8 *)0x4100000DU) /**< \brief (USB) Finite State Machine Status */
+#define REG_USB_DESCADD            (*(RwReg  *)0x41000024U) /**< \brief (USB) Descriptor Address */
+#define REG_USB_PADCAL             (*(RwReg16*)0x41000028U) /**< \brief (USB) USB PAD Calibration */
+#define REG_USB_DEVICE_CTRLB       (*(RwReg16*)0x41000008U) /**< \brief (USB) DEVICE Control B */
+#define REG_USB_DEVICE_DADD        (*(RwReg8 *)0x4100000AU) /**< \brief (USB) DEVICE Device Address */
+#define REG_USB_DEVICE_STATUS      (*(RoReg8 *)0x4100000CU) /**< \brief (USB) DEVICE Status */
+#define REG_USB_DEVICE_FNUM        (*(RoReg16*)0x41000010U) /**< \brief (USB) DEVICE Device Frame Number */
+#define REG_USB_DEVICE_INTENCLR    (*(RwReg16*)0x41000014U) /**< \brief (USB) DEVICE Device Interrupt Enable Clear */
+#define REG_USB_DEVICE_INTENSET    (*(RwReg16*)0x41000018U) /**< \brief (USB) DEVICE Device Interrupt Enable Set */
+#define REG_USB_DEVICE_INTFLAG     (*(RwReg16*)0x4100001CU) /**< \brief (USB) DEVICE Device Interrupt Flag */
+#define REG_USB_DEVICE_EPINTSMRY   (*(RoReg16*)0x41000020U) /**< \brief (USB) DEVICE End Point Interrupt Summary */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG0 (*(RwReg8 *)0x41000100U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR0 (*(WoReg8 *)0x41000104U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET0 (*(WoReg8 *)0x41000105U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS0 (*(RoReg8 *)0x41000106U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG0 (*(RwReg8 *)0x41000107U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR0 (*(RwReg8 *)0x41000108U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET0 (*(RwReg8 *)0x41000109U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 0 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG1 (*(RwReg8 *)0x41000120U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR1 (*(WoReg8 *)0x41000124U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET1 (*(WoReg8 *)0x41000125U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS1 (*(RoReg8 *)0x41000126U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG1 (*(RwReg8 *)0x41000127U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR1 (*(RwReg8 *)0x41000128U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET1 (*(RwReg8 *)0x41000129U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 1 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG2 (*(RwReg8 *)0x41000140U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR2 (*(WoReg8 *)0x41000144U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET2 (*(WoReg8 *)0x41000145U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS2 (*(RoReg8 *)0x41000146U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG2 (*(RwReg8 *)0x41000147U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR2 (*(RwReg8 *)0x41000148U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET2 (*(RwReg8 *)0x41000149U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 2 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG3 (*(RwReg8 *)0x41000160U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR3 (*(WoReg8 *)0x41000164U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET3 (*(WoReg8 *)0x41000165U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS3 (*(RoReg8 *)0x41000166U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG3 (*(RwReg8 *)0x41000167U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR3 (*(RwReg8 *)0x41000168U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET3 (*(RwReg8 *)0x41000169U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 3 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG4 (*(RwReg8 *)0x41000180U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR4 (*(WoReg8 *)0x41000184U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET4 (*(WoReg8 *)0x41000185U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS4 (*(RoReg8 *)0x41000186U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG4 (*(RwReg8 *)0x41000187U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR4 (*(RwReg8 *)0x41000188U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET4 (*(RwReg8 *)0x41000189U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 4 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG5 (*(RwReg8 *)0x410001A0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR5 (*(WoReg8 *)0x410001A4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET5 (*(WoReg8 *)0x410001A5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS5 (*(RoReg8 *)0x410001A6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG5 (*(RwReg8 *)0x410001A7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR5 (*(RwReg8 *)0x410001A8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET5 (*(RwReg8 *)0x410001A9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 5 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG6 (*(RwReg8 *)0x410001C0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR6 (*(WoReg8 *)0x410001C4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET6 (*(WoReg8 *)0x410001C5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS6 (*(RoReg8 *)0x410001C6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG6 (*(RwReg8 *)0x410001C7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR6 (*(RwReg8 *)0x410001C8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET6 (*(RwReg8 *)0x410001C9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 6 */
+#define REG_USB_DEVICE_ENDPOINT_EPCFG7 (*(RwReg8 *)0x410001E0U) /**< \brief (USB) DEVICE_ENDPOINT End Point Configuration 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSCLR7 (*(WoReg8 *)0x410001E4U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Clear 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUSSET7 (*(WoReg8 *)0x410001E5U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status Set 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPSTATUS7 (*(RoReg8 *)0x410001E6U) /**< \brief (USB) DEVICE_ENDPOINT End Point Pipe Status 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTFLAG7 (*(RwReg8 *)0x410001E7U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Flag 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENCLR7 (*(RwReg8 *)0x410001E8U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Clear Flag 7 */
+#define REG_USB_DEVICE_ENDPOINT_EPINTENSET7 (*(RwReg8 *)0x410001E9U) /**< \brief (USB) DEVICE_ENDPOINT End Point Interrupt Set Flag 7 */
+#define REG_USB_HOST_CTRLB         (*(RwReg16*)0x41000008U) /**< \brief (USB) HOST Control B */
+#define REG_USB_HOST_HSOFC         (*(RwReg8 *)0x4100000AU) /**< \brief (USB) HOST Host Start Of Frame Control */
+#define REG_USB_HOST_STATUS        (*(RwReg8 *)0x4100000CU) /**< \brief (USB) HOST Status */
+#define REG_USB_HOST_FNUM          (*(RwReg16*)0x41000010U) /**< \brief (USB) HOST Host Frame Number */
+#define REG_USB_HOST_FLENHIGH      (*(RoReg8 *)0x41000012U) /**< \brief (USB) HOST Host Frame Length */
+#define REG_USB_HOST_INTENCLR      (*(RwReg16*)0x41000014U) /**< \brief (USB) HOST Host Interrupt Enable Clear */
+#define REG_USB_HOST_INTENSET      (*(RwReg16*)0x41000018U) /**< \brief (USB) HOST Host Interrupt Enable Set */
+#define REG_USB_HOST_INTFLAG       (*(RwReg16*)0x4100001CU) /**< \brief (USB) HOST Host Interrupt Flag */
+#define REG_USB_HOST_PINTSMRY      (*(RoReg16*)0x41000020U) /**< \brief (USB) HOST Pipe Interrupt Summary */
+#define REG_USB_HOST_PIPE_PCFG0    (*(RwReg8 *)0x41000100U) /**< \brief (USB) HOST_PIPE End Point Configuration 0 */
+#define REG_USB_HOST_PIPE_BINTERVAL0 (*(RwReg8 *)0x41000103U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 0 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR0 (*(WoReg8 *)0x41000104U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 0 */
+#define REG_USB_HOST_PIPE_PSTATUSSET0 (*(WoReg8 *)0x41000105U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 0 */
+#define REG_USB_HOST_PIPE_PSTATUS0 (*(RoReg8 *)0x41000106U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 0 */
+#define REG_USB_HOST_PIPE_PINTFLAG0 (*(RwReg8 *)0x41000107U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 0 */
+#define REG_USB_HOST_PIPE_PINTENCLR0 (*(RwReg8 *)0x41000108U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 0 */
+#define REG_USB_HOST_PIPE_PINTENSET0 (*(RwReg8 *)0x41000109U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 0 */
+#define REG_USB_HOST_PIPE_PCFG1    (*(RwReg8 *)0x41000120U) /**< \brief (USB) HOST_PIPE End Point Configuration 1 */
+#define REG_USB_HOST_PIPE_BINTERVAL1 (*(RwReg8 *)0x41000123U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 1 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR1 (*(WoReg8 *)0x41000124U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 1 */
+#define REG_USB_HOST_PIPE_PSTATUSSET1 (*(WoReg8 *)0x41000125U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 1 */
+#define REG_USB_HOST_PIPE_PSTATUS1 (*(RoReg8 *)0x41000126U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 1 */
+#define REG_USB_HOST_PIPE_PINTFLAG1 (*(RwReg8 *)0x41000127U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 1 */
+#define REG_USB_HOST_PIPE_PINTENCLR1 (*(RwReg8 *)0x41000128U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 1 */
+#define REG_USB_HOST_PIPE_PINTENSET1 (*(RwReg8 *)0x41000129U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 1 */
+#define REG_USB_HOST_PIPE_PCFG2    (*(RwReg8 *)0x41000140U) /**< \brief (USB) HOST_PIPE End Point Configuration 2 */
+#define REG_USB_HOST_PIPE_BINTERVAL2 (*(RwReg8 *)0x41000143U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 2 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR2 (*(WoReg8 *)0x41000144U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 2 */
+#define REG_USB_HOST_PIPE_PSTATUSSET2 (*(WoReg8 *)0x41000145U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 2 */
+#define REG_USB_HOST_PIPE_PSTATUS2 (*(RoReg8 *)0x41000146U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 2 */
+#define REG_USB_HOST_PIPE_PINTFLAG2 (*(RwReg8 *)0x41000147U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 2 */
+#define REG_USB_HOST_PIPE_PINTENCLR2 (*(RwReg8 *)0x41000148U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 2 */
+#define REG_USB_HOST_PIPE_PINTENSET2 (*(RwReg8 *)0x41000149U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 2 */
+#define REG_USB_HOST_PIPE_PCFG3    (*(RwReg8 *)0x41000160U) /**< \brief (USB) HOST_PIPE End Point Configuration 3 */
+#define REG_USB_HOST_PIPE_BINTERVAL3 (*(RwReg8 *)0x41000163U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 3 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR3 (*(WoReg8 *)0x41000164U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 3 */
+#define REG_USB_HOST_PIPE_PSTATUSSET3 (*(WoReg8 *)0x41000165U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 3 */
+#define REG_USB_HOST_PIPE_PSTATUS3 (*(RoReg8 *)0x41000166U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 3 */
+#define REG_USB_HOST_PIPE_PINTFLAG3 (*(RwReg8 *)0x41000167U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 3 */
+#define REG_USB_HOST_PIPE_PINTENCLR3 (*(RwReg8 *)0x41000168U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 3 */
+#define REG_USB_HOST_PIPE_PINTENSET3 (*(RwReg8 *)0x41000169U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 3 */
+#define REG_USB_HOST_PIPE_PCFG4    (*(RwReg8 *)0x41000180U) /**< \brief (USB) HOST_PIPE End Point Configuration 4 */
+#define REG_USB_HOST_PIPE_BINTERVAL4 (*(RwReg8 *)0x41000183U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 4 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR4 (*(WoReg8 *)0x41000184U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 4 */
+#define REG_USB_HOST_PIPE_PSTATUSSET4 (*(WoReg8 *)0x41000185U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 4 */
+#define REG_USB_HOST_PIPE_PSTATUS4 (*(RoReg8 *)0x41000186U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 4 */
+#define REG_USB_HOST_PIPE_PINTFLAG4 (*(RwReg8 *)0x41000187U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 4 */
+#define REG_USB_HOST_PIPE_PINTENCLR4 (*(RwReg8 *)0x41000188U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 4 */
+#define REG_USB_HOST_PIPE_PINTENSET4 (*(RwReg8 *)0x41000189U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 4 */
+#define REG_USB_HOST_PIPE_PCFG5    (*(RwReg8 *)0x410001A0U) /**< \brief (USB) HOST_PIPE End Point Configuration 5 */
+#define REG_USB_HOST_PIPE_BINTERVAL5 (*(RwReg8 *)0x410001A3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 5 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR5 (*(WoReg8 *)0x410001A4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 5 */
+#define REG_USB_HOST_PIPE_PSTATUSSET5 (*(WoReg8 *)0x410001A5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 5 */
+#define REG_USB_HOST_PIPE_PSTATUS5 (*(RoReg8 *)0x410001A6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 5 */
+#define REG_USB_HOST_PIPE_PINTFLAG5 (*(RwReg8 *)0x410001A7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 5 */
+#define REG_USB_HOST_PIPE_PINTENCLR5 (*(RwReg8 *)0x410001A8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 5 */
+#define REG_USB_HOST_PIPE_PINTENSET5 (*(RwReg8 *)0x410001A9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 5 */
+#define REG_USB_HOST_PIPE_PCFG6    (*(RwReg8 *)0x410001C0U) /**< \brief (USB) HOST_PIPE End Point Configuration 6 */
+#define REG_USB_HOST_PIPE_BINTERVAL6 (*(RwReg8 *)0x410001C3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 6 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR6 (*(WoReg8 *)0x410001C4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 6 */
+#define REG_USB_HOST_PIPE_PSTATUSSET6 (*(WoReg8 *)0x410001C5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 6 */
+#define REG_USB_HOST_PIPE_PSTATUS6 (*(RoReg8 *)0x410001C6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 6 */
+#define REG_USB_HOST_PIPE_PINTFLAG6 (*(RwReg8 *)0x410001C7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 6 */
+#define REG_USB_HOST_PIPE_PINTENCLR6 (*(RwReg8 *)0x410001C8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 6 */
+#define REG_USB_HOST_PIPE_PINTENSET6 (*(RwReg8 *)0x410001C9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 6 */
+#define REG_USB_HOST_PIPE_PCFG7    (*(RwReg8 *)0x410001E0U) /**< \brief (USB) HOST_PIPE End Point Configuration 7 */
+#define REG_USB_HOST_PIPE_BINTERVAL7 (*(RwReg8 *)0x410001E3U) /**< \brief (USB) HOST_PIPE Bus Access Period of Pipe 7 */
+#define REG_USB_HOST_PIPE_PSTATUSCLR7 (*(WoReg8 *)0x410001E4U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Clear 7 */
+#define REG_USB_HOST_PIPE_PSTATUSSET7 (*(WoReg8 *)0x410001E5U) /**< \brief (USB) HOST_PIPE End Point Pipe Status Set 7 */
+#define REG_USB_HOST_PIPE_PSTATUS7 (*(RoReg8 *)0x410001E6U) /**< \brief (USB) HOST_PIPE End Point Pipe Status 7 */
+#define REG_USB_HOST_PIPE_PINTFLAG7 (*(RwReg8 *)0x410001E7U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag 7 */
+#define REG_USB_HOST_PIPE_PINTENCLR7 (*(RwReg8 *)0x410001E8U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Clear 7 */
+#define REG_USB_HOST_PIPE_PINTENSET7 (*(RwReg8 *)0x410001E9U) /**< \brief (USB) HOST_PIPE Pipe Interrupt Flag Set 7 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for USB peripheral ========== */
+#define USB_EPT_NBR                 8        // Number of USB end points (obsolete)
+#define USB_EPT_NUM                 8        // Number of USB end points
+#define USB_GCLK_ID                 4        // Index of Generic Clock
+#define USB_PIPE_NUM                8        // Number of USB pipes
+
+#endif /* _SAML21_USB_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/instance/wdt.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/instance/wdt.h
@@ -1,0 +1,69 @@
+/**
+ * \file
+ *
+ * \brief Instance description for WDT
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_WDT_INSTANCE_
+#define _SAML21_WDT_INSTANCE_
+
+/* ========== Register definition for WDT peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_WDT_CTRLA              (0x40001C00U) /**< \brief (WDT) Control */
+#define REG_WDT_CONFIG             (0x40001C01U) /**< \brief (WDT) Configuration */
+#define REG_WDT_EWCTRL             (0x40001C02U) /**< \brief (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR           (0x40001C04U) /**< \brief (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET           (0x40001C05U) /**< \brief (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG            (0x40001C06U) /**< \brief (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_SYNCBUSY           (0x40001C08U) /**< \brief (WDT) Synchronization Busy */
+#define REG_WDT_CLEAR              (0x40001C0CU) /**< \brief (WDT) Clear */
+#else
+#define REG_WDT_CTRLA              (*(RwReg8 *)0x40001C00U) /**< \brief (WDT) Control */
+#define REG_WDT_CONFIG             (*(RwReg8 *)0x40001C01U) /**< \brief (WDT) Configuration */
+#define REG_WDT_EWCTRL             (*(RwReg8 *)0x40001C02U) /**< \brief (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR           (*(RwReg8 *)0x40001C04U) /**< \brief (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET           (*(RwReg8 *)0x40001C05U) /**< \brief (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG            (*(RwReg8 *)0x40001C06U) /**< \brief (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_SYNCBUSY           (*(RoReg  *)0x40001C08U) /**< \brief (WDT) Synchronization Busy */
+#define REG_WDT_CLEAR              (*(WoReg8 *)0x40001C0CU) /**< \brief (WDT) Clear */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAML21_WDT_INSTANCE_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/pio/saml21e18a.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/pio/saml21e18a.h
@@ -1,0 +1,778 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML21E18A
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21E18A_PIO_
+#define _SAML21E18A_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00                 (1ul <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01                 (1ul <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02                 (1ul <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03                 (1ul <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04                 (1ul <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05                 (1ul <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22                 (1ul << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23                 (1ul << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for RSTC peripheral ========== */
+#define PIN_PA00A_RSTC_EXTWAKE0            0L  /**< \brief RSTC signal: EXTWAKE0 on PA00 mux A */
+#define MUX_PA00A_RSTC_EXTWAKE0            0L
+#define PINMUX_PA00A_RSTC_EXTWAKE0  ((PIN_PA00A_RSTC_EXTWAKE0 << 16) | MUX_PA00A_RSTC_EXTWAKE0)
+#define PORT_PA00A_RSTC_EXTWAKE0   (1ul <<  0)
+#define PIN_PA01A_RSTC_EXTWAKE1            1L  /**< \brief RSTC signal: EXTWAKE1 on PA01 mux A */
+#define MUX_PA01A_RSTC_EXTWAKE1            0L
+#define PINMUX_PA01A_RSTC_EXTWAKE1  ((PIN_PA01A_RSTC_EXTWAKE1 << 16) | MUX_PA01A_RSTC_EXTWAKE1)
+#define PORT_PA01A_RSTC_EXTWAKE1   (1ul <<  1)
+#define PIN_PA02A_RSTC_EXTWAKE2            2L  /**< \brief RSTC signal: EXTWAKE2 on PA02 mux A */
+#define MUX_PA02A_RSTC_EXTWAKE2            0L
+#define PINMUX_PA02A_RSTC_EXTWAKE2  ((PIN_PA02A_RSTC_EXTWAKE2 << 16) | MUX_PA02A_RSTC_EXTWAKE2)
+#define PORT_PA02A_RSTC_EXTWAKE2   (1ul <<  2)
+#define PIN_PA03A_RSTC_EXTWAKE3            3L  /**< \brief RSTC signal: EXTWAKE3 on PA03 mux A */
+#define MUX_PA03A_RSTC_EXTWAKE3            0L
+#define PINMUX_PA03A_RSTC_EXTWAKE3  ((PIN_PA03A_RSTC_EXTWAKE3 << 16) | MUX_PA03A_RSTC_EXTWAKE3)
+#define PORT_PA03A_RSTC_EXTWAKE3   (1ul <<  3)
+#define PIN_PA04A_RSTC_EXTWAKE4            4L  /**< \brief RSTC signal: EXTWAKE4 on PA04 mux A */
+#define MUX_PA04A_RSTC_EXTWAKE4            0L
+#define PINMUX_PA04A_RSTC_EXTWAKE4  ((PIN_PA04A_RSTC_EXTWAKE4 << 16) | MUX_PA04A_RSTC_EXTWAKE4)
+#define PORT_PA04A_RSTC_EXTWAKE4   (1ul <<  4)
+#define PIN_PA05A_RSTC_EXTWAKE5            5L  /**< \brief RSTC signal: EXTWAKE5 on PA05 mux A */
+#define MUX_PA05A_RSTC_EXTWAKE5            0L
+#define PINMUX_PA05A_RSTC_EXTWAKE5  ((PIN_PA05A_RSTC_EXTWAKE5 << 16) | MUX_PA05A_RSTC_EXTWAKE5)
+#define PORT_PA05A_RSTC_EXTWAKE5   (1ul <<  5)
+#define PIN_PA06A_RSTC_EXTWAKE6            6L  /**< \brief RSTC signal: EXTWAKE6 on PA06 mux A */
+#define MUX_PA06A_RSTC_EXTWAKE6            0L
+#define PINMUX_PA06A_RSTC_EXTWAKE6  ((PIN_PA06A_RSTC_EXTWAKE6 << 16) | MUX_PA06A_RSTC_EXTWAKE6)
+#define PORT_PA06A_RSTC_EXTWAKE6   (1ul <<  6)
+#define PIN_PA07A_RSTC_EXTWAKE7            7L  /**< \brief RSTC signal: EXTWAKE7 on PA07 mux A */
+#define MUX_PA07A_RSTC_EXTWAKE7            0L
+#define PINMUX_PA07A_RSTC_EXTWAKE7  ((PIN_PA07A_RSTC_EXTWAKE7 << 16) | MUX_PA07A_RSTC_EXTWAKE7)
+#define PORT_PA07A_RSTC_EXTWAKE7   (1ul <<  7)
+#define PIN_PA08A_RSTC_EXTWAKE8            8L  /**< \brief RSTC signal: EXTWAKE8 on PA08 mux A */
+#define MUX_PA08A_RSTC_EXTWAKE8            0L
+#define PINMUX_PA08A_RSTC_EXTWAKE8  ((PIN_PA08A_RSTC_EXTWAKE8 << 16) | MUX_PA08A_RSTC_EXTWAKE8)
+#define PORT_PA08A_RSTC_EXTWAKE8   (1ul <<  8)
+#define PIN_PA09A_RSTC_EXTWAKE9            9L  /**< \brief RSTC signal: EXTWAKE9 on PA09 mux A */
+#define MUX_PA09A_RSTC_EXTWAKE9            0L
+#define PINMUX_PA09A_RSTC_EXTWAKE9  ((PIN_PA09A_RSTC_EXTWAKE9 << 16) | MUX_PA09A_RSTC_EXTWAKE9)
+#define PORT_PA09A_RSTC_EXTWAKE9   (1ul <<  9)
+#define PIN_PA10A_RSTC_EXTWAKE10          10L  /**< \brief RSTC signal: EXTWAKE10 on PA10 mux A */
+#define MUX_PA10A_RSTC_EXTWAKE10           0L
+#define PINMUX_PA10A_RSTC_EXTWAKE10  ((PIN_PA10A_RSTC_EXTWAKE10 << 16) | MUX_PA10A_RSTC_EXTWAKE10)
+#define PORT_PA10A_RSTC_EXTWAKE10  (1ul << 10)
+#define PIN_PA11A_RSTC_EXTWAKE11          11L  /**< \brief RSTC signal: EXTWAKE11 on PA11 mux A */
+#define MUX_PA11A_RSTC_EXTWAKE11           0L
+#define PINMUX_PA11A_RSTC_EXTWAKE11  ((PIN_PA11A_RSTC_EXTWAKE11 << 16) | MUX_PA11A_RSTC_EXTWAKE11)
+#define PORT_PA11A_RSTC_EXTWAKE11  (1ul << 11)
+#define PIN_PA14A_RSTC_EXTWAKE14          14L  /**< \brief RSTC signal: EXTWAKE14 on PA14 mux A */
+#define MUX_PA14A_RSTC_EXTWAKE14           0L
+#define PINMUX_PA14A_RSTC_EXTWAKE14  ((PIN_PA14A_RSTC_EXTWAKE14 << 16) | MUX_PA14A_RSTC_EXTWAKE14)
+#define PORT_PA14A_RSTC_EXTWAKE14  (1ul << 14)
+#define PIN_PA15A_RSTC_EXTWAKE15          15L  /**< \brief RSTC signal: EXTWAKE15 on PA15 mux A */
+#define MUX_PA15A_RSTC_EXTWAKE15           0L
+#define PINMUX_PA15A_RSTC_EXTWAKE15  ((PIN_PA15A_RSTC_EXTWAKE15 << 16) | MUX_PA15A_RSTC_EXTWAKE15)
+#define PORT_PA15A_RSTC_EXTWAKE15  (1ul << 15)
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0                 7L
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0        (1ul << 14)
+#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0                 7L
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0        (1ul << 27)
+#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0                 7L
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0        (1ul << 30)
+#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1                 7L
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1        (1ul << 15)
+#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2                 7L
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2        (1ul << 16)
+#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3                 7L
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3        (1ul << 17)
+#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4                 7L
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4        (1ul << 10)
+#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5                 7L
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5        (1ul << 11)
+#define PIN_PA22H_GCLK_IO6                22L  /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6                 7L
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6        (1ul << 22)
+#define PIN_PA23H_GCLK_IO7                23L  /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7                 7L
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7        (1ul << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0              0L
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
+#define PIN_PA00A_EIC_EXTINT0              0L  /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0              0L
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0     (1ul <<  0)
+#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1              0L
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
+#define PIN_PA01A_EIC_EXTINT1              1L  /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1              0L
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1     (1ul <<  1)
+#define PIN_PA02A_EIC_EXTINT2              2L  /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2              0L
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2     (1ul <<  2)
+#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2              0L
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
+#define PIN_PA03A_EIC_EXTINT3              3L  /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3              0L
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3     (1ul <<  3)
+#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3              0L
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
+#define PIN_PA04A_EIC_EXTINT4              4L  /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4              0L
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4     (1ul <<  4)
+#define PIN_PA05A_EIC_EXTINT5              5L  /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5              0L
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5     (1ul <<  5)
+#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6              0L
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
+#define PIN_PA22A_EIC_EXTINT6             22L  /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6              0L
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6     (1ul << 22)
+#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7              0L
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
+#define PIN_PA23A_EIC_EXTINT7             23L  /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7              0L
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7     (1ul << 23)
+#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9              0L
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
+#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10             0L
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
+#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10             0L
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
+#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11             0L
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
+#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11             0L
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
+#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12             0L
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
+#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13             0L
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
+#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14             0L
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
+#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15             0L
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
+#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15             0L
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
+#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI                  0L
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+/* ========== PORT definition for TAL peripheral ========== */
+#define PIN_PA27G_TAL_BRK                 27L  /**< \brief TAL signal: BRK on PA27 mux G */
+#define MUX_PA27G_TAL_BRK                  6L
+#define PINMUX_PA27G_TAL_BRK       ((PIN_PA27G_TAL_BRK << 16) | MUX_PA27G_TAL_BRK)
+#define PORT_PA27G_TAL_BRK         (1ul << 27)
+/* ========== PORT definition for USB peripheral ========== */
+#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                   6L
+#define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
+#define PORT_PA24G_USB_DM          (1ul << 24)
+#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                   6L
+#define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
+#define PORT_PA25G_USB_DP          (1ul << 25)
+#define PIN_PA23G_USB_SOF_1KHZ            23L  /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
+#define MUX_PA23G_USB_SOF_1KHZ             6L
+#define PINMUX_PA23G_USB_SOF_1KHZ  ((PIN_PA23G_USB_SOF_1KHZ << 16) | MUX_PA23G_USB_SOF_1KHZ)
+#define PORT_PA23G_USB_SOF_1KHZ    (1ul << 23)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0             4L  /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0             3L
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0    (1ul <<  4)
+#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
+#define PIN_PA05D_SERCOM0_PAD1             5L  /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1             3L
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1    (1ul <<  5)
+#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
+#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
+#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
+#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
+#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
+#define PIN_PA00D_SERCOM1_PAD0             0L  /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0             3L
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0    (1ul <<  0)
+#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
+#define PIN_PA01D_SERCOM1_PAD1             1L  /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1             3L
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1    (1ul <<  1)
+#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
+#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
+#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
+#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
+#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
+#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
+#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
+#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
+#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
+#define PIN_PA22C_SERCOM3_PAD0            22L  /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0             2L
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0    (1ul << 22)
+#define PIN_PA27F_SERCOM3_PAD0            27L  /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
+#define MUX_PA27F_SERCOM3_PAD0             5L
+#define PINMUX_PA27F_SERCOM3_PAD0  ((PIN_PA27F_SERCOM3_PAD0 << 16) | MUX_PA27F_SERCOM3_PAD0)
+#define PORT_PA27F_SERCOM3_PAD0    (1ul << 27)
+#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
+#define PIN_PA23C_SERCOM3_PAD1            23L  /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1             2L
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1    (1ul << 23)
+#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
+#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
+#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
+#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+/* ========== PORT definition for TCC0 peripheral ========== */
+#define PIN_PA04E_TCC0_WO0                 4L  /**< \brief TCC0 signal: WO0 on PA04 mux E */
+#define MUX_PA04E_TCC0_WO0                 4L
+#define PINMUX_PA04E_TCC0_WO0      ((PIN_PA04E_TCC0_WO0 << 16) | MUX_PA04E_TCC0_WO0)
+#define PORT_PA04E_TCC0_WO0        (1ul <<  4)
+#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0                 4L
+#define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
+#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
+#define PIN_PA16F_TCC0_WO0                16L  /**< \brief TCC0 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO0                 5L
+#define PINMUX_PA16F_TCC0_WO0      ((PIN_PA16F_TCC0_WO0 << 16) | MUX_PA16F_TCC0_WO0)
+#define PORT_PA16F_TCC0_WO0        (1ul << 16)
+#define PIN_PA05E_TCC0_WO1                 5L  /**< \brief TCC0 signal: WO1 on PA05 mux E */
+#define MUX_PA05E_TCC0_WO1                 4L
+#define PINMUX_PA05E_TCC0_WO1      ((PIN_PA05E_TCC0_WO1 << 16) | MUX_PA05E_TCC0_WO1)
+#define PORT_PA05E_TCC0_WO1        (1ul <<  5)
+#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1                 4L
+#define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
+#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
+#define PIN_PA17F_TCC0_WO1                17L  /**< \brief TCC0 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO1                 5L
+#define PINMUX_PA17F_TCC0_WO1      ((PIN_PA17F_TCC0_WO1 << 16) | MUX_PA17F_TCC0_WO1)
+#define PORT_PA17F_TCC0_WO1        (1ul << 17)
+#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2                 5L
+#define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
+#define PORT_PA10F_TCC0_WO2        (1ul << 10)
+#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2                 5L
+#define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
+#define PORT_PA18F_TCC0_WO2        (1ul << 18)
+#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3                 5L
+#define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
+#define PORT_PA11F_TCC0_WO3        (1ul << 11)
+#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3                 5L
+#define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
+#define PORT_PA19F_TCC0_WO3        (1ul << 19)
+#define PIN_PA22F_TCC0_WO4                22L  /**< \brief TCC0 signal: WO4 on PA22 mux F */
+#define MUX_PA22F_TCC0_WO4                 5L
+#define PINMUX_PA22F_TCC0_WO4      ((PIN_PA22F_TCC0_WO4 << 16) | MUX_PA22F_TCC0_WO4)
+#define PORT_PA22F_TCC0_WO4        (1ul << 22)
+#define PIN_PA14F_TCC0_WO4                14L  /**< \brief TCC0 signal: WO4 on PA14 mux F */
+#define MUX_PA14F_TCC0_WO4                 5L
+#define PINMUX_PA14F_TCC0_WO4      ((PIN_PA14F_TCC0_WO4 << 16) | MUX_PA14F_TCC0_WO4)
+#define PORT_PA14F_TCC0_WO4        (1ul << 14)
+#define PIN_PA15F_TCC0_WO5                15L  /**< \brief TCC0 signal: WO5 on PA15 mux F */
+#define MUX_PA15F_TCC0_WO5                 5L
+#define PINMUX_PA15F_TCC0_WO5      ((PIN_PA15F_TCC0_WO5 << 16) | MUX_PA15F_TCC0_WO5)
+#define PORT_PA15F_TCC0_WO5        (1ul << 15)
+#define PIN_PA23F_TCC0_WO5                23L  /**< \brief TCC0 signal: WO5 on PA23 mux F */
+#define MUX_PA23F_TCC0_WO5                 5L
+#define PINMUX_PA23F_TCC0_WO5      ((PIN_PA23F_TCC0_WO5 << 16) | MUX_PA23F_TCC0_WO5)
+#define PORT_PA23F_TCC0_WO5        (1ul << 23)
+#define PIN_PA16F_TCC0_WO6                16L  /**< \brief TCC0 signal: WO6 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO6                 5L
+#define PINMUX_PA16F_TCC0_WO6      ((PIN_PA16F_TCC0_WO6 << 16) | MUX_PA16F_TCC0_WO6)
+#define PORT_PA16F_TCC0_WO6        (1ul << 16)
+#define PIN_PA17F_TCC0_WO7                17L  /**< \brief TCC0 signal: WO7 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO7                 5L
+#define PINMUX_PA17F_TCC0_WO7      ((PIN_PA17F_TCC0_WO7 << 16) | MUX_PA17F_TCC0_WO7)
+#define PORT_PA17F_TCC0_WO7        (1ul << 17)
+/* ========== PORT definition for TCC1 peripheral ========== */
+#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0                 4L
+#define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
+#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
+#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0                 4L
+#define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
+#define PORT_PA10E_TCC1_WO0        (1ul << 10)
+#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0                 4L
+#define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
+#define PORT_PA30E_TCC1_WO0        (1ul << 30)
+#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1                 4L
+#define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
+#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
+#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1                 4L
+#define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
+#define PORT_PA11E_TCC1_WO1        (1ul << 11)
+#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1                 4L
+#define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
+#define PORT_PA31E_TCC1_WO1        (1ul << 31)
+#define PIN_PA08F_TCC1_WO2                 8L  /**< \brief TCC1 signal: WO2 on PA08 mux F */
+#define MUX_PA08F_TCC1_WO2                 5L
+#define PINMUX_PA08F_TCC1_WO2      ((PIN_PA08F_TCC1_WO2 << 16) | MUX_PA08F_TCC1_WO2)
+#define PORT_PA08F_TCC1_WO2        (1ul <<  8)
+#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2                 5L
+#define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
+#define PORT_PA24F_TCC1_WO2        (1ul << 24)
+#define PIN_PA09F_TCC1_WO3                 9L  /**< \brief TCC1 signal: WO3 on PA09 mux F */
+#define MUX_PA09F_TCC1_WO3                 5L
+#define PINMUX_PA09F_TCC1_WO3      ((PIN_PA09F_TCC1_WO3 << 16) | MUX_PA09F_TCC1_WO3)
+#define PORT_PA09F_TCC1_WO3        (1ul <<  9)
+#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3                 5L
+#define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
+#define PORT_PA25F_TCC1_WO3        (1ul << 25)
+/* ========== PORT definition for TCC2 peripheral ========== */
+#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0                 4L
+#define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
+#define PORT_PA16E_TCC2_WO0        (1ul << 16)
+#define PIN_PA00E_TCC2_WO0                 0L  /**< \brief TCC2 signal: WO0 on PA00 mux E */
+#define MUX_PA00E_TCC2_WO0                 4L
+#define PINMUX_PA00E_TCC2_WO0      ((PIN_PA00E_TCC2_WO0 << 16) | MUX_PA00E_TCC2_WO0)
+#define PORT_PA00E_TCC2_WO0        (1ul <<  0)
+#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1                 4L
+#define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
+#define PORT_PA17E_TCC2_WO1        (1ul << 17)
+#define PIN_PA01E_TCC2_WO1                 1L  /**< \brief TCC2 signal: WO1 on PA01 mux E */
+#define MUX_PA01E_TCC2_WO1                 4L
+#define PINMUX_PA01E_TCC2_WO1      ((PIN_PA01E_TCC2_WO1 << 16) | MUX_PA01E_TCC2_WO1)
+#define PORT_PA01E_TCC2_WO1        (1ul <<  1)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA22E_TC0_WO0                 22L  /**< \brief TC0 signal: WO0 on PA22 mux E */
+#define MUX_PA22E_TC0_WO0                  4L
+#define PINMUX_PA22E_TC0_WO0       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0         (1ul << 22)
+#define PIN_PA23E_TC0_WO1                 23L  /**< \brief TC0 signal: WO1 on PA23 mux E */
+#define MUX_PA23E_TC0_WO1                  4L
+#define PINMUX_PA23E_TC0_WO1       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1         (1ul << 23)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA24E_TC1_WO0                 24L  /**< \brief TC1 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC1_WO0                  4L
+#define PINMUX_PA24E_TC1_WO0       ((PIN_PA24E_TC1_WO0 << 16) | MUX_PA24E_TC1_WO0)
+#define PORT_PA24E_TC1_WO0         (1ul << 24)
+#define PIN_PA25E_TC1_WO1                 25L  /**< \brief TC1 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC1_WO1                  4L
+#define PINMUX_PA25E_TC1_WO1       ((PIN_PA25E_TC1_WO1 << 16) | MUX_PA25E_TC1_WO1)
+#define PORT_PA25E_TC1_WO1         (1ul << 25)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT0                2L  /**< \brief DAC signal: VOUT0 on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT0                1L
+#define PINMUX_PA02B_DAC_VOUT0     ((PIN_PA02B_DAC_VOUT0 << 16) | MUX_PA02B_DAC_VOUT0)
+#define PORT_PA02B_DAC_VOUT0       (1ul <<  2)
+#define PIN_PA05B_DAC_VOUT1                5L  /**< \brief DAC signal: VOUT1 on PA05 mux B */
+#define MUX_PA05B_DAC_VOUT1                1L
+#define PINMUX_PA05B_DAC_VOUT1     ((PIN_PA05B_DAC_VOUT1 << 16) | MUX_PA05B_DAC_VOUT1)
+#define PORT_PA05B_DAC_VOUT1       (1ul <<  5)
+#define PIN_PA03B_DAC_VREFP                3L  /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP                1L
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP       (1ul <<  3)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA18E_TC4_WO0                 18L  /**< \brief TC4 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC4_WO0                  4L
+#define PINMUX_PA18E_TC4_WO0       ((PIN_PA18E_TC4_WO0 << 16) | MUX_PA18E_TC4_WO0)
+#define PORT_PA18E_TC4_WO0         (1ul << 18)
+#define PIN_PA14E_TC4_WO0                 14L  /**< \brief TC4 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC4_WO0                  4L
+#define PINMUX_PA14E_TC4_WO0       ((PIN_PA14E_TC4_WO0 << 16) | MUX_PA14E_TC4_WO0)
+#define PORT_PA14E_TC4_WO0         (1ul << 14)
+#define PIN_PA19E_TC4_WO1                 19L  /**< \brief TC4 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC4_WO1                  4L
+#define PINMUX_PA19E_TC4_WO1       ((PIN_PA19E_TC4_WO1 << 16) | MUX_PA19E_TC4_WO1)
+#define PORT_PA19E_TC4_WO1         (1ul << 19)
+#define PIN_PA15E_TC4_WO1                 15L  /**< \brief TC4 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC4_WO1                  4L
+#define PINMUX_PA15E_TC4_WO1       ((PIN_PA15E_TC4_WO1 << 16) | MUX_PA15E_TC4_WO1)
+#define PORT_PA15E_TC4_WO1         (1ul << 15)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                 2L  /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0                 1L
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0        (1ul <<  2)
+#define PIN_PA03B_ADC_AIN1                 3L  /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1                 1L
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1        (1ul <<  3)
+#define PIN_PA04B_ADC_AIN4                 4L  /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4                 1L
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4        (1ul <<  4)
+#define PIN_PA05B_ADC_AIN5                 5L  /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5                 1L
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5        (1ul <<  5)
+#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6                 1L
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
+#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7                 1L
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
+#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16                1L
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
+#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17                1L
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
+#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18                1L
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18       (1ul << 10)
+#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19                1L
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19       (1ul << 11)
+#define PIN_PA04B_ADC_VREFP                4L  /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP                1L
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP       (1ul <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                  4L  /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0                  1L
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0         (1ul <<  4)
+#define PIN_PA05B_AC_AIN1                  5L  /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1                  1L
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1         (1ul <<  5)
+#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2                  1L
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2         (1ul <<  6)
+#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3                  1L
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3         (1ul <<  7)
+#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0                  7L
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0         (1ul << 18)
+#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1                  7L
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1         (1ul << 19)
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0             2L  /**< \brief OPAMP signal: OANEG0 on PA02 mux B */
+#define MUX_PA02B_OPAMP_OANEG0             1L
+#define PINMUX_PA02B_OPAMP_OANEG0  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0    (1ul <<  2)
+#define PIN_PA07B_OPAMP_OAOUT0             7L  /**< \brief OPAMP signal: OAOUT0 on PA07 mux B */
+#define MUX_PA07B_OPAMP_OAOUT0             1L
+#define PINMUX_PA07B_OPAMP_OAOUT0  ((PIN_PA07B_OPAMP_OAOUT0 << 16) | MUX_PA07B_OPAMP_OAOUT0)
+#define PORT_PA07B_OPAMP_OAOUT0    (1ul <<  7)
+#define PIN_PA04B_OPAMP_OAOUT2             4L  /**< \brief OPAMP signal: OAOUT2 on PA04 mux B */
+#define MUX_PA04B_OPAMP_OAOUT2             1L
+#define PINMUX_PA04B_OPAMP_OAOUT2  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2    (1ul <<  4)
+#define PIN_PA06B_OPAMP_OAPOS0             6L  /**< \brief OPAMP signal: OAPOS0 on PA06 mux B */
+#define MUX_PA06B_OPAMP_OAPOS0             1L
+#define PINMUX_PA06B_OPAMP_OAPOS0  ((PIN_PA06B_OPAMP_OAPOS0 << 16) | MUX_PA06B_OPAMP_OAPOS0)
+#define PORT_PA06B_OPAMP_OAPOS0    (1ul <<  6)
+#define PIN_PA05B_OPAMP_OAPOS2             5L  /**< \brief OPAMP signal: OAPOS2 on PA05 mux B */
+#define MUX_PA05B_OPAMP_OAPOS2             1L
+#define PINMUX_PA05B_OPAMP_OAPOS2  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2    (1ul <<  5)
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                  4L  /**< \brief CCL signal: IN0 on PA04 mux I */
+#define MUX_PA04I_CCL_IN0                  8L
+#define PINMUX_PA04I_CCL_IN0       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0         (1ul <<  4)
+#define PIN_PA16I_CCL_IN0                 16L  /**< \brief CCL signal: IN0 on PA16 mux I */
+#define MUX_PA16I_CCL_IN0                  8L
+#define PINMUX_PA16I_CCL_IN0       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0         (1ul << 16)
+#define PIN_PA05I_CCL_IN1                  5L  /**< \brief CCL signal: IN1 on PA05 mux I */
+#define MUX_PA05I_CCL_IN1                  8L
+#define PINMUX_PA05I_CCL_IN1       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1         (1ul <<  5)
+#define PIN_PA17I_CCL_IN1                 17L  /**< \brief CCL signal: IN1 on PA17 mux I */
+#define MUX_PA17I_CCL_IN1                  8L
+#define PINMUX_PA17I_CCL_IN1       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1         (1ul << 17)
+#define PIN_PA06I_CCL_IN2                  6L  /**< \brief CCL signal: IN2 on PA06 mux I */
+#define MUX_PA06I_CCL_IN2                  8L
+#define PINMUX_PA06I_CCL_IN2       ((PIN_PA06I_CCL_IN2 << 16) | MUX_PA06I_CCL_IN2)
+#define PORT_PA06I_CCL_IN2         (1ul <<  6)
+#define PIN_PA18I_CCL_IN2                 18L  /**< \brief CCL signal: IN2 on PA18 mux I */
+#define MUX_PA18I_CCL_IN2                  8L
+#define PINMUX_PA18I_CCL_IN2       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2         (1ul << 18)
+#define PIN_PA08I_CCL_IN3                  8L  /**< \brief CCL signal: IN3 on PA08 mux I */
+#define MUX_PA08I_CCL_IN3                  8L
+#define PINMUX_PA08I_CCL_IN3       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3         (1ul <<  8)
+#define PIN_PA30I_CCL_IN3                 30L  /**< \brief CCL signal: IN3 on PA30 mux I */
+#define MUX_PA30I_CCL_IN3                  8L
+#define PINMUX_PA30I_CCL_IN3       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3         (1ul << 30)
+#define PIN_PA09I_CCL_IN4                  9L  /**< \brief CCL signal: IN4 on PA09 mux I */
+#define MUX_PA09I_CCL_IN4                  8L
+#define PINMUX_PA09I_CCL_IN4       ((PIN_PA09I_CCL_IN4 << 16) | MUX_PA09I_CCL_IN4)
+#define PORT_PA09I_CCL_IN4         (1ul <<  9)
+#define PIN_PA10I_CCL_IN5                 10L  /**< \brief CCL signal: IN5 on PA10 mux I */
+#define MUX_PA10I_CCL_IN5                  8L
+#define PINMUX_PA10I_CCL_IN5       ((PIN_PA10I_CCL_IN5 << 16) | MUX_PA10I_CCL_IN5)
+#define PORT_PA10I_CCL_IN5         (1ul << 10)
+#define PIN_PA22I_CCL_IN6                 22L  /**< \brief CCL signal: IN6 on PA22 mux I */
+#define MUX_PA22I_CCL_IN6                  8L
+#define PINMUX_PA22I_CCL_IN6       ((PIN_PA22I_CCL_IN6 << 16) | MUX_PA22I_CCL_IN6)
+#define PORT_PA22I_CCL_IN6         (1ul << 22)
+#define PIN_PA23I_CCL_IN7                 23L  /**< \brief CCL signal: IN7 on PA23 mux I */
+#define MUX_PA23I_CCL_IN7                  8L
+#define PINMUX_PA23I_CCL_IN7       ((PIN_PA23I_CCL_IN7 << 16) | MUX_PA23I_CCL_IN7)
+#define PORT_PA23I_CCL_IN7         (1ul << 23)
+#define PIN_PA24I_CCL_IN8                 24L  /**< \brief CCL signal: IN8 on PA24 mux I */
+#define MUX_PA24I_CCL_IN8                  8L
+#define PINMUX_PA24I_CCL_IN8       ((PIN_PA24I_CCL_IN8 << 16) | MUX_PA24I_CCL_IN8)
+#define PORT_PA24I_CCL_IN8         (1ul << 24)
+#define PIN_PA07I_CCL_OUT0                 7L  /**< \brief CCL signal: OUT0 on PA07 mux I */
+#define MUX_PA07I_CCL_OUT0                 8L
+#define PINMUX_PA07I_CCL_OUT0      ((PIN_PA07I_CCL_OUT0 << 16) | MUX_PA07I_CCL_OUT0)
+#define PORT_PA07I_CCL_OUT0        (1ul <<  7)
+#define PIN_PA19I_CCL_OUT0                19L  /**< \brief CCL signal: OUT0 on PA19 mux I */
+#define MUX_PA19I_CCL_OUT0                 8L
+#define PINMUX_PA19I_CCL_OUT0      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0        (1ul << 19)
+#define PIN_PA11I_CCL_OUT1                11L  /**< \brief CCL signal: OUT1 on PA11 mux I */
+#define MUX_PA11I_CCL_OUT1                 8L
+#define PINMUX_PA11I_CCL_OUT1      ((PIN_PA11I_CCL_OUT1 << 16) | MUX_PA11I_CCL_OUT1)
+#define PORT_PA11I_CCL_OUT1        (1ul << 11)
+#define PIN_PA31I_CCL_OUT1                31L  /**< \brief CCL signal: OUT1 on PA31 mux I */
+#define MUX_PA31I_CCL_OUT1                 8L
+#define PINMUX_PA31I_CCL_OUT1      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1        (1ul << 31)
+#define PIN_PA25I_CCL_OUT2                25L  /**< \brief CCL signal: OUT2 on PA25 mux I */
+#define MUX_PA25I_CCL_OUT2                 8L
+#define PINMUX_PA25I_CCL_OUT2      ((PIN_PA25I_CCL_OUT2 << 16) | MUX_PA25I_CCL_OUT2)
+#define PORT_PA25I_CCL_OUT2        (1ul << 25)
+
+#endif /* _SAML21E18A_PIO_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/pio/saml21g18a.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/pio/saml21g18a.h
@@ -1,0 +1,1089 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML21G18A
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21G18A_PIO_
+#define _SAML21G18A_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00                 (1ul <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01                 (1ul <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02                 (1ul <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03                 (1ul <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04                 (1ul <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05                 (1ul <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12                 (1ul << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13                 (1ul << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20                 (1ul << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21                 (1ul << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22                 (1ul << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23                 (1ul << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02                 (1ul <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03                 (1ul <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08                 (1ul <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09                 (1ul <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10                 (1ul << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11                 (1ul << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB22                          54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22                 (1ul << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                          55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23                 (1ul << 23) /**< \brief PORT Mask  for PB23 */
+/* ========== PORT definition for RSTC peripheral ========== */
+#define PIN_PA00A_RSTC_EXTWAKE0            0L  /**< \brief RSTC signal: EXTWAKE0 on PA00 mux A */
+#define MUX_PA00A_RSTC_EXTWAKE0            0L
+#define PINMUX_PA00A_RSTC_EXTWAKE0  ((PIN_PA00A_RSTC_EXTWAKE0 << 16) | MUX_PA00A_RSTC_EXTWAKE0)
+#define PORT_PA00A_RSTC_EXTWAKE0   (1ul <<  0)
+#define PIN_PA01A_RSTC_EXTWAKE1            1L  /**< \brief RSTC signal: EXTWAKE1 on PA01 mux A */
+#define MUX_PA01A_RSTC_EXTWAKE1            0L
+#define PINMUX_PA01A_RSTC_EXTWAKE1  ((PIN_PA01A_RSTC_EXTWAKE1 << 16) | MUX_PA01A_RSTC_EXTWAKE1)
+#define PORT_PA01A_RSTC_EXTWAKE1   (1ul <<  1)
+#define PIN_PA02A_RSTC_EXTWAKE2            2L  /**< \brief RSTC signal: EXTWAKE2 on PA02 mux A */
+#define MUX_PA02A_RSTC_EXTWAKE2            0L
+#define PINMUX_PA02A_RSTC_EXTWAKE2  ((PIN_PA02A_RSTC_EXTWAKE2 << 16) | MUX_PA02A_RSTC_EXTWAKE2)
+#define PORT_PA02A_RSTC_EXTWAKE2   (1ul <<  2)
+#define PIN_PA03A_RSTC_EXTWAKE3            3L  /**< \brief RSTC signal: EXTWAKE3 on PA03 mux A */
+#define MUX_PA03A_RSTC_EXTWAKE3            0L
+#define PINMUX_PA03A_RSTC_EXTWAKE3  ((PIN_PA03A_RSTC_EXTWAKE3 << 16) | MUX_PA03A_RSTC_EXTWAKE3)
+#define PORT_PA03A_RSTC_EXTWAKE3   (1ul <<  3)
+#define PIN_PA04A_RSTC_EXTWAKE4            4L  /**< \brief RSTC signal: EXTWAKE4 on PA04 mux A */
+#define MUX_PA04A_RSTC_EXTWAKE4            0L
+#define PINMUX_PA04A_RSTC_EXTWAKE4  ((PIN_PA04A_RSTC_EXTWAKE4 << 16) | MUX_PA04A_RSTC_EXTWAKE4)
+#define PORT_PA04A_RSTC_EXTWAKE4   (1ul <<  4)
+#define PIN_PA05A_RSTC_EXTWAKE5            5L  /**< \brief RSTC signal: EXTWAKE5 on PA05 mux A */
+#define MUX_PA05A_RSTC_EXTWAKE5            0L
+#define PINMUX_PA05A_RSTC_EXTWAKE5  ((PIN_PA05A_RSTC_EXTWAKE5 << 16) | MUX_PA05A_RSTC_EXTWAKE5)
+#define PORT_PA05A_RSTC_EXTWAKE5   (1ul <<  5)
+#define PIN_PA06A_RSTC_EXTWAKE6            6L  /**< \brief RSTC signal: EXTWAKE6 on PA06 mux A */
+#define MUX_PA06A_RSTC_EXTWAKE6            0L
+#define PINMUX_PA06A_RSTC_EXTWAKE6  ((PIN_PA06A_RSTC_EXTWAKE6 << 16) | MUX_PA06A_RSTC_EXTWAKE6)
+#define PORT_PA06A_RSTC_EXTWAKE6   (1ul <<  6)
+#define PIN_PA07A_RSTC_EXTWAKE7            7L  /**< \brief RSTC signal: EXTWAKE7 on PA07 mux A */
+#define MUX_PA07A_RSTC_EXTWAKE7            0L
+#define PINMUX_PA07A_RSTC_EXTWAKE7  ((PIN_PA07A_RSTC_EXTWAKE7 << 16) | MUX_PA07A_RSTC_EXTWAKE7)
+#define PORT_PA07A_RSTC_EXTWAKE7   (1ul <<  7)
+#define PIN_PA08A_RSTC_EXTWAKE8            8L  /**< \brief RSTC signal: EXTWAKE8 on PA08 mux A */
+#define MUX_PA08A_RSTC_EXTWAKE8            0L
+#define PINMUX_PA08A_RSTC_EXTWAKE8  ((PIN_PA08A_RSTC_EXTWAKE8 << 16) | MUX_PA08A_RSTC_EXTWAKE8)
+#define PORT_PA08A_RSTC_EXTWAKE8   (1ul <<  8)
+#define PIN_PA09A_RSTC_EXTWAKE9            9L  /**< \brief RSTC signal: EXTWAKE9 on PA09 mux A */
+#define MUX_PA09A_RSTC_EXTWAKE9            0L
+#define PINMUX_PA09A_RSTC_EXTWAKE9  ((PIN_PA09A_RSTC_EXTWAKE9 << 16) | MUX_PA09A_RSTC_EXTWAKE9)
+#define PORT_PA09A_RSTC_EXTWAKE9   (1ul <<  9)
+#define PIN_PA10A_RSTC_EXTWAKE10          10L  /**< \brief RSTC signal: EXTWAKE10 on PA10 mux A */
+#define MUX_PA10A_RSTC_EXTWAKE10           0L
+#define PINMUX_PA10A_RSTC_EXTWAKE10  ((PIN_PA10A_RSTC_EXTWAKE10 << 16) | MUX_PA10A_RSTC_EXTWAKE10)
+#define PORT_PA10A_RSTC_EXTWAKE10  (1ul << 10)
+#define PIN_PA11A_RSTC_EXTWAKE11          11L  /**< \brief RSTC signal: EXTWAKE11 on PA11 mux A */
+#define MUX_PA11A_RSTC_EXTWAKE11           0L
+#define PINMUX_PA11A_RSTC_EXTWAKE11  ((PIN_PA11A_RSTC_EXTWAKE11 << 16) | MUX_PA11A_RSTC_EXTWAKE11)
+#define PORT_PA11A_RSTC_EXTWAKE11  (1ul << 11)
+#define PIN_PA12A_RSTC_EXTWAKE12          12L  /**< \brief RSTC signal: EXTWAKE12 on PA12 mux A */
+#define MUX_PA12A_RSTC_EXTWAKE12           0L
+#define PINMUX_PA12A_RSTC_EXTWAKE12  ((PIN_PA12A_RSTC_EXTWAKE12 << 16) | MUX_PA12A_RSTC_EXTWAKE12)
+#define PORT_PA12A_RSTC_EXTWAKE12  (1ul << 12)
+#define PIN_PA13A_RSTC_EXTWAKE13          13L  /**< \brief RSTC signal: EXTWAKE13 on PA13 mux A */
+#define MUX_PA13A_RSTC_EXTWAKE13           0L
+#define PINMUX_PA13A_RSTC_EXTWAKE13  ((PIN_PA13A_RSTC_EXTWAKE13 << 16) | MUX_PA13A_RSTC_EXTWAKE13)
+#define PORT_PA13A_RSTC_EXTWAKE13  (1ul << 13)
+#define PIN_PA14A_RSTC_EXTWAKE14          14L  /**< \brief RSTC signal: EXTWAKE14 on PA14 mux A */
+#define MUX_PA14A_RSTC_EXTWAKE14           0L
+#define PINMUX_PA14A_RSTC_EXTWAKE14  ((PIN_PA14A_RSTC_EXTWAKE14 << 16) | MUX_PA14A_RSTC_EXTWAKE14)
+#define PORT_PA14A_RSTC_EXTWAKE14  (1ul << 14)
+#define PIN_PA15A_RSTC_EXTWAKE15          15L  /**< \brief RSTC signal: EXTWAKE15 on PA15 mux A */
+#define MUX_PA15A_RSTC_EXTWAKE15           0L
+#define PINMUX_PA15A_RSTC_EXTWAKE15  ((PIN_PA15A_RSTC_EXTWAKE15 << 16) | MUX_PA15A_RSTC_EXTWAKE15)
+#define PORT_PA15A_RSTC_EXTWAKE15  (1ul << 15)
+/* ========== PORT definition for SUPC peripheral ========== */
+#define PIN_PB02H_SUPC_OUT1               34L  /**< \brief SUPC signal: OUT1 on PB02 mux H */
+#define MUX_PB02H_SUPC_OUT1                7L
+#define PINMUX_PB02H_SUPC_OUT1     ((PIN_PB02H_SUPC_OUT1 << 16) | MUX_PB02H_SUPC_OUT1)
+#define PORT_PB02H_SUPC_OUT1       (1ul <<  2)
+#define PIN_PB03H_SUPC_VBAT               35L  /**< \brief SUPC signal: VBAT on PB03 mux H */
+#define MUX_PB03H_SUPC_VBAT                7L
+#define PINMUX_PB03H_SUPC_VBAT     ((PIN_PB03H_SUPC_VBAT << 16) | MUX_PB03H_SUPC_VBAT)
+#define PORT_PB03H_SUPC_VBAT       (1ul <<  3)
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB22H_GCLK_IO0                54L  /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0                 7L
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0        (1ul << 22)
+#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0                 7L
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0        (1ul << 14)
+#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0                 7L
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0        (1ul << 27)
+#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0                 7L
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0        (1ul << 30)
+#define PIN_PB23H_GCLK_IO1                55L  /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1                 7L
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1        (1ul << 23)
+#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1                 7L
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1        (1ul << 15)
+#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2                 7L
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2        (1ul << 16)
+#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3                 7L
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3        (1ul << 17)
+#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4                 7L
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4        (1ul << 10)
+#define PIN_PA20H_GCLK_IO4                20L  /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4                 7L
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4        (1ul << 20)
+#define PIN_PB10H_GCLK_IO4                42L  /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4                 7L
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4        (1ul << 10)
+#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5                 7L
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5        (1ul << 11)
+#define PIN_PA21H_GCLK_IO5                21L  /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5                 7L
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5        (1ul << 21)
+#define PIN_PB11H_GCLK_IO5                43L  /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5                 7L
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5        (1ul << 11)
+#define PIN_PA22H_GCLK_IO6                22L  /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6                 7L
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6        (1ul << 22)
+#define PIN_PA23H_GCLK_IO7                23L  /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7                 7L
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7        (1ul << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0              0L
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
+#define PIN_PA00A_EIC_EXTINT0              0L  /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0              0L
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0     (1ul <<  0)
+#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1              0L
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
+#define PIN_PA01A_EIC_EXTINT1              1L  /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1              0L
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1     (1ul <<  1)
+#define PIN_PA02A_EIC_EXTINT2              2L  /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2              0L
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2     (1ul <<  2)
+#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2              0L
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
+#define PIN_PB02A_EIC_EXTINT2             34L  /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2              0L
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2     (1ul <<  2)
+#define PIN_PA03A_EIC_EXTINT3              3L  /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3              0L
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3     (1ul <<  3)
+#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3              0L
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
+#define PIN_PB03A_EIC_EXTINT3             35L  /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3              0L
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3     (1ul <<  3)
+#define PIN_PA04A_EIC_EXTINT4              4L  /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4              0L
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4     (1ul <<  4)
+#define PIN_PA20A_EIC_EXTINT4             20L  /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4              0L
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4     (1ul << 20)
+#define PIN_PA05A_EIC_EXTINT5              5L  /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5              0L
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5     (1ul <<  5)
+#define PIN_PA21A_EIC_EXTINT5             21L  /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5              0L
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5     (1ul << 21)
+#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6              0L
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
+#define PIN_PA22A_EIC_EXTINT6             22L  /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6              0L
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6     (1ul << 22)
+#define PIN_PB22A_EIC_EXTINT6             54L  /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6              0L
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6     (1ul << 22)
+#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7              0L
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
+#define PIN_PA23A_EIC_EXTINT7             23L  /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7              0L
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7     (1ul << 23)
+#define PIN_PB23A_EIC_EXTINT7             55L  /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7              0L
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7     (1ul << 23)
+#define PIN_PB08A_EIC_EXTINT8             40L  /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8              0L
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8     (1ul <<  8)
+#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9              0L
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
+#define PIN_PB09A_EIC_EXTINT9             41L  /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9              0L
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9     (1ul <<  9)
+#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10             0L
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
+#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10             0L
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
+#define PIN_PB10A_EIC_EXTINT10            42L  /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10             0L
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10    (1ul << 10)
+#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11             0L
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
+#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11             0L
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
+#define PIN_PB11A_EIC_EXTINT11            43L  /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11             0L
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11    (1ul << 11)
+#define PIN_PA12A_EIC_EXTINT12            12L  /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12             0L
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12    (1ul << 12)
+#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12             0L
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
+#define PIN_PA13A_EIC_EXTINT13            13L  /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13             0L
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13    (1ul << 13)
+#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13             0L
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
+#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14             0L
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
+#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15             0L
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
+#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15             0L
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
+#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI                  0L
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+/* ========== PORT definition for TAL peripheral ========== */
+#define PIN_PA27G_TAL_BRK                 27L  /**< \brief TAL signal: BRK on PA27 mux G */
+#define MUX_PA27G_TAL_BRK                  6L
+#define PINMUX_PA27G_TAL_BRK       ((PIN_PA27G_TAL_BRK << 16) | MUX_PA27G_TAL_BRK)
+#define PORT_PA27G_TAL_BRK         (1ul << 27)
+/* ========== PORT definition for USB peripheral ========== */
+#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                   6L
+#define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
+#define PORT_PA24G_USB_DM          (1ul << 24)
+#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                   6L
+#define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
+#define PORT_PA25G_USB_DP          (1ul << 25)
+#define PIN_PA23G_USB_SOF_1KHZ            23L  /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
+#define MUX_PA23G_USB_SOF_1KHZ             6L
+#define PINMUX_PA23G_USB_SOF_1KHZ  ((PIN_PA23G_USB_SOF_1KHZ << 16) | MUX_PA23G_USB_SOF_1KHZ)
+#define PORT_PA23G_USB_SOF_1KHZ    (1ul << 23)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0             4L  /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0             3L
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0    (1ul <<  4)
+#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
+#define PIN_PA05D_SERCOM0_PAD1             5L  /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1             3L
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1    (1ul <<  5)
+#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
+#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
+#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
+#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
+#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
+#define PIN_PA00D_SERCOM1_PAD0             0L  /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0             3L
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0    (1ul <<  0)
+#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
+#define PIN_PA01D_SERCOM1_PAD1             1L  /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1             3L
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1    (1ul <<  1)
+#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
+#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
+#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
+#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
+#define PIN_PA12C_SERCOM2_PAD0            12L  /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0             2L
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0    (1ul << 12)
+#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
+#define PIN_PA13C_SERCOM2_PAD1            13L  /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1             2L
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1    (1ul << 13)
+#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
+#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
+#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
+#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
+#define PIN_PA22C_SERCOM3_PAD0            22L  /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0             2L
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0    (1ul << 22)
+#define PIN_PA27F_SERCOM3_PAD0            27L  /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
+#define MUX_PA27F_SERCOM3_PAD0             5L
+#define PINMUX_PA27F_SERCOM3_PAD0  ((PIN_PA27F_SERCOM3_PAD0 << 16) | MUX_PA27F_SERCOM3_PAD0)
+#define PORT_PA27F_SERCOM3_PAD0    (1ul << 27)
+#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
+#define PIN_PA23C_SERCOM3_PAD1            23L  /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1             2L
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1    (1ul << 23)
+#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
+#define PIN_PA20D_SERCOM3_PAD2            20L  /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2             3L
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2    (1ul << 20)
+#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
+#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
+#define PIN_PA21D_SERCOM3_PAD3            21L  /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3             3L
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3    (1ul << 21)
+#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0            12L  /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0             3L
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0    (1ul << 12)
+#define PIN_PB08D_SERCOM4_PAD0            40L  /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0             3L
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0    (1ul <<  8)
+#define PIN_PA13D_SERCOM4_PAD1            13L  /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1             3L
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1    (1ul << 13)
+#define PIN_PB09D_SERCOM4_PAD1            41L  /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1             3L
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1    (1ul <<  9)
+#define PIN_PA14D_SERCOM4_PAD2            14L  /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2             3L
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2    (1ul << 14)
+#define PIN_PB10D_SERCOM4_PAD2            42L  /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2             3L
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2    (1ul << 10)
+#define PIN_PA15D_SERCOM4_PAD3            15L  /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3             3L
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3    (1ul << 15)
+#define PIN_PB11D_SERCOM4_PAD3            43L  /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3             3L
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3    (1ul << 11)
+/* ========== PORT definition for TCC0 peripheral ========== */
+#define PIN_PA04E_TCC0_WO0                 4L  /**< \brief TCC0 signal: WO0 on PA04 mux E */
+#define MUX_PA04E_TCC0_WO0                 4L
+#define PINMUX_PA04E_TCC0_WO0      ((PIN_PA04E_TCC0_WO0 << 16) | MUX_PA04E_TCC0_WO0)
+#define PORT_PA04E_TCC0_WO0        (1ul <<  4)
+#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0                 4L
+#define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
+#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
+#define PIN_PA16F_TCC0_WO0                16L  /**< \brief TCC0 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO0                 5L
+#define PINMUX_PA16F_TCC0_WO0      ((PIN_PA16F_TCC0_WO0 << 16) | MUX_PA16F_TCC0_WO0)
+#define PORT_PA16F_TCC0_WO0        (1ul << 16)
+#define PIN_PA05E_TCC0_WO1                 5L  /**< \brief TCC0 signal: WO1 on PA05 mux E */
+#define MUX_PA05E_TCC0_WO1                 4L
+#define PINMUX_PA05E_TCC0_WO1      ((PIN_PA05E_TCC0_WO1 << 16) | MUX_PA05E_TCC0_WO1)
+#define PORT_PA05E_TCC0_WO1        (1ul <<  5)
+#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1                 4L
+#define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
+#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
+#define PIN_PA17F_TCC0_WO1                17L  /**< \brief TCC0 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO1                 5L
+#define PINMUX_PA17F_TCC0_WO1      ((PIN_PA17F_TCC0_WO1 << 16) | MUX_PA17F_TCC0_WO1)
+#define PORT_PA17F_TCC0_WO1        (1ul << 17)
+#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2                 5L
+#define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
+#define PORT_PA10F_TCC0_WO2        (1ul << 10)
+#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2                 5L
+#define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
+#define PORT_PA18F_TCC0_WO2        (1ul << 18)
+#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3                 5L
+#define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
+#define PORT_PA11F_TCC0_WO3        (1ul << 11)
+#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3                 5L
+#define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
+#define PORT_PA19F_TCC0_WO3        (1ul << 19)
+#define PIN_PA22F_TCC0_WO4                22L  /**< \brief TCC0 signal: WO4 on PA22 mux F */
+#define MUX_PA22F_TCC0_WO4                 5L
+#define PINMUX_PA22F_TCC0_WO4      ((PIN_PA22F_TCC0_WO4 << 16) | MUX_PA22F_TCC0_WO4)
+#define PORT_PA22F_TCC0_WO4        (1ul << 22)
+#define PIN_PB10F_TCC0_WO4                42L  /**< \brief TCC0 signal: WO4 on PB10 mux F */
+#define MUX_PB10F_TCC0_WO4                 5L
+#define PINMUX_PB10F_TCC0_WO4      ((PIN_PB10F_TCC0_WO4 << 16) | MUX_PB10F_TCC0_WO4)
+#define PORT_PB10F_TCC0_WO4        (1ul << 10)
+#define PIN_PA14F_TCC0_WO4                14L  /**< \brief TCC0 signal: WO4 on PA14 mux F */
+#define MUX_PA14F_TCC0_WO4                 5L
+#define PINMUX_PA14F_TCC0_WO4      ((PIN_PA14F_TCC0_WO4 << 16) | MUX_PA14F_TCC0_WO4)
+#define PORT_PA14F_TCC0_WO4        (1ul << 14)
+#define PIN_PA15F_TCC0_WO5                15L  /**< \brief TCC0 signal: WO5 on PA15 mux F */
+#define MUX_PA15F_TCC0_WO5                 5L
+#define PINMUX_PA15F_TCC0_WO5      ((PIN_PA15F_TCC0_WO5 << 16) | MUX_PA15F_TCC0_WO5)
+#define PORT_PA15F_TCC0_WO5        (1ul << 15)
+#define PIN_PA23F_TCC0_WO5                23L  /**< \brief TCC0 signal: WO5 on PA23 mux F */
+#define MUX_PA23F_TCC0_WO5                 5L
+#define PINMUX_PA23F_TCC0_WO5      ((PIN_PA23F_TCC0_WO5 << 16) | MUX_PA23F_TCC0_WO5)
+#define PORT_PA23F_TCC0_WO5        (1ul << 23)
+#define PIN_PB11F_TCC0_WO5                43L  /**< \brief TCC0 signal: WO5 on PB11 mux F */
+#define MUX_PB11F_TCC0_WO5                 5L
+#define PINMUX_PB11F_TCC0_WO5      ((PIN_PB11F_TCC0_WO5 << 16) | MUX_PB11F_TCC0_WO5)
+#define PORT_PB11F_TCC0_WO5        (1ul << 11)
+#define PIN_PA12F_TCC0_WO6                12L  /**< \brief TCC0 signal: WO6 on PA12 mux F */
+#define MUX_PA12F_TCC0_WO6                 5L
+#define PINMUX_PA12F_TCC0_WO6      ((PIN_PA12F_TCC0_WO6 << 16) | MUX_PA12F_TCC0_WO6)
+#define PORT_PA12F_TCC0_WO6        (1ul << 12)
+#define PIN_PA16F_TCC0_WO6                16L  /**< \brief TCC0 signal: WO6 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO6                 5L
+#define PINMUX_PA16F_TCC0_WO6      ((PIN_PA16F_TCC0_WO6 << 16) | MUX_PA16F_TCC0_WO6)
+#define PORT_PA16F_TCC0_WO6        (1ul << 16)
+#define PIN_PA20F_TCC0_WO6                20L  /**< \brief TCC0 signal: WO6 on PA20 mux F */
+#define MUX_PA20F_TCC0_WO6                 5L
+#define PINMUX_PA20F_TCC0_WO6      ((PIN_PA20F_TCC0_WO6 << 16) | MUX_PA20F_TCC0_WO6)
+#define PORT_PA20F_TCC0_WO6        (1ul << 20)
+#define PIN_PA13F_TCC0_WO7                13L  /**< \brief TCC0 signal: WO7 on PA13 mux F */
+#define MUX_PA13F_TCC0_WO7                 5L
+#define PINMUX_PA13F_TCC0_WO7      ((PIN_PA13F_TCC0_WO7 << 16) | MUX_PA13F_TCC0_WO7)
+#define PORT_PA13F_TCC0_WO7        (1ul << 13)
+#define PIN_PA17F_TCC0_WO7                17L  /**< \brief TCC0 signal: WO7 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO7                 5L
+#define PINMUX_PA17F_TCC0_WO7      ((PIN_PA17F_TCC0_WO7 << 16) | MUX_PA17F_TCC0_WO7)
+#define PORT_PA17F_TCC0_WO7        (1ul << 17)
+#define PIN_PA21F_TCC0_WO7                21L  /**< \brief TCC0 signal: WO7 on PA21 mux F */
+#define MUX_PA21F_TCC0_WO7                 5L
+#define PINMUX_PA21F_TCC0_WO7      ((PIN_PA21F_TCC0_WO7 << 16) | MUX_PA21F_TCC0_WO7)
+#define PORT_PA21F_TCC0_WO7        (1ul << 21)
+/* ========== PORT definition for TCC1 peripheral ========== */
+#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0                 4L
+#define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
+#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
+#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0                 4L
+#define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
+#define PORT_PA10E_TCC1_WO0        (1ul << 10)
+#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0                 4L
+#define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
+#define PORT_PA30E_TCC1_WO0        (1ul << 30)
+#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1                 4L
+#define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
+#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
+#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1                 4L
+#define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
+#define PORT_PA11E_TCC1_WO1        (1ul << 11)
+#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1                 4L
+#define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
+#define PORT_PA31E_TCC1_WO1        (1ul << 31)
+#define PIN_PA08F_TCC1_WO2                 8L  /**< \brief TCC1 signal: WO2 on PA08 mux F */
+#define MUX_PA08F_TCC1_WO2                 5L
+#define PINMUX_PA08F_TCC1_WO2      ((PIN_PA08F_TCC1_WO2 << 16) | MUX_PA08F_TCC1_WO2)
+#define PORT_PA08F_TCC1_WO2        (1ul <<  8)
+#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2                 5L
+#define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
+#define PORT_PA24F_TCC1_WO2        (1ul << 24)
+#define PIN_PA09F_TCC1_WO3                 9L  /**< \brief TCC1 signal: WO3 on PA09 mux F */
+#define MUX_PA09F_TCC1_WO3                 5L
+#define PINMUX_PA09F_TCC1_WO3      ((PIN_PA09F_TCC1_WO3 << 16) | MUX_PA09F_TCC1_WO3)
+#define PORT_PA09F_TCC1_WO3        (1ul <<  9)
+#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3                 5L
+#define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
+#define PORT_PA25F_TCC1_WO3        (1ul << 25)
+/* ========== PORT definition for TCC2 peripheral ========== */
+#define PIN_PA12E_TCC2_WO0                12L  /**< \brief TCC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TCC2_WO0                 4L
+#define PINMUX_PA12E_TCC2_WO0      ((PIN_PA12E_TCC2_WO0 << 16) | MUX_PA12E_TCC2_WO0)
+#define PORT_PA12E_TCC2_WO0        (1ul << 12)
+#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0                 4L
+#define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
+#define PORT_PA16E_TCC2_WO0        (1ul << 16)
+#define PIN_PA00E_TCC2_WO0                 0L  /**< \brief TCC2 signal: WO0 on PA00 mux E */
+#define MUX_PA00E_TCC2_WO0                 4L
+#define PINMUX_PA00E_TCC2_WO0      ((PIN_PA00E_TCC2_WO0 << 16) | MUX_PA00E_TCC2_WO0)
+#define PORT_PA00E_TCC2_WO0        (1ul <<  0)
+#define PIN_PA13E_TCC2_WO1                13L  /**< \brief TCC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TCC2_WO1                 4L
+#define PINMUX_PA13E_TCC2_WO1      ((PIN_PA13E_TCC2_WO1 << 16) | MUX_PA13E_TCC2_WO1)
+#define PORT_PA13E_TCC2_WO1        (1ul << 13)
+#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1                 4L
+#define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
+#define PORT_PA17E_TCC2_WO1        (1ul << 17)
+#define PIN_PA01E_TCC2_WO1                 1L  /**< \brief TCC2 signal: WO1 on PA01 mux E */
+#define MUX_PA01E_TCC2_WO1                 4L
+#define PINMUX_PA01E_TCC2_WO1      ((PIN_PA01E_TCC2_WO1 << 16) | MUX_PA01E_TCC2_WO1)
+#define PORT_PA01E_TCC2_WO1        (1ul <<  1)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA22E_TC0_WO0                 22L  /**< \brief TC0 signal: WO0 on PA22 mux E */
+#define MUX_PA22E_TC0_WO0                  4L
+#define PINMUX_PA22E_TC0_WO0       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0         (1ul << 22)
+#define PIN_PB08E_TC0_WO0                 40L  /**< \brief TC0 signal: WO0 on PB08 mux E */
+#define MUX_PB08E_TC0_WO0                  4L
+#define PINMUX_PB08E_TC0_WO0       ((PIN_PB08E_TC0_WO0 << 16) | MUX_PB08E_TC0_WO0)
+#define PORT_PB08E_TC0_WO0         (1ul <<  8)
+#define PIN_PA23E_TC0_WO1                 23L  /**< \brief TC0 signal: WO1 on PA23 mux E */
+#define MUX_PA23E_TC0_WO1                  4L
+#define PINMUX_PA23E_TC0_WO1       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1         (1ul << 23)
+#define PIN_PB09E_TC0_WO1                 41L  /**< \brief TC0 signal: WO1 on PB09 mux E */
+#define MUX_PB09E_TC0_WO1                  4L
+#define PINMUX_PB09E_TC0_WO1       ((PIN_PB09E_TC0_WO1 << 16) | MUX_PB09E_TC0_WO1)
+#define PORT_PB09E_TC0_WO1         (1ul <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA24E_TC1_WO0                 24L  /**< \brief TC1 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC1_WO0                  4L
+#define PINMUX_PA24E_TC1_WO0       ((PIN_PA24E_TC1_WO0 << 16) | MUX_PA24E_TC1_WO0)
+#define PORT_PA24E_TC1_WO0         (1ul << 24)
+#define PIN_PB10E_TC1_WO0                 42L  /**< \brief TC1 signal: WO0 on PB10 mux E */
+#define MUX_PB10E_TC1_WO0                  4L
+#define PINMUX_PB10E_TC1_WO0       ((PIN_PB10E_TC1_WO0 << 16) | MUX_PB10E_TC1_WO0)
+#define PORT_PB10E_TC1_WO0         (1ul << 10)
+#define PIN_PA25E_TC1_WO1                 25L  /**< \brief TC1 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC1_WO1                  4L
+#define PINMUX_PA25E_TC1_WO1       ((PIN_PA25E_TC1_WO1 << 16) | MUX_PA25E_TC1_WO1)
+#define PORT_PA25E_TC1_WO1         (1ul << 25)
+#define PIN_PB11E_TC1_WO1                 43L  /**< \brief TC1 signal: WO1 on PB11 mux E */
+#define MUX_PB11E_TC1_WO1                  4L
+#define PINMUX_PB11E_TC1_WO1       ((PIN_PB11E_TC1_WO1 << 16) | MUX_PB11E_TC1_WO1)
+#define PORT_PB11E_TC1_WO1         (1ul << 11)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT0                2L  /**< \brief DAC signal: VOUT0 on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT0                1L
+#define PINMUX_PA02B_DAC_VOUT0     ((PIN_PA02B_DAC_VOUT0 << 16) | MUX_PA02B_DAC_VOUT0)
+#define PORT_PA02B_DAC_VOUT0       (1ul <<  2)
+#define PIN_PA05B_DAC_VOUT1                5L  /**< \brief DAC signal: VOUT1 on PA05 mux B */
+#define MUX_PA05B_DAC_VOUT1                1L
+#define PINMUX_PA05B_DAC_VOUT1     ((PIN_PA05B_DAC_VOUT1 << 16) | MUX_PA05B_DAC_VOUT1)
+#define PORT_PA05B_DAC_VOUT1       (1ul <<  5)
+#define PIN_PA03B_DAC_VREFP                3L  /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP                1L
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP       (1ul <<  3)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0            22L  /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0             3L
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0    (1ul << 22)
+#define PIN_PB02D_SERCOM5_PAD0            34L  /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0             3L
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0    (1ul <<  2)
+#define PIN_PA23D_SERCOM5_PAD1            23L  /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1             3L
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1    (1ul << 23)
+#define PIN_PB03D_SERCOM5_PAD1            35L  /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1             3L
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1    (1ul <<  3)
+#define PIN_PA24D_SERCOM5_PAD2            24L  /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2             3L
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2    (1ul << 24)
+#define PIN_PB22D_SERCOM5_PAD2            54L  /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2             3L
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2    (1ul << 22)
+#define PIN_PA20C_SERCOM5_PAD2            20L  /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2             2L
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2    (1ul << 20)
+#define PIN_PA25D_SERCOM5_PAD3            25L  /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3             3L
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3    (1ul << 25)
+#define PIN_PB23D_SERCOM5_PAD3            55L  /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3             3L
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3    (1ul << 23)
+#define PIN_PA21C_SERCOM5_PAD3            21L  /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3             2L
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3    (1ul << 21)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA18E_TC4_WO0                 18L  /**< \brief TC4 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC4_WO0                  4L
+#define PINMUX_PA18E_TC4_WO0       ((PIN_PA18E_TC4_WO0 << 16) | MUX_PA18E_TC4_WO0)
+#define PORT_PA18E_TC4_WO0         (1ul << 18)
+#define PIN_PA14E_TC4_WO0                 14L  /**< \brief TC4 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC4_WO0                  4L
+#define PINMUX_PA14E_TC4_WO0       ((PIN_PA14E_TC4_WO0 << 16) | MUX_PA14E_TC4_WO0)
+#define PORT_PA14E_TC4_WO0         (1ul << 14)
+#define PIN_PA19E_TC4_WO1                 19L  /**< \brief TC4 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC4_WO1                  4L
+#define PINMUX_PA19E_TC4_WO1       ((PIN_PA19E_TC4_WO1 << 16) | MUX_PA19E_TC4_WO1)
+#define PORT_PA19E_TC4_WO1         (1ul << 19)
+#define PIN_PA15E_TC4_WO1                 15L  /**< \brief TC4 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC4_WO1                  4L
+#define PINMUX_PA15E_TC4_WO1       ((PIN_PA15E_TC4_WO1 << 16) | MUX_PA15E_TC4_WO1)
+#define PORT_PA15E_TC4_WO1         (1ul << 15)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                 2L  /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0                 1L
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0        (1ul <<  2)
+#define PIN_PA03B_ADC_AIN1                 3L  /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1                 1L
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1        (1ul <<  3)
+#define PIN_PB08B_ADC_AIN2                40L  /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2                 1L
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2        (1ul <<  8)
+#define PIN_PB09B_ADC_AIN3                41L  /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3                 1L
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3        (1ul <<  9)
+#define PIN_PA04B_ADC_AIN4                 4L  /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4                 1L
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4        (1ul <<  4)
+#define PIN_PA05B_ADC_AIN5                 5L  /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5                 1L
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5        (1ul <<  5)
+#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6                 1L
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
+#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7                 1L
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
+#define PIN_PB02B_ADC_AIN10               34L  /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10                1L
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10       (1ul <<  2)
+#define PIN_PB03B_ADC_AIN11               35L  /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11                1L
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11       (1ul <<  3)
+#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16                1L
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
+#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17                1L
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
+#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18                1L
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18       (1ul << 10)
+#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19                1L
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19       (1ul << 11)
+#define PIN_PA04B_ADC_VREFP                4L  /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP                1L
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP       (1ul <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                  4L  /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0                  1L
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0         (1ul <<  4)
+#define PIN_PA05B_AC_AIN1                  5L  /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1                  1L
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1         (1ul <<  5)
+#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2                  1L
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2         (1ul <<  6)
+#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3                  1L
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3         (1ul <<  7)
+#define PIN_PA12H_AC_CMP0                 12L  /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0                  7L
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0         (1ul << 12)
+#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0                  7L
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0         (1ul << 18)
+#define PIN_PA13H_AC_CMP1                 13L  /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1                  7L
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1         (1ul << 13)
+#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1                  7L
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1         (1ul << 19)
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0             2L  /**< \brief OPAMP signal: OANEG0 on PA02 mux B */
+#define MUX_PA02B_OPAMP_OANEG0             1L
+#define PINMUX_PA02B_OPAMP_OANEG0  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0    (1ul <<  2)
+#define PIN_PB08B_OPAMP_OANEG2            40L  /**< \brief OPAMP signal: OANEG2 on PB08 mux B */
+#define MUX_PB08B_OPAMP_OANEG2             1L
+#define PINMUX_PB08B_OPAMP_OANEG2  ((PIN_PB08B_OPAMP_OANEG2 << 16) | MUX_PB08B_OPAMP_OANEG2)
+#define PORT_PB08B_OPAMP_OANEG2    (1ul <<  8)
+#define PIN_PA07B_OPAMP_OAOUT0             7L  /**< \brief OPAMP signal: OAOUT0 on PA07 mux B */
+#define MUX_PA07B_OPAMP_OAOUT0             1L
+#define PINMUX_PA07B_OPAMP_OAOUT0  ((PIN_PA07B_OPAMP_OAOUT0 << 16) | MUX_PA07B_OPAMP_OAOUT0)
+#define PORT_PA07B_OPAMP_OAOUT0    (1ul <<  7)
+#define PIN_PA04B_OPAMP_OAOUT2             4L  /**< \brief OPAMP signal: OAOUT2 on PA04 mux B */
+#define MUX_PA04B_OPAMP_OAOUT2             1L
+#define PINMUX_PA04B_OPAMP_OAOUT2  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2    (1ul <<  4)
+#define PIN_PA06B_OPAMP_OAPOS0             6L  /**< \brief OPAMP signal: OAPOS0 on PA06 mux B */
+#define MUX_PA06B_OPAMP_OAPOS0             1L
+#define PINMUX_PA06B_OPAMP_OAPOS0  ((PIN_PA06B_OPAMP_OAPOS0 << 16) | MUX_PA06B_OPAMP_OAPOS0)
+#define PORT_PA06B_OPAMP_OAPOS0    (1ul <<  6)
+#define PIN_PB09B_OPAMP_OAPOS1            41L  /**< \brief OPAMP signal: OAPOS1 on PB09 mux B */
+#define MUX_PB09B_OPAMP_OAPOS1             1L
+#define PINMUX_PB09B_OPAMP_OAPOS1  ((PIN_PB09B_OPAMP_OAPOS1 << 16) | MUX_PB09B_OPAMP_OAPOS1)
+#define PORT_PB09B_OPAMP_OAPOS1    (1ul <<  9)
+#define PIN_PA05B_OPAMP_OAPOS2             5L  /**< \brief OPAMP signal: OAPOS2 on PA05 mux B */
+#define MUX_PA05B_OPAMP_OAPOS2             1L
+#define PINMUX_PA05B_OPAMP_OAPOS2  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2    (1ul <<  5)
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                  4L  /**< \brief CCL signal: IN0 on PA04 mux I */
+#define MUX_PA04I_CCL_IN0                  8L
+#define PINMUX_PA04I_CCL_IN0       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0         (1ul <<  4)
+#define PIN_PA16I_CCL_IN0                 16L  /**< \brief CCL signal: IN0 on PA16 mux I */
+#define MUX_PA16I_CCL_IN0                  8L
+#define PINMUX_PA16I_CCL_IN0       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0         (1ul << 16)
+#define PIN_PB22I_CCL_IN0                 54L  /**< \brief CCL signal: IN0 on PB22 mux I */
+#define MUX_PB22I_CCL_IN0                  8L
+#define PINMUX_PB22I_CCL_IN0       ((PIN_PB22I_CCL_IN0 << 16) | MUX_PB22I_CCL_IN0)
+#define PORT_PB22I_CCL_IN0         (1ul << 22)
+#define PIN_PA05I_CCL_IN1                  5L  /**< \brief CCL signal: IN1 on PA05 mux I */
+#define MUX_PA05I_CCL_IN1                  8L
+#define PINMUX_PA05I_CCL_IN1       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1         (1ul <<  5)
+#define PIN_PA17I_CCL_IN1                 17L  /**< \brief CCL signal: IN1 on PA17 mux I */
+#define MUX_PA17I_CCL_IN1                  8L
+#define PINMUX_PA17I_CCL_IN1       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1         (1ul << 17)
+#define PIN_PA06I_CCL_IN2                  6L  /**< \brief CCL signal: IN2 on PA06 mux I */
+#define MUX_PA06I_CCL_IN2                  8L
+#define PINMUX_PA06I_CCL_IN2       ((PIN_PA06I_CCL_IN2 << 16) | MUX_PA06I_CCL_IN2)
+#define PORT_PA06I_CCL_IN2         (1ul <<  6)
+#define PIN_PA18I_CCL_IN2                 18L  /**< \brief CCL signal: IN2 on PA18 mux I */
+#define MUX_PA18I_CCL_IN2                  8L
+#define PINMUX_PA18I_CCL_IN2       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2         (1ul << 18)
+#define PIN_PA08I_CCL_IN3                  8L  /**< \brief CCL signal: IN3 on PA08 mux I */
+#define MUX_PA08I_CCL_IN3                  8L
+#define PINMUX_PA08I_CCL_IN3       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3         (1ul <<  8)
+#define PIN_PA30I_CCL_IN3                 30L  /**< \brief CCL signal: IN3 on PA30 mux I */
+#define MUX_PA30I_CCL_IN3                  8L
+#define PINMUX_PA30I_CCL_IN3       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3         (1ul << 30)
+#define PIN_PA09I_CCL_IN4                  9L  /**< \brief CCL signal: IN4 on PA09 mux I */
+#define MUX_PA09I_CCL_IN4                  8L
+#define PINMUX_PA09I_CCL_IN4       ((PIN_PA09I_CCL_IN4 << 16) | MUX_PA09I_CCL_IN4)
+#define PORT_PA09I_CCL_IN4         (1ul <<  9)
+#define PIN_PA10I_CCL_IN5                 10L  /**< \brief CCL signal: IN5 on PA10 mux I */
+#define MUX_PA10I_CCL_IN5                  8L
+#define PINMUX_PA10I_CCL_IN5       ((PIN_PA10I_CCL_IN5 << 16) | MUX_PA10I_CCL_IN5)
+#define PORT_PA10I_CCL_IN5         (1ul << 10)
+#define PIN_PB10I_CCL_IN5                 42L  /**< \brief CCL signal: IN5 on PB10 mux I */
+#define MUX_PB10I_CCL_IN5                  8L
+#define PINMUX_PB10I_CCL_IN5       ((PIN_PB10I_CCL_IN5 << 16) | MUX_PB10I_CCL_IN5)
+#define PORT_PB10I_CCL_IN5         (1ul << 10)
+#define PIN_PA22I_CCL_IN6                 22L  /**< \brief CCL signal: IN6 on PA22 mux I */
+#define MUX_PA22I_CCL_IN6                  8L
+#define PINMUX_PA22I_CCL_IN6       ((PIN_PA22I_CCL_IN6 << 16) | MUX_PA22I_CCL_IN6)
+#define PORT_PA22I_CCL_IN6         (1ul << 22)
+#define PIN_PA23I_CCL_IN7                 23L  /**< \brief CCL signal: IN7 on PA23 mux I */
+#define MUX_PA23I_CCL_IN7                  8L
+#define PINMUX_PA23I_CCL_IN7       ((PIN_PA23I_CCL_IN7 << 16) | MUX_PA23I_CCL_IN7)
+#define PORT_PA23I_CCL_IN7         (1ul << 23)
+#define PIN_PA24I_CCL_IN8                 24L  /**< \brief CCL signal: IN8 on PA24 mux I */
+#define MUX_PA24I_CCL_IN8                  8L
+#define PINMUX_PA24I_CCL_IN8       ((PIN_PA24I_CCL_IN8 << 16) | MUX_PA24I_CCL_IN8)
+#define PORT_PA24I_CCL_IN8         (1ul << 24)
+#define PIN_PB08I_CCL_IN8                 40L  /**< \brief CCL signal: IN8 on PB08 mux I */
+#define MUX_PB08I_CCL_IN8                  8L
+#define PINMUX_PB08I_CCL_IN8       ((PIN_PB08I_CCL_IN8 << 16) | MUX_PB08I_CCL_IN8)
+#define PORT_PB08I_CCL_IN8         (1ul <<  8)
+#define PIN_PA07I_CCL_OUT0                 7L  /**< \brief CCL signal: OUT0 on PA07 mux I */
+#define MUX_PA07I_CCL_OUT0                 8L
+#define PINMUX_PA07I_CCL_OUT0      ((PIN_PA07I_CCL_OUT0 << 16) | MUX_PA07I_CCL_OUT0)
+#define PORT_PA07I_CCL_OUT0        (1ul <<  7)
+#define PIN_PA19I_CCL_OUT0                19L  /**< \brief CCL signal: OUT0 on PA19 mux I */
+#define MUX_PA19I_CCL_OUT0                 8L
+#define PINMUX_PA19I_CCL_OUT0      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0        (1ul << 19)
+#define PIN_PB02I_CCL_OUT0                34L  /**< \brief CCL signal: OUT0 on PB02 mux I */
+#define MUX_PB02I_CCL_OUT0                 8L
+#define PINMUX_PB02I_CCL_OUT0      ((PIN_PB02I_CCL_OUT0 << 16) | MUX_PB02I_CCL_OUT0)
+#define PORT_PB02I_CCL_OUT0        (1ul <<  2)
+#define PIN_PB23I_CCL_OUT0                55L  /**< \brief CCL signal: OUT0 on PB23 mux I */
+#define MUX_PB23I_CCL_OUT0                 8L
+#define PINMUX_PB23I_CCL_OUT0      ((PIN_PB23I_CCL_OUT0 << 16) | MUX_PB23I_CCL_OUT0)
+#define PORT_PB23I_CCL_OUT0        (1ul << 23)
+#define PIN_PA11I_CCL_OUT1                11L  /**< \brief CCL signal: OUT1 on PA11 mux I */
+#define MUX_PA11I_CCL_OUT1                 8L
+#define PINMUX_PA11I_CCL_OUT1      ((PIN_PA11I_CCL_OUT1 << 16) | MUX_PA11I_CCL_OUT1)
+#define PORT_PA11I_CCL_OUT1        (1ul << 11)
+#define PIN_PA31I_CCL_OUT1                31L  /**< \brief CCL signal: OUT1 on PA31 mux I */
+#define MUX_PA31I_CCL_OUT1                 8L
+#define PINMUX_PA31I_CCL_OUT1      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1        (1ul << 31)
+#define PIN_PB11I_CCL_OUT1                43L  /**< \brief CCL signal: OUT1 on PB11 mux I */
+#define MUX_PB11I_CCL_OUT1                 8L
+#define PINMUX_PB11I_CCL_OUT1      ((PIN_PB11I_CCL_OUT1 << 16) | MUX_PB11I_CCL_OUT1)
+#define PORT_PB11I_CCL_OUT1        (1ul << 11)
+#define PIN_PA25I_CCL_OUT2                25L  /**< \brief CCL signal: OUT2 on PA25 mux I */
+#define MUX_PA25I_CCL_OUT2                 8L
+#define PINMUX_PA25I_CCL_OUT2      ((PIN_PA25I_CCL_OUT2 << 16) | MUX_PA25I_CCL_OUT2)
+#define PORT_PA25I_CCL_OUT2        (1ul << 25)
+#define PIN_PB09I_CCL_OUT2                41L  /**< \brief CCL signal: OUT2 on PB09 mux I */
+#define MUX_PB09I_CCL_OUT2                 8L
+#define PINMUX_PB09I_CCL_OUT2      ((PIN_PB09I_CCL_OUT2 << 16) | MUX_PB09I_CCL_OUT2)
+#define PORT_PB09I_CCL_OUT2        (1ul <<  9)
+
+#endif /* _SAML21G18A_PIO_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/pio/saml21j18a.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/pio/saml21j18a.h
@@ -1,0 +1,1407 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAML21J18A
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21J18A_PIO_
+#define _SAML21J18A_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00                 (1ul <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01                 (1ul <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02                 (1ul <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03                 (1ul <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04                 (1ul <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05                 (1ul <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06                 (1ul <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07                 (1ul <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08                 (1ul <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09                 (1ul <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10                 (1ul << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11                 (1ul << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12                 (1ul << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13                 (1ul << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14                 (1ul << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15                 (1ul << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16                 (1ul << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17                 (1ul << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18                 (1ul << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19                 (1ul << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20                 (1ul << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21                 (1ul << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22                 (1ul << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23                 (1ul << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24                 (1ul << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25                 (1ul << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27                 (1ul << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30                 (1ul << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31                 (1ul << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define PORT_PB00                 (1ul <<  0) /**< \brief PORT Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define PORT_PB01                 (1ul <<  1) /**< \brief PORT Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02                 (1ul <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03                 (1ul <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04                 (1ul <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define PORT_PB05                 (1ul <<  5) /**< \brief PORT Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define PORT_PB06                 (1ul <<  6) /**< \brief PORT Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define PORT_PB07                 (1ul <<  7) /**< \brief PORT Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08                 (1ul <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09                 (1ul <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10                 (1ul << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11                 (1ul << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define PORT_PB12                 (1ul << 12) /**< \brief PORT Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define PORT_PB13                 (1ul << 13) /**< \brief PORT Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define PORT_PB14                 (1ul << 14) /**< \brief PORT Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define PORT_PB15                 (1ul << 15) /**< \brief PORT Mask  for PB15 */
+#define PIN_PB16                          48  /**< \brief Pin Number for PB16 */
+#define PORT_PB16                 (1ul << 16) /**< \brief PORT Mask  for PB16 */
+#define PIN_PB17                          49  /**< \brief Pin Number for PB17 */
+#define PORT_PB17                 (1ul << 17) /**< \brief PORT Mask  for PB17 */
+#define PIN_PB22                          54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22                 (1ul << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                          55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23                 (1ul << 23) /**< \brief PORT Mask  for PB23 */
+#define PIN_PB30                          62  /**< \brief Pin Number for PB30 */
+#define PORT_PB30                 (1ul << 30) /**< \brief PORT Mask  for PB30 */
+#define PIN_PB31                          63  /**< \brief Pin Number for PB31 */
+#define PORT_PB31                 (1ul << 31) /**< \brief PORT Mask  for PB31 */
+/* ========== PORT definition for RSTC peripheral ========== */
+#define PIN_PA00A_RSTC_EXTWAKE0            0L  /**< \brief RSTC signal: EXTWAKE0 on PA00 mux A */
+#define MUX_PA00A_RSTC_EXTWAKE0            0L
+#define PINMUX_PA00A_RSTC_EXTWAKE0  ((PIN_PA00A_RSTC_EXTWAKE0 << 16) | MUX_PA00A_RSTC_EXTWAKE0)
+#define PORT_PA00A_RSTC_EXTWAKE0   (1ul <<  0)
+#define PIN_PA01A_RSTC_EXTWAKE1            1L  /**< \brief RSTC signal: EXTWAKE1 on PA01 mux A */
+#define MUX_PA01A_RSTC_EXTWAKE1            0L
+#define PINMUX_PA01A_RSTC_EXTWAKE1  ((PIN_PA01A_RSTC_EXTWAKE1 << 16) | MUX_PA01A_RSTC_EXTWAKE1)
+#define PORT_PA01A_RSTC_EXTWAKE1   (1ul <<  1)
+#define PIN_PA02A_RSTC_EXTWAKE2            2L  /**< \brief RSTC signal: EXTWAKE2 on PA02 mux A */
+#define MUX_PA02A_RSTC_EXTWAKE2            0L
+#define PINMUX_PA02A_RSTC_EXTWAKE2  ((PIN_PA02A_RSTC_EXTWAKE2 << 16) | MUX_PA02A_RSTC_EXTWAKE2)
+#define PORT_PA02A_RSTC_EXTWAKE2   (1ul <<  2)
+#define PIN_PA03A_RSTC_EXTWAKE3            3L  /**< \brief RSTC signal: EXTWAKE3 on PA03 mux A */
+#define MUX_PA03A_RSTC_EXTWAKE3            0L
+#define PINMUX_PA03A_RSTC_EXTWAKE3  ((PIN_PA03A_RSTC_EXTWAKE3 << 16) | MUX_PA03A_RSTC_EXTWAKE3)
+#define PORT_PA03A_RSTC_EXTWAKE3   (1ul <<  3)
+#define PIN_PA04A_RSTC_EXTWAKE4            4L  /**< \brief RSTC signal: EXTWAKE4 on PA04 mux A */
+#define MUX_PA04A_RSTC_EXTWAKE4            0L
+#define PINMUX_PA04A_RSTC_EXTWAKE4  ((PIN_PA04A_RSTC_EXTWAKE4 << 16) | MUX_PA04A_RSTC_EXTWAKE4)
+#define PORT_PA04A_RSTC_EXTWAKE4   (1ul <<  4)
+#define PIN_PA05A_RSTC_EXTWAKE5            5L  /**< \brief RSTC signal: EXTWAKE5 on PA05 mux A */
+#define MUX_PA05A_RSTC_EXTWAKE5            0L
+#define PINMUX_PA05A_RSTC_EXTWAKE5  ((PIN_PA05A_RSTC_EXTWAKE5 << 16) | MUX_PA05A_RSTC_EXTWAKE5)
+#define PORT_PA05A_RSTC_EXTWAKE5   (1ul <<  5)
+#define PIN_PA06A_RSTC_EXTWAKE6            6L  /**< \brief RSTC signal: EXTWAKE6 on PA06 mux A */
+#define MUX_PA06A_RSTC_EXTWAKE6            0L
+#define PINMUX_PA06A_RSTC_EXTWAKE6  ((PIN_PA06A_RSTC_EXTWAKE6 << 16) | MUX_PA06A_RSTC_EXTWAKE6)
+#define PORT_PA06A_RSTC_EXTWAKE6   (1ul <<  6)
+#define PIN_PA07A_RSTC_EXTWAKE7            7L  /**< \brief RSTC signal: EXTWAKE7 on PA07 mux A */
+#define MUX_PA07A_RSTC_EXTWAKE7            0L
+#define PINMUX_PA07A_RSTC_EXTWAKE7  ((PIN_PA07A_RSTC_EXTWAKE7 << 16) | MUX_PA07A_RSTC_EXTWAKE7)
+#define PORT_PA07A_RSTC_EXTWAKE7   (1ul <<  7)
+#define PIN_PA08A_RSTC_EXTWAKE8            8L  /**< \brief RSTC signal: EXTWAKE8 on PA08 mux A */
+#define MUX_PA08A_RSTC_EXTWAKE8            0L
+#define PINMUX_PA08A_RSTC_EXTWAKE8  ((PIN_PA08A_RSTC_EXTWAKE8 << 16) | MUX_PA08A_RSTC_EXTWAKE8)
+#define PORT_PA08A_RSTC_EXTWAKE8   (1ul <<  8)
+#define PIN_PA09A_RSTC_EXTWAKE9            9L  /**< \brief RSTC signal: EXTWAKE9 on PA09 mux A */
+#define MUX_PA09A_RSTC_EXTWAKE9            0L
+#define PINMUX_PA09A_RSTC_EXTWAKE9  ((PIN_PA09A_RSTC_EXTWAKE9 << 16) | MUX_PA09A_RSTC_EXTWAKE9)
+#define PORT_PA09A_RSTC_EXTWAKE9   (1ul <<  9)
+#define PIN_PA10A_RSTC_EXTWAKE10          10L  /**< \brief RSTC signal: EXTWAKE10 on PA10 mux A */
+#define MUX_PA10A_RSTC_EXTWAKE10           0L
+#define PINMUX_PA10A_RSTC_EXTWAKE10  ((PIN_PA10A_RSTC_EXTWAKE10 << 16) | MUX_PA10A_RSTC_EXTWAKE10)
+#define PORT_PA10A_RSTC_EXTWAKE10  (1ul << 10)
+#define PIN_PA11A_RSTC_EXTWAKE11          11L  /**< \brief RSTC signal: EXTWAKE11 on PA11 mux A */
+#define MUX_PA11A_RSTC_EXTWAKE11           0L
+#define PINMUX_PA11A_RSTC_EXTWAKE11  ((PIN_PA11A_RSTC_EXTWAKE11 << 16) | MUX_PA11A_RSTC_EXTWAKE11)
+#define PORT_PA11A_RSTC_EXTWAKE11  (1ul << 11)
+#define PIN_PA12A_RSTC_EXTWAKE12          12L  /**< \brief RSTC signal: EXTWAKE12 on PA12 mux A */
+#define MUX_PA12A_RSTC_EXTWAKE12           0L
+#define PINMUX_PA12A_RSTC_EXTWAKE12  ((PIN_PA12A_RSTC_EXTWAKE12 << 16) | MUX_PA12A_RSTC_EXTWAKE12)
+#define PORT_PA12A_RSTC_EXTWAKE12  (1ul << 12)
+#define PIN_PA13A_RSTC_EXTWAKE13          13L  /**< \brief RSTC signal: EXTWAKE13 on PA13 mux A */
+#define MUX_PA13A_RSTC_EXTWAKE13           0L
+#define PINMUX_PA13A_RSTC_EXTWAKE13  ((PIN_PA13A_RSTC_EXTWAKE13 << 16) | MUX_PA13A_RSTC_EXTWAKE13)
+#define PORT_PA13A_RSTC_EXTWAKE13  (1ul << 13)
+#define PIN_PA14A_RSTC_EXTWAKE14          14L  /**< \brief RSTC signal: EXTWAKE14 on PA14 mux A */
+#define MUX_PA14A_RSTC_EXTWAKE14           0L
+#define PINMUX_PA14A_RSTC_EXTWAKE14  ((PIN_PA14A_RSTC_EXTWAKE14 << 16) | MUX_PA14A_RSTC_EXTWAKE14)
+#define PORT_PA14A_RSTC_EXTWAKE14  (1ul << 14)
+#define PIN_PA15A_RSTC_EXTWAKE15          15L  /**< \brief RSTC signal: EXTWAKE15 on PA15 mux A */
+#define MUX_PA15A_RSTC_EXTWAKE15           0L
+#define PINMUX_PA15A_RSTC_EXTWAKE15  ((PIN_PA15A_RSTC_EXTWAKE15 << 16) | MUX_PA15A_RSTC_EXTWAKE15)
+#define PORT_PA15A_RSTC_EXTWAKE15  (1ul << 15)
+/* ========== PORT definition for SUPC peripheral ========== */
+#define PIN_PB01H_SUPC_OUT0               33L  /**< \brief SUPC signal: OUT0 on PB01 mux H */
+#define MUX_PB01H_SUPC_OUT0                7L
+#define PINMUX_PB01H_SUPC_OUT0     ((PIN_PB01H_SUPC_OUT0 << 16) | MUX_PB01H_SUPC_OUT0)
+#define PORT_PB01H_SUPC_OUT0       (1ul <<  1)
+#define PIN_PB02H_SUPC_OUT1               34L  /**< \brief SUPC signal: OUT1 on PB02 mux H */
+#define MUX_PB02H_SUPC_OUT1                7L
+#define PINMUX_PB02H_SUPC_OUT1     ((PIN_PB02H_SUPC_OUT1 << 16) | MUX_PB02H_SUPC_OUT1)
+#define PORT_PB02H_SUPC_OUT1       (1ul <<  2)
+#define PIN_PB00H_SUPC_PSOK               32L  /**< \brief SUPC signal: PSOK on PB00 mux H */
+#define MUX_PB00H_SUPC_PSOK                7L
+#define PINMUX_PB00H_SUPC_PSOK     ((PIN_PB00H_SUPC_PSOK << 16) | MUX_PB00H_SUPC_PSOK)
+#define PORT_PB00H_SUPC_PSOK       (1ul <<  0)
+#define PIN_PB03H_SUPC_VBAT               35L  /**< \brief SUPC signal: VBAT on PB03 mux H */
+#define MUX_PB03H_SUPC_VBAT                7L
+#define PINMUX_PB03H_SUPC_VBAT     ((PIN_PB03H_SUPC_VBAT << 16) | MUX_PB03H_SUPC_VBAT)
+#define PORT_PB03H_SUPC_VBAT       (1ul <<  3)
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB14H_GCLK_IO0                46L  /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0                 7L
+#define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
+#define PORT_PB14H_GCLK_IO0        (1ul << 14)
+#define PIN_PB22H_GCLK_IO0                54L  /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0                 7L
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0        (1ul << 22)
+#define PIN_PA14H_GCLK_IO0                14L  /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0                 7L
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0        (1ul << 14)
+#define PIN_PA27H_GCLK_IO0                27L  /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0                 7L
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0        (1ul << 27)
+#define PIN_PA30H_GCLK_IO0                30L  /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0                 7L
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0        (1ul << 30)
+#define PIN_PB15H_GCLK_IO1                47L  /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1                 7L
+#define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
+#define PORT_PB15H_GCLK_IO1        (1ul << 15)
+#define PIN_PB23H_GCLK_IO1                55L  /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1                 7L
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1        (1ul << 23)
+#define PIN_PA15H_GCLK_IO1                15L  /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1                 7L
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1        (1ul << 15)
+#define PIN_PB16H_GCLK_IO2                48L  /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2                 7L
+#define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
+#define PORT_PB16H_GCLK_IO2        (1ul << 16)
+#define PIN_PA16H_GCLK_IO2                16L  /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2                 7L
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2        (1ul << 16)
+#define PIN_PA17H_GCLK_IO3                17L  /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3                 7L
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3        (1ul << 17)
+#define PIN_PB17H_GCLK_IO3                49L  /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3                 7L
+#define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
+#define PORT_PB17H_GCLK_IO3        (1ul << 17)
+#define PIN_PA10H_GCLK_IO4                10L  /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4                 7L
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4        (1ul << 10)
+#define PIN_PA20H_GCLK_IO4                20L  /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4                 7L
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4        (1ul << 20)
+#define PIN_PB10H_GCLK_IO4                42L  /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4                 7L
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4        (1ul << 10)
+#define PIN_PA11H_GCLK_IO5                11L  /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5                 7L
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5        (1ul << 11)
+#define PIN_PA21H_GCLK_IO5                21L  /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5                 7L
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5        (1ul << 21)
+#define PIN_PB11H_GCLK_IO5                43L  /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5                 7L
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5        (1ul << 11)
+#define PIN_PA22H_GCLK_IO6                22L  /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6                 7L
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6        (1ul << 22)
+#define PIN_PB12H_GCLK_IO6                44L  /**< \brief GCLK signal: IO6 on PB12 mux H */
+#define MUX_PB12H_GCLK_IO6                 7L
+#define PINMUX_PB12H_GCLK_IO6      ((PIN_PB12H_GCLK_IO6 << 16) | MUX_PB12H_GCLK_IO6)
+#define PORT_PB12H_GCLK_IO6        (1ul << 12)
+#define PIN_PA23H_GCLK_IO7                23L  /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7                 7L
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7        (1ul << 23)
+#define PIN_PB13H_GCLK_IO7                45L  /**< \brief GCLK signal: IO7 on PB13 mux H */
+#define MUX_PB13H_GCLK_IO7                 7L
+#define PINMUX_PB13H_GCLK_IO7      ((PIN_PB13H_GCLK_IO7 << 16) | MUX_PB13H_GCLK_IO7)
+#define PORT_PB13H_GCLK_IO7        (1ul << 13)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0             16L  /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0              0L
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0     (1ul << 16)
+#define PIN_PB00A_EIC_EXTINT0             32L  /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0              0L
+#define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
+#define PORT_PB00A_EIC_EXTINT0     (1ul <<  0)
+#define PIN_PB16A_EIC_EXTINT0             48L  /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0              0L
+#define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
+#define PORT_PB16A_EIC_EXTINT0     (1ul << 16)
+#define PIN_PA00A_EIC_EXTINT0              0L  /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0              0L
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0     (1ul <<  0)
+#define PIN_PA17A_EIC_EXTINT1             17L  /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1              0L
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1     (1ul << 17)
+#define PIN_PB01A_EIC_EXTINT1             33L  /**< \brief EIC signal: EXTINT1 on PB01 mux A */
+#define MUX_PB01A_EIC_EXTINT1              0L
+#define PINMUX_PB01A_EIC_EXTINT1   ((PIN_PB01A_EIC_EXTINT1 << 16) | MUX_PB01A_EIC_EXTINT1)
+#define PORT_PB01A_EIC_EXTINT1     (1ul <<  1)
+#define PIN_PB17A_EIC_EXTINT1             49L  /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1              0L
+#define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
+#define PORT_PB17A_EIC_EXTINT1     (1ul << 17)
+#define PIN_PA01A_EIC_EXTINT1              1L  /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1              0L
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1     (1ul <<  1)
+#define PIN_PA02A_EIC_EXTINT2              2L  /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2              0L
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2     (1ul <<  2)
+#define PIN_PA18A_EIC_EXTINT2             18L  /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2              0L
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2     (1ul << 18)
+#define PIN_PB02A_EIC_EXTINT2             34L  /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2              0L
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2     (1ul <<  2)
+#define PIN_PA03A_EIC_EXTINT3              3L  /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3              0L
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3     (1ul <<  3)
+#define PIN_PA19A_EIC_EXTINT3             19L  /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3              0L
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3     (1ul << 19)
+#define PIN_PB03A_EIC_EXTINT3             35L  /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3              0L
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3     (1ul <<  3)
+#define PIN_PA04A_EIC_EXTINT4              4L  /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4              0L
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4     (1ul <<  4)
+#define PIN_PA20A_EIC_EXTINT4             20L  /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4              0L
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4     (1ul << 20)
+#define PIN_PB04A_EIC_EXTINT4             36L  /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4              0L
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4     (1ul <<  4)
+#define PIN_PA05A_EIC_EXTINT5              5L  /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5              0L
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5     (1ul <<  5)
+#define PIN_PA21A_EIC_EXTINT5             21L  /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5              0L
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5     (1ul << 21)
+#define PIN_PB05A_EIC_EXTINT5             37L  /**< \brief EIC signal: EXTINT5 on PB05 mux A */
+#define MUX_PB05A_EIC_EXTINT5              0L
+#define PINMUX_PB05A_EIC_EXTINT5   ((PIN_PB05A_EIC_EXTINT5 << 16) | MUX_PB05A_EIC_EXTINT5)
+#define PORT_PB05A_EIC_EXTINT5     (1ul <<  5)
+#define PIN_PA06A_EIC_EXTINT6              6L  /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6              0L
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6     (1ul <<  6)
+#define PIN_PA22A_EIC_EXTINT6             22L  /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6              0L
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6     (1ul << 22)
+#define PIN_PB06A_EIC_EXTINT6             38L  /**< \brief EIC signal: EXTINT6 on PB06 mux A */
+#define MUX_PB06A_EIC_EXTINT6              0L
+#define PINMUX_PB06A_EIC_EXTINT6   ((PIN_PB06A_EIC_EXTINT6 << 16) | MUX_PB06A_EIC_EXTINT6)
+#define PORT_PB06A_EIC_EXTINT6     (1ul <<  6)
+#define PIN_PB22A_EIC_EXTINT6             54L  /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6              0L
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6     (1ul << 22)
+#define PIN_PA07A_EIC_EXTINT7              7L  /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7              0L
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7     (1ul <<  7)
+#define PIN_PA23A_EIC_EXTINT7             23L  /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7              0L
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7     (1ul << 23)
+#define PIN_PB07A_EIC_EXTINT7             39L  /**< \brief EIC signal: EXTINT7 on PB07 mux A */
+#define MUX_PB07A_EIC_EXTINT7              0L
+#define PINMUX_PB07A_EIC_EXTINT7   ((PIN_PB07A_EIC_EXTINT7 << 16) | MUX_PB07A_EIC_EXTINT7)
+#define PORT_PB07A_EIC_EXTINT7     (1ul <<  7)
+#define PIN_PB23A_EIC_EXTINT7             55L  /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7              0L
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7     (1ul << 23)
+#define PIN_PB08A_EIC_EXTINT8             40L  /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8              0L
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8     (1ul <<  8)
+#define PIN_PA09A_EIC_EXTINT9              9L  /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9              0L
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9     (1ul <<  9)
+#define PIN_PB09A_EIC_EXTINT9             41L  /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9              0L
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9     (1ul <<  9)
+#define PIN_PA10A_EIC_EXTINT10            10L  /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10             0L
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10    (1ul << 10)
+#define PIN_PA30A_EIC_EXTINT10            30L  /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10             0L
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10    (1ul << 30)
+#define PIN_PB10A_EIC_EXTINT10            42L  /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10             0L
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10    (1ul << 10)
+#define PIN_PA11A_EIC_EXTINT11            11L  /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11             0L
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11    (1ul << 11)
+#define PIN_PA31A_EIC_EXTINT11            31L  /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11             0L
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11    (1ul << 31)
+#define PIN_PB11A_EIC_EXTINT11            43L  /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11             0L
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11    (1ul << 11)
+#define PIN_PA12A_EIC_EXTINT12            12L  /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12             0L
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12    (1ul << 12)
+#define PIN_PA24A_EIC_EXTINT12            24L  /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12             0L
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12    (1ul << 24)
+#define PIN_PB12A_EIC_EXTINT12            44L  /**< \brief EIC signal: EXTINT12 on PB12 mux A */
+#define MUX_PB12A_EIC_EXTINT12             0L
+#define PINMUX_PB12A_EIC_EXTINT12  ((PIN_PB12A_EIC_EXTINT12 << 16) | MUX_PB12A_EIC_EXTINT12)
+#define PORT_PB12A_EIC_EXTINT12    (1ul << 12)
+#define PIN_PA13A_EIC_EXTINT13            13L  /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13             0L
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13    (1ul << 13)
+#define PIN_PA25A_EIC_EXTINT13            25L  /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13             0L
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13    (1ul << 25)
+#define PIN_PB13A_EIC_EXTINT13            45L  /**< \brief EIC signal: EXTINT13 on PB13 mux A */
+#define MUX_PB13A_EIC_EXTINT13             0L
+#define PINMUX_PB13A_EIC_EXTINT13  ((PIN_PB13A_EIC_EXTINT13 << 16) | MUX_PB13A_EIC_EXTINT13)
+#define PORT_PB13A_EIC_EXTINT13    (1ul << 13)
+#define PIN_PB14A_EIC_EXTINT14            46L  /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14             0L
+#define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
+#define PORT_PB14A_EIC_EXTINT14    (1ul << 14)
+#define PIN_PB30A_EIC_EXTINT14            62L  /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14             0L
+#define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
+#define PORT_PB30A_EIC_EXTINT14    (1ul << 30)
+#define PIN_PA14A_EIC_EXTINT14            14L  /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14             0L
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14    (1ul << 14)
+#define PIN_PA27A_EIC_EXTINT15            27L  /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15             0L
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15    (1ul << 27)
+#define PIN_PB15A_EIC_EXTINT15            47L  /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15             0L
+#define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
+#define PORT_PB15A_EIC_EXTINT15    (1ul << 15)
+#define PIN_PB31A_EIC_EXTINT15            63L  /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15             0L
+#define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
+#define PORT_PB31A_EIC_EXTINT15    (1ul << 31)
+#define PIN_PA15A_EIC_EXTINT15            15L  /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15             0L
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15    (1ul << 15)
+#define PIN_PA08A_EIC_NMI                  8L  /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI                  0L
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI         (1ul <<  8)
+/* ========== PORT definition for TAL peripheral ========== */
+#define PIN_PA27G_TAL_BRK                 27L  /**< \brief TAL signal: BRK on PA27 mux G */
+#define MUX_PA27G_TAL_BRK                  6L
+#define PINMUX_PA27G_TAL_BRK       ((PIN_PA27G_TAL_BRK << 16) | MUX_PA27G_TAL_BRK)
+#define PORT_PA27G_TAL_BRK         (1ul << 27)
+/* ========== PORT definition for USB peripheral ========== */
+#define PIN_PA24G_USB_DM                  24L  /**< \brief USB signal: DM on PA24 mux G */
+#define MUX_PA24G_USB_DM                   6L
+#define PINMUX_PA24G_USB_DM        ((PIN_PA24G_USB_DM << 16) | MUX_PA24G_USB_DM)
+#define PORT_PA24G_USB_DM          (1ul << 24)
+#define PIN_PA25G_USB_DP                  25L  /**< \brief USB signal: DP on PA25 mux G */
+#define MUX_PA25G_USB_DP                   6L
+#define PINMUX_PA25G_USB_DP        ((PIN_PA25G_USB_DP << 16) | MUX_PA25G_USB_DP)
+#define PORT_PA25G_USB_DP          (1ul << 25)
+#define PIN_PA23G_USB_SOF_1KHZ            23L  /**< \brief USB signal: SOF_1KHZ on PA23 mux G */
+#define MUX_PA23G_USB_SOF_1KHZ             6L
+#define PINMUX_PA23G_USB_SOF_1KHZ  ((PIN_PA23G_USB_SOF_1KHZ << 16) | MUX_PA23G_USB_SOF_1KHZ)
+#define PORT_PA23G_USB_SOF_1KHZ    (1ul << 23)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0             4L  /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0             3L
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0    (1ul <<  4)
+#define PIN_PA08C_SERCOM0_PAD0             8L  /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0             2L
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0    (1ul <<  8)
+#define PIN_PA05D_SERCOM0_PAD1             5L  /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1             3L
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1    (1ul <<  5)
+#define PIN_PA09C_SERCOM0_PAD1             9L  /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1             2L
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1    (1ul <<  9)
+#define PIN_PA06D_SERCOM0_PAD2             6L  /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2             3L
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2    (1ul <<  6)
+#define PIN_PA10C_SERCOM0_PAD2            10L  /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2             2L
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2    (1ul << 10)
+#define PIN_PA07D_SERCOM0_PAD3             7L  /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3             3L
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3    (1ul <<  7)
+#define PIN_PA11C_SERCOM0_PAD3            11L  /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3             2L
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3    (1ul << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0            16L  /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0             2L
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0    (1ul << 16)
+#define PIN_PA00D_SERCOM1_PAD0             0L  /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0             3L
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0    (1ul <<  0)
+#define PIN_PA17C_SERCOM1_PAD1            17L  /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1             2L
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1    (1ul << 17)
+#define PIN_PA01D_SERCOM1_PAD1             1L  /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1             3L
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1    (1ul <<  1)
+#define PIN_PA30D_SERCOM1_PAD2            30L  /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2             3L
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2    (1ul << 30)
+#define PIN_PA18C_SERCOM1_PAD2            18L  /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2             2L
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2    (1ul << 18)
+#define PIN_PA31D_SERCOM1_PAD3            31L  /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3             3L
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3    (1ul << 31)
+#define PIN_PA19C_SERCOM1_PAD3            19L  /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3             2L
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3    (1ul << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0             8L  /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0             3L
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0    (1ul <<  8)
+#define PIN_PA12C_SERCOM2_PAD0            12L  /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0             2L
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0    (1ul << 12)
+#define PIN_PA09D_SERCOM2_PAD1             9L  /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1             3L
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1    (1ul <<  9)
+#define PIN_PA13C_SERCOM2_PAD1            13L  /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1             2L
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1    (1ul << 13)
+#define PIN_PA10D_SERCOM2_PAD2            10L  /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2             3L
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2    (1ul << 10)
+#define PIN_PA14C_SERCOM2_PAD2            14L  /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2             2L
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2    (1ul << 14)
+#define PIN_PA11D_SERCOM2_PAD3            11L  /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3             3L
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3    (1ul << 11)
+#define PIN_PA15C_SERCOM2_PAD3            15L  /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3             2L
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3    (1ul << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0            16L  /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0             3L
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0    (1ul << 16)
+#define PIN_PA22C_SERCOM3_PAD0            22L  /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0             2L
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0    (1ul << 22)
+#define PIN_PA27F_SERCOM3_PAD0            27L  /**< \brief SERCOM3 signal: PAD0 on PA27 mux F */
+#define MUX_PA27F_SERCOM3_PAD0             5L
+#define PINMUX_PA27F_SERCOM3_PAD0  ((PIN_PA27F_SERCOM3_PAD0 << 16) | MUX_PA27F_SERCOM3_PAD0)
+#define PORT_PA27F_SERCOM3_PAD0    (1ul << 27)
+#define PIN_PA17D_SERCOM3_PAD1            17L  /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1             3L
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1    (1ul << 17)
+#define PIN_PA23C_SERCOM3_PAD1            23L  /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1             2L
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1    (1ul << 23)
+#define PIN_PA18D_SERCOM3_PAD2            18L  /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2             3L
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2    (1ul << 18)
+#define PIN_PA20D_SERCOM3_PAD2            20L  /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2             3L
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2    (1ul << 20)
+#define PIN_PA24C_SERCOM3_PAD2            24L  /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2             2L
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2    (1ul << 24)
+#define PIN_PA19D_SERCOM3_PAD3            19L  /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3             3L
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3    (1ul << 19)
+#define PIN_PA21D_SERCOM3_PAD3            21L  /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3             3L
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3    (1ul << 21)
+#define PIN_PA25C_SERCOM3_PAD3            25L  /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3             2L
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3    (1ul << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0            12L  /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0             3L
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0    (1ul << 12)
+#define PIN_PB08D_SERCOM4_PAD0            40L  /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0             3L
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0    (1ul <<  8)
+#define PIN_PB12C_SERCOM4_PAD0            44L  /**< \brief SERCOM4 signal: PAD0 on PB12 mux C */
+#define MUX_PB12C_SERCOM4_PAD0             2L
+#define PINMUX_PB12C_SERCOM4_PAD0  ((PIN_PB12C_SERCOM4_PAD0 << 16) | MUX_PB12C_SERCOM4_PAD0)
+#define PORT_PB12C_SERCOM4_PAD0    (1ul << 12)
+#define PIN_PA13D_SERCOM4_PAD1            13L  /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1             3L
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1    (1ul << 13)
+#define PIN_PB09D_SERCOM4_PAD1            41L  /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1             3L
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1    (1ul <<  9)
+#define PIN_PB13C_SERCOM4_PAD1            45L  /**< \brief SERCOM4 signal: PAD1 on PB13 mux C */
+#define MUX_PB13C_SERCOM4_PAD1             2L
+#define PINMUX_PB13C_SERCOM4_PAD1  ((PIN_PB13C_SERCOM4_PAD1 << 16) | MUX_PB13C_SERCOM4_PAD1)
+#define PORT_PB13C_SERCOM4_PAD1    (1ul << 13)
+#define PIN_PB31F_SERCOM4_PAD1            63L  /**< \brief SERCOM4 signal: PAD1 on PB31 mux F */
+#define MUX_PB31F_SERCOM4_PAD1             5L
+#define PINMUX_PB31F_SERCOM4_PAD1  ((PIN_PB31F_SERCOM4_PAD1 << 16) | MUX_PB31F_SERCOM4_PAD1)
+#define PORT_PB31F_SERCOM4_PAD1    (1ul << 31)
+#define PIN_PA14D_SERCOM4_PAD2            14L  /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2             3L
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2    (1ul << 14)
+#define PIN_PB10D_SERCOM4_PAD2            42L  /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2             3L
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2    (1ul << 10)
+#define PIN_PB14C_SERCOM4_PAD2            46L  /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2             2L
+#define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
+#define PORT_PB14C_SERCOM4_PAD2    (1ul << 14)
+#define PIN_PB30F_SERCOM4_PAD2            62L  /**< \brief SERCOM4 signal: PAD2 on PB30 mux F */
+#define MUX_PB30F_SERCOM4_PAD2             5L
+#define PINMUX_PB30F_SERCOM4_PAD2  ((PIN_PB30F_SERCOM4_PAD2 << 16) | MUX_PB30F_SERCOM4_PAD2)
+#define PORT_PB30F_SERCOM4_PAD2    (1ul << 30)
+#define PIN_PA15D_SERCOM4_PAD3            15L  /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3             3L
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3    (1ul << 15)
+#define PIN_PB11D_SERCOM4_PAD3            43L  /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3             3L
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3    (1ul << 11)
+#define PIN_PB15C_SERCOM4_PAD3            47L  /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3             2L
+#define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
+#define PORT_PB15C_SERCOM4_PAD3    (1ul << 15)
+/* ========== PORT definition for TCC0 peripheral ========== */
+#define PIN_PA04E_TCC0_WO0                 4L  /**< \brief TCC0 signal: WO0 on PA04 mux E */
+#define MUX_PA04E_TCC0_WO0                 4L
+#define PINMUX_PA04E_TCC0_WO0      ((PIN_PA04E_TCC0_WO0 << 16) | MUX_PA04E_TCC0_WO0)
+#define PORT_PA04E_TCC0_WO0        (1ul <<  4)
+#define PIN_PA08E_TCC0_WO0                 8L  /**< \brief TCC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TCC0_WO0                 4L
+#define PINMUX_PA08E_TCC0_WO0      ((PIN_PA08E_TCC0_WO0 << 16) | MUX_PA08E_TCC0_WO0)
+#define PORT_PA08E_TCC0_WO0        (1ul <<  8)
+#define PIN_PB30E_TCC0_WO0                62L  /**< \brief TCC0 signal: WO0 on PB30 mux E */
+#define MUX_PB30E_TCC0_WO0                 4L
+#define PINMUX_PB30E_TCC0_WO0      ((PIN_PB30E_TCC0_WO0 << 16) | MUX_PB30E_TCC0_WO0)
+#define PORT_PB30E_TCC0_WO0        (1ul << 30)
+#define PIN_PA16F_TCC0_WO0                16L  /**< \brief TCC0 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO0                 5L
+#define PINMUX_PA16F_TCC0_WO0      ((PIN_PA16F_TCC0_WO0 << 16) | MUX_PA16F_TCC0_WO0)
+#define PORT_PA16F_TCC0_WO0        (1ul << 16)
+#define PIN_PA05E_TCC0_WO1                 5L  /**< \brief TCC0 signal: WO1 on PA05 mux E */
+#define MUX_PA05E_TCC0_WO1                 4L
+#define PINMUX_PA05E_TCC0_WO1      ((PIN_PA05E_TCC0_WO1 << 16) | MUX_PA05E_TCC0_WO1)
+#define PORT_PA05E_TCC0_WO1        (1ul <<  5)
+#define PIN_PA09E_TCC0_WO1                 9L  /**< \brief TCC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TCC0_WO1                 4L
+#define PINMUX_PA09E_TCC0_WO1      ((PIN_PA09E_TCC0_WO1 << 16) | MUX_PA09E_TCC0_WO1)
+#define PORT_PA09E_TCC0_WO1        (1ul <<  9)
+#define PIN_PB31E_TCC0_WO1                63L  /**< \brief TCC0 signal: WO1 on PB31 mux E */
+#define MUX_PB31E_TCC0_WO1                 4L
+#define PINMUX_PB31E_TCC0_WO1      ((PIN_PB31E_TCC0_WO1 << 16) | MUX_PB31E_TCC0_WO1)
+#define PORT_PB31E_TCC0_WO1        (1ul << 31)
+#define PIN_PA17F_TCC0_WO1                17L  /**< \brief TCC0 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO1                 5L
+#define PINMUX_PA17F_TCC0_WO1      ((PIN_PA17F_TCC0_WO1 << 16) | MUX_PA17F_TCC0_WO1)
+#define PORT_PA17F_TCC0_WO1        (1ul << 17)
+#define PIN_PA10F_TCC0_WO2                10L  /**< \brief TCC0 signal: WO2 on PA10 mux F */
+#define MUX_PA10F_TCC0_WO2                 5L
+#define PINMUX_PA10F_TCC0_WO2      ((PIN_PA10F_TCC0_WO2 << 16) | MUX_PA10F_TCC0_WO2)
+#define PORT_PA10F_TCC0_WO2        (1ul << 10)
+#define PIN_PA18F_TCC0_WO2                18L  /**< \brief TCC0 signal: WO2 on PA18 mux F */
+#define MUX_PA18F_TCC0_WO2                 5L
+#define PINMUX_PA18F_TCC0_WO2      ((PIN_PA18F_TCC0_WO2 << 16) | MUX_PA18F_TCC0_WO2)
+#define PORT_PA18F_TCC0_WO2        (1ul << 18)
+#define PIN_PA11F_TCC0_WO3                11L  /**< \brief TCC0 signal: WO3 on PA11 mux F */
+#define MUX_PA11F_TCC0_WO3                 5L
+#define PINMUX_PA11F_TCC0_WO3      ((PIN_PA11F_TCC0_WO3 << 16) | MUX_PA11F_TCC0_WO3)
+#define PORT_PA11F_TCC0_WO3        (1ul << 11)
+#define PIN_PA19F_TCC0_WO3                19L  /**< \brief TCC0 signal: WO3 on PA19 mux F */
+#define MUX_PA19F_TCC0_WO3                 5L
+#define PINMUX_PA19F_TCC0_WO3      ((PIN_PA19F_TCC0_WO3 << 16) | MUX_PA19F_TCC0_WO3)
+#define PORT_PA19F_TCC0_WO3        (1ul << 19)
+#define PIN_PA22F_TCC0_WO4                22L  /**< \brief TCC0 signal: WO4 on PA22 mux F */
+#define MUX_PA22F_TCC0_WO4                 5L
+#define PINMUX_PA22F_TCC0_WO4      ((PIN_PA22F_TCC0_WO4 << 16) | MUX_PA22F_TCC0_WO4)
+#define PORT_PA22F_TCC0_WO4        (1ul << 22)
+#define PIN_PB10F_TCC0_WO4                42L  /**< \brief TCC0 signal: WO4 on PB10 mux F */
+#define MUX_PB10F_TCC0_WO4                 5L
+#define PINMUX_PB10F_TCC0_WO4      ((PIN_PB10F_TCC0_WO4 << 16) | MUX_PB10F_TCC0_WO4)
+#define PORT_PB10F_TCC0_WO4        (1ul << 10)
+#define PIN_PB16F_TCC0_WO4                48L  /**< \brief TCC0 signal: WO4 on PB16 mux F */
+#define MUX_PB16F_TCC0_WO4                 5L
+#define PINMUX_PB16F_TCC0_WO4      ((PIN_PB16F_TCC0_WO4 << 16) | MUX_PB16F_TCC0_WO4)
+#define PORT_PB16F_TCC0_WO4        (1ul << 16)
+#define PIN_PA14F_TCC0_WO4                14L  /**< \brief TCC0 signal: WO4 on PA14 mux F */
+#define MUX_PA14F_TCC0_WO4                 5L
+#define PINMUX_PA14F_TCC0_WO4      ((PIN_PA14F_TCC0_WO4 << 16) | MUX_PA14F_TCC0_WO4)
+#define PORT_PA14F_TCC0_WO4        (1ul << 14)
+#define PIN_PA15F_TCC0_WO5                15L  /**< \brief TCC0 signal: WO5 on PA15 mux F */
+#define MUX_PA15F_TCC0_WO5                 5L
+#define PINMUX_PA15F_TCC0_WO5      ((PIN_PA15F_TCC0_WO5 << 16) | MUX_PA15F_TCC0_WO5)
+#define PORT_PA15F_TCC0_WO5        (1ul << 15)
+#define PIN_PA23F_TCC0_WO5                23L  /**< \brief TCC0 signal: WO5 on PA23 mux F */
+#define MUX_PA23F_TCC0_WO5                 5L
+#define PINMUX_PA23F_TCC0_WO5      ((PIN_PA23F_TCC0_WO5 << 16) | MUX_PA23F_TCC0_WO5)
+#define PORT_PA23F_TCC0_WO5        (1ul << 23)
+#define PIN_PB11F_TCC0_WO5                43L  /**< \brief TCC0 signal: WO5 on PB11 mux F */
+#define MUX_PB11F_TCC0_WO5                 5L
+#define PINMUX_PB11F_TCC0_WO5      ((PIN_PB11F_TCC0_WO5 << 16) | MUX_PB11F_TCC0_WO5)
+#define PORT_PB11F_TCC0_WO5        (1ul << 11)
+#define PIN_PB17F_TCC0_WO5                49L  /**< \brief TCC0 signal: WO5 on PB17 mux F */
+#define MUX_PB17F_TCC0_WO5                 5L
+#define PINMUX_PB17F_TCC0_WO5      ((PIN_PB17F_TCC0_WO5 << 16) | MUX_PB17F_TCC0_WO5)
+#define PORT_PB17F_TCC0_WO5        (1ul << 17)
+#define PIN_PA12F_TCC0_WO6                12L  /**< \brief TCC0 signal: WO6 on PA12 mux F */
+#define MUX_PA12F_TCC0_WO6                 5L
+#define PINMUX_PA12F_TCC0_WO6      ((PIN_PA12F_TCC0_WO6 << 16) | MUX_PA12F_TCC0_WO6)
+#define PORT_PA12F_TCC0_WO6        (1ul << 12)
+#define PIN_PA16F_TCC0_WO6                16L  /**< \brief TCC0 signal: WO6 on PA16 mux F */
+#define MUX_PA16F_TCC0_WO6                 5L
+#define PINMUX_PA16F_TCC0_WO6      ((PIN_PA16F_TCC0_WO6 << 16) | MUX_PA16F_TCC0_WO6)
+#define PORT_PA16F_TCC0_WO6        (1ul << 16)
+#define PIN_PA20F_TCC0_WO6                20L  /**< \brief TCC0 signal: WO6 on PA20 mux F */
+#define MUX_PA20F_TCC0_WO6                 5L
+#define PINMUX_PA20F_TCC0_WO6      ((PIN_PA20F_TCC0_WO6 << 16) | MUX_PA20F_TCC0_WO6)
+#define PORT_PA20F_TCC0_WO6        (1ul << 20)
+#define PIN_PB12F_TCC0_WO6                44L  /**< \brief TCC0 signal: WO6 on PB12 mux F */
+#define MUX_PB12F_TCC0_WO6                 5L
+#define PINMUX_PB12F_TCC0_WO6      ((PIN_PB12F_TCC0_WO6 << 16) | MUX_PB12F_TCC0_WO6)
+#define PORT_PB12F_TCC0_WO6        (1ul << 12)
+#define PIN_PA13F_TCC0_WO7                13L  /**< \brief TCC0 signal: WO7 on PA13 mux F */
+#define MUX_PA13F_TCC0_WO7                 5L
+#define PINMUX_PA13F_TCC0_WO7      ((PIN_PA13F_TCC0_WO7 << 16) | MUX_PA13F_TCC0_WO7)
+#define PORT_PA13F_TCC0_WO7        (1ul << 13)
+#define PIN_PA17F_TCC0_WO7                17L  /**< \brief TCC0 signal: WO7 on PA17 mux F */
+#define MUX_PA17F_TCC0_WO7                 5L
+#define PINMUX_PA17F_TCC0_WO7      ((PIN_PA17F_TCC0_WO7 << 16) | MUX_PA17F_TCC0_WO7)
+#define PORT_PA17F_TCC0_WO7        (1ul << 17)
+#define PIN_PA21F_TCC0_WO7                21L  /**< \brief TCC0 signal: WO7 on PA21 mux F */
+#define MUX_PA21F_TCC0_WO7                 5L
+#define PINMUX_PA21F_TCC0_WO7      ((PIN_PA21F_TCC0_WO7 << 16) | MUX_PA21F_TCC0_WO7)
+#define PORT_PA21F_TCC0_WO7        (1ul << 21)
+#define PIN_PB13F_TCC0_WO7                45L  /**< \brief TCC0 signal: WO7 on PB13 mux F */
+#define MUX_PB13F_TCC0_WO7                 5L
+#define PINMUX_PB13F_TCC0_WO7      ((PIN_PB13F_TCC0_WO7 << 16) | MUX_PB13F_TCC0_WO7)
+#define PORT_PB13F_TCC0_WO7        (1ul << 13)
+/* ========== PORT definition for TCC1 peripheral ========== */
+#define PIN_PA06E_TCC1_WO0                 6L  /**< \brief TCC1 signal: WO0 on PA06 mux E */
+#define MUX_PA06E_TCC1_WO0                 4L
+#define PINMUX_PA06E_TCC1_WO0      ((PIN_PA06E_TCC1_WO0 << 16) | MUX_PA06E_TCC1_WO0)
+#define PORT_PA06E_TCC1_WO0        (1ul <<  6)
+#define PIN_PA10E_TCC1_WO0                10L  /**< \brief TCC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TCC1_WO0                 4L
+#define PINMUX_PA10E_TCC1_WO0      ((PIN_PA10E_TCC1_WO0 << 16) | MUX_PA10E_TCC1_WO0)
+#define PORT_PA10E_TCC1_WO0        (1ul << 10)
+#define PIN_PA30E_TCC1_WO0                30L  /**< \brief TCC1 signal: WO0 on PA30 mux E */
+#define MUX_PA30E_TCC1_WO0                 4L
+#define PINMUX_PA30E_TCC1_WO0      ((PIN_PA30E_TCC1_WO0 << 16) | MUX_PA30E_TCC1_WO0)
+#define PORT_PA30E_TCC1_WO0        (1ul << 30)
+#define PIN_PA07E_TCC1_WO1                 7L  /**< \brief TCC1 signal: WO1 on PA07 mux E */
+#define MUX_PA07E_TCC1_WO1                 4L
+#define PINMUX_PA07E_TCC1_WO1      ((PIN_PA07E_TCC1_WO1 << 16) | MUX_PA07E_TCC1_WO1)
+#define PORT_PA07E_TCC1_WO1        (1ul <<  7)
+#define PIN_PA11E_TCC1_WO1                11L  /**< \brief TCC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TCC1_WO1                 4L
+#define PINMUX_PA11E_TCC1_WO1      ((PIN_PA11E_TCC1_WO1 << 16) | MUX_PA11E_TCC1_WO1)
+#define PORT_PA11E_TCC1_WO1        (1ul << 11)
+#define PIN_PA31E_TCC1_WO1                31L  /**< \brief TCC1 signal: WO1 on PA31 mux E */
+#define MUX_PA31E_TCC1_WO1                 4L
+#define PINMUX_PA31E_TCC1_WO1      ((PIN_PA31E_TCC1_WO1 << 16) | MUX_PA31E_TCC1_WO1)
+#define PORT_PA31E_TCC1_WO1        (1ul << 31)
+#define PIN_PA08F_TCC1_WO2                 8L  /**< \brief TCC1 signal: WO2 on PA08 mux F */
+#define MUX_PA08F_TCC1_WO2                 5L
+#define PINMUX_PA08F_TCC1_WO2      ((PIN_PA08F_TCC1_WO2 << 16) | MUX_PA08F_TCC1_WO2)
+#define PORT_PA08F_TCC1_WO2        (1ul <<  8)
+#define PIN_PA24F_TCC1_WO2                24L  /**< \brief TCC1 signal: WO2 on PA24 mux F */
+#define MUX_PA24F_TCC1_WO2                 5L
+#define PINMUX_PA24F_TCC1_WO2      ((PIN_PA24F_TCC1_WO2 << 16) | MUX_PA24F_TCC1_WO2)
+#define PORT_PA24F_TCC1_WO2        (1ul << 24)
+#define PIN_PB30F_TCC1_WO2                62L  /**< \brief TCC1 signal: WO2 on PB30 mux F */
+#define MUX_PB30F_TCC1_WO2                 5L
+#define PINMUX_PB30F_TCC1_WO2      ((PIN_PB30F_TCC1_WO2 << 16) | MUX_PB30F_TCC1_WO2)
+#define PORT_PB30F_TCC1_WO2        (1ul << 30)
+#define PIN_PA09F_TCC1_WO3                 9L  /**< \brief TCC1 signal: WO3 on PA09 mux F */
+#define MUX_PA09F_TCC1_WO3                 5L
+#define PINMUX_PA09F_TCC1_WO3      ((PIN_PA09F_TCC1_WO3 << 16) | MUX_PA09F_TCC1_WO3)
+#define PORT_PA09F_TCC1_WO3        (1ul <<  9)
+#define PIN_PA25F_TCC1_WO3                25L  /**< \brief TCC1 signal: WO3 on PA25 mux F */
+#define MUX_PA25F_TCC1_WO3                 5L
+#define PINMUX_PA25F_TCC1_WO3      ((PIN_PA25F_TCC1_WO3 << 16) | MUX_PA25F_TCC1_WO3)
+#define PORT_PA25F_TCC1_WO3        (1ul << 25)
+#define PIN_PB31F_TCC1_WO3                63L  /**< \brief TCC1 signal: WO3 on PB31 mux F */
+#define MUX_PB31F_TCC1_WO3                 5L
+#define PINMUX_PB31F_TCC1_WO3      ((PIN_PB31F_TCC1_WO3 << 16) | MUX_PB31F_TCC1_WO3)
+#define PORT_PB31F_TCC1_WO3        (1ul << 31)
+/* ========== PORT definition for TCC2 peripheral ========== */
+#define PIN_PA12E_TCC2_WO0                12L  /**< \brief TCC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TCC2_WO0                 4L
+#define PINMUX_PA12E_TCC2_WO0      ((PIN_PA12E_TCC2_WO0 << 16) | MUX_PA12E_TCC2_WO0)
+#define PORT_PA12E_TCC2_WO0        (1ul << 12)
+#define PIN_PA16E_TCC2_WO0                16L  /**< \brief TCC2 signal: WO0 on PA16 mux E */
+#define MUX_PA16E_TCC2_WO0                 4L
+#define PINMUX_PA16E_TCC2_WO0      ((PIN_PA16E_TCC2_WO0 << 16) | MUX_PA16E_TCC2_WO0)
+#define PORT_PA16E_TCC2_WO0        (1ul << 16)
+#define PIN_PA00E_TCC2_WO0                 0L  /**< \brief TCC2 signal: WO0 on PA00 mux E */
+#define MUX_PA00E_TCC2_WO0                 4L
+#define PINMUX_PA00E_TCC2_WO0      ((PIN_PA00E_TCC2_WO0 << 16) | MUX_PA00E_TCC2_WO0)
+#define PORT_PA00E_TCC2_WO0        (1ul <<  0)
+#define PIN_PA13E_TCC2_WO1                13L  /**< \brief TCC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TCC2_WO1                 4L
+#define PINMUX_PA13E_TCC2_WO1      ((PIN_PA13E_TCC2_WO1 << 16) | MUX_PA13E_TCC2_WO1)
+#define PORT_PA13E_TCC2_WO1        (1ul << 13)
+#define PIN_PA17E_TCC2_WO1                17L  /**< \brief TCC2 signal: WO1 on PA17 mux E */
+#define MUX_PA17E_TCC2_WO1                 4L
+#define PINMUX_PA17E_TCC2_WO1      ((PIN_PA17E_TCC2_WO1 << 16) | MUX_PA17E_TCC2_WO1)
+#define PORT_PA17E_TCC2_WO1        (1ul << 17)
+#define PIN_PA01E_TCC2_WO1                 1L  /**< \brief TCC2 signal: WO1 on PA01 mux E */
+#define MUX_PA01E_TCC2_WO1                 4L
+#define PINMUX_PA01E_TCC2_WO1      ((PIN_PA01E_TCC2_WO1 << 16) | MUX_PA01E_TCC2_WO1)
+#define PORT_PA01E_TCC2_WO1        (1ul <<  1)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA22E_TC0_WO0                 22L  /**< \brief TC0 signal: WO0 on PA22 mux E */
+#define MUX_PA22E_TC0_WO0                  4L
+#define PINMUX_PA22E_TC0_WO0       ((PIN_PA22E_TC0_WO0 << 16) | MUX_PA22E_TC0_WO0)
+#define PORT_PA22E_TC0_WO0         (1ul << 22)
+#define PIN_PB08E_TC0_WO0                 40L  /**< \brief TC0 signal: WO0 on PB08 mux E */
+#define MUX_PB08E_TC0_WO0                  4L
+#define PINMUX_PB08E_TC0_WO0       ((PIN_PB08E_TC0_WO0 << 16) | MUX_PB08E_TC0_WO0)
+#define PORT_PB08E_TC0_WO0         (1ul <<  8)
+#define PIN_PB12E_TC0_WO0                 44L  /**< \brief TC0 signal: WO0 on PB12 mux E */
+#define MUX_PB12E_TC0_WO0                  4L
+#define PINMUX_PB12E_TC0_WO0       ((PIN_PB12E_TC0_WO0 << 16) | MUX_PB12E_TC0_WO0)
+#define PORT_PB12E_TC0_WO0         (1ul << 12)
+#define PIN_PA23E_TC0_WO1                 23L  /**< \brief TC0 signal: WO1 on PA23 mux E */
+#define MUX_PA23E_TC0_WO1                  4L
+#define PINMUX_PA23E_TC0_WO1       ((PIN_PA23E_TC0_WO1 << 16) | MUX_PA23E_TC0_WO1)
+#define PORT_PA23E_TC0_WO1         (1ul << 23)
+#define PIN_PB09E_TC0_WO1                 41L  /**< \brief TC0 signal: WO1 on PB09 mux E */
+#define MUX_PB09E_TC0_WO1                  4L
+#define PINMUX_PB09E_TC0_WO1       ((PIN_PB09E_TC0_WO1 << 16) | MUX_PB09E_TC0_WO1)
+#define PORT_PB09E_TC0_WO1         (1ul <<  9)
+#define PIN_PB13E_TC0_WO1                 45L  /**< \brief TC0 signal: WO1 on PB13 mux E */
+#define MUX_PB13E_TC0_WO1                  4L
+#define PINMUX_PB13E_TC0_WO1       ((PIN_PB13E_TC0_WO1 << 16) | MUX_PB13E_TC0_WO1)
+#define PORT_PB13E_TC0_WO1         (1ul << 13)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA24E_TC1_WO0                 24L  /**< \brief TC1 signal: WO0 on PA24 mux E */
+#define MUX_PA24E_TC1_WO0                  4L
+#define PINMUX_PA24E_TC1_WO0       ((PIN_PA24E_TC1_WO0 << 16) | MUX_PA24E_TC1_WO0)
+#define PORT_PA24E_TC1_WO0         (1ul << 24)
+#define PIN_PB10E_TC1_WO0                 42L  /**< \brief TC1 signal: WO0 on PB10 mux E */
+#define MUX_PB10E_TC1_WO0                  4L
+#define PINMUX_PB10E_TC1_WO0       ((PIN_PB10E_TC1_WO0 << 16) | MUX_PB10E_TC1_WO0)
+#define PORT_PB10E_TC1_WO0         (1ul << 10)
+#define PIN_PB14E_TC1_WO0                 46L  /**< \brief TC1 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC1_WO0                  4L
+#define PINMUX_PB14E_TC1_WO0       ((PIN_PB14E_TC1_WO0 << 16) | MUX_PB14E_TC1_WO0)
+#define PORT_PB14E_TC1_WO0         (1ul << 14)
+#define PIN_PA25E_TC1_WO1                 25L  /**< \brief TC1 signal: WO1 on PA25 mux E */
+#define MUX_PA25E_TC1_WO1                  4L
+#define PINMUX_PA25E_TC1_WO1       ((PIN_PA25E_TC1_WO1 << 16) | MUX_PA25E_TC1_WO1)
+#define PORT_PA25E_TC1_WO1         (1ul << 25)
+#define PIN_PB11E_TC1_WO1                 43L  /**< \brief TC1 signal: WO1 on PB11 mux E */
+#define MUX_PB11E_TC1_WO1                  4L
+#define PINMUX_PB11E_TC1_WO1       ((PIN_PB11E_TC1_WO1 << 16) | MUX_PB11E_TC1_WO1)
+#define PORT_PB11E_TC1_WO1         (1ul << 11)
+#define PIN_PB15E_TC1_WO1                 47L  /**< \brief TC1 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC1_WO1                  4L
+#define PINMUX_PB15E_TC1_WO1       ((PIN_PB15E_TC1_WO1 << 16) | MUX_PB15E_TC1_WO1)
+#define PORT_PB15E_TC1_WO1         (1ul << 15)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PB02E_TC2_WO0                 34L  /**< \brief TC2 signal: WO0 on PB02 mux E */
+#define MUX_PB02E_TC2_WO0                  4L
+#define PINMUX_PB02E_TC2_WO0       ((PIN_PB02E_TC2_WO0 << 16) | MUX_PB02E_TC2_WO0)
+#define PORT_PB02E_TC2_WO0         (1ul <<  2)
+#define PIN_PB16E_TC2_WO0                 48L  /**< \brief TC2 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC2_WO0                  4L
+#define PINMUX_PB16E_TC2_WO0       ((PIN_PB16E_TC2_WO0 << 16) | MUX_PB16E_TC2_WO0)
+#define PORT_PB16E_TC2_WO0         (1ul << 16)
+#define PIN_PB03E_TC2_WO1                 35L  /**< \brief TC2 signal: WO1 on PB03 mux E */
+#define MUX_PB03E_TC2_WO1                  4L
+#define PINMUX_PB03E_TC2_WO1       ((PIN_PB03E_TC2_WO1 << 16) | MUX_PB03E_TC2_WO1)
+#define PORT_PB03E_TC2_WO1         (1ul <<  3)
+#define PIN_PB17E_TC2_WO1                 49L  /**< \brief TC2 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC2_WO1                  4L
+#define PINMUX_PB17E_TC2_WO1       ((PIN_PB17E_TC2_WO1 << 16) | MUX_PB17E_TC2_WO1)
+#define PORT_PB17E_TC2_WO1         (1ul << 17)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA20E_TC3_WO0                 20L  /**< \brief TC3 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC3_WO0                  4L
+#define PINMUX_PA20E_TC3_WO0       ((PIN_PA20E_TC3_WO0 << 16) | MUX_PA20E_TC3_WO0)
+#define PORT_PA20E_TC3_WO0         (1ul << 20)
+#define PIN_PB00E_TC3_WO0                 32L  /**< \brief TC3 signal: WO0 on PB00 mux E */
+#define MUX_PB00E_TC3_WO0                  4L
+#define PINMUX_PB00E_TC3_WO0       ((PIN_PB00E_TC3_WO0 << 16) | MUX_PB00E_TC3_WO0)
+#define PORT_PB00E_TC3_WO0         (1ul <<  0)
+#define PIN_PB22E_TC3_WO0                 54L  /**< \brief TC3 signal: WO0 on PB22 mux E */
+#define MUX_PB22E_TC3_WO0                  4L
+#define PINMUX_PB22E_TC3_WO0       ((PIN_PB22E_TC3_WO0 << 16) | MUX_PB22E_TC3_WO0)
+#define PORT_PB22E_TC3_WO0         (1ul << 22)
+#define PIN_PA21E_TC3_WO1                 21L  /**< \brief TC3 signal: WO1 on PA21 mux E */
+#define MUX_PA21E_TC3_WO1                  4L
+#define PINMUX_PA21E_TC3_WO1       ((PIN_PA21E_TC3_WO1 << 16) | MUX_PA21E_TC3_WO1)
+#define PORT_PA21E_TC3_WO1         (1ul << 21)
+#define PIN_PB01E_TC3_WO1                 33L  /**< \brief TC3 signal: WO1 on PB01 mux E */
+#define MUX_PB01E_TC3_WO1                  4L
+#define PINMUX_PB01E_TC3_WO1       ((PIN_PB01E_TC3_WO1 << 16) | MUX_PB01E_TC3_WO1)
+#define PORT_PB01E_TC3_WO1         (1ul <<  1)
+#define PIN_PB23E_TC3_WO1                 55L  /**< \brief TC3 signal: WO1 on PB23 mux E */
+#define MUX_PB23E_TC3_WO1                  4L
+#define PINMUX_PB23E_TC3_WO1       ((PIN_PB23E_TC3_WO1 << 16) | MUX_PB23E_TC3_WO1)
+#define PORT_PB23E_TC3_WO1         (1ul << 23)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT0                2L  /**< \brief DAC signal: VOUT0 on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT0                1L
+#define PINMUX_PA02B_DAC_VOUT0     ((PIN_PA02B_DAC_VOUT0 << 16) | MUX_PA02B_DAC_VOUT0)
+#define PORT_PA02B_DAC_VOUT0       (1ul <<  2)
+#define PIN_PA05B_DAC_VOUT1                5L  /**< \brief DAC signal: VOUT1 on PA05 mux B */
+#define MUX_PA05B_DAC_VOUT1                1L
+#define PINMUX_PA05B_DAC_VOUT1     ((PIN_PA05B_DAC_VOUT1 << 16) | MUX_PA05B_DAC_VOUT1)
+#define PORT_PA05B_DAC_VOUT1       (1ul <<  5)
+#define PIN_PA03B_DAC_VREFP                3L  /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP                1L
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP       (1ul <<  3)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0            22L  /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0             3L
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0    (1ul << 22)
+#define PIN_PB02D_SERCOM5_PAD0            34L  /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0             3L
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0    (1ul <<  2)
+#define PIN_PB30D_SERCOM5_PAD0            62L  /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0             3L
+#define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
+#define PORT_PB30D_SERCOM5_PAD0    (1ul << 30)
+#define PIN_PB16C_SERCOM5_PAD0            48L  /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0             2L
+#define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
+#define PORT_PB16C_SERCOM5_PAD0    (1ul << 16)
+#define PIN_PA23D_SERCOM5_PAD1            23L  /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1             3L
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1    (1ul << 23)
+#define PIN_PB03D_SERCOM5_PAD1            35L  /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1             3L
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1    (1ul <<  3)
+#define PIN_PB31D_SERCOM5_PAD1            63L  /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1             3L
+#define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
+#define PORT_PB31D_SERCOM5_PAD1    (1ul << 31)
+#define PIN_PB17C_SERCOM5_PAD1            49L  /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1             2L
+#define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
+#define PORT_PB17C_SERCOM5_PAD1    (1ul << 17)
+#define PIN_PA24D_SERCOM5_PAD2            24L  /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2             3L
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2    (1ul << 24)
+#define PIN_PB00D_SERCOM5_PAD2            32L  /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2             3L
+#define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
+#define PORT_PB00D_SERCOM5_PAD2    (1ul <<  0)
+#define PIN_PB22D_SERCOM5_PAD2            54L  /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2             3L
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2    (1ul << 22)
+#define PIN_PA20C_SERCOM5_PAD2            20L  /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2             2L
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2    (1ul << 20)
+#define PIN_PA25D_SERCOM5_PAD3            25L  /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3             3L
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3    (1ul << 25)
+#define PIN_PB01D_SERCOM5_PAD3            33L  /**< \brief SERCOM5 signal: PAD3 on PB01 mux D */
+#define MUX_PB01D_SERCOM5_PAD3             3L
+#define PINMUX_PB01D_SERCOM5_PAD3  ((PIN_PB01D_SERCOM5_PAD3 << 16) | MUX_PB01D_SERCOM5_PAD3)
+#define PORT_PB01D_SERCOM5_PAD3    (1ul <<  1)
+#define PIN_PB23D_SERCOM5_PAD3            55L  /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3             3L
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3    (1ul << 23)
+#define PIN_PA21C_SERCOM5_PAD3            21L  /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3             2L
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3    (1ul << 21)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA18E_TC4_WO0                 18L  /**< \brief TC4 signal: WO0 on PA18 mux E */
+#define MUX_PA18E_TC4_WO0                  4L
+#define PINMUX_PA18E_TC4_WO0       ((PIN_PA18E_TC4_WO0 << 16) | MUX_PA18E_TC4_WO0)
+#define PORT_PA18E_TC4_WO0         (1ul << 18)
+#define PIN_PA14E_TC4_WO0                 14L  /**< \brief TC4 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC4_WO0                  4L
+#define PINMUX_PA14E_TC4_WO0       ((PIN_PA14E_TC4_WO0 << 16) | MUX_PA14E_TC4_WO0)
+#define PORT_PA14E_TC4_WO0         (1ul << 14)
+#define PIN_PA19E_TC4_WO1                 19L  /**< \brief TC4 signal: WO1 on PA19 mux E */
+#define MUX_PA19E_TC4_WO1                  4L
+#define PINMUX_PA19E_TC4_WO1       ((PIN_PA19E_TC4_WO1 << 16) | MUX_PA19E_TC4_WO1)
+#define PORT_PA19E_TC4_WO1         (1ul << 19)
+#define PIN_PA15E_TC4_WO1                 15L  /**< \brief TC4 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC4_WO1                  4L
+#define PINMUX_PA15E_TC4_WO1       ((PIN_PA15E_TC4_WO1 << 16) | MUX_PA15E_TC4_WO1)
+#define PORT_PA15E_TC4_WO1         (1ul << 15)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0                 2L  /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0                 1L
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0        (1ul <<  2)
+#define PIN_PA03B_ADC_AIN1                 3L  /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1                 1L
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1        (1ul <<  3)
+#define PIN_PB08B_ADC_AIN2                40L  /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2                 1L
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2        (1ul <<  8)
+#define PIN_PB09B_ADC_AIN3                41L  /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3                 1L
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3        (1ul <<  9)
+#define PIN_PA04B_ADC_AIN4                 4L  /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4                 1L
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4        (1ul <<  4)
+#define PIN_PA05B_ADC_AIN5                 5L  /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5                 1L
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5        (1ul <<  5)
+#define PIN_PA06B_ADC_AIN6                 6L  /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6                 1L
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6        (1ul <<  6)
+#define PIN_PA07B_ADC_AIN7                 7L  /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7                 1L
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7        (1ul <<  7)
+#define PIN_PB00B_ADC_AIN8                32L  /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8                 1L
+#define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
+#define PORT_PB00B_ADC_AIN8        (1ul <<  0)
+#define PIN_PB01B_ADC_AIN9                33L  /**< \brief ADC signal: AIN9 on PB01 mux B */
+#define MUX_PB01B_ADC_AIN9                 1L
+#define PINMUX_PB01B_ADC_AIN9      ((PIN_PB01B_ADC_AIN9 << 16) | MUX_PB01B_ADC_AIN9)
+#define PORT_PB01B_ADC_AIN9        (1ul <<  1)
+#define PIN_PB02B_ADC_AIN10               34L  /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10                1L
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10       (1ul <<  2)
+#define PIN_PB03B_ADC_AIN11               35L  /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11                1L
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11       (1ul <<  3)
+#define PIN_PB04B_ADC_AIN12               36L  /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12                1L
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12       (1ul <<  4)
+#define PIN_PB05B_ADC_AIN13               37L  /**< \brief ADC signal: AIN13 on PB05 mux B */
+#define MUX_PB05B_ADC_AIN13                1L
+#define PINMUX_PB05B_ADC_AIN13     ((PIN_PB05B_ADC_AIN13 << 16) | MUX_PB05B_ADC_AIN13)
+#define PORT_PB05B_ADC_AIN13       (1ul <<  5)
+#define PIN_PB06B_ADC_AIN14               38L  /**< \brief ADC signal: AIN14 on PB06 mux B */
+#define MUX_PB06B_ADC_AIN14                1L
+#define PINMUX_PB06B_ADC_AIN14     ((PIN_PB06B_ADC_AIN14 << 16) | MUX_PB06B_ADC_AIN14)
+#define PORT_PB06B_ADC_AIN14       (1ul <<  6)
+#define PIN_PB07B_ADC_AIN15               39L  /**< \brief ADC signal: AIN15 on PB07 mux B */
+#define MUX_PB07B_ADC_AIN15                1L
+#define PINMUX_PB07B_ADC_AIN15     ((PIN_PB07B_ADC_AIN15 << 16) | MUX_PB07B_ADC_AIN15)
+#define PORT_PB07B_ADC_AIN15       (1ul <<  7)
+#define PIN_PA08B_ADC_AIN16                8L  /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16                1L
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16       (1ul <<  8)
+#define PIN_PA09B_ADC_AIN17                9L  /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17                1L
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17       (1ul <<  9)
+#define PIN_PA10B_ADC_AIN18               10L  /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18                1L
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18       (1ul << 10)
+#define PIN_PA11B_ADC_AIN19               11L  /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19                1L
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19       (1ul << 11)
+#define PIN_PA04B_ADC_VREFP                4L  /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP                1L
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP       (1ul <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0                  4L  /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0                  1L
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0         (1ul <<  4)
+#define PIN_PA05B_AC_AIN1                  5L  /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1                  1L
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1         (1ul <<  5)
+#define PIN_PA06B_AC_AIN2                  6L  /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2                  1L
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2         (1ul <<  6)
+#define PIN_PA07B_AC_AIN3                  7L  /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3                  1L
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3         (1ul <<  7)
+#define PIN_PA12H_AC_CMP0                 12L  /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0                  7L
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0         (1ul << 12)
+#define PIN_PA18H_AC_CMP0                 18L  /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0                  7L
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0         (1ul << 18)
+#define PIN_PA13H_AC_CMP1                 13L  /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1                  7L
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1         (1ul << 13)
+#define PIN_PA19H_AC_CMP1                 19L  /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1                  7L
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1         (1ul << 19)
+/* ========== PORT definition for OPAMP peripheral ========== */
+#define PIN_PA02B_OPAMP_OANEG0             2L  /**< \brief OPAMP signal: OANEG0 on PA02 mux B */
+#define MUX_PA02B_OPAMP_OANEG0             1L
+#define PINMUX_PA02B_OPAMP_OANEG0  ((PIN_PA02B_OPAMP_OANEG0 << 16) | MUX_PA02B_OPAMP_OANEG0)
+#define PORT_PA02B_OPAMP_OANEG0    (1ul <<  2)
+#define PIN_PB05B_OPAMP_OANEG1            37L  /**< \brief OPAMP signal: OANEG1 on PB05 mux B */
+#define MUX_PB05B_OPAMP_OANEG1             1L
+#define PINMUX_PB05B_OPAMP_OANEG1  ((PIN_PB05B_OPAMP_OANEG1 << 16) | MUX_PB05B_OPAMP_OANEG1)
+#define PORT_PB05B_OPAMP_OANEG1    (1ul <<  5)
+#define PIN_PB08B_OPAMP_OANEG2            40L  /**< \brief OPAMP signal: OANEG2 on PB08 mux B */
+#define MUX_PB08B_OPAMP_OANEG2             1L
+#define PINMUX_PB08B_OPAMP_OANEG2  ((PIN_PB08B_OPAMP_OANEG2 << 16) | MUX_PB08B_OPAMP_OANEG2)
+#define PORT_PB08B_OPAMP_OANEG2    (1ul <<  8)
+#define PIN_PA07B_OPAMP_OAOUT0             7L  /**< \brief OPAMP signal: OAOUT0 on PA07 mux B */
+#define MUX_PA07B_OPAMP_OAOUT0             1L
+#define PINMUX_PA07B_OPAMP_OAOUT0  ((PIN_PA07B_OPAMP_OAOUT0 << 16) | MUX_PA07B_OPAMP_OAOUT0)
+#define PORT_PA07B_OPAMP_OAOUT0    (1ul <<  7)
+#define PIN_PB06B_OPAMP_OAOUT1            38L  /**< \brief OPAMP signal: OAOUT1 on PB06 mux B */
+#define MUX_PB06B_OPAMP_OAOUT1             1L
+#define PINMUX_PB06B_OPAMP_OAOUT1  ((PIN_PB06B_OPAMP_OAOUT1 << 16) | MUX_PB06B_OPAMP_OAOUT1)
+#define PORT_PB06B_OPAMP_OAOUT1    (1ul <<  6)
+#define PIN_PA04B_OPAMP_OAOUT2             4L  /**< \brief OPAMP signal: OAOUT2 on PA04 mux B */
+#define MUX_PA04B_OPAMP_OAOUT2             1L
+#define PINMUX_PA04B_OPAMP_OAOUT2  ((PIN_PA04B_OPAMP_OAOUT2 << 16) | MUX_PA04B_OPAMP_OAOUT2)
+#define PORT_PA04B_OPAMP_OAOUT2    (1ul <<  4)
+#define PIN_PA06B_OPAMP_OAPOS0             6L  /**< \brief OPAMP signal: OAPOS0 on PA06 mux B */
+#define MUX_PA06B_OPAMP_OAPOS0             1L
+#define PINMUX_PA06B_OPAMP_OAPOS0  ((PIN_PA06B_OPAMP_OAPOS0 << 16) | MUX_PA06B_OPAMP_OAPOS0)
+#define PORT_PA06B_OPAMP_OAPOS0    (1ul <<  6)
+#define PIN_PB09B_OPAMP_OAPOS1            41L  /**< \brief OPAMP signal: OAPOS1 on PB09 mux B */
+#define MUX_PB09B_OPAMP_OAPOS1             1L
+#define PINMUX_PB09B_OPAMP_OAPOS1  ((PIN_PB09B_OPAMP_OAPOS1 << 16) | MUX_PB09B_OPAMP_OAPOS1)
+#define PORT_PB09B_OPAMP_OAPOS1    (1ul <<  9)
+#define PIN_PA05B_OPAMP_OAPOS2             5L  /**< \brief OPAMP signal: OAPOS2 on PA05 mux B */
+#define MUX_PA05B_OPAMP_OAPOS2             1L
+#define PINMUX_PA05B_OPAMP_OAPOS2  ((PIN_PA05B_OPAMP_OAPOS2 << 16) | MUX_PA05B_OPAMP_OAPOS2)
+#define PORT_PA05B_OPAMP_OAPOS2    (1ul <<  5)
+/* ========== PORT definition for CCL peripheral ========== */
+#define PIN_PA04I_CCL_IN0                  4L  /**< \brief CCL signal: IN0 on PA04 mux I */
+#define MUX_PA04I_CCL_IN0                  8L
+#define PINMUX_PA04I_CCL_IN0       ((PIN_PA04I_CCL_IN0 << 16) | MUX_PA04I_CCL_IN0)
+#define PORT_PA04I_CCL_IN0         (1ul <<  4)
+#define PIN_PA16I_CCL_IN0                 16L  /**< \brief CCL signal: IN0 on PA16 mux I */
+#define MUX_PA16I_CCL_IN0                  8L
+#define PINMUX_PA16I_CCL_IN0       ((PIN_PA16I_CCL_IN0 << 16) | MUX_PA16I_CCL_IN0)
+#define PORT_PA16I_CCL_IN0         (1ul << 16)
+#define PIN_PB22I_CCL_IN0                 54L  /**< \brief CCL signal: IN0 on PB22 mux I */
+#define MUX_PB22I_CCL_IN0                  8L
+#define PINMUX_PB22I_CCL_IN0       ((PIN_PB22I_CCL_IN0 << 16) | MUX_PB22I_CCL_IN0)
+#define PORT_PB22I_CCL_IN0         (1ul << 22)
+#define PIN_PA05I_CCL_IN1                  5L  /**< \brief CCL signal: IN1 on PA05 mux I */
+#define MUX_PA05I_CCL_IN1                  8L
+#define PINMUX_PA05I_CCL_IN1       ((PIN_PA05I_CCL_IN1 << 16) | MUX_PA05I_CCL_IN1)
+#define PORT_PA05I_CCL_IN1         (1ul <<  5)
+#define PIN_PA17I_CCL_IN1                 17L  /**< \brief CCL signal: IN1 on PA17 mux I */
+#define MUX_PA17I_CCL_IN1                  8L
+#define PINMUX_PA17I_CCL_IN1       ((PIN_PA17I_CCL_IN1 << 16) | MUX_PA17I_CCL_IN1)
+#define PORT_PA17I_CCL_IN1         (1ul << 17)
+#define PIN_PB00I_CCL_IN1                 32L  /**< \brief CCL signal: IN1 on PB00 mux I */
+#define MUX_PB00I_CCL_IN1                  8L
+#define PINMUX_PB00I_CCL_IN1       ((PIN_PB00I_CCL_IN1 << 16) | MUX_PB00I_CCL_IN1)
+#define PORT_PB00I_CCL_IN1         (1ul <<  0)
+#define PIN_PA06I_CCL_IN2                  6L  /**< \brief CCL signal: IN2 on PA06 mux I */
+#define MUX_PA06I_CCL_IN2                  8L
+#define PINMUX_PA06I_CCL_IN2       ((PIN_PA06I_CCL_IN2 << 16) | MUX_PA06I_CCL_IN2)
+#define PORT_PA06I_CCL_IN2         (1ul <<  6)
+#define PIN_PA18I_CCL_IN2                 18L  /**< \brief CCL signal: IN2 on PA18 mux I */
+#define MUX_PA18I_CCL_IN2                  8L
+#define PINMUX_PA18I_CCL_IN2       ((PIN_PA18I_CCL_IN2 << 16) | MUX_PA18I_CCL_IN2)
+#define PORT_PA18I_CCL_IN2         (1ul << 18)
+#define PIN_PB01I_CCL_IN2                 33L  /**< \brief CCL signal: IN2 on PB01 mux I */
+#define MUX_PB01I_CCL_IN2                  8L
+#define PINMUX_PB01I_CCL_IN2       ((PIN_PB01I_CCL_IN2 << 16) | MUX_PB01I_CCL_IN2)
+#define PORT_PB01I_CCL_IN2         (1ul <<  1)
+#define PIN_PA08I_CCL_IN3                  8L  /**< \brief CCL signal: IN3 on PA08 mux I */
+#define MUX_PA08I_CCL_IN3                  8L
+#define PINMUX_PA08I_CCL_IN3       ((PIN_PA08I_CCL_IN3 << 16) | MUX_PA08I_CCL_IN3)
+#define PORT_PA08I_CCL_IN3         (1ul <<  8)
+#define PIN_PA30I_CCL_IN3                 30L  /**< \brief CCL signal: IN3 on PA30 mux I */
+#define MUX_PA30I_CCL_IN3                  8L
+#define PINMUX_PA30I_CCL_IN3       ((PIN_PA30I_CCL_IN3 << 16) | MUX_PA30I_CCL_IN3)
+#define PORT_PA30I_CCL_IN3         (1ul << 30)
+#define PIN_PA09I_CCL_IN4                  9L  /**< \brief CCL signal: IN4 on PA09 mux I */
+#define MUX_PA09I_CCL_IN4                  8L
+#define PINMUX_PA09I_CCL_IN4       ((PIN_PA09I_CCL_IN4 << 16) | MUX_PA09I_CCL_IN4)
+#define PORT_PA09I_CCL_IN4         (1ul <<  9)
+#define PIN_PA10I_CCL_IN5                 10L  /**< \brief CCL signal: IN5 on PA10 mux I */
+#define MUX_PA10I_CCL_IN5                  8L
+#define PINMUX_PA10I_CCL_IN5       ((PIN_PA10I_CCL_IN5 << 16) | MUX_PA10I_CCL_IN5)
+#define PORT_PA10I_CCL_IN5         (1ul << 10)
+#define PIN_PB10I_CCL_IN5                 42L  /**< \brief CCL signal: IN5 on PB10 mux I */
+#define MUX_PB10I_CCL_IN5                  8L
+#define PINMUX_PB10I_CCL_IN5       ((PIN_PB10I_CCL_IN5 << 16) | MUX_PB10I_CCL_IN5)
+#define PORT_PB10I_CCL_IN5         (1ul << 10)
+#define PIN_PA22I_CCL_IN6                 22L  /**< \brief CCL signal: IN6 on PA22 mux I */
+#define MUX_PA22I_CCL_IN6                  8L
+#define PINMUX_PA22I_CCL_IN6       ((PIN_PA22I_CCL_IN6 << 16) | MUX_PA22I_CCL_IN6)
+#define PORT_PA22I_CCL_IN6         (1ul << 22)
+#define PIN_PB06I_CCL_IN6                 38L  /**< \brief CCL signal: IN6 on PB06 mux I */
+#define MUX_PB06I_CCL_IN6                  8L
+#define PINMUX_PB06I_CCL_IN6       ((PIN_PB06I_CCL_IN6 << 16) | MUX_PB06I_CCL_IN6)
+#define PORT_PB06I_CCL_IN6         (1ul <<  6)
+#define PIN_PA23I_CCL_IN7                 23L  /**< \brief CCL signal: IN7 on PA23 mux I */
+#define MUX_PA23I_CCL_IN7                  8L
+#define PINMUX_PA23I_CCL_IN7       ((PIN_PA23I_CCL_IN7 << 16) | MUX_PA23I_CCL_IN7)
+#define PORT_PA23I_CCL_IN7         (1ul << 23)
+#define PIN_PB07I_CCL_IN7                 39L  /**< \brief CCL signal: IN7 on PB07 mux I */
+#define MUX_PB07I_CCL_IN7                  8L
+#define PINMUX_PB07I_CCL_IN7       ((PIN_PB07I_CCL_IN7 << 16) | MUX_PB07I_CCL_IN7)
+#define PORT_PB07I_CCL_IN7         (1ul <<  7)
+#define PIN_PA24I_CCL_IN8                 24L  /**< \brief CCL signal: IN8 on PA24 mux I */
+#define MUX_PA24I_CCL_IN8                  8L
+#define PINMUX_PA24I_CCL_IN8       ((PIN_PA24I_CCL_IN8 << 16) | MUX_PA24I_CCL_IN8)
+#define PORT_PA24I_CCL_IN8         (1ul << 24)
+#define PIN_PB08I_CCL_IN8                 40L  /**< \brief CCL signal: IN8 on PB08 mux I */
+#define MUX_PB08I_CCL_IN8                  8L
+#define PINMUX_PB08I_CCL_IN8       ((PIN_PB08I_CCL_IN8 << 16) | MUX_PB08I_CCL_IN8)
+#define PORT_PB08I_CCL_IN8         (1ul <<  8)
+#define PIN_PB14I_CCL_IN9                 46L  /**< \brief CCL signal: IN9 on PB14 mux I */
+#define MUX_PB14I_CCL_IN9                  8L
+#define PINMUX_PB14I_CCL_IN9       ((PIN_PB14I_CCL_IN9 << 16) | MUX_PB14I_CCL_IN9)
+#define PORT_PB14I_CCL_IN9         (1ul << 14)
+#define PIN_PB15I_CCL_IN10                47L  /**< \brief CCL signal: IN10 on PB15 mux I */
+#define MUX_PB15I_CCL_IN10                 8L
+#define PINMUX_PB15I_CCL_IN10      ((PIN_PB15I_CCL_IN10 << 16) | MUX_PB15I_CCL_IN10)
+#define PORT_PB15I_CCL_IN10        (1ul << 15)
+#define PIN_PB16I_CCL_IN11                48L  /**< \brief CCL signal: IN11 on PB16 mux I */
+#define MUX_PB16I_CCL_IN11                 8L
+#define PINMUX_PB16I_CCL_IN11      ((PIN_PB16I_CCL_IN11 << 16) | MUX_PB16I_CCL_IN11)
+#define PORT_PB16I_CCL_IN11        (1ul << 16)
+#define PIN_PA07I_CCL_OUT0                 7L  /**< \brief CCL signal: OUT0 on PA07 mux I */
+#define MUX_PA07I_CCL_OUT0                 8L
+#define PINMUX_PA07I_CCL_OUT0      ((PIN_PA07I_CCL_OUT0 << 16) | MUX_PA07I_CCL_OUT0)
+#define PORT_PA07I_CCL_OUT0        (1ul <<  7)
+#define PIN_PA19I_CCL_OUT0                19L  /**< \brief CCL signal: OUT0 on PA19 mux I */
+#define MUX_PA19I_CCL_OUT0                 8L
+#define PINMUX_PA19I_CCL_OUT0      ((PIN_PA19I_CCL_OUT0 << 16) | MUX_PA19I_CCL_OUT0)
+#define PORT_PA19I_CCL_OUT0        (1ul << 19)
+#define PIN_PB02I_CCL_OUT0                34L  /**< \brief CCL signal: OUT0 on PB02 mux I */
+#define MUX_PB02I_CCL_OUT0                 8L
+#define PINMUX_PB02I_CCL_OUT0      ((PIN_PB02I_CCL_OUT0 << 16) | MUX_PB02I_CCL_OUT0)
+#define PORT_PB02I_CCL_OUT0        (1ul <<  2)
+#define PIN_PB23I_CCL_OUT0                55L  /**< \brief CCL signal: OUT0 on PB23 mux I */
+#define MUX_PB23I_CCL_OUT0                 8L
+#define PINMUX_PB23I_CCL_OUT0      ((PIN_PB23I_CCL_OUT0 << 16) | MUX_PB23I_CCL_OUT0)
+#define PORT_PB23I_CCL_OUT0        (1ul << 23)
+#define PIN_PA11I_CCL_OUT1                11L  /**< \brief CCL signal: OUT1 on PA11 mux I */
+#define MUX_PA11I_CCL_OUT1                 8L
+#define PINMUX_PA11I_CCL_OUT1      ((PIN_PA11I_CCL_OUT1 << 16) | MUX_PA11I_CCL_OUT1)
+#define PORT_PA11I_CCL_OUT1        (1ul << 11)
+#define PIN_PA31I_CCL_OUT1                31L  /**< \brief CCL signal: OUT1 on PA31 mux I */
+#define MUX_PA31I_CCL_OUT1                 8L
+#define PINMUX_PA31I_CCL_OUT1      ((PIN_PA31I_CCL_OUT1 << 16) | MUX_PA31I_CCL_OUT1)
+#define PORT_PA31I_CCL_OUT1        (1ul << 31)
+#define PIN_PB11I_CCL_OUT1                43L  /**< \brief CCL signal: OUT1 on PB11 mux I */
+#define MUX_PB11I_CCL_OUT1                 8L
+#define PINMUX_PB11I_CCL_OUT1      ((PIN_PB11I_CCL_OUT1 << 16) | MUX_PB11I_CCL_OUT1)
+#define PORT_PB11I_CCL_OUT1        (1ul << 11)
+#define PIN_PA25I_CCL_OUT2                25L  /**< \brief CCL signal: OUT2 on PA25 mux I */
+#define MUX_PA25I_CCL_OUT2                 8L
+#define PINMUX_PA25I_CCL_OUT2      ((PIN_PA25I_CCL_OUT2 << 16) | MUX_PA25I_CCL_OUT2)
+#define PORT_PA25I_CCL_OUT2        (1ul << 25)
+#define PIN_PB09I_CCL_OUT2                41L  /**< \brief CCL signal: OUT2 on PB09 mux I */
+#define MUX_PB09I_CCL_OUT2                 8L
+#define PINMUX_PB09I_CCL_OUT2      ((PIN_PB09I_CCL_OUT2 << 16) | MUX_PB09I_CCL_OUT2)
+#define PORT_PB09I_CCL_OUT2        (1ul <<  9)
+#define PIN_PB17I_CCL_OUT3                49L  /**< \brief CCL signal: OUT3 on PB17 mux I */
+#define MUX_PB17I_CCL_OUT3                 8L
+#define PINMUX_PB17I_CCL_OUT3      ((PIN_PB17I_CCL_OUT3 << 16) | MUX_PB17I_CCL_OUT3)
+#define PORT_PB17I_CCL_OUT3        (1ul << 17)
+
+#endif /* _SAML21J18A_PIO_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/saml21.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/saml21.h
@@ -1,0 +1,62 @@
+/**
+ * \file
+ *
+ * \brief Top header file for SAML21
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21_
+#define _SAML21_
+
+/**
+ * \defgroup SAML21_definitions SAML21 Device Definitions
+ * \brief SAML21 CMSIS Definitions.
+ */
+
+#if   defined(__SAML21E18A__) || defined(__ATSAML21E18A__)
+  #include "saml21e18a.h"
+#elif defined(__SAML21G18A__) || defined(__ATSAML21G18A__)
+  #include "saml21g18a.h"
+#elif defined(__SAML21J18A__) || defined(__ATSAML21J18A__)
+  #include "saml21j18a.h"
+#else
+  #error Library does not support the specified device.
+#endif
+
+#endif /* _SAML21_ */

--- a/cpu/sam21_common/include/cmsis/saml21/include/saml21e18a.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/saml21e18a.h
@@ -1,0 +1,625 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAML21E18A
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21E18A_
+#define _SAML21E18A_
+
+/**
+ * \ingroup SAML21_definitions
+ * \addtogroup SAML21E18A_definitions SAML21E18A definitions
+ * This file defines all structures and symbols for SAML21E18A:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#define CAST(type, value) ((type *)(value))
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else
+#define CAST(type, value) (value)
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAML21E18A */
+/* ************************************************************************** */
+/** \defgroup SAML21E18A_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                 */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M0+ Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M0+ SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M0+ Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M0+ System Tick Interrupt       */
+  /******  SAML21E18A-specific Interrupt Numbers ***********************/
+  SYSTEM_IRQn              =  0, /**<  0 SAML21E18A System Interrupts */
+  MCLK_IRQn                =  0, /**<  0 SAML21E18A Main Clock (MCLK) */
+  OSCCTRL_IRQn             =  0, /**<  0 SAML21E18A Oscillators Control (OSCCTRL) */
+  OSC32KCTRL_IRQn          =  0, /**<  0 SAML21E18A 32k Oscillators Control (OSC32KCTRL) */
+  PAC_IRQn                 =  0, /**<  0 SAML21E18A Peripheral Access Controller (PAC) */
+  PM_IRQn                  =  0, /**<  0 SAML21E18A Power Manager (PM) */
+  SUPC_IRQn                =  0, /**<  0 SAML21E18A Supply Controller (SUPC) */
+  TAL_IRQn                 =  0, /**<  0 SAML21E18A Trigger Allocator (TAL) */
+  WDT_IRQn                 =  1, /**<  1 SAML21E18A Watchdog Timer (WDT) */
+  RTC_IRQn                 =  2, /**<  2 SAML21E18A Real-Time Counter (RTC) */
+  EIC_IRQn                 =  3, /**<  3 SAML21E18A External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  4, /**<  4 SAML21E18A Non-Volatile Memory Controller (NVMCTRL) */
+  DMAC_IRQn                =  5, /**<  5 SAML21E18A Direct Memory Access Controller (DMAC) */
+  USB_IRQn                 =  6, /**<  6 SAML21E18A Universal Serial Bus (USB) */
+  EVSYS_IRQn               =  7, /**<  7 SAML21E18A Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  8, /**<  8 SAML21E18A Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  9, /**<  9 SAML21E18A Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             = 10, /**< 10 SAML21E18A Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 11, /**< 11 SAML21E18A Serial Communication Interface 3 (SERCOM3) */
+  TCC0_IRQn                = 14, /**< 14 SAML21E18A Timer Counter Control 0 (TCC0) */
+  TCC1_IRQn                = 15, /**< 15 SAML21E18A Timer Counter Control 1 (TCC1) */
+  TCC2_IRQn                = 16, /**< 16 SAML21E18A Timer Counter Control 2 (TCC2) */
+  TC0_IRQn                 = 17, /**< 17 SAML21E18A Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 18, /**< 18 SAML21E18A Basic Timer Counter 1 (TC1) */
+  TC4_IRQn                 = 21, /**< 21 SAML21E18A Basic Timer Counter 4 (TC4) */
+  ADC_IRQn                 = 22, /**< 22 SAML21E18A Analog Digital Converter (ADC) */
+  AC_IRQn                  = 23, /**< 23 SAML21E18A Analog Comparators (AC) */
+  DAC_IRQn                 = 24, /**< 24 SAML21E18A Digital-to-Analog Converter (DAC) */
+  PTC_IRQn                 = 25, /**< 25 SAML21E18A Peripheral Touch Controller (PTC) */
+  AES_IRQn                 = 26, /**< 26 SAML21E18A Advanced Encryption Standard (AES) */
+  TRNG_IRQn                = 27, /**< 27 SAML21E18A True Random Generator (TRNG) */
+
+  PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnReservedM12;
+  void* pfnReservedM11;
+  void* pfnReservedM10;
+  void* pfnReservedM9;
+  void* pfnReservedM8;
+  void* pfnReservedM7;
+  void* pfnReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnReservedM4;
+  void* pfnReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                /*  0 Main Clock, Oscillators Control, 32k Oscillators Control, Peripheral Access Controller, Power Manager, Supply Controller, Trigger Allocator */
+  void* pfnWDT_Handler;                   /*  1 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  2 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  3 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  4 Non-Volatile Memory Controller */
+  void* pfnDMAC_Handler;                  /*  5 Direct Memory Access Controller */
+  void* pfnUSB_Handler;                   /*  6 Universal Serial Bus */
+  void* pfnEVSYS_Handler;                 /*  7 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  8 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  9 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /* 10 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 11 Serial Communication Interface 3 */
+  void* pfnReserved12;
+  void* pfnReserved13;
+  void* pfnTCC0_Handler;                  /* 14 Timer Counter Control 0 */
+  void* pfnTCC1_Handler;                  /* 15 Timer Counter Control 1 */
+  void* pfnTCC2_Handler;                  /* 16 Timer Counter Control 2 */
+  void* pfnTC0_Handler;                   /* 17 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 18 Basic Timer Counter 1 */
+  void* pfnReserved19;
+  void* pfnReserved20;
+  void* pfnTC4_Handler;                   /* 21 Basic Timer Counter 4 */
+  void* pfnADC_Handler;                   /* 22 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 23 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 24 Digital-to-Analog Converter */
+  void* pfnPTC_Handler;                   /* 25 Peripheral Touch Controller */
+  void* pfnAES_Handler;                   /* 26 Advanced Encryption Standard */
+  void* pfnTRNG_Handler;                  /* 27 True Random Generator */
+  void* pfnReserved28;
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void SVC_Handler                 ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void SYSTEM_Handler              ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void DMAC_Handler                ( void );
+void USB_Handler                 ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TCC0_Handler                ( void );
+void TCC1_Handler                ( void );
+void TCC2_Handler                ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC4_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+void AES_Handler                 ( void );
+void TRNG_Handler                ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml21.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML21E18A */
+/* ************************************************************************** */
+/** \defgroup SAML21E18A_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc_100.h"
+#include "component/aes.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic_100.h"
+#include "component/evsys.h"
+#include "component/gclk_100.h"
+#include "component/mclk_100.h"
+#include "component/mtb.h"
+#include "component/nvmctrl_301.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac_100.h"
+#include "component/pm_100.h"
+#include "component/port.h"
+#include "component/rstc_100.h"
+#include "component/rtc_100.h"
+#include "component/sercom.h"
+#include "component/supc_100.h"
+#include "component/tal.h"
+#include "component/tc_100.h"
+#include "component/tcc_200.h"
+#include "component/trng.h"
+#include "component/usb.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAML21E18A */
+/* ************************************************************************** */
+/** \defgroup SAML21E18A_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc_100.h"
+#include "instance/aes.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic_100.h"
+#include "instance/evsys.h"
+#include "instance/gclk_100.h"
+#include "instance/mclk_100.h"
+#include "instance/mtb.h"
+#include "instance/nvmctrl_301.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac_100.h"
+#include "instance/pm_100.h"
+#include "instance/port.h"
+#include "instance/rstc_100.h"
+#include "instance/rtc_100.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/supc_100.h"
+#include "instance/tal.h"
+#include "instance/tc0_100.h"
+#include "instance/tc1_100.h"
+#include "instance/tc4_100.h"
+#include "instance/tcc0_200.h"
+#include "instance/tcc1_200.h"
+#include "instance/tcc2_200.h"
+#include "instance/trng.h"
+#include "instance/usb.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAML21E18A */
+/* ************************************************************************** */
+/** \defgroup SAML21E18A_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PM             0 /**< \brief Power Manager (PM) */
+#define ID_MCLK           1 /**< \brief Main Clock (MCLK) */
+#define ID_RSTC           2 /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL        3 /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL     4 /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC           5 /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK           6 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            7 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            8 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            9 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PORT          10 /**< \brief Port Module (PORT) */
+#define ID_TAL           11 /**< \brief Trigger Allocator (TAL) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_USB           32 /**< \brief Universal Serial Bus (USB) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_MTB           35 /**< \brief Cortex-M0+ Micro-Trace Buffer (MTB) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_SERCOM0       64 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       65 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       66 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       67 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TCC0          69 /**< \brief Timer Counter Control 0 (TCC0) */
+#define ID_TCC1          70 /**< \brief Timer Counter Control 1 (TCC1) */
+#define ID_TCC2          71 /**< \brief Timer Counter Control 2 (TCC2) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_DAC           76 /**< \brief Digital-to-Analog Converter (DAC) */
+#define ID_AES           77 /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG          78 /**< \brief True Random Generator (TRNG) */
+
+// Peripheral instances on HPB3 bridge
+#define ID_EVSYS         96 /**< \brief Event System Interface (EVSYS) */
+#define ID_TC4           98 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_ADC           99 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC           100 /**< \brief Analog Comparators (AC) */
+#define ID_PTC          101 /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_OPAMP        102 /**< \brief Operational Amplifier (OPAMP) */
+#define ID_CCL          103 /**< \brief Configurable Custom Logic (CCL) */
+
+// Peripheral instances on HPB4 bridge
+#define ID_PAC          128 /**< \brief Peripheral Access Controller (PAC) */
+#define ID_DMAC         129 /**< \brief Direct Memory Access Controller (DMAC) */
+
+#define ID_PERIPH_COUNT 130 /**< \brief Number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAML21E18A */
+/* ************************************************************************** */
+/** \defgroup SAML21E18A_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x43001000UL) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x43000C00UL) /**< \brief (ADC) APB Base Address */
+#define AES                           (0x42003400UL) /**< \brief (AES) APB Base Address */
+#define CCL                           (0x43001C00UL) /**< \brief (CCL) APB Base Address */
+#define DAC                           (0x42003000UL) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x44000400UL) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40002400UL) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x43000000UL) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40001800UL) /**< \brief (GCLK) APB Base Address */
+#define MCLK                          (0x40000400UL) /**< \brief (MCLK) APB Base Address */
+#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP3                  (0x00806010UL) /**< \brief (NVMCTRL) OTP3 Base Address */
+#define NVMCTRL_OTP4                  (0x00806018UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_OTP5                  (0x00806020UL) /**< \brief (NVMCTRL) OTP5 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define OPAMP                         (0x43001800UL) /**< \brief (OPAMP) APB Base Address */
+#define OSCCTRL                       (0x40000C00UL) /**< \brief (OSCCTRL) APB Base Address */
+#define OSC32KCTRL                    (0x40001000UL) /**< \brief (OSC32KCTRL) APB Base Address */
+#define PAC                           (0x44000000UL) /**< \brief (PAC) APB Base Address */
+#define PM                            (0x40000000UL) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x40002800UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define RSTC                          (0x40000800UL) /**< \brief (RSTC) APB Base Address */
+#define RTC                           (0x40002000UL) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000000UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000400UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42000800UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42000C00UL) /**< \brief (SERCOM3) APB Base Address */
+#define SUPC                          (0x40001400UL) /**< \brief (SUPC) APB Base Address */
+#define TAL                           (0x40002C00UL) /**< \brief (TAL) APB Base Address */
+#define TC0                           (0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC4                           (0x43000800UL) /**< \brief (TC4) APB Base Address */
+#define TCC0                          (0x42001400UL) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42001800UL) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42001C00UL) /**< \brief (TCC2) APB Base Address */
+#define TRNG                          (0x42003800UL) /**< \brief (TRNG) APB Base Address */
+#define USB                           (0x41000000UL) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001C00UL) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x43001000UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x43000C00UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define AES               ((Aes      *)0x42003400UL) /**< \brief (AES) APB Base Address */
+#define AES_INST_NUM      1                          /**< \brief (AES) Number of instances */
+#define AES_INSTS         { AES }                    /**< \brief (AES) Instances List */
+
+#define CCL               ((Ccl      *)0x43001C00UL) /**< \brief (CCL) APB Base Address */
+#define CCL_INST_NUM      1                          /**< \brief (CCL) Number of instances */
+#define CCL_INSTS         { CCL }                    /**< \brief (CCL) Instances List */
+
+#define DAC               ((Dac      *)0x42003000UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DMAC              ((Dmac     *)0x44000400UL) /**< \brief (DMAC) APB Base Address */
+#define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
+#define DMAC_INSTS        { DMAC }                   /**< \brief (DMAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40002400UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x43000000UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40001800UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define MCLK              ((Mclk     *)0x40000400UL) /**< \brief (MCLK) APB Base Address */
+#define MCLK_INST_NUM     1                          /**< \brief (MCLK) Number of instances */
+#define MCLK_INSTS        { MCLK }                   /**< \brief (MCLK) Instances List */
+
+#define MTB               ((Mtb      *)0x41006000UL) /**< \brief (MTB) APB Base Address */
+#define MTB_INST_NUM      1                          /**< \brief (MTB) Number of instances */
+#define MTB_INSTS         { MTB }                    /**< \brief (MTB) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP3                  (0x00806010UL) /**< \brief (NVMCTRL) OTP3 Base Address */
+#define NVMCTRL_OTP4                  (0x00806018UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_OTP5                  (0x00806020UL) /**< \brief (NVMCTRL) OTP5 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define OPAMP             ((Opamp    *)0x43001800UL) /**< \brief (OPAMP) APB Base Address */
+#define OPAMP_INST_NUM    1                          /**< \brief (OPAMP) Number of instances */
+#define OPAMP_INSTS       { OPAMP }                  /**< \brief (OPAMP) Instances List */
+
+#define OSCCTRL           ((Oscctrl  *)0x40000C00UL) /**< \brief (OSCCTRL) APB Base Address */
+#define OSCCTRL_INST_NUM  1                          /**< \brief (OSCCTRL) Number of instances */
+#define OSCCTRL_INSTS     { OSCCTRL }                /**< \brief (OSCCTRL) Instances List */
+
+#define OSC32KCTRL        ((Osc32kctrl *)0x40001000UL) /**< \brief (OSC32KCTRL) APB Base Address */
+#define OSC32KCTRL_INST_NUM 1                          /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS  { OSC32KCTRL }             /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC               ((Pac      *)0x44000000UL) /**< \brief (PAC) APB Base Address */
+#define PAC_INST_NUM      1                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC }                    /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x40002800UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+
+#define PTC_GCLK_ID       33
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RSTC              ((Rstc     *)0x40000800UL) /**< \brief (RSTC) APB Base Address */
+#define RSTC_INST_NUM     1                          /**< \brief (RSTC) Number of instances */
+#define RSTC_INSTS        { RSTC }                   /**< \brief (RSTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40002000UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000000UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000400UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SUPC              ((Supc     *)0x40001400UL) /**< \brief (SUPC) APB Base Address */
+#define SUPC_INST_NUM     1                          /**< \brief (SUPC) Number of instances */
+#define SUPC_INSTS        { SUPC }                   /**< \brief (SUPC) Instances List */
+
+#define TAL               ((Tal      *)0x40002C00UL) /**< \brief (TAL) APB Base Address */
+#define TAL_INST_NUM      1                          /**< \brief (TAL) Number of instances */
+#define TAL_INSTS         { TAL }                    /**< \brief (TAL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC4               ((Tc       *)0x43000800UL) /**< \brief (TC4) APB Base Address */
+#define TC_INST_NUM       3                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC4 }          /**< \brief (TC) Instances List */
+
+#define TCC0              ((Tcc      *)0x42001400UL) /**< \brief (TCC0) APB Base Address */
+#define TCC1              ((Tcc      *)0x42001800UL) /**< \brief (TCC1) APB Base Address */
+#define TCC2              ((Tcc      *)0x42001C00UL) /**< \brief (TCC2) APB Base Address */
+#define TCC_INST_NUM      3                          /**< \brief (TCC) Number of instances */
+#define TCC_INSTS         { TCC0, TCC1, TCC2 }       /**< \brief (TCC) Instances List */
+
+#define TRNG              ((Trng     *)0x42003800UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define USB               ((Usb      *)0x41000000UL) /**< \brief (USB) APB Base Address */
+#define USB_INST_NUM      1                          /**< \brief (USB) Number of instances */
+#define USB_INSTS         { USB }                    /**< \brief (USB) Instances List */
+
+#define WDT               ((Wdt      *)0x40001C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAML21E18A */
+/* ************************************************************************** */
+/** \defgroup SAML21E18A_port PORT Definitions */
+/*@{*/
+
+#include "pio/saml21e18a.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAML21E18A */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            0x40000UL /* 256 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     4096
+#define FLASH_USER_PAGE_SIZE  64
+#define HSRAM_SIZE            0x8000UL /* 32 kB */
+#define LPRAM_SIZE            0x2000UL /* 8 kB */
+
+#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
+#define HSRAM_ADDR            (0x20000000u) /**< HSRAM base address */
+#define LPRAM_ADDR            (0x30000000u) /**< LPRAM base address */
+#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
+#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
+#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
+#define HPB3_ADDR             (0x43000000u) /**< HPB3 base address */
+#define HPB4_ADDR             (0x44000000u) /**< HPB4 base address */
+#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    0x1081000AUL
+#define NVMCTRL_RWW_EEPROM_SIZE 0x2000UL /* 8 kB */
+#define PORT_GROUPS           1
+#define USB_HOST_IMPLEMENTED  1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML21E18A */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAML21E18A_H */

--- a/cpu/sam21_common/include/cmsis/saml21/include/saml21g18a.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/saml21g18a.h
@@ -1,0 +1,637 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAML21G18A
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21G18A_
+#define _SAML21G18A_
+
+/**
+ * \ingroup SAML21_definitions
+ * \addtogroup SAML21G18A_definitions SAML21G18A definitions
+ * This file defines all structures and symbols for SAML21G18A:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#define CAST(type, value) ((type *)(value))
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else
+#define CAST(type, value) (value)
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAML21G18A */
+/* ************************************************************************** */
+/** \defgroup SAML21G18A_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                 */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M0+ Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M0+ SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M0+ Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M0+ System Tick Interrupt       */
+  /******  SAML21G18A-specific Interrupt Numbers ***********************/
+  SYSTEM_IRQn              =  0, /**<  0 SAML21G18A System Interrupts */
+  MCLK_IRQn                =  0, /**<  0 SAML21G18A Main Clock (MCLK) */
+  OSCCTRL_IRQn             =  0, /**<  0 SAML21G18A Oscillators Control (OSCCTRL) */
+  OSC32KCTRL_IRQn          =  0, /**<  0 SAML21G18A 32k Oscillators Control (OSC32KCTRL) */
+  PAC_IRQn                 =  0, /**<  0 SAML21G18A Peripheral Access Controller (PAC) */
+  PM_IRQn                  =  0, /**<  0 SAML21G18A Power Manager (PM) */
+  SUPC_IRQn                =  0, /**<  0 SAML21G18A Supply Controller (SUPC) */
+  TAL_IRQn                 =  0, /**<  0 SAML21G18A Trigger Allocator (TAL) */
+  WDT_IRQn                 =  1, /**<  1 SAML21G18A Watchdog Timer (WDT) */
+  RTC_IRQn                 =  2, /**<  2 SAML21G18A Real-Time Counter (RTC) */
+  EIC_IRQn                 =  3, /**<  3 SAML21G18A External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  4, /**<  4 SAML21G18A Non-Volatile Memory Controller (NVMCTRL) */
+  DMAC_IRQn                =  5, /**<  5 SAML21G18A Direct Memory Access Controller (DMAC) */
+  USB_IRQn                 =  6, /**<  6 SAML21G18A Universal Serial Bus (USB) */
+  EVSYS_IRQn               =  7, /**<  7 SAML21G18A Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  8, /**<  8 SAML21G18A Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  9, /**<  9 SAML21G18A Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             = 10, /**< 10 SAML21G18A Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 11, /**< 11 SAML21G18A Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 12, /**< 12 SAML21G18A Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 13, /**< 13 SAML21G18A Serial Communication Interface 5 (SERCOM5) */
+  TCC0_IRQn                = 14, /**< 14 SAML21G18A Timer Counter Control 0 (TCC0) */
+  TCC1_IRQn                = 15, /**< 15 SAML21G18A Timer Counter Control 1 (TCC1) */
+  TCC2_IRQn                = 16, /**< 16 SAML21G18A Timer Counter Control 2 (TCC2) */
+  TC0_IRQn                 = 17, /**< 17 SAML21G18A Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 18, /**< 18 SAML21G18A Basic Timer Counter 1 (TC1) */
+  TC4_IRQn                 = 21, /**< 21 SAML21G18A Basic Timer Counter 4 (TC4) */
+  ADC_IRQn                 = 22, /**< 22 SAML21G18A Analog Digital Converter (ADC) */
+  AC_IRQn                  = 23, /**< 23 SAML21G18A Analog Comparators (AC) */
+  DAC_IRQn                 = 24, /**< 24 SAML21G18A Digital-to-Analog Converter (DAC) */
+  PTC_IRQn                 = 25, /**< 25 SAML21G18A Peripheral Touch Controller (PTC) */
+  AES_IRQn                 = 26, /**< 26 SAML21G18A Advanced Encryption Standard (AES) */
+  TRNG_IRQn                = 27, /**< 27 SAML21G18A True Random Generator (TRNG) */
+
+  PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnReservedM12;
+  void* pfnReservedM11;
+  void* pfnReservedM10;
+  void* pfnReservedM9;
+  void* pfnReservedM8;
+  void* pfnReservedM7;
+  void* pfnReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnReservedM4;
+  void* pfnReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                /*  0 Main Clock, Oscillators Control, 32k Oscillators Control, Peripheral Access Controller, Power Manager, Supply Controller, Trigger Allocator */
+  void* pfnWDT_Handler;                   /*  1 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  2 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  3 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  4 Non-Volatile Memory Controller */
+  void* pfnDMAC_Handler;                  /*  5 Direct Memory Access Controller */
+  void* pfnUSB_Handler;                   /*  6 Universal Serial Bus */
+  void* pfnEVSYS_Handler;                 /*  7 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  8 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  9 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /* 10 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 11 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 12 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 13 Serial Communication Interface 5 */
+  void* pfnTCC0_Handler;                  /* 14 Timer Counter Control 0 */
+  void* pfnTCC1_Handler;                  /* 15 Timer Counter Control 1 */
+  void* pfnTCC2_Handler;                  /* 16 Timer Counter Control 2 */
+  void* pfnTC0_Handler;                   /* 17 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 18 Basic Timer Counter 1 */
+  void* pfnReserved19;
+  void* pfnReserved20;
+  void* pfnTC4_Handler;                   /* 21 Basic Timer Counter 4 */
+  void* pfnADC_Handler;                   /* 22 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 23 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 24 Digital-to-Analog Converter */
+  void* pfnPTC_Handler;                   /* 25 Peripheral Touch Controller */
+  void* pfnAES_Handler;                   /* 26 Advanced Encryption Standard */
+  void* pfnTRNG_Handler;                  /* 27 True Random Generator */
+  void* pfnReserved28;
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void SVC_Handler                 ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void SYSTEM_Handler              ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void DMAC_Handler                ( void );
+void USB_Handler                 ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TCC0_Handler                ( void );
+void TCC1_Handler                ( void );
+void TCC2_Handler                ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC4_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+void AES_Handler                 ( void );
+void TRNG_Handler                ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml21.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML21G18A */
+/* ************************************************************************** */
+/** \defgroup SAML21G18A_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc_100.h"
+#include "component/aes.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic_100.h"
+#include "component/evsys.h"
+#include "component/gclk_100.h"
+#include "component/mclk_100.h"
+#include "component/mtb.h"
+#include "component/nvmctrl_301.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac_100.h"
+#include "component/pm_100.h"
+#include "component/port.h"
+#include "component/rstc_100.h"
+#include "component/rtc_100.h"
+#include "component/sercom.h"
+#include "component/supc_100.h"
+#include "component/tal.h"
+#include "component/tc_100.h"
+#include "component/tcc_200.h"
+#include "component/trng.h"
+#include "component/usb.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAML21G18A */
+/* ************************************************************************** */
+/** \defgroup SAML21G18A_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc_100.h"
+#include "instance/aes.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic_100.h"
+#include "instance/evsys.h"
+#include "instance/gclk_100.h"
+#include "instance/mclk_100.h"
+#include "instance/mtb.h"
+#include "instance/nvmctrl_301.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac_100.h"
+#include "instance/pm_100.h"
+#include "instance/port.h"
+#include "instance/rstc_100.h"
+#include "instance/rtc_100.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/supc_100.h"
+#include "instance/tal.h"
+#include "instance/tc0_100.h"
+#include "instance/tc1_100.h"
+#include "instance/tc4_100.h"
+#include "instance/tcc0_200.h"
+#include "instance/tcc1_200.h"
+#include "instance/tcc2_200.h"
+#include "instance/trng.h"
+#include "instance/usb.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAML21G18A */
+/* ************************************************************************** */
+/** \defgroup SAML21G18A_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PM             0 /**< \brief Power Manager (PM) */
+#define ID_MCLK           1 /**< \brief Main Clock (MCLK) */
+#define ID_RSTC           2 /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL        3 /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL     4 /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC           5 /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK           6 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            7 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            8 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            9 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PORT          10 /**< \brief Port Module (PORT) */
+#define ID_TAL           11 /**< \brief Trigger Allocator (TAL) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_USB           32 /**< \brief Universal Serial Bus (USB) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_MTB           35 /**< \brief Cortex-M0+ Micro-Trace Buffer (MTB) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_SERCOM0       64 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       65 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       66 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       67 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       68 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_TCC0          69 /**< \brief Timer Counter Control 0 (TCC0) */
+#define ID_TCC1          70 /**< \brief Timer Counter Control 1 (TCC1) */
+#define ID_TCC2          71 /**< \brief Timer Counter Control 2 (TCC2) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_DAC           76 /**< \brief Digital-to-Analog Converter (DAC) */
+#define ID_AES           77 /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG          78 /**< \brief True Random Generator (TRNG) */
+
+// Peripheral instances on HPB3 bridge
+#define ID_EVSYS         96 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM5       97 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC4           98 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_ADC           99 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC           100 /**< \brief Analog Comparators (AC) */
+#define ID_PTC          101 /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_OPAMP        102 /**< \brief Operational Amplifier (OPAMP) */
+#define ID_CCL          103 /**< \brief Configurable Custom Logic (CCL) */
+
+// Peripheral instances on HPB4 bridge
+#define ID_PAC          128 /**< \brief Peripheral Access Controller (PAC) */
+#define ID_DMAC         129 /**< \brief Direct Memory Access Controller (DMAC) */
+
+#define ID_PERIPH_COUNT 130 /**< \brief Number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAML21G18A */
+/* ************************************************************************** */
+/** \defgroup SAML21G18A_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x43001000UL) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x43000C00UL) /**< \brief (ADC) APB Base Address */
+#define AES                           (0x42003400UL) /**< \brief (AES) APB Base Address */
+#define CCL                           (0x43001C00UL) /**< \brief (CCL) APB Base Address */
+#define DAC                           (0x42003000UL) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x44000400UL) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40002400UL) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x43000000UL) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40001800UL) /**< \brief (GCLK) APB Base Address */
+#define MCLK                          (0x40000400UL) /**< \brief (MCLK) APB Base Address */
+#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP3                  (0x00806010UL) /**< \brief (NVMCTRL) OTP3 Base Address */
+#define NVMCTRL_OTP4                  (0x00806018UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_OTP5                  (0x00806020UL) /**< \brief (NVMCTRL) OTP5 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define OPAMP                         (0x43001800UL) /**< \brief (OPAMP) APB Base Address */
+#define OSCCTRL                       (0x40000C00UL) /**< \brief (OSCCTRL) APB Base Address */
+#define OSC32KCTRL                    (0x40001000UL) /**< \brief (OSC32KCTRL) APB Base Address */
+#define PAC                           (0x44000000UL) /**< \brief (PAC) APB Base Address */
+#define PM                            (0x40000000UL) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x40002800UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define RSTC                          (0x40000800UL) /**< \brief (RSTC) APB Base Address */
+#define RTC                           (0x40002000UL) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000000UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000400UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42000800UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42000C00UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001000UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x43000400UL) /**< \brief (SERCOM5) APB Base Address */
+#define SUPC                          (0x40001400UL) /**< \brief (SUPC) APB Base Address */
+#define TAL                           (0x40002C00UL) /**< \brief (TAL) APB Base Address */
+#define TC0                           (0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC4                           (0x43000800UL) /**< \brief (TC4) APB Base Address */
+#define TCC0                          (0x42001400UL) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42001800UL) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42001C00UL) /**< \brief (TCC2) APB Base Address */
+#define TRNG                          (0x42003800UL) /**< \brief (TRNG) APB Base Address */
+#define USB                           (0x41000000UL) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001C00UL) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x43001000UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x43000C00UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define AES               ((Aes      *)0x42003400UL) /**< \brief (AES) APB Base Address */
+#define AES_INST_NUM      1                          /**< \brief (AES) Number of instances */
+#define AES_INSTS         { AES }                    /**< \brief (AES) Instances List */
+
+#define CCL               ((Ccl      *)0x43001C00UL) /**< \brief (CCL) APB Base Address */
+#define CCL_INST_NUM      1                          /**< \brief (CCL) Number of instances */
+#define CCL_INSTS         { CCL }                    /**< \brief (CCL) Instances List */
+
+#define DAC               ((Dac      *)0x42003000UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DMAC              ((Dmac     *)0x44000400UL) /**< \brief (DMAC) APB Base Address */
+#define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
+#define DMAC_INSTS        { DMAC }                   /**< \brief (DMAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40002400UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x43000000UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40001800UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define MCLK              ((Mclk     *)0x40000400UL) /**< \brief (MCLK) APB Base Address */
+#define MCLK_INST_NUM     1                          /**< \brief (MCLK) Number of instances */
+#define MCLK_INSTS        { MCLK }                   /**< \brief (MCLK) Instances List */
+
+#define MTB               ((Mtb      *)0x41006000UL) /**< \brief (MTB) APB Base Address */
+#define MTB_INST_NUM      1                          /**< \brief (MTB) Number of instances */
+#define MTB_INSTS         { MTB }                    /**< \brief (MTB) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP3                  (0x00806010UL) /**< \brief (NVMCTRL) OTP3 Base Address */
+#define NVMCTRL_OTP4                  (0x00806018UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_OTP5                  (0x00806020UL) /**< \brief (NVMCTRL) OTP5 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define OPAMP             ((Opamp    *)0x43001800UL) /**< \brief (OPAMP) APB Base Address */
+#define OPAMP_INST_NUM    1                          /**< \brief (OPAMP) Number of instances */
+#define OPAMP_INSTS       { OPAMP }                  /**< \brief (OPAMP) Instances List */
+
+#define OSCCTRL           ((Oscctrl  *)0x40000C00UL) /**< \brief (OSCCTRL) APB Base Address */
+#define OSCCTRL_INST_NUM  1                          /**< \brief (OSCCTRL) Number of instances */
+#define OSCCTRL_INSTS     { OSCCTRL }                /**< \brief (OSCCTRL) Instances List */
+
+#define OSC32KCTRL        ((Osc32kctrl *)0x40001000UL) /**< \brief (OSC32KCTRL) APB Base Address */
+#define OSC32KCTRL_INST_NUM 1                          /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS  { OSC32KCTRL }             /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC               ((Pac      *)0x44000000UL) /**< \brief (PAC) APB Base Address */
+#define PAC_INST_NUM      1                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC }                    /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x40002800UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+
+#define PTC_GCLK_ID       33
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RSTC              ((Rstc     *)0x40000800UL) /**< \brief (RSTC) APB Base Address */
+#define RSTC_INST_NUM     1                          /**< \brief (RSTC) Number of instances */
+#define RSTC_INSTS        { RSTC }                   /**< \brief (RSTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40002000UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000000UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000400UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x43000400UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SUPC              ((Supc     *)0x40001400UL) /**< \brief (SUPC) APB Base Address */
+#define SUPC_INST_NUM     1                          /**< \brief (SUPC) Number of instances */
+#define SUPC_INSTS        { SUPC }                   /**< \brief (SUPC) Instances List */
+
+#define TAL               ((Tal      *)0x40002C00UL) /**< \brief (TAL) APB Base Address */
+#define TAL_INST_NUM      1                          /**< \brief (TAL) Number of instances */
+#define TAL_INSTS         { TAL }                    /**< \brief (TAL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC4               ((Tc       *)0x43000800UL) /**< \brief (TC4) APB Base Address */
+#define TC_INST_NUM       3                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC4 }          /**< \brief (TC) Instances List */
+
+#define TCC0              ((Tcc      *)0x42001400UL) /**< \brief (TCC0) APB Base Address */
+#define TCC1              ((Tcc      *)0x42001800UL) /**< \brief (TCC1) APB Base Address */
+#define TCC2              ((Tcc      *)0x42001C00UL) /**< \brief (TCC2) APB Base Address */
+#define TCC_INST_NUM      3                          /**< \brief (TCC) Number of instances */
+#define TCC_INSTS         { TCC0, TCC1, TCC2 }       /**< \brief (TCC) Instances List */
+
+#define TRNG              ((Trng     *)0x42003800UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define USB               ((Usb      *)0x41000000UL) /**< \brief (USB) APB Base Address */
+#define USB_INST_NUM      1                          /**< \brief (USB) Number of instances */
+#define USB_INSTS         { USB }                    /**< \brief (USB) Instances List */
+
+#define WDT               ((Wdt      *)0x40001C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAML21G18A */
+/* ************************************************************************** */
+/** \defgroup SAML21G18A_port PORT Definitions */
+/*@{*/
+
+#include "pio/saml21g18a.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAML21G18A */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            0x40000UL /* 256 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     4096
+#define FLASH_USER_PAGE_SIZE  64
+#define HSRAM_SIZE            0x8000UL /* 32 kB */
+#define LPRAM_SIZE            0x2000UL /* 8 kB */
+
+#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
+#define HSRAM_ADDR            (0x20000000u) /**< HSRAM base address */
+#define LPRAM_ADDR            (0x30000000u) /**< LPRAM base address */
+#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
+#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
+#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
+#define HPB3_ADDR             (0x43000000u) /**< HPB3 base address */
+#define HPB4_ADDR             (0x44000000u) /**< HPB4 base address */
+#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    0x10810005UL
+#define NVMCTRL_RWW_EEPROM_SIZE 0x2000UL /* 8 kB */
+#define PORT_GROUPS           2
+#define USB_HOST_IMPLEMENTED  1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML21G18A */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAML21G18A_H */

--- a/cpu/sam21_common/include/cmsis/saml21/include/saml21j18a.h
+++ b/cpu/sam21_common/include/cmsis/saml21/include/saml21j18a.h
@@ -1,0 +1,649 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAML21J18A
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAML21J18A_
+#define _SAML21J18A_
+
+/**
+ * \ingroup SAML21_definitions
+ * \addtogroup SAML21J18A_definitions SAML21J18A definitions
+ * This file defines all structures and symbols for SAML21J18A:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#define CAST(type, value) ((type *)(value))
+#define REG_ACCESS(type, address) (*(type*)(address)) /**< C code: Register value */
+#else
+#define CAST(type, value) (value)
+#define REG_ACCESS(type, address) (address) /**< Assembly code: Register address */
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAML21J18A */
+/* ************************************************************************** */
+/** \defgroup SAML21J18A_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                 */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M0+ Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M0+ SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M0+ Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M0+ System Tick Interrupt       */
+  /******  SAML21J18A-specific Interrupt Numbers ***********************/
+  SYSTEM_IRQn              =  0, /**<  0 SAML21J18A System Interrupts */
+  MCLK_IRQn                =  0, /**<  0 SAML21J18A Main Clock (MCLK) */
+  OSCCTRL_IRQn             =  0, /**<  0 SAML21J18A Oscillators Control (OSCCTRL) */
+  OSC32KCTRL_IRQn          =  0, /**<  0 SAML21J18A 32k Oscillators Control (OSC32KCTRL) */
+  PAC_IRQn                 =  0, /**<  0 SAML21J18A Peripheral Access Controller (PAC) */
+  PM_IRQn                  =  0, /**<  0 SAML21J18A Power Manager (PM) */
+  SUPC_IRQn                =  0, /**<  0 SAML21J18A Supply Controller (SUPC) */
+  TAL_IRQn                 =  0, /**<  0 SAML21J18A Trigger Allocator (TAL) */
+  WDT_IRQn                 =  1, /**<  1 SAML21J18A Watchdog Timer (WDT) */
+  RTC_IRQn                 =  2, /**<  2 SAML21J18A Real-Time Counter (RTC) */
+  EIC_IRQn                 =  3, /**<  3 SAML21J18A External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  4, /**<  4 SAML21J18A Non-Volatile Memory Controller (NVMCTRL) */
+  DMAC_IRQn                =  5, /**<  5 SAML21J18A Direct Memory Access Controller (DMAC) */
+  USB_IRQn                 =  6, /**<  6 SAML21J18A Universal Serial Bus (USB) */
+  EVSYS_IRQn               =  7, /**<  7 SAML21J18A Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  8, /**<  8 SAML21J18A Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  9, /**<  9 SAML21J18A Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             = 10, /**< 10 SAML21J18A Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 11, /**< 11 SAML21J18A Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 12, /**< 12 SAML21J18A Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 13, /**< 13 SAML21J18A Serial Communication Interface 5 (SERCOM5) */
+  TCC0_IRQn                = 14, /**< 14 SAML21J18A Timer Counter Control 0 (TCC0) */
+  TCC1_IRQn                = 15, /**< 15 SAML21J18A Timer Counter Control 1 (TCC1) */
+  TCC2_IRQn                = 16, /**< 16 SAML21J18A Timer Counter Control 2 (TCC2) */
+  TC0_IRQn                 = 17, /**< 17 SAML21J18A Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 18, /**< 18 SAML21J18A Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 19, /**< 19 SAML21J18A Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 20, /**< 20 SAML21J18A Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 21, /**< 21 SAML21J18A Basic Timer Counter 4 (TC4) */
+  ADC_IRQn                 = 22, /**< 22 SAML21J18A Analog Digital Converter (ADC) */
+  AC_IRQn                  = 23, /**< 23 SAML21J18A Analog Comparators (AC) */
+  DAC_IRQn                 = 24, /**< 24 SAML21J18A Digital-to-Analog Converter (DAC) */
+  PTC_IRQn                 = 25, /**< 25 SAML21J18A Peripheral Touch Controller (PTC) */
+  AES_IRQn                 = 26, /**< 26 SAML21J18A Advanced Encryption Standard (AES) */
+  TRNG_IRQn                = 27, /**< 27 SAML21J18A True Random Generator (TRNG) */
+
+  PERIPH_COUNT_IRQn        = 28  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnReservedM12;
+  void* pfnReservedM11;
+  void* pfnReservedM10;
+  void* pfnReservedM9;
+  void* pfnReservedM8;
+  void* pfnReservedM7;
+  void* pfnReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnReservedM4;
+  void* pfnReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnSYSTEM_Handler;                /*  0 Main Clock, Oscillators Control, 32k Oscillators Control, Peripheral Access Controller, Power Manager, Supply Controller, Trigger Allocator */
+  void* pfnWDT_Handler;                   /*  1 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  2 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  3 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  4 Non-Volatile Memory Controller */
+  void* pfnDMAC_Handler;                  /*  5 Direct Memory Access Controller */
+  void* pfnUSB_Handler;                   /*  6 Universal Serial Bus */
+  void* pfnEVSYS_Handler;                 /*  7 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  8 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  9 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /* 10 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 11 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 12 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 13 Serial Communication Interface 5 */
+  void* pfnTCC0_Handler;                  /* 14 Timer Counter Control 0 */
+  void* pfnTCC1_Handler;                  /* 15 Timer Counter Control 1 */
+  void* pfnTCC2_Handler;                  /* 16 Timer Counter Control 2 */
+  void* pfnTC0_Handler;                   /* 17 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 18 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 19 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 20 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 21 Basic Timer Counter 4 */
+  void* pfnADC_Handler;                   /* 22 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 23 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 24 Digital-to-Analog Converter */
+  void* pfnPTC_Handler;                   /* 25 Peripheral Touch Controller */
+  void* pfnAES_Handler;                   /* 26 Advanced Encryption Standard */
+  void* pfnTRNG_Handler;                  /* 27 True Random Generator */
+  void* pfnReserved28;
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void SVC_Handler                 ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void SYSTEM_Handler              ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void DMAC_Handler                ( void );
+void USB_Handler                 ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TCC0_Handler                ( void );
+void TCC1_Handler                ( void );
+void TCC2_Handler                ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+void AES_Handler                 ( void );
+void TRNG_Handler                ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_saml21.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAML21J18A */
+/* ************************************************************************** */
+/** \defgroup SAML21J18A_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc_100.h"
+#include "component/aes.h"
+#include "component/ccl.h"
+#include "component/dac.h"
+#include "component/dmac.h"
+#include "component/dsu.h"
+#include "component/eic_100.h"
+#include "component/evsys.h"
+#include "component/gclk_100.h"
+#include "component/mclk_100.h"
+#include "component/mtb.h"
+#include "component/nvmctrl_301.h"
+#include "component/opamp.h"
+#include "component/oscctrl.h"
+#include "component/osc32kctrl.h"
+#include "component/pac_100.h"
+#include "component/pm_100.h"
+#include "component/port.h"
+#include "component/rstc_100.h"
+#include "component/rtc_100.h"
+#include "component/sercom.h"
+#include "component/supc_100.h"
+#include "component/tal.h"
+#include "component/tc_100.h"
+#include "component/tcc_200.h"
+#include "component/trng.h"
+#include "component/usb.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAML21J18A */
+/* ************************************************************************** */
+/** \defgroup SAML21J18A_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc_100.h"
+#include "instance/aes.h"
+#include "instance/ccl.h"
+#include "instance/dac.h"
+#include "instance/dmac.h"
+#include "instance/dsu.h"
+#include "instance/eic_100.h"
+#include "instance/evsys.h"
+#include "instance/gclk_100.h"
+#include "instance/mclk_100.h"
+#include "instance/mtb.h"
+#include "instance/nvmctrl_301.h"
+#include "instance/opamp.h"
+#include "instance/oscctrl.h"
+#include "instance/osc32kctrl.h"
+#include "instance/pac_100.h"
+#include "instance/pm_100.h"
+#include "instance/port.h"
+#include "instance/rstc_100.h"
+#include "instance/rtc_100.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/supc_100.h"
+#include "instance/tal.h"
+#include "instance/tc0_100.h"
+#include "instance/tc1_100.h"
+#include "instance/tc2_100.h"
+#include "instance/tc3_100.h"
+#include "instance/tc4_100.h"
+#include "instance/tcc0_200.h"
+#include "instance/tcc1_200.h"
+#include "instance/tcc2_200.h"
+#include "instance/trng.h"
+#include "instance/usb.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAML21J18A */
+/* ************************************************************************** */
+/** \defgroup SAML21J18A_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PM             0 /**< \brief Power Manager (PM) */
+#define ID_MCLK           1 /**< \brief Main Clock (MCLK) */
+#define ID_RSTC           2 /**< \brief Reset Controller (RSTC) */
+#define ID_OSCCTRL        3 /**< \brief Oscillators Control (OSCCTRL) */
+#define ID_OSC32KCTRL     4 /**< \brief 32k Oscillators Control (OSC32KCTRL) */
+#define ID_SUPC           5 /**< \brief Supply Controller (SUPC) */
+#define ID_GCLK           6 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            7 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            8 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            9 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PORT          10 /**< \brief Port Module (PORT) */
+#define ID_TAL           11 /**< \brief Trigger Allocator (TAL) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_USB           32 /**< \brief Universal Serial Bus (USB) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_MTB           35 /**< \brief Cortex-M0+ Micro-Trace Buffer (MTB) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_SERCOM0       64 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       65 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       66 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       67 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       68 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_TCC0          69 /**< \brief Timer Counter Control 0 (TCC0) */
+#define ID_TCC1          70 /**< \brief Timer Counter Control 1 (TCC1) */
+#define ID_TCC2          71 /**< \brief Timer Counter Control 2 (TCC2) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_DAC           76 /**< \brief Digital-to-Analog Converter (DAC) */
+#define ID_AES           77 /**< \brief Advanced Encryption Standard (AES) */
+#define ID_TRNG          78 /**< \brief True Random Generator (TRNG) */
+
+// Peripheral instances on HPB3 bridge
+#define ID_EVSYS         96 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM5       97 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC4           98 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_ADC           99 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC           100 /**< \brief Analog Comparators (AC) */
+#define ID_PTC          101 /**< \brief Peripheral Touch Controller (PTC) */
+#define ID_OPAMP        102 /**< \brief Operational Amplifier (OPAMP) */
+#define ID_CCL          103 /**< \brief Configurable Custom Logic (CCL) */
+
+// Peripheral instances on HPB4 bridge
+#define ID_PAC          128 /**< \brief Peripheral Access Controller (PAC) */
+#define ID_DMAC         129 /**< \brief Direct Memory Access Controller (DMAC) */
+
+#define ID_PERIPH_COUNT 130 /**< \brief Number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAML21J18A */
+/* ************************************************************************** */
+/** \defgroup SAML21J18A_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x43001000UL) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x43000C00UL) /**< \brief (ADC) APB Base Address */
+#define AES                           (0x42003400UL) /**< \brief (AES) APB Base Address */
+#define CCL                           (0x43001C00UL) /**< \brief (CCL) APB Base Address */
+#define DAC                           (0x42003000UL) /**< \brief (DAC) APB Base Address */
+#define DMAC                          (0x44000400UL) /**< \brief (DMAC) APB Base Address */
+#define DSU                           (0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40002400UL) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x43000000UL) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40001800UL) /**< \brief (GCLK) APB Base Address */
+#define MCLK                          (0x40000400UL) /**< \brief (MCLK) APB Base Address */
+#define MTB                           (0x41006000UL) /**< \brief (MTB) APB Base Address */
+#define NVMCTRL                       (0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP3                  (0x00806010UL) /**< \brief (NVMCTRL) OTP3 Base Address */
+#define NVMCTRL_OTP4                  (0x00806018UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_OTP5                  (0x00806020UL) /**< \brief (NVMCTRL) OTP5 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define OPAMP                         (0x43001800UL) /**< \brief (OPAMP) APB Base Address */
+#define OSCCTRL                       (0x40000C00UL) /**< \brief (OSCCTRL) APB Base Address */
+#define OSC32KCTRL                    (0x40001000UL) /**< \brief (OSC32KCTRL) APB Base Address */
+#define PAC                           (0x44000000UL) /**< \brief (PAC) APB Base Address */
+#define PM                            (0x40000000UL) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x40002800UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define RSTC                          (0x40000800UL) /**< \brief (RSTC) APB Base Address */
+#define RTC                           (0x40002000UL) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000000UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000400UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42000800UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42000C00UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001000UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x43000400UL) /**< \brief (SERCOM5) APB Base Address */
+#define SUPC                          (0x40001400UL) /**< \brief (SUPC) APB Base Address */
+#define TAL                           (0x40002C00UL) /**< \brief (TAL) APB Base Address */
+#define TC0                           (0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x43000800UL) /**< \brief (TC4) APB Base Address */
+#define TCC0                          (0x42001400UL) /**< \brief (TCC0) APB Base Address */
+#define TCC1                          (0x42001800UL) /**< \brief (TCC1) APB Base Address */
+#define TCC2                          (0x42001C00UL) /**< \brief (TCC2) APB Base Address */
+#define TRNG                          (0x42003800UL) /**< \brief (TRNG) APB Base Address */
+#define USB                           (0x41000000UL) /**< \brief (USB) APB Base Address */
+#define WDT                           (0x40001C00UL) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x43001000UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x43000C00UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define AES               ((Aes      *)0x42003400UL) /**< \brief (AES) APB Base Address */
+#define AES_INST_NUM      1                          /**< \brief (AES) Number of instances */
+#define AES_INSTS         { AES }                    /**< \brief (AES) Instances List */
+
+#define CCL               ((Ccl      *)0x43001C00UL) /**< \brief (CCL) APB Base Address */
+#define CCL_INST_NUM      1                          /**< \brief (CCL) Number of instances */
+#define CCL_INSTS         { CCL }                    /**< \brief (CCL) Instances List */
+
+#define DAC               ((Dac      *)0x42003000UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DMAC              ((Dmac     *)0x44000400UL) /**< \brief (DMAC) APB Base Address */
+#define DMAC_INST_NUM     1                          /**< \brief (DMAC) Number of instances */
+#define DMAC_INSTS        { DMAC }                   /**< \brief (DMAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40002400UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x43000000UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40001800UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define MCLK              ((Mclk     *)0x40000400UL) /**< \brief (MCLK) APB Base Address */
+#define MCLK_INST_NUM     1                          /**< \brief (MCLK) Number of instances */
+#define MCLK_INSTS        { MCLK }                   /**< \brief (MCLK) Instances List */
+
+#define MTB               ((Mtb      *)0x41006000UL) /**< \brief (MTB) APB Base Address */
+#define MTB_INST_NUM      1                          /**< \brief (MTB) Number of instances */
+#define MTB_INSTS         { MTB }                    /**< \brief (MTB) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP3                  (0x00806010UL) /**< \brief (NVMCTRL) OTP3 Base Address */
+#define NVMCTRL_OTP4                  (0x00806018UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_OTP5                  (0x00806020UL) /**< \brief (NVMCTRL) OTP5 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define OPAMP             ((Opamp    *)0x43001800UL) /**< \brief (OPAMP) APB Base Address */
+#define OPAMP_INST_NUM    1                          /**< \brief (OPAMP) Number of instances */
+#define OPAMP_INSTS       { OPAMP }                  /**< \brief (OPAMP) Instances List */
+
+#define OSCCTRL           ((Oscctrl  *)0x40000C00UL) /**< \brief (OSCCTRL) APB Base Address */
+#define OSCCTRL_INST_NUM  1                          /**< \brief (OSCCTRL) Number of instances */
+#define OSCCTRL_INSTS     { OSCCTRL }                /**< \brief (OSCCTRL) Instances List */
+
+#define OSC32KCTRL        ((Osc32kctrl *)0x40001000UL) /**< \brief (OSC32KCTRL) APB Base Address */
+#define OSC32KCTRL_INST_NUM 1                          /**< \brief (OSC32KCTRL) Number of instances */
+#define OSC32KCTRL_INSTS  { OSC32KCTRL }             /**< \brief (OSC32KCTRL) Instances List */
+
+#define PAC               ((Pac      *)0x44000000UL) /**< \brief (PAC) APB Base Address */
+#define PAC_INST_NUM      1                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC }                    /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x40002800UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+
+#define PTC_GCLK_ID       33
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RSTC              ((Rstc     *)0x40000800UL) /**< \brief (RSTC) APB Base Address */
+#define RSTC_INST_NUM     1                          /**< \brief (RSTC) Number of instances */
+#define RSTC_INSTS        { RSTC }                   /**< \brief (RSTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40002000UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000000UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000400UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x43000400UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SUPC              ((Supc     *)0x40001400UL) /**< \brief (SUPC) APB Base Address */
+#define SUPC_INST_NUM     1                          /**< \brief (SUPC) Number of instances */
+#define SUPC_INSTS        { SUPC }                   /**< \brief (SUPC) Instances List */
+
+#define TAL               ((Tal      *)0x40002C00UL) /**< \brief (TAL) APB Base Address */
+#define TAL_INST_NUM      1                          /**< \brief (TAL) Number of instances */
+#define TAL_INSTS         { TAL }                    /**< \brief (TAL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x43000800UL) /**< \brief (TC4) APB Base Address */
+#define TC_INST_NUM       5                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4 } /**< \brief (TC) Instances List */
+
+#define TCC0              ((Tcc      *)0x42001400UL) /**< \brief (TCC0) APB Base Address */
+#define TCC1              ((Tcc      *)0x42001800UL) /**< \brief (TCC1) APB Base Address */
+#define TCC2              ((Tcc      *)0x42001C00UL) /**< \brief (TCC2) APB Base Address */
+#define TCC_INST_NUM      3                          /**< \brief (TCC) Number of instances */
+#define TCC_INSTS         { TCC0, TCC1, TCC2 }       /**< \brief (TCC) Instances List */
+
+#define TRNG              ((Trng     *)0x42003800UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define USB               ((Usb      *)0x41000000UL) /**< \brief (USB) APB Base Address */
+#define USB_INST_NUM      1                          /**< \brief (USB) Number of instances */
+#define USB_INSTS         { USB }                    /**< \brief (USB) Instances List */
+
+#define WDT               ((Wdt      *)0x40001C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAML21J18A */
+/* ************************************************************************** */
+/** \defgroup SAML21J18A_port PORT Definitions */
+/*@{*/
+
+#include "pio/saml21j18a.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAML21J18A */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            0x40000UL /* 256 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     4096
+#define FLASH_USER_PAGE_SIZE  64
+#define HSRAM_SIZE            0x8000UL /* 32 kB */
+#define LPRAM_SIZE            0x2000UL /* 8 kB */
+
+#define FLASH_ADDR            (0x00000000u) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  (0x00800000u) /**< FLASH_USER_PAGE base address */
+#define HSRAM_ADDR            (0x20000000u) /**< HSRAM base address */
+#define LPRAM_ADDR            (0x30000000u) /**< LPRAM base address */
+#define HPB0_ADDR             (0x40000000u) /**< HPB0 base address */
+#define HPB1_ADDR             (0x41000000u) /**< HPB1 base address */
+#define HPB2_ADDR             (0x42000000u) /**< HPB2 base address */
+#define HPB3_ADDR             (0x43000000u) /**< HPB3 base address */
+#define HPB4_ADDR             (0x44000000u) /**< HPB4 base address */
+#define PPB_ADDR              (0xE0000000u) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    0x10810000UL
+#define NVMCTRL_RWW_EEPROM_SIZE 0x2000UL /* 8 kB */
+#define PORT_GROUPS           2
+#define USB_HOST_IMPLEMENTED  1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAML21J18A */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAML21J18A_H */

--- a/cpu/sam21_common/include/sam0.h
+++ b/cpu/sam21_common/include/sam0.h
@@ -31,6 +31,8 @@ extern "C" {
 #include "cmsis/samd21/include/samd21j18a.h"
 #elif defined(__SAMD21G18A__) || defined(__ATSAMD21G18A__)
 #include "cmsis/samd21/include/samd21g18a.h"
+#elif defined(__SAML21J18A__) || defined(__ATSAML21J18A__)
+#include "cmsis/saml21/include/saml21j18a.h"
 #else
   #error "Unsupported SAM0 variant."
 #endif


### PR DESCRIPTION
Add I2C support to SAML21 & SAML21-Xplained board
Most of the change are located in the i2c init function, saml21 and samd21 don't have the same clock management.
I added specific init function for saml21 under the sam21_common directory. Maybe it was not the best way to do it. Any thoughts ?
