### PR TITLE
cpu/stm32/pwm: made channel config more flexible

### DIFF
--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -83,9 +83,11 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM11,
         .rcc_mask = RCC_APB2ENR_TIM11EN,
-        .pins     = { GPIO_PIN(PORT_B, 9), GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF },
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 9), .cc_chan = 0 },
+                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                      { .pin = GPIO_UNDEF, .cc_chan = 0 } },
         .af       = GPIO_AF3,
-        .chan     = 1,
         .bus      = APB2
     }
 };

--- a/boards/nucleo-f207/Makefile.features
+++ b/boards/nucleo-f207/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/nucleo-f207/include/periph_conf.h
+++ b/boards/nucleo-f207/include/periph_conf.h
@@ -58,10 +58,11 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM3,
         .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .pins     = { GPIO_PIN(PORT_C, 6), GPIO_PIN(PORT_C, 7),
-                      GPIO_PIN(PORT_C, 8), GPIO_PIN(PORT_C, 9) },
+        .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_C, 7), .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_C, 8), .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_C, 9), .cc_chan = 3 } },
         .af       = GPIO_AF2,
-        .chan     = 4,
         .bus      = APB1
     }
 };

--- a/boards/nucleo-f303/include/periph_conf.h
+++ b/boards/nucleo-f303/include/periph_conf.h
@@ -125,10 +125,11 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM3,
         .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .pins     = { GPIO_PIN(PORT_C, 6), GPIO_PIN(PORT_C, 7),
-                      GPIO_PIN(PORT_C, 8), GPIO_PIN(PORT_C, 9) },
+        .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_C, 7), .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_C, 8), .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_C, 9), .cc_chan = 3 } },
         .af       = GPIO_AF2,
-        .chan     = 4,
         .bus      = APB1
     }
 };

--- a/boards/nucleo-f334/include/periph_conf.h
+++ b/boards/nucleo-f334/include/periph_conf.h
@@ -109,10 +109,11 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM3,
         .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .pins     = { GPIO_PIN(PORT_C, 6), GPIO_PIN(PORT_C, 7),
-                      GPIO_PIN(PORT_C, 8), GPIO_PIN(PORT_C, 9) },
+        .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_C, 7), .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_C, 8), .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_C, 9), .cc_chan = 3 } },
         .af       = GPIO_AF2,
-        .chan     = 4,
         .bus      = APB1
     }
 };

--- a/boards/nucleo-f446/include/periph_conf.h
+++ b/boards/nucleo-f446/include/periph_conf.h
@@ -134,28 +134,31 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM2,
         .rcc_mask = RCC_APB1ENR_TIM2EN,
-        .pins     = { GPIO_PIN(PORT_A, 15), GPIO_PIN(PORT_B, 3),
-                      GPIO_PIN(PORT_B, 10), GPIO_PIN(PORT_B, 2) },
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 15), .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_B,  3), .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_B, 10), .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_B,  2), .cc_chan = 3} },
         .af       = GPIO_AF1,
-        .chan     = 4,
         .bus      = APB1
     },
     {
         .dev      = TIM3,
         .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .pins     = { GPIO_PIN(PORT_B, 4), GPIO_UNDEF,
-                      GPIO_UNDEF, GPIO_UNDEF },
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 4), .cc_chan = 0 },
+                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
+                      { .pin = GPIO_UNDEF, .cc_chan = 0 } },
         .af       = GPIO_AF2,
-        .chan     = 1,
         .bus      = APB1
     },
     {
         .dev      = TIM8,
         .rcc_mask = RCC_APB2ENR_TIM8EN,
-        .pins     = { GPIO_PIN(PORT_C, 6), GPIO_PIN(PORT_C, 7),
-                      GPIO_PIN(PORT_C, 8), GPIO_PIN(PORT_C, 9) },
+        .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_C, 7), .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_C, 8), .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_C, 9), .cc_chan = 3} },
         .af       = GPIO_AF3,
-        .chan     = 4,
         .bus      = APB2
     },
 };

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -127,19 +127,21 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM3,
         .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .pins     = { GPIO_PIN(PORT_C, 6), GPIO_PIN(PORT_C, 7),
-                      GPIO_PIN(PORT_C, 8), GPIO_PIN(PORT_C, 9) },
+        .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_C, 7), .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_C, 8), .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_C, 9), .cc_chan = 3 } },
         .af       = GPIO_AF2,
-        .chan     = 4,
         .bus      = APB1
     },
     {
         .dev      = TIM4,
         .rcc_mask = RCC_APB1ENR_TIM4EN,
-        .pins     = { GPIO_PIN(PORT_D, 12), GPIO_PIN(PORT_D, 13),
-                      GPIO_PIN(PORT_D, 14), GPIO_PIN(PORT_D, 15) },
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 12), .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_D, 13), .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_D, 14), .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_D, 15), .cc_chan = 3} },
         .af       = GPIO_AF2,
