### PR TITLE
periph/timer: renamed start/stop to poweron/off

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -160,12 +160,12 @@ unsigned int timer_read(tim_t tim)
     return (unsigned int)ctx[tim].dev->CNT;
 }
 
-void timer_stop(tim_t tim)
+void timer_poweroff(tim_t tim)
 {
     ctx[tim].dev->CRB = 0;
 }
 
-void timer_start(tim_t tim)
+void timer_poweron(tim_t tim)
 {
     ctx[tim].dev->CRB = ctx[tim].mode;
 }

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -251,7 +251,7 @@ unsigned int timer_read(tim_t dev)
 /*
  * For stopping the counting of all channels.
  */
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     DEBUG("%s(%u)\n", __FUNCTION__, dev);
 
@@ -260,7 +260,7 @@ void timer_stop(tim_t dev)
     }
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     DEBUG("%s(%u)\n", __FUNCTION__, dev);
 

--- a/cpu/cc26x0/periph/timer.c
+++ b/cpu/cc26x0/periph/timer.c
@@ -107,12 +107,12 @@ unsigned int timer_read(tim_t tim)
     return dev(tim)->TAV & 0xFFFF;
 }
 
-void timer_stop(tim_t tim)
+void timer_poweroff(tim_t tim)
 {
     dev(tim)->CTL = 0;
 }
 
-void timer_start(tim_t tim)
+void timer_poweron(tim_t tim)
 {
     dev(tim)->CTL = GPT_CTL_TAEN;
 }

--- a/cpu/cc430/periph/timer.c
+++ b/cpu/cc430/periph/timer.c
@@ -98,12 +98,12 @@ unsigned int timer_read(tim_t dev)
     return (unsigned int)TIMER_BASE->R;
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     TIMER_BASE->CTL |= CTL_MC_CONT;
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     TIMER_BASE->CTL &= ~(CTL_MC_MASK);
 }

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -118,13 +118,15 @@ unsigned int timer_read(tim_t dev)
     return (unsigned int)timer_config[dev].timer->CNT;
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     timer_config[dev].timer->CMD = TIMER_CMD_STOP;
+    CMU->HFPERCLKEN0 &= ~(0x3 << timer_config[dev].pre_cmu);
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
+    CMU->HFPERCLKEN0 |= (0x3 << timer_config[dev].pre_cmu);
     timer_config[dev].timer->CMD = TIMER_CMD_START;
 }
 

--- a/cpu/kinetis_common/periph/timer.c
+++ b/cpu/kinetis_common/periph/timer.c
@@ -674,7 +674,7 @@ unsigned int timer_read(tim_t dev)
     }
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     if ((unsigned int)dev >= TIMER_NUMOF) {
         /* invalid timer */
@@ -693,7 +693,7 @@ void timer_start(tim_t dev)
     }
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     if ((unsigned int)dev >= TIMER_NUMOF) {
         /* invalid timer */

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -119,7 +119,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     ROM_TimerIntEnable(timer_base, timer_intbit);
 
     _irq_enable(dev);
-    timer_start(dev);
+    timer_poweron(dev);
 
     return 0;
 }
@@ -254,7 +254,7 @@ unsigned int timer_read(tim_t dev)
     return scaled_value;
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     unsigned int timer_base;
     unsigned int timer_side = TIMER_A;
@@ -281,7 +281,7 @@ void timer_start(tim_t dev)
     ROM_TimerEnable(timer_base, timer_side);
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     unsigned int timer_base;
     unsigned int timer_side = TIMER_A;

