### PR TITLE
llvm: include path fixes

### DIFF
--- a/cpu/Makefile.include.llvm
+++ b/cpu/Makefile.include.llvm
@@ -24,11 +24,12 @@ export DBG         = $(GDBPREFIX)gdb
 # LLVM lacks a binutils strip tool as well...
 #export STRIP      = $(LLVMPREFIX)strip
 
-# Clang on Linux uses GCC's C++ headers and libstdc++ (installed with GCC)
-# Ubuntu and Debian use /etc/alternatives/gcc-$(TARGET_ARCH)-include/c++/$(GCC_VERSION)
-# Arch uses /usr/$(TARGET_ARCH)/include/c++/$(GCC_VERSION)
-# Gentoo uses /usr/lib/gcc/$(TARGET_ARCH)/$(GCC_VERSION)/include/g++-v5
-GCC_CXX_INCLUDE_PATTERNS ?= \
+ifneq (,$(TARGET_ARCH))
+  # Clang on Linux uses GCC's C++ headers and libstdc++ (installed with GCC)
+  # Ubuntu and Debian use /etc/alternatives/gcc-$(TARGET_ARCH)-include/c++/$(GCC_VERSION)
+  # Arch uses /usr/$(TARGET_ARCH)/include/c++/$(GCC_VERSION)
+  # Gentoo uses /usr/lib/gcc/$(TARGET_ARCH)/$(GCC_VERSION)/include/g++-v5
+  GCC_CXX_INCLUDE_PATTERNS ?= \
   /etc/alternatives/gcc-$(TARGET_ARCH)-include/c++/*/ \
   /usr/$(TARGET_ARCH)/include/c++/*/ \
   /usr/lib/gcc/$(TARGET_ARCH)/*/include/g++-v8 \
@@ -37,58 +38,57 @@ GCC_CXX_INCLUDE_PATTERNS ?= \
   /usr/lib/gcc/$(TARGET_ARCH)/*/include/g++-v5 \
   #
 
-# Try to find the proper multilib directory using GCC, this may fail if a cross-
-# GCC is not installed.
-ifeq ($(GCC_MULTI_DIR),)
-  GCC_MULTI_DIR := $(shell $(PREFIX)gcc $(CFLAGS) -print-multi-directory 2>/dev/null)
-endif
+  # Try to find the proper multilib directory using GCC, this may fail if a cross-
+  # GCC is not installed.
+  ifeq ($(GCC_MULTI_DIR),)
+    GCC_MULTI_DIR := $(shell $(PREFIX)gcc $(CFLAGS) -print-multi-directory 2>/dev/null)
+  endif
 
-ifneq (,$(TARGET_ARCH))
   # Tell clang to cross compile
   export CFLAGS     += -target $(TARGET_ARCH)
   export CXXFLAGS   += -target $(TARGET_ARCH)
   export LINKFLAGS  += -target $(TARGET_ARCH)
