### PR TITLE
periph timer: init does not require return value

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -87,15 +87,13 @@ static ctx_t *ctx[] = {{ NULL }};
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 {
     DEBUG("timer.c: freq = %ld\n", freq);
     uint8_t pre = 0;
 
     /* make sure given device is valid */
-    if (tim >= TIMER_NUMOF) {
-        return -1;
-    }
+    assert(tim < TIMER_NUMOF);
 
     /* figure out if freq is applicable */
     for (; pre < PRESCALE_NUMOF; pre++) {
@@ -103,10 +101,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
             break;
         }
     }
-    if (pre == PRESCALE_NUMOF) {
-        DEBUG("timer.c: prescaling failed!\n");
-        return -1;
-    }
+    assert(pre != PRESCALE_NUMOF);
 
     /* stop and reset timer */
     ctx[tim].dev->CRA = 0;
@@ -122,8 +117,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     /* enable timer with calculated prescaler */
     ctx[tim].dev->CRB = (pre + 1);
     DEBUG("timer.c: prescaler set at %d\n", pre + 1);
-
-    return 0;
 }
 
 int timer_set(tim_t tim, int channel, unsigned int timeout)

--- a/cpu/cc26x0/periph/timer.c
+++ b/cpu/cc26x0/periph/timer.c
@@ -42,12 +42,10 @@ static inline gpt_reg_t *dev(tim_t tim)
     return timer_config[tim].dev;
 }
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* make sure given timer is valid */
-    if (tim >= TIMER_NUMOF) {
-        return -1;
-    }
+    assert(tim < TIMER_NUMOF);
 
     /* enable the times clock */
     PRCM->GPTCLKGR |= (1 << timer_config[tim].num);
@@ -70,8 +68,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     /* enable global timer interrupt and start the timer */
     timer_irq_enable(tim);
     dev(tim)->CTL = GPT_CTL_TAEN;
-
-    return 0;
 }
 
 int timer_set(tim_t tim, int channel, unsigned int timeout)

--- a/cpu/cc430/periph/timer.c
+++ b/cpu/cc430/periph/timer.c
@@ -40,16 +40,13 @@ static timer_cb_t isr_cb;
 static void *isr_arg;
 
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* using fixed TIMER_BASE for now */
-    if (dev != 0) {
-        return -1;
-    }
+    assert(dev == 0);
+
     /* TODO: configure time-base depending on freq value */
-    if (freq != 1000000ul) {
-        return -1;
-    }
+    assert(freq == 1000 * 1000);
 
     /* reset the timer A configuration */
     TIMER_BASE->CTL = CTL_CLR;
@@ -64,7 +61,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     }
     /* start the timer in continuous mode */
     TIMER_BASE->CTL |= CTL_MC_CONT;
-    return 0;
 }
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -36,14 +36,12 @@
 static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
 
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     TIMER_TypeDef *pre, *tim;
 
     /* test if given timer device is valid */
-    if (dev >= TIMER_NUMOF) {
-        return -1;
-    }
+    assert(dev < TIMER_NUMOF);
 
     /* save callback */
     isr_ctx[dev].cb = cb;
@@ -79,7 +77,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     /* start both timers */
     tim->CMD = TIMER_CMD_START;
     pre->CMD = TIMER_CMD_START;
-    return 0;
 }
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -65,11 +65,9 @@ static inline unsigned int _llvalue_to_scaled_value(unsigned long long corrected
     return scaledv;
 }
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
-    if (dev >= TIMER_NUMOF){
-        return -1;
-    }
+    assert(dev < TIMER_NUMOF);
 
     config[dev].cb = cb;
     config[dev].arg = arg;
@@ -98,7 +96,8 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
         break;
 #endif
     default:
-        return -1; /* unreachable */
+        /* assert a valid timer */
+        assert(0);
     }
 
 
@@ -117,8 +116,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 
     timer_irq_enable(dev);
     timer_start(dev);
-
-    return 0;
 }
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)

