### PR TITLE
msp430: Add newlib support

### DIFF
--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -14,4 +14,38 @@ export ASFLAGS += $(CFLAGS_CPU) --defsym $(CPU_MODEL)=1 $(CFLAGS_DBG)
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -Wl,--gc-sections -static -lgcc
 
 # Import all toolchain settings
-include $(RIOTCPU)/Makefile.include.gnu
+include $(RIOTCPU)/Makefile.include.$(TOOLCHAIN)
+
+# Test that the compiler exists, try to adjust PREFIX otherwise
+ifeq (,$(shell sh -c 'command -v $(CC)'))
+export PREFIX:=$(PREFIX)elf-
+endif
+
+ifeq (,$(MSP430_USE_NEWLIB))
+# MSPGCC (the old compiler) is usually used with msp-libc, while the new
+# upstream GCC msp430 port (sometimes referred to as the Red Hat MSP430
+# compiler) is usually accompanied by newlib.
+# The new msp430 port started with version 4.9.x, the latest release of the old
+# mspgcc is 4.6.3 from the beginning of 2012 and doesn't look like it will receive
+# any updates. We use the numbers to decide if we use newlib by default.
+CC_VERSION := $(shell $(CC) -dumpversion 2>&1)
+
+ifeq (4.9, $(firstword $(sort 4.9 $(CC_VERSION))))
+# CC_VERSION is at least 4.9
+MSP430_USE_NEWLIB := 1
+else
+MSP430_USE_NEWLIB := 0
+endif
+endif
+
+ifeq (1,$(MSP430_USE_NEWLIB))
+
+# use newlib as libc
+export USEMODULE += newlib
+
+# use the nano-specs of Newlib when available
+ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+export LINKFLAGS += -specs=nano.specs -lc -lnosys
+endif
+
+endif

--- a/cpu/Makefile.include.msp430_common
+++ b/cpu/Makefile.include.msp430_common
@@ -40,6 +40,9 @@ endif
 
 ifeq (1,$(MSP430_USE_NEWLIB))
 
+# Temporarily disabled memory allocation from heap
+export CFLAGS += -DDISABLE_HEAP_ALLOC
+
 # use newlib as libc
 export USEMODULE += newlib
 

--- a/cpu/msp430_common/cpu.c
+++ b/cpu/msp430_common/cpu.c
@@ -62,6 +62,7 @@ NORETURN void cpu_switch_context_exit(void)
     UNREACHABLE();
 }
 
+#if !(MODULE_NEWLIB)
 /**
  * mspgcc handles main specially - it does not return but falls
  * through to section .fini9.
@@ -69,6 +70,7 @@ NORETURN void cpu_switch_context_exit(void)
  * behave like a regular function. This enables a common
  * thread_stack_init behavior. */
 __attribute__((section (".fini9"))) void __main_epilogue(void) { __asm__("ret"); }
+#endif
 
 //----------------------------------------------------------------------------
 // Processor specific routine - here for MSP

--- a/cpu/msp430_common/include/cpu.h
+++ b/cpu/msp430_common/include/cpu.h
@@ -23,6 +23,13 @@
 
 #include <stdio.h>
 
+#if ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5) && (__GNUC_MINOR__ < 9))
+#include <intrinsics.h>   /* MSP430-gcc compiler instrinsics */
+#define __get_SR_register __read_status_register
+#elif ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)) || (__GNUC__ >= 5)
+#include <in430.h>
+#endif
+
 #include <msp430.h>
 #include "board.h"
 

