### PR TITLE
boards/fox: use second UART in Darwin platforms

### DIFF
--- a/boards/fox/Makefile.include
+++ b/boards/fox/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL = stm32f103re
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*B)))
 
 # setup serial terminal
 include $(RIOTBOARD)/Makefile.include.serial


### PR DESCRIPTION
As for iotlab-m3 platforms, the fox uses the second available UART for STDIO.