### PR TITLE
periph/i2c: remodeling part 1: deprecate existing API

### DIFF
--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -25,7 +25,7 @@
 
 #include "mutex.h"
 #include "cpu.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "thread.h"
 #ifdef MODULE_XTIMER
 #include "xtimer.h"
@@ -92,7 +92,7 @@ static uint32_t scl_delay;
             DEBUG("%s at %s:%u\n", #cond, RIOT_FILE_NOPATH, __LINE__); \
         }
 
-void cc2538_i2c_init_master(uint32_t speed_hz);
+void cc2538_i2c_depr_init_master(uint32_t speed_hz);
 
 static void i2cm_ctrl_write(uint_fast8_t value) {
     WARN_IF(I2CM_STAT & BUSY);
@@ -194,7 +194,7 @@ static uint_fast8_t i2c_ctrl_blocking(uint_fast8_t flags)
 #ifdef MODULE_XTIMER
         DEBUG("Master is still BUSY after %u usec. Resetting.\n", xtimer_timeout);
 #endif
-        cc2538_i2c_init_master(speed_hz);
+        cc2538_i2c_depr_init_master(speed_hz);
     }
 
     WARN_IF(I2CM_STAT & BUSY);
@@ -213,7 +213,7 @@ void isr_i2c(void)
     cortexm_isr_end();
 }
 
-void cc2538_i2c_init_master(uint32_t speed_hz)
+void cc2538_i2c_depr_init_master(uint32_t speed_hz)
 {
     SYS_CTRL_RCGCI2C |= 1; /**< Enable the I2C0 clock. */
     SYS_CTRL_SCGCI2C |= 1; /**< Enable the I2C0 clock. */
@@ -263,7 +263,7 @@ void cc2538_i2c_init_master(uint32_t speed_hz)
     I2CM_IMR = 1;
 }
 
-int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+int i2c_depr_init_master(i2c_t dev, i2c_speed_t speed)
 {
     switch (dev) {
 #if I2C_0_EN
@@ -299,7 +299,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
             return -2;
     }
 
-    cc2538_i2c_init_master(speed_hz);
+    cc2538_i2c_depr_init_master(speed_hz);
 
     /* Pre-compute an SCL delay in microseconds */
     scl_delay = US_PER_SEC;
@@ -315,7 +315,7 @@ int i2c_init_slave(i2c_t dev, uint8_t address)
     return -1;
 }
 
-int i2c_acquire(i2c_t dev)
+int i2c_depr_acquire(i2c_t dev)
 {
     if (dev == I2C_0) {
         mutex_lock(&mutex);
@@ -326,7 +326,7 @@ int i2c_acquire(i2c_t dev)
     }
 }
 
-int i2c_release(i2c_t dev)
+int i2c_depr_release(i2c_t dev)
 {
     if (dev == I2C_0) {
         mutex_unlock(&mutex);
@@ -339,19 +339,19 @@ int i2c_release(i2c_t dev)
 
 static bool i2c_busy(void) {
     if (I2CM_STAT & BUSY) {
-        cc2538_i2c_init_master(speed_hz);
+        cc2538_i2c_depr_init_master(speed_hz);
         return (I2CM_STAT & BUSY) != 0;
     }
 
     return false;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
+int i2c_depr_read_byte(i2c_t dev, uint8_t address, void *data)
 {
-    return i2c_read_bytes(dev, address, data, 1);
+    return i2c_depr_read_bytes(dev, address, data, 1);
 }
 
-static int i2c_read_bytes_dumb(uint8_t address, uint8_t *data, int length)
+static int i2c_depr_read_bytes_dumb(uint8_t address, uint8_t *data, int length)
 {
     int n = 0;
     uint_fast8_t stat;
@@ -414,7 +414,7 @@ static int i2c_read_bytes_dumb(uint8_t address, uint8_t *data, int length)
     return n;
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
+int i2c_depr_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     switch (dev) {
 #if I2C_0_EN
@@ -442,15 +442,15 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
         }
     }
 
-    return i2c_read_bytes_dumb(address, data, length);
+    return i2c_depr_read_bytes_dumb(address, data, length);
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
+int i2c_depr_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
-    return i2c_read_regs(dev, address, reg, data, 1);
+    return i2c_depr_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
+int i2c_depr_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     uint_fast8_t stat;
 
@@ -486,16 +486,16 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
     }
     else {
         /* Receive data from slave */
-        return i2c_read_bytes_dumb(address, data, length);
+        return i2c_depr_read_bytes_dumb(address, data, length);
     }
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
+int i2c_depr_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
-    return i2c_write_bytes(dev, address, &data, 1);
+    return i2c_depr_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
+int i2c_depr_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     int n = 0;
     const uint8_t *my_data = data;
@@ -547,12 +547,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
     return n;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
+int i2c_depr_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
-    return i2c_write_regs(dev, address, reg, &data, 1);
+    return i2c_depr_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
+int i2c_depr_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     uint_fast8_t stat;
     const uint8_t *my_data = data;
@@ -634,7 +634,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     }
 }
 
-void i2c_poweron(i2c_t dev)
+void i2c_depr_poweron(i2c_t dev)
 {
     if (dev == I2C_0) {
         SYS_CTRL_RCGCI2C |= 1; /**< Enable the I2C0 clock. */
@@ -648,7 +648,7 @@ void i2c_poweron(i2c_t dev)
     }
 }
 
