### PR TITLE
sys: fmt: fix fmt_lpad() documentation and (str==NULL) case

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -249,24 +249,27 @@ size_t fmt_lpad(char *out, size_t in_len, size_t pad_len, char pad_char)
         return in_len;
     }
 
-    size_t n = pad_len - in_len;
+    if (out) {
+        size_t n = pad_len - in_len;
 
-    if (FMT_USE_MEMMOVE) {
-        memmove(out + n, out, in_len);
-        memset(out, pad_char, n);
-    }
-    else {
-        char *pos = out + pad_len - 1;
-        out += in_len -1;
-
-        while(in_len--) {
-            *pos-- = *out--;
+        if (FMT_USE_MEMMOVE) {
+            memmove(out + n, out, in_len);
+            memset(out, pad_char, n);
         }
+        else {
+            char *pos = out + pad_len - 1;
+            out += in_len -1;
 
-        while (n--) {
-            *pos-- = pad_char;
+            while(in_len--) {
+                *pos-- = *out--;
+            }
+
+            while (n--) {
+                *pos-- = pad_char;
+            }
         }
     }
+
     return pad_len;
 }
 

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -301,7 +301,7 @@ void print_str(const char* str);
 /**
  * @brief Pad string to the left
  *
- * This function left-pads a given string @p out with @p pad_char
+ * This function left-pads a given string @p str with @p pad_char.
  *
  * For example, calling
  *
@@ -309,14 +309,17 @@ void print_str(const char* str);
  *
  * would result in "   abcd".
  *
+ * The function only writes to @p str if str is non-NULL and @p pad_len is < @p
+ * in_len.
+ *
  * @note Caller must ensure @p str can take pad_len characters!
  *
- * @param[inout]    str         string to pad
+ * @param[inout]    str         string to pad (or NULL)
  * @param[in]       in_len      length of str
  * @param[in]       pad_len     total length after padding
  * @param[in]       pad_char    char to use as pad char
  *
- * @returns pad_len
+ * @returns         max(in_len, pad_len)
  */
 size_t fmt_lpad(char *str, size_t in_len, size_t pad_len, char pad_char);
 


### PR DESCRIPTION
Fixes #6806.