### PR TITLE
cpu: native: make syscalls vfs ready (introduce real_fcntl)

### DIFF
--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -103,11 +103,11 @@ void native_async_read_add_handler(int fd, void *arg, native_async_read_callback
     _sigio_child(_next_index);
 #else
     /* configure fds to send signals on io */
-    if (fcntl(fd, F_SETOWN, _native_pid) == -1) {
+    if (real_fcntl(fd, F_SETOWN, _native_pid) == -1) {
         err(EXIT_FAILURE, "native_async_read_add_handler(): fcntl(F_SETOWN)");
     }
     /* set file access mode to non-blocking */
-    if (fcntl(fd, F_SETFL, O_NONBLOCK | O_ASYNC) == -1) {
+    if (real_fcntl(fd, F_SETFL, O_NONBLOCK | O_ASYNC) == -1) {
         err(EXIT_FAILURE, "native_async_read_add_handler(): fcntl(F_SETFL)");
     }
 #endif /* not OSX */

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -96,6 +96,7 @@ extern int (*real_accept)(int socket, ...);
 extern int (*real_bind)(int socket, ...);
 extern int (*real_chdir)(const char *path);
 extern int (*real_close)(int);
+extern int (*real_fcntl)(int, int, ...);
 /* The ... is a hack to save includes: */
 extern int (*real_creat)(const char *path, ...);
 extern int (*real_dup2)(int, int);

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -68,6 +68,7 @@ int (*real_getifaddrs)(struct ifaddrs **ifap);
 int (*real_getpid)(void);
 int (*real_chdir)(const char *path);
 int (*real_close)(int);
+int (*real_fcntl)(int, int, ...);
 int (*real_creat)(const char *path, ...);
 int (*real_dup2)(int, int);
 int (*real_execve)(const char *, char *const[], char *const[]);
@@ -454,6 +455,7 @@ void _native_init_syscalls(void)
     *(void **)(&real_pipe) = dlsym(RTLD_NEXT, "pipe");
     *(void **)(&real_chdir) = dlsym(RTLD_NEXT, "chdir");
     *(void **)(&real_close) = dlsym(RTLD_NEXT, "close");
+    *(void **)(&real_fcntl) = dlsym(RTLD_NEXT, "fcntl");
     *(void **)(&real_creat) = dlsym(RTLD_NEXT, "creat");
     *(void **)(&real_fork) = dlsym(RTLD_NEXT, "fork");
     *(void **)(&real_dup2) = dlsym(RTLD_NEXT, "dup2");


### PR DESCRIPTION
When compiling `vfs` on native with asynchronous reading (e.g. with `netdev_tap`) linking fails, due to `native/async_read` using `fcntl` (which is implemented by `vfs`, but not accessing the system). This fixes it in the usual manner for native.