### PR TITLE
add static IPv6 lladdr for tests

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -40,6 +40,12 @@ USEMODULE += netstats_rpl
 # development process:
 CFLAGS += -DDEVELHELP
 
+# Comment the following 2 lines out to specify static link lokal IPv6 address
+# this might be useful for testing, in cases whre you cannot or do not want to
+# run a shell with ifconfig to get the real link lokal address.
+#IPV6_STATIC_LLADDR ?= '"fe80::cafe:cafe:cafe:1"'
+#CFLAGS += -DGNRC_IPV6_STATIC_LLADDR=$(IPV6_STATIC_LLADDR)
+
 # Comment this out to join RPL DODAGs even if DIOs do not contain
 # DODAG Configuration Options (see the doc for more info)
 # CFLAGS += -DGNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -68,6 +68,25 @@ extern "C" {
 #define GNRC_IPV6_MSG_QUEUE_SIZE    (8U)
 #endif
 
+#ifdef DOXYGEN
+/**
+ * @brief   Add a static IPv6 link local address to any network interface
+ *
+ * This macro allows to specify a certain link local IPv6 address to be assigned
+ * to a network interface on startup, which might be handy for testing.
+ * Note: a) a interface will keep its auto-generated link local address, too
+ *       b) the address is incremented by 1, if multiple interfaces are present
+ *
+ * To use the macro just add it to `CFLAGS` in the application's Makefile, like:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ * IPV6_STATIC_LLADDR ?= '"fe80::cafe:cafe:cafe:1"'
+ * CFLAGS += -DGNRC_IPV6_STATIC_LLADDR=$(STATIC_IPV6_LLADDR)
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+#define GNRC_IPV6_STATIC_LLADDR
+#endif /* DOXYGEN */
+
 /**
  * @brief   The PID to the IPv6 thread.
  *

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -852,7 +852,19 @@ void gnrc_ipv6_netif_init_by_dev(void)
             _add_addr_to_entry(ipv6_if, &addr, 64, 0);
 
         }
-
+#ifdef GNRC_IPV6_STATIC_LLADDR
+        /* parse addr from string and explicitely set a link lokal prefix
+         * if ifnum > 1 each interface will get its own link local address
+         * with GNRC_IPV6_STATIC_LLADDR + i
+         */
+        char lladdr_str[] = GNRC_IPV6_STATIC_LLADDR;
+        ipv6_addr_t lladdr;
+        if(ipv6_addr_from_str(&lladdr, lladdr_str) != NULL) {
+            lladdr.u8[15] += i;
+            assert(ipv6_addr_is_link_local(&lladdr));
+            _add_addr_to_entry(ipv6_if, &lladdr, 64, 0);
+        }
+#endif
         /* set link MTU */
         if ((gnrc_netapi_get(ifs[i], NETOPT_MAX_PACKET_SIZE, 0, &tmp,
                              sizeof(uint16_t)) >= 0)) {


### PR DESCRIPTION
This PR adds functionality to set an static link local IPv6 address, this might be handy to test network applications. I know there are netif functions to set an address but that would require fiddling the source code. 

With this PR you just pass a parameter via Makefile to the compiler and that will set a pre-known IPv6 address. If multiple (IPv6) interfaces exists, each interface will get a static address incremented by 1.