### PR TITLE
doc: fix doxygen grouping of driver hd44780

### DIFF
--- a/drivers/include/hd44780.h
+++ b/drivers/include/hd44780.h
@@ -6,20 +6,20 @@
  * directory for more details.
  */
 
- /**
-  * @defgroup    drivers_hd44780 HD44780 LCD driver
-  * @ingroup     drivers_displays
-  * @brief       Driver for the Hitachi HD44780 LCD driver
-  *
-  * @note        The driver currently supports direct addressing, no I2C
-  *
-  * @{
-  *
-  * @file
-  * @brief       Interface definition for the HD44780 LCD driver
-  *
-  * @author      Sebastian Meiling <s@mlng.net>
-  */
+/**
+ * @defgroup    driver_hd44780 HD44780 LCD driver
+ * @ingroup     drivers_actuators
+ * @brief       Driver for the Hitachi HD44780 LCD driver
+ *
+ * @note        The driver currently supports direct addressing, no I2C
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the HD44780 LCD driver
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ */
 #ifndef HD44780_H
 #define HD44780_H
 


### PR DESCRIPTION
this PR moves the display driver into group drivers actuators, similar to pcd8544.