### PR TITLE
net/gnrc/pktbuf: Add gnrc_pktbuf_merge

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -276,6 +276,47 @@ gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *ol
  */
 gnrc_pktsnip_t *gnrc_pktbuf_duplicate_upto(gnrc_pktsnip_t *pkt, gnrc_nettype_t type);
 
+/**
+ * @brief   Merge pktsnip chain to single pktsnip.
+ *
+ *          Example:
+ *              Input:
+ *                                                                  buffer
+ *              +---------------------------+                      +------+
+ *              | size = 8                  | data       +-------->|      |
+ *              | type = NETTYPE_IPV6       |------------+         +------+
+ *              +---------------------------+                      .      .
+ *                    | next                                       .      .
+ *                    v                                            .      .
+ *              +---------------------------+                      +------+
+ *              | size = 40                 | data    +----------->|      |
+ *              | type = NETTYPE_UDP        |---------+            +------+
+ *              +---------------------------+                      .      .
+ *                    | next                                       .      .
+ *                    v
+ *              +---------------------------+                      +------+
+ *              | size = 14                 | data +-------------->|      |
+ *              | type = NETTYPE_UNDEF      |------+               +------+
+ *              +---------------------------+                      .      .
+ *
+ *
+ *              Output:
+ *                                                                  buffer
+ *              +---------------------------+                      +------+
+ *              | size = 62                 | data       +-------->|      |
+ *              | type = NETTYPE_IPV6       |------------+         |      |
+ *              +---------------------------+                      |      |
+ *                                                                 |      |
+ *                                                                 +------+
+ *                                                                 .      .
+ *
+ * @param[in,out] pkt   The snip to merge.
+ *
+ * @return  0, on success
+ * @return  ENOMEM, if no space is left in the packet buffer.
+ */
+int gnrc_pktbuf_merge(gnrc_pktsnip_t *pkt);
+
 #ifdef DEVELHELP
 /**
  * @brief   Prints some statistics about the packet buffer to stdout.

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -607,4 +607,49 @@ gnrc_pktsnip_t *gnrc_pktbuf_duplicate_upto(gnrc_pktsnip_t *pkt, gnrc_nettype_t t
     return new;
 }
 
+int gnrc_pktbuf_merge(gnrc_pktsnip_t *pkt)
+{
+    gnrc_pktsnip_t *next;
+    int iter = 0;
+
+    size_t size = gnrc_pkt_len(pkt);
+    if (pkt->size >= size) {
+        return 0;
+    }
+
+    mutex_lock(&_mutex);
+
+    /* Allocate new buffer */
+    uint8_t *new_data = _pktbuf_alloc(size);
+    if (new_data == NULL) {
+        DEBUG("pktbuf: error allocating new data section\n");
+        mutex_unlock(&_mutex);
+        return ENOMEM;
+    }
+
+    /* Copy data to new buffer */
+    next = pkt;
+    while (next != NULL) {
+        if (next->data != NULL) {
+            memcpy(&new_data[iter], next->data, next->size);
+            iter += next->size;
+        }
+        next = next->next;
+    }
+
+    /* Use first pktsnip for new data */
+    next = pkt->next;
+    pkt->next = NULL;
+    _pktbuf_free(pkt->data, pkt->size);
+    pkt->data = new_data;
+    pkt->size = size;
+
+    mutex_unlock(&_mutex);
+
+    /* Release old pktsnips and data*/
+    gnrc_pktbuf_release(next);
+
+    return 0;
+}
+
 /** @} */

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -647,6 +647,44 @@ static void test_pktbuf_realloc_data__success3(void)
     TEST_ASSERT(gnrc_pktbuf_is_empty());
 }
 
+static void test_pktbuf_merge_data__memfull(void)
+{
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, (GNRC_PKTBUF_SIZE/4), GNRC_NETTYPE_TEST);
+    pkt = gnrc_pktbuf_add(pkt, NULL, (GNRC_PKTBUF_SIZE/4)+1, GNRC_NETTYPE_TEST);
+
+    TEST_ASSERT_EQUAL_INT(ENOMEM, gnrc_pktbuf_merge(pkt));
+    gnrc_pktbuf_release(pkt);
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_pktbuf_merge_data__success1(void)
+{
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, 0, GNRC_NETTYPE_TEST);
+
+    TEST_ASSERT_NOT_NULL(pkt);
+    TEST_ASSERT_NULL(pkt->data);
+
+    TEST_ASSERT_EQUAL_INT(0, gnrc_pktbuf_merge(pkt));
+    gnrc_pktbuf_release(pkt);
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_pktbuf_merge_data__success2(void)
+{
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, TEST_STRING4, sizeof(TEST_STRING4), GNRC_NETTYPE_TEST);
+    pkt = gnrc_pktbuf_add(pkt, TEST_STRING8, sizeof(TEST_STRING8), GNRC_NETTYPE_TEST);
+    pkt = gnrc_pktbuf_add(pkt, TEST_STRING16, sizeof(TEST_STRING16), GNRC_NETTYPE_TEST);
+
+    TEST_ASSERT_EQUAL_INT(0, gnrc_pktbuf_merge(pkt));
+    TEST_ASSERT_NULL(pkt->next);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING16, pkt->data);
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING8, (char *) pkt->data+sizeof(TEST_STRING16));
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING4, (char *) pkt->data+sizeof(TEST_STRING16)+sizeof(TEST_STRING8));
+    gnrc_pktbuf_release(pkt);
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+    TEST_ASSERT(gnrc_pktbuf_is_sane());
+}
+
 static void test_pktbuf_hold__pkt_null(void)
 {
     gnrc_pktbuf_hold(NULL, 1);
@@ -846,6 +884,9 @@ Test *tests_pktbuf_tests(void)
         new_TestFixture(test_pktbuf_realloc_data__success),
         new_TestFixture(test_pktbuf_realloc_data__success2),
         new_TestFixture(test_pktbuf_realloc_data__success3),
+        new_TestFixture(test_pktbuf_merge_data__memfull),
+        new_TestFixture(test_pktbuf_merge_data__success1),
+        new_TestFixture(test_pktbuf_merge_data__success2),
         new_TestFixture(test_pktbuf_hold__pkt_null),
         new_TestFixture(test_pktbuf_hold__pkt_external),
         new_TestFixture(test_pktbuf_hold__success),


### PR DESCRIPTION
This adds a ```gnrc_pktbuf_merge(gnrc_pktsnip_t *pkt)``` function.
It's main use is pulling data together in the memory to be able to use hash or crypto functions on the packet which take consecutive byte arrays as an input. This should make it easier to implement protocols like [IKE](https://en.wikipedia.org/wiki/Internet_Key_Exchange), [ESP](https://en.wikipedia.org/wiki/IPsec#Encapsulating_Security_Payload), [DTLS](https://en.wikipedia.org/wiki/Datagram_Transport_Layer_Security) and others using MAC.