### PR TITLE
pkg: cmsis-dsp: fix compile warning

### DIFF
--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -3,9 +3,7 @@ PKG_URL=https://github.com/gebart/CMSIS-DSP.git
 PKG_VERSION=v1.4.5a-riot2
 PKG_LICENSE=BSD-3-Clause
 
-ifneq ($(RIOTBASE),)
-include $(RIOTBASE)/Makefile.base
-endif
+CFLAGS += -Wno-strict-aliasing
 
 .PHONY: all
 


### PR DESCRIPTION
```
make -C /home/kaspar/src/riot/tests/pkg_cmsis-dsp/bin/pkg/samr21-xpro/cmsis-dsp
FilteringFunctions/arm_fir_fast_q15.c: In function 'arm_fir_fast_q15':
FilteringFunctions/arm_fir_fast_q15.c:129:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     x0 = *__SIMD32(px)++;
     ^~
FilteringFunctions/arm_fir_fast_q15.c:132:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     x2 = *__SIMD32(px)++;
     ^~
FilteringFunctions/arm_fir_fast_q15.c:141:7: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
       c0 = *__SIMD32(pb)++;
       ^~
FilteringFunctions/arm_fir_fast_q15.c:173:7: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
       c0 = *__SIMD32(pb)++;
       ^~
FilteringFunctions/arm_fir_fast_q15.c:211:7: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
       c0 = *__SIMD32(pb)++;
       ^~
FilteringFunctions/arm_fir_fast_q15.c:225:7: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
       x0 = *__SIMD32(px);
       ^~
FilteringFunctions/arm_fir_fast_q15.c:246:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     *__SIMD32(pDst)++ =
     ^
FilteringFunctions/arm_fir_fast_q15.c:249:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     *__SIMD32(pDst)++ =
     ^
cc1: all warnings being treated as errors
```

...


I don't know why these suddenly appear. possibly a toolchain upgrade?