### PR TITLE
hashes/sha256: add iterative hmac calc. functions

### DIFF
--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -2,6 +2,7 @@
  * Copyright 2005 Colin Percival
  * Copyright 2013 Christian Mehlis & René Kijewski
  * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * Copyright 2016 OTA keys S.A.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,6 +40,7 @@
  * @author      Christian Mehlis
  * @author      Rene Kijewski
  * @author      Martin Landsmann
+ * @author      Hermann Lelong
  *
  * @}
  */
@@ -277,8 +279,8 @@ void *sha256(const void *data, size_t len, void *digest)
     return digest;
 }
 
-const void *hmac_sha256(const void *key, size_t key_length,
-                        const void *data, size_t len, void *digest)
+
+void hmac_sha256_init(hmac_context_t *ctx, const void *key, size_t key_length)
 {
     unsigned char k[SHA256_INTERNAL_BLOCK_SIZE];
 
@@ -305,16 +307,29 @@ const void *hmac_sha256(const void *key, size_t key_length,
     }
 
     /*
-     * Create the inner hash
+     * Initiate calculation of the inner hash
      * tmp = hash(i_key_pad CONCAT message)
      */
-    sha256_context_t c;
-    unsigned char tmp[SHA256_DIGEST_LENGTH];
+    sha256_init(&ctx->c_in);
+    sha256_update(&ctx->c_in, i_key_pad, SHA256_INTERNAL_BLOCK_SIZE);
 
-    sha256_init(&c);
-    sha256_update(&c, i_key_pad, SHA256_INTERNAL_BLOCK_SIZE);
-    sha256_update(&c, data, len);
-    sha256_final(&c, tmp);
+    /*
+     * Initiate calculation of the outer hash
+     * result = hash(o_key_pad CONCAT tmp)
+     */
+    sha256_init(&ctx->c_out);
+    sha256_update(&ctx->c_out, o_key_pad, SHA256_INTERNAL_BLOCK_SIZE);
+
+}
+
+void hmac_sha256_update(hmac_context_t *ctx, const void *data, size_t len)
+{
+    sha256_update(&ctx->c_in, data, len);
+}
+
+void hmac_sha256_final(hmac_context_t *ctx, void *digest)
+{
+    unsigned char tmp[SHA256_DIGEST_LENGTH];
 
     static unsigned char m[SHA256_DIGEST_LENGTH];
 
@@ -322,14 +337,20 @@ const void *hmac_sha256(const void *key, size_t key_length,
         digest = m;
     }
 
-    /*
-     * Create the outer hash
-     * result = hash(o_key_pad CONCAT tmp)
-     */
-    sha256_init(&c);
-    sha256_update(&c, o_key_pad, SHA256_INTERNAL_BLOCK_SIZE);
-    sha256_update(&c, tmp, SHA256_DIGEST_LENGTH);
-    sha256_final(&c, digest);
+    sha256_final(&ctx->c_in, tmp);
+    sha256_update(&ctx->c_out, tmp, SHA256_DIGEST_LENGTH);
+    sha256_final(&ctx->c_out, digest);
+}
+
+const void *hmac_sha256(const void *key, size_t key_length,
+                        const void *data, size_t len, void *digest)
+{
+
+    hmac_context_t ctx;
+
+    hmac_sha256_init(&ctx, key, key_length);
+    hmac_sha256_update(&ctx,data, len);
+    hmac_sha256_final(&ctx, digest);
 
     return digest;
 }

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -2,6 +2,7 @@
  * Copyright 2005 Colin Percival
  * Copyright 2013 Christian Mehlis & René Kijewski
  * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * Copyright 2016 OTA keys S.A.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,6 +40,7 @@
  * @author      Colin Percival
  * @author      Christian Mehlis
  * @author      Rene Kijewski
+ * @author      Hermann Lelong
  */
 
 #ifndef _SHA256_H_
