### PR TITLE
cpu/native: allow for multiple netdev2_tap devices

### DIFF
--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -69,11 +69,12 @@ void native_async_read_setup(void) {
 void native_async_read_cleanup(void) {
     unregister_interrupt(SIGIO);
 
-#ifdef __MACH__
     for (int i = 0; i < _next_index; i++) {
+#ifdef __MACH__
         kill(_sigio_child_pids[i], SIGKILL);
-    }
 #endif
+        real_close(_fds[i]);
+    }
 }
 
 void native_async_read_continue(int fd) {

--- a/cpu/native/include/netdev2_tap.h
+++ b/cpu/native/include/netdev2_tap.h
@@ -55,24 +55,12 @@ typedef struct {
 } netdev2_tap_params_t;
 
 /**
- * @brief global device struct. driver only supports one tap device as of now.
- */
-extern netdev2_tap_t netdev2_tap;
-
-/**
  * @brief Setup netdev2_tap_t structure.
  *
  * @param dev       the preallocated netdev2_tap device handle to setup
  * @param params    initialization parameters
  */
 void netdev2_tap_setup(netdev2_tap_t *dev, const netdev2_tap_params_t *params);
-
-/**
- * @brief Cleanup tap resources
- *
- * @param dev  the netdev2_tap device handle to cleanup
- */
-void netdev2_tap_cleanup(netdev2_tap_t *dev);
 
 #ifdef __cplusplus
 }

