### PR TITLE
boards: *: remove SPI_*_EN as comments suggest

### DIFF
--- a/boards/arduino-common/include/periph_conf.h
+++ b/boards/arduino-common/include/periph_conf.h
@@ -79,7 +79,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           1           /* set to 0 to disable SPI */
-#define SPI_0_EN            1           /* remove once SPI rework is done */
 #define MEGA_PRR            PRR         /* Power Reduction Register is PRR */
 /** @} */
 

--- a/boards/arduino-mega2560/include/periph_conf.h
+++ b/boards/arduino-mega2560/include/periph_conf.h
@@ -96,7 +96,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           1           /* set to 0 to disable SPI */
-#define SPI_0_EN            1           /* remove once SPI rework is done */
 #define MEGA_PRR            PRR0        /* Power Reduction Register is PRR0 */
 /** @} */
 

--- a/boards/avsextrem/include/periph_conf.h
+++ b/boards/avsextrem/include/periph_conf.h
@@ -60,7 +60,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           (1U)
-#define SPI_0_EN            (1)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/msb-430/include/periph_conf.h
+++ b/boards/msb-430/include/periph_conf.h
@@ -72,7 +72,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           (1U)
-#define SPI_0_EN            (1U)
 
 /* SPI configuration */
 #define SPI_BASE            (USART_0)

--- a/boards/msb-430h/include/periph_conf.h
+++ b/boards/msb-430h/include/periph_conf.h
@@ -74,7 +74,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           (1U)
-#define SPI_0_EN            (1U)
 
 /* SPI configuration */
 #define SPI_BASE            (USART_0)

--- a/boards/telosb/include/periph_conf.h
+++ b/boards/telosb/include/periph_conf.h
@@ -72,7 +72,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           (1U)
-#define SPI_0_EN            (1U)
 
 /* SPI configuration */
 #define SPI_BASE            (USART_0)

--- a/boards/waspmote-pro/include/periph_conf.h
+++ b/boards/waspmote-pro/include/periph_conf.h
@@ -103,8 +103,7 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           1           /* set to 0 to disable SPI */
-#define SPI_0_EN            1           /* remove once SPI rework is done */
-#define MEGA_PRR            PRR0        /* Power Reduction Resgister */
+#define MEGA_PRR            PRR0        /* Power Reduction Register */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/wsn430-common/include/periph_conf.h
+++ b/boards/wsn430-common/include/periph_conf.h
@@ -72,7 +72,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           (1U)
-#define SPI_0_EN            (1U)
 
 /* SPI configuration */
 #define SPI_BASE            (USART_0)

--- a/boards/z1/include/periph_conf.h
+++ b/boards/z1/include/periph_conf.h
@@ -72,7 +72,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           (1U)
-#define SPI_0_EN            (1U)
 
 /* SPI configuration */
 #define SPI_USE_USCI

--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -41,7 +41,7 @@ void spi_init(spi_t bus)
     /* power off the SPI peripheral */
     MEGA_PRR |= (1 << PRSPI);
     /* trigger the pin configuration */
-    spi_init_pins(bus);;
+    spi_init_pins(bus);
 }
 
 void spi_init_pins(spi_t bus)


### PR DESCRIPTION
Found this while working on updated SPI implementation for EFM32.

I split it into two parts: one where the comment suggested to remove them, and one for remaining boards where I am not sure, but I think it should also be removed.

While I was at it, an additional commit fixes double semi colon :-)