### PR TITLE
doc: fix calliope-mini group name

### DIFF
--- a/boards/calliope-mini/include/board.h
+++ b/boards/calliope-mini/include/board.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    boards_mini Calliope mini
+ * @defgroup    boards_calliope-mini Calliope mini
  * @ingroup     boards
  * @brief       Board specific files for the Calliope mini
  * @{


### PR DESCRIPTION
The board is referred to as `boards_calliope-mini` throughout the doc, but it's name definition contains a typo ;-).