### PR TITLE
cpu/stm32: add PM implementation (WIP)

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -47,6 +47,7 @@ PSEUDOMODULES += netstats_rpl
 PSEUDOMODULES += newlib
 PSEUDOMODULES += newlib_nano
 PSEUDOMODULES += pktqueue
+PSEUDOMODULES += pm
 PSEUDOMODULES += printf_float
 PSEUDOMODULES += saul_adc
 PSEUDOMODULES += saul_default

--- a/core/include/pm.h
+++ b/core/include/pm.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    core_pm Power Management
+ * @ingroup     core
+ * @brief       The kernels power management interface
+ * @{
+ *
+ * This simple power management interface is based on the following assumptions:
+ *
+ * - CPUs define up to 4 power modes (from zero, the lowest power mode, to
+ *   PM_NUM_MODES-1, the highest)
+ * - there is an implicit extra idle mode (which has the number PM_NUM_MODES)
+ * - individual power modes can be blocked/unblocked, e.g., by peripherals
+ * - if a mode is blocked, so are implicitly all lower modes
+ * - the idle thread automatically selects and sets the lowest unblocked mode
+ *
+ * The following functions need to be implemented for each platform:
+ *
+ * pm_init()
+ * pm_set()
+ *
+ *
+ * @file
+ * @brief       Power management interface
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef PM_H_
+#define PM_H_
+
+#ifdef MODULE_PM
+
+#include "assert.h"
+#include "cpu_pm.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#ifndef PM_BLOCKER_INITIAL
+#define PM_BLOCKER_INITIAL { .val_u32=0x01010101 }
+#endif
+
+/**
+ * @brief Power Management mode typedef
+ */
+typedef union {
+    uint32_t val_u32;
+    uint8_t val_u8[PM_NUM_MODES];
+} pm_blocker_t;
+
+/**
+ * @brief Global variable for keeping track of blocked modes
+ */
+extern volatile pm_blocker_t pm_blocker;
+
+/**
+ * @brief   Initialization of power management
+ *
+ * This function is invoked once during boot.
+ * It needs to be implemented for each cpu.
+ */
+void pm_init(void);
+
+/**
+ * @brief   Switches the MCU to a new power mode
+ *
+ * This function will be called by the idle thread after determining the lowest
+ * non-blocked mode.
+ *
+ * It needs to be implemented for each cpu.
+ *
+ * @param[in]   mode      Target power mode
+ */
+void pm_set(unsigned mode);
+
+/**
+ * @brief   Block a power mode
+ *
+ * @param[in]   mode      power mode to block
+ */
+static inline void pm_block(unsigned mode)
+{
+    assert(pm_blocker.val_u8[mode] != 255);
+
+    unsigned state = irq_disable();
+    pm_blocker.val_u8[mode]++;
+    irq_restore(state);
+}
+
+/**
+ * @brief   Unblock a power mode
+ *
+ * @param[in]   mode      power mode to unblock
+ */
+static inline void pm_unblock(unsigned mode)
+{
+    assert(pm_blocker.val_u8[mode] > 0);
+
+    unsigned state = irq_disable();
+    pm_blocker.val_u8[mode]--;
+    irq_restore(state);
+}
+
+/**
+ * @brief   Switches the MCU to the lowest possible power mode
+ *
+ * This function will be called by the idle thread.
+ */
+void pm_set_lowest(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MODULE_PM */
+
+#endif /* __PM_H_ */
+/** @} */

--- a/core/include/pm.h
+++ b/core/include/pm.h
@@ -39,7 +39,7 @@
 #ifdef MODULE_PM
 
 #include "assert.h"
-#include "cpu_pm.h"
+#include "periph_cpu.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2013 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -24,9 +25,14 @@
 #include "kernel_init.h"
 #include "sched.h"
 #include "thread.h"
-#include "lpm.h"
 #include "irq.h"
 #include "log.h"
+
+#ifdef MODULE_PM
+#include "pm.h"
+#else
+#include "lpm.h"
+#endif
 
 #ifdef MODULE_SCHEDSTATISTICS
 #include "sched.h"
@@ -38,8 +44,6 @@
 #ifdef MODULE_AUTO_INIT
 #include <auto_init.h>
 #endif
-
-volatile int lpm_prevent_sleep = 0;
 
 extern int main(void);
 static void *main_trampoline(void *arg)
@@ -61,11 +65,19 @@ static void *main_trampoline(void *arg)
     return NULL;
 }
 
+#ifndef MODULE_PM
+volatile int lpm_prevent_sleep = 0;
+#endif
+
 static void *idle_thread(void *arg)
 {
-    (void) arg;
+    (void)arg;
 
     while (1) {
+#ifdef MODULE_PM
+        pm_set_lowest();
+#else
+        puts("oldidle");
         if (lpm_prevent_sleep) {
             lpm_set(LPM_IDLE);
         }
@@ -74,6 +86,7 @@ static void *idle_thread(void *arg)
             /* lpm_set(LPM_SLEEP); */
             /* lpm_set(LPM_POWERDOWN); */
         }
+#endif
     }
 
     return NULL;
@@ -83,7 +96,7 @@ const char *main_name = "main";
 const char *idle_name = "idle";
 
 static char main_stack[THREAD_STACKSIZE_MAIN];
-static char idle_stack[THREAD_STACKSIZE_IDLE];
+static char idle_stack[THREAD_STACKSIZE_IDLE + 2048];
 
 void kernel_init(void)
 {

--- a/core/pm.c
+++ b/core/pm.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     core_internal
+ * @{
+ *
+ * @file
+ * @brief       Platform-independent power management code
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include "pm.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifdef MODULE_PM
+
+volatile pm_blocker_t pm_blocker = PM_BLOCKER_INITIAL;
+
+void pm_set_lowest(void)
+{
+    pm_blocker_t blocker = (pm_blocker_t) pm_blocker;
+    unsigned mode = 0;
+    while (mode < PM_NUM_MODES) {
+        if (! (blocker.val_u8[mode])) {
+            break;
+        }
+        mode++;
+    }
+
+    /* set lowest mode if blocker is still the same */
+    unsigned state = irq_disable();
+    if (blocker.val_u32 == pm_blocker.val_u32) {
+        DEBUG("pm: setting mode %u\n", mode);
+        pm_set(mode);
+    }
+    else {
+        DEBUG("pm: mode block changed\n");
+    }
+    irq_restore(state);
+}
+
+#endif /* MODULE_PM */

--- a/cpu/cortexm_common/cortexm.c
+++ b/cpu/cortexm_common/cortexm.c
@@ -61,3 +61,17 @@ void cortexm_init(void)
     SCB->CCR |= SCB_CCR_STKALIGN_Msk;
 #endif
 }
+
+void cortexm_sleep(int deep)
+{
+    if (deep) {
+        SCB->SCR |=  (SCB_SCR_SLEEPDEEP_Msk);
+    }
+    else {
+        SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
+    }
+
+    /* ensure that all memory accesses have completed and trigger sleeping */
+    __DSB();
+    __WFI();
+}

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -68,6 +68,13 @@ void cpu_init(void);
 void cortexm_init(void);
 
 /**
+ * @brief   Put the CPU into (deep) sleep mode, using the `WFI` instruction
+ *
+ * @param[in] deep      !=0 for deep sleep, 0 for light sleep
+ */
+void cortexm_sleep(int deep);
+
+/**
  * @brief   Prints the current content of the link register (lr)
  */
 static inline void cpu_print_last_instruction(void)

--- a/cpu/cortexm_common/panic.c
+++ b/cpu/cortexm_common/panic.c
@@ -21,8 +21,13 @@
  */
 
 #include "cpu.h"
-#include "lpm.h"
 #include "log.h"
+
+#ifdef MODULE_PM
+#include "pm.h"
+#else
+#include "lpm.h"
+#endif
 
 #ifdef DEVELHELP
 static void print_ipsr(void)
@@ -44,7 +49,12 @@ void panic_arch(void)
     __asm__("bkpt #0");
     /* enter infinite loop, into deepest possible sleep mode */
     while (1) {
+#ifdef MODULE_PM
+        pm_blocker.val_u32 = 0;
+        pm_set_lowest();
+#else
         lpm_set(LPM_OFF);
+#endif
     }
 #endif
 }

--- a/cpu/samd21/cpu_pm.c
+++ b/cpu/samd21/cpu_pm.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 Saurabh Singh
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_samd21
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the kernels power management interface
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Saurabh Singh <saurabh@cezy.co>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include "pm.h"
+#include "cpu_pm.h"
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+enum system_sleepmode {
+    /**
+     *  Idle 0 mode.
+     *  Potential Wake Up sources: Synchronous(APB, AHB), asynchronous.
+     */
+    SYSTEM_SLEEPMODE_IDLE_0,
+    /**
+     *  Idle 1 mode.
+     *  Potential Wake Up sources: Synchronous (APB), asynchronous
+     */
+    SYSTEM_SLEEPMODE_IDLE_1,
+    /**
+     *  Idle 2 mode.
+     *  Potential Wake Up sources: Asynchronous
+     */
+    SYSTEM_SLEEPMODE_IDLE_2,
+    /**
+     * Standby mode.
+     * Potential Wake Up sources: Asynchronous
+     */
+    SYSTEM_SLEEPMODE_STANDBY,
+};
+
+void pm_set(unsigned mode)
+{
+    switch (mode) {
+        case 0:
+            /* Standby Mode
+             * Potential Wake Up sources: asynchronous
+             */
+            SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+            break;
+        case 1:
+            /* Sleep mode Idle 2
+             * Potential Wake Up sources: asynchronous
+             */
+            SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+            PM->SLEEP.reg = SYSTEM_SLEEPMODE_IDLE_2;
+            break;
+        case 2:
+            /* Sleep mode Idle 1
+             * Potential Wake Up sources: Synchronous (APB), asynchronous
+             */
+            SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+            PM->SLEEP.reg = SYSTEM_SLEEPMODE_IDLE_1;
+            break;
+        case 3:
+            /* Sleep mode Idle 0
+             * Potential Wake Up sources: Synchronous (APB, AHB), asynchronous
+            */
+            SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+            PM->SLEEP.reg = SYSTEM_SLEEPMODE_IDLE_0;
+            break;
+        default:
+            DEBUG("pm: invalid power mode selected.\n");
+    }
+
+    /* Executes a device DSB (Data Synchronization Barrier) */
+    __DSB();
+    /* Enter standby mode */
+    __WFI();
+}

--- a/cpu/samd21/include/cpu_pm.h
+++ b/cpu/samd21/include/cpu_pm.h
@@ -1,0 +1,8 @@
+#ifndef CPU_PM_H
+#define CPU_PM_H
+
+#include "cpu.h"
+
+#define PM_NUM_MODES    (3)
+
+#endif /* CPU_PM_H */

--- a/cpu/samd21/lpm_arch.c
+++ b/cpu/samd21/lpm_arch.c
@@ -19,6 +19,11 @@
  *
  * @}
  */
