### PR TITLE
cpu/arm7_common: s/u_long/unsigned long/

### DIFF
--- a/cpu/arm7_common/bootloader.c
+++ b/cpu/arm7_common/bootloader.c
@@ -62,9 +62,9 @@ void DEBUG_Routine(void)
 /*-----------------------------------------------------------------------------------*/
 volatile int arm_abortflag = 0;
 
-void abtorigin(const char *vector, u_long *lnk_ptr1)
+void abtorigin(const char *vector, unsigned long *lnk_ptr1)
 {
-    register u_long    *lnk_ptr2;
+    register unsigned long *lnk_ptr2;
     register unsigned long *sp;
     register unsigned int   cpsr, spsr;
 
@@ -85,7 +85,7 @@ void abtorigin(const char *vector, u_long *lnk_ptr1)
 void UNDEF_Routine(void)
 {
     /* cppcheck-suppress variableScope */
-    register u_long    *lnk_ptr;
+    register unsigned long *lnk_ptr;
     __asm__ __volatile__("sub %0, lr, #8" : "=r"(lnk_ptr));     // get aborting instruction
 
     if (arm_abortflag == 0) {
@@ -99,7 +99,7 @@ void UNDEF_Routine(void)
 void PABT_Routine(void)
 {
     /* cppcheck-suppress variableScope */
-    register u_long    *lnk_ptr;
+    register unsigned long *lnk_ptr;
     __asm__ __volatile__("sub %0, lr, #8" : "=r"(lnk_ptr));     // get aborting instruction
 
     if (arm_abortflag == 0) {
@@ -113,7 +113,7 @@ void PABT_Routine(void)
 void DABT_Routine(void)
 {
     /* cppcheck-suppress variableScope */
-    register u_long    *lnk_ptr;
+    register unsigned long *lnk_ptr;
     __asm__ __volatile__("sub %0, lr, #8" : "=r"(lnk_ptr));     // get aborting instruction
 
     if (arm_abortflag == 0) {


### PR DESCRIPTION
On my system many build tests failed for the `msba2` with an error message stating, that the type `u_long` is not defined. Changing this to `unsigned long` fixes this transparently...

@OlegHahm was also able to reproduce the bulid fail for `tests/periph_pwm`