### PR TITLE
[Pkg] IoTivity Pkg for RIOT OS

### DIFF
--- a/examples/iotivity_examples/README.md
+++ b/examples/iotivity_examples/README.md
@@ -1,0 +1,336 @@
+IoTivity Examples
+===============
+These examples implement some simple clients and a server to test the IoTivity package for RIOT-OS. The pkg is based on the [IoTivity-Constrained][1] library.
+All examples use the realm-local multicast address **ff03:158** instead of the link-local multicast address **ff02::158**. Every payload is [CBOR][2] encoded.
+All examples have been tested on Native and SAMR21-XPRO.
+##Index
+ - [Iotivity Examples](#examples)
+   - [Server Example](#server_ex)
+   - [Client Example](#client_ex)
+   - [Client_Switch Example](#client_sw_ex)
+   - [BR_FW Example](#br_fw_ex)
+ - [Scenarios](#scenarios)
+   - [Node-to-Node Communications](#n2n_comm)
+     -  [Server and Client (Periodic PUT) - native target](#sc_pput_native)
+     -  [Server and Client (Periodic PUT) - SAMR21-XPRO target](#sc_pput_samr21)
+     -  [Server and Client_Switch  - SAMR21-XPRO target](#sc_sw_samr21)
+   - [Linux-to-Nodes Communications](#l2n_comm)
+     - [Preliminary Step](#l2n_pre)
+     - [Start the Server](#l2n_srv)
+     - [Start the Border Router](#l2n_br)
+     - [Server output](#l2n_out)
+     - [Testing](#l2n_tst)
+ - [Good Practice](#good)
+
+#<a name="examples"></a>Examples
+
+##<a name="server_ex"></a>Server Example
+This example implements an IoTivity Server that contains 4 resources.
+ 1. */oic/res*: returns the representation of resources available on the server.  Defined [here][3].
+ 2. */oic/p*: returns information about the platform on which the server runs. Defined [here][3].
+ 3. */oic/d*: returns information about the device on which the server runs. Defined [here][3].
+ 4. */light/1* : it is a light (LED) management resource (implemented in resources/res-light.c). Resource Type: *oic.r.light*.
+	- GET: returns the status of the LED. The payload is: `{state: true/false}`
+	- PUT: changes the status of the LED. The payload is: `{state: true/false}`
+	- OBSERVE: the registered client is notified when the status changes. The payload is the same of the GET response.
+
+## <a name="client_ex"></a>Client Example
+This example implements a simple client. It is able to discover resources with ResourceType *oic.r.light*. Once it finds a resource, it registers for OBSERVE notifications. It changes the status every second by sending a periodic PUT request.
+
+##<a name="client_sw_ex"></a>Client_Switch Example
+This example implements a simple client. It is able to discover resources with ResourceType *oic.r.light*. Once it finds a resource, it registers for OBSERVE notifications. It changes the status when the User Button is pressed. If the button  is not present it is just an observer.
+
+##<a name="br_fw_ex"></a>BR_FW Example
+It is an "enhanced" version of the GNRC Border Router. It implements a simple forwarder (UDP server/client) for multicast requests with destination ff03::158 port 5683.
+
+#<a name="scenarios"></a>Scenarios
+It is possible to deploy 2 different scenarios with these examples.
+
+##<a name="n2n_comm"></a>Node-to-Node Communications
+In this scenario, we will deploy an IoTivity Client and IoTivity Server on different nodes. We can choose two different clients for this scenario: client (periodic PUT) or client_switch (PUT sent on User Button pressed). The first one runs well both on native either on SAMR21-XPRO boards, the second one runs just on SAMR21-XPRO boards. Native target hasn't the button.
+
+### <a name="sc_pput_native"></a>Server and Client (Periodic PUT) - native target
+Create taps interfaces (to which RIOT will connect). Go to `/dist/tools/tapsetup` and type
+```
+$ sudo ./tapsetup -c
+```
+After this step we have created three tap interfaces: tap0, tap1 and tapbr0.
+Now, we compile the server. Go to `/examples/iotivity-examples/server` and type
+```
+$ make all BOARD=native
+```
+Run the server by invoking
+```
+$ sudo bin/native/ocf_server.elf tap0
+```
+The server output will be similar to this
+```
+RIOT native interrupts/signals initialized.
+LED_RED_OFF
+LED_GREEN_ON
+RIOT native board initialized.
+RIOT native hardware initialization complete.
+
+main(): This is RIOT! (Version: 2017.01-devel-13-g2b77e-mattia-Latitude-E6410-pkg/iotivity)
+server_oic: Waiting for address autoconfiguration...ipadapter: waiting for server requests...
+ipadapter: waiting for multicast requests...
+server_oic: LED0 is OFF
+LED_RED_OFF
+oc_main: Stack successfully initialized
+server_oic: Configured network interfaces:
+Iface  5   HWaddr: e6:e8:ff:6b:0c:f2
+
+           MTU:1500  HL:64  RTR  RTR_ADV
+           Source address length: 6
+           Link type: wired
+           inet6 addr: ff02::1/128  scope: local [multicast]
+           inet6 addr: fe80::e4e8:ffff:fe6b:cf2/64  scope: local
+           inet6 addr: ff02::1:ff6b:cf2/128  scope: local [multicast]
+           inet6 addr: ff02::2/128  scope: local [multicast]
+           inet6 addr: ff02::1a/128  scope: local [multicast]
+           inet6 addr: ff03::158/128  scope: global [multicast]
+```
+It is waiting for requests.
+Open a new terminal window, go to `/examples/iotivity-examples/client` and type
+```
+$ make all BOARD=native
+```
+Run the client by invoking
+```
+$ sudo bin/native/ocf_client.elf tap1
+```
+The client runs and it starts with the discovery phase
+```
+RIOT native interrupts/signals initialized.
+LED_RED_OFF
+LED_GREEN_ON
+RIOT native board initialized.
+RIOT native hardware initialization complete.
+
+main(): This is RIOT! (Version: 2017.01-devel-13-g2b77e-mattia-Latitude-E6410-pkg/iotivity)
+LED_RED_OFF
+client_oic: Waiting for address autoconfiguration...ipadapter: waiting for server requests...
+ipadapter: waiting for multicast requests...
+oc_main: Stack successfully initialized
+client_oic: Configured network interfaces:Iface  5   HWaddr: a6:ab:89:bd:1f:80
+
+           MTU:1500  HL:64  RTR  RTR_ADV
+           Source address length: 6
+           Link type: wired
+           inet6 addr: ff02::1/128  scope: local [multicast]
+           inet6 addr: fe80::a4ab:89ff:febd:1f80/64  scope: local
+           inet6 addr: ff02::1:ffbd:1f80/128  scope: local [multicast]
+           inet6 addr: ff02::2/128  scope: local [multicast]
+           inet6 addr: ff02::1a/128  scope: local [multicast]
+           inet6 addr: ff03::158/128  scope: global [multicast]
+
+client_oic: continue discovery
+Outgoing message to [ff03:0000:0000:0000:0000:0000:0000:0158]:5683
+client_oic: continue discovery
+...
+ipadapter: got server request
+Incoming message from [fe80:0000:0000:0000:241c:c8ff:fe14:3d79]:56789
+ipadapter: waiting for server requests...
+client_oic: Discovery done
+client_oic: Ready...
+LED_RED_ON
+```
+Once the resource is discovered, the client registers as an Observer of the resource and it switches on its LED as notification of Discovery Completed.
+From this point it will send a PUT request every second.
+Client Output:
+```
+client_oic: Sent PUT request
+Outgoing message to [fe80:0000:0000:0000:241c:c8ff:fe14:3d79]:56789
+ipadapter: got server request
+Incoming message from [fe80:0000:0000:0000:241c:c8ff:fe14:3d79]:56789
+ipadapter: waiting for server requests...
+client_oic: PUT_light:
+client_oic: PUT response OK
+ipadapter: got server request
+Incoming message from [fe80:0000:0000:0000:241c:c8ff:fe14:3d79]:56789
+ipadapter: waiting for server requests...
+client_oic: OBSERVE_light: key state, value 0
+```
+Server output:
+```
+Incoming message from [fe80:0000:0000:0000:a4ab:89ff:febd:1f80]:56789
+ipadapter: waiting for server requests...
+server_oic: PUT request
+server_oic: key: state value: 0
+server_oic: LED0 is OFF
+LED_RED_OFF
+Outgoing message to [fe80:0000:0000:0000:a4ab:89ff:febd:1f80]:56789
+server_oic: GET request
+server_oic: Light state 0
+Outgoing message to [fe80:0000:0000:0000:a4ab:89ff:febd:1f80]:56789
+```
+TAPs interfaces can be easily deleted. Go to `/dist/tools/tapsetup` and type
+```
+$ sudo ./tapsetup -d
+```
+
+###<a name="sc_pput_samr21"></a> Server and Client (Periodic PUT) - SAMR21-XPRO target
+Now, we reproduce the previous scenario using two [SAMR21-XPRO][4] nodes.
+Connect your nodes, go to `/examples/iotivity-examples/server` and check the list of USB-connected nodes by typing:
+```
+$ make list-ttys
+```
+The output will be similar to
+```
+/sys/bus/usb/devices/2-1.3: Atmel Corp. EDBG CMSIS-DAP serial: 'ATML2127031800001234', tty(s): ttyACM0
+/sys/bus/usb/devices/2-1.4: Atmel Corp. EDBG CMSIS-DAP serial: 'ATML2127031800004321', tty(s): ttyACM1
+```
+We will use Serial Numbers in order to identify the designed node during the compilation phase.
+Now, we compile the server
+```
+$ make flash BOARD=samr21-xpro SERIAL=server_node_serial
+```
+then we open the serial connection
+```
+$ make term BOARD=samr21-xpro SERIAL=server_node_serial
+```
+The server starts and it is waiting for incoming requests.
+Now,  open a new terminal window, go to `/examples/iotivity-examples/client` and type
+```
+$ make flash BOARD=samr21-xpro SERIAL=client_node_serial
+$ make term BOARD=samr21-xpro SERIAL=client_node_serial
+```
+Client starts the discovery phase. Once it finds a resource (with ResourceType **oic.r.light**), it registers as an observer on the resource, then it switches on its LED and it finally starts with periodic PUT requests. The server LED will blink periodically.
+Client and Server terminal outputs are similar to the outputs in case of native target.
+
+###<a name="sc_sw_samr21"></a> Server and Client_Switch - SAMR21-XPRO target
+This deployment emulates a smart home scenario in which we have a SmartBulb (server) and a SmartSwitch (client_switch). It requires two SAMR21-XPRO nodes or similar.
+Connect your nodes, go to `/examples/iotivity-examples/server` and check the list of USB-connected nodes by typing:
+```
+$ make list-ttys
+```
+The output will be similar to
+```
+/sys/bus/usb/devices/2-1.3: Atmel Corp. EDBG CMSIS-DAP serial: 'ATML2127031800001234', tty(s): ttyACM0
+/sys/bus/usb/devices/2-1.4: Atmel Corp. EDBG CMSIS-DAP serial: 'ATML2127031800004321', tty(s): ttyACM1
+```
+We will use Serial Numbers in order to identify the designed node during the compilation phase.
+
+Now, we compile the server
+```
+$ make flash BOARD=samr21-xpro SERIAL=server_node_serial
+```
+then we open the serial connection
+```
+$ make term BOARD=samr21-xpro SERIAL=server_node_serial
+```
+The server starts and it is waiting for incoming requests.
+
+Now, we open a new terminal window, go to `/examples/iotivity-examples/client_switch` and type
+```
+$ make flash BOARD=samr21-xpro SERIAL=client_node_serial
+$ make term BOARD=samr21-xpro SERIAL=client_node_serial
+```
+Client performs the discovery phase. Once it is completed, client registers as an Observer of the resource, then it switches on its LED.
+Client is now ready to send a PUT request when the User Button is pressed. The server LED will change the status when the button is pressed. Terminal outputs are similar to outputs in previous examples.
+
+##<a name="l2n_comm"></a>Linux-to-Nodes communications
+In this scenario, we will deploy an IoTivity server on a RIOT node and the IoTivity client will run on a Linux machine. This architecture requires the "enhanced" version of the Border Router [BR_FW](br_fw). It requires two SAMR21-XPRO nodes or similar.
+
+###<a name="l2n_pre"></a>Preliminary step
+Connect your nodes, go to `/examples/iotivity-examples/server` and check the list of USB-connected nodes by typing:
+```
+$ make list-ttys
+```
+The output will be similar to
+```
+/sys/bus/usb/devices/2-1.3: Atmel Corp. EDBG CMSIS-DAP serial: 'ATML2127031800001234', tty(s): ttyACM0
+/sys/bus/usb/devices/2-1.4: Atmel Corp. EDBG CMSIS-DAP serial: 'ATML2127031800004321', tty(s): ttyACM1
+```
+We will use Serial Numbers in order to identify the designed node during the compilation phase.
+
+###<a name="l2n_srv"></a>Start the Server
+Open a terminal window, go to `/examples/iotivity-examples/server` and type
+```
+$ make flash BOARD=samr21-xpro SERIAL=server_node_serial
+```
+then we open the serial connection
+```
+$ make term BOARD=samr21-xpro SERIAL=server_node_serial
+```
+The server starts the initialization phase, then it is ready for incoming requests.
+
+###<a name="l2n_br"></a>Start the Border Router
+Step 1) Open a terminal window in `/example/iotivity-examples/br_fw/` and type
+```
+$ make flash BOARD=samr21-xpro SERIAL=br_node_serial
+```
+Step 2) Once the flashing is finished, we have to open a network interface. Type
+```
+$  PORT=/dev/ttyACM0 make term
+```
+Step 3) We have to complete the routing strategy on the BR, so in the RIOT shell type
+```
+> ifconfig 7 add 2001:db8::2
+> fibroute add :: via 2001:db8::1 dev 7
+```
+Now the BR is ready. The network is configured as follow:
+- Serial Port: **/dev/ttyACM0**
+- Interface: **tap0**
+- Address Prefix: **2001:db8::\64**
+- Routing on tap0 of multicast packets with destination **ff03::158**
+
+It is possible to configure the network with different parameters by invoking directly the initialization script instead of executing the Step 2:
+```
+$ make host-tools
+$ sudo ./start_network_mcast.sh <serial-port> <tap-device> <IPv6-prefix> <IPv6-mcast>
+```
+then run the Step 3 with the proper changes.
+
+We can check the reachability of the server by typing in another terminal window
+```
+$ ping6 <IPv6 server>
+```
+The IPv6 address of the server can be found by typing in the Border Router console:
+```
+> routers
+```
+The output will be similar to
+```
+if  Router                          state      type
+---------------------------------------------------
+ 6  2001:db8::5859:1c2a:64c7:c48a   REACHABLE   REG
+```
+
+###<a name="l2n_out"></a>Server Output
+Managing a GET request the output is like
+```
+2016-11-04 14:39:32,115 - INFO # ipadapter: got server request
+2016-11-04 14:39:32,121 - INFO # Incoming message from [2001:0db8:0000:0000:0000:0000:0000:0001]:56214
+2016-11-04 14:39:32,125 - INFO # ipadapter: waiting for server requests...
+2016-11-04 14:39:32,128 - INFO # server_oic: GET request
+2016-11-04 14:39:32,130 - INFO # server_oic: Light state 0
+2016-11-04 14:39:32,145 - INFO # Outgoing message to [2001:0db8:0000:0000:0000:0000:0000:0001]:56214
+```
+Managing a PUT request the output is like
+```
+2016-11-04 14:39:35,119 - INFO # ipadapter: got server request
+2016-11-04 14:39:35,125 - INFO # Incoming message from [2001:0db8:0000:0000:0000:0000:0000:0001]:56214
+2016-11-04 14:39:35,128 - INFO # ipadapter: waiting for server requests...
+2016-11-04 14:39:35,134 - INFO # server_oic: PUT request
+2016-11-04 14:39:35,136 - INFO # server_oic: key: state value: 1
+2016-11-04 14:39:35,138 - INFO # server_oic: LED0 is ON
+2016-11-04 14:39:35,141 - INFO # Outgoing message to [2001:0db8:0000:0000:0000:0000:0000:0001]:56214
+```
+
+###<a name="l2n_tst"></a>Testing
+There are many different ways to test this scenario.
+
+ - Tools: you can use [coap-cbor-cli][5] to perform get request. Put -c as argument.
+ - Iotivity Client: you can write an iotivity client that runs on Linux. [Here][6] and [Here][7] there are some sample clients that can be used to test this scenario.
+
+#<a name="good"></a>Good Practice
+Discoveries and Requests are usually fast, but a timeout delay of some seconds on responses can be useful. In these examples, delays are set to 1 second for discoveries and they can be increased. For requests coming from a linux-based client, timeout delays should be higher (e.g. 5-10 seconds for discoveries and 3 seconds for requests). They can be tuned depending on the application. The minimum value is around 1 second.
+
+[1]: https://github.com/iotivity/iotivity-constrained/
+[2]: http://cbor.io/
+[3]: https://openconnectivity.org/resources/specifications
+[4]: http://www.atmel.com/tools/ATSAMR21-XPRO.aspx
+[5]: https://github.com/domabo/coap-cbor-cli
+[6]: https://github.com/Agile-IoT/agile-iotivity/tree/master/IoTivity/Simple-Client-Linux
+[7]: https://github.com/Agile-IoT/agile-iotivity/tree/master/IoTivity/Interactive-Client-Linux

--- a/examples/iotivity_examples/br_fw/Makefile
+++ b/examples/iotivity_examples/br_fw/Makefile
@@ -1,0 +1,102 @@
+# name of your application
+APPLICATION = ocf_br_fw
+
+CFLAGS += -DOC_SERVER
+CFLAGS += -DOC_CLIENT
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../..
+
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
+                          nrf6310 pca10000 pca10005 spark-core \
+                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
+                          yunjia-nrf51822 z1 nucleo-f072
+
+# use ethos (ethernet over serial) for network communication and stdio over
+# UART, but not on native, as native has a tap interface towards the host.
+ifeq (,$(filter native,$(BOARD)))
+GNRC_NETIF_NUMOF := 2
+USEMODULE += ethos gnrc_netdev2
+
+# ethos baudrate can be configured from make command
+ETHOS_BAUDRATE ?= 115200
+CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
+FEATURES_REQUIRED += periph_uart
+endif
+
+# Include packages that pull up and auto-init the link layer.
+# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+# Specify the mandatory networking modules for 6LoWPAN border router
+USEMODULE += gnrc_sixlowpan_border_router_default
+# Add forwarding table
+USEMODULE += fib
+# Additional networking modules that can be dropped if not needed
+USEMODULE += gnrc_icmpv6_echo
+# Add also the shell, some shell commands
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+#USEMODULE += gnrc_pktdump
+# include UHCP client
+USEMODULE += gnrc_uhcpc
+#UDP
+USEMODULE += gnrc_udp
+USEMODULE += gnrc_conn_udp
+#rpl
+# Add a routing protocol
+USEMODULE += gnrc_rpl
+USEMODULE += auto_init_gnrc_rpl
+USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_ndp_router
+#Other modules
+USEMODULE += pthread
+USEMODULE += shell
+USEMODULE += shell_commands
+
+SECURE ?= 0
+export SECURE
+
+
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+#CFLAGS += -DDEVELHELP
+
+# Use different settings when compiling for one of the following (low-memory)
+# boards
+LOW_MEMORY_BOARDS := nucleo-f334
+
+ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
+$(info Using low-memory configuration for iotivity_server.)
+## low-memory tuning values
+# lower pktbuf buffer size
+CFLAGS += -DGNRC_PKTBUF_SIZE=1000
+# disable fib, rpl
+DISABLE_MODULE += fib gnrc_rpl
+USEMODULE += prng_minstd
+endif
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+TAP ?= tap0
+IPV6_PREFIX ?= 2001:db8::/64
+IPV6_MCAST_OIC ?= ff03::158
+
+include $(RIOTBASE)/Makefile.include
+.PHONY: host-tools
+
+term: host-tools
+	$(AD) sudo ./start_network_mcast.sh $(PORT) $(TAP) $(IPV6_PREFIX) $(IPV6_MCAST_OIC)
+
+host-tools:
+	$(AD)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools

--- a/examples/iotivity_examples/br_fw/main.c
+++ b/examples/iotivity_examples/br_fw/main.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2016 CREATE-NET
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     Examples
+ * @{
+ *
+ * @file        main.c
+ * @brief       This is a BR with multicast forwarding for OIC discovery
+ *
+ * @author      Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+ *                              <m.antonini@create-net.org>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "net/af.h"
+#include "shell.h"
+#include "xtimer.h"
+#include "msg.h"
+#include "net/gnrc.h"
+#include "net/gnrc/conn.h"
+#include "net/gnrc/ipv6.h"
+#include "net/gnrc/rpl.h"
+#include "net/gnrc/udp.h"
+#include "net/conn/udp.h"
+#include "thread.h"
+#define MAIN_QUEUE_SIZE     (8)
+#define OIC_FW_QUEUE_SIZE     (8)
+#define MAX_PAYLOAD_SIZE (256)
+#define MULTICAST_PORT (5683)
+
+#define PRINTipaddr(addr, port)                                                  \
+    printf(                                                                       \
+        "[%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%"    \
+        "02x]:%d",                                                                 \
+        (addr)[0], (addr)[1],      \
+        (addr)[2], (addr)[3],      \
+        (addr)[4], (addr)[5],      \
+        (addr)[6], (addr)[7],      \
+        (addr)[8], (addr)[9],      \
+        (addr)[10], (addr)[11],    \
+        (addr)[12], (addr)[13],    \
+        (addr)[14], (addr)[15],    \
+        port)
+
+static uint8_t buffer2[MAX_PAYLOAD_SIZE];
+
+static msg_t _oic_fw_msg_queue[OIC_FW_QUEUE_SIZE];
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+static kernel_pid_t interface_pid;
+
+char oic_forwarding_thread_stack[THREAD_STACKSIZE_DEFAULT];
+
+uint8_t wk_addr[16] = { 0xff, 0x03, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0x01, 0x58 };
+
+void handle_incoming_message(uint8_t *payload, int *size, uint8_t *addr,
+                             uint8_t addr_len, uint16_t port)
+{
+    char *addr_str = NULL;
+    uint8_t buffer[*size];
+
+    memcpy(buffer, payload, *size);
+
+    ipv6_addr_to_str(addr_str, (ipv6_addr_t *)addr, addr_len);
+    printf("forwarder: pck from ");
+    PRINTipaddr(addr, port);
+    printf("\n");
+    printf("forwarder: payload size %d B\n", *size);
+
+    conn_udp_sendto(buffer, *size, addr, 16,
+                    wk_addr, 16, AF_INET6,
+                    port, MULTICAST_PORT);
+}
+
+void *start_oic_forwarding_loop(void *arg)
+{
+    (void)arg;
+
+    msg_init_queue(_oic_fw_msg_queue, OIC_FW_QUEUE_SIZE);
+
+    static uint8_t addr[16] = { 0 };
+    uint8_t remote_addr[16] = { 0 };
+    size_t remote_addr_len;
+    uint16_t remote_port;
+
+    conn_udp_t conn;
+
+    int n = conn_udp_create(&conn, addr, sizeof(addr), AF_INET6, MULTICAST_PORT);
+
+    if (n != 0) {
+        printf("forwarder: failed to register multicast receive socket\n");
+        return NULL;
+    }
+
+
+    ipv6_addr_t *if_addr =
+        gnrc_ipv6_netif_add_addr(interface_pid, (ipv6_addr_t *)&wk_addr, 128, 0);
+
+    if (if_addr == NULL) {
+        printf("forwarder: error.. could not join multicast group\n");
+        return NULL;
+    }
+
+    gnrc_ipv6_netif_addr_get(if_addr)->valid = UINT32_MAX;
+    gnrc_ipv6_netif_addr_get(if_addr)->preferred = UINT32_MAX;
+
+    while (1) {
+        printf("forwarder: waiting for multicast requests...\n");
+        n = conn_udp_recvfrom(&conn, (char *)buffer2, MAX_PAYLOAD_SIZE, remote_addr,
+                              &remote_addr_len, &remote_port);
+        if (n < 0) {
+            printf("forwarder_multicast_recv: error in conn_udp_recvfrom().n=%d\n", n);
+            continue;
+        }
+
+        printf("forwarder: got multicast request\n");
+
+        handle_incoming_message(buffer2, &n, remote_addr, remote_addr_len, remote_port);
+    }
+
+    return NULL;
+}
+
+
+int main(void)
+{
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("RIOT border router + OIC discovery forwarder");
+
+    kernel_pid_t interfaces[GNRC_NETIF_NUMOF];
+    size_t if_num = gnrc_netif_get(interfaces);
+
+    if (if_num == 0) {
+        printf("forwarder: error.. no available network interface\n");
+        return -1;
+    }
+
+    interface_pid = interfaces[0];
+
+    thread_create(oic_forwarding_thread_stack, sizeof(oic_forwarding_thread_stack),
+                  THREAD_PRIORITY_MAIN, THREAD_CREATE_STACKTEST,  start_oic_forwarding_loop,
+                  NULL, "oic_fw_thread");
+
+    /* start shell */
+    puts("All up, running the shell now");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+
+
+    /* should be never reached */
+    return 0;
+}

--- a/examples/iotivity_examples/br_fw/start_network_mcast.sh
+++ b/examples/iotivity_examples/br_fw/start_network_mcast.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+ETHOS_DIR="$(dirname $(readlink -f $0))"/../../../dist/tools/ethos
+
+create_tap() {
+    ip tuntap add ${TAP} mode tap user ${USER}
+    ip link set ${TAP} up
+    sysctl -w net.ipv6.conf.${TAP}.forwarding=1
+    sysctl -w net.ipv6.conf.${TAP}.accept_ra=0
+    ip a a ${NETPREFIX}::1/64 dev ${TAP}
+    ip r d ${NETPREFIX}::/64 dev ${TAP}
+    ip r a ${NETPREFIX}::2 dev ${TAP}
+    ip r a ${NETPREFIX}::/64 via ${NETPREFIX}::2 dev ${TAP} metric 1
+}
+
+create_mcast_route() {
+    ip -6 route add ${IPMCAST} dev ${TAP} table local
+}
+
+remove_tap() {
+    ip tuntap del ${TAP} mode tap
+}
+
+cleanup() {
+    echo "Cleaning up..."
+    remove_tap
+    kill ${UHCPD_PID}
+    trap "" INT QUIT TERM EXIT
+}
+
+start_uhcpd() {
+    ${UHCPD} ${TAP} ${PREFIX} > /dev/null &
+    UHCPD_PID=$!
+}
+
+PORT=$1
+TAP=$2
+PREFIX=$3
+NETPREFIX=$(echo $3 |  awk -v delimeter="::" '{split($0,a,delimeter)} END{print a[1]}')
+IPMCAST=$4
+
+UHCPD="$(readlink -f "${ETHOS_DIR}/../uhcpd/bin")/uhcpd"
+
+[ -z "${PORT}" -o -z "${TAP}" -o -z "${PREFIX}" -o -z "${IPMCAST}" ] && {
+    echo "usage: $0 <serial-port> <tap-device> <prefix> <ip-mcast>"
+    exit 1
+}
+
+trap "cleanup" INT QUIT TERM EXIT
+
+
+create_tap  && create_mcast_route && start_uhcpd && "${ETHOS_DIR}/ethos" ${TAP} ${PORT}

--- a/examples/iotivity_examples/client/Makefile
+++ b/examples/iotivity_examples/client/Makefile
@@ -1,0 +1,69 @@
+# name of your application
+APPLICATION = ocf_client
+
+CFLAGS += -DOC_CLIENT
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../..
+
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
+                          nrf6310 pca10000 pca10005 spark-core \
+                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
+                          yunjia-nrf51822 z1 nucleo-f072
+
+# Include packages that pull up and auto-init the link layer.
+# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+# Specify the mandatory networking modules for IPv6 and UDP
+USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_udp
+USEMODULE += gnrc_conn_udp
+# Add a routing protocol
+USEMODULE += gnrc_rpl
+USEMODULE += auto_init_gnrc_rpl
+# Additional networking modules that can be dropped if not needed
+USEMODULE += gnrc_icmpv6_echo
+
+#Other modules
+USEMODULE += pthread
+USEMODULE += gnrc_ndp_router
+USEMODULE += shell
+USEMODULE += shell_commands
+
+USEPKG += iotivity
+
+SECURE ?= 0
+export SECURE
+
+
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+#CFLAGS += -DDEVELHELP
+
+# Use different settings when compiling for one of the following (low-memory)
+# boards
+LOW_MEMORY_BOARDS := nucleo-f334
+
+ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
+$(info Using low-memory configuration for iotivity_server.)
+## low-memory tuning values
+# lower pktbuf buffer size
+CFLAGS += -DGNRC_PKTBUF_SIZE=1000
+# disable fib, rpl
+DISABLE_MODULE += fib gnrc_rpl
+USEMODULE += prng_minstd
+endif
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/iotivity_examples/client/client.c
+++ b/examples/iotivity_examples/client/client.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2016 CREATE-NET
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     Examples
+ * @{
+ *
+ * @file        client.c
+ * @brief       This is a simple IoTivity Client
+ *
+ * @author      Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+ *                              <m.antonini@create-net.org>
+ *
+ * @}
+ */
+#include "oc_api.h"
+#include "pthread_cond.h"
+#include "thread.h"
+#include "xtimer.h"
+
+#define MAX_URI_LENGTH (30)
+
+static void observe_light(oc_client_response_t *data);
+extern int _netif_config(int argc, char **argv);
+
+static int quit;
+static mutex_t mutex;
+static pthread_cond_t cv;
+static struct timespec ts;
+static bool got_discovery_response = false;
+static bool observe_stopped = false;
+static char light_1[MAX_URI_LENGTH];
+static oc_server_handle_t light_server;
+static bool light_state = false;
+
+static char _oc_main_stack[THREAD_STACKSIZE_MAIN];
+#define OC_QUEUE_SIZE     (8)
+static msg_t _oc_msg_queue[OC_QUEUE_SIZE];
+
+static void
+set_device_custom_property(void *data)
+{
+    oc_set_custom_device_property(purpose, "operate lamp");
+}
+
+static void
+set_led_state(bool led_state)
+{
+    if (led_state) {
+        LED0_ON;
+    }
+    else {
+        LED0_OFF;
+    }
+}
+
+static void
+app_init(void)
+{
+    oc_init_platform("RIOT-OS", NULL, NULL);
+    oc_add_device("/oic/d", "oic.d.switch", "RIOT switch", "1.0", "1.0",
+                  set_device_custom_property, NULL);
+}
+
+static oc_event_callback_retval_t
+stop_observe(void *data)
+{
+    PRINT("client_oic: Stopping OBSERVE\n");
+    oc_stop_observe(light_1, &light_server);
+    observe_stopped = true;
+    return DONE;
+}
+
+static void
+put_light(oc_client_response_t *data)
+{
+    PRINT("client_oic: PUT_light:\n");
+    if (data->code == OC_STATUS_CHANGED) {
+        PRINT("client_oic: PUT response OK\n");
+    }
+    else {
+        PRINT("client_oic: PUT response code %d\n", data->code);
+    }
+}
+
+static void
+observe_light(oc_client_response_t *data)
+{
+    PRINT("client_oic: OBSERVE_light: ");
+    oc_rep_t *rep = data->payload;
+    while (rep != NULL) {
+        PRINT("key %s, value ", oc_string(rep->name));
+        switch (rep->type) {
+            case BOOL:
+                PRINT("%d\n", rep->value_boolean);
+                light_state = rep->value_boolean;
+                break;
+            default:
+                break;
+        }
+        rep = rep->next;
+    }
+}
+
+static oc_discovery_flags_t
+discovery(const char *di, const char *uri, oc_string_array_t types,
+          oc_interface_mask_t interfaces, oc_server_handle_t *server,
+          void *user_data)
+{
+    int i;
+    int uri_len = strlen(uri);
+
+    uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
+
+    for (i = 0; i < oc_string_array_get_allocated_size(types); i++) {
+        char *t = oc_string_array_get_item(types, i);
+        if (strlen(t) == 11 && strncmp(t, "oic.r.light", 11) == 0) {
+            memcpy(&light_server, server, sizeof(oc_server_handle_t));
+
+            strncpy(light_1, uri, uri_len);
+            light_1[uri_len] = '\0';
+
+            got_discovery_response = true;
+
+            return OC_STOP_DISCOVERY;
+        }
+    }
+    return OC_CONTINUE_DISCOVERY;
+}
+
+static oc_event_callback_retval_t
+periodic_put(void *data)
+{
+    if (observe_stopped) {
+        PRINT("client_oic: Stop periodic PUT\n");
+        return DONE;
+    }
+
+    if (oc_init_put(light_1, &light_server, NULL, &put_light, HIGH_QOS, NULL)) {
+        oc_rep_start_root_object();
+        oc_rep_set_boolean(root, state, !light_state);
+        oc_rep_end_root_object();
+        if (oc_do_put()) {
+            PRINT("client_oic: Sent PUT request\n");
+        }
+        else {
+            PRINT("client_oic: Could not send PUT\n");
+        }
+    }
+    else {
+        PRINT("client_oic: Could not init PUT\n");
+    }
+    return CONTINUE;
+}
+
+static oc_event_callback_retval_t
+do_discovery(void *data)
+{
+    if (got_discovery_response) {
+        PRINT("client_oic: Discovery done\n");
+        PRINT("client_oic: Ready...\n");
+        oc_do_observe(light_1, &light_server, NULL, &observe_light, LOW_QOS, NULL);
+        oc_set_delayed_callback(NULL, &periodic_put, 1);
+        oc_set_delayed_callback(NULL, &stop_observe, 100);
+        set_led_state(true);
+        return DONE;
+    }
+    oc_do_ip_discovery("oic.r.light", &discovery, NULL);
+    PRINT("client_oic: continue discovery\n");
+    return CONTINUE;
+}
+
+static void
+issue_requests(void)
+{
+    oc_set_delayed_callback(NULL, &do_discovery, 1);
+}
+
+static void
+signal_event_loop_func(void)
+{
+    mutex_lock(&mutex);
+    pthread_cond_signal(&cv);
+    mutex_unlock(&mutex);
+}
+
+void *
+oc_main_thread(void *arg)
+{
+    (void)arg;
+
+    pthread_cond_init(&cv, NULL);
+
+    static const oc_handler_t handler = { .init = app_init,
+                                          .signal_event_loop = signal_event_loop_func,
+                                          .requests_entry = issue_requests };
+
+    msg_init_queue(_oc_msg_queue, OC_QUEUE_SIZE);
+
+    if (oc_main_init(&handler) < 0) {
+        PRINT("client_oic: failed to initialize stack\n");
+        return NULL;
+    }
+    PRINT("client_oic: Configured network interfaces:");
+    _netif_config(0, NULL);
+
+    oc_clock_time_t next_event;
+    while (quit == 0) {
+        next_event = oc_main_poll();
+        mutex_lock(&mutex);
+        if (next_event == 0) {
+            pthread_cond_wait(&cv, &mutex);
+        }
+        else if (oc_clock_time() < next_event) {
+            ts.tv_sec = (next_event / OC_CLOCK_SECOND);
+            ts.tv_nsec = (next_event % OC_CLOCK_SECOND) * 1.e09 / OC_CLOCK_SECOND;
+            pthread_cond_timedwait(&cv, &mutex, &ts);
+        }
+        mutex_unlock(&mutex);
+    }
+
+    oc_main_shutdown();
+
+    return NULL;
+}
+
+int
+main(void)
+{
+    set_led_state(false);
+    PRINT("client_oic: Waiting for address autoconfiguration...");
+    xtimer_sleep(10);
+    thread_create(_oc_main_stack, sizeof(_oc_main_stack), 2, 0, oc_main_thread,
+                  NULL, "OCF event thread");
+
+    fgetc(stdin);
+
+    quit = 1;
+    signal_event_loop_func();
+
+    return 0;
+}

--- a/examples/iotivity_examples/client/config.h
+++ b/examples/iotivity_examples/client/config.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 CREATE-NET
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     Examples
+ * @{
+ *
+ * @file        config.c
+ * @brief       This is a configuration file for IoTivity environment
+ *
+ * @author      Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+ *                              <m.antonini@create-net.org>
+ *
+ * @}
+ */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define OC_DEBUG 0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Time resolution */
+#include <stdint.h>
+typedef uint64_t oc_clock_time_t;
+/* 1 clock tick = 1ms */
+#define OC_CLOCK_CONF_TICKS_PER_SECOND (1000)
+
+#define OC_BYTES_POOL_SIZE (900)
+#define OC_INTS_POOL_SIZE (4)
+#define OC_DOUBLES_POOL_SIZE (4)
+
+/* Server-side parameters */
+/* Maximum number of server resources */
+#define MAX_APP_RESOURCES (1)
+
+/* Common paramters */
+/* Maximum number of concurrent requests */
+#define MAX_NUM_CONCURRENT_REQUESTS (2)
+
+/* Estimated number of nodes in payload tree structure */
+#define EST_NUM_REP_OBJECTS (60)
+
+/* Maximum size of request/response PDUs */
+#define MAX_PAYLOAD_SIZE (512)
+
+/* Number of devices on the OCF platform */
+#define MAX_NUM_DEVICES (1)
+
+/* Platform payload size */
+#define MAX_PLATFORM_PAYLOAD_SIZE (256)
+
+/* Device payload size */
+#define MAX_DEVICE_PAYLOAD_SIZE (256)
+
+/* Security layer */
+/* Maximum number of authorized clients */
+#define MAX_NUM_SUBJECTS (1)
+
+/* Maximum number of concurrent DTLS sessions */
+#define MAX_DTLS_PEERS (1)
+
+/* Max inactivity timeout before tearing down DTLS connection */
+#define DTLS_INACTIVITY_TIMEOUT (10)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_H */

--- a/examples/iotivity_examples/client_switch/Makefile
+++ b/examples/iotivity_examples/client_switch/Makefile
@@ -1,0 +1,69 @@
+# name of your application
+APPLICATION = ocf_client
+
+CFLAGS += -DOC_CLIENT
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../..
+
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
+                          nrf6310 pca10000 pca10005 spark-core \
+                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
+                          yunjia-nrf51822 z1 nucleo-f072
+
+# Include packages that pull up and auto-init the link layer.
+# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+# Specify the mandatory networking modules for IPv6 and UDP
+USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_udp
+USEMODULE += gnrc_conn_udp
+# Add a routing protocol
+USEMODULE += gnrc_rpl
+USEMODULE += auto_init_gnrc_rpl
+# Additional networking modules that can be dropped if not needed
+USEMODULE += gnrc_icmpv6_echo
+
+#Other modules
+USEMODULE += pthread
+USEMODULE += gnrc_ndp_router
+USEMODULE += shell
+USEMODULE += shell_commands
+
+USEPKG += iotivity
+
+SECURE ?= 0
+export SECURE
+
+
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+#CFLAGS += -DDEVELHELP
+
+# Use different settings when compiling for one of the following (low-memory)
+# boards
+LOW_MEMORY_BOARDS := nucleo-f334
+
+ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
+$(info Using low-memory configuration for iotivity_server.)
+## low-memory tuning values
+# lower pktbuf buffer size
+CFLAGS += -DGNRC_PKTBUF_SIZE=1000
+# disable fib, rpl
+DISABLE_MODULE += fib gnrc_rpl
+USEMODULE += prng_minstd
+endif
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/iotivity_examples/client_switch/client_switch.c
+++ b/examples/iotivity_examples/client_switch/client_switch.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2016 CREATE-NET
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     Examples
+ * @{
+ *
+ * @file        client_switch.c
+ * @brief       This is an Iotivity client. It sends a PUT when the
+ *              User button is pressed.
+ *
+ * @author      Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+ *                              <m.antonini@create-net.org>
+ *
+ * @}
+ */
+
+#include "oc_api.h"
+#include "pthread_cond.h"
+#include "thread.h"
+#include "xtimer.h"
+#include "periph/gpio.h"
+
+#define MAX_URI_LENGTH (30)
+
+static void observe_light(oc_client_response_t *data);
+extern int _netif_config(int argc, char **argv);
+
+static int quit;
+static mutex_t mutex;
+static pthread_cond_t cv;
+static struct timespec ts;
+static bool got_discovery_response = false;
+static char light_1[MAX_URI_LENGTH];
+static oc_server_handle_t light_server;
+static bool light_state = false;
+static bool led_state = false;
+
+static char _oc_main_stack[THREAD_STACKSIZE_MAIN];
+
+static void
+set_led_state(bool led_state)
+{
+    if (led_state) {
+        LED0_ON;
+    }
+    else {
+        LED0_OFF;
+    }
+}
+
+static void
+set_device_custom_property(void *data)
+{
+    oc_set_custom_device_property(purpose, "operate lamp");
+}
+
+static void
+app_init(void)
+{
+    oc_init_platform("RIOT-OS", NULL, NULL);
+    oc_add_device("/oic/d", "oic.d.switch", "RIOT switch", "1.0", "1.0",
+                  set_device_custom_property, NULL);
+}
+
+static oc_event_callback_retval_t
+stop_observe(void *data)
+{
+    PRINT("client_oic: Stopping OBSERVE\n");
+    oc_stop_observe(light_1, &light_server);
+    return DONE;
+}
+
+static void
+put_light(oc_client_response_t *data)
+{
+    PRINT("client_oic: PUT_light:\n");
+    if (data->code == OC_STATUS_CHANGED) {
+        PRINT("client_oic: PUT response OK\n");
+    }
+    else {
+        PRINT("client_oic: PUT response code %d\n", data->code);
+    }
+}
+
+static void
+observe_light(oc_client_response_t *data)
+{
+    PRINT("client_oic: OBSERVE_light: ");
+    oc_rep_t *rep = data->payload;
+    while (rep != NULL) {
+        PRINT("key %s, value ", oc_string(rep->name));
+        switch (rep->type) {
+            case BOOL:
+                PRINT("%d\n", rep->value_boolean);
+                light_state = rep->value_boolean;
+                break;
+            default:
+                break;
+        }
+        rep = rep->next;
+    }
+}
+
+static oc_discovery_flags_t
+discovery(const char *di, const char *uri, oc_string_array_t types,
+          oc_interface_mask_t interfaces, oc_server_handle_t *server,
+          void *user_data)
+{
+    int i;
+    int uri_len = strlen(uri);
+
+    uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
+
+    for (i = 0; i < oc_string_array_get_allocated_size(types); i++) {
+        char *t = oc_string_array_get_item(types, i);
+        if (strlen(t) == 11 && strncmp(t, "oic.r.light", 11) == 0) {
+            memcpy(&light_server, server, sizeof(oc_server_handle_t));
+
+            strncpy(light_1, uri, uri_len);
+            light_1[uri_len] = '\0';
+
+            got_discovery_response = true;
+
+            return OC_STOP_DISCOVERY;
+        }
+    }
+    return OC_CONTINUE_DISCOVERY;
+}
+
+#ifdef BUTTON_GPIO
+void button_callback(void)
+{
+    gpio_irq_disable(BUTTON_GPIO);
+    if (oc_init_put(light_1, &light_server, NULL, &put_light, HIGH_QOS, NULL)) {
+        oc_rep_start_root_object();
+        oc_rep_set_boolean(root, state, !light_state);
+        oc_rep_end_root_object();
+        if (oc_do_put()) {
+            PRINT("client_oic: Sent PUT request\n");
+        }
+        else {
+            PRINT("client_oic: Could not send PUT\n");
+        }
+    }
+    else {
+        PRINT("client_oic: Could not init PUT\n");
+    }
+    xtimer_usleep(140000);
+    gpio_irq_enable(BUTTON_GPIO);
+}
+#endif
+
+static oc_event_callback_retval_t
+operate(void *data)
+{
+    PRINT("client_oic: Ready...\n");
+    set_led_state(true);
+    oc_do_observe(light_1, &light_server, NULL, &observe_light, LOW_QOS, NULL);
+#ifdef BUTTON_GPIO
+    gpio_init_int(BUTTON_GPIO, GPIO_IN_PU, GPIO_RISING, (gpio_cb_t)button_callback, NULL);
+#endif
+    oc_set_delayed_callback(NULL, &stop_observe, 10000);
+    return DONE;
+}
+
+static oc_event_callback_retval_t
+do_discovery(void *data)
+{
+    if (got_discovery_response) {
+        PRINT("client_oic: Discovery done\n");
+        oc_set_delayed_callback(NULL, &operate, 1);
+        return DONE;
+    }
+    oc_do_ip_discovery("oic.r.light", &discovery, NULL);
+    PRINT("client_oic: continue discovery\n");
+    return CONTINUE;
+}
+
+static void
+issue_requests(void)
+{
+    oc_set_delayed_callback(NULL, &do_discovery, 1);
+}
+
+static void
+signal_event_loop_func(void)
+{
+    mutex_lock(&mutex);
+    pthread_cond_signal(&cv);
+    mutex_unlock(&mutex);
+}
+
+void *
+oc_main_thread(void *arg)
+{
+    (void)arg;
+
+    pthread_cond_init(&cv, NULL);
+
+    static const oc_handler_t handler = { .init = app_init,
+                                          .signal_event_loop = signal_event_loop_func,
+                                          .requests_entry = issue_requests };
+    if (oc_main_init(&handler) < 0) {
+        PRINT("client_oic: failed to initialize stack\n");
+        return NULL;
+    }
+    PRINT("client_oic: Configured network interfaces:");
+    _netif_config(0, NULL);
+
+    oc_clock_time_t next_event;
+    while (quit == 0) {
+        next_event = oc_main_poll();
+        mutex_lock(&mutex);
+        if (next_event == 0) {
+            pthread_cond_wait(&cv, &mutex);
+        }
+        else if (oc_clock_time() < next_event) {
+            ts.tv_sec = (next_event / OC_CLOCK_SECOND);
+            ts.tv_nsec = (next_event % OC_CLOCK_SECOND) * 1.e09 / OC_CLOCK_SECOND;
+            pthread_cond_timedwait(&cv, &mutex, &ts);
+        }
+        mutex_unlock(&mutex);
+    }
+
+    oc_main_shutdown();
+
+    return NULL;
+}
+
+int
+main(void)
+{
+    set_led_state(led_state);
+    PRINT("client_oic: Waiting for address autoconfiguration...");
+    xtimer_sleep(10);
+    thread_create(_oc_main_stack, sizeof(_oc_main_stack), 2, 0, oc_main_thread,
+                  NULL, "OCF event thread");
+
+    fgetc(stdin);
+
+    quit = 1;
+    signal_event_loop_func();
+
+    return 0;
+}

--- a/examples/iotivity_examples/client_switch/config.h
+++ b/examples/iotivity_examples/client_switch/config.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 CREATE-NET
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     Examples
+ * @{
+ *
+ * @file        config.c
+ * @brief       This is a configuration file for IoTivity environment
+ *
+ * @author      Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+ *                              <m.antonini@create-net.org>
+ *
+ * @}
+ */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define OC_DEBUG 0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Time resolution */
+#include <stdint.h>
+typedef uint64_t oc_clock_time_t;
+/* 1 clock tick = 1ms */
+#define OC_CLOCK_CONF_TICKS_PER_SECOND (1000)
+
+#define OC_BYTES_POOL_SIZE (900)
+#define OC_INTS_POOL_SIZE (4)
+#define OC_DOUBLES_POOL_SIZE (4)
+
+/* Server-side parameters */
+/* Maximum number of server resources */
+#define MAX_APP_RESOURCES (1)
+
+/* Common paramters */
+/* Maximum number of concurrent requests */
+#define MAX_NUM_CONCURRENT_REQUESTS (2)
+
+/* Estimated number of nodes in payload tree structure */
+#define EST_NUM_REP_OBJECTS (60)
+
+/* Maximum size of request/response PDUs */
+#define MAX_PAYLOAD_SIZE (512)
+
+/* Number of devices on the OCF platform */
+#define MAX_NUM_DEVICES (1)
+
+/* Platform payload size */
+#define MAX_PLATFORM_PAYLOAD_SIZE (256)
+
+/* Device payload size */
+#define MAX_DEVICE_PAYLOAD_SIZE (256)
+
+/* Security layer */
+/* Maximum number of authorized clients */
+#define MAX_NUM_SUBJECTS (1)
+
+/* Maximum number of concurrent DTLS sessions */
+#define MAX_DTLS_PEERS (1)
+
+/* Max inactivity timeout before tearing down DTLS connection */
+#define DTLS_INACTIVITY_TIMEOUT (10)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_H */

--- a/examples/iotivity_examples/server/Makefile
+++ b/examples/iotivity_examples/server/Makefile
@@ -1,0 +1,83 @@
+# name of your application
+APPLICATION = ocf_server
+
+CFLAGS += -DOC_SERVER
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../..
+
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
+                          nrf6310 pca10000 pca10005 spark-core \
+                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
+                          yunjia-nrf51822 z1 nucleo-f072
+
+#Add IoTivity resources
+RES_SRC = $(wildcard ./resources/*.c)
+RES_OBJ = $(RES_SRC:.c=.o)
+APPDEPS += ${RES_OBJ}
+
+
+# Include packages that pull up and auto-init the link layer.
+# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+# Specify the mandatory networking modules for IPv6 and UDP
+USEMODULE += gnrc_ipv6_router_default
+USEMODULE += gnrc_udp
+USEMODULE += gnrc_conn_udp
+# Add a routing protocol
+USEMODULE += gnrc_rpl
+USEMODULE += auto_init_gnrc_rpl
+# Additional networking modules that can be dropped if not needed
+USEMODULE += gnrc_icmpv6_echo
+
+#Other modules
+USEMODULE += pthread
+USEMODULE += gnrc_ndp_router
+USEMODULE += shell
+USEMODULE += shell_commands
+
+USEPKG += iotivity
+
+SECURE ?= 0
+export SECURE
+
+
+# Set a custom 802.15.4 channel if needed
+DEFAULT_CHANNEL ?= 26
+CFLAGS += -DDEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+#CFLAGS += -DDEVELHELP
+
+# Use different settings when compiling for one of the following (low-memory)
+# boards
+LOW_MEMORY_BOARDS := nucleo-f334
+
+ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
+$(info Using low-memory configuration for iotivity_server.)
+## low-memory tuning values
+# lower pktbuf buffer size
+CFLAGS += -DGNRC_PKTBUF_SIZE=1000
+# disable fib, rpl
+DISABLE_MODULE += fib gnrc_rpl
+USEMODULE += prng_minstd
+endif
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include
+
+%.o: %.c
+	${CC} -c -o $@ $< ${CFLAGS} ${INCLUDES}
+
+clean: clean_resources
+
+clean_resources:
+	rm -rf ${RES_OBJ}

--- a/examples/iotivity_examples/server/config.h
+++ b/examples/iotivity_examples/server/config.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 CREATE-NET
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     Examples
+ * @{
+ *
+ * @file        config.c
+ * @brief       This is a configuration file for IoTivity environment
+ *
+ * @author      Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+ *                              <m.antonini@create-net.org>
+ *
+ * @}
+ */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define OC_DEBUG 0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Time resolution */
+#include <stdint.h>
+typedef uint64_t oc_clock_time_t;
+/* 1 clock tick = 1ms */
+#define OC_CLOCK_CONF_TICKS_PER_SECOND (1000)
+
+#define OC_BYTES_POOL_SIZE (900)
+#define OC_INTS_POOL_SIZE (4)
+#define OC_DOUBLES_POOL_SIZE (4)
+
+/* Server-side parameters */
+/* Maximum number of server resources */
+#define MAX_APP_RESOURCES (1)
+
+/* Common paramters */
+/* Maximum number of concurrent requests */
+#define MAX_NUM_CONCURRENT_REQUESTS (2)
+
+/* Estimated number of nodes in payload tree structure */
+#define EST_NUM_REP_OBJECTS (60)
+
+/* Maximum size of request/response PDUs */
+#define MAX_PAYLOAD_SIZE (512)
+
+/* Number of devices on the OCF platform */
+#define MAX_NUM_DEVICES (1)
+
+/* Platform payload size */
+#define MAX_PLATFORM_PAYLOAD_SIZE (256)
+
+/* Device payload size */
+#define MAX_DEVICE_PAYLOAD_SIZE (256)
+
+/* Security layer */
+/* Maximum number of authorized clients */
+#define MAX_NUM_SUBJECTS (1)
+
+/* Maximum number of concurrent DTLS sessions */
+#define MAX_DTLS_PEERS (1)
+
+/* Max inactivity timeout before tearing down DTLS connection */
+#define DTLS_INACTIVITY_TIMEOUT (10)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_H */

--- a/examples/iotivity_examples/server/resources/res-light.c
+++ b/examples/iotivity_examples/server/resources/res-light.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2016 CREATE-NET
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     Examples
+ * @{
+ *
+ * @file        res-light.c
+ * @brief       Resource light definition. Handler are defined here.
+ *
+ * @author      Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+ *                              <m.antonini@create-net.org>
+ *
+ * @}
+ */
+
+#include "oc_api.h"
+#include "board.h"
+
+
+static oc_resource_t *res_light = NULL;
+static bool res_light_state = false;
+
+static void
+res_light_set_led_state(bool light_state)
+{
+    if (light_state) {
+        PRINT("server_oic: LED0 is ON\n");
+        LED0_ON;
+    }
+    else {
+        PRINT("server_oic: LED0 is OFF\n");
+        LED0_OFF;
+    }
+}
+
+
+static void
+res_light_get_handler(oc_request_t *request, oc_interface_mask_t interface, void *user_data)
+{
+    PRINT("server_oic: GET request\n");
+    oc_rep_start_root_object();
+    switch (interface) {
+        case OC_IF_BASELINE:
+            oc_process_baseline_interface(request->resource);
+        case OC_IF_RW:
+            oc_rep_set_boolean(root, state, res_light_state);
+            break;
+        default:
+            break;
+    }
+    oc_rep_end_root_object();
+    oc_send_response(request, OC_STATUS_OK);
+    PRINT("server_oic: Light state %d\n", res_light_state);
+}
+
+static void
+res_light_put_handler(oc_request_t *request, oc_interface_mask_t interface, void *user_data)
+{
+    PRINT("server_oic: PUT request\n");
+    bool state = false;
+    oc_rep_t *rep = request->request_payload;
+
+    while (rep != NULL) {
+        PRINT("server_oic: key: %s ", oc_string(rep->name));
+        switch (rep->type) {
+            case BOOL:
+                state = rep->value_boolean;
+                PRINT("value: %d\n", state);
+                break;
+            default:
+                oc_send_response(request, OC_STATUS_BAD_REQUEST);
+                return;
+                break;
+        }
+        rep = rep->next;
+    }
+    oc_send_response(request, OC_STATUS_CHANGED);
+    res_light_state = state;
+    res_light_set_led_state(res_light_state);
+}
+
+void
+res_light_register(void)
+{
+    res_light = oc_new_resource("/light/1", 1, 0);
+    oc_resource_bind_resource_type(res_light, "oic.r.light");
+    oc_resource_bind_resource_interface(res_light, OC_IF_RW);
+    oc_resource_set_default_interface(res_light, OC_IF_RW);
+
+//TODO: Security is not supported by the pkg
+#ifdef OC_SECURITY
+    oc_resource_make_secure(res_light);
+#endif
+
+    oc_resource_set_discoverable(res_light, true);
+    oc_resource_set_observable(res_light, true);
+    oc_resource_set_request_handler(res_light, OC_GET, res_light_get_handler, NULL);
+    oc_resource_set_request_handler(res_light, OC_PUT, res_light_put_handler, NULL);
+    oc_add_resource(res_light);
+
+    res_light_set_led_state(false); //RIMANE TRUE... PERCHe'
+}

--- a/examples/iotivity_examples/server/server.c
+++ b/examples/iotivity_examples/server/server.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2016 CREATE-NET
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     Examples
+ * @{
+ *
+ * @file        server.c
+ * @brief       This is an IoTivity Server.
+ *
+ * @author      Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+ *                              <m.antonini@create-net.org>
+ *
+ * @}
+ */
+
+#include "oc_api.h"
+#include "xtimer.h"
+#include "pthread_cond.h"
+#include "thread.h"
+
+extern int _netif_config(int argc, char **argv);
+
+static int quit;
+static mutex_t mutex;
+static pthread_cond_t cv;
+static struct timespec ts;
+static char _oc_main_stack[THREAD_STACKSIZE_MAIN];
+
+#define OC_QUEUE_SIZE     (8)
+static msg_t _oc_msg_queue[OC_QUEUE_SIZE];
+
+//Resources registration functions
+extern void res_light_register(void);
+
+static void
+app_init(void)
+{
+    oc_init_platform("RIOT-OS", NULL, NULL);
+
+    oc_add_device("/oic/d", "oic.d.light", "RIOT's light", "1.0", "1.0", NULL,
+                  NULL);
+}
+
+
+static void
+register_resources_func(void)
+{
+    res_light_register();
+}
+
+static void
+signal_event_loop_func(void)
+{
+    mutex_lock(&mutex);
+    pthread_cond_signal(&cv);
+    mutex_unlock(&mutex);
+}
+
+void *
+oc_main_thread(void *arg)
+{
+    (void)arg;
+
+    pthread_cond_init(&cv, NULL);
+
+    static const oc_handler_t handler = { .init = app_init,
+                                          .signal_event_loop = signal_event_loop_func,
+                                          .register_resources =
+                                              register_resources_func };
+
+    msg_init_queue(_oc_msg_queue, OC_QUEUE_SIZE);
+
+    if (oc_main_init(&handler) < 0) {
+        PRINT("server_oic: failed to initialize stack\n");
+        return NULL;
+    }
+
+    /* print network addresses */
+    puts("server_oic: Configured network interfaces:");
+    _netif_config(0, NULL);
+
+
+
+    oc_clock_time_t next_event;
+    while (!quit) {
+        next_event = oc_main_poll();
+        mutex_lock(&mutex);
+        if (next_event == 0) {
+            pthread_cond_wait(&cv, &mutex);
+        }
+        else {
+            ts.tv_sec = (next_event / OC_CLOCK_SECOND);
+            ts.tv_nsec = (next_event % OC_CLOCK_SECOND) * 1.e09 / OC_CLOCK_SECOND;
+            pthread_cond_timedwait(&cv, &mutex, &ts);
+        }
+        mutex_unlock(&mutex);
+    }
+
+    oc_main_shutdown();
+
+    return NULL;
+}
+
+int
+main(void)
+{
+    PRINT("server_oic: Waiting for address autoconfiguration...");
+    xtimer_sleep(10);
+
+    thread_create(_oc_main_stack, sizeof(_oc_main_stack), 6, 0, oc_main_thread,
+                  NULL, "OCF event thread");
+
+    fgetc(stdin);
+
+    quit = 1;
+    signal_event_loop_func();
+
+    return 0;
+}

--- a/pkg/iotivity/Makefile
+++ b/pkg/iotivity/Makefile
@@ -1,0 +1,31 @@
+PKG_NAME=iotivity-constrained
+PKG_URL=https://github.com/iotivity/iotivity-constrained
+PKG_VERSION=96b50da1762d016790ac7fa516d95a0252bb2f72
+PKG_DIR=$(CURDIR)
+
+PKG_LIB=$(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+
+
+MODULE_MAKEFILE := $(PKG_DIR)/Makefile.module
+
+export PKG_DIR
+export PKG_LIB
+export PKG_NAME
+
+export RIOT_CFLAGS = ${CFLAGS} ${INCLUDES}
+
+all: git-download submodules-download copy_makefile
+	@"$(MAKE)" -BC $(PKG_BUILDDIR) lib-iotivity.a
+	@cp $(PKG_BUILDDIR)/lib-iotivity.a ${BINDIR}/iotivity.a
+
+copy_makefile:
+	@cp ./Makefile.tomove $(PKG_LIB)/Makefile
+
+
+submodules-download:
+	@git -C $(PKG_LIB) submodule update --init
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+clean:: copy_makefile
+	@"$(MAKE)" -BC $(PKG_BUILDDIR) clean

--- a/pkg/iotivity/Makefile.include
+++ b/pkg/iotivity/Makefile.include
@@ -1,0 +1,14 @@
+INCLUDES += \
+			-I$(BINDIRBASE)/pkg/$(BOARD)/iotivity-constrained \
+			-I$(BINDIRBASE)/pkg/$(BOARD)/iotivity-constrained/port \
+			-I$(BINDIRBASE)/pkg/$(BOARD)/iotivity-constrained/port/riot \
+			-I$(BINDIRBASE)/pkg/$(BOARD)/iotivity-constrained/include \
+			-I$(BINDIRBASE)/pkg/$(BOARD)/iotivity-constrained/util \
+			-I$(BINDIRBASE)/pkg/$(BOARD)/iotivity-constrained/util/pt \
+			-I$(BINDIRBASE)/..
+
+ifeq ($(SECURE),1)
+	INCLUDES += \
+			-I$(BINDIRBASE)/pkg/$(BOARD)/iotivity-constrained/deps/tinydtls \
+			-I$(BINDIRBASE)/pkg/$(BOARD)/iotivity-constrained/deps/tinydtls/sha2
+endif

--- a/pkg/iotivity/Makefile.module
+++ b/pkg/iotivity/Makefile.module
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/pkg/iotivity/Makefile.tomove
+++ b/pkg/iotivity/Makefile.tomove
@@ -1,0 +1,41 @@
+IOTIVITY_CFLAGS = -std=gnu99 -fno-asynchronous-unwind-tables -fno-omit-frame-pointer -Wall -Wno-format-zero-length -Wno-main -ffreestanding -Os -fno-stack-protector -ffunction-sections -fdata-sections -Wno-unused-but-set-variable -fno-reorder-functions -fno-defer-pop -Wno-pointer-sign -fno-strict-overflow -Werror=implicit-int
+
+CBOR = ./deps/tinycbor/src/cborencoder.c ./deps/tinycbor/src/cborencoder_close_container_checked.c ./deps/tinycbor/src/cborparser.c
+
+DTLS = ./deps/tinydtls/ccm.c  ./deps/tinydtls/hmac.c  ./deps/tinydtls/netq.c  ./deps/tinydtls/peer.c  ./deps/tinydtls/dtls_time.c  ./deps/tinydtls/session.c  ./deps/tinydtls/sha2/sha2.c  ./deps/tinydtls/ecc/ecc.c  ./deps/tinydtls/aes/rijndael.c  ./deps/tinydtls/crypto.c  ./deps/tinydtls/dtls.c
+
+DTLSFLAGS = -DDTLSV12 -DWITH_SHA256 -DDTLS_CHECK_CONTENTTYPE -DWITH_OCF -I./deps/tinydtls -DNDEBUG
+
+SRC_DEPS = ${CBOR}
+SRC_CORE = $(wildcard ./messaging/coap/*.c ./api/*.c ./util/*.c ./util/pt/*.c)
+VPATH=./util/pt:./messaging/coap/:./util/:./api/:./deps/tinycbor/src/:
+SRC_PORT = $(wildcard ./port/riot/*.c)
+
+ifeq ($(SECURE),1)
+	SRC_SECURE += $(wildcard ./security/*.c)
+	SRC_DEPS += ${DTLS}
+	CFLAGS += ${DTLSFLAGS} -DOC_SECURITY
+	VPATH += ./security/:./deps/tinydtls/:./deps/tinydtls/aes/:./deps/tinydtls/sha2/:./deps/tinydtls/ecc/:
+endif
+
+
+SRC = ${SRC_DEPS} ${SRC_PORT} ${SRC_CORE}
+
+ifeq ($(SECURE),1)
+	SRC += ${SRC_SECURE}
+endif
+
+OBJ = $(SRC:.c=.o)
+
+
+
+lib-iotivity.a: ${OBJ}
+	@${AR} rcs $@ ${OBJ}
+
+$(OBJ): %.o: %.c
+	@${CC} -o $@ ${RIOT_CFLAGS} ${IOTIVITY_CFLAGS} -c $<
+
+clean: clean_iotivity
+
+clean_iotivity:
+	rm -rf ${OBJ}

--- a/pkg/iotivity/patches/00001-Change-Multicast-IP.patch
+++ b/pkg/iotivity/patches/00001-Change-Multicast-IP.patch
@@ -1,0 +1,36 @@
+From fd12434d6614921313ce77e5b1886907e97d83ea Mon Sep 17 00:00:00 2001
+From: Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+Date: Wed, 2 Nov 2016 14:44:13 +0100
+Subject: [PATCH] Changed multicast addresses from link-local to realm-local
+
+---
+ api/oc_client_api.c   | 2 +-
+ port/riot/ipadapter.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/api/oc_client_api.c b/api/oc_client_api.c
+index 9513628..d6b1c71 100644
+--- a/api/oc_client_api.c
++++ b/api/oc_client_api.c
+@@ -256,7 +256,7 @@ oc_stop_observe(const char *uri, oc_server_handle_t *server)
+ bool
+ oc_do_ip_discovery(const char *rt, oc_discovery_cb_t handler, void *user_data)
+ {
+-  oc_make_ip_endpoint(mcast, IP | MULTICAST, 5683, 0xff, 0x02, 0, 0, 0, 0, 0, 0,
++  oc_make_ip_endpoint(mcast, IP | MULTICAST, 5683, 0xff, 0x03, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0x01, 0x58);
+   mcast.ipv6_addr.scope = 0;
+ 
+diff --git a/port/riot/ipadapter.c b/port/riot/ipadapter.c
+index d3f49cf..d59542b 100644
+--- a/port/riot/ipadapter.c
++++ b/port/riot/ipadapter.c
+@@ -134,7 +134,7 @@ multicast_receive_thread(void *arg)
+ {
+   (void)arg;
+ 
+-  uint8_t wk_addr[16] = { 0xff, 0x02, 0, 0, 0, 0, 0,    0,
++  uint8_t wk_addr[16] = { 0xff, 0x03, 0, 0, 0, 0, 0,    0,
+                           0,    0,    0, 0, 0, 0, 0x01, 0x58 };
+   static uint8_t addr[16];
+   uint8_t remote_addr[16] = { 0 };

--- a/pkg/iotivity/patches/00001-Remove-Config.h.patch
+++ b/pkg/iotivity/patches/00001-Remove-Config.h.patch
@@ -1,0 +1,80 @@
+From a7929873d1a941ddb5a9feb11912dae9d7992579 Mon Sep 17 00:00:00 2001
+From: Mattia Antonini <mattia.antonini1@studenti.unipr.it>
+Date: Wed, 2 Nov 2016 15:03:13 +0100
+Subject: [PATCH] removed config.h
+
+---
+ port/riot/config.h | 63 ------------------------------------------------------
+ 1 file changed, 63 deletions(-)
+ delete mode 100644 port/riot/config.h
+
+diff --git a/port/riot/config.h b/port/riot/config.h
+deleted file mode 100644
+index 49f7f7a..0000000
+--- a/port/riot/config.h
++++ /dev/null
+@@ -1,63 +0,0 @@
+-/*
+- // Copyright (c) 2016 Intel Corporation
+- //
+- // Licensed under the Apache License, Version 2.0 (the "License");
+- // you may not use this file except in compliance with the License.
+- // You may obtain a copy of the License at
+- //
+- //      http://www.apache.org/licenses/LICENSE-2.0
+- //
+- // Unless required by applicable law or agreed to in writing, software
+- // distributed under the License is distributed on an "AS IS" BASIS,
+- // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- // See the License for the specific language governing permissions and
+- // limitations under the License.
+- */
+-
+-#ifndef CONFIG_H
+-#define CONFIG_H
+-
+-/* Time resolution */
+-#include <stdint.h>
+-typedef uint64_t oc_clock_time_t;
+-/* 1 clock tick = 1ms */
+-#define OC_CLOCK_CONF_TICKS_PER_SECOND (1000)
+-
+-#define OC_BYTES_POOL_SIZE (900)
+-#define OC_INTS_POOL_SIZE (4)
+-#define OC_DOUBLES_POOL_SIZE (4)
+-
+-/* Server-side parameters */
+-/* Maximum number of server resources */
+-#define MAX_APP_RESOURCES (1)
+-
+-/* Common paramters */
+-/* Maximum number of concurrent requests */
+-#define MAX_NUM_CONCURRENT_REQUESTS (2)
+-
+-/* Estimated number of nodes in payload tree structure */
+-#define EST_NUM_REP_OBJECTS (60)
+-
+-/* Maximum size of request/response PDUs */
+-#define MAX_PAYLOAD_SIZE (512)
+-
+-/* Number of devices on the OCF platform */
+-#define MAX_NUM_DEVICES (1)
+-
+-/* Platform payload size */
+-#define MAX_PLATFORM_PAYLOAD_SIZE (256)
+-
+-/* Device payload size */
+-#define MAX_DEVICE_PAYLOAD_SIZE (256)
+-
+-/* Security layer */
+-/* Maximum number of authorized clients */
+-#define MAX_NUM_SUBJECTS (1)
+-
+-/* Maximum number of concurrent DTLS sessions */
+-#define MAX_DTLS_PEERS (1)
+-
+-/* Max inactivity timeout before tearing down DTLS connection */
+-#define DTLS_INACTIVITY_TIMEOUT (10)
+-
+-#endif /* CONFIG_H */
+


### PR DESCRIPTION
This PR adds the IoTivity-Constrained library on top of RIOT-OS.  This version of IoTivity is designed for constrained nodes and it contains also the glue code for RIOT. The pkg can be included like other pkgs (e.g. microcoap, etc).

It is available [here](https://github.com/iotivity/iotivity-constrained/).

In particular under:
- /pkg/iotivity : there are makefiles of the pkg
- /examples/iotivity-examples : there are some working examples (with a brief tutorial)

Any feedback will be appreciated.

P.S. I have problem with labels... I can't add them. Anyway, they are PKG, new feature