### PR TITLE
Sema: Fix Typo related to return values in documentation.

### DIFF
--- a/sys/include/sema.h
+++ b/sys/include/sema.h
@@ -91,7 +91,7 @@ void sema_create(sema_t *sema, unsigned int value);
  *
  * Destroying a semaphore upon which other threads are currently blocked
  * will wake the other threads causing the @ref sema_wait (or
- * @ref sema_wait_timed) to return error (-ECANCELLED).
+ * @ref sema_wait_timed) to return error (-ECANCELED).
  *
  * @param[in] sema  The semaphore to destroy.
  */


### PR DESCRIPTION
I'll stumbled upon a small documentation typo related to an error return code.