### PR TITLE
boards/arduino-common: fix software interrupt for context swap

### DIFF
--- a/boards/arduino-common/include/board.h
+++ b/boards/arduino-common/include/board.h
@@ -55,16 +55,16 @@ extern "C" {
 
 /**
  ** Context swap defines
- ** Setup to use PJ6 which is pin change interrupt 15 (PCINT15)
+ ** Setup to use PC5 which is pin change interrupt 13 (PCINT13)
  ** This emulates a software triggered interrupt
  ***/
 #define AVR_CONTEXT_SWAP_INIT do { \
-            DDRC |= (1 << PC6); \
+            DDRC |= (1 << PC5); \
             PCICR |= (1 << PCIE1); \
-            PCMSK1 |= (1 << PCINT14); \
+            PCMSK1 |= (1 << PCINT13); \
 } while (0)
 #define AVR_CONTEXT_SWAP_INTERRUPT_VECT  PCINT1_vect
-#define AVR_CONTEXT_SWAP_TRIGGER   PORTC ^= (1 << PC6)
+#define AVR_CONTEXT_SWAP_TRIGGER   PORTC ^= (1 << PC5)
 
 
 /**


### PR DESCRIPTION
fix issue #6264 
It wasn't working with pin1/PC6/PINT14
Use pin28/PC5/PINT13 instead