### PR TITLE
tests/emb6: msb-430 insufficient memory

### DIFF
--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -7,7 +7,7 @@ FEATURES_REQUIRED = periph_gpio periph_spi  # for at86rf231
 
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := msb-430h stm32f0discovery telosb weio z1 \
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h stm32f0discovery telosb weio z1 \
                              wsn430-v1_3b wsn430-v1_4
 
 USEPKG += emb6


### PR DESCRIPTION
According to Jenkins, the `msb-430` has not enough memory for the `emb6` test. So linking needs to be ignored. I wonder why Murdock is not linking this board, although it is not listed here in `BOARD_INSUFFICIENT_MEMORY` @kaspar030 ? Is the `buildtest` target using wildcards, so that `msb-430` is matching `msb-430h`?