### PR TITLE
gnrc_netdev2_eth: check bytes_expected > 0

### DIFF
--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_eth.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_eth.c
@@ -35,7 +35,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netdev2_t *gnrc_netdev2)
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
     gnrc_pktsnip_t *pkt = NULL;
 
-    if (bytes_expected) {
+    if (bytes_expected > 0) {
         pkt = gnrc_pktbuf_add(NULL, NULL,
                 bytes_expected,
                 GNRC_NETTYPE_UNDEF);


### PR DESCRIPTION
`bytes_expected` should be greater than 0, because it is used to allocate pktbuf entries