### PR TITLE
cc2538: Minor indentation fix

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -277,9 +277,11 @@ static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned count)
 
         rfcore_write_fifo(vector[i].iov_base, vector[i].iov_len);
     }
-    #ifdef MODULE_NETSTATS_L2
-            netdev->stats.tx_bytes += pkt_len;
-    #endif
+
+#ifdef MODULE_NETSTATS_L2
+    netdev->stats.tx_bytes += pkt_len;
+#endif
+
     /* Set first byte of TX FIFO to the packet length */
     rfcore_poke_tx_fifo(0, pkt_len + CC2538_AUTOCRC_LEN);
 
@@ -325,10 +327,11 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
         /* GNRC is expecting len bytes of data */
         pkt_len = len;
     }
-    #ifdef MODULE_NETSTATS_L2
-        netdev->stats.rx_count++;
-        netdev->stats.rx_bytes += pkt_len;
-    #endif
+
+#ifdef MODULE_NETSTATS_L2
+    netdev->stats.rx_count++;
+    netdev->stats.rx_bytes += pkt_len;
+#endif
     rfcore_read_fifo(buf, pkt_len);
 
     if (info != NULL && RFCORE->XREG_RSSISTATbits.RSSI_VALID) {


### PR DESCRIPTION
#5985 added netstats to the cc2538 driver, but indentation was slightly off.