### PR TITLE
gnrc_pktbuf: add asserts to fix static analyzer error

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -191,6 +191,8 @@ gnrc_pktsnip_t *gnrc_pktbuf_start_write(gnrc_pktsnip_t *pkt);
 /**
  * @brief   Create a IOVEC representation of the packet pointed to by *pkt*
  *
+ * @pre `(len != NULL)`
+ *
  * @details This function will create a new packet snip in the packet buffer,
  *          which points to the given *pkt* and contains a IOVEC representation
  *          of the referenced packet in its data section.

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -276,6 +276,7 @@ gnrc_pktsnip_t *gnrc_pktbuf_get_iovec(gnrc_pktsnip_t *pkt, size_t *len)
     gnrc_pktsnip_t *head;
     struct iovec *vec;
 
+    assert(len != NULL);
     if (pkt == NULL) {
         *len = 0;
         return NULL;
@@ -289,6 +290,8 @@ gnrc_pktsnip_t *gnrc_pktbuf_get_iovec(gnrc_pktsnip_t *pkt, size_t *len)
         *len = 0;
         return NULL;
     }
+
+    assert(head->data != NULL);
     vec = (struct iovec *)(head->data);
     /* fill the IOVEC */
     while (pkt != NULL) {


### PR DESCRIPTION
This PR adds asserts in `gnrc_pktbuf_get_iovec` to fix following warning raised by `make scan-build-analyze`:

```
/RIOT/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c:295:23: warning: Access to field 'iov_base' results in a dereference of a null pointer (loaded from variable 'vec')
        vec->iov_base = pkt->data;
        ~~~           ^
1 warning generated.
```

Reviewing the code showed this will not happen as long as `pkt != NULL` which is checked right at the beginning. However, the extra assert will calm down the analyzer.