### PR TITLE
sys: net: uhcpc: port to sock

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -36,7 +36,7 @@ endif
 
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))
     USEMODULE += uhcpc
-    USEMODULE += gnrc_conn_udp
+    USEMODULE += gnrc_sock_udp
     USEMODULE += fmt
 endif
 


### PR DESCRIPTION
This PR ports uhcpc to use sock instead of conn.

This saves 20 lines and looks a lot nicer than before.
Unfortunately the binary gets around 1k bigger, due to sock's implementation being larger than conn. (~700b vs ~1.5k, plus conn needs mbox, which is another ~300b, on SAM R21).