### PR TITLE
cppcheck: Provide consistent reason formatting for all cppcheck-suppresses

### DIFF
--- a/cpu/arm7_common/bootloader.c
+++ b/cpu/arm7_common/bootloader.c
@@ -84,7 +84,8 @@ void abtorigin(const char *vector, unsigned long *lnk_ptr1)
 /*-----------------------------------------------------------------------------------*/
 void UNDEF_Routine(void)
 {
-    /* cppcheck-suppress variableScope */
+    /* cppcheck-suppress variableScope
+     * (reason: used within __asm__ which cppcheck doesn't pick up) */
     register unsigned long *lnk_ptr;
     __asm__ __volatile__("sub %0, lr, #8" : "=r"(lnk_ptr));     // get aborting instruction
 
@@ -98,7 +99,8 @@ void UNDEF_Routine(void)
 /*-----------------------------------------------------------------------------------*/
 void PABT_Routine(void)
 {
-    /* cppcheck-suppress variableScope */
+    /* cppcheck-suppress variableScope
+     * (reason: used within __asm__ which cppcheck doesn't pick up) */
     register unsigned long *lnk_ptr;
     __asm__ __volatile__("sub %0, lr, #8" : "=r"(lnk_ptr));     // get aborting instruction
 
@@ -112,7 +114,8 @@ void PABT_Routine(void)
 /*-----------------------------------------------------------------------------------*/
 void DABT_Routine(void)
 {
-    /* cppcheck-suppress variableScope */
+    /* cppcheck-suppress variableScope
+     * (reason: used within __asm__ which cppcheck doesn't pick up) */
     register unsigned long *lnk_ptr;
     __asm__ __volatile__("sub %0, lr, #8" : "=r"(lnk_ptr));     // get aborting instruction
 

--- a/cpu/x86/x86_pci.c
+++ b/cpu/x86/x86_pci.c
@@ -218,7 +218,8 @@ static void pci_find_function(unsigned bus, unsigned dev, unsigned fun)
     printf("  %02x:%02x.%x \"%s\": \"%s\" (%s: %s, rev: %02hhx)\n",
            bus, dev, fun, vendor_name, device_name, baseclass_name, subclass_name, class.revision_id);
 
-    /* cppcheck-suppress memleakOnRealloc */
+    /* cppcheck-suppress memleakOnRealloc
+     * (reason: TODO this is a bug) */
     known_pci_devices = realloc(known_pci_devices, sizeof (*known_pci_devices) * (num_known_pci_devices + 1));
     struct x86_known_pci_device *d = calloc(1, sizeof *d);
     known_pci_devices[num_known_pci_devices] = d;

--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -89,7 +89,6 @@ typedef struct {
  *
  * @return The sum of the two timestamps
  */
-/* cppcheck-suppress passedByValue */
 timex_t timex_add(const timex_t a, const timex_t b);
 
 /**
@@ -100,7 +99,6 @@ timex_t timex_add(const timex_t a, const timex_t b);
  *
  * @return The difference a - b
  */
-/* cppcheck-suppress passedByValue */
 timex_t timex_sub(const timex_t a, const timex_t b);
 
 /**
@@ -123,7 +121,6 @@ timex_t timex_set(uint32_t seconds, uint32_t microseconds);
  * @return 0 if equal
  * @return 1 if a is bigger
  */
-/* cppcheck-suppress passedByValue */
 int timex_cmp(const timex_t a, const timex_t b);
 
 /**
@@ -157,7 +154,6 @@ static inline int timex_isnormalized(const timex_t *time)
  *
  * @return timex representation as uint64_t
  */
-/* cppcheck-suppress passedByValue */
 static inline uint64_t timex_uint64(const timex_t a)
 {
     return (uint64_t) a.seconds * US_PER_SEC + a.microseconds;

--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -234,10 +234,11 @@ void gnrc_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
     assert(ipv6_iface != NULL);
 #endif
     gnrc_pktsnip_t *hdr, *pkt = NULL;
-    /* both suppressions, since they are needed in the MODULE_GNRC_SIXLOWPAN_ND branch */
-    /* cppcheck-suppress variableScope */
+    /* cppcheck-suppress variableScope
+     * (reason: they are needed in the MODULE_GNRC_SIXLOWPAN_ND branch) */
     uint8_t l2src[8];
-    /* cppcheck-suppress variableScope */
+    /* cppcheck-suppress variableScope
+     * (reason: they are needed in the MODULE_GNRC_SIXLOWPAN_ND branch) */
     size_t l2src_len = 0;
 
     DEBUG("ndp internal: send neighbor solicitation (iface: %" PRIkernel_pid ", src: %s, ",

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -72,8 +72,8 @@ void rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
               size_t frag_size, size_t offset)
 {
     rbuf_t *entry;
-    /* cppcheck is clearly wrong here */
-    /* cppcheck-suppress variableScope */
+    /* cppcheck-suppress variableScope
+     * (reason: cppcheck is clearly wrong here) */
     unsigned int data_offset = 0;
     size_t original_size = frag_size;
     sixlowpan_frag_t *frag = pkt->data;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -618,7 +618,6 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src
         DEBUG("RPL: Could not allocate new parent.\n");
         return;
     }
-    /* cppcheck-suppress nullPointer */
     else if (parent != NULL) {
         trickle_increment_counter(&dodag->trickle);
     }

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -147,10 +147,9 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
     else if ((remote != NULL) && (gnrc_ep_addr_any(remote))) {
         return -EINVAL;
     }
-    /* compiler evaluates lazily so this isn't a redundundant check and cppcheck
-     * is being weird here anyways */
-    /* cppcheck-suppress nullPointerRedundantCheck */
-    /* cppcheck-suppress nullPointer */
+    /* cppcheck-suppress nullPointerRedundantCheck
+     * (reason: compiler evaluates lazily so this isn't a redundundant check and
+     * cppcheck is being weird here anyways) */
     if ((sock == NULL) || (sock->local.family == AF_UNSPEC)) {
         /* no sock or sock currently unbound */
         memset(&local, 0, sizeof(local));

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -241,10 +241,9 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
     else if (sock->remote.family == AF_UNSPEC) {
         return -ENOTCONN;
     }
-    /* compiler evaluates lazily so this isn't a redundundant check and cppcheck
-     * is being weird here anyways */
-    /* cppcheck-suppress nullPointerRedundantCheck */
-    /* cppcheck-suppress nullPointer */
+    /* cppcheck-suppress nullPointerRedundantCheck
+     * (reason: compiler evaluates lazily so this isn't a redundundant check and
+     * cppcheck is being weird here anyways) */
     if ((sock == NULL) || (sock->local.family == AF_UNSPEC)) {
         /* no sock or sock currently unbound */
         memset(&local, 0, sizeof(local));

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -47,7 +47,8 @@
 typedef union {
     /* is not supposed to be used, this is only for the case that no
      * sock module was added (maybe useful for UNIX sockets?) */
-    /* cppcheck-suppress unusedStructMember */
+    /* cppcheck-suppress unusedStructMember
+     * (reason: is not supposed to be used) */
     int undef;
 #ifdef MODULE_SOCK_IP
     sock_ip_t raw;              /**< raw IP sock */

--- a/tests/cpp11_condition_variable/main.cpp
+++ b/tests/cpp11_condition_variable/main.cpp
@@ -52,8 +52,8 @@ int main() {
     data = "Example data";
     {
       lock_guard<mutex> lk(m);
-      // reason: variable is read in the thread created above
-      /* cppcheck-suppress unreadVariable */
+      /* cppcheck-suppress unreadVariable
+       * (reason variable is read in the thread created above) */
       ready = true;
       cv.notify_one();
     }

--- a/tests/unittests/tests-base64/tests-base64.c
+++ b/tests/unittests/tests-base64/tests-base64.c
@@ -208,9 +208,9 @@ static void test_base64_06_stream_encode(void)
 
     /* required output size +2 extra bytes */
     size_t encoded_size = 264 + 2;
-    /* cppcheck-suppress unassignedVariable */
+    /* cppcheck-suppress unassignedVariable
+     * (reason: the above array is used/assigned in base64_encode() using its pointer) */
     unsigned char encode_result[encoded_size];
-    /* the above array is used/assigned in base64_encode() using its pointer. */
 
     int remain = strlen((char *)stream_encode);
     int out_iter = 0;
@@ -264,9 +264,9 @@ static void test_base64_07_stream_decode(void)
     /* required output size +2 extra bytes */
     size_t decoded_size = 196 + 2;
 
-    /* cppcheck-suppress unassignedVariable */
+    /* cppcheck-suppress unassignedVariable
+     * (reason: the above array is used/assigned in base64_decode() using its pointer) */
     unsigned char stream_decoded[decoded_size];
-    /* the above array is used/assigned in base64_decode() using its pointer. */
 
     size_t encoded_size = strlen((char *)encoded);
     int remain = encoded_size;

--- a/tests/unittests/tests-cbor/tests-cbor.c
+++ b/tests/unittests/tests-cbor/tests-cbor.c
@@ -664,7 +664,8 @@ static void test_float_half(void)
     /* check border conditions */
     CBOR_CHECK(float, float_half, stream, -.0f, HEX_LITERAL(0xf9, 0x80, 0x00), EQUAL_FLOAT);
     CBOR_CHECK(float, float_half, stream, .0f, HEX_LITERAL(0xf9, 0x00, 0x00), EQUAL_FLOAT);
-    /* cppcheck-suppress nanInArithmeticExpression */
+    /* cppcheck-suppress nanInArithmeticExpression
+     * (reason: we're actively trying to check against 'INFINITY') */
     CBOR_CHECK(float, float_half, stream, INFINITY, HEX_LITERAL(0xf9, 0x7c, 0x00), EQUAL_FLOAT);
     /* TODO: Broken: encode_float_half issue? */
     /*CBOR_CHECK(float, float_half, stream, NAN, HEX_LITERAL(0xf9, 0x7e, 0x00), EQUAL_FLOAT);*/
@@ -694,14 +695,11 @@ static void test_float(void)
     /* check border conditions */
     CBOR_CHECK(float, float, stream, .0f,
                HEX_LITERAL(0xfa, 0x00, 0x00, 0x00, 0x00), EQUAL_FLOAT);
-    /* cppcheck-suppress nanInArithmeticExpression */
-    CBOR_CHECK(float, float, stream, INFINITY,
-    /* cppcheck-suppress nanInArithmeticExpression */
-               HEX_LITERAL(0xfa, 0x7f, 0x80, 0x00, 0x00), EQUAL_FLOAT);
-    /* cppcheck-suppress nanInArithmeticExpression */
+    /* cppcheck-suppress nanInArithmeticExpression
+     * (reason: we're actively trying to check against 'INFINITY') */
+    CBOR_CHECK(float, float, stream, INFINITY, HEX_LITERAL(0xfa, 0x7f, 0x80, 0x00, 0x00), EQUAL_FLOAT);
     CBOR_CHECK(float, float, stream, NAN,
                HEX_LITERAL(0xfa, 0x7f, 0xc0, 0x00, 0x00), EQUAL_FLOAT);
-    /* cppcheck-suppress nanInArithmeticExpression */
     CBOR_CHECK(float, float, stream, -INFINITY,
                HEX_LITERAL(0xfa, 0xff, 0x80, 0x00, 0x00), EQUAL_FLOAT);
 
@@ -726,14 +724,13 @@ static void test_double(void)
     /* check border conditions */
     CBOR_CHECK(double, double, stream, .0f,
                HEX_LITERAL(0xfb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00), EQUAL_FLOAT);
-    /* cppcheck-suppress nanInArithmeticExpression */
-    CBOR_CHECK(double, double, stream, INFINITY,
-    /* cppcheck-suppress nanInArithmeticExpression */
-               HEX_LITERAL(0xfb, 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00), EQUAL_FLOAT);
-    /* cppcheck-suppress nanInArithmeticExpression */
+    /* cppcheck-suppress nanInArithmeticExpression
+     * (reason: we're actively trying to check against 'INFINITY') */
+    CBOR_CHECK(double, double, stream, INFINITY, HEX_LITERAL(0xfb, 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00), EQUAL_FLOAT);
+
     CBOR_CHECK(double, double, stream, NAN,
                HEX_LITERAL(0xfb, 0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00), EQUAL_FLOAT);
-    /* cppcheck-suppress nanInArithmeticExpression */
+
     CBOR_CHECK(double, double, stream, -INFINITY,
                HEX_LITERAL(0xfb, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00), EQUAL_FLOAT);
 

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -559,10 +559,9 @@ static void test_fib_14_exact_and_prefix_match(void)
     memset(addr_nxt, 0, add_buf_size);
     memset(addr_lookup, 0, add_buf_size);
 
-    /* cppcheck: addr_lookup is only passed but not required to be read,
-    *            since we test prefix matching
-    */
-    /* cppcheck-suppress redundantCopy */
+    /* cppcheck-suppress redundantCopy
+     * (reason: addr_lookup is only passed but not required to be read,
+     *  since we test prefix matching) */
     snprintf(addr_lookup, add_buf_size, "Test addr124");
     ret = fib_get_next_hop(&test_fib_table, &iface_id,
                            (uint8_t *)addr_nxt, &add_buf_size, &next_hop_flags,
@@ -728,9 +727,8 @@ static void test_fib_17_get_entry_set(void)
     fib_destination_set_entry_t arr_dst[arr_size];
     char prefix[addr_buf_size];
     memset(prefix,0, addr_buf_size);
-    /* cppcheck: prefix is set to all 0 before adding an address
-    */
-    /* cppcheck-suppress redundantCopy */
+    /* cppcheck-suppress redundantCopy
+     * (reason: prefix is set to all 0 before adding an address) */
     snprintf(prefix, addr_buf_size, "Test address 1");
 
     int ret = fib_get_destination_set(&test_fib_table,
@@ -743,8 +741,8 @@ static void test_fib_17_get_entry_set(void)
     arr_size = 20;
 
     memset(prefix,0, addr_buf_size);
-    /* cppcheck: prefix is set to all 0 before adding an address */
-    /* cppcheck-suppress redundantCopy */
+    /* cppcheck-suppress redundantCopy
+     * (reason: prefix is set to all 0 before adding an address) */
     snprintf(prefix, addr_buf_size, "Test address 0");
 
     ret = fib_get_destination_set(&test_fib_table,
@@ -757,8 +755,8 @@ static void test_fib_17_get_entry_set(void)
     arr_size = 20;
 
     memset(prefix, 0, addr_buf_size);
-    /* cppcheck: prefix is set to all 0 before adding an address */
-    /* cppcheck-suppress redundantCopy */
+    /* cppcheck-suppress redundantCopy
+     * (reason: prefix is set to all 0 before adding an address) */
     snprintf(prefix, addr_buf_size, "Test address");
 
     ret = fib_get_destination_set(&test_fib_table,


### PR DESCRIPTION
I tried to tackle #1895 by adding a rationale to all suppressions that were not explained before, and also re-formatted all existing explanations to match the format:

```
/* cppcheck-suppress <suppression>
 * (reason: <reason>) */
```

I would propose this format to be our "standard format", since previously everyone kind of did their own thing which sometimes made it hard to see where the reasoning was and which suppression it belonged to. I also removed suppressions which my current cppcheck (1.76.1) did not complain about. Let's see what Murdock says. 

There are also two suppressions marked with `TODO`, I'd appreciate help trying to explain them properly :)

Fixes #1895
