### PR TITLE
boards/nucleo_common, boards/remote_common: remove extra underscore in header guard

### DIFF
--- a/boards/nucleo-common/include/board_common.h
+++ b/boards/nucleo-common/include/board_common.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef BOARD_COMMON__H
-#define BOARD_COMMON__H
+#ifndef BOARD_COMMON_H
+#define BOARD_COMMON_H
 
 #include "cpu.h"
 #include "periph_conf.h"
@@ -55,5 +55,5 @@ void board_init(void);
 }
 #endif
 
-#endif /* BOARD_COMMON__H */
+#endif /* BOARD_COMMON_H */
 /** @} */

--- a/boards/remote-common/include/board_common.h
+++ b/boards/remote-common/include/board_common.h
@@ -19,8 +19,8 @@
  *              Antonio Lignan <alinan@zolertia.com>
  */
 
-#ifndef BOARD_COMMON__H
-#define BOARD_COMMON__H
+#ifndef BOARD_COMMON_H
+#define BOARD_COMMON_H
 
 #include "cpu.h"
 #include "periph/gpio.h"
@@ -94,5 +94,5 @@ void board_init(void);
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif
-#endif /* BOARD_COMMON__H */
+#endif /* BOARD_COMMON_H */
 /** @} */


### PR DESCRIPTION
This PR fixes the "problem" for `nucleo-common` and `remote-common`.