### PR TITLE
tests/unittests: add stm32f3discovery to BOARD_INSUFFICIENT_MEMORY

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -2,7 +2,7 @@ APPLICATION = unittests
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon cc2650stk chronos msb-430 msb-430h pca10000 \
-                          pca10005 spark-core stm32f0discovery \
+                          pca10005 spark-core stm32f0discovery stm32f3discovery \
                           telosb wsn430-v1_3b wsn430-v1_4 z1 nucleo-f103 \
                           nucleo-f334 yunjia-nrf51822 samr21-xpro \
                           arduino-mega2560 airfy-beacon nrf51dongle nrf6310 \


### PR DESCRIPTION
Fixes:

```
"make" -C /home/kaspar/src/riot/sys/net/gnrc/transport_layer/udp
/usr/lib/gcc/arm-none-eabi/6.2.0/../../../../arm-none-eabi/bin/ld: /home/kaspar/src/riot/tests/unittests/bin/stm32f3discovery/unittests.elf section `.text' will not fit in region `rom'
/usr/lib/gcc/arm-none-eabi/6.2.0/../../../../arm-none-eabi/bin/ld: region `rom' overflowed by 304 bytes
collect2: error: ld returned 1 exit status
```