### PR TITLE
boards: fix remaining doxygen @brief in periph config

### DIFF
--- a/boards/iotlab-common/include/periph_conf_common.h
+++ b/boards/iotlab-common/include/periph_conf_common.h
@@ -116,7 +116,7 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @brief   DAC configuration
+ * @name   DAC configuration
  * @{
  */
 #define DAC_NUMOF           (0)

--- a/boards/nucleo-f410/include/periph_conf.h
+++ b/boards/nucleo-f410/include/periph_conf.h
@@ -188,7 +188,7 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @brief   DAC configuration
+ * @name   DAC configuration
  * @{
  */
 #define DAC_NUMOF           (0)

--- a/boards/nucleo-f411/include/periph_conf.h
+++ b/boards/nucleo-f411/include/periph_conf.h
@@ -227,14 +227,14 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @brief   ADC configuration
+ * @name   ADC configuration
  * @{
  */
 #define ADC_NUMOF          (0)
 /** @} */
 
 /**
- * @brief   DAC configuration
+ * @name   DAC configuration
  * @{
  */
 #define DAC_NUMOF           (0)

--- a/boards/nucleo-l053/include/periph_conf.h
+++ b/boards/nucleo-l053/include/periph_conf.h
@@ -164,7 +164,7 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @brief   ADC configuration
+ * @name   ADC configuration
  * @{
  */
 #define ADC_NUMOF           (0)
@@ -172,7 +172,7 @@ static const spi_conf_t spi_config[] = {
 
 
 /**
- * @brief   DAC configuration
+ * @name   DAC configuration
  * @{
  */
 #define DAC_NUMOF           (0)

--- a/boards/nucleo-l073/include/periph_conf.h
+++ b/boards/nucleo-l073/include/periph_conf.h
@@ -164,7 +164,7 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @brief   ADC configuration
+ * @name   ADC configuration
  * @{
  */
 #define ADC_NUMOF           (0)
@@ -172,7 +172,7 @@ static const spi_conf_t spi_config[] = {
 
 
 /**
- * @brief   DAC configuration
+ * @name   DAC configuration
  * @{
  */
 #define DAC_NUMOF           (0)

--- a/boards/nucleo-l476/include/periph_conf.h
+++ b/boards/nucleo-l476/include/periph_conf.h
@@ -221,14 +221,14 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @brief   ADC configuration
+ * @name   ADC configuration
  * @{
  */
 #define ADC_NUMOF           (0)
 /** @} */
 
 /**
- * @brief   DAC configuration
+ * @name   DAC configuration
  * @{
  */
 #define DAC_NUMOF           (0)

--- a/boards/nucleo32-l031/include/periph_conf.h
+++ b/boards/nucleo32-l031/include/periph_conf.h
@@ -150,7 +150,7 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @brief   ADC configuration
+ * @name   ADC configuration
  * @{
  */
 #define ADC_NUMOF           (0)
@@ -158,7 +158,7 @@ static const spi_conf_t spi_config[] = {
 
 
 /**
- * @brief   DAC configuration
+ * @name   DAC configuration
  * @{
  */
 #define DAC_NUMOF           (0)


### PR DESCRIPTION
There were still some remaining for ADC and DAC.