-void i2c_poweroff(i2c_t dev)
+void i2c_depr_poweroff(i2c_t dev)
 {
     if (dev == I2C_0) {
         /* Disable I2C master interrupts */

--- a/cpu/kinetis_common/periph/i2c.c
+++ b/cpu/kinetis_common/periph/i2c.c
@@ -30,7 +30,7 @@
 #include "irq.h"
 #include "mutex.h"
 #include "periph_conf.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #define ENABLE_DEBUG    (0)
 /* Define ENABLE_TRACE to 1 to enable printing of all TX/RX bytes to UART for extra verbose debugging */
@@ -63,7 +63,7 @@ static mutex_t locks[] =  {
 #endif
 };
 
-int i2c_acquire(i2c_t dev)
+int i2c_depr_acquire(i2c_t dev)
 {
     if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
@@ -72,7 +72,7 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+int i2c_depr_release(i2c_t dev)
 {
     if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
@@ -81,9 +81,9 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+int i2c_depr_init_master(i2c_t dev, i2c_speed_t speed)
 {
-    DEBUG("i2c_init_master: %lu, %lu\n", (unsigned long)dev, (unsigned long) speed);
+    DEBUG("i2c_depr_init_master: %lu, %lu\n", (unsigned long)dev, (unsigned long) speed);
     I2C_Type *i2c;
     PORT_Type *i2c_port;
     int pin_scl = 0;
@@ -331,12 +331,12 @@ static inline void _i2c_reset(I2C_Type *dev)
 }
 
 
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
+int i2c_depr_read_byte(i2c_t dev, uint8_t address, void *data)
 {
-    return i2c_read_bytes(dev, address, data, 1);
+    return i2c_depr_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
+int i2c_depr_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     I2C_Type *i2c;
     int n = 0;
@@ -369,12 +369,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
     return n;
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
+int i2c_depr_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
-    return i2c_write_bytes(dev, address, &data, 1);
+    return i2c_depr_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
+int i2c_depr_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     I2C_Type *i2c;
     int n = 0;
@@ -402,13 +402,13 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
     return n;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
+int i2c_depr_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
-    return i2c_read_regs(dev, address, reg, data, 1);
+    return i2c_depr_read_regs(dev, address, reg, data, 1);
 
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
+int i2c_depr_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     I2C_Type *i2c;
     int n = 0;
@@ -454,12 +454,12 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
     return n;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
+int i2c_depr_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
-    return i2c_write_regs(dev, address, reg, &data, 1);
+    return i2c_depr_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
+int i2c_depr_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     I2C_Type *i2c;
     int n = 0;
@@ -494,7 +494,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     return n;
 }
 
-void i2c_poweron(i2c_t dev)
+void i2c_depr_poweron(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN
@@ -506,7 +506,7 @@ void i2c_poweron(i2c_t dev)
     }
 }
 
-void i2c_poweroff(i2c_t dev)
+void i2c_depr_poweroff(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN

--- a/cpu/nrf51/periph/i2c.c
+++ b/cpu/nrf51/periph/i2c.c
@@ -21,7 +21,7 @@
 #include "cpu.h"
 #include "mutex.h"
 #include "assert.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph_conf.h"
 
 #define ENABLE_DEBUG        (0)
@@ -88,7 +88,7 @@ static int write(i2c_t bus, uint8_t addr, const void *data, int len, int stop)
     return len;
 }
 
-int i2c_init_master(i2c_t bus, i2c_speed_t speed)
+int i2c_depr_init_master(i2c_t bus, i2c_speed_t speed)
 {
     if (bus >= I2C_NUMOF) {
         return -1;
@@ -118,26 +118,26 @@ int i2c_init_master(i2c_t bus, i2c_speed_t speed)
     return 0;
 }
 
-int i2c_acquire(i2c_t bus)
+int i2c_depr_acquire(i2c_t bus)
 {
     assert(bus <= I2C_NUMOF);
     mutex_lock(&locks[bus]);
     return 0;
 }
 
-int i2c_release(i2c_t bus)
+int i2c_depr_release(i2c_t bus)
 {
     assert(bus <= I2C_NUMOF);
     mutex_unlock(&locks[bus]);
     return 0;
 }
 
-int i2c_read_byte(i2c_t bus, uint8_t address, void *data)
+int i2c_depr_read_byte(i2c_t bus, uint8_t address, void *data)
 {
-    return i2c_read_bytes(bus, address, data, 1);
+    return i2c_depr_read_bytes(bus, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t bus, uint8_t address, void *data, int length)
+int i2c_depr_read_bytes(i2c_t bus, uint8_t address, void *data, int length)
 {
     uint8_t *in_buf = (uint8_t *)data;
 
@@ -185,36 +185,36 @@ int i2c_read_bytes(i2c_t bus, uint8_t address, void *data, int length)
     return length;
 }
 
-int i2c_read_reg(i2c_t bus, uint8_t address, uint8_t reg, void *data)
+int i2c_depr_read_reg(i2c_t bus, uint8_t address, uint8_t reg, void *data)
 {
     write(bus, address, &reg, 1, 0);
-    return i2c_read_bytes(bus, address, data, 1);
+    return i2c_depr_read_bytes(bus, address, data, 1);
 }
 
-int i2c_read_regs(i2c_t bus, uint8_t address, uint8_t reg,
+int i2c_depr_read_regs(i2c_t bus, uint8_t address, uint8_t reg,
                   void *data, int length)
 {
     write(bus, address, &reg, 1, 0);
-    return i2c_read_bytes(bus, address, data, length);
+    return i2c_depr_read_bytes(bus, address, data, length);
 }
 
-int i2c_write_byte(i2c_t bus, uint8_t address, uint8_t data)
+int i2c_depr_write_byte(i2c_t bus, uint8_t address, uint8_t data)
 {
     return write(bus, address, &data, 1, 1);
 }
 
-int i2c_write_bytes(i2c_t bus, uint8_t address, const void *data, int length)
+int i2c_depr_write_bytes(i2c_t bus, uint8_t address, const void *data, int length)
 {
     return write(bus, address, data, length, 1);
 }
 
-int i2c_write_reg(i2c_t bus, uint8_t address, uint8_t reg, uint8_t data)
+int i2c_depr_write_reg(i2c_t bus, uint8_t address, uint8_t reg, uint8_t data)
 {
     write(bus, address, &reg, 1, 0);
     return write(bus, address, &data, 1, 1);
 }
 
-int i2c_write_regs(i2c_t bus, uint8_t address, uint8_t reg,
+int i2c_depr_write_regs(i2c_t bus, uint8_t address, uint8_t reg,
                    const void *data, int length)
 {
     write(bus, address, &reg, 1, 0);

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -22,7 +22,7 @@
 #include "board.h"
 #include "mutex.h"
 #include "periph_conf.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #include "sched.h"
 #include "thread.h"
@@ -41,8 +41,8 @@
 #define BUSSTATE_BUSY SERCOM_I2CM_STATUS_BUSSTATE(3)
 
 /* static function definitions */
-static void _i2c_poweron(SercomI2cm *sercom);
-static void _i2c_poweroff(SercomI2cm *sercom);
+static void _i2c_depr_poweron(SercomI2cm *sercom);
+static void _i2c_depr_poweroff(SercomI2cm *sercom);
 
 static int _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag);
 static inline int _write(SercomI2cm *dev, const uint8_t *data, int length);
@@ -68,7 +68,7 @@ static mutex_t locks[] = {
 #endif
 };
 
-int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+int i2c_depr_init_master(i2c_t dev, i2c_speed_t speed)
 {
     SercomI2cm *I2CSercom = 0;
     gpio_t pin_scl = 0;
@@ -99,7 +99,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     }
 
     /* DISABLE I2C MASTER */
-    i2c_poweroff(dev);
+    i2c_depr_poweroff(dev);
 
     /* Reset I2C */
     I2CSercom->CTRLA.reg = SERCOM_I2CS_CTRLA_SWRST;
@@ -175,7 +175,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     }
 
     /* ENABLE I2C MASTER */
-    i2c_poweron(dev);
+    i2c_depr_poweron(dev);
 
     /* Start timeout if bus state is unknown. */
     while ((I2CSercom->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk) == BUSSTATE_UNKNOWN) {
@@ -187,7 +187,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     return 0;
 }
 
-int i2c_acquire(i2c_t dev)
+int i2c_depr_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -196,7 +196,7 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+int i2c_depr_release(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -205,12 +205,12 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
+int i2c_depr_read_byte(i2c_t dev, uint8_t address, void *data)
 {
-    return i2c_read_bytes(dev, address, data, 1);
+    return i2c_depr_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
+int i2c_depr_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     SercomI2cm *i2c;
 
@@ -237,12 +237,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
     return length;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
+int i2c_depr_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
-    return i2c_read_regs(dev, address, reg, data, 1);
+    return i2c_depr_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
+int i2c_depr_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     SercomI2cm *i2c;
 
@@ -265,15 +265,15 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
     if (_write(i2c, &reg, 1) < 0) {
         return 0;
     }
-    return i2c_read_bytes(dev, address, data, length);
+    return i2c_depr_read_bytes(dev, address, data, length);
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
+int i2c_depr_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
-    return i2c_write_bytes(dev, address, &data, 1);
+    return i2c_depr_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
+int i2c_depr_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     SercomI2cm *I2CSercom;
 
@@ -298,12 +298,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 }
 
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
+int i2c_depr_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
-    return i2c_write_regs(dev, address, reg, &data, 1);
+    return i2c_depr_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
+int i2c_depr_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     SercomI2cm *i2c;
 
@@ -334,7 +334,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     return length;
 }
 
-static void _i2c_poweron(SercomI2cm *sercom)
+static void _i2c_depr_poweron(SercomI2cm *sercom)
 {
     if (sercom == NULL) {
         return;
@@ -343,12 +343,12 @@ static void _i2c_poweron(SercomI2cm *sercom)
     while (sercom->SYNCBUSY.bit.ENABLE) {}
 }
 
-void i2c_poweron(i2c_t dev)
+void i2c_depr_poweron(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN
         case I2C_0:
-            _i2c_poweron(&I2C_0_DEV);
+            _i2c_depr_poweron(&I2C_0_DEV);
             break;
 #endif
         default:
@@ -356,7 +356,7 @@ void i2c_poweron(i2c_t dev)
     }
 }
 
-static void _i2c_poweroff(SercomI2cm *sercom)
+static void _i2c_depr_poweroff(SercomI2cm *sercom)
 {
     if (sercom == NULL) {
         return;
@@ -365,12 +365,12 @@ static void _i2c_poweroff(SercomI2cm *sercom)
     while (sercom->SYNCBUSY.bit.ENABLE) {}
 }
 
-void i2c_poweroff(i2c_t dev)
+void i2c_depr_poweroff(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN
         case I2C_0:
-            _i2c_poweroff(&I2C_0_DEV);
+            _i2c_depr_poweroff(&I2C_0_DEV);
             break;
 #endif
         default:

--- a/cpu/stm32f1/periph/i2c.c
+++ b/cpu/stm32f1/periph/i2c.c
@@ -30,7 +30,7 @@
 #include "irq.h"
 #include "mutex.h"
 #include "periph_conf.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/gpio.h"
 
 #define ENABLE_DEBUG    (0)
@@ -80,7 +80,7 @@ static uint8_t err_flag[] = {
 #endif
 };
 
-int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+int i2c_depr_init_master(i2c_t dev, i2c_speed_t speed)
 {
     I2C_TypeDef *i2c;
     gpio_t pin_scl, pin_sda;
@@ -181,7 +181,7 @@ static void _pin_config(gpio_t scl, gpio_t sda)
     gpio_init_af(sda, GPIO_AF_OUT_OD);
 }
 
-int i2c_acquire(i2c_t dev)
+int i2c_depr_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -190,7 +190,7 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+int i2c_depr_release(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -199,12 +199,12 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
+int i2c_depr_read_byte(i2c_t dev, uint8_t address, void *data)
 {
-    return i2c_read_bytes(dev, address, data, 1);
+    return i2c_depr_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
+int i2c_depr_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     int i = 0;
     I2C_TypeDef *i2c;
@@ -290,13 +290,13 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
     return length;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
+int i2c_depr_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
-    return i2c_read_regs(dev, address, reg, data, 1);
+    return i2c_depr_read_regs(dev, address, reg, data, 1);
 
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
+int i2c_depr_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -328,15 +328,15 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
     }
 
     DEBUG("Now start a read transaction\n");
-    return i2c_read_bytes(dev, address, data, length);
+    return i2c_depr_read_bytes(dev, address, data, length);
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
+int i2c_depr_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
-    return i2c_write_bytes(dev, address, &data, 1);
+    return i2c_depr_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
+int i2c_depr_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -374,12 +374,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
     }
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
+int i2c_depr_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
-    return i2c_write_regs(dev, address, reg, &data, 1);
+    return i2c_depr_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
+int i2c_depr_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -417,7 +417,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     }
 }
 
-void i2c_poweron(i2c_t dev)
+void i2c_depr_poweron(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN
@@ -433,7 +433,7 @@ void i2c_poweron(i2c_t dev)
     }
 }
 
-void i2c_poweroff(i2c_t dev)
+void i2c_depr_poweroff(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN

--- a/cpu/stm32f2/periph/i2c.c
+++ b/cpu/stm32f2/periph/i2c.c
@@ -27,7 +27,7 @@
 #include "irq.h"
 #include "mutex.h"
 #include "periph_conf.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -80,7 +80,7 @@ static uint8_t err_flag[] = {
 #endif
 };
 
-int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+int i2c_depr_init_master(i2c_t dev, i2c_speed_t speed)
 {
     I2C_TypeDef *i2c;
     GPIO_TypeDef *port_scl;
@@ -193,7 +193,7 @@ static void _pin_config(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda, int pin_
     }
 }
 
-int i2c_acquire(i2c_t dev)
+int i2c_depr_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -202,7 +202,7 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+int i2c_depr_release(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -211,12 +211,12 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
+int i2c_depr_read_byte(i2c_t dev, uint8_t address, void *data)
 {
-    return i2c_read_bytes(dev, address, data, 1);
+    return i2c_depr_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
+int i2c_depr_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -423,12 +423,12 @@ static int _read_bytes(I2C_TypeDef *i2c, uint8_t address, uint8_t *data, int len
     return length;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
+int i2c_depr_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
-    return i2c_read_regs(dev, address, reg, data, 1);
+    return i2c_depr_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
+int i2c_depr_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     I2C_TypeDef *i2c;
     int res;
@@ -464,12 +464,12 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
     return _read_bytes(i2c, address, data, length, &err_flag[dev]);
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
+int i2c_depr_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
-    return i2c_write_bytes(dev, address, &data, 1);
+    return i2c_depr_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
+int i2c_depr_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     I2C_TypeDef *i2c;
     int res;
@@ -520,12 +520,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
     return length;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
+int i2c_depr_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
-    return i2c_write_regs(dev, address, reg, &data, 1);
+    return i2c_depr_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
+int i2c_depr_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     I2C_TypeDef *i2c;
     int res;
@@ -582,7 +582,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     return length;
 }
 
-void i2c_poweron(i2c_t dev)
+void i2c_depr_poweron(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN
@@ -593,7 +593,7 @@ void i2c_poweron(i2c_t dev)
     }
 }
 
-void i2c_poweroff(i2c_t dev)
+void i2c_depr_poweroff(i2c_t dev)
 {
     int cnt = 0;
 

--- a/cpu/stm32f3/periph/i2c.c
+++ b/cpu/stm32f3/periph/i2c.c
@@ -30,7 +30,7 @@
 #include "irq.h"
 #include "mutex.h"
 #include "periph_conf.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -68,7 +68,7 @@ static mutex_t locks[] =  {
 #endif
 };
 
-int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+int i2c_depr_init_master(i2c_t dev, i2c_speed_t speed)
 {
     I2C_TypeDef *i2c;
     GPIO_TypeDef *port_scl;
@@ -227,7 +227,7 @@ static void _pin_config(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda,
     }
 }
 
-int i2c_acquire(i2c_t dev)
+int i2c_depr_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -236,7 +236,7 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+int i2c_depr_release(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -245,12 +245,12 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
+int i2c_depr_read_byte(i2c_t dev, uint8_t address, void *data)
 {
-    return i2c_read_bytes(dev, address, data, 1);
+    return i2c_depr_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
+int i2c_depr_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -282,12 +282,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
     return length;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
+int i2c_depr_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
-    return i2c_read_regs(dev, address, reg, data, 1);
+    return i2c_depr_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
+int i2c_depr_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -320,15 +320,15 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
 
     /* send repeated start sequence, read registers and end transmission */
     DEBUG("ACK received, send repeated start sequence\n");
-    return i2c_read_bytes(dev, address, data, length);
+    return i2c_depr_read_bytes(dev, address, data, length);
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
+int i2c_depr_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
-    return i2c_write_bytes(dev, address, &data, 1);
+    return i2c_depr_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
+int i2c_depr_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -360,12 +360,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
     return length;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
+int i2c_depr_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
-    return i2c_write_regs(dev, address, reg, &data, 1);
+    return i2c_depr_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
+int i2c_depr_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -406,7 +406,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     return length;
 }
 
-void i2c_poweron(i2c_t dev)
+void i2c_depr_poweron(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN
@@ -422,7 +422,7 @@ void i2c_poweron(i2c_t dev)
     }
 }
 
-void i2c_poweroff(i2c_t dev)
+void i2c_depr_poweroff(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN

--- a/cpu/stm32f4/periph/i2c.c
+++ b/cpu/stm32f4/periph/i2c.c
@@ -28,7 +28,7 @@
 #include "irq.h"
 #include "mutex.h"
 #include "periph_conf.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -63,7 +63,7 @@ static mutex_t locks[] =  {
 #endif
 };
 
-int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+int i2c_depr_init_master(i2c_t dev, i2c_speed_t speed)
 {
     I2C_TypeDef *i2c;
     GPIO_TypeDef *port_scl;
@@ -221,7 +221,7 @@ static void _toggle_pins(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda, int pin
     port_sda->ODR |= (1 << pin_sda);
 }
 
-int i2c_acquire(i2c_t dev)
+int i2c_depr_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -230,7 +230,7 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+int i2c_depr_release(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -239,12 +239,12 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
+int i2c_depr_read_byte(i2c_t dev, uint8_t address, void *data)
 {
-    return i2c_read_bytes(dev, address, data, 1);
+    return i2c_depr_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
+int i2c_depr_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     unsigned int state;
     int i = 0;
@@ -371,12 +371,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
     return length;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
+int i2c_depr_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
-    return i2c_read_regs(dev, address, reg, data, 1);
+    return i2c_depr_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
+int i2c_depr_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -399,15 +399,15 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
     i2c->DR = reg;
     _stop(i2c);
     DEBUG("Now start a read transaction\n");
-    return i2c_read_bytes(dev, address, data, length);
+    return i2c_depr_read_bytes(dev, address, data, length);
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
+int i2c_depr_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
-    return i2c_write_bytes(dev, address, &data, 1);
+    return i2c_depr_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
+int i2c_depr_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -435,12 +435,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
     return length;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
+int i2c_depr_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
-    return i2c_write_regs(dev, address, reg, &data, 1);
+    return i2c_depr_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
+int i2c_depr_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     I2C_TypeDef *i2c;
 
@@ -468,7 +468,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     return length;
 }
 
-void i2c_poweron(i2c_t dev)
+void i2c_depr_poweron(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN
@@ -479,7 +479,7 @@ void i2c_poweron(i2c_t dev)
     }
 }
 
-void i2c_poweroff(i2c_t dev)
+void i2c_depr_poweroff(i2c_t dev)
 {
     switch (dev) {
 #if I2C_0_EN

--- a/cpu/stm32l1/periph/i2c.c
+++ b/cpu/stm32l1/periph/i2c.c
@@ -27,7 +27,7 @@
 
 #include "cpu.h"
 #include "mutex.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -64,7 +64,7 @@ static mutex_t locks[] =  {
 #endif
 };
 
-int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+int i2c_depr_init_master(i2c_t dev, i2c_speed_t speed)
 {
     int ccr;
 
@@ -88,7 +88,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     I2C_TypeDef *i2c = i2c_config[dev].dev;
 
     /* enable I2C clock */
-    i2c_poweron(dev);
+    i2c_depr_poweron(dev);
 
     /* set IRQn priority */
     NVIC_SetPriority(i2c_config[dev].er_irqn, I2C_IRQ_PRIO);
@@ -122,7 +122,7 @@ static void _i2c_init(I2C_TypeDef *i2c, int ccr)
     i2c->CR1 |= I2C_CR1_PE;
 }
 
-int i2c_acquire(i2c_t dev)
+int i2c_depr_acquire(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -131,7 +131,7 @@ int i2c_acquire(i2c_t dev)
     return 0;
 }
 
-int i2c_release(i2c_t dev)
+int i2c_depr_release(i2c_t dev)
 {
     if (dev >= I2C_NUMOF) {
         return -1;
@@ -140,12 +140,12 @@ int i2c_release(i2c_t dev)
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
+int i2c_depr_read_byte(i2c_t dev, uint8_t address, void *data)
 {
-    return i2c_read_bytes(dev, address, data, 1);
+    return i2c_depr_read_bytes(dev, address, data, 1);
 }
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
+int i2c_depr_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     unsigned int state;
     int i = 0;
@@ -265,12 +265,12 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
     return length;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
+int i2c_depr_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
 {
-    return i2c_read_regs(dev, address, reg, data, 1);
+    return i2c_depr_read_regs(dev, address, reg, data, 1);
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
+int i2c_depr_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
 {
     if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
@@ -286,15 +286,15 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
     i2c->DR = reg;
     _stop(i2c);
     DEBUG("Now start a read transaction\n");
-    return i2c_read_bytes(dev, address, data, length);
+    return i2c_depr_read_bytes(dev, address, data, length);
 }
 
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
+int i2c_depr_write_byte(i2c_t dev, uint8_t address, uint8_t data)
 {
-    return i2c_write_bytes(dev, address, &data, 1);
+    return i2c_depr_write_bytes(dev, address, &data, 1);
 }
 
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
+int i2c_depr_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
 {
     if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
@@ -315,12 +315,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
     return length;
 }
 
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
+int i2c_depr_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
 {
-    return i2c_write_regs(dev, address, reg, &data, 1);
+    return i2c_depr_write_regs(dev, address, reg, &data, 1);
 }
 
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
+int i2c_depr_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
 {
     if ((unsigned int)dev >= I2C_NUMOF) {
         return -1;
@@ -341,14 +341,14 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     return length;
 }
 
-void i2c_poweron(i2c_t dev)
+void i2c_depr_poweron(i2c_t dev)
 {
     if ((unsigned int)dev < I2C_NUMOF) {
         periph_clk_en(APB1, (RCC_APB1ENR_I2C1EN << dev));
     }
 }
 
-void i2c_poweroff(i2c_t dev)
+void i2c_depr_poweroff(i2c_t dev)
 {
     if ((unsigned int)dev < I2C_NUMOF) {
         while (i2c_config[dev].dev->SR2 & I2C_SR2_BUSY) {}

--- a/doit.sh
+++ b/doit.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+echo "i2c_init_master"
+git grep -l 'i2c_init_master' | xargs sed -i 's/i2c_init_master/i2c_depr_init_master/g'
+echo "i2c_acquire"
+git grep -l 'i2c_acquire' | xargs sed -i 's/i2c_acquire/i2c_depr_acquire/g'
+echo "i2c_release"
+git grep -l 'i2c_release' | xargs sed -i 's/i2c_release/i2c_depr_release/g'
+echo "i2c_read_bytes"
+git grep -l 'i2c_read_bytes' | xargs sed -i 's/i2c_read_bytes/i2c_depr_read_bytes/g'
+echo "i2c_read_byte"
+git grep -l 'i2c_read_byte' | xargs sed -i 's/i2c_read_byte/i2c_depr_read_byte/g'
+echo "i2c_read_regs"
+git grep -l 'i2c_read_regs' | xargs sed -i 's/i2c_read_regs/i2c_depr_read_regs/g'
+echo "i2c_read_reg"
+git grep -l 'i2c_read_reg' | xargs sed -i 's/i2c_read_reg/i2c_depr_read_reg/g'
+echo "i2c_write_bytes"
+git grep -l 'i2c_write_bytes' | xargs sed -i 's/i2c_write_bytes/i2c_depr_write_bytes/g'
+echo "i2c_write_byte"
+git grep -l 'i2c_write_byte' | xargs sed -i 's/i2c_write_byte/i2c_depr_write_byte/g'
+echo "i2c_write_regs"
+git grep -l 'i2c_write_regs' | xargs sed -i 's/i2c_write_regs/i2c_depr_write_regs/g'
+echo "i2c_write_reg"
+git grep -l 'i2c_write_reg' | xargs sed -i 's/i2c_write_reg/i2c_depr_write_reg/g'
+echo "i2c_poweron"
+git grep -l 'i2c_poweron' | xargs sed -i 's/i2c_poweron/i2c_depr_poweron/g'
+echo "i2c_poweroff"
+git grep -l 'i2c_poweroff' | xargs sed -i 's/i2c_poweroff/i2c_depr_poweroff/g'
+
+echo "periph/i2c"
+git grep -l 'periph/i2c_depr.h' | xargs sed -i 's/periph\/i2c.h/periph\/i2c_depr.h/g'

--- a/drivers/at30tse75x/at30tse75x.c
+++ b/drivers/at30tse75x/at30tse75x.c
@@ -14,7 +14,7 @@
  */
 
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "xtimer.h"
 
 #include "at30tse75x.h"
@@ -37,41 +37,41 @@ static inline float temperature_to_float(uint16_t temp)
 
 static int at30tse75x_get_register(at30tse75x_t* dev, uint8_t reg, uint16_t* data)
 {
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_read_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
         DEBUG("[at30tse75x] Can't read register 0x%x\n", reg);
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
 
 static int at30tse75x_set_register(at30tse75x_t* dev, uint8_t reg, uint16_t* data)
 {
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_write_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
         DEBUG("[at30tse75x] Can't write to register 0x%x\n", reg);
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
 
 static int at30tse75x_reset(at30tse75x_t* dev)
 {
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_write_byte(dev->i2c, 0x00, AT30TSE75X_CMD__GENERAL_CALL_RESET) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_byte(dev->i2c, 0x00, AT30TSE75X_CMD__GENERAL_CALL_RESET) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     /* Wait for reset to complete */
     xtimer_usleep(500);
     return 0;
@@ -79,28 +79,28 @@ static int at30tse75x_reset(at30tse75x_t* dev)
 
 int at30tse75x_get_config(at30tse75x_t* dev, uint8_t* data)
 {
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_read_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data) <= 0) {
+    if (i2c_depr_read_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data) <= 0) {
         DEBUG("[at30tse75x] Can't read CONFIG register\n");
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
 
 int at30tse75x_set_config(at30tse75x_t* dev, uint8_t data)
 {
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_write_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data) <= 0) {
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data) <= 0) {
         DEBUG("[at30tse75x] Can't write to CONFIG register\n");
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
@@ -220,13 +220,13 @@ int at30tse75x_set_limit_high(at30tse75x_t* dev, int8_t t_high)
 
 int at30tse75x_save_config(at30tse75x_t* dev)
 {
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if(i2c_write_byte(dev->i2c, dev->addr, AT30TSE75X_CMD__SAVE_TO_NVRAM) != 1) {
-        i2c_release(dev->i2c);
+    if(i2c_depr_write_byte(dev->i2c, dev->addr, AT30TSE75X_CMD__SAVE_TO_NVRAM) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     /* Wait for copy to complete */
     xtimer_usleep(5000);
     return 0;
@@ -234,13 +234,13 @@ int at30tse75x_save_config(at30tse75x_t* dev)
 
 int at30tse75x_restore_config(at30tse75x_t* dev)
 {
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if(i2c_write_byte(dev->i2c, dev->addr, AT30TSE75X_CMD__RESTORE_FROM_NVRAM) != 1) {
-        i2c_release(dev->i2c);
+    if(i2c_depr_write_byte(dev->i2c, dev->addr, AT30TSE75X_CMD__RESTORE_FROM_NVRAM) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     /* Wait for copy to complete */
     xtimer_usleep(200);
     return 0;
@@ -294,13 +294,13 @@ int at30tse75x_init(at30tse75x_t* dev, i2c_t i2c, i2c_speed_t speed, uint8_t add
     }
     dev->addr = addr;
 
-    i2c_acquire(dev->i2c);
-    if(i2c_init_master(dev->i2c, speed) != 0) {
+    i2c_depr_acquire(dev->i2c);
+    if(i2c_depr_init_master(dev->i2c, speed) != 0) {
         DEBUG("[at30tse75x] Can't initialize I2C master\n");
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     /* Reset the device */
     if(at30tse75x_reset(dev) != 0) {

--- a/drivers/bh1750fvi/bh1750fvi.c
+++ b/drivers/bh1750fvi/bh1750fvi.c
@@ -37,12 +37,12 @@ int bh1750fvi_init(bh1750fvi_t *dev, bh1750fvi_params_t *params)
     dev->addr = params->addr;
 
     /* initialize the I2C bus */
-    i2c_acquire(dev->i2c);
-    i2c_init_master(dev->i2c, params->clk);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_init_master(dev->i2c, params->clk);
 
     /* send a power down command to make sure we can speak to the device */
-    res = i2c_write_byte(dev->i2c, dev->addr, OP_POWER_DOWN);
-    i2c_release(dev->i2c);
+    res = i2c_depr_write_byte(dev->i2c, dev->addr, OP_POWER_DOWN);
+    i2c_depr_release(dev->i2c);
     if (res < 0) {
         return BH1750FVI_ERR_I2C;
     }
@@ -56,19 +56,19 @@ uint16_t bh1750fvi_sample(bh1750fvi_t *dev)
 
     /* power on the device and send single H-mode measurement command */
     DEBUG("[bh1750fvi] sample: triggering a conversion\n");
-    i2c_acquire(dev->i2c);
-    i2c_write_byte(dev->i2c, dev->addr, OP_POWER_ON);
-    i2c_write_byte(dev->i2c, dev->addr, OP_SINGLE_HRES1);
-    i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_write_byte(dev->i2c, dev->addr, OP_POWER_ON);
+    i2c_depr_write_byte(dev->i2c, dev->addr, OP_SINGLE_HRES1);
+    i2c_depr_release(dev->i2c);
 
     /* wait for measurement to complete */
     xtimer_usleep(DELAY_HMODE);
 
     /* read the results */
     DEBUG("[bh1750fvi] sample: reading the results\n");
-    i2c_acquire(dev->i2c);
-    i2c_read_bytes(dev->i2c, dev->addr, raw, 2);
-    i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_read_bytes(dev->i2c, dev->addr, raw, 2);
+    i2c_depr_release(dev->i2c);
 
     /* and finally we calculate the actual LUX value */
     tmp = (raw[0] << 24) | (raw[1] << 16);

--- a/drivers/bme280/bme280.c
+++ b/drivers/bme280/bme280.c
@@ -26,7 +26,7 @@
 #include "bme280.h"
 #include "bme280_internals.h"
 #include "bme280_params.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "xtimer.h"
 
 #define ENABLE_DEBUG        (0)
@@ -72,7 +72,7 @@ int bme280_init(bme280_t* dev, const bme280_params_t* params)
     dev->params = *params;
 
     /* Initialize I2C interface */
-    if (i2c_init_master(dev->params.i2c_dev, I2C_SPEED_NORMAL)) {
+    if (i2c_depr_init_master(dev->params.i2c_dev, I2C_SPEED_NORMAL)) {
         DEBUG("[Error] I2C device not enabled\n");
         return BME280_ERR_I2C;
     }
@@ -219,7 +219,7 @@ static int read_calibration_data(bme280_t* dev)
     uint8_t offset = 0x88;
 
     memset(buffer, 0, sizeof(buffer));
-    nr_bytes = i2c_read_regs(dev->params.i2c_dev, dev->params.i2c_addr, offset,
+    nr_bytes = i2c_depr_read_regs(dev->params.i2c_dev, dev->params.i2c_addr, offset,
                              buffer, nr_bytes_to_read);
     if (nr_bytes != nr_bytes_to_read) {
         LOG_ERROR("Unable to read calibration data\n");
@@ -254,7 +254,7 @@ static int read_calibration_data(bme280_t* dev)
     DEBUG("[INFO] Chip ID = 0x%02X\n", buffer[BME280_CHIP_ID_REG - offset]);
 
     /* Config is only be writable in sleep mode */
-    (void)i2c_write_reg(dev->params.i2c_dev, dev->params.i2c_addr,
+    (void)i2c_depr_write_reg(dev->params.i2c_dev, dev->params.i2c_addr,
                         BME280_CTRL_MEAS_REG, 0);
 
     uint8_t b;
@@ -309,7 +309,7 @@ static int do_measurement(bme280_t* dev)
     int nr_bytes_to_read = sizeof(measurement_regs);
     uint8_t offset = BME280_PRESSURE_MSB_REG;
 
-    nr_bytes = i2c_read_regs(dev->params.i2c_dev, dev->params.i2c_addr,
+    nr_bytes = i2c_depr_read_regs(dev->params.i2c_dev, dev->params.i2c_addr,
                              offset, measurement_regs, nr_bytes_to_read);
     if (nr_bytes != nr_bytes_to_read) {
         LOG_ERROR("Unable to read temperature data\n");
@@ -334,14 +334,14 @@ static uint8_t read_u8_reg(bme280_t* dev, uint8_t reg)
 {
     uint8_t b;
     /* Assuming device is correct, it should return 1 (nr bytes) */
-    (void)i2c_read_reg(dev->params.i2c_dev, dev->params.i2c_addr, reg, &b);
+    (void)i2c_depr_read_reg(dev->params.i2c_dev, dev->params.i2c_addr, reg, &b);
     return b;
 }
 
 static void write_u8_reg(bme280_t* dev, uint8_t reg, uint8_t b)
 {
     /* Assuming device is correct, it should return 1 (nr bytes) */
-    (void)i2c_write_reg(dev->params.i2c_dev, dev->params.i2c_addr, reg, b);
+    (void)i2c_depr_write_reg(dev->params.i2c_dev, dev->params.i2c_addr, reg, b);
 }
 
 static uint16_t get_uint16_le(const uint8_t *buffer, size_t offset)

--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -25,7 +25,7 @@
 
 #include "assert.h"
 #include "xtimer.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "hdc1000.h"
 
 #define ENABLE_DEBUG    (0)
@@ -42,22 +42,22 @@ int hdc1000_init(hdc1000_t *dev, const hdc1000_params_t *params)
     memcpy(&dev->p, params, sizeof(hdc1000_params_t));
 
     /* initialize the I2C bus */
-    i2c_acquire(dev->p.i2c);
-    if (i2c_init_master(dev->p.i2c, I2C_SPEED) < 0) {
-        i2c_release(dev->p.i2c);
+    i2c_depr_acquire(dev->p.i2c);
+    if (i2c_depr_init_master(dev->p.i2c, I2C_SPEED) < 0) {
+        i2c_depr_release(dev->p.i2c);
         return HDC1000_NOBUS;
     }
 
     /* try if we can interact with the device by reading its manufacturer ID */
-    if (i2c_read_regs(dev->p.i2c, dev->p.addr,
+    if (i2c_depr_read_regs(dev->p.i2c, dev->p.addr,
                       HDC1000_MANUFACTURER_ID, reg, 2) != 2) {
-        i2c_release(dev->p.i2c);
+        i2c_depr_release(dev->p.i2c);
         return HDC1000_NOBUS;
     }
 
     tmp = ((uint16_t)reg[0] << 8) | reg[1];
     if (tmp != HDC1000_MID_VALUE) {
-        i2c_release(dev->p.i2c);
+        i2c_depr_release(dev->p.i2c);
         return HDC1000_NODEV;
     }
 
@@ -66,11 +66,11 @@ int hdc1000_init(hdc1000_t *dev, const hdc1000_params_t *params)
     reg[0] = (tmp >> 8);
     reg[1] = tmp;
 
-    if (i2c_write_regs(dev->p.i2c, dev->p.addr, HDC1000_CONFIG, reg, 2) != 2) {
-        i2c_release(dev->p.i2c);
+    if (i2c_depr_write_regs(dev->p.i2c, dev->p.addr, HDC1000_CONFIG, reg, 2) != 2) {
+        i2c_depr_release(dev->p.i2c);
         return HDC1000_NOBUS;
     }
-    i2c_release(dev->p.i2c);
+    i2c_depr_release(dev->p.i2c);
 
     /* all set */
     return HDC1000_OK;
@@ -80,15 +80,15 @@ void hdc1000_trigger_conversion(hdc1000_t *dev)
 {
     assert(dev);
 
-    i2c_acquire(dev->p.i2c);
+    i2c_depr_acquire(dev->p.i2c);
 
     /* Trigger the measurements by executing a write access
      * to the address 0x00 (HDC1000_TEMPERATURE).
      * Conversion Time is 6.50ms for each value for 14 bit resolution.
      */
-    i2c_write_byte(dev->p.i2c, dev->p.addr, HDC1000_TEMPERATURE);
+    i2c_depr_write_byte(dev->p.i2c, dev->p.addr, HDC1000_TEMPERATURE);
 
-    i2c_release(dev->p.i2c);
+    i2c_depr_release(dev->p.i2c);
 }
 
 void hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum)
@@ -99,9 +99,9 @@ void hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum)
     uint16_t traw, hraw;
 
     /* first we read the RAW results from the device */
-    i2c_acquire(dev->p.i2c);
-    i2c_read_bytes(dev->p.i2c, dev->p.addr, buf, 4);
-    i2c_release(dev->p.i2c);
+    i2c_depr_acquire(dev->p.i2c);
+    i2c_depr_read_bytes(dev->p.i2c, dev->p.addr, buf, 4);
+    i2c_depr_release(dev->p.i2c);
 
     /* and finally we convert the values to their physical representation */
     if (temp) {

--- a/drivers/hih6130/hih6130.c
+++ b/drivers/hih6130/hih6130.c
@@ -23,7 +23,7 @@
 #include <stdint.h>
 
 #include "hih6130.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "xtimer.h"
 
 #define ENABLE_DEBUG    (0)
@@ -57,15 +57,15 @@ enum {
 /** @brief Trigger a new measurement on the sensor */
 static inline int hih6130_measurement_request(hih6130_t *dev)
 {
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
 
     /* An empty write request triggers a new measurement */
-    if (i2c_write_bytes(dev->i2c, dev->addr, NULL, 0) < 0) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_bytes(dev->i2c, dev->addr, NULL, 0) < 0) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
@@ -82,14 +82,14 @@ static inline int hih6130_get_humidity_temperature_raw(hih6130_t *dev, uint16_t 
     int status;
     uint8_t buf[HIH6130_FULL_DATA_LENGTH];
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
 
-    if (i2c_read_bytes(dev->i2c, dev->addr, &buf[0], sizeof(buf)) != sizeof(buf)) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_read_bytes(dev->i2c, dev->addr, &buf[0], sizeof(buf)) != sizeof(buf)) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     /* data is in big-endian format, with status bits in the first byte. */
     switch (buf[0] & HIH6130_STATUS_MASK) {

--- a/drivers/ina220/ina220.c
+++ b/drivers/ina220/ina220.c
@@ -24,7 +24,7 @@
 
 #include "ina220.h"
 #include "ina220-regs.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "byteorder.h"
 
 #define ENABLE_DEBUG    (0)
@@ -39,7 +39,7 @@ static int ina220_read_reg(ina220_t *dev, uint8_t reg, uint16_t *out)
     } tmp = { .u16 = 0 };
     int status = 0;
 
-    status = i2c_read_regs(dev->i2c, dev->addr, reg, &tmp.c[0], 2);
+    status = i2c_depr_read_regs(dev->i2c, dev->addr, reg, &tmp.c[0], 2);
 
     if (status != 2) {
         return -1;
@@ -60,7 +60,7 @@ static int ina220_write_reg(ina220_t *dev, uint8_t reg, uint16_t in)
 
     tmp.u16 = HTONS(in);
 
-    status = i2c_write_regs(dev->i2c, dev->addr, reg, &tmp.c[0], 2);
+    status = i2c_depr_write_regs(dev->i2c, dev->addr, reg, &tmp.c[0], 2);
 
     if (status != 2) {
         return -1;

--- a/drivers/include/at30tse75x.h
+++ b/drivers/include/at30tse75x.h
@@ -26,7 +26,7 @@
 #define AT30TSE75X_H
 
 #include <stdint.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/bh1750fvi.h
+++ b/drivers/include/bh1750fvi.h
@@ -21,7 +21,7 @@
 #ifndef BH1750FVI_H
 #define BH1750FVI_H
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/bme280.h
+++ b/drivers/include/bme280.h
@@ -31,7 +31,7 @@
 #define BME280_H
 
 #include "saul.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/bmp180.h
+++ b/drivers/include/bmp180.h
@@ -22,7 +22,7 @@
 #define BMP180_H
 
 #include "saul.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -40,7 +40,7 @@
 
 #include <stdint.h>
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "hdc1000_regs.h"
 
 #ifdef __cplusplus

--- a/drivers/include/hih6130.h
+++ b/drivers/include/hih6130.h
@@ -25,7 +25,7 @@
 
 #include <stdint.h>
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/ina220.h
+++ b/drivers/include/ina220.h
@@ -26,7 +26,7 @@
 
 #include <stdint.h>
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/isl29020.h
+++ b/drivers/include/isl29020.h
@@ -22,7 +22,7 @@
 #define ISL29020_H
 
 #include <stdint.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/isl29125.h
+++ b/drivers/include/isl29125.h
@@ -50,7 +50,7 @@
 
 #include <stdint.h>
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/gpio.h"
 #include "color.h"
 

--- a/drivers/include/jc42.h
+++ b/drivers/include/jc42.h
@@ -31,7 +31,7 @@
 #ifndef JC42_TEMP_H
 #define JC42_TEMP_H
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "saul.h"
 
 

--- a/drivers/include/l3g4200d.h
+++ b/drivers/include/l3g4200d.h
@@ -25,7 +25,7 @@
 
 #include <stdint.h>
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/gpio.h"
 
 #ifdef __cplusplus

--- a/drivers/include/lis3mdl.h
+++ b/drivers/include/lis3mdl.h
@@ -22,7 +22,7 @@
 #define LIS3MDL_H
 
 #include <stdint.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/gpio.h"
 
 #ifdef __cplusplus

--- a/drivers/include/lps331ap.h
+++ b/drivers/include/lps331ap.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
  /**
   * @brief The sensors default I2C address

--- a/drivers/include/lsm303dlhc.h
+++ b/drivers/include/lsm303dlhc.h
@@ -22,7 +22,7 @@
 #define LSM303DLHC_H
 
 #include <stdint.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/gpio.h"
 
 #ifdef __cplusplus

--- a/drivers/include/mag3110.h
+++ b/drivers/include/mag3110.h
@@ -32,7 +32,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/drivers/include/mma8x5x.h
+++ b/drivers/include/mma8x5x.h
@@ -31,7 +31,7 @@
 #define MMA8X5X_H
 
 #include <stdint.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -31,7 +31,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/drivers/include/mpu9150.h
+++ b/drivers/include/mpu9150.h
@@ -21,7 +21,7 @@
 #ifndef MPU9150_H
 #define MPU9150_H
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/periph/i2c_depr.h
+++ b/drivers/include/periph/i2c_depr.h
@@ -45,7 +45,11 @@
  * http://www.nxp.com/documents/user_manual/UM10204.pdf
  *
  * @note        The current version of this interface only supports the
-                7-bit addressing mode.
+ *              7-bit addressing mode.
+ *
+ * @deprecated
+ * @note        This interface is DEPRECATED, do not use it for any new
+ *              features. Use the updated `periph/i2c.h` interface instead.
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
@@ -130,7 +134,7 @@ typedef enum {
  * @return                  -1 on undefined device given
  * @return                  -2 on unsupported speed value
  */
-int i2c_init_master(i2c_t dev, i2c_speed_t speed);
+int i2c_depr_init_master(i2c_t dev, i2c_speed_t speed);
 
 /**
  * @brief   Get mutually exclusive access to the given I2C bus
@@ -143,7 +147,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed);
  * @return              0 on success
  * @return              -1 on error
  */
-int i2c_acquire(i2c_t dev);
+int i2c_depr_acquire(i2c_t dev);
 
 /**
  * @brief   Release the given I2C device to be used by others
@@ -153,7 +157,7 @@ int i2c_acquire(i2c_t dev);
  * @return              0 on success
  * @return              -1 on error
  */
-int i2c_release(i2c_t dev);
+int i2c_depr_release(i2c_t dev);
 
 /**
  * @brief   Read one byte from an I2C device with the given address
@@ -166,7 +170,7 @@ int i2c_release(i2c_t dev);
  * @return                  -1 on undefined device given
  * @return                  -2 on invalid address
  */
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data);
+int i2c_depr_read_byte(i2c_t dev, uint8_t address, void *data);
 
 /**
  * @brief   Read multiple bytes from an I2C device with the given address
@@ -179,7 +183,7 @@ int i2c_read_byte(i2c_t dev, uint8_t address, void *data);
  * @return                  the number of bytes that were read
  * @return                  -1 on undefined device given
  */
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length);
+int i2c_depr_read_bytes(i2c_t dev, uint8_t address, void *data, int length);
 
 /**
  * @brief   Read one byte from a register at the I2C slave with the given
@@ -193,7 +197,7 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length);
  * @return                  the number of bytes that were read
  * @return                  -1 on undefined device given
  */
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data);
+int i2c_depr_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data);
 
 /**
  * @brief   Read multiple bytes from a register at the I2C slave with the given
@@ -208,7 +212,7 @@ int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data);
  * @return                  the number of bytes that were read
  * @return                  -1 on undefined device given
  */
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg,
+int i2c_depr_read_regs(i2c_t dev, uint8_t address, uint8_t reg,
                   void *data, int length);
 
 /**
@@ -221,7 +225,7 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg,
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data);
+int i2c_depr_write_byte(i2c_t dev, uint8_t address, uint8_t data);
 
 /**
  * @brief   Write multiple bytes to an I2C device with the given address
@@ -234,7 +238,7 @@ int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data);
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length);
+int i2c_depr_write_bytes(i2c_t dev, uint8_t address, const void *data, int length);
 
 /**
  * @brief   Write one byte to a register at the I2C slave with the given address
@@ -247,7 +251,7 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length);
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data);
+int i2c_depr_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data);
 
 /**
  * @brief   Write multiple bytes to a register at the I2C slave with the given
@@ -262,7 +266,7 @@ int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data);
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg,
+int i2c_depr_write_regs(i2c_t dev, uint8_t address, uint8_t reg,
                    const void *data, int length);
 
 /**
@@ -270,14 +274,14 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg,
  *
  * @param[in] dev           the I2C device to power on
  */
-void i2c_poweron(i2c_t dev);
+void i2c_depr_poweron(i2c_t dev);
 
 /**
  * @brief   Power off the given I2C peripheral
  *
  * @param[in] dev           the I2C device to power off
  */
-void i2c_poweroff(i2c_t dev);
+void i2c_depr_poweroff(i2c_t dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/i2c_depr.h
+++ b/drivers/include/periph/i2c_depr.h
@@ -49,7 +49,7 @@
  *
  * @deprecated
  * @note        This interface is DEPRECATED, do not use it for any new
- *              features. Use the updated `periph/i2c.h` interface instead.
+ *              features. Use the updated `periph/i2c_depr.h` interface instead.
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/drivers/include/pn532.h
+++ b/drivers/include/pn532.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 #include "mutex.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/spi.h"
 #include "periph/gpio.h"
 #include <stdint.h>

--- a/drivers/include/si70xx.h
+++ b/drivers/include/si70xx.h
@@ -21,7 +21,7 @@
 #ifndef SI70XX_H
 #define SI70XX_H
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/srf02.h
+++ b/drivers/include/srf02.h
@@ -25,7 +25,7 @@
 #define SRF02_H
 
 #include <stdint.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/srf08.h
+++ b/drivers/include/srf08.h
@@ -28,7 +28,7 @@
 #define SRF08_H
 
 #include <stdint.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/tcs37727.h
+++ b/drivers/include/tcs37727.h
@@ -26,7 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/drivers/include/tmp006.h
+++ b/drivers/include/tmp006.h
@@ -77,7 +77,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/drivers/io1_xplained/io1_xplained.c
+++ b/drivers/io1_xplained/io1_xplained.c
@@ -25,7 +25,7 @@
 #include "io1_xplained_internals.h"
 #include "io1_xplained_params.h"
 #include "at30tse75x.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/gpio.h"
 #include "xtimer.h"
 

--- a/drivers/isl29020/isl29020.c
+++ b/drivers/isl29020/isl29020.c
@@ -21,7 +21,7 @@
 
 #include "isl29020.h"
 #include "isl29020-internal.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -38,15 +38,15 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
     dev->lux_fac = (float)((1 << (10 + (2 * range))) - 1) / 0xffff;
 
     /* acquire exclusive access to the bus */
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* initialize the I2C bus */
-    i2c_init_master(i2c, I2C_SPEED_NORMAL);
+    i2c_depr_init_master(i2c, I2C_SPEED_NORMAL);
 
     /* configure and enable the sensor */
     tmp = ISL29020_CMD_EN | ISL29020_CMD_MODE | ISL29020_RES_INT_16 | range | (mode << 5);
-    res = i2c_write_reg(dev->i2c, address, ISL29020_REG_CMD, tmp);
+    res = i2c_depr_write_reg(dev->i2c, address, ISL29020_REG_CMD, tmp);
     /* release the bus for other threads */
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     if (res < 1) {
         return -1;
     }
@@ -59,11 +59,11 @@ int isl29020_read(isl29020_t *dev)
     uint16_t res;
     int ret;
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* read lighting value */
-    ret = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_LDATA, &low);
-    ret += i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_HDATA, &high);
-    i2c_release(dev->i2c);
+    ret = i2c_depr_read_reg(dev->i2c, dev->address, ISL29020_REG_LDATA, &low);
+    ret += i2c_depr_read_reg(dev->i2c, dev->address, ISL29020_REG_HDATA, &high);
+    i2c_depr_release(dev->i2c);
     if (ret < 2) {
         return -1;
     }
@@ -78,19 +78,19 @@ int isl29020_enable(isl29020_t *dev)
     int res;
     uint8_t tmp;
 
-    i2c_acquire(dev->i2c);
-    res = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_CMD, &tmp);
+    i2c_depr_acquire(dev->i2c);
+    res = i2c_depr_read_reg(dev->i2c, dev->address, ISL29020_REG_CMD, &tmp);
     if (res < 1) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
     tmp |= ISL29020_CMD_EN;
-    res = i2c_write_reg(dev->i2c, dev->address, ISL29020_REG_CMD, tmp);
+    res = i2c_depr_write_reg(dev->i2c, dev->address, ISL29020_REG_CMD, tmp);
     if (res < 1) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -99,18 +99,18 @@ int isl29020_disable(isl29020_t *dev)
     int res;
     uint8_t tmp;
 
-    i2c_acquire(dev->i2c);
-    res = i2c_read_reg(dev->i2c, dev->address, ISL29020_REG_CMD, &tmp);
+    i2c_depr_acquire(dev->i2c);
+    res = i2c_depr_read_reg(dev->i2c, dev->address, ISL29020_REG_CMD, &tmp);
     if (res < 1) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
     tmp &= ~(ISL29020_CMD_EN);
-    res = i2c_write_reg(dev->i2c, dev->address, ISL29020_REG_CMD, tmp);
+    res = i2c_depr_write_reg(dev->i2c, dev->address, ISL29020_REG_CMD, tmp);
     if (res < 1) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }

--- a/drivers/isl29125/isl29125.c
+++ b/drivers/isl29125/isl29125.c
@@ -25,7 +25,7 @@
 
 #include "isl29125.h"
 #include "isl29125-internal.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/gpio.h"
 #include "color.h"
 
@@ -58,36 +58,36 @@ int isl29125_init(isl29125_t *dev, i2c_t i2c, gpio_t gpio,
     /* TODO: implement configuration 2: infrared compensation configuration */
 
     /* acquire exclusive access to the bus */
-    DEBUG("isl29125_init: i2c_acquire\n");
-    (void) i2c_acquire(dev->i2c);
+    DEBUG("isl29125_init: i2c_depr_acquire\n");
+    (void) i2c_depr_acquire(dev->i2c);
 
     /* initialize the I2C bus */
-    DEBUG("isl29125_init: i2c_init_master\n");
-    (void) i2c_init_master(i2c, I2C_SPEED_NORMAL);
+    DEBUG("isl29125_init: i2c_depr_init_master\n");
+    (void) i2c_depr_init_master(i2c, I2C_SPEED_NORMAL);
 
     /* verify the device ID */
-    DEBUG("isl29125_init: i2c_read_reg\n");
+    DEBUG("isl29125_init: i2c_depr_read_reg\n");
     uint8_t reg_id;
-    int ret = i2c_read_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_ID, &reg_id);
+    int ret = i2c_depr_read_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_ID, &reg_id);
     if ((reg_id == ISL29125_ID) && (ret == 1)) {
         DEBUG("isl29125_init: ID successfully verified\n");
     }
     else {
         DEBUG("isl29125_init: ID could not be verified, ret: %i\n", ret);
-        (void) i2c_release(dev->i2c);
+        (void) i2c_depr_release(dev->i2c);
         return -1;
     }
 
     /* configure and enable the sensor */
-    DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_RESET)\n");
-    (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_RESET, ISL29125_CMD_RESET);
+    DEBUG("isl29125_init: i2c_depr_write_reg(ISL29125_REG_RESET)\n");
+    (void) i2c_depr_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_RESET, ISL29125_CMD_RESET);
 
-    DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_CONF1)\n");
-    (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, conf1);
+    DEBUG("isl29125_init: i2c_depr_write_reg(ISL29125_REG_CONF1)\n");
+    (void) i2c_depr_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, conf1);
 
     /* release the I2C bus */
-    DEBUG("isl29125_init: i2c_release\n");
-    (void) i2c_release(dev->i2c);
+    DEBUG("isl29125_init: i2c_depr_release\n");
+    (void) i2c_depr_release(dev->i2c);
 
     DEBUG("isl29125_init: success\n");
     return 0;
@@ -125,20 +125,20 @@ int isl29125_init_int(isl29125_t *dev, isl29125_interrupt_status_t interrupt_sta
         hthhb = (uint8_t)(higher_threshold >> 8);
     }
 
-    DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_CONF3)\n");
-    (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF3, conf3);
+    DEBUG("isl29125_init: i2c_depr_write_reg(ISL29125_REG_CONF3)\n");
+    (void) i2c_depr_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF3, conf3);
 
-    DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_LTHLB)\n");
-    (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_LTHLB, lthlb);
+    DEBUG("isl29125_init: i2c_depr_write_reg(ISL29125_REG_LTHLB)\n");
+    (void) i2c_depr_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_LTHLB, lthlb);
 
-    DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_LTHHB)\n");
-    (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_LTHHB, lthhb);
+    DEBUG("isl29125_init: i2c_depr_write_reg(ISL29125_REG_LTHHB)\n");
+    (void) i2c_depr_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_LTHHB, lthhb);
 
-    DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_HTHLB)\n");
-    (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHLB, hthlb);
+    DEBUG("isl29125_init: i2c_depr_write_reg(ISL29125_REG_HTHLB)\n");
+    (void) i2c_depr_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHLB, hthlb);
 
-    DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_HTHHB)\n");
-    (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHHB, hthhb);
+    DEBUG("isl29125_init: i2c_depr_write_reg(ISL29125_REG_HTHHB)\n");
+    (void) i2c_depr_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHHB, hthhb);
 
     if (gpio_init_int(dev->gpio, GPIO_IN, GPIO_FALLING, cb, arg) < 0) {
         DEBUG("error: gpio_init_int failed\n");
@@ -151,14 +151,14 @@ int isl29125_init_int(isl29125_t *dev, isl29125_interrupt_status_t interrupt_sta
 void isl29125_read_rgb_lux(isl29125_t *dev, isl29125_rgb_t *dest)
 {
     /* acquire exclusive access to the bus */
-    (void) i2c_acquire(dev->i2c);
+    (void) i2c_depr_acquire(dev->i2c);
 
     /* read values */
     uint8_t bytes[6];
-    (void) i2c_read_regs(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6);
+    (void) i2c_depr_read_regs(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6);
 
     /* release the I2C bus */
-    (void) i2c_release(dev->i2c);
+    (void) i2c_depr_release(dev->i2c);
 
     /* possibly shift by 4 to normalize 12 to 16 bit */
     int resfactor = (dev->res == ISL29125_RESOLUTION_12) ? 4 : 0;
@@ -179,14 +179,14 @@ void isl29125_read_rgb_lux(isl29125_t *dev, isl29125_rgb_t *dest)
 void isl29125_read_rgb_color(isl29125_t *dev, color_rgb_t *dest)
 {
     /* acquire exclusive access to the bus */
-    (void) i2c_acquire(dev->i2c);
+    (void) i2c_depr_acquire(dev->i2c);
 
     /* read values */
     uint8_t bytes[6];
-    (void) i2c_read_regs(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6);
+    (void) i2c_depr_read_regs(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6);
 
     /* release the I2C bus */
-    (void) i2c_release(dev->i2c);
+    (void) i2c_depr_release(dev->i2c);
 
     /* factor normalize 12 or 16 bit to 8 bit */
     int normfactor = (dev->res == ISL29125_RESOLUTION_12) ? 4 : 8;
@@ -200,27 +200,27 @@ void isl29125_set_mode(isl29125_t *dev, isl29125_mode_t mode)
 {
     uint8_t conf1;
 
-    (void) i2c_acquire(dev->i2c);
+    (void) i2c_depr_acquire(dev->i2c);
 
-    (void) i2c_read_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, &conf1);
+    (void) i2c_depr_read_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, &conf1);
     conf1 &= ~ISL29125_CON1_MASK_MODE;
     conf1 |= mode;
-    (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, conf1);
+    (void) i2c_depr_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, conf1);
 
-    (void) i2c_release(dev->i2c);
+    (void) i2c_depr_release(dev->i2c);
 }
 
 int isl29125_read_irq_status(isl29125_t *dev)
 {
     /* acquire exclusive access to the bus */
-    (void) i2c_acquire(dev->i2c);
+    (void) i2c_depr_acquire(dev->i2c);
 
     /* read status register */
     uint8_t irq_status;
-    (void) i2c_read_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_STATUS, &irq_status);
+    (void) i2c_depr_read_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_STATUS, &irq_status);
 
     /* release the I2C bus */
-    (void) i2c_release(dev->i2c);
+    (void) i2c_depr_release(dev->i2c);
 
     /* return bit 0 (RGBTHF)*/
     return (irq_status & 0x01);

--- a/drivers/jc42/include/jc42_params.h
+++ b/drivers/jc42/include/jc42_params.h
@@ -22,7 +22,7 @@
 #define JC42_PARAMS_H
 
 #include "jc42.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/jc42/jc42.c
+++ b/drivers/jc42/jc42.c
@@ -19,7 +19,7 @@
  */
 
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "byteorder.h"
 
 #include "jc42.h"
@@ -30,25 +30,25 @@
 
 static int jc42_get_register(jc42_t* dev, uint8_t reg, uint16_t* data)
 {
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
         DEBUG("[jc42] Problem reading register 0x%x\n", reg);
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return JC42_NODEV;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return JC42_OK;
 }
 
 static int jc42_set_register(jc42_t* dev, uint8_t reg, uint16_t* data)
 {
-    i2c_acquire(dev->i2c);
-    if (i2c_write_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
         DEBUG("[jc42] Problem writing to register 0x%x\n", reg);
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return JC42_NODEV;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return JC42_OK;
 }
@@ -83,13 +83,13 @@ int jc42_init(jc42_t* dev, jc42_params_t* params)
     uint16_t config;
     dev->i2c = params->i2c;
     dev->addr = params->addr;
-    i2c_acquire(dev->i2c);
-    if (i2c_init_master(dev->i2c, params->speed) != 0) {
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_init_master(dev->i2c, params->speed) != 0) {
         DEBUG("[jc42] Problem initializing I2C master\n");
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return JC42_NOI2C;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     /* Poll the device, fail if unavailable */
     if (jc42_get_config(dev, &config) != 0) {

--- a/drivers/l3g4200d/l3g4200d.c
+++ b/drivers/l3g4200d/l3g4200d.c
@@ -23,7 +23,7 @@
 
 #include "l3g4200d.h"
 #include "l3g4200d-regs.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/gpio.h"
 
 #define ENABLE_DEBUG    (0)
@@ -62,25 +62,25 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
     }
 
     /* acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* initialize the I2C bus */
-    if (i2c_init_master(i2c, I2C_SPEED) < 0) {
+    if (i2c_depr_init_master(i2c, I2C_SPEED) < 0) {
         /* Release the bus for other threads. */
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
     /* configure CTRL_REG1 */
     tmp = ((mode & 0xf) << L3G4200D_CTRL1_MODE_POS) | L3G4200D_CTRL1_ALLON;
-    if (i2c_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
     tmp = ((scale & 0x3) << L3G4200D_CTRL4_FS_POS) | L3G4200D_CTRL4_BDU;
-    if (i2c_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL4, tmp) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL4, tmp) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -89,10 +89,10 @@ int l3g4200d_read(l3g4200d_t *dev, l3g4200d_data_t *data)
     uint8_t tmp[6];
     int16_t res;
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* get acceleration in x direction */
-    i2c_read_regs(dev->i2c, dev->addr, L3G4200D_REG_OUT_X_L | L3G4200D_AUTOINC, tmp, 6);
-    i2c_release(dev->i2c);
+    i2c_depr_read_regs(dev->i2c, dev->addr, L3G4200D_REG_OUT_X_L | L3G4200D_AUTOINC, tmp, 6);
+    i2c_depr_release(dev->i2c);
 
     /* parse and normalize data into result vector */
     res = (tmp[1] << 8) | tmp[0];
@@ -109,18 +109,18 @@ int l3g4200d_enable(l3g4200d_t *dev)
     uint8_t tmp;
     int res;
 
-    i2c_acquire(dev->i2c);
-    res = i2c_read_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, &tmp);
+    i2c_depr_acquire(dev->i2c);
+    res = i2c_depr_read_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, &tmp);
     if (res < 1) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return res;
     }
     tmp |= L3G4200D_CTRL1_PD;
-    if (i2c_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -129,17 +129,17 @@ int l3g4200d_disable(l3g4200d_t *dev)
     uint8_t tmp;
     int res;
 
-    i2c_acquire(dev->i2c);
-    res = i2c_read_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, &tmp);
+    i2c_depr_acquire(dev->i2c);
+    res = i2c_depr_read_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, &tmp);
     if (res < 1) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return res;
     }
     tmp &= ~L3G4200D_CTRL1_PD;
-    if (i2c_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, L3G4200D_REG_CTRL1, tmp) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }

--- a/drivers/lis3mdl/lis3mdl.c
+++ b/drivers/lis3mdl/lis3mdl.c
@@ -64,14 +64,14 @@ int lis3mdl_init(lis3mdl_t *dev,
     dev->i2c = i2c;
     dev->addr = address;
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
 
-    if (i2c_init_master(i2c, I2C_SPEED_NORMAL) < 0) {
+    if (i2c_depr_init_master(i2c, I2C_SPEED_NORMAL) < 0) {
         DEBUG("LIS3MDL: Master initialization failed\n");
         return -1;
     }
 
-    i2c_read_reg(dev->i2c, dev->addr, LIS3DML_WHO_AM_I_REG, &tmp);
+    i2c_depr_read_reg(dev->i2c, dev->addr, LIS3DML_WHO_AM_I_REG, &tmp);
     if (tmp != LIS3MDL_CHIP_ID) {
         DEBUG("LIS3MDL: Identification failed\n");
         return -1;
@@ -80,18 +80,18 @@ int lis3mdl_init(lis3mdl_t *dev,
     tmp = ( LIS3MDL_MASK_REG1_TEMP_EN   /* enable temperature sensor */
           | xy_mode                     /* set x-, y-axis operative mode */
           | odr);                       /* set output data rate */
-    i2c_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG1, tmp);
+    i2c_depr_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG1, tmp);
 
     /* set Full-scale configuration */
-    i2c_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG2, scale);
+    i2c_depr_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG2, scale);
 
     /* set continuous-conversion mode */
-    i2c_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG3, op_mode);
+    i2c_depr_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG3, op_mode);
 
     /* set z-axis operative mode */
-    i2c_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG4, z_mode);
+    i2c_depr_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG4, z_mode);
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
@@ -100,15 +100,15 @@ void lis3mdl_read_mag(lis3mdl_t *dev, lis3mdl_3d_data_t *data)
 {
     uint8_t tmp[2] = {0, 0};
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
 
-    i2c_read_regs(dev->i2c, dev->addr, LIS3MDL_OUT_X_L_REG, &tmp[0], 2);
+    i2c_depr_read_regs(dev->i2c, dev->addr, LIS3MDL_OUT_X_L_REG, &tmp[0], 2);
     data->x_axis = (tmp[1] << 8) | tmp[0];
 
-    i2c_read_regs(dev->i2c, dev->addr, LIS3MDL_OUT_Y_L_REG, &tmp[0], 2);
+    i2c_depr_read_regs(dev->i2c, dev->addr, LIS3MDL_OUT_Y_L_REG, &tmp[0], 2);
     data->y_axis = (tmp[1] << 8) | tmp[0];
 
-    i2c_read_regs(dev->i2c, dev->addr, LIS3MDL_OUT_Z_L_REG, &tmp[0], 2);
+    i2c_depr_read_regs(dev->i2c, dev->addr, LIS3MDL_OUT_Z_L_REG, &tmp[0], 2);
     data->z_axis = (tmp[1] << 8) | tmp[0];
 
     data->x_axis = _twos_complement(data->x_axis);
@@ -120,14 +120,14 @@ void lis3mdl_read_mag(lis3mdl_t *dev, lis3mdl_3d_data_t *data)
     data->y_axis /= GAUSS_DIVIDER;
     data->z_axis /= GAUSS_DIVIDER;
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 }
 
 void lis3mdl_read_temp(lis3mdl_t *dev, int16_t *value)
 {
-    i2c_acquire(dev->i2c);
-    i2c_read_regs(dev->i2c, dev->addr, LIS3MDL_TEMP_OUT_L_REG, (uint8_t*)value, 2);
-    i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_read_regs(dev->i2c, dev->addr, LIS3MDL_TEMP_OUT_L_REG, (uint8_t*)value, 2);
+    i2c_depr_release(dev->i2c);
 
     *value = _twos_complement(*value);
 
@@ -136,11 +136,11 @@ void lis3mdl_read_temp(lis3mdl_t *dev, int16_t *value)
 
 void lis3mdl_enable(lis3mdl_t *dev)
 {
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* Z-axis medium-power mode */
-    i2c_write_reg(dev->i2c, dev->addr,
+    i2c_depr_write_reg(dev->i2c, dev->addr,
                   LIS3MDL_CTRL_REG3, LIS3MDL_MASK_REG3_Z_MEDIUM_POWER);
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 }
 
 void lis3mdl_disable(lis3mdl_t *dev)
@@ -148,7 +148,7 @@ void lis3mdl_disable(lis3mdl_t *dev)
     uint8_t tmp = ( LIS3MDL_MASK_REG3_LOW_POWER_EN   /**< enable power-down mode */
                   | LIS3MDL_MASK_REG3_Z_LOW_POWER);  /**< Z-axis low-power mode */
 
-    i2c_acquire(dev->i2c);
-    i2c_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG3, tmp);
-    i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_write_reg(dev->i2c, dev->addr, LIS3MDL_CTRL_REG3, tmp);
+    i2c_depr_release(dev->i2c);
 }

--- a/drivers/lps331ap/lps331ap.c
+++ b/drivers/lps331ap/lps331ap.c
@@ -25,7 +25,7 @@
 
 #include <stdint.h>
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "lps331ap.h"
 #include "lps331ap-internal.h"
 
@@ -55,22 +55,22 @@ int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t r
     dev->address = address;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* initialize underlying I2C bus */
-    if (i2c_init_master(dev->i2c, BUS_SPEED) < 0) {
+    if (i2c_depr_init_master(dev->i2c, BUS_SPEED) < 0) {
         /* Release the bus for other threads. */
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
     /* configure device, for simple operation only CTRL_REG1 needs to be touched */
     tmp = LPS331AP_CTRL_REG1_DBDU | LPS331AP_CTRL_REG1_PD |
           (rate << LPS331AP_CTRL_REG1_ODR_POS);
-    if (i2c_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
@@ -81,11 +81,11 @@ int lps331ap_read_temp(lps331ap_t *dev)
     int16_t val = 0;
     float res = TEMP_BASE;      /* reference value -> see datasheet */
 
-    i2c_acquire(dev->i2c);
-    i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_TEMP_OUT_L, &tmp);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_read_reg(dev->i2c, dev->address, LPS331AP_REG_TEMP_OUT_L, &tmp);
     val |= tmp;
-    i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_TEMP_OUT_H, &tmp);
-    i2c_release(dev->i2c);
+    i2c_depr_read_reg(dev->i2c, dev->address, LPS331AP_REG_TEMP_OUT_H, &tmp);
+    i2c_depr_release(dev->i2c);
     val |= (tmp << 8);
 
     /* compute actual temperature value in °C */
@@ -101,13 +101,13 @@ int lps331ap_read_pres(lps331ap_t *dev)
     int32_t val = 0;
     float res;
 
-    i2c_acquire(dev->i2c);
-    i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_XL, &tmp);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_XL, &tmp);
     val |= tmp;
-    i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_L, &tmp);
+    i2c_depr_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_L, &tmp);
     val |= (tmp << 8);
-    i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_H, &tmp);
-    i2c_release(dev->i2c);
+    i2c_depr_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_H, &tmp);
+    i2c_depr_release(dev->i2c);
     val |= (tmp << 16);
     /* see if value is negative */
     if (tmp & 0x80) {
@@ -126,14 +126,14 @@ int lps331ap_enable(lps331ap_t *dev)
     uint8_t tmp;
     int status;
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, &tmp) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, &tmp) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
     tmp |= (LPS331AP_CTRL_REG1_PD);
-    status = i2c_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp);
-    i2c_release(dev->i2c);
+    status = i2c_depr_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp);
+    i2c_depr_release(dev->i2c);
 
     return status;
 }
