### PR TITLE
tests,examples: sort BOARD_INSUFFICIENT_MEMORY alphabetically

### DIFF
--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -13,12 +13,12 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
                    z1 \
                    nrf52dk # see #6022
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon nrf51dongle nrf6310 nucleo-f103 \
-                             nucleo-f334 pca10000 pca10005 spark-core \
-                             stm32f0discovery weio yunjia-nrf51822 nucleo-f072 \
-                             cc2650stk nucleo-f030 nucleo-f070 microbit \
-                             calliope-mini nucleo32-f042 nucleo32-f303 opencm904 \
-                             maple-mini nucleo32-f031 nucleo-l073 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon calliope-mini cc2650stk maple-mini \
+                             microbit nrf51dongle nrf6310 nucleo32-f031 \
+                             nucleo32-f042 nucleo32-f303 nucleo-f030 nucleo-f070 \
+                             nucleo-f072 nucleo-f103 nucleo-f334 nucleo-l053 \
+                             nucleo-l073 opencm904 pca10000 pca10005 spark-core \
+                             stm32f0discovery weio yunjia-nrf51822
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/emcute/Makefile
+++ b/examples/emcute/Makefile
@@ -8,9 +8,9 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos msb-430 msb-430h nucleo-f030 nucleo-l053 \
-                             nucleo-f070 nucleo-f072 nucleo-f334 nucleo32-f031 \
-                             nucleo32-f303 nucleo32-f042 stm32f0discovery telosb \
+                             chronos msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
+                             nucleo32-f303 nucleo-f030 nucleo-f070 nucleo-f072 \
+                             nucleo-f334 nucleo-l053 stm32f0discovery telosb \
                              waspmote-pro weio wsn430-v1_3b wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -9,9 +9,9 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo-f334 \
-                             stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
-                             z1 nucleo32-f042 nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
+                             nucleo-f030 nucleo-f334 nucleo-l053 stm32f0discovery \
+                             telosb weio wsn430-v1_3b wsn430-v1_4 z1
 
 # Must read nordic_softdevice_ble package before nanocoap package. However,
 # can't read it explicitly here because it is read later, as a dependency for

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -7,13 +7,13 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon cc2650stk maple-mini msb-430 msb-430h pca10000 \
-                             pca10005 nrf51dongle nrf6310 nucleo-f103 nucleo-f334 \
-                             spark-core stm32f0discovery telosb \
-                             weio wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1 nucleo-f072 \
-                             nucleo-f030 nucleo-f070 microbit calliope-mini \
-                             nucleo32-f042 nucleo32-f303 opencm904 nucleo32-f031 \
-                             nucleo-l073 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon calliope-mini cc2650stk maple-mini \
+                             microbit msb-430 msb-430h nrf51dongle nrf6310 \
+                             nucleo32-f031 nucleo32-f042 nucleo32-f303 nucleo-f030 \
+                             nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f334 \
+                             nucleo-l053 nucleo-l073 opencm904 pca10000 pca10005 \
+                             spark-core stm32f0discovery telosb weio wsn430-v1_3b \
+                             wsn430-v1_4 yunjia-nrf51822 z1
 
 BOARD_BLACKLIST += mips-malta # No UART available.
 

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -7,11 +7,11 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f103 nucleo-f334 \
-                             spark-core stm32f0discovery telosb weio \
-                             wsn430-v1_3b wsn430-v1_4 z1 nucleo-f072 nucleo-f030 \
-                             nucleo-f070 microbit calliope-mini nucleo32-f042 \
-                             nucleo32-f303 nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := calliope-mini chronos microbit msb-430 msb-430h \
+                             nucleo32-f031 nucleo32-f042 nucleo32-f303 nucleo-f030 \
+                             nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f334 \
+                             nucleo-l053 spark-core stm32f0discovery telosb weio \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -7,12 +7,12 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
-                          nrf6310 nucleo-f103 nucleo-f334 pca10000 pca10005 \
-                          spark-core stm32f0discovery telosb weio wsn430-v1_3b \
-                          wsn430-v1_4 yunjia-nrf51822 z1 nucleo-f072 nucleo-f030 \
-                          nucleo-f070 microbit calliope-mini nucleo32-f042 \
-                          nucleo32-f303 nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon calliope-mini chronos microbit msb-430 \
+                             msb-430h nrf51dongle nrf6310 nucleo32-f031 \
+                             nucleo32-f042 nucleo32-f303 nucleo-f030 nucleo-f070 \
+                             nucleo-f072 nucleo-f103 nucleo-f334 nucleo-l053 \
+                             pca10000 pca10005 spark-core stm32f0discovery telosb \
+                             weio wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/microcoap_server/Makefile
+++ b/examples/microcoap_server/Makefile
@@ -7,9 +7,9 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo32-f042 \
-                             pca10000 pca10005 stm32f0discovery telosb weio z1 \
-                             nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
+                             nucleo-f030 nucleo-l053 pca10000 pca10005 \
+                             stm32f0discovery telosb weio z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -7,8 +7,8 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo32-f042 \
-                             stm32f0discovery telosb weio nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
+                             nucleo-f030 nucleo-l053 stm32f0discovery telosb weio
 
 # blacklist this until #6022 is sorted out
 BOARD_BLACKLIST := nrf52dk

