### PR TITLE
doc: sock: fix broken markdown link

### DIFF
--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -63,7 +63,7 @@
  * network stack it uses.
  * The network stack used under the bonnet is specified by including the
  * appropriate module (for example `USEMODULE += gnrc_sock_udp` for
- * [GNRC's](net_gnrc) version of this API).
+ * [GNRC's](@ref net_gnrc) version of this API).
  *
  * This allows for network stack agnostic code on the application layer.
  * The application code to establish a connection is always the same, allowing


### PR DESCRIPTION
Without the `@ref`, the url is not displayed correctly.
See http://doc.riot-os.org/group__net__sock.html