### PR TITLE
netdev2: unify doc

### DIFF
--- a/cpu/nrf5x_common/include/nrfmin.h
+++ b/cpu/nrf5x_common/include/nrfmin.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    drivers_nrf5x_nrfmin NRF Minimal Radio Driver
- * @ingroup     drivers_netdev_netdev2
+ * @defgroup    drivers_nrf5x_nrfmin NRF minimal radio driver
+ * @ingroup     drivers_netdev
  * @brief       Minimal driver for the NRF51 radio
  *
  * This driver uses the nRF5x radio in a proprietary/custom way, defining our

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    drivers_at86rf2xx AT86RF2xx based drivers
- * @ingroup     drivers_netdev_netdev2
+ * @ingroup     drivers_netdev
  *
  * This module contains drivers for radio devices in Atmel's AT86RF2xx series.
  * The driver is aimed to work with all devices of this series.

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    drivers_cc2420 CC2420 driver
- * @ingroup     drivers_netdev_netdev2
+ * @ingroup     drivers_netdev
  * @{
  *
  * @file

--- a/drivers/include/enc28j60.h
+++ b/drivers/include/enc28j60.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_enc28j60 ENC28J60
+ * @defgroup    drivers_enc28j60 ENC28J60
  * @ingroup     drivers_netdev
  * @brief       Driver for the ENC28J60 Ethernet Adapter
  * @{

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    drivers_ethos ethos
+ * @defgroup    drivers_ethos Ethernet-over-serial driver
  * @ingroup     drivers_netdev
  * @brief       Driver for the ethernet-over-serial module
  * @{

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    drivers_mrf24j40 MRF24J40 based drivers
- * @ingroup     drivers_netdev_netdev2
+ * @ingroup     drivers_netdev
  *
  * This module contains drivers for radio devices in Microchip MRF24J40 series.
  * The driver is aimed to work with all devices of this series.

--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    drivers_nrf24l01p NRF24L01+ Driver Interface
+ * @defgroup    drivers_nrf24l01p NRF24L01+ driver interface
  * @ingroup     drivers_netdev
  *
  * @brief       Low-level driver for nrf24l01+ transceiver

--- a/drivers/include/w5100.h
+++ b/drivers/include/w5100.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    drivers_w5100 W5100
- * @ingroup     drivers_netdev_netdev2
+ * @ingroup     drivers_netdev
  * @brief       Driver for W5100 ethernet devices
  *
  * This device driver only exposes the MACRAW mode of W5100 devices, so it does

--- a/sys/include/net/netdev2_test.h
+++ b/sys/include/net/netdev2_test.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    sys_netdev2_test    Netdev2 dummy test driver
- * @ingroup     drivers_netdev_netdev2
+ * @defgroup    sys_netdev2_test    netdev2 dummy test driver
+ * @ingroup     drivers_netdev
  * @brief       Provides a test dummy for the netdev2 interface.
  *
  * See the following simple packet traversal timer for an example. Note that


### PR DESCRIPTION
The current documentation tree for network devices is currently quite disorganized:

![current_netdev2_tree](https://cloud.githubusercontent.com/assets/675644/22691145/557af468-ed39-11e6-8f15-7ee7317a936d.png)

* Some devices are mixed in with the doc for the `netdev2` *interface*
* Capitalization is quite a mixed back

This PR fixes most of these issues by moving all driver doc out of the doc of the `netdev2` API and unifying the capitalization of the group titels.