### PR TITLE
tcp: move header file and adapt includes

### DIFF
--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -22,9 +22,9 @@
 #ifndef GNRC_TCP_H_
 #define GNRC_TCP_H_
 
+#include "net/tcp.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/nettype.h"
-#include "net/gnrc/tcp/hdr.h"
 #include "net/gnrc/tcp/tcb.h"
 
 #ifdef MODULE_GNRC_IPV6

--- a/sys/include/net/tcp.h
+++ b/sys/include/net/tcp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Simon Brummer
+ * Copyright (C) 2017 Simon Brummer
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,20 +7,20 @@
  */
 
 /**
- * @defgroup    net_gnrc_tcp TCP
- * @ingroup     net_gnrc
- * @brief       RIOT's tcp implementation for the gnrc stack
+ * @defgroup    net_tcp TCP
+ * @ingroup     net
+ * @brief       Provides TCP header and helper functions
  *
  * @{
  *
  * @file
- * @brief      TCP Header
+ * @brief      TCP header and helper functions
  *
  * @author     Simon Brummer <brummer.simon@googlemail.com>
  */
 
-#ifndef GNRC_TCP_HDR_H_
-#define GNRC_TCP_HDR_H_
+#ifndef TCP_H
+#define TCP_H
 
 #include "byteorder.h"
 
@@ -52,5 +52,5 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* GNRC_TCP_TCB_H_ */
+#endif /* TCP_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -20,9 +20,9 @@
 #include <utlist.h>
 #include <errno.h>
 #include "net/af.h"
+#include "net/tcp.h"
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/tcp.h"
-#include "net/gnrc/tcp/hdr.h"
 #include "internal/pkt.h"
 #include "internal/fsm.h"
 #include "internal/helper.h"

--- a/sys/net/gnrc/transport_layer/tcp/internal/helper.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/helper.h
@@ -22,8 +22,8 @@
 #ifndef GNRC_TCP_INTERNAL_HELPER_H_
 #define GNRC_TCP_INTERNAL_HELPER_H_
 
+#include "net/tcp.h"
 #include "net/gnrc/netapi.h"
-#include "net/gnrc/tcp/hdr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/net/gnrc/transport_layer/tcp/internal/option.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/option.h
@@ -23,8 +23,8 @@
 #define GNRC_TCP_INTERNAL_OPTION_H_
 
 #include "helper.h"
+#include "net/tcp.h"
 #include "net/gnrc/tcp.h"
-#include "net/gnrc/tcp/hdr.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
moves the TCP header definition and file into a common location, similar to UDP. 

Rational: the TCP header definition and struct is **not** GNRC specific, but might be (re)used by other (non-gnrc) parts in RIOT as well.