### PR TITLE
msp430: Discard order argument when using __sync_xxx for atomics

### DIFF
--- a/cpu/msp430_common/include/stdatomic.h
+++ b/cpu/msp430_common/include/stdatomic.h
@@ -308,7 +308,7 @@ typedef _Atomic(uintmax_t)          atomic_uintmax_t;
 #if __has_builtin(__sync_swap)
 /* Clang provides a full-barrier atomic exchange - use it if available. */
 #define atomic_exchange_explicit(object, desired, order)        \
-    ((void)(order), __sync_swap(&(object)->__val, desired))
+    __sync_swap(&(object)->__val, desired)
 #else
 /*
  * __sync_lock_test_and_set() is only an acquire barrier in theory (although in
@@ -324,20 +324,21 @@ __extension__ ({                            \
     __sync_lock_test_and_set(&(__o)->__val, __d);           \
 })
 #endif
+/* Ignoring the order argument when using __sync builtins */
 #define atomic_fetch_add_explicit(object, operand, order)       \
-    ((void)(order), __sync_fetch_and_add(&(object)->__val,      \
-        __atomic_apply_stride(object, operand)))
+    __sync_fetch_and_add(&(object)->__val,      \
+        __atomic_apply_stride(object, operand))
 #define atomic_fetch_and_explicit(object, operand, order)       \
-    ((void)(order), __sync_fetch_and_and(&(object)->__val, operand))
+    __sync_fetch_and_and(&(object)->__val, operand)
 #define atomic_fetch_or_explicit(object, operand, order)        \
-    ((void)(order), __sync_fetch_and_or(&(object)->__val, operand))
+    __sync_fetch_and_or(&(object)->__val, operand)
 #define atomic_fetch_sub_explicit(object, operand, order)       \
-    ((void)(order), __sync_fetch_and_sub(&(object)->__val,      \
-        __atomic_apply_stride(object, operand)))
+    __sync_fetch_and_sub(&(object)->__val,      \
+        __atomic_apply_stride(object, operand))
 #define atomic_fetch_xor_explicit(object, operand, order)       \
-    ((void)(order), __sync_fetch_and_xor(&(object)->__val, operand))
+    __sync_fetch_and_xor(&(object)->__val, operand)
 #define atomic_load_explicit(object, order)             \
-    ((void)(order), __sync_fetch_and_add(&(object)->__val, 0))
+    __sync_fetch_and_add(&(object)->__val, 0)
 #define atomic_store_explicit(object, desired, order)           \
     ((void)atomic_exchange_explicit(object, desired, order))
 #endif

--- a/tests/emb6/ping.c
+++ b/tests/emb6/ping.c
@@ -90,7 +90,7 @@ static void handle_reply(uip_ipaddr_t *source, uint8_t ttl, uint8_t *data,
 
     ipv6_addr_to_str(addr_str, (ipv6_addr_t *)source, sizeof(addr_str));
 
-    (void)atomic_fetch_add(&received, 1); /* Ignore return value, we only want to increment the counter */
+    atomic_fetch_add(&received, 1);
     printf("%" PRIu16 " bytes from %s: icmp_seq=%" PRIu16 " ttl=%u quota=%i/%i\n",
            datalen, addr_str, byteorder_ntohs(ping->seq), (unsigned)ttl,
            atomic_load(&received), atomic_load(&num));


### PR DESCRIPTION
Fixes the false positive -Wunused-value warning when building with gcc-4.6.3 on msp430.
Previously we had to explicitly ignore the value to avoid getting
```
error: value computed is not used [-Werror=unused-value]
```

The compiler mistakenly thinks that the `atomic_fetch_add` call is without side effects when used in the original implementation with the comma operator. I think it is likely a compiler bug, but the compiler is age old and I don't have any more time to spend on this.

With this PR, the order argument is silently discarded by the preprocessor, instead of evaluated and the result discarded. The order argument is ignored in our implementations of the helper library anyway, and it would just bad coding practice if you pass functions with side effects as the order argument on the atomic operation, so it should not really make any difference.