### PR TITLE
Refactors uart_stdio<funct> to more generic stdio_<func> interface

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -367,7 +367,8 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   ifeq (,$(filter newlib_syscalls_%,$(USEMODULE)))
     USEMODULE += newlib_syscalls_default
   endif
-  ifeq (,$(filter rtt_stdio,$(USEMODULE)))
+  # if there is no stdio module, default to UART
+  ifeq (,$(filter %_stdio,$(USEMODULE)))
     USEMODULE += uart_stdio
   endif
 endif
@@ -383,6 +384,10 @@ ifneq (,$(filter rtt_stdio,$(USEMODULE)))
 endif
 
 ifneq (,$(filter uart_stdio,$(USEMODULE)))
+  USEMODULE += isrpipe
+endif
+
+ifneq (,$(filter ethos_stdio,$(USEMODULE)))
   USEMODULE += isrpipe
 endif
 

--- a/boards/arduino-atmega-common/board.c
+++ b/boards/arduino-atmega-common/board.c
@@ -60,7 +60,7 @@ void board_init(void)
 void SystemInit(void)
 {
     /* initialize UART_0 for use as stdout */
-    uart_stdio_init();
+    stdio_init();
 
     stdout = &uart_stdout;
     stdin = &uart_stdin;
@@ -72,7 +72,7 @@ void SystemInit(void)
 static int uart_putchar(char c, FILE *stream)
 {
     (void) stream;
-    uart_stdio_write(&c, 1);
+    stdio_write(&c, 1);
     return 0;
 }
 
@@ -80,6 +80,6 @@ int uart_getchar(FILE *stream)
 {
     (void) stream;
     char c;
-    uart_stdio_read(&c, 1);
+    stdio_read(&c, 1);
     return (int)c;
 }

--- a/boards/msb-430-common/board_init.c
+++ b/boards/msb-430-common/board_init.c
@@ -23,7 +23,7 @@
 #include "cpu.h"
 #include "irq.h"
 #include "board.h"
-#include "uart_stdio.h"
+#include "riot_stdio.h"
 #include "periph_conf.h"
 #include "msp430.h"
 #include "debug.h"
@@ -202,5 +202,5 @@ void board_init(void)
     msp430_set_cpu_speed(CLOCK_CORECLOCK);
 
     /* finally initialize STDIO over UART */
-    uart_stdio_init();
+    stdio_init();
 }

--- a/boards/telosb/board.c
+++ b/boards/telosb/board.c
@@ -9,7 +9,7 @@
 
 #include "cpu.h"
 #include "board.h"
-#include "uart_stdio.h"
+#include "riot_stdio.h"
 
 void uart_init(void);
 
@@ -123,7 +123,7 @@ void board_init(void)
     msp430_init_dco();
 
     /* initialize STDIO over UART */
-    uart_stdio_init();
+    stdio_init();
 
     /* enable interrupts */
     __bis_SR_register(GIE);

--- a/boards/waspmote-pro/board.c
+++ b/boards/waspmote-pro/board.c
@@ -27,7 +27,7 @@
 
 #include "board.h"
 #include "cpu.h"
-#include "uart_stdio.h"
+#include "riot_stdio.h"
 
 void led_init(void);
 void SystemInit(void);
@@ -89,7 +89,7 @@ void led_init(void)
 void SystemInit(void)
 {
     /* initialize UART_0 for use as stdout */
-    uart_stdio_init();
+    stdio_init();
 
     stdout = &uart_stdout;
     stdin = &uart_stdin;
@@ -101,7 +101,7 @@ void SystemInit(void)
 static int uart_putchar(char c, FILE *stream)
 {
     (void) stream;
-    uart_stdio_write(&c, 1);
+    stdio_write(&c, 1);
     return 0;
 }
 
@@ -109,6 +109,6 @@ int uart_getchar(FILE *stream)
 {
     (void) stream;
     char c;
-    uart_stdio_read(&c, 1);
+    stdio_read(&c, 1);
     return (int)c;
 }

--- a/boards/wsn430-common/board_init.c
+++ b/boards/wsn430-common/board_init.c
@@ -12,7 +12,7 @@
 #include "board.h"
 #include "msp430.h"
 #include "debug.h"
-#include "uart_stdio.h"
+#include "riot_stdio.h"
 
 volatile static uint32_t __msp430_cpu_speed = MSP430_INITIAL_CPU_SPEED;
 
@@ -110,5 +110,5 @@ void board_init(void)
     msp430_set_cpu_speed(MCLK_8MHZ_SCLK_8MHZ);
 
     /* initialize STDIO over UART */
-    uart_stdio_init();
+    stdio_init();
 }

