### PR TITLE
cpu/cortexm: added and use central yield_from_isr() function

### DIFF
--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -21,8 +21,6 @@
 #include <stdint.h>
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -534,9 +532,7 @@ void isr_gpioa(void)
         mis >>= 1;
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 /** @brief Interrupt service routine for Port B */
@@ -559,9 +555,7 @@ void isr_gpiob(void)
         mis >>= 1;
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 /** @brief Interrupt service routine for Port C */
@@ -584,9 +578,7 @@ void isr_gpioc(void)
         mis >>= 1;
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 /** @brief Interrupt service routine for Port D */
@@ -609,7 +601,5 @@ void isr_gpiod(void)
         mis >>= 1;
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -24,8 +24,8 @@
 #include <stdint.h>
 
 #include "mutex.h"
+#include "cpu.h"
 #include "periph/i2c.h"
-#include "sched.h"
 #include "thread.h"
 #ifdef MODULE_XTIMER
 #include "xtimer.h"
@@ -210,9 +210,7 @@ void isr_i2c(void)
     /* Unlock the wait mutex */
     mutex_unlock(&i2c_wait_mutex);
 
-        if (sched_context_switch_request) {
-            thread_yield();
-        }
+    cortexm_isr_end();
 }
 
 void cc2538_i2c_init_master(uint32_t speed_hz)

--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -27,8 +27,6 @@
 #include "mutex.h"
 #include "periph/spi.h"
 #include "periph_conf.h"
-#include "thread.h"
-#include "sched.h"
 
 /* guard file in case no SPI device is defined */
 #if SPI_NUMOF

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -23,8 +23,6 @@
 
 #include "board.h"
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/timer.h"
 #include "periph_conf.h"
 
@@ -332,9 +330,7 @@ static void irq_handler_a(int n) {
         config[n].cb(config[n].arg, 0);
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 static void irq_handler_b(int n) {
@@ -357,9 +353,7 @@ static void irq_handler_b(int n) {
         config[n].cb(config[n].arg, 1);
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 void isr_timer0_chan0(void) {irq_handler_a(0);}

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -22,8 +22,6 @@
 
 #include "board.h"
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 #include "periph_conf.h"
 
@@ -124,9 +122,7 @@ void UART_0_ISR(void)
         reset(UART_0_DEV);
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif /* UART_0_EN */
 
@@ -148,9 +144,7 @@ void UART_1_ISR(void)
         reset(UART_1_DEV);
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif /* UART_1_EN */
 

--- a/cpu/cc2538/radio/cc2538_rf_internal.c
+++ b/cpu/cc2538/radio/cc2538_rf_internal.c
@@ -19,9 +19,7 @@
  * @}
  */
 
-#include "sched.h"
-#include "thread.h"
-
+#include "cpu.h"
 #include "cc2538.h"
 #include "cc2538_rf.h"
 #include "cc2538_rf_netdev.h"
@@ -71,9 +69,7 @@ void isr_rfcorerxtx(void)
 
    _irq_handler();
 
-   if (sched_context_switch_request) {
-        thread_yield();
-   }
+    cortexm_isr_end();
 }
 
 uint_fast8_t rfcore_read_byte(void)

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 
 #define GPIO_ISR_CHAN_NUMOF     (32)
@@ -128,7 +126,5 @@ void isr_edge(void)
             gpio_chan[pin].cb(gpio_chan[pin].arg);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/cc26x0/periph/timer.c
+++ b/cpu/cc26x0/periph/timer.c
@@ -22,8 +22,6 @@
 #include <stdio.h>
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph_conf.h"
 #include "periph/timer.h"
 
@@ -144,9 +142,7 @@ static inline void isr_handler(tim_t tim)
         ctx[tim].cb(ctx[tim].arg, 0);
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef TIMER_0_ISR

--- a/cpu/cc26x0/periph/uart.c
+++ b/cpu/cc26x0/periph/uart.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 
 /**
@@ -131,7 +129,5 @@ void isr_uart(void)
         ctx[0].rx_cb(ctx[0].arg, (uint8_t)UART->DR);
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -32,8 +32,10 @@
 
 #include <stdio.h>
 
-#include "cpu_conf.h"
 #include "irq.h"
+#include "sched.h"
+#include "thread.h"
+#include "cpu_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -86,6 +88,18 @@ static inline void cpu_print_last_instruction(void)
 static inline void cpu_sleep_until_event(void)
 {
     __WFE();
+}
+
+/**
+ * @brief   Trigger a conditional context scheduler run / context switch
+ *
+ * This function is supposed to be called in the end of each ISR.
+ */
+static inline void cortexm_isr_end(void)
+{
+    if (sched_context_switch_request) {
+        thread_yield();
+    }
 }
 
 #ifdef __cplusplus

--- a/cpu/ezr32wg/periph/gpio.c
+++ b/cpu/ezr32wg/periph/gpio.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -154,7 +152,5 @@ void isr_gpio_even(void)
             GPIO->IFC = (1 << i);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/timer.h"
 #include "periph_conf.h"
 
@@ -156,8 +154,6 @@ void TIMER_0_ISR(void)
             isr_ctx[0].cb(isr_ctx[0].arg, i);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif /* TIMER_0_EN */

--- a/cpu/ezr32wg/periph/uart.c
+++ b/cpu/ezr32wg/periph/uart.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 
 #include "periph/uart.h"
 #include "periph/gpio.h"
@@ -104,9 +102,7 @@ static inline void rx_irq(int dev)
         uint8_t data = (uint8_t)_uart(dev)->RXDATA;
         isr_ctx[dev].rx_cb(isr_ctx[dev].arg, data);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef UART_0_ISR_RX

--- a/cpu/kinetis_common/periph/gpio.c
+++ b/cpu/kinetis_common/periph/gpio.c
@@ -26,8 +26,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "sched.h"
-#include "thread.h"
 #include "cpu.h"
 #include "periph/gpio.h"
 
@@ -297,9 +295,7 @@ static inline void irq_handler(PORT_Type *port, int port_num)
             isr_ctx[ctx].cb(isr_ctx[ctx].arg);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef PORTA_BASE

--- a/cpu/kinetis_common/periph/rtt.c
+++ b/cpu/kinetis_common/periph/rtt.c
@@ -30,8 +30,6 @@
 #include "cpu.h"
 #include "periph/rtt.h"
 #include "periph_conf.h"
-#include "sched.h"
-#include "thread.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -194,9 +192,7 @@ void RTT_ISR(void)
         }
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #endif /* RTC_NUMOF */

