### PR TITLE
mulle: Use hardware CS for on-board LIS3DH

### DIFF
--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -122,7 +122,7 @@ void board_init(void);
  */
 #define LIS3DH_INT1                 GPIO_PIN(PORT_C, 18)
 #define LIS3DH_INT2                 GPIO_PIN(PORT_C, 17)
-#define LIS3DH_CS                   GPIO_PIN(PORT_D, 0)
+#define LIS3DH_CS                   SPI_HWCS(0)
 #define LIS3DH_CLK                  SPI_CLK_5MHZ
 #define LIS3DH_SPI                  SPI_DEV(0)
 /** @} */

--- a/drivers/lis3dh/lis3dh.c
+++ b/drivers/lis3dh/lis3dh.c
@@ -27,7 +27,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#define SPI_MODE            SPI_MODE_0
+#define SPI_MODE            SPI_MODE_3
 
 static inline int lis3dh_write_bits(const lis3dh_t *dev, const lis3dh_reg_t reg,
                                     const uint8_t mask,  const uint8_t values);


### PR DESCRIPTION
This PR changes the board configuration to use hardware CS for the on-board LIS3DH accelerometer and changes the lis3dh driver to use SPI mode 3, which is what the LIS3DH data sheet specifies.