### PR TITLE
boards/remotes: fix includes in board.h

### DIFF
--- a/boards/remote-pa/include/board.h
+++ b/boards/remote-pa/include/board.h
@@ -24,6 +24,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "board_common.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/boards/remote-reva/include/board.h
+++ b/boards/remote-reva/include/board.h
@@ -23,6 +23,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "board_common.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/boards/remote-revb/include/board.h
+++ b/boards/remote-revb/include/board.h
@@ -23,6 +23,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "board_common.h"
 
 #ifdef __cplusplus
  extern "C" {


### PR DESCRIPTION
Remote boards are not working on current master. `git bisect` pointed me to a commit and I systematically added the changes until I found out, these includes are missing. 