### PR TITLE
net/sock: include net/af.h

### DIFF
--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -103,6 +103,8 @@
 
 #include <stdint.h>
 
+#include "net/af.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
When using sock, it is very very probable, that one needs to define the used family (e.g. `AF_INET6` or `AF_INET`). Including this header in `sock.h` 'packages' this header with sock, so that one does not need to explicitly include it when using sock.