### PR TITLE
gcoap/nanocoap: Exclude unused nanocoap messaging functions

### DIFF
--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -26,6 +26,9 @@ BOARD_BLACKLIST := nrf52dk
 #GCOAP_TOKENLEN = 2
 #CFLAGS += -DGCOAP_TOKENLEN=$(GCOAP_TOKENLEN)
 
+# nanocoap message send/receive functions not used
+export NANOCOAP_UTIL_ONLY := 1
+
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default

--- a/examples/gcoap/Makefile.slip
+++ b/examples/gcoap/Makefile.slip
@@ -42,6 +42,9 @@ INCLUDES += -I$(CURDIR)
 CFLAGS += -DSLIP_UART=$(SLIP_UART)
 CFLAGS += -DSLIP_BAUDRATE=$(SLIP_BAUDRATE)
 
+# nanocoap message send/receive functions not used
+export NANOCOAP_UTIL_ONLY := 1
+
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default

--- a/pkg/nanocoap/Makefile.nanocoap
+++ b/pkg/nanocoap/Makefile.nanocoap
@@ -1,5 +1,11 @@
 MODULE=nanocoap
 
-SRC := nanocoap.c nanocoap_sock.c
+
+ifeq (, $(NANOCOAP_UTIL_ONLY))
+    SRC := nanocoap.c nanocoap_sock.c
+else
+    SRC := nanocoap.c
+    CFLAGS += -DNANOCOAP_UTIL_ONLY
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nanocoap/patches/0001-Add-macro-to-exclude-non-utility-functions.patch
+++ b/pkg/nanocoap/patches/0001-Add-macro-to-exclude-non-utility-functions.patch
@@ -1,0 +1,66 @@
+From badd5195238bfe82bfb321dc3a38e11ca10912b1 Mon Sep 17 00:00:00 2001
+From: Ken Bannister <kb2ma@runbox.com>
+Date: Tue, 21 Mar 2017 23:13:58 -0400
+Subject: [PATCH] Add macro to exclude non-utility functions.
+
+---
+ nanocoap/nanocoap.c | 4 ++++
+ nanocoap/nanocoap.h | 2 ++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/nanocoap/nanocoap.c b/nanocoap/nanocoap.c
+index 8f75cb9..9eda696 100644
+--- a/nanocoap/nanocoap.c
++++ b/nanocoap/nanocoap.c
+@@ -120,6 +120,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
+     return 0;
+ }
+ 
++#ifndef NANOCOAP_UTIL_ONLY
+ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_len)
+ {
+     if (coap_get_code_class(pkt) != COAP_REQ) {
+@@ -194,6 +195,7 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
+ 
+     return len;
+ }
++#endif
+ 
+ ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t token_len, unsigned code, uint16_t id)
+ {
+@@ -344,6 +346,7 @@ size_t coap_put_option_url(uint8_t *buf, uint16_t lastonum, const char *url)
+     return bufpos - buf;
+ }
+ 
++#ifndef NANOCOAP_UTIL_ONLY
+ ssize_t coap_well_known_core_default_handler(coap_pkt_t* pkt, uint8_t *buf, \
+                                              size_t len)
+ {
+@@ -369,3 +372,4 @@ ssize_t coap_well_known_core_default_handler(coap_pkt_t* pkt, uint8_t *buf, \
+ 
+     return coap_build_reply(pkt, COAP_CODE_205, buf, len, payload_len);
+ }
++#endif
+diff --git a/nanocoap/nanocoap.h b/nanocoap/nanocoap.h
+index 96f2497..7167988 100644
+--- a/nanocoap/nanocoap.h
++++ b/nanocoap/nanocoap.h
+@@ -156,6 +156,7 @@ extern const coap_resource_t coap_resources[];
+ extern const unsigned coap_resources_numof;
+ 
+ int coap_parse(coap_pkt_t* pkt, uint8_t *buf, size_t len);
++#ifndef NANOCOAP_UTIL_ONLY
+ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
+         uint8_t *rbuf, unsigned rlen, unsigned payload_len);
+ 
+@@ -166,6 +167,7 @@ ssize_t coap_reply_simple(coap_pkt_t *pkt,
+         const uint8_t *payload, uint8_t payload_len);
+ 
+ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_len);
++#endif
+ 
+ ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t token_len, unsigned code, uint16_t id);
+ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *odata, size_t olen);
+-- 
+2.7.4
+

--- a/tests/unittests/tests-gcoap/Makefile.include
+++ b/tests/unittests/tests-gcoap/Makefile.include
@@ -1,3 +1,6 @@
+# nanocoap message send/receive functions not used
+export NANOCOAP_UTIL_ONLY := 1
+
 # Specify the mandatory networking modules
 USEMODULE += gcoap
 USEMODULE += gnrc_ipv6


### PR DESCRIPTION
gcoap depends on nanocoap. However, the RIOT pkg for nanocoap includes messaging functionality that gcoap already implements. Specifically, gcoap does not use `nanocoap_sock.c` nor some functions in the remaining `nanocoap.c` implementation file. Removal of this functionality results in a savings of 743 B in the text section of an executable. See the [Memory Use](https://github.com/kb2ma/RIOT/wiki/Memory-Use) page in the gcoap wiki.

This PR patches nanocoap to remove the unnecessary file and functions based on the presence of the NANOCOAP_UTIL_ONLY flag in the build environment. The gcoap Make files have been updated to include this flag.

Depends on PR [#6469](https://github.com/RIOT-OS/RIOT/pull/6469).
