### PR TITLE
git-cache: proper check for existing cache

### DIFF
--- a/dist/tools/git/git-cache
+++ b/dist/tools/git/git-cache
@@ -6,12 +6,13 @@ git_cache() {
 
 init() {
     set -ex
-    test -d "${GIT_CACHE_DIR}/.git" || {
+    test -d "${GIT_CACHE_DIR}" && git -C ${GIT_CACHE_DIR} rev-parse
+    if (( $? )); then
         mkdir -p "${GIT_CACHE_DIR}"
 
         git_cache init --bare
         git_cache config core.compression 1
-    }
+    fi
     set +ex
 }
 

--- a/dist/tools/git/git-cache
+++ b/dist/tools/git/git-cache
@@ -6,13 +6,12 @@ git_cache() {
 
 init() {
     set -ex
-    test -d "${GIT_CACHE_DIR}" && git -C ${GIT_CACHE_DIR} rev-parse
-    if (( $? )); then
+    test -d "${GIT_CACHE_DIR}" || {
         mkdir -p "${GIT_CACHE_DIR}"
 
         git_cache init --bare
         git_cache config core.compression 1
-    fi
+    }
     set +ex
 }
 


### PR DESCRIPTION
git-cache fails to detect existing gitcache folders, because bare repositories do not have a `.git` folder.