### PR TITLE
cppcheck: grnc/netif/hdr fix cppcheck warnings

### DIFF
--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr.c
@@ -40,59 +40,43 @@ gnrc_pktsnip_t *gnrc_netif_hdr_build(uint8_t *src, uint8_t src_len, uint8_t *dst
 
 uint8_t gnrc_netif_hdr_get_flag(gnrc_pktsnip_t* pkt)
 {
-    gnrc_netif_hdr_t* netif_hdr;
-
     assert(pkt != NULL);
-    pkt = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
-    if (pkt) {
-        netif_hdr = pkt->data;
-        if (netif_hdr) {
-            return netif_hdr->flags;
-        }
-    }
 
+    pkt = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
+    if (pkt && pkt->data) {
+        gnrc_netif_hdr_t *netif_hdr = pkt->data;
+        return netif_hdr->flags;
+    }
     return 0U;
 }
 
 int gnrc_netif_hdr_get_dstaddr(gnrc_pktsnip_t* pkt, uint8_t** pointer_to_addr)
 {
-    int res;
-    gnrc_netif_hdr_t* netif_hdr;
-
     assert(pkt != NULL);
+
     pkt = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
-    if (pkt) {
-        netif_hdr = pkt->data;
-        if (netif_hdr) {
-            if ((res = netif_hdr->dst_l2addr_len) <= 0) {
-                return -ENOENT;
-            }
+    if (pkt && pkt->data) {
+        gnrc_netif_hdr_t *netif_hdr = pkt->data;
+        if (netif_hdr->dst_l2addr_len > 0) {
             *pointer_to_addr = gnrc_netif_hdr_get_dst_addr(netif_hdr);
-            return res;
+            return netif_hdr->dst_l2addr_len;
         }
     }
-
     return -ENOENT;
 }
 
 int gnrc_netif_hdr_get_srcaddr(gnrc_pktsnip_t* pkt, uint8_t** pointer_to_addr)
 {
-    int res;
-    gnrc_netif_hdr_t* netif_hdr;
-
     assert(pkt != NULL);
+
     pkt = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
-    if (pkt) {
-        netif_hdr = pkt->data;
-        if (netif_hdr) {
-            if ((res = netif_hdr->src_l2addr_len) <= 0) {
-                return -ENOENT;
-            }
+    if (pkt && pkt->data) {
+        gnrc_netif_hdr_t *netif_hdr = pkt->data;
+        if (netif_hdr->src_l2addr_len > 0) {
             *pointer_to_addr = gnrc_netif_hdr_get_src_addr(netif_hdr);
-            return res;
+            return netif_hdr->src_l2addr_len;
         }
     }
-
     return -ENOENT;
 }
 


### PR DESCRIPTION
fix cppcheck warnings:

```
[gnrc_netif_hdr.c:43]: (style) The scope of the variable 'netif_hdr' can be reduced.
[gnrc_netif_hdr.c:59]: (style) The scope of the variable 'res' can be reduced.
[gnrc_netif_hdr.c:80]: (style) The scope of the variable 'res' can be reduced.
```

and code cleanup