### PR TITLE
cpu/cortexm: added shared cortexm_sleep() function

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -91,6 +91,25 @@ static inline void cpu_sleep_until_event(void)
 }
 
 /**
+ * @brief   Put the CPU into (deep) sleep mode, using the `WFI` instruction
+ *
+ * @param[in] deep      !=0 for deep sleep, 0 for light sleep
+ */
+static inline void cortexm_sleep(int deep)
+{
+    if (deep) {
+        SCB->SCR |=  (SCB_SCR_SLEEPDEEP_Msk);
+    }
+    else {
+        SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
+    }
+
+    /* ensure that all memory accesses have completed and trigger sleeping */
+    __DSB();
+    __WFI();
+}
+
+/**
  * @brief   Trigger a conditional context scheduler run / context switch
  *
  * This function is supposed to be called in the end of each ISR.

--- a/cpu/cortexm_common/pm.c
+++ b/cpu/cortexm_common/pm.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de
+ *               2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,11 +15,10 @@
  * @brief       common periph/pm functions
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
-
-#include <stdio.h>
 
 #include "cpu.h"
 #include "periph/pm.h"
@@ -26,10 +26,7 @@
 #ifndef FEATURES_PERIPH_PM
 void pm_set_lowest(void)
 {
-    /* Executes a device DSB (Data Synchronization Barrier) */
-    __DSB();
-    /* Enter standby mode */
-    __WFI();
+    cortexm_sleep(0);
 }
 #endif
 


### PR DESCRIPTION
Added a sleep function to be shared among all Cortex-M-based CPUs.

This PR does not make use of this function for existing CPUs yet (i.e. stm, saml/d, kinetis), as I will address these separately.