### PR TITLE
dist tools: header guard checker

### DIFF
--- a/boards/nucleo32-f303/include/board.h
+++ b/boards/nucleo32-f303/include/board.h
@@ -18,8 +18,8 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef BOARD_H_
-#define BOARD_H_
+#ifndef BOARD_H
+#define BOARD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,5 +47,5 @@ void board_init(void);
 }
 #endif
 
-#endif /* BOARD_H_ */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/nucleo32-f303/include/periph_conf.h
+++ b/boards/nucleo32-f303/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef PERIPH_CONF_H_
-#define PERIPH_CONF_H_
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #include "periph_cpu.h"
 
@@ -152,5 +152,5 @@ static const pwm_conf_t pwm_config[] = {
 }
 #endif
 
-#endif /* PERIPH_CONF_H_ */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/cpu/native/include/netdev2_tap_params.h
+++ b/cpu/native/include/netdev2_tap_params.h
@@ -16,8 +16,8 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NETDEV2_TAP_PARAMS_H_
-#define NETDEV2_TAP_PARAMS_H_
+#ifndef NETDEV2_TAP_PARAMS_H
+#define NETDEV2_TAP_PARAMS_H
 
 #include "netdev2_tap.h"
 
@@ -46,5 +46,5 @@ extern netdev2_tap_params_t netdev2_tap_params[NETDEV2_TAP_MAX];
 }
 #endif
 
-#endif /* NETDEV2_TAP_PARAMS_H_ */
+#endif /* NETDEV2_TAP_PARAMS_H */
 /** @} */

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -86,6 +86,7 @@ then
         run ./dist/tools/licenses/check.sh ${CI_BASE_BRANCH} --diff-filter=AC
         run ./dist/tools/doccheck/check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/externc/check.sh ${CI_BASE_BRANCH}
+        run ./dist/tools/headerguards/check.sh
 
         # TODO:
         #   Remove all but `${CI_BASE_BRANCH}` parameters to cppcheck (and remove second

--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -7,13 +7,13 @@
 # directory for more details.
 
 # customizable
-DIRS="core drivers sys"
+DIRS="core drivers pkg sys"
 
 # prepare
 EXIT_CODE=0
 
 # check files
-if FILES=$(git grep -lE 'ifndef\ +(_.*|.*_H_$)' ${DIRS})
+if FILES=$(git grep -lE 'ifndef\ +(_.*_H$|.*_H_$)' ${DIRS})
 then
     EXIT_CODE=1
     for LINE in ${FILES}

--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Copyright 2017 Oliver Hahm <oliver.hahm@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# customizable
+DIRS="core drivers sys"
+
+# prepare
+EXIT_CODE=0
+
+# check files
+if FILES=$(git grep -lE 'ifndef\ +(_.*|.*_H_$)' ${DIRS})
+then
+    EXIT_CODE=1
+    for LINE in ${FILES}
+    do
+        echo "files with invalid header guard (leading or trailing underscore): ${LINE}"
+    done
+fi
+
+exit ${EXIT_CODE}

--- a/pkg/oonf_api/patches/0001-add-RIOT-support.patch
+++ b/pkg/oonf_api/patches/0001-add-RIOT-support.patch
@@ -238,8 +238,8 @@ index 0000000..9bf6622
 + *
 + */
 +
-+#ifndef RFC5444_API_CONFIG_H_
-+#define RFC5444_API_CONFIG_H_
++#ifndef RFC5444_API_CONFIG_H
++#define RFC5444_API_CONFIG_H
 +
 +#define DISALLOW_CONSUMER_CONTEXT_DROP false
 +#define WRITER_STATE_MACHINE true

--- a/pkg/tlsf/patch.txt
+++ b/pkg/tlsf/patch.txt
@@ -63,8 +63,8 @@ index 0000000..2d8bb4d
 --- /dev/null
 +++ tlsf-malloc.h
 @@ -0,0 +1,26 @@
-+#ifndef __TLSF_MALLOC_H
-+#define __TLSF_MALLOC_H
++#ifndef TLSF_MALLOC_H
++#define TLSF_MALLOC_H
 +
 +#include <stdbool.h>
 +#include <stddef.h>

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -120,8 +120,8 @@
  * @author Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
 
-#ifndef _BLOOM_FILTER_H
-#define _BLOOM_FILTER_H
+#ifndef BLOOM_FILTER_H
+#define BLOOM_FILTER_H
 
 #include <stdlib.h>
 #include <stdbool.h>
@@ -233,4 +233,4 @@ bool bloom_check(bloom_t *bloom, const uint8_t *buf, size_t len);
 #endif
 
 /** @} */
-#endif /* _BLOOM_FILTER_H */
+#endif /* BLOOM_FILTER_H */

--- a/sys/include/ecc/hamming256.h
+++ b/sys/include/ecc/hamming256.h
@@ -15,8 +15,8 @@
  * @author      Lucas Jenß <lucas@x3ro.de>
  */
 
-#ifndef _HAMMING256_H
-#define _HAMMING256_H
+#ifndef HAMMING256_H
+#define HAMMING256_H
 
 #include <stdint.h>
 

--- a/sys/include/hashes/sha1.h
+++ b/sys/include/hashes/sha1.h
@@ -23,8 +23,8 @@
 /* This code is public-domain - it is based on libcrypt
  * placed in the public domain by Wei Dai and other contributors. */
 
-#ifndef _SHA1_H
-#define _SHA1_H
+#ifndef SHA1_H
+#define SHA1_H
 
 #include <stdint.h>
 
@@ -118,5 +118,5 @@ void sha1_final_hmac(sha1_context *ctx, void *digest);
 }
 #endif
 
-#endif /* _SHA1_H */
+#endif /* SHA1_H */
 /** @} */

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -41,8 +41,8 @@
  * @author      Rene Kijewski
  */
 
-#ifndef _SHA256_H
-#define _SHA256_H
+#ifndef SHA256_H
+#define SHA256_H
 
 #include <inttypes.h>
 
@@ -203,4 +203,4 @@ int sha256_chain_verify_element(void *element,
 #endif
 
 /** @} */
-#endif /* _SHA256_H */
+#endif /* SHA256_H */

--- a/sys/include/uuid.h
+++ b/sys/include/uuid.h
@@ -50,8 +50,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef UUID_H_
-#define UUID_H_
+#ifndef UUID_H
+#define UUID_H
 
 #include <stddef.h>
 
@@ -115,5 +115,5 @@ void uuid_base(void *buf, size_t len);
 }
 #endif
 
-#endif /* UUID_H_ */
+#endif /* UUID_H */
 /** @} */

--- a/sys/posix/include/netinet/in.h
+++ b/sys/posix/include/netinet/in.h
@@ -20,8 +20,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef _NETINET_IN_H
-#define _NETINET_IN_H
+#ifndef NETINET_IN_H
+#define NETINET_IN_H
 
 #include <inttypes.h>
 #include <sys/socket.h>
@@ -271,4 +271,4 @@ extern const struct in6_addr in6addr_loopback;
 /**
  * @}
  */
-#endif /* _NETINET_IN_H */
+#endif /* NETINET_IN_H */

--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -26,8 +26,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef _SYS_SOCKET_H
-#define _SYS_SOCKET_H
+#ifndef SYS_SOCKET_H
+#define SYS_SOCKET_H
 
 #ifdef CPU_NATIVE
 /* Ignore Linux definitions in native */


### PR DESCRIPTION
Addressing https://github.com/RIOT-OS/RIOT/pull/6407#issuecomment-273946850:
fix freshly introduced header guards and providing a script to avoid reintroducing wrong guards (at least in main folders).