### PR TITLE
boards: remove local Makefile.dep includes

### DIFF
--- a/boards/arduino-zero/Makefile.include
+++ b/boards/arduino-zero/Makefile.include
@@ -6,9 +6,6 @@ export CPU_MODEL = samd21g18a
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 

--- a/boards/sodaq-autonomo/Makefile.include
+++ b/boards/sodaq-autonomo/Makefile.include
@@ -8,9 +8,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 export OFLAGS = -O binary
 
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
-
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial
 


### PR DESCRIPTION
No need for these, as $(RIOTBOARD)/$(BOARD)/Makefile.dep is globally included from $(RIOBASE)/Makefile.dep.