### PR TITLE
emb6: prepare for #6211

### DIFF
--- a/pkg/emb6/patches/0002-Rename-colliding-files-and-functions.patch
+++ b/pkg/emb6/patches/0002-Rename-colliding-files-and-functions.patch
@@ -1,4 +1,4 @@
-From de750156c6f7f9d69f6974203b27aa22d5695bbb Mon Sep 17 00:00:00 2001
+From fe4bfbc5c6ae1524c34170bab2e1bcde263685a5 Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mail@martine-lenders.eu>
 Date: Thu, 4 Feb 2016 22:15:23 +0100
 Subject: [PATCH 2/4] Rename colliding files and functions
@@ -9,26 +9,26 @@ Subject: [PATCH 2/4] Rename colliding files and functions
  emb6/inc/net/ipv6/uip-ds6-route.h              |   2 +-
  emb6/inc/net/rpl/rpl-private.h                 |   2 +-
  emb6/inc/net/rpl/rpl.h                         |   2 +-
- emb6/src/apl/er-coap/er-coap-observe.c         |   2 +-
- emb6/src/apl/er-coap/er-coap-transactions.c    |   4 +-
+ emb6/src/apl/er-coap/er-coap-observe.c         |   4 +-
+ emb6/src/apl/er-coap/er-coap-transactions.c    |   6 +-
  emb6/src/apl/er-coap/er-coap.c                 |   2 +-
  emb6/src/apl/rest-engine/rest-engine.c         |   4 +-
  emb6/src/mac/framer-802154.c                   |   2 +-
  emb6/src/mac/sicslowmac.c                      |   2 +-
  emb6/src/net/ipv6/multicast/roll-tm.c          |   2 +-
  emb6/src/net/ipv6/multicast/smrf.c             |   2 +-
- emb6/src/net/ipv6/multicast/uip-mcast6-route.c |   4 +-
- emb6/src/net/ipv6/nbr-table.c                  |   4 +-
+ emb6/src/net/ipv6/multicast/uip-mcast6-route.c |   6 +-
+ emb6/src/net/ipv6/nbr-table.c                  |   6 +-
  emb6/src/net/ipv6/uip-ds6-nbr.c                |   2 +-
- emb6/src/net/ipv6/uip-ds6-route.c              |   6 +-
+ emb6/src/net/ipv6/uip-ds6-route.c              |  16 +--
  emb6/src/net/ipv6/uip-ds6.c                    |   6 +-
- emb6/src/net/ipv6/uip-icmp6.c                  |   4 +-
- emb6/src/net/ipv6/uip-nameserver.c             |   4 +-
+ emb6/src/net/ipv6/uip-icmp6.c                  |   6 +-
+ emb6/src/net/ipv6/uip-nameserver.c             |   8 +-
  emb6/src/net/ipv6/uip-nd6.c                    |   2 +-
  emb6/src/net/rpl/rpl-dag.c                     |   2 +-
  emb6/src/net/rpl/rpl-timers.c                  |   2 +-
  emb6/src/net/sicslowpan/sicslowpan.c           |   2 +-
- emb6/src/tport/tcp-socket.c                    |   4 +-
+ emb6/src/tport/tcp-socket.c                    |   6 +-
  emb6/src/tport/udp-socket.c                    |   2 +-
  target/bsp/bsp.c                               |   2 +-
  target/if/at86rf212b/at86rf212b.c              |   2 +-
@@ -39,16 +39,16 @@ Subject: [PATCH 2/4] Rename colliding files and functions
  utils/inc/random.h                             |  57 ---------
  utils/inc/ringbuffer.h                         | 162 ------------------------
  utils/inc/timer.h                              |   4 +-
- utils/src/ctimer.c                             |   8 +-
- utils/src/etimer.c                             |   6 +-
+ utils/src/ctimer.c                             |  16 +--
+ utils/src/etimer.c                             |  12 +-
  utils/src/evproc.c                             |   2 +-
- utils/src/list.c                               |   4 +-
- utils/src/mmem.c                               |   4 +-
- utils/src/queuebuf.c                           |   4 +-
+ utils/src/list.c                               |  10 +-
+ utils/src/mmem.c                               |   6 +-
+ utils/src/queuebuf.c                           |   6 +-
  utils/src/random.c                             |   2 +-
  utils/src/ringbuffer.c                         |   2 +-
  utils/src/timer.c                              |   6 +-
- 44 files changed, 442 insertions(+), 442 deletions(-)
+ 44 files changed, 467 insertions(+), 467 deletions(-)
  delete mode 100644 utils/inc/clist.h
  create mode 100644 utils/inc/emb6_clist.h
  create mode 100644 utils/inc/emb6_random.h
@@ -66,7 +66,7 @@ index 2912049..682b7c2 100644
  #include "ctimer.h"
 -#include "random.h"
 +#include "emb6_random.h"
-
+ 
  #if NETSTACK_CONF_WITH_IPV6
  #include "uip-ds6.h"
 diff --git a/emb6/inc/apl/rest-engine/rest-engine.h b/emb6/inc/apl/rest-engine/rest-engine.h
