### PR TITLE
boards/pba-d-01-kw2x: add Darwin serial port

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -8,6 +8,7 @@ export MCPU = cortex-m4
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 .PHONY: flash
 flash: $(RIOTCPU)/kinetis_common/dist/wdog-disable.bin


### PR DESCRIPTION
Very small addition to support `make term` on OS X.