### PR TITLE
cortexm_common: ifdef stack_base to fix unused error

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -53,7 +53,9 @@ extern uint32_t _sram;
 extern uint32_t _eram;
 /** @} */
 
+#ifdef MODULE_MPU_STACK_GUARD
 static const uintptr_t stack_base = (uintptr_t)&_sstack;
+#endif
 
 /**
  * @brief   Allocation of the interrupt stack


### PR DESCRIPTION
`BOARD=samr21-xpro make` (for any example) fails for me with
```
RIOT/cpu/cortexm_common/vectors_cortexm.c:56:24: error: 'stack_base' defined but not used [-Werror=unused-const-variable=]
 static const uintptr_t stack_base = (uintptr_t)&_sstack;
                        ^~~~~~~~~~
cc1: all warnings being treated as errors
```

*arm-none-eabi-gcc (Arch Repository) 6.2.0*

`stack_base` is only used, if `MODULE_MPU_STACK_GUARD` is defined.