### PR TITLE
make: Add support for specifying a different compiler for assembler

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -53,8 +53,8 @@ $(BINDIR)/$(MODULE).a $(OBJ): | $(BINDIR)/$(MODULE)/
 $(BINDIR)/$(MODULE).a: $(OBJ) | ${DIRS:%=ALL--%}
 	$(Q)$(AR) $(ARFLAGS) $@ $?
 
-
 CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
+CCASFLAGS = $(filter-out $(CCASUWFLAGS), $(CFLAGS)) $(CCASEXFLAGS)
 
 # compile and generate dependency info
 
@@ -76,7 +76,7 @@ $(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
 	$(Q)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
 
 $(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S
-	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+	$(Q)$(CCAS) $(CCASFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 # pull in dependency info for *existing* .o files
 # deleted header files will be silently ignored

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -27,9 +27,12 @@ export TARGET_ARCH           # The target platform name, in GCC triple notation,
 export PREFIX                # The prefix of the toolchain commands, usually "$(TARGET_ARCH)-", e.g. "arm-none-eabi-" or "msp430-".
 export CC                    # The C compiler to use.
 export CXX                   # The CXX compiler to use.
+export CCAS                  # The C compiler to use for assembler files, typically the same as CC.
 export CFLAGS                # The compiler flags. Must only ever be used with `+=`.
-export CXXUWFLAGS            # (Patters of) flags in CFLAGS, that should not be passed to CXX.
+export CXXUWFLAGS            # (Patterns of) flags in CFLAGS that should not be passed to CXX.
 export CXXEXFLAGS            # Additional flags that should be passed to CXX.
+export CCASUWFLAGS           # (Patterns of) flags in CFLAGS that should not be passed to CCAS.
+export CCASEXFLAGS           # Additional flags that should be passed to CCAS.
 export AR                    # The command to create the object file archives.
 export ARFLAGS               # Command-line options to pass to AR, default `rcs`.
 export AS                    # The assembler.

--- a/cpu/Makefile.include.gnu
+++ b/cpu/Makefile.include.gnu
@@ -1,18 +1,19 @@
 export GDBPREFIX ?= $(PREFIX)
-export CC = $(PREFIX)gcc
-export CXX = $(PREFIX)g++
+export CC         = $(PREFIX)gcc
+export CXX        = $(PREFIX)g++
+export CCAS      ?= $(CC)
 ifeq ($(LTO),1)
-export AR = $(PREFIX)gcc-ar
+export AR         = $(PREFIX)gcc-ar
 else
-export AR = $(PREFIX)ar
+export AR         = $(PREFIX)ar
 endif
-export AS = $(PREFIX)as
-export LINK = $(PREFIX)gcc
-export SIZE = $(PREFIX)size
-export OBJCOPY = $(shell command -v $(PREFIX)objcopy gobjcopy objcopy | head -n 1)
+export AS         = $(PREFIX)as
+export LINK       = $(PREFIX)gcc
+export SIZE       = $(PREFIX)size
+export OBJCOPY   ?= $(shell command -v $(PREFIX)objcopy gobjcopy objcopy | head -n 1)
 ifeq ($(OBJCOPY),)
 $(warning objcopy not found. Hex file will not be created.)
-export OBJCOPY = true
+export OBJCOPY    = true
 endif
-export OBJDUMP = $(PREFIX)objdump
-export DBG = $(GDBPREFIX)gdb
+export OBJDUMP    = $(PREFIX)objdump
+export DBG        = $(GDBPREFIX)gdb

--- a/cpu/Makefile.include.llvm
+++ b/cpu/Makefile.include.llvm
@@ -9,6 +9,7 @@ export LLVMPREFIX :=
 endif
 export CC          = clang
 export CXX         = clang++
+export CCAS       ?= $(CC)
 export LINK        = $(CC)
 export AS          = $(LLVMPREFIX)as
 export AR          = $(LLVMPREFIX)ar


### PR DESCRIPTION
This will allow us to specify a separate compiler for assembly sources which are compiled with GCC (not AS). Clang has a problem with some of the assembly headers in the MIPS port and using GCC for the asm sources instead will allow Clang to build all of the C code. PR on the MIPS part is coming.