### PR TITLE
core: fix stdio.h include for assert

### DIFF
--- a/core/assert.c
+++ b/core/assert.c
@@ -13,6 +13,8 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <stdio.h>
+
 #include "assert.h"
 
 #ifdef DEBUG_ASSERT_VERBOSE

--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -54,8 +54,6 @@ extern const char assert_crash_message[];
 #ifdef NDEBUG
 #define assert(ignore)((void) 0)
 #elif defined(DEBUG_ASSERT_VERBOSE)
-#include <stdio.h>
-
 /**
  * @brief   Function to handle failed assertion
  *


### PR DESCRIPTION
Since `DEBUG_ASSERT_VERBOSE` wasn't activated on Murdock (but #6144 takes care of that), this somehow fell through.