### PR TITLE
drivers/io1_xplained: driver cleanup + better saul integration

### DIFF
--- a/drivers/include/io1_xplained.h
+++ b/drivers/include/io1_xplained.h
@@ -29,42 +29,46 @@ extern "C" {
 #endif
 
 /**
- * @brief Device descriptor for the IO1 Xplained extension.
+ * @brief IO1 Xplained driver return codes
  */
-typedef struct {
-    at30tse75x_t temp  /**< On-board temperature sensor */;
-} io1_xplained_t;
-
+enum {
+    IO1_XPLAINED_OK = 0,           /**< Initialization successful */
+    IO1_XPLAINED_NOTEMP,           /**< Error during temperature sensor initialization */
+    IO1_XPLAINED_NOLED,            /**< Error during extension LED initialization */
+    IO1_XPLAINED_NOGPIO1,          /**< Error during extension GPIO1 initialization */
+    IO1_XPLAINED_NOGPIO2,          /**< Error during extension GPIO2 initialization */
+    IO1_XPLAINED_READ_OK,          /**< Temperature read successful */
+    IO1_XPLAINED_READ_ERR          /**< Error when reading temperature sensor */
+};
 
 /**
  * @brief Device initialization parameters
  */
 typedef struct {
-    uint8_t addr;      /**< extension custom address */
+    uint8_t addr;                  /**< extension custom address */
 } io1_xplained_params_t;
 
 /**
- * @brief export SAUL endpoints
- * @{
+ * @brief Device descriptor for the IO1 Xplained extension.
  */
-extern const saul_driver_t io1_xplained_temperature_saul_driver;
-/** @} */
-
-/**
- * @brief auto-initialize all configured IO1 Xplained extensions
- */
-void io1_xplained_auto_init(void);
+typedef struct {
+    io1_xplained_params_t params;  /**< Initialization parameters */
+    at30tse75x_t temp;             /**< On-board temperature sensor */
+} io1_xplained_t;
 
 /**
  * @brief Initialize the given IO1 Xplained extension
  *
  * @param[out] dev          Initialized device descriptor of IO1 Xplained extension
- * @param[in]  addr         Custom address of the extension board
+ * @param[in]  params       Device initialization parameters
  *
- * @return                  0 on success
- * @return                  -1 if given I2C is not enabled in board config
+ * @return                  IO1_XPLAINED_OK on success
+ * @return                  -IO1_XPLAINED_NOTEMP if temperature sensor initialization failed
+ * @return                  -IO1_XPLAINED_NOLED if LED initialization failed
+ * @return                  -IO1_XPLAINED_NOGPIO1 if GPIO1 initialization failed
+ * @return                  -IO1_XPLAINED_NOGPIO2 if GPIO2 initialization failed
  */
-int io1_xplained_init(io1_xplained_t *dev, uint8_t addr);
+int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params);
 
 /**
  * @brief Read temperature value from the given IO1 Xplained extension, returned in °C
@@ -72,34 +76,25 @@ int io1_xplained_init(io1_xplained_t *dev, uint8_t addr);
  * @param[in] dev           Device descriptor of IO1 Xplained to read from
  * @param[out] temperature  Temperature in °C
  *
- * @return                  0 on success
- * @return                  -1 if device's I2C is not enabled in board config
+ * @return                  IO1_XPLAINED_READ_OK on success
+ * @return                  -IO1_XPLAINED_READ_ERR if temperature sensor read failed
  */
 int io1_xplained_read_temperature(io1_xplained_t *dev, float *temperature);
 
 /**
  * @brief Set the on-board led of the IO1 Xplained extension
- *
- * @return                0 on success
- * @return                -1 if extension GPIO is not enabled in board config
  */
-int io1_xplained_set_led(void);
+void io1_xplained_set_led(void);
 
 /**
  * @brief Clear the on-board led of the IO1 Xplained extension
- *
- * @return                0 on success
- * @return                -1 if extension GPIO is not enabled in board config
  */
-int io1_xplained_clear_led(void);
+void io1_xplained_clear_led(void);
 
 /**
  * @brief Toggle the on-board led of the IO1 Xplained extension
- *
- * @return                0 on success
- * @return                -1 if extension GPIO is not enabled in board config
  */
-int io1_xplained_toggle_led(void);
+void io1_xplained_toggle_led(void);
 
 #ifdef __cplusplus
 }

--- a/drivers/io1_xplained/Makefile
+++ b/drivers/io1_xplained/Makefile
@@ -1,3 +1,1 @@
-MODULE = io1_xplained
-
 include $(RIOTBASE)/Makefile.base

