### PR TITLE
sys/auto_init: unified logging for saul&netif

### DIFF
--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -19,6 +19,7 @@
 
 #ifdef MODULE_AT86RF2XX
 
+#include "log.h"
 #include "board.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/ieee802154.h"
@@ -26,9 +27,6 @@
 
 #include "at86rf2xx.h"
 #include "at86rf2xx_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
@@ -51,13 +49,14 @@ void auto_init_at86rf2xx(void)
         const at86rf2xx_params_t *p = &at86rf2xx_params[i];
         int res;
 
-        DEBUG("Initializing AT86RF2xx radio at SPI_%i\n", p->spi);
+        LOG_DEBUG("[auto_init_netif] initializing at86rf2xx #%u\n", i);
+
         at86rf2xx_setup(&at86rf2xx_devs[i], (at86rf2xx_params_t*) p);
         res = gnrc_netdev2_ieee802154_init(&gnrc_adpt[i],
                                            (netdev2_ieee802154_t *)&at86rf2xx_devs[i]);
 
         if (res < 0) {
-            DEBUG("Error initializing AT86RF2xx radio device!\n");
+            LOG_ERROR("[auto_init_netif] error initializing at86rf2xx radio #%u\n", i);
         }
         else {
             gnrc_netdev2_init(_at86rf2xx_stacks[i],

--- a/sys/auto_init/netif/auto_init_cc110x.c
+++ b/sys/auto_init/netif/auto_init_cc110x.c
@@ -19,6 +19,8 @@
 
 #ifdef MODULE_CC110X
 
+#include "log.h"
+#include "debug.h"
 #include "board.h"
 #include "net/gnrc/netdev2.h"
 #include "gnrc_netdev2_cc110x.h"
@@ -26,9 +28,6 @@
 
 #include "cc110x.h"
 #include "cc110x_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
@@ -48,19 +47,21 @@ static gnrc_netdev2_t _gnrc_netdev2_devs[CC110X_NUM];
 
 void auto_init_cc110x(void)
 {
-    for (int i = 0; i < CC110X_NUM; i++) {
+    for (unsigned i = 0; i < CC110X_NUM; i++) {
         const cc110x_params_t *p = &cc110x_params[i];
-        DEBUG("Initializing CC110X radio at SPI_%i\n", p->spi);
+
+        LOG_DEBUG("[auto_init_netif] initializing cc110x #%u\n", i);
+
         int res = netdev2_cc110x_setup(&cc110x_devs[i], p);
         if (res < 0) {
-            DEBUG("Error initializing CC110X radio device!\n");
+            LOG_ERROR("[auto_init_netif] error initializing cc110x #%u\n", i);
         }
         else {
             gnrc_netdev2_cc110x_init(&_gnrc_netdev2_devs[i], &cc110x_devs[i]);
             res = gnrc_netdev2_init(_stacks[i], CC110X_MAC_STACKSIZE,
                     CC110X_MAC_PRIO, "cc110x", &_gnrc_netdev2_devs[i]);
             if (res < 0) {
-                DEBUG("Error starting gnrc_cc110x thread for CC110X!\n");
+                LOG_ERROR("[auto_init_netif] error starting gnrc_cc110x thread\n");
             }
         }
     }

--- a/sys/auto_init/netif/auto_init_cc2420.c
+++ b/sys/auto_init/netif/auto_init_cc2420.c
@@ -21,6 +21,7 @@
 
 #ifdef MODULE_CC2420
 
+#include "log.h"
 #include "board.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/ieee802154.h"
@@ -28,9 +29,6 @@
 
 #include "cc2420.h"
 #include "cc2420_params.h"
-
-#define ENABLE_DEBUG    (0)
-#include "debug.h"
 
 /**
  * @brief   MAC layer stack parameters
@@ -59,14 +57,14 @@ static char _cc2420_stacks[CC2420_NUMOF][CC2420_MAC_STACKSIZE];
 void auto_init_cc2420(void)
 {
     for (unsigned i = 0; i < CC2420_NUMOF; i++) {
-        DEBUG("Initializing CC2420 radios #%u\n", i);
+        LOG_DEBUG("[auto_init_netif] initializing cc2420 #%u\n", i);
 
         cc2420_setup(&cc2420_devs[i], &cc2420_params[i]);
         int res = gnrc_netdev2_ieee802154_init(&gnrc_adpt[i],
                                                (netdev2_ieee802154_t *)&cc2420_devs[i]);
 
         if (res < 0) {
-            DEBUG("Error initializing CC2420 radio device!\n");
+            LOG_ERROR("[auto_init_netif] error initializing cc2420 #%u\n", i);
         }
         else {
             gnrc_netdev2_init(_cc2420_stacks[i],

--- a/sys/auto_init/netif/auto_init_cc2538_rf.c
+++ b/sys/auto_init/netif/auto_init_cc2538_rf.c
@@ -19,13 +19,11 @@
 
 #ifdef MODULE_CC2538_RF
 
+#include "log.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/ieee802154.h"
 
 #include "cc2538_rf.h"
-
-#define ENABLE_DEBUG 0
-#include "debug.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
@@ -44,13 +42,14 @@ void auto_init_cc2538_rf(void)
 {
     int res;
 
-    DEBUG("Initializing CC2538 radio...\n");
+    LOG_DEBUG("[auto_init_netif] initializing cc2538 radio\n");
+
     cc2538_setup(&cc2538_rf_dev);
     res = gnrc_netdev2_ieee802154_init(&gnrc_adpt,
                                        (netdev2_ieee802154_t *)&cc2538_rf_dev);
 
     if (res < 0) {
-        DEBUG("Error initializing CC2538 radio device!\n");
+        LOG_ERROR("[auto_init_netif] error initializing cc2538 radio\n");
     }
     else {
         gnrc_netdev2_init(_cc2538_rf_stack,

--- a/sys/auto_init/netif/auto_init_enc28j60.c
+++ b/sys/auto_init/netif/auto_init_enc28j60.c
@@ -21,13 +21,11 @@
 
 #ifdef MODULE_ENC28J60
 
+#include "log.h"
 #include "enc28j60.h"
 #include "enc28j60_params.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/eth.h"
-
-#define ENABLE_DEBUG    (0)
-#include "debug.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
@@ -60,8 +58,9 @@ static char stack[ENC28J60_NUM][ENC28J60_MAC_STACKSIZE];
 
 void auto_init_enc28j60(void)
 {
-    for (int i = 0; i < ENC28J60_NUM; i++) {
-        DEBUG("auto_init_enc28j60(): initializing device [%i]...\n", i);
+    for (unsigned i = 0; i < ENC28J60_NUM; i++) {
+        LOG_DEBUG("[auto_init_netif] initializing enc28j60 #%u\n", i);
+
         /* setup netdev2 device */
         enc28j60_setup(&dev[i], &enc28j60_params[i]);
         /* initialize netdev2 <-> gnrc adapter state */

--- a/sys/auto_init/netif/auto_init_encx24j600.c
+++ b/sys/auto_init/netif/auto_init_encx24j600.c
@@ -19,9 +19,8 @@
 
 #ifdef MODULE_ENCX24J600
 
-#define ENABLE_DEBUG (0)
+#include "log.h"
 #include "debug.h"
-
 #include "encx24j600.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/eth.h"
@@ -45,7 +44,8 @@ static gnrc_netdev2_t _gnrc_encx24j600;
 
 void auto_init_encx24j600(void)
 {
-    DEBUG("auto_init_encx24j600(): initializing device...\n");
+    LOG_DEBUG("[auto_init_netif] initializing encx24j600 #0\n");
+
     /* setup netdev2 device */
     encx24j600_params_t p;
     p.spi       = ENCX24J600_SPI;

--- a/sys/auto_init/netif/auto_init_ethos.c
+++ b/sys/auto_init/netif/auto_init_ethos.c
@@ -19,13 +19,12 @@
 
 #ifdef MODULE_ETHOS
 
+#include "log.h"
+#include "debug.h"
 #include "ethos.h"
 #include "periph/uart.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/eth.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief global ethos object, used by uart_stdio
@@ -51,7 +50,7 @@ static uint8_t _inbuf[2048];
 
 void auto_init_ethos(void)
 {
-    DEBUG("auto_init_ethos(): initializing device...\n");
+    LOG_DEBUG("[auto_init_netif] initializing ethos #0\n");
 
     /* setup netdev2 device */
     ethos_params_t p;

--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -21,6 +21,7 @@
 
 #ifdef MODULE_KW2XRF
 
+#include "log.h"
 #include "board.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/nomac.h"
@@ -28,9 +29,6 @@
 
 #include "kw2xrf.h"
 #include "kw2xrf_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
@@ -48,10 +46,11 @@ static char _nomac_stacks[KW2XRF_NUM][KW2XRF_MAC_STACKSIZE];
 
 void auto_init_kw2xrf(void)
 {
-    for (int i = 0; i < KW2XRF_NUM; i++) {
+    for (unsigned i = 0; i < KW2XRF_NUM; i++) {
         const kw2xrf_params_t *p = &kw2xrf_params[i];
 
-        DEBUG("Initializing KW2xrf radio at SPI_%i\n", p->spi);
+        LOG_DEBUG("[auto_init_netif] initializing kw2xrf #%u\n", i);
+
         int res = kw2xrf_init(&kw2xrf_devs[i],
                 p->spi,
                 p->spi_speed,
@@ -59,7 +58,7 @@ void auto_init_kw2xrf(void)
                 p->int_pin);
 
         if (res < 0) {
-            DEBUG("Error initializing KW2xrf radio device!\n");
+            LOG_ERROR("[auto_init_netif] initializing kw2xrf #%u\n", i);
         }
         else {
             gnrc_nomac_init(_nomac_stacks[i],

--- a/sys/auto_init/netif/auto_init_netdev2_tap.c
+++ b/sys/auto_init/netif/auto_init_netdev2_tap.c
@@ -19,9 +19,8 @@
 
 #ifdef MODULE_NETDEV2_TAP
 
-#define ENABLE_DEBUG (0)
+#include "log.h"
 #include "debug.h"
-
 #include "netdev2_tap_params.h"
 #include "net/gnrc/netdev2/eth.h"
 
@@ -34,9 +33,12 @@ static gnrc_netdev2_t _gnrc_netdev2_tap[NETDEV2_TAP_MAX];
 
 void auto_init_netdev2_tap(void)
 {
-    for (int i = 0; i < NETDEV2_TAP_MAX; i++) {
+    for (unsigned i = 0; i < NETDEV2_TAP_MAX; i++) {
         const netdev2_tap_params_t *p = &netdev2_tap_params[i];
-        DEBUG("Initializing netdev2_tap on TAP %s\n", *(p->tap_name));
+
+        LOG_DEBUG("[auto_init_netif] initializing netdev2_tap #%u on TAP %s\n",
+                  i, *(p->tap_name));
+
         netdev2_tap_setup(&netdev2_tap[i], p);
         gnrc_netdev2_eth_init(&_gnrc_netdev2_tap[i], (netdev2_t*)&netdev2_tap[i]);
 

--- a/sys/auto_init/netif/auto_init_slip.c
+++ b/sys/auto_init/netif/auto_init_slip.c
@@ -19,6 +19,7 @@
 
 #ifdef MODULE_GNRC_SLIP
 
+#include "log.h"
 #include "board.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/nomac.h"
@@ -26,9 +27,6 @@
 
 #include "net/gnrc/slip.h"
 #include "slip_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 #define SLIP_NUM (sizeof(gnrc_slip_params)/sizeof(gnrc_slip_params_t))
 
@@ -50,15 +48,17 @@ static char _slip_stacks[SLIP_NUM][SLIP_STACKSIZE];
 
 void auto_init_slip(void)
 {
-    for (unsigned int i = 0; i < SLIP_NUM; i++) {
+    for (unsigned i = 0; i < SLIP_NUM; i++) {
         const gnrc_slip_params_t *p = &gnrc_slip_params[i];
-        DEBUG("Initializing SLIP radio at UART_%d\n", p->uart);
+
+        LOG_DEBUG("[auto_init_netif] initializing slip #%u\n", i);
+
         kernel_pid_t res = gnrc_slip_init(&slip_devs[i], p->uart, p->baudrate,
                                           _slip_stacks[i], SLIP_STACKSIZE,
                                           SLIP_PRIO);
 
         if (res <= KERNEL_PID_UNDEF) {
-            DEBUG("Error initializing SLIP radio device!\n");
+            LOG_ERROR("[auto_init_netif] error initializing slip #%u\n", i);
         }
     }
 }

--- a/sys/auto_init/netif/auto_init_w5100.c
+++ b/sys/auto_init/netif/auto_init_w5100.c
@@ -19,13 +19,11 @@
 
 #ifdef MODULE_W5100
 
+#include "log.h"
 #include "w5100.h"
 #include "w5100_params.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/eth.h"
-
-#define ENABLE_DEBUG    (0)
-#include "debug.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
@@ -56,8 +54,9 @@ static char stack[W5100_NUM][MAC_STACKSIZE];
 
 void auto_init_w5100(void)
 {
-    for (int i = 0; i < W5100_NUM; i++) {
-        DEBUG("auto_init_w5100(): initializing device [%i]...\n", i);
+    for (unsigned i = 0; i < W5100_NUM; i++) {
+        LOG_DEBUG("[auto_init_netif] initializing w5100 #%u\n", i);
+
         /* setup netdev2 device */
         w5100_setup(&dev[i], &w5100_params[i]);
         /* initialize netdev2 <-> gnrc adapter state */

--- a/sys/auto_init/netif/auto_init_xbee.c
+++ b/sys/auto_init/netif/auto_init_xbee.c
@@ -21,12 +21,10 @@
 
 #ifdef MODULE_XBEE
 
+#include "log.h"
 #include "board.h"
 #include "net/gnrc/netdev2/xbee_adpt.h"
 #include "xbee_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Calculate the number of configured XBee devices
@@ -50,8 +48,8 @@ static char stacks[XBEE_NUM][XBEE_MAC_STACKSIZE];
 
 void auto_init_xbee(void)
 {
-    for (size_t i = 0; i < XBEE_NUM; i++) {
-        DEBUG("Initializing XBee radio #%u\n", i);
+    for (unsigned i = 0; i < XBEE_NUM; i++) {
+        LOG_DEBUG("[auto_init_netif] initializing xbee #%u\n", i);
 
         xbee_setup(&xbee_devs[i], &xbee_params[i]);
         gnrc_netdev2_xbee_init(&gnrc_adpt[i], &xbee_devs[i]);

--- a/sys/auto_init/saul/auto_init_adc.c
+++ b/sys/auto_init/saul/auto_init_adc.c
@@ -21,13 +21,11 @@
 
 #ifdef MODULE_SAUL_ADC
 
+#include "log.h"
 #include "saul_reg.h"
 #include "saul/periph.h"
 #include "adc_params.h"
 #include "periph/gpio.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define the number of configured sensors
@@ -54,12 +52,12 @@ extern saul_driver_t adc_saul_driver;
 
 void auto_init_adc(void)
 {
-    DEBUG("auto init SAUL ADC\n");
-    for (unsigned int i = 0; i < SAUL_ADC_NUMOF; i++) {
+    for (unsigned i = 0; i < SAUL_ADC_NUMOF; i++) {
         const saul_adc_params_t *p = &saul_adc_params[i];
         saul_adcs[i] = p;
 
-        DEBUG("[auto_init_saul] initializing direct ADC\n");
+        LOG_DEBUG("[auto_init_saul] initializing direct ADC #%u\n", i);
+
         saul_reg_entries[i].dev = &saul_adcs[i];
         saul_reg_entries[i].name = p->name;
         saul_reg_entries[i].driver = &adc_saul_driver;

--- a/sys/auto_init/saul/auto_init_bmp180.c
+++ b/sys/auto_init/saul/auto_init_bmp180.c
@@ -51,10 +51,12 @@ extern const saul_driver_t bmp180_pressure_saul_driver;
 void auto_init_bmp180(void)
 {
     for (unsigned i = 0; i < BMP180_NUMOF; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing bmp180 #%u\n", i);
+
         if (bmp180_init(&bmp180_devs[i],
                         bmp180_params[i].i2c_dev,
                         bmp180_params[i].mode) < 0) {
-            LOG_ERROR("Unable to initialize BMP180 sensor #%i\n", i);
+            LOG_ERROR("[auto_init_saul] error initializing bmp180 #%u\n", i);
             return;
         }
 

--- a/sys/auto_init/saul/auto_init_gpio.c
+++ b/sys/auto_init/saul/auto_init_gpio.c
@@ -21,13 +21,11 @@
 
 #ifdef MODULE_SAUL_GPIO
 
+#include "log.h"
 #include "saul_reg.h"
 #include "saul/periph.h"
 #include "gpio_params.h"
 #include "periph/gpio.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define the number of configured sensors
@@ -52,11 +50,11 @@ extern saul_driver_t gpio_saul_driver;
 
 void auto_init_gpio(void)
 {
-    DEBUG("auto init gpio SAUL\n");
     for (unsigned int i = 0; i < SAUL_GPIO_NUMOF; i++) {
         const saul_gpio_params_t *p = &saul_gpio_params[i];
 
-        DEBUG("[auto_init_saul] initializing direct GPIO\n");
+        LOG_DEBUG("[auto_init_saul] initializing GPIO #%u\n", i);
+
         saul_gpios[i] = p->pin;
         saul_reg_entries[i].dev = &(saul_gpios[i]);
         saul_reg_entries[i].name = p->name;

--- a/sys/auto_init/saul/auto_init_hdc1000.c
+++ b/sys/auto_init/saul/auto_init_hdc1000.c
@@ -27,9 +27,6 @@
 #include "hdc1000.h"
 #include "hdc1000_params.h"
 
-#define ENABLE_DEBUG (1)
-#include "debug.h"
-
 /**
  * @brief   Define the number of configured sensors
  */
@@ -56,11 +53,12 @@ extern saul_driver_t hdc1000_saul_hum_driver;
 
 void auto_init_hdc1000(void)
 {
-    for (int i = 0; i < HDC1000_NUM; i++) {
-        DEBUG("[auto_init_saul] initializing hdc1000 light sensor\n");
+    for (unsigned i = 0; i < HDC1000_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing hdc1000 #%u\n", i);
+
         int res = hdc1000_init(&hdc1000_devs[i], &hdc1000_params[i]);
         if (res < 0) {
-            DEBUG("[auto_init_saul] error during initialization\n");
+            LOG_ERROR("[auto_init_saul] error initializing hdc1000 #%u\n", i);
         }
         else {
             saul_entries[(i * 2)].dev = &(hdc1000_devs[i]);

--- a/sys/auto_init/saul/auto_init_isl29020.c
+++ b/sys/auto_init/saul/auto_init_isl29020.c
@@ -21,12 +21,10 @@
 
 #ifdef MODULE_ISL29020
 
+#include "log.h"
 #include "saul_reg.h"
 #include "isl29020.h"
 #include "isl29020_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define the number of configured sensors
@@ -54,11 +52,12 @@ void auto_init_isl29020(void)
     for (unsigned int i = 0; i < ISL29020_NUM; i++) {
         const isl29020_params_t *p = &isl29020_params[i];
 
-        DEBUG("[auto_init_saul] initializing isl29020 light sensor\n");
+        LOG_DEBUG("[auto_init_saul] initializing isl29020 #%u\n", i);
+
         int res = isl29020_init(&isl29020_devs[i], p->i2c, p->addr,
                                 p->range, p->mode);
         if (res < 0) {
-            DEBUG("[auto_init_saul] error during initialization\n");
+            LOG_ERROR("[auto_init_saul] error initializing isl29020 #%u\n", i);
         }
         else {
             saul_entries[i].dev = &(isl29020_devs[i]);

--- a/sys/auto_init/saul/auto_init_jc42.c
+++ b/sys/auto_init/saul/auto_init_jc42.c
@@ -52,8 +52,11 @@ void auto_init_jc42(void)
 {
     for (unsigned i = 0; i < JC42_NUMOF; i++) {
         const jc42_params_t *p = &jc42_params[i];
+
+        LOG_DEBUG("[auto_init_saul] initializing jc42 #%u\n", i);
+
         if (jc42_init(&jc42_devs[i], (jc42_params_t*) p) < 0) {
-            LOG_ERROR("Unable to initialize jc42 sensor #%i\n", i);
+            LOG_ERROR("[auto_init_saul] error initializing jc42 #%u\n", i);
             return;
         }
 

--- a/sys/auto_init/saul/auto_init_l3g4200d.c
+++ b/sys/auto_init/saul/auto_init_l3g4200d.c
@@ -21,12 +21,10 @@
 
 #ifdef MODULE_L3G4200D
 
+#include "log.h"
 #include "saul_reg.h"
 #include "l3g4200d.h"
 #include "l3g4200d_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define the number of configured sensors
@@ -54,11 +52,12 @@ void auto_init_l3g4200d(void)
     for (unsigned int i = 0; i < L3G4200D_NUM; i++) {
         const l3g4200d_params_t *p = &l3g4200d_params[i];
 
-        DEBUG("[auto_init_saul] initializing l3g4200d gyroscope\n");
+        LOG_DEBUG("[auto_init_saul] initializing l3g4200d #%u\n", i);
+
         int res = l3g4200d_init(&l3g4200d_devs[i], p->i2c, p->addr,
                                 p->int1_pin, p->int2_pin, p->mode, p->scale);
         if (res < 0) {
-            DEBUG("[auto_init_saul] error during initialization\n");
+            LOG_ERROR("[auto_init_saul] error initializing l3g4200d #%u\n", i);
         }
         else {
             saul_entries[i].dev = &(l3g4200d_devs[i]);

--- a/sys/auto_init/saul/auto_init_lis3dh.c
+++ b/sys/auto_init/saul/auto_init_lis3dh.c
@@ -21,12 +21,10 @@
 
 #ifdef MODULE_LIS3DH
 
+#include "log.h"
 #include "saul_reg.h"
 #include "lis3dh.h"
 #include "lis3dh_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define the number of configured sensors
@@ -55,15 +53,16 @@ void auto_init_lis3dh(void)
         const lis3dh_params_t *p = &lis3dh_params[i];
         int res;
 
-        DEBUG("[auto_init_saul] initializing lis3dh accelerometer\n");
+        LOG_DEBUG("[auto_init_saul] initializing lis3dh #%u\n", i);
+
         res = lis3dh_init(&lis3dh_devs[i], p->spi, p->cs, p->scale);
         if (res < 0) {
-            DEBUG("[auto_init_saul] error during lis3dh_init\n");
+            LOG_ERROR("[auto_init_saul] error initializing lis3dh #%u\n", i);
             continue;
         }
         res = lis3dh_set_odr(&lis3dh_devs[i], p->odr);
         if (res < 0) {
-            DEBUG("[auto_init_saul] error during lis3dh_set_odr\n");
+            LOG_ERROR("[auto_init_saul] error setting ODR for lis3dh #%u\n", i);
             continue;
         }
 

--- a/sys/auto_init/saul/auto_init_lps331ap.c
+++ b/sys/auto_init/saul/auto_init_lps331ap.c
@@ -21,12 +21,10 @@
 
 #ifdef MODULE_LPS331AP
 
+#include "log.h"
 #include "saul_reg.h"
 #include "lps331ap.h"
 #include "lps331ap_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define the number of configured sensors
@@ -54,11 +52,11 @@ void auto_init_lps331ap(void)
     for (unsigned int i = 0; i < LPS331AP_NUM; i++) {
         const lps331ap_params_t *p = &lps331ap_params[i];
 
-        DEBUG("[auto_init_saul] initializing lps331ap pressure sensor\n");
+        LOG_DEBUG("[auto_init_saul] initializing lps331ap #%u\n", i);
+
         int res = lps331ap_init(&lps331ap_devs[i], p->i2c, p->addr, p->rate);
-        DEBUG("not done\n");
         if (res < 0) {
-            DEBUG("[auto_init_saul] error during initialization\n");
+            LOG_ERROR("[auto_init_saul] error initializing lps331ap #%u\n", i);
         }
         else {
             saul_entries[i].dev = &(lps331ap_devs[i]);

--- a/sys/auto_init/saul/auto_init_lsm303dlhc.c
+++ b/sys/auto_init/saul/auto_init_lsm303dlhc.c
@@ -21,12 +21,10 @@
 
 #ifdef MODULE_LSM303DLHC
 
+#include "log.h"
 #include "saul_reg.h"
 #include "lsm303dlhc.h"
 #include "lsm303dlhc_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define the number of configured sensors
@@ -56,13 +54,14 @@ void auto_init_lsm303dlhc(void)
     for (unsigned int i = 0; i < LSM303DLHC_NUM; i++) {
         const lsm303dlhc_params_t *p = &lsm303dlhc_params[i];
 
-        DEBUG("[auto_init_saul] initializing lsm303dlhc acc/mag sensor\n");
+        LOG_DEBUG("[auto_init_saul] initializing lsm303dlhc #%u\n", i);
+
         int res = lsm303dlhc_init(&lsm303dlhc_devs[i], p->i2c,
                                   p->acc_pin, p->mag_pin,
                                   p->acc_addr, p->acc_rate, p->acc_scale,
                                   p->mag_addr, p->mag_rate, p->mag_gain);
         if (res < 0) {
-            DEBUG("[auto_init_saul] error during initialization\n");
+            LOG_ERROR("[auto_init_saul] error initializing lsm303dlhc #%u\n", i);
         }
         else {
             saul_entries[(i * 2)].dev = &(lsm303dlhc_devs[i]);

--- a/sys/auto_init/saul/auto_init_mma8x5x.c
+++ b/sys/auto_init/saul/auto_init_mma8x5x.c
@@ -53,8 +53,10 @@ extern saul_driver_t mma8x5x_saul_driver;
 void auto_init_mma8x5x(void)
 {
     for (unsigned i = 0; i < MMA8X5X_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing mma8x5x #%u\n", i);
+
         if (mma8x5x_init(&mma8x5x_devs[i], &mma8x5x_params[i]) != MMA8X5X_OK) {
-            LOG_ERROR("Unable to initialize MMA8x5x sensor #%i\n", i);
+            LOG_ERROR("[auto_init_saul] error initializing mma8x5x #%u\n", i);
             return;
         }
 

--- a/sys/auto_init/saul/auto_init_si70xx.c
+++ b/sys/auto_init/saul/auto_init_si70xx.c
@@ -52,11 +52,13 @@ extern const saul_driver_t si70xx_relative_humidity_saul_driver;
 void auto_init_si70xx(void)
 {
     for (unsigned i = 0; i < SI70XX_NUMOF; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing SI70xx #%u\n", i);
+
         int res = si70xx_init(&si70xx_devs[i],
                               si70xx_params[i].i2c_dev,
                               si70xx_params[i].address);
         if (res < 0) {
-            LOG_ERROR("Unable to initialize SI70xx sensor #%i\n", i);
+            LOG_ERROR("[auto_init_saul] error initializing SI70xx #%i\n", i);
             return;
         }
 


### PR DESCRIPTION
When devices are initialized through auto-init, they all were behaving differently regarding their logging, e.g. using either `LOG_xx` or `DEBUG`. This PR makes them all use `LOG_xx` in the same manner. Now users will in the default configuration see during bootup if some initialization has failed. When setting up the log level, one can further now very simply see, which devices are actually initialized during startup...