### PR TITLE
pkg: add minmea NMEA parsing library

### DIFF
--- a/pkg/minmea/Makefile
+++ b/pkg/minmea/Makefile
@@ -1,0 +1,12 @@
+PKG_NAME=minmea
+PKG_URL=https://github.com/kaspar030/minmea
+PKG_VERSION=f3253039a32af98924b0606316a83c8129dff4d4
+PKG_LICENSE=WTFPL
+
+.PHONY: all
+
+all: git-download
+	@cp Makefile.${PKG_NAME} $(PKG_BUILDDIR)/Makefile
+	"$(MAKE)" -C $(PKG_BUILDDIR)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/minmea/Makefile.include
+++ b/pkg/minmea/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(PKGDIRBASE)/minmea

--- a/pkg/minmea/Makefile.minmea
+++ b/pkg/minmea/Makefile.minmea
@@ -1,0 +1,10 @@
+MODULE=minmea
+
+CFLAGS += -D_POSIX_C_SOURCE=199309L -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_DARWIN_C_SOURCE
+
+# see minmea README.md
+CFLAGS += -Dtimegm=mktime
+
+SRC := minmea.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/minmea/README.md
+++ b/pkg/minmea/README.md
@@ -1,0 +1,11 @@
+# Introduction
+
+"Minmea is a minimalistic GPS parser library written in pure C intended for
+resource-constrained platforms, especially microcontrollers and other embedded
+systems."
+
+See https://github.com/cloudyourcar/minmea for more information.
+
+# License
+
+Licensed under WTFPL.

--- a/tests/pkg_minmea/Makefile
+++ b/tests/pkg_minmea/Makefile
@@ -1,0 +1,9 @@
+APPLICATION = pkg_minmea
+include ../Makefile.tests_common
+
+USEPKG += minmea
+
+# The MSP-430 toolchain lacks mktime and NAN
+BOARD_BLACKLIST := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_minmea/main.c
+++ b/tests/pkg_minmea/main.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     test
+ * @{
+ *
+ * @file
+ * @brief       minmea GPS NMEA parser library package test application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "minmea.h"
+
+static const char *_gll = "$GNGLL,5229.0178,N,01326.7605,E,114350.000,A,A*45";
+
+int main(void)
+{
+    struct minmea_sentence_gll frame;
+
+    int res = minmea_parse_gll(&frame, _gll);
+    if (!res) {
+        puts("error parsing GPS sentence");
+    }
+    else {
+        printf("parsed coordinates: lat=%f lon=%f\n",
+                minmea_tocoord(&frame.latitude),
+                minmea_tocoord(&frame.longitude));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
"Minmea is a minimalistic GPS parser library written in pure C intended for
resource-constrained platforms, especially microcontrollers and other embedded
systems."

See https://github.com/cloudyourcar/minmea for more information.