### PR TITLE
tools: static_tests.sh: rm dependency to 'riot' remote

### DIFF
--- a/dist/tools/static-tests.sh
+++ b/dist/tools/static-tests.sh
@@ -11,35 +11,15 @@
 cd "$(dirname "$0")/../../"
 
 function dep {
-    which $1 2>&1 1>/dev/null
+    command -v $1 2>&1 1>/dev/null
     if (( $? != 0 )); then
         echo "Dependency not met: $1"
         exit 1
     fi
 }
 
-function abort {
-    echo "$(tput setaf 1)$1$(tput sgr0)"
-    exit 1
-}
-
-function request_confirmation {
-    read -p "$(tput setaf 4)$1 (y/n) $(tput sgr0)"
-    [ "$REPLY" == "y" ] || abort "Aborted!"
-}
-
 # Make sure all required commands are available
 dep cppcheck
 dep pcregrep
 
-RIOT_REMOTE_COUNT="$(git remote | grep "^riot$" | wc -l)"
-if (( "$RIOT_REMOTE_COUNT" != 1 )); then
-    echo "The static test setup expect a remote called 'riot', pointing to the"
-    echo "central repository. This remote currently does not exist."
-    request_confirmation "Do you wish to create it?"
-
-    git remote add riot https://github.com/RIOT-OS/RIOT.git
-    git fetch riot
-fi
-
-BUILDTEST_MCU_GROUP=static-tests ./dist/tools/travis-scripts/build_and_test.sh
+BUILDTEST_MCU_GROUP=static-tests ./dist/tools/ci/build_and_test.sh


### PR DESCRIPTION
I have no idea why a `riot` remote is necessary for the static tests. I couldn't find any reference in the test scripts under `dist/tools`, but maybe I missed something?