### PR TITLE
unittests: Add missing check for result of vfs_opendir in tests-spiffs

### DIFF
--- a/tests/unittests/tests-spiffs/tests-spiffs.c
+++ b/tests/unittests/tests-spiffs/tests-spiffs.c
@@ -252,6 +252,7 @@ static void tests_spiffs_readdir(void)
 
     vfs_DIR dirp;
     res = vfs_opendir(&dirp, "/test-spiffs");
+    TEST_ASSERT_EQUAL_INT(0, res);
 
     vfs_dirent_t entry;
     int nb_files = 0;


### PR DESCRIPTION
We forgot to check that the opendir call succeeded.