### PR TITLE
LLVM+newlib include path search fixes

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -70,7 +70,7 @@ $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.cpp $(RIOTBUILD_CONFIG_HEADER_C)
 	$(AD)$(CCACHE) $(CXX) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CXXFLAGS) $(INCLUDES) $(CXXINCLUDES) -MD -MP -c -o $@ $(abspath $<)
+		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 $(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
 	$(AD)$(AS) $(ASFLAGS) -o $@ $(abspath $<)

--- a/Makefile.include
+++ b/Makefile.include
@@ -175,9 +175,6 @@ export TOOLCHAIN
 # will most likely not need to touch this.
 export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
 
-# Import all toolchain settings
-include $(RIOTCPU)/Makefile.include.$(TOOLCHAIN)
-
 # Add standard include directories
 INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
@@ -188,6 +185,9 @@ include $(RIOTBASE)/Makefile.pseudomodules
 include $(RIOTBASE)/Makefile.defaultmodules
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
 include $(RIOTCPU)/$(CPU)/Makefile.include
+
+# Import all toolchain settings
+include $(RIOTCPU)/Makefile.include.$(TOOLCHAIN)
 
 # get number of interfaces straight before resolving dependencies
 GNRC_NETIF_NUMOF ?= 1

--- a/cpu/Makefile.include.llvm
+++ b/cpu/Makefile.include.llvm
@@ -40,7 +40,7 @@ GCC_CXX_INCLUDE_PATTERNS ?= \
 # Try to find the proper multilib directory using GCC, this may fail if a cross-
 # GCC is not installed.
 ifeq ($(GCC_MULTI_DIR),)
-  GCC_MULTI_DIR := $(shell $(PREFIX)gcc -print-multi-directory $(CFLAGS) 2>/dev/null)
+  GCC_MULTI_DIR := $(shell $(PREFIX)gcc $(CFLAGS) -print-multi-directory 2>/dev/null)
 endif
 
 # Tell clang to cross compile
@@ -57,8 +57,8 @@ export LINKFLAGS  += -target $(TARGET_ARCH)
 # previous tool chain installations.
 GCC_CXX_INCLUDES ?= \
     $(addprefix \
-        -isystem $(lastword $(sort \
-            $(foreach pat, $(GCC_CXX_INCLUDE_PATTERNS), $(wildcard $(pat))))), \
+        -isystem $(firstword \
+            $(foreach pat, $(GCC_CXX_INCLUDE_PATTERNS), $(lastword $(sort $(wildcard $(pat)))))), \
         /. /$(TARGET_ARCH)/$(GCC_MULTI_DIR) /backward \
     )
 

--- a/cpu/Makefile.include.llvm
+++ b/cpu/Makefile.include.llvm
@@ -31,6 +31,9 @@ export DBG         = $(GDBPREFIX)gdb
 GCC_CXX_INCLUDE_PATTERNS ?= \
   /etc/alternatives/gcc-$(TARGET_ARCH)-include/c++/*/ \
   /usr/$(TARGET_ARCH)/include/c++/*/ \
+  /usr/lib/gcc/$(TARGET_ARCH)/*/include/g++-v8 \
+  /usr/lib/gcc/$(TARGET_ARCH)/*/include/g++-v7 \
+  /usr/lib/gcc/$(TARGET_ARCH)/*/include/g++-v6 \
   /usr/lib/gcc/$(TARGET_ARCH)/*/include/g++-v5 \
   #
 

--- a/cpu/Makefile.include.llvm
+++ b/cpu/Makefile.include.llvm
@@ -43,10 +43,12 @@ ifeq ($(GCC_MULTI_DIR),)
   GCC_MULTI_DIR := $(shell $(PREFIX)gcc $(CFLAGS) -print-multi-directory 2>/dev/null)
 endif
 
-# Tell clang to cross compile
-export CFLAGS     += -target $(TARGET_ARCH)
-export CXXFLAGS   += -target $(TARGET_ARCH)
-export LINKFLAGS  += -target $(TARGET_ARCH)
+ifneq (,$(TARGET_ARCH))
+  # Tell clang to cross compile
+  export CFLAGS     += -target $(TARGET_ARCH)
+  export CXXFLAGS   += -target $(TARGET_ARCH)
+  export LINKFLAGS  += -target $(TARGET_ARCH)
+endif
 
 # Use the wildcard Makefile function to search for existing directories matching
 # the patterns above. We use the -isystem gcc/clang argument to add the include

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -48,17 +48,25 @@ NEWLIB_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_PATTERNS)))
 # If nothing was found we will try to fall back to searching for a cross-gcc in
 # the current PATH and use a relative path for the includes
 ifeq (,$(NEWLIB_INCLUDE_DIR))
