### PR TITLE
examples/nanocoap_server: add resource for coap PUT/POST request

### DIFF
--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -35,6 +35,9 @@ USEPKG += nanocoap
 # optionally enable nanocoap's debug output
 #CFLAGS += -DNANOCOAP_DEBUG
 
+# include this for nicely formatting the returned internal value
+USEMODULE += fmt
+
 # include this for printing IP addresses
 USEMODULE += shell_commands
 

--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -6,10 +6,15 @@
  * directory for more details.
  */
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
+#include "fmt.h"
 #include "nanocoap.h"
+
+/* internal value that can be read/written via CoAP */
+static uint8_t internal_value = 0;
 
 static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len)
 {
@@ -17,10 +22,41 @@ static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len)
             COAP_FORMAT_TEXT, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
 }
 
+static ssize_t _riot_value_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len)
+{
+    ssize_t p = 0;
+    char rsp[16];
+    unsigned code = COAP_CODE_EMPTY;
+
+    /* read coap method type in packet */
+    unsigned method_flag = coap_method2flag(coap_get_code_detail(pkt));
+
+    switch(method_flag) {
+    case COAP_GET:
+        /* write the response buffer with the internal value */
+        p += fmt_u32_dec(rsp, internal_value);
+        code = COAP_CODE_205;
+        break;
+    case COAP_PUT:
+    case COAP_POST:
+    {
+        /* convert the payload to an integer and update the internal value */
+        char payload[16] = { 0 };
+        memcpy(payload, (char*)pkt->payload, pkt->payload_len);
+        internal_value = strtol(payload, NULL, 10);
+        code = COAP_CODE_CHANGED;
+    }
+    }
+
+    return coap_reply_simple(pkt, code, buf, len,
+            COAP_FORMAT_TEXT, (uint8_t*)rsp, p);
+}
+
 /* must be sorted by path (alphabetically) */
 const coap_resource_t coap_resources[] = {
     COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
     { "/riot/board", COAP_GET, _riot_board_handler },
+    { "/riot/value", COAP_GET | COAP_PUT | COAP_POST, _riot_value_handler },
 };
 
 const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);


### PR DESCRIPTION
I thought the nanocoap server example could be slightly extended with a resources handling coap PUT requests.

The idea is just to update an internal static value with PUT and retrieve the value with GET. Of course this has no real meaning but in real life it can be used to control a LED, display text, control a motor or whatever.

While writing this change, I found an issue with the internal payload buffer of the coap packet not being reset after it has been consumed. I proposed another PR in the [upstream nanocoap code](https://github.com/kaspar030/sock/pull/7).

Waiting for #6274 