--- a/drivers/io1_xplained/include/io1_xplained_params.h
+++ b/drivers/io1_xplained/include/io1_xplained_params.h
@@ -21,9 +21,10 @@
 
 #include "board.h"
 #include "io1_xplained.h"
-#include "saul.h"
+#include "io1_xplained_internals.h"
 #include "saul_reg.h"
 #include "saul/periph.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,53 +54,27 @@ static const io1_xplained_params_t io1_xplained_params[] =
 };
 
 /**
- * @brief   Get the number of configured IO1 Xplained extension
- */
-#define IO1_XPLAINED_NUMOF   (sizeof(io1_xplained_params) / sizeof(io1_xplained_params[0]))
-
-/**
- * @brief   Reference the gpio driver struct
- */
-extern saul_driver_t gpio_saul_driver;
-
-#ifdef MODULE_SAUL_REG
-/**
  * @brief   Allocate and configure entries to the SAUL registry
  */
-saul_reg_t io1_xplained_saul_reg[][4] =
+saul_reg_info_t io1_xplained_saul_reg_info[][4] =
 {
     {
-        {
-            .name = "Temperature (IO1 Xplained)",
-            .driver = &io1_xplained_temperature_saul_driver
-        },
-        {
-            .name = "LED (IO1 Xplained)",
-            .driver = &gpio_saul_driver
-        },
-        {
-            .name = "GPIO1 (IO1 Xplained)",
-            .driver = &gpio_saul_driver
-        },
-        {
-            .name = "GPIO2 (IO1 Xplained)",
-            .driver = &gpio_saul_driver
-        },
+        { .name = "Temperature (IO1 Xplained)" },
+        { .name = "LED (IO1 Xplained)" },
+        { .name = "GPIO1 (IO1 Xplained)" },
+        { .name = "GPIO2 (IO1 Xplained)" }
     }
 };
-#endif
 
-#ifdef MODULE_SAUL_GPIO
 /**
  * @brief   Allocate and configure the extension LED gpios
  */
-static gpio_t io1_xplained_saul_gpios[3] =
+gpio_t io1_xplained_saul_gpios[3] =
 {
     IO1_LED_PIN,
     IO1_GPIO1_PIN,
     IO1_GPIO2_PIN,
 };
-#endif
 
 
 #ifdef __cplusplus

--- a/drivers/io1_xplained/io1_xplained.c
+++ b/drivers/io1_xplained/io1_xplained.c
@@ -18,105 +18,72 @@
  * @}
  */
 
-#include <math.h>
-
 #include "log.h"
 #include "io1_xplained.h"
 #include "io1_xplained_internals.h"
-#include "io1_xplained_params.h"
 #include "at30tse75x.h"
 #include "periph/i2c.h"
 #include "periph/gpio.h"
-#include "xtimer.h"
-
-#define ENABLE_DEBUG        (0)
-#include "debug.h"
-
-/**
- * @brief   Allocation of memory for device descriptors
- */
-io1_xplained_t io1_xplained_devs[IO1_XPLAINED_NUMOF];
 
 /*---------------------------------------------------------------------------*
  *                          IO1 Xplained Core API                            *
  *---------------------------------------------------------------------------*/
 
-int io1_xplained_init(io1_xplained_t *dev, uint8_t addr)
+int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params)
 {
+    dev->params = *params;
+
     /* Initialize I2C interface */
     if (at30tse75x_init(&dev->temp,
                         I2C_DEV(0),
-                        I2C_SPEED_NORMAL, (TEMPERATURE_BASE_ADDR | addr)) < 0) {
-        DEBUG("[Error] Cannot initialize temperature sensor.\n");
-        return -1;
+                        I2C_SPEED_NORMAL, (TEMPERATURE_BASE_ADDR | dev->params.addr)) < 0) {
+        LOG_ERROR("Cannot initialize temperature sensor.\n");
+        return -IO1_XPLAINED_NOTEMP;
     }
 
     /* Use maximum resolution */
     at30tse75x_set_resolution(&dev->temp, AT30TSE75X_RESOLUTION_12BIT);
 
     if (gpio_init(IO1_LED_PIN, GPIO_OUT) < 0) {
-        DEBUG("[Error] GPIO LED not enabled\n");
-        return -1;
+        LOG_ERROR("GPIO LED not enabled\n");
+        return -IO1_XPLAINED_NOLED;
     }
 
     if (gpio_init(IO1_GPIO1_PIN, GPIO_OUT) < 0) {
-        DEBUG("[Error] GPIO1 not enabled\n");
-        return -1;
+        LOG_ERROR("GPIO1 not enabled\n");
+        return -IO1_XPLAINED_NOGPIO1;
     }
 
     if (gpio_init(IO1_GPIO2_PIN, GPIO_OUT) < 0) {
-        DEBUG("[Error] GPIO2 not enabled\n");
-        return -1;
+        LOG_ERROR("GPIO2 not enabled\n");
+        return -IO1_XPLAINED_NOGPIO2;
     }
 
