### PR TITLE
drivers/cc110x: add xtimer as module dependency

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -37,6 +37,7 @@ endif
 ifneq (,$(filter cc110x,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += uuid
+  USEMODULE += xtimer
   ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += gnrc_cc110x
 	# XXX: this can be modelled as a dependency for gnrc_netdev_default as soon


### PR DESCRIPTION
adds missing dependency, this popped up during test of #5469 and #6453 respectively when compiling the kw2xrf driver test for board msba2 with cc110x. The latter needs xtimer, linker error without this fix:

```
/RIOT/tests/driver_kw2xrf/bin/msba2/cc110x.a(cc110x-spi.o): In function `_xtimer_tsleep32':
/RIOT/sys/include/xtimer/implementation.h:147: undefined reference to `_xtimer_tsleep'
/RIOT/tests/driver_kw2xrf/bin/msba2/cc110x.a(cc110x.o): In function `_xtimer_tsleep32':
/RIOT/sys/include/xtimer/implementation.h:147: undefined reference to `_xtimer_tsleep'
/RIOT/sys/include/xtimer/implementation.h:147: undefined reference to `_xtimer_tsleep'
collect2: error: ld returned 1 exit status
make: *** [all] Error 1
```