### PR TITLE
periph timer: remove timer_irq_(en|dis)able

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -170,17 +170,6 @@ void timer_start(tim_t tim)
     ctx[tim].dev->CRB = ctx[tim].mode;
 }
 
-void timer_irq_enable(tim_t tim)
-{
-    *ctx[tim].mask = ctx[tim].isrs;
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    ctx[tim].isrs = *(ctx[tim].mask);
-    *ctx[tim].mask = 0;
-}
-
 #ifdef TIMER_NUMOF
 static inline void _isr(tim_t tim, int chan)
 {

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -65,6 +65,9 @@ static const int IRQn_lut[GPTIMER_NUMOF] = {
     GPTIMER_3A_IRQn
 };
 
+/* enable timer interrupts */
+static inline void _irq_enable(tim_t dev);
+
 /**
  * @brief Setup the given timer
  *
@@ -142,7 +145,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     }
 
     /* Enable interrupts for given timer: */
-    timer_irq_enable(dev);
+    _irq_enable(dev);
 
     return 0;
 }
@@ -274,7 +277,7 @@ void timer_start(tim_t dev)
     }
 }
 
-void timer_irq_enable(tim_t dev)
+static inline void _irq_enable(tim_t dev)
 {
     DEBUG("%s(%u)\n", __FUNCTION__, dev);
 
@@ -288,22 +291,6 @@ void timer_irq_enable(tim_t dev)
             irqn++;
             NVIC_SetPriority(irqn, TIMER_IRQ_PRIO);
             NVIC_EnableIRQ(irqn);
-        }
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    DEBUG("%s(%u)\n", __FUNCTION__, dev);
-
-    if (dev < TIMER_NUMOF) {
-        IRQn_Type irqn = IRQn_lut[GPTIMER_GET_NUM(timer_config[dev].dev)];
-
-        NVIC_DisableIRQ(irqn);
-
-        if (timer_config[dev].channels == 2) {
-            irqn++;
-            NVIC_DisableIRQ(irqn);
         }
     }
 }

--- a/cpu/cc26x0/periph/timer.c
+++ b/cpu/cc26x0/periph/timer.c
@@ -68,7 +68,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     /* set the timer speed */
     dev(tim)->TAPR = (RCOSC48M_FREQ / freq) - 1;
     /* enable global timer interrupt and start the timer */
-    timer_irq_enable(tim);
+    NVIC_EnableIRQ(GPTIMER_0A_IRQN + (2 * timer_config[tim].num));
     dev(tim)->CTL = GPT_CTL_TAEN;
 
     return 0;
@@ -115,16 +115,6 @@ void timer_stop(tim_t tim)
 void timer_start(tim_t tim)
 {
     dev(tim)->CTL = GPT_CTL_TAEN;
-}
-
-void timer_irq_enable(tim_t tim)
-{
-    NVIC_EnableIRQ(GPTIMER_0A_IRQN + (2 * timer_config[tim].num));
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    NVIC_DisableIRQ(GPTIMER_0A_IRQN + (2 * timer_config[tim].num));
 }
 
 /**

--- a/cpu/cc430/periph/timer.c
+++ b/cpu/cc430/periph/timer.c
@@ -108,23 +108,6 @@ void timer_stop(tim_t dev)
     TIMER_BASE->CTL &= ~(CTL_MC_MASK);
 }
 
-void timer_irq_enable(tim_t dev)
-{
-
-    /* TODO: not supported, yet
-     *
-     * Problem here: there is no means, of globally disabling timer interrupts.
-     * We could just enable the interrupts for all CC channels, but this would
-     * mean, that we might enable interrupts for channels, that are not active.
-     * I guess we need to remember the interrupt state of all channels before
-     * disabling and then restore this state when enabling again?! */
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    /* TODO: not supported, yet */
-}
-
 ISR(TIMER_ISR_CC0, isr_timer_a_cc0)
 {
     __enter_isr();

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -128,16 +128,6 @@ void timer_start(tim_t dev)
     timer_config[dev].timer->CMD = TIMER_CMD_START;
 }
 
