### PR TITLE
periph/uart: uart_write() must be fully synchronous

### DIFF
--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -153,6 +153,10 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg);
  * given buffer have been send. The way this data is send is up to the
  * implementation: active waiting, interrupt driven, DMA, etc.
  *
+ * @note    The function MUST only return, after the transfer of the given data
+ *          is complete, meaning that all bytes MUST have been actually shifted
+ *          out before the function returns.
+ *
  * @param[in] uart          UART device to use for transmission
  * @param[in] data          data buffer to send
  * @param[in] len           number of bytes to send


### PR DESCRIPTION
In #5899, a discussion started over the need of a separate `uart_tx_flush()` function. I argue that there is not need for this, as `uart_write()` should be synchronous, meaning that the it blocks until all data has been send out. 

Now in some implementations, this is not 100% true, as `uart_write()` blocks only until the last byte(s) have been written to the UARTs internal buffer, which is not the same as the bytes actually have been shifted out on the wire. So IMHO this is a consequence of the API description not being precise enough - I hope to change this with this PR.

The reasons I see for making write fully synchronous are:
- no trouble with active UART when e.g. going to sleep
- no need for a separate `flush` function, so simpler and cleaner interface
- identical behavior for with and without DMA
- as we use multi-threading, we do not block the complete CPU when waiting for `write` to finish

The effort to implement the correct behavior of `write()` are very minor, for most CPUs a simple additional
```c
while (STATUS_REG & TXCOMPLETE_BIT) {}
```
at the end of the `write()` function will suffice (see e.g. #6187)

If we reach a consensus here, I will open a separate issue tracking the state of the existing UART drivers.