### PR TITLE
cppcheck: fix warning in sc_saul_reg

### DIFF
--- a/sys/shell/commands/sc_saul_reg.c
+++ b/sys/shell/commands/sc_saul_reg.c
@@ -140,7 +140,7 @@ int _saul(int argc, char **argv)
     if (argc < 2) {
         list();
     }
-    else if (argc >= 2) {
+    else {
         if (strcmp(argv[1], "read") == 0) {
             read(argc, argv);
         }


### PR DESCRIPTION
fix cppcheck warning:

```
[commands/sc_saul_reg.c:143]: (style) Condition 'argc>=2' is always true
```