### PR TITLE
cppcheck: Don't Run cppcheck on ASM files.

### DIFF
--- a/dist/tools/cppcheck/check.sh
+++ b/dist/tools/cppcheck/check.sh
@@ -17,7 +17,7 @@ else
 fi
 
 BRANCH=${1}
-FILEREGEX='\.([CcHhSs]|[ch]pp)$'
+FILEREGEX='\.([CcHh]|[ch]pp)$'
 EXCLUDE='^(.+/include/vendor/)'
 
 # If no branch but an option is given, unset BRANCH.


### PR DESCRIPTION
cppcheck doesn't understand ASM style comments beginning with '#' and tries to
parse them:

I get this error:
 `cpu/mips_pic32_common/reset_mod.S:84: error (syntaxError): syntax error`
from this line:
 `beqz s1, init_resources # Branch if this is NOT an NMI exception.`

If I place the comment inside C-style comments cppcheck passes, ie

 `beqz s1, init_resources # /*Branch if this is NOT an NMI exception.*/`

Note current in-tree ASM files fail cppcheck (they must have been added before
this check) for example:

cpu/lpc2387/asmfunc.s