### PR TITLE
dist: enable cppcheck warnings for all files

### DIFF
--- a/cpu/kinetis_common/periph/rtt.c
+++ b/cpu/kinetis_common/periph/rtt.c
@@ -57,6 +57,8 @@ void rtt_init(void)
     RTT_UNLOCK();
     /* Reset RTC */
     rtt->CR = RTC_CR_SWR_MASK;
+    /* cppcheck-suppress redundantAssignment
+     * reset routine */
     rtt->CR = 0;
 
     if (rtt->SR & RTC_SR_TIF_MASK) {

--- a/cpu/lpc2387/asmfunc.s
+++ b/cpu/lpc2387/asmfunc.s
@@ -6,9 +6,11 @@
  * directory for more details.
  */
 
+/*
 @-----------------------------------------------------------@
 @ Fast Block Copy (declared in diskio.h)
 @-----------------------------------------------------------@
+*/
 
 .global copy_un2al
 .arm

--- a/cpu/x86/x86_memory.c
+++ b/cpu/x86/x86_memory.c
@@ -76,6 +76,8 @@ void x86_init_gdt(void)
             .limit_16_19_and_flags = 0,
             .base_24_31            = 0,
         },
+        /* cppcheck-suppress duplicateExpression
+         * it's for consistent look & feel */
         [0x0008 / 8] = {
             .limit_0_15            = 0xFFFF,
             .base_0_15             = 0,

--- a/cpu/x86/x86_pci.c
+++ b/cpu/x86/x86_pci.c
@@ -181,7 +181,7 @@ static void pci_setup_ios(struct x86_known_pci_device *dev)
                 printf("    BAR %u: memory, physical = 0x%08x-0x%08x, virtual = 0x%08x-0x%08x\n",
                        bar_num,
                        physical_start, physical_start + length - 1,
-                       (unsigned) ptr, (uintptr_t) ptr + length - 1);
+                       (unsigned) ptr, (unsigned) ((uintptr_t) ptr + length - 1));
             }
         }
     }

--- a/cpu/x86/x86_pit.c
+++ b/cpu/x86/x86_pit.c
@@ -55,7 +55,7 @@ void x86_pit_set2(unsigned channel, unsigned mode, uint16_t max)
 {
     unsigned old_flags = irq_disable();
     outb(PIT_COMMAND_PORT, ((channel - 1) << 6) | mode | PIT_ACCESS_MODE_LO_HI);
-    outb(PIT_CHANNEL_0_PORT + channel - 1, max && 0xff);
+    outb(PIT_CHANNEL_0_PORT + channel - 1, max & 0xff);
     outb(PIT_CHANNEL_0_PORT + channel - 1, max >> 8);
     irq_restore(old_flags);
 }

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -91,8 +91,7 @@ then
         #   Remove all but `${CI_BASE_BRANCH}` parameters to cppcheck (and remove second
         #   invocation) once all warnings of cppcheck have been taken care of
         #   in ${CI_BASE_BRANCH}.
-        run ./dist/tools/cppcheck/check.sh ${CI_BASE_BRANCH} --diff-filter=MR --error-exitcode=0
-        run ./dist/tools/cppcheck/check.sh ${CI_BASE_BRANCH} --diff-filter=AC
+        run ./dist/tools/cppcheck/check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
         exit $RESULT
     fi

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -86,11 +86,6 @@ then
         run ./dist/tools/licenses/check.sh ${CI_BASE_BRANCH} --diff-filter=AC
         run ./dist/tools/doccheck/check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/externc/check.sh ${CI_BASE_BRANCH}
-
-        # TODO:
-        #   Remove all but `${CI_BASE_BRANCH}` parameters to cppcheck (and remove second
-        #   invocation) once all warnings of cppcheck have been taken care of
-        #   in ${CI_BASE_BRANCH}.
         run ./dist/tools/cppcheck/check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
         exit $RESULT

--- a/dist/tools/cppcheck/check.sh
+++ b/dist/tools/cppcheck/check.sh
@@ -53,7 +53,6 @@ if [ -z "${FILES}" ]; then
     exit
 fi
 
