### PR TITLE
sys/auto_init: fix return statement in some device auto init function

### DIFF
--- a/sys/auto_init/saul/auto_init_bme280.c
+++ b/sys/auto_init/saul/auto_init_bme280.c
@@ -44,29 +44,29 @@ void auto_init_bme280(void)
         int res = bme280_init(&bme280_devs[i], &bme280_params[i]);
         if (res < 0) {
             LOG_ERROR("[auto_init_saul] error initializing BME280 #%i\n", i);
+            continue;
         }
-        else {
-            /* temperature */
-            saul_entries[se_ix].dev = &bme280_devs[i];
-            saul_entries[se_ix].name = bme280_saul_reg_info[i][0].name;
-            saul_entries[se_ix].driver = &bme280_temperature_saul_driver;
-            saul_reg_add(&saul_entries[se_ix]);
-            se_ix++;
 
-            /* relative humidity */
-            saul_entries[se_ix].dev = &bme280_devs[i];
-            saul_entries[se_ix].name = bme280_saul_reg_info[i][1].name;
-            saul_entries[se_ix].driver = &bme280_relative_humidity_saul_driver;
-            saul_reg_add(&saul_entries[se_ix]);
-            se_ix++;
+        /* temperature */
+        saul_entries[se_ix].dev = &bme280_devs[i];
+        saul_entries[se_ix].name = bme280_saul_reg_info[i][0].name;
+        saul_entries[se_ix].driver = &bme280_temperature_saul_driver;
+        saul_reg_add(&saul_entries[se_ix]);
+        se_ix++;
 
-            /* pressure */
-            saul_entries[se_ix].dev = &bme280_devs[i];
-            saul_entries[se_ix].name = bme280_saul_reg_info[i][2].name;
-            saul_entries[se_ix].driver = &bme280_pressure_saul_driver;
-            saul_reg_add(&saul_entries[se_ix]);
-            se_ix++;
-        }
+        /* relative humidity */
+        saul_entries[se_ix].dev = &bme280_devs[i];
+        saul_entries[se_ix].name = bme280_saul_reg_info[i][1].name;
+        saul_entries[se_ix].driver = &bme280_relative_humidity_saul_driver;
+        saul_reg_add(&saul_entries[se_ix]);
+        se_ix++;
+
+        /* pressure */
+        saul_entries[se_ix].dev = &bme280_devs[i];
+        saul_entries[se_ix].name = bme280_saul_reg_info[i][2].name;
+        saul_entries[se_ix].driver = &bme280_pressure_saul_driver;
+        saul_reg_add(&saul_entries[se_ix]);
+        se_ix++;
     }
 }
 

--- a/sys/auto_init/saul/auto_init_bmp180.c
+++ b/sys/auto_init/saul/auto_init_bmp180.c
@@ -57,7 +57,7 @@ void auto_init_bmp180(void)
                         bmp180_params[i].i2c_dev,
                         bmp180_params[i].mode) < 0) {
             LOG_ERROR("[auto_init_saul] error initializing bmp180 #%u\n", i);
-            return;
+            continue;
         }
 
         /* temperature */

--- a/sys/auto_init/saul/auto_init_dht.c
+++ b/sys/auto_init/saul/auto_init_dht.c
@@ -48,17 +48,17 @@ void auto_init_dht(void)
 
         if (dht_init(&dht_devs[i], &dht_params[i]) != DHT_OK) {
             LOG_ERROR("[auto_init_saul] error initializing dht #%u\n", i);
+            continue;
         }
-        else {
-            saul_entries[(i * 2)].dev = &(dht_devs[i]);
-            saul_entries[(i * 2)].name = dht_saul_info[i][0].name;
-            saul_entries[(i * 2)].driver = &dht_temp_saul_driver;
-            saul_entries[(i * 2) + 1].dev = &(dht_devs[i]);
-            saul_entries[(i * 2) + 1].name = dht_saul_info[i][1].name;
-            saul_entries[(i * 2) + 1].driver = &dht_hum_saul_driver;
-            saul_reg_add(&(saul_entries[(i * 2)]));
-            saul_reg_add(&(saul_entries[(i * 2) + 1]));
-        }
+
+        saul_entries[(i * 2)].dev = &(dht_devs[i]);
+        saul_entries[(i * 2)].name = dht_saul_info[i][0].name;
+        saul_entries[(i * 2)].driver = &dht_temp_saul_driver;
+        saul_entries[(i * 2) + 1].dev = &(dht_devs[i]);
+        saul_entries[(i * 2) + 1].name = dht_saul_info[i][1].name;
+        saul_entries[(i * 2) + 1].driver = &dht_hum_saul_driver;
+        saul_reg_add(&(saul_entries[(i * 2)]));
+        saul_reg_add(&(saul_entries[(i * 2) + 1]));
     }
 }
 

--- a/sys/auto_init/saul/auto_init_hdc1000.c
+++ b/sys/auto_init/saul/auto_init_hdc1000.c
@@ -59,17 +59,17 @@ void auto_init_hdc1000(void)
         int res = hdc1000_init(&hdc1000_devs[i], &hdc1000_params[i]);
         if (res < 0) {
             LOG_ERROR("[auto_init_saul] error initializing hdc1000 #%u\n", i);
+            continue;
         }
