### PR TITLE
ethos: Add OS X compatibility

### DIFF
--- a/dist/tools/ethos/start_network_osx.sh
+++ b/dist/tools/ethos/start_network_osx.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+ETHOS_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+
+configure_tap() {
+    sysctl -w net.inet6.ip6.forwarding=1
+    ifconfig tap0 inet6 fe80::1 prefixlen 64
+    ifconfig lo0 inet6 fd00:dead:beef::1 prefixlen 128
+    route -n add -inet6 -prefixlen 64 ${PREFIX} fe80::2
+}
+
+cleanup() {
+    ifconfig lo0 inet6 -alias fd00:dead:beef::1
+    route delete -inet6 ${PREFIX} -prefixlen 64 fe80::2
+    sysctl -w net.inet6.ip6.forwarding=0
+    trap "" INT QUIT TERM EXIT
+}
+
+start_uhcpd() {
+    ${UHCPD} ${TAP} ${PREFIX}
+}
+
+TAP=$1
+PREFIX=$2
+
+UHCPD="$(cd "${ETHOS_DIR}/../uhcpd/bin" && pwd -P)/uhcpd"
+
+[ -z "${TAP}" -o -z "${PREFIX}" ] && {
+    echo "usage: $0 <tap-device> <prefix>"
+    exit 1
+}
+
+trap "cleanup" INT QUIT TERM EXIT
+
+configure_tap && start_uhcpd


### PR DESCRIPTION
This was a bit past due but here it is. However, there are some things I didn't succeed:

 - The tap device cannot be configured without an `open()` instruction, so it's not configurable until ethos open it. Thus, the original script cannot work, since the previous instructions will fail because ethos is launched at last.
A workaround is to start ethos manually and then the script, which will configure the interface and launch uhcpd.

 - I tried the gnrc_boder_router example, but I didn't succeed to route over OS X. I think the routing table is correctly configured but for some reason I cannot ping any device over the air with the prefix given by the BR. Maybe @Yonezawa-T2 has more hints?

I can mark it WIP until having the routes working, but ethos is useful for other things than the BR.