-# TODO: switch back to 8 jobs when/if cppcheck issue is resolved
-cppcheck --std=c99 --enable=style --force --error-exitcode=2 --quiet -j 1 \
+cppcheck --std=c99 --enable=style --force --error-exitcode=2 --quiet -j 8 \
          --template "{file}:{line}: {severity} ({id}): {message}"         \
          --inline-suppr ${DEFAULT_SUPPRESSIONS} ${@} ${FILES}

--- a/dist/tools/tunslip/tapslip6.c
+++ b/dist/tools/tunslip/tapslip6.c
@@ -172,7 +172,6 @@ after_fread:
 
     if (ret == 0) {
         clearerr(inslip);
-        return;
         fprintf(stderr, "serial_to_tun: EOF\n");
         exit(1);
     }

--- a/dist/tools/tunslip/tunslip.c
+++ b/dist/tools/tunslip/tunslip.c
@@ -307,7 +307,7 @@ done:
 
     if (op == DHCP_OPTION_END) {
         *t++ = op;
-        *p++;
+        (*p)++;
     }
 
     optlen = t - pkt.m.options;
@@ -535,7 +535,6 @@ after_fread:
 
     if (ret == 0) {
         clearerr(inslip);
-        return;
         fprintf(stderr, "serial_to_tun: EOF\n");
         exit(1);
     }

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -118,7 +118,6 @@ stamptime(void)
     long secs, msecs;
     struct timeval tv;
     time_t t;
-    char timec[20];
 
     gettimeofday(&tv, NULL) ;
     msecs = tv.tv_usec / 1000;
@@ -136,6 +135,7 @@ stamptime(void)
         fprintf(stderr, "%04li.%03li ", secs, msecs);
     }
     else {
+        char timec[20];
         startsecs = secs;
         startmsecs = msecs;
         t = time(NULL);
@@ -190,6 +190,8 @@ serial_to_tun(FILE *inslip, int outfd)
         unsigned char inbuf[2000];
     } uip;
     static unsigned int inbufptr = 0;
+    /* cppcheck-suppress variableScope
+     * rationale: cannot be reduced if built on linux */
     int ret;
     unsigned char c;
 
@@ -209,7 +211,7 @@ serial_to_tun(FILE *inslip, int outfd)
                 stamptime();
             }
 
-            fprintf(stderr, "*** dropping large %d byte packet\n", inbufptr);
+            fprintf(stderr, "*** dropping large %u byte packet\n", inbufptr);
             inbufptr = 0;
         }
 
@@ -324,7 +326,7 @@ serial_to_tun(FILE *inslip, int outfd)
                                 stamptime();
                             }
 
