### PR TITLE
drivers: add periph/flashsector driver for STM32F4

### DIFF
--- a/boards/nucleo-f411/Makefile.features
+++ b/boards/nucleo-f411/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_flashsector
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/cpu/stm32_common/periph/flashsector.c
+++ b/cpu/stm32_common/periph/flashsector.c
@@ -159,22 +159,22 @@ void *flashsector_addr(int sector)
         offset = FLASHSECTOR_SMALL_SECTOR * 1024U * 8 + (FLASHSECTOR_SMALL_SECTOR * 1024U * 8) * (sector - 5);
     }
 
-    return (void *)(CPU_FLASH_BASE + offset);
+    return (void *)(FLASH_BASE + offset);
 }
 
 /* remember, that the first sector is number 0 */
 int flashsector_sector(void *addr)
 {
-    uint8_t pseudo_sector = ((int)addr - CPU_FLASH_BASE) / FLASHSECTOR_SMALL_SECTOR;
+    uint8_t pseudo_sector = ((uint32_t)addr - FLASH_BASE) / (uint32_t)(FLASHSECTOR_SMALL_SECTOR * 1024U);
 
     if (pseudo_sector < 4) {
         return pseudo_sector;
     }
-    else if (pseudo_sector > 8) {
+    else if (4 <= pseudo_sector && pseudo_sector < 8) {
         return 4;
     }
     else {
-        return ((pseudo_sector / 4) + 4);
+        return ((pseudo_sector / 8) + 4);
     }
 
 }

--- a/cpu/stm32_common/periph/flashsector.c
+++ b/cpu/stm32_common/periph/flashsector.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32_common
+ * @{
+ *
+ * @file
+ * @brief       Low-level flash sector driver implementation
+ *
+ * @author      Jannik Beyerstedt <jannik.beyerstedt@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "assert.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+#if defined(FLASHSECTOR_SMALL_SECTOR) && defined(FLASHSECTOR_BANK_SIZE)
+#include "periph/flashsector.h"
+
+void flashsector_write(int sector, void *data, int size)
+{
+    assert(sector < FLASHSECTOR_NUMOF);
+
+    uint16_t *sector_addr = flashsector_addr(sector);
+    uint16_t *data_addr = (uint16_t *)data;
+    uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
+
+    // /* the internal RC oscillator (HSI) must be enabled */
+    RCC->CR |= (RCC_CR_HSION);
+    while (!(RCC->CR & RCC_CR_HSIRDY)) {
+    }
+
+    /* unlock the flash module */
+    DEBUG("[flashsector] unlocking the flash module\n");
+    if ((FLASH->CR & FLASH_CR_LOCK)) {
+        FLASH->KEYR = FLASH_KEY1;
+        FLASH->KEYR = FLASH_KEY2;
+    }
+
+    /* ERASE sequence */
+    /* make sure no flash operation is ongoing */
+    DEBUG("[flashsector] erase: waiting for any operation to finish\n");
+    while (FLASH->SR & FLASH_SR_BSY) {
+    }
+    /* set sector erase bit and program sector address */
+    DEBUG("[flashsector] erase: setting the erase bit programming parallelism\n");
+    FLASH->CR &= ~FLASH_CR_PSIZE;       /* clear PSIZE first */
+    FLASH->CR |= FLASH_PSIZE_HALF_WORD; /* 16 bit programming */
+    FLASH->CR &= ~FLASH_CR_SNB;         /* clear FLASH_CR_SNB first */
+    FLASH->CR |= FLASH_CR_SER | (sector << POSITION_VAL(FLASH_CR_SNB));
+    DEBUG("address to erase: %p\n", flashsector_addr(sector));
+    /* trigger the sector erase and wait for it to be finished */
+    DEBUG("[flashsector] erase: trigger the sector erase\n");
+    FLASH->CR |= FLASH_CR_STRT;
+    DEBUG("[flashsector] erase: wait as long as device is busy\n");
+    while (FLASH->SR & FLASH_SR_BSY) {
+    }
+    /* clear SER bit */
+    FLASH->CR &= ~FLASH_CR_SER;
+
+    /* WRITE sequence */
+    if (data != NULL) {
+        DEBUG("[flashsector] write: now writing the data\n");
+        /* set the PG bit and programming word size, then program data */
+        FLASH->CR &= ~FLASH_CR_PSIZE;       /* clear PSIZE first */
+        FLASH->CR |= FLASH_PSIZE_HALF_WORD; /* 16 bit programming */
+        FLASH->CR |= FLASH_CR_PG;
+        for (unsigned i = 0; i < (size / 2); i++) {
+            //*(__IO uint16_t*)sector_addr++ = data_addr[i];
+            *sector_addr++ = data_addr[i];
+            while (FLASH->SR & FLASH_SR_BSY) {
+            }
+        }
+        /* clear program bit again */
+        FLASH->CR &= (~FLASH_CR_PG);
+        DEBUG("[flashsector] write: done writing data\n");
+    }
+
+    /* finally, lock the flash module again */
+    DEBUG("flashsector] now locking the flash module again\n");
+    FLASH->CR |= FLASH_CR_LOCK;
+
+    /* restore the HSI state */
+    if (!hsi_state) {
+        RCC->CR &= ~(RCC_CR_HSION);
+        while (RCC->CR & RCC_CR_HSIRDY) {
+        }
+    }
+}
+
+/* remember, that the first sector is number 0 */
+void *flashsector_addr(int sector)
+{
+    uint32_t offset = 0;
+
+    if (sector < 5) {
+        offset = FLASHSECTOR_SMALL_SECTOR * 1024U * sector;
+    }
+    else if (5 == sector) {
+        offset = FLASHSECTOR_SMALL_SECTOR * 1024U * 8;
+    }
+    else {
+        offset = FLASHSECTOR_SMALL_SECTOR * 1024U * 8 + (FLASHSECTOR_SMALL_SECTOR * 1024U * 8) * (sector - 5);
+    }
+
+    return (void *)(CPU_FLASH_BASE + offset);
+}
+
+/* remember, that the first sector is number 0 */
+int flashsector_sector(void *addr)
+{
+    uint8_t pseudo_sector = ((int)addr - CPU_FLASH_BASE) / FLASHSECTOR_SMALL_SECTOR;
+
+    if (pseudo_sector < 4) {
+        return pseudo_sector;
+    }
+    else if (pseudo_sector > 8) {
+        return 4;
+    }
+    else {
+        return ((pseudo_sector / 4) + 4);
+    }
+
+}
+
+#endif /* defined(FLASHSECTOR_SMALL_SECTOR) && defined(FLASHSECTOR_BANK_SIZE) */

--- a/cpu/stm32_common/periph/flashsector.c
+++ b/cpu/stm32_common/periph/flashsector.c
@@ -76,8 +76,7 @@ void flashsector_write(int sector, void *data, int size)
         FLASH->CR |= FLASH_PSIZE_HALF_WORD; /* 16 bit programming */
         FLASH->CR |= FLASH_CR_PG;
         for (unsigned i = 0; i < (size / 2); i++) {
-            //*(__IO uint16_t*)sector_addr++ = data_addr[i];
-            *sector_addr++ = data_addr[i];
+            *(__IO uint16_t*)sector_addr++ = data_addr[i];
             while (FLASH->SR & FLASH_SR_BSY) {
             }
         }

--- a/cpu/stm32_common/periph/flashsector.c
+++ b/cpu/stm32_common/periph/flashsector.c
@@ -99,8 +99,8 @@ void flashsector_write(int sector, void *data, int size)
 }
 
 void flashsector_write_only(void *target, void *data, int size) {
-    uint16_t *target_addr = (uint16_t *)target;
-    uint16_t *data_addr = (uint16_t *)data;
+    __IO uint16_t *target_addr = (uint16_t *)target;
+    __IO uint16_t *data_addr = (uint16_t *)data;
     uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
 
     /* the internal RC oscillator (HSI) must be enabled */
@@ -123,8 +123,7 @@ void flashsector_write_only(void *target, void *data, int size) {
         FLASH->CR |= FLASH_PSIZE_HALF_WORD; /* 16 bit programming */
         FLASH->CR |= FLASH_CR_PG;
         for (unsigned i = 0; i < (size / 2); i++) {
-            //*(__IO uint16_t*)sector_addr++ = data_addr[i];
-            *target_addr++ = data_addr[i];
+            *(__IO uint16_t*)target_addr++ = data_addr[i];
             while (FLASH->SR & FLASH_SR_BSY) {
             }
         }

--- a/cpu/stm32f4/Makefile.include
+++ b/cpu/stm32f4/Makefile.include
@@ -3,6 +3,9 @@ export CPU_FAM  = stm32f4
 
 USEMODULE += pm_layered
 
+# this STM32 CPU has flash sectors instead of (equally sized) pages
+export CFLAGS += -DFLASH_SECTORS
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 
 include $(RIOTCPU)/Makefile.include.cortexm_common

--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -46,6 +46,37 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Flash sector configuration
+ * @{
+ */
+#if defined(CPU_MODEL_STM32F401RE)
+#define FLASHSECTOR_SMALL_SECTOR    (16U)
+#define FLASHSECTOR_BANK_SIZE       (512U)
+#define FLASHSECTOR_NUMOF           (8U)
+#elif defined(CPU_MODEL_STM32F407VG)
+#define FLASHSECTOR_SMALL_SECTOR    (16U)
+#define FLASHSECTOR_BANK_SIZE       (1024U)
+#define FLASHSECTOR_NUMOF           (12U)
+#elif defined(CPU_MODEL_STM32F411RE)
+#define FLASHSECTOR_SMALL_SECTOR    (16U)
+#define FLASHSECTOR_BANK_SIZE       (512U)
+#define FLASHSECTOR_NUMOF           (8U)
+#elif defined(CPU_MODEL_STM32F413ZH)
+#define FLASHSECTOR_SMALL_SECTOR    (16U)
+#define FLASHSECTOR_BANK_SIZE       (1536U)
+#define FLASHSECTOR_NUMOF           (16U)
+#elif defined(CPU_MODEL_STM32F415RG)
+#define FLASHSECTOR_SMALL_SECTOR    (16U)
+#define FLASHSECTOR_BANK_SIZE       (1024U)
+#define FLASHSECTOR_NUMOF           (12U)
+#elif defined(CPU_MODEL_STM32F446RE)
+#define FLASHSECTOR_SMALL_SECTOR    (16U)
+#define FLASHSECTOR_BANK_SIZE       (512U)
+#define FLASHSECTOR_NUMOF           (8U)
+#endif
+/** @} */
+
+/**
  * @brief   ARM Cortex-M specific CPU configuration
  * @{
  */

--- a/drivers/include/periph/flashsector.h
+++ b/drivers/include/periph/flashsector.h
@@ -125,10 +125,21 @@ int flashsector_sector(void *addr);
  * @param[in] sector    sector to write
  * @param[in] data      data to write to the sector, MUST be @p size byte.
  *                      Set to NULL for sector erase only.
- * @param[in]  size     size of the data to write (in byte).
+ * @param[in] size      size of the data to write (in byte).
                         Ignored, if sector erase is requested
  */
 void flashsector_write(int sector, void *data, int size);
+
+/**
+ * @brief   Write the given data to flash memory, but do not erase before
+ *
+ * @param[in] target    address to write data to
+ * @param[in] data      data to write to the sector, MUST be @p size byte.
+ *                      Set to NULL for sector erase only.
+ * @param[in] size      size of the data to write (in byte).
+                        Ignored, if sector erase is requested
+ */
+void flashsector_write_only(void *target, void *data, int size);
 
 /**
  * @brief   Read the first part of given sector into the given memory location

--- a/drivers/include/periph/flashsector.h
+++ b/drivers/include/periph/flashsector.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_flashsector Flash sector driver
+ * @ingroup     drivers_periph
+ * @brief       Low-level flash sector interface
+ *
+ * @{
+ * @file
+ * @brief       Low-level flash sector peripheral driver interface
+ *
+ * This interface provides a very simple and straight forward way for writing
+ * a MCU's internal flash. This interface is only capable of reading, verifying,
+ * and writing complete flash sectors, it has no support for partial flash
+ * access.
+ * This enables for very slim and efficient implementations.
+ *
+ * A module for more fine-grained access of memory locations can easily be
+ * programmed on top of this interface.
+ *
+ * TODO: add support for devices with dual bank memory, e.g. switch to dual bank
+ * mode, if FLASHSECTOR_2ND_BANK_START is defined and specifies the address of
+ * the first sector in the second bank
+ *
+ * @note        Flash memory has only a limited amount of erase cycles (mostly
+ *              around 10K times), so using this interface in some kind of loops
+ *              can damage you MCU!
+ *
+ * @author      Jannik Beyerstedt <jannik.beyerstedt@haw-hamburg.de>
+ */
+
+#ifndef FLASHSECTOR_H
+#define FLASHSECTOR_H
+
+#include <stdint.h>
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* HAL Library macros */
+#define POSITION_VAL(VAL)     (__CLZ(__RBIT(VAL)))
+
+/**
+ * @brief   defines for flash programming parallelism
+ */
+#define FLASH_PSIZE_BYTE           0x00000000U
+#define FLASH_PSIZE_HALF_WORD      0x00000100U
+#define FLASH_PSIZE_WORD           0x00000200U
+#define FLASH_PSIZE_DOUBLE_WORD    0x00000300U
+#define CR_PSIZE_MASK              0xFFFFFCFFU
+
+/**
+ * @brief   flash keys form STM32F4xx
+ */
+#define RDP_KEY                  ((uint16_t)0x00A5)
+#define FLASH_KEY1               0x45670123U
+#define FLASH_KEY2               0xCDEF89ABU
+#define FLASH_OPT_KEY1           0x08192A3BU
+#define FLASH_OPT_KEY2           0x4C5D6E7FU
+
+/**
+ * @brief   Per default, we expect the internal flash to start at address 0
+ */
+#ifndef CPU_FLASH_BASE
+#define CPU_FLASH_BASE      (0)
+#endif
+
+/**
+ * @brief   Make sure the size of the smallest sector and the total bank size
+ *          are defined. All sizes in KB.
+ */
+#ifndef FLASHSECTOR_SMALL_SECTOR
+#error "periph/flashsector: FLASHSECTOR_SMALL_SECTOR not defined"
+#endif
+#ifndef FLASHSECTOR_BANK_SIZE
+#error "periph/flashsector: FLASHSECTOR_BANK_SIZE not defined"
+#endif
+
+/**
+ * @brief   Return values used in this interface
+ */
+enum {
+    FLASHSECTOR_OK      =  0,     /**< everything succeeded */
+    FLASHSECTOR_NOMATCH = -1      /**< sector differs from target data */
+};
+
+/**
+ * @brief   Translate the given sector number into the sector's starting address
+ *
+ * @note    The given sector MUST be valid, otherwise the returned address points
+ *          to an undefined memory location!
+ *
+ * @param[in] sector    sector number to get the address of
+ *
+ * @return              starting memory address of the given sector
+ */
+void *flashsector_addr(int sector);
+
+/**
+ * @brief   Translate the given address into the corresponding sector number
+ *
+ * The given address can be any address inside a sector.
+ *
+ * @note    The given address MUST be a valid flash address!
+ *
+ * @param[in] addr      address inside the targeted sector
+ *
+ * @return              sector containing the given address
+ */
+int flashsector_sector(void *addr);
+
+/**
+ * @brief   Write the given sector with the given data
+ *
+ * @param[in] sector    sector to write
+ * @param[in] data      data to write to the sector, MUST be @p size byte.
+ *                      Set to NULL for sector erase only.
+ * @param[in]  size     size of the data to write (in byte).
+                        Ignored, if sector erase is requested
+ */
+void flashsector_write(int sector, void *data, int size);
+
+/**
+ * @brief   Read the first part of given sector into the given memory location
+ *
+ * @param[in]  page     sector to read
+ * @param[out] data     memory to write the page to, MUST be @p size byte
+ * @param[in]  size     size of the memory location (in byte)
+ */
+void flashsector_read(int sector, void *data, int size);
+
+/**
+ * @brief   Verify the given sector against the given data
+ *
+ * @param[in] sector    sector to verify
+ * @param[in] data      data to compare sector against, MUST be @p size byte
+ * @param[in] size      size of the data to compare (in byte)
+ *
+ * @return              FLASHSECTOR_OK if data in the sector is identical to @p data
+ * @return              FLASHSECTOR_NOMATCH if data and sector content diverge
+ */
+int flashsector_verify(int sector, void *data, int size);
+
+/**
+ * @brief   Write the given sector and verify the results
+ *
+ * This is a convenience function wrapping flashsector_write and flashsector_verify.
+ *
+ * @param[in] sector    sector to write
+ * @param[in] data      data to write to the sector, MUST be @p size byte
+ * @param[in] size      size of the data to compare (in byte)
+ *
+ * @return              FLASHSECTOR_OK on success
+ * @return              FLASHSECTOR_NOMATCH if data and sector content diverge
+ */
+int flashsector_write_and_verify(int sector, void *data, int size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FLASHSECTOR_H */
+/** @} */

--- a/drivers/periph_common/flashsector.c
+++ b/drivers/periph_common/flashsector.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers
+ * @{
+ *
+ * @file
+ * @brief       Common flash sector functions
+ *
+ * @author      Jannik Beyerstedt <jannik.beyerstedt@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include "cpu.h"
+#include "assert.h"
+
+/* guard this file, must be done before including periph/flashsector.h
+ * TODO: remove as soon as periph drivers can be build selectively */
+#if defined(FLASHSECTOR_SMALL_SECTOR) && defined(FLASHSECTOR_BANK_SIZE)
+
+#include "periph/flashsector.h"
+
+void flashsector_read(int sector, void *data, int size)
+{
+    assert(sector < FLASHSECTOR_NUMOF);
+
+    memcpy(data, flashsector_addr(sector), size);
+}
+
+int flashsector_verify(int sector, void *data, int size)
+{
+    assert(sector < FLASHSECTOR_NUMOF);
+
+    if (memcmp(flashsector_addr(sector), data, size) == 0) {
+        return FLASHSECTOR_OK;
+    }
+    else {
+        return FLASHSECTOR_NOMATCH;
+    }
+}
+
+int flashsector_write_and_verify(int sector, void *data, int size)
+{
+    flashsector_write(sector, data, size);
+    return flashsector_verify(sector, data, size);
+}
+
+#endif /* defined(FLASHSECTOR_SMALL_SECTOR) && defined(FLASHSECTOR_BANK_SIZE) */

--- a/tests/periph_flashsector/Makefile
+++ b/tests/periph_flashsector/Makefile
@@ -1,0 +1,9 @@
+APPLICATION = periph_flashpage
+BOARD ?= nucleo-f411
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_flashsector
+
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_flashsector/README.md
+++ b/tests/periph_flashsector/README.md
@@ -1,0 +1,39 @@
+Expected result
+===============
+Use the provided shell commands, to read and write sectors from/to the MCU's
+internal flash memory. For altering the data in a flash sector, use a sequence
+similar to this:
+- read some sector from the flash, this will load the first 1024 byte into a
+local buffer
+```
+read 2 1024
+```
+- edit the contents of the local buffer, here we write 'Hello_RIOT' to position
+  100
+```
+edit 100 Hello_RIOT
+```
+- write the local buffer to any target sector in the flash. CAUTION: if you
+  override any sector, that contains program code (or even the interrupt vector),
+  you will most like encounter hard faults and crashes which can only be fixed
+  by re-flashing the node...
+```
+write 2
+```
+- check if the contents were written, dump the first 1024 byte
+```
+dump 2 1024
+```
+- now power off the node, wait a bit and power it back on. The contents of the
+  sector written previously should still be there
+
+What else to check:
+- Erase a sector with previously known contents, to make sure the erasing works
+- also check the sectors before and after the targeted sector, to see if the
+  sector size is correct, and that you are only erasing the actual sector and
+  not any parts of the neighboring sector.
+
+Background
+==========
+This test provides you with tools to test implementations of the `flashsector`
+peripheral driver interface.

--- a/tests/periph_flashsector/main.c
+++ b/tests/periph_flashsector/main.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Manual test application for sectored Flash peripheral driver
+ *
+ * @author      Jannik Beyerstedt <jannik.beyerstedt@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "shell.h"
+#include "periph/flashsector.h"
+
+#define LINE_LEN            (16)
+#define BUFFER_SIZE         (2048U)
+
+/**
+ * @brief   Allocate space for 2KB of flash data in RAM
+ */
+static uint8_t sector_mem[BUFFER_SIZE];
+
+
+static int getsector(const char *str)
+{
+    int sector = atoi(str);
+    if ((sector >= FLASHSECTOR_NUMOF) || (sector < 0)) {
+        printf("error: sector %i is invalid\n", sector);
+        return -1;
+    }
+    return sector;
+}
+
+static int getsize(const char *str)
+{
+    int size = atoi(str);
+    if ((size >= BUFFER_SIZE) || (size < 0)) {
+        printf("error: size %i is too big for local buffer\n", size);
+        return -1;
+    }
+    return size;
+}
+
+static void dumpchar(uint8_t mem)
+{
+    if (mem >= ' ' && mem <= '~') {
+        printf("  %c  ", mem);
+    }
+    else {
+        printf("  ?? ");
+    }
+}
+
+static void memdump(void *addr, size_t len)
+{
+    unsigned pos = 0;
+    uint8_t *mem = (uint8_t *)addr;
+
+    while (pos < (unsigned)len) {
+        for (unsigned i = 0; i < LINE_LEN; i++) {
+            printf("0x%02x ", mem[pos + i]);
+        }
+        puts("");
+        for (unsigned i = 0; i < LINE_LEN; i++) {
+            dumpchar(mem[pos++]);
+        }
+        puts("");
+    }
+}
+
+static void dump_local(void)
+{
+    puts("Local sector buffer:");
+    memdump(sector_mem, BUFFER_SIZE);
+}
+
+static int cmd_info(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    printf("Flash start addr:\t0x%08x\n", (int)CPU_FLASH_BASE);
+    printf("Number of sectors:\t%i\n", (int)FLASHSECTOR_NUMOF);
+    printf("Internal buffer size:\t0x%08x\n", (int)BUFFER_SIZE);
+
+    return 0;
+}
+
+static int cmd_dump(int argc, char **argv)
+{
+    int sector, size;
+    void *addr;
+
+    if (argc < 3) {
+        printf("usage: %s <sector> <byte>\n", argv[0]);
+        return 1;
+    }
+
+    sector = getsector(argv[1]);
+    if (sector < 0) {
+        return 1;
+    }
+
+    size = getsize(argv[2]);
+    if (size < 0) {
+        return 1;
+    }
+    addr = flashsector_addr(sector);
+
+    printf("Flash sector %i at address %p, first %i byte\n", sector, addr, size);
+    memdump(addr, size);
+
+    return 0;
+}
+
+static int cmd_dump_local(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    dump_local();
+
+    return 0;
+}
+
+static int cmd_read(int argc, char **argv)
+{
+    int sector, size;
+
+    if (argc < 3) {
+        printf("usage: %s <sector> <size>\n", argv[0]);
+        return 1;
+    }
+
+    sector = getsector(argv[1]);
+    if (sector < 0) {
+        return 1;
+    }
+
+    size = getsize(argv[2]);
+    if (size < 0) {
+        return 1;
+    }
+
+    flashsector_read(sector, sector_mem, size);
+    printf("Read first %i bytes of flash sector %i into local sector buffer\n", size, sector);
+    dump_local();
+
+    return 0;
+}
+
+static int cmd_write(int argc, char **argv)
+{
+    int sector;
+
+    if (argc < 2) {
+        printf("usage: %s <sector>\n", argv[0]);
+        return 1;
+    }
+
+    sector = getsector(argv[1]);
+    if (sector < 0) {
+        return 1;
+    }
+
+    if (flashsector_write_and_verify(sector, sector_mem, BUFFER_SIZE) != FLASHSECTOR_OK) {
+        printf("error: verification for sector %i failed\n", sector);
+        return 1;
+    }
+
+    printf("wrote local buffer to flash sector %i at addr %p\n",
+           sector, flashsector_addr(sector));
+    return 0;
+}
+
+static int cmd_erase(int argc, char **argv)
+{
+    int sector;
+
+    if (argc < 2) {
+        printf("usage: %s <sector>\n", argv[0]);
+        return 1;
+    }
+
+    sector = getsector(argv[1]);
+    if (sector < 0) {
+        return 1;
+    }
+    flashsector_write(sector, NULL, 0);
+
+    printf("successfully erased sector %i (addr %p)\n",
+           sector, flashsector_addr(sector));
+    return 0;
+}
+
+static int cmd_edit(int argc, char **argv)
+{
+    int offset;
+    size_t data_len;
+
+    if (argc < 3) {
+        printf("usage: %s <offset> <data>\n", argv[0]);
+        return 1;
+    }
+
+    offset = atoi(argv[1]);
+    if (offset >= BUFFER_SIZE) {
+        printf("error: given offset is out of bounce\n");
+        return -1;
+    }
+    data_len = strlen(argv[2]);
+    if ((data_len + offset) > BUFFER_SIZE) {
+        data_len = BUFFER_SIZE - offset;
+    }
+
+    memcpy(&sector_mem[offset], argv[2], data_len);
+    dump_local();
+
+    return 0;
+}
+
+static int cmd_test(int argc, char **argv)
+{
+    int sector;
+    char fill = 'a';
+
+    if (argc < 2) {
+        printf("usage: %s <sector>\n", argv[0]);
+        return 1;
+    }
+
+    sector = getsector(argv[1]);
+    if (sector < 0) {
+        return 1;
+    }
+
+    for (int i = 0; i < sizeof(sector_mem); i++) {
+        sector_mem[i] = (uint8_t)fill++;
+        if (fill > 'z') {
+            fill = 'a';
+        }
+    }
+
+    if (flashsector_write_and_verify(sector, sector_mem, BUFFER_SIZE) != FLASHSECTOR_OK) {
+        printf("error verifying the content of sector %i\n", sector);
+        return 1;
+    }
+
+    printf("wrote local sector to flash sector %i at addr %p\n",
+           sector, flashsector_addr(sector));
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "info", "Show information about sectors", cmd_info },
+    { "dump", "Dump the selected sector to STDOUT", cmd_dump },
+    { "dump_local", "Dump the local sector buffer to STDOUT", cmd_dump_local },
+    { "read", "Read and output the given sector", cmd_read },
+    { "write", "Write (ASCII) data to the given sector", cmd_write },
+    { "erase", "Erase the given sector", cmd_erase },
+    { "edit", "Write bytes to the local sector", cmd_edit },
+    { "test", "Write and verify test pattern", cmd_test },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("ROM flash read write test\n");
+    puts("Please refer to the README.md for further information\n");
+
+    cmd_info(0, NULL);
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
This branch adds a driver for the sectored flash of STM32F4 microcontrollers. The interface is pretty much the same, as the flashpages driver and the test is also mostly copied from the flashpages test.
The driver is currently only tested on an STM32F411 nucleo board, so the feature is only added for this board. But it should work with all STM32F4s, if the flash size, number of sectors and size of the smallest sector is defined.
It is possible to characterize the flash only by using these three parameters, because every sectored STM32 flash (until now) has the following layout:
```
4 sectors á smallest_sector_size
1 sectors á 4 * smallest_sector_size
n sectors á 8 * smallest_sector_size
```
For smaller flash sizes, only the first 4 sectors are present.

Flash with multiple flash banks is not supported.

This driver should be easily adaptable for other STM32 microcontrollers, but I don’t have the boards to test it.