### PR TITLE
boards/nucleo-f072: improve periph configuration

### DIFF
--- a/boards/nucleo-f072/Makefile.features
+++ b/boards/nucleo-f072/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f072/Makefile.features
+++ b/boards/nucleo-f072/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f072/include/periph_conf.h
+++ b/boards/nucleo-f072/include/periph_conf.h
@@ -48,15 +48,31 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev      = TIM2,
-        .max      = 0xffffffff,
-        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .dev      = TIM14,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM14EN,
         .bus      = APB1,
-        .irqn     = TIM2_IRQn
+        .irqn     = TIM14_IRQn
+    },
+    {
+        .dev      = TIM16,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB2ENR_TIM16EN,
+        .bus      = APB2,
+        .irqn     = TIM16_IRQn
+    },
+    {
+        .dev      = TIM17,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB2ENR_TIM17EN,
+        .bus      = APB2,
+        .irqn     = TIM17_IRQn
     }
 };
 
-#define TIMER_0_ISR         isr_tim2
+#define TIMER_0_ISR         isr_tim14
+#define TIMER_1_ISR         isr_tim16
+#define TIMER_2_ISR         isr_tim17
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
@@ -92,6 +108,46 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart1)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @brief   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM2,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 3)  /* D3 */, .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_B, 10) /* D6 */, .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_B, 11)         , .cc_chan = 3 },
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0 } },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM3,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 4) /* D5 */, .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_B, 5) /* D4 */, .cc_chan = 1 },
+                      { .pin = GPIO_UNDEF,                   .cc_chan = 0 },
+                      { .pin = GPIO_UNDEF,                   .cc_chan = 0 } },
+        .af       = GPIO_AF1,
+        .bus      = APB1
+    },
+    {
+        .dev      = TIM15,
+        .rcc_mask = RCC_APB2ENR_TIM15EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 14), .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_B, 15), .cc_chan = 1 },
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0 },
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0 } },
+        .af       = GPIO_AF1,
+        .bus      = APB2
+    }
+};
+
+#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
 /** @} */
 
 /**

--- a/boards/nucleo-f072/include/periph_conf.h
+++ b/boards/nucleo-f072/include/periph_conf.h
@@ -95,17 +95,28 @@ static const uart_conf_t uart_config[] = {
     {
         .dev      = USART1,
         .rcc_mask = RCC_APB2ENR_USART1EN,
-        .rx_pin   = GPIO_PIN(PORT_B, 7),
-        .tx_pin   = GPIO_PIN(PORT_B, 6),
-        .rx_af    = GPIO_AF0,
-        .tx_af    = GPIO_AF0,
+        .rx_pin   = GPIO_PIN(PORT_A, 10),
+        .tx_pin   = GPIO_PIN(PORT_A, 9),
+        .rx_af    = GPIO_AF1,
+        .tx_af    = GPIO_AF1,
         .bus      = APB2,
         .irqn     = USART1_IRQn
+    },
+    {
+        .dev      = USART3,
+        .rcc_mask = RCC_APB1ENR_USART3EN,
+        .rx_pin   = GPIO_PIN(PORT_C, 11),
+        .tx_pin   = GPIO_PIN(PORT_C, 10),
+        .rx_af    = GPIO_AF1,
+        .tx_af    = GPIO_AF1,
+        .bus      = APB1,
+        .irqn     = USART3_8_IRQn
     }
 };
 
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart3_8)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */

--- a/boards/nucleo-f072/include/periph_conf.h
+++ b/boards/nucleo-f072/include/periph_conf.h
@@ -99,18 +99,16 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 #define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 },\
-    { GPIO_PIN(PORT_A, 1), 1 },\
-    { GPIO_PIN(PORT_A, 4), 4 },\
-    { GPIO_PIN(PORT_B, 0), 8 },\
+    { GPIO_PIN(PORT_A, 0), 0 }, \
+    { GPIO_PIN(PORT_A, 1), 1 }, \
+    { GPIO_PIN(PORT_A, 4), 4 }, \
+    { GPIO_PIN(PORT_B, 0), 8 }, \
     { GPIO_PIN(PORT_C, 1), 11 },\
     { GPIO_PIN(PORT_C, 0), 10 } \
 }
 
 #define ADC_NUMOF           (6)
-
 /** @} */
-
 
 /**
  * @brief   DAC configuration


### PR DESCRIPTION
Yet another update of a nucleo periph configuration. This one is for the nucleo-f072 and is similar to #6452 