### PR TITLE
sys: net: sock: add uint32_t ipv4 address to address union

### DIFF
--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -172,7 +172,8 @@ typedef struct {
          */
         uint8_t ipv6[16];
 #endif
-        uint8_t ipv4[4];    /**< IPv4 address mode */
+        uint8_t ipv4[4];        /**< IPv4 address mode */
+        uint32_t ipv4_u32;      /**< IPv4 address *in network byte order* */
     } addr;                 /**< address */
 
     /**
@@ -208,7 +209,8 @@ struct _sock_tl_ep {
          */
         uint8_t ipv6[16];
 #endif
-        uint8_t ipv4[4];    /**< IPv4 address mode */
+        uint8_t ipv4[4];        /**< IPv4 address mode */
+        uint32_t ipv4_u32;      /**< IPv4 address *in network byte order* */
     } addr;                 /**< address */
 
     /**


### PR DESCRIPTION
#5945 changed the ipv4 address type to an array (as it is for ipv6).

But "What we gain by introducing an uint32_t version of the IPv4 address is the ability to do 32bit register compares due to 4b alignment, which, apart from being easier to code (and read), is probably way more efficient than having to do memcpys and memcmps."
