### PR TITLE
backport: drivers/at86rf2xx: improve precondition checks on state transition

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -421,7 +421,16 @@ void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state)
 static inline void _set_state(at86rf2xx_t *dev, uint8_t state)
 {
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_STATE, state);
-    while (at86rf2xx_get_status(dev) != state);
+
+    /* To prevent a possible race condition when changing to
+     * RX_AACK_ON state the state doesn't get read back in that
+     * case. See discussion
+     * in https://github.com/RIOT-OS/RIOT/pull/5244
+     */
+    if (state != AT86RF2XX_STATE_RX_AACK_ON) {
+        while (at86rf2xx_get_status(dev) != state);
+    }
+
     dev->state = state;
 }
 

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -429,15 +429,16 @@ void at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
 {
     uint8_t old_state = at86rf2xx_get_status(dev);
 
-    if (state == old_state) {
-        return;
-    }
     /* make sure there is no ongoing transmission, or state transition already
      * in progress */
     while (old_state == AT86RF2XX_STATE_BUSY_RX_AACK ||
            old_state == AT86RF2XX_STATE_BUSY_TX_ARET ||
            old_state == AT86RF2XX_STATE_IN_PROGRESS) {
         old_state = at86rf2xx_get_status(dev);
+    }
+
+    if (state == old_state) {
+        return;
     }
 
     /* we need to go via PLL_ON if we are moving between RX_AACK_ON <-> TX_ARET_ON */


### PR DESCRIPTION
Backport of #5244.