### PR TITLE
boards/nucleo-f030: adapt to automatically included common boards deps

### DIFF
--- a/boards/nucleo-f030/Makefile.dep
+++ b/boards/nucleo-f030/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep


### PR DESCRIPTION
This backports the change from #5891 to new nucleo-f030 board.