--- a/cpu/kinetis_common/periph/spi.c
+++ b/cpu/kinetis_common/periph/spi.c
@@ -14,8 +14,6 @@
 #include "cpu.h"
 #include "periph/spi.h"
 #include "periph_conf.h"
-#include "thread.h"
-#include "sched.h"
 #include "mutex.h"
 
 #define ENABLE_DEBUG (0)
@@ -1498,9 +1496,7 @@ static inline void irq_handler_transfer(SPI_Type *spi, spi_t dev)
     }
 
     /* see if a thread with higher priority wants to run now */
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #if SPI_0_EN

--- a/cpu/kinetis_common/periph/timer.c
+++ b/cpu/kinetis_common/periph/timer.c
@@ -27,8 +27,6 @@
 
 #include "cpu.h"
 #include "board.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph_conf.h"
 #include "periph/timer.h"
 
@@ -324,9 +322,7 @@ inline static void pit_irq_handler(tim_t dev)
 
     PIT->CHANNEL[ch].TFLG = PIT_TFLG_TIF_MASK;
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 /* ****** LPTMR module functions ****** */
@@ -572,9 +568,7 @@ inline static void lptmr_irq_handler(tim_t tim)
     /* Clear interrupt flag */
     BITBAND_REG32(hw->CSR, LPTMR_CSR_TCF_SHIFT) = 1;
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 /* ****** Common timer API functions ****** */

--- a/cpu/kinetis_common/periph/uart.c
+++ b/cpu/kinetis_common/periph/uart.c
@@ -24,8 +24,6 @@
 #include <math.h>
 
 #include "cpu.h"
-#include "thread.h"
-#include "sched.h"
 #include "periph_conf.h"
 #include "periph/uart.h"
 