-  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell which $(PREFIX)gcc))../$(TARGET_ARCH)/include))
+  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell command -v $(PREFIX)gcc))../$(TARGET_ARCH)/include))
 endif
 
-NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR)
+ifeq ($(TOOLCHAIN),llvm)
+  # A cross GCC already knows the target libc include path (build-in at compile time)
+  # but Clang, when cross-compiling, needs to be told where to find the headers
+  # for the system being built.
+  # We also add -nostdinc to avoid including the host system headers by mistake
+  # in case some header is missing from the cross tool chain
+  NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR) -nostdinc
+  NEWLIB_INCLUDES += $(addprefix -isystem ,$(abspath $(wildcard $(dir $(NEWLIB_INCLUDE_DIR))/usr/include)))
+endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
   NEWLIB_NANO_INCLUDE_DIR ?= $(NEWLIB_INCLUDE_DIR)/newlib-nano
   # newlib-nano overrides newlib.h and its include dir should therefore go before
-  # the regular newlib include dir.
-  NEWLIB_INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(NEWLIB_INCLUDES)
+  # the regular system include dirs.
+  INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
 endif
 
-# Newlib includes should go before GCC includes.
-export INCLUDES := $(NEWLIB_INCLUDES) $(INCLUDES)
+# Newlib includes should go after GCC includes.
+export INCLUDES += $(NEWLIB_INCLUDES)

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -17,7 +17,6 @@ endif
 
 export LINKFLAGS += -lc -lnosys
 
-ifeq (1,$(USE_NEWLIB_NANO))
 # Search for Newlib include directories
 
 # Since Clang is not installed as a separate instance for each crossdev target
@@ -51,10 +50,14 @@ NEWLIB_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_PATTERNS)))
 ifeq (,$(NEWLIB_INCLUDE_DIR))
   NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell which $(PREFIX)gcc))../$(TARGET_ARCH)/include))
 endif
+
+NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR)
+
+ifeq (1,$(USE_NEWLIB_NANO))
   NEWLIB_NANO_INCLUDE_DIR ?= $(NEWLIB_INCLUDE_DIR)/nano
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular newlib include dir.
-  NEWLIB_INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR)
+  NEWLIB_INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(NEWLIB_INCLUDES)
 endif
 
 # Newlib includes should go before GCC includes.

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -54,7 +54,7 @@ endif
 NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR)
 
 ifeq (1,$(USE_NEWLIB_NANO))
-  NEWLIB_NANO_INCLUDE_DIR ?= $(NEWLIB_INCLUDE_DIR)/nano
+  NEWLIB_NANO_INCLUDE_DIR ?= $(NEWLIB_INCLUDE_DIR)/newlib-nano
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular newlib include dir.
   NEWLIB_INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(NEWLIB_INCLUDES)


### PR DESCRIPTION
This PR contains some small fixes for the Makefiles to get the build system working with Clang/LLVM again after being broken since #6065.
Also included is a change to place C++ header includes before C includes on the command line when building C++ files. This was the original cause for the error about missing includes in #6065.
Added one more check for TARGET_ARCH in the LLVM makefile to avoid adding -target to CFLAGS when building for native.
Tested in a make buildtest with TOOLCHAIN=llvm set. Native and most Cortex-M platforms build successfully, stm32f2 and lpc2387 need some fixes in order to build with Clang. MSP430 and AVR are not supported by LLVM.