### PR TITLE
iana: rename to portrange

### DIFF
--- a/sys/include/net/iana/portrange.h
+++ b/sys/include/net/iana/portrange.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_iana  IANA Port Numbers
+ * @defgroup    net_iana_portrange  IANA Port Ranges
  * @ingroup     net
  * @brief       Service Name and Transport Protocol Port Number Registry
  * @{


### PR DESCRIPTION
See https://github.com/RIOT-OS/RIOT/pull/6268#issuecomment-269250910 ff

> I find this naming unfortunate...
>
> 1. There is already a number of headers importing IANA defined values (`net/protnum.h`, `net/ethertype.h`, ...)
> 2. We don't define e.g. IPv6 values in an `ietf.h` header
>    2.1 it's too generic