### PR TITLE
[backport] native: fix netdev2_tap for macOS

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -29,9 +29,7 @@
 #include <unistd.h>
 
 #ifdef __MACH__
-#define _POSIX_C_SOURCE
 #include <net/if.h>
-#undef _POSIX_C_SOURCE
 #include <sys/types.h>
 #include <ifaddrs.h>
 #include <net/if_dl.h>


### PR DESCRIPTION
backport of #6134