### PR TITLE
Atmega adc support

### DIFF
--- a/boards/arduino-atmega-common/Makefile.features
+++ b/boards/arduino-atmega-common/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/arduino-atmega-common/include/arduino_pinmap.h
+++ b/boards/arduino-atmega-common/include/arduino_pinmap.h
@@ -156,6 +156,26 @@ extern "C" {
 #define ARDUINO_PIN_A15         ARDUINO_PIN_69
 #endif
 
+/* arduino ADC notation compatibility */
+#define A0                     0
+#define A1                     1
+#define A2                     2
+#define A3                     3
+#define A4                     4
+#define A5                     5
+#ifdef CPU_ATMEGA2560
+#define A6                     0
+#define A7                     1
+#define A8                     2
+#define A9                     3
+#define A10                    10
+#define A11                    11
+#define A12                    12
+#define A13                    13
+#define A14                    14
+#define A15                    15
+#endif
+
 /** @ */
 
 #ifdef __cplusplus

--- a/boards/arduino-atmega-common/include/periph_conf.h
+++ b/boards/arduino-atmega-common/include/periph_conf.h
@@ -142,6 +142,41 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @brief ADC configuration
+ *
+ * @{
+ */
+#ifdef CPU_ATMEGA328P
+#define ADC_NUMOF       (6)
+#endif
+#ifdef CPU_ATMEGA2560
+#define ADC_NUMOF       (16)
+#endif
+
+/* ADC Channels */
+#define ADC_PIN_0           0
+#define ADC_PIN_1           1
+#define ADC_PIN_2           2
+#define ADC_PIN_3           3
+#define ADC_PIN_4           4
+#define ADC_PIN_5           5
+#ifdef CPU_ATMEGA2560
+#define ADC_PIN_6           6
+#define ADC_PIN_7           7
+#define ADC_PIN_8           8
+#define ADC_PIN_9           9
+#define ADC_PIN_10          10
+#define ADC_PIN_11          11
+#define ADC_PIN_12          12
+#define ADC_PIN_13          13
+#define ADC_PIN_14          14
+#define ADC_PIN_15          15
+#endif
+/** @} */
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/waspmote-pro/include/periph_conf.h
+++ b/boards/waspmote-pro/include/periph_conf.h
@@ -106,6 +106,24 @@ extern "C" {
 #define MEGA_PRR            PRR0        /* Power Reduction Register */
 /** @} */
 
+/**
+* @brief ADC configuration
+*
+* @{
+*/
+#define ADC_NUMOF       (8)
+/* ADC Channels */
+#define ADC_PIN_0           0
+#define ADC_PIN_1           1
+#define ADC_PIN_2           2
+#define ADC_PIN_3           3
+#define ADC_PIN_4           4
+#define ADC_PIN_5           5
+#define ADC_PIN_6           6
+#define ADC_PIN_7           7
+/** @} */
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega_common/periph/adc.c
+++ b/cpu/atmega_common/periph/adc.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016 Laurent Navet <laurent.navet@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     driver_periph
+ * @{
+ *
+ * @file
+ * @brief       Low-level ADC driver implementation for ATmega family
+ *
+ * @author      Laurent Navet <laurent.navet@gmail.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/adc.h"
+#include "periph_conf.h"
+
+int adc_init(adc_t line)
+{
+    /* check if the line is valid */
+    if (line >= ADC_NUMOF) {
+        return -1;
+    }
+
+    /* configure line as input */
+#ifdef CPU_ATMEGA260
+    if(line < 8)
+        DDRF &= ~(1 << line);
+    else
+        DDRK &= ~(1 << (line-8));
+#else
+    DDRD &= ~(1 << line);
+#endif
+    /* Disable corresponding Digital input */
+    if(line < 8)
+        DIDR0 |= (1 << line);
+#ifdef DIDR2
+    else
+        DIDR2 |= (1 << (line-8));
+#endif
+    /* Enable ADC */
+    ADCSRA |= (1 << ADEN);
+
+    /* Enable ADC with Prescaling = /128 = 125KHz */
+    ADCSRA=(1 << ADEN)|(1 << ADPS2)|(1 << ADPS1)|(1 << ADPS0);
+
+    /* Ref Voltage is Vcc(5V) */
+    ADMUX = (1 << REFS0);
+
+    /* Select pin channel */
+    ADMUX |= line;
+
+    return 0;
+}
+
+int adc_sample(adc_t line, adc_res_t res)
+{
+    int sample = 0;
+
+    /* Start a new conversion. By default, this conversion will
+       be performed in single conversion mode. */
+    ADCSRA |= (1 << ADSC);
+
+    /* Wait until the conversion is complete */
+    while(ADCSRA & (1 << ADIF));
+
+    /* Get conversion result */
+    sample = ADCW;
+
+    /* Clear the ADIF flag */
+    ADCSRA |= ( 1 << ADIF );
+
+    return sample;
+}

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -21,6 +21,7 @@
 extern "C" {
 #include "xtimer.h"
 #include "periph/gpio.h"
+#include "periph/adc.h"
 }
 
 #include "arduino.hpp"
@@ -57,4 +58,10 @@ int digitalRead(int pin)
 void delay(unsigned long msec)
 {
     xtimer_usleep(1000 * msec);
+}
+
+int analogRead(int pin)
+{
+    adc_init((adc_t)pin);
+    return adc_sample((adc_t)pin, (adc_res_t)0);
 }

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -21,7 +21,9 @@
 extern "C" {
 #include "xtimer.h"
 #include "periph/gpio.h"
+#ifdef ADC_NUMOF
 #include "periph/adc.h"
+#endif
 }
 
 #include "arduino.hpp"
@@ -60,8 +62,10 @@ void delay(unsigned long msec)
     xtimer_usleep(1000 * msec);
 }
 
+#ifdef ADC_NUMOF
 int analogRead(int pin)
 {
     adc_init((adc_t)pin);
     return adc_sample((adc_t)pin, (adc_res_t)0);
 }
+#endif

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -82,5 +82,14 @@ int digitalRead(int pin);
  */
 void delay(unsigned long msec);
 
+/**
+ * @brief   Read the current value of the given analog pin
+ *
+ * @param[in] pin       pin to read
+ *
+ * @return a value between 0 to 1023 that is proportionnal
+ * to the voltage applied to the pin
+ */
+int analogRead(int pin);
 #endif /* ARDUINO_H */
 /** @} */

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -90,6 +90,8 @@ void delay(unsigned long msec);
  * @return a value between 0 to 1023 that is proportionnal
  * to the voltage applied to the pin
  */
+#ifdef ADC_NUMOF
 int analogRead(int pin);
+#endif
 #endif /* ARDUINO_H */
 /** @} */


### PR DESCRIPTION
This PR improve and obsolete PR #6148 by adding adc support to atmega based boards.
For now it covers atmega328p and atmega2560, atmega1281 should be trivial to add.
atmega2560 is only build tested, so it needs real testing by someone having the needed hardware.
* Prescaler is fixed to /128 (125kHz)
* Vref is fixed to 5V
Also, it needs PR #6581 to build properly.
