### PR TITLE
tests: add missing include for Makefile.tests_common

### DIFF
--- a/tests/conn_ip/Makefile
+++ b/tests/conn_ip/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = conn_ip
+include ../Makefile.tests_common
 
 BOARD ?= native
 

--- a/tests/conn_ip/Makefile
+++ b/tests/conn_ip/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = conn_ip
 include ../Makefile.tests_common
 
-BOARD ?= native
-
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f334 stm32f0discovery telosb \
@@ -18,8 +16,6 @@ USEMODULE += od
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
-
-QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = cpp11_condition_variable
 include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
 # ROM is overflowing for these boards when using
 # gcc-arm-none-eabi-4.9.3.2015q2-1trusty1 from ppa:terry.guo/gcc-arm-embedded
 # (Travis is using this PPA currently, 2015-06-23)
@@ -20,9 +17,6 @@ RIOTBASE ?= $(CURDIR)/../..
 # which is not needed in a production environment but helps in the
 # development process:
 CFLAGS += -DDEVELHELP
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
 
 # If you want to add some extra flags when compile c++ files, add these flags
 # to CXXEXFLAGS variable

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = cpp11_condition_variable
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = cpp11_mutex
 include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
 # ROM is overflowing for these boards when using
 # gcc-arm-none-eabi-4.9.3.2015q2-1trusty1 from ppa:terry.guo/gcc-arm-embedded
 # (Travis is using this PPA currently, 2015-06-23)
@@ -20,9 +17,6 @@ RIOTBASE ?= $(CURDIR)/../..
 # which is not needed in a production environment but helps in the
 # development process:
 CFLAGS += -DDEVELHELP
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
 
 # If you want to add some extra flags when compile c++ files, add these flags
 # to CXXEXFLAGS variable

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = cpp11_mutex
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = cpp11_thread
 include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
 # ROM is overflowing for these boards when using
 # gcc-arm-none-eabi-4.9.3.2015q2-1trusty1 from ppa:terry.guo/gcc-arm-embedded
 # (Travis is using this PPA currently, 2015-06-23)
@@ -20,9 +17,6 @@ RIOTBASE ?= $(CURDIR)/../..
 # which is not needed in a production environment but helps in the
 # development process:
 CFLAGS += -DDEVELHELP
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
 
 # If you want to add some extra flags when compile c++ files, add these flags
 # to CXXEXFLAGS variable

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = cpp11_thread
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -1,8 +1,9 @@
 APPLICATION = emb6
+# overwrite board, do not set native as default
+BOARD ?= samr21-xpro
+include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_gpio periph_spi  # for at86rf231
-
-BOARD ?= samr21-xpro
 
 RIOTBASE ?= $(CURDIR)/../..
 

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -36,6 +36,4 @@ DRIVER ?= at86rf231
 # include the selected driver
 USEMODULE += $(DRIVER)
 
-QUIET ?= 1
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/fault_handler/Makefile
+++ b/tests/fault_handler/Makefile
@@ -2,14 +2,8 @@
 APPLICATION = fault_handler
 include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
 
 CFLAGS += -DDEVELHELP=1
 

--- a/tests/fault_handler/Makefile
+++ b/tests/fault_handler/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = fault_handler
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = gnrc_ipv6_ext
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = gnrc_ipv6_ext
 include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
@@ -32,9 +29,6 @@ USEMODULE += ps
 # which is not needed in a production environment but helps in the
 # development process:
 CFLAGS += -DDEVELHELP
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = gnrc_sixlowpan
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = gnrc_sixlowpan
 include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
@@ -28,9 +25,6 @@ USEMODULE += gnrc_pktdump
 # which is not needed in a production environment but helps in the
 # development process:
 CFLAGS += -DDEVELHELP
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = gnrc_sock_ip
 include ../Makefile.tests_common
 
-BOARD ?= native
-
 RIOTBASE ?= $(CURDIR)/../..
 
 USEMODULE += gnrc_sock_ip
@@ -12,8 +10,6 @@ USEMODULE += ps
 CFLAGS += -DDEVELHELP
 CFLAGS += -DGNRC_PKTBUF_SIZE=200
 CFLAGS += -DTEST_SUITES
-
-QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = gnrc_sock_ip
+include ../Makefile.tests_common
 
 BOARD ?= native
 

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = gnrc_sock_udp
 include ../Makefile.tests_common
 
