### PR TITLE
tools: pyterm: specify custom format prefix via command line

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -80,7 +80,7 @@ class SerCmd(cmd.Cmd):
 
     def __init__(self, port=None, baudrate=None, toggle=None, tcp_serial=None,
                  confdir=None, conffile=None, host=None, run_name=None,
-                 log_dir_name=None, newline=None):
+                 log_dir_name=None, newline=None, formatter=None):
         """Constructor.
 
         Args:
@@ -106,6 +106,8 @@ class SerCmd(cmd.Cmd):
         self.run_name = run_name
         self.log_dir_name = log_dir_name
         self.newline = newline
+        if not formatter is None:
+            self.fmt_str = formatter
 
         if not self.host:
             self.host = defaulthostname
@@ -126,7 +128,7 @@ class SerCmd(cmd.Cmd):
         self.json_regs = dict()
         self.init_cmd = []
         self.load_config()
-        if self.fmt_str == None:
+        if not hasattr(self, "fmt_str") or self.fmt_str is None:
             self.fmt_str = default_fmt_str
         else:
             self.fmt_str = str(self.fmt_str.replace('"', '')) + "%(message)s"
@@ -490,8 +492,8 @@ class SerCmd(cmd.Cmd):
                     self.init_cmd.append(self.config.get(sec, opt))
             else:
                 for opt in self.config.options(sec):
-                    if opt not in self.__dict__:
-                        self.__dict__[opt] = self.config.get(sec, opt)
+                    if not hasattr(self, opt):
+                        setattr(self, opt, self.config.get(sec, opt))
 
     def timer_handler(self, line):
         """Handles a scheduled timer event.
@@ -705,6 +707,13 @@ if __name__ == "__main__":
                         help="Specify the config filename, default is %s"
                         % defaultfile,
                         default=defaultfile)
+    parser.add_argument("-f", "--format",
+                        help="The format prefix for output and log entries, "
+                        "default is %s"
+                        % str.replace(default_fmt_str, '%', '%%'))
+    parser.add_argument("-np", "--noprefix",
+                        action="store_true",
+                        help="Disable format prefix, raw output")
     parser.add_argument("-s", "--server",
                         help="Connect via TCP to this server to send output "
                         "as JSON")
@@ -724,9 +733,11 @@ if __name__ == "__main__":
                         default=defaultnewline)
     args = parser.parse_args()
 
+    if (args.noprefix):
+        args.format = ""
     myshell = SerCmd(args.port, args.baudrate, args.toggle, args.tcp_serial,
                      args.directory, args.config, args.host, args.run_name,
-                     args.log_dir_name, args.newline)
+                     args.log_dir_name, args.newline, args.format)
     myshell.prompt = ''
 
     if args.server and args.tcp_port:


### PR DESCRIPTION
This is based on #6308 and adds a command line argument to either set or disable the format prefix for pyterm's output and log.