### PR TITLE
tools/tapsetup: change default bridge name on macOS

### DIFF
--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -185,7 +185,7 @@ case "$(uname -s)" in
     Darwin)
         PLATFORM="OSX"
         if echo "$BRNAME" | grep -v -q "^bridge"; then
-            BRNAME=bridge0
+            BRNAME=bridge42
         fi ;;
     FreeBSD)
         PLATFORM="FreeBSD"


### PR DESCRIPTION
The default bridge name used by tapsetup `bridge0` is already used
by the macOS. This changes the default to `bridge42`.