--- a/cpu/lpc11u34/periph/timer.c
+++ b/cpu/lpc11u34/periph/timer.c
@@ -41,26 +41,24 @@
  */
 static timer_isr_ctx_t config[TIMER_NUMOF];
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
-    if (dev == TIMER_0) {
-        /* save callback */
-        config[TIMER_0].cb = cb;
-        config[TIMER_0].arg = arg;
-        /* enable power for timer */
-        TIMER_0_CLKEN();
-        /* set to timer mode */
-        TIMER_0_DEV->CTCR = 0;
-        /* configure prescaler */
-        TIMER_0_DEV->PR = (TIMER_0_FREQ / freq) - 1;
-        /* configure and enable timer interrupts */
-        NVIC_SetPriority(TIMER_0_IRQ, TIMER_IRQ_PRIO);
-        NVIC_EnableIRQ(TIMER_0_IRQ);
-        /* enable timer */
-        TIMER_0_DEV->TCR |= 1;
-        return 0;
-    }
-    return -1;
+    assert(dev == TIMER_0);
+
+    /* save callback */
+    config[TIMER_0].cb = cb;
+    config[TIMER_0].arg = arg;
+    /* enable power for timer */
+    TIMER_0_CLKEN();
+    /* set to timer mode */
+    TIMER_0_DEV->CTCR = 0;
+    /* configure prescaler */
+    TIMER_0_DEV->PR = (TIMER_0_FREQ / freq) - 1;
+    /* configure and enable timer interrupts */
+    NVIC_SetPriority(TIMER_0_IRQ, TIMER_IRQ_PRIO);
+    NVIC_EnableIRQ(TIMER_0_IRQ);
+    /* enable timer */
+    TIMER_0_DEV->TCR |= 1;
 }
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -41,28 +41,26 @@
  */
 static timer_isr_ctx_t config[TIMER_NUMOF];
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
-    if (dev == TIMER_0) {
-        /* save callback */
-        config[TIMER_0].cb = cb;
-        config[TIMER_0].arg = arg;
-        /* enable power for timer */
-        TIMER_0_CLKEN();
-        /* let timer run with full frequency */
-        TIMER_0_PLKSEL();
-        /* set to timer mode */
-        TIMER_0_DEV->CTCR = 0;
-        /* configure prescaler */
-        TIMER_0_DEV->PR = (TIMER_0_FREQ / freq) - 1;
-        /* configure and enable timer interrupts */
-        NVIC_SetPriority(TIMER_0_IRQ, TIMER_IRQ_PRIO);
-        NVIC_EnableIRQ(TIMER_0_IRQ);
-        /* enable timer */
-        TIMER_0_DEV->TCR |= 1;
-        return 0;
-    }
-    return -1;
+    assert(dev == TIMER_0);
+    /* save callback */
+    config[TIMER_0].cb = cb;
+    config[TIMER_0].arg = arg;
+    /* enable power for timer */
+    TIMER_0_CLKEN();
+    /* let timer run with full frequency */
+    TIMER_0_PLKSEL();
+    /* set to timer mode */
+    TIMER_0_DEV->CTCR = 0;
+    /* configure prescaler */
+    TIMER_0_DEV->PR = (TIMER_0_FREQ / freq) - 1;
+    /* configure and enable timer interrupts */
+    NVIC_SetPriority(TIMER_0_IRQ, TIMER_IRQ_PRIO);
+    NVIC_EnableIRQ(TIMER_0_IRQ);
+    /* enable timer */
+    TIMER_0_DEV->TCR |= 1;
+    return 0;
 }
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -108,15 +108,13 @@ static inline void pwr_clk_and_isr(tim_t tim)
     }
 }
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* get the timers base register */
     lpc23xx_timer_t *dev = get_dev(tim);
 
     /* make sure the timer device is valid */
-    if (dev == NULL) {
-        return -1;
-    }
+    assert(dev != NULL);
 
     /* save the callback */
     isr_ctx[tim].cb = cb;
