### PR TITLE
boards/nucleo-common: fix port on OS X

### DIFF
--- a/boards/nucleo-common/Makefile.include
+++ b/boards/nucleo-common/Makefile.include
@@ -1,6 +1,6 @@
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial


### PR DESCRIPTION
This fixes the default port on OS X systems to access the STDIO on nucleo boards