### PR TITLE
boards/nucleo144: fix uninitialized on-board leds

### DIFF
--- a/boards/nucleo144-f303/board.c
+++ b/boards/nucleo144-f303/board.c
@@ -28,4 +28,6 @@ void board_init(void)
 
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
 }

--- a/boards/nucleo144-f429/board.c
+++ b/boards/nucleo144-f429/board.c
@@ -28,4 +28,6 @@ void board_init(void)
 
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
 }

--- a/boards/nucleo144-f446/board.c
+++ b/boards/nucleo144-f446/board.c
@@ -28,4 +28,6 @@ void board_init(void)
 
     /* initialize the boards LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
 }


### PR DESCRIPTION
A small fix with on-board leds for nucleo-144: those boards have 3 of them.