### PR TITLE
kinetis: Remove LPTIMER_CNR_NEEDS_LATCHING

### DIFF
--- a/cpu/k60/include/cpu_conf.h
+++ b/cpu/k60/include/cpu_conf.h
@@ -140,19 +140,6 @@ extern "C"
 /** IRQ channel for hwtimer interrupts */
 #define LPTIMER_IRQ_CHAN          LPTMR0_IRQn
 
-#if K60_CPU_REV == 1
-/*
- * The CNR register latching in LPTMR0 was added in silicon rev 2.x. With
- * rev 1.x we do not need to do anything in order to read the current timer counter
- * value
- */
-#define LPTIMER_CNR_NEEDS_LATCHING 0
-
-#elif K60_CPU_REV == 2
-
-#define LPTIMER_CNR_NEEDS_LATCHING 1
-
-#endif
 /** @} */
 
 /**

--- a/cpu/k64f/include/cpu_conf.h
+++ b/cpu/k64f/include/cpu_conf.h
@@ -78,7 +78,6 @@ extern "C"
 #define LPTIMER_DEV                      (LPTMR0) /**< LPTIMER hardware module */
 #define LPTIMER_CLKEN()                  (SIM->SCGC5 |= SIM_SCGC5_LPTMR_MASK) /**< Enable LPTMR0 clock gate */
 #define LPTIMER_CLKDIS()                 (SIM->SCGC5 &= ~SIM_SCGC5_PTMR_MASK) /**< Disable LPTMR0 clock gate */
-#define LPTIMER_CNR_NEEDS_LATCHING       1 /**< LPTMR.CNR register do not need latching */
 
 #ifdef __cplusplus
 }

--- a/cpu/kw2x/include/cpu_conf.h
+++ b/cpu/kw2x/include/cpu_conf.h
@@ -83,7 +83,6 @@ extern "C"
 #define LPTIMER_DEV                      (LPTMR0) /**< LPTIMER hardware module */
 #define LPTIMER_CLKEN()                  (SIM->SCGC5 |= SIM_SCGC5_LPTMR_MASK) /**< Enable LPTMR0 clock gate */
 #define LPTIMER_CLKDIS()                 (SIM->SCGC5 &= ~SIM_SCGC5_PTMR_MASK) /**< Disable LPTMR0 clock gate */
-#define LPTIMER_CNR_NEEDS_LATCHING       1 /**< LPTMR.CNR register do not need latching */
 
 /**
  * @name KW2XD SiP internal interconnects between MCU and Modem.


### PR DESCRIPTION
The macro is no longer supported in the timer driver after the last refactoring.
I will kick out the old MK60DZ10 support in a follow up PR because of multiple problems on that CPU.