### PR TITLE
auto_init: fix array-initializer order for gnrc_netdev2 stacks

### DIFF
--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -43,7 +43,7 @@
 
 static at86rf2xx_t at86rf2xx_devs[AT86RF2XX_NUM];
 static gnrc_netdev2_t gnrc_adpt[AT86RF2XX_NUM];
-static char _at86rf2xx_stacks[AT86RF2XX_MAC_STACKSIZE][AT86RF2XX_NUM];
+static char _at86rf2xx_stacks[AT86RF2XX_NUM][AT86RF2XX_MAC_STACKSIZE];
 
 void auto_init_at86rf2xx(void)
 {

--- a/sys/auto_init/netif/auto_init_cc110x.c
+++ b/sys/auto_init/netif/auto_init_cc110x.c
@@ -42,7 +42,7 @@
 #define CC110X_NUM (sizeof(cc110x_params)/sizeof(cc110x_params[0]))
 
 static netdev2_cc110x_t cc110x_devs[CC110X_NUM];
-static char _stacks[CC110X_MAC_STACKSIZE][CC110X_NUM];
+static char _stacks[CC110X_NUM][CC110X_MAC_STACKSIZE];
 
 static gnrc_netdev2_t _gnrc_netdev2_devs[CC110X_NUM];
 

--- a/sys/auto_init/netif/auto_init_enc28j60.c
+++ b/sys/auto_init/netif/auto_init_enc28j60.c
@@ -55,7 +55,7 @@ static gnrc_netdev2_t gnrc_adpt[ENC28J60_NUM];
 /**
  * @brief   Stacks for the MAC layer threads
  */
-static char stack[ENC28J60_MAC_STACKSIZE][ENC28J60_NUM];
+static char stack[ENC28J60_NUM][ENC28J60_MAC_STACKSIZE];
 
 
 void auto_init_enc28j60(void)

--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -44,7 +44,7 @@
 #define KW2XRF_NUM (sizeof(kw2xrf_params)/sizeof(kw2xrf_params[0]))
 
 static kw2xrf_t kw2xrf_devs[KW2XRF_NUM];
-static char _nomac_stacks[KW2XRF_MAC_STACKSIZE][KW2XRF_NUM];
+static char _nomac_stacks[KW2XRF_NUM][KW2XRF_MAC_STACKSIZE];
 
 void auto_init_kw2xrf(void)
 {

--- a/sys/auto_init/netif/auto_init_slip.c
+++ b/sys/auto_init/netif/auto_init_slip.c
@@ -46,7 +46,7 @@ static gnrc_slip_dev_t slip_devs[SLIP_NUM];
 /**
  * @brief   Stacks for the MAC layer threads
  */
-static char _slip_stacks[SLIP_STACKSIZE][SLIP_NUM];
+static char _slip_stacks[SLIP_NUM][SLIP_STACKSIZE];
 
 void auto_init_slip(void)
 {

--- a/sys/auto_init/netif/auto_init_w5100.c
+++ b/sys/auto_init/netif/auto_init_w5100.c
@@ -51,7 +51,7 @@ static gnrc_netdev2_t gnrc_adpt[W5100_NUM];
 /**
  * @brief   Stacks for the MAC layer threads
  */
-static char stack[MAC_STACKSIZE][W5100_NUM];
+static char stack[W5100_NUM][MAC_STACKSIZE];
 
 
 void auto_init_w5100(void)

--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -46,7 +46,7 @@
  */
 static xbee_t xbee_devs[XBEE_NUM];
 static gnrc_netdev2_t gnrc_adpt[XBEE_NUM];
-static char stacks[XBEE_MAC_STACKSIZE][XBEE_NUM];
+static char stacks[XBEE_NUM][XBEE_MAC_STACKSIZE];
 
 void auto_init_xbee(void)
 {


### PR DESCRIPTION
While working on #6311 I noticed, that quite a few stacks arrays for the gnrc_netdev2 auto-initialization have their initializers switched around. This leads to faulty code, since apart from a few byte all threads will have the same stack (and TCB) which leads to funny errors, like only the last initialized thread answering to IPC messages of *all* devices of that type. 