@@ -143,14 +143,14 @@ int lps331ap_disable(lps331ap_t *dev)
     uint8_t tmp;
     int status;
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, &tmp) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, &tmp) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
     tmp &= ~(LPS331AP_CTRL_REG1_PD);
-    status = i2c_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp);
-    i2c_release(dev->i2c);
+    status = i2c_depr_write_reg(dev->i2c, dev->address, LPS331AP_REG_CTRL_REG1, tmp);
+    i2c_depr_release(dev->i2c);
 
     return status;
 }

--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -45,14 +45,14 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
     dev->mag_gain    = mag_gain;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    i2c_init_master(i2c, I2C_SPEED_NORMAL);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_init_master(i2c, I2C_SPEED_NORMAL);
 
     DEBUG("lsm303dlhc reboot...");
-    res = i2c_write_reg(dev->i2c, dev->acc_address,
+    res = i2c_depr_write_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_CTRL5_A, LSM303DLHC_REG_CTRL5_A_BOOT);
     /* Release the bus for other threads. */
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     DEBUG("[OK]\n");
 
     /* configure accelerometer */
@@ -61,15 +61,15 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
           | LSM303DLHC_CTRL1_A_YEN
           | LSM303DLHC_CTRL1_A_ZEN
           | acc_sample_rate);
