### PR TITLE
newlib+llvm: Use --sysroot instead of -nostdinc

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -1,26 +1,22 @@
 ifneq (,$(filter newlib_nano,$(USEMODULE)))
-  # Test if nano.specs is available
-  ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-    USE_NEWLIB_NANO = 1
-    ifeq ($(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(CC) -xc - -o /dev/null -lc -specs=nano.specs -Wall -Wextra -pedantic 2>&1 | grep -q "use of wchar_t values across objects may fail" ; echo $$?),0)
-        CFLAGS += -fshort-wchar
-        LINKFLAGS += -Wl,--no-wchar-size-warning
+  ifeq ($(TOOLCHAIN), llvm)
+    # Clang does not use .specs files
+    # Test if libc_nano is found
+    ifneq ($(shell LC_ALL=C $(CC) $(CFLAGS) -xc - -o /dev/null -lc_nano 2>&1 >/dev/null </dev/null | grep -q 'find -lc_nano'; echo $$?),0)
+      USE_NEWLIB_NANO = 1
+    endif
+  else
+    # Test if nano.specs is available
+    ifeq ($(shell $(LINK) -specs=nano.specs -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+      USE_NEWLIB_NANO = 1
     endif
   endif
 endif
 
+$(info USE_NEWLIB_NANO = $(USE_NEWLIB_NANO))
+
 ifneq (,$(filter newlib_gnu_source,$(USEMODULE)))
   CFLAGS += -D_GNU_SOURCE=1
-endif
-
-ifeq (1,$(USE_NEWLIB_NANO))
-  export LINKFLAGS += -specs=nano.specs
-endif
-
-ifeq ($(TARGET_ARCH),mips-mti-elf)
- export LINKFLAGS += -lc
-else
- export LINKFLAGS += -lc -lnosys
 endif
 
 # Search for Newlib include directories
@@ -66,10 +62,21 @@ ifeq ($(TOOLCHAIN),llvm)
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
+  LINKFLAGS += -lc_nano
+  ifneq ($(TOOLCHAIN),llvm)
+    LINKFLAGS += -specs=nano.specs
+  endif
+  ifeq ($(shell echo "int main(){} void _exit(int n) {(void)n;while(1);}" | LC_ALL=C $(CC) -xc - -o /dev/null -lc -specs=nano.specs -Wall -Wextra -pedantic 2>&1 | grep -q "use of wchar_t values across objects may fail" ; echo $$?),0)
+      CFLAGS += -fshort-wchar
+      LINKFLAGS += -Wl,--no-wchar-size-warning
+  endif
+
   NEWLIB_NANO_INCLUDE_DIR ?= $(NEWLIB_INCLUDE_DIR)/newlib-nano
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
+else
+  LINKFLAGS += -lc
 endif
 
 # Newlib includes should go before GCC includes. This is especially important

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -61,9 +61,7 @@ ifeq ($(TOOLCHAIN),llvm)
   # A cross GCC already knows the target libc include path (build-in at compile time)
   # but Clang, when cross-compiling, needs to be told where to find the headers
   # for the system being built.
-  # We also add -nostdinc to avoid including the host system headers by mistake
-  # in case some header is missing from the cross tool chain
-  NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR) -nostdinc
+  NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR)
   NEWLIB_INCLUDES += $(addprefix -isystem ,$(abspath $(wildcard $(dir $(NEWLIB_INCLUDE_DIR))/usr/include)))
 endif
 

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -75,7 +75,7 @@ ifneq (,$(TARGET_ARCH))
   # include paths.
   export CFLAGS     += -target $(TARGET_ARCH) --sysroot $(GCC_SYSROOT)
   export CXXFLAGS   += -target $(TARGET_ARCH) --sysroot $(GCC_SYSROOT)
-  export LINKFLAGS  += -target $(TARGET_ARCH) --sysroot $(GCC_SYSROOT)
+  export LINKFLAGS  += -target $(TARGET_ARCH) --sysroot $(GCC_SYSROOT) -L$(GCC_SYSROOT)/lib -L$(GCC_SYSROOT)/usr/lib
 
   # Use the wildcard Makefile function to search for existing directories matching
   # the patterns above. We use the -isystem gcc/clang argument to add the include


### PR DESCRIPTION
Depends on ~~#6670~~ 

This PR cleans up the LLVM include header path search to use the Clang supplied headers for the compiler-specifics in C instead of GCC's counterpart. For C++ we still need GCC (libstdc++).

Affected headers are the compiler bundled headers with close ties to compiler internals, such as `<limits.h>`