### PR TITLE
mailmap: initial mail mappings

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,20 @@
+Cenk Gündoğan <mail-github@cgundogan.de> <cnkgndgn@gmail.com>
+Cenk Gündoğan <mail-github@cgundogan.de> <mail@cgundogan.de>
+Hauke Petersen <devel@haukepetersen.de> <hauke.petersen@fu-berlin.de>
+Hauke Petersen <devel@haukepetersen.de> <mail@haukepetersen.de>
+Joakim Nohlgård <joakim.nohlgard@eistec.se> <joakim.gebart@eistec.se>
+Joakim Nohlgård <joakim.nohlgard@eistec.se> <joakim@gebart.se>
+Kaspar Schleiser <kaspar@schleiser.de>
+Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de> <ludwig.ortmann@fu-berlin.de>
+Martine Lenders <m.lenders@fu-berlin.de> <authmillenon@gmail.com>
+Martine Lenders <m.lenders@fu-berlin.de> <mail@martin-lenders.de>
+Martine Lenders <m.lenders@fu-berlin.de> <mail@martine-lenders.eu>
+Martine Lenders <m.lenders@fu-berlin.de> <mlenders@inf.fu-berlin.de>
+Oleg Hahm <oleg@hobbykeller.org> <oleg@hobbykeller.org>
+Oleg Hahm <oleg@hobbykeller.org> <gello@gmx.de>
+Oleg Hahm <oleg@hobbykeller.org> <oliver.hahm@inria.fr>
+Oleg Hahm <oleg@hobbykeller.org> <oleg@scherbe.des-mesh.net>
+Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+René Kijewski <rene.kijewski@fu-berlin.de>
+René Kijewski <rene.kijewski@fu-berlin.de> <kijewski@mi.fu-berlin.de>
+Sebastian Meiling <s@mlng.net>


### PR DESCRIPTION
git provides a feature to map auther names/email addresses, which is pretty handy if e.g. the mail address or names change due to whatever reasons.

I provide an initial mapping file (ascending sort order) that I built by manually inspecting the output of `git shortlog -sne`.

AFAIK, mail mappings affect the output of `git shortlog`, `git blame`  and (only when configured to do so)  `git log`.

I have no strong opinion about this PR. Is a clean shortlog summary worth the effort to maintain such a file?