-    i2c_acquire(dev->i2c);
-    res += i2c_write_reg(dev->i2c, dev->acc_address,
+    i2c_depr_acquire(dev->i2c);
+    res += i2c_depr_write_reg(dev->i2c, dev->acc_address,
                          LSM303DLHC_REG_CTRL1_A, tmp);
     /* update on read, MSB @ low address, scale and high-resolution */
     tmp = (acc_scale | LSM303DLHC_CTRL4_A_HR);
-    res += i2c_write_reg(dev->i2c, dev->acc_address,
+    res += i2c_depr_write_reg(dev->i2c, dev->acc_address,
                          LSM303DLHC_REG_CTRL4_A, tmp);
     /* no interrupt generation */
-    res += i2c_write_reg(dev->i2c, dev->acc_address,
+    res += i2c_depr_write_reg(dev->i2c, dev->acc_address,
                          LSM303DLHC_REG_CTRL3_A, LSM303DLHC_CTRL3_A_I1_NONE);
     /* configure acc data ready pin */
     gpio_init(acc_pin, GPIO_IN);
@@ -77,15 +77,15 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
     /* configure magnetometer and temperature */
     /* enable temperature output and set sample rate */
     tmp = LSM303DLHC_TEMP_EN | mag_sample_rate;
-    res += i2c_write_reg(dev->i2c, dev->mag_address,
+    res += i2c_depr_write_reg(dev->i2c, dev->mag_address,
                          LSM303DLHC_REG_CRA_M, tmp);
     /* configure z-axis gain */
-    res += i2c_write_reg(dev->i2c, dev->mag_address,
+    res += i2c_depr_write_reg(dev->i2c, dev->mag_address,
                          LSM303DLHC_REG_CRB_M, mag_gain);
     /* set continuous mode */
-    res += i2c_write_reg(dev->i2c, dev->mag_address,
+    res += i2c_depr_write_reg(dev->i2c, dev->mag_address,
                          LSM303DLHC_REG_MR_M, LSM303DLHC_MAG_MODE_CONTINUOUS);
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     /* configure mag data ready pin */
     gpio_init(mag_pin, GPIO_IN);
 
@@ -97,30 +97,30 @@ int lsm303dlhc_read_acc(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
     int res;
     uint8_t tmp;
 
-    i2c_acquire(dev->i2c);
-    i2c_read_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_STATUS_A, &tmp);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_read_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_STATUS_A, &tmp);
     DEBUG("lsm303dlhc status: %x\n", tmp);
     DEBUG("lsm303dlhc: wait for acc values ... ");
 
-    res = i2c_read_reg(dev->i2c, dev->acc_address,
+    res = i2c_depr_read_reg(dev->i2c, dev->acc_address,
                        LSM303DLHC_REG_OUT_X_L_A, &tmp);
     data->x_axis = tmp;
-    res += i2c_read_reg(dev->i2c, dev->acc_address,
+    res += i2c_depr_read_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_OUT_X_H_A, &tmp);
     data->x_axis |= tmp<<8;
-    res += i2c_read_reg(dev->i2c, dev->acc_address,
+    res += i2c_depr_read_reg(dev->i2c, dev->acc_address,
                        LSM303DLHC_REG_OUT_Y_L_A, &tmp);
     data->y_axis = tmp;
-    res += i2c_read_reg(dev->i2c, dev->acc_address,
+    res += i2c_depr_read_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_OUT_Y_H_A, &tmp);
     data->y_axis |= tmp<<8;
-    res += i2c_read_reg(dev->i2c, dev->acc_address,
+    res += i2c_depr_read_reg(dev->i2c, dev->acc_address,
                        LSM303DLHC_REG_OUT_Z_L_A, &tmp);
     data->z_axis = tmp;
-    res += i2c_read_reg(dev->i2c, dev->acc_address,
+    res += i2c_depr_read_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_OUT_Z_H_A, &tmp);
     data->z_axis |= tmp<<8;
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     DEBUG("read ... ");
 
     data->x_axis = data->x_axis>>4;
@@ -145,10 +145,10 @@ int lsm303dlhc_read_mag(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
 
     DEBUG("read ... ");
 
-    i2c_acquire(dev->i2c);
-    res = i2c_read_regs(dev->i2c, dev->mag_address,
+    i2c_depr_acquire(dev->i2c);
+    res = i2c_depr_read_regs(dev->i2c, dev->mag_address,
                         LSM303DLHC_REG_OUT_X_H_M, data, 6);
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     if (res < 6) {
         DEBUG("[!!failed!!]\n");
@@ -173,9 +173,9 @@ int lsm303dlhc_read_temp(lsm303dlhc_t *dev, int16_t *value)
 {
     int res;
 
-    i2c_acquire(dev->i2c);
-    res = i2c_read_regs(dev->i2c, dev->mag_address, LSM303DLHC_REG_TEMP_OUT_H, value, 2);
-    i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    res = i2c_depr_read_regs(dev->i2c, dev->mag_address, LSM303DLHC_REG_TEMP_OUT_H, value, 2);
+    i2c_depr_release(dev->i2c);
 
     if (res < 2) {
         return -1;
@@ -192,14 +192,14 @@ int lsm303dlhc_disable(lsm303dlhc_t *dev)
 {
     int res;
 
-    i2c_acquire(dev->i2c);
-    res = i2c_write_reg(dev->i2c, dev->acc_address,
+    i2c_depr_acquire(dev->i2c);
+    res = i2c_depr_write_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_CTRL1_A, LSM303DLHC_CTRL1_A_POWEROFF);
-    res += i2c_write_reg(dev->i2c, dev->mag_address,
+    res += i2c_depr_write_reg(dev->i2c, dev->mag_address,
                         LSM303DLHC_REG_MR_M, LSM303DLHC_MAG_MODE_SLEEP);
-    res += i2c_write_reg(dev->i2c, dev->acc_address,
+    res += i2c_depr_write_reg(dev->i2c, dev->acc_address,
                         LSM303DLHC_REG_CRA_M, LSM303DLHC_TEMP_DIS);
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return (res < 3) ? -1 : 0;
 }
@@ -211,23 +211,23 @@ int lsm303dlhc_enable(lsm303dlhc_t *dev)
                   | LSM303DLHC_CTRL1_A_YEN
                   | LSM303DLHC_CTRL1_A_ZEN
                   | LSM303DLHC_CTRL1_A_N1344HZ_L5376HZ);
-    i2c_acquire(dev->i2c);
-    res = i2c_write_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_CTRL1_A, tmp);
+    i2c_depr_acquire(dev->i2c);
+    res = i2c_depr_write_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_CTRL1_A, tmp);
 
     tmp = (LSM303DLHC_CTRL4_A_BDU| LSM303DLHC_CTRL4_A_SCALE_2G | LSM303DLHC_CTRL4_A_HR);
-    res += i2c_write_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_CTRL4_A, tmp);
-    res += i2c_write_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_CTRL3_A, LSM303DLHC_CTRL3_A_I1_DRDY1);
+    res += i2c_depr_write_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_CTRL4_A, tmp);
+    res += i2c_depr_write_reg(dev->i2c, dev->acc_address, LSM303DLHC_REG_CTRL3_A, LSM303DLHC_CTRL3_A_I1_DRDY1);
     gpio_init(dev->acc_pin, GPIO_IN);
 
     tmp = LSM303DLHC_TEMP_EN | LSM303DLHC_TEMP_SAMPLE_75HZ;
-    res += i2c_write_reg(dev->i2c, dev->mag_address, LSM303DLHC_REG_CRA_M, tmp);
+    res += i2c_depr_write_reg(dev->i2c, dev->mag_address, LSM303DLHC_REG_CRA_M, tmp);
 
-    res += i2c_write_reg(dev->i2c, dev->mag_address,
+    res += i2c_depr_write_reg(dev->i2c, dev->mag_address,
                         LSM303DLHC_REG_CRB_M, LSM303DLHC_GAIN_5);
 
-    res += i2c_write_reg(dev->i2c, dev->mag_address,
+    res += i2c_depr_write_reg(dev->i2c, dev->mag_address,
                         LSM303DLHC_REG_MR_M, LSM303DLHC_MAG_MODE_CONTINUOUS);
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     gpio_init(dev->mag_pin, GPIO_IN);
 

--- a/drivers/mag3110/mag3110.c
+++ b/drivers/mag3110/mag3110.c
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "mag3110.h"
 #include "mag3110_reg.h"
 
@@ -36,13 +36,13 @@ int mag3110_test(mag3110_t *dev)
     uint8_t reg;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_WHO_AM_I, &reg, 1) != 1) {
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MAG3110_WHO_AM_I, &reg, 1) != 1) {
         /* Release the bus for other threads. */
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     if (reg != MAG3110_ID) {
         return -1;
@@ -64,13 +64,13 @@ int mag3110_init(mag3110_t *dev, i2c_t i2c, uint8_t address, uint8_t dros)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* initialize the I2C bus */
-    if (i2c_init_master(i2c, I2C_SPEED) < 0) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_init_master(i2c, I2C_SPEED) < 0) {
+        i2c_depr_release(dev->i2c);
         return -2;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     if (mag3110_test(dev)) {
         return -3;
@@ -79,19 +79,19 @@ int mag3110_init(mag3110_t *dev, i2c_t i2c, uint8_t address, uint8_t dros)
     /* enable automatic magnetic sensor reset */
     reg = MAG3110_CTRL_REG2_AUTO_MRST_EN;
 
-    i2c_acquire(dev->i2c);
-    if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG2, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG2, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -4;
     }
 
     reg = MAG3110_CTRL_REG1_DROS(dros);
 
-    if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -4;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     dev->initialized = true;
 
@@ -109,12 +109,12 @@ int mag3110_set_user_offset(mag3110_t *dev, int16_t x, int16_t y, int16_t z)
     buf[4] = (z >> 8);
     buf[5] = z;
 
-    i2c_acquire(dev->i2c);
-    if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_OFF_X_MSB, buf, 6) != 6) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MAG3110_OFF_X_MSB, buf, 6) != 6) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
@@ -127,19 +127,19 @@ int mag3110_set_active(mag3110_t *dev)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
     reg |= MAG3110_CTRL_REG1_AC;
 
-    if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
@@ -148,19 +148,19 @@ int mag3110_set_standby(mag3110_t *dev)
 {
     uint8_t reg;
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
     reg &= ~MAG3110_CTRL_REG1_AC;
 
-    if (i2c_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MAG3110_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }
@@ -173,12 +173,12 @@ int mag3110_is_ready(mag3110_t *dev)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_DR_STATUS, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MAG3110_DR_STATUS, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return (int)(reg & MAG3110_DR_STATUS_ZYXDR);
 }
@@ -191,12 +191,12 @@ int mag3110_read(mag3110_t *dev, int16_t *x, int16_t *y, int16_t *z, uint8_t *st
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_DR_STATUS, buf, 7) != 7) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MAG3110_DR_STATUS, buf, 7) != 7) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     *status = buf[0];
     *x = ((int16_t)buf[1] << 8) | buf[2];
@@ -212,12 +212,12 @@ int mag3110_read_dtemp(mag3110_t *dev, int8_t *dtemp)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MAG3110_DIE_TEMP, dtemp, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MAG3110_DIE_TEMP, dtemp, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return 0;
 }

--- a/drivers/mma8x5x/mma8x5x.c
+++ b/drivers/mma8x5x/mma8x5x.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #include "assert.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "mma8x5x.h"
 #include "mma8x5x_regs.h"
 
@@ -49,38 +49,38 @@ int mma8x5x_init(mma8x5x_t *dev, const mma8x5x_params_t *params)
     memcpy(dev, params, sizeof(mma8x5x_params_t));
 
     /* initialize the I2C bus */
-    i2c_acquire(BUS);
-    if (i2c_init_master(BUS, I2C_SPEED) < 0) {
-        i2c_release(BUS);
+    i2c_depr_acquire(BUS);
+    if (i2c_depr_init_master(BUS, I2C_SPEED) < 0) {
+        i2c_depr_release(BUS);
         DEBUG("[mma8x5x] init - error: unable to initialize I2C bus\n");
         return MMA8X5X_NOI2C;
     }
 
     /* test if the target device responds */
-    i2c_read_reg(BUS, ADDR, MMA8X5X_WHO_AM_I, &reg);
+    i2c_depr_read_reg(BUS, ADDR, MMA8X5X_WHO_AM_I, &reg);
     if (reg != dev->params.type) {
-        i2c_release(BUS);
+        i2c_depr_release(BUS);
         DEBUG("[mma8x5x] init - error: invalid WHO_AM_I value [0x%02x]\n",
                (int)reg);
         return MMA8X5X_NODEV;
     }
 
     /* reset the device */
-    i2c_write_reg(BUS, ADDR, MMA8X5X_CTRL_REG2, MMA8X5X_CTRL_REG2_RST);
+    i2c_depr_write_reg(BUS, ADDR, MMA8X5X_CTRL_REG2, MMA8X5X_CTRL_REG2_RST);
     do {
-        i2c_read_reg(BUS, ADDR, MMA8X5X_CTRL_REG2, &reg);
+        i2c_depr_read_reg(BUS, ADDR, MMA8X5X_CTRL_REG2, &reg);
     } while (reg & MMA8X5X_CTRL_REG2_RST);
     /* configure the user offset */
-    i2c_write_regs(BUS, ADDR, MMA8X5X_OFF_X, dev->params.offset, 3);
+    i2c_depr_write_regs(BUS, ADDR, MMA8X5X_OFF_X, dev->params.offset, 3);
     /* configure range, rate, and activate the device */
     reg = (dev->params.range & MMA8X5X_XYZ_DATA_CFG_FS_MASK);
-    i2c_write_reg(BUS, ADDR, MMA8X5X_XYZ_DATA_CFG, reg);
+    i2c_depr_write_reg(BUS, ADDR, MMA8X5X_XYZ_DATA_CFG, reg);
     reg = ((dev->params.rate & MMA8X5X_CTRL_REG1_DR_MASK) |
            MMA8X5X_CTRL_REG1_ACTIVE);
-    i2c_write_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, reg);
+    i2c_depr_write_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, reg);
 
     /* finally release the bus */
-    i2c_release(BUS);
+    i2c_depr_release(BUS);
 
     DEBUG("[mma8x5x] init: successful\n");
 
@@ -100,9 +100,9 @@ void mma8x5x_set_user_offset(mma8x5x_t *dev, int8_t x, int8_t y, int8_t z)
     DEBUG("[mma8x5x] setting user offset to X: %3i, Y: %3i, Z: %3i\n",
           (int)x, (int)y, (int)z);
 
-    i2c_acquire(BUS);
-    i2c_write_regs(BUS, ADDR, MMA8X5X_OFF_X, buf, 3);
-    i2c_release(BUS);
+    i2c_depr_acquire(BUS);
+    i2c_depr_write_regs(BUS, ADDR, MMA8X5X_OFF_X, buf, 3);
+    i2c_depr_release(BUS);
 }
 
 void mma8x5x_set_active(mma8x5x_t *dev)