+
+  # Use the wildcard Makefile function to search for existing directories matching
+  # the patterns above. We use the -isystem gcc/clang argument to add the include
+  # directories as system include directories, which means they will not be
+  # searched until after all the project specific include directories (-I/path)
+  # We sort the list of found directories and take the last one, it will likely be
+  # the most recent GCC version. This avoids using old headers left over from
+  # previous tool chain installations.
+  GCC_CXX_INCLUDES ?= \
+      $(addprefix \
+          -isystem $(firstword \
+              $(foreach pat, $(GCC_CXX_INCLUDE_PATTERNS), $(lastword $(sort $(wildcard $(pat)))))), \
+          /. /$(TARGET_ARCH)/$(GCC_MULTI_DIR) /backward \
+      )
+
+  # If nothing was found we will try to fall back to searching for a cross-gcc in
+  # the current PATH and use a relative path for the includes
+  ifeq (,$(GCC_CXX_INCLUDES))
+    GCC_CXX_INCLUDES := $(addprefix -isystem ,$(wildcard $(dir $(shell which $(PREFIX)gcc))../$(TARGET_TRIPLE)/include))
+  endif
+
+  # Pass the includes to the C++ compilation rule in Makefile.base
+  export CXXINCLUDES += $(GCC_CXX_INCLUDES)
+
+  # Some C headers (e.g. limits.h) are located with the GCC libraries
+  GCC_C_INCLUDE_PATTERNS ?= \
+    /usr/lib/gcc/$(TARGET_TRIPLE)/*/ \
+    #
+
+  GCC_C_INCLUDES ?= \
+      $(addprefix -isystem ,$(wildcard $(addprefix \
+          $(lastword $(sort \
+              $(foreach pat, $(GCC_C_INCLUDE_PATTERNS), $(wildcard $(pat))))), \
+          include include-fixed) \
+      ))
+
+  # If nothing was found we will try to fall back to searching for the libgcc used
+  # by an installed cross-GCC and use its headers.
+  ifeq (,$(GCC_C_INCLUDES))
+    GCC_C_INCLUDES := $(addprefix -isystem ,$(wildcard $(addprefix $(dir $(shell $(PREFIX)gcc -print-libgcc-file-name)), include include-fixed)))
+  endif
+
+  export INCLUDES += $(GCC_C_INCLUDES)
 endif
-
-# Use the wildcard Makefile function to search for existing directories matching
-# the patterns above. We use the -isystem gcc/clang argument to add the include
-# directories as system include directories, which means they will not be
-# searched until after all the project specific include directories (-I/path)
-# We sort the list of found directories and take the last one, it will likely be
-# the most recent GCC version. This avoids using old headers left over from
-# previous tool chain installations.
-GCC_CXX_INCLUDES ?= \
-    $(addprefix \
-        -isystem $(firstword \
-            $(foreach pat, $(GCC_CXX_INCLUDE_PATTERNS), $(lastword $(sort $(wildcard $(pat)))))), \
-        /. /$(TARGET_ARCH)/$(GCC_MULTI_DIR) /backward \
-    )
-
-# If nothing was found we will try to fall back to searching for a cross-gcc in
-# the current PATH and use a relative path for the includes
-ifeq (,$(GCC_CXX_INCLUDES))
-  GCC_CXX_INCLUDES := $(addprefix -isystem ,$(wildcard $(dir $(shell which $(PREFIX)gcc))../$(TARGET_TRIPLE)/include))
-endif
-
-# Pass the includes to the C++ compilation rule in Makefile.base
-export CXXINCLUDES += $(GCC_CXX_INCLUDES)
-
-# Some C headers (e.g. limits.h) are located with the GCC libraries
-GCC_C_INCLUDE_PATTERNS ?= \
-  /usr/lib/gcc/$(TARGET_TRIPLE)/*/ \
-  #
-
-GCC_C_INCLUDES ?= \
-    $(addprefix -isystem ,$(wildcard $(addprefix \
-        $(lastword $(sort \
-            $(foreach pat, $(GCC_C_INCLUDE_PATTERNS), $(wildcard $(pat))))), \
-        include include-fixed) \
-    ))
-
-# If nothing was found we will try to fall back to searching for the libgcc used
-# by an installed cross-GCC and use its headers.
-ifeq (,$(GCC_C_INCLUDES))
-  GCC_C_INCLUDES := $(addprefix -isystem ,$(wildcard $(addprefix $(dir $(shell $(PREFIX)gcc -print-libgcc-file-name)), include include-fixed)))
-endif
-
-export INCLUDES += $(GCC_C_INCLUDES)

--- a/sys/newlib/Makefile.include
+++ b/sys/newlib/Makefile.include
@@ -68,5 +68,9 @@ ifeq (1,$(USE_NEWLIB_NANO))
   INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
 endif
 
-# Newlib includes should go after GCC includes.
-export INCLUDES += $(NEWLIB_INCLUDES)
+# Newlib includes should go before GCC includes. This is especially important
+# when using Clang, because Clang will yield compilation errors on some GCC-
+# bundled headers. Clang compatible versions of those headers are already
+# provided by Newlib, so placing this directory first will eliminate those problems.
+# The above problem was observed with LLVM 3.9.1 when building against GCC 6.3.0 headers.
+export INCLUDES := $(NEWLIB_INCLUDES) $(INCLUDES)


### PR DESCRIPTION
This PR contains two changes to the include path handling when building with LLVM/Clang:
 - Only use GCC include paths if cross compiling
 - Place newlib includes before other system includes

The first part makes native use the system default headers instead of trying to use GCC headers for the host system when GCC is installed alongside Clang.
The second part ensures that Newlib headers can override the GCC headers when building with Clang. In particular, Clang-3.9.1 seems to choke when building the unit tests for atomic when using the stdatomic.h from GCC-6.3.0. Newlib contains another version of stdatomic.h (which in turn seems to stem from FreeBSD) which works with both GCC and Clang, and even the old GCC-4.6 (msp430).