### PR TITLE
CI: Murdock2: use same builddir for all compile jobs

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -62,6 +62,11 @@ compile() {
     local appdir=$1
     local board=$2
 
+    # set build directory. CI ensures only one build at a time in $(pwd).
+    rm -rf build
+    export BINDIR="$(pwd)/build"
+    export PKGDIRBASE="${BINDIR}/pkg"
+
     [ -n "$DWQ_WORKER" ] && \
         echo "-- running on worker ${DWQ_WORKER} thread ${DWQ_WORKER_THREAD}, build number $DWQ_WORKER_BUILDNUM."
 
@@ -81,8 +86,10 @@ compile() {
         fi
     fi
 
+    echo "-- build directory size: $(du -sh ${BINDIR} | cut -f1)"
+
     # cleanup
-    rm -Rf "${appdir}/bin/${board}" "${appdir}/bin/pkg/${board}"
+    rm -Rf build
 
     return $RES
 }


### PR DESCRIPTION
This PR makes Murdock2 execute all compile jobs use ```build/````as BINDIR and ```build/pkg``` as PKDIRBASE. As @cgundogan found out, this greatly increases ccache hits, going up from \<5% to \>50% *with cold cache*.

~~(Waiting #6728)~~