### PR TITLE
llvm: hide redefines of atomic sync operations

### DIFF
--- a/core/atomic_c11.c
+++ b/core/atomic_c11.c
@@ -348,7 +348,7 @@ bool __atomic_compare_exchange_c(size_t len, void *ptr, void *expected,
     irq_restore(mask);
     return ret;
 }
-
+#if !defined(__llvm__) && !defined(__clang__)
 /* Memory barrier helper function, for platforms without barrier instructions */
 void __sync_synchronize(void) __attribute__((__weak__));
 void __sync_synchronize(void) {
@@ -359,5 +359,5 @@ void __sync_synchronize(void) {
      */
     __asm__ volatile ("" : : : "memory");
 }
-
+#endif
 /** @} */

--- a/core/atomic_sync.c
+++ b/core/atomic_sync.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include "irq.h"
 
+#if !defined(__llvm__) && !defined(__clang__)
 /* GCC documentation refers to the types as I1, I2, I4, I8, I16 */
 typedef uint8_t  I1;
 typedef uint16_t I2;
@@ -222,5 +223,5 @@ TEMPLATE_SYNC_OP_AND_FETCH_N(nand, &, 1, ~) /* __sync_nand_and_fetch_1 */
 TEMPLATE_SYNC_OP_AND_FETCH_N(nand, &, 2, ~) /* __sync_nand_and_fetch_2 */
 TEMPLATE_SYNC_OP_AND_FETCH_N(nand, &, 4, ~) /* __sync_nand_and_fetch_4 */
 TEMPLATE_SYNC_OP_AND_FETCH_N(nand, &, 8, ~) /* __sync_nand_and_fetch_8 */
-
+#endif
 /** @} */


### PR DESCRIPTION
fixes #6595 