### PR TITLE
atmega328p/startup.c: Clear watchdog flag

### DIFF
--- a/cpu/atmega328p/startup.c
+++ b/cpu/atmega328p/startup.c
@@ -65,6 +65,12 @@ void init8_ovr(void)
  */
 void reset_handler(void)
 {
+    /* reset the watchdog if the reboot was triggered due to it */
+    if (MCUSR & 1 << WDRF) {
+        MCUSR &= ~(1 << WDRF);
+        WDTCSR |= 1 << WDCE;
+        WDTCSR = 0;
+    }
     /* initialize the board and startup the kernel */
     board_init();
     /* startup the kernel */


### PR DESCRIPTION
When the atmega328p is restarted by the watchdog, the WDRF bit in
the MCUSR register will also set the WDE bit, enabling the
watchdog. Since we use the watchdog for reboot (see
cpu/atmega_common/periph/pm.c), this means that the CPU will just
loop-reboot when a reboot is issued.

From the Atmel documentation about WDE in WDTCSR:
  "WDE is overridden by WDRF in MCUSR. This means that WDE is
  always set when WDRF is set. To clear WDE, WDRF must be cleared
  first. This feature ensures multiple resets during conditions
  causing failure, and a safe start-up after the failure."