### PR TITLE
cpu/stm32l1: check if GPIO in AF or AIN mode

### DIFF
--- a/cpu/stm32l1/periph/gpio.c
+++ b/cpu/stm32l1/periph/gpio.c
@@ -171,13 +171,16 @@ int gpio_read(gpio_t pin)
 {
     GPIO_TypeDef *port = _port(pin);
     uint32_t pin_num = _pin_num(pin);
-
-    if (port->MODER & (3 << (pin_num * 2))) {   /* if configured as output */
+    uint8_t port_mode = (port->MODER & (3 << (pin_num * 2))) >> (pin_num * 2);
+    
+    if (port_mode == 1) {   /* if configured as output */
         return port->ODR & (1 << pin_num);      /* read output data reg */
     }
-    else {
-        return port->IDR & (1 << pin_num);      /* else read input data reg */
+    if (port_mode == 0) {   /* if configured as output */
+        return port->IDR & (1 << pin_num);      /* read input data reg */
     }
+    
+    return -1; /* return error if configured as AF or AIN */
 }
 
 void gpio_set(gpio_t pin)

--- a/cpu/stm32l1/periph/gpio.c
+++ b/cpu/stm32l1/periph/gpio.c
@@ -82,8 +82,9 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     port->OTYPER |=  (((mode >> 4) & 0x1) << pin_num);
     /* finally set pin speed to maximum and reset output */
     port->OSPEEDR |= (3 << (2 * pin_num));
+#if defined (STM32L1XX_HD) || defined (STM32L1XX_XL)
     port->BRR = (1 << pin_num);
-
+#endif
     return 0;
 }
 


### PR DESCRIPTION
gpio_read should return an error if GPIO is in Alternate Functions or Analog Input mode (as for now it returns port->ODR which is incorrect).

Should apply to other Cortex-based MCUs as well.

P.S. Is there any particular reason to return not "0" or "1" as int8_t, but exact position of the pin's bit in the register? E.g. 2^13 if pin 13 is in "1" state.