### PR TITLE
drivers: encx24j600: misc compilation fixes

### DIFF
--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -22,6 +22,10 @@
 #include <assert.h>
 #include <errno.h>
 
+#ifdef MODULE_NETSTATS_L2
+#include <string.h>
+#endif
+
 #include "mutex.h"
 #include "encx24j600.h"
 #include "encx24j600_internal.h"
@@ -282,7 +286,7 @@ static int _init(netdev2_t *encdev)
     unlock(dev);
 
 #ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
+    memset(&encdev->stats, 0, sizeof(netstats_t));
 #endif
     return 0;
 }
@@ -359,7 +363,7 @@ static int _recv(netdev2_t *netdev, void *buf, size_t len, void *info)
     if (buf) {
 #ifdef MODULE_NETSTATS_L2
         netdev->stats.rx_count++;
-        netdev2->stats.rx_bytes += len;
+        netdev->stats.rx_bytes += len;
 #endif
         /* read packet (without 4 bytes checksum) */
         sram_op(dev, ENC_RRXDATA, 0xFFFF, buf, payload_len);


### PR DESCRIPTION
The driver doesn't compile at least with netstats enabled.

To test, add these lines to ```examples/gnrc_minimal```:

```
USEMODULE += encx24j600 gnrc_netdev2
CFLAGS += -DENCX24J600_SPI=0 "-DENCX24J600_CS=GPIO_PIN(PORT_C,10)" "-DENCX24J600_INT=GPIO_PIN(PORT_D,2)"
```

... and try to compile, e.g., for nucleo-f334.