### PR TITLE
boards/cpu: added hwrng for nucleo-l476 / stm32l4

### DIFF
--- a/boards/nucleo-l476/Makefile.features
+++ b/boards/nucleo-l476/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/cpu/stm32l4/cpu.c
+++ b/cpu/stm32l4/cpu.c
@@ -143,6 +143,9 @@ static void cpu_clock_init(void)
     while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
 #endif
 
+    /* select the MSI clock for the 48MHz clock tree (USB, RNG) */
+    RCC->CCIPR = (RCC_CCIPR_CLK48SEL_0 | RCC_CCIPR_CLK48SEL_1);
+
     /* if configured: enable the HSE clock */
 #if CLOCK_HSE
     RCC->CR |= RCC_CR_HSEON;

--- a/tests/periph_hwrng/main.c
+++ b/tests/periph_hwrng/main.c
@@ -31,7 +31,7 @@ int main(void)
     uint8_t buf[LIMIT];
 
     puts("\nHWRNG peripheral driver test\n");
-    printf("This test will print from 1 to %i random bytes about every"
+    printf("This test will print from 1 to %i random bytes about every "
            "second\n\n", LIMIT);
 
     puts("Initializing the HWRNG driver.\n");


### PR DESCRIPTION
~~rebased on #6814 and #6820~~

Enabled the `hwrng` for the `nucleo-l476`. To get it to work, I fixed the missing 48MHz clock tree source assignment for the `stm32l4` CPU.