### PR TITLE
make: rename AD to Q

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -17,10 +17,10 @@ all: $(BINDIR)/$(MODULE).a ..nothing
 clean:: ${DIRS:%=CLEAN--%}
 
 ${DIRS:%=ALL--%}:
-	"$(MAKE)" -C ${@:ALL--%=%}
+	$(QQ)"$(MAKE)" -C ${@:ALL--%=%}
 
 ${DIRS:%=CLEAN--%}:
-	"$(MAKE)" -C ${@:CLEAN--%=%} clean
+	$(QQ)"$(MAKE)" -C ${@:CLEAN--%=%} clean
 
 ifeq ($(strip $(SRC)),)
     SRC := $(filter-out $(SRC_NOLTO), $(wildcard *.c))

--- a/Makefile.base
+++ b/Makefile.base
@@ -46,12 +46,12 @@ OBJ := $(OBJC) $(OBJCXX) $(ASMOBJ) $(ASSMOBJ)
 DEP := $(OBJC:.o=.d) $(OBJCXX:.o=.d) $(ASSMOBJ:.o=.d)
 
 $(BINDIR)/$(MODULE)/:
-	$(AD)mkdir -p $@
+	$(Q)mkdir -p $@
 
 $(BINDIR)/$(MODULE).a $(OBJ): | $(BINDIR)/$(MODULE)/
 
 $(BINDIR)/$(MODULE).a: $(OBJ) | ${DIRS:%=ALL--%}
-	$(AD)$(AR) $(ARFLAGS) $@ $?
+	$(Q)$(AR) $(ARFLAGS) $@ $?
 
 
 CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
@@ -61,22 +61,22 @@ CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
 $(OBJC_LTO): CFLAGS+=$(LTOFLAGS)
 
 $(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(RIOTBUILD_CONFIG_HEADER_C)
-	$(AD)$(CCACHE) $(CC) \
+	$(Q)$(CCACHE) $(CC) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.cpp $(RIOTBUILD_CONFIG_HEADER_C)
-	$(AD)$(CCACHE) $(CXX) \
+	$(Q)$(CCACHE) $(CXX) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CXXFLAGS) $(INCLUDES) $(CXXINCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 $(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
-	$(AD)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
+	$(Q)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
 
 $(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S
-	$(AD)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 # pull in dependency info for *existing* .o files
 # deleted header files will be silently ignored

--- a/Makefile.include
+++ b/Makefile.include
@@ -83,10 +83,10 @@ endif
 QUIET ?= 1
 
 ifeq ($(QUIET),1)
-  AD=@
+  Q=@
   MAKEFLAGS += --no-print-directory
 else
-  AD=
+  Q=
 endif
 
 # Fail on warnings. Can be overridden by `make WERROR=0`.

--- a/Makefile.include
+++ b/Makefile.include
@@ -268,15 +268,15 @@ all: ..in-docker-container
 else
 ## make script for your application. Build RIOT-base here!
 all: ..compiler-check ..build-message $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=${BINDIR}/%.a) $(APPDEPS)
-	$(AD)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTBASE)/Makefile.application
+	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTBASE)/Makefile.application
 ifeq (,$(RIOTNOLINK))
 ifeq ($(BUILDOSXNATIVE),1)
