### PR TITLE
drivers/w5100: set src addr to known state

### DIFF
--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -180,6 +180,13 @@ static int init(netdev2_t *netdev)
     wreg(dev, S0_MR, MR_MACRAW);
     wreg(dev, S0_CR, CR_OPEN);
 
+    /* set the source IP address to something random to prevent the device to do
+     * stupid thing (e.g. answering ICMP echo requests on its own) */
+    wreg(dev, REG_SIPR0, 0x01);
+    wreg(dev, REG_SIPR1, 0x01);
+    wreg(dev, REG_SIPR2, 0x01);
+    wreg(dev, REG_SIPR3, 0x01);
+
     /* start receiving packets */
     wreg(dev, S0_CR, CR_RECV);
 


### PR DESCRIPTION
For some reason, the `w5100` was responding to ICMP requests on its own, when the src IP address was set to 0.0.0.0. To prevent this, we set the src IP to some other (random) value.