### PR TITLE
sys/xtimer: allow frequencies multiple of 921600Hz

### DIFF
--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -253,10 +253,8 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
 #else
 #error Unknown hardware timer frequency (XTIMER_HZ), check board.h and/or add an implementation in sys/include/xtimer/tick_conversion.h
 #endif
-/*
- * End of optimisations
- */
-#endif
+
+#endif /* XTIMER_HZ == 1MHz */
 
 #ifdef __cplusplus
 }

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -132,7 +132,7 @@ inline static uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
  */
 #endif
 /*
- * Now, check if XTIMER_HZ is a frequency multiple of 1MHz (or 15675, which is
+ * Now, check if XTIMER_HZ is a frequency multiple of 1MHz (or 15625, which is
  * a lower divisor for lower frequencies, e.g. 32768)
  */
 #elif (XTIMER_HZ % 15625 == 0)


### PR DESCRIPTION
This PR will add xtimer compatibility for boards running at frequencies multiple of 576 (e.g. waspmote-pro running at 14.7456 MHz with timers prescaled to this frequency).

Partially (re) fixes #5597. An upcoming PR will fix the xtimer configuration on the waspmote.