### PR TITLE
unittests: fix array length error on OSX

### DIFF
--- a/tests/unittests/tests-base64/tests-base64.c
+++ b/tests/unittests/tests-base64/tests-base64.c
@@ -303,13 +303,16 @@ static void test_base64_07_stream_decode(void)
 
 static void test_base64_08_encode_16_bytes(void)
 {
-    const int buffer_size = 16;
+    /* FIXME: init as enum here and below required,
+     * to fix folding-constant compiler error on OS X
+     */
+    enum { buffer_size = 16 };
     unsigned char buffer[buffer_size];
     for (int i = 0; i < buffer_size; ++i) {
         buffer[i] = 'a';
     }
 
-    const size_t expected_out_size = 24;
+    enum { expected_out_size = 24 };
     size_t element_base64_out_size = expected_out_size;
     unsigned char element_base64_out[expected_out_size];
 
@@ -329,7 +332,7 @@ static void test_base64_08_encode_16_bytes(void)
 
 static void test_base64_09_encode_size_determination(void)
 {
-    int buffer_size = 20;
+    enum { buffer_size = 20 };
     unsigned char buffer[buffer_size];
     for (int i = 0; i < buffer_size; ++i) {
         buffer[i] = 'a';

--- a/tests/unittests/tests-fib/tests-fib.c
+++ b/tests/unittests/tests-fib/tests-fib.c
@@ -709,7 +709,8 @@ static void test_fib_16_prefix_match(void)
 */
 static void test_fib_17_get_entry_set(void)
 {
-    static const size_t addr_buf_size = 16;
+    /* FIXME: init as enum to fix folding-constant compiler error on OS X */
+    enum { addr_buf_size = 16 };
     char addr_dst[addr_buf_size];
     char addr_nxt[addr_buf_size];
 


### PR DESCRIPTION
fixes multiple errors in `tests-base64` unittest on OSX, like the following one:

```
/RIOT/tests/unittests/tests-base64/tests-base64.c:307:26: error: variable length array folded to constant array as an
      extension [-Werror,-Wgnu-folding-constant]
    unsigned char buffer[buffer_size];
```