--- a/examples/posix_sockets/Makefile
+++ b/examples/posix_sockets/Makefile
@@ -7,11 +7,11 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle nrf6310 \
-                             nucleo-f334 pca10000 pca10005 stm32f0discovery telosb weio \
-                             wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1 nucleo-f072 \
-                             nucleo-f030 nucleo-f070 nucleo32-f042 nucleo32-f031 \
-                             nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
+                             nrf6310 nucleo32-f031 nucleo32-f042 nucleo-f030 \
+                             nucleo-f070 nucleo-f072 nucleo-f334 nucleo-l053 \
+                             pca10000 pca10005 stm32f0discovery telosb weio \
+                             wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/riot_and_cpp/Makefile
+++ b/examples/riot_and_cpp/Makefile
@@ -6,7 +6,7 @@ BOARD ?= native
 
 # stm32f0discovery objects are too big with ARM Embedded Toolchain v4.9.3 20141119
 # (used currently by travis)
-BOARD_INSUFFICIENT_MEMORY=stm32f0discovery weio nucleo32-f042 nucleo32-f031
+BOARD_INSUFFICIENT_MEMORY= nucleo32-f031 nucleo32-f042 stm32f0discovery weio
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/bloom_bytes/Makefile
+++ b/tests/bloom_bytes/Makefile
@@ -1,7 +1,8 @@
 APPLICATION = bloom_bytes
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h telosb wsn430-v1_3b \
+                             wsn430-v1_4 z1
 
 USEMODULE += hashes
 USEMODULE += bloom

