### PR TITLE
mtd: Redefine MTD_0 as a mtd_dev_t *

### DIFF
--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -47,7 +47,7 @@ void board_init(void)
 #define MTD_NATIVE_FILENAME    "MEMORY.bin"
 #endif
 
-mtd_native_dev_t mtd0 = {
+static mtd_native_dev_t mtd0_dev = {
     .dev = {
         .driver = &native_flash_driver,
         .sector_count = MTD_NATIVE_SECTOR_NUM,
@@ -56,4 +56,6 @@ mtd_native_dev_t mtd0 = {
     },
     .fname = MTD_NATIVE_FILENAME,
 };
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&mtd0_dev;
 #endif

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -57,7 +57,7 @@ void _native_LED_RED_TOGGLE(void);
 #define MTD_0 mtd0
 
 /** mtd flash emulation device */
-extern mtd_native_dev_t mtd0;
+extern mtd_dev_t *mtd0;
 #endif
 
 #ifdef __cplusplus

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -304,7 +304,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
                 break;
 #ifdef MODULE_MTD_NATIVE
             case 'm':
-                mtd0.fname = strndup(optarg, PATH_MAX - 1);
+                ((mtd_native_dev_t *)mtd0)->fname = strndup(optarg, PATH_MAX - 1);
                 break;
 #endif
             default:

--- a/tests/unittests/tests-mtd/tests-mtd.c
+++ b/tests/unittests/tests-mtd/tests-mtd.c
@@ -27,7 +27,7 @@
 
 /* Define MTD_0 in board.h to use the board mtd if any */
 #ifdef MTD_0
-#define _dev MTD_0
+#define dev (MTD_0)
 #else
 /* Test mock object implementing a simple RAM-based mtd */
 #ifndef SECTOR_COUNT
@@ -116,27 +116,24 @@ static mtd_dev_t _dev = {
     .pages_per_sector = PAGE_PER_SECTOR,
     .page_size = PAGE_SIZE,
 };
+
+static mtd_dev_t *dev = (mtd_dev_t*) &_dev;
+
 #endif /* MTD_0 */
 
 static void setup_teardown(void)
 {
-    mtd_dev_t *dev = (mtd_dev_t*) &_dev;
-
     mtd_erase(dev, 0, dev->pages_per_sector * dev->page_size);
 }
 
 static void test_mtd_init(void)
 {
-    mtd_dev_t *dev = (mtd_dev_t*) &_dev;
-
     int ret = mtd_init(dev);
     TEST_ASSERT_EQUAL_INT(0, ret);
 }
 
 static void test_mtd_erase(void)
 {
-    mtd_dev_t *dev = (mtd_dev_t*) &_dev;
-
     /* Erase first sector */
     int ret = mtd_erase(dev, 0, dev->pages_per_sector * dev->page_size);
     TEST_ASSERT_EQUAL_INT(0, ret);
@@ -162,7 +159,6 @@ static void test_mtd_erase(void)
 
 static void test_mtd_write_erase(void)
 {
-    mtd_dev_t *dev = (mtd_dev_t*) &_dev;
     const char buf[] = "ABCDEFGHIJK";
     uint8_t buf_empty[] = {0xff, 0xff, 0xff};
     char buf_read[sizeof(buf) + sizeof(buf_empty)];
@@ -184,7 +180,6 @@ static void test_mtd_write_erase(void)
 
 static void test_mtd_write_read(void)
 {
-    mtd_dev_t *dev = (mtd_dev_t*) &_dev;
     const char buf[] = "ABCDEFGH";
     uint8_t buf_empty[] = {0xff, 0xff, 0xff};
     char buf_read[sizeof(buf) + sizeof(buf_empty)];
@@ -221,7 +216,6 @@ static void test_mtd_write_read(void)
 
 static void test_mtd_write_read_flash(void)
 {
-    mtd_dev_t *dev = (mtd_dev_t*) &_dev;
     const uint8_t buf1[] = {0xee, 0xdd, 0xcc};
     const uint8_t buf2[] = {0x33, 0x33, 0x33};
     const uint8_t buf_expected[] = {0x22, 0x11, 0x0};
@@ -247,7 +241,7 @@ static void test_mtd_write_read_flash(void)
 static void test_mtd_vfs(void)
 {
     int fd;
-    fd = vfs_bind(VFS_ANY_FD, O_RDWR, &mtd_vfs_ops, &_dev);
+    fd = vfs_bind(VFS_ANY_FD, O_RDWR, &mtd_vfs_ops, dev);
     const char buf[] = "mnopqrst";
     uint8_t buf_empty[] = {0xff, 0xff, 0xff};
     char buf_read[sizeof(buf) + sizeof(buf_empty)];


### PR DESCRIPTION
Unconditional casting in tests-mtd can hide programmer mistakes, such as accidentally giving a `mtd_dev_t **` instead of `mtd_dev_t *`
(I caused some hardfaults with this when trying out #6762 on Mulle)