@@ -232,9 +230,7 @@ static inline void irq_handler(uart_t uartnum, KINETIS_UART *dev)
     }
 #endif
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 
 }
 

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -21,8 +21,6 @@
 #include <stdint.h>
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph_conf.h"
 #include "periph/timer.h"
 #include "mutex.h"
@@ -371,9 +369,7 @@ void isr_wtimer0a(void)
     /* Clears both IT */
     ROM_TimerIntClear(WTIMER0_BASE, TIMER_TIMA_TIMEOUT | TIMER_TIMA_MATCH);
     config[TIMER_0].cb(config[TIMER_0].arg, 0);
-    if (sched_context_switch_request){
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif /* TIMER_0_EN */
 
@@ -383,9 +379,7 @@ void isr_wtimer1a(void)
     ROM_TimerIntClear(WTIMER1_BASE, TIMER_TIMA_TIMEOUT | TIMER_TIMA_MATCH);
 
     config[TIMER_1].cb(config[TIMER_0].arg, 0);
-    if (sched_context_switch_request){
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif /* TIMER_1_EN */
 

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -22,8 +22,6 @@
 
 #include "assert.h"
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 #include "periph_conf.h"
 
@@ -141,7 +139,5 @@ void isr_uart0(void)
             config[UART_0].rx_cb(config[UART_0].arg, (uint8_t)lchar);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/lpc11u34/periph/gpio.c
+++ b/cpu/lpc11u34/periph/gpio.c
@@ -19,7 +19,6 @@
  */
 
 #include "cpu.h"
-#include "thread.h"
 #include "periph/gpio.h"
 
 /* Static IOCON registers definition */
@@ -463,9 +462,7 @@ static inline void isr_common(uint8_t int_id) {
     LPC_GPIO_PIN_INT->IST |= (1 << int_id); /* Clear pending interrupt */
     gpio_config[int_id].cb(gpio_config[int_id].arg);
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 void isr_pinint0(void)

--- a/cpu/lpc11u34/periph/timer.c
+++ b/cpu/lpc11u34/periph/timer.c
@@ -20,8 +20,6 @@
 #include <stdint.h>
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph_conf.h"
 #include "periph/timer.h"
 
@@ -166,9 +164,7 @@ void TIMER_0_ISR(void)
         TIMER_0_DEV->MCR &= ~(1 << 9);
         config[TIMER_0].cb(config[TIMER_0].arg, 3);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #endif /* TIMER_0_EN */

--- a/cpu/lpc11u34/periph/uart.c
+++ b/cpu/lpc11u34/periph/uart.c
@@ -18,8 +18,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 
 /**
@@ -136,8 +134,6 @@ void UART_0_ISR(void)
         uint8_t data = (uint8_t)UART_0_DEV->RBR;
         config[UART_0].rx_cb(config[UART_0].arg, data);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -20,8 +20,6 @@
 #include <stdint.h>
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph_conf.h"
 #include "periph/timer.h"
 
@@ -169,9 +167,7 @@ void TIMER_0_ISR(void)
         TIMER_0_DEV->MCR &= ~(1 << 9);
         config[TIMER_0].cb(config[TIMER_0].arg, 3);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif
 

--- a/cpu/lpc1768/periph/uart.c
+++ b/cpu/lpc1768/periph/uart.c
@@ -20,8 +20,6 @@
 #include <stdint.h>
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 #include "periph_conf.h"
 
@@ -203,9 +201,7 @@ void UART_0_ISR(void)
         uint8_t data = (uint8_t)UART_0_DEV->RBR;
         config[UART_0].rx_cb(config[UART_0].arg, data);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif
 
@@ -216,8 +212,6 @@ void UART_1_ISR(void)
         uint8_t data = (uint8_t)UART_1_DEV->RBR;
         config[UART_1].rx_cb(config[UART_1].arg, data);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif

--- a/cpu/nrf51/periph/rtt.c
+++ b/cpu/nrf51/periph/rtt.c
@@ -23,8 +23,6 @@
 
 #include "cpu.h"
 #include "board.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph_conf.h"
 #include "periph/rtt.h"
 
@@ -131,9 +129,7 @@ void RTT_ISR(void)
         RTT_DEV->EVENTS_OVRFLW = 0;
         overflow_cb(overflow_arg);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #endif /* RTT_NUMOF */

--- a/cpu/nrf51/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf51/radio/nrfmin/nrfmin.c
@@ -20,8 +20,6 @@
 
 #include "cpu.h"
 #include "mutex.h"
-#include "thread.h"
-#include "sched.h"
 #include "periph_conf.h"
 #include "periph/cpuid.h"
 #include "nrfmin.h"
@@ -454,9 +452,7 @@ void isr_radio(void)
             }
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 /*

--- a/cpu/nrf52/periph/rtt.c
+++ b/cpu/nrf52/periph/rtt.c
@@ -24,8 +24,6 @@
 
 #include "cpu.h"
 #include "board.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph_conf.h"
 #include "periph/rtt.h"
 
@@ -125,7 +123,5 @@ void RTT_ISR(void)
         overflow_cb(overflow_arg);
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -26,8 +26,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_cpu.h"
 #include "periph_conf.h"
@@ -128,7 +126,5 @@ void isr_gpiote(void)
         NRF_GPIOTE->EVENTS_IN[0] = 0;
         exti_chan.cb(exti_chan.arg);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -22,8 +22,6 @@
  * @}
  */
 
-#include "sched.h"
-#include "thread.h"
 #include "periph/timer.h"
 
 #define F_TIMER             (16000000U)     /* the timer is clocked at 16MHz */
@@ -164,9 +162,7 @@ static inline void irq_handler(int num)
             }
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef TIMER_0_ISR

--- a/cpu/nrf5x_common/periph/uart.c
+++ b/cpu/nrf5x_common/periph/uart.c
@@ -26,8 +26,6 @@
 #include <stdint.h>
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 #include "periph_cpu.h"
 #include "periph_conf.h"
@@ -180,7 +178,5 @@ void isr_uart0(void)
         uint8_t byte = (uint8_t)(NRF_UART0->RXD & 0xff);
         uart_config.rx_cb(uart_config.arg, byte);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -22,8 +22,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
@@ -304,9 +302,7 @@ static inline void isr_handler(Pio *port, int port_num)
             exti_ctx[ctx].cb(exti_ctx[ctx].arg);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 void isr_pioa(void)

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -23,8 +23,6 @@
 
 #include "cpu.h"
 #include "mutex.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 #include "periph/spi.h"
@@ -356,9 +354,7 @@ static inline void irq_handler_transfer(Spi *spi, spi_t dev)
     }
 
     /* See if a thread with higher priority wants to run now */
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #if SPI_0_EN

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -23,8 +23,6 @@
 
 #include "board.h"
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/timer.h"
 #include "periph_conf.h"
 
