### PR TITLE
cpu: stm32: use unsigned as loop counter

### DIFF
--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -131,7 +131,7 @@ static inline void irq_handler(tim_t tim)
 {
     uint32_t status = (dev(tim)->SR & dev(tim)->DIER);
 
-    for (uint8_t i = 0; i < TIMER_CHAN; i++) {
+    for (unsigned int i = 0; i < TIMER_CHAN; i++) {
         if (status & (TIM_SR_CC1IF << i)) {
             dev(tim)->DIER &= ~(TIM_DIER_CC1IE << i);
             isr_ctx[tim].cb(isr_ctx[tim].arg, i);


### PR DESCRIPTION
Small fix to an unintended change in #6184.