### PR TITLE
native: fix netdev2_tap for macOS

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -29,9 +29,7 @@
 #include <unistd.h>
 
 #ifdef __MACH__
-#define _POSIX_C_SOURCE
 #include <net/if.h>
-#undef _POSIX_C_SOURCE
 #include <sys/types.h>
 #include <ifaddrs.h>
 #include <net/if_dl.h>


### PR DESCRIPTION
required for #6122, fixes following error:

```
"/Applications/Xcode.app/Contents/Developer/usr/bin/make" -C RIOT/cpu/native/netdev2_tap
RIOT/cpu/native/netdev2_tap/netdev2_tap.c:32:9: error: '_POSIX_C_SOURCE' macro redefined [-Werror,-Wmacro-redefined]
#define _POSIX_C_SOURCE
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/sys/cdefs.h:637:9: note: previous definition is here
#define _POSIX_C_SOURCE         200112L
        ^
1 error generated.
```