### PR TITLE
make: remove pkg/*/ from clean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ docclean:
 
 clean:
 	@echo "Cleaning all build products for the current board"
-	@find ./pkg/ ./examples/ ./tests/ -maxdepth 2 -mindepth 2 -type f -name Makefile -execdir "${MAKE}" clean ';'
+	@find ./examples/ ./tests/ -maxdepth 2 -mindepth 2 -type f -name Makefile -execdir "${MAKE}" clean ';'
 
 distclean: docclean
 	@echo "Cleaning all build products"
-	@find ./pkg/ ./examples/ ./tests/ -maxdepth 2 -mindepth 2 -type f -name Makefile -execdir "${MAKE}" distclean ';'
+	@find ./examples/ ./tests/ -maxdepth 2 -mindepth 2 -type f -name Makefile -execdir "${MAKE}" distclean ';'
 
 welcome:
 	@echo "Welcome to RIOT - The friendly OS for IoT!"


### PR DESCRIPTION
Previously, our packages downloaded and partly built in ```pkg/<pkgname>/```. With the initial introduction of murdock, that has been moved to ```$(BINDIRBASE)/pkg/$(BOARD)```, but the targets in out main Makefile have not been updated.