### PR TITLE
periph/hwrng: use void* buf for hwrng_read()

### DIFF
--- a/cpu/cc2538/periph/hwrng.c
+++ b/cpu/cc2538/periph/hwrng.c
@@ -69,16 +69,18 @@ void hwrng_init(void)
     RFCORE_SFR_RFST = ISRFOFF;
 }
 
-void hwrng_read(uint8_t *buf, unsigned int num)
+void hwrng_read(void *buf, unsigned int num)
 {
     unsigned count;
+    uint8_t *b = (uint8_t *)buf;
+
     for (count = 0; count < num; ) {
         /* Clock the RNG LSFR once: */
         SOC_ADC->cc2538_adc_adccon1.ADCCON1bits.RCTRL = 1;
 
         /* Read up to 2 bytes of hwrng data: */
-        buf[count++] = SOC_ADC_RNDL;
+        b[count++] = SOC_ADC_RNDL;
         if (count >= num) break;
-        buf[count++] = SOC_ADC_RNDH;
+        b[count++] = SOC_ADC_RNDH;
     }
 }

--- a/cpu/kinetis_common/periph/hwrng_rnga.c
+++ b/cpu/kinetis_common/periph/hwrng_rnga.c
@@ -32,9 +32,10 @@ void hwrng_init(void)
     /* nothing to do here */
 }
 
-void hwrng_read(uint8_t *buf, unsigned int num)
+void hwrng_read(void *buf, unsigned int num)
 {
     unsigned int count = 0;
+    uint8_t *b = (uint8_t *)buf;
 
     /* power on and enable the device */
     HWRNG_CLKEN();
@@ -53,7 +54,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
 
         /* copy data into result vector */
         for (int i = 0; i < 4 && count < num; i++) {
-            buf[count++] = (uint8_t)tmp;
+            b[count++] = (uint8_t)tmp;
             tmp = tmp >> 8;
         }
     }

--- a/cpu/kinetis_common/periph/hwrng_rngb.c
+++ b/cpu/kinetis_common/periph/hwrng_rngb.c
@@ -33,9 +33,10 @@ void hwrng_init(void)
     /* nothing to be done here */
 }
 
-void hwrng_read(uint8_t *buf, unsigned int num)
+void hwrng_read(void *buf, unsigned int num)
 {
     unsigned int count = 0;
+    uint8_t *b = (uint8_t *)buf;
 
     HWRNG_CLKEN();
 
@@ -59,7 +60,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
 
         /* copy data into result vector */
         for (int i = 0; i < 4 && count < num; i++) {
-            buf[count++] = (uint8_t)tmp;
+            b[count++] = (uint8_t)tmp;
             tmp = tmp >> 8;
         }
     }

--- a/cpu/native/periph/hwrng.c
+++ b/cpu/native/periph/hwrng.c
@@ -70,8 +70,10 @@ void hwrng_init(void)
     initialized = 1;
 }
 
