### PR TITLE
CoAP examples: make example a host instead of router

### DIFF
--- a/examples/microcoap_server/Makefile
+++ b/examples/microcoap_server/Makefile
@@ -7,21 +7,16 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
-                          nrf6310 pca10000 pca10005 spark-core \
-                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
-                          yunjia-nrf51822 z1 nucleo-f072 nucleo-f030 nucleo-f070 \
-                          microbit calliope-mini nucleo-f042
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo-f042 \
+                             pca10000 pca10005 stm32f0discovery telosb weio z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_udp
-# Add a routing protocol
-USEMODULE += gnrc_rpl
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 
@@ -48,8 +43,6 @@ $(info Using low-memory configuration for microcoap_server.)
 ## low-memory tuning values
 # lower pktbuf buffer size
 CFLAGS += -DGNRC_PKTBUF_SIZE=1000
-# disable fib, rpl
-DISABLE_MODULE += fib gnrc_rpl
 USEMODULE += prng_minstd
 endif
 

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -7,11 +7,8 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
-                          nrf6310 pca10000 pca10005 spark-core \
-                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
-                          yunjia-nrf51822 z1 nucleo-f072 nucleo-f030 \
-                          nucleo-f042
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo-f042 \
+                             stm32f0discovery telosb weio
 
 # blacklist this until #6022 is sorted out
 BOARD_BLACKLIST := nrf52dk
@@ -21,10 +18,7 @@ BOARD_BLACKLIST := nrf52dk
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_udp
-# Add a routing protocol
-USEMODULE += gnrc_rpl
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 
@@ -52,8 +46,6 @@ $(info Using low-memory configuration for microcoap_server.)
 ## low-memory tuning values
 # lower pktbuf buffer size
 CFLAGS += -DGNRC_PKTBUF_SIZE=1000
-# disable fib, rpl
-DISABLE_MODULE += fib gnrc_rpl
 USEMODULE += prng_minstd
 endif
 


### PR DESCRIPTION
There was some confusion that there was no host example. Since the microcoap example also contains RPL to be able to route which makes the example more complicated (and additionally isn't even documented in its README), I thought it might be a good idea to remove routing capabilities from that example.