-BOARD ?= native
-
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f042
@@ -15,8 +13,6 @@ USEMODULE += ps
 CFLAGS += -DDEVELHELP
 CFLAGS += -DGNRC_PKTBUF_SIZE=400
 CFLAGS += -DTEST_SUITES
-
-QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = gnrc_sock_udp
+include ../Makefile.tests_common
 
 BOARD ?= native
 

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -1,6 +1,7 @@
 APPLICATION = lwip
-
+# overwrite board, do not set native as default
 BOARD ?= iotlab-m3
+include ../Makefile.tests_common
 
 RIOTBASE ?= $(CURDIR)/../..
 

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -44,8 +44,6 @@ endif
 
 USEMODULE += $(DRIVER)
 
-QUIET ?= 1
-
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -1,5 +1,4 @@
 APPLICATION = lwip_sock_ip
-
 include ../Makefile.tests_common
 
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the

--- a/tests/malloc/Makefile
+++ b/tests/malloc/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = malloc
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/malloc/Makefile
+++ b/tests/malloc/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = malloc
 include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
@@ -12,8 +9,5 @@ RIOTBASE ?= $(CURDIR)/../..
 # which is not needed in a production environment but helps in the
 # development process:
 CFLAGS += -DDEVELHELP
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = minimal
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = minimal
 include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
@@ -13,8 +10,5 @@ CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 
 #
 DISABLE_MODULE += auto_init
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/msg_send_receive/Makefile
+++ b/tests/msg_send_receive/Makefile
@@ -1,6 +1,5 @@
 # name of your application
 APPLICATION = msg_send_receive
-
 include ../Makefile.tests_common
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/od/Makefile
+++ b/tests/od/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = od
 include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
@@ -14,9 +11,6 @@ USEMODULE += od
 # which is not needed in a production environment but helps in the
 # development process:
 CFLAGS += -DDEVELHELP
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/od/Makefile
+++ b/tests/od/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = od
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/periph_pwm/Makefile
+++ b/tests/periph_pwm/Makefile
@@ -1,4 +1,4 @@
-export APPLICATION = periph_pwm
+APPLICATION = periph_pwm
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_pwm

--- a/tests/periph_rtc/Makefile
+++ b/tests/periph_rtc/Makefile
@@ -1,4 +1,4 @@
-export APPLICATION = periph_rtc
+APPLICATION = periph_rtc
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_rtc

--- a/tests/periph_rtt/Makefile
+++ b/tests/periph_rtt/Makefile
@@ -1,4 +1,4 @@
-export APPLICATION = periph_rtt
+APPLICATION = periph_rtt
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_rtt

--- a/tests/periph_spi/Makefile
+++ b/tests/periph_spi/Makefile
@@ -1,4 +1,4 @@
-export APPLICATION = periph_spi
+APPLICATION = periph_spi
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -1,4 +1,4 @@
-export APPLICATION = periph_timer
+APPLICATION = periph_timer
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_timer

--- a/tests/periph_uart/Makefile
+++ b/tests/periph_uart/Makefile
@@ -1,4 +1,4 @@
-export APPLICATION = periph_uart
+APPLICATION = periph_uart
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_uart

--- a/tests/xtimer_periodic_wakeup/Makefile
+++ b/tests/xtimer_periodic_wakeup/Makefile
@@ -1,7 +1,6 @@
 APPLICATION = xtimer_sleep_until
 include ../Makefile.tests_common
 
-BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := chronos

--- a/tests/xtimer_remove/Makefile
+++ b/tests/xtimer_remove/Makefile
@@ -1,7 +1,6 @@
 APPLICATION = xtimer_remove
 include ../Makefile.tests_common
 
-BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 USEMODULE += xtimer

--- a/tests/xtimer_reset/Makefile
+++ b/tests/xtimer_reset/Makefile
@@ -1,7 +1,6 @@
 APPLICATION = xtimer_reset
 include ../Makefile.tests_common
 
-BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 USEMODULE += xtimer

--- a/tests/zep/Makefile
+++ b/tests/zep/Makefile
@@ -14,7 +14,6 @@ USEMODULE += gnrc_pktdump
 USEMODULE += shell
 USEMODULE += shell_commands
 
-
 # set optional default values for ZEP parameters if unset
 ZEP_DST      ?= "\"::1\""
 ZEP_SRC_PORT ?= GNRC_ZEP_DEFAULT_PORT


### PR DESCRIPTION
follow up PR to #6326, adding missing include for `Makefile.tests_common` to all tests. Is required for #6341, too.