### PR TITLE
cpp11-compat: no exceptions in noexcept function

### DIFF
--- a/sys/cpp11-compat/condition_variable.cpp
+++ b/sys/cpp11-compat/condition_variable.cpp
@@ -78,11 +78,6 @@ void condition_variable::notify_all() noexcept {
 }
 
 void condition_variable::wait(unique_lock<mutex>& lock) noexcept {
-  if (!lock.owns_lock()) {
-    throw std::system_error(
-      std::make_error_code(std::errc::operation_not_permitted),
-      "Mutex not locked.");
-  }
   priority_queue_node_t n;
   n.priority = sched_active_thread->priority;
   n.data = sched_active_pid;


### PR DESCRIPTION
Not sure, if that's the right solution. But since g++6.* `-wterminate` is the default => g++ complains about possible exceptions in functions marked (explicitely or implicitely) with `noexcept`.