### PR TITLE
test/thread_flags: remove unused module 'xtimer'

### DIFF
--- a/tests/thread_flags/Makefile
+++ b/tests/thread_flags/Makefile
@@ -3,7 +3,6 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 
-USEMODULE += xtimer
 USEMODULE += core_thread_flags
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
the test never uses the `xtimer`...