### PR TITLE
Boards: Add Maple mini

### DIFF
--- a/boards/maple-mini/Makefile
+++ b/boards/maple-mini/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/maple-mini/Makefile.features
+++ b/boards/maple-mini/Makefile.features
@@ -1,0 +1,13 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/maple-mini/Makefile.include
+++ b/boards/maple-mini/Makefile.include
@@ -1,0 +1,13 @@
+# define the cpu used by the maple-mini board
+export CPU = stm32f1
+export CPU_MODEL = stm32f103cb
+
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# setup serial terminal
+include $(RIOTBOARD)/Makefile.include.serial
+
+# this board uses openocd
+include $(RIOTBOARD)/Makefile.include.openocd

--- a/boards/maple-mini/board.c
+++ b/boards/maple-mini/board.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Frits Kuipers
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_maple-mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the maple-mini board
+ *
+ * @author      Frits Kuipers <frits.kuipers@gmail.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the boards LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+}

--- a/boards/maple-mini/dist/openocd.cfg
+++ b/boards/maple-mini/dist/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink-v2-1.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f1x.cfg]
+
+reset_config srst_only

--- a/boards/maple-mini/include/board.h
+++ b/boards/maple-mini/include/board.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Frits Kuipers
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    boards_maple-mini maple-mini
+ * @ingroup     boards
+ * @brief       Board specific files for the maple-mini board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the maple-mini board
+ *
+ * @author      Frits Kuipers <frits.kuipers@gmail.com>
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      5
+/** @} */
+
+/**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_B, 1)
+
+#define LED_PORT            GPIOB
+#define LED0_MASK           (1 << 1)
+
+#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)
+#define LED0_OFF            (LED_PORT->BRR  = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->ODR ^= LED0_MASK)
+/** @} */
+
+/**
+ * @brief   User button
+ */
+#define BTN_B1_PIN          GPIO_PIN(PORT_B, 8)
+
+/**
+ * @brief Use the USART1 for STDIO on this board
+ */
+#define UART_STDIO_DEV      UART_DEV(1)
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H_ */
+/** @} */