@@ -58,7 +60,7 @@ extern "C" {
 #define SHA256_INTERNAL_BLOCK_SIZE (64)
 
 /**
- * @brief Context for ciper operatins based on sha256
+ * @brief Context for ciper operations based on sha256
  */
 typedef struct {
     /** global state */
@@ -68,6 +70,16 @@ typedef struct {
     /** data buffer */
     unsigned char buf[64];
 } sha256_context_t;
+
+/**
+ * @brief Context for HMAC operations based on sha256
+ */
+typedef struct {
+    /** Context for inner hash calculation */
+    sha256_context_t c_in;
+    /** Context for outer hash calculation */
+    sha256_context_t c_out;
+} hmac_context_t;
 
 /**
  * @brief sha256-chain indexed element
@@ -115,6 +127,31 @@ void sha256_final(sha256_context_t *ctx, void *digest);
  *               if digest == NULL, one static buffer is used
  */
 void *sha256(const void *data, size_t len, void *digest);
+
+/**
+ * @brief hmac_sha256_init HMAC SHA-256 calculation. Initiate calculation of a HMAC
+ * @param ctx hmac_context_t handle to use
+ * @param[in] key key used in the hmac-sha256 computation
+ * @param[in] key_length the size in bytes of the key
+ */
+void hmac_sha256_init(hmac_context_t *ctx, const void *key, size_t key_length);
+
+/**
+ * @brief hmac_sha256_update Add data bytes for HMAC calculation
+ * @param ctx hmac_context_t handle to use
+ * @param data[in] pointer to the buffer to generate hash from
+ * @param len[in] length of the buffer
+ */
+void hmac_sha256_update(hmac_context_t *ctx, const void *data, size_t len);
+
+/**
+ * @brief hmac_sha256_final HMAC SHA-256 finalization. Finish HMAC calculation and export the value
+ * @param ctx hmac_context_t handle to use
+ * @param[out] digest the computed hmac-sha256,
+ *             length MUST be SHA256_DIGEST_LENGTH
+ *             if digest == NULL, a static buffer is used
+ */
+void hmac_sha256_final(hmac_context_t *ctx, void *digest);
 
 /**
  * @brief function to compute a hmac-sha256 from a given message

--- a/tests/unittests/tests-hashes/tests-hashes-sha256-hmac.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha256-hmac.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * Copyright 2016 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -153,6 +154,180 @@ static void test_hashes_hmac_sha256_hash_PRF6(void)
                  "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2", hmac));
 }
 
+static void test_hashes_hmac_sha256_ite_hash_sequence(void)
+{
+    unsigned char key[64];
+    hmac_context_t ctx;
+    /* prepare an empty key */
+    memset((void*)key, 0x0, 64);
+    static uint8_t hmac[SHA256_DIGEST_LENGTH];
+
+    /* use an empty message */
+    const unsigned char *m = NULL;
+    hmac_sha256_init(&ctx, key, sizeof(key));
+    hmac_sha256_update(&ctx, m, 0);
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad", hmac));
+
+    /* use a real message */
+    const unsigned char str[] = "The quick brown fox jumps over the lazy dog";
+    key[0] = 'k';
+    key[1] = 'e';
+    key[2] = 'y';
+
+    hmac_sha256_init(&ctx, key, sizeof(key));
+    hmac_sha256_update(&ctx, str, strlen((char*)str));
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8", hmac));
+}
+
+/*
+        The followig testcases are taken from:
+        https://tools.ietf.org/html/rfc4868#section-2.7.1
+*/
+
+static void test_hashes_hmac_sha256_ite_hash_PRF1(void)
+{
+    /* Test Case PRF-1: */
+    hmac_context_t ctx;
+    const unsigned char strPRF1[] = "Hi There";
+    unsigned char key[20];
+    static unsigned char hmac[SHA256_DIGEST_LENGTH];
+    memset(key, 0x0b, sizeof(key));
+
+    hmac_sha256_init(&ctx, key, sizeof(key));
+    hmac_sha256_update(&ctx, strPRF1, strlen((char*)strPRF1));
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7", hmac));
+}
+
+static void test_hashes_hmac_sha256_ite_hash_PRF2(void)
+{
+    /* Test Case PRF-2: */
+    hmac_context_t ctx;
+    const unsigned char strPRF2[] = "what do ya want for nothing?";
+    unsigned char key[4] = {'J', 'e', 'f', 'e'};
+    static unsigned char hmac[SHA256_DIGEST_LENGTH];
+
+    hmac_sha256_init(&ctx, key, sizeof(key));
+    hmac_sha256_update(&ctx, strPRF2, strlen((char*)strPRF2));
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843", hmac));
+}
+
+static void test_hashes_hmac_sha256_ite_hash_PRF3(void)
+{
+    /* Test Case PRF-3: */
+    hmac_context_t ctx;
+    char unsigned strPRF3[50];
+    unsigned char key[20];
+    static unsigned char hmac[SHA256_DIGEST_LENGTH];
+
+    memset(strPRF3, 0xdd, sizeof(strPRF3));
+    memset(key, 0xaa, sizeof(key));
+
+    hmac_sha256_init(&ctx, key, sizeof(key));
+    hmac_sha256_update(&ctx, strPRF3, sizeof(strPRF3));
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe", hmac));
+}
+
+static void test_hashes_hmac_sha256_ite_hash_PRF4(void)
+{
+    /* Test Case PRF-4: */
+    hmac_context_t ctx;
+    char unsigned strPRF4[50];
+    unsigned char key[25];
+    static unsigned char hmac[SHA256_DIGEST_LENGTH];
+
+    memset(strPRF4, 0xcd, sizeof(strPRF4));
+    /*
+    * set key to: 0102030405060708090a0b0c0d0e0f10111213141516171819
+    */
+    for (size_t i = 0; i < sizeof(key); ++i) {
+        key[i] = i+1;
+    }
+
+    hmac_sha256_init(&ctx, key, sizeof(key));
+    hmac_sha256_update(&ctx, strPRF4, sizeof(strPRF4));
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b", hmac));
+}
+
+static void test_hashes_hmac_sha256_ite_hash_PRF5(void)
+{
+    /* Test Case PRF-5: */
+    hmac_context_t ctx;
+    const unsigned char strPRF5[] = "Test Using Larger Than Block-Size Key - Hash Key First";
+    unsigned char longKey[131];
+    static unsigned char hmac[SHA256_DIGEST_LENGTH];
+    memset(longKey, 0xaa, sizeof(longKey));
+
+    hmac_sha256_init(&ctx, longKey, sizeof(longKey));
+    hmac_sha256_update(&ctx, strPRF5, strlen((char*)strPRF5));
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54", hmac));
+}
+
+static void test_hashes_hmac_sha256_ite_hash_PRF6(void)
+{
+    /* Test Case PRF-6: */
+    hmac_context_t ctx;
+    const unsigned char strPRF6[] = "This is a test using a larger than block-size key and a "
+                           "larger than block-size data. The key needs to be hashed "
+                           "before being used by the HMAC algorithm.";
+    unsigned char longKey[131];
+    static unsigned char hmac[SHA256_DIGEST_LENGTH];
+    memset(longKey, 0xaa, sizeof(longKey));
+
+    /* the same key is used as above: 131 x 0xa */
+
+    hmac_sha256_init(&ctx, longKey, sizeof(longKey));
+    hmac_sha256_update(&ctx, strPRF6, strlen((char*)strPRF6));
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2", hmac));
+}
+
+static void test_hashes_hmac_sha256_ite_hash_PRF6_split(void)
+{
+    /* Test Case PRF-6: */
+    hmac_context_t ctx;
+    const unsigned char strPRF6_1[] = "This is a test using a larger than block-size key and a ";
+    const unsigned char strPRF6_2[] = "larger than block-size data. The key needs to be hashed ";
+    const unsigned char strPRF6_3[] = "before being used by the HMAC algorithm.";
+
+    unsigned char longKey[131];
+    static unsigned char hmac[SHA256_DIGEST_LENGTH];
+    memset(longKey, 0xaa, sizeof(longKey));
+
+    /* the same key is used as above: 131 x 0xa */
+
+    hmac_sha256_init(&ctx, longKey, sizeof(longKey));
+    hmac_sha256_update(&ctx, strPRF6_1, strlen((char*)strPRF6_1));
+    hmac_sha256_update(&ctx, strPRF6_2, strlen((char*)strPRF6_2));
+    hmac_sha256_update(&ctx, strPRF6_3, strlen((char*)strPRF6_3));
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2", hmac));
+}
+
 Test *tests_hashes_sha256_hmac_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -163,6 +338,14 @@ Test *tests_hashes_sha256_hmac_tests(void)
         new_TestFixture(test_hashes_hmac_sha256_hash_PRF4),
         new_TestFixture(test_hashes_hmac_sha256_hash_PRF5),
         new_TestFixture(test_hashes_hmac_sha256_hash_PRF6),
+        new_TestFixture(test_hashes_hmac_sha256_ite_hash_sequence),
+        new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF1),
+        new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF2),
+        new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF3),
+        new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF4),
+        new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF5),
+        new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF6),
+        new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF6_split),
     };
 
     EMB_UNIT_TESTCALLER(hashes_sha256_tests, NULL, NULL,


### PR DESCRIPTION
Add init, update, and final functions to do HMAC
calculation using blocks, instead of one shot operation.

This is done the same way than for SHA256 iterative calculation.

The old function is still available.

Unit tests OK.