-	$(AD)$(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $$(find $(BASELIBS) -size +8c) $(LINKFLAGS) $(LINKFLAGPREFIX)-no_pie
+	$(Q)$(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $$(find $(BASELIBS) -size +8c) $(LINKFLAGS) $(LINKFLAGPREFIX)-no_pie
 else
-	$(AD)$(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group  $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map $(LINKFLAGPREFIX)--cref $(LINKFLAGS)
+	$(Q)$(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group  $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map $(LINKFLAGPREFIX)--cref $(LINKFLAGS)
 endif
-	$(AD)$(SIZE) $(ELFFILE)
-	$(AD)$(OBJCOPY) $(OFLAGS) $(ELFFILE) $(HEXFILE)
+	$(Q)$(SIZE) $(ELFFILE)
+	$(Q)$(OBJCOPY) $(OFLAGS) $(ELFFILE) $(HEXFILE)
 endif
 endif # BUILD_IN_DOCKER
 
@@ -303,7 +303,7 @@ endif
 
 # include Makefile.includes for packages in $(USEPKG)
 $(RIOTPKG)/%/Makefile.include::
-	$(AD)"$(MAKE)" -C $(RIOTPKG)/$* Makefile.include
+	$(Q)"$(MAKE)" -C $(RIOTPKG)/$* Makefile.include
 
 .PHONY: $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
 -include $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
@@ -349,7 +349,7 @@ term: $(filter flash, $(MAKECMDGOALS))
 	$(TERMPROG) $(TERMFLAGS)
 
 list-ttys:
-	$(AD)$(RIOTBASE)/dist/tools/usb-serial/list-ttys.sh
+	$(Q)$(RIOTBASE)/dist/tools/usb-serial/list-ttys.sh
 
 doc:
 	make -BC $(RIOTBASE) doc
@@ -392,7 +392,7 @@ eclipsesym: $(CURDIR)/eclipsesym.xml
 eclipsesym.xml: $(CURDIR)/eclipsesym.xml
 
 $(CURDIR)/eclipsesym.xml:
-	$(AD)printf "%s\n" $(CC) $(CFLAGS_WITH_MACROS) $(INCLUDES) | \
+	$(Q)printf "%s\n" $(CC) $(CFLAGS_WITH_MACROS) $(INCLUDES) | \
 		$(RIOTBASE)/dist/tools/eclipsesym/cmdline2xml.sh > $@
 
 # Extra make goals for testing and comparing changes.
@@ -476,12 +476,12 @@ else # RIOT_VERSION
   endif
 
   clean:
-	-$(AD)rm -rf $(BINDIR)
+	-$(Q)rm -rf $(BINDIR)
 
   $(BINDIR)/riot-version/$(NUM_RIOT_VERSION)/Makefile.include:
-	$(AD)rm -rf $(@D)
-	$(AD)mkdir -p $(@D)
-	$(AD)cd $(RIOTBASE) && git archive --format=tar $(NUM_RIOT_VERSION) | ( cd $(@D) && tar x 1>&2 )
+	$(Q)rm -rf $(@D)
+	$(Q)mkdir -p $(@D)
+	$(Q)cd $(RIOTBASE) && git archive --format=tar $(NUM_RIOT_VERSION) | ( cd $(@D) && tar x 1>&2 )
 
   ..delegate: $(BINDIR)/riot-version/$(NUM_RIOT_VERSION)/Makefile.include
 	@$(COLOR_ECHO) '$(COLOR_GREEN)Using RIOT_VERSION=${NUM_RIOT_VERSION}$(COLOR_RESET)' 1>&2
@@ -517,7 +517,7 @@ include $(RIOTBASE)/Makefile.modules
 .PHONY: $(RIOTBUILD_CONFIG_HEADER_C)
 $(RIOTBUILD_CONFIG_HEADER_C):
 	@mkdir -p '$(dir $@)'
-	$(AD)'$(RIOTBASE)/dist/tools/genconfigheader/genconfigheader.sh' '$@' $(CFLAGS_WITH_MACROS)
+	$(Q)'$(RIOTBASE)/dist/tools/genconfigheader/genconfigheader.sh' '$@' $(CFLAGS_WITH_MACROS)
 
 CFLAGS_WITH_MACROS := $(CFLAGS)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -89,6 +89,8 @@ else
   Q=
 endif
 
+QQ=
+
 # Fail on warnings. Can be overridden by `make WERROR=0`.
 WERROR ?= 1
 export WERROR
@@ -211,6 +213,8 @@ ifeq ($(RIOT_CI_BUILD),1)
         $(info CI-build: skipping link step)
         RIOTNOLINK:=1
     endif
+    # be more quiet when building for CI
+    QQ:=@
 endif
 
 # if you want to publish the board into the sources as an uppercase #define
@@ -315,7 +319,7 @@ INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
 .PHONY: $(USEPKG:%=${BINDIR}/%.a)
 $(USEPKG:%=${BINDIR}/%.a): $(RIOTBUILD_CONFIG_HEADER_C)
 	@mkdir -p ${BINDIR}
-	"$(MAKE)" -C $(RIOTPKG)/$(patsubst ${BINDIR}/%.a,%,$@)
+	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$(patsubst ${BINDIR}/%.a,%,$@)
 
 clean:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i clean ; done

--- a/Makefile.scan-build
+++ b/Makefile.scan-build
@@ -67,8 +67,8 @@ scan-build-analyze: clean
 	  $(COLOR_ECHO) '$(COLOR_YELLOW)Recommend using TOOLCHAIN=llvm for best results.$(COLOR_RESET)'; \
 	  $(COLOR_ECHO) '$(COLOR_YELLOW)Ignore any "error: unknown register name '\''rX'\'' in asm" messages.$(COLOR_RESET)'; \
 	fi
-	$(AD)mkdir -p '$(SCANBUILD_OUTPUTDIR)'
-	$(AD)env -i $(ENVVARS) \
+	$(Q)mkdir -p '$(SCANBUILD_OUTPUTDIR)'
+	$(Q)env -i $(ENVVARS) \
 	    scan-build -o '$(SCANBUILD_OUTPUTDIR)' $(SCANBUILD_ARGS) \
 	      make -C $(CURDIR) all $(strip $(CMDVARS)) FORCE_ASSERTS=1;
 endif # BUILD_IN_DOCKER

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -1,4 +1,4 @@
-export AD                    # Used in front of Makefile lines to suppress the printing of the command if user did not opt-in to see them.
+export Q                     # Used in front of Makefile lines to suppress the printing of the command if user did not opt-in to see them.
 export QUIET                 # The parameter to use whether to show verbose makefile commands or not.
 
 export APPLICATION           # The application, set in the Makefile which is run by the user.

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -1,4 +1,5 @@
 export Q                     # Used in front of Makefile lines to suppress the printing of the command if user did not opt-in to see them.
+export QQ                    # as Q, but be more quiet
 export QUIET                 # The parameter to use whether to show verbose makefile commands or not.
 
 export APPLICATION           # The application, set in the Makefile which is run by the user.

--- a/cpu/kinetis_common/Makefile.include
+++ b/cpu/kinetis_common/Makefile.include
@@ -12,7 +12,7 @@ export USEMODULE += kinetis_common_periph
 
 # Define a recipe to build the watchdog disable binary, used when flashing
 $(RIOTCPU)/kinetis_common/dist/wdog-disable.bin: $(RIOTCPU)/kinetis_common/dist/wdog-disable.s
-	$(AD)$(MAKE) -C $(RIOTCPU)/kinetis_common/dist/ $(notdir $@)
+	$(Q)$(MAKE) -C $(RIOTCPU)/kinetis_common/dist/ $(notdir $@)
 
 # Reset the default goal to not make wdog-disable.bin the default target.
 .DEFAULT_GOAL :=

--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -42,39 +42,39 @@ iotlab-exp: $(IOTLAB_AUTH) all
 	    $(eval NODES_PARAM := "-l$(IOTLAB_NODES),archi=$(IOTLAB_TYPE)+site=$(IOTLAB_SITE),$(BINARY),$(IOTLAB_PROFILE)")
     endif
 
-    ifeq (,$(AD))
+    ifeq (,$(Q))
 	    @echo "experiment-cli submit -d $(IOTLAB_DURATION) $(NODES_PARAM) -n $(IOTLAB_EXP_NAME)"
     endif
 	$(eval NEW_ID := $(shell experiment-cli submit -d $(IOTLAB_DURATION) $(NODES_PARAM) -n $(IOTLAB_EXP_NAME) | grep -Eo '[[:digit:]]+'))
-	$(AD)experiment-cli wait -i $(NEW_ID)
+	$(Q)experiment-cli wait -i $(NEW_ID)
 
     ifdef IOTLAB_LOGGING
-	    $(AD)ssh -t $(IOTLAB_AUTHORITY) "tmux new -d -s riot-$(NEW_ID)\
+	    $(Q)ssh -t $(IOTLAB_AUTHORITY) "tmux new -d -s riot-$(NEW_ID)\
 	    'script -fac "'"'"serial_aggregator -i $(NEW_ID)"'"'"\
 	     RIOT_LOG-$(IOTLAB_EXP_NAME)-$(NEW_ID)'"
     endif
 
 iotlab-flash: $(IOTLAB_AUTH) iotlab-check-exp all
-	$(AD)node-cli --update $(BINARY) -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
+	$(Q)node-cli --update $(BINARY) -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
 
 iotlab-reset: $(IOTLAB_AUTH) iotlab-check-exp
-	$(AD)node-cli --reset -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
+	$(Q)node-cli --reset -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
 
 iotlab-debug-server: $(IOTLAB_AUTH) iotlab-check-exp
 	$(eval DEBUG_TYPE := $(shell echo $(IOTLAB_TYPE) | cut -d: -f1))
 	$(eval DEBUG_NODE := $(shell echo $(IOTLAB_DEBUG_NODE) | sed 's/$(DEBUG_TYPE)-\([0-9]*\)/\1/'))
 
-	$(AD)node-cli --debug-start -i $(IOTLAB_EXP_ID) -l $(IOTLAB_SITE),$(DEBUG_TYPE),$(DEBUG_NODE)
+	$(Q)node-cli --debug-start -i $(IOTLAB_EXP_ID) -l $(IOTLAB_SITE),$(DEBUG_TYPE),$(DEBUG_NODE)
 	@echo "Debug on node $(IOTLAB_DEBUG_NODE)"
-	$(AD)ssh -N -L $(IOTLAB_DEBUG_PORT):$(IOTLAB_DEBUG_NODE):3333 $(IOTLAB_AUTHORITY)
+	$(Q)ssh -N -L $(IOTLAB_DEBUG_PORT):$(IOTLAB_DEBUG_NODE):3333 $(IOTLAB_AUTHORITY)
 
 iotlab-stop: $(IOTLAB_AUTH) iotlab-check-exp
-	$(AD)experiment-cli stop -i $(IOTLAB_EXP_ID)
+	$(Q)experiment-cli stop -i $(IOTLAB_EXP_ID)
 
 iotlab-term: iotlab-check-exp
-	$(AD)ssh -t $(IOTLAB_AUTHORITY) "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
+	$(Q)ssh -t $(IOTLAB_AUTHORITY) "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
 
-	$(AD)ssh -t $(IOTLAB_AUTHORITY) \
+	$(Q)ssh -t $(IOTLAB_AUTHORITY) \
 	"tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID) \
 	'$(if $(IOTLAB_LOGGING), \
 	script -fac "'"'"serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE)"'"'" \

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -58,10 +58,10 @@ include $(RIOTBASE)/Makefile.include
 .PHONY: host-tools
 
 term: host-tools
-	$(AD)sudo sh $(RIOTBASE)/dist/tools/ethos/start_network.sh $(PORT) $(TAP) $(IPV6_PREFIX)
+	$(Q)sudo sh $(RIOTBASE)/dist/tools/ethos/start_network.sh $(PORT) $(TAP) $(IPV6_PREFIX)
 
 host-tools:
-	$(AD)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools
+	$(Q)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools
 
 # Set a custom channel if needed
 ifneq (,$(filter cc110x,$(USEMODULE)))          # radio is cc110x sub-GHz

--- a/examples/iotivity_examples/br_fw/Makefile
+++ b/examples/iotivity_examples/br_fw/Makefile
@@ -96,7 +96,7 @@ include $(RIOTBASE)/Makefile.include
 .PHONY: host-tools
 
 term: host-tools
-	$(AD) sudo ./start_network_mcast.sh $(PORT) $(TAP) $(IPV6_PREFIX) $(IPV6_MCAST_OIC)
+	$(Q) sudo ./start_network_mcast.sh $(PORT) $(TAP) $(IPV6_PREFIX) $(IPV6_MCAST_OIC)
 
 host-tools:
-	$(AD)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools
+	$(Q)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools

--- a/pkg/Makefile.http
+++ b/pkg/Makefile.http
@@ -25,11 +25,11 @@ $(CURDIR)/$(PKG_NAME)-$(PKG_VERSION)/Makefile: $(CURDIR)/$(PKG_NAME)-$(PKG_VERSI
 $(CURDIR)/$(PKG_NAME)-$(PKG_VERSION)/: $(CURDIR)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
 	# Here you unpack the file.
 	# This example assumes the common pattern that the archive contains its data in a subfolder with the same name as itself.
-	$(AD)$(UNZIP_HERE) $<
+	$(Q)$(UNZIP_HERE) $<
 
 $(CURDIR)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT):
 	# Get PKG_VERSION of package from PKG_URL
-	$(AD)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
+	$(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
 
 clean::
 	# Reset package to checkout state.

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -6,6 +6,6 @@ PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
 .PHONY: all
 
 all: git-download
-	$(AD)$(MAKE) -C $(PKG_BUILDDIR)
+	$(Q)$(MAKE) -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nordic_softdevice_ble/Makefile
+++ b/pkg/nordic_softdevice_ble/Makefile
@@ -23,7 +23,7 @@ $(BINDIR)/softdevice.hex: $(PKG_SRCDIR)/.extracted
 $(PKG_SRCDIR)/.extracted: $(PKG_BUILDDIR)/$(PKG_FILE)
 	rm -rf $(@D)
 	mkdir -p $(@D)
-	$(AD)cd $(@D) && $(UNZIP_HERE) $(PKG_BUILDDIR)/$(PKG_FILE)
+	$(Q)cd $(@D) && $(UNZIP_HERE) $(PKG_BUILDDIR)/$(PKG_FILE)
 
 # this file doesn't compile with RIOT, but is not needed either
 	rm $(PKG_BUILDDIR)/src/components/ble/common/ble_conn_params.c
@@ -40,7 +40,7 @@ $(PKG_SRCDIR)/.extracted: $(PKG_BUILDDIR)/$(PKG_FILE)
 
 $(PKG_BUILDDIR)/$(PKG_FILE):
 	@mkdir -p $(@D)
-	$(AD)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)
+	$(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)
 
 clean::
 	rm -rf $(PKG_SRCDIR)/

--- a/pkg/tlsf/Makefile
+++ b/pkg/tlsf/Makefile
@@ -11,17 +11,17 @@ PKG_SRCDIR=$(PKG_BUILDDIR)/src
 all: $(PKG_SRCDIR)/$(PKG_NAME).a
 
 $(PKG_SRCDIR)/$(PKG_NAME).a: $(PKG_SRCDIR)/Makefile
-	$(AD)make -C $(<D)
+	$(Q)make -C $(<D)
 
 $(PKG_SRCDIR)/Makefile: $(PKG_BUILDDIR)/$(PKG_FILE) $(CURDIR)/patch.txt
 	rm -rf $(@D)
 	mkdir -p $(@D)
-	$(AD)cd $(@D) && $(UNZIP_HERE) $(PKG_BUILDDIR)/$(PKG_FILE)
-	$(AD)cd $(@D) && patch --binary -p0 -N -i $(CURDIR)/patch.txt
+	$(Q)cd $(@D) && $(UNZIP_HERE) $(PKG_BUILDDIR)/$(PKG_FILE)
+	$(Q)cd $(@D) && patch --binary -p0 -N -i $(CURDIR)/patch.txt
 
 $(PKG_BUILDDIR)/$(PKG_FILE):
 	@mkdir -p $(@D)
-	$(AD)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)
+	$(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)
 
 clean::
 	rm -rf $(PKG_SRCDIR)/


### PR DESCRIPTION
The variable "AD" was used to add "@" to makefile recipe lines depending on the QUIET setting.

Does anyone remember why the variable was called like this?

Anyhow, this PR changes the variable name to a short "Q".