### PR TITLE
pkg: add pkg license information

### DIFF
--- a/pkg/aversiveplusplus/Makefile
+++ b/pkg/aversiveplusplus/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=aversiveplusplus
 PKG_URL=https://github.com/AversivePlusPlus/AversivePlusPlus.git
 PKG_VERSION=7189e63551fd156719528016d585d870996d8834
+PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all
 

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=ccn-lite
 PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
 PKG_VERSION=0b1de2da1ef407ee5793c0e7eda420391ae056dc
+PKG_LICENSE=ISC
 
 .PHONY: all
 

--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=cmsis-dsp
 PKG_URL=https://github.com/gebart/CMSIS-DSP.git
 PKG_VERSION=v1.4.5a-riot2
+PKG_LICENSE=BSD-3-Clause
 
 ifneq ($(RIOTBASE),)
 include $(RIOTBASE)/Makefile.base

--- a/pkg/emb6/Makefile
+++ b/pkg/emb6/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=emb6
 PKG_URL=https://github.com/hso-esk/emb6.git
 PKG_VERSION=14e4a3cfff01644e078870e14e16a1fe60dcc895
-PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all
 

--- a/pkg/iotivity/Makefile
+++ b/pkg/iotivity/Makefile
@@ -1,10 +1,9 @@
 PKG_NAME=iotivity-constrained
 PKG_URL=https://github.com/iotivity/iotivity-constrained
 PKG_VERSION=96b50da1762d016790ac7fa516d95a0252bb2f72
