### PR TITLE
pkg/oonf_api: add test and macos fix

### DIFF
--- a/pkg/oonf_api/Makefile.include
+++ b/pkg/oonf_api/Makefile.include
@@ -1,1 +1,5 @@
 INCLUDES += -I$(BINDIRBASE)/pkg/$(BOARD)/oonf_api/src-api
+
+ifeq ($(shell uname -s),Darwin)
+	CFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+endif

--- a/tests/pkg_oonf_api/Makefile
+++ b/tests/pkg_oonf_api/Makefile
@@ -1,0 +1,12 @@
+APPLICATION = test_pkg_oonf_api
+include ../Makefile.tests_common
+
+BOARD_WHITELIST := native
+
+USEMODULE += gnrc_ipv6
+USEMODULE += gnrc_conn_udp
+USEMODULE += oonf_common
+USEMODULE += oonf_rfc5444
+USEPKG += oonf_api
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_oonf_api/main.c
+++ b/tests/pkg_oonf_api/main.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Check if the oonf_api package builds.
+ *
+ * @author      smlng <s@mlng.net>
+ *
+ */
+
+#include <stdio.h>
+
+int main(void)
+{
+    printf("oonf_api package compiled!");
+    return 0;
+}


### PR DESCRIPTION
this PR mainly replaces #5588. It adds:
* a compile test for the OONF API package and
* CFLAGS for macOS, where build fails due to pedantic `clang` compiler.