### PR TITLE
boards: fix typo in author name

### DIFF
--- a/boards/nucleo-f070/include/board.h
+++ b/boards/nucleo-f070/include/board.h
@@ -19,7 +19,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Mohmmad Ayman <mohmmad.khzrag@gmail.com>
  * @author      José Alamos <jialamos@uc.cl>
- * @author      Alexandre Aabdie <alexandre.abadie@inria.fr>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
 #ifndef BOARD_H

--- a/boards/nucleo-f070/include/periph_conf.h
+++ b/boards/nucleo-f070/include/periph_conf.h
@@ -15,7 +15,7 @@
  * @brief       Peripheral MCU configuration for the nucleo-f070 board
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- * @author      Alexandre Aabdie <alexandre.abadie@inria.fr>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
 #ifndef PERIPH_CONF_H

--- a/boards/nucleo-l073/include/board.h
+++ b/boards/nucleo-l073/include/board.h
@@ -17,7 +17,7 @@
  * @brief       Board specific definitions for the nucleo-l073 board
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- * @author      Alexandre Aabdie <alexandre.abadie@inria.fr>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
 #ifndef BOARD_H

--- a/boards/nucleo-l073/include/periph_conf.h
+++ b/boards/nucleo-l073/include/periph_conf.h
@@ -15,7 +15,7 @@
  * @brief       Peripheral MCU configuration for the nucleo-l073 board
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- * @author      Alexandre Aabdie <alexandre.abadie@inria.fr>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
 #ifndef PERIPH_CONF_H


### PR DESCRIPTION
Typo found by @lebrush when reviewing #6628. Copy-paste...