@@ -130,7 +128,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     dev->PR = (CLOCK_PCLK / freq) - 1;
     /* enable timer */
     dev->TCR = 1;
-    return 0;
 }
 
 int timer_set(tim_t tim, int channel, unsigned int timeout)

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -40,16 +40,12 @@ static timer_cb_t isr_cb;
 static void *isr_arg;
 
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* using fixed TIMER_BASE for now */
-    if (dev != 0) {
-        return -1;
-    }
+    assert(dev == 0);
     /* TODO: configure time-base depending on freq value */
-    if (freq != 1000000ul) {
-        return -1;
-    }
+    assert(freq == 1000 * 1000);
 
     /* reset the timer A configuration */
     TIMER_BASE->CTL = TIMER_CTL_CLR;
@@ -64,7 +60,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     }
     /* start the timer in continuous mode */
     TIMER_BASE->CTL |= TIMER_CTL_MC_CONT;
-    return 0;
 }
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -77,16 +77,12 @@ void native_isr_timer(void)
     _callback(_cb_arg, 0);
 }
 
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     (void)freq;
     DEBUG("%s\n", __func__);
-    if (dev >= TIMER_NUMOF) {
-        return -1;
-    }
-    if (freq != NATIVE_TIMER_SPEED) {
-        return -1;
-    }
+    assert(dev < TIMER_NUMOF);
+    assert(freq < NATIVE_TIMER_SPEED);
 
     /* initialize time delta */
     time_null = 0;
@@ -96,8 +92,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     _callback = cb;
     _cb_arg = arg;
     timer_irq_enable(dev);
-
-    return 0;
 }
 
 static void do_timer_set(unsigned int offset)

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -42,12 +42,10 @@ static inline NRF_TIMER_Type *dev(tim_t tim)
     return timer_config[tim].dev;
 }
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* make sure the given timer is valid */
-    if (tim >= TIMER_NUMOF) {
-        return -1;
-    }
+    assert(tim < TIMER_NUMOF);
 
     /* save interrupt context */
     ctx[tim].cb = cb;
@@ -74,9 +72,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
         }
         cando /= 2;
     }
-    if (i == 10) {
-        return -1;
-    }
+    assert(i != 10);
 
     /* reset compare state */
     dev(tim)->EVENTS_COMPARE[0] = 0;
@@ -87,8 +83,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     timer_irq_enable(tim);
     /* start the timer */
     dev(tim)->TASKS_START = 1;
-
-    return 0;
 }
 
 int timer_set(tim_t tim, int chan, unsigned int value)

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -74,12 +74,10 @@ static inline Tc *dev(tim_t tim)
  * For each timer, channel 1 is used to implement a prescaler. Channel 1 is
  * driven by the MCK / 2 (42MHz) (TIMER_CLOCK1).
  */
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* check if device is valid */
-    if (tim >= TIMER_NUMOF) {
-        return -1;
-    }
+    assert(tim < TIMER_NUMOF);
 
     /* enable the device clock */
     clk_en(tim);
@@ -117,8 +115,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
     /* enable global interrupts for given timer */
     timer_irq_enable(tim);
-
-    return 0;
 }
 
 int timer_set(tim_t tim, int channel, unsigned int timeout)

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -39,12 +39,10 @@ static timer_isr_ctx_t config[TIMER_NUMOF];
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* at the moment, the timer can only run at 1MHz */
-    if (freq != 1000000ul) {
-        return -1;
-    }
+    assert(freq == 1000 * 1000);
 
 /* select the clock generator depending on the main clock source:
  * GCLK0 (1MHz) if we use the internal 8MHz oscillator
@@ -66,9 +64,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     switch (dev) {
 #if TIMER_0_EN
     case TIMER_0:
-        if (TIMER_0_DEV.CTRLA.bit.ENABLE) {
-            return 0;
-        }
+        assert(!TIMER_0_DEV.CTRLA.bit.ENABLE);
         PM->APBCMASK.reg |= PM_APBCMASK_TC3;
         /* reset timer */
         TIMER_0_DEV.CTRLA.bit.SWRST = 1;
