### PR TITLE
examples: port microcoap example to sock

### DIFF
--- a/examples/microcoap_server/Makefile
+++ b/examples/microcoap_server/Makefile
@@ -25,7 +25,7 @@ USEMODULE += gnrc_rpl
 USEMODULE += gnrc_icmpv6_echo
 
 #
-USEMODULE += gnrc_conn_udp
+USEMODULE += gnrc_sock_udp
 
 USEPKG += microcoap
 CFLAGS += -DMICROCOAP_DEBUG

--- a/examples/microcoap_server/main.c
+++ b/examples/microcoap_server/main.c
@@ -21,9 +21,6 @@
 #include "msg.h"
 #include "xtimer.h"
 
-#define MAIN_QUEUE_SIZE     (8)
-static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
-
 void microcoap_server_loop(void);
 
 /* import "ifconfig" shell command, used for printing addresses */
@@ -32,9 +29,6 @@ extern int _netif_config(int argc, char **argv);
 int main(void)
 {
     puts("RIOT microcoap example application");
-
-    /* microcoap_server uses conn which uses gnrc which needs a msg queue */
-    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
     puts("Waiting for address autoconfiguration...");
     xtimer_sleep(3);


### PR DESCRIPTION
Ports the microcoap example to sock.
