### PR TITLE
test/driver_xbee: fix xbee param UART export in Makefile

### DIFF
--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -19,7 +19,7 @@ USEMODULE += shell_commands
 XBEE_UART ?= "1"
 
 # export UART to params file
-CFLAGS += -DXBEE_UART=$(XBEE_UART)
+CFLAGS += -DXBEE_PARAM_UART=$(XBEE_UART)
 
 # No need of big buffer for this test
 CFLAGS += -DGNRC_PKTBUF_SIZE=512


### PR DESCRIPTION
Playing with xbee, I noticed that the UART param used with the Xbee is not correctly exported from the Makefile. This is fixed by this PR.