### PR TITLE
boards/nucleo-l1: use LSI as default RTC clock

### DIFF
--- a/boards/nucleo-l1/include/periph_conf.h
+++ b/boards/nucleo-l1/include/periph_conf.h
@@ -32,6 +32,7 @@ extern "C" {
  **/
 #define CLOCK_HSI           (16000000U)             /* frequency of internal oscillator */
 #define CLOCK_CORECLOCK     (32000000U)             /* targeted core clock frequency */
+#define CLOCK_HAS_LSE       (0)                     /* no external low-speed oscillator available */
 /* configuration of PLL prescaler and multiply values */
 /* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
 #define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2

--- a/boards/nucleo144-f746/Makefile.features
+++ b/boards/nucleo144-f746/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo144-f746/include/periph_conf.h
+++ b/boards/nucleo144-f746/include/periph_conf.h
@@ -139,6 +139,11 @@ static const uart_conf_t uart_config[] = {
 #define DAC_NUMOF           (0)
 /** @} */
 
+/**
+ * @brief   Enable the RTC
+ */
+#define RTC_NUMOF           (1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -233,6 +233,7 @@ void rtc_clear_alarm(void)
     rtc_callback.arg = NULL;
 }
 
+
 void rtc_poweron(void)
 {
 #if defined(CPU_FAM_STM32L1)
@@ -240,15 +241,21 @@ void rtc_poweron(void)
     RCC->CSR |= RCC_CSR_RTCRST;
     RCC->CSR &= ~(RCC_CSR_RTCRST);
 
+#if CLOCK_HAS_LSE
     /* Enable the LSE clock (external 32.768 kHz oscillator) */
     RCC->CSR &= ~(RCC_CSR_LSEON);
     RCC->CSR &= ~(RCC_CSR_LSEBYP);
     RCC->CSR |= RCC_CSR_LSEON;
     while ( (RCC->CSR & RCC_CSR_LSERDY) == 0 ) {}
-
     /* Switch RTC to LSE clock source */
     RCC->CSR &= ~(RCC_CSR_RTCSEL);
     RCC->CSR |= RCC_CSR_RTCSEL_LSE;
+#else
+    /* Enable the LSI clock */
+    RCC->CSR = RCC_CSR_LSION;
+    while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
+    RCC->CSR |= RCC_CSR_RTCSEL_LSI;
+#endif
 
     /* Enable the RTC */
     RCC->CSR |= RCC_CSR_RTCEN;

--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2015 Lari Lehtomäki
  *               2016 Laksh Bhatia
  *               2016-2017 OTA keys S.A.
+ *               2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -17,11 +18,13 @@
  * @author      Lari Lehtomäki <lari@lehtomaki.fi>
  * @author      Laksh Bhatia <bhatialaksh3@gmail.com>
  * @author      Vincent Dupont <vincent@otakeys.com>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @}
  */
 
 #include <time.h>
 #include "cpu.h"
+#include "stmclk.h"
 #include "periph/rtc.h"
 #include "periph_conf.h"
 
@@ -32,28 +35,51 @@
 /* guard file in case no RTC device was specified */
 #if RTC_NUMOF
 
-#define RTC_WRITE_PROTECTION_KEY1   (0xCA)
-#define RTC_WRITE_PROTECTION_KEY2   (0x53)
-
-#if CLOCK_HAS_LSE
-#define RTC_SYNC_PRESCALER          (0xff)  /**< prescaler for 32.768 kHz oscillator */
-#define RTC_ASYNC_PRESCALER         (0x7f)  /**< prescaler for 32.768 kHz oscillator */
+/* map some CPU specific register names */
+#ifdef CPU_FAM_STM32L1
+#define EN_REG              (RCC->CSR)
+#define EN_BIT              (RCC_CSR_RTCEN)
+#define CLKSEL_MASK         (RCC_CSR_RTCSEL)
+#define CLKSEL_LSE          (RCC_CSR_RTCSEL_LSE)
+#define CLKSEL_LSI          (RCC_CSR_RTCSEL_LSI)
 #else
