### PR TITLE
cc110x: only handle NETOPT_PROTO if gnrc_netif module is present

### DIFF
--- a/drivers/cc110x/cc110x-netdev2.c
+++ b/drivers/cc110x/cc110x-netdev2.c
@@ -95,10 +95,12 @@ static int _get(netdev2_t *dev, netopt_t opt, void *value, size_t value_len)
             assert(value_len == 2);
             *((uint16_t *) value) = NETDEV2_TYPE_CC110X;
             return 2;
+#ifdef MODULE_GNRC_NETIF
         case NETOPT_PROTO:
             assert(value_len == sizeof(gnrc_nettype_t));
             *((gnrc_nettype_t *)value) = cc110x->proto;
             return sizeof(gnrc_nettype_t);
+#endif
         case NETOPT_CHANNEL:
             assert(value_len > 1);
             *((uint16_t *)value) = (uint16_t)cc110x->radio_channel;
@@ -145,6 +147,7 @@ static int _set(netdev2_t *dev, netopt_t opt, void *value, size_t value_len)
                 return -EINVAL;
             }
             return 1;
+#ifdef MODULE_GNRC_NETIF
         case NETOPT_PROTO:
             if (value_len != sizeof(gnrc_nettype_t)) {
                 return -EINVAL;
@@ -154,6 +157,7 @@ static int _set(netdev2_t *dev, netopt_t opt, void *value, size_t value_len)
                 return sizeof(gnrc_nettype_t);
             }
             break;
+#endif
         default:
             return -ENOTSUP;
     }


### PR DESCRIPTION
The cc110x_t::proto field is only present when the `gnrc_netif` module
is present. Handling its corresponding `NETOPT_PROTO` value leads to a
compile error when trying to compile without GNRC.