### PR TITLE
posix: fix close() if fd_obj was closed already

### DIFF
--- a/sys/posix/unistd.c
+++ b/sys/posix/unistd.c
@@ -22,7 +22,7 @@ int close(int fildes)
 {
     fd_t *fd_obj = fd_get(fildes);
 
-    if (!fd_obj) {
+    if (!fd_obj || (fd_obj->close == NULL)) {
         errno = EBADF;
         return -1;
     }


### PR DESCRIPTION
While working on #6761 I found a bug in `fd.c`: If the fd was closed already (or never created) `fd_get()` will return the array element regardless, since it just checks if the given file descriptor could be in the array (which in and of itself is fine). This PR adds a check if the close function is set (which could also be the case for other file descriptors that might not be closable).