### PR TITLE
iotlab-m3: add missing makefile include to dependencies

### DIFF
--- a/boards/iotlab-m3/Makefile.dep
+++ b/boards/iotlab-m3/Makefile.dep
@@ -1,3 +1,5 @@
+include $(RIOTBOARD)/iotlab-common/Makefile.dep
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += isl29020
   USEMODULE += lps331ap


### PR DESCRIPTION
This got lost somehow in 10e9336. Without this fix gnrc_netdev_default
does not include the at86rf2xx module.