@@ -75,34 +75,34 @@ index 2c16c2b..fc0dca5 100644
 +++ b/emb6/inc/apl/rest-engine/rest-engine.h
 @@ -41,7 +41,7 @@
  #define REST_ENGINE_H_
-
-
+ 
+ 
 -#include "clist.h"
 +#include "emb6_clist.h"
  #include "etimer.h"
-
-
+ 
+ 
 diff --git a/emb6/inc/net/ipv6/uip-ds6-route.h b/emb6/inc/net/ipv6/uip-ds6-route.h
 index 000b327..31ed0e9 100644
 --- a/emb6/inc/net/ipv6/uip-ds6-route.h
 +++ b/emb6/inc/net/ipv6/uip-ds6-route.h
 @@ -42,7 +42,7 @@
  #define UIP_DS6_ROUTE_H
-
+ 
  #include "stimer.h"
 -#include "clist.h"
 +#include "emb6_clist.h"
-
+ 
  void uip_ds6_route_init(void);
-
+ 
 diff --git a/emb6/inc/net/rpl/rpl-private.h b/emb6/inc/net/rpl/rpl-private.h
 index 9da5744..5ded041 100644
 --- a/emb6/inc/net/rpl/rpl-private.h
 +++ b/emb6/inc/net/rpl/rpl-private.h
 @@ -39,7 +39,7 @@
-
+ 
  #include "rpl.h"
-
+ 
 -#include "clist.h"
 +#include "emb6_clist.h"
  #include "uip.h"
@@ -115,14 +115,14 @@ index 574ca5e..7269948 100644
 @@ -41,7 +41,7 @@
  #include "emb6_conf.h"
  #include "emb6.h"
-
+ 
 -#include "clist.h"
 +#include "emb6_clist.h"
  #include "uip.h"
  #include "uip-ds6.h"
  #include "ctimer.h"
 diff --git a/emb6/src/apl/er-coap/er-coap-observe.c b/emb6/src/apl/er-coap/er-coap-observe.c
-index 57754ac..6be690e 100644
+index 57754ac..84659a9 100644
 --- a/emb6/src/apl/er-coap/er-coap-observe.c
 +++ b/emb6/src/apl/er-coap/er-coap-observe.c
 @@ -80,7 +80,7 @@ coap_add_observer(uip_ipaddr_t *addr, uint16_t port, const uint8_t *token,
@@ -132,10 +132,19 @@ index 57754ac..6be690e 100644
 -    list_add(observers_list, o);
 +    emb6_list_add(observers_list, o);
    }
-
+ 
    return o;
+@@ -95,7 +95,7 @@ coap_remove_observer(coap_observer_t *o)
+          o->token[1]);
+ 
+   memb_free(&observers_memb, o);
+-  list_remove(observers_list, o);
++  emb6_list_remove(observers_list, o);
+ }
+ /*---------------------------------------------------------------------------*/
+ int
 diff --git a/emb6/src/apl/er-coap/er-coap-transactions.c b/emb6/src/apl/er-coap/er-coap-transactions.c
-index e40f4c9..4b3ffe1 100644
+index e40f4c9..7cbf254 100644
 --- a/emb6/src/apl/er-coap/er-coap-transactions.c
 +++ b/emb6/src/apl/er-coap/er-coap-transactions.c
 @@ -43,7 +43,7 @@
@@ -144,18 +153,27 @@ index e40f4c9..4b3ffe1 100644
  #include "memb.h"
 -#include "random.h"
 +#include "emb6_random.h"
-
+ 
  #include "tcpip.h"
-
+ 
 @@ -84,7 +84,7 @@ coap_new_transaction(uint16_t mid, uip_ipaddr_t *addr, uint16_t port)
      t->addr = *addr;
      t->port = port;
-
+ 
 -    list_add(transactions_list, t); /* list itself makes sure same element is not added twice */
 +    emb6_list_add(transactions_list, t); /* list itself makes sure same element is not added twice */
    }
-
+ 
    return t;
+@@ -148,7 +148,7 @@ coap_clear_transaction(coap_transaction_t *t)
+     PRINTF("Freeing transaction %u: %p\n\r", t->mid, t);
+ 
+     etimer_stop(&t->retrans_timer);
+-    list_remove(transactions_list, t);
++    emb6_list_remove(transactions_list, t);
+     memb_free(&transactions_memb, t);
+   }
+ }
 diff --git a/emb6/src/apl/er-coap/er-coap.c b/emb6/src/apl/er-coap/er-coap.c
 index 40f6874..a8125a2 100644
 --- a/emb6/src/apl/er-coap/er-coap.c
@@ -163,10 +181,10 @@ index 40f6874..a8125a2 100644
 @@ -39,7 +39,7 @@
  #include <string.h>
  #include <stdio.h>
-
+ 
 -#include "random.h"
 +#include "emb6_random.h"
-
+ 
  #include "er-coap.h"
  #include "er-coap-transactions.h"
 diff --git a/emb6/src/apl/rest-engine/rest-engine.c b/emb6/src/apl/rest-engine/rest-engine.c
@@ -179,9 +197,9 @@ index fd8d1ba..818f326 100644
    struct periodic_resource_s * periodic = resource->un_handler.periodic;
 -  list_add(restful_services, resource);
 +  emb6_list_add(restful_services, resource);
