### PR TITLE
boards/nucleo144-f303: initial support

### DIFF
--- a/boards/nucleo144-f303/Makefile
+++ b/boards/nucleo144-f303/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo144-f303/Makefile.dep
+++ b/boards/nucleo144-f303/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep

--- a/boards/nucleo144-f303/Makefile.features
+++ b/boards/nucleo144-f303/Makefile.features
@@ -1,0 +1,13 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# load the common Makefile.features for Nucleo 144 boards
+include $(RIOTBOARD)/nucleo144-common/Makefile.features
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/nucleo144-f303/Makefile.include
+++ b/boards/nucleo144-f303/Makefile.include
@@ -1,0 +1,6 @@
+# define the cpu used by the nucleo144-f303 board
+export CPU = stm32f3
+export CPU_MODEL = stm32f303ze
+
+# load the common Makefile.include for Nucleo-144 boards
+include $(RIOTBOARD)/nucleo144-common/Makefile.include

--- a/boards/nucleo144-f303/board.c
+++ b/boards/nucleo144-f303/board.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo144-f303
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the nucleo144-f303 board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+}

--- a/boards/nucleo144-f303/dist/openocd.cfg
+++ b/boards/nucleo144-f303/dist/openocd.cfg
@@ -1,0 +1,1 @@
+source [find board/st_nucleo_f3.cfg]

