### PR TITLE
boards/nucleo32: enable SPI and deactivate LED0 auto init by default

### DIFF
--- a/boards/nucleo32-common/include/gpio_params.h
+++ b/boards/nucleo32-common/include/gpio_params.h
@@ -31,11 +31,13 @@ extern "C" {
  */
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
+#ifdef AUTO_INIT_LED0
     {
         .name = "LD3(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     }
+#endif
 };
 
 #ifdef __cplusplus

--- a/boards/nucleo32-f031/Makefile.features
+++ b/boards/nucleo32-f031/Makefile.features
@@ -3,6 +3,7 @@ FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo32-f031/board.c
+++ b/boards/nucleo32-f031/board.c
@@ -28,6 +28,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo32-f031/include/periph_conf.h
+++ b/boards/nucleo32-f031/include/periph_conf.h
@@ -124,6 +124,46 @@ static const pwm_conf_t pwm_config[] = {
 /** @} */
 
 /**
+ * @name   SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 48000000Hz */
+        7,  /* -> 187500Hz */
+        6,  /* -> 375000Hz */
+        5,  /* -> 750000Hz */
+        2,  /* -> 6000000Hz */
+        1   /* -> 12000000Hz */
+    },
+    {       /* for APB2 @ 48000000Hz */
+        7,  /* -> 187500Hz */
+        6,  /* -> 375000Hz */
+        5,  /* -> 750000Hz */
+        2,  /* -> 6000000Hz */
+        1   /* -> 12000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+        .miso_pin = GPIO_PIN(PORT_B, 4),
+        .sclk_pin = GPIO_PIN(PORT_B, 3),
+        .cs_pin   = GPIO_UNDEF,
+        .af       = GPIO_AF0,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
  * @name RTC configuration
  * @{
  */

--- a/boards/nucleo32-f042/Makefile.features
+++ b/boards/nucleo32-f042/Makefile.features
@@ -3,6 +3,7 @@ FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo32-f042/board.c
+++ b/boards/nucleo32-f042/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo32-f042/include/periph_conf.h
+++ b/boards/nucleo32-f042/include/periph_conf.h
@@ -133,6 +133,45 @@ static const pwm_conf_t pwm_config[] = {
 #define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
 /** @} */
 
+/**
+ * @name   SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 48000000Hz */
+        7,  /* -> 187500Hz */
+        6,  /* -> 375000Hz */
+        5,  /* -> 750000Hz */
+        2,  /* -> 6000000Hz */
+        1   /* -> 12000000Hz */
+    },
+    {       /* for APB2 @ 48000000Hz */
+        7,  /* -> 187500Hz */
+        6,  /* -> 375000Hz */
+        5,  /* -> 750000Hz */
+        2,  /* -> 6000000Hz */
+        1   /* -> 12000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+        .miso_pin = GPIO_PIN(PORT_B, 4),
+        .sclk_pin = GPIO_PIN(PORT_B, 3),
+        .cs_pin   = GPIO_UNDEF,
+        .af       = GPIO_AF0,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
 
 /**
  * @name RTC configuration

--- a/boards/nucleo32-f303/Makefile.features
+++ b/boards/nucleo32-f303/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo32-f303/board.c
+++ b/boards/nucleo32-f303/board.c
@@ -26,6 +26,9 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-    /* initialize the boards LEDs */
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/boards/nucleo32-f303/include/periph_conf.h
+++ b/boards/nucleo32-f303/include/periph_conf.h
@@ -128,6 +128,46 @@ static const pwm_conf_t pwm_config[] = {
 /** @} */
 
 /**
+ * @name   SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 32000000Hz */
+        7,  /* -> 125000Hz */
+        5,  /* -> 500000Hz */
+        4,  /* -> 1000000Hz */
+        2,  /* -> 4000000Hz */
+        1   /* -> 8000000Hz */
+    },
+    {       /* for APB2 @ 64000000Hz */
+        7,  /* -> 250000Hz */
+        6,  /* -> 500000Hz */
+        5,  /* -> 1000000Hz */
+        3,  /* -> 4000000Hz */
+        2   /* -> 8000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+        .miso_pin = GPIO_PIN(PORT_B, 4),
+        .sclk_pin = GPIO_PIN(PORT_B, 3),
+        .cs_pin   = GPIO_UNDEF,
+        .af       = GPIO_AF0,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
  * @name RTC configuration
  * @{
  */

--- a/boards/nucleo32-l031/Makefile.features
+++ b/boards/nucleo32-l031/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo32-l031/board.c
+++ b/boards/nucleo32-l031/board.c
@@ -29,6 +29,9 @@ void board_init(void)
     /* initialize the boards LED */
     gpio_init(LED0_PIN, GPIO_OUT);
 
-    /* initialize the CPU */
-    cpu_init();
+#ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
+    gpio_init(LED0_PIN, GPIO_OUT);
+#endif
 }

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -1,6 +1,9 @@
 APPLICATION = driver_at86rf2xx
 include ../Makefile.tests_common
 
+# exclude boards with insufficient memory
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
+
 FEATURES_REQUIRED = periph_spi periph_gpio
 
 DISABLE_MODULE += auto_init

--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -3,7 +3,8 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-f334 nucleo-l053 \
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
+                             nucleo32-l031 nucleo-f334 nucleo-l053 \
                              stm32f0discovery telosb weio z1
 
 USEMODULE += gnrc_netdev

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -3,7 +3,8 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-l053 stm32f0discovery telosb \
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
+                             nucleo32-l031 nucleo-l053 stm32f0discovery telosb \
                              weio z1
 
 USEMODULE += gnrc_netdev

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -3,7 +3,8 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := nucleo-f334 nucleo-l053 stm32f0discovery weio
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 \
+                             nucleo-f334 nucleo-l053 stm32f0discovery weio
 
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_netdev_default

--- a/tests/driver_nrf24l01p_lowlevel/Makefile
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile
@@ -1,6 +1,9 @@
 APPLICATION = driver_nrf24l01p_lowlevel
 include ../Makefile.tests_common
 
+# exclude boards with insufficient memory
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
+
 FEATURES_REQUIRED = periph_spi
 
 USEMODULE += shell

--- a/tests/driver_sdcard_spi/Makefile
+++ b/tests/driver_sdcard_spi/Makefile
@@ -1,6 +1,9 @@
 APPLICATION = driver_sdcard_spi
 include ../Makefile.tests_common
 
+# exclude boards with insufficient memory
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
+
 USEMODULE += sdcard_spi
 USEMODULE += auto_init_storage
 USEMODULE += fmt

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -5,7 +5,8 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_gpio periph_spi  # for at86rf231
 
-BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-l053 stm32f0discovery telosb \
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo32-l031 nucleo32-f031 \
+                             nucleo32-f042 nucleo-l053 stm32f0discovery telosb \
                              weio wsn430-v1_3b wsn430-v1_4 z1
 
 USEPKG += emb6

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -6,8 +6,9 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := arduino-mega2560 msb-430h telosb waspmote-pro z1 arduino-uno \
                    arduino-duemilanove msb-430 wsn430-v1_4 wsn430-v1_3b
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-mega2560 msb-430h nrf6310 \
-                             nucleo32-f031 nucleo-f030 nucleo-f072 nucleo-f302 \
-                             nucleo-f334 nucleo-l053 pca10005 stm32f0discovery \
+                             nucleo32-f031 nucleo32-f031 nucleo32-f042 nucleo32-f303 \
+                             nucleo32-l031 nucleo-f030 nucleo-f072 \
+                             nucleo-f302 nucleo-f334 nucleo-l053 pca10005 stm32f0discovery \
                              telosb weio yunjia-nrf51822 z1
 
 # including lwip_ipv6_mld would currently break this test on at86rf2xx radios

--- a/tests/pthread_barrier/Makefile
+++ b/tests/pthread_barrier/Makefile
@@ -6,7 +6,7 @@ BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove
 # arduino mega2560 uno duemilanove: unknown type name: clockid_t
 
 # exclude boards with insufficient memory
-BOARD_INSUFFICIENT_MEMORY := stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 stm32f0discovery
 
 # Modules to include.
 USEMODULE += pthread


### PR DESCRIPTION
Since this is the same problem with the on-board LED being shared with the SPI clock.