### PR TITLE
cpu/stm32f3: fix for non-functional i2c

### DIFF
--- a/cpu/stm32f3/cpu.c
+++ b/cpu/stm32f3/cpu.c
@@ -140,5 +140,15 @@ static void cpu_clock_init(void)
     /* disable the HSI if we use the HSE */
     RCC->CR &= ~(RCC_CR_HSION);
     while (RCC->CR & RCC_CR_HSIRDY) {}
+
+    /* swith I2Cx clock source to SYSCLK */
+    RCC->CFGR3 &= ~(RCC_CFGR3_I2CSW);
+    RCC->CFGR3 |= RCC_CFGR3_I2C1SW_SYSCLK;
+#ifdef RCC_CFGR3_I2C2SW_SYSCLK
+    RCC->CFGR3 |= RCC_CFGR3_I2C2SW_SYSCLK;
+#endif
+#ifdef RCC_CFGR3_I2C3SW_SYSCLK
+    RCC->CFGR3 |= RCC_CFGR3_I2C3SW_SYSCLK;
+#endif
 #endif
 }


### PR DESCRIPTION
According to the STM32F3 clocktree (ref. manual p. 126) the I2CX
hardware is driven by either HSI or SYSCLK.
If HSI is deactivated SYSCLK clock must be selected as I2CX clock.

Without this change i2c can't be used. This regression was introduced by cc5a06d954cdb3beb388e81b75d26a9a0c28216f (" cpu: Add clock source selection based on CLOCK_HSE or CLOCK_HSI for STM32F3 family.").