### PR TITLE
Atmega328p adc support

### DIFF
--- a/boards/arduino-common/Makefile.features
+++ b/boards/arduino-common/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/arduino-common/include/arduino_pinmap.h
+++ b/boards/arduino-common/include/arduino_pinmap.h
@@ -64,6 +64,13 @@ extern "C" {
 #define ARDUINO_PIN_A3          ARDUINO_PIN_17
 #define ARDUINO_PIN_A4          ARDUINO_PIN_18
 #define ARDUINO_PIN_A5          ARDUINO_PIN_19
+/* arduino notation compatibility */
+#define A0			0
+#define A1			1
+#define A2			2
+#define A3			3
+#define A4			4
+#define A5			5
 /** @ */
 
 #ifdef __cplusplus

--- a/boards/arduino-common/include/periph_conf.h
+++ b/boards/arduino-common/include/periph_conf.h
@@ -83,6 +83,21 @@ extern "C" {
 #define MEGA_PRR            PRR         /* Power Reduction Register is PRR */
 /** @} */
 
+/**
+ * @brief ADC configuration
+ *
+ * @{
+ */
+#define ADC_NUMOF       (6)
+    /* ADC Channels */
+#define ADC_CHAN_0           0 // Maybe ADC_PIN_x is better ?
+#define ADC_CHAN_1           1
+#define ADC_CHAN_2           2
+#define ADC_CHAN_3           3
+#define ADC_CHAN_4           4
+#define ADC_CHAN_5           5
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/arduino-common/include/periph_conf.h
+++ b/boards/arduino-common/include/periph_conf.h
@@ -90,12 +90,12 @@ extern "C" {
  */
 #define ADC_NUMOF       (6)
     /* ADC Channels */
-#define ADC_CHAN_0           0 // Maybe ADC_PIN_x is better ?
-#define ADC_CHAN_1           1
-#define ADC_CHAN_2           2
-#define ADC_CHAN_3           3
-#define ADC_CHAN_4           4
-#define ADC_CHAN_5           5
+#define ADC_PIN_0           0
+#define ADC_PIN_1           1
+#define ADC_PIN_2           2
+#define ADC_PIN_3           3
+#define ADC_PIN_4           4
+#define ADC_PIN_5           5
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/atmega328p/Makefile
+++ b/cpu/atmega328p/Makefile
@@ -1,6 +1,6 @@
 # define the module that is build
 MODULE = cpu
 # add a list of subdirectories, that should also be build
-DIRS = $(ATMEGA_COMMON)
+DIRS = $(ATMEGA_COMMON) periph
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/atmega328p/periph/Makefile
+++ b/cpu/atmega328p/periph/Makefile
@@ -1,0 +1,3 @@
+MODULE = periph
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/atmega328p/periph/adc.c
+++ b/cpu/atmega328p/periph/adc.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 Laurent Navet <laurent.navet@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_atmega328p
+ * @{
+ *
+ * @file
+ * @brief       Low-level ADC driver implementation for atmega328p mcu
+ *
+ * @author      Laurent Navet <laurent.navet@gmail.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/adc.h"
+#include "periph_conf.h"
+
+int adc_init(adc_t line)
+{
+    /* check if the line is valid */
+    if (line >= ADC_NUMOF) {
+        return -1;
+    }
+
+    /* configure line as input */
+    DDRD &= (1 << line);
+
+    /* Disable corresponding Digital input */
+    DIDR0 |= (1 << line);
+
+    /* Enable ADC */
+    ADCSRA |= (1 << ADEN);
+
+    /* Enable ADC with Prescaling = /128 = 125KHz */
+    ADCSRA=(1 << ADEN)|(1 << ADPS2)|(1 << ADPS1)|(1 << ADPS0);
+
+    /* Ref Voltage is Vcc(5V) */
+    ADMUX = (1 << REFS0);
+
+    /* Select pin channel */
+    ADMUX |= line;
+
+    return 0;
+}
+
+int adc_sample(adc_t line, adc_res_t res)
+{
+    int sample = 0;
+
+    /* Start a new conversion. By default, this conversion will
+       be performed in single conversion mode. */
+    ADCSRA |= (1 << ADSC);
+
+    /* Wait until the conversion is complete */
+    while(ADCSRA & (1 << ADIF));
+
+    /* Get conversion result */
+    sample = ADCW;
+
+    /* Clear the ADIF flag */
+    ADCSRA |= ( 1 << ADIF );
+
+    return sample;
+}

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -21,6 +21,7 @@
 extern "C" {
 #include "xtimer.h"
 #include "periph/gpio.h"
+#include "periph/adc.h"
 }
 
 #include "arduino.hpp"
@@ -57,4 +58,10 @@ int digitalRead(int pin)
 void delay(int msec)
 {
     xtimer_usleep(1000 * msec);
+}
+
+int analogRead(int pin)
+{
+    adc_init(pin);
+    return adc_sample(pin, (adc_res_t)0);
 }

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -62,6 +62,6 @@ void delay(int msec)
 
 int analogRead(int pin)
 {
-    adc_init(pin);
-    return adc_sample(pin, (adc_res_t)0);
+    adc_init((adc_t)pin);
+    return adc_sample((adc_t)pin, (adc_res_t)0);
 }

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -82,5 +82,15 @@ int digitalRead(int pin);
  */
 void delay(int msec);
 
+/**
+ * @brief   Read the current value of the given analog pin
+ *
+ * @param[in] pin       pin to read
+ *
+ * @return a value between 0 to 1023 that is proportionnal
+ * to the voltage applied to the pin
+ */
+int analogRead(int pin);
+
 #endif /* ARDUINO_H */
 /** @} */

--- a/tests/driver_mq3/main.c
+++ b/tests/driver_mq3/main.c
@@ -55,7 +55,7 @@ int main(void)
 
         printf("RAW: %4i, per mille: %1i.%03i\n", raw, alc_a, alc_b);
 
-        xtimer_usleep(500 * 1000);
+        xtimer_usleep((uint32_t)500 * 1000);
     }
     return 0;
 }


### PR DESCRIPTION
This is a basic adc support for arduino atmega328p based boards.
* Prescaler is fixed to /128 (125kHz)
* Vref is fixed to 5V

A simple test program I've used to test with a potentiometer [here](https://github.com/mali/RIOT/blob/arduino-tests/arduino_tests/adc/main.c)

Comments needed :-)