### PR TITLE
cpu/stm32f0: add flashpage driver from stm32f1 + fix stm32f1 driver

### DIFF
--- a/cpu/stm32f0/include/cpu_conf.h
+++ b/cpu/stm32f0/include/cpu_conf.h
@@ -55,6 +55,31 @@ extern "C" {
 #define CPU_IRQ_NUMOF                   (31U)
 /** @} */
 
+/**
+ * @brief   Flash page configuration
+ *
+ * STM32F03x, STM32F04x, STM32F05x: up to 64 pages of 1K
+ * STM32F07x, STM32F09x: up to 128 pages of 2K
+ *
+ * @{
+ */
+#if defined(CPU_MODEL_STM32F091RC) || defined(CPU_MODEL_STM32F072RB)
+#define FLASHPAGE_SIZE      (2048U)
+#elif defined(CPU_MODEL_STM32F051R8) || defined(CPU_MODEL_STM32F042K6) \
+   || defined(CPU_MODEL_STM32F070RB) || defined(CPU_MODEL_STM32F030R8)
+#define FLASHPAGE_SIZE      (1024U)
+#endif
+
+#if defined(CPU_MODEL_STM32F091RC)
+#define FLASHPAGE_NUMOF     (128U)
+#elif defined(CPU_MODEL_STM32F051R8) || defined(CPU_MODEL_STM32F072RB) \
+   || defined(CPU_MODEL_STM32F030R8) || defined(CPU_MODEL_STM32F070RB)
+#define FLASHPAGE_NUMOF     (64U)
+#elif defined(CPU_MODEL_STM32F042K6)
+#define FLASHPAGE_NUMOF     (32U)
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f0/periph/flashpage.c
+++ b/cpu/stm32f0/periph/flashpage.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32f0
+ * @{
+ *
+ * @file
+ * @brief       Low-level flash page driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "assert.h"
+#include "periph/flashpage.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+void flashpage_write(int page, void *data)
+{
+    assert(page < FLASHPAGE_NUMOF);
+
+    uint16_t *page_addr = flashpage_addr(page);
+    uint16_t *data_addr = (uint16_t *)data;
+    uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
+
+    /* the internal RC oscillator (HSI) must be enabled */
+    RCC->CR |= (RCC_CR_HSION);
+    while (!(RCC->CR & RCC_CR_HSIRDY)) {}
+
+    /* unlock the flash module */
+    DEBUG("[flashpage] unlocking the flash module\n");
+    if (FLASH->CR & FLASH_CR_LOCK) {
+        FLASH->KEYR = FLASH_KEY1;
+        FLASH->KEYR = FLASH_KEY2;
+    }
+
+    /* ERASE sequence */
+    /* make sure no flash operation is ongoing */
+    DEBUG("[flashpage] erase: waiting for any operation to finish\n");
+    while (FLASH->SR & FLASH_SR_BSY) {}
+    /* set page erase bit and program page address */
+    DEBUG("[flashpage] erase: setting the erase bit and page address\n");
+    FLASH->CR |= FLASH_CR_PER;
+    FLASH->AR = (uint32_t)flashpage_addr(page);
+    DEBUG("address to erase: %p\n", flashpage_addr(page));
+    /* trigger the page erase and wait for it to be finished */
+    DEBUG("[flashpage] erase: trigger the page erase\n");
+    FLASH->CR |= FLASH_CR_STRT;
+    DEBUG("[flashpage] erase: wait as long as device is busy\n");
+    while (FLASH->SR & FLASH_SR_BSY) {}
+    /* reset PER bit */
+    DEBUG("[flashpage] erase: resetting the page erase bit\n");
+    FLASH->CR &= ~(FLASH_CR_PER);
+
+    /* WRITE sequence */
+    if (data != NULL) {
+        DEBUG("[flashpage] write: now writing the data\n");
+        /* set PG bit and program page to flash */
+        FLASH->CR |= FLASH_CR_PG;
+        for (unsigned i = 0; i < (FLASHPAGE_SIZE / 2); i++) {
+            *page_addr++ = data_addr[i];
+            while (FLASH->SR & FLASH_SR_BSY) {}
+        }
+        /* clear program bit again */
+        FLASH->CR &= ~(FLASH_CR_PG);
+        DEBUG("[flashpage] write: done writing data\n");
+    }
+
+    /* finally, lock the flash module again */
+    DEBUG("flashpage] now locking the flash module again\n");
+    FLASH->CR |= FLASH_CR_LOCK;
+
+    /* restore the HSI state */
+    if (!hsi_state) {
+        RCC->CR &= ~(RCC_CR_HSION);
+        while (RCC->CR & RCC_CR_HSIRDY) {}
+    }
+}

--- a/cpu/stm32f1/periph/flashpage.c
+++ b/cpu/stm32f1/periph/flashpage.c
@@ -81,7 +81,7 @@ void flashpage_write(int page, void *data)
     FLASH->CR |= FLASH_CR_LOCK;
 
     /* restore the HSI state */
-    if (hsi_state) {
+    if (!hsi_state) {
         RCC->CR &= ~(RCC_CR_HSION);
         while (RCC->CR & RCC_CR_HSIRDY) {}
     }


### PR DESCRIPTION
Hi,

This adds the flashpage driver to stm32f0. It's a copy/paste of the stm32f1. We could maybe move that to stm32_common, but the f2 and f4 (at least, it didn't check f3 and l1) flash are quite different and the driver can not be shared with the whole stm32 family.

It also fixes HSI disabling at the end of the write process.

Tested on nucleo-f091 and nucleo-f042 with tests/periph_flashpage.