### PR TITLE
shell: introduce txtsnd pseudomodule

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -22,6 +22,7 @@ PSEUDOMODULES += gnrc_sixlowpan_nd_border_router
 PSEUDOMODULES += gnrc_sixlowpan_router
 PSEUDOMODULES += gnrc_sixlowpan_router_default
 PSEUDOMODULES += gnrc_sock_check_reuse
+PSEUDOMODULES += gnrc_txtsnd
 PSEUDOMODULES += log
 PSEUDOMODULES += log_printfnoformat
 PSEUDOMODULES += lwip_arp

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -47,6 +47,8 @@ ifneq (,$(filter $(BOARD),$(BOARD_PROVIDES_NETIF)))
   USEMODULE += gnrc_netdev_default
   # automatically initialize the network interface
   USEMODULE += auto_init_gnrc_netif
+  # shell command to send L2 packets with a simple string
+  USEMODULE += gnrc_txtsnd
   # the application dumps received packets to stdout
   USEMODULE += gnrc_pktdump
 

--- a/examples/posix_sockets/README.md
+++ b/examples/posix_sockets/README.md
@@ -44,7 +44,6 @@ Running the `help` command on an iotlab-m3:
 2015-09-22 14:54:54,451 - INFO # mersenne_init        initializes the PRNG
 2015-09-22 14:54:54,453 - INFO # mersenne_get         returns 32 bit of pseudo randomness
 2015-09-22 14:54:54,454 - INFO # ifconfig             Configure network interfaces
-2015-09-22 14:54:54,455 - INFO # txtsnd               Sends a custom string as is over the link layer
 2015-09-22 14:54:54,457 - INFO # ncache               manage neighbor cache by hand
 2015-09-22 14:54:54,459 - INFO # routers              IPv6 default router list
 ```

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -181,7 +181,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_GNRC_NETIF
     {"ifconfig", "Configure network interfaces", _netif_config},
+#ifdef MODULE_GNRC_TXTSND
     {"txtsnd", "Sends a custom string as is over the link layer", _netif_send },
+#endif
 #endif
 #ifdef MODULE_FIB
     {"fibroute", "Manipulate the FIB (info: 'fibroute [add|del]')", _fib_route_handler},

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := stm32f0discovery nucleo-f334 weio
 
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_netif
+USEMODULE += gnrc_txtsnd
 USEMODULE += gnrc_nomac
 USEMODULE += gnrc_pktdump
 USEMODULE += shell

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := nucleo-f030 nucleo-f334 stm32f0discovery weio \
 
 USEMODULE += xbee
 USEMODULE += gnrc_netif
+USEMODULE += gnrc_txtsnd
 USEMODULE += gnrc_netdev2
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_pktdump


### PR DESCRIPTION
This commit allows to enable/disable the txtsnd shell command. The
command is used to send strings over L2 in GNRC. Until now the command
was automatically enabled if GNRC and shell_commands were present, which
may lead to confusion if no L2 packet handler is registered.

Fixes #5034.