### PR TITLE
posix_sockets: port to vfs for file descriptors

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -367,8 +367,8 @@ endif
 
 ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += bitfield
-  USEMODULE += posix
   USEMODULE += random
+  USEMODULE += vfs
 endif
 
 ifneq (,$(filter rtt_stdio,$(USEMODULE)))

--- a/cpu/atmega_common/posix_unistd.c
+++ b/cpu/atmega_common/posix_unistd.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @brief   Implements various POSIX syscalls
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ */
+
+#include <errno.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#ifdef MODULE_VFS
+#include "vfs.h"
+#elif defined(MODULE_UART_STDIO)
+#include "uart_stdio.h"
+#endif
+
+int close(int fd)
+{
+#ifdef MODULE_VFS
+    int res = vfs_close(fd);
+    if (res < 0) {
+        errno = -res;
+        return -1;
+    }
+    return res;
+#else
+    (void)fd;
+    errno = ENODEV;
+    return -1;
+#endif
+}
+
+off_t lseek(int fd, off_t off, int whence)
+{
+#ifdef MODULE_VFS
+    off_t res = vfs_lseek(fd, off, whence);
+    if (res < 0) {
+        errno = -res;
+        return -1;
+    }
+    return res;
+#else
+    (void)fd;
+    (void)off;
+    (void)whence;
+    errno = ENODEV;
+    return -1;
+#endif
+}
+
+int fcntl(int fd, int cmd, int arg)
+{
+#ifdef MODULE_VFS
+    int res = vfs_fcntl(fd, cmd, arg);
+    if (res < 0) {
+        errno = -res;
+        return -1;
+    }
+    return res;
+#else
+    (void)fd;
+    (void)cmd;
+    (void)arg;
+    errno = ENODEV;
+    return -1;
+#endif
+}
+
+int fstat(int fd, struct stat *buf)
+{
+#ifdef MODULE_VFS
+    int res = vfs_fstat(fd, buf);
+    if (res < 0) {
+        errno = -res;
+        return -1;
+    }
+    return res;
+#else
+    (void)fd;
+    (void)buf;
+    errno = ENODEV;
+    return -1;
+#endif
+}
+
+ssize_t read(int fd, void *dest, size_t count)
+{
+#ifdef MODULE_VFS
+    ssize_t res = vfs_read(fd, dest, count);
+    if (res < 0) {
+        errno = -res;
+        return -1;
+    }
+    return res;
+#elif defined(MODULE_UART_STDIO)
+    if (fd == 0) {
+        return uart_stdio_read(dest, count);
+    }
+    errno = EBADF;
+    return -1;
+#else
+    (void)fd;
+    (void)dest;
+    (void)count;
+    errno = ENODEV;
+    return -1;
+#endif
+}
+
+ssize_t write(int fd, const void *src, size_t count)
+{
+#ifdef MODULE_VFS
+    ssize_t res = vfs_write(fd, src, count);
+    if (res < 0) {
+        errno = -res;
+        return -1;
+    }
+    return res;
+#elif defined(MODULE_UART_STDIO)
+    if (fd == 0) {
+        return uart_stdio_write(src, count);
+    }
+    errno = EBADF;
+    return -1;
+#else
+    (void)fd;
+    (void)src;
+    (void)count;
+    errno = ENODEV;
+    return -1;
+#endif
+}
+
+/** @} */


### PR DESCRIPTION
`posix_fd` is not as well-thought out as `vfs` and on top of it not compatible to it. Currently the only module using `posix_fd` is `posix_sockets` which gets ported to `vfs` in this PR. Will remove `posix_fd` as a follow-up. @francois-berder-imgtec sorry, I needed to revert some of your changes in #6697, since `vfs` uses the usual RIOT error handling. However, a wrapper now sets the `errno` correctly.

Requires ~~#6775 (on native)~~ (merged) and ~~#6776~~ (merged) to compile successfully.