### PR TITLE
cortexm: fix thread_yield() -> thread_yield_higher() in ISRs

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -122,7 +122,7 @@ static inline void cortexm_sleep(int deep)
 static inline void cortexm_isr_end(void)
 {
     if (sched_context_switch_request) {
-        thread_yield();
+        thread_yield_higher();
     }
 }
 

--- a/tests/isr_yield_higher/Makefile
+++ b/tests/isr_yield_higher/Makefile
@@ -1,0 +1,11 @@
+APPLICATION = isr_yield_higher
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	./tests/test.py

--- a/tests/isr_yield_higher/main.c
+++ b/tests/isr_yield_higher/main.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   Application for testing cooperative scheduling of same-priority
+ *          threads
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "thread.h"
+#include "xtimer.h"
+
+#define TEST_TIME (200000U)
+
+static char t2_stack[THREAD_STACKSIZE_MAIN];
+
+static void *second_thread(void *arg)
+{
+    (void) arg;
+    if (xtimer_now_usec() < TEST_TIME) {
+        puts("TEST FAILED");
+    }
+    else {
+        puts("TEST SUCCESSFUL");
+    }
+    return NULL;
+}
+
+static void _cb(void *arg)
+{
+    (void)arg;
+    puts("timer triggered");
+    sched_context_switch_request = 1;
+}
+
+int main(void)
+{
+    (void) thread_create(
+            t2_stack, sizeof(t2_stack),
+            THREAD_PRIORITY_MAIN,
+            THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+            second_thread, NULL, "nr2");
+
+    puts("first thread started");
+
+    xtimer_t timer;
+    timer.callback = _cb;
+    xtimer_set(&timer, TEST_TIME/2);
+
+    while(xtimer_now_usec() < TEST_TIME) {}
+
+    puts("first thread done");
+
+    return 0;
+}

--- a/tests/isr_yield_higher/tests/test.py
+++ b/tests/isr_yield_higher/tests/test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect('first thread started')
+    child.expect('timer triggered')
+    child.expect('first thread done')
+    child.expect('TEST SUCCESSFUL')
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, echo=False))


### PR DESCRIPTION
Threads with the same priority are supposed to be scheduled cooperatively, but most ISR's call ```thread_yield()```, causing the current priority's circular list to advance.

Automatically done using

```git grep -l sched_context_switch_request | xargs perl -0pi -e 's/if \(sched_context_switch_request\) \{\n        thread_yield\(\);/if \(sched_context_switch_request\) \{\n        thread_yield_higher\(\);/'```