@@ -113,11 +113,11 @@ void mma8x5x_set_active(mma8x5x_t *dev)
 
     DEBUG("[mma8x5x] put device to active mode\n");
 
-    i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, &reg);
+    i2c_depr_acquire(BUS);
+    i2c_depr_read_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, &reg);
     reg |= MMA8X5X_CTRL_REG1_ACTIVE;
-    i2c_write_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, reg);
-    i2c_release(BUS);
+    i2c_depr_write_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, reg);
+    i2c_depr_release(BUS);
 }
 
 void mma8x5x_set_standby(mma8x5x_t *dev)
@@ -128,11 +128,11 @@ void mma8x5x_set_standby(mma8x5x_t *dev)
 
     DEBUG("[mma8x5x] put device to standby mode\n");
 
-    i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, &reg);
+    i2c_depr_acquire(BUS);
+    i2c_depr_read_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, &reg);
     reg &= ~MMA8X5X_CTRL_REG1_ACTIVE;
-    i2c_write_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, reg);
-    i2c_release(BUS);
+    i2c_depr_write_reg(BUS, ADDR, MMA8X5X_CTRL_REG1, reg);
+    i2c_depr_release(BUS);
 }
 
 int mma8x5x_is_ready(mma8x5x_t *dev)
@@ -143,9 +143,9 @@ int mma8x5x_is_ready(mma8x5x_t *dev)
 
     DEBUG("[mma8x5x] checking for new available data\n");
 
