### PR TITLE
boards/nucleo144-common: add arduino feature

### DIFF
--- a/boards/nucleo144-common/Makefile.features
+++ b/boards/nucleo144-common/Makefile.features
@@ -1,2 +1,3 @@
 # Various common features of Nucleo-144 boards
 FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += arduino

--- a/boards/nucleo144-common/include/arduino_board.h
+++ b/boards/nucleo144-common/include/arduino_board.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C)  2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo144-common
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Alexandre Abadie  <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_14,
+    ARDUINO_PIN_15,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/nucleo144-common/include/arduino_pinmap.h
+++ b/boards/nucleo144-common/include/arduino_pinmap.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C)  2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo144-common
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#if defined(CPU_MODEL_STM32F303ZE)
+#define ARDUINO_PIN_0           GPIO_PIN(PORT_C, 5)
+#define ARDUINO_PIN_1           GPIO_PIN(PORT_C, 4)
+#else
+#define ARDUINO_PIN_0           GPIO_PIN(PORT_G, 9)
+#define ARDUINO_PIN_1           GPIO_PIN(PORT_G, 14)
+#endif
+#define ARDUINO_PIN_2           GPIO_PIN(PORT_F, 15)
+#define ARDUINO_PIN_3           GPIO_PIN(PORT_E, 13)
+#define ARDUINO_PIN_4           GPIO_PIN(PORT_F, 14)
+#define ARDUINO_PIN_5           GPIO_PIN(PORT_E, 11)
+#define ARDUINO_PIN_6           GPIO_PIN(PORT_E, 9)
+#define ARDUINO_PIN_7           GPIO_PIN(PORT_F, 13)
+
+#define ARDUINO_PIN_8           GPIO_PIN(PORT_F, 12)
+#define ARDUINO_PIN_9           GPIO_PIN(PORT_D, 15)
+#define ARDUINO_PIN_10          GPIO_PIN(PORT_D, 14)
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_A, 7)
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_A, 6)
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_A, 5)
+
+#define ARDUINO_PIN_14          GPIO_PIN(PORT_B, 8)
+#define ARDUINO_PIN_15          GPIO_PIN(PORT_B, 9)
+
+#define ARDUINO_PIN_A0          GPIO_PIN(PORT_A, 3)
+#define ARDUINO_PIN_A1          GPIO_PIN(PORT_C, 0)
+#define ARDUINO_PIN_A2          GPIO_PIN(PORT_C, 3)
+#if defined(CPU_MODEL_STM32F413ZH)
+#define ARDUINO_PIN_A3          GPIO_PIN(PORT_C, 1)
+#define ARDUINO_PIN_A4          GPIO_PIN(PORT_C, 4)
+#define ARDUINO_PIN_A5          GPIO_PIN(PORT_C, 5)
+#elif defined(CPU_MODEL_STM32F303ZE)
+#define ARDUINO_PIN_A3          GPIO_PIN(PORT_D, 11)
+#define ARDUINO_PIN_A4          GPIO_PIN(PORT_D, 12)
+#define ARDUINO_PIN_A5          GPIO_PIN(PORT_D, 13)
+#else
+#define ARDUINO_PIN_A3          GPIO_PIN(PORT_F, 3)
+#define ARDUINO_PIN_A4          GPIO_PIN(PORT_F, 5)
+#define ARDUINO_PIN_A5          GPIO_PIN(PORT_F, 10)
+#endif
+/** @ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/nucleo144-common/include/board_common.h
+++ b/boards/nucleo144-common/include/board_common.h
@@ -25,6 +25,7 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
+#include "arduino_pinmap.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The nucleo-144 boards have a compatible arduino pinout. This PR brings this feature to this family of boards.