### PR TITLE
Make: buildtest: match exact board name

### DIFF
--- a/Makefile.buildtests
+++ b/Makefile.buildtests
@@ -39,7 +39,7 @@ buildtest:
 	BUILDTESTOK=true; \
 	APP_RETRY=0; \
 	for BOARD in $$($(MAKE) -s info-boards-supported); do \
-	  RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_MEMORY) | grep $${BOARD} 2>&1 >/dev/null && echo 1); \
+	  RIOTNOLINK=$$(echo $(BOARD_INSUFFICIENT_MEMORY) | grep "\<$${BOARD}\>" 2>&1 >/dev/null && echo 1); \
 	  ${COLOR_ECHO} -n "Building for $${BOARD} "; \
 	  [ -n "$${RIOTNOLINK}" ] && ${COLOR_ECHO} -n "(no linking) "; \
 	  for NTH_TRY in 1 2 3; do \


### PR DESCRIPTION
Currently, the `make buildtest` matches `msb-430` when determining whether an application needs to be linked or not, although only `msb-430h` is blacklisted. With this patch the board names are matched exactly, not as substrings.

See https://github.com/RIOT-OS/RIOT/pull/6482