### PR TITLE
cc2538/periph/gpio: workaround for old defines and some fixes

### DIFF
--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -26,7 +26,7 @@
 #include "periph/gpio.h"
 
 #define GPIO_MASK           (0xfffff000)
-#define PORTNUM_MASK        (0x00003000)
+#define PORTNUM_MASK        (0x00007000)
 #define PORTNUM_SHIFT       (12U)
 #define PIN_MASK            (0x00000007)
 #define MODE_NOTSUP         (0xff)
@@ -46,7 +46,8 @@ static inline int port_num(gpio_t pin)
     if(((uint32_t)pin &GPIO_MASK) == 0){
         return ((pin & 0x18) >> 3);
     }
-    return (int)(((pin - (uint32_t)GPIO_A) & PORTNUM_MASK) >> PORTNUM_SHIFT);
+    //return (int)(((pin - (uint32_t)GPIO_A) & PORTNUM_MASK) >> PORTNUM_SHIFT);
+    return (int)((pin & PORTNUM_MASK) >> PORTNUM_SHIFT) - 1;
 }
 
 static inline int pin_num(gpio_t pin)
@@ -182,7 +183,7 @@ static inline void handle_isr(cc2538_gpio_t *gpio, int port_num)
 {
     uint32_t state       = gpio->MIS;
     gpio->IC             = 0x000000ff;
-    gpio->IRQ_DETECT_ACK = (0xff << (port_num * 8));
+    gpio->IRQ_DETECT_ACK = (0xff << (port_num * GPIO_BITS_PER_PORT));
 
     for (int i = 0; i < GPIO_BITS_PER_PORT; i++) {
         if (state & (1 << i)) {

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -106,7 +106,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     isr_ctx[port_num(pin)][pin_num(pin)].arg = arg;
 
     /* enable power-up interrupts for this GPIO port: */
-    SYS_CTRL->IWE |= (1 << port_num(pin));
+    SYS_CTRL->IWE |= port_num(pin);
 
     /* configure the active flank(s) */
     gpio(pin)->IS &= ~pin_mask(pin);
@@ -119,7 +119,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
         case GPIO_RISING:
             gpio(pin)->IBE &= ~pin_mask(pin);
             gpio(pin)->IEV |=  pin_mask(pin);
-            gpio(pin)->P_EDGE_CTRL &= ~(1 << pp_num(pin));
+            gpio(pin)->P_EDGE_CTRL &= (1 << pp_num(pin));
             break;
         case GPIO_BOTH:
             gpio(pin)->IBE |= pin_mask(pin);
@@ -183,7 +183,7 @@ static inline void handle_isr(cc2538_gpio_t *gpio, int port_num)
 {
     uint32_t state       = gpio->MIS;
     gpio->IC             = 0x000000ff;
-    gpio->IRQ_DETECT_ACK = (0xff << (port_num * GPIO_BITS_PER_PORT));
+    gpio->IRQ_DETECT_ACK = 0x000000ff;
 
     for (int i = 0; i < GPIO_BITS_PER_PORT; i++) {
         if (state & (1 << i)) {

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -182,7 +182,7 @@ static inline void handle_isr(cc2538_gpio_t *gpio, int port_num)
 {
     uint32_t state       = gpio->MIS;
     gpio->IC             = 0x000000ff;
-    gpio->IRQ_DETECT_ACK = 0x000000ff;
+    gpio->IRQ_DETECT_ACK = (0xff << (port_num * 8));
 
     for (int i = 0; i < GPIO_BITS_PER_PORT; i++) {
         if (state & (1 << i)) {

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -46,7 +46,6 @@ static inline int port_num(gpio_t pin)
     if(((uint32_t)pin &GPIO_MASK) == 0){
         return ((pin & 0x18) >> 3);
     }
-    //return (int)(((pin - (uint32_t)GPIO_A) & PORTNUM_MASK) >> PORTNUM_SHIFT);
     return (int)((pin & PORTNUM_MASK) >> PORTNUM_SHIFT) - 1;
 }
 


### PR DESCRIPTION
Temporary workaround for issue mentioned in #6650. Also some small fixes, as the interrupts haven't been working anymore. Enabling interrupts for PORT_D GPIO pins still causes my board to freeze, but interrupts are now working again for all other ports. 