### PR TITLE
sys/pm_layered: include board.h

### DIFF
--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -21,6 +21,7 @@
 #include "irq.h"
 #include "periph/pm.h"
 #include "pm_layered.h"
+#include "board.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"


### PR DESCRIPTION
It would be handy to be able to define PM_BLOCKER_INITIAL in the board periph_conf.h. At the moment this is difficult because that file is not included. 

It's a bit low level to expect the users to define it in their application makefiles, so I think allowing platforms to define it (if not defined in the makefile) and take on the burden of explaining to the users how it affects their use of the platform is appropriate.

This change does not affect any existing boards because nobody defines PM_BLOCKER_INITIAL, but our as-yet-to-be-upstreamed SAMR21-based platform does.