-#if defined(CPU_FAM_STM32F0)
-#define RTC_SYNC_PRESCALER          (319)  /**< prescaler for 40 kHz oscillator */
-#define RTC_ASYNC_PRESCALER         (124)  /**< prescaler for 40 kHz oscillator */
-#elif defined(CPU_FAM_STM32L1)
-#define RTC_SYNC_PRESCALER          (295)  /**< prescaler for 37 kHz oscillator */
-#define RTC_ASYNC_PRESCALER         (124)  /**< prescaler for 37 kHz oscillator */
-#else
-#define RTC_SYNC_PRESCALER          (249)  /**< prescaler for 32 kHz oscillator */
-#define RTC_ASYNC_PRESCALER         (127)  /**< prescaler for 32 kHz oscillator */
+#define EN_REG              (RCC->BDCR)
+#define EN_BIT              (RCC_BDCR_RTCEN)
+#define CLKSEL_MASK         (RCC_BDCR_RTCSEL_Msk)
+#define CLKSEL_LSE          (RCC_BDCR_RTCSEL_0)
+#define CLKSEL_LSI          (RCC_BDCR_RTCSEL_1)
 #endif
-#endif /* CLOCK_HAS_LSE */
 
-#define MCU_YEAR_OFFSET              (100)  /**< struct tm counts years since 1900
-                                                but RTC has only two-digit year
-                                                hence the offset of 100 years. */
+#ifdef CPU_FAM_STM32F1
+#define IRQN                (RTC_IRQn)
+#else
+#define IRQN                (RTC_Alarm_IRQn)
+#endif
+
+/* write protection values */
+#define WPK1                (0xCA)
+#define WPK2                (0x53)
+
+/* figure out sync and async prescaler */
+#if CLOCK_LSE
+#define PRE_SYNC            (255)
+#define PRE_ASYNC           (127)
+#elif (CLOCK_LSI == 40000)
+#define PRE_SYNC            (319)
+#define PRE_ASYNC           (124)
+#elif (CLOCK_LSI == 37000)
+#define PRE_SYNC            (295)
+#define PRE_ASYNC           (124)
+#elif (CLOCK_LSI == 32000)
+#define PRE_SYNC            (249)
+#define PRE_ASYNC           (127)
+#else
+#error "rtc: unable to determine RTC SYNC and ASYNC prescalers from LSI value"
+#endif
+
+#define MCU_YEAR_OFFSET     (100)  /**< struct tm counts years since 1900
+                                        but RTC has only two-digit year
+                                        hence the offset of 100 years. */
 
 typedef struct {
     rtc_alarm_cb_t cb;          /**< callback called from RTC interrupt */
@@ -64,6 +90,28 @@ static rtc_state_t rtc_callback;
 
 static uint8_t byte2bcd(uint8_t value);
 
+static inline void rtc_unlock(void)
+{
+    /* enable backup clock domain */
+    stmclk_bdp_unlock();
+    /* unlock RTC */
+    RTC->WPR = WPK1;
+    RTC->WPR = WPK2;
+    /* enter RTC init mode */
+    RTC->ISR |= RTC_ISR_INIT;
+    while ((RTC->ISR & RTC_ISR_INITF) == 0) {}
+}
+
+static inline void rtc_lock(void)
+{
+    /* exit RTC init mode */
+    RTC->ISR &= ~RTC_ISR_INIT;
+    /* lock RTC device */
+    RTC->WPR = 0xff;
+    /* disable backup clock domain */
+    stmclk_bdp_lock();
+}
+
 /**
  * @brief Initializes the RTC to use LSE (external 32.768 kHz oscillator) as a
  * clocl source. Verify that your board has this oscillator. If other clock
@@ -71,34 +119,20 @@ static uint8_t byte2bcd(uint8_t value);
  */
 void rtc_init(void)
 {
-    /* Enable write access to RTC registers */
-    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-#if defined(CPU_FAM_STM32F7)
-    PWR->CR1 |= PWR_CR1_DBP;
+    /* enable low frequency clock */
+    stmclk_enable_lfclk();
+
+    /* select input clock and enable the RTC */
+    stmclk_bdp_unlock();
+    EN_REG &= ~(CLKSEL_MASK);
+#if CLOCK_LSE
+    EN_REG |= (CLKSEL_LSE | EN_BIT);
 #else
-    PWR->CR |= PWR_CR_DBP;
+    EN_REG |= (CLKSEL_LSI | EN_BIT);
 #endif
 
-#if CLOCK_HAS_LSE
-#if defined(CPU_FAM_STM32L1)
-    if (!(RCC->CSR & RCC_CSR_RTCEN)) {
-#else
-    if (!(RCC->BDCR & RCC_BDCR_RTCEN)) {
-#endif
-        rtc_poweron();
-    }
-#else
-    rtc_poweron();
-#endif
-
-    /* Unlock RTC write protection */
-    RTC->WPR = RTC_WRITE_PROTECTION_KEY1;
-    RTC->WPR = RTC_WRITE_PROTECTION_KEY2;
-
-    /* Enter RTC Init mode */
-    RTC->ISR = 0;
-    RTC->ISR |= RTC_ISR_INIT;
-    while ((RTC->ISR & RTC_ISR_INITF) == 0) {}
+    /* unlock the RTC */
+    rtc_unlock();
 
     /* Set 24-h clock */
     RTC->CR &= ~RTC_CR_FMT;
@@ -106,33 +140,19 @@ void rtc_init(void)
     RTC->CR |= RTC_CR_TSE;
 
     /* Configure the RTC PRER */
-    RTC->PRER = RTC_SYNC_PRESCALER;
-    RTC->PRER |= (RTC_ASYNC_PRESCALER << 16);
+    RTC->PRER = PRE_SYNC;
+    RTC->PRER |= (PRE_ASYNC << 16);
 
-    /* Exit RTC init mode */
-    RTC->ISR &= (uint32_t) ~RTC_ISR_INIT;
+    /* enable global RTC interrupt */
+    NVIC_EnableIRQ(IRQN);
+    /* @todo any need for adaption the default IRQ priority for the RTC? */
 
-    /* Enable RTC write protection */
-    RTC->WPR = 0xff;
+    rtc_lock();
 }
 
 int rtc_set_time(struct tm *time)
 {
-    /* Enable write access to RTC registers */
-    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-#if defined(CPU_FAM_STM32F7)
-    PWR->CR1 |= PWR_CR1_DBP;
-#else
-    PWR->CR |= PWR_CR_DBP;
-#endif
-
-    /* Unlock RTC write protection */
-    RTC->WPR = RTC_WRITE_PROTECTION_KEY1;
-    RTC->WPR = RTC_WRITE_PROTECTION_KEY2;
-
-    /* Enter RTC Init mode */
-    RTC->ISR |= RTC_ISR_INIT;
-    while ((RTC->ISR & RTC_ISR_INITF) == 0) {}
+    rtc_unlock();
 
     /* Set 24-h clock */
     RTC->CR &= ~RTC_CR_FMT;
@@ -145,10 +165,8 @@ int rtc_set_time(struct tm *time)
                (((uint32_t)byte2bcd(time->tm_min) <<  8) & (RTC_TR_MNT | RTC_TR_MNU)) |
                (((uint32_t)byte2bcd(time->tm_sec) <<  0) & (RTC_TR_ST | RTC_TR_SU)));
 
-    /* Exit RTC init mode */
-    RTC->ISR &= (uint32_t) ~RTC_ISR_INIT;
-    /* Enable RTC write protection */
-    RTC->WPR = 0xFF;
+    rtc_lock();
+
     return 0;
 }
 
@@ -176,21 +194,10 @@ int rtc_get_time(struct tm *time)
 
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
-    /* Enable write access to RTC registers */
-    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-#if defined(CPU_FAM_STM32F7)
-    PWR->CR1 |= PWR_CR1_DBP;
-#else
-    PWR->CR |= PWR_CR_DBP;
-#endif
+    rtc_unlock();
 
-    /* Unlock RTC write protection */
-    RTC->WPR = RTC_WRITE_PROTECTION_KEY1;
-    RTC->WPR = RTC_WRITE_PROTECTION_KEY2;
-
-    /* Enter RTC Init mode */
-    RTC->ISR |= RTC_ISR_INIT;
-    while ((RTC->ISR & RTC_ISR_INITF) == 0) {}
+    rtc_callback.cb = cb;
+    rtc_callback.arg = arg;
 
     RTC->CR &= ~(RTC_CR_ALRAE);
     while ((RTC->ISR & RTC_ISR_ALRAWF) == 0) {}
@@ -205,23 +212,10 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
     RTC->CR |= RTC_CR_ALRAIE;
     RTC->ISR &= ~(RTC_ISR_ALRAF);
 
-    /* Exit RTC init mode */
-    RTC->ISR &= (uint32_t) ~RTC_ISR_INIT;
-    /* Enable RTC write protection */
-    RTC->WPR = 0xFF;
-
     EXTI->IMR  |= EXTI_IMR_MR17;
     EXTI->RTSR |= EXTI_RTSR_TR17;
-#if defined(CPU_FAM_STM32F0)
-    NVIC_SetPriority(RTC_IRQn, 10);
-    NVIC_EnableIRQ(RTC_IRQn);
-#else
-    NVIC_SetPriority(RTC_Alarm_IRQn, 10);
-    NVIC_EnableIRQ(RTC_Alarm_IRQn);
-#endif
 
-    rtc_callback.cb = cb;
-    rtc_callback.arg = arg;
+    rtc_lock();
 
     return 0;
 }
