### PR TITLE
pkg/relic: fix for macOS

### DIFF
--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -19,6 +19,8 @@ $(PKG_BUILDDIR)/comp-options.cmake: fix_source
 $(PKG_BUILDDIR)/Makefile: $(PKG_BUILDDIR)/comp-options.cmake
 	cd "$(PKG_BUILDDIR)" && COMP="$(filter-out -Werror=old-style-definition -Werror=strict-prototypes, $(CFLAGS) ) " cmake -DCMAKE_TOOLCHAIN_FILE=comp-options.cmake -DCHECK=off -DTESTS=0 -DBENCH=0 -DSHLIB=off -Wno-dev $(RELIC_CONFIG_FLAGS) .
 
+CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function
+
 fix_source: git-download
 	./fix-util_print_wo_args.sh $(PKG_BUILDDIR)
 	./fix-old-style-definitions.sh $(PKG_BUILDDIR)

--- a/pkg/relic/fix-old-style-definitions.sh
+++ b/pkg/relic/fix-old-style-definitions.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-find ${1} -name "*.[ch]" | xargs sed -i 's/() {/(void) {/'
+. ${RIOTBASE}/pkg/relic/os_util.sh
+find ${1} -type f -name "*.[ch]" -exec ${SEDBIN} 's/() {/(void) {/' {} +

--- a/pkg/relic/fix-util_print_wo_args.sh
+++ b/pkg/relic/fix-util_print_wo_args.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-find ${1} -name "*.[ch]" | xargs sed -i 's/util_print("\(.*\)")/util_print("\1", NULL)/g'
+. ${RIOTBASE}/pkg/relic/os_util.sh
+find ${1} -type f -name "*.[ch]" -exec ${SEDBIN} 's/util_print("\(.*\)")/util_print("\1", NULL)/g' {} +

--- a/pkg/relic/os_util.sh
+++ b/pkg/relic/os_util.sh
@@ -1,0 +1,6 @@
+OSNAME=`uname -s`
+SEDBIN="sed -i"
+if [ "${OSNAME}" = "Darwin" ] ; then
+    SEDBIN="sed -i ''"
+    LANG=C
+fi


### PR DESCRIPTION
This PR fixes some incompatible shell scripts, i.e. calling `sed`, on macOS and compiler error when compiling for target `native`.