### PR TITLE
tests: add xtimer_usleep test

### DIFF
--- a/tests/xtimer_usleep/Makefile
+++ b/tests/xtimer_usleep/Makefile
@@ -1,0 +1,9 @@
+APPLICATION = xtimer_usleep
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	./tests/01-run.py

--- a/tests/xtimer_usleep/main.c
+++ b/tests/xtimer_usleep/main.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       xtimer_usleep test application
+ *
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+#include "timex.h"
+
+#define ONE_SEC_SLEEP     (1 * SEC_IN_USEC)
+#define FIVE_SEC_SLEEP    (5 * SEC_IN_USEC)
+#define TEN_SEC_SLEEP     (10 * SEC_IN_USEC)
+
+int main(void)
+{
+    int t = 9;
+
+    printf("This test will print \"Slept for X sec...\" every 1, 5 and 10 seconds.\n");
+    printf("\n<======== If using pyterm, this is the time when started.\n\n");
+
+    while (t) {
+        xtimer_usleep(ONE_SEC_SLEEP);
+        printf("Slept for 1 sec...\n");
+        xtimer_usleep(FIVE_SEC_SLEEP);
+        printf("Slept for 5 sec...\n");
+        xtimer_usleep(TEN_SEC_SLEEP);
+        printf("Slept for 10 sec...\n");
+        t--;
+    }
+    printf("Test end.\n");
+
+    return 0;
+}

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2017 Francisco Acosta <francisco.acosta@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+from datetime import datetime
+
+class InvalidTimeout(Exception):
+    pass
+
+def testfunc(child):
+    exp_diff1 = 1000000
+    exp_diff5 = 5000000
+    exp_diff10 = 10000000
+    child.expect(u"This test will print \"Slept for X sec...\" every 1, 5 and 10 seconds.\r\n")
+    child.expect(u"\r\n")
+    child.expect(u"<======== If using pyterm, this is the time when started.")
+    child.expect(u"\r\n")
+    m = 9
+    while (m):
+        n = 3
+        while (n):
+            if n == 3:
+                exp_diff = exp_diff1
+            if n == 2:
+                exp_diff = exp_diff5
+            elif n == 1:
+                exp_diff = exp_diff10
+            start = datetime.now()
+            child.expect(u"Slept for \\d+ sec...", timeout=11)
+            stop = datetime.now()
+            diff = (stop - start)
+            diff = (diff.seconds * 1000000) + diff.microseconds
+            # fail within 5% of expected
+            if diff > (exp_diff + (exp_diff1 * 0.05)) or \
+               diff < (exp_diff - (exp_diff1 * 0.05)):
+                raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
+            else:
+                print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+            n = n - 1
+        m = m -1
+
+    child.expect(u"Test end.", timeout=15)
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
While checking some xtimer functionalities on several boards, I realised that xtimer_usleep was failing, and we didn't have a test. So, here there is.