### PR TITLE
tests: cleanup, remove redundant RIOTBASE definition

### DIFF
--- a/tests/conn_ip/Makefile
+++ b/tests/conn_ip/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = conn_ip
 include ../Makefile.tests_common
 
-RIOTBASE ?= $(CURDIR)/../..
-
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
                              nucleo32-l031 nucleo-f030 nucleo-f070 nucleo-f334 nucleo-l053 \
                              stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -10,9 +10,6 @@ include ../Makefile.tests_common
 # not pull in all C++ locale code whenever exceptions are used.
 BOARD_INSUFFICIENT_MEMORY := nucleo-f334 spark-core stm32f0discovery
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -10,9 +10,6 @@ include ../Makefile.tests_common
 # not pull in all C++ locale code whenever exceptions are used.
 BOARD_INSUFFICIENT_MEMORY := nucleo-f334 spark-core stm32f0discovery
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -10,9 +10,6 @@ include ../Makefile.tests_common
 # not pull in all C++ locale code whenever exceptions are used.
 BOARD_INSUFFICIENT_MEMORY := nucleo-f334 spark-core stm32f0discovery
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -5,8 +5,6 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_gpio periph_spi  # for at86rf231
 
-RIOTBASE ?= $(CURDIR)/../..
-
 BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-l053 stm32f0discovery telosb \
                              weio wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/fault_handler/Makefile
+++ b/tests/fault_handler/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = fault_handler
 include ../Makefile.tests_common
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 CFLAGS += -DDEVELHELP=1
 
 ifeq ($(shell uname),Darwin)

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = gnrc_ipv6_ext
 include ../Makefile.tests_common
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \
                              nrf51dongle nrf6310 nucleo32-f031 nucleo32-f042 \
                              nucleo32-l031 nucleo-f030 nucleo-f103 nucleo-f334 nucleo-l053 \

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = gnrc_sixlowpan
 include ../Makefile.tests_common
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \
                              nrf51dongle nrf6310 nucleo32-f031 nucleo32-f042 \
                              nucleo32-l031 nucleo-f030 nucleo-f070 nucleo-f103 \

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -3,8 +3,6 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 
-RIOTBASE ?= $(CURDIR)/../..
-
 USEMODULE += gnrc_sock_ip
 USEMODULE += gnrc_ipv6
 USEMODULE += ps

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = gnrc_sock_udp
 include ../Makefile.tests_common
 
-RIOTBASE ?= $(CURDIR)/../..
-
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
 
 USEMODULE += gnrc_sock_check_reuse

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -28,9 +28,6 @@ CFLAGS += -DCYCLES=$(TCP_TEST_CYCLES)
 # development process:
 #CFLAGS += -DDEVELHELP
 
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
-
 # Modules to include
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = gnrc_tcp_client
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -18,9 +18,6 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              pca10000 pca10005 sb-430 sb-430h stm32f0discovery telosb \
                              weio wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 # Target Address, Target Port and number of Test Cycles
 CFLAGS += -DTARGET_ADDR=\"$(TCP_TARGET_ADDR)\"
 CFLAGS += -DTARGET_PORT=$(TCP_TARGET_PORT)

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -1,5 +1,6 @@
 # name of your application
 APPLICATION = gnrc_tcp_server
+include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -24,9 +24,6 @@ CFLAGS += -DLOCAL_PORT=$(TCP_LOCAL_PORT)
 # development process:
 #CFLAGS += -DDEVELHELP
 
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
-
 # Modules to include
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -16,9 +16,6 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              pca10000 pca10005 sb-430 sb-430h stm32f0discovery telosb \
                              weio wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 # Specify local Port to open
 CFLAGS += -DLOCAL_PORT=$(TCP_LOCAL_PORT)
 

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -3,8 +3,6 @@ APPLICATION = lwip
 BOARD ?= iotlab-m3
 include ../Makefile.tests_common
 
-RIOTBASE ?= $(CURDIR)/../..
-
 BOARD_BLACKLIST := arduino-mega2560 msb-430h telosb waspmote-pro z1 arduino-uno \
                    arduino-duemilanove msb-430 wsn430-v1_4 wsn430-v1_3b
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-mega2560 msb-430h nrf6310 \

--- a/tests/malloc/Makefile
+++ b/tests/malloc/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = malloc
 include ../Makefile.tests_common
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = minimal
 include ../Makefile.tests_common
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 #
 CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 

--- a/tests/od/Makefile
+++ b/tests/od/Makefile
@@ -2,9 +2,6 @@
 APPLICATION = od
 include ../Makefile.tests_common
 
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
 USEMODULE += od
 
 # Comment this out to disable code in RIOT that does safety checking

--- a/tests/xtimer_periodic_wakeup/Makefile
+++ b/tests/xtimer_periodic_wakeup/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = xtimer_sleep_until
 include ../Makefile.tests_common
 
-RIOTBASE ?= $(CURDIR)/../..
-
 BOARD_INSUFFICIENT_MEMORY := chronos
 
 USEMODULE += xtimer

--- a/tests/xtimer_remove/Makefile
+++ b/tests/xtimer_remove/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = xtimer_remove
 include ../Makefile.tests_common
 
-RIOTBASE ?= $(CURDIR)/../..
-
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_reset/Makefile
+++ b/tests/xtimer_reset/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = xtimer_reset
 include ../Makefile.tests_common
 
-RIOTBASE ?= $(CURDIR)/../..
-
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
    - RIOTBASE is set already in Makefile.tests_common
    - also add missing include ../Makefile.tests_common
      in gnrc_tcp_client/server