### PR TITLE
examples/gnrc_networking: update blacklist

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -7,11 +7,11 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
-                          nrf6310 nucleo-f103 nucleo-f334 pca10000 pca10005 spark-core \
-                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
-                          yunjia-nrf51822 z1 nucleo-f072 nucleo-f030 nucleo-f070 \
-                          microbit calliope-mini nucleo32-f042 nucleo32-f303
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f103 nucleo-f334 \
+                             spark-core stm32f0discovery telosb weio \
+                             wsn430-v1_3b wsn430-v1_4 z1 nucleo-f072 nucleo-f030 \
+                             nucleo-f070 microbit calliope-mini nucleo32-f042 \
+                             nucleo32-f303
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present


### PR DESCRIPTION
NRF51822 based boards have enough memory for this project -> remove from `BOARD_INSUFFICIENT_MEMORY`