### PR TITLE
tests/unittests/relic: remove nucleo-f410 from blacklist

### DIFF
--- a/tests/unittests/tests-relic/Makefile
+++ b/tests/unittests/tests-relic/Makefile
@@ -4,6 +4,6 @@ MODULE = tests-relic
 BOARD_BLACKLIST := arduino-mega2560 chronos f4vi1 msb-430 msb-430h msbiot \
                    qemu-i386 redbee-econotag stm32f0discovery \
                    stm32f3discovery telosb wsn430-v1_3b wsn430-v1_4 z1 \
-                   waspmote-pro nucleo-f410
+                   waspmote-pro
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
Follow-up PR from #6025.

Instead of updating the sort, I removed the board because it should be skipped from the unittests.