### PR TITLE
boards/nucleo144-f413: fix i2c clock

### DIFF
--- a/boards/nucleo144-f413/include/periph_conf.h
+++ b/boards/nucleo144-f413/include/periph_conf.h
@@ -218,7 +218,7 @@ static const spi_conf_t spi_config[] = {
 #define I2C_NUMOF           (1U)
 #define I2C_0_EN            1
 #define I2C_IRQ_PRIO        1
-#define I2C_APBCLK          (42000000U)
+#define I2C_APBCLK          (50000000U)
 
 /* I2C 0 device configuration */
 #define I2C_0_DEV           I2C1


### PR DESCRIPTION
APB clock definition for i2c driver was wrong