### PR TITLE
drivers: added missing default xx_params.h files

### DIFF
--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -85,3 +85,6 @@ endif
 ifneq (,$(filter hdc1000,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/hdc1000/include
 endif
+ifneq (,$(filter lis3dh,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/lis3dh/include
+endif

--- a/drivers/isl29020/include/isl29020_params.h
+++ b/drivers/isl29020/include/isl29020_params.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_isl29020
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for ISL29020 devices
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef ISL29020_PARAMS_H
+#define ISL29020_PARAMS_H
+
+#include "board.h"
+#include "isl29020.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters
+ * @{
+ */
+#ifndef ISL29020_PARAM_I2C
+#define ISL29020_PARAM_I2C              I2C_DEV(0)
+#endif
+#ifndef ISL29020_PARAM_ADDR
+#define ISL29020_PARAM_ADDR             (0x44)
+#endif
+#ifndef ISL29020_PARAM_RANGE
+#define ISL29020_PARAM_RANGE            (ISL29020_RANGE_16K)
+#endif
+#ifndef ISL29020_PARAM_MODE
+#define ISL29020_PARAM_MODE             (ISL29020_MODE_AMBIENT)
+#endif
+
+#define ISL29020_PARAMS_DEFAULT         { .i2c   = ISL29020_PARAM_I2C, \
+                                          .addr  = ISL29020_PARAM_ADDR, \
+                                          .range = ISL29020_PARAM_RANGE, \
+                                          .mode  = ISL29020_PARAM_MODE,}
+/**@}*/
+
+/**
+ * @brief   Allocate some memory to store the actual configuration
+ */
+static const isl29020_params_t isl29020_params[] =
+{
+#ifdef ISL29020_PARAMS_CUSTOM
+    ISL29020_PARAMS_CUSTOM,
+#else
+    ISL29020_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t isl29020_saul_info[] =
+{
+    { .name = "isl29020" }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ISL29020_PARAMS_H */
+/** @} */

--- a/drivers/l3g4200d/include/l3g4200d_params.h
+++ b/drivers/l3g4200d/include/l3g4200d_params.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_l3g4200d
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for L3G4200D devices
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef L3G4200D_PARAMS_H
+#define L3G4200D_PARAMS_H
+
+#include "board.h"
+#include "l3g4200d.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters
+ * @{
+ */
+#ifndef L3G4200D_PARAM_I2C
+#define L3G4200D_PARAM_I2C          I2C_DEV(0)
+#endif
+#ifndef L3G4200D_PARAM_ADDR
+#define L3G4200D_PARAM_ADDR         (0x68)
+#endif
+#ifndef L3G4200D_PARAM_INT1
+#define L3G4200D_PARAM_INT1         (GPIO_PIN(0, 0))
+#endif
+#ifndef L3G4200D_PARAM_INT2
+#define L3G4200D_PARAM_INT2         (GPIO_PIN(0, 1))
+#endif
+#ifndef L3G4200D_PARAM_MODE
+#define L3G4200D_PARAM_MODE         (L3G4200D_MODE_200_25)
+#endif
+#ifndef L3G4200D_PARAM_SCALE
+#define L3G4200D_PARAM_SCALE        (L3G4200D_SCALE_500DPS)
+#endif
+
+#define L3G4200D_PARAMS_DEFAULT     { .i2c      = L3G4200D_PARAM_I2C, \
+                                      .addr     = L3G4200D_PARAM_ADDR, \
+                                      .int1_pin = L3G4200D_PARAM_INT1, \
+                                      .int2_pin = L3G4200D_PARAM_INT2, \
+                                      .mode     = L3G4200D_PARAM_MODE, \
+                                      .scale    = L3G4200D_PARAM_SCALE }
+/**@}*/
+
+/**
+ * @brief   Allocate some memory to store the actual configuration
+ */
+static const l3g4200d_params_t l3g4200d_params[] =
+{
+#ifdef L3G4200D_PARAMS_CUSTOM
+    L3G4200D_PARAMS_CUSTOM,
+#else
+    L3G4200D_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t l3g4200d_saul_info[] =
+{
+    { .name = "l3g4200d" }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* L3G4200D_PARAMS_H */
+/** @} */

--- a/drivers/lis3dh/include/lis3dh_params.h
+++ b/drivers/lis3dh/include/lis3dh_params.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_lis3dh
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for LIS3DH devices
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef LIS3DH_PARAMS_H
+#define LIS3DH_PARAMS_H
+
+#include "board.h"
+#include "lis3dh.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters
+ * @{
+ */
+#ifndef LIS3DH_PARAM_SPI
+#define LIS3DH_PARAM_SPI            (SPI_0)
+#endif
+#ifndef LIS3DH_PARAM_CS
+#define LIS3DH_PARAM_CS             (GPIO_PIN(0, 0))
+#endif
+#ifndef LIS3DH_PARAM_INT1
+#define LIS3DH_PARAM_INT1           (GPIO_PIN(0, 1))
+#endif
+#ifndef LIS3DH_PARAM_INT2
+#define LIS3DH_PARAM_INT2           (GPIO_PIN(0, 2))
+#endif
+#ifndef LIS3DH_PARAM_SCALE
+#define LIS3DH_PARAM_SCALE          (4)
+#endif
+#ifndef LIS3DH_PARAM_ODR
+#define LIS3DH_PARAM_ODR            (LIS3DH_ODR_100Hz)
+#endif
+
+#define LIS3DH_PARAMS_DEFAULT       { .spi   = LIS3DH_PARAM_SPI, \
+                                      .cs    = LIS3DH_PARAM_CS, \
+                                      .int1  = LIS3DH_PARAM_INT1, \
+                                      .int2  = LIS3DH_PARAM_INT2, \
+                                      .scale = LIS3DH_PARAM_SCALE, \
+                                      .odr   = LIS3DH_PARAM_ODR }
+/**@}*/
+
+/**
+ * @brief   Allocate some memory to store the actual configuration
+ */
+static const lis3dh_params_t lis3dh_params[] =
+{
+#ifdef LIS3DH_PARAMS_CUSTOM
+    LIS3DH_PARAMS_CUSTOM,
+#else
+    LIS3DH_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t lis3dh_saul_info[] =
+{
+    { .name = "lis3dh" }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS3DH_PARAMS_H */
+/** @} */

--- a/drivers/lps331ap/include/lps331ap_params.h
+++ b/drivers/lps331ap/include/lps331ap_params.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_lps331ap
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for LPS331AP devices
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef LPS331AP_PARAMS_H
+#define LPS331AP_PARAMS_H
+
+#include "board.h"
+#include "lps331ap.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters
+ * @{
+ */
+#ifndef LPS331AP_PARAM_I2C
+#define LPS331AP_PARAM_I2C              I2C_DEV(0)
+#endif
+#ifndef LPS331AP_PARAM_ADDR
+#define LPS331AP_PARAM_ADDR             (0x44)
+#endif
+#ifndef LPS331AP_PARAM_RATE
+#define LPS331AP_PARAM_RATE             (LPS331AP_RATE_7HZ)
+#endif
+
+#define LPS331AP_PARAMS_DEFAULT         { .i2c  = LPS331AP_PARAM_I2C,  \
+                                          .addr = LPS331AP_PARAM_ADDR, \
+                                          .rate = LPS331AP_PARAM_RATE }
+/**@}*/
+
+/**
+ * @brief   Allocate some memory to store the actual configuration
+ */
+static const lps331ap_params_t lps331ap_params[] =
+{
+#ifdef LPS331AP_PARAMS_CUSTOM
+    LPS331AP_PARAMS_CUSTOM,
+#else
+    LPS331AP_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t lps331ap_saul_info[] =
+{
+    { .name = "lps331ap" }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LPS331AP_PARAMS_H */
+/** @} */

--- a/drivers/lsm303dlhc/include/lsm303dlhc_params.h
+++ b/drivers/lsm303dlhc/include/lsm303dlhc_params.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_lsm303dlhc
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for LSM303DLHC devices
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef LSM303DLHC_PARAMS_H
+#define LSM303DLHC_PARAMS_H
+
+#include "board.h"
+#include "lsm303dlhc.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters
+ * @{
+ */
+#ifndef LSM303DLHC_PARAM_I2C
+#define LSM303DLHC_PARAM_I2C            I2C_DEV(0)
+#endif
+#ifndef LSM303DLHC_PARAM_ACC_ADDR
+#define LSM303DLHC_PARAM_ACC_ADDR       (0x19)
+#endif
+#ifndef LSM303DLHC_PARAM_ACC_PIN
+#define LSM303DLHC_PARAM_ACC_PIN        (GPIO_PIN(0, 0))
+#endif
+#ifndef LSM303DLHC_PARAM_ACC_RATE
+#define LSM303DLHC_PARAM_ACC_RATE       (LSM303DLHC_ACC_SAMPLE_RATE_10HZ)
+#endif
+#ifndef LSM303DLHC_PARAM_ACC_SCALE
+#define LSM303DLHC_PARAM_ACC_SCALE      (LSM303DLHC_ACC_SCALE_4G)
+#endif
+#ifndef LSM303DLHC_PARAM_MAG_ADDR
+#define LSM303DLHC_PARAM_MAG_ADDR       (0x1e)
+#endif
+#ifndef LSM303DLHC_PARAM_MAG_PIN
+#define LSM303DLHC_PARAM_MAG_PIN        (GPIO_PIN(0, 1))
+#endif
+#ifndef LSM303DLHC_PARAM_MAG_RATE
+#define LSM303DLHC_PARAM_MAG_RATE       (LSM303DLHC_MAG_SAMPLE_RATE_15HZ)
+#endif
+#ifndef LSM303DLHC_PARAM_MAG_GAIN
+#define LSM303DLHC_PARAM_MAG_GAIN       (LSM303DLHC_MAG_GAIN_450_400_GAUSS)
+#endif
+
+#define LSM303DLHC_PARAMS_DEFAULT       { .i2c       = LSM303DLHC_PARAM_I2C, \
+                                          .acc_addr  = LSM303DLHC_PARAM_ACC_ADDR, \
+                                          .acc_pin   = LSM303DLHC_PARAM_ACC_PIN, \
+                                          .acc_rate  = LSM303DLHC_PARAM_ACC_RATE, \
+                                          .acc_scale = LSM303DLHC_PARAM_ACC_SCALE, \
+                                          .mag_addr  = LSM303DLHC_PARAM_MAG_ADDR, \
+                                          .mag_pin   = LSM303DLHC_PARAM_MAG_PIN, \
+                                          .mag_rate  = LSM303DLHC_PARAM_MAG_RATE, \
+                                          .mag_gain  = LSM303DLHC_PARAM_MAG_GAIN }
+/**@}*/
+
+/**
+ * @brief   Allocate some memory to store the actual configuration
+ */
+static const lsm303dlhc_params_t lsm303dlhc_params[] =
+{
+#ifdef LSM303DLHC_PARAMS_CUSTOM
+    LSM303DLHC_PARAMS_CUSTOM,
+#else
+    LSM303DLHC_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t lsm303dlhc_saul_info[] =
+{
+    { .name = "lsm303dlhc" }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LSM303DLHC_PARAMS_H */
+/** @} */


### PR DESCRIPTION
Some drivers were missing default `xx_params.h` files. This prevented them to build with any board (e.g. for testing). So here are those missing files...