### PR TITLE
dist/tools/pyterm: fix pyterm when config file is empty

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -125,8 +125,9 @@ class SerCmd(cmd.Cmd):
         self.ignores = []
         self.json_regs = dict()
         self.init_cmd = []
+        self.fmt_str = None
         self.load_config()
-        if self.fmt_str == None:
+        if self.fmt_str is None:
             self.fmt_str = default_fmt_str
         else:
             self.fmt_str = str(self.fmt_str.replace('"', '')) + "%(message)s"


### PR DESCRIPTION
This should fix a regression introduced by #6308 : indeed `self.fmt_str` is not set if it's not present in the pyterm config file. The fix simply consists in initializing it to `None` before loading the config.
