### PR TITLE
cbor: fix redefined macro error on macOS

### DIFF
--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -8,5 +8,5 @@ endif
 export USEMODULE += periph
 
 ifeq ($(shell uname -s),Darwin)
-export CFLAGS += -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE
+export CFLAGS += -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE
 endif

--- a/sys/cbor/Makefile
+++ b/sys/cbor/Makefile
@@ -1,6 +1,9 @@
 MODULE = cbor
 
 CFLAGS += -DCBOR_NO_PRINT
+ifneq ($(shell uname -s),Darwin)
+	CFLAGS += -D_XOPEN_SOURCE=600
+endif
 
 ifeq (,$(filter native,$(BOARD)))
 	# build the minimal subset for non-native

--- a/sys/include/cbor.h
+++ b/sys/include/cbor.h
@@ -101,11 +101,6 @@
 #ifndef CBOR_H
 #define CBOR_H
 
-#ifndef CBOR_NO_CTIME
-/* 'strptime' is only declared when this macro is defined */
-#define _XOPEN_SOURCE
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
This fixes the following issue on macOS, where the macro `_XOPEN_SOURCE` is redefined:

```
/RIOT/sys/include/cbor.h:106:9: error: '_XOPEN_SOURCE' macro redefined [-Werror,-Wmacro-redefined]
#define _XOPEN_SOURCE
        ^
/RIOT/tests/unittests/bin/native/riotbuild/riotbuild.h:12:9: note: previous definition is here
#define _XOPEN_SOURCE 1
        ^
1 error generated.
```