### PR TITLE
random: doc: warn about global PRNG state

### DIFF
--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -39,6 +39,10 @@ extern "C" {
 /**
  * @brief initializes PRNG with a seed
  *
+ * @warning Currently, the random module uses a global state
+ * => multiple calls to @ref random_init will reset the existing
+ * state of the PRNG.
+ *
  * @param s seed for the PRNG
  */
 void random_init(uint32_t s);


### PR DESCRIPTION
Currently, the random module and all available PRNGs use a global state. I.e. if multiple "applications" use `random_init`, the state will be overwritten. This PR adds a hint to the doc.