### PR TITLE
netdev2_tap: assert address len >= ETHERNET_ADDR_LEN

### DIFF
--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -147,7 +147,7 @@ static int _set(netdev2_t *dev, netopt_t opt, void *value, size_t value_len)
 
     switch (opt) {
         case NETOPT_ADDRESS:
-            assert(value_len==ETHERNET_ADDR_LEN);
+            assert(value_len >= ETHERNET_ADDR_LEN);
             _set_mac_addr(dev, (uint8_t*)value);
             break;
         case NETOPT_PROMISCUOUSMODE:


### PR DESCRIPTION
Using the shell: `ifconfig 4 set addr 11:22:33` crashes on native, because an assert is hit that expects the addr length to be `ETHERNET_ADDRESS_LEN`. As we already can provide return values for netopt set operations, I propose to change the `assert` to an actual `if` statement.
Currently, compiling without `asserts` would still allow to specify addresses with `length < ETHERNET_ADDRESS_LEN` and hence may lead to unexpected issues (random bytes in the address).

EDIT: assert address length to be `>= ETHERNET_ADDRESS_LEN`