### PR TITLE
sys/auto_init: optimized for at86rf and mrf24j40

### DIFF
--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -46,12 +46,11 @@ static char _at86rf2xx_stacks[AT86RF2XX_NUM][AT86RF2XX_MAC_STACKSIZE];
 void auto_init_at86rf2xx(void)
 {
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {
-        const at86rf2xx_params_t *p = &at86rf2xx_params[i];
         int res;
 
         LOG_DEBUG("[auto_init_netif] initializing at86rf2xx #%u\n", i);
 
-        at86rf2xx_setup(&at86rf2xx_devs[i], (at86rf2xx_params_t*) p);
+        at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i]);
         res = gnrc_netdev2_ieee802154_init(&gnrc_adpt[i],
                                            (netdev2_ieee802154_t *)&at86rf2xx_devs[i]);
 

--- a/sys/auto_init/netif/auto_init_mrf24j40.c
+++ b/sys/auto_init/netif/auto_init_mrf24j40.c
@@ -19,6 +19,7 @@
 
 #ifdef MODULE_MRF24J40
 
+#include "log.h"
 #include "board.h"
 #include "net/gnrc/netdev2.h"
 #include "net/gnrc/netdev2/ieee802154.h"
@@ -26,9 +27,6 @@
 
 #include "mrf24j40.h"
 #include "mrf24j40_params.h"
-
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
@@ -48,16 +46,16 @@ static char _mrf24j40_stacks[MRF24J40_NUM][MRF24J40_MAC_STACKSIZE];
 void auto_init_mrf24j40(void)
 {
     for (unsigned i = 0; i < MRF24J40_NUM; i++) {
-        const mrf24j40_params_t *p = &mrf24j40_params[i];
         int res;
 
-        DEBUG("Initializing MRF24J40 radio at SPI_%i\n", p->spi);
-        mrf24j40_setup(&mrf24j40_devs[i], (mrf24j40_params_t *) p);
+        LOG_DEBUG("[auto_init_netif] initializing mrf24j40 #%u\n", i);
+
+        mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i]);
         res = gnrc_netdev2_ieee802154_init(&gnrc_adpt[i],
                                            (netdev2_ieee802154_t *)&mrf24j40_devs[i]);
 
         if (res < 0) {
-            DEBUG("Error initializing MRF24J40 radio device!\n");
+            LOG_ERROR("[auto_init_netif] error initializing mrf24j40 #%u\n", i);
         }
         else {
             gnrc_netdev2_init(_mrf24j40_stacks[i],


### PR DESCRIPTION
Seems like the `at86rf2xx` code is likely to be taken as reference for other implementations, so here is a little cleanup. Further the newly added driver for the `mrf24j40` did not follow the latest style for using `log` instead of debug, so also fixed.