### PR TITLE
drivers: move SAUL config to _params.h + minor fixes

### DIFF
--- a/drivers/bmp180/include/bmp180_params.h
+++ b/drivers/bmp180/include/bmp180_params.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Inria
+ *               2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -33,14 +34,14 @@ extern "C" {
  * @{
  */
 #ifndef BMP180_PARAM_I2C_DEV
-#define BMP180_PARAM_I2C_DEV         (0)
+#define BMP180_PARAM_I2C_DEV         I2C_DEV(0)
 #endif
 #ifndef BMP180_PARAM_MODE
 #define BMP180_PARAM_MODE            BMP180_ULTRALOWPOWER
 #endif
 
-#define BMP180_PARAMS_DEFAULT        {.i2c_dev = BMP180_PARAM_I2C_DEV,  \
-                                      .mode    = BMP180_PARAM_MODE }
+#define BMP180_PARAMS_DEFAULT        { .i2c_dev = BMP180_PARAM_I2C_DEV,  \
+                                       .mode    = BMP180_PARAM_MODE }
 /**@}*/
 
 /**
@@ -53,6 +54,17 @@ static const bmp180_params_t bmp180_params[] =
 #else
     BMP180_PARAMS_DEFAULT,
 #endif
+};
+
+/**
+ * @brief   Configure SAUL registry entries
+ */
+static const saul_reg_info_t bmp180_saul_reg_info[][2] =
+{
+    {
+        { .name = "bmp180-temp" },
+        { .name = "bmp180-press" }
+    }
 };
 
 #ifdef __cplusplus

--- a/drivers/jc42/include/jc42_params.h
+++ b/drivers/jc42/include/jc42_params.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
+ *               2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Default configuration for jc42
  *
  * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef JC42_PARAMS_H
