### PR TITLE
drivers/pwm: removed deprecated PWM_x defines

### DIFF
--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -95,25 +95,6 @@ enum {
     UART_UNDEFINED          /**< Deprecated symbol, use UART_UNDEF instead */
 };
 
-/**
- * @brief   Legacy definitions of PWM devices
- */
-enum {
-#if PWM_0_EN
-    PWM_0,              /*< 1st PWM device */
-#endif
-#if PWM_1_EN
-    PWM_1,              /*< 2nd PWM device */
-#endif
-#if PWM_2_EN
-    PWM_2,              /*< 3rd PWM device */
-#endif
-#if PWM_3_EN
-    PWM_3,              /*< 4th PWM device */
-#endif
-    PWM_UNDEFINED       /**< Deprecated symbol, use PWM_UNDEF instead */
-};
-
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -26,8 +26,6 @@
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
-/* TODO: remove once all platforms are ported to this interface */
-#include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
waiting on ~~#6230,~~ ~~#6208~~,~~#6207, and #6186~~