### PR TITLE
Examples/gnrc_networking: fix typos in README file of gnrc_networking example.

### DIFF
--- a/examples/gnrc_networking/README.md
+++ b/examples/gnrc_networking/README.md
@@ -115,7 +115,7 @@ In a second terminal, start a second RIOT instance, this time listening on `tap1
 
 In the RIOT shell, you can now send a message to the first RIOT instance:
 
-    > udp send fe80::ccf5:e1ff:fec5:f75 8808 testmessage
+    > udp send fe80::ccf5:e1ff:fec5:f75a 8808 testmessage
 
 *(Make sure to copy the actual
 [link-local address](https://en.wikipedia.org/wiki/Link-local_address) of your first


### PR DESCRIPTION
It seems that there is a minor typos in the `README` file of `gnrc_networking` example when instructing UDP transmission. This is to correct it.