--- a/boards/maple-mini/include/gpio_params.h
+++ b/boards/maple-mini/include/gpio_params.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 Frits Kuipers
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_maple-mini
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Frits Kuipers <frits.kuipers@gmail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    Button/LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "BUTTON",
+        .pin = BTN_B1_PIN,
+        .mode = GPIO_IN
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/maple-mini/include/periph_conf.h
+++ b/boards/maple-mini/include/periph_conf.h
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2016 Frits Kuipers
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_maple-mini
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the maple-mini board
+ *
+ * @author      Frits Kuipers <frits.kuipers@gmail.com>
+ */
+
+#ifndef PERIPH_CONF_H_
+#define PERIPH_CONF_H_
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Clock system configuration
+ * @{
+ */
+#define CLOCK_HSE           (8000000U)              /* external oscillator */
+#define CLOCK_CORECLOCK     (72000000U)             /* desired core clock frequency */
+
+/* the actual PLL values are automatically generated */
+#define CLOCK_PLL_DIV       (1)
+#define CLOCK_PLL_MUL       CLOCK_CORECLOCK / CLOCK_HSE
+
+/* AHB, APB1, APB2 dividers */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2
+
+/* Bus clocks */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+#define CLOCK_APB2          (CLOCK_CORECLOCK)
+
+/* Flash latency */
+#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY_2    /* for >= 72 MHz */
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (0)
+/** @} */
+
+/**
+ * @brief   DAC configuration
+ * @{
+ */
+#define DAC_NUMOF           (0)
+/** @} */
+
+/**
+ * @brief   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM2,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
+    },
+    {
+        .dev      = TIM3,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim3
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @brief UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = USART2,
+        .rcc_mask = RCC_APB1ENR_USART2EN,
+        .rx_pin   = GPIO_PIN(PORT_A, 3),
+        .tx_pin   = GPIO_PIN(PORT_A, 2),
+        .bus      = APB1,
+        .irqn     = USART2_IRQn
+    },
+    {
+        .dev      = USART1,
+        .rcc_mask = RCC_APB2ENR_USART1EN,
+        .rx_pin   = GPIO_PIN(PORT_A, 10),
+        .tx_pin   = GPIO_PIN(PORT_A, 9),
+        .bus      = APB2,
+        .irqn     = USART1_IRQn
+    },
+    {
+        .dev      = USART3,
+        .rcc_mask = RCC_APB1ENR_USART3EN,
+        .rx_pin   = GPIO_PIN(PORT_B, 11),
+        .tx_pin   = GPIO_PIN(PORT_B, 10),
+        .bus      = APB1,
+        .irqn     = USART3_IRQn
+    }
+};
+
+#define UART_0_ISR          isr_usart2
+#define UART_1_ISR          isr_usart1
+#define UART_2_ISR          isr_usart3
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF           (2U)
+#define I2C_0_EN            1
+#define I2C_1_EN            0
+#define I2C_IRQ_PRIO        1
+#define I2C_APBCLK          (36000000U)
+
+/* I2C 0 device configuration */
+#define I2C_0_DEV           I2C1
+#define I2C_0_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C1EN)
+#define I2C_0_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
+#define I2C_0_EVT_IRQ       I2C1_EV_IRQn
+#define I2C_0_EVT_ISR       isr_i2c1_ev
+#define I2C_0_ERR_IRQ       I2C1_ER_IRQn
+#define I2C_0_ERR_ISR       isr_i2c1_er
+/* I2C 0 pin configuration */
+#define I2C_0_SCL_PIN       GPIO_PIN(PORT_B, 6) /* D15 */
+#define I2C_0_SDA_PIN       GPIO_PIN(PORT_B, 7) /* D16 */
+
+/* I2C 1 device configuration */
+#define I2C_1_DEV           I2C2
+#define I2C_1_CLKEN()       (RCC->APB1ENR |= RCC_APB1ENR_I2C2EN)
+#define I2C_1_CLKDIS()      (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C2EN))
+#define I2C_1_EVT_IRQ       I2C2_EV_IRQn
+#define I2C_1_EVT_ISR       isr_i2c2_ev
+#define I2C_1_ERR_IRQ       I2C2_ER_IRQn
+#define I2C_1_ERR_ISR       isr_i2c2_er
+/* I2C 1 pin configuration */
+#define I2C_1_SCL_PIN       GPIO_PIN(PORT_B, 10) /* D1 */
+#define I2C_1_SDA_PIN       GPIO_PIN(PORT_B, 11) /* D0 */
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+#define SPI_NUMOF           (2U)
+#define SPI_0_EN            1
+#define SPI_1_EN            0
+#define SPI_IRQ_PRIO        1
+
+/* SPI 0 device config */
+#define SPI_0_DEV               SPI1
+#define SPI_0_CLKEN()           (RCC->APB2ENR |= RCC_APB2ENR_SPI1EN)
+#define SPI_0_CLKDIS()          (RCC->APB2ENR &= ~RCC_APB2ENR_SPI1EN)
+#define SPI_0_IRQ               SPI1_IRQn
+#define SPI_0_IRQ_HANDLER       isr_spi1
+#define SPI_0_BUS_DIV           1
+
+/* SPI 0 pin configuration */
+#define SPI_0_CLK_PIN           GPIO_PIN(PORT_A, 5) /* D6 */
+#define SPI_0_MISO_PIN          GPIO_PIN(PORT_A, 6) /* D5 */
+#define SPI_0_MOSI_PIN          GPIO_PIN(PORT_A, 7) /* D4 */
+
+/* SPI 1 device config */
+#define SPI_1_DEV               SPI2
+#define SPI_1_CLKEN()           (RCC->APB1ENR |= RCC_APB1ENR_SPI2EN)
+#define SPI_1_CLKDIS()          (RCC->APB1ENR &= ~RCC_APB1ENR_SPI2EN)
+#define SPI_1_IRQ               SPI2_IRQn
+#define SPI_1_IRQ_HANDLER       isr_spi2
+#define SPI_1_BUS_DIV           1
+/* SPI 1 pin configuration */
+#define SPI_1_CLK_PIN           GPIO_PIN(PORT_B, 13) /* D30 */
+#define SPI_1_MISO_PIN          GPIO_PIN(PORT_B, 14) /* D29 */
+#define SPI_1_MOSI_PIN          GPIO_PIN(PORT_B, 15) /* D28 */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H_ */

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -17,7 +17,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon nrf51dongle nrf6310 nucleo-f103 \
                              nucleo-f334 pca10000 pca10005 spark-core \
                              stm32f0discovery weio yunjia-nrf51822 nucleo-f072 \
                              cc2650stk nucleo-f030 nucleo-f070 microbit \
-                             calliope-mini nucleo32-f042 nucleo32-f303 opencm9-04
+                             calliope-mini nucleo32-f042 nucleo32-f303 opencm9-04 \
+                             maple-mini
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -7,8 +7,8 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon cc2650stk msb-430 msb-430h pca10000 pca10005 \
-                             nrf51dongle nrf6310 nucleo-f103 nucleo-f334 \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon cc2650stk maple-mini msb-430 msb-430h pca10000 \
+                             pca10005 nrf51dongle nrf6310 nucleo-f103 nucleo-f334 \
                              spark-core stm32f0discovery telosb \
                              weio wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1 nucleo-f072 \
                              nucleo-f030 nucleo-f070 microbit calliope-mini \

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -5,10 +5,10 @@ include ../Makefile.tests_common
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
-                          nrf6310 nucleo-f103 nucleo-f334 pca10000 pca10005 spark-core \
-                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
-                          yunjia-nrf51822 z1 nucleo-f030 nucleo32-f042
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 maple-mini msb-430h \
+                          nrf51dongle nrf6310 nucleo-f103 nucleo-f334 pca10000 pca10005 \
+                          spark-core stm32f0discovery telosb weio wsn430-v1_3b \
+                          wsn430-v1_4 yunjia-nrf51822 z1 nucleo-f030 nucleo32-f042
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -5,7 +5,7 @@ include ../Makefile.tests_common
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h nrf51dongle \
                           nrf6310 nucleo-f103 nucleo-f334 pca10000 pca10005 spark-core \
                           stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
                           yunjia-nrf51822 z1 nucleo-f030 nucleo-f070 nucleo32-f042

--- a/tests/mpu_stack_guard/Makefile
+++ b/tests/mpu_stack_guard/Makefile
@@ -14,6 +14,7 @@ BOARD_WHITELIST += limifrog-v1      # cortex-m3
 BOARD_WHITELIST += mbed_lpc1768     # cortex-m3
 BOARD_WHITELIST += msbiot           # cortex-m4f
 BOARD_WHITELIST += mulle            # cortex-m4
+BOARD_WHITELIST += maple-mini       # cortex-m3
 BOARD_WHITELIST += nrf52dk          # cortex-m4f
 BOARD_WHITELIST += nucleo-f103      # cortex-m3
 BOARD_WHITELIST += nucleo-f207      # cortex-m3

--- a/tests/pkg_cmsis-dsp/Makefile
+++ b/tests/pkg_cmsis-dsp/Makefile
@@ -15,6 +15,7 @@ BOARD_WHITELIST := \
   mulle \
   nucleo-f091 \
   nucleo-f103 \
+  nucleo-f103 \
   nucleo-f303 \
   nucleo-f334 \
   nucleo-f401 \

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,8 +1,8 @@
 APPLICATION = thread_cooperation
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := cc2650stk chronos msb-430 msb-430h mbed_lpc1768 \
-                          stm32f0discovery pca10000 pca10005 \
+BOARD_INSUFFICIENT_MEMORY := cc2650stk chronos maple-mini msb-430 msb-430h \
+                          mbed_lpc1768 stm32f0discovery pca10000 pca10005 \
                           yunjia-nrf51822 spark-core airfy-beacon nucleo-f103 \
                           nucleo-f334 nrf51dongle nrf6310 weio nucleo-f072 \
                           nucleo-f030 nucleo-f070 microbit calliope-mini \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -2,7 +2,7 @@ APPLICATION = unittests
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon cc2650stk chronos ek-lm4f120xl \
-                          msb-430 msb-430h pca10000 \
+                          maple-mini msb-430 msb-430h pca10000 \
                           pca10005 spark-core stm32f0discovery stm32f3discovery \
                           telosb wsn430-v1_3b wsn430-v1_4 z1 nucleo-f103 \
                           nucleo-f334 yunjia-nrf51822 samr21-xpro \


### PR DESCRIPTION
This PR adds support for the maple-mini board. The board is based on a stm32f103. A lot of  cheap clones can be found on aliexpress/ebay.

These board files require a programmer (e.g. st-link v2) to flash RIOT on the device. It overwrites the maple-mini boot-loader.  

The maple-mini can be connected to the programmer as follows:

| SWD connector    | Maple mini    |
| -----------------|:--------------|
| VCC                     | nc                    |
| SWCLK               | D21                  |
| GND                    | GND            |
| SWDIO             | D22           |
| NRST             | RST           |
| SWO              | nc            |

This method requires disabling the flash protection of the maple-mini.  This can be done as follows:

```
# First change to the RIOT root directory
openocd -f 'boards/maple-mini/dist/openocd.cfg'

# Start telnet in a different bash session
telnet localhost 4444
reset
flash protect 0 0 last off
reset run
```

Programming with a programmer enables debugging and the space of the boot-loader can be used for your program. Although it is more of a hassle, I think it is worth the advantage.

The schematics of this board are [open-source](https://github.com/leaflabs/maplemini).

[docs](http://docs.leaflabs.com/static.leaflabs.com/pub/leaflabs/maple-docs/0.0.12/hardware/maple-mini.html)