### PR TITLE
drivers/tcs37727: SAUL support + misc fixes

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.dep
+++ b/boards/pba-d-01-kw2x/Makefile.dep
@@ -5,4 +5,5 @@ endif
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += mma8x5x
   USEMODULE += hdc1000
+  USEMODULE += tcs37727
 endif

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -112,8 +112,9 @@ extern "C"
  * @name Define the interface for the TCS3772 light sensor
  * @{
  */
-#define TCS37727_I2C        (I2C_DEV(0))
-#define TCS37727_ADDR       (0x29)
+#define TCS37727_PARAMS     { .i2c   = I2C_DEV(0), \
+                              .addr  = 0x29, \
+                              .atime = TCS37727_PARAM_ATIME }
 /** @} */
 
 /**

--- a/drivers/tcs37727/include/tcs37727_params.h
+++ b/drivers/tcs37727/include/tcs37727_params.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_tcs37727
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for TCS37727 devices
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef TCS37727_PARAMS_H
+#define TCS37727_PARAMS_H
+
+#include "board.h"
+#include "tcs37727.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Set default configuration parameters for TCS37727 devices
+ * @{
+ */
+#ifndef TCS37727_PARAM_I2C
+#define TCS37727_PARAM_I2C          I2C_DEV(0)
+#endif
+#ifndef TCS37727_PARAM_ADDR
+#define TCS37727_PARAM_ADDR         (TCS37727_I2C_ADDRESS)
+#endif
+#ifndef TCS37727_PARAM_ATIME
+#define TCS37727_PARAM_ATIME        (TCS37727_ATIME_DEFAULT)
+#endif
+
+#ifndef TCS37727_PARAMS
+#define TCS37727_PARAMS             { .i2c   = TCS37727_PARAM_I2C,  \
+                                      .addr  = TCS37727_PARAM_ADDR, \
+                                      .atime = TCS37727_PARAM_ATIME }
+#endif
+/**@}*/
+
+/**
+ * @brief   TCS37727 configuration
+ */
+static const tcs37727_params_t tcs37727_params[] =
+{
+    TCS37727_PARAMS
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t tcs37727_saul_info[] =
+{
+    { .name = "tcs37727" }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TCS37727_PARAMS_H */
+/** @} */

--- a/drivers/tcs37727/tcs37727_saul.c
+++ b/drivers/tcs37727/tcs37727_saul.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_tcs37727
+ * @{
+ *
+ * @file
+ * @brief       TCS37727 adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "tcs37727.h"
+
+static int read(void *dev, phydat_t *res)
+{
+    tcs37727_t *d = (tcs37727_t *)dev;
+    tcs37727_data_t val;
+
+    tcs37727_read(d, &val);
+
+    res->val[0] = (int16_t)val.red;
+    res->val[1] = (int16_t)val.green;
+    res->val[2] = (int16_t)val.blue;
+    res->unit = UNIT_CD;
+    res->scale = 0;
+
+    return 3;
+}
+
+const saul_driver_t tcs37727_saul_driver = {
+    .read = read,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_COLOR,
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -318,6 +318,10 @@ void auto_init(void)
     extern void auto_init_dht(void);
     auto_init_dht();
 #endif
+#ifdef MODULE_TCS37727
+    extern void auto_init_tcs37727(void);
+    auto_init_tcs37727();
+#endif
 
 #endif /* MODULE_AUTO_INIT_SAUL */
 

--- a/sys/auto_init/saul/auto_init_tcs37727.c
+++ b/sys/auto_init/saul/auto_init_tcs37727.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of TCS37727 light sensors
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_TCS37727
+
+#include "log.h"
+#include "saul_reg.h"
+#include "tcs37727.h"
+#include "tcs37727_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define TCS37727_NUM    (sizeof(tcs37727_params) / sizeof(tcs37727_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static tcs37727_t tcs37727_devs[TCS37727_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[TCS37727_NUM];
+
+void auto_init_tcs37727(void)
+{
+    for (unsigned i = 0; i < TCS37727_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing tcs29020 #%u\n", i);
+
+        int res = tcs37727_init(&tcs37727_devs[i], &tcs37727_params[i]);
+        if (res != TCS37727_OK) {
+            LOG_ERROR("[auto_init_saul] error initializing tcs37727 #%u\n", i);
+        }
+        else {
+            saul_entries[i].dev = &(tcs37727_devs[i]);
+            saul_entries[i].name = tcs37727_saul_info[i].name;
+            saul_entries[i].driver = &tcs37727_saul_driver;
+            saul_reg_add(&(saul_entries[i]));
+        }
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_TCS37727 */

--- a/tests/driver_tcs37727/Makefile
+++ b/tests/driver_tcs37727/Makefile
@@ -6,12 +6,4 @@ FEATURES_REQUIRED = periph_i2c
 USEMODULE += tcs37727
 USEMODULE += xtimer
 
-# set default device parameters in case they are undefined
-TEST_TCS37727_I2C  ?= I2C_DEV\(0\)
-TEST_TCS37727_ADDR ?= 0x29
-
-# export parameters
-CFLAGS += -DTEST_TCS37727_I2C=$(TEST_TCS37727_I2C)
-CFLAGS += -DTEST_TCS37727_ADDR=$(TEST_TCS37727_ADDR)
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tcs37727/main.c
+++ b/tests/driver_tcs37727/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *               2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,30 +8,25 @@
  */
 
 /**
- * @ingroup tests
+ * @ingroup     tests
  * @{
  *
  * @file
  * @brief       Test application for the TCS37727 sensor driver.
  *
  * @author      Felix Siebel <f.siebel@phytec.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
-
-#ifndef TEST_TCS37727_I2C
-#error "TEST_TCS37727_I2C not defined"
-#endif
-#ifndef TEST_TCS37727_ADDR
-#error "TEST_TCS37727_ADDR not defined"
-#endif
 
 #include <stdio.h>
 
 #include "xtimer.h"
 #include "tcs37727.h"
+#include "tcs37727_params.h"
 
-#define SLEEP       (1000 * 1000U)
+#define SLEEP       (1 * US_PER_SEC)
 
 int main(void)
 {
@@ -38,10 +34,9 @@ int main(void)
     tcs37727_data_t data;
 
     puts("TCS37727 RGBC Data; Sensor driver test application\n");
-    printf("Initializing TCS37727 sensor at I2C_%i... ", TEST_TCS37727_I2C);
+    printf("Initializing first configured TCS37727 sensor...");
 
-    if (tcs37727_init(&dev, TEST_TCS37727_I2C, TEST_TCS37727_ADDR,
-                      TCS37727_ATIME_DEFAULT) == 0) {
+    if (tcs37727_init(&dev, &tcs37727_params[0]) == TCS37727_OK) {
         puts("[OK]\n");
     }
     else {
@@ -49,17 +44,12 @@ int main(void)
         return -1;
     }
 
-    if (tcs37727_set_rgbc_active(&dev)) {
-        puts("Measurement start failed.");
-        return -1;
-    }
-
     while (1) {
         tcs37727_read(&dev, &data);
         printf("R: %5"PRIu32" G: %5"PRIu32" B: %5"PRIu32" C: %5"PRIu32"\n",
                data.red, data.green, data.blue, data.clear);
-        printf("CT : %5"PRIu32" Lux: %6"PRIu32" AGAIN: %2d ATIME %d\n",
-               data.ct, data.lux, dev.again, dev.atime_us);
+        printf("CT : %5"PRIu32" Lux: %6"PRIu32" AGAIN: %2d ATIME %"PRIu32"\n",
+               data.ct, data.lux, dev.again, dev.p.atime);
 
         xtimer_usleep(SLEEP);
     }


### PR DESCRIPTION
- added default parameters file
- let init() function use param struct
- named return values
- simplified init function
- sensor now active after init was called
- simplified return values
- added SAUL mapping for the `pba-d-01-kw2x`