### PR TITLE
dist/tools/cppcheck: Improve cmdline parameter handling

### DIFF
--- a/dist/tools/cppcheck/check.sh
+++ b/dist/tools/cppcheck/check.sh
@@ -19,7 +19,28 @@ else
     DEFAULT_SUPPRESSIONS=--suppress="unusedStructMember"
 fi
 
-FILES=$(changed_files)
+FILES=""
+CPPCHECK_OPTIONS=""
+IN_FILES_SECTION=false
+while [ $# -gt 0 ]; do
+    if [ "$1" = "--" ]; then
+        IN_FILES_SECTION=true
+        shift
+        continue
+    fi
+
+    if [ "$IN_FILES_SECTION" = false ]; then
+        CPPCHECK_OPTIONS="${CPPCHECK_OPTIONS} $1"
+    else
+        FILES="${FILES} $1"
+    fi
+
+    shift
+done
+
+if [ -z "${FILES}" ]; then
+    FILES=$(changed_files)
+fi
 
 if [ -z "${FILES}" ]; then
     exit
@@ -28,4 +49,4 @@ fi
 # TODO: switch back to 8 jobs when/if cppcheck issue is resolved
 cppcheck --std=c99 --enable=style --force --error-exitcode=2 --quiet -j 1 \
          --template "{file}:{line}: {severity} ({id}): {message}"         \
-         --inline-suppr ${DEFAULT_SUPPRESSIONS} ${@} ${FILES}
+         --inline-suppr ${DEFAULT_SUPPRESSIONS} ${CPPCHECK_OPTIONS} ${@} ${FILES}


### PR DESCRIPTION
While looking at #1895 I had the urge to be able to check just a single file with `cppcheck`. Since the script itself was a little cluttered with commandline option checks, and they seemed to be positional too, I rewrote the option handling to be somewhat more  extensible. As a positive side effect it was rather easy to add my desired `--file` option which just checks a single file.
