### PR TITLE
Make: newlib: use sh instead of exec/fork

### DIFF
--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -48,7 +48,7 @@ NEWLIB_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_PATTERNS)))
 # If nothing was found we will try to fall back to searching for a cross-gcc in
 # the current PATH and use a relative path for the includes
 ifeq (,$(NEWLIB_INCLUDE_DIR))
-  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell command -v $(PREFIX)gcc))../$(TARGET_ARCH)/include))
+  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell command -v $(PREFIX)gcc;))../$(TARGET_ARCH)/include))
 endif
 
 ifeq ($(TOOLCHAIN),llvm)


### PR DESCRIPTION
In some cases, `Make` is able to optimize the execution of a command in a recipe to not invoke the shell, but using exec/fork directly. This won't work however with shell built-ins, like it is the case for `command`. By adding a `;`, this command becomes "too complicated" for `Make` and is forced to invoke the shell. Can be verified by changing the `ifeq` (1 line above) to `ifneq`, otherwise this line will most likely never be executed in case your toolchain setup is as expected (several lines above).