### PR TITLE
periph/wdg: independent watchdog timer support on stm32l1 + common .h file

### DIFF
--- a/cpu/stm32l1/periph/iwdg.c
+++ b/cpu/stm32l1/periph/iwdg.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016 Unwired Devices [info@unwds.com]
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup
+ * @ingroup
+ * @brief
+ * @{
+ * @file		iwdg.com
+ * @brief       STM32L1 Independent Watchdog
+ * @author      EP [ep@unwds.com]
+ */
+
+#include <stdbool.h>
+
+#include "assert.h"
+
+#include "stm32l1xx.h"
+#include "periph/wdg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define IWDG_KR_KEY_RELOAD      ((uint16_t)0xAAAA)
+#define IWDG_KR_KEY_ENABLE      ((uint16_t)0xCCCC)
+
+#define IWDG_UNLOCK             ((uint16_t)0x5555)
+#define IWDG_LOCK               ((uint16_t)0x0000)
+
+static inline void iwdg_unlock(void)
+{
+    IWDG->KR = IWDG_UNLOCK;
+}
+
+static inline void iwdg_lock(void)
+{
+    IWDG->KR = IWDG_LOCK;
+}
+
+void wdg_set_prescaler(uint8_t prescaler)
+{
+    /* Check valid prescaler values */
+    assert(prescaler == 0x00    ||
+           prescaler == 0x01   ||
+           prescaler == 0x02   ||
+           prescaler == 0x03   ||
+           prescaler == 0x04   ||
+           prescaler == 0x05   ||
+           prescaler == 0x06);
+
+    /* Unlock IWDG and write new prescaler value */
+    iwdg_unlock();
+    IWDG->PR = prescaler;
+    iwdg_lock();
+}
+
+void wdg_set_reload(uint16_t reload)
+{
+    /* Check reload value limit */
+    assert(reload <= IWDG_RLR_RL);
+
+    /* Unlock IWDG and write new reload value */
+    iwdg_unlock();
+    IWDG->RLR = reload;
+    iwdg_lock();
+}
+
+void wdg_enable(void)
+{
+    /* Enable IWDG */
+    IWDG->KR = IWDG_KR_KEY_ENABLE;
+}
+
+void wdg_reload(void)
+{
+    IWDG->KR = IWDG_KR_KEY_RELOAD;
+}
+
+bool wdg_reset_occurred(void)
+{
+    return RCC->CSR & RCC_CSR_IWDGRSTF;
+}
+
+uint32_t wdg_get_value(void)
+{
+    return IWDG->RLR;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/drivers/include/periph/wdg.h
+++ b/drivers/include/periph/wdg.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016 Unwired Devices [info@unwds.com]
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup
+ * @ingroup
+ * @brief
+ * @{
+ * @file		wdg.h
+ * @brief       Common watchdog peripheral interface
+ * @author      EP [ep@unwds.com]
+ */
+#ifndef DRIVERS_INCLUDE_PERIPH_WDG_H_
+#define DRIVERS_INCLUDE_PERIPH_WDG_H_
+
+#include <stdbool.h>
+
+/**
+ * @brief Sets watchdog timer prescaler.
+ *
+ * @param prescaler watchdog timer prescaler value
+ */
+void wdg_set_prescaler(uint8_t prescaler);
+
+/**
+ * @brief Sets watchdog timer reload value.
+ *
+ * @param reload watchdog timer reload value
+ */
+void wdg_set_reload(uint16_t reload);
+
+/**
+ * @brief Enables watchdog timer. Once enabled, it cannot be disabled.
+ */
+void wdg_enable(void);
+
+/**
+ * @brief Reloads watchdog timer.
+ *
+ * @note Reload should be called by application before timer overflows, or watchdog timer will cause general reset.
+ */
+void wdg_reload(void);
+
+/**
+ * @brief Indicates that previous device reset was caused by watchdog.
+ *
+ * @return true if previous reset was caused by watchdog, false otherwise
+ */
+bool wdg_reset_occurred(void);
+
+/**
+ * @brief Gets current reload value in watchdog timer.
+ *
+ * @return current reload value
+ */
+uint32_t wdg_get_value(void);
+
+#endif /* DRIVERS_INCLUDE_PERIPH_WDG_H_ */

--- a/tests/periph_wdg/Makefile
+++ b/tests/periph_wdg/Makefile
@@ -1,0 +1,6 @@
+export APPLICATION = periph_wdg
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_wdg/main.c
+++ b/tests/periph_wdg/main.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016 Unwired Devices [info@unwds.com]
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief WDG test application.
+ *
+ * Tested on:
+ * - STM32L151
+ *
+ * @author EP <ep@unwds.com>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "cpu_conf.h"
+#include "periph/wdg.h"
+#include "xtimer.h"
+
+#define WDG_RELOAD (uint16_t) 0x0FFF
+#define WDG_PRESCALER 0x03
+
+int main(void)
+{
+    xtimer_init();
+
+    /* Wait 5 seconds to avoid reset loop and possible bricking */
+    xtimer_sleep(5);
+
+    puts("Test for the WDG driver");
+    puts("This test will setup the WDG, reload it and then hangs up in infinite loop\n");
+
+    /* Check that previous reset was initiated by watchdog timer  */
+    if (wdg_reset_occurred()) {
+        puts("[!] Reset by WDG occurred");
+
+        for (;; ) ;  /* Hang here */
+    }
+
+    puts("[!] Setting up watchdog timer...");
+
+    /* Setup WDG */
+    wdg_set_prescaler(WDG_PRESCALER);
+    wdg_set_reload(WDG_RELOAD);
+    wdg_reload();
+
+	/* Enable WDG */
+    wdg_enable();
+
+    puts("[!] Watchdog enabled. Sleeping 150 ms...");
+
+    /* Wait 150 ms */
+    xtimer_usleep(1000 * 150);
+
+    puts("[!] Reloading watchdog...");
+    wdg_reload();
+
+    /* Freeze */
+    puts("[!] Watchdog reloaded. Now freezing...");
+
+    volatile int seconds;
+    for (seconds = 0;; seconds++) {
+        printf("[*] Freeze: %d second(s)\n", seconds);
+        xtimer_sleep(1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Independent Watchdog timer (`IWDG`) support for `L1` family and (maybe) a common interface for watchdog implementations on other `STM32` families or other MCUs with watchdogs working by the same principle: prescaler & reload value.

Cheers!