### PR TITLE
boards/nucleos: deactivate LED0 auto init by default

### DIFF
--- a/boards/nucleo-common/include/gpio_params.h
+++ b/boards/nucleo-common/include/gpio_params.h
@@ -31,11 +31,13 @@ extern "C" {
  */
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
+#ifdef AUTO_INIT_LED0
     {
         .name = "LED(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },
+#endif
     {
         .name = "Button(B1 User)",
         .pin = BTN_B1_PIN,

--- a/boards/nucleo-f030/board.c
+++ b/boards/nucleo-f030/board.c
@@ -26,9 +26,12 @@
 
 void board_init(void)
 {
-    /* initialize the boards LED */
-    gpio_init(LED0_PIN, GPIO_OUT);
-
     /* initialize the CPU */
     cpu_init();
+
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
+    gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f070/board.c
+++ b/boards/nucleo-f070/board.c
@@ -26,9 +26,12 @@
 
 void board_init(void)
 {
-    /* initialize the boards LED */
-    gpio_init(LED0_PIN, GPIO_OUT);
-
     /* initialize the CPU */
     cpu_init();
+
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
+    gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f072/board.c
+++ b/boards/nucleo-f072/board.c
@@ -25,9 +25,12 @@
 
 void board_init(void)
 {
-    /* initialize the boards LED */
-    gpio_init(LED0_PIN, GPIO_OUT);
-
     /* initialize the CPU */
     cpu_init();
+
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
+    gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f091/board.c
+++ b/boards/nucleo-f091/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f103/board.c
+++ b/boards/nucleo-f103/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f302/board.c
+++ b/boards/nucleo-f302/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f303/board.c
+++ b/boards/nucleo-f303/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f334/board.c
+++ b/boards/nucleo-f334/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f401/board.c
+++ b/boards/nucleo-f401/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f410/board.c
+++ b/boards/nucleo-f410/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f411/board.c
+++ b/boards/nucleo-f411/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-f446/board.c
+++ b/boards/nucleo-f446/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-l053/board.c
+++ b/boards/nucleo-l053/board.c
@@ -26,9 +26,12 @@
 
 void board_init(void)
 {
-    /* initialize the boards LED */
-    gpio_init(LED0_PIN, GPIO_OUT);
-
     /* initialize the CPU */
     cpu_init();
+
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
+    gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-l073/board.c
+++ b/boards/nucleo-l073/board.c
@@ -26,9 +26,12 @@
 
 void board_init(void)
 {
-    /* initialize the boards LED */
-    gpio_init(LED0_PIN, GPIO_OUT);
-
     /* initialize the CPU */
     cpu_init();
+
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
+    gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo-l1/board.c
+++ b/boards/nucleo-l1/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }


### PR DESCRIPTION
Should fix #6501 

The problem doesn't exist with 32 and 144 pins versions of the nucleo boards.

I accept any better proposition for the macro name.