### PR TITLE
drivers/bmp180: move bmp180 driver to saul auto init using the correct way

### DIFF
--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -30,11 +30,6 @@
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-/**
- * @brief   Allocation of memory for device descriptors
- */
-bmp180_t bmp180_devs[BMP180_NUMOF];
-
 /* Internal function prototypes */
 static int _read_ut(bmp180_t *dev, int32_t *ut);
 static int _read_up(bmp180_t *dev, int32_t *up);
@@ -111,21 +106,6 @@ int bmp180_init(bmp180_t *dev, i2c_t i2c, uint8_t mode)
     DEBUG("MC: %i\n",  (int)dev->calibration.mc);
     DEBUG("MD: %i\n",  (int)dev->calibration.md);
     return 0;
-}
-
-void bmp180_auto_init(void)
-{
-    for (unsigned i = 0; i < BMP180_NUMOF; i++) {
-        if (bmp180_init(&bmp180_devs[i], bmp180_params[i].i2c_dev, bmp180_params[i].mode) < 0) {
-            LOG_ERROR("Unable to initialize BMP180 sensor #%i\n", i);
-        }
-#ifdef MODULE_SAUL_REG
-        for (unsigned j = 0; j < 2; j++) {
-            bmp180_saul_reg[i][j].dev = &bmp180_devs[i];
-            saul_reg_add(&bmp180_saul_reg[i][j]);
-        }
-#endif
-    }
 }
 
 int bmp180_read_temperature(bmp180_t *dev, int32_t *temperature)

--- a/drivers/bmp180/include/bmp180_params.h
+++ b/drivers/bmp180/include/bmp180_params.h
@@ -55,30 +55,6 @@ static const bmp180_params_t bmp180_params[] =
 #endif
 };
 
-/**
- * @brief   Get the number of configured BMP180 devices
- */
-#define BMP180_NUMOF       (sizeof(bmp180_params) / sizeof(bmp180_params[0]))
-
-#ifdef MODULE_SAUL_REG
-/**
- * @brief   Allocate and configure entries to the SAUL registry
- */
-saul_reg_t bmp180_saul_reg[][2] =
-{
-    {
-        {
-            .name = "bmp180-temp",
-            .driver = &bmp180_temperature_saul_driver
-        },
-        {
-            .name = "bmp180-press",
-            .driver = &bmp180_pressure_saul_driver
-        },
-    }
-};
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/bmp180.h
+++ b/drivers/include/bmp180.h
@@ -69,8 +69,8 @@ typedef struct {
  * @brief Device initialization parameters
  */
 typedef struct {
-    i2c_t i2c_dev;
-    uint8_t mode;
+    i2c_t i2c_dev;   /**< I2C device which is used */
+    uint8_t mode;    /**< Oversampling mode */
 } bmp180_params_t;
 
 /**
@@ -80,11 +80,6 @@ typedef struct {
 extern const saul_driver_t bmp180_temperature_saul_driver;
 extern const saul_driver_t bmp180_pressure_saul_driver;
 /** @} */
-
-/**
- * @brief auto-initialize all configured BMP180 devices
- */
-void bmp180_auto_init(void);
 
 /**
  * @brief Initialize the given BMP180 device

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -20,10 +20,6 @@
 
 #include "auto_init.h"
 
-#ifdef MODULE_BMP180
-#include "bmp180.h"
-#endif
-
 #ifdef MODULE_IO1_XPLAINED
 #include "io1_xplained.h"
 #endif
@@ -111,10 +107,6 @@ void auto_init(void)
 #ifdef MODULE_RTC
     DEBUG("Auto init rtc module.\n");
     rtc_init();
-#endif
-#ifdef MODULE_BMP180
-    DEBUG("Auto init BMP180 module.\n");
-    bmp180_auto_init();
 #endif
 #ifdef MODULE_IO1_XPLAINED
     DEBUG("Auto init IO1 Xplained extension module.\n");
@@ -292,6 +284,10 @@ void auto_init(void)
 #ifdef MODULE_SI70XX
     extern void auto_init_si70xx(void);
     auto_init_si70xx();
+#endif
+#ifdef MODULE_BMP180
+    extern void auto_init_bmp180(void);
+    auto_init_bmp180();
 #endif
 
 #endif /* MODULE_AUTO_INIT_SAUL */

--- a/sys/auto_init/saul/auto_init_bmp180.c
+++ b/sys/auto_init/saul/auto_init_bmp180.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of BMP180 driver.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_BMP180
+
+#include "log.h"
+#include "saul_reg.h"
+
+#include "bmp180_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define BMP180_NUMOF    (sizeof(bmp180_params) / sizeof(bmp180_params[0]))
+
+/**
+ * @brief   Allocation of memory for device descriptors
+ */
+static bmp180_t bmp180_devs[BMP180_NUMOF];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[BMP180_NUMOF * 2];
+
+/**
+ * @brief   Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t bmp180_temperature_saul_driver;
+extern const saul_driver_t bmp180_pressure_saul_driver;
+/** @} */
+
+/**
+ * @brief   Allocate and configure entries to the SAUL registry
+ */
+saul_reg_t bmp180_saul_reg_info[][2] =
+{
+    {
+        {
+            .name= "bmp180-temp",
+            .driver = &bmp180_temperature_saul_driver
+        },
+        {
+            .name = "bmp180-press",
+            .driver = &bmp180_pressure_saul_driver
+        }
+    }
+};
+
+void auto_init_bmp180(void)
+{
+    for (unsigned i = 0; i < BMP180_NUMOF; i++) {
+        if (bmp180_init(&bmp180_devs[i],
+                        bmp180_params[i].i2c_dev,
+                        bmp180_params[i].mode) < 0) {
+            LOG_ERROR("Unable to initialize BMP180 sensor #%i\n", i);
+            return;
+        }
+
+        /* temperature */
+        saul_entries[(i * 2)].dev = &(bmp180_devs[i]);
+        saul_entries[(i * 2)].name = bmp180_saul_reg_info[i][0].name;
+        saul_entries[(i * 2)].driver = &bmp180_temperature_saul_driver;
+
+        /* atmospheric pressure */
+        saul_entries[(i * 2) + 1].dev = &(bmp180_devs[i]);
+        saul_entries[(i * 2) + 1].name = bmp180_saul_reg_info[i][1].name;
+        saul_entries[(i * 2) + 1].driver = &bmp180_pressure_saul_driver;
+
+        /* register to saul */
+        saul_reg_add(&(saul_entries[(i * 2)]));
+        saul_reg_add(&(saul_entries[(i * 2) + 1]));
+    }
+}
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_BMP180 */


### PR DESCRIPTION
This is a fix that prevents the bmp180 from being initialized twice at startup. The driver is still available via saul using both `bmp180` and `auto_init_saul` modules.