### PR TITLE
boards: add hwrng feature in nucleo144-(f207|f413)

### DIFF
--- a/boards/nucleo144-f207/Makefile.features
+++ b/boards/nucleo144-f207/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo144-f413/Makefile.features
+++ b/boards/nucleo144-f413/Makefile.features
@@ -1,12 +1,13 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_pwm
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/nucleo144-common/Makefile.features


### PR DESCRIPTION
Enable hwrng on nucleo144-f207 and nucleo144-f413. 