### PR TITLE
tests/pkg_oonf_api: exchange printf with puts

### DIFF
--- a/tests/pkg_oonf_api/main.c
+++ b/tests/pkg_oonf_api/main.c
@@ -18,6 +18,6 @@
 
 int main(void)
 {
-    printf("oonf_api package compiled!");
+    puts("oonf_api package compiled!");
     return 0;
 }


### PR DESCRIPTION
* A missing `\n` at the end of the printed string prevented to print the message, e.g. on an `iotlab-m3`.
* puts fits here