### PR TITLE
doc: drivers/pn532: add missing ingroup

### DIFF
--- a/drivers/include/pn532.h
+++ b/drivers/include/pn532.h
@@ -8,6 +8,7 @@
 
 /**
  * @defgroup  drivers_pn532 PN532 NFC Reader
+ * @ingroup drivers
  *
  * @{
  * @file


### PR DESCRIPTION
I wasn't sure where to put it in a lower level than drivers as it didn't really fit in any of the groups.