### PR TITLE
boards/nucleo-f446: configure a few pwm pins

### DIFF
--- a/boards/nucleo-f446/Makefile.features
+++ b/boards/nucleo-f446/Makefile.features
@@ -5,6 +5,7 @@ FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_pwm
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/nucleo-common/Makefile.features

--- a/boards/nucleo-f446/include/periph_conf.h
+++ b/boards/nucleo-f446/include/periph_conf.h
@@ -54,13 +54,6 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev      = TIM2,
-        .max      = 0xffffffff,
-        .rcc_mask = RCC_APB1ENR_TIM2EN,
-        .bus      = APB1,
-        .irqn     = TIM2_IRQn
-    },
-    {
         .dev      = TIM5,
         .max      = 0xffffffff,
         .rcc_mask = RCC_APB1ENR_TIM5EN,
@@ -69,8 +62,7 @@ static const timer_conf_t timer_config[] = {
     }
 };
 
-#define TIMER_0_ISR         isr_tim2
-#define TIMER_1_ISR         isr_tim5
+#define TIMER_0_ISR         isr_tim5
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
@@ -100,6 +92,43 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @brief   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .pins     = { GPIO_PIN(PORT_A, 15), GPIO_PIN(PORT_B, 3),
+                      GPIO_PIN(PORT_B, 10), GPIO_PIN(PORT_B, 2) },
+        .af       = GPIO_AF1,
+        .chan     = 4,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .pins     = { GPIO_PIN(PORT_B, 4), GPIO_UNDEF,
+                      GPIO_UNDEF, GPIO_UNDEF },
+        .af       = GPIO_AF2,
+        .chan     = 1,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM8,
+        .rcc_mask = RCC_APB2ENR_TIM8EN,
+        .pins     = { GPIO_PIN(PORT_C, 6), GPIO_PIN(PORT_C, 7),
+                      GPIO_PIN(PORT_C, 8), GPIO_PIN(PORT_C, 9) },
+        .af       = GPIO_AF3,
+        .chan     = 4,
+        .bus      = APB2
+    },
+};
+
+#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
 /** @} */
 
 /**


### PR DESCRIPTION
Configure 9 pins with PWM capability :
- D3, D5, D6 and D9 on the Arduino connectors
- PC6, PC7, PC8, PC9 and PB2 on the Morpho connectors

I had to remove TIM2 from the configured timers because it's used for the PWM pins on the Arduino connectors. TIM5 is used for the default timer now.