--- a/tests/conn_ip/Makefile
+++ b/tests/conn_ip/Makefile
@@ -3,9 +3,10 @@ include ../Makefile.tests_common
 
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f334 stm32f0discovery telosb \
-                             weio wsn430-v1_3b wsn430-v1_4 z1 nucleo-f030 nucleo-f070 \
-                             nucleo32-f042 nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
+                             nucleo-f030 nucleo-f070 nucleo-f334 nucleo-l053 \
+                             stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
+                             z1
 
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -8,7 +8,7 @@ include ../Makefile.tests_common
 # Debian jessie libstdc++-arm-none-eabi-newlib-4.8.3-9+4 works fine, though.
 # Remove this line if Travis is upgraded to a different toolchain which does
 # not pull in all C++ locale code whenever exceptions are used.
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery spark-core nucleo-f334
+BOARD_INSUFFICIENT_MEMORY := nucleo-f334 spark-core stm32f0discovery
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -8,7 +8,7 @@ include ../Makefile.tests_common
 # Debian jessie libstdc++-arm-none-eabi-newlib-4.8.3-9+4 works fine, though.
 # Remove this line if Travis is upgraded to a different toolchain which does
 # not pull in all C++ locale code whenever exceptions are used.
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery spark-core nucleo-f334
+BOARD_INSUFFICIENT_MEMORY := nucleo-f334 spark-core stm32f0discovery
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -8,7 +8,7 @@ include ../Makefile.tests_common
 # Debian jessie libstdc++-arm-none-eabi-newlib-4.8.3-9+4 works fine, though.
 # Remove this line if Travis is upgraded to a different toolchain which does
 # not pull in all C++ locale code whenever exceptions are used.
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery spark-core nucleo-f334
+BOARD_INSUFFICIENT_MEMORY := nucleo-f334 spark-core stm32f0discovery
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -3,8 +3,8 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := msb-430h nucleo-f334 stm32f0discovery telosb \
-                             weio z1 msb-430 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-f334 nucleo-l053 \
+                             stm32f0discovery telosb weio z1
 
 USEMODULE += gnrc_netdev2
 USEMODULE += gnrc_netdev_default

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -3,8 +3,8 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h stm32f0discovery telosb weio z1 \
-                             nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-l053 stm32f0discovery telosb \
+                             weio z1
 
 USEMODULE += gnrc_netdev2
 USEMODULE += gnrc_netdev_default

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery nucleo-f334 weio nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := nucleo-f334 nucleo-l053 stm32f0discovery weio
 
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_netdev_default

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -3,8 +3,8 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_uart periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := nucleo-f030 nucleo-f334 stm32f0discovery weio \
-                             nucleo32-f042 nucleo32-f031
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo-f030 nucleo-f334 \
+                             stm32f0discovery weio
 
 USEMODULE += xbee
 USEMODULE += gnrc_netif

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -7,8 +7,8 @@ FEATURES_REQUIRED = periph_gpio periph_spi  # for at86rf231
 
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h stm32f0discovery telosb weio z1 \
-                             wsn430-v1_3b wsn430-v1_4 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-l053 stm32f0discovery telosb \
+                             weio wsn430-v1_3b wsn430-v1_4 z1
 
 USEPKG += emb6
 

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -5,11 +5,11 @@ include ../Makefile.tests_common
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 maple-mini msb-430h \
-                          nrf51dongle nrf6310 nucleo-f103 nucleo-f334 pca10000 pca10005 \
-                          spark-core stm32f0discovery telosb weio wsn430-v1_3b \
-                          wsn430-v1_4 yunjia-nrf51822 z1 nucleo-f030 nucleo32-f042 \
-                          nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \
+                             nrf51dongle nrf6310 nucleo32-f031 nucleo32-f042 \
+                             nucleo-f030 nucleo-f103 nucleo-f334 nucleo-l053 \
+                             pca10000 pca10005 spark-core stm32f0discovery telosb \
+                             weio wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -5,11 +5,12 @@ include ../Makefile.tests_common
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h nrf51dongle \
-                          nrf6310 nucleo-f103 nucleo-f334 pca10000 pca10005 spark-core \
-                          stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
-                          yunjia-nrf51822 z1 nucleo-f030 nucleo-f070 nucleo32-f042 \
-                          nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \
+                             nrf51dongle nrf6310 nucleo32-f031 nucleo32-f042 \
+                             nucleo-f030 nucleo-f070 nucleo-f103 nucleo-f334 \
+                             nucleo-l053 pca10000 pca10005 spark-core \
+                             stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
+                             yunjia-nrf51822 z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := nucleo32-f042 nucleo32-f031
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
 
 USEMODULE += gnrc_sock_check_reuse
 USEMODULE += gnrc_sock_udp

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -10,14 +10,13 @@ TCP_TARGET_PORT ?= 80
 TCP_TEST_CYCLES ?= 10
 
 # Mark Boards with insufficient memory
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560\
-                             arduino-uno calliope-mini chronos microbit sb-430\
-                             sb-430h nrf51dongle nrf6310 nucleo-f030\
-                             nucleo32-f042 nucleo-f070 nucleo-f072 nucleo32-f303\
-                             nucleo-f334 pca10000 pca10005 stm32f0discovery\
-                             telosb weio wsn430-v1_3b wsn430-v1_4\
-                             yunjia-nrf51822 z1 msb-430 msb-430h nucleo32-f031\
-                             nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
+                             arduino-uno calliope-mini chronos microbit msb-430 \
+                             msb-430h nrf51dongle nrf6310 nucleo32-f031 \
+                             nucleo32-f042 nucleo32-f303 nucleo-f030 nucleo-f070 \
+                             nucleo-f072 nucleo-f334 nucleo-l053 pca10000 pca10005 \
+                             sb-430 sb-430h stm32f0discovery telosb weio \
+                             wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -8,14 +8,13 @@ PORT ?= tap0
 TCP_LOCAL_PORT ?= 80
 
 # Mark Boards with insufficient memory
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560\
-                             arduino-uno calliope-mini chronos microbit sb-430\
-                             sb-430h nrf51dongle nrf6310 nucleo-f030\
-                             nucleo32-f042 nucleo-f070 nucleo-f072 nucleo32-f303\
-                             nucleo-f334 pca10000 pca10005 stm32f0discovery\
-                             telosb weio wsn430-v1_3b wsn430-v1_4\
-                             yunjia-nrf51822 z1 msb-430 msb-430h nucleo32-f031\
-                             nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
+                             arduino-uno calliope-mini chronos microbit msb-430 \
+                             msb-430h nrf51dongle nrf6310 nucleo32-f031 \
+                             nucleo32-f042 nucleo32-f303 nucleo-f030 nucleo-f070 \
+                             nucleo-f072 nucleo-f334 nucleo-l053 pca10000 pca10005 \
+                             sb-430 sb-430h stm32f0discovery telosb weio \
+                             wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -8,7 +8,7 @@ BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove
 # The MSP boards don't feature round(), exp(), and log(), which are used in the unittests
 BOARD_BLACKLIST += chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
