### PR TITLE
sys/uuid: fix signedness warning

### DIFF
--- a/sys/uuid/uuid.c
+++ b/sys/uuid/uuid.c
@@ -39,7 +39,7 @@ void uuid_custom(void *buf, size_t len, int gen)
 {
     uuid_base(buf, len);
 
-    for (int i = 0; i < sizeof(gen); i++) {
+    for (size_t i = 0; i < sizeof(gen); i++) {
         ((uint8_t *)buf)[i % len] ^= ((gen >> (i * 8)) & 0xff);
     }
 }


### PR DESCRIPTION
minor fix for

```
/RIOT/sys/uuid/uuid.c:42:23: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
    for (int i = 0; i < sizeof(gen); i++) {
                    ~ ^ ~~~~~~~~~~~
1 error generated.

```
