### PR TITLE
tests: Add missing test targets

### DIFF
--- a/tests/mutex_order/Makefile
+++ b/tests/mutex_order/Makefile
@@ -5,3 +5,8 @@ BOARD_INSUFFICIENT_MEMORY := stm32f0discovery weio nucleo-f030 nucleo32-f042 nuc
                              nucleo-l053
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
+# So clears `TERMFLAGS` before run.
+	TERMFLAGS= tests/01-run.py

--- a/tests/rmutex/Makefile
+++ b/tests/rmutex/Makefile
@@ -5,3 +5,8 @@ BOARD_INSUFFICIENT_MEMORY := stm32f0discovery weio nucleo-f030 nucleo32-f031 \
                              nucleo32-f042 nucleo-l053
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
+# So clears `TERMFLAGS` before run.
+	TERMFLAGS= tests/01-run.py

--- a/tests/thread_flood/Makefile
+++ b/tests/thread_flood/Makefile
@@ -4,3 +4,8 @@ include ../Makefile.tests_common
 DISABLE_MODULE += auto_init
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
+# So clears `TERMFLAGS` before run.
+	TERMFLAGS= tests/test_thread.py


### PR DESCRIPTION
Add test targets to Makefiles of three tests that have a `tests/` folder with a test (python) script in it, but no matching target. I've put them in separate commits for now but I'll be happy to squash them if that's more concise...