-PKG_DIR=$(CURDIR)
+PKG_LICENSE=Apache-2.0
 
 PKG_LIB=$(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
-
 
 MODULE_MAKEFILE := $(PKG_DIR)/Makefile.module
 

--- a/pkg/jsmn/Makefile
+++ b/pkg/jsmn/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=jsmn
 PKG_URL=https://github.com/zserge/jsmn
 PKG_VERSION=b77d84ba48e057aa464b6c6b6f6209e632918cb3
+PKG_LICENSE=MIT
 
 .PHONY: all
 

--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -1,11 +1,7 @@
 PKG_NAME=libcoap
 PKG_URL=https://github.com/obgm/libcoap
 PKG_VERSION=ef41ce5d02d64cec0751882ae8fd95f6c32bc018
-
-ifneq ($(RIOTBASE),)
-INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
-			-I$(RIOTBASE)/sys/posix/include -I$(RIOTBASE)/sys/posix/pnet/include
-endif
+PKG_LICENSE=BSD-2-Clause
 
 .PHONY: all
 

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME     := libfixmath
 PKG_VERSION  := ad9ed940e57d43432b276e95aee6ca9df6f23ccd
-PKG_URL      := git://github.com/PetteriAimonen/libfixmath
-PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+PKG_URL      := https://github.com/PetteriAimonen/libfixmath
+PKG_LICENSE  := MIT
 
 .PHONY: all
 

--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=lwip
 PKG_URL=git://git.savannah.nongnu.org/lwip.git
 PKG_VERSION=fd4a109ffa6513b28a0c780a952cef1110423717
-PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all
 

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -1,11 +1,7 @@
 PKG_NAME=micro-ecc
 PKG_URL=https://github.com/kmackay/micro-ecc.git
 PKG_VERSION=b6c0cdbe7d20af48b0c2a909a66ff00b093d1542
-
-ifneq ($(RIOTBASE),)
-INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
-			-I$(RIOTBASE)/sys/posix/include
-endif
+PKG_LICENSE=BSD-2-Clause
 
 .PHONY: all
 

--- a/pkg/microcoap/Makefile
+++ b/pkg/microcoap/Makefile
@@ -1,11 +1,7 @@
 PKG_NAME=microcoap
-PKG_URL=git://github.com/1248/microcoap.git
+PKG_URL=https://github.com/1248/microcoap.git
 PKG_VERSION=9cb1dcda2182a8dca8483b230cda8b591a924c82
-
-ifneq ($(RIOTBASE),)
-INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
-			-I$(RIOTBASE)/sys/posix/include
-endif
+PKG_LICENSE=MIT
 
 .PHONY: all
 

--- a/pkg/nanocoap/Makefile
+++ b/pkg/nanocoap/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=nanocoap
 PKG_URL=https://github.com/kaspar030/sock
 PKG_VERSION=cf2aff1b4322cee06bb5b24d0215bb764372fba7
+PKG_LICENSE=LGPL-2.1
 
 .PHONY: all
 

--- a/pkg/nordic_softdevice_ble/Makefile
+++ b/pkg/nordic_softdevice_ble/Makefile
@@ -2,6 +2,7 @@ PKG_NAME = nordic_softdevice_ble
 PKG_VERSION = 3288530
 PKG_FILE = nrf5_iot_sdk_$(PKG_VERSION).zip
 PKG_URL = https://developer.nordicsemi.com/nRF5_IoT_SDK/nRF5_IoT_SDK_v0.9.x/$(PKG_FILE)
+PKG_LICENSE = nordic-bsd
 PKG_DIR=$(CURDIR)
 PKG_BUILDDIR=$(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
 PKG_SRCDIR=$(PKG_BUILDDIR)/src

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -1,11 +1,7 @@
 PKG_NAME=oonf_api
 PKG_URL=https://github.com/OLSR/OONF.git
 PKG_VERSION=v0.3.0
-
-ifneq ($(RIOTBASE),)
-INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
-			-I$(RIOTBASE)/sys/posix/include
-endif
+PKG_LICENSE=BSD-3-Clause
 
 MODULE:=$(PKG_NAME)
 

--- a/pkg/openwsn/Makefile
+++ b/pkg/openwsn/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=openwsn
 PKG_URL=https://github.com/openwsn-berkeley/openwsn-fw.git
 PKG_VERSION=ff25e5d0ae5d344ed793a724d60532fb917bf1f8
+PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all
 

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -1,11 +1,7 @@
 PKG_NAME=relic
-PKG_URL=http://github.com/relic-toolkit/relic.git
+PKG_URL=https://github.com/relic-toolkit/relic.git
 PKG_VERSION=cdcfaeef101d18c3231c3b46359c519dd72682e8
-
-ifneq ($(RIOTBASE),)
-INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include \
-			-I$(RIOTBASE)/sys/posix/include -I$(RIOTBASE)/sys/posix/pnet/include
-endif
+PKG_LICENSE=LGPL-2.1
 
 .PHONY: all
 

--- a/pkg/tiny-asn1/Makefile
+++ b/pkg/tiny-asn1/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME = tiny-asn1
 PKG_URL = https://gitlab.com/matthegap/tiny-asn1.git
 PKG_VERSION = b09f058966c6296904487c3f8fc04c68fe83b2cc
+PKG_LICENSE = LGPL-3
 
 export TINYASN1_ROOT=$(CURDIR)
 INCLUDES+=-I$(TINYASN1_ROOT)/src
@@ -9,4 +10,5 @@ INCLUDES+=-I$(TINYASN1_ROOT)/src
 
 all: git-download
 	$(MAKE) -C $(PKG_BUILDDIR)/src
+
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME=tinydtls
-PKG_URL=git://github.com/rfuentess/TinyDTLS.git
+PKG_URL=https://github.com/rfuentess/TinyDTLS.git
 # PKG_VERSION=RIOT-OS
 PKG_VERSION=d06ad84d3e8bd3e86f7557faee34b68d5f8c0129
-PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+PKG_LICENSE=EPL-1.0,EDL-1.0
 
 .PHONY: all
 

--- a/pkg/tlsf/Makefile
+++ b/pkg/tlsf/Makefile
@@ -2,6 +2,7 @@ PKG_NAME = tlsf
 PKG_VERSION = 3.0
 PKG_FILE = tlsf-$(PKG_VERSION).zip
 PKG_URL = http://download.riot-os.org/$(PKG_FILE)
+PKG_LICENSE = PD
 PKG_DIR=$(CURDIR)
 PKG_BUILDDIR=$(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
 PKG_SRCDIR=$(PKG_BUILDDIR)/src

--- a/pkg/u8g2/Makefile
+++ b/pkg/u8g2/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=u8g2
 PKG_URL=https://github.com/olikraus/u8g2
 PKG_VERSION=2c9ca376e0e0eaa496494926ccfd77b035518c8d
+PKG_LICENSE=BSD-2-Clause
 
 .PHONY: all
 

--- a/pkg/wakaama/Makefile
+++ b/pkg/wakaama/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=wakaama
-PKG_URL=git://github.com/eclipse/wakaama.git
+PKG_URL=https://github.com/eclipse/wakaama.git
 PKG_VERSION=69a32cfae39f66fe4eec4cc8d1cd48ced7ad447c
+PKG_LICENSE=EDL-1.0,EPL-1.0
 
 .PHONY: all
 


### PR DESCRIPTION
While writing licensing guides for the wiki, I realised I had no clue which package has which license.

This PR adds the license in a machine parseable form (PKG_LICENSE) to the makefile.

I tried to use github's short designators (Apache-2.0, LGPL-2.1, BSD-3-Clause...).

Additionally I piggybacked some Makefile cleanups, and all github URLs are now https (some where http://, some git://).