### PR TITLE
boards/nucleo-f030: configure some PWM pins, add ADC configuration

### DIFF
--- a/boards/nucleo-f030/Makefile.features
+++ b/boards/nucleo-f030/Makefile.features
@@ -1,6 +1,8 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f030/include/periph_conf.h
+++ b/boards/nucleo-f030/include/periph_conf.h
@@ -49,15 +49,31 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev      = TIM3,
+        .dev      = TIM14,
         .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .rcc_mask = RCC_APB1ENR_TIM14EN,
         .bus      = APB1,
-        .irqn     = TIM3_IRQn
+        .irqn     = TIM14_IRQn
+    },
+    {
+        .dev      = TIM16,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB2ENR_TIM16EN,
+        .bus      = APB2,
+        .irqn     = TIM16_IRQn
+    },
+    {
+        .dev      = TIM17,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB2ENR_TIM17EN,
+        .bus      = APB2,
+        .irqn     = TIM17_IRQn
     }
 };
 
-#define TIMER_0_ISR         isr_tim3
+#define TIMER_0_ISR         (isr_tim14)
+#define TIMER_1_ISR         (isr_tim16)
+#define TIMER_2_ISR         (isr_tim17)
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
@@ -80,10 +96,10 @@ static const uart_conf_t uart_config[] = {
     {
         .dev        = USART1,
         .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_B, 7),
-        .tx_pin     = GPIO_PIN(PORT_B, 6),
-        .rx_af      = GPIO_AF0,
-        .tx_af      = GPIO_AF0,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF1,
+        .tx_af      = GPIO_AF1,
         .bus        = APB2,
         .irqn       = USART1_IRQn
     }
@@ -96,22 +112,50 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @brief   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 4) /* D5 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_B, 5) /* D4 */, .cc_chan = 1},
+                      { .pin = GPIO_UNDEF,                   .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                   .cc_chan = 0} },
+        .af       = GPIO_AF1,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM15,
+        .rcc_mask = RCC_APB2ENR_TIM15EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 14), .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_B, 15), .cc_chan = 1},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .af       = GPIO_AF1,
+        .bus      = APB2
+    }
+};
+
+#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+/** @} */
+
+/**
  * @brief   ADC configuration
  * @{
  */
 #define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 },\
-    { GPIO_PIN(PORT_A, 1), 1 },\
-    { GPIO_PIN(PORT_A, 4), 4 },\
-    { GPIO_PIN(PORT_B, 0), 8 },\
+    { GPIO_PIN(PORT_A, 0), 0 }, \
+    { GPIO_PIN(PORT_A, 1), 1 }, \
+    { GPIO_PIN(PORT_A, 4), 4 }, \
+    { GPIO_PIN(PORT_B, 0), 8 }, \
     { GPIO_PIN(PORT_C, 1), 11 },\
     { GPIO_PIN(PORT_C, 0), 10 } \
 }
 
 #define ADC_NUMOF           (6)
-
 /** @} */
-
 
 /**
  * @brief   DAC configuration


### PR DESCRIPTION
This extends the periph support for the nucleo-f030:
* configured 2 extra timers and changed TIM3 to TIM14
* changed second UART pins (PA9 and PA10) are on the same side of the board. It's also more consistent with other nucleo boards
* fixed `periph_adc` not being set in the Makefile whereas it's configured and available
* Configured some PWMs : I couldn't strictly followed what is written on the board because of the incompatible alternate functions. PC7 (D9) configured on TIM3 second channel requires AF0 and PB4 (D5) on TIM3 first channel requires AF1). D3 and D6 cannot be configured as PWM on this board.
