### PR TITLE
jenkins: propagate cause of failure to GitHub commit status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -213,7 +213,7 @@ def abortPreviousBuilds()
 def abortOnError(msg)
 {
     if ((currentBuild.result != null) && (currentBuild.result == 'FAILURE')) {
-        githubNotify context: 'Jenkins', description: "${currentBuild.result}", status: 'FAILURE', targetUrl: "${env.BUILD_URL}artifact"
+        githubNotify context: 'Jenkins', description: msg, status: 'FAILURE', targetUrl: "${env.BUILD_URL}artifact"
         error msg
     }
 }


### PR DESCRIPTION
Currently, jenkins shows `FAILURE` on failure in the commit status. This PR propagates the cause of failure, so that it says `examples failed`, or `tests failed`, etc.

Do you have other opinions on what to echo to the user?