### PR TITLE
kinetis: Refactor interrupt vector definition

### DIFF
--- a/cpu/k60/vectors.c
+++ b/cpu/k60/vectors.c
@@ -157,8 +157,7 @@ WEAK_DEFAULT void isr_software(void);
 /**
  * @brief Interrupt vector definition
  */
-__attribute__((used, section(".vector_table")))
-const void *interrupt_vector[] = {
+ISR_VECTORS const void *interrupt_vector[] = {
     /* Stack pointer */
     (void *)(&_estack),             /* pointer to the top of the empty stack */
     /* Cortex-M4 handlers */

--- a/cpu/k64f/vectors.c
+++ b/cpu/k64f/vectors.c
@@ -132,8 +132,7 @@ WEAK_DEFAULT void isr_enet_receive(void);
 WEAK_DEFAULT void isr_enet_error(void);
 
 /* interrupt vector table */
-__attribute__((used, section(".vector_table")))
-const void *interrupt_vector[] = {
+ISR_VECTORS const void *interrupt_vector[] = {
     /* Stack pointer */
     (void *)(&_estack),             /* pointer to the top of the empty stack */
     /* Cortex-M4 handlers */

--- a/cpu/kinetis_common/ldscripts/kinetis.ld
+++ b/cpu/kinetis_common/ldscripts/kinetis.ld
@@ -23,14 +23,14 @@
 SECTIONS
 {
     /* Interrupt vectors 0x00-0x3ff. */
-    .vector_table :
+    .vectors :
     {
         _isr_vectors = .;
-        KEEP(*(.vector_table))
+        KEEP(*(.vectors .vectors.*))
     } > vectors
-    ASSERT (SIZEOF(.vector_table) == 0x400, "Interrupt vector table of invalid size.")
-    ASSERT (ADDR(.vector_table) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
-    ASSERT (LOADADDR(.vector_table) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
+    ASSERT (SIZEOF(.vectors) == 0x400, "Interrupt vector table of invalid size.")
+    ASSERT (ADDR(.vectors) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
+    ASSERT (LOADADDR(.vectors) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
 
     /* Flash configuration field, very important in order to not accidentally lock the device */
     /* Flash configuration field 0x400-0x40f. */

--- a/cpu/kw2x/vectors.c
+++ b/cpu/kw2x/vectors.c
@@ -108,8 +108,7 @@ WEAK_DEFAULT void isr_porte(void);
 WEAK_DEFAULT void isr_swi(void);
 
 /* interrupt vector table */
-__attribute__((used, section(".vector_table")))
-const void *interrupt_vector[] = {
+ISR_VECTORS const void *interrupt_vector[] = {
     /* Stack pointer */
     (void *)(&_estack),             /* pointer to the top of the empty stack */
     /* Cortex-M4 handlers */


### PR DESCRIPTION
... to match the vector definition in other Cortex-M platforms.

Because kinetis.ld comes before cortexm_base.ld, the section .vectors will be placed in the correct location, the second `KEEP(.vectors)` in cortexm_base.ld will not add any symbols because the ISR vector table has already been placed by kinetis.ld

For reference, the include chain goes like this:
`$(CPU_NAME).ld` -> include `kinetis.ld` -> include `cortexm_base.ld`