### PR TITLE
gnrc_priority_queue:  fix doxygen document.

### DIFF
--- a/sys/include/net/gnrc/priority_pktqueue.h
+++ b/sys/include/net/gnrc/priority_pktqueue.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Daniel Krebs
+ *               2016 INRIA
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,16 +8,16 @@
  */
 
 /**
- * @{
- * @defgroup    net_gnrc_priority_pktqueue Priority packet queue
+ * @defgroup    net_gnrc_priority_pktqueue Priority packet queue for GNRC
  * @ingroup     net_gnrc
+ * @brief       Wrapper for priority_queue that holds gnrc_pktsnip_t*
+ * @{
+ *
  * @file
- * @brief       Wrapper for priority_queue that holds gnrc_pktsnip_t* and is
- *              aware of it's length.
+ * @brief       gnrc priority packet queue API
  *
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>
- * @}
  */
 
 #ifndef GNRC_PRIORITY_PKTQUEUE_H
@@ -133,3 +134,4 @@ void gnrc_priority_pktqueue_push(gnrc_priority_pktqueue_t* queue,
 #endif
 
 #endif /* GNRC_PRIORITY_PKTQUEUE_H */
+/** @} */

--- a/sys/net/gnrc/priority_pktqueue/priority_pktqueue.c
+++ b/sys/net/gnrc/priority_pktqueue/priority_pktqueue.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Daniel Krebs
+ *               2016 INRIA
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,12 +8,11 @@
  */
 
 /**
+ * @ingroup     net_gnrc_priority_pktqueue
  * @{
- * @defgroup    net_gnrc_priority_pktqueue Priority packet queue
- * @ingroup     net_gnrc
+ *
  * @file
- * @brief       Wrapper for priority_queue that holds gnrc_pktsnip_t* and is
- *              aware of it's length.
+ * @brief       gnrc priority packet queue implementation
  *
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>


### PR DESCRIPTION
Fix doxygen document for `gnrc_priority_pktqueue`.