### PR TITLE
cpu/stm32_common: add UART HW flow control

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -186,6 +186,14 @@ typedef struct {
     uint8_t dma_stream;     /**< DMA stream used for TX */
     uint8_t dma_chan;       /**< DMA channel used for TX */
 #endif
+#ifdef UART_USE_HW_FC
+    gpio_t cts_pin;         /**< CTS pin - set to GPIO_UNDEF when not using HW flow control */
+    gpio_t rts_pin;         /**< RTS pin */
+#ifndef CPU_FAM_STM32F1
+    gpio_af_t cts_af;       /**< alternate function for CTS pin */
+    gpio_af_t rts_af;       /**< alternate function for RTS pin */
+#endif
+#endif
 } uart_conf_t;
 
 /**


### PR DESCRIPTION
This adds back HW flow control support in the UART driver. It's optional and compiled only if UART_USE_HW_FC is defined.

Tested on nucleo-f207.
Compile test OK for all boards.

I'm not sure about the stm32f1 specific code.