### PR TITLE
stm32_common/spi: fix receive after transmit-only error

### DIFF
--- a/cpu/stm32_common/periph/spi.c
+++ b/cpu/stm32_common/periph/spi.c
@@ -172,6 +172,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
             *DR = outbuf[i];
         }
         /* wait until everything is finished and empty the receive buffer */
+        while (!(dev(bus)->SR & SPI_SR_TXE)) {}
         while (dev(bus)->SR & SPI_SR_BSY) {}
         while (dev(bus)->SR & SPI_SR_RXNE) {
             dev(bus)->DR;       /* we might just read 2 bytes at once here */


### PR DESCRIPTION
This line fixes SPI transmissions on at least the faster class of stm32 devices.

The main problem is that there is a slight delay between the SPI transfer register being written and the BUSY bit being set. From the [datasheet of the stm32f405..439](http://www.st.com/resource/en/reference_manual/dm00031020.pdf) (20MB warning)
```
During discontinuous communications, there is a 2 APB clock period delay between the
write operation to SPI_DR and the BSY bit setting. As a consequence, it is mandatory to
wait first until TXE=1 and then until BSY=0 after writing the last data.
```

With this delay, after a write only operation, it is possible that the RXNE bit is checked while the data has not yet been received. If a read/write SPI transfer happens next, the old receive data is read.

As adviced by the datasheet, this patch inserts a TXE check in the write only path of the SPI code. A different solution might be to wait until the RXNE bit is set before reading the DR register, but this solution is not explicitly advised by the datasheet.

I only had time to check this solution on the stm32f4discovery board. I'm interested whether this patch breaks anything on the slower class of stm32 devices.

fixes #6519 
And I'm curious to know if this also fixes #6750

All credits to @phectori for digging around in the datasheets :)