### PR TITLE
mailmap: add missing mail address of mine

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -10,6 +10,7 @@ Martine Lenders <m.lenders@fu-berlin.de> <authmillenon@gmail.com>
 Martine Lenders <m.lenders@fu-berlin.de> <mail@martin-lenders.de>
 Martine Lenders <m.lenders@fu-berlin.de> <mail@martine-lenders.eu>
 Martine Lenders <m.lenders@fu-berlin.de> <mlenders@inf.fu-berlin.de>
+Martine Lenders <m.lenders@fu-berlin.de> <authmill@datalove.me>
 Oleg Hahm <oleg@hobbykeller.org> <oleg@hobbykeller.org>
 Oleg Hahm <oleg@hobbykeller.org> <gello@gmx.de>
 Oleg Hahm <oleg@hobbykeller.org> <oliver.hahm@inria.fr>


### PR DESCRIPTION
Very old mail address of mine that I don't really use any more, but
for some reason it is in RIOT's history, so here we go.