--- a/boards/nucleo144-f303/include/board.h
+++ b/boards/nucleo144-f303/include/board.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    boards_nucleo144-f303 Nucleo144-F303
+ * @ingroup     boards
+ * @brief       Board specific files for the nucleo144-f303 board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the nucleo144-f303 board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name xtimer configuration
+ * @{
+ */
+#define XTIMER_DEV          TIMER_DEV(0)
+#define XTIMER_CHAN         (0)
+#define XTIMER_OVERHEAD     (6)
+#define XTIMER_BACKOFF      (5)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/nucleo144-f303/include/periph_conf.h
+++ b/boards/nucleo144-f303/include/periph_conf.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo144-f303
+ * @{
+ *
+ * @file
+ * @name        Peripheral MCU configuration for the nucleo144-f303 board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Clock system configuration
+ * @{
+ */
+#define CLOCK_HSE           (8000000U)          /* external oscillator */
+#define CLOCK_CORECLOCK     (72000000U)         /* desired core clock frequency */
+
+/* the actual PLL values are automatically generated */
+#define CLOCK_PLL_MUL       (CLOCK_CORECLOCK / CLOCK_HSE)
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2
+#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY_1
+
+/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+/** @} */
+
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM2,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim2
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 9),
+        .tx_pin     = GPIO_PIN(PORT_D, 8),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART3_IRQn,
+#ifdef UART_USE_DMA
+        .dma_stream = 6,
+        .dma_chan   = 4
+#endif
+    },
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+#ifdef UART_USE_DMA
+        .dma_stream = 5,
+        .dma_chan   = 4
+#endif
+    },
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 7),
+        .tx_pin     = GPIO_PIN(PORT_B, 6),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+#ifdef UART_USE_DMA
+        .dma_stream = 4,
+        .dma_chan   = 4
+#endif
+    },
+};
+
+#define UART_0_ISR          (isr_usart3)
+#define UART_0_DMA_ISR      (isr_dma1_stream6)
+#define UART_1_ISR          (isr_usart2)
+#define UART_1_DMA_ISR      (isr_dma1_stream5)
+#define UART_2_ISR          (isr_usart1)
+#define UART_2_DMA_ISR      (isr_dma1_stream4)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @brief   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 8),  .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_A, 9),  .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_A, 10), .cc_chan = 2},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .af       = GPIO_AF6,
+        .bus      = APB2
+    }
+};
+
+#define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+/** @} */
+
+/**
+ * @name   SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 36000000Hz */
+        7,  /* -> 140625Hz */
+        6,  /* -> 281250Hz */
+        4,  /* -> 1125000Hz */
+        2,  /* -> 4500000Hz */
+        1   /* -> 9000000Hz */
+    },
+    {       /* for APB2 @ 72000000Hz */
+        7,  /* -> 281250Hz */
+        7,  /* -> 281250Hz */
+        5,  /* -> 1125000Hz */
+        3,  /* -> 4500000Hz */
+        2   /* -> 9000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_PIN(PORT_A, 4),
+        .af       = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF           (0U)
+/** @} */
+
+/**
+ * @name   ADC configuration
+ * @{
+ */
+#define ADC_NUMOF          (0)
+/** @} */
+
+/**
+ * @name   DAC configuration
+ * @{
+ */
+#define DAC_NUMOF           (0)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/stm32f3/include/cpu_conf.h
+++ b/cpu/stm32f3/include/cpu_conf.h
@@ -24,16 +24,13 @@
 
 #include "cpu_conf_common.h"
 
-#ifdef CPU_MODEL_STM32F303VC
+#if defined(CPU_MODEL_STM32F303VC)
 #include "vendor/stm32f303xc.h"
-#endif
-#ifdef CPU_MODEL_STM32F334R8
+#elif defined(CPU_MODEL_STM32F334R8)
 #include "vendor/stm32f334x8.h"
-#endif
-#ifdef CPU_MODEL_STM32F303RE
+#elif defined(CPU_MODEL_STM32F303RE) || defined(CPU_MODEL_STM32F303ZE)
 #include "vendor/stm32f303xe.h"
-#endif
-#ifdef CPU_MODEL_STM32F303K8
+#elif defined(CPU_MODEL_STM32F303K8)
 #include "vendor/stm32f303x8.h"
 #endif
 #ifdef CPU_MODEL_STM32F302R8

--- a/cpu/stm32f3/ldscripts/stm32f303ze.ld
+++ b/cpu/stm32f3/ldscripts/stm32f303ze.ld
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_stm32f3
+ * @{
+ *
+ * @file
+ * @brief           Memory definitions for the STM32F303ZE
+ *
+ * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+MEMORY
+{
+    rom (rx)    : ORIGIN = 0x08000000, LENGTH = 512K
+    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 64K
+    ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 16K
+    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
+}
+
+_cpuid_address = ORIGIN(cpuid);
+
+INCLUDE cortexm_base.ld

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -27,8 +27,8 @@ DISABLE_TEST_FOR_ARM7 := tests-relic
 
 ARM_CORTEX_M_BOARDS := airfy-beacon arduino-due arduino-zero cc2538dk ek-lm4f120xl \
                        f4vi1 fox frdm-k64f iotlab-m3 limifrog-v1 mbed_lpc1768 msbiot \
-                       mulle nrf51dongle nrf6310 nucleo144-f429 nucleo144-f446 nucleo32-f031 \
-                       nucleo32-f303 nucleo32-l031 nucleo-f030 nucleo-f070 nucleo-f091 \
+                       mulle nrf51dongle nrf6310 nucleo144-f303 nucleo144-f429 nucleo144-f446 \
+                       nucleo32-f031 nucleo32-f303 nucleo32-l031 nucleo-f030 nucleo-f070 nucleo-f091 \
                        nucleo-f302 nucleo-f303 nucleo-f334 nucleo-f401 nucleo-f410 nucleo-f411 \
                        nucleo-l053 nucleo-l073 nucleo-l1 opencm904 openmote-cc2538 pba-d-01-kw2x \
                        pca10000 pca10005 remote saml21-xpro samr21-xpro slwstk6220a sodaq-autonomo \


### PR DESCRIPTION
Another port of Nucleo board. This one is for the [Nucleo-F303ZE](http://www.st.com/en/evaluation-tools/nucleo-f303ze.html).

~~Let's wait for the CI to fix the usual memory overflow issues.~~