### PR TITLE
gnrc_ndp: do not add new neighbors as TENTATIVE on 6LR

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -54,23 +54,6 @@ static void _stale_nc(kernel_pid_t iface, ipv6_addr_t *ipaddr, uint8_t *l2addr,
     if (l2addr_len != -ENOTSUP) {
         gnrc_ipv6_nc_t *nc_entry = gnrc_ipv6_nc_get(iface, ipaddr);
         if (nc_entry == NULL) {
-#ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
-            /* tentative type see https://tools.ietf.org/html/rfc6775#section-6.3 */
-            gnrc_ipv6_netif_t *ipv6_iface = gnrc_ipv6_netif_get(iface);
-            if ((ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN) &&
-                (ipv6_iface->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER)) {
-                if ((nc_entry = gnrc_ipv6_nc_add(iface, ipaddr, l2addr,
-                                                 (uint16_t)l2addr_len,
-                                                 GNRC_IPV6_NC_STATE_STALE |
-                                                 GNRC_IPV6_NC_TYPE_TENTATIVE)) != NULL) {
-                    xtimer_set_msg(&nc_entry->type_timeout,
-                                   (GNRC_SIXLOWPAN_ND_TENTATIVE_NCE_LIFETIME * US_PER_SEC),
-                                   &nc_entry->type_timeout_msg,
-                                   gnrc_ipv6_pid);
-                }
-                return;
-            }
-#endif
             gnrc_ipv6_nc_add(iface, ipaddr, l2addr, (uint16_t)l2addr_len,
                              GNRC_IPV6_NC_STATE_STALE);
         }


### PR DESCRIPTION
RFC 6775 [describes in the section of processing RS](https://tools.ietf.org/html/rfc6775#section-6.3) to set the AR type of an address on `TENTATIVE`. Problem: since we don't implement [multi-hop DAD](https://tools.ietf.org/html/rfc6775#section-8.2) at the moment the address stays this type and is removed after the timeout. I suspect this to be part of the problem in #5790.

If it does not fix this issue not, this is still a bug, since setting a state timeout for a NCE that is not properly resolved is faulty behavior. This behavior is labeled as MAY in the RFC, so removing it should be fine.