### PR TITLE
examples/nanocoap_server: update nanocoap version

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -13,7 +13,7 @@
 
 static ssize_t _riot_board_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len)
 {
-    return coap_reply_simple(pkt, buf, len,
+    return coap_reply_simple(pkt, COAP_CODE_205, buf, len,
             COAP_FORMAT_TEXT, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
 }
 

--- a/pkg/nanocoap/Makefile
+++ b/pkg/nanocoap/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=nanocoap
 PKG_URL=https://github.com/kaspar030/sock
-PKG_VERSION=cf2aff1b4322cee06bb5b24d0215bb764372fba7
+PKG_VERSION=4035239dce751216038bb2dc8632aa4a734d68a7
 PKG_LICENSE=LGPL-2.1
 
 .PHONY: all


### PR DESCRIPTION
Use latest version of nanocoap with configurable return code (see https://github.com/kaspar030/sock/pull/10 and https://github.com/kaspar030/sock/pull/9)

This new version make it possible to provide a correct return code with PUT/POST request. This was required in #6136