### PR TITLE
sntp: extend API for common real time types 

### DIFF
--- a/sys/include/net/ntp_packet.h
+++ b/sys/include/net/ntp_packet.h
@@ -47,6 +47,12 @@ extern "C" {
 #define NTP_PORT             (123U)     /**< NTP port number */
 
 /**
+ * @brief   Offset in seconds of NTP timestamp (seconds from 1990-01-01 00:00:00 UTC)
+ *          to UNIX timestamp (seconds from 1970-01-01 00:00:00 UTC).
+ */
+#define NTP_UNIX_OFFSET      (2208988800)
+
+/**
  * @brief NTP modes
  */
 typedef enum {

--- a/sys/include/net/sntp.h
+++ b/sys/include/net/sntp.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Luminița Lăzărescu <cluminita.lazarescu@gmail.com>
+ * Copyright (C) 2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -23,7 +24,11 @@
 #define SNTP_H
 
 #include <stdint.h>
+#include <time.h>
+
+#include "net/ntp_packet.h"
 #include "net/sock/udp.h"
+#include "xtimer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +51,16 @@ int sntp_sync(sock_udp_ep_t *server, uint32_t timeout);
  * @return Real time offset in microseconds relative to 1900-01-01 00:00 UTC
  */
 int64_t sntp_get_offset(void);
+
+/**
+ * @brief   Get time in microseconds from 1970-01-01 00:00:00 UTC.
+ *
+ * @return  Time in microseconds from 1970-01-01 00:00:00 UTC
+ */
+static inline uint64_t sntp_get_unix_usec(void)
+{
+    return (uint64_t)(sntp_get_offset() - (NTP_UNIX_OFFSET * US_PER_SEC) + xtimer_now_usec64());
+}
 
 #ifdef __cplusplus
 }

--- a/tests/sntp/Makefile
+++ b/tests/sntp/Makefile
@@ -1,0 +1,23 @@
+# name of your application
+APPLICATION = sntp
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 \
+                             nucleo32-f042 nucleo32-l031 nucleo-f030 \
+                             nucleo-f334 nucleo-l053 stm32f0discovery \
+                             telosb weio z1
+
+USEMODULE += sntp
+USEMODULE += gnrc_sock_udp
+USEMODULE += gnrc_ipv6_default
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_netdev_default
+USEMODULE += shell
+USEMODULE += shell_commands
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sntp/README.md
+++ b/tests/sntp/README.md
@@ -1,0 +1,6 @@
+About
+=====
+This test application allows you to type `ntpdate <server>` and get the current
+date + the offset in microseconds of the NTP timestamp (seconds from 1900-01-01)
+from the current `xtimer_now_usec64()` back utilizing SNTP. Make sure that
+`<server>` is reachable and has an NTP daemon installed.

--- a/tests/sntp/main.c
+++ b/tests/sntp/main.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Tests sntp module.
+ *
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+
+static char line_buf[SHELL_DEFAULT_BUFSIZE];
+
+int main(void)
+{
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
Provides `sntp`'s API with means to get the current time in some common types. Namely

* ~~`struct tm` and~~ (can be calculated from UNIX timestamps using libc's `gmtime`).
* UNIX timestamps (in microseconds)

Also fixes some errors that were not catched, since the module is not build by CI currently. A provided test application in this PR solves this problem.