### PR TITLE
netdev2_tap: return actual byte number on read request

### DIFF
--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -55,11 +55,6 @@ extern "C" {
  */
 #define NATIVE_ETH_PROTO 0x1234
 
-#if (defined(GNRC_PKTBUF_SIZE)) && (GNRC_PKTBUF_SIZE < 2048)
-#   undef  GNRC_PKTBUF_SIZE
-#   define GNRC_PKTBUF_SIZE     (2048)
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -215,6 +215,8 @@ static int _recv(netdev2_t *netdev2, void *buf, size_t len, void *info)
     (void)info;
 
     if (!buf) {
+        int waiting_bytes;
+
         if (len > 0) {
             /* no memory available in pktbuf, discarding the frame */
             DEBUG("netdev2_tap: discarding the frame\n");
@@ -234,9 +236,9 @@ static int _recv(netdev2_t *netdev2, void *buf, size_t len, void *info)
             _continue_reading(dev);
         }
 
-        /* no way of figuring out packet size without racey buffering,
-         * so we return the maximum possible size */
-        return ETHERNET_FRAME_LEN;
+        /* get number of waiting bytes at dev->tap_fd */
+        real_ioctl(dev->tap_fd, FIONREAD, &waiting_bytes);
+        return waiting_bytes;
     }
 
     int nread = real_read(dev->tap_fd, buf, len);


### PR DESCRIPTION
While working on #6121 I found a way to get the number of bytes on the next read. I think `netdev2_tap` can benefit a lot from this, too ;-).