### PR TITLE
cortexm_common: add FPU support for cortex-m4f and cortex-m7

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -8,6 +8,7 @@ PSEUDOMODULES += conn_can_isotp_multi
 PSEUDOMODULES += cord_ep_standalone
 PSEUDOMODULES += cord_epsim_standalone
 PSEUDOMODULES += core_%
+PSEUDOMODULES += cortexm_fpu
 PSEUDOMODULES += ecc_%
 PSEUDOMODULES += emb6_router
 PSEUDOMODULES += event_%

--- a/pkg/cmsis-dsp/patches/0001-include-cpu_conf.h.patch
+++ b/pkg/cmsis-dsp/patches/0001-include-cpu_conf.h.patch
@@ -1,0 +1,25 @@
+From 53e086efc203ad8e1646524c732588d27aabfc53 Mon Sep 17 00:00:00 2001
+From: Vincent Dupont <vincent@otakeys.com>
+Date: Mon, 20 Feb 2017 19:00:08 +0100
+Subject: [PATCH] include cpu_conf.h
+
+---
+ include/arm_math.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/arm_math.h b/include/arm_math.h
+index e4b2f62..cde16bf 100644
+--- a/include/arm_math.h
++++ b/include/arm_math.h
+@@ -288,6 +288,8 @@
+ #ifndef _ARM_MATH_H
+ #define _ARM_MATH_H
+ 
++#include "cpu_conf.h"
++
+ #define __CMSIS_GENERIC         /* disable NVIC and Systick functions */
+ 
+ #if defined(ARM_MATH_CM7)
+-- 
+2.9.3
+

--- a/tests/thread_float/Makefile
+++ b/tests/thread_float/Makefile
@@ -1,0 +1,16 @@
+APPLICATION = thread_float
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-uno arduino-duemilanove \
+			     alliope-mini cc2650stk chronos maple-mini \
+                             mbed_lpc1768 microbit msb-430 msb-430h nrf51dongle \
+                             nrf6310 nucleo-f031k6 nucleo-f042k6 \
+                             opencm9-04 pca10000 pca10005 spark-core \
+                             stm32f0discovery weio yunjia-nrf51822
+
+USEMODULE += printf_float
+USEMODULE += xtimer
+
+#DISABLE_MODULE += cortexm_fpu
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/thread_float/main.c
+++ b/tests/thread_float/main.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2017 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief Thread test application
+ *
+ * @author Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "thread.h"
+#include "msg.h"
+#include "xtimer.h"
+#include "timex.h"
+
+static char t1_stack[THREAD_STACKSIZE_MAIN];
+static char t2_stack[THREAD_STACKSIZE_MAIN];
+static char t3_stack[THREAD_STACKSIZE_MAIN];
+
+static kernel_pid_t p1, p2, p3;
+
+static xtimer_t timer;
+#define OFFSET (10 * XTIMER_BACKOFF)
+
+static mutex_t lock = MUTEX_INIT;
+
+static void timer_cb(void *arg)
+{
+    (void) arg;
+
+    thread_yield();
+    xtimer_set(&timer, OFFSET);
+}
+
+static void *thread1(void *arg)
+{
+    (void) arg;
+
+    float f, init;
+
+    printf("THREAD %" PRIkernel_pid " start\n", thread_getpid());
+
+    init = 1.0 * thread_getpid();
+    f = init;
+
+    while (1) {
+        for (unsigned long i = 0; i < 10000ul; i++) {
+            f = f + 1.0 / f;
+        }
+        mutex_lock(&lock);
+        printf("T(%" PRIkernel_pid "): %f\n", thread_getpid(), (double)f);
+        mutex_unlock(&lock);
+        init += 1.0;
+        f = init;
+    }
+    return NULL;
+}
+
+static void *thread2(void *arg)
+{
+    (void) arg;
+
+    float f, init;
+
+    printf("THREAD %" PRIkernel_pid " start\n", thread_getpid());
+
+    init = 1.0 * thread_getpid();
+    f = init;
+
+    while (1) {
+        for (unsigned long i = 0; i < 100000ul; i++) {
+            f = f + 1.0 / f;
+        }
+        init += 1.0;
+        f = init;
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN + 1,
+                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       thread1, NULL, "nr1");
+    p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN + 1,
+                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       thread2, NULL, "nr2");
+    p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN + 1,
+                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+                       thread1, NULL, "nr3");
+    puts("THREADS CREATED\n");
+
+
+    timer.callback = timer_cb;
+    xtimer_set(&timer, OFFSET);
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #1366.

Not sure if every cases are covered, but it works with nucleo-f401 and nucleo-f413.
I added a test app based on `thread_msg` which uses float.

No hard fault so far and float results seem OK with different threads.