### PR TITLE
tests: mutex_order: updated test and fixed README [2016.10-backport]

### DIFF
--- a/tests/mutex_order/Makefile
+++ b/tests/mutex_order/Makefile
@@ -3,6 +3,4 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := stm32f0discovery weio nucleo-f030
 
-USEMODULE += xtimer
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/mutex_order/README.md
+++ b/tests/mutex_order/README.md
@@ -1,25 +1,25 @@
 Expected result
 ===============
-When successful, you should see 10 different threads printing their PID and
-priority. The thread with the lowest priority will print its status first,
-followed by the other threads in the order of their priority (highest next). The
-output should look like the following:
+When successful, you should see 5 different threads printing their PID and
+priority. The thread with the lowest priority should be able to lock (and
+unlock) the mutex first, followed by the other threads in the order of their
+priority (highest next). The output should look like the following:
 
 ```
 main(): This is RIOT! (Version: xxx)
 Mutex order test
 Please refer to the README.md for more information
 
-T3 (prio 6): locking mutex now
-T4 (prio 0): locking mutex now
-T5 (prio 4): locking mutex now
-T6 (prio 2): locking mutex now
-T7 (prio 1): locking mutex now
-T3 (prio 6): unlocking mutex now
-T4 (prio 0): unlocking mutex now
+T3 (prio 6): trying to lock mutex now
+T4 (prio 4): trying to lock mutex now
+T5 (prio 0): trying to lock mutex now
+T6 (prio 2): trying to lock mutex now
+T7 (prio 1): trying to lock mutex now
+T5 (prio 0): unlocking mutex now
 T7 (prio 1): unlocking mutex now
 T6 (prio 2): unlocking mutex now
-T5 (prio 4): unlocking mutex now
+T4 (prio 4): unlocking mutex now
+T3 (prio 6): unlocking mutex now
 
 Test END, check the order of priorities above.
 ```

--- a/tests/mutex_order/tests/01-run.py
+++ b/tests/mutex_order/tests/01-run.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2016 Oliver Hahm <oliver.hahm@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+thread_prio = {
+        3:  6,
+        4:  4,
+        5:  0,
+        6:  2,
+        7:  1
+        }
+
+def testfunc(child):
+    for k in thread_prio.keys():
+        child.expect(u"T%i \(prio %i\): trying to lock mutex now" % (k, thread_prio[k]))
+
+    last = -1
+    for i in range(len(thread_prio)):
+        child.expect(u"T\d+ \(prio (\d+)\): locked mutex now")
+        assert(int(child.match.group(1)) > last)
+        last = int(child.match.group(1))
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
Backport for https://github.com/RIOT-OS/RIOT/pull/6051