### PR TITLE
od: quick-fix for newlib-nano [2016.10-backport]

### DIFF
--- a/sys/include/od.h
+++ b/sys/include/od.h
@@ -114,7 +114,12 @@ extern "C" {
 #define OD_FLAGS_LENGTH_1       (0x0010)    /**< 1 byte */
 #define OD_FLAGS_LENGTH_2       (0x0020)    /**< 2 byte */
 #define OD_FLAGS_LENGTH_4       (0x0000)    /**< 4 byte and default */
-#define OD_FLAGS_LENGTH_8       (0x0080)    /**< 8 byte */
+/**
+ * @brief   8 byte
+ *
+ * @warning not working with newlib-nano
+ */
+#define OD_FLAGS_LENGTH_8       (0x0080)
 #define OD_FLAGS_LENGTH_CHAR    (OD_FLAGS_LENGTH_1)    /**< alias for OD_FLAGS_LENGTH_1 */
 #define OD_FLAGS_LENGTH_SHORT   (0x0002)    /**< sizeof(short) byte */
 #define OD_FLAGS_LENGTH_LONG    (0x0004)    /**< sizeof(long) byte */

--- a/sys/od/od.c
+++ b/sys/od/od.c
@@ -303,12 +303,16 @@ static void _print_date(const void *data, size_t offset, char *format, uint8_t l
             break;
 
         case 8:
+#ifndef MODULE_NEWLIB
             if (flags & OD_FLAGS_BYTES_INT) {
                 printf(format, ((int64_t *)data)[offset]);
             }
             else {
                 printf(format, ((uint64_t *)data)[offset]);
             }
+#else
+            printf("%s", format);
+#endif
 
             break;
 

--- a/tests/od/main.c
+++ b/tests/od/main.c
@@ -143,6 +143,7 @@ int main(void)
             OD_FLAGS_BYTES_HEX | OD_FLAGS_LENGTH_4));
 
     /* Test different 8-byte-wise byte formats */
+#ifndef MODULE_NEWLIB
     CALL(od(long_str, sizeof(long_str), OD_WIDTH_DEFAULT,
             OD_FLAGS_BYTES_INT | OD_FLAGS_LENGTH_8));
     CALL(od(long_str, sizeof(long_str), OD_WIDTH_DEFAULT,
@@ -151,6 +152,7 @@ int main(void)
             OD_FLAGS_BYTES_UINT | OD_FLAGS_LENGTH_8));
     CALL(od(long_str, sizeof(long_str), OD_WIDTH_DEFAULT,
             OD_FLAGS_BYTES_HEX | OD_FLAGS_LENGTH_8));
+#endif
 
     /* Test different char-wise byte formats */
     CALL(od(long_str, sizeof(long_str), OD_WIDTH_DEFAULT,

--- a/tests/od/tests/01-run.py
+++ b/tests/od/tests/01-run.py
@@ -13,6 +13,9 @@ sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
 def testfunc(child):
+    # check if running with newlib
+    print("ATTENTION: This script is currently not suitable for non-native platforms")
+
     # test data width vs. output width discrepency
     child.expect_exact(r'od(short_str, sizeof(short_str), OD_WIDTH_DEFAULT, 0)')
     child.expect_exact(r'000000000 000000041101')


### PR DESCRIPTION
Backport to #6080 