### PR TITLE
doc: Doxygen strip include fix

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -22,4 +22,4 @@ latex:
 	( cat riot.doxyfile ; echo "GENERATE_LATEX= yes" ) | doxygen -
 
 clean:
-	-@rm -rf latex man html doxygen_objdb_*.tmp
+	-@rm -rf latex man html doxygen_objdb_*.tmp doxygen_entrydb_*.tmp

--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -1,7 +1,7 @@
 RIOTBASE=$(shell git rev-parse --show-toplevel)
 # Generate list of quoted absolute include paths. Evaluated in riot.doxyfile.
 export STRIP_FROM_INC_PATH_LIST=$(shell \
-    git ls-tree -dr --full-tree --name-only HEAD |\
+    git ls-tree -dr --full-tree --name-only HEAD core drivers sys |\
     grep '/include$$' |\
     sed 's/.*/\"$(subst /,\/,${RIOTBASE})\/\0\"/')
 

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -841,6 +841,9 @@ EXCLUDE_PATTERNS       = */board/*/tools/* \
                          */sys/random/tinymt32/* \
                          */cpu/stm32f2/include/stm32f2*.h \
                          */cpu/stm32f4/include/stm32f4*.h \
+                         */cpu/stellaris_common/include/stellaris_periph \
+                         */cpu/native/osx-libc-extra \
+                         */toolchain/* \
 
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names


### PR DESCRIPTION
Fixes #6367 for all occurrences except w5100_params.h

Piggybacked a tiny enhancement for the clean Makefile target in doc as well.