### PR TITLE
nrf24l01p: add disable crc function

### DIFF
--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -547,6 +547,15 @@ int nrf24l01p_enable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 int nrf24l01p_disable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 
 /**
+* @brief Disable CRC error detection on the nrf24l01+ transceiver.
+*
+* @param[in] dev    Transceiver device to use.
+*
+* @return           0.
+*/
+int nrf24l01p_disable_crc(nrf24l01p_t *dev);
+
+/**
 * @brief Enable CRC error detection on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -815,7 +815,13 @@ int nrf24l01p_disable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
     return nrf24l01p_write_reg(dev, REG_EN_RXADDR, pipe_conf);
 }
 
+int nrf24l01p_disable_crc(nrf24l01p_t *dev)
+{
+    char conf;
 
+    nrf24l01p_read_reg(dev, REG_CONFIG, &conf);
+    return nrf24l01p_write_reg(dev, REG_CONFIG, (conf & ~(EN_CRC)));
+}
 
 int nrf24l01p_enable_crc(nrf24l01p_t *dev, nrf24l01p_crc_t crc)
 {

--- a/tests/driver_nrf24l01p_lowlevel/README.md
+++ b/tests/driver_nrf24l01p_lowlevel/README.md
@@ -107,3 +107,12 @@ nrf24l01p_rx_handler got a message: Received packet.
 32 31 30 29 28 27 26 25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1
 
 ```
+
+## Compatibility with SI24R1 or other NRF24l01p clones
+CRC and Auto-ACK should be disabled.
+Use
+```
+nrf24l01p_disable_all_auto_ack(&nrf24l01p_0);
+nrf24l01p_disable_crc(&nrf24l01p_0);
+```
+after `nrf24l01p_init(&nrf24l01p_0, SPI_PORT, CE_PIN, CS_PIN, IRQ_PIN) < 0)`


### PR DESCRIPTION
Clones like `si24r1` are incompatible when crc and auto-ack are activated. This PR adds the functionality to disable the crc and adds a note about compatibility to the test application.