--- a/cpu/native/include/netdev2_tap_params.h
+++ b/cpu/native/include/netdev2_tap_params.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     netdev2
+ * @brief
+ * @{
+ *
+ * @file
+ * @brief       Default configuration for the netdev2_tap driver
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NETDEV2_TAP_PARAMS_H_
+#define NETDEV2_TAP_PARAMS_H_
+
+#include "netdev2_tap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Number of allocated parameters at @ref netdev2_tap_params
+ *
+ * @note    This was decided to only be configurable on compile-time to be
+ *          more similar to actual boards
+ */
+#ifndef NETDEV2_TAP_MAX
+#define NETDEV2_TAP_MAX             (1)
+#endif
+
+/**
+ * @brief   Configuration parameters for @ref netdev2_tap_t
+ *
+ * @note    This variable is set on native start-up based on arguments provided
+ */
+extern netdev2_tap_params_t netdev2_tap_params[NETDEV2_TAP_MAX];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NETDEV2_TAP_PARAMS_H_ */
+/** @} */

--- a/cpu/native/include/tty_uart.h
+++ b/cpu/native/include/tty_uart.h
@@ -33,11 +33,6 @@ extern "C" {
  */
 void tty_uart_setup(uart_t uart, const char *name);
 
-/**
- * @brief   closes files opened
- */
-void uart_cleanup(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -387,4 +387,3 @@ static int _init(netdev2_t *netdev)
     DEBUG("gnrc_tapnet: initialized.\n");
     return 0;
 }
-

--- a/cpu/native/netdev2_tap/netdev2_tap.c
+++ b/cpu/native/netdev2_tap/netdev2_tap.c
@@ -60,9 +60,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/* support one tap interface for now */
-netdev2_tap_t netdev2_tap;
-
 /* netdev2 interface */
 static int _init(netdev2_t *netdev);
 static int _send(netdev2_t *netdev, const struct iovec *vector, unsigned n);
@@ -107,10 +104,6 @@ static inline void _isr(netdev2_t *netdev)
 
 static int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
 {
-    if (dev != (netdev2_t *)&netdev2_tap) {
-        return -ENODEV;
-    }
-
     int res = 0;
 
     switch (opt) {
@@ -138,11 +131,6 @@ static int _get(netdev2_t *dev, netopt_t opt, void *value, size_t max_len)
 static int _set(netdev2_t *dev, netopt_t opt, void *value, size_t value_len)
 {
     (void)value_len;
-
-    if (dev != (netdev2_t *)&netdev2_tap) {
-        return -ENODEV;
-    }
-
     int res = 0;
 
     switch (opt) {
@@ -307,9 +295,8 @@ void netdev2_tap_setup(netdev2_tap_t *dev, const netdev2_tap_params_t *params) {
 
 static void _tap_isr(int fd, void *arg) {
     (void) fd;
-    (void) arg;
 
-    netdev2_t *netdev = (netdev2_t *)&netdev2_tap;
+    netdev2_t *netdev = (netdev2_t *)arg;
 
     if (netdev->event_callback) {
         netdev->event_callback(netdev, NETDEV2_EVENT_ISR);
@@ -392,7 +379,7 @@ static int _init(netdev2_t *netdev)
 
     /* configure signal handler for fds */
     native_async_read_setup();
-    native_async_read_add_handler(dev->tap_fd, NULL, _tap_isr);
+    native_async_read_add_handler(dev->tap_fd, netdev, _tap_isr);
 
 #ifdef MODULE_NETSTATS_L2
     memset(&netdev->stats, 0, sizeof(netstats_t));
@@ -401,16 +388,3 @@ static int _init(netdev2_t *netdev)
     return 0;
 }
 
-void netdev2_tap_cleanup(netdev2_tap_t *dev)
-{
-    /* Do we have a device */
-    if (!dev) {
-        return;
-    }
-
-    /* cleanup signal handling */
-    native_async_read_cleanup();
-
-    /* close the tap device */
-    real_close(dev->tap_fd);
-}

--- a/cpu/native/periph/pm.c
+++ b/cpu/native/periph/pm.c
@@ -22,7 +22,7 @@
 
 #include "periph/pm.h"
 #include "native_internal.h"
-#include "netdev2_tap.h"
+#include "async_read.h"
 #include "tty_uart.h"
 
 #define ENABLE_DEBUG (0)
@@ -50,11 +50,7 @@ void pm_reboot(void)
 {
     printf("\n\n\t\t!! REBOOT !!\n\n");
 
-#ifdef MODULE_NETDEV2_TAP
-    netdev2_tap_cleanup(&netdev2_tap);
-#endif
-
-    uart_cleanup();
+    native_async_read_cleanup();
 
     if (real_execve(_native_argv[0], _native_argv, NULL) == -1) {
         err(EXIT_FAILURE, "reboot: execve");

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -175,14 +175,4 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     _native_write(tty_fds[uart], data, len);
 }
 
-void uart_cleanup(void) {
-    native_async_read_cleanup();
-
-    for (uart_t uart = 0; uart < UART_NUMOF; uart++) {
-        if (uart_config[uart].rx_cb != NULL) {
-            real_close(tty_fds[uart]);
-        }
-    }
-}
-
 /** @} */

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -60,8 +60,9 @@ int _native_rng_mode = 0;
 const char *_native_unix_socket_path = NULL;
 
 #ifdef MODULE_NETDEV2_TAP
-#include "netdev2_tap.h"
-extern netdev2_tap_t netdev2_tap;
+#include "netdev2_tap_params.h"
+
+netdev2_tap_params_t netdev2_tap_params[NETDEV2_TAP_MAX];
 #endif
 
 static const char short_opts[] = ":hi:s:deEoc:";
@@ -199,7 +200,9 @@ void usage_exit(int status)
     real_printf("usage: %s", _progname);
 
 #if defined(MODULE_NETDEV2_TAP)
-    real_printf(" <tap interface>");
+    for (int i = 0; i < NETDEV2_TAP_MAX; i++) {
+        real_printf(" <tap interface %d>", i + 1);
+    }
 #endif
 
     real_printf(" [-i <id>] [-d] [-e|-E] [-o] [-c <tty>]\n");
@@ -287,9 +290,11 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
         }
     }
 #ifdef MODULE_NETDEV2_TAP
-    if (argv[optind] == NULL) {
-        /* no tap parameter left */
-        usage_exit(EXIT_FAILURE);
+    for (int i = 0; i < NETDEV2_TAP_MAX; i++) {
+        if (argv[optind + i] == NULL) {
+            /* no tap parameter left */
+            usage_exit(EXIT_FAILURE);
+        }
     }
 #endif
 
@@ -317,9 +322,9 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
     native_cpu_init();
     native_interrupt_init();
 #ifdef MODULE_NETDEV2_TAP
-    netdev2_tap_params_t p;
-    p.tap_name = &(argv[optind]);
-    netdev2_tap_setup(&netdev2_tap, &p);
+    for (int i = 0; i < NETDEV2_TAP_MAX; i++) {
+        netdev2_tap_params[i].tap_name = &argv[optind + i];
+    }
 #endif
 
     board_init();

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -20,6 +20,7 @@
 
 #ifdef MODULE_NETDEV2_TAP
 #include "netdev2_tap.h"
+#include "netdev2_tap_params.h"
 #endif
 
 #ifdef MODULE_AT86RF2XX
@@ -33,7 +34,7 @@
 #include "debug.h"
 
 #ifdef MODULE_NETDEV2_TAP
-#define LWIP_NETIF_NUMOF        (1)
+#define LWIP_NETIF_NUMOF        (NETDEV2_TAP_MAX)
 #endif
 
 #ifdef MODULE_AT86RF2XX     /* is mutual exclusive with above ifdef */
@@ -42,6 +43,10 @@
 
 #ifdef LWIP_NETIF_NUMOF
 static struct netif netif[LWIP_NETIF_NUMOF];
+#endif
+
+#ifdef MODULE_NETDEV2_TAP
+static netdev2_tap_t netdev2_taps[LWIP_NETIF_NUMOF];
 #endif
 
 #ifdef MODULE_AT86RF2XX
@@ -53,9 +58,13 @@ void lwip_bootstrap(void)
     /* TODO: do for every eligable netdev2 */
 #ifdef LWIP_NETIF_NUMOF
 #ifdef MODULE_NETDEV2_TAP
-    if (netif_add(&netif[0], &netdev2_tap, lwip_netdev2_init, tcpip_input) == NULL) {
-        DEBUG("Could not add netdev2_tap device\n");
-        return;
+    for (int i = 0; i < LWIP_NETIF_NUMOF; i++) {
+        netdev2_tap_setup(&netdev2_taps[i], &netdev2_tap_params[i]);
+        if (netif_add(&netif[i], &netdev2_taps[i], lwip_netdev2_init,
+                      tcpip_input) == NULL) {
+            DEBUG("Could not add netdev2_tap device\n");
+            return;
+        }
     }
 #elif defined(MODULE_AT86RF2XX)
     for (int i = 0; i < LWIP_NETIF_NUMOF; i++) {

--- a/sys/auto_init/netif/auto_init_netdev2_tap.c
+++ b/sys/auto_init/netif/auto_init_netdev2_tap.c
@@ -22,33 +22,28 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#include "netdev2_tap.h"
-#include "net/gnrc/netdev2.h"
+#include "netdev2_tap_params.h"
 #include "net/gnrc/netdev2/eth.h"
 
-extern netdev2_tap_t netdev2_tap;
-
-/**
- * @brief   Define stack parameters for the MAC layer thread
- * @{
- */
 #define TAP_MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
-#ifndef TAP_MAC_PRIO
-#define TAP_MAC_PRIO                (GNRC_NETDEV2_MAC_PRIO)
-#endif
+#define TAP_MAC_PRIO                (THREAD_PRIORITY_MAIN - 3)
 
-/**
- * @brief   Stacks for the MAC layer threads
- */
-static char _netdev2_eth_stack[TAP_MAC_STACKSIZE + DEBUG_EXTRA_STACKSIZE];
-static gnrc_netdev2_t _gnrc_netdev2_tap;
+static netdev2_tap_t netdev2_tap[NETDEV2_TAP_MAX];
+static char _netdev2_eth_stack[NETDEV2_TAP_MAX][TAP_MAC_STACKSIZE + DEBUG_EXTRA_STACKSIZE];
+static gnrc_netdev2_t _gnrc_netdev2_tap[NETDEV2_TAP_MAX];
 
 void auto_init_netdev2_tap(void)
 {
-    gnrc_netdev2_eth_init(&_gnrc_netdev2_tap, (netdev2_t*)&netdev2_tap);
+    for (int i = 0; i < NETDEV2_TAP_MAX; i++) {
+        const netdev2_tap_params_t *p = &netdev2_tap_params[i];
+        DEBUG("Initializing netdev2_tap on TAP %s\n", *(p->tap_name));
+        netdev2_tap_setup(&netdev2_tap[i], p);
+        gnrc_netdev2_eth_init(&_gnrc_netdev2_tap[i], (netdev2_t*)&netdev2_tap[i]);
 
-    gnrc_netdev2_init(_netdev2_eth_stack, TAP_MAC_STACKSIZE,
-            TAP_MAC_PRIO, "gnrc_netdev2_tap", &_gnrc_netdev2_tap);
+        gnrc_netdev2_init(_netdev2_eth_stack[i], TAP_MAC_STACKSIZE,
+                          TAP_MAC_PRIO, "gnrc_netdev2_tap",
+                          &_gnrc_netdev2_tap[i]);
+    }
 }
 
 #else


### PR DESCRIPTION
Adaptation of #5614 with start-up sequence. Tested with `gnrc_networking` with

```bash
PORT="tapX tapY"
CFLAGS="-DNETDEV2_TAP_MAX=2 -DGNRC_NETIF_NUMOF=2"
```

Currently the initialization of the (absolute) number of devices is fixed to `NETDEV2_TAP_MAX`, but with a clean-up of the argument parsing in native we could fix that. I leave this to a follow-up PR.