### PR TITLE
thread.h: extend doc for msg_waiters and msg_array

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -172,27 +172,31 @@ struct _thread {
 
     kernel_pid_t pid;               /**< thread's process id            */
 
-#ifdef MODULE_CORE_THREAD_FLAGS
+#if defined(MODULE_CORE_THREAD_FLAGS) || defined(DOXYGEN)
     thread_flags_t flags;           /**< currently set flags            */
 #endif
 
     clist_node_t rq_entry;          /**< run queue entry                */
 
 #if defined(MODULE_CORE_MSG) || defined(MODULE_CORE_THREAD_FLAGS) \
-    || defined(MODULE_CORE_MBOX)
+    || defined(MODULE_CORE_MBOX) || defined(DOXYGEN)
     void *wait_data;                /**< used by msg, mbox and thread
                                          flags                          */
 #endif
-#if defined(MODULE_CORE_MSG)
-    list_node_t msg_waiters;        /**< threads waiting on message     */
-    cib_t msg_queue;                /**< message queue                  */
-    msg_t *msg_array;               /**< memory holding messages        */
+#if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
+    list_node_t msg_waiters;        /**< threads waiting for their message
+                                         to be delivered to this thread
+                                         (i.e. all blocked sends)       */
+    cib_t msg_queue;                /**< index of this [thread's message queue]
+                                         (thread_t::msg_array), if any  */
+    msg_t *msg_array;               /**< memory holding messages sent
+                                         to this thread's message queue */
 #endif
-
-#if defined(DEVELHELP) || defined(SCHED_TEST_STACK) || defined(MODULE_MPU_STACK_GUARD)
+#if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
+    || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)
     char *stack_start;              /**< thread's stack start address   */
 #endif
-#ifdef DEVELHELP
+#if defined(DEVELHELP) || defined(DOXYGEN)
     const char *name;               /**< thread's name                  */
     int stack_size;                 /**< thread's stack size            */
 #endif


### PR DESCRIPTION
I've found the documentation for _thread.msg_waiters and _thread.msg_array to be a bit ambiguous. This PR attempts to explain what they do more clearly.