@@ -254,92 +248,23 @@ void rtc_clear_alarm(void)
 
 void rtc_poweron(void)
 {
-#if defined(CPU_FAM_STM32L1)
-    /* Reset RTC domain */
-    RCC->CSR |= RCC_CSR_RTCRST;
-    RCC->CSR &= ~(RCC_CSR_RTCRST);
-
-#if CLOCK_HAS_LSE
-    /* Enable the LSE clock (external 32.768 kHz oscillator) */
-    RCC->CSR &= ~(RCC_CSR_LSEON);
-    RCC->CSR &= ~(RCC_CSR_LSEBYP);
-    RCC->CSR |= RCC_CSR_LSEON;
-    while ( (RCC->CSR & RCC_CSR_LSERDY) == 0 ) {}
-    /* Switch RTC to LSE clock source */
-    RCC->CSR &= ~(RCC_CSR_RTCSEL);
-    RCC->CSR |= RCC_CSR_RTCSEL_LSE;
-#else
-    /* Enable the LSI clock */
-    RCC->CSR = RCC_CSR_LSION;
-    while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
-    RCC->CSR |= RCC_CSR_RTCSEL_LSI;
-#endif
-
-    /* Enable the RTC */
-    RCC->CSR |= RCC_CSR_RTCEN;
-#else
-    /* Reset RTC domain */
-    RCC->BDCR |= RCC_BDCR_BDRST;
-    RCC->BDCR &= ~(RCC_BDCR_BDRST);
-
-#if CLOCK_HAS_LSE
-    /* Enable the LSE clock (external 32.768 kHz oscillator) */
-    RCC->BDCR &= ~(RCC_BDCR_LSEON);
-    RCC->BDCR &= ~(RCC_BDCR_LSEBYP);
-    RCC->BDCR |= RCC_BDCR_LSEON;
-    while ((RCC->BDCR & RCC_BDCR_LSERDY) == 0) {}
-
-    /* Switch RTC to LSE clock source */
-    RCC->BDCR &= ~(RCC_BDCR_RTCSEL);
-    RCC->BDCR |= RCC_BDCR_RTCSEL_0;
-#else
-    /* Enable the LSI clock */
-    RCC->CSR = RCC_CSR_LSION;
-    while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
-    RCC->BDCR |= RCC_BDCR_RTCSEL_1;
-#endif
-    /* Enable the RTC */
-    RCC->BDCR |= RCC_BDCR_RTCEN;
-#endif
+    /* enable write access to RTC registers -> unlock backup power domain */
+    stmclk_bdp_unlock();
+    /* enable RTC */
+    EN_REG |= EN_BIT;
+    stmclk_bdp_lock();
 }
 
 void rtc_poweroff(void)
 {
-#if defined(CPU_FAM_STM32L1)
-    /* Reset RTC domain */
-    RCC->CSR |= RCC_CSR_RTCRST;
-    RCC->CSR &= ~(RCC_CSR_RTCRST);
-    /* Disable the RTC */
-    RCC->CSR &= ~RCC_CSR_RTCEN;
-#if CLOCK_HAS_LSE
-    /* Disable LSE clock */
-    RCC->CSR &= ~(RCC_CSR_LSEON);
-#else
-    /* Disable LSI clock */
-    RCC->CSR &= ~(RCC_CSR_LSION);
-#endif
-#else
-    /* Reset RTC domain */
-    RCC->BDCR |= RCC_BDCR_BDRST;
-    RCC->BDCR &= ~(RCC_BDCR_BDRST);
-    /* Disable the RTC */
-    RCC->BDCR &= ~RCC_BDCR_RTCEN;
-#if CLOCK_HAS_LSE
-    /* Disable LSE clock */
-    RCC->BDCR &= ~(RCC_BDCR_LSEON);
-#else
-    /* Disable LSI clock */
-    RCC->CSR &= ~(RCC_CSR_LSION);
-#endif
-#endif
+    stmclk_bdp_unlock();
+    EN_REG &= ~EN_BIT;
+    stmclk_bdp_lock();
 }
 
