### PR TITLE
ndp: sixlowpan_nd: import protocol constants

### DIFF
--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -31,9 +31,7 @@ extern "C" {
 
 /**
  * @name    Router advertisement flags
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.2">
- *          RFC 4861, section 4.2
- *      </a>
+ * @see     [RFC 4861, section 4.2](https://tools.ietf.org/html/rfc4861#section-4.2)
  * @{
  */
 #define NDP_RTR_ADV_FLAGS_MASK      (0xc0)
@@ -44,10 +42,31 @@ extern "C" {
  */
 
 /**
+ * @brief   Router advertisement constants
+ * @see     [RFC 4861, section 4.2](https://tools.ietf.org/html/rfc4861#section-4.2)
+ * @{
+ */
+#define NDP_RTR_ADV_CUR_HL_UNSPEC   (0) /**< current hop limit unspecified by advertising router */
+
+/**
+ * @brief   maximum router lifetime in seconds
+ * @see     [RFC 4861, section 6.2.1](https://tools.ietf.org/html/rfc4861#section-6.2.1)
+ */
+#define NDP_RTR_ADV_LTIME_SEC_MAX   (9000)
+
+/**
+ * @brief   router should not be a default router
+ * @see     [RFC 4861, section 6.2.1](https://tools.ietf.org/html/rfc4861#section-6.2.1)
+ */
+#define NDP_NBR_ADV_LTIME_NOT_DR    (0)
+
+#define NDP_NBR_ADV_REACH_TIME      (0)     /**< reachable time unspecified by advertising router */
+#define NDP_NBR_ADV_RETRANS_TIMER   (0)     /**< retrans. timer unspecified by advertising router */
+/** @} */
+
+/**
  * @name    Neighbor advertisement flags
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.4">
- *          RFC 4861, section 4.2
- *      </a>
+ * @see     [RFC 4861, section 4.2](https://tools.ietf.org/html/rfc4861#section-4.2)
  * @{
  */
 #define NDP_NBR_ADV_FLAGS_MASK      (0xe0)
@@ -61,9 +80,8 @@ extern "C" {
 /**
  * @name    NDP option types
  * @{
- * @see <a href="http://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-5">
- *          IANA, IPv6 Neighbor Discovery Option Formats
- *      </a>
+ * @see     [IANA, IPv6 Neighbor Discovery Option Formats]
+ *          (http://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-5")
  */
 #define NDP_OPT_SL2A                (1)     /**< source link-layer address option */
 #define NDP_OPT_TL2A                (2)     /**< target link-layer address option */
@@ -73,9 +91,7 @@ extern "C" {
 #define NDP_OPT_AR                  (33)    /**< address registration option */
 #define NDP_OPT_6CTX                (34)    /**< 6LoWPAN context option */
 #define NDP_OPT_ABR                 (35)    /**< authoritative border router option */
-/**
- * @}
- */
+/** @} */
 
 /**
  * @{
@@ -84,28 +100,69 @@ extern "C" {
 #define NDP_OPT_PI_FLAGS_MASK       (0xc0)
 #define NDP_OPT_PI_FLAGS_L          (0x80)  /**< on-link */
 #define NDP_OPT_PI_FLAGS_A          (0x40)  /**< autonomous address configuration */
+/** @} */
+
 /**
- * @}
+ * @{
+ * @name    Prefix information option constants
+ * @see     [RFC 4861, section 4.6.2](https://tools.ietf.org/html/rfc4861#section-4.6.2)
  */
+#define NDP_OPT_PI_VALID_LTIME_INF  (UINT32_MAX)    /**< infinite valid lifetime */
+#define NDP_OPT_PI_PREF_LTIME_INF   (UINT32_MAX)    /**< infinite preferred lifetime */
+/** @} */
 
 /**
  * @{
  * @name    Lengths for fixed length options
- * @brief   Options don't use bytes as their length unit, but 8 bytes.
+ * @note    Options don't use bytes as their length unit, but 8 bytes.
  */
 #define NDP_OPT_PI_LEN              (4U)
 #define NDP_OPT_MTU_LEN             (1U)
+/** @} */
+
 /**
- * @}
+ * @{
+ * @name    Router constants
+ * @see     [RFC 4861, section 10](https://tools.ietf.org/html/rfc4861#section-10)
  */
+#define NDP_MAX_INIT_RA_INTERVAL        (16000U)   /**< MAX_INITIAL_RTR_ADVERT_INTERVAL (in ms) */
+#define NDP_MAX_INIT_RA_NUMOF           (3U)       /**< MAX_INITIAL_RTR_ADVERTISEMENT */
+#define NDP_MAX_FIN_RA_NUMOF            (3U)       /**< MAX_FINAL_RTR_ADVERTISEMENT */
+#define NDP_MIN_MS_DELAY_BETWEEN_RAS    (3000U)    /**< MIN_DELAY_BETWEEN_RAS (in ms) */
+#define NDP_MAX_RA_DELAY                (500U)     /**< MAX_RA_DELAY_TIME (in ms) */
+/** @} */
+
+/**
+ * @{
+ * @name    Host constants
+ * @see     [RFC 4861, section 10](https://tools.ietf.org/html/rfc4861#section-10)
+ */
+#define NDP_MAX_RS_MS_DELAY         (1000U)     /**< MAX_RTR_SOLICITATION_DELAY (in ms) */
+#define NDP_RS_MS_INTERVAL          (4000U)     /**< RTR_SOLICITATION_INTERVAL (in ms) */
+#define NDP_MAX_RS_NUMOF            (3U)        /**< MAX_RTR_SOLICITATIONS */
+/** @} */
+
+/**
+ * @name    Node constants
+ * @see     [RFC 4861, section 10](https://tools.ietf.org/html/rfc4861#section-10)
+ * @{
+ */
+#define NDP_MAX_MC_SOL_NUMOF        (3U)        /**< MAX_MULTICAST_SOLICIT */
+#define NDP_MAX_UC_SOL_NUMOF        (3U)        /**< MAX_UNICAST_SOLICIT */
+#define NDP_MAX_ANYCAST_MS_DELAY    (1000U)     /**< MAX_ANYCAST_DELAY_TIME (in ms) */
+#define NDP_MAX_NA_NUMOF            (3U)        /**< MAX_NEIGHBOR_ADVERTISEMENT */
+#define NDP_REACH_MS                (30000U)    /**< REACHABLE_TIME (in ms) */
+#define NDP_RETRANS_TIMER_MS        (1000U)     /**< RETRANS_TIMER (in ms) */
+#define NDP_DELAY_FIRST_PROBE_MS    (5000U)     /**< DELAY_FIRST_PROBE_TIME (in ms) */
+#define NDP_MIN_RANDOM_FACTOR       (500U)      /**< MIN_RANDOM_FACTOR (x 1000) */
+#define NDP_MAX_RANDOM_FACTOR       (1500U)     /**< MAX_RANDOM_FACTOR (x 1000) */
+/** @} */
 
 /**
  * @brief   Router solicitation message format.
  * @extends icmpv6_hdr_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.1">
- *          RFC 4861, section 4.1
- *      </a>
+ * @see     [RFC 4861, section 4.1](https://tools.ietf.org/html/rfc4861#section-4.1)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< message type */
@@ -118,9 +175,7 @@ typedef struct __attribute__((packed)) {
  * @brief   Router advertisement message format.
  * @extends icmpv6_hdr_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.2">
- *          RFC 4861, section 4.2
- *      </a>
+ * @see     [RFC 4861, section 4.2](https://tools.ietf.org/html/rfc4861#section-4.2)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;                       /**< message type */
@@ -137,9 +192,7 @@ typedef struct __attribute__((packed)) {
  * @brief   Neighbor solicitation message format.
  * @extends icmpv6_hdr_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.3">
- *          RFC 4861, section 4.3
- *      </a>
+ * @see     [RFC 4861, section 4.3](https://tools.ietf.org/html/rfc4861#section-4.3)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< message type */
@@ -153,9 +206,7 @@ typedef struct __attribute__((packed)) {
  * @brief   Neighbor advertisement message format.
  * @extends icmpv6_hdr_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.4">
- *          RFC 4861, section 4.4
- *      </a>
+ * @see     [RFC 4861, section 4.4](https://tools.ietf.org/html/rfc4861#section-4.4)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< message type */
@@ -167,12 +218,10 @@ typedef struct __attribute__((packed)) {
 } ndp_nbr_adv_t;
 
 /**
- * @brief   Neighbor advertisement message format.
+ * @brief   Redirect message format.
  * @extends icmpv6_hdr_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.5">
- *          RFC 4861, section 4.5
- *      </a>
+ * @see     [RFC 4861, section 4.5](https://tools.ietf.org/html/rfc4861#section-4.5)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< message type */
@@ -185,9 +234,7 @@ typedef struct __attribute__((packed)) {
 
 /**
  * @brief   General NDP option format
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.6">
- *          RFC 4861, section 4.6
- *      </a>
+ * @see     [RFC 4861, section 4.6](https://tools.ietf.org/html/rfc4861#section-4.6)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;   /**< option type */
@@ -201,9 +248,7 @@ typedef struct __attribute__((packed)) {
  * @brief   Prefix information option format
  * @extends ndp_opt_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.6.2">
- *          RFC 4861, section 4.6.2
- *      </a>
+ * @see     [RFC 4861, section 4.6.2](https://tools.ietf.org/html/rfc4861#section-4.6.2)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;                   /**< option type */
@@ -220,9 +265,7 @@ typedef struct __attribute__((packed)) {
  * @brief   Redirected header option format
  * @extends ndp_opt_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.6.3">
- *          RFC 4861, section 4.6.3
- *      </a>
+ * @see     [RFC 4861, section 4.6.3](https://tools.ietf.org/html/rfc4861#section-4.6.3)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< option type */
@@ -234,9 +277,7 @@ typedef struct __attribute__((packed)) {
  * @brief   MTU option format
  * @extends ndp_opt_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc4861#section-4.6.4">
- *          RFC 4861, section 4.6.4
- *      </a>
+ * @see     [RFC 4861, section 4.6.4](https://tools.ietf.org/html/rfc4861#section-4.6.4)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< option type */

--- a/sys/include/net/sixlowpan/nd.h
+++ b/sys/include/net/sixlowpan/nd.h
@@ -11,9 +11,7 @@
  * @ingroup     net_sixlowpan
  * @brief       Message types and helper functions for Neighbor Discovery Optimization for 6LoWPAN
  *              (6LoWPAN-ND)
- * @see <a href="https://tools.ietf.org/html/rfc6775#section-4">
- *          RFC 6775, section 4
- *      </a>
+ * @see         [RFC 6775, section 4](https://tools.ietf.org/html/rfc6775#section-4)
  * @{
  *
  * @file
@@ -37,7 +35,7 @@ extern "C" {
 /**
  * @{
  * @name    Lengths for fixed length options
- * @brief   Options don't use bytes as their length unit, but 8 bytes.
+ * @note    Options don't use bytes as their length unit, but 8 bytes.
  */
 #define SIXLOWPAN_ND_OPT_AR_LEN                 (2U)
 #define SIXLOWPAN_ND_OPT_ABR_LEN                (3U)
@@ -47,11 +45,20 @@ extern "C" {
 
 /**
  * @{
+ * @name    Authoritative border router option constants
+ * @see     [RFC 6775, section 4.3](https://tools.ietf.org/html/rfc6775#section-4.3)
+ */
+/**
+ * @brief   Valid lifetime (in minutes) assumed if sixlowpan_nd_opt_abr_t::ltime
+ *          is 0.
+ */
+#define SIXLOWPAN_ND_OPT_ABR_LTIME_DEFAULT      (10000U)
+
+/**
+ * @{
  * @name    Status values for address registration option and DARs
  *
- * @see <a href="https://tools.ietf.org/html/rfc6775#section-4.1">
- *          RFC 6775, section 4.1
- *      </a>
+ * @see     [RFC 6775, section 4.1](https://tools.ietf.org/html/rfc6775#section-4.1)
  */
 #define SIXLOWPAN_ND_STATUS_SUCCESS             (0) /**< success */
 #define SIXLOWPAN_ND_STATUS_DUP                 (1) /**< duplicate address */
@@ -72,12 +79,53 @@ extern "C" {
  */
 
 /**
+ * @name    6LoWPAN border router constants
+ * @see     [RFC 6775, section 9](https://tools.ietf.org/html/rfc6775#section-9)
+ * @{
+ */
+#define SIXLOWPAN_ND_MIN_CTX_CHANGE_SEC_DELAY   (300U)  /**< MIN_CONTEXT_CHANGE_DELAY (in sec) */
+/** @} */
+
+/**
+ * @name    6LoWPAN router constants
+ * @see     [RFC 6775, section 9](https://tools.ietf.org/html/rfc6775#section-9)
+ * @{
+ */
+#define SIXLOWPAN_ND_MAX_RA_NUMOF               (3U)        /**< MAX_RTR_ADVERTISEMENTS */
+#define SIXLOWPAN_ND_MIN_MS_DELAY_BETWEEN_RAS   (10000U)    /**< MIN_DELAY_BETWEEN_RAS (in ms) */
+#define SIXLOWPAN_ND_MAX_RA_MS_DELAY            (2000U)     /**< MAX_RA_DELAY_TIME (in ms) */
+#define SIXLOWPAN_ND_TENTATIVE_NCE_SEC_LTIME    (20U)       /**< TENTATIVE_NCE_LIFETIME (in sec) */
+/** @} */
+
+/**
+ * @name    Router constants
+ * @see     [RFC 6775, section 9](https://tools.ietf.org/html/rfc6775#section-9)
+ * @{
+ */
+#define SIXLOWPAN_ND_MULTIHOP_HL                (64U)       /**< MULTIHOP_HOPLIMIT */
+/** @} */
+
+/**
+ * @name    Host constants
+ * @see     [RFC 6775, section 9](https://tools.ietf.org/html/rfc6775#section-9)
+ * @{
+ */
+/**
+ * @brief   RTR_SOLICITATION_INTERVAL (in msec)
+ */
+#define SIXLOWPAN_ND_RS_MSEC_INTERVAL           (10000U)
+#define SIXLOWPAN_ND_MAX_RS_NUMOF               (3U)        /**< MAX_RTR_SOLICITATIONS */
+/**
+ * @brief   MAX_RTR_SOLICITATIONS_INTERVAL (in seconds)
+ */
+#define SIXLOWPAN_ND_MAX_RS_SEC_INTERVAL        (60U)
+/** @} */
+
+/**
  * @brief   Duplicate address request and confirmation message format.
  * @extends icmpv6_hdr_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc6775#section-4.4">
- *          RFC 6775, section 4.4
- *      </a>
+ * @see     [RFC 6775, section 4.4](https://tools.ietf.org/html/rfc6775#section-4.4)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< message type */
@@ -94,9 +142,7 @@ typedef struct __attribute__((packed)) {
  * @brief   Address registration option format
  * @extends ndp_opt_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc6775#section-4.1">
- *          RFC 6775, section 4.1
- *      </a>
+ * @see     [RFC 6775, section 4.1](https://tools.ietf.org/html/rfc6775#section-4.1)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< option type */
@@ -112,9 +158,7 @@ typedef struct __attribute__((packed)) {
  * @brief   6LoWPAN context option format
  * @extends ndp_opt_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc6775#section-4.2">
- *          RFC 6775, section 4.2
- *      </a>
+ * @see     [RFC 6775, section 4.2](https://tools.ietf.org/html/rfc6775#section-4.2)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< option type */
@@ -129,9 +173,7 @@ typedef struct __attribute__((packed)) {
  * @brief   Authoritative border router option format
  * @extends ndp_opt_t
  *
- * @see <a href="https://tools.ietf.org/html/rfc6775#section-4.3">
- *          RFC 6775, section 4.3
- *      </a>
+ * @see     [RFC 6775, section 4.3](https://tools.ietf.org/html/rfc6775#section-4.3)
  */
 typedef struct __attribute__((packed)) {
     uint8_t type;           /**< option type */


### PR DESCRIPTION
For the new neighbor discovery I want the protocol related constants in
a central place (will remove the spread-out definitions of the old
implementation when I remove that one).

Also includes some doc fixes of the `ndp` and `sixlowpan_nd` module.