### PR TITLE
cpu/stm32f0: fix include guards.

### DIFF
--- a/cpu/stm32f0/include/stm32f030x8.h
+++ b/cpu/stm32f0/include/stm32f030x8.h
@@ -51,8 +51,8 @@
   * @{
   */
 
-#ifndef __STM32F030x8_H
-#define __STM32F030x8_H
+#ifndef STM32F030x8_H
+#define STM32F030x8_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -5385,7 +5385,7 @@ typedef struct
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F030x8_H */
+#endif /* STM32F030x8_H */
 
 /**
   * @}

--- a/cpu/stm32f0/include/stm32f070xb.h
+++ b/cpu/stm32f0/include/stm32f070xb.h
@@ -51,8 +51,8 @@
   * @{
   */
 
-#ifndef __STM32F070xB_H
-#define __STM32F070xB_H
+#ifndef STM32F070xB_H
+#define STM32F070xB_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -5749,7 +5749,7 @@ typedef struct
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F070xB_H */
+#endif /* STM32F070xB_H */
 
 /**
   * @}


### PR DESCRIPTION
Pull request created as per the issue  [#2623](https://github.com/RIOT-OS/RIOT/issues/2623#).