### PR TITLE
sys/hashes/sha256: remove unnecessary include

### DIFF
--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -47,7 +47,6 @@
 #include <assert.h>
 
 #include "hashes/sha256.h"
-#include "board.h"
 
 #ifdef __BIG_ENDIAN__
 /* Copy a vector of big-endian uint32_t into a vector of bytes */


### PR DESCRIPTION
Fix #6280 