### PR TITLE
tests, xtimer_hang: fix 32Bit timers, 16MHz

### DIFF
--- a/tests/xtimer_hang/README.md
+++ b/tests/xtimer_hang/README.md
@@ -1,5 +1,11 @@
 # xTimer hang test
 
-This test prints `Testing... (<percentage>)` every `TEST_INTERVAL` ms for
-`TEST_SECONDS` seconds. Prints `[SUCCESS]` on completion, if it stops or
-hangs before, the test failed.
+This is a runtime test for the RIOT xtimer implementation it prints text
+`Testing... (<percentage>)` (approximately) every `TEST_INTERVAL_MS` ms
+(milliseconds) for an overall test duration of `TEST_TIME_S` seconds.
+
+The test will print `[SUCCESS]` on completion, if it stops or hangs before,
+the test has failed.
+
+Please note (again), this is a runtime test to check if xtimer runs into a
+deadlock, it is not about clock stability nor accuracy of timing intervals.

--- a/tests/xtimer_hang/main.c
+++ b/tests/xtimer_hang/main.c
@@ -29,9 +29,8 @@
 #include "thread.h"
 #include "log.h"
 
-#define TEST_SECONDS            (10LU)
-#define TEST_TIME               (TEST_SECONDS * US_PER_SEC)
-#define TEST_INTERVAL           (100LU)
+#define TEST_TIME_S             (10LU)
+#define TEST_INTERVAL_MS        (100LU)
 #define TEST_TIMER_STACKSIZE    (THREAD_STACKSIZE_DEFAULT)
 
 char stack_timer1[TEST_TIMER_STACKSIZE];
@@ -58,16 +57,16 @@ int main(void)
                   3, THREAD_CREATE_STACKTEST,
                   timer_func, &sleep_timer2, "timer2");
 
-    uint32_t ticks_now = 0;
-    uint32_t ticks_start = _xtimer_now();
-    uint32_t ticks_until = ticks_start + _xtimer_ticks_from_usec(TEST_TIME);
-
+    uint32_t now = 0;
+    uint32_t start = xtimer_now_usec();
+    uint32_t until = start + (TEST_TIME_S * US_PER_SEC);
     puts("[START]");
-    while((ticks_now = _xtimer_now()) < ticks_until) {
-        uint8_t percent = 100*(ticks_now - ticks_start)/(ticks_until - ticks_start);
-        xtimer_usleep(TEST_INTERVAL * US_PER_MS);
-        printf("Testing... (%u%%)\n", percent);
+    while((now = xtimer_now_usec()) < until) {
+        unsigned percent = (100 * (now - start)) / (until - start);
+        xtimer_usleep(TEST_INTERVAL_MS * US_PER_MS);
+        printf("Testing (%3u%%)\n", percent);
     }
+    puts("Testing (100%)");
     puts("[SUCCESS]");
     return 0;
 }


### PR DESCRIPTION
in #6663 I fixed the output for slow boards/mcu, however the new output has problems with fast (16MHz, 32Bit) timers. This PR corrects this, tested with boards arduino duemilanove and pba-d-01-kw2x (phytec).