-    DEBUG("[Info] IO1 Xplained extension initialized!\n");
+    LOG_DEBUG("IO1 Xplained extension initialized!\n");
 
-    return 0;
-}
-
-void io1_xplained_auto_init(void)
-{
-    for (unsigned i = 0; i < IO1_XPLAINED_NUMOF; i++) {
-        if (io1_xplained_init(&io1_xplained_devs[i],
-                              io1_xplained_params[i].addr) < 0) {
-            LOG_ERROR("Unable to initialize IO1 Xplained #%i\n", i);
-        }
-#ifdef MODULE_SAUL_REG
-        io1_xplained_saul_reg[i][0].dev = &io1_xplained_devs[i];
-        saul_reg_add(&io1_xplained_saul_reg[i][0]);
-#endif
-#ifdef MODULE_SAUL_GPIO
-        for (unsigned j = 1; j < 4; j++) {
-            io1_xplained_saul_reg[i][j].dev = &(io1_xplained_saul_gpios[j-1]);
-            saul_reg_add(&(io1_xplained_saul_reg[i][j]));
-        }
-#endif
-    }
+    return IO1_XPLAINED_OK;
 }
 
 int io1_xplained_read_temperature(io1_xplained_t *dev, float *temperature)
 {
     if (at30tse75x_get_temperature(&dev->temp, temperature) < 0) {
-        DEBUG("[Error] Cannot read IO1 Xplained temperatuse sensor.\n");
-        return -1;
+        LOG_ERROR("Cannot read temperature sensor.\n");
+        return -IO1_XPLAINED_READ_ERR;
     }
-    return 0;
+    return IO1_XPLAINED_READ_OK;
 }
 
-int io1_xplained_set_led(void)
+void io1_xplained_set_led(void)
 {
     gpio_set(IO1_LED_PIN);
-    return 0;
 }
 
-int io1_xplained_clear_led(void)
+void io1_xplained_clear_led(void)
 {
     gpio_clear(IO1_LED_PIN);
-    return 0;
 }
 
-int io1_xplained_toggle_led(void)
+void io1_xplained_toggle_led(void)
 {
     gpio_toggle(IO1_LED_PIN);
-    return 0;
 }

--- a/drivers/io1_xplained/io1_xplained_saul.c
+++ b/drivers/io1_xplained/io1_xplained_saul.c
@@ -22,7 +22,6 @@
 
 #include "saul.h"
 #include "io1_xplained.h"
-#include "xtimer.h"
 
 static float temperature;
 

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -20,10 +20,6 @@
 
 #include "auto_init.h"
 
-#ifdef MODULE_IO1_XPLAINED
-#include "io1_xplained.h"
-#endif
-
 #ifdef MODULE_SHT11
 #include "sht11.h"
 #endif
@@ -103,10 +99,6 @@ void auto_init(void)
 #ifdef MODULE_RTC
     DEBUG("Auto init rtc module.\n");
     rtc_init();
-#endif
-#ifdef MODULE_IO1_XPLAINED
-    DEBUG("Auto init IO1 Xplained extension module.\n");
-    io1_xplained_auto_init();
 #endif
 #ifdef MODULE_SHT11
     DEBUG("Auto init SHT11 module.\n");
@@ -318,6 +310,10 @@ void auto_init(void)
 #ifdef MODULE_VEML6070
     extern void auto_init_veml6070(void);
     auto_init_veml6070();
+#endif
+#ifdef MODULE_IO1_XPLAINED
+    extern void auto_init_io1_xplained(void);
+    auto_init_io1_xplained();
 #endif
 #ifdef MODULE_ADXL345
     extern void auto_init_adxl345(void);

