### PR TITLE
CI: enable LLVM in Jenkins

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -153,8 +153,12 @@ ifneq (0,$(shell test -d $(RIOTBOARD)/$(BOARD); echo $$?))
 endif
 
 # Use TOOLCHAIN environment variable to select the toolchain to use.
-# Default: gnu
+# Default for macOS: llvm; for other OS: gnu
+ifeq ($(BOARD)$(OS),nativeDarwin)
+TOOLCHAIN ?= llvm
+else
 TOOLCHAIN ?= gnu
+endif
 
 # TOOLCHAIN = clang is an alias for TOOLCHAIN = llvm
 ifeq (clang,$(TOOLCHAIN))

--- a/pkg/oonf_api/Makefile.include
+++ b/pkg/oonf_api/Makefile.include
@@ -1,5 +1,5 @@
 INCLUDES += -I$(PKGDIRBASE)/oonf_api/src-api
 
-ifeq ($(shell uname -s),Darwin)
-	CFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+ifeq ($(TOOLCHAIN), llvm)
+    CFLAGS += -Wno-keyword-macro -Wno-parentheses-equality
 endif

--- a/pkg/relic/patches/0004-add-new-line-to-relic_cp_vbnn_ibs.patch
+++ b/pkg/relic/patches/0004-add-new-line-to-relic_cp_vbnn_ibs.patch
@@ -1,0 +1,24 @@
+From 770c04135121725fa401abf848a8e35f8887f1de Mon Sep 17 00:00:00 2001
+From: smlng <s@mlng.net>
+Date: Wed, 15 Feb 2017 13:22:23 +0100
+Subject: [PATCH] relic: add new line to relic_cp_vbnn_ibs.c
+
+---
+ src/cp/relic_cp_vbnn_ibs.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/cp/relic_cp_vbnn_ibs.c b/src/cp/relic_cp_vbnn_ibs.c
+index c8607068d42a..f532b56de687 100644
+--- a/src/cp/relic_cp_vbnn_ibs.c
++++ b/src/cp/relic_cp_vbnn_ibs.c
+@@ -325,4 +325,5 @@ int cp_vbnn_ibs_user_verify(ec_t sig_R, bn_t sig_z, bn_t sig_h, uint8_t *identit
+ 		ec_free(tmp);
+ 	}
+ 	return result;
+-}
+\ No newline at end of file
++}
++
+-- 
+2.11.0
+

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -2,7 +2,7 @@ PKG_BUILDDIR ?= $(PKGDIRBASE)/tinydtls
 
 INCLUDES += -I$(PKG_BUILDDIR)
 
-ifeq ($(shell uname -s),Darwin)
+ifeq ($(TOOLCHAIN), llvm)
     CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function
 endif
 


### PR DESCRIPTION
this PR enables all tests on native using LLVM toolchain, it depends on ~~#6598~~ #6609.