### PR TITLE
cpu/stm32f2: fix include guards.

### DIFF
--- a/cpu/stm32f2/include/cpu_conf.h
+++ b/cpu/stm32f2/include/cpu_conf.h
@@ -18,8 +18,8 @@
  * @author          Nick v. IJzendoorn <nijzendoorn@engineering-spirit.nl
  */
 
-#ifndef __CPU_CONF_H
-#define __CPU_CONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -50,5 +50,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __CPU_CONF_H */
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f2/include/stm32f205xx.h
+++ b/cpu/stm32f2/include/stm32f205xx.h
@@ -48,8 +48,8 @@
   * @{
   */
 
-#ifndef __STM32F205xx_H
-#define __STM32F205xx_H
+#ifndef STM32F205xx_H
+#define STM32F205xx_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -7287,7 +7287,7 @@ USB_OTG_HostChannelTypeDef;
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F205xx_H */
+#endif /* STM32F205xx_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/cpu/stm32f2/include/stm32f207xx.h
+++ b/cpu/stm32f2/include/stm32f207xx.h
@@ -48,8 +48,8 @@
   * @{
   */
 
-#ifndef __STM32F207xx_H
-#define __STM32F207xx_H
+#ifndef STM32F207xx_H
+#define STM32F207xx_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -7892,7 +7892,7 @@ USB_OTG_HostChannelTypeDef;
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F207xx_H */
+#endif /* STM32F207xx_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/cpu/stm32f2/include/stm32f215xx.h
+++ b/cpu/stm32f2/include/stm32f215xx.h
@@ -48,8 +48,8 @@
   * @{
   */
 
-#ifndef __STM32F215xx_H
-#define __STM32F215xx_H
+#ifndef STM32F215xx_H
+#define STM32F215xx_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -7446,7 +7446,7 @@ USB_OTG_HostChannelTypeDef;
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F215xx_H */
+#endif /* STM32F215xx_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/cpu/stm32f2/include/stm32f217xx.h
+++ b/cpu/stm32f2/include/stm32f217xx.h
@@ -48,8 +48,8 @@
   * @{
   */
 
-#ifndef __STM32F217xx_H
-#define __STM32F217xx_H
+#ifndef STM32F217xx_H
+#define STM32F217xx_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -8052,7 +8052,7 @@ USB_OTG_HostChannelTypeDef;
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F217xx_H */
+#endif /* STM32F217xx_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 


### PR DESCRIPTION
Pull request created as per the issue  [#2623](https://github.com/RIOT-OS/RIOT/issues/2623#).