### PR TITLE
mulle: Configure hardware CS for all on-board SPI slaves

### DIFF
--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -110,7 +110,7 @@ void board_init(void);
  */
 #define AT86RF2XX_PARAMS_BOARD      {.spi = SPI_DEV(0), \
                                      .spi_clk = SPI_CLK_5MHZ, \
-                                     .cs_pin = GPIO_PIN(PORT_D, 4), \
+                                     .cs_pin = SPI_HWCS(1), \
                                      .int_pin = GPIO_PIN(PORT_B, 9), \
                                      .sleep_pin = GPIO_PIN(PORT_E, 6), \
                                      .reset_pin = GPIO_PIN(PORT_C, 12)}
@@ -142,7 +142,7 @@ void board_init(void);
 /** @{ */
 #define MULLE_NVRAM_SPI_DEV             SPI_DEV(0)
 #define MULLE_NVRAM_SPI_CLK             SPI_CLK_5MHZ
-#define MULLE_NVRAM_SPI_CS              GPIO_PIN(PORT_D, 6) /**< FRAM CS pin */
+#define MULLE_NVRAM_SPI_CS              SPI_HWCS(3) /**< FRAM CS pin */
 #define MULLE_NVRAM_CAPACITY            512     /**< FRAM size, in bytes */
 #define MULLE_NVRAM_SPI_ADDRESS_COUNT   1       /**< FRAM addressing size, in bytes */
 /** @} */

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -265,9 +265,9 @@ static const spi_conf_t spi_config[] = {
         .pin_clk  = GPIO_PIN(PORT_D, 1),
         .pin_cs   = {
             GPIO_PIN(PORT_D, 0),
-            GPIO_UNDEF,
-            GPIO_UNDEF,
-            GPIO_UNDEF,
+            GPIO_PIN(PORT_D, 4),
+            GPIO_PIN(PORT_D, 5),
+            GPIO_PIN(PORT_D, 6),
             GPIO_UNDEF
         },
         .pcr      = GPIO_AF_2,


### PR DESCRIPTION
Follow up on #6572. Define the parameters for SPI0 hardware CS 1,2,3 pins in addition to the original HWCS 0.