### PR TITLE
cpu/stm32_common/dist: prevent spi_divtable tool to add a trailing whitespace

### DIFF
--- a/cpu/stm32_common/dist/spi_divtable/spi_divtable.c
+++ b/cpu/stm32_common/dist/spi_divtable/spi_divtable.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
             printf("        %i%c  /* -> %iHz */\n",
                    br, ((t < (tnum - 1)) ? ',' : ' '), real_clk(apb[bus], br));
         }
-        printf("    }%c\n", ((bus == 0) ? ',' : ' '));
+        printf("    }%s\n", ((bus == 0) ? "," : ""));
     }
     puts("};");
 


### PR DESCRIPTION
I noticed that this tool adds a trailing whitespace when generating the spi table for stm32 cpus.

This PR fixes this (Maybe there are better solutions though).