### PR TITLE
boards/nucleo: include arduino pinmap in board definitions

### DIFF
--- a/boards/nucleo-common/include/arduino_pinmap.h
+++ b/boards/nucleo-common/include/arduino_pinmap.h
@@ -44,9 +44,15 @@ extern "C" {
 #define ARDUINO_PIN_8           GPIO_PIN(PORT_A, 9)
 #define ARDUINO_PIN_9           GPIO_PIN(PORT_C, 7)
 #define ARDUINO_PIN_10          GPIO_PIN(PORT_B, 6)
+#ifdef CPU_MODEL_STM32F302R8
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_B, 15)
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_B, 14)
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_B, 13) /* on-board LED */
+#else
 #define ARDUINO_PIN_11          GPIO_PIN(PORT_A, 7)
 #define ARDUINO_PIN_12          GPIO_PIN(PORT_A, 6)
 #define ARDUINO_PIN_13          GPIO_PIN(PORT_A, 5) /* on-board LED */
+#endif
 
 #define ARDUINO_PIN_A0          GPIO_PIN(PORT_C, 0)
 #define ARDUINO_PIN_A1          GPIO_PIN(PORT_C, 1)

--- a/boards/nucleo-common/include/board_common.h
+++ b/boards/nucleo-common/include/board_common.h
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
+#include "arduino_pinmap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/nucleo-common/include/board_common.h
+++ b/boards/nucleo-common/include/board_common.h
@@ -33,9 +33,13 @@ extern "C" {
  * @brief   LED pin definitions and handlers
  * @{
  */
+#ifdef CPU_MODEL_STM32F302R8
+#define LED0_PIN            GPIO_PIN(PORT_B, 13)
+#define LED0_MASK           (1 << 13)
+#else
 #define LED0_PIN            GPIO_PIN(PORT_A, 5)
-
 #define LED0_MASK           (1 << 5)
+#endif
 
 #define LED0_ON             (GPIOA->BSRR = LED0_MASK)
 #define LED0_OFF            (GPIOA->BSRR = (LED0_MASK << 16))

--- a/boards/nucleo-f302/include/board.h
+++ b/boards/nucleo-f302/include/board.h
@@ -27,35 +27,10 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
+#include "board_common.h"
 
 #ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * @brief   LED pin definitions and handlers
- * @{
- */
-#define LED0_PIN            GPIO_PIN(PORT_B, 13)
-#define LED0_MASK           (1 << 13)
-
-#define LED0_ON             (GPIOB->BSRR = LED0_MASK)
-#define LED0_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (GPIOB->ODR     ^= LED0_MASK)
-/** @} */
-
-/**
- * @brief   User button
- */
-#define BTN_B1_PIN          GPIO_PIN(PORT_C, 13)
-
-/**
- * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
- */
-void board_init(void);
-
-#ifdef __cplusplus
-}
+extern "C" {}
 #endif
 
 #endif /* BOARD_H */

--- a/boards/nucleo32-common/include/board_common.h
+++ b/boards/nucleo32-common/include/board_common.h
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
+#include "arduino_pinmap.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Discovered this issue while looking at #6787.