### PR TITLE
make: fix export features

### DIFF
--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -25,6 +25,10 @@ export BINDIR                # This is the folder where the application should b
 export APPDIR                # The base folder containing the application
 export PKGDIRBASE            # The base folder for building packages
 
+export FEATURES_REQUIRED     # List of required features by the application
+export FEATURES_PROVIDED     # List of provided features by the board
+export FEATURES_OPTIONAL     # List of nice to have features
+
 export TARGET_ARCH           # The target platform name, in GCC triple notation, e.g. "arm-none-eabi", "i686-elf", "avr"
 export PREFIX                # The prefix of the toolchain commands, usually "$(TARGET_ARCH)-", e.g. "arm-none-eabi-" or "msp430-".
 export CC                    # The C compiler to use.

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -65,11 +65,8 @@ ifneq (,$(filter vfs,$(USEMODULE)))
   SRC += sc_vfs.c
 endif
 
-# TODO
-# Conditional building not possible at the moment due to
-# https://github.com/RIOT-OS/RIOT/issues/2058
-# The implementation is guarded in the source file instead, this
-# should be changed once the issue has been resolved
-SRC += sc_rtc.c
+ifneq (,$(filter periph_rtc,$(FEATURES_PROVIDED)))
+  SRC += sc_rtc.c
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -20,8 +20,6 @@
  * @}
  */
 
-#ifdef FEATURE_PERIPH_RTC
-
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
@@ -188,18 +186,3 @@ int _rtc_handler(int argc, char **argv)
     }
     return 0;
 }
-
-#else
-
-#include <stdio.h>
-
-int _rtc_handler(int argc, char **argv)
-{
-    (void) argc;
-    (void) argv;
-
-    puts("not implemented");
-    return 1;
-}
-
-#endif /* FEATURE_RTC */


### PR DESCRIPTION
Fixes #2058

The current approach in the build system is to export all the variables required by the `make -C ...`. 
Another option would be to create a `Makefile.build` in the `riotbuild` folder and import it in `Makefile.base`.