### PR TITLE
boards/nucleo-f091: update UART, PWM and ADC periph configuration

### DIFF
--- a/boards/nucleo-f091/Makefile.features
+++ b/boards/nucleo-f091/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm

--- a/boards/nucleo-f091/Makefile.features
+++ b/boards/nucleo-f091/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f091/include/periph_conf.h
+++ b/boards/nucleo-f091/include/periph_conf.h
@@ -139,9 +139,17 @@ static const pwm_conf_t pwm_config[] = {
  * @brief   ADC configuration
  * @{
  */
-#define ADC_NUMOF          (0)
-/** @} */
+#define ADC_CONFIG {            \
+    { GPIO_PIN(PORT_A, 0), 0 },\
+    { GPIO_PIN(PORT_A, 1), 1 },\
+    { GPIO_PIN(PORT_A, 4), 4 },\
+    { GPIO_PIN(PORT_B, 0), 8 },\
+    { GPIO_PIN(PORT_C, 1), 11 },\
+    { GPIO_PIN(PORT_C, 0), 10 } \
+}
 
+#define ADC_NUMOF           (6)
+/** @} */
 /**
  * @brief   DAC configuration
  * @{

--- a/boards/nucleo-f091/include/periph_conf.h
+++ b/boards/nucleo-f091/include/periph_conf.h
@@ -47,15 +47,15 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev      = TIM2,
-        .max      = 0xffffffff,
+        .dev      = TIM14,
+        .max      = 0x0000ffff,
         .rcc_mask = RCC_APB1ENR_TIM2EN,
         .bus      = APB1,
-        .irqn     = TIM2_IRQn
+        .irqn     = TIM14_IRQn
     }
 };
 
-#define TIMER_0_ISR         isr_tim2
+#define TIMER_0_ISR         isr_tim14
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
@@ -91,6 +91,36 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @brief   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 3)  /* D3 */, .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_B, 10) /* D6 */, .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_B, 11)         , .cc_chan = 3 },
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0 } },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 4) /* D5 */, .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_C, 7) /* D9 */, .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_C, 8),          .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_C, 9),          .cc_chan = 3 } },
+        .af       = GPIO_AF0,
+        .bus      = APB1
+    }
+};
+
+#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
 /** @} */
 
 /**

--- a/boards/nucleo-f091/include/periph_conf.h
+++ b/boards/nucleo-f091/include/periph_conf.h
@@ -78,17 +78,28 @@ static const uart_conf_t uart_config[] = {
     {
         .dev        = USART1,
         .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_B, 7),
-        .tx_pin     = GPIO_PIN(PORT_B, 6),
-        .rx_af      = GPIO_AF0,
-        .tx_af      = GPIO_AF0,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF1,
+        .tx_af      = GPIO_AF1,
         .bus        = APB2,
         .irqn       = USART1_IRQn
-    }
+    },
+    {
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_C, 11),
+        .tx_pin     = GPIO_PIN(PORT_C, 10),
+        .rx_af      = GPIO_AF1,
+        .tx_af      = GPIO_AF1,
+        .bus        = APB1,
+        .irqn       = USART3_8_IRQn
+    },
 };
 
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart3_8)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */


### PR DESCRIPTION
This is a similar change as in #6376 but adapted to nucleo-f091.