@@ -187,9 +185,7 @@ static inline void isr_handler(tim_t tim)
         }
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef TIMER_0_ISR

--- a/cpu/sam3/periph/uart.c
+++ b/cpu/sam3/periph/uart.c
@@ -20,8 +20,6 @@
 
 #include "cpu.h"
 #include "board.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 
 #define ENABLE_DEBUG (0)
@@ -101,9 +99,7 @@ static inline void isr_handler(int num)
     if (dev->UART_SR & UART_SR_RXRDY) {
         ctx[num].rx_cb(ctx[num].arg, (uint8_t)dev->UART_RHR);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef UART_0_ISR

--- a/cpu/samd21/periph/gpio.c
+++ b/cpu/samd21/periph/gpio.c
@@ -21,8 +21,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -222,7 +220,5 @@ void isr_eic(void)
             }
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/samd21/periph/rtc.c
+++ b/cpu/samd21/periph/rtc.c
@@ -19,8 +19,6 @@
 #include "cpu.h"
 #include "periph/rtc.h"
 #include "periph_conf.h"
-#include "sched.h"
-#include "thread.h"
 
 /* guard file in case no RTC device was specified */
 #if RTC_NUMOF
@@ -195,9 +193,7 @@ void isr_rtc(void)
         reference_year += 64;
         rtcMode2->INTFLAG.reg = RTC_MODE2_INTFLAG_OVF;
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #endif /* RTC_NUMOF */

--- a/cpu/samd21/periph/rtt.c
+++ b/cpu/samd21/periph/rtt.c
@@ -19,8 +19,6 @@
 #include "cpu.h"
 #include "periph/rtt.h"
 #include "periph_conf.h"