--- a/boards/z1/board.c
+++ b/boards/z1/board.c
@@ -24,7 +24,7 @@
 
 #include "cpu.h"
 #include "board.h"
-#include "uart_stdio.h"
+#include "riot_stdio.h"
 
 static void z1_ports_init(void)
 {
@@ -216,7 +216,7 @@ void board_init(void)
     msp430_init_dco();
 
     /* initialize STDIO over UART */
-    uart_stdio_init();
+    stdio_init();
 
     /* enable interrupts */
     __bis_SR_register(GIE);

--- a/cpu/msp430fxyz/msp430_stdio.c
+++ b/cpu/msp430fxyz/msp430_stdio.c
@@ -21,7 +21,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "uart_stdio.h"
+#include "riot_stdio.h"
 
 /**
  * @brief   Get one character from STDIO - used by the libc
@@ -29,7 +29,7 @@
 int getchar(void)
 {
     char c;
-    uart_stdio_read(&c, 1);
+    stdio_read(&c, 1);
     return c;
 }
 
@@ -40,7 +40,7 @@ int getchar(void)
 int putchar(int c)
 {
     char _c = c;
-    return uart_stdio_write(&_c, 1);
+    return stdio_write(&_c, 1);
 }
 
 /**
@@ -49,7 +49,7 @@ int putchar(int c)
 ssize_t write(int fildes, const void *buf, size_t nbyte)
 {
     if (fildes == STDOUT_FILENO) {
-        return uart_stdio_write(buf, nbyte);
+        return stdio_write(buf, nbyte);
     }
     else {
         return -1;

--- a/dist/tools/ethos/README.md
+++ b/dist/tools/ethos/README.md
@@ -8,8 +8,8 @@ To use, add
 
     #
     GNRC_NETIF_NUMOF := 2
-    USEMODULE += ethos gnrc_netdev2
-    CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=115200 -DUSE_ETHOS_FOR_STDIO
+    USEMODULE += ethos ethos_stdio gnrc_netdev2
+    CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=115200
 
 to app Makefile, "make clean all flash", then run this tool so follows:
     # sudo ./ethos <tap-device> <serial>

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -33,10 +33,10 @@
 #include "net/eui64.h"
 #include "net/ethernet.h"
 
-#ifdef USE_ETHOS_FOR_STDIO
-#include "uart_stdio.h"
+#ifdef MODULE_ETHOS_STDIO
+#include "riot_stdio.h"
 #include "isrpipe.h"
-extern isrpipe_t uart_stdio_isrpipe;
+extern isrpipe_t ethos_stdio_isrpipe;
 #endif
 
 #define ENABLE_DEBUG (0)
@@ -48,7 +48,6 @@ static const netdev2_driver_t netdev2_driver_ethos;
 
 static const uint8_t _esc_esc[] = {ETHOS_ESC_CHAR, (ETHOS_ESC_CHAR ^ 0x20)};
 static const uint8_t _esc_delim[] = {ETHOS_ESC_CHAR, (ETHOS_FRAME_DELIMITER ^ 0x20)};
-
 
 void ethos_setup(ethos_t *dev, const ethos_params_t *params)
 {
@@ -99,10 +98,10 @@ static void _handle_char(ethos_t *dev, char c)
                 _reset_state(dev);
             }
             break;
-#ifdef USE_ETHOS_FOR_STDIO
+#ifdef MODULE_ETHOS_STDIO
         case ETHOS_FRAME_TYPE_TEXT:
             dev->framesize++;
-            isrpipe_write_one(&uart_stdio_isrpipe, c);
+            isrpipe_write_one(&ethos_stdio_isrpipe, c);
 #endif
     }
 }

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -31,15 +31,9 @@
 extern "C" {
 #endif
 
-/* if using ethos + stdio, use UART_STDIO values unless overridden */
-#ifdef USE_ETHOS_FOR_STDIO
-#include "uart_stdio.h"
-#ifndef ETHOS_UART
-#define ETHOS_UART     UART_STDIO_DEV
-#endif
-#ifndef ETHOS_BAUDRATE
-#define ETHOS_BAUDRATE UART_STDIO_BAUDRATE
-#endif
+/* if using ethos + stdio */
+#ifdef MODULE_ETHOS_STDIO
+#include "riot_stdio.h"
 #endif
 
 /**

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -18,11 +18,11 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon cc2650stk maple-mini msb-430 msb-430h 
 # UART, but not on native, as native has a tap interface towards the host.
 ifeq (,$(filter native,$(BOARD)))
 GNRC_NETIF_NUMOF := 2
-USEMODULE += ethos gnrc_netdev2
+USEMODULE += ethos ethos_stdio gnrc_netdev2
 
 # ethos baudrate can be configured from make command
 ETHOS_BAUDRATE ?= 115200
-CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
+CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
 FEATURES_REQUIRED += periph_uart
 endif
 

--- a/examples/gnrc_border_router/README.md
+++ b/examples/gnrc_border_router/README.md
@@ -101,8 +101,8 @@ has the following:
 ```make
 ifeq (,$(filter native,$(BOARD)))
 GNRC_NETIF_NUMOF := 2
-USEMODULE += ethos gnrc_netdev2
-CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=115200 -DUSE_ETHOS_FOR_STDIO
+USEMODULE += ethos ethos_stdio gnrc_netdev2
+CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=115200
 FEATURES_REQUIRED += periph_uart
 endif
 # include UHCP client

--- a/sys/auto_init/netif/auto_init_ethos.c
+++ b/sys/auto_init/netif/auto_init_ethos.c
@@ -27,7 +27,7 @@
 #include "net/gnrc/netdev2/eth.h"
 
 /**
- * @brief global ethos object, used by uart_stdio
+ * @brief global ethos object, used by ethos_stdio
  */
 ethos_t ethos;
 

--- a/sys/ethos_stdio/Makefile
+++ b/sys/ethos_stdio/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/ethos_stdio/ethos_stdio.c
+++ b/sys/ethos_stdio/ethos_stdio.c
@@ -15,7 +15,7 @@
  * @file
  * @brief UART stdio implementation
  *
- * This file implements a UART callback and read/write functions.
+ * This file implements ETHOS stdio read/write functions.
  *
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
@@ -30,27 +30,29 @@
 #include "riot_stdio.h"
 
 #include "board.h"
-#include "periph/uart.h"
 #include "isrpipe.h"
+
+#include "ethos.h"
+extern ethos_t ethos;
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-static char _rx_buf_mem[UART_STDIO_RX_BUFSIZE];
-isrpipe_t uart_stdio_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
+static char _rx_buf_mem[ETHOS_RX_BUFSIZE];
+isrpipe_t ethos_stdio_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
 
 void stdio_init(void)
 {
-    uart_init(UART_STDIO_DEV, UART_STDIO_BAUDRATE, (uart_rx_cb_t) isrpipe_write_one, &uart_stdio_isrpipe);
+    uart_init(ETHOS_UART, ETHOS_BAUDRATE, (uart_rx_cb_t) isrpipe_write_one, &ethos_stdio_isrpipe);
 }
 
 int stdio_read(char* buffer, int count)
 {
-    return isrpipe_read(&uart_stdio_isrpipe, buffer, count);
+    return isrpipe_read(&ethos_stdio_isrpipe, buffer, count);
 }
 
 int stdio_write(const char* buffer, int len)
 {
-    uart_write(UART_STDIO_DEV, (uint8_t *)buffer, (size_t)len);
+    ethos_send_frame(&ethos, (uint8_t*)buffer, len, ETHOS_FRAME_TYPE_TEXT);
     return len;
 }

--- a/sys/include/ethos_stdio.h
+++ b/sys/include/ethos_stdio.h
@@ -7,10 +7,10 @@
  */
 
 /**
- * @defgroup    sys_uart_stdio UART stdio
+ * @defgroup    sys_ethos_stdio ETHOS stdio
  * @ingroup     sys_stdio
  *
- * @brief       stdio over UART defines
+ * @brief       stdio over ETHOS defines
  *
  * @{
  * @file
@@ -18,40 +18,44 @@
  * @author      Anthony Merlino  <anthony@vergeaero.com>
  */
 
-#ifndef UART_STDIO_H
-#define UART_STDIO_H
+#ifndef ETHOS_STDIO_H
+#define ETHOS_STDIO_H
 
 /* Boards may override the default STDIO UART device */
 #include <stdint.h>
 #include "board.h"
 
+/* ETHOS defaults to use UART defines if not overridden */
+#include "uart_stdio.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifndef UART_STDIO_DEV
+#ifndef ETHOS_UART
 /**
  * @brief UART device to use for STDIO
  */
-#define UART_STDIO_DEV           UART_DEV(0)
+#define ETHOS_UART          UART_STDIO_DEV
 #endif
 
-#ifndef UART_STDIO_BAUDRATE
+#ifndef ETHOS_BAUDRATE
 /**
  * @brief Baudrate for STDIO
  */
-#define UART_STDIO_BAUDRATE      (115200)
+#define ETHOS_BAUDRATE      UART_STDIO_BAUDRATE
 #endif
 
-#ifndef UART_STDIO_RX_BUFSIZE
+#ifndef ETHOS_RX_BUFSIZE
 /**
  * @brief Buffer size for STDIO
  */
-#define UART_STDIO_RX_BUFSIZE    (64)
+#define ETHOS_RX_BUFSIZE    UART_STDIO_RX_BUFSIZE
 #endif
 
 #ifdef __cplusplus
 }
 #endif
