### PR TITLE
core, log: fix tautology compare error with toolchain llvm

### DIFF
--- a/core/include/log.h
+++ b/core/include/log.h
@@ -73,7 +73,16 @@ enum {
 /**
  * @brief Log message if level <= LOG_LEVEL
  */
-#define LOG(level, ...) if (level <= LOG_LEVEL) log_write(level, __VA_ARGS__)
+#ifdef __clang__    /* following pragmas required for clang 3.8.0 */
+#define LOG(level, ...) do { \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wtautological-compare\"") \
+    if ((level) <= LOG_LEVEL) log_write((level), __VA_ARGS__); } while (0U) \
+    _Pragma("clang diagnostic pop")
+#else
+#define LOG(level, ...) do { \
+    if ((level) <= LOG_LEVEL) log_write((level), __VA_ARGS__); } while (0U)
+#endif /* __clang__ */
 
 /**
  * @brief logging convenience defines


### PR DESCRIPTION
replaces #6612, see comments there