+
+#define _COMPILATION_UNIT_NOT_EMPTY
+
+#ifdef MODULE_PM
+
 #include "cpu.h"
 #include "arch/lpm_arch.h"
 
@@ -124,3 +129,5 @@ void lpm_arch_begin_awake(void){ }
 
 /** Not needed */
 void lpm_arch_end_awake(void){ }
+
+#endif /* MODULE_PM */

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -45,6 +45,22 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   PM configuration
+ */
+#define PM_NUM_MODES        (3U)
+
+/**
+ * @brief   STM32 specific sleep modes
+ * @{
+ */
+enum {
+    PM_0_SLEEP   = 0,       /**< 'light' sleep, wakeup from any interrupt */
+    PM_1_STOP    = 1,       /**< STOP mode with voltage regulator on */
+    PM_2_STANDBY = 2        /**< STANDBY mode, voltage regulator off */
+};
+/** @} */
+
+/**
  * @brief   Available peripheral buses
  */
 typedef enum {

--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014-2016 Freie Universität Berlin
+ *               2015 Engineering-Spirit
+ *               2016 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32_common
+ * @{
+ *
+ * @file
+ * @brief       Low-level PWM driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Fabian Nack <nack@inf.fu-berlin.de>
+ * @author      Nick v. IJzendoorn <nijzndoorn@engineering-spirit.nl>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph_cpu.h"
+
+void pm_set(unsigned mode)
+{
+    int deepsleep = 1;
+
+    switch (mode) {
+        case PM_0_SLEEP:
+            deepsleep = 0;
+            break;
+        case PM_1_STOP:
+            /* enter stop mode on deepsleep with voltage regulator on */
+            PWR->CR &= ~(PWR_CR_PDDS | PWR_CR_LPDS);
+            break;
+        case PM_2_STANDBY:
+            /* enter standby mode on deepsleep with voltage regulator off and
+             * clear flags */
+            PWR->CR |= (PWR_CR_PDDS | PWR_CR_CWUF | PWR_CR_CSBF);
+            /* Enable WKUP pin to use for wakeup from standby mode */
+            PWR->CSR |= PWR_CSR_EWUP;
+            break;
+        default:
+            /* unknown mode -> do nothing */
+            return;
+    }
+
+    /* call the shared function to set the CPU into the selected sleep mode */
+    cortexm_sleep(deepsleep);
+}

--- a/tests/pm/Makefile
+++ b/tests/pm/Makefile
@@ -1,0 +1,23 @@
+# name of your application
+APPLICATION = pm
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= samr21-xpro
+
+BOARD_WHITELIST += samr21-xpro
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+USEMODULE += pm
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pm/main.c
+++ b/tests/pm/main.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Power Management test application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "periph/gpio.h"
+#include "pm.h"
+#include "xtimer.h"
+
+#define SLEEP (5U)
+
+static void cb(void *arg)
+{
+    puts("*");
+}
+
+int main(void)
+{
+    printf("PM test application started.\n"
+           "Will now alternate between sleeping and spinning\n"
+           "every %u seconds.\n"
+           "While sleeping, the LED is off, while spinning, the led is on.\n"
+           "Every four cycles, one more power mode will be unlocked.\n"
+           "The board's first button can be used to generate an interrupt,\n"
+           "(which just prints \"*\").\n",
+            SLEEP);
+
+    puts("initializing button...");
+    gpio_init_int(BUTTON_GPIO, GPIO_IN_PU, GPIO_RISING, cb, NULL);
+
+    unsigned mode = PM_NUM_MODES;
+    unsigned n = 1;
+    while(1) {
+        if ((n % 4) == 0) {
+            mode--;
+            printf("unblocking mode %u\n", mode);
+            pm_unblock(mode);
+        }
+        if (n++ & 1) {
+            printf("sleeping %u\n", SLEEP);
+            LED0_OFF;
+            xtimer_sleep(SLEEP);
+        }
+        else {
+            printf("spinning %u\n", SLEEP);
+            LED0_ON;
+            xtimer_spin(SLEEP * (1000000));
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
rebased on #6160

first quick draft to get a feeling how the PM interface would look like when implemented for a specific CPU.

So far only linked in the `timer` periph driver...