### PR TITLE
tests: pkg_aversiveplusplus: temporarily disable CI building

### DIFF
--- a/tests/pkg_aversiveplusplus/Makefile
+++ b/tests/pkg_aversiveplusplus/Makefile
@@ -1,6 +1,11 @@
 APPLICATION = pkg_aversiveplusplus
 include ../Makefile.tests_common
 
+# temporarily disable for CI
+ifeq ($(RIOT_CI_BUILD), 1)
+BOARD_WHITELIST := "none"
+endif
+
 USEPKG += aversiveplusplus
 FEATURES_REQUIRED += cpp
 CXXEXFLAGS += -std=c++11


### PR DESCRIPTION
I propose disable building of this package during the release sprint.

It fetches >20 submodules, which we currently cannot cache. so the CI is stalled doing checkouts for minutes.