### PR TITLE
at86rf2xx: remove CCA check

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -144,30 +144,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     DEBUG("at86rf2xx_reset(): reset complete.\n");
 }
 
-bool at86rf2xx_cca(at86rf2xx_t *dev)
-{
-    uint8_t tmp;
-    uint8_t status;
-
-    at86rf2xx_assert_awake(dev);
-
-    /* trigger CCA measurment */
-    tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_CC_CCA);
-    tmp &= AT86RF2XX_PHY_CC_CCA_MASK__CCA_REQUEST;
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_CC_CCA, tmp);
-    /* wait for result to be ready */
-    do {
-        status = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS);
-    } while (!(status & AT86RF2XX_TRX_STATUS_MASK__CCA_DONE));
-    /* return according to measurement */
-    if (status & AT86RF2XX_TRX_STATUS_MASK__CCA_STATUS) {
-        return true;
-    }
-    else {
-        return false;
-    }
-}
-
 size_t at86rf2xx_send(at86rf2xx_t *dev, uint8_t *data, size_t len)
 {
     /* check data length */

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -340,16 +340,6 @@ static int _get(netdev2_t *netdev, netopt_t opt, void *val, size_t max_len)
             }
             break;
 
-        case NETOPT_IS_CHANNEL_CLR:
-            if (at86rf2xx_cca(dev)) {
-                *((netopt_enable_t *)val) = NETOPT_ENABLE;
-            }
-            else {
-                *((netopt_enable_t *)val) = NETOPT_DISABLE;
-            }
-            res = sizeof(netopt_enable_t);
-            break;
-
         case NETOPT_CSMA_RETRIES:
             if (max_len < sizeof(uint8_t)) {
                 res = -EOVERFLOW;

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -182,16 +182,6 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params);
 void at86rf2xx_reset(at86rf2xx_t *dev);
 
 /**
- * @brief   Trigger a clear channel assessment
- *
- * @param[in] dev           device to use
- *
- * @return                  true if channel is clear
- * @return                  false if channel is busy
- */
-bool at86rf2xx_cca(at86rf2xx_t *dev);
-
-/**
  * @brief   Get the short address of the given device
  *
  * @param[in] dev           device to read from


### PR DESCRIPTION
Rationale: the datasheet states that "It is not recommended to manually
initiate an CCA measurement when using the Extended Operating Mode."
Since the driver for now only supports the extended operating mode, it
should not provide this feature.

Addresses #3169.