-        else {
-            saul_entries[(i * 2)].dev = &(hdc1000_devs[i]);
-            saul_entries[(i * 2)].name = hdc1000_saul_info[i].name;
-            saul_entries[(i * 2)].driver = &hdc1000_saul_temp_driver;
-            saul_entries[(i * 2) + 1].dev = &(hdc1000_devs[i]);
-            saul_entries[(i * 2) + 1].name = hdc1000_saul_info[i].name;
-            saul_entries[(i * 2) + 1].driver = &hdc1000_saul_hum_driver;
-            saul_reg_add(&(saul_entries[(i * 2)]));
-            saul_reg_add(&(saul_entries[(i * 2) + 1]));
-        }
+
+        saul_entries[(i * 2)].dev = &(hdc1000_devs[i]);
+        saul_entries[(i * 2)].name = hdc1000_saul_info[i].name;
+        saul_entries[(i * 2)].driver = &hdc1000_saul_temp_driver;
+        saul_entries[(i * 2) + 1].dev = &(hdc1000_devs[i]);
+        saul_entries[(i * 2) + 1].name = hdc1000_saul_info[i].name;
+        saul_entries[(i * 2) + 1].driver = &hdc1000_saul_hum_driver;
+        saul_reg_add(&(saul_entries[(i * 2)]));
+        saul_reg_add(&(saul_entries[(i * 2) + 1]));
     }
 }
 

--- a/sys/auto_init/saul/auto_init_isl29020.c
+++ b/sys/auto_init/saul/auto_init_isl29020.c
@@ -58,13 +58,13 @@ void auto_init_isl29020(void)
                                 p->range, p->mode);
         if (res < 0) {
             LOG_ERROR("[auto_init_saul] error initializing isl29020 #%u\n", i);
+            continue;
         }
-        else {
-            saul_entries[i].dev = &(isl29020_devs[i]);
-            saul_entries[i].name = isl29020_saul_info[i].name;
-            saul_entries[i].driver = &isl29020_saul_driver;
-            saul_reg_add(&(saul_entries[i]));
-        }
+
+        saul_entries[i].dev = &(isl29020_devs[i]);
+        saul_entries[i].name = isl29020_saul_info[i].name;
+        saul_entries[i].driver = &isl29020_saul_driver;
+        saul_reg_add(&(saul_entries[i]));
     }
 }
 

--- a/sys/auto_init/saul/auto_init_jc42.c
+++ b/sys/auto_init/saul/auto_init_jc42.c
@@ -57,7 +57,7 @@ void auto_init_jc42(void)
 
         if (jc42_init(&jc42_devs[i], (jc42_params_t*) p) < 0) {
             LOG_ERROR("[auto_init_saul] error initializing jc42 #%u\n", i);
-            return;
+            continue;
         }
 
         /* temperature */

--- a/sys/auto_init/saul/auto_init_l3g4200d.c
+++ b/sys/auto_init/saul/auto_init_l3g4200d.c
@@ -58,13 +58,13 @@ void auto_init_l3g4200d(void)
                                 p->int1_pin, p->int2_pin, p->mode, p->scale);
         if (res < 0) {
             LOG_ERROR("[auto_init_saul] error initializing l3g4200d #%u\n", i);
+            continue;
         }
-        else {
-            saul_entries[i].dev = &(l3g4200d_devs[i]);
-            saul_entries[i].name = l3g4200d_saul_info[i].name;
-            saul_entries[i].driver = &l3g4200d_saul_driver;
-            saul_reg_add(&(saul_entries[i]));
-        }
+
+        saul_entries[i].dev = &(l3g4200d_devs[i]);
+        saul_entries[i].name = l3g4200d_saul_info[i].name;
+        saul_entries[i].driver = &l3g4200d_saul_driver;
+        saul_reg_add(&(saul_entries[i]));
     }
 }
 

--- a/sys/auto_init/saul/auto_init_lps331ap.c
+++ b/sys/auto_init/saul/auto_init_lps331ap.c
@@ -57,13 +57,13 @@ void auto_init_lps331ap(void)
         int res = lps331ap_init(&lps331ap_devs[i], p->i2c, p->addr, p->rate);
         if (res < 0) {
             LOG_ERROR("[auto_init_saul] error initializing lps331ap #%u\n", i);
+            continue;
         }
-        else {
-            saul_entries[i].dev = &(lps331ap_devs[i]);
-            saul_entries[i].name = lps331ap_saul_info[i].name;
-            saul_entries[i].driver = &lps331ap_saul_driver;
-            saul_reg_add(&(saul_entries[i]));
-        }
+
+        saul_entries[i].dev = &(lps331ap_devs[i]);
+        saul_entries[i].name = lps331ap_saul_info[i].name;
+        saul_entries[i].driver = &lps331ap_saul_driver;
+        saul_reg_add(&(saul_entries[i]));
     }
 }
 