--- a/sys/auto_init/saul/auto_init_io1_xplained.c
+++ b/sys/auto_init/saul/auto_init_io1_xplained.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of IO1 Xplained extension driver.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_IO1_XPLAINED
+
+#include "log.h"
+#include "saul_reg.h"
+
+#include "io1_xplained.h"
+#include "io1_xplained_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define IO1_XPLAINED_NUMOF    (sizeof(io1_xplained_params) / sizeof(io1_xplained_params[0]))
+
+/**
+ * @brief   Allocation of memory for device descriptors
+ */
+static io1_xplained_t io1_xplained_devs[IO1_XPLAINED_NUMOF];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[IO1_XPLAINED_NUMOF * 4];
+
+/**
+ * @brief   Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t _saul_driver;
+extern const saul_driver_t io1_xplained_temperature_saul_driver;
+/** @} */
+
+void auto_init_io1_xplained(void)
+{
+    for (unsigned i = 0; i < IO1_XPLAINED_NUMOF; i++) {
+        if (io1_xplained_init(&io1_xplained_devs[i],
+                              &io1_xplained_params[i]) != IO1_XPLAINED_OK) {
+            LOG_ERROR("Unable to initialize IO1 Xplained #%i\n", i);
+            continue;
+        }
+
+        /* Temperature */
+        saul_entries[i * 4].dev = &(io1_xplained_devs[i]);
+        saul_entries[i * 4].name = io1_xplained_saul_reg_info[i][0].name;
+        saul_entries[i * 4].driver = &io1_xplained_temperature_saul_driver;
+        saul_reg_add(&(saul_entries[i * 4]));
+
+        /* GPIOs */
+        for (unsigned j = 1; j < 4; j++) {
+            saul_entries[i * 4 + j].dev = &(io1_xplained_saul_gpios[j - 1]);
+            saul_entries[i * 4 + j].name = io1_xplained_saul_reg_info[i][j - 1].name;
+            saul_reg_add(&(saul_entries[i * 4 + j]));
+        }
+    }
+}
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_IO1_XPLAINED */

--- a/tests/driver_io1_xplained/Makefile
+++ b/tests/driver_io1_xplained/Makefile
@@ -5,10 +5,4 @@ USEMODULE += io1_xplained
 USEMODULE += xtimer
 USEMODULE += printf_float
 
-# set default device parameters in case they are undefined
-TEST_ADDR ?= 0x07
-
-# export parameters
-CFLAGS += -DTEST_ADDR=$(TEST_ADDR)
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_io1_xplained/main.c
+++ b/tests/driver_io1_xplained/main.c
@@ -18,14 +18,11 @@
  * @}
  */
 
-#ifndef TEST_ADDR
-#error "TEST_ADDR not defined"
-#endif
-
 #include <stdio.h>
 #include <inttypes.h>
 
 #include "io1_xplained.h"
+#include "io1_xplained_params.h"
 #include "xtimer.h"
 #include "board.h"
 
@@ -35,21 +32,17 @@ int main(void)
 {
     io1_xplained_t dev;
     float temperature;
-    int result;
 
     puts("IO1 Xplained extention test application\n");
+    puts("+-------------Initializing------------+\n");
 
-    printf("+------------Initializing------------+\n");
-    result = io1_xplained_init(&dev, TEST_ADDR);
-    if (result == -1) {
+    if (io1_xplained_init(&dev, &io1_xplained_params[0]) != IO1_XPLAINED_OK) {
         puts("[Error] Cannot initialize the IO1 Xplained extension\n");
         return 1;
     }
-    else {
-        printf("Initialization successful\n\n");
-    }
 
-    printf("\n+--------Starting tests --------+\n");
+    puts("Initialization successful");
+    puts("\n+--------Starting tests --------+");
     while (1) {
         /* Get temperature in degrees celsius */
         io1_xplained_read_temperature(&dev, &temperature);


### PR DESCRIPTION
Following recent changes with driver integration into saul, I reworked a bit the Atmel IO1 Xplained extension board driver.

If you don't have the hardware, use IoTLab custom nodes in Saclay site:
* Build a firmware:
```
$ cd examples/default
$ USEMODULE=io1_xplained make BOARD=samr21-xpro 
```
* Launch an experiment using the cli-tools (see [this page](https://github.com/iot-lab/iot-lab/wiki/CLI-Tools-Installation) to see how to install them:
```
$ experiment-cli  submit -d 60 -l saclay,custom,1,./bin/samr21-xpro/default.elf
$ experiment-cli wait
```
* ssh to Saclay site and use serial_aggregator:
```
$ ssh <login>@saclay.iot-lab.info
saclay$  serial_aggregator
```
* play with the shell