-                            printf("Packet from SLIP of length %d - write TUN\n", inbufptr);
+                            printf("Packet from SLIP of length %u - write TUN\n", inbufptr);
 
                             if (verbose > 4) {
 #if WIRESHARK_IMPORT_FORMAT
@@ -648,6 +650,8 @@ devopen(const char *dev, int flags)
 {
     char t[1024];
     strcpy(t, "/dev/");
+    /* cppcheck-suppress bufferAccessOutOfBounds
+     * reason: seems to be a cppcheck bug */
     strncat(t, dev, sizeof(t) - 5);
     return open(t, flags);
 }
@@ -868,10 +872,6 @@ ifconf(const char *tundev, const char *ipaddr)
 
         if (prefix != NULL) {
             *prefix = '\0';
-            prefix++;
-        }
-        else {
-            prefix = "64";
         }
 
         if (timestamp) {

--- a/drivers/adt7310/adt7310.c
+++ b/drivers/adt7310/adt7310.c
@@ -218,6 +218,8 @@ float adt7310_read_float(adt7310_t *dev)
 {
     int16_t raw = adt7310_read_raw(dev);
     if (raw == INT16_MIN) {
+        /* ignore cppcheck: we want to create a NaN here */
+        /* cppcheck-suppress duplicateExpression */
         return (0.0f / 0.0f); /* return NaN */
     }
     if (!dev->high_res) {

--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -96,7 +96,6 @@ void hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum)
     assert(dev);
 
     uint8_t buf[4];
-    uint16_t traw, hraw;
 
     /* first we read the RAW results from the device */
     i2c_acquire(dev->p.i2c);
@@ -105,11 +104,11 @@ void hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum)
 
     /* and finally we convert the values to their physical representation */
     if (temp) {
-        traw = ((uint16_t)buf[0] << 8) | buf[1];
+        uint16_t traw = ((uint16_t)buf[0] << 8) | buf[1];
         *temp = (int16_t)((((int32_t)traw * 16500) >> 16) - 4000);
     }
     if (hum) {
-        hraw = ((uint16_t)buf[2] << 8) | buf[3];
+        uint16_t hraw = ((uint16_t)buf[2] << 8) | buf[3];
         *hum  = (int16_t)(((int32_t)hraw * 10000) >> 16);
     }
 }

--- a/pkg/nordic_softdevice_ble/src/ble-mac.c
+++ b/pkg/nordic_softdevice_ble/src/ble-mac.c
@@ -172,13 +172,12 @@ int ble_mac_send(uint8_t dest[8], void *data, size_t len)
     od_hex_dump(data, len, OD_WIDTH_DEFAULT);
 #endif
 
-    int i;
     ble_ipsp_handle_t *handle;
     int ret = -1;
 
     if ((!dest) || _is_broadcast(dest)) {
         DEBUG("broadcast\n");
-        for (i = 0; i < BLE_MAC_MAX_INTERFACE_NUM; i++) {
+        for (int i = 0; i < BLE_MAC_MAX_INTERFACE_NUM; i++) {
             if (interfaces[i].handle.cid != 0 && interfaces[i].handle.conn_handle != 0) {
                 ret = _send_to_peer(&interfaces[i].handle, data, len);
                 DEBUG("ret=%i\n", ret);
@@ -207,9 +206,7 @@ static uint32_t ble_mac_ipsp_evt_handler_irq(ble_ipsp_handle_t *p_handle, ble_ip
 {
     uint32_t retval = NRF_SUCCESS;
 
-    ble_mac_interface_t *p_instance = NULL;
-
-    p_instance = ble_mac_interface_lookup(p_handle);
+    ble_mac_interface_t *p_instance = ble_mac_interface_lookup(p_handle);
 
     if (p_handle) {
         DEBUG("ble-mac: IPSP event [handle:%d CID 0x%04X]\n", p_handle->conn_handle, p_handle->cid);

--- a/pkg/nordic_softdevice_ble/src/ble-mac.c
+++ b/pkg/nordic_softdevice_ble/src/ble-mac.c
@@ -73,6 +73,9 @@ static ble_mac_callback_t _callback;
  */
 static ble_mac_interface_t *ble_mac_interface_lookup(ble_ipsp_handle_t *handle)
 {
+    if (handle == NULL) {
+        return NULL;
+    }
     for (int i = 0; i < BLE_MAC_MAX_INTERFACE_NUM; i++) {
         if (interfaces[i].handle.conn_handle == handle->conn_handle &&
             interfaces[i].handle.cid == handle->cid) {

--- a/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
+++ b/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
@@ -80,9 +80,7 @@ static void _ble_mac_callback(ble_mac_event_enum_t event, void* arg)
 
 static void _handle_raw_sixlowpan(ble_mac_inbuf_t *inbuf)
 {
-    gnrc_pktsnip_t *pkt = NULL;
-
-    pkt = gnrc_pktbuf_add(NULL, inbuf->payload,
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, inbuf->payload,
             inbuf->len,
             GNRC_NETTYPE_SIXLOWPAN);
 

--- a/sys/cpp11-compat/include/riot/chrono.hpp
+++ b/sys/cpp11-compat/include/riot/chrono.hpp
@@ -52,7 +52,7 @@ class time_point {
   /**
    * @brief Create time point from timex_t struct.
    */
-  inline time_point(timex_t&& tp) : m_handle(tp) {}
+  explicit inline time_point(timex_t&& tp) : m_handle(tp) {}
   /**
    * @brief Use default copy constructor.
    */

--- a/sys/crypto/chacha.c
+++ b/sys/crypto/chacha.c
@@ -53,6 +53,8 @@ static void _doubleround(void *output_, const uint32_t input[16], uint8_t rounds
 
     rounds *= 4;
     for (unsigned i = 0; i < rounds; ++i) {
+        /* cppcheck-suppress duplicateExpressionTernary
+         * (reason: Externally imported code beautification) */
         uint32_t *a = &output[((i + ((i & 4) ? 0 : 0)) & 3) + (4 * 0)];
         uint32_t *b = &output[((i + ((i & 4) ? 1 : 0)) & 3) + (4 * 1)];
         uint32_t *c = &output[((i + ((i & 4) ? 2 : 0)) & 3) + (4 * 2)];

--- a/sys/crypto/modes/cbc.c
+++ b/sys/crypto/modes/cbc.c
@@ -58,7 +58,7 @@ int cipher_decrypt_cbc(cipher_t* cipher, uint8_t iv[16],
                        uint8_t* input, size_t length, uint8_t* output)
 {
     size_t offset = 0;
-    uint8_t* input_block, *output_block, *input_block_last, block_size;
+    uint8_t* input_block, *input_block_last, block_size;
 
 
     block_size = cipher_get_block_size(cipher);
@@ -69,7 +69,7 @@ int cipher_decrypt_cbc(cipher_t* cipher, uint8_t iv[16],
     input_block_last = iv;
     do {
         input_block = input + offset;
-        output_block = output + offset;
+        uint8_t *output_block = output + offset;
 
         if (cipher_decrypt(cipher, input_block, output_block) != 1) {
             return CIPHER_ERR_DEC_FAILED;

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -51,6 +51,8 @@ static inline uint32_t _xtimer_lltimer_now(void)
  */
 static inline uint32_t _xtimer_lltimer_mask(uint32_t val)
 {
+    /* cppcheck-suppress shiftTooManyBits
+     * (reason: cppcheck bug. `XTIMER_MASK` is zero when `XTIMER_WIDTH` is 32) */
     return val & ~XTIMER_MASK;
 }
 

--- a/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
+++ b/sys/net/gnrc/conn/udp/gnrc_conn_udp.c
@@ -93,7 +93,7 @@ int conn_udp_sendto(const void *data, size_t len, const void *src, size_t src_le
                     const void *dst, size_t dst_len, int family, uint16_t sport,
                     uint16_t dport)
 {
-    gnrc_pktsnip_t *pkt, *hdr = NULL;
+    gnrc_pktsnip_t *pkt, *hdr;
 
     pkt = gnrc_pktbuf_add(NULL, (void *)data, len, GNRC_NETTYPE_UNDEF); /* data will only be copied */
     hdr = gnrc_udp_hdr_build(pkt, sport, dport);

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -792,6 +792,8 @@ void gnrc_ipv6_netif_init_by_dev(void)
     kernel_pid_t ifs[GNRC_NETIF_NUMOF];
     size_t ifnum = gnrc_netif_get(ifs);
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER
+    /* cppcheck-suppress unreadVariable
+     * (reason: cppcheck bug. abr_init is read in if below) */
     bool abr_init = false;
 #endif
 

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -672,6 +672,8 @@ void gnrc_ndp_retrans_nbr_sol(gnrc_ipv6_nc_t *nc_entry)
                 mutex_unlock(&ipv6_iface->mutex);
             }
         }
+        /* cppcheck-suppress knownConditionTrueFalse
+         * cppcheck bug: probes_remaining is initialized to a value > 1 */
         else if (nc_entry->probes_remaining <= 1) {
 
             /* For a 6LoWPAN router entries may be set to UNREACHABLE instead

--- a/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
+++ b/sys/net/gnrc/network_layer/ndp/node/gnrc_ndp_node.c
@@ -80,6 +80,8 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
     }
 #endif
 
+    /* cppcheck-suppress knownConditionTrueFalse
+     * cppcheck bug: next_hop_ip might be initialized if a FIB is available */
     if (next_hop_ip == NULL) {            /* no route to host */
         if (!dst_link_local) {
             if (iface == KERNEL_PID_UNDEF) {

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -142,6 +142,8 @@ kernel_pid_t gnrc_sixlowpan_nd_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_ND_ROUTER
     /* next hop determination: https://tools.ietf.org/html/rfc6775#section-6.5.4 */
+    /* cppcheck-suppress redundantAssignment
+     * This path is only present for a certain configuration */
     nc_entry = gnrc_ipv6_nc_get(iface, dst);
 #ifdef MODULE_FIB
     if ((next_hop != NULL) && (nc_entry == NULL)) {
@@ -161,6 +163,8 @@ kernel_pid_t gnrc_sixlowpan_nd_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_
     }
 #endif
     /* next hop determination according to: https://tools.ietf.org/html/rfc6775#section-5.6 */
+    /* cppcheck-suppress knownConditionTrueFalse
+     * cppcheck bug: next_hop might be set before */
     if ((next_hop == NULL) && ipv6_addr_is_link_local(dst)) {   /* prefix is "on-link" */
         /* multicast is not handled here anyway so we don't need to check that */
         next_hop = dst;
@@ -175,6 +179,8 @@ kernel_pid_t gnrc_sixlowpan_nd_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_
     }
 
     /* address resolution of next_hop: https://tools.ietf.org/html/rfc6775#section-5.7 */
+    /* cppcheck-suppress knownConditionTrueFalse
+     * cppcheck bug: nc_entry might be set before */
     if ((nc_entry == NULL) || (next_hop != dst)) {
         /* get if not gotten from previous check */
         nc_entry = gnrc_ipv6_nc_get(iface, next_hop);

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -128,7 +128,7 @@ kernel_pid_t gnrc_sixlowpan_nd_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_
     kernel_pid_t fib_iface;
     ipv6_addr_t next_hop_actual;    /* FIB copies address into this variable */
     /* don't look-up link local addresses in FIB */
-    if ((next_hop == NULL) && !ipv6_addr_is_link_local(dst)) {
+    if (!ipv6_addr_is_link_local(dst)) {
         size_t next_hop_size = sizeof(ipv6_addr_t);
         uint32_t next_hop_flags = 0;
         if ((next_hop == NULL) &&

--- a/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
+++ b/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
@@ -48,9 +48,8 @@ const uint8_t gnrc_rpl_p2p_lifetime_lookup[4] = { 1, 4, 16, 64 };
 
 void gnrc_rpl_p2p_update(void)
 {
-    gnrc_rpl_p2p_ext_t *p2p_ext;
     for (uint8_t i = 0; i < GNRC_RPL_P2P_EXTS_NUMOF; ++i) {
-        p2p_ext = &gnrc_rpl_p2p_exts[i];
+        gnrc_rpl_p2p_ext_t *p2p_ext = &gnrc_rpl_p2p_exts[i];
         if ((p2p_ext->state) && (p2p_ext->lifetime_sec > 0)) {
             p2p_ext->lifetime_sec -= GNRC_RPL_LIFETIME_UPDATE_STEP;
             if (p2p_ext->lifetime_sec <= 0) {

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -69,10 +69,9 @@ static bool _dyn_port_used(uint16_t port)
  */
 static uint16_t _get_dyn_port(sock_udp_t *sock)
 {
-    uint16_t port;
     unsigned count = GNRC_SOCK_DYN_PORTRANGE_NUM;
     do {
-        port = GNRC_SOCK_DYN_PORTRANGE_MIN +
+        uint16_t port = GNRC_SOCK_DYN_PORTRANGE_MIN +
                (_dyn_port_next * GNRC_SOCK_DYN_PORTRANGE_OFF) % GNRC_SOCK_DYN_PORTRANGE_NUM;
         _dyn_port_next++;
         if ((sock == NULL) || (sock->flags & SOCK_FLAGS_REUSE_EP) ||

--- a/sys/quad_math/muldi3.c
+++ b/sys/quad_math/muldi3.c
@@ -97,7 +97,7 @@ quad_t __muldi3(quad_t a, quad_t b)
 {
     union uu u, v, low, prod;
     u_int high, mid, udiff, vdiff;
-    int negall, negmid;
+    int negall;
 #define u1  u.ul[H]
 #define u0  u.ul[L]
 #define v1  v.ul[H]
@@ -131,6 +131,7 @@ quad_t __muldi3(quad_t a, quad_t b)
         prod.q = __lmulq(u0, v0);
     }
     else {
+        int negmid;
         /*
          * Compute the three intermediate products, remembering
          * whether the middle term is negative.  We can discard

--- a/sys/quad_math/qdivrem.c
+++ b/sys/quad_math/qdivrem.c
@@ -78,6 +78,8 @@ __qdivrem(u_quad_t uq, u_quad_t vq, u_quad_t *arq)
         /* divide by zero. */
         static volatile const unsigned int zero = 0;
 
+        /* cppcheck-suppress zerodiv
+         * Divission by zero is on purpose here */
         tmp.ul[H] = tmp.ul[L] = 1 / zero;
 
         if (arq) {

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -31,9 +31,8 @@
 
 int _gnrc_rpl_init(char *arg)
 {
-    gnrc_ipv6_netif_t *entry = NULL;
     kernel_pid_t iface_pid = (kernel_pid_t) atoi(arg);
-    entry = gnrc_ipv6_netif_get(iface_pid);
+    gnrc_ipv6_netif_t *entry = gnrc_ipv6_netif_get(iface_pid);
 
     if (entry == NULL) {
         puts("unknown interface specified");
@@ -55,8 +54,7 @@ int _gnrc_rpl_dodag_root(char *arg1, char *arg2)
         return 1;
     }
 
-    gnrc_rpl_instance_t *inst = NULL;
-    inst = gnrc_rpl_root_init(instance_id, &dodag_id, false, false);
+    gnrc_rpl_instance_t *inst = gnrc_rpl_root_init(instance_id, &dodag_id, false, false);
     if (inst == NULL) {
         char addr_str[IPV6_ADDR_MAX_STR_LEN];
         printf("error: could not add DODAG (%s) to instance (%d)\n",

--- a/sys/universal_address/universal_address.c
+++ b/sys/universal_address/universal_address.c
@@ -72,6 +72,9 @@ static mutex_t mtx_access = MUTEX_INIT;
  */
 static universal_address_container_t *universal_address_find_entry(uint8_t *addr, size_t addr_size)
 {
+    /* cppcheck-suppress unsignedLessThanZero
+     * (reason: UNIVERSAL_ADDRESS_MAX_ENTRIES may be zero in which case this
+     * code is optimized out) */
     for (size_t i = 0; i < UNIVERSAL_ADDRESS_MAX_ENTRIES; ++i) {
         if (universal_address_table[i].address_size == addr_size) {
             if (memcmp((universal_address_table[i].address), addr, addr_size) == 0) {
@@ -93,9 +96,9 @@ static universal_address_container_t *universal_address_get_next_unused_entry(vo
 {
     /* cppcheck-suppress unsignedLessThanZero
      * (reason: UNIVERSAL_ADDRESS_MAX_ENTRIES may be zero in which case this
-     * code is optimized out)
-     */
+     * code is optimized out) */
     if (universal_address_table_filled < UNIVERSAL_ADDRESS_MAX_ENTRIES) {
+        /* cppcheck-suppress unsignedLessThanZero */
         for (size_t i = 0; i < UNIVERSAL_ADDRESS_MAX_ENTRIES; ++i) {
             if (universal_address_table[i].use_count == 0) {
                 return &(universal_address_table[i]);
@@ -298,6 +301,9 @@ void universal_address_init(void)
 {
     mutex_lock(&mtx_access);
 
+    /* cppcheck-suppress unsignedLessThanZero
+     * (reason: UNIVERSAL_ADDRESS_MAX_ENTRIES may be zero in which case this
+     * code is optimized out) */
     for (size_t i = 0; i < UNIVERSAL_ADDRESS_MAX_ENTRIES; ++i) {
         universal_address_table[i].use_count = 0;
         universal_address_table[i].address_size = 0;
@@ -311,6 +317,9 @@ void universal_address_reset(void)
 {
     mutex_lock(&mtx_access);
 
+    /* cppcheck-suppress unsignedLessThanZero
+     * (reason: UNIVERSAL_ADDRESS_MAX_ENTRIES may be zero in which case this
+     * code is optimized out) */
     for (size_t i = 0; i < UNIVERSAL_ADDRESS_MAX_ENTRIES; ++i) {
         universal_address_table[i].use_count = 0;
     }
@@ -352,6 +361,9 @@ void universal_address_print_table(void)
     printf("[universal_address_print_table] universal_address_table_filled: %d\n", \
            (int)universal_address_table_filled);
 
+    /* cppcheck-suppress unsignedLessThanZero
+     * (reason: UNIVERSAL_ADDRESS_MAX_ENTRIES may be zero in which case this
+     * code is optimized out) */
     for (size_t i = 0; i < UNIVERSAL_ADDRESS_MAX_ENTRIES; ++i) {
         universal_address_print_entry(&universal_address_table[i]);
     }

--- a/sys/universal_address/universal_address.c
+++ b/sys/universal_address/universal_address.c
@@ -91,6 +91,10 @@ static universal_address_container_t *universal_address_find_entry(uint8_t *addr
  */
 static universal_address_container_t *universal_address_get_next_unused_entry(void)
 {
+    /* cppcheck-suppress unsignedLessThanZero
+     * (reason: UNIVERSAL_ADDRESS_MAX_ENTRIES may be zero in which case this
+     * code is optimized out)
+     */
     if (universal_address_table_filled < UNIVERSAL_ADDRESS_MAX_ENTRIES) {
         for (size_t i = 0; i < UNIVERSAL_ADDRESS_MAX_ENTRIES; ++i) {
             if (universal_address_table[i].use_count == 0) {

--- a/tests/driver_hdc1000/main.c
+++ b/tests/driver_hdc1000/main.c
@@ -33,7 +33,6 @@ int main(void)
 {
     hdc1000_t dev;
     int16_t temp, hum;
-    size_t len;
     char tstr[8];
     char hstr[8];
 
@@ -49,6 +48,7 @@ int main(void)
     }
 
     while (1) {
+        size_t len;
         hdc1000_read(&dev, &temp, &hum);
 
         len = fmt_s16_dfp(tstr, temp, 2);

--- a/tests/driver_pn532/main.c
+++ b/tests/driver_pn532/main.c
@@ -50,6 +50,8 @@ int main(void)
     ret = pn532_init_i2c(&pn532, &pn532_conf[0]);
 #elif defined(PN532_SUPPORT_SPI)
     ret = pn532_init_spi(&pn532, &pn532_conf[0]);
+#else
+#error None of PN532_SUPPORT_I2C and PN532_SUPPORT_SPI set!
 #endif
 
     if (ret != 0) {

--- a/tests/leds/main.c
+++ b/tests/leds/main.c
@@ -77,6 +77,8 @@ int main(void)
 #endif
 
     puts("On-board LED test\n");
+    /* cppcheck-suppress knownConditionTrueFalse
+     * rationale: board-dependent ifdefs */
     if (numof == 0) {
         puts("NO LEDs AVAILABLE");
     }

--- a/tests/periph_hwrng/main.c
+++ b/tests/periph_hwrng/main.c
@@ -31,7 +31,7 @@ int main(void)
     uint8_t buf[LIMIT];
 
     puts("\nHWRNG peripheral driver test\n");
-    printf("This test will print from 1 to %i random bytes about every "
+    printf("This test will print from 1 to %u random bytes about every "
            "second\n\n", LIMIT);
 
     puts("Initializing the HWRNG driver.\n");

--- a/tests/pthread_cleanup/main.c
+++ b/tests/pthread_cleanup/main.c
@@ -68,7 +68,7 @@ int main(void) {
     void *res;
     pthread_join(th_id, (void **) &res);
 
-    printf("Result: %u\n", (int) (intptr_t) res);
+    printf("Result: %i\n", (int) (intptr_t) res);
     puts("Done.");
     return 0;
 }

--- a/tests/unittests/tests-crypto/tests-crypto.h
+++ b/tests/unittests/tests-crypto/tests-crypto.h
@@ -40,7 +40,7 @@ void tests_crypto(void);
  */
 Test *tests_crypto_chacha_tests(void);
 
-static inline int compare(uint8_t a[16], uint8_t b[16], uint8_t len)
+static inline int compare(uint8_t *a, uint8_t *b, uint8_t len)
 {
     int result = 1;
 


### PR DESCRIPTION
This PR aims to fix (or reasonably suppress) all cppcheck warnings.

Currently, we have warnings in the following folders:
- [x] cpu - 0 ~~1~~ ~~6~~ warnings
- [x] dist - 0 ~~8~~ warnings (maybe ignore?)
- [x] drivers - 0 ~~3~~ warnings
- [x] pkg - 0 ~~3~~ warnings
- [x] sys - 0 ~~1~~ ~~6~~ ~~10~~ ~~21~~ ~~27~~ warnings
- [x] tests - 0 ~~9~~ warnings