### PR TITLE
drivers/cc2420: calculate CRC and check CRC_OK bit on packet reception

### DIFF
--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -304,6 +304,9 @@ void cc2420_tx_exec(cc2420_t *dev);
  * @param[out] buf          buffer to write data to
  * @param[in]  max_len      number of bytes to read from device
  * @param[in]  info         to be removed
+ *
+ * @return                  the number of bytes in the Rx FIFO
+ * @return                  the number of bytes written to @p buf if present
  */
 int cc2420_rx(cc2420_t *dev, uint8_t *buf, size_t max_len, void *info);
 


### PR DESCRIPTION
First start calculating the CRC in hardware when receiving a frame.

Then, other than the at86rf2xx transceivers the cc2420 don't consider the
`CRC_OK` flag when reporting a successful packet reception. This change
introduces a check for this bit and drops the packet else by flushing
the RX FIFO.

(I'd love to be proven wrong and we are doing CRCs in this driver already.)
