### PR TITLE
isl29125: added interrupt configuration register

### DIFF
--- a/drivers/include/isl29125.h
+++ b/drivers/include/isl29125.h
@@ -107,6 +107,37 @@ typedef struct {
 } isl29125_t;
 
 /**
+ * @brief Configuration-3 Register 0x03 B1:0
+ */
+typedef enum {
+    ISL29125_INTERRUPT_STATUS_NONE = 0x00,      /** No interrupt*/
+    ISL29125_INTERRUPT_STATUS_GREEN = 0x01,      /** GREEN interrupt*/
+    ISL29125_INTERRUPT_STATUS_RED = 0x02,      /** RED interrupt*/
+    ISL29125_INTERRUPT_STATUS_BLUE = 0x03      /** BLUE interrupt*/
+} isl29125_interrupt_status_t;
+
+/**
+ * @brief Configuration-3 Register 0x03 B3:2
+ */
+typedef enum {
+    ISL29125_INTERRUPT_PERSIST_1 = (0x00 << 2),      /** Interrupt Persist: Number of integration cycle 1*/
+    ISL29125_INTERRUPT_PERSIST_2 = (0x01 << 2),      /** Interrupt Persist: Number of integration cycle 2*/
+    ISL29125_INTERRUPT_PERSIST_4 = (0x02 << 2),      /** Interrupt Persist: Number of integration cycle 4*/
+    ISL29125_INTERRUPT_PERSIST_8 = (0x03 << 2)      /** Interrupt Persist: Number of integration cycle 8*/
+} isl29125_interrupt_persist_t;
+
+/**
+ * @brief Configuration-3 Register 0x03 B4
+ */
+typedef enum {
+    ISL29125_INTERRUPT_CONV_DIS = (0x0 << 4),      /** RGB Conversion done to ~INT Control disable*/
+    ISL29125_INTERRUPT_CONV_EN = (0x1 << 4),      /** RGB Conversion done to ~INT Control enable*/
+} isl29125_interrupt_conven_t;
+
+//-------------------------------------------------------------------------------------------------------
+
+
+/**
  * @brief initialize a new ISL29125 device
  *
  * @param[in] dev           device descriptor of an ISL29125 device
@@ -115,13 +146,23 @@ typedef struct {
  * @param[in] mode          operation mode
  * @param[in] range         measurement range
  * @param[in] resolution    AD conversion resolution
+ * @param[in] interrupt_status          Interrupt status
+ * @param[in] interrupt_persist         Interrupt persistency
+ * @param[in] interrupt_conven          RGB conversion done to interrupt control, enable
+ * @param[in] lower_threshold           Lower interrupt threshold
+ * @param[in] upper_threshold           Upper interrupt threshold
  *
  * @return              0 on success
  * @return              -1 on error
  */
 int isl29125_init(isl29125_t *dev, i2c_t i2c, gpio_t gpio,
                   isl29125_mode_t mode, isl29125_range_t range,
-                  isl29125_resolution_t resolution);
+                  isl29125_resolution_t resolution,
+                  isl29125_interrupt_status_t interrupt_status,
+                  isl29125_interrupt_persist_t interrupt_persist,
+                  isl29125_interrupt_conven_t interrupt_conven,
+                  uint16_t lower_threshold,
+                  uint16_t higher_threshold);
 
 /**
  * @brief read RGB values from device
@@ -146,6 +187,37 @@ void isl29125_read_rgb_color(isl29125_t *dev, color_rgb_t *dest);
  * @param[in] mode      operation mode
  */
 void isl29125_set_mode(isl29125_t *dev, isl29125_mode_t mode);
+
+/**
+ * @brief read isl29125 interrupt status
+ *
+ * @param[in] dev       device descriptor of an ISL29125 device
+ */
+int isl29125_read_irq_status(isl29125_t *dev);
+
+/**
+ * @brief   Initialize a GPIO pin for external interrupt usage
+ *
+ * The registered callback function will be called in interrupt context every
+ * time the defined flank(s) are detected.
+ *
+ * The interrupt is activated automatically after the initialization.
+ *
+ * @param[in] pin       pin to initialize
+ * @param[in] mode      mode of the pin, see @c gpio_mode_t
+ * @param[in] flank     define the active flank(s)
+ * @param[in] cb        callback that is called from interrupt context
+ * @param[in] arg       optional argument passed to the callback
+ *
+ * @return              0 on success
+ * @return              1 on error
+ */
+int init_ext_int(int po, int pi, gpio_mode_t mode, gpio_flank_t flank);
+
+/**
+ * @brief interrupt callback
+ */
+void cb(void *arg);
 
 #ifdef __cplusplus
 }

--- a/tests/driver_isl29125/Makefile
+++ b/tests/driver_isl29125/Makefile
@@ -1,4 +1,8 @@
 APPLICATION = driver_isl29125
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= samr21-xpro
+
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c


### PR DESCRIPTION
added interrupt configuration register for rgb sensor isl29125 and adapted test for interrupt use