### PR TITLE
tests/driver_mq3: fix build upon avr 8 bits MCU

### DIFF
--- a/tests/driver_mq3/main.c
+++ b/tests/driver_mq3/main.c
@@ -55,7 +55,7 @@ int main(void)
 
         printf("RAW: %4i, per mille: %1i.%03i\n", raw, alc_a, alc_b);
 
-        xtimer_usleep(500 * 1000);
+        xtimer_usleep((uint32_t)500 * SEC_IN_MS);
     }
     return 0;
 }

--- a/tests/driver_mq3/main.c
+++ b/tests/driver_mq3/main.c
@@ -55,7 +55,7 @@ int main(void)
 
         printf("RAW: %4i, per mille: %1i.%03i\n", raw, alc_a, alc_b);
 
-        xtimer_usleep((uint32_t)500 * SEC_IN_MS);
+        xtimer_usleep((uint32_t)500 * 1000);
     }
     return 0;
 }


### PR DESCRIPTION
this test won't build with avr MCU like atmega328p because of
tests/driver_mq3/main.c:58:27: error: integer overflow in expression [-Werror=overflow]
         xtimer_usleep(500 * 1000);

also use timex.h constant define.
see #6148 