-#include "sched.h"
-#include "thread.h"
 
 /* guard file in case no RTT device was specified */
 #if RTT_NUMOF
@@ -202,9 +200,7 @@ void RTT_ISR(void)
         rtcMode0->INTFLAG.bit.OVF = 1;
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -27,8 +27,6 @@
 #include "periph/timer.h"
 #include "periph_conf.h"
 
-#include "sched.h"
-#include "thread.h"
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
@@ -344,9 +342,7 @@ void TIMER_0_ISR(void)
         }
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif /* TIMER_0_EN */
 
@@ -367,11 +363,8 @@ void TIMER_1_ISR(void)
             TIMER_1_DEV.INTENCLR.reg = TC_INTENCLR_MC1;
             config[TIMER_1].cb(config[TIMER_1].arg, 1);
         }
-
     }
 
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif /* TIMER_1_EN */

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -21,8 +21,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 
 #include "periph/uart.h"
 #include "periph/gpio.h"
@@ -142,9 +140,7 @@ static inline void irq_handler(int dev)
         /* clear error flag */
         uart->INTFLAG.reg = SERCOM_USART_INTFLAG_ERROR;
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef UART_0_ISR

--- a/cpu/saml21/periph/gpio.c
+++ b/cpu/saml21/periph/gpio.c
@@ -24,8 +24,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 
 #define ENABLE_DEBUG (0)
@@ -216,8 +214,5 @@ void isr_eic(void)
             gpio_config[i].cb(gpio_config[i].arg);
         }
     }
-
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/saml21/periph/rtc.c
+++ b/cpu/saml21/periph/rtc.c
@@ -20,8 +20,6 @@
 #include "cpu.h"
 #include "periph/rtc.h"
 #include "periph_conf.h"
-#include "sched.h"
-#include "thread.h"
 
 /* guard file in case no RTC device was specified */
 #if RTC_NUMOF
@@ -231,9 +229,7 @@ void isr_rtc(void)
         * Start RTC again with reference_year 64 years more (Be careful with alarm set) */
         reference_year += 64;
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #endif /* RTC_NUMOF */

--- a/cpu/saml21/periph/rtt.c
+++ b/cpu/saml21/periph/rtt.c
@@ -22,7 +22,6 @@
 #include <stdint.h>
 #include "periph/rtt.h"
 #include "board.h"
-#include "thread.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -143,8 +142,5 @@ void isr_rtc(void)
             _cmp0_cb(_cmp0_arg);
         }
     }
-
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/saml21/periph/timer.c
+++ b/cpu/saml21/periph/timer.c
@@ -31,8 +31,6 @@
 #include "periph/timer.h"
 #include "periph_conf.h"
 
-#include "sched.h"
-#include "thread.h"
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
@@ -238,9 +236,6 @@ void TIMER_0_ISR(void)
             config[TIMER_0].cb(config[TIMER_0].arg, 1);
         }
     }
-
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 #endif /* TIMER_0_EN */

--- a/cpu/saml21/periph/uart.c
+++ b/cpu/saml21/periph/uart.c
@@ -22,8 +22,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 
 /**
@@ -143,10 +141,7 @@ static inline void irq_handler(uint8_t uartnum, SercomUsart *dev)
         /* clear error flag */
         dev->INTFLAG.bit.ERROR = 1;
     }
-
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 void uart_poweron(uart_t uart)

--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -20,8 +20,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/timer.h"
 
 /**
@@ -132,9 +130,7 @@ static inline void irq_handler(tim_t tim)
             isr_ctx[tim].cb(isr_ctx[tim].arg, i);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef TIMER_0_ISR

--- a/cpu/stm32f0/periph/gpio.c
+++ b/cpu/stm32f0/periph/gpio.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -208,7 +206,5 @@ void isr_exti(void)
             isr_ctx[i].cb(isr_ctx[i].arg);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/stm32f0/periph/rtc.c
+++ b/cpu/stm32f0/periph/rtc.c
@@ -20,8 +20,6 @@
 #include "cpu.h"
 #include "periph/rtc.h"
 #include "periph_conf.h"
-#include "sched.h"
-#include "thread.h"
 
 /* guard file in case no RTC device was specified */
 #if RTC_NUMOF
