### PR TITLE
boards/nucleo-f103: remove STDIO_UART definition

### DIFF
--- a/boards/nucleo-f103/include/board.h
+++ b/boards/nucleo-f103/include/board.h
@@ -28,11 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Use the first UART for STDIO on this board
- */
-#define UART_STDIO_DEV      UART_DEV(0)
-
-/**
  * @name xtimer configuration
  */
 #define XTIMER_WIDTH        (16)


### PR DESCRIPTION
#5981 changed the default STDIO_UART to `UART_DEV(0)`. This is the default value, so no need to redefine it...