### PR TITLE
drivers/lis3dh: fixed bug and simplified init()

### DIFF
--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -120,7 +120,6 @@ void board_init(void);
  * @name LIS3DH configuration
  * @{
  */
-
 #define LIS3DH_INT1                 GPIO_PIN(PORT_C, 18)
 #define LIS3DH_INT2                 GPIO_PIN(PORT_C, 17)
 #define LIS3DH_CS                   GPIO_PIN(PORT_D, 0)

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -108,6 +108,11 @@ ifneq (,$(filter kw2xrf,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter lis3dh,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_gpio
+    FEATURES_REQUIRED += periph_spi
+endif
+
 ifneq (,$(filter lm75a,$(USEMODULE)))
     USEMODULE += xtimer
 endif

--- a/drivers/include/lis3dh.h
+++ b/drivers/include/lis3dh.h
@@ -714,16 +714,12 @@ typedef struct __attribute__((packed))
  * @brief Initialize a LIS3DH sensor instance
  *
  * @param[in]  dev          Device descriptor of sensor to initialize
- * @param[in]  spi          SPI bus the accelerometer is connected to
- * @param[in]  clk          SPI bus speed
- * @param[in]  cs_pin       GPIO connected to the chip select pin of the accelerometer
- * @param[in]  scale        Initial scale setting of the sensor
+ * @param[in]  params       Configuration parameters
  *
  * @return                  0 on success
  * @return                  -1 on error
  */
-int lis3dh_init(lis3dh_t *dev, spi_t spi, spi_clk_t clk,
-                gpio_t cs_pin, uint8_t scale);
+int lis3dh_init(lis3dh_t *dev, const lis3dh_params_t *params);
 
 /**
  * @brief Read 3D acceleration data from the accelerometer

--- a/sys/auto_init/saul/auto_init_lis3dh.c
+++ b/sys/auto_init/saul/auto_init_lis3dh.c
@@ -50,17 +50,16 @@ extern saul_driver_t lis3dh_saul_driver;
 void auto_init_lis3dh(void)
 {
     for (unsigned int i = 0; i < LIS3DH_NUM; i++) {
-        const lis3dh_params_t *p = &lis3dh_params[i];
         int res;
 
         LOG_DEBUG("[auto_init_saul] initializing lis3dh #%u\n", i);
 
-        res = lis3dh_init(&lis3dh_devs[i], p->spi, p->clk, p->cs, p->scale);
+        res = lis3dh_init(&lis3dh_devs[i], &lis3dh_params[i]);
         if (res < 0) {
             LOG_ERROR("[auto_init_saul] error initializing lis3dh #%u\n", i);
             continue;
         }
-        res = lis3dh_set_odr(&lis3dh_devs[i], p->odr);
+        res = lis3dh_set_odr(&lis3dh_devs[i], lis3dh_params[i].odr);
         if (res < 0) {
             LOG_ERROR("[auto_init_saul] error setting ODR for lis3dh #%u\n", i);
             continue;

--- a/tests/driver_lis3dh/Makefile
+++ b/tests/driver_lis3dh/Makefile
@@ -1,21 +1,7 @@
 APPLICATION = driver_lis3dh
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_spi periph_gpio
-
 USEMODULE += lis3dh
 USEMODULE += xtimer
-
-# set default device parameters in case they are undefined
-TEST_LIS3DH_SPI  ?= SPI_DEV\(0\)
-TEST_LIS3DH_CS   ?= GPIO_PIN\(0,0\)
-TEST_LIS3DH_INT1 ?= GPIO_PIN\(0,1\)
-TEST_LIS3DH_INT2 ?= GPIO_PIN\(0,2\)
-
-# export parameters
-CFLAGS += -DTEST_LIS3DH_SPI=$(TEST_LIS3DH_SPI)
-CFLAGS += -DTEST_LIS3DH_CS=$(TEST_LIS3DH_CS)
-CFLAGS += -DTEST_LIS3DH_INT1=$(TEST_LIS3DH_INT1)
-CFLAGS += -DTEST_LIS3DH_INT2=$(TEST_LIS3DH_INT2)
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lis3dh/main.c
+++ b/tests/driver_lis3dh/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Eistec AB
+ *               2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -13,55 +14,20 @@
  * @file
  * @brief       Test application for the LIS3DH accelerometer driver
  *
- * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
 
 #include <stdio.h>
 
-#include "board.h"
 #include "xtimer.h"
-#include "periph/spi.h"
-#include "periph/gpio.h"
 #include "lis3dh.h"
-
-/* Check for definition of hardware pins, default to board.h values if not set. */
-#ifndef TEST_LIS3DH_SPI
-#ifdef LIS3DH_SPI
-#define TEST_LIS3DH_SPI LIS3DH_SPI
-#else
-#error "TEST_LIS3DH_SPI not defined"
-#endif
-#endif
-#ifndef TEST_LIS3DH_CS
-#ifdef LIS3DH_CS
-#define TEST_LIS3DH_CS LIS3DH_CS
-#else
-#error "TEST_LIS3DH_CS not defined"
-#endif
-#endif
-#ifndef TEST_LIS3DH_INT1
-#ifdef LIS3DH_INT1
-#define TEST_LIS3DH_INT1 LIS3DH_INT1
-#else
-#error "TEST_LIS3DH_INT1 not defined"
-#endif
-#endif
-#ifndef TEST_LIS3DH_INT2
-#ifdef LIS3DH_INT2
-#define TEST_LIS3DH_INT2 LIS3DH_INT2
-#else
-#error "TEST_LIS3DH_INT2 not defined"
-#endif
-#endif
+#include "lis3dh_params.h"
 
 
-#define SCALE       4
-#define ODR         LIS3DH_ODR_100Hz
 #define SLEEP       (100 * 1000U)
-#define SPI_CONF    (SPI_CONF_SECOND_FALLING)
-#define SPI_CLK     (SPI_CLK_10MHZ)
 
 #define WATERMARK_LEVEL 16
 
@@ -81,7 +47,7 @@ int main(void)
     puts("LIS3DH accelerometer driver test application\n");
 
     puts("Initializing LIS3DH sensor... ");
-    if (lis3dh_init(&dev, TEST_LIS3DH_SPI, SPI_CLK, TEST_LIS3DH_CS, SCALE) == 0) {
+    if (lis3dh_init(&dev, &lis3dh_params[0]) == 0) {
         puts("[OK]");
     }
     else {
@@ -90,7 +56,7 @@ int main(void)
     }
 
     puts("Set ODR... ");
-    if (lis3dh_set_odr(&dev, ODR) == 0) {
+    if (lis3dh_set_odr(&dev, lis3dh_params[0].odr) == 0) {
         puts("[OK]");
     }
     else {
@@ -99,7 +65,7 @@ int main(void)
     }
 
     puts("Set scale... ");
-    if (lis3dh_set_scale(&dev, SCALE) == 0) {
+    if (lis3dh_set_scale(&dev, lis3dh_params[0].scale) == 0) {
         puts("[OK]");
     }
     else {
@@ -144,7 +110,8 @@ int main(void)
     }
 
     puts("Set INT1 callback");
-    if (gpio_init_int(TEST_LIS3DH_INT1, GPIO_IN, GPIO_RISING, test_int1, (void*)&int1_count) == 0) {
+    if (gpio_init_int(lis3dh_params[0].int1, GPIO_IN, GPIO_RISING,
+                      test_int1, (void*)&int1_count) == 0) {
         puts("[OK]");
     }
     else {
@@ -172,7 +139,7 @@ int main(void)
                 puts("[Failed]\n");
                 return 1;
             }
-            int1 = gpio_read(TEST_LIS3DH_INT1);
+            int1 = gpio_read(lis3dh_params[0].int1);
             printf("X: %6d Y: %6d Z: %6d Temp: %6d, INT1: %08x\n",
                    acc_data.acc_x, acc_data.acc_y, acc_data.acc_z, temperature, int1);
             --fifo_level;


### PR DESCRIPTION
Now the driver is working fine here at my desk with the `mulle` board.

One thing that I find a little confusing, though: The driver is running the SPI bus in `MODE_0` (pol and pha set to `0`). From the datasheet, the device should run however in `MODE_3` (pol and pha set to `1`). But when I tell the driver to use `MODE_3`, I can't interact with the sensor anymore...

@gebart: would you mind to have a quick look at this? Thx!