### PR TITLE
icmpv6: udp: fix formatter of checksum in header print functions

### DIFF
--- a/sys/net/network_layer/icmpv6/icmpv6_hdr_print.c
+++ b/sys/net/network_layer/icmpv6/icmpv6_hdr_print.c
@@ -22,6 +22,6 @@
 void icmpv6_hdr_print(icmpv6_hdr_t *hdr)
 {
     printf("   type: %3" PRIu8 "  code: %3" PRIu8 "\n", hdr->type, hdr->code);
-    printf("   cksum: 0x4%" PRIx16 "\n", byteorder_ntohs(hdr->csum));
+    printf("   cksum: 0x%04" PRIx16 "\n", byteorder_ntohs(hdr->csum));
 }
 /** @} */

--- a/sys/net/transport_layer/udp/udp_hdr_print.c
+++ b/sys/net/transport_layer/udp/udp_hdr_print.c
@@ -27,6 +27,6 @@ void udp_hdr_print(udp_hdr_t *hdr)
 {
     printf("   src-port: %5" PRIu16 "  dst-port: %5" PRIu16 "\n",
            byteorder_ntohs(hdr->src_port), byteorder_ntohs(hdr->dst_port));
-    printf("   length: %" PRIu16 "  cksum: 0x4%" PRIx16 "\n",
+    printf("   length: %" PRIu16 "  cksum: 0x%04" PRIx16 "\n",
            byteorder_ntohs(hdr->length), byteorder_ntohs(hdr->checksum));
 }


### PR DESCRIPTION
As observed in #6509.