### PR TITLE
boards: fix PWM doxygen doc in periph_conf

### DIFF
--- a/boards/arduino-due/include/periph_conf.h
+++ b/boards/arduino-due/include/periph_conf.h
@@ -103,7 +103,7 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_chan_conf_t pwm_chan[] = {

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -125,7 +125,7 @@ static const adc_conf_t adc_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -42,7 +42,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   PWM device and pinout configuration
+ * @name    PWM device and pinout configuration
  *
  * Currently, we only support a single device and 3 channels, the implementation
  * is fixed on PWM1.

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -76,7 +76,7 @@ static const timer_conf_t timer_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -183,7 +183,7 @@ static const adc_conf_t adc_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo-f030/include/periph_conf.h
+++ b/boards/nucleo-f030/include/periph_conf.h
@@ -96,7 +96,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo-f070/include/periph_conf.h
+++ b/boards/nucleo-f070/include/periph_conf.h
@@ -108,7 +108,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo-f072/include/periph_conf.h
+++ b/boards/nucleo-f072/include/periph_conf.h
@@ -106,7 +106,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo-f091/include/periph_conf.h
+++ b/boards/nucleo-f091/include/periph_conf.h
@@ -147,7 +147,7 @@ static const spi_conf_t spi_config[] = {
 
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo-f303/include/periph_conf.h
+++ b/boards/nucleo-f303/include/periph_conf.h
@@ -118,7 +118,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo-f334/include/periph_conf.h
+++ b/boards/nucleo-f334/include/periph_conf.h
@@ -102,7 +102,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo-f401/include/periph_conf.h
+++ b/boards/nucleo-f401/include/periph_conf.h
@@ -111,7 +111,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo-f446/include/periph_conf.h
+++ b/boards/nucleo-f446/include/periph_conf.h
@@ -127,7 +127,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo144-f207/include/periph_conf.h
+++ b/boards/nucleo144-f207/include/periph_conf.h
@@ -51,7 +51,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo32-f042/include/periph_conf.h
+++ b/boards/nucleo32-f042/include/periph_conf.h
@@ -94,7 +94,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/nucleo32-f303/include/periph_conf.h
+++ b/boards/nucleo32-f303/include/periph_conf.h
@@ -98,7 +98,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -141,7 +141,7 @@ static const adc_conf_t adc_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -120,7 +120,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -152,7 +152,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name    PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {


### PR DESCRIPTION
Still remaining @brief in the doxygen documentation of the PWM configuration of some boards.

This PR fixes this.