### PR TITLE
pkg: quiet pkg builds

### DIFF
--- a/dist/tools/functions.sh
+++ b/dist/tools/functions.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# run arguments as command, only print output when command errors
+quiet() {
+    OUT="$("$@" 2>&1)"
+    RES=$?
+    [ -n "$OUT" ] && [ $RES -ne 0 -o "$QUIET" = "0" ] && echo "$OUT"
+    return $RES
+}

--- a/dist/tools/functions.sh
+++ b/dist/tools/functions.sh
@@ -3,14 +3,16 @@
 quote()
 {
     while [ $# -ne 0 ]; do
-        printf '%q\n' "$1"
+        printf "'"
+        printf '%s' "$1" | sed "s/'/'\\\\''/g"
+        printf "'\n"
         shift
     done
 }
 
 # run arguments as command, only print output when command errors
 quiet() {
-    OUT="$($(quote "$@") 2>&1)"
+    OUT="$(eval $(quote "$@") 2>&1)"
     RES=$?
     [ -n "$OUT" ] && [ $RES -ne 0 -o "$QUIET" = "0" ] && echo "$OUT"
     return $RES

--- a/dist/tools/functions.sh
+++ b/dist/tools/functions.sh
@@ -1,8 +1,16 @@
 #!/bin/sh
 
+quote()
+{
+    while [ $# -ne 0 ]; do
+        printf '%q\n' "$1"
+        shift
+    done
+}
+
 # run arguments as command, only print output when command errors
 quiet() {
-    OUT="$("$@" 2>&1)"
+    OUT="$($(quote "$@") 2>&1)"
     RES=$?
     [ -n "$OUT" ] && [ $RES -ne 0 -o "$QUIET" = "0" ] && echo "$OUT"
     return $RES

--- a/pkg/heatshrink/Makefile
+++ b/pkg/heatshrink/Makefile
@@ -5,6 +5,6 @@ PKG_VERSION=7d419e1fa4830d0b919b9b6a91fe2fb786cf3280
 .PHONY: all
 
 all: git-download
-	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.heatshrink
+	$(QQ)"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.heatshrink
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -43,3 +43,5 @@ clean::
 
 distclean::
 	$(Q)rm -rf "$(PKG_BUILDDIR)"
+
+endif

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -21,20 +21,19 @@ endif
 
 ifneq (,$(wildcard $(PKG_DIR)/patches))
 $(PKG_BUILDDIR)/.git-patched: $(PKG_BUILDDIR)/.git-downloaded $(PKG_DIR)/Makefile $(PKG_DIR)/patches/*.patch
-	git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION)
-	git -C $(PKG_BUILDDIR) am --ignore-whitespace "$(PKG_DIR)"/patches/*.patch
-	touch $@
+	$(Q)git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION)
+	$(Q)git -C $(PKG_BUILDDIR) am --ignore-whitespace "$(PKG_DIR)"/patches/*.patch
+	$(Q)touch $@
 endif
 
 $(PKG_BUILDDIR)/.git-downloaded:
-	rm -Rf $(PKG_BUILDDIR)
-	mkdir -p $(PKG_BUILDDIR)
-	$(GITCACHE) clone "$(PKG_URL)" "$(PKG_VERSION)" "$(PKG_BUILDDIR)"
-	$(GIT_APPLY_PATCHES)
-	touch $@
+	$(Q)rm -Rf $(PKG_BUILDDIR)
+	$(Q)mkdir -p $(PKG_BUILDDIR)
+	$(Q)$(GITCACHE) clone "$(PKG_URL)" "$(PKG_VERSION)" "$(PKG_BUILDDIR)"
+	$(Q)touch $@
 
 clean::
-	@test -d $(PKG_BUILDDIR) && { \
+	$(Q)test -d $(PKG_BUILDDIR) && { \
 		rm $(PKG_BUILDDIR)/.git-patched ; \
 		git -C $(PKG_BUILDDIR) clean -f ; \
 		git -C $(PKG_BUILDDIR) checkout "$(PKG_VERSION)"; \
@@ -43,6 +42,4 @@ clean::
 	} > /dev/null 2>&1 || true
 
 distclean::
-	rm -rf "$(PKG_BUILDDIR)"
-
-endif
+	$(Q)rm -rf "$(PKG_BUILDDIR)"

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -6,21 +6,29 @@ PKG_LICENSE=LGPL-2.1
 .PHONY: all
 
 all: $(PKG_BUILDDIR)/Makefile
-	"$(MAKE)" -C $(PKG_BUILDDIR) && \
-	cp $(PKG_BUILDDIR)/lib/librelic_s.a $(BINDIR)/$(PKG_NAME).a
+	$(QQ) . $(RIOTBASE)/dist/tools/functions.sh ; \
+		quiet "$(MAKE)" -C $(PKG_BUILDDIR)
+	$(Q)cp $(PKG_BUILDDIR)/lib/librelic_s.a $(BINDIR)/$(PKG_NAME).a
 
 $(PKG_BUILDDIR)/comp-options.cmake: fix_source
-	cd "$(PKG_BUILDDIR)" && perl $(PKG_DIR)/generate-cmake-xcompile.perl > comp-options.cmake
+	$(Q)cd "$(PKG_BUILDDIR)" && perl $(PKG_DIR)/generate-cmake-xcompile.perl > comp-options.cmake
 
 $(PKG_BUILDDIR)/Makefile: $(PKG_BUILDDIR)/comp-options.cmake
-	cd "$(PKG_BUILDDIR)" && COMP="$(filter-out -Werror=old-style-definition -Werror=strict-prototypes, $(CFLAGS) ) " cmake -DCMAKE_TOOLCHAIN_FILE=comp-options.cmake -DCHECK=off -DTESTS=0 -DBENCH=0 -DSHLIB=off -Wno-dev $(RELIC_CONFIG_FLAGS) .
+	$(Q) . $(RIOTBASE)/dist/tools/functions.sh ; \
+		cd "$(PKG_BUILDDIR)" && \
+		COMP="$(filter-out -Werror=old-style-definition -Werror=strict-prototypes, $(CFLAGS))" \
+			quiet cmake \
+				-DCMAKE_TOOLCHAIN_FILE=comp-options.cmake \
+				-DCHECK=off -DTESTS=0 -DBENCH=0 -DSHLIB=off \
+				-Wno-dev $(RELIC_CONFIG_FLAGS) .
 
 CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function -Wno-newline-eof
 
 fix_source: git-download
-	./fix-util_print_wo_args.sh $(PKG_BUILDDIR)
-	./fix-old-style-definitions.sh $(PKG_BUILDDIR)
+	$(Q)./fix-util_print_wo_args.sh $(PKG_BUILDDIR)
+	$(Q)./fix-old-style-definitions.sh $(PKG_BUILDDIR)
 
 clean::
 	@rm -rf $(BINDIR)/$(PKG_NAME).a
+
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
This PR

- prepends $(Q) to most pkg/pkg.mk lines
- adds a shell helper library containing a "quiet" helper in dist/tools/functions.sh
- quiets the relic build using that helper