### PR TITLE
boards: nucleo-f401: add RTC config

### DIFF
--- a/boards/nucleo-f401/Makefile.features
+++ b/boards/nucleo-f401/Makefile.features
@@ -3,6 +3,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f401/include/periph_conf.h
+++ b/boards/nucleo-f401/include/periph_conf.h
@@ -223,6 +223,13 @@ static const spi_conf_t spi_config[] = {
 #define DAC_NUMOF           (0)
 /** @} */
 
+/**
+ * @name   RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR adds RTC configuration to Nucleo-f401 periph_conf.h.