### PR TITLE
core/mutex: support locked initialization

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -50,6 +50,18 @@ typedef struct {
 #define MUTEX_INIT { { NULL } }
 
 /**
+ * @brief Static initializer for mutex_t with a locked mutex
+ */
+#define MUTEX_INIT_LOCKED { { MUTEX_LOCKED } }
+
+/**
+ * @internal
+ * @brief This is the value of the mutex when locked and no threads are waiting
+ *        for it
+ */
+#define MUTEX_LOCKED ((void *)-1)
+
+/**
  * @brief Initializes a mutex object.
  * @details For initialization of variables use MUTEX_INIT instead.
  *          Only use the function call for dynamically allocated mutexes.

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -35,8 +35,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#define MUTEX_LOCKED ((void*)-1)
-
 int _mutex_lock(mutex_t *mutex, int blocking)
 {
     unsigned irqstate = irq_disable();


### PR DESCRIPTION
This change adds support to statically initialize locked mutexs.