@@ -236,9 +234,7 @@ void isr_rtc(void)
         rtc_callback.cb(rtc_callback.arg);
         RTC->ISR &= ~RTC_ISR_ALRAF;
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 /**

--- a/cpu/stm32f0/periph/uart.c
+++ b/cpu/stm32f0/periph/uart.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 
 /**
@@ -204,9 +202,7 @@ static inline void irq_handler(uint8_t uartnum, USART_TypeDef *dev)
         /* do nothing on overrun */
         dev->ICR |= USART_ICR_ORECF;
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #if UART_0_EN

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -24,8 +24,6 @@
 #include "periph/gpio.h"
 #include "periph_cpu.h"
 #include "periph_conf.h"
-#include "thread.h"
-#include "sched.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -223,7 +221,5 @@ void isr_exti(void)
             exti_ctx[i].cb(exti_ctx[i].arg);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/stm32f1/periph/rtt.c
+++ b/cpu/stm32f1/periph/rtt.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/rtt.h"
 #include "periph_conf.h"
 
@@ -197,9 +195,7 @@ void RTT_ISR(void)
         RTT_DEV->CRL &= ~(RTC_CRL_OWF);
         overflow_cb(overflow_arg);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #endif /* RTT_NUMOF */

--- a/cpu/stm32f1/periph/uart.c
+++ b/cpu/stm32f1/periph/uart.c
@@ -27,9 +27,6 @@
 #include "periph/uart.h"
 #include "periph/gpio.h"
 
-#include "sched.h"
-#include "thread.h"
-
 /**
  * @brief Allocate memory to store the callback functions.
  */
@@ -112,9 +109,7 @@ static inline void irq_handler(uart_t uart)
         /* ORE is cleared by reading SR and DR sequentially */
         dev(uart)->DR;
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef UART_0_ISR

--- a/cpu/stm32f2/periph/gpio.c
+++ b/cpu/stm32f2/periph/gpio.c
@@ -20,8 +20,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -215,7 +213,5 @@ void isr_exti(void)
             exti_chan[i].cb(exti_chan[i].arg);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/stm32f2/periph/rtc.c
+++ b/cpu/stm32f2/periph/rtc.c
@@ -19,8 +19,6 @@
 #include "cpu.h"
 #include "periph/rtc.h"
 #include "periph_conf.h"
-#include "sched.h"
-#include "thread.h"
 
 /* guard file in case no RTC device was specified */
 #if RTC_NUMOF
@@ -254,9 +252,7 @@ void isr_rtc_alarm(void)
         RTC->ISR &= ~RTC_ISR_ALRAF;
     }
     EXTI->PR |= EXTI_PR_PR17;
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 /**

--- a/cpu/stm32f2/periph/spi.c
+++ b/cpu/stm32f2/periph/spi.c
@@ -26,8 +26,6 @@
 #include "mutex.h"
 #include "periph/spi.h"
 #include "periph_conf.h"
-#include "thread.h"
-#include "sched.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -426,9 +424,7 @@ static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev)
         spi->DR = data;
     }
     /* see if a thread with higher priority wants to run now */
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #if SPI_0_EN

--- a/cpu/stm32f2/periph/uart.c
+++ b/cpu/stm32f2/periph/uart.c
@@ -23,8 +23,6 @@
  */
 
 #include "cpu.h"
-#include "thread.h"
-#include "sched.h"
 #include "mutex.h"
 #include "periph/uart.h"
 #include "periph/gpio.h"
@@ -200,9 +198,7 @@ static inline void irq_handler(int uart, USART_TypeDef *dev)
         char data = (char)dev->DR;
         uart_ctx[uart].rx_cb(uart_ctx[uart].arg, data);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 static inline void dma_handler(int uart, int stream)
@@ -215,9 +211,7 @@ static inline void dma_handler(int uart, int stream)
         dma_base(stream)->HIFCR = dma_ifc(stream);
     }
     mutex_unlock(&tx_sync[uart]);
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef UART_0_ISR

--- a/cpu/stm32f3/periph/gpio.c
+++ b/cpu/stm32f3/periph/gpio.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -215,7 +213,5 @@ void isr_exti(void)
             exti_chan[i].cb(exti_chan[i].arg);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/stm32f3/periph/spi.c
