### PR TITLE
gcoap: fix compiler error on macOS

### DIFF
--- a/sys/net/gnrc/application_layer/coap/gcoap.c
+++ b/sys/net/gnrc/application_layer/coap/gcoap.c
@@ -550,7 +550,7 @@ size_t gcoap_req_send(uint8_t *buf, size_t len, ipv6_addr_t *addr, uint16_t port
         memo->resp_handler = resp_handler;
 
         size_t res = _send_buf(buf, len, addr, port);
-        if (res && GCOAP_NON_TIMEOUT) {
+        if (res && (GCOAP_NON_TIMEOUT > 0)) {
             /* start response wait timer */
             memo->timeout_msg.type        = GCOAP_NETAPI_MSG_TYPE_TIMEOUT;
             memo->timeout_msg.content.ptr = (char *)memo;


### PR DESCRIPTION
This fixes the following compiler error on macOS:

```
/RIOT/sys/net/gnrc/application_layer/coap/gcoap.c:553:17: error: use of logical '&&' with constant operand
      [-Werror,-Wconstant-logical-operand]
        if (res && GCOAP_NON_TIMEOUT) {
                ^  ~~~~~~~~~~~~~~~~~
/RIOT/sys/net/gnrc/application_layer/coap/gcoap.c:553:17: note: use '&' for a bitwise operation
        if (res && GCOAP_NON_TIMEOUT) {
                ^~
                &
/RIOT/sys/net/gnrc/application_layer/coap/gcoap.c:553:17: note: remove constant to silence this warning
        if (res && GCOAP_NON_TIMEOUT) {
               ~^~~~~~~~~~~~~~~~~~~~
1 error generated.
```