-    i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, MMA8X5X_STATUS, &reg);
-    i2c_release(BUS);
+    i2c_depr_acquire(BUS);
+    i2c_depr_read_reg(BUS, ADDR, MMA8X5X_STATUS, &reg);
+    i2c_depr_release(BUS);
 
     if (reg & MMA8X5X_STATUS_ZYXDR) {
         return MMA8X5X_DATA_READY;
@@ -161,9 +161,9 @@ void mma8x5x_read(mma8x5x_t *dev, mma8x5x_data_t *data)
 
     assert(dev);
 
-    i2c_acquire(BUS);
-    i2c_read_regs(BUS, ADDR, MMA8X5X_STATUS, buf, 7);
-    i2c_release(BUS);
+    i2c_depr_acquire(BUS);
+    i2c_depr_read_regs(BUS, ADDR, MMA8X5X_STATUS, buf, 7);
+    i2c_depr_release(BUS);
 
     data->x = ((int16_t)(buf[1] << 8 | buf[2])) / (16 >> dev->params.range);
     data->y = ((int16_t)(buf[3] << 8 | buf[4])) / (16 >> dev->params.range);

--- a/drivers/mpl3115a2/mpl3115a2.c
+++ b/drivers/mpl3115a2/mpl3115a2.c
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "mpl3115a2.h"
 #include "mpl3115a2_reg.h"
 
@@ -36,14 +36,14 @@ int mpl3115a2_test(mpl3115a2_t *dev)
     uint8_t reg;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_WHO_AM_I, &reg, 1) != 1) {
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MPL3115A2_WHO_AM_I, &reg, 1) != 1) {
         /* Release the bus for other threads. */
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     if (reg != MPL3115A2_ID) {
         return -1;
     }
@@ -64,13 +64,13 @@ int mpl3115a2_init(mpl3115a2_t *dev, i2c_t i2c, uint8_t address, uint8_t os_rati
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* initialize the I2C bus */
-    if (i2c_init_master(i2c, I2C_SPEED) < 0) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_init_master(i2c, I2C_SPEED) < 0) {
+        i2c_depr_release(dev->i2c);
         return -2;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     if (mpl3115a2_test(dev)) {
         return -3;
@@ -78,24 +78,24 @@ int mpl3115a2_init(mpl3115a2_t *dev, i2c_t i2c, uint8_t address, uint8_t os_rati
 
     reg = MPL3115A2_CTRL_REG1_OS(os_ratio);
 
-    i2c_acquire(dev->i2c);
-    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -4;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     reg = MPL3115A2_PT_DATA_CFG_TDEFE
           | MPL3115A2_PT_DATA_CFG_PDEFE
           | MPL3115A2_PT_DATA_CFG_DREM;
 
-    i2c_acquire(dev->i2c);
-    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_PT_DATA_CFG, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MPL3115A2_PT_DATA_CFG, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -4;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     dev->initialized = true;
 
     return 0;
@@ -108,13 +108,13 @@ int mpl3115a2_reset(mpl3115a2_t *dev)
     dev->initialized = false;
     reg = MPL3115A2_CTRL_REG1_RST;
 
-    i2c_acquire(dev->i2c);
-    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -126,20 +126,20 @@ int mpl3115a2_set_active(mpl3115a2_t *dev)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
     reg |= MPL3115A2_CTRL_REG1_SBYB;
 
-    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -147,20 +147,20 @@ int mpl3115a2_set_standby(mpl3115a2_t *dev)
 {
     uint8_t reg;
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
     reg &= ~MPL3115A2_CTRL_REG1_SBYB;
 
-    if (i2c_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_regs(dev->i2c, dev->addr, MPL3115A2_CTRL_REG1, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -172,13 +172,13 @@ int mpl3115a2_is_ready(mpl3115a2_t *dev)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_STATUS, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MPL3115A2_STATUS, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return reg & MPL3115A2_STATUS_PTDR;
 }
 
@@ -190,12 +190,12 @@ int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_STATUS, buf, 4) != 4) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MPL3115A2_STATUS, buf, 4) != 4) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     *status = buf[0];
 
@@ -213,12 +213,12 @@ int mpl3115a2_read_temp(mpl3115a2_t *dev, int16_t *temp)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, MPL3115A2_OUT_T_MSB, buf, 2) != 2) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, MPL3115A2_OUT_T_MSB, buf, 2) != 2) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     *temp = ((int16_t)(((int16_t)buf[0] << 8) | buf[1]) * 10) / 256;
 

--- a/drivers/mpu9150/mpu9150.c
+++ b/drivers/mpu9150/mpu9150.c
@@ -20,7 +20,7 @@
 
 #include "mpu9150.h"
 #include "mpu9150-regs.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "xtimer.h"
 
 #define ENABLE_DEBUG        (0)
@@ -63,21 +63,21 @@ int mpu9150_init(mpu9150_t *dev, i2c_t i2c, mpu9150_hw_addr_t hw_addr,
     dev->conf = DEFAULT_STATUS;
 
     /* Initialize I2C interface */
-    if (i2c_init_master(dev->i2c_dev, I2C_SPEED_FAST)) {
+    if (i2c_depr_init_master(dev->i2c_dev, I2C_SPEED_FAST)) {
         DEBUG("[Error] I2C device not enabled\n");
         return -1;
     }
 
     /* Acquire exclusive access */
-    i2c_acquire(dev->i2c_dev);
+    i2c_depr_acquire(dev->i2c_dev);
 
     /* Reset MPU9150 registers and afterwards wake up the chip */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, MPU9150_PWR_RESET);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, MPU9150_PWR_RESET);
     xtimer_usleep(MPU9150_RESET_SLEEP_US);
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, MPU9150_PWR_WAKEUP);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, MPU9150_PWR_WAKEUP);
 
     /* Release the bus, it is acquired again inside each function */
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
 
     /* Set default full scale ranges and sample rate */
     mpu9150_set_gyro_fsr(dev, MPU9150_GYRO_FSR_2000DPS);
@@ -85,24 +85,24 @@ int mpu9150_init(mpu9150_t *dev, i2c_t i2c, mpu9150_hw_addr_t hw_addr,
     mpu9150_set_sample_rate(dev, MPU9150_DEFAULT_SAMPLE_RATE);
 
     /* Disable interrupt generation */
-    i2c_acquire(dev->i2c_dev);
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_INT_ENABLE_REG, REG_RESET);
+    i2c_depr_acquire(dev->i2c_dev);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_INT_ENABLE_REG, REG_RESET);
 
     /* Initialize magnetometer */
     if (compass_init(dev)) {
-        i2c_release(dev->i2c_dev);
+        i2c_depr_release(dev->i2c_dev);
         return -2;
     }
     /* Release the bus, it is acquired again inside each function */
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
     mpu9150_set_compass_sample_rate(dev, 10);
     /* Enable all sensors */
-    i2c_acquire(dev->i2c_dev);
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, MPU9150_PWR_PLL);
-    i2c_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, &temp);
+    i2c_depr_acquire(dev->i2c_dev);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, MPU9150_PWR_PLL);
+    i2c_depr_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, &temp);
     temp &= ~(MPU9150_PWR_ACCEL | MPU9150_PWR_GYRO);
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, temp);
-    i2c_release(dev->i2c_dev);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, temp);
+    i2c_depr_release(dev->i2c_dev);
     xtimer_usleep(MPU9150_PWR_CHANGE_SLEEP_US);
 
     return 0;
@@ -117,12 +117,12 @@ int mpu9150_set_accel_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(dev->i2c_dev)) {
+    if (i2c_depr_acquire(dev->i2c_dev)) {
         return -1;
     }
 
     /* Read current power management 2 configuration */
-    i2c_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, &pwr_2_setting);
+    i2c_depr_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, &pwr_2_setting);
     /* Prepare power register settings */
     if (pwr_conf == MPU9150_SENSOR_PWR_ON) {
         pwr_1_setting = MPU9150_PWR_WAKEUP;
@@ -135,13 +135,13 @@ int mpu9150_set_accel_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
     /* Configure power management 1 register if needed */
     if ((dev->conf.gyro_pwr == MPU9150_SENSOR_PWR_OFF)
             && (dev->conf.compass_pwr == MPU9150_SENSOR_PWR_OFF)) {
-        i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, pwr_1_setting);
+        i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, pwr_1_setting);
     }
     /* Enable/disable accelerometer standby in power management 2 register */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, pwr_2_setting);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, pwr_2_setting);
 
     /* Release the bus */
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
 
     dev->conf.accel_pwr = pwr_conf;
     xtimer_usleep(MPU9150_PWR_CHANGE_SLEEP_US);
@@ -158,16 +158,16 @@ int mpu9150_set_gyro_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(dev->i2c_dev)) {
+    if (i2c_depr_acquire(dev->i2c_dev)) {
         return -1;
     }
 
     /* Read current power management 2 configuration */
-    i2c_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, &pwr_2_setting);
+    i2c_depr_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, &pwr_2_setting);
     /* Prepare power register settings */
     if (pwr_conf == MPU9150_SENSOR_PWR_ON) {
         /* Set clock to pll */
-        i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, MPU9150_PWR_PLL);
+        i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, MPU9150_PWR_PLL);
         pwr_2_setting &= ~(MPU9150_PWR_GYRO);
     }
     else {
@@ -175,21 +175,21 @@ int mpu9150_set_gyro_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
         if ((dev->conf.accel_pwr == MPU9150_SENSOR_PWR_OFF)
                 && (dev->conf.compass_pwr == MPU9150_SENSOR_PWR_OFF)) {
             /* All sensors turned off, put the MPU-9150 to sleep */
-            i2c_write_reg(dev->i2c_dev, dev->hw_addr,
+            i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr,
                     MPU9150_PWR_MGMT_1_REG, BIT_PWR_MGMT1_SLEEP);
         }
         else {
             /* Reset clock to internal oscillator */
-            i2c_write_reg(dev->i2c_dev, dev->hw_addr,
+            i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr,
                     MPU9150_PWR_MGMT_1_REG, MPU9150_PWR_WAKEUP);
         }
         pwr_2_setting |= MPU9150_PWR_GYRO;
     }
     /* Enable/disable gyroscope standby in power management 2 register */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, pwr_2_setting);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_2_REG, pwr_2_setting);
 
     /* Release the bus */
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
 
     dev->conf.gyro_pwr = pwr_conf;
     xtimer_usleep(MPU9150_PWR_CHANGE_SLEEP_US);
@@ -206,12 +206,12 @@ int mpu9150_set_compass_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(dev->i2c_dev)) {
+    if (i2c_depr_acquire(dev->i2c_dev)) {
         return -1;
     }
 
     /* Read current user control configuration */
-    i2c_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, &usr_ctrl_setting);
+    i2c_depr_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, &usr_ctrl_setting);
     /* Prepare power register settings */
     if (pwr_conf == MPU9150_SENSOR_PWR_ON) {
         pwr_1_setting = MPU9150_PWR_WAKEUP;
@@ -226,15 +226,15 @@ int mpu9150_set_compass_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
     /* Configure power management 1 register if needed */
     if ((dev->conf.gyro_pwr == MPU9150_SENSOR_PWR_OFF)
             && (dev->conf.accel_pwr == MPU9150_SENSOR_PWR_OFF)) {
-        i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, pwr_1_setting);
+        i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_PWR_MGMT_1_REG, pwr_1_setting);
     }
     /* Configure mode writing by slave line 1 */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE1_DATA_OUT_REG, s1_do_setting);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE1_DATA_OUT_REG, s1_do_setting);
     /* Enable/disable I2C master mode */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, usr_ctrl_setting);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, usr_ctrl_setting);
 
     /* Release the bus */
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
 
     dev->conf.compass_pwr = pwr_conf;
     xtimer_usleep(MPU9150_PWR_CHANGE_SLEEP_US);
@@ -266,13 +266,13 @@ int mpu9150_read_gyro(mpu9150_t *dev, mpu9150_results_t *output)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(dev->i2c_dev)) {
+    if (i2c_depr_acquire(dev->i2c_dev)) {
         return -1;
     }
     /* Read raw data */
-    i2c_read_regs(dev->i2c_dev, dev->hw_addr, MPU9150_GYRO_START_REG, data, 6);
+    i2c_depr_read_regs(dev->i2c_dev, dev->hw_addr, MPU9150_GYRO_START_REG, data, 6);
     /* Release the bus */
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
 
     /* Normalize data according to configured full scale range */
     temp = (data[0] << 8) | data[1];
@@ -309,13 +309,13 @@ int mpu9150_read_accel(mpu9150_t *dev, mpu9150_results_t *output)
     }
 
     /* Acquire exclusive access */
-    if (i2c_acquire(dev->i2c_dev)) {
+    if (i2c_depr_acquire(dev->i2c_dev)) {
         return -1;
     }
     /* Read raw data */
-    i2c_read_regs(dev->i2c_dev, dev->hw_addr, MPU9150_ACCEL_START_REG, data, 6);
+    i2c_depr_read_regs(dev->i2c_dev, dev->hw_addr, MPU9150_ACCEL_START_REG, data, 6);
     /* Release the bus */
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
 
     /* Normalize data according to configured full scale range */
     temp = (data[0] << 8) | data[1];
@@ -333,13 +333,13 @@ int mpu9150_read_compass(mpu9150_t *dev, mpu9150_results_t *output)
     uint8_t data[6];
 
     /* Acquire exclusive access */
-    if (i2c_acquire(dev->i2c_dev)) {
+    if (i2c_depr_acquire(dev->i2c_dev)) {
         return -1;
     }
     /* Read raw data */
-    i2c_read_regs(dev->i2c_dev, dev->hw_addr, MPU9150_EXT_SENS_DATA_START_REG, data, 6);
+    i2c_depr_read_regs(dev->i2c_dev, dev->hw_addr, MPU9150_EXT_SENS_DATA_START_REG, data, 6);
     /* Release the bus */
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
 
     output->x_axis = (data[1] << 8) | data[0];
     output->y_axis = (data[3] << 8) | data[2];
@@ -367,13 +367,13 @@ int mpu9150_read_temperature(mpu9150_t *dev, int32_t *output)
     int16_t temp;
 
     /* Acquire exclusive access */
-    if (i2c_acquire(dev->i2c_dev)) {
+    if (i2c_depr_acquire(dev->i2c_dev)) {
         return -1;
     }
     /* Read raw temperature value */
-    i2c_read_regs(dev->i2c_dev, dev->hw_addr, MPU9150_TEMP_START_REG, data, 2);
+    i2c_depr_read_regs(dev->i2c_dev, dev->hw_addr, MPU9150_TEMP_START_REG, data, 2);
     /* Release the bus */
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
 
     temp = (data[0] << 8) | data[1];
     *output = ((((int32_t)temp) * 1000) / 340) + (35*1000);
@@ -392,12 +392,12 @@ int mpu9150_set_gyro_fsr(mpu9150_t *dev, mpu9150_gyro_ranges_t fsr)
         case MPU9150_GYRO_FSR_500DPS:
         case MPU9150_GYRO_FSR_1000DPS:
         case MPU9150_GYRO_FSR_2000DPS:
-            if (i2c_acquire(dev->i2c_dev)) {
+            if (i2c_depr_acquire(dev->i2c_dev)) {
                 return -1;
             }
-            i2c_write_reg(dev->i2c_dev, dev->hw_addr,
+            i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr,
                     MPU9150_GYRO_CFG_REG, (fsr << 3));
-            i2c_release(dev->i2c_dev);
+            i2c_depr_release(dev->i2c_dev);
             dev->conf.gyro_fsr = fsr;
             break;
         default:
@@ -418,12 +418,12 @@ int mpu9150_set_accel_fsr(mpu9150_t *dev, mpu9150_accel_ranges_t fsr)
         case MPU9150_ACCEL_FSR_4G:
         case MPU9150_ACCEL_FSR_8G:
         case MPU9150_ACCEL_FSR_16G:
-            if (i2c_acquire(dev->i2c_dev)) {
+            if (i2c_depr_acquire(dev->i2c_dev)) {
                 return -1;
             }
-            i2c_write_reg(dev->i2c_dev, dev->hw_addr,
+            i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr,
                     MPU9150_ACCEL_CFG_REG, (fsr << 3));
-            i2c_release(dev->i2c_dev);
+            i2c_depr_release(dev->i2c_dev);
             dev->conf.accel_fsr = fsr;
             break;
         default:
@@ -447,17 +447,17 @@ int mpu9150_set_sample_rate(mpu9150_t *dev, uint16_t rate)
     /* Compute divider to achieve desired sample rate and write to rate div register */
     divider = (1000 / rate - 1);
 
-    if (i2c_acquire(dev->i2c_dev)) {
+    if (i2c_depr_acquire(dev->i2c_dev)) {
         return -1;
     }
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_RATE_DIV_REG, divider);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_RATE_DIV_REG, divider);
 
     /* Store configured sample rate */
     dev->conf.sample_rate = 1000 / (((uint16_t) divider) + 1);
 
     /* Always set LPF to a maximum of half the configured sampling rate */
     conf_lpf(dev, (dev->conf.sample_rate >> 1));
-    i2c_release(dev->i2c_dev);
+    i2c_depr_release(dev->i2c_dev);
 
     return 0;
 }
@@ -477,11 +477,11 @@ int mpu9150_set_compass_sample_rate(mpu9150_t *dev, uint8_t rate)
     /* Compute divider to achieve desired sample rate and write to slave ctrl register */
     divider = (dev->conf.sample_rate / rate - 1);
 
-    if (i2c_acquire(dev->i2c_dev)) {
+    if (i2c_depr_acquire(dev->i2c_dev)) {
         return -1;
     }
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE4_CTRL_REG, divider);
-    i2c_release(dev->i2c_dev);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE4_CTRL_REG, divider);
+    i2c_depr_release(dev->i2c_dev);
 
     /* Store configured sample rate */
     dev->conf.compass_sample_rate = dev->conf.sample_rate / (((uint16_t) divider) + 1);
@@ -506,58 +506,58 @@ static int compass_init(mpu9150_t *dev)
     conf_bypass(dev, 1);
 
     /* Check whether compass answers correctly */
-    i2c_read_reg(dev->i2c_dev, dev->comp_addr, COMPASS_WHOAMI_REG, data);
+    i2c_depr_read_reg(dev->i2c_dev, dev->comp_addr, COMPASS_WHOAMI_REG, data);
     if (data[0] != MPU9150_COMP_WHOAMI_ANSWER) {
         DEBUG("[Error] Wrong answer from compass\n");
         return -1;
     }
 
     /* Configure Power Down mode */
-    i2c_write_reg(dev->i2c_dev, dev->comp_addr, COMPASS_CNTL_REG, MPU9150_COMP_POWER_DOWN);
+    i2c_depr_write_reg(dev->i2c_dev, dev->comp_addr, COMPASS_CNTL_REG, MPU9150_COMP_POWER_DOWN);
     xtimer_usleep(MPU9150_COMP_MODE_SLEEP_US);
     /* Configure Fuse ROM access */
-    i2c_write_reg(dev->i2c_dev, dev->comp_addr, COMPASS_CNTL_REG, MPU9150_COMP_FUSE_ROM);
+    i2c_depr_write_reg(dev->i2c_dev, dev->comp_addr, COMPASS_CNTL_REG, MPU9150_COMP_FUSE_ROM);
     xtimer_usleep(MPU9150_COMP_MODE_SLEEP_US);
     /* Read sensitivity adjustment values from Fuse ROM */
-    i2c_read_regs(dev->i2c_dev, dev->comp_addr, COMPASS_ASAX_REG, data, 3);
+    i2c_depr_read_regs(dev->i2c_dev, dev->comp_addr, COMPASS_ASAX_REG, data, 3);
     dev->conf.compass_x_adj = data[0];
     dev->conf.compass_y_adj = data[1];
     dev->conf.compass_z_adj = data[2];
     /* Configure Power Down mode again */
-    i2c_write_reg(dev->i2c_dev, dev->comp_addr, COMPASS_CNTL_REG, MPU9150_COMP_POWER_DOWN);
+    i2c_depr_write_reg(dev->i2c_dev, dev->comp_addr, COMPASS_CNTL_REG, MPU9150_COMP_POWER_DOWN);
     xtimer_usleep(MPU9150_COMP_MODE_SLEEP_US);
 
     /* Disable Bypass Mode to configure MPU as master to the compass */
     conf_bypass(dev, 0);
 
     /* Configure MPU9150 for single master mode */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_I2C_MST_REG, BIT_WAIT_FOR_ES);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_I2C_MST_REG, BIT_WAIT_FOR_ES);
 
     /* Set up slave line 0 */
     /* Slave line 0 reads the compass data */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr,
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr,
             MPU9150_SLAVE0_ADDR_REG, (BIT_SLAVE_RW | dev->comp_addr));
     /* Slave line 0 read starts at compass data register */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE0_REG_REG, COMPASS_DATA_START_REG);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE0_REG_REG, COMPASS_DATA_START_REG);
     /* Enable slave line 0 and configure read length to 6 consecutive registers */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE0_CTRL_REG, (BIT_SLAVE_EN | 0x06));
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE0_CTRL_REG, (BIT_SLAVE_EN | 0x06));
 
     /* Set up slave line 1 */
     /* Slave line 1 writes to the compass */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE1_ADDR_REG, dev->comp_addr);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE1_ADDR_REG, dev->comp_addr);
     /* Slave line 1 write starts at compass control register */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE1_REG_REG, COMPASS_CNTL_REG);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE1_REG_REG, COMPASS_CNTL_REG);
     /* Enable slave line 1 and configure write length to 1 register */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE1_CTRL_REG, (BIT_SLAVE_EN | 0x01));
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_SLAVE1_CTRL_REG, (BIT_SLAVE_EN | 0x01));
     /* Configure data which is written by slave line 1 to compass control */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr,
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr,
             MPU9150_SLAVE1_DATA_OUT_REG, MPU9150_COMP_SINGLE_MEASURE);
 
     /* Slave line 0 and 1 operate at each sample */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr,
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr,
             MPU9150_I2C_DELAY_CTRL_REG, (BIT_SLV0_DELAY_EN | BIT_SLV1_DELAY_EN));
     /* Set I2C bus to VDD */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_YG_OFFS_TC_REG, BIT_I2C_MST_VDDIO);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_YG_OFFS_TC_REG, BIT_I2C_MST_VDDIO);
 
     return 0;
 }
