### PR TITLE
tests: xtimer hang, correct output

### DIFF
--- a/tests/xtimer_hang/README.md
+++ b/tests/xtimer_hang/README.md
@@ -1,0 +1,5 @@
+# xTimer hang test
+
+This test prints `Testing... (<percentage>)` every `TEST_INTERVAL` ms for
+`TEST_SECONDS` seconds. Prints `[SUCCESS]` on completion, if it stops or
+hangs before, the test failed.

--- a/tests/xtimer_hang/main.c
+++ b/tests/xtimer_hang/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Daniel Krebs <github@daniel-krebs.net>
  *               2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2017 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -18,6 +19,7 @@
  *
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Sebastian Meiling <s@mlng.net>
  *
  * @}
  */
@@ -25,67 +27,47 @@
 
 #include "xtimer.h"
 #include "thread.h"
+#include "log.h"
 
-#define TEST_SECONDS        (10LU)
-#define TEST_TIME           (TEST_SECONDS * US_PER_SEC)
-#define STACKSIZE_TIMER     (THREAD_STACKSIZE_DEFAULT)
+#define TEST_SECONDS            (10LU)
+#define TEST_TIME               (TEST_SECONDS * US_PER_SEC)
+#define TEST_INTERVAL           (100LU)
+#define TEST_TIMER_STACKSIZE    (THREAD_STACKSIZE_DEFAULT)
 
-char stack_timer1[STACKSIZE_TIMER];
-char stack_timer2[STACKSIZE_TIMER];
+char stack_timer1[TEST_TIMER_STACKSIZE];
+char stack_timer2[TEST_TIMER_STACKSIZE];
 
-unsigned int count = 0;
-
-void* timer_func1(void* arg)
+void* timer_func(void* arg)
 {
-    (void)arg;
-    while(1)
-    {
-        xtimer_usleep(1000);
-    }
-}
-
-void* timer_func2(void* arg)
-{
-    (void)arg;
-    while(1)
-    {
-        xtimer_usleep(1100);
+    LOG_DEBUG("run thread %" PRIkernel_pid "\n", thread_getpid());
+    while(1) {
+        xtimer_usleep(*(uint32_t *)(arg));
     }
 }
 
 int main(void)
 {
-    puts("xTimer hang test\n");
+    LOG_DEBUG("[INIT]\n");
+    uint32_t sleep_timer1 = 1000;
+    uint32_t sleep_timer2 = 1100;
 
-    printf("This test will print \"Testing... (<percentage>)\" every 100ms for %u seconds.\n", (unsigned)TEST_SECONDS);
-    printf("If it stops before, the test failed.\n\n");
+    thread_create(stack_timer1, TEST_TIMER_STACKSIZE,
+                  2, THREAD_CREATE_STACKTEST,
+                  timer_func, &sleep_timer1, "timer1");
+    thread_create(stack_timer2, TEST_TIMER_STACKSIZE,
+                  3, THREAD_CREATE_STACKTEST,
+                  timer_func, &sleep_timer2, "timer2");
 
-    thread_create(stack_timer1,
-                  STACKSIZE_TIMER,
-                  2,
-                  THREAD_CREATE_STACKTEST,
-                  timer_func1,
-                  NULL,
-                  "timer1");
+    uint32_t ticks_now = 0;
+    uint32_t ticks_start = _xtimer_now();
+    uint32_t ticks_until = ticks_start + _xtimer_ticks_from_usec(TEST_TIME);
 
-    thread_create(stack_timer2,
-                  STACKSIZE_TIMER,
-                  3,
-                  THREAD_CREATE_STACKTEST,
-                  timer_func2,
-                  NULL,
-                  "timer2");
-
-    xtimer_ticks32_t end = xtimer_now();
-    end.ticks32 += _xtimer_ticks_from_usec(TEST_TIME);
-    while(_xtimer_now() < end.ticks32)
-    {
-        count++;
-        xtimer_usleep(100LU * 1000);
-        printf("Testing... (%u%%)\n", count);
+    puts("[START]");
+    while((ticks_now = _xtimer_now()) < ticks_until) {
+        uint8_t percent = 100*(ticks_now - ticks_start)/(ticks_until - ticks_start);
+        xtimer_usleep(TEST_INTERVAL * US_PER_MS);
+        printf("Testing... (%u%%)\n", percent);
     }
-
-    printf("Test successful.\n");
-
+    puts("[SUCCESS]");
     return 0;
 }


### PR DESCRIPTION
the percentage in output was static not actually relative to test completion. On slow boards, such as arduino duemilanove, last output was something around 90%. This PR corrects the output, by calculative the _real_ percentage of test completion. Plus minor code optimization and style correction, and move test description into separate README.