### PR TITLE
examples: added stand-alone SAUL example

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -548,6 +548,8 @@ endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul
+  USEMODULE += saul_reg
+  USEMODULE += auto_init_saul
 endif
 
 ifneq (,$(filter saul,$(USEMODULE)))

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -32,9 +32,7 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 # include and auto-initialize all available sensors
-USEMODULE += saul_reg
 USEMODULE += saul_default
-USEMODULE += auto_init_saul
 
 BOARD_PROVIDES_NETIF := airfy-beacon cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
         microbit native nrf51dongle nrf52dk nrf6310 openmote-cc2538 pba-d-01-kw2x \

--- a/examples/saul/Makefile
+++ b/examples/saul/Makefile
@@ -1,0 +1,26 @@
+# name of your application
+APPLICATION = default
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# we want to use SAUL:
+USEMODULE += saul_default
+# include the shell:
+USEMODULE += shell
+USEMODULE += shell_commands
+# additional modules for debugging:
+USEMODULE += ps
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/saul/README.md
+++ b/examples/saul/README.md
@@ -1,0 +1,19 @@
+examples/saul
+================
+This application demonstrates the usage of SAUL and the SAUL registry.
+
+Usage
+=====
+Simply build and flash the application for your target board:
+```
+BOARD=YOUR_BOARD_NAME_HERE make flash term
+```
+
+Now you should have access to the RIOT shell on your board. For interacting
+with SAUL devices, use the `saul` shell command, e.g.:
+```
+saul            <- this will list all available devices mapped into
+                   the SAUL registry
+saul read 0     <- read values from device #0
+saul write 1 0  <- write a `0` to SAUL device #1
+```

--- a/examples/saul/main.c
+++ b/examples/saul/main.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Example for demonstrating SAUL and the SAUL registry
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+
+int main(void)
+{
+    puts("Welcome to RIOT!\n");
+    puts("Type `help` for help, type `saul` to see all SAUL devices\n");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/saul/Makefile
+++ b/tests/saul/Makefile
@@ -2,9 +2,7 @@ APPLICATION = saul
 include ../Makefile.tests_common
 
 # include and auto-initialize all available sensors
-USEMODULE += saul_reg
 USEMODULE += saul_default
-USEMODULE += auto_init_saul
 
 USEMODULE += xtimer
 


### PR DESCRIPTION
This example basically cuts the SAUL part out of the `default` example. I think this is useful for (i) showing how to setup SAUL when using it stand-alone, and (ii) when testing SAUL mappings/implementations as with example we don't have to compile all the networking code (as we would have with the default example).

If there are strong opinions against this example, I won't fight for it - but in general I think this would be useful to have...