### PR TITLE
cpu/cortexm_common: fix include guards.

### DIFF
--- a/cpu/cortexm_common/include/core_cmFunc.h
+++ b/cpu/cortexm_common/include/core_cmFunc.h
@@ -38,8 +38,8 @@
   #pragma clang system_header   /* treat file as system include file */
 #endif
 
-#ifndef __CORE_CMFUNC_H
-#define __CORE_CMFUNC_H
+#ifndef CORE_CMFUNC_H
+#define CORE_CMFUNC_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -91,4 +91,4 @@
 }
 #endif
 
-#endif /* __CORE_CMFUNC_H */
+#endif /* CORE_CMFUNC_H */

--- a/cpu/cortexm_common/include/core_cmInstr.h
+++ b/cpu/cortexm_common/include/core_cmInstr.h
@@ -38,8 +38,8 @@
   #pragma clang system_header   /* treat file as system include file */
 #endif
 
-#ifndef __CORE_CMINSTR_H
-#define __CORE_CMINSTR_H
+#ifndef CORE_CMINSTR_H
+#define CORE_CMINSTR_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -91,4 +91,4 @@
 }
 #endif
 
-#endif /* __CORE_CMINSTR_H */
+#endif /* CORE_CMINSTR_H */

--- a/cpu/cortexm_common/include/core_cmSimd.h
+++ b/cpu/cortexm_common/include/core_cmSimd.h
@@ -38,8 +38,8 @@
   #pragma clang system_header   /* treat file as system include file */
 #endif
 
-#ifndef __CORE_CMSIMD_H
-#define __CORE_CMSIMD_H
+#ifndef CORE_CMSIMD_H
+#define CORE_CMSIMD_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -93,4 +93,4 @@
 }
 #endif
 
-#endif /* __CORE_CMSIMD_H */
+#endif /* CORE_CMSIMD_H */


### PR DESCRIPTION
Pull request created as per the issue  [#2623](https://github.com/RIOT-OS/RIOT/issues/2623#).