### PR TITLE
examples: fix off-by-one error in TinyDTLS example

### DIFF
--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -502,18 +502,13 @@ static void client_send(char *addr_str, char *data, unsigned int delay)
 
 int udp_client_cmd(int argc, char **argv)
 {
-    if (argc < 2) {
+    uint32_t delay = 1000000;
+
+    if (argc < 3) {
         printf("usage: %s <addr> <data> [<delay in us>]\n", argv[0]);
         return 1;
     }
-
-    uint32_t delay = 1000000;
-    if (argc < 3) {
-        printf("usage: %s <addr> <data> [<delay in us>]\n",
-               argv[0]);
-        return 1;
-    }
-    if (argc > 3) {
+    else if (argc > 3) {
         delay = (uint32_t)atoi(argv[3]);
     }
     client_send(argv[1], argv[2],  delay);

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -435,7 +435,7 @@ static void stop_server(void)
 
 int udp_server_cmd(int argc, char **argv)
 {
-    if (argc < 1) {
+    if (argc < 2) {
         printf("usage: %s start|stop\n", argv[0]);
         return 1;
     }


### PR DESCRIPTION
Fixes an off-by-one error in the TinyDTLS example. Without this fix the example crashes if one types just

```
dtlss
```

in the application.