### PR TITLE
ps: add state name for STATUS_MBOX_BLOCKED

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -31,7 +31,7 @@
 #endif
 
 /* list of states copied from tcb.h */
-const char *state_names[] = {
+static const char *state_names[] = {
     [STATUS_RUNNING] = "running",
     [STATUS_PENDING] = "pending",
     [STATUS_STOPPED] = "stopped",
@@ -41,7 +41,8 @@ const char *state_names[] = {
     [STATUS_SEND_BLOCKED] = "bl send",
     [STATUS_REPLY_BLOCKED] = "bl reply",
     [STATUS_FLAG_BLOCKED_ANY] = "bl anyfl",
-    [STATUS_FLAG_BLOCKED_ALL] = "bl allfl"
+    [STATUS_FLAG_BLOCKED_ALL] = "bl allfl",
+    [STATUS_MBOX_BLOCKED] = "bl mbox",
 };
 
 /**


### PR DESCRIPTION
With `mbox` in use it might happen that a shell application crashes on `ps`. This is due to the fact that no name is defined for `STATUS_MBOX_BLOCKED` which was introduced in #4919. This PR fixes that.