### PR TITLE
dist/tools/ci: toolchain versions: Fix heading formatting

### DIFF
--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -43,7 +43,7 @@ function run {
     OUT_LENGTH="$(echo -n $OUT | wc -c)"
     if (( "$OUT_LENGTH" > 0 )); then
         echo -e "Command output:\n"
-        (printf "%s" "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
+        (echo "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
         echo ""
     fi
 }

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -40,10 +40,11 @@ function run {
     set_result $NEW_RESULT
 
     # Indent command output so that its easily discernable from the rest
-    OUT_LENGTH="$(echo -n $OUT | wc -c)"
-    if (( "$OUT_LENGTH" > 0 )); then
-        echo -e "Command output:\n"
-        (echo "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
+    if [ -n "$OUT" ]; then
+        echo "Command output:"
+        echo ""
+        # Using printf to avoid problems if the command output begins with a -
+        (printf "%s\n" "$OUT" | while IFS= read -r line; do printf "\t%s\n" "$line"; done)
         echo ""
     fi
 }

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -47,7 +47,8 @@ avr_libc_version() {
     printf "%s (%s)" "$(get_define "$cc" avr/version.h __AVR_LIBC_VERSION_STRING__)" "$(get_define "$cc" avr/version.h __AVR_LIBC_DATE_STRING__)"
 }
 
-printf "Installed toolchain versions:\n"
+printf "%s\n" "Installed toolchain versions"
+printf "%s\n" "----------------------------"
 VER=$(gcc --version | head -n 1)
 if [ -n "$VER" ]; then
     printf "%20s: %s\n" "native gcc" "$VER"


### PR DESCRIPTION
Changes the heading formatting for the print toolchain versions script.

https://github.com/RIOT-OS/RIOT/pull/6390#issuecomment-273718671