### PR TITLE
CI: show toolchain versions during static-tests

### DIFF
--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -78,6 +78,8 @@ then
             exit $RESULT
         fi
 
+        run ./dist/tools/ci/print_toolchain_versions.sh
+
         run ./dist/tools/whitespacecheck/check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/licenses/check.sh ${CI_BASE_BRANCH} --diff-filter=MR --error-exitcode=0
         run ./dist/tools/licenses/check.sh ${CI_BASE_BRANCH} --diff-filter=AC

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+gcc_version() {
+    local cc
+    if [ -z "$1" ]; then
+        cc=gcc
+    else
+        cc=$1-gcc
+    fi
+    local ver=
+    if command -v "$cc" 2>&1 >/dev/null; then
+        ver=$("$cc" --version | head -n 1)
+    fi
+    if [ -z "$ver" ]; then
+        ver=missing/error
+    fi
+    printf "%s" "$ver"
+}
+
+get_define() {
+    local cc="$1"
+    local line=
+    if command -v "$cc" 2>&1 >/dev/null; then
+        line=$(echo "$3" | "$cc" -x c -include "$2" -E -o - - 2>&1 | sed -e '/^[   ]*#/d' -e '/^[  ]*$/d')
+    fi
+    if [ -z "$line" ]; then
+        line=missing/error
+    fi
+    printf "%s" "$line"
+}
+
+newlib_version() {
+    if [ -z "$1" ]; then
+        cc=gcc
+    else
+        cc=$1-gcc
+    fi
+    printf "%s" "$(get_define "$cc" newlib.h _NEWLIB_VERSION)"
+}
+
+avr_libc_version() {
+    if [ -z "$1" ]; then
+        cc=gcc
+    else
+        cc=$1-gcc
+    fi
+    printf "%s (%s)" "$(get_define "$cc" avr/version.h __AVR_LIBC_VERSION_STRING__)" "$(get_define "$cc" avr/version.h __AVR_LIBC_DATE_STRING__)"
+}
+
+printf "Installed toolchain versions:\n"
+VER=$(gcc --version | head -n 1)
+if [ -n "$VER" ]; then
+    printf "%20s: %s\n" "native gcc" "$VER"
+fi
+for p in msp430 avr arm-none-eabi; do
+    printf "%20s: %s\n" "$p-gcc" "$(gcc_version "$p")"
+done
+VER=$(clang --version | head -n 1)
+if [ -n "$VER" ]; then
+    printf "%20s: %s\n" "clang" "$VER"
+fi
+
+for p in arm-none-eabi; do
+    printf "%20s: %s\n" "$p-newlib" "$(newlib_version "$p")"
+done
+for p in avr; do
+    printf "%20s: %s\n" "$p-libc" "$(avr_libc_version "$p")"
+done
+exit 0


### PR DESCRIPTION
Added a small script to print installed toolchain versions of the supported platforms. This script is called during static-tests but should always return success regardless whether anything is missing. The intention is only to show more clearly what compiler versions are used for the CI builds.