--- a/cpu/lpc11u34/periph/timer.c
+++ b/cpu/lpc11u34/periph/timer.c
@@ -114,14 +114,14 @@ unsigned int timer_read(tim_t dev)
     return 0;
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     if (dev == TIMER_0) {
         TIMER_0_DEV->TCR |= 1;
     }
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     if (dev == TIMER_0) {
         TIMER_0_DEV->TCR &= ~(1);

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -116,14 +116,14 @@ unsigned int timer_read(tim_t dev)
     return 0;
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     if (dev == TIMER_0) {
         TIMER_0_DEV->TCR |= 1;
     }
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     if (dev == TIMER_0) {
         TIMER_0_DEV->TCR &= ~(1);

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -165,12 +165,12 @@ unsigned int timer_read(tim_t tim)
     return (unsigned int)(get_dev(tim)->TC);
 }
 
-void timer_start(tim_t tim)
+void timer_poweron(tim_t tim)
 {
     get_dev(tim)->TCR = 1;
 }
 
-void timer_stop(tim_t tim)
+void timer_poweroff(tim_t tim)
 {
     get_dev(tim)->TCR = 0;
 }

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -98,12 +98,12 @@ unsigned int timer_read(tim_t dev)
     return (unsigned int)TIMER_BASE->R;
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     TIMER_BASE->CTL |= TIMER_CTL_MC_CONT;
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     TIMER_BASE->CTL &= ~(TIMER_CTL_MC_MASK);
 }

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -156,13 +156,13 @@ int timer_clear(tim_t dev, int channel)
     return 1;
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     (void)dev;
     DEBUG("%s\n", __func__);
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     (void)dev;
     DEBUG("%s\n", __func__);

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -130,14 +130,20 @@ unsigned int timer_read(tim_t tim)
     return dev(tim)->CC[timer_config[tim].channels];
 }
 
-void timer_start(tim_t tim)
+void timer_poweron(tim_t tim)
 {
+#if CPU_FAM_NRF51
+    dev(tim)->POWER = 1;
+#endif
     dev(tim)->TASKS_START = 1;
 }
 
-void timer_stop(tim_t tim)
+void timer_poweroff(tim_t tim)
 {
     dev(tim)->TASKS_STOP = 1;
+#if CPU_FAM_NRF51
+    dev(tim)->POWER = 0;
+#endif
 }
 
 static inline void irq_handler(int num)

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -39,10 +39,26 @@ static inline void clk_en(tim_t tim)
     uint8_t id = timer_config[tim].id_ch0;
 
     if (id < 32) {
-        PMC->PMC_PCER0 = ((1 << id) | (1 << (id + 1)));
-    } else {
+        PMC->PMC_PCER0 = (0x3 << id);
+    }
+    else {
         id -= 32;
-        PMC->PMC_PCER1 = ((1 << id) | (1 << (id + 1)));
+        PMC->PMC_PCER1 = (0x3 << id);
+    }
+}
+
+/**
+ * @brief   Disable the clock for the selected channels
+ */
+static inline void clk_dis(tim_t tim)
+{
+    uint8_t id = timer_config[tim].id_ch0;
+    if (id < 32) {
+        PMC->PMC_PCDR0 = (0x3 << id);
+    }
+    else {
+        id -= 32;
+        PMC->PMC_PCDR1 = (0x3 << id);
     }
 }
 
@@ -154,14 +170,16 @@ unsigned int timer_read(tim_t tim)
     return dev(tim)->TC_CHANNEL[0].TC_CV;
 }
 
-void timer_start(tim_t tim)
+void timer_poweron(tim_t tim)
 {
+    clk_en(tim);
     dev(tim)->TC_CHANNEL[1].TC_CCR = (TC_CCR_CLKEN | TC_CCR_SWTRG);
 }
 
-void timer_stop(tim_t tim)
+void timer_poweroff(tim_t tim)
 {
     dev(tim)->TC_CHANNEL[1].TC_CCR = TC_CCR_CLKDIS;
+    clk_dis(tim);
 }
 
 static inline void isr_handler(tim_t tim)

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -124,7 +124,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     /* enable interrupts for given timer */
     _irq_enable(dev);
 
-    timer_start(dev);
+    timer_poweron(dev);
 
     return 0;
 }
