### PR TITLE
saml21: transfer SPI pins definition to periph_conf.h

### DIFF
--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -73,6 +73,20 @@ extern "C" {
  */
 #define SPI_NUMOF          (1)
 #define SPI_0_EN           1
+
+/*      SPI0             */
+#define SPI_0_DEV           SERCOM0->SPI
+#define SPI_IRQ_0           SERCOM0_IRQn
+#define SPI_0_GCLK_ID       SERCOM0_GCLK_ID_CORE
+/* SPI 0 pin configuration */
+#define SPI_0_SCLK          GPIO_PIN(PA, 07)
+#define SPI_0_SCLK_MUX      GPIO_MUX_D
+#define SPI_0_MISO          GPIO_PIN(PA, 04)
+#define SPI_0_MISO_MUX      GPIO_MUX_D
+#define SPI_0_MISO_PAD      SPI_PAD_MISO_0
+#define SPI_0_MOSI          GPIO_PIN(PA, 06)
+#define SPI_0_MOSI_MUX      GPIO_MUX_D
+#define SPI_0_MOSI_PAD      SPI_PAD_MOSI_2_SCK_3
 /** @} */
 
 /**

--- a/cpu/saml21/periph/spi.c
+++ b/cpu/saml21/periph/spi.c
@@ -72,7 +72,8 @@ typedef struct spi_saml21 {
 static const spi_saml21_t spi[] = {
 #if SPI_0_EN
     /* SPI device */   /* MCLK flag */        /* GLCK id */         /* SCLK */  /* MISO */  /* MOSI */ /* dipo+dopo */
-    { &(SERCOM0->SPI), MCLK_APBCMASK_SERCOM0, SERCOM0_GCLK_ID_CORE, { GPIO_PIN(PA,7), 3 }, { GPIO_PIN(PA,4), 3 }, { GPIO_PIN(PA,6), 3 }, 0, 1 }
+    { &(SERCOM0->SPI), MCLK_APBCMASK_SERCOM0, SERCOM0_GCLK_ID_CORE, { SPI_0_SCLK, SPI_0_SCLK_MUX }, \
+    { SPI_0_MISO, SPI_0_MISO_MUX }, { SPI_0_MOSI, SPI_0_MOSI_MUX }, SPI_PAD_MISO_0, SPI_PAD_MOSI_2_SCK_3 }
 #endif
 };
 


### PR DESCRIPTION
Transfer SPI pins definition from spi.c to periph_conf.h to allow users to configure SPI pins without modify driver.
