### PR TITLE
6lo: Avoid null ptr dereference when SAC=0, DAC=1, DAM=00, M=1

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -367,7 +367,7 @@ size_t gnrc_sixlowpan_iphc_decode(gnrc_pktsnip_t **dec_hdr, gnrc_pktsnip_t *pkt,
             dci = iphc_hdr[CID_EXT_IDX] & 0x0f;
         }
 
-        if (iphc_hdr[IPHC2_IDX] & SIXLOWPAN_IPHC2_DAM) {
+        if (iphc_hdr[IPHC2_IDX] & (SIXLOWPAN_IPHC2_M | SIXLOWPAN_IPHC2_DAM)) {
             ctx = gnrc_sixlowpan_ctx_lookup_id(dci);
 
             if (ctx == NULL) {


### PR DESCRIPTION
[gnrc_sixlowpan_iphc.c:461-478](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c#L461:L478) results in multiple null pointer dereferences in this case.

Adding the M flag to the check for when to look up the context fixes the problem. Please review whether this is the correct behaviour.