### PR TITLE
README: update mcu/boards support information

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ but not limited to:
 * a preemptive, tickless scheduler with priorities
 * flexible memory management
 * high resolution, long-term timers
-* support for AVR, MSP430, ARM7, and ARM Cortex-M on over 50 boards
+* support for AVR, MSP430, MIPS, ARM7, and ARM Cortex-M on over 80 boards
 * the native port allows to run RIOT as-is on Linux, BSD, and MacOS. Multiple
   instances of RIOT running on a single machine can also be interconnected via
   a simple virtual Ethernet bridge


### PR DESCRIPTION
This PR simply updates the general information about MCU types and number of boards supported by RIOT in the main README file.