-BOARD_INSUFFICIENT_MEMORY := weio nucleo32-f042 nucleo32-f031
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 weio
 
 USEMODULE += libfixmath-unittests
 

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -8,9 +8,9 @@ RIOTBASE ?= $(CURDIR)/../..
 BOARD_BLACKLIST := arduino-mega2560 msb-430h telosb waspmote-pro z1 arduino-uno \
                    arduino-duemilanove msb-430 wsn430-v1_4 wsn430-v1_3b
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-mega2560 msb-430h nrf6310 \
-                             nucleo-f334 pca10005 stm32f0discovery telosb \
-                             weio yunjia-nrf51822 z1 nucleo-f030 nucleo-f072 \
-                             nucleo32-f031 nucleo-l053
+                             nucleo32-f031 nucleo-f030 nucleo-f072 nucleo-f334 \
+                             nucleo-l053 pca10005 stm32f0discovery telosb weio \
+                             yunjia-nrf51822 z1
 
 # including lwip_ipv6_mld would currently break this test on at86rf2xx radios
 USEMODULE += lwip lwip_ipv6_autoconfig lwip_conn_ip lwip_netdev2

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -6,8 +6,8 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
-BOARD_INSUFFICIENT_MEMORY = nucleo-f030 nucleo32-f042 nucleo-f334 \
-                            stm32f0discovery weio nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY = nucleo32-f031 nucleo32-f042 nucleo-f030 nucleo-f334 \
+                            nucleo-l053 stm32f0discovery weio
 
 LWIP_IPV4 ?= 0
 

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -7,7 +7,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
-BOARD_INSUFFICIENT_MEMORY = nucleo-f030 nucleo32-f031 nucleo32-f042 nucleo-f334 \
+BOARD_INSUFFICIENT_MEMORY = nucleo32-f031 nucleo32-f042 nucleo-f030 nucleo-f334 \
                             nucleo-l053 stm32f0discovery weio
 
 LWIP_IPV4 ?= 0

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -7,7 +7,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1
-BOARD_INSUFFICIENT_MEMORY = nucleo32-f042 nucleo-f030 nucleo32-f031 nucleo-f042 \
+BOARD_INSUFFICIENT_MEMORY = nucleo32-f031 nucleo32-f042 nucleo-f030 nucleo-f042 \
                             nucleo-f334 nucleo-l053 stm32f0discovery weio
 
 LWIP_IPV4 ?= 0

