### PR TITLE
pm_layerd: fix initial value for PM_BLOCKER_INITIAL

### DIFF
--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -88,6 +88,17 @@ typedef uint16_t gpio_t;
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 /** @} */
 
+/**
+ * @brief   define number of usable power modes
+ */
+#define PM_NUM_MODES    (1U)
+
+/**
+ * @brief   Override the default initial PM blocker
+ * @todo   we block all modes per default, until PM is cleanly implemented
+ */
+#define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
+
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes
@@ -290,11 +301,6 @@ enum {
  * @param[in] pcr       value for the PORT's PCR register
  */
 void gpio_init_port(gpio_t pin, uint32_t pcr);
-
-/**
- * @brief   define number of usable power modes
- */
-#define PM_NUM_MODES    (1U)
 
 #ifdef __cplusplus
 }

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -59,6 +59,15 @@ typedef uint32_t gpio_t;
  */
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
 
+/**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (3)
+/** @todo   we block all modes per default, until PM is cleanly implemented */
+#define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
+/** @} */
+
 #ifndef DOXYGEN
 /**
  * @brief   Override active flank configuration values

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -111,8 +111,6 @@ static inline int _sercom_id(SercomUsart *sercom)
     return ((((uint32_t)sercom) >> 10) & 0x7) - 2;
 }
 
-#define PM_NUM_MODES    (3)
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -60,8 +60,6 @@ typedef enum {
 /** @} */
 #endif /* ndef DOXYGEN */
 
-#define PM_NUM_MODES    (3)
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -56,6 +56,12 @@ extern "C" {
  */
 #define PM_NUM_MODES    (2U)
 
+/**
+ * @brief   Override the default initial PM blocker
+ * @todo   we block all modes per default, until PM is cleanly implemented
+ */
+#define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
+
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO mode options

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -30,7 +30,7 @@
 #endif
 
 #ifndef PM_BLOCKER_INITIAL
-#define PM_BLOCKER_INITIAL { .val_u32=0x01010101 }
+#define PM_BLOCKER_INITIAL { .val_u32 = 0 }
 #endif
 
 /**


### PR DESCRIPTION
the current value was a debugging left-over and should actually be 0.

Rationale: per default, all power modes should be allowed. If a CPU does not want to allow a certain mode, it should disable it on a per-CPU base...