### PR TITLE
doc/saul: add cross link between SAUL and SAUL registry

### DIFF
--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -31,6 +31,8 @@
  *              operations. It probably needs to be extended to handling events,
  *              thresholds, and so on.
  *
+ * @see @ref sys_saul_reg
+ *
  * @{
  *
  * @file

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -11,6 +11,8 @@
  * @ingroup     sys
  * @brief       Global sensor/actuator registry for SAUL devices
  *
+ * @see @ref drivers_saul
+ *
  * @{
  *
  * @file


### PR DESCRIPTION
fix issue #6631 
tested by generating pdf doc from latex files.