--- a/tests/mutex_order/Makefile
+++ b/tests/mutex_order/Makefile
@@ -1,8 +1,8 @@
 APPLICATION = mutex_order
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery weio nucleo-f030 nucleo32-f042 nucleo32-f031 \
-                             nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo-f030 nucleo-l053 \
+                             stm32f0discovery weio
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -4,8 +4,8 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb \
                    wsn430-v1_3b wsn430-v1_4 z1 waspmote-pro arduino-uno \
                    arduino-duemilanove
-BOARD_INSUFFICIENT_MEMORY := nucleo-f334 stm32f0discovery weio nucleo-f030 \
-                             nucleo32-f042 nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo-f030 nucleo-f334 \
+                             nucleo-l053 stm32f0discovery weio
 
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_sock_udp

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -4,9 +4,10 @@ include ../Makefile.tests_common
 # msp430 and avr have problems with int width and libcoaps usage of :x notation in structs
 BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb wsn430-v1_3b \
                    wsn430-v1_4 z1 waspmote-pro arduino-uno arduino-duemilanove
-BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f334 nucleo-f030 \
-                             stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 z1 \
-                             nucleo-f070 nucleo32-f042 nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
+                             nucleo-f030 nucleo-f070 nucleo-f334 nucleo-l053 \
+                             stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
+                             z1
 
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_sock_udp

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -1,10 +1,10 @@
 APPLICATION = posix_semaphore
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h mbed_lpc1768 chronos stm32f0discovery \
-                          pca10000 pca10005 weio yunjia-nrf51822 nrf6310 spark-core \
-                          nucleo-f334 nucleo-f030 nucleo32-f042 nucleo32-f031 \
-                          nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := chronos mbed_lpc1768 msb-430 msb-430h nrf6310 \
+                             nucleo32-f031 nucleo32-f042 nucleo-f030 nucleo-f334 \
+                             nucleo-l053 pca10000 pca10005 spark-core \
+                             stm32f0discovery weio yunjia-nrf51822
 
 USEMODULE += fmt
 USEMODULE += posix_semaphore

--- a/tests/pthread_barrier/Makefile
+++ b/tests/pthread_barrier/Makefile
@@ -6,7 +6,7 @@ BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove
 # arduino mega2560 uno duemilanove: unknown type name: clockid_t
 
 # exclude boards with insufficient memory
-BOARD_INSUFFICIENT_MEMORY :=  stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := stm32f0discovery
 
 # Modules to include.
 USEMODULE += pthread

--- a/tests/pthread_condition_variable/Makefile
+++ b/tests/pthread_condition_variable/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove
 # arduino mega2560 uno duemilanove: unknown type name: clockid_t
 
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery nucleo32-f031
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 stm32f0discovery
 
 USEMODULE += posix
 USEMODULE += pthread

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -10,9 +10,9 @@ USEMODULE += random
 
 CFLAGS += -DNATIVE_AUTO_EXIT
 
