### PR TITLE
cpu/stm32f4: fix include guards.

### DIFF
--- a/cpu/stm32f4/include/stm32f446xx.h
+++ b/cpu/stm32f4/include/stm32f446xx.h
@@ -49,8 +49,8 @@
   * @{
   */
 
-#ifndef __STM32F446xx_H
-#define __STM32F446xx_H
+#ifndef STM32F446xx_H
+#define STM32F446xx_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -8262,7 +8262,7 @@ typedef struct
 }
 #endif /* __cplusplus */
 
-#endif /* __STM32F446xx_H */
+#endif /* STM32F446xx_H */
 
 
 


### PR DESCRIPTION
Pull request created as per the issue  [#2623](https://github.com/RIOT-OS/RIOT/issues/2623#).