### PR TITLE
boards/nucleo-l1: export led and button via saul

### DIFF
--- a/boards/nucleo-l1/Makefile.dep
+++ b/boards/nucleo-l1/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/nucleo-common/Makefile.dep


### PR DESCRIPTION
While trying #6714 I noticed the on board led and button weren't exported via saul. This PR fills this gap ;)