### PR TITLE
cpu/cortexm: disable interrupts before sleeping

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -105,8 +105,10 @@ static inline void cortexm_sleep(int deep)
     }
 
     /* ensure that all memory accesses have completed and trigger sleeping */
+    __disable_irq();
     __DSB();
     __WFI();
+    __enable_irq();
 }
 
 /**


### PR DESCRIPTION
fixes #6484 (though temporarily for now)

A real fix will be provided with #6239