### PR TITLE
core: bugfix: ringbuffer_remove

### DIFF
--- a/core/ringbuffer.c
+++ b/core/ringbuffer.c
@@ -117,12 +117,12 @@ unsigned ringbuffer_remove(ringbuffer_t *restrict rb, unsigned n)
         rb->start = rb->avail = 0;
     }
     else {
-        rb->start -= n;
+        rb->start += n;
         rb->avail -= n;
 
         /* compensate underflow */
         if (rb->start > rb->size) {
-            rb->start += rb->size;
+            rb->start -= rb->size;
         }
     }
 

--- a/tests/unittests/tests-core/tests-core-ringbuffer.c
+++ b/tests/unittests/tests-core/tests-core-ringbuffer.c
@@ -114,10 +114,28 @@ static void tests_core_ringbuffer(void)
     run_add();
 }
 
+static void tests_core_ringbuffer_remove(void)
+{
+    char mem[3];
+    ringbuffer_t buf;
+    ringbuffer_init(&buf, mem, sizeof(mem));
+
+    ringbuffer_add_one(&buf, 0);
+    ringbuffer_add_one(&buf, 1);
+    ringbuffer_add_one(&buf, 2);
+
+    ringbuffer_remove(&buf, 1);
+
+    TEST_ASSERT_EQUAL_INT(1, ringbuffer_get_one(&buf));
+    TEST_ASSERT_EQUAL_INT(2, ringbuffer_get_one(&buf));
+
+}
+
 Test *tests_core_ringbuffer_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(tests_core_ringbuffer),
+        new_TestFixture(tests_core_ringbuffer_remove),
     };
 
     EMB_UNIT_TESTCALLER(ringbuffer_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
The ringbuffer_remove() function does not work as expected. The oldest elements in the buffer should be removed first, this is currently not the case. This PR provides a potential bugfix and a testcase. 