### PR TITLE
cpu/cortexm_common: simplify ARVALID tests and fix BFARVALID test.

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -212,6 +212,9 @@ __attribute__((naked)) void hard_fault_default(void)
 __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, uint32_t exc_return, uint32_t* r4_to_r11_stack)
 {
 #if CPU_HAS_EXTENDED_FAULT_REGISTERS
+    static const uint32_t BFARVALID_MASK = (0x80 << SCB_CFSR_BUSFAULTSR_Pos);
+    static const uint32_t MMARVALID_MASK = (0x80 << SCB_CFSR_MEMFAULTSR_Pos);
+
     /* Copy status register contents to local stack storage, this must be
      * done before any calls to other functions to avoid corrupting the
      * register contents. */
@@ -274,11 +277,11 @@ __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, 
     printf(" HFSR: 0x%08" PRIx32 "\n", hfsr);
     printf(" DFSR: 0x%08" PRIx32 "\n", dfsr);
     printf(" AFSR: 0x%08" PRIx32 "\n", afsr);
-    if (((cfsr & SCB_CFSR_BUSFAULTSR_Msk) >> SCB_CFSR_BUSFAULTSR_Pos) & 0x80) {
+    if (cfsr & BFARVALID_MASK) {
         /* BFAR valid flag set */
         printf(" BFAR: 0x%08" PRIx32 "\n", bfar);
     }
-    if (((cfsr & SCB_CFSR_MEMFAULTSR_Msk) >> SCB_CFSR_MEMFAULTSR_Pos) & 0x80) {
+    if (cfsr & MMARVALID_MASK) {
         /* MMFAR valid flag set */
         printf("MMFAR: 0x%08" PRIx32 "\n", mmfar);
     }


### PR DESCRIPTION
The `BFARVALID` test essentially evaluated to `(cfsr & 0xff) >> 8`, which is never true. This patch fixes the `BFARVALID` test and reduces both validity tests to simple masks of the CFSR value.