### PR TITLE
boards/opencm904: remap uart pins

### DIFF
--- a/boards/opencm904/board.c
+++ b/boards/opencm904/board.c
@@ -39,4 +39,7 @@ void board_init(void)
 
     /* configure the RIOT vector table location to internal flash + bootloader offset */
     SCB->VTOR = LOCATION_VTABLE;
+
+    /* remap USART1 to PB7 and PB6 */
+    AFIO->MAPR |= AFIO_MAPR_USART1_REMAP;
 }

--- a/boards/opencm904/include/board.h
+++ b/boards/opencm904/include/board.h
@@ -55,9 +55,18 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   User button
+ * @brief User button
  */
 #define BTN_B1_PIN          GPIO_PIN(PORT_C, 15)
+
+/**
+ * @brief Pin used to switch RX and TX mode for the Dynamixel TTL bus
+ *
+ * set   = TX mode
+ * clear = RX mode
+ *
+ */
+#define DXL_DIR_PIN         GPIO_PIN(PORT_B, 5)
 
 /**
  * @brief Use the USART2 for STDIO on this board

--- a/boards/opencm904/include/periph_conf.h
+++ b/boards/opencm904/include/periph_conf.h
@@ -106,8 +106,8 @@ static const uart_conf_t uart_config[] = {
     {
         .dev        = USART1,
         .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 10),
-        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_pin     = GPIO_PIN(PORT_B, 7),
+        .tx_pin     = GPIO_PIN(PORT_B, 6),
         .bus        = APB2,
         .irqn       = USART1_IRQn
     },


### PR DESCRIPTION
The opencm904 need the USART1 to be mapped on alternativ pins to use the dynamixel TTL bus.
The periph_uart driver is not able to "remap" uart pins when needed.
So that, I need to do that in `board_init`.