### PR TITLE
static-tests: report cppcheck errors in modified files as errors

### DIFF
--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -88,7 +88,7 @@ then
         #   Remove all but `${CI_BASE_BRANCH}` parameters to cppcheck (and remove second
         #   invocation) once all warnings of cppcheck have been taken care of
         #   in ${CI_BASE_BRANCH}.
-        run ./dist/tools/cppcheck/check.sh ${CI_BASE_BRANCH} --diff-filter=ACMR
+        run ./dist/tools/cppcheck/check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
         exit $RESULT
     fi

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -88,8 +88,7 @@ then
         #   Remove all but `${CI_BASE_BRANCH}` parameters to cppcheck (and remove second
         #   invocation) once all warnings of cppcheck have been taken care of
         #   in ${CI_BASE_BRANCH}.
-        run ./dist/tools/cppcheck/check.sh ${CI_BASE_BRANCH} --diff-filter=MR --error-exitcode=0
-        run ./dist/tools/cppcheck/check.sh ${CI_BASE_BRANCH} --diff-filter=AC
+        run ./dist/tools/cppcheck/check.sh ${CI_BASE_BRANCH} --diff-filter=ACMR
         run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
         exit $RESULT
     fi


### PR DESCRIPTION
I'm not sure who thought this was a good idea, but if they are not
reported as errors no-one will look at this.

(licences do the same fig-leave check by the way).
