### PR TITLE
boards/nucleo-f302: remove unicode character that breaks buildtest target

### DIFF
--- a/boards/nucleo-f302/Makefile.features
+++ b/boards/nucleo-f302/Makefile.features
@@ -1,4 +1,4 @@
-﻿# Put defined MCU peripherals here (in alphabetical order)
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c


### PR DESCRIPTION
fixes #6833

I think my editor was still misconfigured at the time I wrote this file (UTF8 by default).

I simply removed the byte order mask (BOM) using VIM: `:set nobomb`.

See http://www.fileformat.info/info/unicode/char/FEFF/index.htm