-
+ 
    PRINTF("Activating: %s\n\r", resource->url);
-
+ 
 @@ -112,7 +112,7 @@ rest_activate_resource(resource_t *resource, char *path)
    if((resource->flags & IS_PERIODIC) && periodic->periodic_handler
       && periodic->period) {
@@ -189,7 +207,7 @@ index fd8d1ba..818f326 100644
 -    list_add(restful_periodic_services, periodic);
 +    emb6_list_add(restful_periodic_services, periodic);
    }
-
+ 
    for(periodic_resource =
 diff --git a/emb6/src/mac/framer-802154.c b/emb6/src/mac/framer-802154.c
 index f99486d..359ee6b 100644
@@ -201,9 +219,9 @@ index f99486d..359ee6b 100644
  #include "packetbuf.h"
 -#include "random.h"
 +#include "emb6_random.h"
-
-
-
+ 
+ 
+ 
 diff --git a/emb6/src/mac/sicslowmac.c b/emb6/src/mac/sicslowmac.c
 index 7219fa8..c741131 100644
 --- a/emb6/src/mac/sicslowmac.c
@@ -214,9 +232,9 @@ index 7219fa8..c741131 100644
  #include "queuebuf.h"
 -#include "random.h"
 +#include "emb6_random.h"
-
+ 
  #define DEBUG DEBUG_NONE
-
+ 
 diff --git a/emb6/src/net/ipv6/multicast/roll-tm.c b/emb6/src/net/ipv6/multicast/roll-tm.c
 index 8fb1717..8b36300 100644
 --- a/emb6/src/net/ipv6/multicast/roll-tm.c
@@ -229,7 +247,7 @@ index 8fb1717..8b36300 100644
 +#include "emb6_random.h"
  //#include "dev/watchdog.h"
  //#include <string.h>
-
+ 
 diff --git a/emb6/src/net/ipv6/multicast/smrf.c b/emb6/src/net/ipv6/multicast/smrf.c
 index 474c41d..9b4a3a5 100644
 --- a/emb6/src/net/ipv6/multicast/smrf.c
@@ -241,10 +259,10 @@ index 474c41d..9b4a3a5 100644
 -#include "random.h"
 +#include "emb6_random.h"
  //#include "net/netstack.h"
-
+ 
  #define DEBUG DEBUG_NONE
 diff --git a/emb6/src/net/ipv6/multicast/uip-mcast6-route.c b/emb6/src/net/ipv6/multicast/uip-mcast6-route.c
-index aa0caff..55d245d 100644
+index aa0caff..995ff0c 100644
 --- a/emb6/src/net/ipv6/multicast/uip-mcast6-route.c
 +++ b/emb6/src/net/ipv6/multicast/uip-mcast6-route.c
 @@ -43,7 +43,7 @@
@@ -263,10 +281,19 @@ index aa0caff..55d245d 100644
 -    list_add(mcast_route_list, locmcastrt);
 +    emb6_list_add(mcast_route_list, locmcastrt);
    }
-
+ 
    /* Reaching here means we either found the prefix or allocated a new one */
+@@ -106,7 +106,7 @@ uip_mcast6_route_rm(uip_mcast6_route_t *route)
+       locmcastrt != NULL;
+       locmcastrt = list_item_next(locmcastrt)) {
+     if(locmcastrt == route) {
+-      list_remove(mcast_route_list, route);
++      emb6_list_remove(mcast_route_list, route);
+       memb_free(&mcast_route_memb, route);
+       return;
+     }
 diff --git a/emb6/src/net/ipv6/nbr-table.c b/emb6/src/net/ipv6/nbr-table.c
-index 7dedece..3719135 100644
+index 7dedece..d72c1c9 100644
 --- a/emb6/src/net/ipv6/nbr-table.c
 +++ b/emb6/src/net/ipv6/nbr-table.c
 @@ -41,7 +41,7 @@
@@ -276,15 +303,24 @@ index 7dedece..3719135 100644
 -#include "clist.h"
 +#include "emb6_clist.h"
  #include "nbr-table.h"
-
+ 
  /* List of link-layer addresses of the neighbors, used as key in the tables */
+@@ -221,7 +221,7 @@ nbr_table_allocate(void)
+       /* Empty used map */
+       used_map[index_from_key(least_used_key)] = 0;
+       /* Remove neighbor from list */
+-      list_remove(nbr_table_keys, least_used_key);
++      emb6_list_remove(nbr_table_keys, least_used_key);
+       /* Return associated key */
+       return least_used_key;
+     }
 @@ -295,7 +295,7 @@ nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr)
      }
-
+ 
      /* Add neighbor to list */
 -    list_add(nbr_table_keys, key);
 +    emb6_list_add(nbr_table_keys, key);
-
+ 
      /* Get index from newly allocated neighbor */
      index = index_from_key(key);
 diff --git a/emb6/src/net/ipv6/uip-ds6-nbr.c b/emb6/src/net/ipv6/uip-ds6-nbr.c
