### PR TITLE
doc: adapt consistent naming for CPU CC26x0

### DIFF
--- a/cpu/cc26x0/doc.txt
+++ b/cpu/cc26x0/doc.txt
@@ -1,15 +1,17 @@
 /**
- * @defgroup        cpu_cc26x0 Texas Instruments CC26x0
+ * @defgroup        cpu_cc26x0 TI CC26x0
  * @ingroup         cpu
  * @brief           Texas Instruments CC26x0 Cortex-M3 MCU specific code
  */
 
 /**
- * @defgroup        cpu_specific_peripheral_memory_map Texas Instruments CC26x0 peripheral memory map
+ * @defgroup        cpu_specific_peripheral_memory_map TI CC26x0 peripheral memory map
  * @ingroup         cpu
+ * @brief           Texas Instruments CC26x0 memory mappings for peripherals
  */
 
 /**
- * @defgroup        cpu_cc26x0_definitions Texas Instruments CC26x0 definitions
+ * @defgroup        cpu_cc26x0_definitions TI CC26x0 definitions
  * @ingroup         cpu_cc26x0
+ * @brief           Texas Instruments CC26x0 specific defines
  */


### PR DESCRIPTION
shortens "Texas Instruments" to "TI" in doxygen docu, matching other docs like CC2538.