### PR TITLE
jenkins: ccache optimizations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,7 +178,8 @@ def make_build(label, board, desc, arg)
                                                 for app in ${apps}; do
                                                     if [[ \$(make -sC \$app info-boards-supported | tr ' ' '\n' | sed -n '/^${board}\$/p') ]]; then
                                                         echo \"\n\nBuilding \$app for ${board}\" >> success_${board}_${desc}.log
-                                                        make -j\${NPROC} -C \$app all >> success_${board}_${desc}.log 2>&1 || RESULT=1
+                                                        rm -rf jenkins_bin; mkdir jenkins_bin
+                                                        CFLAGS_DBG=\"\" BINDIR=\$(pwd)/jenkins_bin make -j\${NPROC} -C \$app all >> success_${board}_${desc}.log 2>&1 || RESULT=1
                                                     fi;
                                                 done;
                                                 if ((\$RESULT)); then

--- a/boards/arduino-common/Makefile.include
+++ b/boards/arduino-common/Makefile.include
@@ -37,7 +37,7 @@ endif
 # define build specific options
 export CFLAGS_CPU   = -mmcu=atmega328p  $(CFLAGS_FPU)
 export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
-export CFLAGS_DBG   = -ggdb -g3
+export CFLAGS_DBG  ?= -ggdb -g3
 export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -36,7 +36,7 @@ endif
 # define build specific options
 export CFLAGS_CPU   = -mmcu=atmega2560  $(CFLAGS_FPU)
 export CFLAGS_LINK  = -fno-builtin -fshort-enums
-export CFLAGS_DBG   = -ggdb -g3
+export CFLAGS_DBG  ?= -ggdb -g3
 export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -6,7 +6,7 @@ TERMPROG ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
 
 export CFLAGS_CPU   = -mcpu=arm7tdmi-s
 export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
-export CFLAGS_DBG   = -ggdb -g3
+export CFLAGS_DBG  ?= -ggdb -g3
 export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -46,7 +46,7 @@ endif
 # define build specific options
 export CFLAGS_CPU   = -mmcu=atmega1281  $(CFLAGS_FPU)
 export CFLAGS_LINK  = -fno-builtin -fshort-enums
-export CFLAGS_DBG   = -ggdb -g3
+export CFLAGS_DBG  ?= -ggdb -g3
 export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)

--- a/cpu/Makefile.include.cortexm_common
+++ b/cpu/Makefile.include.cortexm_common
@@ -9,7 +9,7 @@ ifneq (llvm,$(TOOLCHAIN))
 export CFLAGS_CPU  += -mno-thumb-interwork
 endif
 export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
-export CFLAGS_DBG   = -ggdb -g3
+export CFLAGS_DBG  ?= -ggdb -g3
 export CFLAGS_OPT  ?= -Os
 
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -4,7 +4,7 @@ export TARGET_ARCH ?= msp430
 # define build specific options
 CFLAGS_CPU   = -mmcu=$(CPU_MODEL) -std=gnu99
 CFLAGS_LINK  = -ffunction-sections -fdata-sections
-CFLAGS_DBG   = -gdwarf-2
+CFLAGS_DBG  ?= -gdwarf-2
 CFLAGS_OPT  ?= -Os
 # export compiler flags
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT)


### PR DESCRIPTION
This PR introduces some optimizations to better utilize the ccache.
1. By building in the same bin dir the ccache is using the same path when determining cached objects.
1. By exluding the debug symbols, ccache seems to have a better hit rate.

On my local ccache, the ccache size reduced vastly and the hit rate skyrocketed ..
Let's see how this behaves on production.