### PR TITLE
pkg: add tweetnacl as a package

### DIFF
--- a/pkg/tweetnacl/Makefile
+++ b/pkg/tweetnacl/Makefile
@@ -1,0 +1,12 @@
+PKG_NAME=tweetnacl
+PKG_URL=https://github.com/RIOT-OS/tweetnacl
+PKG_VERSION=7ea05c7098a16c87fa66e9166ce301666f3f2623
+PKG_LICENSE=PD
+
+.PHONY: all
+
+all: git-download
+	@cp $(RIOTBASE)/pkg/tweetnacl/src/* $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tweetnacl/Makefile.include
+++ b/pkg/tweetnacl/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(BINDIRBASE)/pkg/$(BOARD)/tweetnacl/

--- a/pkg/tweetnacl/README.md
+++ b/pkg/tweetnacl/README.md
@@ -1,0 +1,44 @@
+# TweetNaCl RIOT package
+TweetNaCl is the world's first auditable high-security cryptographic library.
+TweetNaCl fits into just 100 tweets while supporting all 25 of the C NaCl
+functions used by applications. TweetNaCl is a self-contained public-domain C
+library, so it can easily be integrated into applications.
+
+NaCl (pronounced "salt") is a new easy-to-use high-speed software library for
+network communication, encryption, decryption, signatures, etc. NaCl's goal is
+to provide all of the core operations needed to build higher-level
+cryptographic tools.
+
+Of course, other libraries already exist for these core operations. NaCl
+advances the state of the art by improving security, by improving usability,
+and by improving speed.
+
+(from https://nacl.cr.yp.to/ and http://tweetnacl.cr.yp.to/)
+
+You can find the API and more information [here](https://nacl.cr.yp.to/), since
+the sources are not documented due to the aim for fitting in 100 tweets.
+
+## Requirements
+TweetNaCl requires more than 2K of stack, so beware that you're allocating at
+least `THREAD_STACKSIZE_DEFAULT + 2048` bytes.
+
+You can do it easily by adding:
+
+```makefile
+CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_DEFAULT + 2048)'
+```
+
+to your makefile.
+
+## Usage
+Just add it as a package in your application:
+
+```makefile
+USEPKG += tweetnacl
+```
+
+And don't forget to include the header:
+
+```c
+#include <tweetnacl.h>
+```

--- a/pkg/tweetnacl/src/Makefile
+++ b/pkg/tweetnacl/src/Makefile
@@ -1,0 +1,3 @@
+MODULE=tweetnacl
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/tweetnacl/src/randombytes.c
+++ b/pkg/tweetnacl/src/randombytes.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "random.h"
+
+#include <stdio.h>
+
+void randombytes(uint8_t *target, uint64_t n)
+{
+    uint32_t random;
+    uint8_t *random_pos = (uint8_t*)&random;
+    unsigned _n = 0;
+
+    while (n--) {
+        if (! (_n++ & 0x3)) {
+            random = random_uint32();
+            random_pos = (uint8_t *) &random;
+        }
+        *target++ = *random_pos++;
+    }
+}

--- a/tests/unittests/tests-tweetnacl/Makefile
+++ b/tests/unittests/tests-tweetnacl/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-tweetnacl/Makefile.include
+++ b/tests/unittests/tests-tweetnacl/Makefile.include
@@ -1,0 +1,2 @@
+USEMODULE += random
+USEPKG += tweetnacl

--- a/tests/unittests/tests-tweetnacl/tests-tweetnacl.c
+++ b/tests/unittests/tests-tweetnacl/tests-tweetnacl.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     unittests
+ * @{
+ *
+ * @file
+ * @brief       tweetnacl NaCl crypto library tests
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <tweetnacl.h>
+#include "embUnit.h"
+#include "tests-tweetnacl.h"
+
+static const char message[] = "0123456789abcdef";
+static char r[sizeof(message)];
+
+#define MLEN (sizeof(message) + crypto_box_ZEROBYTES)
+
+static unsigned char alice_pk[crypto_box_PUBLICKEYBYTES];
+static unsigned char alice_sk[crypto_box_SECRETKEYBYTES];
+static unsigned char bob_pk[crypto_box_PUBLICKEYBYTES];
+static unsigned char bob_sk[crypto_box_SECRETKEYBYTES];
+static unsigned char m[MLEN];
+static unsigned char c[MLEN];
+static const unsigned char n[crypto_box_NONCEBYTES];
+static unsigned char result[MLEN];
+
+static void setUp(void)
+{
+    /* Initialize */
+    random_init(0);
+}
+
+static void tearDown(void)
+{
+    /* Finalize */
+}
+
+static void test_tweetnacl_01(void)
+{
+    int res;
+
+    /* Creating keypair ALICE... */
+    crypto_box_keypair(alice_pk, alice_sk);
+
+    /* Creating keypair BOB... */
+    crypto_box_keypair(bob_pk, bob_sk);
+
+    memset(m, 0, crypto_box_ZEROBYTES);
+    memcpy(m + crypto_box_ZEROBYTES, message, MLEN - crypto_box_ZEROBYTES);
+
+    /* Encrypting using pk_bob... */
+    crypto_box(c, m, MLEN, n, bob_pk, alice_sk);
+
+    memset(result, '\0', sizeof(result));
+
+    /* Decrypting... */
+    res = crypto_box_open(result, c, MLEN, n, alice_pk, bob_sk);
+
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    memset(r, 0, sizeof(r));
+    memcpy(r, result + crypto_box_ZEROBYTES, MLEN - crypto_box_ZEROBYTES);
+
+    TEST_ASSERT_EQUAL_STRING("0123456789abcdef", (const char*)r);
+}
+
+Test *tests_tweetnacl_all(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_tweetnacl_01)
+    };
+
+    EMB_UNIT_TESTCALLER(tweetnacl_tests, setUp, tearDown, fixtures);
+    return (Test*)&tweetnacl_tests;
+}
+
+void tests_tweetnacl(void)
+{
+    TESTS_RUN(tests_tweetnacl_all());
+}

--- a/tests/unittests/tests-tweetnacl/tests-tweetnacl.h
+++ b/tests/unittests/tests-tweetnacl/tests-tweetnacl.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016 Martin Landsmann
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``tweetnacl`` package
+ *
+ * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ */
+#ifndef TESTS_TWEETNACL_H
+#define TESTS_TWEETNACL_H
+
+#include "embUnit/embUnit.h"
+#include "random.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MANDATORY function for collecting random Bytes
+ *        required by the tweetnacl package
+ */
+extern void randombytes(uint8_t *target, uint64_t n);
+
+/**
+*  @brief   The entry point of this test suite.
+*/
+void tests_tweetnacl(void);
+
+/**
+ * @brief   Generates tests for tweetnacl
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_tweetnacl_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_TWEETNACL_H */
+/** @} */


### PR DESCRIPTION
4th attempt for tweetnacl.

This time the repository resides in git, and two very small modifications were done to make it compile with clang (caused some warnings for different size integers comparisons).