-#if defined(CPU_FAM_STM32F0)
-void isr_rtc(void)
-#else
 void isr_rtc_alarm(void)
-#endif
 {
+    /* @todo do we need access to the backup clock domain when playing around here? */
     if (RTC->ISR & RTC_ISR_ALRAF) {
         if (rtc_callback.cb != NULL) {
             rtc_callback.cb(rtc_callback.arg);

--- a/cpu/stm32f0/include/cpu_conf.h
+++ b/cpu/stm32f0/include/cpu_conf.h
@@ -83,6 +83,11 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @brief   LSI clock speed [in Hz]
+ */
+#define CLOCK_LSI                       (40000U)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f0/vectors.c
+++ b/cpu/stm32f0/vectors.c
@@ -37,7 +37,7 @@ WEAK_DEFAULT void isr_systick(void);
 /* STM32F0 specific interrupt vectors */
 WEAK_DEFAULT void isr_wwdg(void);
 WEAK_DEFAULT void isr_pvd(void);
-WEAK_DEFAULT void isr_rtc(void);
+WEAK_DEFAULT void isr_rtc_alarm(void);
 WEAK_DEFAULT void isr_flash(void);
 WEAK_DEFAULT void isr_rcc(void);
 WEAK_DEFAULT void isr_exti(void);
@@ -90,7 +90,7 @@ ISR_VECTORS const void *interrupt_vector[] = {
     /* STM specific peripheral handlers */
     (void*) isr_wwdg,               /* windowed watchdog */
     (void*) isr_pvd,                /* power control */
-    (void*) isr_rtc,                /* real time clock */
+    (void*) isr_rtc_alarm,          /* real time clock */
     (void*) isr_flash,              /* flash memory controller */
     (void*) isr_rcc,                /* reset and clock control */
     (void*) isr_exti,               /* external interrupt lines 0 and 1 */

--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -60,6 +60,11 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   LSI clock speed [in Hz]
+ */
+#define CLOCK_LSI                       (32000U)
+
+/**
  * @brief Configure the CPU's clock system
  *
  * @param[in] source    source clock frequency

--- a/cpu/stm32f7/include/cpu_conf.h
+++ b/cpu/stm32f7/include/cpu_conf.h
@@ -45,6 +45,11 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @brief   LSI clock speed [in Hz]
+ */
+#define CLOCK_LSI                       (37000U)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -38,6 +38,11 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
+/**
+ * @brief   LSI clock speed [in Hz]
+ */
+#define CLOCK_LSI                       (37000U)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
fixes #6502
~~rebased on #6499 (needed for testing)~~

seems like not all `nucleo-l1` boards have an external low-speed oscillator (LSE) attached. So I propose to make it configurable in the board's periph_conf and choose the LSI (internal low-speed oscillator) per default.