### PR TITLE
tests: fix sizeof_tcb output [2016.10-backport]

### DIFF
--- a/tests/sizeof_tcb/main.c
+++ b/tests/sizeof_tcb/main.c
@@ -23,13 +23,15 @@
 
 #include "thread.h"
 
-#define P(NAME) printf("\t%-*s%4zu%4zu\n", 11, #NAME, sizeof(((thread_t *) 0)->NAME), offsetof(thread_t, NAME));
+#define P(NAME) printf("\t%-*s%4u%4u\n", 11, #NAME, \
+                       (unsigned)sizeof(((thread_t *) 0)->NAME), \
+                       (unsigned)offsetof(thread_t, NAME));
 
 int main(void)
 {
     puts("\tmember, sizeof, offsetof");
 
-    printf("sizeof(thread_t): %zu\n", sizeof(thread_t));
+    printf("sizeof(thread_t): %u\n", (unsigned)sizeof(thread_t));
 
     P(sp);
     P(status);


### PR DESCRIPTION
Backport to #6078.