### PR TITLE
posix: sockets: Implement SO_RCVTIMEO option in setsockopt

### DIFF
--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -491,16 +491,8 @@ static inline int getsockopt(int socket, int level, int option_name, void *optio
     return -1;
 }
 
-static inline int setsockopt(int socket, int level, int option_name, const void *option_value,
-                             socklen_t option_len)
-{
-    (void)socket;
-    (void)level;
-    (void)option_name;
-    (void)option_value;
-    (void)option_len;
-    return -1;
-}
+int setsockopt(int socket, int level, int option_name, const void *option_value,
+               socklen_t option_len);
 
 /** @} */
 


### PR DESCRIPTION
AwaLWM2M needs to be polled regularly to check for incoming data.
Since RIOT only supports timeout at the GNRC sock layer while
the network abstraction for RIOT in AwaLWM2M uses the posix layer,
this causes RIOT to be blocked waiting for data that never arrive.

This commit implements only the SO_RCVTIMEO option in setsockopt to
allow users to set a receive timeout for a socket at the posix layer.

Signed-off-by: Francois Berder <francois.berder@imgtec.com>