@@ -254,7 +254,7 @@ unsigned int timer_read(tim_t dev)
 
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     switch (dev) {
 #if TIMER_0_EN
@@ -272,7 +272,7 @@ void timer_stop(tim_t dev)
     }
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     switch (dev) {
 #if TIMER_0_EN

--- a/cpu/saml21/periph/timer.c
+++ b/cpu/saml21/periph/timer.c
@@ -79,7 +79,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     /* enable interrupts for given timer */
     _irq_enable(dev);
 
-    timer_start(dev);
+    timer_poweron(dev);
 
     return 0;
 }
@@ -163,11 +163,9 @@ unsigned int timer_read(tim_t dev)
     default:
         return 0;
     }
-
-
 }
 
-void timer_stop(tim_t dev)
+void timer_poweroff(tim_t dev)
 {
     switch (dev) {
 #if TIMER_0_EN
@@ -180,7 +178,7 @@ void timer_stop(tim_t dev)
     }
 }
 
-void timer_start(tim_t dev)
+void timer_poweron(tim_t dev)
 {
     switch (dev) {
 #if TIMER_0_EN

--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -84,8 +84,8 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
     /* enable the timer's interrupt */
     NVIC_EnableIRQ(timer_config[tim].irqn);
-    /* reset the counter and start the timer */
-    timer_start(tim);
+    /* start the timer */
+    dev(tim)->CR1 |= TIM_CR1_CEN;
 
     return 0;
 }
@@ -124,14 +124,16 @@ unsigned int timer_read(tim_t tim)
     return (unsigned int)dev(tim)->CNT;
 }
 
-void timer_start(tim_t tim)
+void timer_poweron(tim_t tim)
 {
+    periph_clk_en(timer_config[tim].bus, timer_config[tim].rcc_mask);
     dev(tim)->CR1 |= TIM_CR1_CEN;
 }
 
-void timer_stop(tim_t tim)
+void timer_poweroff(tim_t tim)
 {
     dev(tim)->CR1 &= ~(TIM_CR1_CEN);
+    periph_clk_dis(timer_config[tim].bus, timer_config[tim].rcc_mask);
 }
 
 static inline void irq_handler(tim_t tim)

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -149,22 +149,27 @@ int timer_clear(tim_t dev, int channel);
 unsigned int timer_read(tim_t dev);
 
 /**
- * @brief Start the given timer
+ * @brief Power on and start the given timer
  *
- * This function is only needed if the timer was stopped manually before.
+ * When this function is called, the given timer is powered on and resumes its
+ * previously configured operation.
+ *
+ * Calling this function without initializing the timer first leads to
+ * indeterministic behavior.
  *
  * @param[in] dev           the timer device to start
  */
-void timer_start(tim_t dev);
+void timer_poweron(tim_t dev);
 
 /**
- * @brief Stop the given timer
+ * @brief Stop and power off the given timer
  *
- * This will effect all of the timer's channels.
+ * The given timer will be stopped and powered down. This effects all the
+ * timer's configured channels.
  *
  * @param[in] dev           the timer to stop
  */
-void timer_stop(tim_t dev);
+void timer_poweroff(tim_t dev);
 
 #ifdef __cplusplus
 }

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -65,7 +65,7 @@ static int test_timer(unsigned num)
     else {
         printf("TIMER_%u: initialization successful\n", num);
     }
-    timer_stop(TIMER_DEV(num));
+    timer_poweroff(TIMER_DEV(num));
     printf("TIMER_%u: stopped\n", num);
     /* set each available channel */
     for (unsigned i = 0; i < MAX_CHANNELS; i++) {
@@ -84,7 +84,7 @@ static int test_timer(unsigned num)
     }
     /* start the timer */
     printf("TIMER_%u: starting\n", num);
-    timer_start(TIMER_DEV(num));
+    timer_poweron(TIMER_DEV(num));
     /* wait for all channels to fire */
     do {
         ++sw_count;


### PR DESCRIPTION
Towards unification of periph interfaces: now all are using `poweron()` and `poweroff()` for enabling and disabling (and at the same time powering) the underlying peripheral.