### PR TITLE
doc: hashes and isrpipe doxygen fixes

### DIFF
--- a/sys/hashes/doc.txt
+++ b/sys/hashes/doc.txt
@@ -10,7 +10,7 @@
  * @defgroup    sys_hashes Hashes
  * @ingroup     sys
  *
- * @brief       RIOT provides a collection of hash algorithms.
+ * @brief       A collection of hash algorithms.
  *
  * RIOT supports the following hash functions:
  *

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @ingroup     sys_hashes Hashes
- * @ingroup     sys
- * @brief       Hash function library
+ * @ingroup     sys_hashes
  * @{
  *
  * @file

--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -7,10 +7,13 @@
  */
 
 /**
+ * @defgroup isr_pipe ISR Pipe
  * @ingroup sys
+ * @brief ISR -> userspace pipe
+ *
  * @{
  * @file
- * @brief       ISR -> userspace pipe interface
+ * @brief       isrpipe Interface
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *


### PR DESCRIPTION
sys/hashes
- fix group membership
- improve description style

sys/isrpipe
- create group for isrpipe instead of adding it to sys directly
- alter file description accordingly