### PR TITLE
make: allow some ordering of package builds

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -573,3 +573,7 @@ USEPKG := $(sort $(USEPKG))
 ifneq ($(OLD_USEMODULE) $(OLD_USEPKG),$(USEMODULE) $(USEPKG))
     include $(RIOTBASE)/Makefile.dep
 endif
+
+USEPKG_BUILDFIRST := nordic_softdevice_ble
+
+USEPKG := $(USEPKG_BUILDFIRST) $(filter-out $(USEPKG_BUILDFIRST),$(USEPKG))

--- a/Makefile.include
+++ b/Makefile.include
@@ -304,7 +304,7 @@ USEMODULE_INCLUDES_ = $(shell echo $(USEMODULE_INCLUDES) | tr ' ' '\n' | awk '!a
 INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
 
 .PHONY: $(USEPKG:%=${BINDIR}/%.a)
-$(USEPKG:%=${BINDIR}/%.a): $(RIOTBUILD_CONFIG_HEADER_C)
+$(USEPKG:%=${BINDIR}/%.a): $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG_BUILDFIRST:%=${BINDIR}/%.a)
 	@mkdir -p ${BINDIR}
 	"$(MAKE)" -C $(RIOTPKG)/$(patsubst ${BINDIR}/%.a,%,$@)
 

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -10,8 +10,7 @@ RIOTBASE ?= $(CURDIR)/../..
 # TinyDTLS only has support for 32-bit architectures ATM
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 \
-                   z1 \
-                   nrf52dk # see #6022
+                   z1
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon nrf51dongle nrf6310 nucleo-f103 \
                              nucleo-f334 pca10000 pca10005 spark-core \

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -13,11 +13,6 @@ BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo-f334 \
                              stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
                              z1
 
-# Must read nordic_softdevice_ble package before nanocoap package. However,
-# can't read it explicitly here because it is read later, as a dependency for
-# the nrf52dk board.
-BOARD_BLACKLIST := nrf52dk
-
 ## Uncomment to redefine port, for example use 61616 for RFC 6282 UDP compression.
 #GCOAP_PORT = 5683
 #CFLAGS += -DGCOAP_PORT=$(GCOAP_PORT)

--- a/examples/gcoap/Makefile.slip
+++ b/examples/gcoap/Makefile.slip
@@ -14,11 +14,6 @@ BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo-f334 \
                              stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
                              z1
 
-# Must read nordic_softdevice_ble package before nanocoap package. However,
-# can't read it explicitly here because it is read later, as a dependency for
-# the nrf52dk board.
-BOARD_BLACKLIST := nrf52dk
-
 # Redefine port, for example use 61616 for RFC 6282 UDP compression.
 #GCOAP_PORT = 5683
 #CFLAGS += -DGCOAP_PORT=$(GCOAP_PORT)

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -12,9 +12,6 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
                           stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
                           yunjia-nrf51822 z1 nucleo-f072 nucleo-f030
 
-# blacklist this until #6022 is sorted out
-BOARD_BLACKLIST := nrf52dk
-
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default


### PR DESCRIPTION
Previously, packages would be built in alphabetical ordering and possibly in parallel.
This PR adds an option to build certain packages prior to others and adds them as dependencies.

Fixes #6022.