-BOARD_INSUFFICIENT_MEMORY += chronos mbed_lpc1768 msb-430 msb-430h stm32f0discovery \
-                          pca10000 pca10005 yunjia-nrf51822 spark-core nucleo-f334 \
-                          airfy-beacon nrf51dongle nrf6310 weio nucleo-f030 \
-                          nucleo32-f042 nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY += airfy-beacon chronos mbed_lpc1768 msb-430 msb-430h \
+                             nrf51dongle nrf6310 nucleo32-f031 nucleo32-f042 \
+                             nucleo-f030 nucleo-f334 nucleo-l053 pca10000 pca10005 \
+                             spark-core stm32f0discovery weio yunjia-nrf51822
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/rmutex/Makefile
+++ b/tests/rmutex/Makefile
@@ -1,8 +1,8 @@
 APPLICATION = rmutex
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery weio nucleo-f030 nucleo32-f031 \
-                             nucleo32-f042 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo-f030 nucleo-l053 \
+                             stm32f0discovery weio
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/slip/Makefile
+++ b/tests/slip/Makefile
@@ -1,8 +1,9 @@
 APPLICATION = driver_slip
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-f334 stm32f0discovery weio \
-                          nucleo-f030 nucleo32-f042 nucleo32-f031 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
+                             nucleo-f030 nucleo-f334 nucleo-l053 stm32f0discovery \
+                             weio
 
 BOARD_BLACKLIST += mips-malta
 

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,13 +1,13 @@
 APPLICATION = thread_cooperation
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := cc2650stk chronos maple-mini msb-430 msb-430h \
-                          mbed_lpc1768 stm32f0discovery pca10000 pca10005 \
-                          yunjia-nrf51822 spark-core airfy-beacon nucleo-f103 \
-                          nucleo-f334 nrf51dongle nrf6310 weio nucleo-f072 \
-                          nucleo-f030 nucleo-f070 microbit calliope-mini \
-                          nucleo32-f042 nucleo32-f303 opencm904 nucleo32-f031 \
-                          nucleo-l073 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon calliope-mini cc2650stk chronos maple-mini \
+                             mbed_lpc1768 microbit msb-430 msb-430h nrf51dongle \
+                             nrf6310 nucleo32-f031 nucleo32-f042 nucleo32-f303 \
+                             nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 \
+                             nucleo-f334 nucleo-l053 nucleo-l073 opencm904 pca10000 \
+                             pca10005 spark-core stm32f0discovery weio \
+                             yunjia-nrf51822
 
 DISABLE_MODULE += auto_init
 

--- a/tests/thread_msg/Makefile
+++ b/tests/thread_msg/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = thread_msg
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery nucleo32-f042 nucleo32-f031
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 stm32f0discovery
 
 DISABLE_MODULE += auto_init
 

