### PR TITLE
gnrc_netdev2: fix grouping of sub-headers in doc

### DIFF
--- a/sys/include/net/gnrc/netdev2/eth.h
+++ b/sys/include/net/gnrc/netdev2/eth.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup   net_gnrc
+ * @ingroup net_gnrc_netdev2
  * @{
  *
  * @file

--- a/sys/include/net/gnrc/netdev2/ieee802154.h
+++ b/sys/include/net/gnrc/netdev2/ieee802154.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup net_gnrc
+ * @ingroup net_gnrc_netdev2
  * @brief
  * @{
  *

--- a/sys/include/net/gnrc/netdev2/xbee_adpt.h
+++ b/sys/include/net/gnrc/netdev2/xbee_adpt.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @addtogroup  net_gnrc
+ * @ingroup net_gnrc_netdev2
  * @{
  *
  * @file


### PR DESCRIPTION
This 

1. unifies the group inclusions of `gnrc_netdev2`'s sub-headers
1. puts the headers in the correct group
2. includes the headers to `gnrc_netdev2`'s doc, but not there content, which leaves the doc uncluttered.