### PR TITLE
sys: Fix pthread includes to support avr-libs

### DIFF
--- a/pkg/iotivity/Makefile
+++ b/pkg/iotivity/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=iotivity-constrained
 PKG_URL=https://github.com/iotivity/iotivity-constrained
-PKG_VERSION=96b50da1762d016790ac7fa516d95a0252bb2f72
+PKG_VERSION=830bb7a42d2804830a57dfe8bc469fac1317c46a
 PKG_LICENSE=Apache-2.0
 
 PKG_LIB=$(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)

--- a/sys/posix/pthread/include/pthread.h
+++ b/sys/posix/pthread/include/pthread.h
@@ -22,6 +22,10 @@
 
 #include <time.h>
 
+#ifndef __WITH_AVRLIBC__
+#define HAVE_MALLOC_H 1
+#endif
+
 #include "mutex.h"
 #include "sched.h"
 

--- a/sys/posix/pthread/include/pthread_cond.h
+++ b/sys/posix/pthread/include/pthread_cond.h
@@ -25,7 +25,7 @@
 #   include "msp430_types.h"
 #endif
 
-#if defined(__MACH__)
+#if defined(__MACH__) || defined(__WITH_AVRLIBC__)
 typedef int clockid_t;
 #endif
 

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -19,7 +19,6 @@
  * @}
  */
 
-#include <malloc.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
@@ -33,6 +32,10 @@
 #include "sched.h"
 
 #include "pthread.h"
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
 
 #define ENABLE_DEBUG (0)
 

--- a/sys/posix/pthread/pthread_tls.c
+++ b/sys/posix/pthread/pthread_tls.c
@@ -16,9 +16,11 @@
  * @}
  */
 
-#include <malloc.h>
-
 #include "pthread.h"
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"


### PR DESCRIPTION
Missing malloc.h and clock_id_t were causing issues to build.

It was tested with this configuration:

- linux ubuntu 14.04.5
- arduino-mega2560 board
- avr-libc-1.8.0-4.1

Change-Id: I2080dfb43c75805b255f6c65a09ee2c0c0e54f6a
Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>