### PR TITLE
doxygen: some fixes

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -55,11 +55,14 @@ typedef struct {
 #define MUTEX_INIT_LOCKED { { MUTEX_LOCKED } }
 
 /**
- * @internal
+ * @cond INTERNAL
  * @brief This is the value of the mutex when locked and no threads are waiting
  *        for it
  */
 #define MUTEX_LOCKED ((void *)-1)
+/**
+ * @endcond
+ */
 
 /**
  * @brief Initializes a mutex object.

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -87,7 +87,7 @@
  *
  * Reading from the top down, you can see that first, stack memory for our thread
  * `rcv_thread` is preallocated, followed by an implementation of the thread's
- * function. Communication between threads is done using @ref core_msg: in this
+ * function. Communication between threads is done using @ref core_msg. In this
  * case, `rcv_thread` will print the process id of each thread that sent a
  * message to `rcv_thread`.
  *

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -61,6 +61,7 @@ extern "C" {
 typedef void (*_native_callback_t)(void);
 
 /**
+ * @cond INTERNAL
  * internal functions
  */
 void native_cpu_init(void);
@@ -158,6 +159,10 @@ extern const char *_native_unix_socket_path;
 ssize_t _native_read(int fd, void *buf, size_t count);
 ssize_t _native_write(int fd, const void *buf, size_t count);
 ssize_t _native_writev(int fildes, const struct iovec *iov, int iovcnt);
+
+/**
+ * @endcond
+ */
 
 /**
  * register interrupt handler handler for interrupt sig

--- a/doc.txt
+++ b/doc.txt
@@ -1,11 +1,30 @@
 /**
+ * @defgroup utils Utilities
+ * @brief Utilities and helper functionality
+ *
+ *        Additional scripts and configuration options to ease RIOT
+ *        development.
+ * @{
+ */
+
+/**
  * @def DEVELHELP
  * @brief   This global macro activates some behavior that helps you while
  *          developing but is otherwise optimized out.
  */
+#if DOXYGEN
+#   define DEVELHELP
+#endif
 
 /**
  * @def TEST_SUITES
  * @brief   This global macro activates functionality that is needed for
  *          automated testing but not needed otherwise.
+ */
+#if DOXYGEN
+#   define TEST_SUITES
+#endif
+
+/**
+ * @}
  */

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -43,7 +43,7 @@ RIOT is developed by an open community that anyone is welcome to join:
  - Follow us on [Twitter](https://twitter.com/RIOT_OS) for news from the RIOT
    community.
  - Contact us on IRC for live support and discussions:
-   [irc.freenode.org #riot-os](irc://irc.freenode.org/riot-os)
+   [irc.freenode.org \#riot-os](irc://irc.freenode.org/riot-os)
 
 
 The quickest start                                        {#the-quickest-start}

--- a/pkg/ccn-lite/ccn-lite-riot.h
+++ b/pkg/ccn-lite/ccn-lite-riot.h
@@ -108,6 +108,9 @@ extern "C" {
 #define free_3ptr_list(a,b,c)   ccnl_free(a), ccnl_free(b), ccnl_free(c)
 #define free_4ptr_list(a,b,c,d) ccnl_free(a), ccnl_free(b), ccnl_free(c), ccnl_free(d);
 #define free_5ptr_list(a,b,c,d,e) ccnl_free(a), ccnl_free(b), ccnl_free(c), ccnl_free(d), ccnl_free(e);
+/**
+ * @}
+ */
 
 /**
  * Frees all memory directly and indirectly allocated for prefix information
@@ -131,10 +134,13 @@ extern "C" {
  */
 #define CCNL_QUEUE_SIZE     (8)
 
+/**
+ * @brief Data structure for interest packet
+ */
 typedef struct {
-    struct ccnl_prefix_s *prefix;
-    unsigned char *buf;
-    size_t buflen;
+    struct ccnl_prefix_s *prefix;   /**< requested prefix */
+    unsigned char *buf;             /**< buffer to store the interest packet */
+    size_t buflen;                  /**< size of the buffer */
 } ccnl_interest_t;
 
 
@@ -216,9 +222,11 @@ struct ccnl_interest_s *ccnl_send_interest(struct ccnl_prefix_s *prefix,
 /**
  * @brief Wait for incoming content chunk
  *
- * @pre The thread has to register for CCNL_CONT_CHUNK in @ref netreg first
+ * @pre The thread has to register for CCNL_CONT_CHUNK in @ref net_gnrc_netreg
+ *      first
  *
- * @post The thread should unregister from @ref netreg after this function returns
+ * @post The thread should unregister from @ref net_gnrc_netreg after this
+ *       function returns
  *
  * @param[out] buf      Buffer to stores the received content
  * @param[in]  buf_len  Size of @p buf
@@ -242,6 +250,16 @@ int ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout);
 int ccnl_fib_add_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
                        struct ccnl_face_s *face);
 
+/**
+ * @brief Remove entry from the CCN-Lite FIB
+ *
+ * @par[in] relay   Local relay struct
+ * @par[in] pfx     Prefix of the FIB entry, may be NULL
+ * @par[in] face    Face for the FIB entry, may be NULL
+ *
+ * @return 0    on success
+ * @return -1   on error
+ */
 int ccnl_fib_rem_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx, struct ccnl_face_s *face);
 
 /**


### PR DESCRIPTION
One more step to address #2137. Fixes all doxygen warnings for core, doc and pkg subfolders.