### PR TITLE
boards/fox: add periph_flashpage feature

### DIFF
--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt


### PR DESCRIPTION
Since this board embeds a stm32f103 CPU, the periph_flashpage feature is also provided.

This change makes me think, should we move the features proper of CPUs to the CPU level? @haukepetersen what do you think?