### PR TITLE
drivers/periph: add doc on power management aspects

### DIFF
--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -30,6 +30,18 @@
  * waiting for the result of a conversion (e.g. through putting the calling
  * thread to sleep while waiting for the conversion results).
  *
+ * # (Low-) Power Implications
+ *
+ * The ADC peripheral(s) **should** only be powered on while adc_sample() is
+ * active. For implementing adc_sample() this means, that the peripheral should
+ * be powered on (i.e. through peripheral clock gating) at the beginning of the
+ * function and it should be powered back off at the end of the function.
+ *
+ * If the adc_sample() function is implemented in a way, that it will put the
+ * active thread to sleep for a certain amount of time, the implementation
+ * might need to block certain power states.
+ *
+ *
  * @todo        Extend interface for continuous mode?
  *
  * @{

--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -13,6 +13,13 @@
  *
  * Provides access the CPU's serial number
  *
+ * # (Low-) Power Implications
+ *
+ * The implementation **should** make sure, that calling cpuid_get() does not
+ * introduce any long-term power usage penalties. If e.g. some peripheral has to
+ * be powered on for the CPU ID to be read, the implementation **should** take
+ * care to disable the peripheral again after the read is finished.
+ *
  * @{
  * @file
  * @brief       Low-level CPUID peripheral driver interface definitions

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -27,6 +27,18 @@
  * so that any particular bit-width configuration on this driver level would not
  * have much effect...
  *
+ * # (Low-) Power Implications
+ *
+ * The configured DAC peripherals are active (and consume power) from the point
+ * of initialization. When calling dac_poweroff(), the implementation **should**
+ * disable the given DAC line and put the DAC peripheral to sleep (e.g. through
+ * peripheral clock gating). When woken up again through dac_poweron(), the
+ * given DAC line **should** transparently continue it's previous operation.
+ *
+ * The DAC driver implementation may need to block (and free) certain power
+ * modes in the driver's dac_init(), dac_poweron(), and the dac_poweroff()
+ * functions.
+ *
  * @{
  * @file
  * @brief       DAC peripheral driver interface definition

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -24,6 +24,16 @@
  *              around 10K times), so using this interface in some kind of loops
  *              can damage you MCU!
  *
+ * # (Low-) Power Implications
+ *
+ * The flashpage driver implementation **should** make sure, that the CPU uses
+ * no additional energy while the flashpage driver is inactive. This means, that
+ * any particular CPU peripherals used for reading and writing flash pages
+ * **should** be disabled before the read and write functions return.
+ *
+ * If an implementation puts the calling thread to sleep for a duration of time,
+ * the implementation might need to take care of blocking certain power modes.
+ *
  * @{
  * @file
  * @brief       Low-level flash page peripheral driver interface

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -43,6 +43,23 @@
  * definitions in `RIOT/boards/ * /include/periph_conf.h` will define the selected
  * GPIO pin.
  *
+ * # (Low-) Power Implications
+ *
+ * On almost all platforms, we can only control the peripheral power state of
+ * full ports (i.e. groups of pins), but not for single GPIO pins. Together with
+ * CPU specific alternate function handling for pins used by other peripheral
+ * drivers, this can make it quite complex to keep track of pins that are
+ * currently used at a certain moment. To simplify the implementations (and ease
+ * the memory consumption), we expect ports to be powered on (e.g. through
+ * peripheral clock gating) when first used and never be powered off again.
+ *
+ * GPIO driver implementations **should** power on the corresponding port during
+ * gpio_init() and gpio_init_int().
+ *
+ * For external interrupts to work, some platforms may need to block certain
+ * power modes (although this is not very likely). This should be done during
+ * gpio_init_int().
+ *
  * @{
  * @file
  * @brief       Low-level GPIO peripheral driver interface definitions

--- a/drivers/include/periph/hwrng.h
+++ b/drivers/include/periph/hwrng.h
@@ -20,6 +20,16 @@
  * @note    Refer to your platforms MCU reference manual for information on the
  *          quality of the used (pseudo) random number generator!
  *
+ * # (Low-) Power Implications
+ *
+ * The HWRNG implementation **should** consume no additional power while no read
+ * operation is in progress. This means, that the HWRNG peripheral should be
+ * disabled (e.g. through peripheral clock gating) after the initialization and
+ * that it **should** only be turned on while hwrng_read() is active.
+ *
+ * If the implementation puts the active thread to sleep during hwrng_read(), it
+ * might need to block certain power modes on some platforms during this time.
+ *
  * @{
  * @file
  * @brief       Hardware random number generator driver interface

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -16,6 +16,17 @@
  * conform to the `struct tm` specification.
  * Compare: http://pubs.opengroup.org/onlinepubs/7908799/xsh/time.h.html
  *
+ * # (Low-) Power Implications
+ *
+ * After the RTC has been initialized (i.e. after calling rtc_init()), the RTC
+ * should be powered on and running. The RTC can then be powered off manually
+ * at a later point in time by calling the rtc_poweroff() function. When the RTC
+ * is powered back on using the rtc_poweron() function, it **should**
+ * transparently continue its previously configured operation.
+ *
+ * On many CPUs, certain power states might need to be blocked in rtc_init(), so
+ * that it is ensured that the RTC will function properly while it is enabled.
+ *
  * @{
  * @file
  * @brief       Low-level RTC peripheral driver interface definitions

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -11,6 +11,17 @@
  * @ingroup     drivers_periph
  * @brief       Low-level RTT (Real Time Timer) peripheral driver
  *
+ * # (Low-) Power Implications
+ *
+ * After the RTT has been initialized (i.e. after calling rtt_init()), the RTT
+ * should be powered on and running. The RTT can then be powered off manually
+ * at a later point in time by calling the rtt_poweroff() function. When the RTT
+ * is powered back on using the rtt_poweron() function, it **should**
+ * transparently continue its previously configured operation.
+ *
+ * On many CPUs, certain power states might need to be blocked in rtt_init(), so
+ * that it is ensured that the RTT will function properly while it is enabled.
+ *
  * @{
  * @file
  * @brief       Low-level RTT (Real Time Timer) peripheral driver interface

--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -43,6 +43,19 @@
  *    configures the bus with specific parameters (clock, mode) for the duration
  *    of that transaction.
  *
+ * # (Low-) Power Implications
+ *
+ * As SPI buses are shared peripherals and the interfaces implements a
+ * transaction based paradigm, we leverage this for the SPI peripherals power
+ * management. After calling spi_init(), the SPI peripheral **should** be
+ * completely powered off (e.g. through peripheral clock gating). It **should**
+ * subsequently only be powered on and enabled in between spi_acquire() and
+ * spi_release() blocks.
+ *
+ * In case the SPI driver implementation puts the active thread to sleep during
+ * data transfer (e.g. when using DMA), the implementation might need to block
+ * certain power states during that time.
+ *
  * @{
  * @file
  * @brief       Low-level SPI peripheral driver interface definition

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -10,8 +10,20 @@
  * @defgroup    drivers_periph_timer Timer
  * @ingroup     drivers_periph
  * @brief       Low-level timer peripheral driver
- * @{
  *
+ * # (Low-) Power Implications
+ *
+ * After calling timer_init(), the underlying hardware timer **should** be
+ * powered on and running. When a timer is explicitly stopped by calling
+ * timer_stop(), the timer **should** be stopped and powered down (e.g. by
+ * peripheral clock gating). Once the timer is started again (by calling
+ * timer_start()), it should transparently continue its previously configured
+ * operation.
+ *
+ * While the timer is active, the implementation might need to block certain
+ * power modes on specific CPU implementation.
+ *
+ * @{
  * @file
  * @brief       Low-level timer peripheral driver interface definitions
  *
@@ -159,6 +171,9 @@ void timer_start(tim_t dev);
  * @brief Stop the given timer
  *
  * This will effect all of the timer's channels.
+ *
+ * When the timer is stopped, the underlying timer peripheral should be
+ * completely powered off.
  *
  * @param[in] dev           the timer to stop
  */

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -36,6 +36,17 @@
  * to STDIO in RIOT which is used for standard input/output functions like
  * `printf()` or `puts()`.
  *
+ * # (Low-) Power Implications
+ *
+ * After initialization, the UART peripheral **should** be powered on and
+ * active. The UART can later be explicitly put to sleep and woken up by calling
+ * the uart_poweron() and uart_poweroff() functions. Once woken up using
+ * uart_poweron(), the UART **should** transparently continue it's previously
+ * configured operation.
+ *
+ * While the UART is active, the implementation might need to block certain
+ * power states.
+ *
  * @{
  *
  * @file


### PR DESCRIPTION
It seemed to me, that for some users, the power handling for peripherals was not quite clear, so here is a proposal on adding some power mode specific documentation and design considerations explicitly to each peripheral driver in RIOT. I hope, that with this additional implementations, it should be clear to everyone implementing an interface when to power a peripheral off and when to power it on...

I skipped `periph/pwm.h` on purpose, it will be addressed in a separate PR.

