### PR TITLE
doc: correct typos

### DIFF
--- a/boards/doc.txt
+++ b/boards/doc.txt
@@ -10,7 +10,9 @@
  * @defgroup    boards Boards
  * @brief       Board specific definitions and implementations
  *
- * The boards module contains all definitions and implementations, that are specific to a certain board. Boards
- * generally consist of a fixed configuration of a controller and some external devices as sensors or radios. All
- * aspects concerning pin-configurion, mcu clock and driver configuration should go into this module.
+ * The boards module contains all definitions and implementations, that are
+ * specific to a certain board. Generally, boards consist of a fixed
+ * configuration of a controller and some external devices such as sensors or
+ * radios. All aspects concerning configuration of GPIO pins, MCU clock and
+ * device drivers should go into this module.
  */

--- a/core/doc.txt
+++ b/core/doc.txt
@@ -10,14 +10,14 @@
  * @defgroup core Kernel
  * @brief The RIOT micro-kernel containing the core functionality
  *
- * The kernel module contains only the basic OS functionality such as the sheduler, threading, synchronization
- * and IRQ-handling. The only exception is the integration of the hardware timer into this module.
+ * The kernel module contains the basic OS functionality such as the scheduler,
+ * threading, synchronization and IRQ-handling.
  */
 
 /**
  * @defgroup    core_util Kernel utilities
  * @ingroup     core
- * @brief       Utilies and data structures used by the kernel
+ * @brief       Utilities and data structures used by the kernel
  */
 
 /**

--- a/cpu/doc.txt
+++ b/cpu/doc.txt
@@ -11,6 +11,6 @@
  * @brief CPU specific implementations
  *
  * This module contains all CPU specific source files. In case of multiple CPUs
- * sharing the same architecture, the implementation is split in a cpu specific
- * and a architecture specific part (eg. arm-common and lpc2387).
+ * sharing the same architecture, the implementation is split into several CPU
+ * specific parts and an architecture part (e.g. arm7_common and lpc2387).
  */


### PR DESCRIPTION
just stumbled over some minor typos in several (sub) doc.txt and fixed them