### PR TITLE
tests: thread_flags: print success message

### DIFF
--- a/tests/thread_flags/main.c
+++ b/tests/thread_flags/main.c
@@ -23,6 +23,8 @@
 
 static char stack[THREAD_STACKSIZE_MAIN];
 
+volatile unsigned done;
+
 static void *_thread(void *arg)
 {
     (void) arg;
@@ -49,6 +51,8 @@ static void *_thread(void *arg)
     puts("thread(): waiting for any flag, one by one");
     flags = thread_flags_wait_one(0xFFFF);
     printf("thread(): received flags: 0x%04x\n", (unsigned)flags & 0xFFFF);
+
+    done = 1;
 
     return NULL;
 }
@@ -79,6 +83,9 @@ int main(void)
     _set(thread, 0x2);
     _set(thread, 0x4);
 
-    while(1) {};
+    while(!done) {};
+
+    puts("test finished.");
+
     return 0;
 }


### PR DESCRIPTION
The test previously stuck without message, even after completing. This PR just adds a message indicating the tests has finished.