### PR TITLE
gnrc_sock_udp: add sendto

### DIFF
--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -53,6 +53,9 @@ extern "C" {
 #define GNRC_UDP_STACK_SIZE     (THREAD_STACKSIZE_DEFAULT)
 #endif
 
+#define GNRC_UDP_PORTRANGE_MIN (49152U)
+#define GNRC_UDP_PORTRANGE_MAX (65535U)
+#define GNRC_UDP_PORTRANGE_LEN (GNRC_UDP_PORTRANGE_MAX - GNRC_UDP_PORTRANGE_MIN)
 /**
  * @brief   Calculate the checksum for the given packet
  *

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -63,7 +63,7 @@
  * implementation (e.g. `gnrc_ipv6_default` for @ref net_gnrc GNRC) and at least
  * one network device.
  *
- * After including the header file for @ref net_sock_udp "UDP sock", we create some 
+ * After including the header file for @ref net_sock_udp "UDP sock", we create some
  * buffer space `buf` to store the data received by the server:
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
@@ -398,6 +398,36 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
  */
 ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
                       uint32_t timeout, sock_udp_ep_t *remote);
+
+/**
+ * @brief   Sends a UDP message to destination end point
+ *
+ * @pre `(dst_udp_ep != NULL)) && ((len == 0) || (data != NULL))`
+ *
+ * @param[in] sock          A raw IPv4/IPv6 sock object. May be `NULL`.
+ *                          A sensible local end point should be selected by
+ *                          the implementation in that case.
+ * @param[in] data          Pointer where the received data should be stored.
+ *                          May be `NULL` if `len == 0`.
+ * @param[in] len           Maximum space available at @p data.
+ * @param[in] dst_udp_ep    Destination end point for the sent data.
+ *                          sock_udp_ep_t::port must not be 0.
+ *
+ * @return  The number of bytes sent on success.
+ * @return  -EAFNOSUPPORT, if `remote != NULL` and sock_udp_ep_t::family of
+ *          @p remote is != AF_UNSPEC and not supported.
+ * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not
+ *          reachable.
+ * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_udp_ep_t::netif of @p remote is not a valid
+ *          interface or contradicts the given local interface (i.e.
+ *          neither the local end point of `sock` nor remote are assigned to
+ *          `SOCK_ADDR_ANY_NETIF` but are nevertheless different.
+ * @return  -EINVAL, if sock_udp_ep_t::port of @p remote is 0.
+ * @return  -ENOMEM, if no memory was available to send @p data.
+ */
+ssize_t sock_udp_sendto(sock_udp_t *sock, const void *data, size_t len,
+                        const sock_udp_ep_t *dst_udp_ep);
 
 /**
  * @brief   Sends a UDP message to remote end point


### PR DESCRIPTION
This PR started with the following error when calling `make scan-build-analyze`:

```
/RIOT/sys/net/gnrc/sock/udp/gnrc_sock_udp.c:252:10: warning: Dereference of null pointer
        (sock->remote.family != AF_UNSPEC)) {
         ^~~~~~~~~~~~~~~~~~~
1 warning generated.
```

Trying to resolve this issue I thought it might be nice to have an explicit `sock_udp_sendto` call, ~~then~~ than the rather complicated checking in `sock_udp_send`. This PR adds such function without breaking API and existing applications using it.

However, if approved I would like to remove the `remote` parameter from `sock_udp_send` and adapt applications to use `sendto` where required instead. Which means `sock_udp_send` would only be used for _connected_ UDP socks and `sendto` otherwise.