### PR TITLE
conn: add deprecation note

### DIFF
--- a/sys/include/net/conn.h
+++ b/sys/include/net/conn.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    net_conn    Application connection API
  * @ingroup     net
+ * @deprecated  Please use @ref net_sock instead
  * @brief       Provides a minimal common API for applications to connect to the
  *              different network stacks.
  *

--- a/sys/include/net/conn/ip.h
+++ b/sys/include/net/conn/ip.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    net_conn_ip     Raw IPv4/IPv6 connections
  * @ingroup     net_conn
+ * @deprecated  Please use @ref net_sock_ip instead
  * @brief       Connection submodule for raw IPv4/IPv6 connections
  * @{
  *

--- a/sys/include/net/conn/tcp.h
+++ b/sys/include/net/conn/tcp.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    net_conn_tcp    TCP connections
  * @ingroup     net_conn
+ * @deprecated  Please use @ref net_sock_tcp instead
  * @brief       Connection submodule for TCP connections
  * @{
  *

--- a/sys/include/net/conn/udp.h
+++ b/sys/include/net/conn/udp.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    net_conn_udp    UDP connections
  * @ingroup     net_conn
+ * @deprecated  Please use @ref net_sock_udp instead
  * @brief       Connection submodule for UDP connections
  * @{
  *


### PR DESCRIPTION
Now that sock is merged for at least one stack, it's time to officially deprecate `conn`.