### PR TITLE
boards/weio : Various bug corrections

### DIFF
--- a/boards/weio/include/board.h
+++ b/boards/weio/include/board.h
@@ -34,9 +34,9 @@ extern "C" {
  * @brief   LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN            GPIO_PIN(0, 13)
-#define LED1_PIN            GPIO_PIN(0, 14)
-#define LED2_PIN            GPIO_PIN(0, 15)
+#define LED0_PIN            GPIO_PIN(1, 13)
+#define LED1_PIN            GPIO_PIN(1, 14)
+#define LED2_PIN            GPIO_PIN(1, 15)
 
 #define LED_PORT            LPC_GPIO
 #define LED0_MASK           BIT13

--- a/cpu/lpc11u34/include/periph_cpu.h
+++ b/cpu/lpc11u34/include/periph_cpu.h
@@ -59,7 +59,7 @@ typedef uint16_t gpio_t;
 /**
  * @brief   Define a custom GPIO_PIN macro for the lpc11u34
  */
-#define GPIO_PIN(port, pin)     (gpio_t)((port << 16) | pin)
+#define GPIO_PIN(port, pin)     (gpio_t)((port << 8) | pin)
 
 /**
  * @brief   Number of PWM channels per PWM peripheral


### PR DESCRIPTION
The port definition for LEDs was wrong (port 0 instead of 1).
The GPIO_PIN macro in ```periph_cpu.h``` was not consistent with the PORT_SHIFT definition in gpio.c