@@ -31,7 +33,7 @@ extern "C" {
  * @{
  */
 #ifndef JC42_PARAM_I2C_DEV
-#define JC42_PARAM_I2C_DEV         (0)
+#define JC42_PARAM_I2C_DEV         I2C_DEV(0)
 #endif
 #ifndef JC42_PARAM_ADDR
 #define JC42_PARAM_ADDR            (0x18)
@@ -40,9 +42,9 @@ extern "C" {
 #define JC42_PARAM_SPEED           I2C_SPEED_FAST
 #endif
 
-#define JC42_PARAMS_DEFAULT        {.i2c = JC42_PARAM_I2C_DEV,  \
-                                    .speed    = JC42_PARAM_SPEED, \
-                                    .addr     = JC42_PARAM_ADDR }
+#define JC42_PARAMS_DEFAULT        { .i2c   = JC42_PARAM_I2C_DEV,  \
+                                     .speed = JC42_PARAM_SPEED, \
+                                     .addr  = JC42_PARAM_ADDR }
 /**@}*/
 
 /**
@@ -55,6 +57,14 @@ static const jc42_params_t jc42_params[] =
 #else
     JC42_PARAMS_DEFAULT,
 #endif
+};
+
+/**
+ * @brief   Configure SAUL registry entries
+ */
+static const saul_reg_info_t jc42_saul_reg_info[] =
+{
+    { .name= "jc42" }
 };
 
 #ifdef __cplusplus

--- a/drivers/si70xx/include/si70xx_params.h
+++ b/drivers/si70xx/include/si70xx_params.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 Inria
+ *               2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,12 +15,15 @@
  * @brief       Default configuration for Si7006/13/20/21
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef SI70XX_PARAMS_H
 #define SI70XX_PARAMS_H
 
+#include "board.h"
 #include "si70xx.h"
+#include "saul_reg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,14 +34,14 @@ extern "C" {
  * @{
  */
 #ifndef SI70XX_PARAM_I2C_DEV
-#define SI70XX_PARAM_I2C_DEV         (0)
+#define SI70XX_PARAM_I2C_DEV         I2C_DEV(0)
 #endif
 #ifndef SI70XX_PARAM_ADDR
 #define SI70XX_PARAM_ADDR            (0x80)
 #endif
 
-#define SI70XX_PARAMS_DEFAULT        {.i2c_dev = SI70XX_PARAM_I2C_DEV,  \
-                                      .address = SI70XX_PARAM_ADDR }
+#define SI70XX_PARAMS_DEFAULT        { .i2c_dev = SI70XX_PARAM_I2C_DEV,  \
+                                       .address = SI70XX_PARAM_ADDR }
 /**@}*/
 
 /**
@@ -50,6 +54,17 @@ static const si70xx_params_t si70xx_params[] =
 #else
     SI70XX_PARAMS_DEFAULT,
 #endif
+};
+
+/**
+ * @brief   Configure SAUL registry entries
+ */
+static const saul_reg_info_t si70xx_saul_reg_info[][2] =
+{
+    {
+        { .name = "si70xx-temp" },
+        { .name = "si70xx-hum" }
+    }
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_bmp180.c
+++ b/sys/auto_init/saul/auto_init_bmp180.c
@@ -48,23 +48,6 @@ extern const saul_driver_t bmp180_temperature_saul_driver;
 extern const saul_driver_t bmp180_pressure_saul_driver;
 /** @} */
 
-/**
- * @brief   Allocate and configure entries to the SAUL registry
- */
-saul_reg_t bmp180_saul_reg_info[][2] =
-{
-    {
-        {
-            .name= "bmp180-temp",
-            .driver = &bmp180_temperature_saul_driver
-        },
-        {
-            .name = "bmp180-press",
-            .driver = &bmp180_pressure_saul_driver
-        }
-    }
-};
-
 void auto_init_bmp180(void)
 {
     for (unsigned i = 0; i < BMP180_NUMOF; i++) {

--- a/sys/auto_init/saul/auto_init_jc42.c
+++ b/sys/auto_init/saul/auto_init_jc42.c
@@ -48,17 +48,6 @@ static saul_reg_t saul_entries[JC42_NUMOF];
 extern const saul_driver_t jc42_temperature_saul_driver;
 /** @} */
 
-/**
- * @brief   Allocate and configure entries to the SAUL registry
- */
-saul_reg_t jc42_saul_reg_info[]=
-{
-    {
-        .name= "jc42",
-        .driver = &jc42_temperature_saul_driver
-    }
-};
-
 void auto_init_jc42(void)
 {
     for (unsigned i = 0; i < JC42_NUMOF; i++) {

--- a/sys/auto_init/saul/auto_init_si70xx.c
+++ b/sys/auto_init/saul/auto_init_si70xx.c
@@ -49,23 +49,6 @@ extern const saul_driver_t si70xx_temperature_saul_driver;
 extern const saul_driver_t si70xx_relative_humidity_saul_driver;
 /** @} */
 
-/**
- * @brief   Allocate and configure entries to the SAUL registry
- */
-saul_reg_t si70xx_saul_reg_info[][2] =
-{
-    {
-        {
-            .name = "si70xx-temp",
-            .driver = &si70xx_temperature_saul_driver
-        },
-        {
-            .name = "si70xx-hum",
-            .driver = &si70xx_relative_humidity_saul_driver
-        }
-    }
-};
-
 void auto_init_si70xx(void)
 {
     for (unsigned i = 0; i < SI70XX_NUMOF; i++) {
@@ -73,7 +56,7 @@ void auto_init_si70xx(void)
                               si70xx_params[i].i2c_dev,
                               si70xx_params[i].address);
         if (res < 0) {
-            LOG_ERROR("Unable to initialize BMP180 sensor #%i\n", i);
+            LOG_ERROR("Unable to initialize SI70xx sensor #%i\n", i);
             return;
         }
 


### PR DESCRIPTION
The SAUL registry configuration for device drivers should be done in the device's `xxx_params.h` file. If more than one device of a kind is configured, one normally wants to give them unique names in the saul registry, and this is best done in the same position of code/configuration.

Secondly, the current version can lead to array out-of-bound access. E.g. somebody overrides the default configuration for the `si7xx` in the application and two devices are configured, then the auto-init cod for the `si7xx` will try to call `saul_entries[i * 2].name = si70xx_saul_reg_info[i][0].name;` with `i == 1`, but the `si7xx_saul_reg_info[]` array has only one configured entry... -> so defining the saul configuration together with the device configuration is most suitable.

Third, the current version wastes RAM: the SAUL reg configuration entries are allocated in RAM, using `sizeof(saul_reg_t)` (16 byte @ 32-bit) for each configuration entry. To prevent this, the configuration entries should be allocated as `saul_reg_info_t` in ROM, now only using `sizeof(saul_reg_info_t)` (4 byte @ 32-bit).

All these issues should be solved with this PR. Also this PR includes some minor style fixes and uses the correct I2C device definition (`I2C_DEV(0)` instead of `0`).