### PR TITLE
enable feature cpp on board pba-d-01-kw2x

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -12,6 +12,7 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
+FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -218,8 +218,8 @@ static const spi_conf_t spi_config[] = {
             GPIO_UNDEF,
             GPIO_UNDEF
         },
-        .simmask  = SIM_SCGC6_SPI0_MASK,
-        .pcr      = GPIO_AF_2
+        .pcr      = GPIO_AF_2,
+        .simmask  = SIM_SCGC6_SPI0_MASK
     },
     {
         .dev      = SPI1,
@@ -233,8 +233,8 @@ static const spi_conf_t spi_config[] = {
             GPIO_UNDEF,
             GPIO_UNDEF
         },
-        .simmask  = SIM_SCGC6_SPI1_MASK,
-        .pcr      = GPIO_AF_2
+        .pcr      = GPIO_AF_2,
+        .simmask  = SIM_SCGC6_SPI1_MASK
     }
 };
 


### PR DESCRIPTION
found #1323 and made a fix for the phytec board. Basically, cpp requires correct order when initializing C structs