### PR TITLE
cpu: native: don't handle pending signals in isr_thread_yield

### DIFF
--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -189,11 +189,6 @@ void isr_thread_yield(void)
 {
     DEBUG("isr_thread_yield\n");
 
-    if (_native_sigpend > 0) {
-        DEBUG("isr_thread_yield(): handling signals\n\n");
-        native_irq_handler();
-    }
-
     sched_run();
     ucontext_t *ctx = (ucontext_t *)(sched_active_thread->sp);
     DEBUG("isr_thread_yield: switching to(%" PRIkernel_pid ")\n\n", sched_active_pid);


### PR DESCRIPTION
I've been hitting a bug were a thread wouldn't get scheduled anymore even after putting it on the respective runqueue.

I think the problem is a possibly nested call of isr_thread_yield():

1. ISR (e.g., incoming network packet) triggers
2. ISR sets a thread's status, calls thread_yield_higher() to trigger context switch
3. thread_yield_higher() calls isr_thread_yield()
4. isr_thread_yield() previously handled pending signals using native_irq_handler()
5. native_irq_handler() calls cpu_switch_context_exit()

... somehow now the thread woken up by 2.) doesn't get scheduled anymore.

I don't know why (tm), but removing the pending signal handling from isr_thread_yield() solves this.