### PR TITLE
jenkins: use FAILURE instead of UNSTABLE for GitHub commit status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,12 +142,17 @@ stage("examples") {
     abortOnError("examples failed")
 }
 
+def buildState = 'SUCCESS'
+
 if (currentBuild.result == null) {
     currentBuild.result = 'SUCCESS'
 }
+else if (currentBuild.result != 'SUCCESS') {
+    buildState = 'FAILURE'
+}
 
 /* set commit status in GitHub with url pointing to logs manually (necessary workaround for now) */
-githubNotify context: 'Jenkins', description: "${currentBuild.result}", status: "${currentBuild.result}",targetUrl: "${env.BUILD_URL}artifact"
+githubNotify context: 'Jenkins', description: "${currentBuild.result}", status: buildState, targetUrl: "${env.BUILD_URL}artifact"
 
 /* create a job */
 def make_build(label, board, desc, arg)
@@ -208,7 +213,7 @@ def abortPreviousBuilds()
 def abortOnError(msg)
 {
     if ((currentBuild.result != null) && (currentBuild.result == 'FAILURE')) {
-        githubNotify context: 'Jenkins', description: "${currentBuild.result}", status: "${currentBuild.result}",targetUrl: "${env.BUILD_URL}artifact"
+        githubNotify context: 'Jenkins', description: "${currentBuild.result}", status: 'FAILURE', targetUrl: "${env.BUILD_URL}artifact"
         error msg
     }
 }


### PR DESCRIPTION
When a build is `UNSTABLE`, Jenkins will try to announce that to GitHub. But this terminology is not correct for GitHub => use `FAILURE` instead.