### PR TITLE
boards/nucleo144-f429: add hwrng feature

### DIFF
--- a/boards/nucleo144-f429/Makefile.features
+++ b/boards/nucleo144-f429/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi


### PR DESCRIPTION
Looks like this CPU also have RNG defined.