### PR TITLE
cpu/cortexm_common: use linker variable to initialize SCB->VTOR

### DIFF
--- a/boards/opencm904/board.c
+++ b/boards/opencm904/board.c
@@ -37,9 +37,6 @@ void board_init(void)
     /* disable bootloader's TIMER update interrupt */
     TIM2->DIER &= ~(TIM_DIER_UIE);
 
-    /* configure the RIOT vector table location to internal flash + bootloader offset */
-    SCB->VTOR = LOCATION_VTABLE;
-
     /* remap USART1 to PB7 and PB6 */
     AFIO->MAPR |= AFIO_MAPR_USART1_REMAP;
 }

--- a/boards/opencm904/include/board.h
+++ b/boards/opencm904/include/board.h
@@ -26,13 +26,6 @@ extern "C" {
 #endif
 
 /**
- * @name Define the location of the RIOT image in flash
- * @{
- */
-#define LOCATION_VTABLE     (0x08003000)
-/** @} */
-
-/**
  * @name xtimer configuration
  * @{
  */

--- a/boards/spark-core/board.c
+++ b/boards/spark-core/board.c
@@ -40,6 +40,4 @@ void board_init(void)
     SysTick->CTRL = 0;
     /* signal to spark bootloader: do not enable IWDG! set Stop Mode Flag! */
     BKP->DR9 = 0xAFFF;
-    /* configure the RIOT vector table location to internal flash + spark bootloader offset */
-    SCB->VTOR = LOCATION_VTABLE;
 }

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -31,11 +31,6 @@
 #endif
 
 /**
- * @name Define the location of the RIOT image in flash
- */
-#define LOCATION_VTABLE     (0x08005000)
-
-/**
  * @name Tell the xtimer that we use a 16-bit peripheral timer
  */
 #define XTIMER_WIDTH        (16)

--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -26,6 +26,11 @@
  */
 #define FULL_FPU_ACCESS         (0x00f00000)
 
+/**
+ * Interrupt vector base address, defined by the linker
+ */
+extern const void *_isr_vectors;
+
 void cortexm_init(void)
 {
     /* initialize the FPU on Cortex-M4F CPUs */
@@ -37,7 +42,7 @@ void cortexm_init(void)
     /* configure the vector table location to internal flash */
 #if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
     defined(CPU_ARCH_CORTEX_M4F)
-    SCB->VTOR = CPU_FLASH_BASE;
+    SCB->VTOR = (uint32_t)&_isr_vectors;
 #endif
 
     /* initialize the interrupt priorities */

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -41,6 +41,7 @@ SECTIONS
     {
         . = ALIGN(4);
         _sfixed = .;
+        _isr_vectors = DEFINED(_isr_vectors) ? _isr_vectors : . ;
         KEEP(*(.vectors .vectors.*))
         *(.text .text.* .gnu.linkonce.t.*)
         *(.glue_7t) *(.glue_7)

--- a/cpu/kinetis_common/ldscripts/kinetis.ld
+++ b/cpu/kinetis_common/ldscripts/kinetis.ld
@@ -25,7 +25,7 @@ SECTIONS
     /* Interrupt vectors 0x00-0x3ff. */
     .vector_table :
     {
-        _vector_rom = .;
+        _isr_vectors = .;
         KEEP(*(.vector_table))
     } > vectors
     ASSERT (SIZEOF(.vector_table) == 0x400, "Interrupt vector table of invalid size.")


### PR DESCRIPTION
Use the actual vector base address from the linker to initialize the vector base address register.

It's easier to overwrite from an application with a custom linker file.