### PR TITLE
cpu/stm32f4: Add I2C low speed support to the stm32f4

### DIFF
--- a/cpu/stm32f4/periph/i2c.c
+++ b/cpu/stm32f4/periph/i2c.c
@@ -73,7 +73,13 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
 
     /* read speed configuration */
     switch (speed) {
+        case I2C_SPEED_LOW:
+            /* 10Kbit/s */
+            ccr = I2C_APBCLK / 20000;
+            break;
+
         case I2C_SPEED_NORMAL:
+            /* 100Kbit/s */
             ccr = I2C_APBCLK / 200000;
             break;
 


### PR DESCRIPTION
This patch adds a low speed mode to the stm32f4 microcontrollers. I only have an stm32f401 here, so I only could test on that board, but I expect no problems on the other boards from this line. Speed was verified with a logic analyzer.