### PR TITLE
cpu/cortexm_common: fix periph_pm typo

### DIFF
--- a/cpu/cortexm_common/periph/pm.c
+++ b/cpu/cortexm_common/periph/pm.c
@@ -23,7 +23,7 @@
 #include "cpu.h"
 #include "periph/pm.h"
 
-#ifndef FEATURES_PERIPH_PM
+#ifndef FEATURE_PERIPH_PM
 void pm_set_lowest(void)
 {
     cortexm_sleep(0);


### PR DESCRIPTION
#6160 mispelled FEATURE_PERIPH_PM with an extraneous S which caused a default pm_set_lowest to always be used even if the platform provides it.

@kaspar030 this should be a trivial review