@@ -88,9 +84,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 #endif
 #if TIMER_1_EN
     case TIMER_1:
-        if (TIMER_1_DEV.CTRLA.bit.ENABLE) {
-            return 0;
-        }
+        assert(!TIMER_1_DEV.CTRLA.bit.ENABLE);
         PM->APBCMASK.reg |= PM_APBCMASK_TC4;
         /* reset timer */
         TIMER_1_DEV.CTRLA.bit.SWRST = 1;
@@ -112,7 +106,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 #endif
     case TIMER_UNDEFINED:
     default:
-        return -1;
+        assert(0);
     }
 
     /* save callback */
@@ -123,8 +117,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     timer_irq_enable(dev);
 
     timer_start(dev);
-
-    return 0;
 }
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)

--- a/cpu/saml21/periph/timer.c
+++ b/cpu/saml21/periph/timer.c
@@ -42,7 +42,7 @@ static timer_isr_ctx_t config[TIMER_NUMOF];
 /**
  * @brief Setup the given timer
  */
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* configure GCLK0 to feed TC0 & TC1*/;
     GCLK->PCHCTRL[TC0_GCLK_ID].reg |= GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
@@ -52,9 +52,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     switch (dev) {
 #if TIMER_0_EN
     case TIMER_0:
-        if (TIMER_0_DEV.CTRLA.bit.ENABLE) {
-            return 0;
-        }
+        assert(!TIMER_0_DEV.CTRLA.bit.ENABLE);
         MCLK->APBCMASK.reg |= MCLK_APBCMASK_TC0;
         /* reset timer */
         TIMER_0_DEV.CTRLA.bit.SWRST = 1;
@@ -66,7 +64,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 #endif
     case TIMER_UNDEFINED:
     default:
-        return -1;
+        assert(0);
     }
 
     /* save callback */
@@ -77,8 +75,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     timer_irq_enable(dev);
 
     timer_start(dev);
-
-    return 0;
 }
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)

--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -35,12 +35,10 @@ static inline TIM_TypeDef *dev(tim_t tim)
     return timer_config[tim].dev;
 }
 
-int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
+void timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 {
     /* check if device is valid */
-    if (tim >= TIMER_NUMOF) {
-        return -1;
-    }
+    assert(tim < TIMER_NUMOF);
 
     /* remember the interrupt context */
     isr_ctx[tim].cb = cb;
@@ -69,8 +67,6 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     timer_irq_enable(tim);
     /* reset the counter and start the timer */
     timer_start(tim);
-
-    return 0;
 }
 
 int timer_set(tim_t tim, int channel, unsigned int timeout)

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -93,11 +93,8 @@ typedef struct {
  * @param[in] callback      this callback is called in interrupt context, the
  *                          emitting channel is passed as argument
  * @param[in] arg           argument to the callback
- *
- * @return                  0 on success
- * @return                  -1 if speed not applicable or unknown device given
  */
-int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg);
+void timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg);
 
 /**
  * @brief Set a given timer channel for the given timer device

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -58,13 +58,8 @@ static int test_timer(unsigned num)
     }
 
     /* initialize and halt timer */
-    if (timer_init(TIMER_DEV(num), TIM_SPEED, cb, NULL) < 0) {
-        printf("TIMER_%u: ERROR on initialization - skipping\n\n", num);
-        return 0;
-    }
-    else {
-        printf("TIMER_%u: initialization successful\n", num);
-    }
+    timer_init(TIMER_DEV(num), TIM_SPEED, cb, NULL) < 0;
+    printf("TIMER_%u initialized\n", num);
     timer_stop(TIMER_DEV(num));
     printf("TIMER_%u: stopped\n", num);
     /* set each available channel */


### PR DESCRIPTION
The return value is not checked anyway and asserting is good enough here.