### PR TITLE
micro-ecc: require hardware RNG [2016.10-backport]

### DIFF
--- a/pkg/micro-ecc/Makefile.dep
+++ b/pkg/micro-ecc/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_hwrng

--- a/tests/pkg_micro-ecc/Makefile
+++ b/tests/pkg_micro-ecc/Makefile
@@ -1,7 +1,6 @@
 APPLICATION = pkg_micro-ecc
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_hwrng
 USEPKG += micro-ecc
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
Backport to #6028.