### PR TITLE
cpu: native: fix thread_yield_higher isr_is_in() case

### DIFF
--- a/cpu/native/native_cpu.c
+++ b/cpu/native/native_cpu.c
@@ -225,7 +225,7 @@ void thread_yield_higher(void)
         irq_enable();
     }
     else {
-        isr_thread_yield();
+        sched_context_switch_request = 1;
     }
 }
 


### PR DESCRIPTION
Previously, native created a new "setcontext" context whenever ```thread_yield_higher()``` was called. That's unnecessary and broken. At the end of interrupt our interrupt handlers, ```sched_context_switch_request``` is checked and triggers an eventually needed context switch.

Fixes #6642.