@@ -301,19 +337,19 @@ index 360fdbc..53ad8da 100644
  #include "packetbuf.h"
  #include "uip-ds6-nbr.h"
 diff --git a/emb6/src/net/ipv6/uip-ds6-route.c b/emb6/src/net/ipv6/uip-ds6-route.c
-index c732f78..0bd1da5 100644
+index c732f78..e54a18f 100644
 --- a/emb6/src/net/ipv6/uip-ds6-route.c
 +++ b/emb6/src/net/ipv6/uip-ds6-route.c
 @@ -42,7 +42,7 @@
  #include "uip-ds6.h"
  #include "uip.h"
-
+ 
 -#include "clist.h"
 +#include "emb6_clist.h"
  #include "memb.h"
  #include "nbr-table.h"
-
-@@ -133,7 +133,7 @@ uip_ds6_notification_add(struct uip_ds6_notification *n,
+ 
+@@ -133,14 +133,14 @@ uip_ds6_notification_add(struct uip_ds6_notification *n,
  {
    if(n != NULL && c != NULL) {
      n->callback = c;
@@ -322,15 +358,59 @@ index c732f78..0bd1da5 100644
    }
  }
  /*---------------------------------------------------------------------------*/
+ void
+ uip_ds6_notification_rm(struct uip_ds6_notification *n)
+ {
+-  list_remove(notificationlist, n);
++  emb6_list_remove(notificationlist, n);
+ }
+ #endif
+ /*---------------------------------------------------------------------------*/
+@@ -249,7 +249,7 @@ uip_ds6_route_lookup(uip_ipaddr_t *addr)
+          list. The list is ordered by how recently we looked them up:
+          the least recently used route will be at the end of the
+          list - for fast lookups (assuming multiple packets to the same node). */
+-      list_remove(routelist, found_route);
++      emb6_list_remove(routelist, found_route);
+       list_push(routelist, found_route);
+   }
+ 
 @@ -375,7 +375,7 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
-
+ 
      nbrr->route = r;
      /* Add the route to this neighbor */
 -    list_add(routes->route_list, nbrr);
 +    emb6_list_add(routes->route_list, nbrr);
      r->neighbor_routes = routes;
      num_routes++;
-
+ 
+@@ -421,7 +421,7 @@ uip_ds6_route_rm(uip_ds6_route_t *route)
+     PRINTF("\n\r");
+ 
+     /* Remove the route from the route list */
+-    list_remove(routelist, route);
++    emb6_list_remove(routelist, route);
+ 
+     /* Find the corresponding neighbor_route and remove it. */
+     for(neighbor_route = list_head(route->neighbor_routes->route_list);
+@@ -433,7 +433,7 @@ uip_ds6_route_rm(uip_ds6_route_t *route)
+         uip_debug_ipaddr_print(&route->ipaddr);
+         PRINTF("\n");
+     }
+-    list_remove(route->neighbor_routes->route_list, neighbor_route);
++    emb6_list_remove(route->neighbor_routes->route_list, neighbor_route);
+     if(list_head(route->neighbor_routes->route_list) == NULL) {
+       /* If this was the only route using this neighbor, remove the
+          neibhor from the table */
+@@ -581,7 +581,7 @@ uip_ds6_defrt_rm(uip_ds6_defrt_t *defrt)
+       d = list_item_next(d)) {
+     if(d == defrt) {
+       PRINTF("Removing default route\n\r");
+-      list_remove(defaultrouterlist, defrt);
++      emb6_list_remove(defaultrouterlist, defrt);
+       memb_free(&defaultroutermemb, defrt);
+       ANNOTATE("#L %u 0\n\r", defrt->ipaddr.u8[sizeof(uip_ipaddr_t) - 1]);
+ #if UIP_DS6_NOTIFICATIONS
 diff --git a/emb6/src/net/ipv6/uip-ds6.c b/emb6/src/net/ipv6/uip-ds6.c
 index 0e2f16a..ad3f4cd 100644
 --- a/emb6/src/net/ipv6/uip-ds6.c
@@ -363,7 +443,7 @@ index 0e2f16a..ad3f4cd 100644
      return;
    }
 diff --git a/emb6/src/net/ipv6/uip-icmp6.c b/emb6/src/net/ipv6/uip-icmp6.c
-index 00828a3..484d0bf 100644
+index 00828a3..2d8b485 100644
 --- a/emb6/src/net/ipv6/uip-icmp6.c
 +++ b/emb6/src/net/ipv6/uip-icmp6.c
 @@ -114,7 +114,7 @@ uip_icmp6_input(uint8_t type, uint8_t icode)
@@ -375,7 +455,7 @@ index 00828a3..484d0bf 100644
  }
  /*---------------------------------------------------------------------------*/
  static void
-@@ -393,7 +393,7 @@ uip_icmp6_echo_reply_callback_add(struct uip_icmp6_echo_reply_notification *n,
+@@ -393,14 +393,14 @@ uip_icmp6_echo_reply_callback_add(struct uip_icmp6_echo_reply_notification *n,
  {
      if(n != NULL && c != NULL) {
          n->callback = c;
@@ -384,8 +464,16 @@ index 00828a3..484d0bf 100644
      }
  }
  /*---------------------------------------------------------------------------*/
+ void
+ uip_icmp6_echo_reply_callback_rm(struct uip_icmp6_echo_reply_notification *n)
+ {
+-    list_remove(echo_reply_callback_list, n);
++    emb6_list_remove(echo_reply_callback_list, n);
+ }
+ /*---------------------------------------------------------------------------*/
+ UIP_ICMP6_HANDLER(echo_request_handler, ICMP6_ECHO_REQUEST,
 diff --git a/emb6/src/net/ipv6/uip-nameserver.c b/emb6/src/net/ipv6/uip-nameserver.c
-index 9701b26..175e2be 100644
+index 9701b26..4d1d6d3 100644
 --- a/emb6/src/net/ipv6/uip-nameserver.c
 +++ b/emb6/src/net/ipv6/uip-nameserver.c
 @@ -46,7 +46,7 @@
@@ -395,10 +483,10 @@ index 9701b26..175e2be 100644
 -#include "clist.h"
 +#include "emb6_clist.h"
  #include "memb.h"
-
+ 
  #include <string.h>
 @@ -113,7 +113,7 @@ uip_nameserver_update(uip_ipaddr_t *nameserver, uint32_t lifetime)
-
+ 
    if(e == NULL) {
      if((e = memb_alloc(&dnsmemb)) != NULL) {
 -      list_add(dns, e);
@@ -406,6 +494,24 @@ index 9701b26..175e2be 100644
      } else {
        uip_nameserver_record *p;
        for(e = list_head(dns), p = list_head(dns); p != NULL;
+@@ -130,7 +130,7 @@ uip_nameserver_update(uip_ipaddr_t *nameserver, uint32_t lifetime)
+   if(e != NULL) {
+     if(lifetime == 0) {
+       memb_free(&dnsmemb, e);
+-      list_remove(dns, e);
++      emb6_list_remove(dns, e);
+     } else {
+       e->added = bsp_getTick();
+       e->lifetime = lifetime;
+@@ -154,7 +154,7 @@ purge(void)
+   uint32_t time = bsp_getTick();
+   for(e = list_head(dns); e != NULL; e = list_item_next(e)) {
+     if(DNS_EXPIRATION(e) < time) {
+-      list_remove(dns, e);
++      emb6_list_remove(dns, e);
+       memb_free(&dnsmemb, e);
+       e = list_head(dns);
+     }
 diff --git a/emb6/src/net/ipv6/uip-nd6.c b/emb6/src/net/ipv6/uip-nd6.c
 index 8758a8f..f04b6b3 100644
 --- a/emb6/src/net/ipv6/uip-nd6.c
@@ -416,7 +522,7 @@ index 8758a8f..f04b6b3 100644
  #include "bsp.h"
 -#include "random.h"
 +#include "emb6_random.h"
-
+ 
  /*------------------------------------------------------------------*/
  #define DEBUG DEBUG_NONE
 diff --git a/emb6/src/net/rpl/rpl-dag.c b/emb6/src/net/rpl/rpl-dag.c
@@ -431,7 +537,7 @@ index cc11eab..4a85b70 100644
 +#include "emb6_clist.h"
  #include "memb.h"
  #include "ctimer.h"
-
+ 
 diff --git a/emb6/src/net/rpl/rpl-timers.c b/emb6/src/net/rpl/rpl-timers.c
 index 9b235d4..439b45d 100644
 --- a/emb6/src/net/rpl/rpl-timers.c
@@ -443,14 +549,14 @@ index 9b235d4..439b45d 100644
 -#include "random.h"
 +#include "emb6_random.h"
  #include "ctimer.h"
-
+ 
  #define DEBUG DEBUG_NONE
 diff --git a/emb6/src/net/sicslowpan/sicslowpan.c b/emb6/src/net/sicslowpan/sicslowpan.c
 index 8c909cf..79afefe 100644
 --- a/emb6/src/net/sicslowpan/sicslowpan.c
 +++ b/emb6/src/net/sicslowpan/sicslowpan.c
 @@ -1738,7 +1738,7 @@ input(void)
-
+ 
        sicslowpan_len = frag_size;
        reass_tag = frag_tag;
 -      timer_set(&reass_timer, SICSLOWPAN_REASS_MAXAGE * bsp_get(E_BSP_GET_TRES));
@@ -459,17 +565,17 @@ index 8c909cf..79afefe 100644
               sicslowpan_len, reass_tag);
        linkaddr_copy(&frag_sender, packetbuf_addr(PACKETBUF_ADDR_SENDER));
 diff --git a/emb6/src/tport/tcp-socket.c b/emb6/src/tport/tcp-socket.c
-index 3974bad..e5702a6 100644
+index 3974bad..05490f6 100644
 --- a/emb6/src/tport/tcp-socket.c
 +++ b/emb6/src/tport/tcp-socket.c
 @@ -31,7 +31,7 @@
-
+ 
  #include "emb6.h"
  #include "bsp.h"
 -#include "clist.h"
 +#include "emb6_clist.h"
  #include "etimer.h"
-
+ 
  #include "tcp-socket.h"
 @@ -276,7 +276,7 @@ tcp_socket_register(struct tcp_socket *s, void *ptr,
    s->output_data_maxlen = output_databuf_len;
@@ -477,15 +583,24 @@ index 3974bad..e5702a6 100644
    s->event_callback = event_callback;
 -  list_add(socketlist, s);
 +  emb6_list_add(socketlist, s);
-
+ 
    s->listen_port = 0;
    s->flags = TCP_SOCKET_FLAGS_NONE;
+@@ -386,7 +386,7 @@ tcp_socket_unregister(struct tcp_socket *s)
+   if(s->c != NULL) {
+     tcp_attach(s->c, NULL);
+   }
+-  list_remove(socketlist, s);
++  emb6_list_remove(socketlist, s);
+   return 1;
+ }
+ /*---------------------------------------------------------------------------*/
 diff --git a/emb6/src/tport/udp-socket.c b/emb6/src/tport/udp-socket.c
 index be27a5f..545f6bd 100644
 --- a/emb6/src/tport/udp-socket.c
 +++ b/emb6/src/tport/udp-socket.c
 @@ -31,7 +31,7 @@
-
+ 
  #include "emb6.h"
  #include "bsp.h"
 -#include "clist.h"
@@ -499,7 +614,7 @@ index 85c9976..bf266b8 100644
 +++ b/target/bsp/bsp.c
 @@ -63,7 +63,7 @@
  #include "board_conf.h"
-
+ 
  #include "etimer.h"
 -#include "random.h"
 +#include "emb6_random.h"
@@ -513,10 +628,10 @@ index aba87d5..c059568 100644
 @@ -67,7 +67,7 @@
  #include "ctimer.h"
  #include "packetbuf.h"
-
+ 
 -#include "ringbuffer.h"
 +#include "emb6_ringbuffer.h"
-
+ 
  /*==============================================================================
                                       MACROS
 diff --git a/utils/inc/clist.h b/utils/inc/clist.h
@@ -611,7 +726,7 @@ index 0e26be8..0000000
 - *
 - * The list variable is declared as static to make it easy to use in a
 - * single C module without unnecessarily exporting the name to other
-- * modules.
+- * modules. 
 - *
 - * \param name The name of the list.
 - */
@@ -690,7 +805,7 @@ index 0e26be8..0000000
 -/** @} */
 diff --git a/utils/inc/emb6_clist.h b/utils/inc/emb6_clist.h
 new file mode 100644
-index 0000000..f65f01e
+index 0000000..a104f29
 --- /dev/null
 +++ b/utils/inc/emb6_clist.h
 @@ -0,0 +1,163 @@
@@ -750,7 +865,7 @@ index 0000000..f65f01e
 + * Lists can be manipulated by inserting or removing elements from
 + * either sides of the list (list_push(), emb6_list_add(), list_pop(),
 + * list_chop()). A specified element can also be removed from inside a
-+ * list with list_remove(). The head and tail of a list can be
++ * list with emb6_list_remove(). The head and tail of a list can be
 + * extracted using list_head() and list_tail(), respectively.
 + *
 + * @{
@@ -780,7 +895,7 @@ index 0000000..f65f01e
 + *
 + * The list variable is declared as static to make it easy to use in a
 + * single C module without unnecessarily exporting the name to other
-+ * modules.
++ * modules. 
 + *
 + * \param name The name of the list.
 + */
@@ -842,7 +957,7 @@ index 0000000..f65f01e
 +void * list_chop(list_t list);
 +
 +void   emb6_list_add(list_t list, void *item);
-+void   list_remove(list_t list, void *item);
++void   emb6_list_remove(list_t list, void *item);
 +
 +int    list_length(list_t list);
 +
@@ -1335,14 +1450,14 @@ index ca34bf5..ac1e354 100644
 @@ -93,7 +93,7 @@ struct timer {
    clock_time_t interval;
  };
-
+ 
 -void timer_set(struct timer *t, clock_time_t interval);
 +void timer_emb6_set(struct timer *t, clock_time_t interval);
  void timer_reset(struct timer *t);
  void timer_restart(struct timer *t);
  int timer_expired(struct timer *t);
 diff --git a/utils/src/ctimer.c b/utils/src/ctimer.c
-index 9ef215e..9e0f465 100644
+index 9ef215e..723534b 100644
 --- a/utils/src/ctimer.c
 +++ b/utils/src/ctimer.c
 @@ -66,7 +66,7 @@
@@ -1351,58 +1466,91 @@ index 9ef215e..9e0f465 100644
  #include "timer.h"
 -#include "clist.h"
 +#include "emb6_clist.h"
-
+ 
  /*==============================================================================
                               LOCAL MACROS
+@@ -102,7 +102,7 @@ void ctimer_refresh(c_event_t event, void * data)
+         pst_cTim != NULL; \
+         pst_cTim = pst_cTim->next) {
+       if(&pst_cTim->etimer == data) {
+-          list_remove(gp_ctimList, pst_cTim);
++          emb6_list_remove(gp_ctimList, pst_cTim);
+           if(pst_cTim->f != NULL) {
+               pst_cTim->f(pst_cTim->ptr);
+           }
 @@ -143,7 +143,7 @@ void ctimer_set(struct ctimer *c, clock_time_t t,
          c->etimer.timer.interval = t;
      }
-
+ 
 -    list_add(gp_ctimList, c);
 +    emb6_list_add(gp_ctimList, c);
  }
  /*============================================================================*/
  /*  ctimer_reset()                                                     */
-@@ -155,7 +155,7 @@ void ctimer_reset(struct ctimer *c)
+@@ -154,8 +154,8 @@ void ctimer_reset(struct ctimer *c)
+     etimer_reset(&c->etimer);
    }
-
-   list_remove(gp_ctimList, c);
+ 
+-  list_remove(gp_ctimList, c);
 -  list_add(gp_ctimList, c);
++  emb6_list_remove(gp_ctimList, c);
 +  emb6_list_add(gp_ctimList, c);
  }
  /*============================================================================*/
  /*  ctimer_restart()                                                     */
-@@ -167,7 +167,7 @@ void ctimer_restart(struct ctimer *c)
+@@ -166,8 +166,8 @@ void ctimer_restart(struct ctimer *c)
+     etimer_restart(&c->etimer);
    }
-
-   list_remove(gp_ctimList, c);
+ 
+-  list_remove(gp_ctimList, c);
 -  list_add(gp_ctimList, c);
++  emb6_list_remove(gp_ctimList, c);
 +  emb6_list_add(gp_ctimList, c);
  }
  /*============================================================================*/
  /*  ctimer_stop()                                                     */
+@@ -180,7 +180,7 @@ void ctimer_stop(struct ctimer *pst_stopTim)
+         pst_stopTim->etimer.next = NULL;
+         pst_stopTim->etimer.active = TMR_NOT_ACTIVE;
+     }
+-    list_remove(gp_ctimList, pst_stopTim);
++    emb6_list_remove(gp_ctimList, pst_stopTim);
+ }
+ /*============================================================================*/
+ /*  ctimer_expired()                                                     */
 diff --git a/utils/src/etimer.c b/utils/src/etimer.c
-index e29c533..4661ab0 100644
+index e29c533..59ba8d8 100644
 --- a/utils/src/etimer.c
 +++ b/utils/src/etimer.c
 @@ -62,7 +62,7 @@
  ==============================================================================*/
-
+ 
  #include "etimer.h"
 -#include "clist.h"
 +#include "emb6_clist.h"
-
+ 
  #include "emb6_conf.h"
  #include "emb6.h"
-@@ -98,7 +98,7 @@ static     char         gc_init = 0;
+@@ -97,8 +97,8 @@ static     char         gc_init = 0;
+ /*============================================================================*/
  static void _etimer_addTimer(struct etimer *pst_timer)
  {
-     list_remove(gp_etimList, pst_timer);
+-    list_remove(gp_etimList, pst_timer);
 -    list_add(gp_etimList, pst_timer);
++    emb6_list_remove(gp_etimList, pst_timer);
 +    emb6_list_add(gp_etimList, pst_timer);
      pst_timer->active = TMR_ACTIVE;
  }
-
+ 
+@@ -151,7 +151,7 @@ void etimer_request_poll(void)
+             // Generate timer expired event
+             evproc_putEvent(E_EVPROC_TAIL,EVENT_TYPE_TIMER_EXP,pst_tTim);
+             // Remove matched timer from the list
+-            list_remove(gp_etimList, pst_tTim);
++            emb6_list_remove(gp_etimList, pst_tTim);
+             // Change active flag
+             pst_tTim->active = TMR_NOT_ACTIVE;
+         } /* if */
 @@ -164,7 +164,7 @@ void etimer_request_poll(void)
  /*============================================================================*/
  void etimer_set(struct etimer *pst_et, clock_time_t l_interval, pfn_callback_t pfn_callback)
@@ -1412,33 +1560,42 @@ index e29c533..4661ab0 100644
      _etimer_addTimer(pst_et);
      evproc_regCallback(EVENT_TYPE_TIMER_EXP, pfn_callback);
      LOG_INFO("add new timer %p\n\r",pst_et);
+@@ -244,7 +244,7 @@ clock_time_t etimer_next_expiration_time(void)
+ /*============================================================================*/
+ void etimer_stop(struct etimer *pst_et)
+ {
+-    list_remove(gp_etimList, pst_et);
++    emb6_list_remove(gp_etimList, pst_et);
+     pst_et->active = TMR_NOT_ACTIVE;
+ } /* etimer_stop() */
+ 
 diff --git a/utils/src/evproc.c b/utils/src/evproc.c
 index 585b027..9544f0f 100644
 --- a/utils/src/evproc.c
 +++ b/utils/src/evproc.c
 @@ -62,7 +62,7 @@
-
+ 
  #include "bsp.h"
  #include "evproc.h"
 -#include "clist.h"
 +#include "emb6_clist.h"
  #include "logger.h"
-
+ 
  /*==============================================================================
 diff --git a/utils/src/list.c b/utils/src/list.c
-index 38d006f..d6fedd8 100644
+index 38d006f..270da21 100644
 --- a/utils/src/list.c
 +++ b/utils/src/list.c
 @@ -46,7 +46,7 @@
   *
   */
-
+ 
 -#include "clist.h"
 +#include "emb6_clist.h"
-
+ 
  #define NULL 0
-
-@@ -141,7 +141,7 @@ list_tail(list_t list)
+ 
+@@ -141,12 +141,12 @@ list_tail(list_t list)
   *
   */
  void
@@ -1446,42 +1603,75 @@ index 38d006f..d6fedd8 100644
 +emb6_list_add(list_t list, void *item)
  {
    struct list *l;
-
+ 
+   /* Make sure not to add the same element twice */
+-  list_remove(list, item);
++  emb6_list_remove(list, item);
+ 
+   ((struct list *)item)->next = NULL;
+   
+@@ -168,7 +168,7 @@ list_push(list_t list, void *item)
+   /*  struct list *l;*/
+ 
+   /* Make sure not to add the same element twice */
+-  list_remove(list, item);
++  emb6_list_remove(list, item);
+ 
+   ((struct list *)item)->next = *list;
+   *list = item;
+@@ -238,7 +238,7 @@ list_pop(list_t list)
+  */
+ /*---------------------------------------------------------------------------*/
+ void
+-list_remove(list_t list, void *item)
++emb6_list_remove(list_t list, void *item)
+ {
+   struct list *l, *r;
+   
 diff --git a/utils/src/mmem.c b/utils/src/mmem.c
-index 795af1d..f2e3ddc 100644
+index 795af1d..d88471a 100644
 --- a/utils/src/mmem.c
 +++ b/utils/src/mmem.c
 @@ -45,7 +45,7 @@
-
-
+ 
+ 
  #include "mmem.h"
 -#include "clist.h"
 +#include "emb6_clist.h"
  //#include "lib_conf.h"
  #include <string.h>
-
+ 
 @@ -89,7 +89,7 @@ mmem_alloc(struct mmem *m, unsigned int size)
-
+ 
    /* We had enough memory so we add this memory block to the end of
       the list of allocated memory blocks. */
 -  list_add(mmemlist, m);
 +  emb6_list_add(mmemlist, m);
-
+ 
    /* Set up the pointer so that it points to the first available byte
       in the memory block. */
+@@ -136,7 +136,7 @@ mmem_free(struct mmem *m)
+   avail_memory += m->size;
+ 
+   /* Remove the memory block from the list. */
+-  list_remove(mmemlist, m);
++  emb6_list_remove(mmemlist, m);
+ }
+ /*---------------------------------------------------------------------------*/
+ /**
 diff --git a/utils/src/queuebuf.c b/utils/src/queuebuf.c
-index 7a9f13f..8b96816 100644
+index 7a9f13f..809e9c1 100644
 --- a/utils/src/queuebuf.c
 +++ b/utils/src/queuebuf.c
 @@ -128,7 +128,7 @@ static struct ctimer renew_timer;
  #endif
-
+ 
  #if QUEUEBUF_DEBUG
 -#include "clist.h"
 +#include "emb6_clist.h"
  LIST(queuebuf_list);
  #endif /* QUEUEBUF_DEBUG */
-
+ 
 @@ -349,7 +349,7 @@ queuebuf_new_from_packetbuf(void)
      buf = memb_alloc(&bufmem);
      if(buf != NULL) {
@@ -1491,19 +1681,28 @@ index 7a9f13f..8b96816 100644
        buf->file = file;
        buf->line = line;
        buf->time = clock_time();
+@@ -450,7 +450,7 @@ queuebuf_free(struct queuebuf *buf)
+     printf("#A q=%d\n", queuebuf_len);
+ #endif /* QUEUEBUF_STATS */
+ #if QUEUEBUF_DEBUG
+-    list_remove(queuebuf_list, buf);
++    emb6_list_remove(queuebuf_list, buf);
+ #endif /* QUEUEBUF_DEBUG */
+   } else if(memb_inmemb(&refbufmem, buf)) {
+     memb_free(&refbufmem, buf);
 diff --git a/utils/src/random.c b/utils/src/random.c
 index 72f5d12..00aed18 100644
 --- a/utils/src/random.c
 +++ b/utils/src/random.c
 @@ -36,7 +36,7 @@
   */
-
-
+ 
+ 
 -#include "random.h"
 +#include "emb6_random.h"
-
+ 
  #include <stdlib.h>
-
+ 
 diff --git a/utils/src/ringbuffer.c b/utils/src/ringbuffer.c
 index 5736f8f..52216c5 100644
 --- a/utils/src/ringbuffer.c
@@ -1511,7 +1710,7 @@ index 5736f8f..52216c5 100644
 @@ -24,7 +24,7 @@
   */
  /*============================================================================*/
-
+ 
 -#include "ringbuffer.h"
 +#include "emb6_ringbuffer.h"
  /**
@@ -1548,6 +1747,6 @@ index 95c8426..a774c09 100644
   * current time.
   *
   * \note A periodic timer will drift if this function is used to reset
---
-1.9.1
+-- 
+2.7.4
 


### PR DESCRIPTION
**This is a patch change, so please review carefully!!1!** :wink:

#6211 introduces a new function `list_remove()`. Unfortunately, there is a function of the same name in emb6. Since I did that before for other functions like `clist` and `list` I continue the effort here and renamed their `list_remove()` to `emb6_list_remove()`.