--- a/tests/thread_msg_seq/Makefile
+++ b/tests/thread_msg_seq/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = thread_msg_seq
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery nucleo32-f042 nucleo32-f031
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 stm32f0discovery
 
 DISABLE_MODULE += auto_init
 

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,20 +1,18 @@
 APPLICATION = unittests
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon cc2650stk chronos ek-lm4f120xl \
-                          maple-mini msb-430 msb-430h pca10000 \
-                          pca10005 spark-core stm32f0discovery stm32f3discovery \
-                          telosb wsn430-v1_3b wsn430-v1_4 z1 nucleo-f103 \
-                          nucleo-f334 yunjia-nrf51822 samr21-xpro \
-                          arduino-mega2560 airfy-beacon nrf51dongle nrf6310 \
-                          weio waspmote-pro nucleo-f072 arduino-uno \
-                          arduino-duemilanove sodaq-autonomo arduino-zero \
-                          nucleo-f030 nucleo-f070 nucleo-f091 pba-d-01-kw2x \
-                          saml21-xpro microbit calliope-mini limifrog-v1 \
-                          slwstk6220a ek-lm4f120xl stm32f3discovery \
-                          slwstk6220a nucleo32-f042 nucleo32-f303 opencm904 \
-                          seeeduino_arch-pro remote-pa remote-revb remote-reva \
-                          nucleo32-f031 nucleo-l073 nucleo-l053
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
+                             arduino-uno arduino-zero calliope-mini cc2650stk \
+                             chronos ek-lm4f120xl limifrog-v1 maple-mini microbit \
+                             msb-430 msb-430h nrf51dongle nrf6310 nucleo32-f031 \
+                             nucleo32-f042 nucleo32-f303 nucleo-f030 nucleo-f070 \
+                             nucleo-f072 nucleo-f091 nucleo-f103 nucleo-f334 \
+                             nucleo-l053 nucleo-l073 opencm904 pba-d-01-kw2x \
+                             pca10000 pca10005 remote-pa remote-reva remote-revb \
+                             saml21-xpro samr21-xpro seeeduino_arch-pro slwstk6220a \
+                             sodaq-autonomo spark-core stm32f0discovery \
+                             stm32f3discovery telosb waspmote-pro weio wsn430-v1_3b \
+                             wsn430-v1_4 yunjia-nrf51822 z1
 
 USEMODULE += embunit
 

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -25,14 +25,15 @@ endif
 ARM7_BOARDS := msba2 avrextrem
 DISABLE_TEST_FOR_ARM7 := tests-relic
 
-ARM_CORTEX_M_BOARDS := airfy-beacon arduino-due cc2538dk ek-lm4f120xl f4vi1 fox frdm-k64f \
-                       iotlab-m3 limifrog-v1 mbed_lpc1768 msbiot mulle nrf51dongle nrf6310 \
-                       nucleo-f091 nucleo-f303 nucleo-f334 nucleo-f401 nucleo-l1 openmote-cc2538 \
-                       pba-d-01-kw2x pca10000 pca10005 remote saml21-xpro samr21-xpro slwstk6220a \
-                       spark-core stm32f0discovery stm32f3discovery stm32f4discovery udoo weio \
-                       yunjia-nrf51822 sodaq-autonomo arduino-zero nucleo-f030 nucleo-f070 \
-                       nucleo32-f303 opencm904 nucleo-f411 nucleo32-f031 nucleo-l073 \
-                       nucleo-l053
+ARM_CORTEX_M_BOARDS := airfy-beacon arduino-due arduino-zero cc2538dk ek-lm4f120xl \
+                       f4vi1 fox frdm-k64f iotlab-m3 limifrog-v1 mbed_lpc1768 msbiot \
+                       mulle nrf51dongle nrf6310 nucleo32-f031 nucleo32-f303 \
+                       nucleo-f030 nucleo-f070 nucleo-f091 nucleo-f303 nucleo-f334 \
+                       nucleo-f401 nucleo-f411 nucleo-l053 nucleo-l073 nucleo-l1 \
+                       opencm904 openmote-cc2538 pba-d-01-kw2x pca10000 pca10005 \
+                       remote saml21-xpro samr21-xpro slwstk6220a sodaq-autonomo \
+                       spark-core stm32f0discovery stm32f3discovery stm32f4discovery \
+                       udoo weio yunjia-nrf51822
 
 DISABLE_TEST_FOR_ARM_CORTEX_M := tests-relic
 

--- a/tests/xtimer_drift/Makefile
+++ b/tests/xtimer_drift/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = xtimer_drift
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := nucleo32-f042 nucleo32-f031
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
 
 USEMODULE += xtimer
 

--- a/tests/xtimer_longterm/Makefile
+++ b/tests/xtimer_longterm/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = xtimer_longterm
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := nucleo32-f042 nucleo32-f031
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
 
 USEMODULE += xtimer
 


### PR DESCRIPTION
This PR sorts alphabetically the BOARD_INSUFFICIENT_MEMORY variable from various Makefiles.