### PR TITLE
stm32l1/periph/rtc.c: fixed 24-h clock format

### DIFF
--- a/cpu/stm32l1/periph/rtc.c
+++ b/cpu/stm32l1/periph/rtc.c
@@ -65,7 +65,8 @@ void rtc_init(void)
     while ( (RTC->ISR & RTC_ISR_INITF) == 0 );
 
     /* Set 24-h clock */
-    RTC->CR |= RTC_CR_FMT;
+    RTC->CR &= ~RTC_CR_FMT;
+  
     /* Timestamps enabled */
     RTC->CR |= RTC_CR_TSE;
 


### PR DESCRIPTION
Hi.

Previously there was actually setting of 12-h clock format with comment "Enabling 24-h format". Possibly typo, fixed with according to ST's RTC AN3371: Table 2, row 6.

How to check that mistake is present:
- Set time 23:59:55
- Set alarm to next day's 0:0:0
- Wait 5 seconds
- Alarm doesn't occur

If you poll the clock while waiting, you can see transition from 23:59:59 to 24:0:0 without day changing. After applying this fix, the transition becomes from 23:59:59 to 0:0:0 of a next day and alarm will occur 5 seconds later.

Possibly, the same mistake present in STM32F0's RTC driver.

Best regards.