--- a/cpu/msp430_common/include/msp430_types.h
+++ b/cpu/msp430_common/include/msp430_types.h
@@ -19,6 +19,8 @@
 extern "C" {
 #endif
 
+#if !(MODULE_NEWLIB)
+
 #ifndef EINVAL
 /**
  * @brief defines EINVAL if MSP430 toolchain is too old to provide it itself
@@ -83,6 +85,8 @@ typedef      int32_t suseconds_t; /**< Used for time in microseconds */
 typedef     uint32_t timer_t;     /**< Used for timer ID returned by timer_create() */
 typedef     uint16_t uid_t;       /**< Used for user IDs */
 typedef     uint32_t useconds_t;  /**< Used for time in microseconds */
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/cpu/msp430_common/include/stdio.h
+++ b/cpu/msp430_common/include/stdio.h
@@ -35,7 +35,9 @@ extern "C" {
 #define SEEK_CUR	1	/* Seek from current position.  */
 #define SEEK_END	2	/* Seek from end of file.  */
 
+#if !(MODULE_NEWLIB)
 int getchar(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/cpu/msp430_common/include/stdio.h
+++ b/cpu/msp430_common/include/stdio.h
@@ -21,8 +21,8 @@
 #define RIOT_MSP430_STDIO_H
 
 /*
- * The MSP430 toolchain does not provide getchar in stdio.h.
- * As a workaround, we include the system stdio.h here and then add getchar.
+ * msp430-libc does not provide getchar in stdio.h, but newlib does.
+ * As a workaround, we declare getchar separately and include the system stdio.h
  */
 
 #include_next <stdio.h>

--- a/cpu/msp430_common/include/sys/time.h
+++ b/cpu/msp430_common/include/sys/time.h
@@ -9,7 +9,11 @@
 #ifndef TIME_H
 #define TIME_H
 
+#if MODULE_NEWLIB
+#include_next <sys/time.h>
+#else
 #include "msp430_types.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/msp430_common/include/sys/types.h
+++ b/cpu/msp430_common/include/sys/types.h
@@ -9,7 +9,11 @@
 #ifndef SYS_TYPES_H
 #define SYS_TYPES_H
 
+#if MODULE_NEWLIB
+#include_next <sys/types.h>
+#else
 #include "msp430_types.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/msp430_common/msp430-main.c
+++ b/cpu/msp430_common/msp430-main.c
@@ -104,9 +104,11 @@ init_ports(void)
 }
 
 /*---------------------------------------------------------------------------*/
+#if !(MODULE_NEWLIB)
 /* msp430-ld may align _end incorrectly. Workaround in cpu_init. */
 extern int _end;        /* Not in sys/unistd.h */
 static char *cur_break = (char *) &_end;
+#endif
 
 void msp430_cpu_init(void)
 {
@@ -114,15 +116,18 @@ void msp430_cpu_init(void)
     init_ports();
     irq_enable();
 
+#if !(MODULE_NEWLIB)
     if ((uintptr_t)cur_break & 1) { /* Workaround for msp430-ld bug!*/
         cur_break++;
     }
+#endif
 }
 /*---------------------------------------------------------------------------*/
 #define asmv(arg) __asm__ __volatile__(arg)
 
-#define STACK_EXTRA 32
+#if !(MODULE_NEWLIB)
 
+#define STACK_EXTRA 32
 
 /*
  * Allocate memory from the heap. Check that we don't collide with the
@@ -149,6 +154,7 @@ void *sbrk(int incr)
     */
     return old_break;
 }
+#endif
 /*---------------------------------------------------------------------------*/
 /*
  * Mask all interrupts that can be masked.

--- a/cpu/msp430fxyz/flashrom.c
+++ b/cpu/msp430fxyz/flashrom.c
@@ -18,9 +18,9 @@
  * @}
  */
 
-#include "irq.h"
 #include <stddef.h>
 #include <stdint.h>
+
 #include "cpu.h"
 #include "irq.h"
 
@@ -57,7 +57,7 @@ uint8_t flashrom_write(uint8_t *dst, const uint8_t *src, size_t size)
         *(dst++) = *(src++);                /* program Flash word */
 
         while (!(FCTL3 & WAIT)) {
-            nop();
+            __nop();
         }
     }
 
@@ -105,6 +105,6 @@ static inline void busy_wait(void)
 {
     /* Wait for BUSY = 0, not needed unless run from RAM */
     while (FCTL3 & 0x0001) {
-        nop();
+        __nop();
     }
 }

--- a/cpu/msp430fxyz/msp430_stdio.c
+++ b/cpu/msp430fxyz/msp430_stdio.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#if !(MODULE_NEWLIB)
+
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -55,3 +57,5 @@ ssize_t write(int fildes, const void *buf, size_t nbyte)
         return -1;
     }
 }
+
+#endif

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -48,7 +48,7 @@ NEWLIB_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_PATTERNS)))
 # If nothing was found we will try to fall back to searching for a cross-gcc in
 # the current PATH and use a relative path for the includes
 ifeq (,$(NEWLIB_INCLUDE_DIR))
-  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell command -v $(PREFIX)gcc;))../$(TARGET_ARCH)/include))
+  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell which $(PREFIX)gcc))../$(TARGET_ARCH)/include))
 endif
 
 ifeq ($(TOOLCHAIN),llvm)

--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -90,6 +90,7 @@ void _exit(int n)
     while(1);
 }
 
+#ifndef DISABLE_HEAP_ALLOC
 /**
  * @brief Allocate memory from the heap.
  *
@@ -115,6 +116,7 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t incr)
     irq_restore(state);
     return res;
 }
+#endif
 
 /**
  * @brief Get the process-ID of the current thread


### PR DESCRIPTION
This PR is made based on #4766. I rebased and took some commits from the original PR and they are little squashed, and some of them aren't used.
Unlike the original PR, I tend to use ldscripts from TI without changes.

Although I can build successfully, there are two issues. Please refer to the log below.
 - `Command not found` is shown when starting build process, but I failed to find exact point of that.
 -  As we talked in IRC, the generated `hex` is too large for `hello-world`.  (29Kb)

```
$ make BOARD=msb-430
make: command: Command not found
Building application "hello-world" for "msb-430" with MCU "msp430fxyz".

"make" -C /home/joykim/iot/RIOT/boards/msb-430
"make" -C /home/joykim/iot/RIOT/boards/msb-430-common
"make" -C /home/joykim/iot/RIOT/boards/msb-430-common/drivers
"make" -C /home/joykim/iot/RIOT/core
"make" -C /home/joykim/iot/RIOT/cpu/msp430fxyz
"make" -C /home/joykim/iot/RIOT/cpu/msp430_common
"make" -C /home/joykim/iot/RIOT/cpu/msp430fxyz/periph
"make" -C /home/joykim/iot/RIOT/drivers
"make" -C /home/joykim/iot/RIOT/drivers/periph_common
"make" -C /home/joykim/iot/RIOT/sys
"make" -C /home/joykim/iot/RIOT/sys/auto_init
"make" -C /home/joykim/iot/RIOT/sys/isrpipe
"make" -C /home/joykim/iot/RIOT/sys/newlib
"make" -C /home/joykim/iot/RIOT/sys/oneway-malloc
"make" -C /home/joykim/iot/RIOT/sys/tsrb
"make" -C /home/joykim/iot/RIOT/sys/uart_stdio
   text    data     bss     dec     hex filename
  10193     274    1074   11541    2d15 /home/joykim/iot/RIOT/examples/hello-world/bin/msb-430/hello-world.elf
```
