### PR TITLE
boards/nucle-f0xx: fixed timer configuration

### DIFF
--- a/boards/nucleo-f030/include/board.h
+++ b/boards/nucleo-f030/include/board.h
@@ -24,29 +24,18 @@
 #ifndef BOARD_H
 #define BOARD_H
 
-#include <stdint.h>
 #include "board_common.h"
-
-#include "cpu.h"
-#include "periph_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief   xtimer configuration
+ * @brief   Xtimer configuration
  * @{
  */
-#define XTIMER_WIDTH        (16)
+#define XTIMER_WIDTH                (16)
 /** @} */
-
-
-
-/**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
 
 #ifdef __cplusplus
 }

--- a/boards/nucleo-f030/include/periph_conf.h
+++ b/boards/nucleo-f030/include/periph_conf.h
@@ -49,31 +49,15 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev      = TIM14,
+        .dev      = TIM1,
         .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB1ENR_TIM14EN,
-        .bus      = APB1,
-        .irqn     = TIM14_IRQn
-    },
-    {
-        .dev      = TIM16,
-        .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB2ENR_TIM16EN,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
         .bus      = APB2,
-        .irqn     = TIM16_IRQn
-    },
-    {
-        .dev      = TIM17,
-        .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB2ENR_TIM17EN,
-        .bus      = APB2,
-        .irqn     = TIM17_IRQn
+        .irqn     = TIM1_CC_IRQn
     }
 };
 
-#define TIMER_0_ISR         (isr_tim14)
-#define TIMER_1_ISR         (isr_tim16)
-#define TIMER_2_ISR         (isr_tim17)
+#define TIMER_0_ISR         (isr_tim1_cc)
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */

--- a/boards/nucleo-f070/include/board.h
+++ b/boards/nucleo-f070/include/board.h
@@ -25,21 +25,18 @@
 #ifndef BOARD_H
 #define BOARD_H
 
-#include <stdint.h>
 #include "board_common.h"
-
-#include "cpu.h"
-#include "periph_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 /**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ * @brief   Xtimer configuration
+ * @{
  */
-void board_init(void);
+#define XTIMER_WIDTH                (16)
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/boards/nucleo-f070/include/periph_conf.h
+++ b/boards/nucleo-f070/include/periph_conf.h
@@ -49,31 +49,15 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev      = TIM14,
+        .dev      = TIM1,
         .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB1ENR_TIM14EN,
-        .bus      = APB1,
-        .irqn     = TIM14_IRQn
-    },
-    {
-        .dev      = TIM16,
-        .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB2ENR_TIM16EN,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
         .bus      = APB2,
-        .irqn     = TIM16_IRQn
-    },
-    {
-        .dev      = TIM17,
-        .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB2ENR_TIM17EN,
-        .bus      = APB2,
-        .irqn     = TIM17_IRQn
+        .irqn     = TIM1_CC_IRQn
     }
 };
 
-#define TIMER_0_ISR         isr_tim14
-#define TIMER_1_ISR         isr_tim16
-#define TIMER_2_ISR         isr_tim17
+#define TIMER_0_ISR         isr_tim1_cc
 
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))

--- a/boards/nucleo-f072/include/board.h
+++ b/boards/nucleo-f072/include/board.h
@@ -23,21 +23,18 @@
 #ifndef BOARD_H
 #define BOARD_H
 
-#include <stdint.h>
 #include "board_common.h"
-
-#include "cpu.h"
-#include "periph_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 /**
- * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ * @brief   Xtimer configuration
+ * @{
  */
-void board_init(void);
+#define XTIMER_WIDTH                (16)
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/boards/nucleo-f072/include/periph_conf.h
+++ b/boards/nucleo-f072/include/periph_conf.h
@@ -48,31 +48,15 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev      = TIM14,
+        .dev      = TIM1,
         .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB1ENR_TIM14EN,
-        .bus      = APB1,
-        .irqn     = TIM14_IRQn
-    },
-    {
-        .dev      = TIM16,
-        .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB2ENR_TIM16EN,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
         .bus      = APB2,
-        .irqn     = TIM16_IRQn
-    },
-    {
-        .dev      = TIM17,
-        .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB2ENR_TIM17EN,
-        .bus      = APB2,
-        .irqn     = TIM17_IRQn
+        .irqn     = TIM1_CC_IRQn
     }
 };
 
-#define TIMER_0_ISR         isr_tim14
-#define TIMER_1_ISR         isr_tim16
-#define TIMER_2_ISR         isr_tim17
+#define TIMER_0_ISR         isr_tim1_cc
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */

--- a/boards/nucleo-f091/include/board.h
+++ b/boards/nucleo-f091/include/board.h
@@ -28,6 +28,13 @@
 extern "C" {
 #endif
 
+/**
+ * @brief   Xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH                (16)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f091/include/periph_conf.h
+++ b/boards/nucleo-f091/include/periph_conf.h
@@ -47,15 +47,15 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev      = TIM14,
+        .dev      = TIM1,
         .max      = 0x0000ffff,
-        .rcc_mask = RCC_APB1ENR_TIM2EN,
-        .bus      = APB1,
-        .irqn     = TIM14_IRQn
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .bus      = APB2,
+        .irqn     = TIM1_CC_IRQn
     }
 };
 
-#define TIMER_0_ISR         isr_tim14
+#define TIMER_0_ISR         isr_tim1_cc
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */


### PR DESCRIPTION
Timers were broken on the nucleo-f0xx boards. The reason was a mixture of broken timer configuration and a miss-conception by the timer driver: the timer driver expects the configured timer to have exactly 4 capture compare channels. But apparently not all timers on the STM32F0s have 4 of them, some have only a single channel (e.g. TIM14), while other have 2 of them (e.g. TIM15/16/17).

This PR fixes the issue for now by choosing `TIM1` as default timer for all STM32F0 based nucleo boards.

I will also open an issue for adapting the timer driver to cope with non-4-cc-channel timers...