### PR TITLE
pkg/tinydtls: add compiler flags to Makefile.include

### DIFF
--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -2,6 +2,10 @@ PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/tinydtls
 
 INCLUDES += -I$(PKG_BUILDDIR)
 
+ifeq ($(shell uname -s),Darwin)
+    CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function
+endif
+
 ifneq (,$(filter tinydtls_aes,$(USEMODULE)))
   DIRS += $(PKG_BUILDDIR)/aes
 endif


### PR DESCRIPTION
resolves two compile errors with _tinydtls_ package on macOS:

```
/RIOT/examples/dtls-echo/bin/pkg/native/tinydtls/dtls.c:194:37: error: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Werror,-Wgnu-zero-variadic-macro-arguments]
   ? (Context)->h->which((Context), ##__VA_ARGS__)                      \
                                    ^
```

and 

```
/RIOT/examples/dtls-echo/bin/pkg/native/tinydtls
dtls_debug.c:108:1: error: unused function 'dtls_strnlen' [-Werror,-Wunused-function]
dtls_strnlen(const char *s, size_t maxlen) {
^
```