### PR TITLE
sys: sema: semaphore bugfixes

### DIFF
--- a/pkg/lwip/contrib/sys_arch.c
+++ b/pkg/lwip/contrib/sys_arch.c
@@ -88,7 +88,7 @@ u32_t sys_arch_sem_wait(sys_sem_t *sem, u32_t count)
         return (u32_t)(stop / US_PER_MS);
     }
     else {
-        sema_wait_timed((sema_t *)sem, 0);
+        sema_wait((sema_t *)sem);
         return 0;
     }
 }

--- a/sys/include/sema.h
+++ b/sys/include/sema.h
@@ -98,18 +98,43 @@ void sema_create(sema_t *sema, unsigned int value);
 void sema_destroy(sema_t *sema);
 
 /**
+ * @brief Wait for a semaphore, blocking or non-blocking.
+ *
+ * @details For commit purposes you should probably use sema_wait(),
+ *          sema_wait_timed() and sema_try_wait() instead.
+ *
+ * @pre `(sema != NULL)`
+ *
+ * @param[in]  sema       A semaphore.
+ * @param[in]  block      if true, block until semaphore is available.
+ * @param[in]  timeout    if blocking, time in microseconds until the semaphore
+ *                        times out. 0 waits forever.
+ *
+ * @return  0 on success
+ * @return  -ETIMEDOUT, if the semaphore times out.
+ * @return  -ECANCELED, if the semaphore was destroyed.
+ * @return  -EAGAIN,    if the semaphore is not posted (only if block = 0)
+ */
+int _sema_wait(sema_t *sema, int block, uint64_t timeout);
+
+/**
  * @brief   Wait for a semaphore being posted.
  *
  * @pre `(sema != NULL)`
  *
  * @param[in]  sema     A semaphore.
- * @param[in]  timeout  Time in microseconds until the semaphore times out. 0 for no timeout.
+ * @param[in]  timeout  Time in microseconds until the semaphore times out.
+ *                      0 does not wait.
  *
  * @return  0 on success
  * @return  -ETIMEDOUT, if the semaphore times out.
  * @return  -ECANCELED, if the semaphore was destroyed.
+ * @return  -EAGAIN,    if the semaphore is not posted (only if timeout = 0)
  */
-int sema_wait_timed(sema_t *sema, uint64_t timeout);
+static inline int sema_wait_timed(sema_t *sema, uint64_t timeout)
+{
+    return _sema_wait(sema, (timeout != 0), timeout);
+}
 
 /**
  * @brief   Wait for a semaphore being posted (without timeout).
@@ -123,7 +148,7 @@ int sema_wait_timed(sema_t *sema, uint64_t timeout);
  */
 static inline int sema_wait(sema_t *sema)
 {
-    return sema_wait_timed(sema, 0);
+    return _sema_wait(sema, 1, 0);
 }
 
 /**
@@ -137,7 +162,10 @@ static inline int sema_wait(sema_t *sema)
  * @return  -EAGAIN, if the semaphore is not posted.
  * @return  -ECANCELED, if the semaphore was destroyed.
  */
-int sema_try_wait(sema_t *sema);
+static inline int sema_try_wait(sema_t *sema)
+{
+    return _sema_wait(sema, 0, 0);
+}
 
 /**
  * @brief   Signal semaphore.


### PR DESCRIPTION
While testing the semaphore implementation in the real world (not only existing tests) I found two issues introduced by #6155.

 - ~~Timeout 0 was expected to lock indefinitely (0 for no timeout meant "waits forever").~~ we'll keep it like this and update lwip to call the blocking method instead
 - Value has to be re-tested after owning the mutex as otherwise it can't be guaranteed that the value didn't change in the meantime.
