### PR TITLE
pyterm: log to `stdout` per default

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -148,7 +148,7 @@ class SerCmd(cmd.Cmd):
             os.makedirs(directory)
         logging.basicConfig(filename=directory + os.path.sep + self.run_name +
                             '.log', level=logging.DEBUG, format=self.fmt_str)
-        ch = logging.StreamHandler()
+        ch = logging.StreamHandler(sys.stdout)
         ch.setLevel(logging.DEBUG)
 
         # create logger


### PR DESCRIPTION
Fixes #6139.

Does anybody see a need to make this configurable?