### PR TITLE
gcoap: Fix compilation and unit test errors for zero-length token

### DIFF
--- a/sys/net/application_layer/coap/gcoap.c
+++ b/sys/net/application_layer/coap/gcoap.c
@@ -390,7 +390,6 @@ void gcoap_register_listener(gcoap_listener_t *listener)
 
 int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code,
                                                               char *path) {
-    uint8_t token[GCOAP_TOKENLEN];
     ssize_t hdrlen;
     (void)len;
 
@@ -398,6 +397,8 @@ int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code,
     memset(pdu->url, 0, NANOCOAP_URL_MAX);
 
     /* generate token */
+#if GCOAP_TOKENLEN
+    uint8_t token[GCOAP_TOKENLEN];
     for (size_t i = 0; i < GCOAP_TOKENLEN; i += 4) {
         uint32_t rand = random_uint32();
         memcpy(&token[i],
@@ -405,8 +406,11 @@ int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code,
                (GCOAP_TOKENLEN - i >= 4) ? 4 : GCOAP_TOKENLEN - i);
     }
     hdrlen = coap_build_hdr(pdu->hdr, COAP_TYPE_NON, &token[0], GCOAP_TOKENLEN,
-                                                     code,
-                                                   ++_coap_state.last_message_id);
+                            code, ++_coap_state.last_message_id);
+#else
+    hdrlen = coap_build_hdr(pdu->hdr, COAP_TYPE_NON, NULL, GCOAP_TOKENLEN,
+                            code, ++_coap_state.last_message_id);
+#endif
 
     if (hdrlen > 0) {
         /* Reserve some space between the header and payload to write options later */

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -64,13 +64,16 @@ static void test_gcoap__client_get_req(void)
 /*
  * Client GET response success case. Test parsing response.
  * Response for /time resource from libcoap example
+ * Includes 2-byte token
  */
 static void test_gcoap__client_get_resp(void)
 {
     uint8_t buf[GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
     int res;
-    char exp_payload[] = "Oct 22 10:46:48";
+    size_t hdr_fixed_len = 4;
+    char exp_payload[]   = "Oct 22 10:46:48";
+    size_t exp_tokenlen  = 2;
 
     uint8_t pdu_data[] = {
         0x52, 0x45, 0xe6, 0x02, 0x9b, 0xce, 0xc0, 0x21,
@@ -84,8 +87,8 @@ static void test_gcoap__client_get_resp(void)
 
     TEST_ASSERT_EQUAL_INT(0, res);
     TEST_ASSERT_EQUAL_INT(COAP_CLASS_SUCCESS, coap_get_code_class(&pdu));
-    TEST_ASSERT_EQUAL_INT(GCOAP_TOKENLEN, coap_get_token_len(&pdu));
-    TEST_ASSERT_EQUAL_INT(4 + GCOAP_TOKENLEN, coap_get_total_hdr_len(&pdu));
+    TEST_ASSERT_EQUAL_INT(exp_tokenlen, coap_get_token_len(&pdu));
+    TEST_ASSERT_EQUAL_INT(hdr_fixed_len + exp_tokenlen, coap_get_total_hdr_len(&pdu));
     TEST_ASSERT_EQUAL_INT(COAP_TYPE_NON, coap_get_type(&pdu));
     TEST_ASSERT_EQUAL_INT(strlen(exp_payload), pdu.payload_len);
 

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -25,7 +25,7 @@
 /*
  * Client GET request success case. Test request generation.
  * Request /time resource from libcoap example
- * Includes 2-byte token
+ * Includes token of length GCOAP_TOKENLEN.
  */
 static void test_gcoap__client_get_req(void)
 {
@@ -34,17 +34,27 @@ static void test_gcoap__client_get_req(void)
     size_t len;
     char path[] = "/time";
 
-    uint8_t pdu_data[] = {
-        0x52, 0x01, 0xe6, 0x02, 0x9b, 0xce, 0xb4, 0x74,
-        0x69, 0x6d, 0x65
-    };
+    /* Create expected pdu_data, with token length from GCOAP_TOKENLEN. */
+    size_t hdr_fixed_len = 4;
+    uint8_t hdr_fixed[]  = { 0x52, 0x01, 0xe6, 0x02 };
+    size_t options_len   = 5;
+    uint8_t options[]    = { 0xb4, 0x74, 0x69, 0x6d, 0x65 };
+
+    uint8_t pdu_data[hdr_fixed_len + GCOAP_TOKENLEN + options_len];
+
+    memcpy(&pdu_data[0], &hdr_fixed[0], hdr_fixed_len);
+#if GCOAP_TOKENLEN
+    /* actual value is random */
+    memset(&pdu_data[hdr_fixed_len], 0x9b, GCOAP_TOKENLEN);
+#endif
+    memcpy(&pdu_data[hdr_fixed_len + GCOAP_TOKENLEN], &options[0], options_len);
 
     len = gcoap_request(&pdu, &buf[0], GCOAP_PDU_BUF_SIZE, COAP_METHOD_GET,
                                                            &path[0]);
 
     TEST_ASSERT_EQUAL_INT(COAP_METHOD_GET, coap_get_code(&pdu));
     TEST_ASSERT_EQUAL_INT(GCOAP_TOKENLEN, coap_get_token_len(&pdu));
-    TEST_ASSERT_EQUAL_INT(4 + GCOAP_TOKENLEN, coap_get_total_hdr_len(&pdu));
+    TEST_ASSERT_EQUAL_INT(hdr_fixed_len + GCOAP_TOKENLEN, coap_get_total_hdr_len(&pdu));
     TEST_ASSERT_EQUAL_INT(COAP_TYPE_NON, coap_get_type(&pdu));
     TEST_ASSERT_EQUAL_STRING(&path[0], (char *)&pdu.url[0]);
     TEST_ASSERT_EQUAL_INT(0, pdu.payload_len);


### PR DESCRIPTION
Depends on [PR #6117](https://github.com/RIOT-OS/RIOT/pull/6117).

The macro GCOAP_TOKENLEN defines the length of the token in a CoAP request. The value is 2 by default, but when set to 0, compilation fails:

```
... gcoap.c: In function ‘gcoap_req_init’:
... gcoap.c:394:13: error: ISO C forbids zero-size array ‘token’ [-Werror=pedantic]
     uint8_t token[GCOAP_TOKENLEN];
             ^
... gcoap.c:402:26: error: comparison of unsigned expression < 0 is always false [-Werror=type-limits]
     for (size_t i = 0; i < GCOAP_TOKENLEN; i += 4) {
                          ^
```
The first commit wraps the code above in an #if directive for GCOAP_TOKENLEN.

The second and third commits fix unit tests when GCOAP_TOKENLEN is not set to the default value. In addition, the second commit now provides a meaningful check on use of the GCOAP_TOKENLEN value when creating a request.