### PR TITLE
CI: fix whitespace handling in command output

### DIFF
--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -43,7 +43,7 @@ function run {
     OUT_LENGTH="$(echo -n $OUT | wc -c)"
     if (( "$OUT_LENGTH" > 0 )); then
         echo -e "Command output:\n"
-        (echo $OUT | while read -r line; do echo -ne "\t"; echo $line; done)
+        (printf "%s" "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
         echo ""
     fi
 }


### PR DESCRIPTION
All newlines were stripped before and leading whitespace was trimmed
which made the output very difficult to read.