-        .chan     = 4,
         .bus      = APB1
     }
 };

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -159,21 +159,21 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM1,
         .rcc_mask = RCC_APB2ENR_TIM1EN,
-        .pins     = { GPIO_PIN(PORT_E,  9), GPIO_PIN(PORT_E, 11),
-                      GPIO_PIN(PORT_E, 11), GPIO_PIN(PORT_E, 14) },
+        .chan     = { { .pin = GPIO_PIN(PORT_E,  9), .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_E, 11), .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_E, 11), .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_E, 14), .cc_chan = 3 } },
         .af       = GPIO_AF1,
-        .chan     = 4,
         .bus      = APB2
     },
-    {
-        .dev      = TIM3,
-        .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .pins     = { GPIO_PIN(PORT_B, 4), GPIO_PIN(PORT_B, 5),
-                      GPIO_PIN(PORT_B, 0), GPIO_PIN(PORT_B, 1) },
-        .af       = GPIO_AF2,
-        .chan     = 4,
-        .bus      = APB1
-    }
+    // {
+    //     .dev      = TIM3,
+    //     .rcc_mask = RCC_APB1ENR_TIM3EN,
+    //     .chan     = { GPIO_PIN(PORT_B, 4), GPIO_PIN(PORT_B, 5),
+    //                   GPIO_PIN(PORT_B, 0), GPIO_PIN(PORT_B, 1) },
+    //     .af       = GPIO_AF2,
+    //     .bus      = APB1
+    // }
 };
 
 #define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -130,15 +130,23 @@ typedef struct {
 } timer_conf_t;
 
 /**
+ * @brief   PWM channel
+ */
+typedef struct {
+    gpio_t pin;             /**< GPIO pin mapped to this channel */
+    uint8_t cc_chan;        /**< capture compare channel used */
+} pwm_chan_t;
+
+/**
  * @brief   PWM configuration
  */
 typedef struct {
-    TIM_TypeDef *dev;       /**< Timer used */
-    uint32_t rcc_mask;      /**< bit in clock enable register */
-    gpio_t pins[4];         /**< pins used, set to GPIO_UNDEF if not used */
-    gpio_af_t af;           /**< alternate function used */
-    uint8_t chan;           /**< number of configured channels */
-    uint8_t bus;            /**< APB bus */
+    TIM_TypeDef *dev;               /**< Timer used */
+    uint32_t rcc_mask;              /**< bit in clock enable register */
+    pwm_chan_t chan[TIMER_CHAN];    /**< channel mapping, set to {GPIO_UNDEF, 0}
+                                     *   if not used */
+    gpio_af_t af;                   /**< alternate function used */
+    uint8_t bus;                    /**< APB bus */
 } pwm_conf_t;
 
 /**

--- a/cpu/stm32_common/periph/pwm.c
+++ b/cpu/stm32_common/periph/pwm.c
@@ -58,9 +58,11 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     }
 
     /* configure the used pins */
-    for (unsigned i = 0; i < pwm_config[pwm].chan; i++) {
-        gpio_init(pwm_config[pwm].pins[i], GPIO_OUT);
-        gpio_init_af(pwm_config[pwm].pins[i], pwm_config[pwm].af);
+    unsigned i = 0;
+    while ((i < TIMER_CHAN) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+        gpio_init(pwm_config[pwm].chan[i].pin, GPIO_OUT);
+        gpio_init_af(pwm_config[pwm].chan[i].pin, pwm_config[pwm].af);
+        i++;
     }
 
     /* configure the PWM frequency and resolution by setting the auto-reload
@@ -100,19 +102,26 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
 uint8_t pwm_channels(pwm_t pwm)
 {
     assert(pwm < PWM_NUMOF);
-    return pwm_config[pwm].chan;
+
+    unsigned i = 0;
+    while ((i < TIMER_CHAN) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+        i++;
+    }
+    return (uint8_t)i;
 }
 
 void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
 {
-    assert((pwm < PWM_NUMOF) && (channel < pwm_config[pwm].chan));
+    assert((pwm < PWM_NUMOF) &&
+           (channel < TIMER_CHAN) &&
+           (pwm_config[pwm].chan[channel].pin != GPIO_UNDEF));
 
     /* norm value to maximum possible value */
     if (value > dev(pwm)->ARR) {
         value = (uint16_t)dev(pwm)->ARR;
     }
     /* set new value */
-    dev(pwm)->CCR[channel] = value;
+    dev(pwm)->CCR[pwm_config[pwm].chan[channel].cc_chan] = value;
 }
 
 void pwm_start(pwm_t pwm)


### PR DESCRIPTION
alternative to #6350

Now the logical PWM channels used be RIOT are decoupled from the actual used HW CC channels.