-void timer_irq_enable(tim_t dev)
-{
-    NVIC_EnableIRQ(timer_config[dev].irqn);
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    NVIC_DisableIRQ(timer_config[dev].irqn);
-}
-
 void timer_reset(tim_t dev)
 {
     timer_config[dev].timer->CNT = 0;

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -46,6 +46,9 @@ static timer_conf_t config[TIMER_NUMOF];
 
 #include "hw_timer.h"
 
+/* enable timer interrupts */
+static inline void _irq_enable(tim_t dev);
+
 /* Missing from driverlib */
 static inline unsigned long
 PRIV_TimerPrescaleSnapshotGet(unsigned long ulbase, unsigned long ultimer) {
@@ -115,7 +118,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 
     ROM_TimerIntEnable(timer_base, timer_intbit);
 
-    timer_irq_enable(dev);
+    _irq_enable(dev);
     timer_start(dev);
 
     return 0;
@@ -305,7 +308,7 @@ void timer_stop(tim_t dev)
     ROM_TimerDisable(timer_base, timer_side);
 }
 
-void timer_irq_enable(tim_t dev)
+static inline void _irq_enable(tim_t dev)
 {
     unsigned int timer_intbase;
 
@@ -330,37 +333,6 @@ void timer_irq_enable(tim_t dev)
 
     ROM_IntPrioritySet(timer_intbase, 32);
     ROM_IntEnable(timer_intbase);
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    unsigned int timer_base;
-    unsigned int timer_intbit = TIMER_TIMA_TIMEOUT;
-    unsigned int timer_intbase;
-
-    if (dev >= TIMER_NUMOF){
-        return;
-    }
-
-    switch(dev){
-#if TIMER_0_EN
-    case TIMER_0:
-        timer_base = WTIMER0_BASE;
-        timer_intbase = INT_WTIMER0A;
-        break;
-#endif
-#if TIMER_1_EN
-    case TIMER_1:
-        timer_base = WTIMER1_BASE;
-        timer_intbase = INT_WTIMER1A;
-        break;
-#endif
-    default:
-        return; /* unreachable */
-    }
-
-    ROM_IntEnable(timer_intbase);
-    ROM_TimerIntDisable(timer_base, timer_intbit);
 }
 
 #if TIMER_0_EN

--- a/cpu/lpc11u34/periph/timer.c
+++ b/cpu/lpc11u34/periph/timer.c
@@ -128,20 +128,6 @@ void timer_stop(tim_t dev)
     }
 }
 
-void timer_irq_enable(tim_t dev)
-{
-    if (dev == TIMER_0) {
-        NVIC_EnableIRQ(TIMER_0_IRQ);
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    if (dev == TIMER_0) {
-        NVIC_DisableIRQ(TIMER_0_IRQ);
-    }
-}
-
 void TIMER_0_ISR(void)
 {
     if (TIMER_0_DEV->IR & MR0_FLAG) {

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -130,20 +130,6 @@ void timer_stop(tim_t dev)
     }
 }
 
-void timer_irq_enable(tim_t dev)
-{
-    if (dev == TIMER_0) {
-        NVIC_EnableIRQ(TIMER_0_IRQ);
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    if (dev == TIMER_0) {
-        NVIC_DisableIRQ(TIMER_0_IRQ);
-    }
-}
-
 #if TIMER_0_EN
 void TIMER_0_ISR(void)
 {

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -175,18 +175,6 @@ void timer_stop(tim_t tim)
     get_dev(tim)->TCR = 0;
 }
 
-void timer_irq_enable(tim_t tim)
-{
-    (void) tim;
-    /* TODO */
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    (void) tim;
-    /* TODO */
-}
-
 static inline void isr_handler(lpc23xx_timer_t *dev, int tim_num)
 {
     for (unsigned i = 0; i < TIMER_CHAN_NUMOF; i++) {

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -108,23 +108,6 @@ void timer_stop(tim_t dev)
     TIMER_BASE->CTL &= ~(TIMER_CTL_MC_MASK);
 }
 
-void timer_irq_enable(tim_t dev)
-{
-
-    /* TODO: not supported, yet
-     *
-     * Problem here: there is no means, of globally disabling timer interrupts.
-     * We could just enable the interrupts for all CC channels, but this would
-     * mean, that we might enable interrupts for channels, that are not active.
-     * I guess we need to remember the interrupt state of all channels before
-     * disabling and then restore this state when enabling again?! */
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    /* TODO: not supported, yet */
-}
-
 ISR(TIMER_ISR_CC0, isr_timer_a_cc0)
 {
     __enter_isr();

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -92,10 +92,11 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     time_null = 0;
     time_null = timer_read(0);
 
-    timer_irq_disable(dev);
     _callback = cb;
     _cb_arg = arg;
-    timer_irq_enable(dev);
+    if (register_interrupt(SIGALRM, native_isr_timer) != 0) {
+        DEBUG("darn!\n\n");
+    }
 
     return 0;
 }
@@ -153,30 +154,6 @@ int timer_clear(tim_t dev, int channel)
     do_timer_set(0);
 
     return 1;
-}
-
-void timer_irq_enable(tim_t dev)
-{
-    (void)dev;
-    DEBUG("%s\n", __func__);
-
-    if (register_interrupt(SIGALRM, native_isr_timer) != 0) {
-        DEBUG("darn!\n\n");
-    }
-
-    return;
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    (void)dev;
-    DEBUG("%s\n", __func__);
-
-    if (unregister_interrupt(SIGALRM) != 0) {
-        DEBUG("darn!\n\n");
-    }
-
-    return;
 }
 
 void timer_start(tim_t dev)

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -84,7 +84,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     dev(tim)->EVENTS_COMPARE[2] = 0;
 
     /* enable interrupts */
-    timer_irq_enable(tim);
+    NVIC_EnableIRQ(timer_config[tim].irqn);
     /* start the timer */
     dev(tim)->TASKS_START = 1;
 
@@ -138,16 +138,6 @@ void timer_start(tim_t tim)
 void timer_stop(tim_t tim)
 {
     dev(tim)->TASKS_STOP = 1;
-}
-
-void timer_irq_enable(tim_t tim)
-{
-    NVIC_EnableIRQ(timer_config[tim].irqn);
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    NVIC_DisableIRQ(timer_config[tim].irqn);
 }
 
 static inline void irq_handler(int num)

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -116,7 +116,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     dev(tim)->TC_CHANNEL[1].TC_CCR = (TC_CCR_CLKEN | TC_CCR_SWTRG);
 
     /* enable global interrupts for given timer */
-    timer_irq_enable(tim);
+    NVIC_EnableIRQ(timer_config[tim].id_ch0);
 
     return 0;
 }
@@ -162,16 +162,6 @@ void timer_start(tim_t tim)
 void timer_stop(tim_t tim)
 {
     dev(tim)->TC_CHANNEL[1].TC_CCR = TC_CCR_CLKDIS;
-}
-
-void timer_irq_enable(tim_t tim)
-{
-    NVIC_EnableIRQ(timer_config[tim].id_ch0);
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    NVIC_DisableIRQ(timer_config[tim].id_ch0);
 }
 
 static inline void isr_handler(tim_t tim)

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -35,6 +35,8 @@
  */
 static timer_isr_ctx_t config[TIMER_NUMOF];
 
+/* enable timer interrupts */
+static inline void _irq_enable(tim_t dev);
 
 /**
  * @brief Setup the given timer
@@ -120,7 +122,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     config[dev].arg = arg;
 
     /* enable interrupts for given timer */
-    timer_irq_enable(dev);
+    _irq_enable(dev);
 
     timer_start(dev);
 
@@ -288,7 +290,7 @@ void timer_start(tim_t dev)
     }
 }
 