@@ -570,19 +570,19 @@ static int compass_init(mpu9150_t *dev)
 static void conf_bypass(mpu9150_t *dev, uint8_t bypass_enable)
 {
    uint8_t data;
-   i2c_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, &data);
+   i2c_depr_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, &data);
 
    if (bypass_enable) {
        data &= ~(BIT_I2C_MST_EN);
-       i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, data);
+       i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, data);
        xtimer_usleep(MPU9150_BYPASS_SLEEP_US);
-       i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_INT_PIN_CFG_REG, BIT_I2C_BYPASS_EN);
+       i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_INT_PIN_CFG_REG, BIT_I2C_BYPASS_EN);
    }
    else {
        data |= BIT_I2C_MST_EN;
-       i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, data);
+       i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, data);
        xtimer_usleep(MPU9150_BYPASS_SLEEP_US);
-       i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_INT_PIN_CFG_REG, REG_RESET);
+       i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_INT_PIN_CFG_REG, REG_RESET);
    }
 }
 
@@ -616,5 +616,5 @@ static void conf_lpf(mpu9150_t *dev, uint16_t half_rate)
     }
 
     /* Write LPF setting to configuration register */
-    i2c_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_LPF_REG, lpf_setting);
+    i2c_depr_write_reg(dev->i2c_dev, dev->hw_addr, MPU9150_LPF_REG, lpf_setting);
 }

--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -25,7 +25,7 @@
 #include "mutex.h"
 #include "pn532.h"
 #include "periph/gpio.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "periph/spi.h"
 
 #define ENABLE_DEBUG    (0)
@@ -122,7 +122,7 @@ int pn532_init(pn532_t *dev, const pn532_params_t *params, pn532_mode_t mode)
     dev->mode = mode;
     if (mode == PN532_I2C) {
 #ifdef PN532_SUPPORT_I2C
-        if (i2c_init_master(dev->conf->i2c, I2C_SPEED_FAST) != 0) {
+        if (i2c_depr_init_master(dev->conf->i2c, I2C_SPEED_FAST) != 0) {
             DEBUG("pn532: initialization of I2C bus failed\n");
             return -1;
         }
@@ -174,9 +174,9 @@ static int _write(pn532_t *dev, char *buff, unsigned len)
 
     if (dev->mode == PN532_I2C) {
 #ifdef PN532_SUPPORT_I2C
-        i2c_acquire(dev->conf->i2c);
-        ret = i2c_write_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len);
-        i2c_release(dev->conf->i2c);
+        i2c_depr_acquire(dev->conf->i2c);
+        ret = i2c_depr_write_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len);
+        i2c_depr_release(dev->conf->i2c);
 #endif
     }
     else {
@@ -206,10 +206,10 @@ static int _read(pn532_t *dev, char *buff, unsigned len)
 
     if (dev->mode == PN532_I2C) {
 #ifdef PN532_SUPPORT_I2C
-        i2c_acquire(dev->conf->i2c);
+        i2c_depr_acquire(dev->conf->i2c);
         /* len+1 for RDY after read is accepted */
-        ret = i2c_read_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len + 1);
-        i2c_release(dev->conf->i2c);
+        ret = i2c_depr_read_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len + 1);
+        i2c_depr_release(dev->conf->i2c);
 #endif
     }
     else {

--- a/drivers/si70xx/si70xx.c
+++ b/drivers/si70xx/si70xx.c
@@ -30,10 +30,10 @@ static uint32_t si70xx_measure(si70xx_t *dev, uint8_t command)
 {
     uint8_t result[2];
 
-    i2c_acquire(dev->i2c_dev);
-    i2c_write_byte(dev->i2c_dev, dev->address, command);
-    i2c_read_bytes(dev->i2c_dev, dev->address, result, 2);
-    i2c_release(dev->i2c_dev);
+    i2c_depr_acquire(dev->i2c_dev);
+    i2c_depr_write_byte(dev->i2c_dev, dev->address, command);
+    i2c_depr_read_bytes(dev->i2c_dev, dev->address, result, 2);
+    i2c_depr_release(dev->i2c_dev);
 
     /* reconstruct raw result */
     return ((uint32_t)result[0] << 8) + (result[1] & 0xfc);
@@ -63,9 +63,9 @@ int si70xx_init(si70xx_t *dev, i2c_t i2c_dev, uint8_t address)
     dev->address = address;
 
     /* setup the i2c bus */
-    i2c_acquire(dev->i2c_dev);
-    int result = i2c_init_master(dev->i2c_dev, I2C_SPEED_NORMAL);
-    i2c_release(dev->i2c_dev);
+    i2c_depr_acquire(dev->i2c_dev);
+    int result = i2c_depr_init_master(dev->i2c_dev, I2C_SPEED_NORMAL);
+    i2c_depr_release(dev->i2c_dev);
 
     if (result != 0) {
         return result;
@@ -77,9 +77,9 @@ int si70xx_init(si70xx_t *dev, i2c_t i2c_dev, uint8_t address)
     }
 
     /* initialize the peripheral */
-    i2c_acquire(dev->i2c_dev);
-    i2c_write_byte(dev->i2c_dev, dev->address, SI70XX_RESET);
-    i2c_release(dev->i2c_dev);
+    i2c_depr_acquire(dev->i2c_dev);
+    i2c_depr_write_byte(dev->i2c_dev, dev->address, SI70XX_RESET);
+    i2c_depr_release(dev->i2c_dev);
 
     /* sensor is ready after at most 25 ms */
     xtimer_usleep(25 * US_PER_MS);
@@ -142,17 +142,17 @@ uint64_t si70xx_get_serial(si70xx_t *dev)
     out[0] = SI70XX_READ_ID_FIRST_A;
     out[1] = SI70XX_READ_ID_FIRST_B;
 
-    i2c_acquire(dev->i2c_dev);
-    i2c_write_bytes(dev->i2c_dev, dev->address, out, 2);
-    i2c_read_bytes(dev->i2c_dev, dev->address, in_first, 8);
+    i2c_depr_acquire(dev->i2c_dev);
+    i2c_depr_write_bytes(dev->i2c_dev, dev->address, out, 2);
+    i2c_depr_read_bytes(dev->i2c_dev, dev->address, in_first, 8);
 
     /* read the higher bytes */
     out[0] = SI70XX_READ_ID_SECOND_A;
     out[1] = SI70XX_READ_ID_SECOND_B;
 
-    i2c_write_bytes(dev->i2c_dev, dev->address, out, 2);
-    i2c_read_bytes(dev->i2c_dev, dev->address, in_second, 8);
-    i2c_release(dev->i2c_dev);
+    i2c_depr_write_bytes(dev->i2c_dev, dev->address, out, 2);
+    i2c_depr_read_bytes(dev->i2c_dev, dev->address, in_second, 8);
+    i2c_depr_release(dev->i2c_dev);
 
     /* calculate the ID */
     uint32_t id_first = ((uint32_t)in_first[0] << 24) + ((uint32_t)in_first[2] << 16) +
@@ -177,10 +177,10 @@ uint8_t si70xx_get_revision(si70xx_t *dev)
     out[0] = SI70XX_READ_REVISION_A;
     out[1] = SI70XX_READ_REVISION_B;
 
-    i2c_acquire(dev->i2c_dev);
-    i2c_write_bytes(dev->i2c_dev, dev->address, out, 2);
-    i2c_read_byte(dev->i2c_dev, dev->address, &in);
-    i2c_release(dev->i2c_dev);
+    i2c_depr_acquire(dev->i2c_dev);
+    i2c_depr_write_bytes(dev->i2c_dev, dev->address, out, 2);
+    i2c_depr_read_byte(dev->i2c_dev, dev->address, &in);
+    i2c_depr_release(dev->i2c_dev);
 
     return in;
 }

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -26,7 +26,7 @@
 
 #include "xtimer.h"
 #include "srf02.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
@@ -64,23 +64,23 @@ int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr)
     uint8_t rev;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* initialize i2c interface */
-    if (i2c_init_master(dev->i2c, BUS_SPEED) < 0) {
+    if (i2c_depr_init_master(dev->i2c, BUS_SPEED) < 0) {
         DEBUG("[srf02] error initializing I2C bus\n");
         return -1;
     }
     /* try to read the software revision (read the CMD reg) from the device */
-    i2c_read_reg(i2c, dev->addr, REG_CMD, &rev);
+    i2c_depr_read_reg(i2c, dev->addr, REG_CMD, &rev);
     if (rev == 0 || rev == 255) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         DEBUG("[srf02] error reading the devices software revision\n");
         return -1;
     } else {
         DEBUG("[srf02] software revision: 0x%02x\n", rev);
     }
     /* Release the bus for other threads. */
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     DEBUG("[srf02] initialization successful\n");
     return 0;
@@ -90,9 +90,9 @@ void srf02_trigger(srf02_t *dev, srf02_mode_t mode)
 {
     /* trigger a new measurement by writing the mode to the CMD register */
     DEBUG("[srf02] trigger new reading\n");
-    i2c_acquire(dev->i2c);
-    i2c_write_reg(dev->i2c, dev->addr, REG_CMD, mode);
-    i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_write_reg(dev->i2c, dev->addr, REG_CMD, mode);
+    i2c_depr_release(dev->i2c);
 }
 
 uint16_t srf02_read(srf02_t *dev)
@@ -100,9 +100,9 @@ uint16_t srf02_read(srf02_t *dev)
     uint8_t res[2];
 
     /* read the results */
-    i2c_acquire(dev->i2c);
-    i2c_read_regs(dev->i2c, dev->addr, REG_HIGH, res, 2);
-    i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    i2c_depr_read_regs(dev->i2c, dev->addr, REG_HIGH, res, 2);
+    i2c_depr_release(dev->i2c);
     DEBUG("[srf02] result - high: 0x%02x low: 0x%02x\n", res[0], res[1]);
 
     /* compile result - TODO: fix for different host byte order other than LE */
@@ -122,17 +122,17 @@ uint16_t srf02_get_distance(srf02_t *dev, srf02_mode_t mode)
 void srf02_set_addr(srf02_t *dev, uint8_t new_addr)
 {
     /* get access to the bus */
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
 
     DEBUG("[srf02] reprogramming device address to 0x%02x\n", (int)new_addr);
 
     /* write the new address, for this we need to follow a certain sequence */
-    i2c_write_reg(dev->i2c, dev->addr, REG_CMD, CMD_ADDR_SEQ1);
-    i2c_write_reg(dev->i2c, dev->addr, REG_CMD, CMD_ADDR_SEQ2);
-    i2c_write_reg(dev->i2c, dev->addr, REG_CMD, CMD_ADDR_SEQ3);
-    i2c_write_reg(dev->i2c, dev->addr, REG_CMD, new_addr);
+    i2c_depr_write_reg(dev->i2c, dev->addr, REG_CMD, CMD_ADDR_SEQ1);
+    i2c_depr_write_reg(dev->i2c, dev->addr, REG_CMD, CMD_ADDR_SEQ2);
+    i2c_depr_write_reg(dev->i2c, dev->addr, REG_CMD, CMD_ADDR_SEQ3);
+    i2c_depr_write_reg(dev->i2c, dev->addr, REG_CMD, new_addr);
     dev->addr = (new_addr >> 1);
 
     /* release the bus */
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 }

--- a/drivers/srf08/srf08.c
+++ b/drivers/srf08/srf08.c
@@ -25,7 +25,7 @@
 #include <stdio.h>
 #include "xtimer.h"
 #include "srf08.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -39,11 +39,11 @@ int srf08_init(srf08_t *dev, i2c_t i2c, uint8_t addr, i2c_speed_t speed)
     dev->addr = addr;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* initialize i2c interface */
-    status = i2c_init_master(dev->i2c, speed);
+    status = i2c_depr_init_master(dev->i2c, speed);
     /* Release the bus for other threads. */
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     if(status < 0) {
         return -1;
@@ -68,10 +68,10 @@ int srf08_set_max_range(srf08_t *dev, uint8_t max_range)
     int status;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    status = i2c_write_reg(dev->i2c, dev->addr, SRF08_RANGE_REG, max_range);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_write_reg(dev->i2c, dev->addr, SRF08_RANGE_REG, max_range);
     /* Release the bus for other threads. */
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return status;
 }
@@ -82,10 +82,10 @@ int srf08_set_max_gain(srf08_t *dev, uint8_t gain)
     int status;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    status = i2c_write_reg(dev->i2c, dev->addr, SRF08_GAIN_REG, gain);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_write_reg(dev->i2c, dev->addr, SRF08_GAIN_REG, gain);
     /* Release the bus for other threads. */
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     return status;
 }
