### PR TITLE
vagrant: improved instructions in vagrant README for adding new boards

### DIFF
--- a/dist/tools/vagrant/README.md
+++ b/dist/tools/vagrant/README.md
@@ -51,8 +51,8 @@ This feature allows you to conveniently develop code for RIOT with your preferre
 your host system and use the VM for compiling, flashing devices and running the native port of RIOT.
 
 ## Additional Information
-1. VirtualBox: For new boards it is necessary to add missing usb filters to the Vagrantfile so that VirtualBox is able to capture the devices.
-  * For Linux Guest Systems: For new boards it is necessary to add new udev rules to `dist/tools/vagrant/udev_rules`.
+1. VirtualBox: For new boards it is necessary to add a usb filter (open VirtualBox, click on USB and add the new filter for your board). 
+  * For Linux Guest Systems: For new boards it is necessary to add new udev rules in the Vagrant config (in `dist/tools/vagrant/udev_rules`) so that Vagrant can capture the device.
     The needed `vendor id` and `product id` can be obtained by running `vboxmanage list usbhost`.
   * For Linux Host Systems: Additionally, in order to allow USB access from within the guest system, the host system user
     must be a member of the `vboxusers` group (see [here](https://www.virtualbox.org/manual/ch02.html#idm1051)).


### PR DESCRIPTION
One step is confusing in the current README concerning adding a new board to be captured by Vagrant.

Here's a proposal to make that step clearer in this README: basically spell out that you need to open VirtualBox ;) on top of modifying the udev rules.