+
 /** @} */
-#endif /* UART_STDIO_H */
+#endif /* ETHOS_STDIO_H */

--- a/sys/include/riot_stdio.h
+++ b/sys/include/riot_stdio.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_stdio RIOT stdio
+ * @ingroup     sys
+ *
+ * @brief       stdio init/read/write functions
+ *
+ * @{
+ * @file
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Anthony Merlino  <anthony@vergeaero.com>
+ */
+#ifndef RIOT_STDIO_H
+#define RIOT_STDIO_H
+
+#include <stdint.h>
+
+#ifdef MODULE_UART_STDIO
+#include "uart_stdio.h"
+#endif
+
+#ifdef MODULE_RTT_STDIO
+#include "rtt_stdio.h"
+#endif
+
+#ifdef MODULE_ETHOS_STDIO
+#include "ethos_stdio.h"
+#endif
+
+/**
+ * @brief initialize the module
+ */
+void stdio_init(void);
+
+/**
+ * @brief read @p len bytes from stdio into @p buffer
+ *
+ * @param[out]  buffer  buffer to read into
+ * @param[in]   len     nr of bytes to read
+ *
+ * @return nr of bytes read
+ * @return <0 on error
+ */
+int stdio_read(char* buffer, int len);
+
+/**
+ * @brief write @p len bytes from @p buffer
+ *
+ * @param[in]   buffer  buffer to read from
+ * @param[in]   len     nr of bytes to write
+ *
+ * @return nr of bytes written
+ * @return <0 on error
+ */
+int stdio_write(const char* buffer, int len);
+
+/** @} */
+#endif /* RIOT_STDIO_H */

--- a/sys/include/rtt_stdio.h
+++ b/sys/include/rtt_stdio.h
@@ -8,15 +8,15 @@
 
 /**
  * @defgroup    sys_rtt_stdio SEGGER RTT stdio
- * @ingroup     sys
+ * @ingroup     sys_stdio
  *
- * @brief       stdio init/read/write functions for SEGGER RTT. This is
- *              designed to shadow the functions in uart_stdio
+ * @brief       stdio init/read/write functions for SEGGER RTT.
  *
  * @{
  * @file
  *
  * @author      Michael Andersen <m.andersen@cs.berkeley.edu>
+ *
  */
 #ifndef RTT_STDIO_H
 #define RTT_STDIO_H
@@ -24,33 +24,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief initialize the module. This is a noop.
- */
-void uart_stdio_init(void);
-
-/**
- * @brief read @p len bytes from stdio uart into @p buffer
- *
- * @param[out]  buffer  buffer to read into
- * @param[in]   len     nr of bytes to read
- *
- * @return nr of bytes read
- * @return <0 on error
- */
-int uart_stdio_read(char* buffer, int len);
-
-/**
- * @brief write @p len bytes from @p buffer into uart
- *
- * @param[in]   buffer  buffer to read from
- * @param[in]   len     nr of bytes to write
- *
- * @return nr of bytes written
- * @return <0 on error
- */
-int uart_stdio_write(const char* buffer, int len);
 
 /**
  * @brief enable stdin polling, at a power consumption cost. This is enabled

--- a/sys/newlib/syscalls.c
+++ b/sys/newlib/syscalls.c
@@ -40,7 +40,7 @@
 #include "log.h"
 #include "periph/pm.h"
 
-#include "uart_stdio.h"
+#include "riot_stdio.h"
 
 #ifdef MODULE_XTIMER
 #include <sys/time.h>
@@ -60,7 +60,7 @@ char *heap_top = &_sheap + 4;
  */
 void _init(void)
 {
-    uart_stdio_init();
+    stdio_init();
 }
 
 /**
@@ -191,7 +191,7 @@ _ssize_t _read_r(struct _reent *r, int fd, void *buffer, size_t count)
 {
     (void)r;
     (void)fd;
-    return uart_stdio_read(buffer, count);
+    return stdio_read(buffer, count);
 }
 
 /**
@@ -213,7 +213,7 @@ _ssize_t _write_r(struct _reent *r, int fd, const void *data, size_t count)
 {
     (void) r;
     (void) fd;
-    return uart_stdio_write(data, count);
+    return stdio_write(data, count);
 }
 
 /**

--- a/sys/rtt_stdio/rtt_stdio.c
+++ b/sys/rtt_stdio/rtt_stdio.c
@@ -67,7 +67,7 @@
  * @file
  * @brief SEGGER RTT stdio implementation
  *
- * This file implements UART read/write functions, but it
+ * This file implements read/write functions, but it
  * is actually a virtual UART backed by a ringbuffer that
  * complies with SEGGER RTT. It is designed to shadow
  * uart_stdio that is used by newlib.
@@ -79,8 +79,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <rtt_stdio.h>
 
+#include "riot_stdio.h"
 #include "thread.h"
 #include "mutex.h"
 #include "xtimer.h"
@@ -277,7 +277,7 @@ int rtt_write(const char* buf_ptr, unsigned num_bytes) {
     return num_bytes_written;
 }
 
-void uart_stdio_init(void) {
+void stdio_init(void) {
     #ifndef RTT_STDIO_DISABLE_STDIN
     stdin_enabled = 1;
     #endif
@@ -305,7 +305,7 @@ void rtt_stdio_enable_blocking_stdout(void) {
    actually have an RTT console (because we are deployed on
    a battery somewhere) then we REALLY don't want to poll
    especially since we are not expecting to EVER get input. */
-int uart_stdio_read(char* buffer, int count) {
+int stdio_read(char* buffer, int count) {
     int res = rtt_read(buffer, count);
     if (res == 0) {
         if (!stdin_enabled) {
@@ -324,7 +324,7 @@ int uart_stdio_read(char* buffer, int count) {
     return res;
 }
 
-int uart_stdio_write(const char* buffer, int len) {
+int stdio_write(const char* buffer, int len) {
     int written = rtt_write(buffer, len);
     xtimer_ticks32_t last_wakeup = xtimer_now();
     while (blocking_stdout && written < len) {

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -28,7 +28,7 @@
 #include "msg.h"
 #include "ringbuffer.h"
 #include "periph/uart.h"
-#include "uart_stdio.h"
+#include "riot_stdio.h"
 
 #define SHELL_BUFSIZE       (128U)
 #define UART_BUFSIZE        (128U)


### PR DESCRIPTION
See issue #6510 for details.

Renames uart_stdio.h to riot_stdio.h
Renames uart_stdio_init to stdio_init
Renames uart_stdio_read to stdio_read
Renames uart_stdio_write to stdio_write
Removes unused uart_stdio_rx_cb
Moves ethos_stdio configuration to be it's own module
Removes ethos code from uart_stdio
Adds appopriate stdio includes from riot_stdio.h depending on module includes.
Adds new uart_stdio.h and ethos_stdio.h includes to sys/include/