### PR TITLE
cc2538: fix xtimer

### DIFF
--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -80,8 +80,8 @@ extern "C" {
 #define XTIMER_DEV          (0)
 #define XTIMER_CHAN         (0)
 #define XTIMER_WIDTH        (16)
-#define XTIMER_SHIFT        (4)
-#define XTIMER_HZ           (16000000UL)
+#define XTIMER_SHIFT        (0)
+#define XTIMER_HZ           (1000000UL)
 #define XTIMER_BACKOFF      (50)
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -67,8 +67,8 @@
 #define XTIMER_DEV          (0)
 #define XTIMER_CHAN         (0)
 #define XTIMER_WIDTH        (16)
-#define XTIMER_SHIFT        (4)
-#define XTIMER_HZ           (16000000UL)
+#define XTIMER_SHIFT        (0)
+#define XTIMER_HZ           (1000000UL)
 #define XTIMER_BACKOFF      (50)
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */

--- a/boards/remote-common/include/board_common.h
+++ b/boards/remote-common/include/board_common.h
@@ -80,8 +80,8 @@
 #define XTIMER_DEV          (0)
 #define XTIMER_CHAN         (0)
 #define XTIMER_WIDTH        (16)
-#define XTIMER_SHIFT        (4)
-#define XTIMER_HZ           (16000000UL)
+#define XTIMER_SHIFT        (0)
+#define XTIMER_HZ           (1000000UL)
 #define XTIMER_BACKOFF      (50)
 #define XTIMER_ISR_BACKOFF  (40)
 /** @} */

--- a/cpu/cc2538/Makefile.features
+++ b/cpu/cc2538/Makefile.features
@@ -1,0 +1,1 @@
+FEATURES_PROVIDED += periph_pm


### PR DESCRIPTION
This PR fixes #6419, at least for me. 

It basically reverts xtimer configuration introduces in #5608, and resets XTIMER_SHIFT to 0 and XTIMER_HZ 1000000 (1 MHz).  I have to admit, I'm not sure why this helps, but it does. In the last days I made extensive tests using the hardware timer and xtimer.

The cc2538 has 4 timers each can be configured in 16Bit mode with 2 channels and 32 Bit mode with 1 channel. For the latter only a frequency of 16 MHz is allowed, as prescaler is only available in 16 Bit mode. However, using 16Bit timer with 16Mhz or a 32Bit timer with 16 MHz the tests `xtimer_drift` and `xtimer_periodic_wakeup` always fail, and `xtimer_usleep` for 16Bit + 16MHz, too.  All tests succeeded when using a 16 Bit timer with 1 MHz (which is the old setting).

Can someone please confirm?