### PR TITLE
boards/nucleo32-f031: replace @brief with @name in periph conf

### DIFF
--- a/boards/nucleo32-f031/include/periph_conf.h
+++ b/boards/nucleo32-f031/include/periph_conf.h
@@ -43,7 +43,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Timer configuration
+ * @name   Timer configuration
  * @{
  */
 static const timer_conf_t timer_config[] = {
@@ -62,7 +62,7 @@ static const timer_conf_t timer_config[] = {
 /** @} */
 
 /**
- * @brief UART configuration
+ * @name UART configuration
  * @{
  */
 static const uart_conf_t uart_config[] = {
@@ -84,7 +84,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   PWM configuration
+ * @name   PWM configuration
  * @{
  */
 static const pwm_conf_t pwm_config[] = {
@@ -135,7 +135,7 @@ static const pwm_conf_t pwm_config[] = {
 /** @} */
 
 /**
- * @brief   ADC configuration
+ * @name   ADC configuration
  * @{
  */
 #define ADC_CONFIG {            \
@@ -150,7 +150,7 @@ static const pwm_conf_t pwm_config[] = {
 /** @} */
 
 /**
- * @brief   DAC configuration
+ * @name   DAC configuration
  * @{
  */
 #define DAC_NUMOF           (0)


### PR DESCRIPTION
Another partial fix of #6466 