+++ b/cpu/stm32f3/periph/spi.c
@@ -30,8 +30,6 @@
 #include "mutex.h"
 #include "periph/spi.h"
 #include "periph_conf.h"
-#include "thread.h"
-#include "sched.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -395,9 +393,7 @@ static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev)
         spi->DR = data;
     }
     /* see if a thread with higher priority wants to run now */
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #if SPI_0_EN

--- a/cpu/stm32f3/periph/uart.c
+++ b/cpu/stm32f3/periph/uart.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 
 /**
@@ -204,9 +202,7 @@ static inline void irq_handler(uint8_t uartnum, USART_TypeDef *dev)
         /* do nothing on overrun */
         dev->ICR |= USART_ICR_ORECF;
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #if UART_0_EN

--- a/cpu/stm32f4/periph/gpio.c
+++ b/cpu/stm32f4/periph/gpio.c
@@ -20,8 +20,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -215,7 +213,5 @@ void isr_exti(void)
             exti_chan[i].cb(exti_chan[i].arg);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/stm32f4/periph/spi.c
+++ b/cpu/stm32f4/periph/spi.c
@@ -26,8 +26,6 @@
 #include "mutex.h"
 #include "periph/spi.h"
 #include "periph_conf.h"
-#include "thread.h"
-#include "sched.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -426,9 +424,7 @@ static inline void irq_handler_transfer(SPI_TypeDef *spi, spi_t dev)
         spi->DR = data;
     }
     /* see if a thread with higher priority wants to run now */
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #if SPI_0_EN

--- a/cpu/stm32f4/periph/uart.c
+++ b/cpu/stm32f4/periph/uart.c
@@ -20,8 +20,6 @@
  */
 
 #include "cpu.h"
-#include "thread.h"
-#include "sched.h"
 #include "mutex.h"
 #include "periph/uart.h"
 #include "periph/gpio.h"
@@ -147,9 +145,7 @@ static inline void irq_handler(int uart, USART_TypeDef *dev)
         uint8_t data = (uint8_t)dev->DR;
         uart_ctx[uart].rx_cb(uart_ctx[uart].arg, data);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 static inline void dma_handler(int uart, int stream)
@@ -157,9 +153,7 @@ static inline void dma_handler(int uart, int stream)
     /* clear DMA done flag */
     dma_base(stream)->IFCR[dma_hl(stream)] = dma_ifc(stream);
     mutex_unlock(&_tx_dma_sync[uart]);
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #ifdef UART_0_ISR

--- a/cpu/stm32l1/periph/gpio.c
+++ b/cpu/stm32l1/periph/gpio.c
@@ -21,8 +21,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -220,7 +218,5 @@ void isr_exti(void)
             exti_chan[i].cb(exti_chan[i].arg);
         }
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }

--- a/cpu/stm32l1/periph/rtc.c
+++ b/cpu/stm32l1/periph/rtc.c
@@ -22,8 +22,6 @@
 #include "cpu.h"
 #include "periph/rtc.h"
 #include "periph_conf.h"
-#include "sched.h"
-#include "thread.h"
 
 /* guard file in case no RTC device was specified */
 #if RTC_NUMOF
@@ -235,9 +233,7 @@ void isr_rtc_alarm(void)
         rtc_callback.cb(rtc_callback.arg);
         RTC->ISR &= ~RTC_ISR_ALRAF;
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 /**

--- a/cpu/stm32l1/periph/uart.c
+++ b/cpu/stm32l1/periph/uart.c
@@ -19,8 +19,6 @@
  */
 
 #include "cpu.h"
-#include "sched.h"
-#include "thread.h"
 #include "periph/uart.h"
 #include "periph/gpio.h"
 
@@ -177,9 +175,7 @@ static inline void irq_handler(uint8_t uartnum, USART_TypeDef *dev)
         uint8_t data = (uint8_t)dev->DR;
         uart_config[uartnum].rx_cb(uart_config[uartnum].arg, data);
     }
-    if (sched_context_switch_request) {
-        thread_yield();
-    }
+    cortexm_isr_end();
 }
 
 #if UART_0_EN


### PR DESCRIPTION
a) adds a little convenience
b) one step into using the periph drivers without RIOT