@@ -100,11 +100,11 @@ int srf08_get_distances(srf08_t *dev, uint16_t *range_array, int num_echos, srf0
     char max_reg_no_read = (num_echos * sizeof(range_bytes)) +1;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* set ranging mode */
-    status = i2c_write_reg(dev->i2c, dev->addr, SRF08_COMMAND_REG, ranging_mode);
+    status = i2c_depr_write_reg(dev->i2c, dev->addr, SRF08_COMMAND_REG, ranging_mode);
     /* Release the bus for other threads. */
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     if (!status) {
         DEBUG("Write the ranging command to the i2c-interface is failed\n");
@@ -123,11 +123,11 @@ int srf08_get_distances(srf08_t *dev, uint16_t *range_array, int num_echos, srf0
          register_location += sizeof(range_bytes)) {
 
         /* Acquire exclusive access to the bus. */
-        i2c_acquire(dev->i2c);
+        i2c_depr_acquire(dev->i2c);
         /* read the echo bytes */
-        status = i2c_read_regs(dev->i2c, dev->addr, register_location, range_bytes, sizeof(range_bytes));
+        status = i2c_depr_read_regs(dev->i2c, dev->addr, register_location, range_bytes, sizeof(range_bytes));
         /* Release the bus for other threads. */
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
 
         if (!status) {
             DEBUG("Read the echo bytes from the i2c-interface is failed\n");

--- a/drivers/tcs37727/tcs37727.c
+++ b/drivers/tcs37727/tcs37727.c
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "tcs37727.h"
 #include "tcs37727-internal.h"
 
@@ -35,14 +35,14 @@ static int tcs37727_test(tcs37727_t *dev)
 {
     uint8_t id;
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
 
-    if (i2c_read_reg(dev->i2c, dev->addr, TCS37727_ID, &id) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_read_reg(dev->i2c, dev->addr, TCS37727_ID, &id) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     if (id != TCS37727_ID_VALUE) {
         return -1;
@@ -58,39 +58,39 @@ int tcs37727_init(tcs37727_t *dev, i2c_t i2c, uint8_t address, int atime_us)
     dev->addr = address;
     dev->initialized = false;
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
 
     /* initialize the I2C bus */
-    if (i2c_init_master(i2c, I2C_SPEED) < 0) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_init_master(i2c, I2C_SPEED) < 0) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     if (tcs37727_test(dev)) {
         return -2;
     }
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
 
-    if (i2c_write_reg(dev->i2c, dev->addr, TCS37727_CONTROL,
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, TCS37727_CONTROL,
                       TCS37727_CONTROL_AGAIN_4) != 1) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -3;
     }
     dev->again = 4;
 
-    if (i2c_write_reg(dev->i2c, dev->addr, TCS37727_ATIME,
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, TCS37727_ATIME,
                       TCS37727_ATIME_TO_REG(atime_us)) != 1) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -3;
     }
     dev->atime_us = atime_us;
 
     dev->initialized = true;
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -102,20 +102,20 @@ int tcs37727_set_rgbc_active(tcs37727_t *dev)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, TCS37727_ENABLE, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, TCS37727_ENABLE, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
     reg |= (TCS37727_ENABLE_AEN | TCS37727_ENABLE_PON);
 
-    if (i2c_write_reg(dev->i2c, dev->addr, TCS37727_ENABLE, reg) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, TCS37727_ENABLE, reg) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -127,9 +127,9 @@ int tcs37727_set_rgbc_standby(tcs37727_t *dev)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, TCS37727_ENABLE, &reg, 1) != 1) {
-        i2c_release(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
+    if (i2c_depr_read_regs(dev->i2c, dev->addr, TCS37727_ENABLE, &reg, 1) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
@@ -138,12 +138,12 @@ int tcs37727_set_rgbc_standby(tcs37727_t *dev)
         reg &= ~TCS37727_ENABLE_PON;
     }
 
-    if (i2c_write_reg(dev->i2c, dev->addr, TCS37727_ENABLE, reg) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, TCS37727_ENABLE, reg) != 1) {
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -204,19 +204,19 @@ static uint8_t tcs37727_trim_gain(tcs37727_t *dev, int rawc)
         return 0;
     }
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     uint8_t reg = 0;
-    if (i2c_read_reg(dev->i2c, dev->addr, TCS37727_CONTROL, &reg) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_read_reg(dev->i2c, dev->addr, TCS37727_CONTROL, &reg) != 1) {
+        i2c_depr_release(dev->i2c);
         return -2;
     }
     reg &= ~TCS37727_CONTROL_AGAIN_MASK;
     reg |= reg_again;
-    if (i2c_write_reg(dev->i2c, dev->addr, TCS37727_CONTROL, reg) != 1) {
-        i2c_release(dev->i2c);
+    if (i2c_depr_write_reg(dev->i2c, dev->addr, TCS37727_CONTROL, reg) != 1) {
+        i2c_depr_release(dev->i2c);
         return -2;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     dev->again = val_again;
 
     return 0;
@@ -230,15 +230,15 @@ int tcs37727_read(tcs37727_t *dev, tcs37727_data_t *data)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
 
-    if (i2c_read_regs(dev->i2c, dev->addr,
+    if (i2c_depr_read_regs(dev->i2c, dev->addr,
                       (TCS37727_INC_TRANS | TCS37727_CDATA), buf, 8) != 8) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     int32_t tmpc = ((uint16_t)buf[1] << 8) | buf[0];
     int32_t tmpr = ((uint16_t)buf[3] << 8) | buf[2];

--- a/drivers/tmp006/tmp006.c
+++ b/drivers/tmp006/tmp006.c
@@ -23,7 +23,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <math.h>
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "tmp006.h"
 
 #define ENABLE_DEBUG    (0)
@@ -64,14 +64,14 @@ int tmp006_test(tmp006_t *dev)
     uint16_t tmp;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    status = i2c_read_regs(dev->i2c, dev->addr, TMP006_DEVICE_ID, reg, 2);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_read_regs(dev->i2c, dev->addr, TMP006_DEVICE_ID, reg, 2);
     if (status != 2) {
         /* Release the bus for other threads. */
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     tmp = ((uint16_t)reg[0] << 8) | reg[1];
 
@@ -95,14 +95,14 @@ int tmp006_init(tmp006_t *dev, i2c_t i2c, uint8_t address, uint8_t conv_rate)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* initialize the I2C bus */
-    status = i2c_init_master(i2c, I2C_SPEED);
+    status = i2c_depr_init_master(i2c, I2C_SPEED);
     if (status < 0) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -2;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     if (tmp006_test(dev)) {
         return -3;
@@ -113,13 +113,13 @@ int tmp006_init(tmp006_t *dev, i2c_t i2c, uint8_t address, uint8_t conv_rate)
     reg[1] = tmp;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    status = i2c_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
     if (status != 2) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -4;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     dev->initialized = true;
     return 0;
 }
@@ -134,13 +134,13 @@ int tmp006_reset(tmp006_t *dev)
     dev->initialized = false;
 
     /* Acquire exclusive access to the bus. */
-    i2c_acquire(dev->i2c);
-    status = i2c_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
     if (status != 2) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -153,21 +153,21 @@ int tmp006_set_active(tmp006_t *dev)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    status = i2c_read_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_read_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
     if (status != 2) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
 
     reg[0] |= (TMP006_CONFIG_MOD(TMP006_CONFIG_MOD_CC) >> 8);
 
-    status = i2c_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
+    status = i2c_depr_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
     if (status != 2) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -176,23 +176,23 @@ int tmp006_set_standby(tmp006_t *dev)
     int status;
     uint8_t reg[2];
 
-    i2c_acquire(dev->i2c);
-    status = i2c_read_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_read_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
     if (status != 2) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     reg[0] &= ~(TMP006_CONFIG_MOD(TMP006_CONFIG_MOD_CC) >> 8);
 
-    i2c_acquire(dev->i2c);
-    status = i2c_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_write_regs(dev->i2c, dev->addr, TMP006_CONFIG, reg, 2);
     if (status != 2) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     return 0;
 }
 
@@ -205,14 +205,14 @@ int tmp006_read(tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
+    i2c_depr_acquire(dev->i2c);
     /* Register bytes are sent MSB first. */
-    status = i2c_read_regs(dev->i2c, dev->addr, TMP006_CONFIG, buf, 2);
+    status = i2c_depr_read_regs(dev->i2c, dev->addr, TMP006_CONFIG, buf, 2);
     if (status != 2) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     *drdy = buf[1] & (TMP006_CONFIG_DRDY);
 
@@ -221,23 +221,23 @@ int tmp006_read(tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy)
         return -1;
     }
 
-    i2c_acquire(dev->i2c);
-    status = i2c_read_regs(dev->i2c, dev->addr, TMP006_V_OBJECT, buf, 2);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_read_regs(dev->i2c, dev->addr, TMP006_V_OBJECT, buf, 2);
     if (status != 2) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
 
     *rawv = ((uint16_t)buf[0] << 8) | buf[1];
 
-    i2c_acquire(dev->i2c);
-    status = i2c_read_regs(dev->i2c, dev->addr, TMP006_T_AMBIENT, buf, 2);
+    i2c_depr_acquire(dev->i2c);
+    status = i2c_depr_read_regs(dev->i2c, dev->addr, TMP006_T_AMBIENT, buf, 2);
     if (status != 2) {
-        i2c_release(dev->i2c);
+        i2c_depr_release(dev->i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_depr_release(dev->i2c);
     *rawt = ((uint16_t)buf[0] << 8) | buf[1];
     return 0;
 }

--- a/pkg/u8g2/patches/0001-u8g2-add-riot-os-makefiles.patch
+++ b/pkg/u8g2/patches/0001-u8g2-add-riot-os-makefiles.patch
@@ -1,7 +1,7 @@
-From a2a2cfb145902cb36cbe82bdaf68d97686bb9724 Mon Sep 17 00:00:00 2001
+From 4f8dc165085ee710d4075109d32105f08667b7db Mon Sep 17 00:00:00 2001
 From: Bas Stottelaar <basstottelaar@gmail.com>
 Date: Tue, 24 May 2016 20:17:39 +0200
-Subject: [PATCH 1/3] u8g2: add riot-os makefiles.
+Subject: [PATCH 1/4] u8g2: add riot-os makefiles.
 
 ---
  Makefile                 | 22 ++++++++++++++++++++++

--- a/pkg/u8g2/patches/0002-u8g2-add-riot-os-interface.patch
+++ b/pkg/u8g2/patches/0002-u8g2-add-riot-os-interface.patch
@@ -35,7 +35,7 @@ index 0000000..e0c042c
 +#include "xtimer.h"
 +
 +#include "periph/spi.h"
-+#include "periph/i2c.h"
++#include "periph/i2c_depr.h"
 +#include "periph/gpio.h"
 +
 +#include <stdio.h>

--- a/pkg/u8g2/patches/0002-u8g2-add-riot-os-interface.patch
+++ b/pkg/u8g2/patches/0002-u8g2-add-riot-os-interface.patch
@@ -1,7 +1,7 @@
-From 5acedd785fd31b43171c6855ecd5323bfd31c9e2 Mon Sep 17 00:00:00 2001
+From bc8b22f935be89eb7f30e6eb4af783c1dc298690 Mon Sep 17 00:00:00 2001
 From: Bas Stottelaar <basstottelaar@gmail.com>
 Date: Wed, 22 Jun 2016 18:04:31 +0200
-Subject: [PATCH 2/3] u8g2: add riot-os interface.
+Subject: [PATCH 2/4] u8g2: add riot-os interface.
 
 ---
  csrc/u8g2.h        |   3 +
@@ -35,7 +35,7 @@ index 0000000..e0c042c
 +#include "xtimer.h"
 +
 +#include "periph/spi.h"
-+#include "periph/i2c_depr.h"
++#include "periph/i2c.h"
 +#include "periph/gpio.h"
 +
 +#include <stdio.h>
@@ -252,5 +252,4 @@ index b396344..7dcd659 100644
  }
 -- 
 1.9.1
-
 

--- a/pkg/u8g2/patches/0003-u8g2-adapted-RIOT-interface-to-SPI-changes.patch
+++ b/pkg/u8g2/patches/0003-u8g2-adapted-RIOT-interface-to-SPI-changes.patch
@@ -1,7 +1,7 @@
-From 51897f66e18e291c3f3d528a0678eb195341d18d Mon Sep 17 00:00:00 2001
+From 54ffc084a379688043cab2ca2d779d6f83aa8ebd Mon Sep 17 00:00:00 2001
 From: Hauke Petersen <hauke.petersen@fu-berlin.de>
 Date: Wed, 25 Jan 2017 12:29:36 +0100
-Subject: [PATCH 3/3] u8g2: adapted RIOT interface to SPI changes
+Subject: [PATCH 3/4] u8g2: adapted RIOT interface to SPI changes
 
 ---
  csrc/u8g2_riotos.c | 33 +++++++++++++++++----------------

--- a/pkg/u8g2/patches/0004-u8g2-adapted-I2C-function-calls.patch
+++ b/pkg/u8g2/patches/0004-u8g2-adapted-I2C-function-calls.patch
@@ -1,0 +1,47 @@
+From cd6c70801b9698261f23cfbe851d1a3b2bcc9060 Mon Sep 17 00:00:00 2001
+From: Hauke Petersen <hauke.petersen@fu-berlin.de>
+Date: Thu, 9 Feb 2017 12:07:11 +0100
+Subject: [PATCH 4/4] u8g2: adapted I2C function calls
+
+---
+ csrc/u8g2_riotos.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/csrc/u8g2_riotos.c b/csrc/u8g2_riotos.c
+index bd06ccb..c78894d 100644
+--- a/csrc/u8g2_riotos.c
++++ b/csrc/u8g2_riotos.c
+@@ -3,7 +3,7 @@
+ #include "xtimer.h"
+ 
+ #include "periph/spi.h"
+-#include "periph/i2c.h"
++#include "periph/i2c_depr.h"
+ #include "periph/gpio.h"
+ 
+ #include <stdio.h>
+@@ -143,17 +143,17 @@ uint8_t u8x8_byte_riotos_hw_i2c(u8x8_t *u8g2, uint8_t msg, uint8_t arg_int, void
+             }
+             break;
+         case U8X8_MSG_BYTE_INIT:
+-            i2c_init_master(dev, I2C_SPEED_FAST);
++            i2c_depr_init_master(dev, I2C_SPEED_FAST);
+             break;
+         case U8X8_MSG_BYTE_SET_DC:
+             break;
+         case U8X8_MSG_BYTE_START_TRANSFER:
+-            i2c_acquire(dev);
++            i2c_depr_acquire(dev);
+             index = 0;
+             break;
+         case U8X8_MSG_BYTE_END_TRANSFER:
+-            i2c_write_bytes(dev, u8x8_GetI2CAddress(u8g2), buffer, index);
+-            i2c_release(dev);
++            i2c_depr_write_bytes(dev, u8x8_GetI2CAddress(u8g2), buffer, index);
++            i2c_depr_release(dev);
+             break;
+         default:
+             return 0;
+-- 
+1.9.1
+

--- a/tests/driver_hih6130/main.c
+++ b/tests/driver_hih6130/main.c
@@ -40,7 +40,7 @@ int main(void)
 
     puts("HIH6130 sensor driver test application\n");
     printf("Initializing I2C_%i... ", TEST_HIH6130_I2C);
-    if (i2c_init_master(TEST_HIH6130_I2C, I2C_SPEED_FAST) < 0) {
+    if (i2c_depr_init_master(TEST_HIH6130_I2C, I2C_SPEED_FAST) < 0) {
         puts("[Failed]");
         return -1;
     }

--- a/tests/driver_ina220/main.c
+++ b/tests/driver_ina220/main.c
@@ -49,7 +49,7 @@ int main(void)
 
     puts("INA220 sensor driver test application\n");
     printf("Initializing I2C_%i... ", TEST_INA220_I2C);
-    if (i2c_init_master(TEST_INA220_I2C, I2C_SPEED_FAST) < 0) {
+    if (i2c_depr_init_master(TEST_INA220_I2C, I2C_SPEED_FAST) < 0) {
         return -1;
     }
 

--- a/tests/driver_jc42/main.c
+++ b/tests/driver_jc42/main.c
@@ -34,7 +34,7 @@
 
 #include "xtimer.h"
 
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
 #include "jc42.h"
 

--- a/tests/driver_srf08/main.c
+++ b/tests/driver_srf08/main.c
@@ -35,7 +35,7 @@
 
 #include "xtimer.h"
 #include "srf08.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 
  #define SLEEP       (1000 * 1000U)
 

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 
 #include "periph_conf.h"
-#include "periph/i2c.h"
+#include "periph/i2c_depr.h"
 #include "shell.h"
 
 #define BUFSIZE        (128U)
@@ -52,7 +52,7 @@ int cmd_init_master(int argc, char **argv)
     dev = atoi(argv[1]);
     speed = atoi(argv[2]);
 
-    res = i2c_init_master(dev, speed);
+    res = i2c_depr_init_master(dev, speed);
     if (res == -1) {
         puts("Error: Init: Given device not available");
         return 1;
@@ -92,16 +92,16 @@ int cmd_write(int argc, char **argv)
     }
 
     if (length == 1) {
-        printf("i2c_write_byte(I2C_%i, 0x%02x, 0x%02x)\n", i2c_dev, addr, data[0]);
-        res = i2c_write_byte(i2c_dev, addr, data[0]);
+        printf("i2c_depr_write_byte(I2C_%i, 0x%02x, 0x%02x)\n", i2c_dev, addr, data[0]);
+        res = i2c_depr_write_byte(i2c_dev, addr, data[0]);
     }
     else {
-        printf("i2c_write_bytes(I2C_%i, 0x%02x, [", i2c_dev, addr);
+        printf("i2c_depr_write_bytes(I2C_%i, 0x%02x, [", i2c_dev, addr);
         for (int i = 0; i < length; i++) {
             printf(", 0x%02x", data[i]);
         }
         puts("])");
-        res = i2c_write_bytes(i2c_dev, addr, data, length);
+        res = i2c_depr_write_bytes(i2c_dev, addr, data, length);
     }
 
     if (res < 0) {
@@ -138,17 +138,17 @@ int cmd_write_reg(int argc, char **argv)
     }
 
     if (length == 1) {
-        printf("i2c_write_reg(I2C_%i, 0x%02x, 0x%02x, 0x%02x)\n",
+        printf("i2c_depr_write_reg(I2C_%i, 0x%02x, 0x%02x, 0x%02x)\n",
                i2c_dev, addr, reg, data[0]);
-        res = i2c_write_reg(i2c_dev, addr, reg, data[0]);
+        res = i2c_depr_write_reg(i2c_dev, addr, reg, data[0]);
     }
     else {
-        printf("i2c_write_regs(I2C_%i, 0x%02x, 0x%02x, [", i2c_dev, addr, reg);
+        printf("i2c_depr_write_regs(I2C_%i, 0x%02x, 0x%02x, [", i2c_dev, addr, reg);
         for (int i = 0; i < length; i++) {
             printf("0x%02x, ", data[i]);
         }
         puts("])");
-        res = i2c_write_regs(i2c_dev, addr, reg, data, length);
+        res = i2c_depr_write_regs(i2c_dev, addr, reg, data, length);
     }
 
     if (res < 1) {
@@ -186,12 +186,12 @@ int cmd_read(int argc, char **argv)
         return 1;
     }
     else if (length == 1) {
-        printf("i2c_read_byte(I2C_%i, 0x%02x, uint8_t *res)\n", i2c_dev, addr);
-        res = i2c_read_byte(i2c_dev, addr, data);
+        printf("i2c_depr_read_byte(I2C_%i, 0x%02x, uint8_t *res)\n", i2c_dev, addr);
+        res = i2c_depr_read_byte(i2c_dev, addr, data);
     }
     else {
-        printf("i2c_read_bytes(I2C_%i, 0x%02x, uint8_t *res, %i)\n", i2c_dev, addr, length);
-        res = i2c_read_bytes(i2c_dev, addr, data, length);
+        printf("i2c_depr_read_bytes(I2C_%i, 0x%02x, uint8_t *res, %i)\n", i2c_dev, addr, length);
+        res = i2c_depr_read_bytes(i2c_dev, addr, data, length);
     }
 
     if (res < 1) {
@@ -234,12 +234,12 @@ int cmd_read_reg(int argc, char **argv)
         return 1;
     }
     else if (length == 1) {
-        printf("i2c_read_reg(I2C_%i, 0x%02x, 0x%02x, uint8_t *res)\n", i2c_dev, addr, reg);
-        res = i2c_read_reg(i2c_dev, addr, reg, data);
+        printf("i2c_depr_read_reg(I2C_%i, 0x%02x, 0x%02x, uint8_t *res)\n", i2c_dev, addr, reg);
+        res = i2c_depr_read_reg(i2c_dev, addr, reg, data);
     }
     else {
-        printf("i2c_read_regs(I2C_%i, 0x%02x, 0x%02x, uint8_t *res, %i)\n", i2c_dev, addr, reg, length);
-        res = i2c_read_regs(i2c_dev, addr, reg, data, length);
+        printf("i2c_depr_read_regs(I2C_%i, 0x%02x, 0x%02x, uint8_t *res, %i)\n", i2c_dev, addr, reg, length);
+        res = i2c_depr_read_regs(i2c_dev, addr, reg, data, length);
     }
 
     if (res < 1) {


### PR DESCRIPTION
supersedes #4926 

For the remodeling of the I2C interface, I propose i different path than we took for the `spi` interface: 
- rename all existing code (done with this PR)
- introduce the new API (#6576)
- introduce a new test application and a testing scheme
- port existing CPUs and drivers to new interface (#6577)

This PR is renaming the old I2C API to `i2c_depr_`:
```
git grep -l 'i2c_init_master' | xargs sed -i 's/i2c_init_master/i2c_depr_init_master/g'
git grep -l 'i2c_acquire' | xargs sed -i 's/i2c_acquire/i2c_depr_acquire/g'
git grep -l 'i2c_release' | xargs sed -i 's/i2c_release/i2c_depr_release/g'
git grep -l 'i2c_read_bytes' | xargs sed -i 's/i2c_read_bytes/i2c_depr_read_bytes/g'
git grep -l 'i2c_read_byte' | xargs sed -i 's/i2c_read_byte/i2c_depr_read_byte/g'
git grep -l 'i2c_read_regs' | xargs sed -i 's/i2c_read_regs/i2c_depr_read_regs/g'
git grep -l 'i2c_read_reg' | xargs sed -i 's/i2c_read_reg/i2c_depr_read_reg/g'
git grep -l 'i2c_write_bytes' | xargs sed -i 's/i2c_write_bytes/i2c_depr_write_bytes/g'
git grep -l 'i2c_write_byte' | xargs sed -i 's/i2c_write_byte/i2c_depr_write_byte/g'
git grep -l 'i2c_write_regs' | xargs sed -i 's/i2c_write_regs/i2c_depr_write_regs/g'
git grep -l 'i2c_write_reg' | xargs sed -i 's/i2c_write_reg/i2c_depr_write_reg/g'
git grep -l 'i2c_poweron' | xargs sed -i 's/i2c_poweron/i2c_depr_poweron/g'
git grep -l 'i2c_poweroff' | xargs sed -i 's/i2c_poweroff/i2c_depr_poweroff/g'

git grep -l 'periph/i2c_depr.h' | xargs sed -i 's/periph\/i2c.h/periph\/i2c_depr.h/g'
```