--- a/sys/auto_init/saul/auto_init_lsm303dlhc.c
+++ b/sys/auto_init/saul/auto_init_lsm303dlhc.c
@@ -62,17 +62,17 @@ void auto_init_lsm303dlhc(void)
                                   p->mag_addr, p->mag_rate, p->mag_gain);
         if (res < 0) {
             LOG_ERROR("[auto_init_saul] error initializing lsm303dlhc #%u\n", i);
+            continue;
         }
-        else {
-            saul_entries[(i * 2)].dev = &(lsm303dlhc_devs[i]);
-            saul_entries[(i * 2)].name = lsm303dlhc_saul_info[i].name;
-            saul_entries[(i * 2)].driver = &lsm303dlhc_saul_acc_driver;
-            saul_entries[(i * 2) + 1].dev = &(lsm303dlhc_devs[i]);
-            saul_entries[(i * 2) + 1].name = lsm303dlhc_saul_info[i].name;
-            saul_entries[(i * 2) + 1].driver = &lsm303dlhc_saul_mag_driver;
-            saul_reg_add(&(saul_entries[(i * 2)]));
-            saul_reg_add(&(saul_entries[(i * 2) + 1]));
-        }
+
+        saul_entries[(i * 2)].dev = &(lsm303dlhc_devs[i]);
+        saul_entries[(i * 2)].name = lsm303dlhc_saul_info[i].name;
+        saul_entries[(i * 2)].driver = &lsm303dlhc_saul_acc_driver;
+        saul_entries[(i * 2) + 1].dev = &(lsm303dlhc_devs[i]);
+        saul_entries[(i * 2) + 1].name = lsm303dlhc_saul_info[i].name;
+        saul_entries[(i * 2) + 1].driver = &lsm303dlhc_saul_mag_driver;
+        saul_reg_add(&(saul_entries[(i * 2)]));
+        saul_reg_add(&(saul_entries[(i * 2) + 1]));
     }
 }
 

--- a/sys/auto_init/saul/auto_init_mma8x5x.c
+++ b/sys/auto_init/saul/auto_init_mma8x5x.c
@@ -57,7 +57,7 @@ void auto_init_mma8x5x(void)
 
         if (mma8x5x_init(&mma8x5x_devs[i], &mma8x5x_params[i]) != MMA8X5X_OK) {
             LOG_ERROR("[auto_init_saul] error initializing mma8x5x #%u\n", i);
-            return;
+            continue;
         }
 
         saul_entries[i].dev = &(mma8x5x_devs[i]);

--- a/sys/auto_init/saul/auto_init_si70xx.c
+++ b/sys/auto_init/saul/auto_init_si70xx.c
@@ -59,7 +59,7 @@ void auto_init_si70xx(void)
                               si70xx_params[i].address);
         if (res < 0) {
             LOG_ERROR("[auto_init_saul] error initializing SI70xx #%i\n", i);
-            return;
+            continue;
         }
 
         /* temperature */

--- a/sys/auto_init/saul/auto_init_tcs37727.c
+++ b/sys/auto_init/saul/auto_init_tcs37727.c
@@ -49,13 +49,13 @@ void auto_init_tcs37727(void)
         int res = tcs37727_init(&tcs37727_devs[i], &tcs37727_params[i]);
         if (res != TCS37727_OK) {
             LOG_ERROR("[auto_init_saul] error initializing tcs37727 #%u\n", i);
+            continue;
         }
-        else {
-            saul_entries[i].dev = &(tcs37727_devs[i]);
-            saul_entries[i].name = tcs37727_saul_info[i].name;
-            saul_entries[i].driver = &tcs37727_saul_driver;
-            saul_reg_add(&(saul_entries[i]));
-        }
+
+        saul_entries[i].dev = &(tcs37727_devs[i]);
+        saul_entries[i].name = tcs37727_saul_info[i].name;
+        saul_entries[i].driver = &tcs37727_saul_driver;
+        saul_reg_add(&(saul_entries[i]));
     }
 }
 

--- a/sys/auto_init/saul/auto_init_tsl2561.c
+++ b/sys/auto_init/saul/auto_init_tsl2561.c
@@ -58,7 +58,7 @@ void auto_init_tsl2561(void)
                          tsl2561_params[i].gain,
                          tsl2561_params[i].integration) != TSL2561_OK) {
             LOG_ERROR("[auto_init_saul] error initializing tsl2561 #%u\n", i);
-            return;
+            continue;
         }
 
         /* illuminance */

--- a/sys/auto_init/saul/auto_init_veml6070.c
+++ b/sys/auto_init/saul/auto_init_veml6070.c
@@ -55,7 +55,7 @@ void auto_init_veml6070(void)
         if (veml6070_init(&veml6070_devs[i],
                           &veml6070_params[i]) != VEML6070_OK) {
             LOG_ERROR("[auto_init_saul] error initializing veml6070 #%u\n", i);
-            return;
+            continue;
         }
 
         saul_entries[(i)].dev = &(veml6070_devs[i]);


### PR DESCRIPTION
While reviewing #6749, I noticed that the auto init function of some devices were not behaving correctly in case of a failure. If one has several devices and only one fails during initialization, the whole initialization process could be stopped.

This PR fixes this.