### PR TITLE
Jenkins: add git-cache init before build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,6 +161,7 @@ def make_build(label, board, desc, arg)
                 deleteDir()
                 fetchPR(env.CHANGE_ID, "--depth=1", "")
                 def build_dir = pwd()
+                sh "./dist/tools/git/git-cache init"
                 timestamps {
                     def apps = arg.join(' ')
                     echo "building ${apps} for ${board} on nodes with ${label}"


### PR DESCRIPTION
title says it all, but the problem is that all builds fail in Jenkins if the GITCACHE_DIR is not initialized.

This PR solves this by running `git-cache init` before every build on any CI worker.