### PR TITLE
periph: removed broken xx_NUMOF checks

### DIFF
--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -53,15 +53,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Make sure the number of available ADC lines is defined
- * @{
- */
-#ifndef ADC_NUMOF
-#error "ADC_NUMOF undefined"
-#endif
-/** @} */
-
-/**
  * @brief   Define default ADC type identifier
  * @{
  */

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -49,15 +49,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Make sure the number of available DAC lines is defined
- * @{
- */
-#ifndef DAC_NUMOF
-#define "DAC_NUMOF undefined"
-#endif
-/** @} */
-
-/**
  * @brief   Define default DAC type identifier
  * @{
  */

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -58,15 +58,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Make sure the number of available UART devices is defined
- * @{
- */
-#ifndef UART_NUMOF
-#error "UART_NUMOF undefined for the target platform"
-#endif
-/** @} */
-
-/**
  * @brief   Define default UART type identifier
  * @{
  */


### PR DESCRIPTION
fixes #6522

These checks lead to unwanted compile errors in case no peripheral of that type is configured. These checks were already removed for all other periph drivers, so this is basically a cleanup PR...