### PR TITLE
Provide arduino feature to Nucleo boards

### DIFF
--- a/boards/nucleo-common/Makefile.features
+++ b/boards/nucleo-common/Makefile.features
@@ -1,0 +1,3 @@
+# Various common features of Nucleo boards
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += arduino

--- a/boards/nucleo-common/include/arduino_board.h
+++ b/boards/nucleo-common/include/arduino_board.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo-common
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Hauke Petersen  <hauke.petersen@fu-berlin.de>
+ * @author      Alexandre Abadie  <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 13 on this board
+ */
+#define ARDUINO_LED         (13)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/nucleo-common/include/arduino_pinmap.h
+++ b/boards/nucleo-common/include/arduino_pinmap.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C)  2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-zero
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PORT_A, 3)
+#define ARDUINO_PIN_1           GPIO_PIN(PORT_A, 2)
+#define ARDUINO_PIN_2           GPIO_PIN(PORT_A, 10)
+#define ARDUINO_PIN_3           GPIO_PIN(PORT_B, 3)
+#define ARDUINO_PIN_4           GPIO_PIN(PORT_B, 5)
+#define ARDUINO_PIN_5           GPIO_PIN(PORT_B, 4)
+#define ARDUINO_PIN_6           GPIO_PIN(PORT_B, 10)
+#define ARDUINO_PIN_7           GPIO_PIN(PORT_A, 8)
+
+#define ARDUINO_PIN_8           GPIO_PIN(PORT_A, 9)
+#define ARDUINO_PIN_9           GPIO_PIN(PORT_C, 7)
+#define ARDUINO_PIN_10          GPIO_PIN(PORT_B, 6)
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_A, 7)
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_A, 6)
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_A, 5) /* on-board LED */
+
+#define ARDUINO_PIN_A0          GPIO_PIN(PORT_C, 0)
+#define ARDUINO_PIN_A1          GPIO_PIN(PORT_C, 1)
+#define ARDUINO_PIN_A2          GPIO_PIN(PORT_B, 0)
+#define ARDUINO_PIN_A3          GPIO_PIN(PORT_A, 4)
+#define ARDUINO_PIN_A4          GPIO_PIN(PORT_A, 1)
+#define ARDUINO_PIN_A5          GPIO_PIN(PORT_A, 0)
+/** @ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/nucleo-f030/Makefile.features
+++ b/boards/nucleo-f030/Makefile.features
@@ -5,8 +5,8 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1

--- a/boards/nucleo-f070/Makefile.features
+++ b/boards/nucleo-f070/Makefile.features
@@ -5,8 +5,8 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1

--- a/boards/nucleo-f072/Makefile.features
+++ b/boards/nucleo-f072/Makefile.features
@@ -5,8 +5,8 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1

--- a/boards/nucleo-f091/Makefile.features
+++ b/boards/nucleo-f091/Makefile.features
@@ -5,8 +5,8 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1

--- a/boards/nucleo-f103/Makefile.features
+++ b/boards/nucleo-f103/Makefile.features
@@ -6,8 +6,8 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/nucleo-f207/Makefile.features
+++ b/boards/nucleo-f207/Makefile.features
@@ -8,8 +8,8 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/nucleo-f303/Makefile.features
+++ b/boards/nucleo-f303/Makefile.features
@@ -7,8 +7,8 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2

--- a/boards/nucleo-f334/Makefile.features
+++ b/boards/nucleo-f334/Makefile.features
@@ -5,8 +5,8 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2

--- a/boards/nucleo-f401/Makefile.features
+++ b/boards/nucleo-f401/Makefile.features
@@ -6,8 +6,8 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/nucleo-f446/Makefile.features
+++ b/boards/nucleo-f446/Makefile.features
@@ -6,8 +6,8 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/nucleo-l1/Makefile.features
+++ b/boards/nucleo-l1/Makefile.features
@@ -7,8 +7,8 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/nucleo-common/Makefile.features
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2


### PR DESCRIPTION
This is kind of interesting since those boards provide Arduino compatible pinouts.

I tested it on 2 boards - nucleo-f030 and nucleo-f401 - with success.

Notice that this branch is build on top of #5996.
