### PR TITLE
periph/uart: enable to run UART in TX only mode

### DIFF
--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -36,19 +36,20 @@
 
 
 /**
- * @brief  Maximum percentage error in calculated baud before switching to double speed transmission (U2X)
+ * @brief   Maximum percentage error in calculated baud before switching to
+ *          double speed transmission (U2X)
  *
  * Takes whole numbers from 0 to 100, inclusive, with a default of 2.
  */
 #if defined(UART_BAUD_TOL)
-// BAUD_TOL is defined here as it is used by the setbaud.h utility
+/* BAUD_TOL is defined here as it is used by the setbaud.h utility */
 #define BAUD_TOL UART_BAUD_TOL
 #else
 #define BAUD_TOL 2
 #endif
 
 #if defined(UART_STDIO_BAUDRATE)
-// BAUD and F_CPU are required by setbaud.h to calculated BRR
+/* BAUD and F_CPU are required by setbaud.h to calculated BRR */
 #define BAUD UART_STDIO_BAUDRATE
 #define F_CPU CLOCK_CORECLOCK
 #include <util/setbaud.h>
@@ -129,8 +130,15 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     dev[uart]->CSRC = (1 << UCSZ00) | (1 << UCSZ01);
     /* set clock divider */
     _set_brr(uart, baudrate);
+
     /* enable RX and TX and the RX interrupt */
-    dev[uart]->CSRB = ((1 << RXCIE0) | (1 << RXEN0) | (1 << TXEN0));
+    if (rx_cb) {
+        dev[uart]->CSRB = ((1 << RXCIE0) | (1 << RXEN0) | (1 << TXEN0));
+    }
+    else {
+        dev[uart]->CSRB = (1 << TXEN0);
+    }
+
 
     return UART_OK;
 }

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
+ * Copyright (C) 2014-2017 Freie Universität Berlin
  * Copyright (C) 2016 OTA keys
  *
  * This file is subject to the terms and conditions of the GNU Lesser
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     cpu_stm32f2
+ * @ingroup     cpu_stm32_common
  * @{
  *
  * @file
@@ -56,8 +56,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     isr_ctx[uart].rx_cb = rx_cb;
     isr_ctx[uart].arg   = arg;
 
-    /* configure RX and TX pin */
-    gpio_init(uart_config[uart].rx_pin, GPIO_IN);
+    /* configure TX pin */
     gpio_init(uart_config[uart].tx_pin, GPIO_OUT);
     /* set TX pin high to avoid garbage during further initialization */
     gpio_set(uart_config[uart].tx_pin);
@@ -65,8 +64,14 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     gpio_init_af(uart_config[uart].tx_pin, GPIO_AF_OUT_PP);
 #else
     gpio_init_af(uart_config[uart].tx_pin, uart_config[uart].tx_af);
-    gpio_init_af(uart_config[uart].rx_pin, uart_config[uart].rx_af);
 #endif
+    /* configure RX pin */
+    if (rx_cb) {
+        gpio_init(uart_config[uart].rx_pin, GPIO_IN);
+#ifndef CPU_FAM_STM32F1
+        gpio_init_af(uart_config[uart].rx_pin, uart_config[uart].rx_af);
+#endif
+    }
 
     /* enable the clock */
     periph_clk_en(uart_config[uart].bus, uart_config[uart].rcc_mask);

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -133,10 +133,14 @@ enum {
  * - 1 stop bit
  * - baudrate as given
  *
+ * If no callback parameter is given (rx_cb := NULL), the UART will be
+ * initialized in TX only mode.
+ *
  * @param[in] uart          UART device to initialize
  * @param[in] baudrate      desired baudrate in baud/s
  * @param[in] rx_cb         receive callback, executed in interrupt context once
- *                          for every byte that is received (RX buffer filled)
+ *                          for every byte that is received (RX buffer filled),
+ *                          set to NULL for TX only mode
  * @param[in] arg           optional context passed to the callback functions
  *
  * @return                  UART_OK on success


### PR DESCRIPTION
Without explicitly stating, the current UART interface is able to initialize the UART in TX only mode. This PR documents this option and implements it for a selected number of CPUs.

If you guys ACK this PR, I will open an issue listing the implementations that would need adaption, many of whom need complete remodeling anyhow (towards removing `periph/dem_enums.h`).