### PR TITLE
native: netdev2_tap: `FIONREAD` does not work on tun/tap

### DIFF
--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -55,6 +55,11 @@ extern "C" {
  */
 #define NATIVE_ETH_PROTO 0x1234
 
+#if (defined(GNRC_PKTBUF_SIZE)) && (GNRC_PKTBUF_SIZE < 2048)
+#   undef  GNRC_PKTBUF_SIZE
+#   define GNRC_PKTBUF_SIZE     (2048)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -215,8 +215,6 @@ static int _recv(netdev2_t *netdev2, void *buf, size_t len, void *info)
     (void)info;
 
     if (!buf) {
-        int waiting_bytes;
-
         if (len > 0) {
             /* no memory available in pktbuf, discarding the frame */
             DEBUG("netdev2_tap: discarding the frame\n");
@@ -236,9 +234,9 @@ static int _recv(netdev2_t *netdev2, void *buf, size_t len, void *info)
             _continue_reading(dev);
         }
 
-        /* get number of waiting bytes at dev->tap_fd */
-        real_ioctl(dev->tap_fd, FIONREAD, &waiting_bytes);
-        return waiting_bytes;
+        /* no way of figuring out packet size without racey buffering,
+         * so we return the maximum possible size */
+        return ETHERNET_FRAME_LEN;
     }
 
     int nread = real_read(dev->tap_fd, buf, len);


### PR DESCRIPTION
On my system, `real_ioctl` for a tun/tap fd with `FIONREAD` returns `-EINVAL` and thus `waiting_bytes` becomes a very large random number. `waiting_bytes` is used to allocate a pktbuf entry in `gnrc_netdev_eth.c`, but this fails because of the aforesaid problem. So, at least for me, communication between two tap interfaces does not work.

I am using `Linux 4.8.11-1-ARCH`. No idea whether the current `ioctl` call works with previous kernels.

* The first commit changes `netdev2_tap:_recv` to return `ETHERNET_FRAME_LEN`, because *peeking* into the tap buffer doesn't seem to work.
* The second commit is a minor enhancement in `gnrc_netdev_2_eth.c:_recv`: a negative value shouldn't be used for allocating a pktbuf entry.


EDIT: this PR basically just reverts #6122 now