### PR TITLE
drivers/xbee: removed unused cpuid.h include

### DIFF
--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -27,7 +27,6 @@
 #include "msg.h"
 #include "net/eui64.h"
 #include "net/ieee802154.h"
-#include "periph/cpuid.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"


### PR DESCRIPTION
The `xbee` driver is not using the `cpuid` module anywhere, so no need to include its header....