-void timer_irq_enable(tim_t dev)
+static inline void _irq_enable(tim_t dev)
 {
     switch (dev) {
 #if TIMER_0_EN
@@ -299,24 +301,6 @@ void timer_irq_enable(tim_t dev)
 #if TIMER_1_EN
         case TIMER_1:
             NVIC_EnableIRQ(TC4_IRQn);
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_DisableIRQ(TC3_IRQn);
-            break;
-#endif
-#if TIMER_1_EN
-        case TIMER_1:
-            NVIC_DisableIRQ(TC4_IRQn);
             break;
 #endif
         case TIMER_UNDEFINED:

--- a/cpu/saml21/periph/timer.c
+++ b/cpu/saml21/periph/timer.c
@@ -39,6 +39,9 @@
  */
 static timer_isr_ctx_t config[TIMER_NUMOF];
 
+/* enable timer interrupts */
+static inline void _irq_enable(tim_t dev);
+
 /**
  * @brief Setup the given timer
  */
@@ -74,7 +77,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     config[dev].arg = arg;
 
     /* enable interrupts for given timer */
-    timer_irq_enable(dev);
+    _irq_enable(dev);
 
     timer_start(dev);
 
@@ -190,25 +193,12 @@ void timer_start(tim_t dev)
     }
 }
 
-void timer_irq_enable(tim_t dev)
+static inline void _irq_enable(tim_t dev)
 {
     switch (dev) {
 #if TIMER_0_EN
         case TIMER_0:
             NVIC_EnableIRQ(TC0_IRQn);
-            break;
-#endif
-        case TIMER_UNDEFINED:
-            break;
-    }
-}
-
-void timer_irq_disable(tim_t dev)
-{
-    switch (dev) {
-#if TIMER_0_EN
-        case TIMER_0:
-            NVIC_DisableIRQ(TC0_IRQn);
             break;
 #endif
         case TIMER_UNDEFINED:

--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -66,7 +66,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     dev(tim)->EGR = TIM_EGR_UG;
 
     /* enable the timer's interrupt */
-    timer_irq_enable(tim);
+    NVIC_EnableIRQ(timer_config[tim].irqn);
     /* reset the counter and start the timer */
     timer_start(tim);
 
@@ -115,16 +115,6 @@ void timer_start(tim_t tim)
 void timer_stop(tim_t tim)
 {
     dev(tim)->CR1 &= ~(TIM_CR1_CEN);
-}
-
-void timer_irq_enable(tim_t tim)
-{
-    NVIC_EnableIRQ(timer_config[tim].irqn);
-}
-
-void timer_irq_disable(tim_t tim)
-{
-    NVIC_DisableIRQ(timer_config[tim].irqn);
 }
 
 static inline void irq_handler(tim_t tim)

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -166,20 +166,6 @@ void timer_start(tim_t dev);
  */
 void timer_stop(tim_t dev);
 
-/**
- * @brief Enable the interrupts for the given timer
- *
- * @param[in] dev           timer to enable interrupts for
- */
-void timer_irq_enable(tim_t dev);
-
-/**
- * @brief Disable interrupts for the given timer
- *
- * @param[in] dev           the timer to disable interrupts for
- */
-void timer_irq_disable(tim_t dev);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Revives #5979. I think once #6359 is merged, we can also get rid of these two functions.