### PR TITLE
LLVM toolchain: set CFLAGS for pkgs

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -153,7 +153,12 @@ ifneq (0,$(shell test -d $(RIOTBOARD)/$(BOARD); echo $$?))
 endif
 
 # Use TOOLCHAIN environment variable to select the toolchain to use.
-# Default: gnu
+# Default for macOS: llvm; for other OS: gnu
+ifeq ($(BOARD),native)
+ifeq ($(OS),Darwin)
+TOOLCHAIN ?= llvm
+endif
+endif
 TOOLCHAIN ?= gnu
 
 # TOOLCHAIN = clang is an alias for TOOLCHAIN = llvm

--- a/pkg/oonf_api/Makefile.include
+++ b/pkg/oonf_api/Makefile.include
@@ -1,5 +1,5 @@
 INCLUDES += -I$(PKGDIRBASE)/oonf_api/src-api
 
-ifeq ($(shell uname -s),Darwin)
-	CFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+ifeq ($(TOOLCHAIN), llvm)
+    CFLAGS += -Wno-keyword-macro -Wno-parentheses-equality
 endif

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -2,7 +2,7 @@ PKG_BUILDDIR ?= $(PKGDIRBASE)/tinydtls
 
 INCLUDES += -I$(PKG_BUILDDIR)
 
-ifeq ($(shell uname -s),Darwin)
+ifeq ($(TOOLCHAIN), llvm)
     CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function
 endif
 


### PR DESCRIPTION
set CFLAGS for packages oonf_api and tinydtls to work around compiler errors when using llvm toolchain on Linux. Is also required by #6600 ...