### PR TITLE
cpu/samd21: fix NVM wait states

### DIFF
--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -33,9 +33,9 @@ static void clk_init(void)
 
     /* adjust NVM wait states, see table 42.30 (p. 1070) in the datasheet */
 #if (CLOCK_CORECLOCK > 24000000)
-    PM->APBAMASK.reg |= PM_AHBMASK_NVMCTRL;
+    PM->APBBMASK.reg |= PM_APBBMASK_NVMCTRL;
     NVMCTRL->CTRLB.reg |= NVMCTRL_CTRLB_RWS(1);
-    PM->APBAMASK.reg &= ~PM_AHBMASK_NVMCTRL;
+    PM->APBBMASK.reg &= ~PM_APBBMASK_NVMCTRL;
 #endif
 
     /* configure internal 8MHz oscillator to run without prescaler */


### PR DESCRIPTION
While looking in cpu/samd21 I found a small bug. See commit.
Moreover, I've noticed another bug but I don't know how to fix it. I opened an issue because it also related to Atmel CMSIS see #6874 
Cheers !