### PR TITLE
make: use C compiler to build assembler files

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -73,10 +73,10 @@ $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.cpp $(RIOTBUILD_CONFIG_HEADER_C)
 		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 $(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
-	$(Q)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
+	$(Q)$(AS) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 $(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S
-	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
+	$(Q)$(AS) $(CFLAGS) $(INCLUDES) -MD -MP -c -o $@ $(abspath $<)
 
 # pull in dependency info for *existing* .o files
 # deleted header files will be silently ignored

--- a/cpu/Makefile.include.gnu
+++ b/cpu/Makefile.include.gnu
@@ -6,7 +6,7 @@ export AR = $(PREFIX)gcc-ar
 else
 export AR = $(PREFIX)ar
 endif
-export AS = $(PREFIX)as
+export AS = $(PREFIX)gcc
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(shell command -v $(PREFIX)objcopy gobjcopy objcopy | head -n 1)

--- a/cpu/Makefile.include.llvm
+++ b/cpu/Makefile.include.llvm
@@ -10,7 +10,7 @@ endif
 export CC          = clang
 export CXX         = clang++
 export LINK        = $(CC)
-export AS          = $(LLVMPREFIX)as
+export AS          = clang
 export AR          = $(LLVMPREFIX)ar
 export NM          = $(LLVMPREFIX)nm
 # There is no LLVM linker yet, use GNU binutils.


### PR DESCRIPTION
The C compiler transparently calls its assembler, anyway.