### PR TITLE
drivers/si70xx: fix saul auto initialization

### DIFF
--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -76,3 +76,6 @@ endif
 ifneq (,$(filter xbee,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/xbee/include
 endif
+ifneq (,$(filter si70xx,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/si70xx/include
+endif

--- a/drivers/si70xx/include/si70xx_params.h
+++ b/drivers/si70xx/include/si70xx_params.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_si70xx
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for Si7006/13/20/21
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef SI70XX_PARAMS_H
+#define SI70XX_PARAMS_H
+
+#include "si70xx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters for the Si7006/13/20/21 sensor
+ * @{
+ */
+#ifndef SI70XX_PARAM_I2C_DEV
+#define SI70XX_PARAM_I2C_DEV         (0)
+#endif
+#ifndef SI70XX_PARAM_ADDR
+#define SI70XX_PARAM_ADDR            (0x80)
+#endif
+
+#define SI70XX_PARAMS_DEFAULT        {.i2c_dev = SI70XX_PARAM_I2C_DEV,  \
+                                      .address = SI70XX_PARAM_ADDR }
+/**@}*/
+
+/**
+ * @brief   Configure Si7006/13/20/21
+ */
+static const si70xx_params_t si70xx_params[] =
+{
+#ifdef SI70XX_PARAMS_CUSTOM
+    SI70XX_PARAMS_CUSTOM,
+#else
+    SI70XX_PARAMS_DEFAULT,
+#endif
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SI70XX_PARAMS_H */
+/** @} */

--- a/sys/auto_init/saul/auto_init_si70xx.c
+++ b/sys/auto_init/saul/auto_init_si70xx.c
@@ -49,30 +49,47 @@ extern const saul_driver_t si70xx_temperature_saul_driver;
 extern const saul_driver_t si70xx_relative_humidity_saul_driver;
 /** @} */
 
+/**
+ * @brief   Allocate and configure entries to the SAUL registry
+ */
+saul_reg_t si70xx_saul_reg_info[][2] =
+{
+    {
+        {
+            .name = "si70xx-temp",
+            .driver = &si70xx_temperature_saul_driver
+        },
+        {
+            .name = "si70xx-hum",
+            .driver = &si70xx_relative_humidity_saul_driver
+        }
+    }
+};
+
 void auto_init_si70xx(void)
 {
-    for (int i = 0; i < SI70XX_NUMOF; i++) {
+    for (unsigned i = 0; i < SI70XX_NUMOF; i++) {
         int res = si70xx_init(&si70xx_devs[i],
                               si70xx_params[i].i2c_dev,
                               si70xx_params[i].address);
         if (res < 0) {
             LOG_ERROR("Unable to initialize BMP180 sensor #%i\n", i);
+            return;
         }
-        else {
-            /* temperature */
-            saul_entries[i * 2].dev = &si70xx_devs[i];
-            saul_entries[i * 2].name = si70xx_saul_reg_info[i].name;
-            saul_entries[i * 2].driver = &si70xx_temperature_saul_driver;
 
-            /* relative humidity */
-            saul_entries[(i * 2) + 1].dev = &si70xx_devs[i];
-            saul_entries[(i * 2) + 1].name = si70xx_saul_reg_info[i +1].name;
-            saul_entries[(i * 2) + 1].driver = \
+        /* temperature */
+        saul_entries[i * 2].dev = &si70xx_devs[i];
+        saul_entries[i * 2].name = si70xx_saul_reg_info[i][0].name;
+        saul_entries[i * 2].driver = &si70xx_temperature_saul_driver;
+
+        /* relative humidity */
+        saul_entries[(i * 2) + 1].dev = &si70xx_devs[i];
+        saul_entries[(i * 2) + 1].name = si70xx_saul_reg_info[i][1].name;
+        saul_entries[(i * 2) + 1].driver = \
                 &si70xx_relative_humidity_saul_driver;
 
-            saul_reg_add(&saul_entries[i * 2]);
-            saul_reg_add(&saul_entries[(i * 2) + 1]);
-        }
+        saul_reg_add(&saul_entries[i * 2]);
+        saul_reg_add(&saul_entries[(i * 2) + 1]);
     }
 }
 


### PR DESCRIPTION
Fixes a build issue when using the `si70xx` module along with `auto_init_saul`. To reproduce the problem, add the following line to `examples/default/Makefile` :
```
USEMODULE += si70xx
```
and run `make BOARD=<any board with I2C support>`.

I'd also like to add a non regression test that just try to build a simple example where `auto_init_saul` and `si70xx` are both activated but I'm not sure where to put it. It could also be used for other sensors listed in `sys/auto_init/saul`. Any advice is welcome :)