### PR TITLE
boards/opencm9-04: disable bootloader's timer interrupt

### DIFF
--- a/boards/opencm9-04/board.c
+++ b/boards/opencm9-04/board.c
@@ -34,6 +34,9 @@ void board_init(void)
     /* disable bootloader's USB */
     RCC->APB1ENR &= ~RCC_APB1ENR_USBEN;
 
+    /* disable bootloader's TIMER update interrupt */
+    TIM2->DIER &= ~(TIM_DIER_UIE);
+
     /* configure the RIOT vector table location to internal flash + bootloader offset */
     SCB->VTOR = LOCATION_VTABLE;
 }


### PR DESCRIPTION
Hello !

I was working on a stm32f103cb (board : opencm9-04)
And when I added the module xtimer, my application did not reach the main function.

I figured out that the timer_update interrupt was triggered continuously at timer initialisation.
I just added a line to clear the timer interrupt flag at the end of the interruption.

It feels weird... Have someone got this problem with a stm32 before ?