### PR TITLE
cpu/stm32f1: cmsis fix flash latency bit

### DIFF
--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -42,8 +42,6 @@ extern "C" {
 /* resulting bus clocks */
 #define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
 #define CLOCK_APB2          (CLOCK_CORECLOCK)
-/* configuration of flash access cycles */
-#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY_2
 /** @} */
 
 /**

--- a/boards/iotlab-common/include/periph_conf_common.h
+++ b/boards/iotlab-common/include/periph_conf_common.h
@@ -40,8 +40,6 @@ extern "C" {
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 72MHz */
 #define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 72MHz */
 #define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* APB1 clock -> 36MHz */
-/* configuration of flash access cycles */
-#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY_2
 
 /* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
 #define CLOCK_AHB           (CLOCK_CORECLOCK / 1)

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -38,8 +38,6 @@ extern "C" {
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
 #define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1
 #define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2    /* max 36 MHz (!) */
-/* Flash latency */
-#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY_2    /* for >= 72 MHz */
 
 /* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
 #define CLOCK_AHB           (CLOCK_CORECLOCK / 1)

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -42,8 +42,6 @@
 /* resulting bus clocks */
 #define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
 #define CLOCK_APB2          (CLOCK_CORECLOCK)
-/* configuration of flash access cycles */
-#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY_2
 /** @} */
 
  /**

--- a/cpu/stm32f1/cpu.c
+++ b/cpu/stm32f1/cpu.c
@@ -28,6 +28,15 @@
 #include "cpu.h"
 #include "periph_conf.h"
 
+/* Configuration of flash access cycles */
+#if CLOCK_CORECLOCK <= 24000000
+#define FLASH_LATENCY (0) /* Zero wait state, if 0 < SYSCLK≤ 24 MHz */
+#elif CLOCK_CORECLOCK <= 48000000
+#define FLASH_LATENCY (1) /* One wait states, if 24 MHz < SYSCLK ≤ 48 MHz */
+#elif CLOCK_CORECLOCK <= 72000000
+#define FLASH_LATENCY (2) /* Two wait states, if 48 MHz < SYSCLK ≤ 72 MHz */
+#endif
+
 /* See if we want to use the PLL */
 #if defined(CLOCK_PLL_DIV) || defined(CLOCK_PLL_MUL)
 #define CLOCK_USE_PLL              1
@@ -121,11 +130,8 @@ static void clk_init(void)
     /* Wait till the high speed clock source is ready
      * NOTE: the MCU will stay here forever if you use an external clock source and it's not connected */
     while ((RCC->CR & CLOCK_CR_SOURCE_RDY) == 0) {}
-    /* Enable Prefetch Buffer */
-    FLASH->ACR |= FLASH_ACR_PRFTBE;
-    /* Set the flash wait state */
-    FLASH->ACR &= ~((uint32_t)FLASH_ACR_LATENCY);
-    FLASH->ACR |= (uint32_t)CLOCK_FLASH_LATENCY;
+    /* Enable prefetch buffer and set flash wait state */
+    FLASH->ACR = (uint32_t)(FLASH_ACR_PRFTBE | FLASH_LATENCY);
     /* HCLK = SYSCLK */
     RCC->CFGR |= (uint32_t)CLOCK_AHB_DIV;
     /* PCLK2 = HCLK */


### PR DESCRIPTION
Section 3.3.3 of the reference manual for [stm32f103xx](http://www.st.com/content/ccc/resource/technical/document/reference_manual/59/b9/ba/7f/11/af/43/d5/CD00171190.pdf/files/CD00171190.pdf/jcr:content/translations/en.CD00171190.pdf) CPUs explains in the register description for `FLASH_ACR->LATENCY`:

*Bits 2:0 LATENCY: Latency
These bits represent the ratio of the SYSCLK (system clock) period to the Flash access
time.
000 Zero wait state, if 0 < SYSCLK≤ 24 MHz
001 One wait state, if 24 MHz < SYSCLK ≤ 48 MHz
010 Two wait states, if 48 MHz < SYSCLK ≤ 72 MHz*

but the [CMSIS header](https://github.com/RIOT-OS/RIOT/blob/master/cpu/stm32f1/include/stm32f103xe.h#L6302) defines odd bits for this purpose. In previous versions of the header file, this wasn't the case. I also checked the latest version by ST which has the same problem as well.

Should I take the second commit out? 