### PR TITLE
tests: fix default board for tests

### DIFF
--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -1,3 +1,6 @@
+ifneq (,$(filter driver_%,$(APPLICATION)))
+    BOARD ?= samr21-xpro
+endif
 BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 QUIET ?= 1

--- a/tests/board_calliope-mini/Makefile
+++ b/tests/board_calliope-mini/Makefile
@@ -1,7 +1,6 @@
 APPLICATION = board_calliope-mini
-include ../Makefile.tests_common
-
 BOARD ?= calliope-mini
+include ../Makefile.tests_common
 
 # This test application is for the Calliope mini only
 BOARD_WHITELIST := calliope-mini

--- a/tests/driver_lis3mdl/Makefile
+++ b/tests/driver_lis3mdl/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = driver_lis3mdl
+BOARD ?= limifrog-v1
 include ../Makefile.tests_common
 
 # only this board is known (yet) to provide the sensor LIS3MDL

--- a/tests/mpu_stack_guard/Makefile
+++ b/tests/mpu_stack_guard/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = mpu_stack_guard
+BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 BOARD_WHITELIST += arduino-due      # cortex-m3

--- a/tests/periph_adc/Makefile
+++ b/tests/periph_adc/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = periph_adc
+BOARD ?= pba-d-01-kw2x
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_adc

--- a/tests/periph_dac/Makefile
+++ b/tests/periph_dac/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = periph_dac
+BOARD ?= stm32f4discovery
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_dac

--- a/tests/periph_flashpage/Makefile
+++ b/tests/periph_flashpage/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = periph_flashpage
+BOARD ?= iotlab-m3
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_flashpage

--- a/tests/periph_i2c/Makefile
+++ b/tests/periph_i2c/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = periph_i2c
+BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/periph_pwm/Makefile
+++ b/tests/periph_pwm/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = periph_pwm
+BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_pwm

--- a/tests/periph_rtt/Makefile
+++ b/tests/periph_rtt/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = periph_rtt
+BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_rtt

--- a/tests/periph_spi/Makefile
+++ b/tests/periph_spi/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = periph_spi
+BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi

--- a/tests/pkg_cmsis-dsp/Makefile
+++ b/tests/pkg_cmsis-dsp/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = cmsis-dsp
+BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 USEPKG += cmsis-dsp

--- a/tests/warn_conflict/Makefile
+++ b/tests/warn_conflict/Makefile
@@ -1,4 +1,5 @@
 APPLICATION = warn_conflict
+BOARD ?= stm32f4discovery
 include ../Makefile.tests_common
 
 # The stm32f4discovery is the only board that provides known conflicting features,


### PR DESCRIPTION
with #6444 the default board is set to `native`. For certain tests (like this one) this needs to be overwritten, by defining `BOARD` **before** `include ../Makefile.tests_common`.