### PR TITLE
nanocoap: add POSIX include path

### DIFF
--- a/pkg/nanocoap/Makefile.include
+++ b/pkg/nanocoap/Makefile.include
@@ -1,1 +1,2 @@
 INCLUDES += -I$(BINDIRBASE)/pkg/$(BOARD)/nanocoap/nanocoap
+INCLUDES += -I$(RIOTBASE)/sys/posix/include


### PR DESCRIPTION
Somehow I overlooked this during testing: Since nanocoap uses `arpa/inet.h` for the address family name defintions this needs to be in the include path. In RIOT this resides in `sys/posix/include`.