### PR TITLE
kinetis: Fix ADC clock computation

### DIFF
--- a/cpu/kinetis_common/periph/adc.c
+++ b/cpu/kinetis_common/periph/adc.c
@@ -158,15 +158,15 @@ int adc_init(adc_t line)
      * than 12 MHz */
     /* For the calibration it is important that the ADC clock is <= 4 MHz */
     uint32_t adiv;
-    int i = 4;
-    if (CLOCK_BUSCLOCK > (ADC_MAX_CLK * 8)) {
+    if (CLOCK_BUSCLOCK > (ADC_MAX_CLK << 3)) {
         adiv = ADC_CFG1_ADIV(3) | ADC_CFG1_ADICLK(1);
     }
     else {
-        while ((i > 0) && (CLOCK_BUSCLOCK < (ADC_MAX_CLK * i))) {
-            i--;
+        unsigned int i = 0;
+        while ((i < 3) && (CLOCK_BUSCLOCK > (ADC_MAX_CLK << i))) {
+            ++i;
         }
-        adiv = ADC_CFG1_ADIV(i - 1);
+        adiv = ADC_CFG1_ADIV(i);
     }
 
     /* set configuration register 1: clocking and precision */


### PR DESCRIPTION
The ADC prescaler computation was broken and gave too high ADC clock for
module clocks slower than 32 MHz (the >32 MHz case is already handled
separately)

The prescaler parameter `adiv` has the following allowed values:
```
00 ADCLK = bus clock
01 ADCLK = bus clock / 2
10 ADCLK = bus clock / 4
11 ADCLK = bus clock / 8
```
additionally, the condition `2 MHz <= ADCLK <= 4 MHz` must be fulfilled for the calibration to work properly, or else spurious calibration failed errors will appear (guess how I know that? ;) )