-void hwrng_read(uint8_t *buf, unsigned int num)
+void hwrng_read(void *buf, unsigned int num)
 {
+    uint8_t *b = (uint8_t *)buf;
+
     if (!initialized) {
         warnx("hwrng_read: random device not initialized, failing\n");
         return;
@@ -80,10 +82,10 @@ void hwrng_read(uint8_t *buf, unsigned int num)
     DEBUG("hwrng_read: writing %u bytes\n", num);
     switch (_native_rng_mode) {
         case 0:
-            _native_rng_read_hq(buf, num);
+            _native_rng_read_hq(b, num);
             break;
         case 1:
-            _native_rng_read_det(buf, num);
+            _native_rng_read_det(b, num);
             break;
         default:
             err(EXIT_FAILURE, "hwrng_read: _native_rng_mode is in invalid state %i\n",

--- a/cpu/nrf5x_common/periph/hwrng.c
+++ b/cpu/nrf5x_common/periph/hwrng.c
@@ -29,9 +29,10 @@ void hwrng_init(void)
     /* nothing to do here */
 }
 
-void hwrng_read(uint8_t *buf, unsigned int num)
+void hwrng_read(void *buf, unsigned int num)
 {
     unsigned int count = 0;
+    uint8_t *b = (uint8_t *)buf;
 
     /* power on RNG */
 #ifdef CPU_FAM_NRF51
@@ -46,7 +47,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
             cpu_sleep_until_event();
         }
 
-        buf[count++] = (uint8_t)NRF_RNG->VALUE;
+        b[count++] = (uint8_t)NRF_RNG->VALUE;
         /* NRF51 PAN #21 -> read value before clearing VALRDY */
         NRF_RNG->EVENTS_VALRDY = 0;
     }

--- a/cpu/sam3/periph/hwrng.c
+++ b/cpu/sam3/periph/hwrng.c
@@ -32,9 +32,10 @@ void hwrng_init(void)
     /* no need for initialization */
 }
 
-void hwrng_read(uint8_t *buf, unsigned int num)
+void hwrng_read(void *buf, unsigned int num)
 {
     unsigned count = 0;
+    uint8_t *b = (uint8_t *)buf;
 
     /* enable clock signal for TRNG module */
     PMC->PMC_PCER1 |= PMC_PCER1_PID41;
@@ -48,7 +49,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
         uint32_t tmp = TRNG->TRNG_ODATA;
         /* extract copy bytes to result */
         for (int i = 0; i < 4 && count < num; i++) {
-            buf[count++] = (uint8_t)tmp;
+            b[count++] = (uint8_t)tmp;
             tmp = tmp >> 8;
         }
     }

--- a/cpu/stm32f2/periph/hwrng.c
+++ b/cpu/stm32f2/periph/hwrng.c
@@ -36,11 +36,12 @@ void hwrng_init(void)
 }
 
 
-void hwrng_read(uint8_t *buf, unsigned int num)
+void hwrng_read(void *buf, unsigned int num)
 {
     /* cppcheck-suppress variableScope */
     uint32_t tmp;
     unsigned int count = 0;
+    uint8_t *b = (uint8_t *)buf;
 
     /* enable RNG reset state */
     periph_clk_en(AHB2, RCC_AHB2ENR_RNGEN);
@@ -54,7 +55,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
         tmp = RNG->DR;
         /* copy data into result vector */
         for (int i = 0; i < 4 && count < num; i++) {
-            buf[count++] = (uint8_t)tmp;
+            b[count++] = (uint8_t)tmp;
             tmp = tmp >> 8;
         }
     }

--- a/cpu/stm32f4/periph/hwrng.c
+++ b/cpu/stm32f4/periph/hwrng.c
@@ -30,9 +30,10 @@ void hwrng_init(void)
     /* no need for initialization */
 }
 
-void hwrng_read(uint8_t *buf, unsigned int num)
+void hwrng_read(void *buf, unsigned int num)
 {
     unsigned int count = 0;
+    uint8_t *b = (uint8_t *)buf;
 
     /* power on and enable the device */
     periph_clk_en(AHB2, RCC_AHB2ENR_RNGEN);
@@ -46,7 +47,7 @@ void hwrng_read(uint8_t *buf, unsigned int num)
         uint32_t tmp = RNG->DR;
         /* copy data into result vector */
         for (int i = 0; i < 4 && count < num; i++) {
-            buf[count++] = (uint8_t)tmp;
+            b[count++] = (uint8_t)tmp;
             tmp = tmp >> 8;
         }
     }

--- a/drivers/include/periph/hwrng.h
+++ b/drivers/include/periph/hwrng.h
@@ -57,7 +57,7 @@ void hwrng_init(void);
  * @param[in] buf   destination buffer to write the bytes to
  * @param[in] num   number of bytes to get from device
  */
-void hwrng_read(uint8_t *buf, unsigned int num);
+void hwrng_read(void *buf, unsigned int num);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
for consistency with other peripheral drivers, I propose to use a `void *` typed parameter for the buffer here as well...