### PR TITLE
posix_sockets: Various fixes in posix network implementation

### DIFF
--- a/sys/posix/include/netinet/in.h
+++ b/sys/posix/include/netinet/in.h
@@ -239,7 +239,7 @@ struct sockaddr_in6 {
     /**
      * Protocol family, always AF_INET6. Member of struct sockaddr_in6
      */
-    int             sin6_family;    /**< Protocol family, always AF_INET6 */
+    sa_family_t     sin6_family;    /**< Protocol family, always AF_INET6 */
     in_port_t       sin6_port;      /**< Port number */
     uint32_t        sin6_flowinfo;  /**< IPv6 traffic class and flow information */
     struct in6_addr sin6_addr;      /**< IPv6 address */


### PR DESCRIPTION
- Fix size of ```sockaddr_in6``` structure
- Fix return value of ```recvfrom``` and ```sendto```
- Return error if a call to ```_sockaddr_to_ep``` fails in ```sendto```