### PR TITLE
cc2538-bsl.py: add chip id for cc2538em

### DIFF
--- a/dist/tools/cc2538-bsl/cc2538-bsl.py
+++ b/dist/tools/cc2538-bsl/cc2538-bsl.py
@@ -90,7 +90,9 @@ def mdebug(level, message, attr='\n'):
         print(message, end=attr, file=sys.stderr)
 
 # Takes chip IDs (obtained via Get ID command) to human-readable names
-CHIP_ID_STRS = {0xb964: 'CC2538'}
+CHIP_ID_STRS = {0xb964: 'CC2538',
+                0xb965: 'CC2538'
+                }
 
 RETURN_CMD_STRS = {0x40: 'Success',
                    0x41: 'Unknown command',


### PR DESCRIPTION
The new version of the *cc2538-bsl* tool introduces check of chip ids. I have two cc2538em boards with a chip id that's not in the list.
This PR adds the missing id. The fix is also send to the tools upstream, but until it is merged I would like to test with the *cc2538dk* without changing the python file with every tested PR.