### PR TITLE
doc: correct naming of doxygen group in core

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -64,7 +64,7 @@ extern "C" {
 #endif
 
 /**
- *
+ * @name Debugging defines
  * @{
  */
 #if ENABLE_DEBUG

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -85,7 +85,7 @@ enum {
 #endif /* __clang__ */
 
 /**
- * @brief logging convenience defines
+ * @name Logging convenience defines
  * @{
  */
 #define LOG_ERROR(...) LOG(LOG_ERROR, __VA_ARGS__)

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -132,13 +132,13 @@
 #endif
 
 /**
- * @brief Thread status list
+ * @name List of thread states
  * @{
  */
 #define STATUS_NOT_FOUND        (-1)            /**< Describes an illegal thread status */
 
 /**
- * @brief Blocked states.
+ * @name Blocked states
  * @{
  */
 #define STATUS_STOPPED              0   /**< has terminated                     */
@@ -153,7 +153,7 @@
 /** @} */
 
 /**
- * @brief These have to be on a run queue.
+ * @name Queued states
  * @{*/
 #define STATUS_ON_RUNQUEUE      STATUS_RUNNING  /**< to check if on run queue:
                                                  `st >= STATUS_ON_RUNQUEUE`             */


### PR DESCRIPTION
this refines doxygen docu in `core`, groups in doxygen should have `@name` instead of `@brief`.