### PR TITLE
git-cache: bump to latest commit from kaspar030/git-cache.git

### DIFF
--- a/dist/tools/git/README.md
+++ b/dist/tools/git/README.md
@@ -16,7 +16,7 @@ In order to set up the cache, do:
   The used path can be overridden using the "GIT_CACHE_DIR" environment
   variable.
   The cache repository will be used to cache multiple remote repositories.
-- add a repository to the cache: "git cache add \<URL\> [\<name\>]
+- add a repository to the cache: "git cache add \<URL\>
 - whenever needed (at least once after adding a repository),
   run "git cache update"
 

--- a/dist/tools/git/git-cache
+++ b/dist/tools/git/git-cache
@@ -5,69 +5,70 @@ git_cache() {
 }
 
 init() {
-    set -ex
+    set -e
     local _git_dir="$(git_cache rev-parse --git-dir 2>/dev/null)"
-    test "$_git_dir" == "." -o "$_git_dir" == ".git" || {
+    [ "$_git_dir" = "." -o "$_git_dir" = ".git" ] || {
         mkdir -p "${GIT_CACHE_DIR}"
 
         git_cache init --bare
         git_cache config core.compression 1
     }
-    set +ex
+    set +e
 }
 
 add() {
-    set -ex
-    if [ $# -eq 1 ]; then
-        local repo="$1"
-        local name="$(_remote_name $repo)"
-    else
-        local repo="$1"
-        local name="$2"
-    fi
+    set -e
+    local repo="$1"
+    local name="$(_remote_name $repo)"
 
     if ! is_cached "$repo"; then
         git_cache remote add "$name" "$repo"
     else
         echo "git-cache: $url already in cache"
     fi
-    set +ex
+    set +e
 }
 
 update() {
-    set -ex
+    set -e
     local REMOTE=${1:---all}
     git_cache fetch $REMOTE
-    set +ex
+    set +e
 }
 
 is_cached() {
-    set +ex
+    set +e
     local url="$1"
     local REMOTES="$(git_cache remote show)"
     for remote in $REMOTES; do
-        test "$(git_cache remote get-url $remote)" == "$url" && return 0
+        [ "$(git_cache ls-remote --get-url $remote)" = "$url" ] && return 0
     done
-    set -ex
+    set -e
     return 1
 }
 
 list() {
     local REMOTES="$(git_cache remote show)"
     for remote in $REMOTES; do
-        echo "${remote}: $(git_cache remote get-url $remote)"
+        echo "$(git_cache ls-remote --get-url $remote)"
     done
 }
 
 drop() {
-    set -ex
+    set -e
     local REMOTE=${1}
     [ -z "$REMOTE" ] && {
-        echo "usage: git cache drop <name>"
+        echo "usage: git cache drop <url>"
         exit 1
     }
-    git_cache remote remove $REMOTE
-    set +ex
+    local REMOTES="$(git_cache remote show)"
+    for remote in $REMOTES; do
+        [ "$(git_cache ls-remote --get-url $remote)" = "$REMOTE" ] && {
+            git_cache remote remove $remote
+            break
+        }
+    done
+    set +e
 }
 
 _check_commit() {
@@ -75,33 +76,32 @@ _check_commit() {
 }
 
 _remote_name() {
-    basename "$*" .git
+    echo "$*" | md5sum | cut -d\  -f1
 }
 
 clone() {
-    set -ex
+    set -e
     local REMOTE="${1}"
     local SHA1="${2}"
     local REMOTE_NAME="$(_remote_name $REMOTE)"
     local TARGET_PATH="${3:-${REMOTE_NAME}}"
 
-    if [ "$GIT_CACHE_AUTOADD" == "1" ]; then
+    if [ "$GIT_CACHE_AUTOADD" = "1" ]; then
         if ! is_cached "$REMOTE"; then
+            echo "git cache: auto-adding $REMOTE"
             add "$REMOTE"
             update "$(_remote_name $REMOTE)"
         fi
     fi
 
     if _check_commit $2 2>&1; then
-        git init "${TARGET_PATH}"
         git_cache tag commit$SHA1 $SHA1 || true # ignore possibly already existing tag
-        git -C "${TARGET_PATH}" fetch --tags --depth=1 "${GIT_CACHE_DIR}" refs/tags/commit$SHA1
-        git -C "${TARGET_PATH}" checkout FETCH_HEAD
+        git clone --reference "${GIT_CACHE_DIR}" "${GIT_CACHE_DIR}" "${TARGET_PATH}" --branch commit$SHA1
     else
-        git clone "${REMOTE}" "${TARGET_PATH}"
+        git clone --reference "${GIT_CACHE_DIR}" "${REMOTE}" "${TARGET_PATH}"
         git -C "${TARGET_PATH}" checkout $SHA1
     fi
-    set +ex
+    set +e
 }
 
 usage() {
@@ -111,11 +111,10 @@ usage() {
     echo "usage:"
     echo ""
     echo "    git cache init                initialize git cache"
-    echo "    git cache add <url> [<name>]  add repository <url> with name <name>"
-    echo "                                  (if no name given, use \"basename $url .git\""
+    echo "    git cache add <url>           add repository <url>"
     echo "    git cache list                list cached repositories"
-    echo "    git cache drop <name>         drop repo from cache"
-    echo "    git cache update [<name>]     fetch repo named <name> (or all)"
+    echo "    git cache drop <url>          drop repo from cache"
+    echo "    git cache update [<url>]      fetch repo <url> (or all)"
     echo "    git cache clone <url> <SHA1>  clone repository <url> from cache"
     echo "    git cache show-path           print's the path that can be used as "
     echo "                                  '--reference' parameter"
@@ -124,8 +123,13 @@ usage() {
     echo '    git clone --reference $(git cache show-path) <repo>'
 }
 
+[ $# -eq 0 ] && {
+    usage
+    exit 1
+}
+
 ACTION=$1
-shift
+shift 1
 
 export GIT_CACHE_DIR=${GIT_CACHE_DIR:-${HOME}/.gitcache}
 


### PR DESCRIPTION
Better use `=` to check the value of `GIT_CACHE_AUTOADD`. While the current check works for me on `bash@4.4.5`, it somehow fails for `bash@4.3.46`.

`bash@4.3.46` evaluates:
```
+ [  == 1 ]
RIOT/dist/tools/git/git-cache: 88: [: unexpected operator
```

`bash@4.4.5` evaluates:
```
+ '[' '' == 1 ']'
```

With a signle `=` it appears to work in both cases.

---

EDIT: This PR now bumps the `git-cache` to the current version (84be6b4 from kaspar030/git-cache.git)