### PR TITLE
drivers/at86rf2xx: fix buffer-less SPI transfer

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -160,8 +160,11 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
     /* copy payload */
     at86rf2xx_fb_read(dev, (uint8_t *)buf, pkt_len);
 
-    /* Ignore FCS but advance fb read */
-    at86rf2xx_fb_read(dev, NULL, 2);
+    /* Ignore FCS but advance fb read - we must give a temporary buffer here,
+     * as we are not allowed to issue SPI transfers without any buffer */
+    uint8_t tmp[2];
+    at86rf2xx_fb_read(dev, tmp, 2);
+    (void)tmp;
 
     if (info != NULL) {
         netdev2_ieee802154_rx_info_t *radio_info = info;


### PR DESCRIPTION
While testing #4780, we found the `at86rf2xx` driver hard-faulting when receiving packets. The reason was a bug in the `at86` driver, where an empty (i.e. no `in` and `out` buffers given) SPI transfer was triggered. On some platforms this was mitigated by calling many single `spi_transfer_byte` from within `spi_transfer_bytes` (e.g. `samr21-xpro`). On other platforms I sincerely wonder why we don't see hardfaults, e.g. on the `iotlab-m3` we call `spi->DR = (uint8_t)out[i];` with `out` being `NULL`...

Anyway, this PR should fix this for good.