### PR TITLE
cc2538: fix timer_set for channel B

### DIFF
--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -174,7 +174,7 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
             gptimer->ICR = TBMIM;
 
             /* set timeout value */
-            gptimer->TAMATCHR = (gptimer->CFG == GPTMCFG_32_BIT_TIMER)? (gptimer->TBV + timeout) : (gptimer->TBV - timeout);
+            gptimer->TBMATCHR = (gptimer->CFG == GPTMCFG_32_BIT_TIMER)? (gptimer->TBV + timeout) : (gptimer->TBV - timeout);
             gptimer->cc2538_gptimer_imr.IMR |= TBMIM; /**< Enable the Timer B Match Interrupt */
             break;
     }


### PR DESCRIPTION
when using the hardware timer in 16Bit mode with 2 channels, the `timer_set` for channel B was wrong. This PR corrects this.