### PR TITLE
tests: remove non existing board name nucleo-f042

### DIFF
--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -12,7 +12,7 @@ TCP_TEST_CYCLES ?= 10
 # Mark Boards with insufficient memory
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560\
                              arduino-uno calliope-mini chronos microbit sb-430\
-                             sb-430h nrf51dongle nrf6310 nucleo-f030 nucleo-f042\
+                             sb-430h nrf51dongle nrf6310 nucleo-f030\
                              nucleo32-f042 nucleo-f070 nucleo-f072 nucleo32-f303\
                              nucleo-f334 pca10000 pca10005 stm32f0discovery\
                              telosb weio wsn430-v1_3b wsn430-v1_4\

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -10,7 +10,7 @@ TCP_LOCAL_PORT ?= 80
 # Mark Boards with insufficient memory
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560\
                              arduino-uno calliope-mini chronos microbit sb-430\
-                             sb-430h nrf51dongle nrf6310 nucleo-f030 nucleo-f042\
+                             sb-430h nrf51dongle nrf6310 nucleo-f030\
                              nucleo32-f042 nucleo-f070 nucleo-f072 nucleo32-f303\
                              nucleo-f334 pca10000 pca10005 stm32f0discovery\
                              telosb weio wsn430-v1_3b wsn430-v1_4\


### PR DESCRIPTION
Which has bee replaced with `nucleo32-f042` and is also already in the list.