### PR TITLE
doc: remove unhelpful lists

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -591,20 +591,20 @@ STRICT_PROTO_MATCHING  = NO
 # documentation.
 # The default value is: YES.
 
-GENERATE_TODOLIST      = YES
+GENERATE_TODOLIST      = NO
 
 # The GENERATE_TESTLIST tag can be used to enable ( YES) or disable ( NO) the
 # test list. This list is created by putting \test commands in the
 # documentation.
 # The default value is: YES.
 
-GENERATE_TESTLIST      = YES
+GENERATE_TESTLIST      = NO
 
 # The GENERATE_BUGLIST tag can be used to enable ( YES) or disable ( NO) the bug
 # list. This list is created by putting \bug commands in the documentation.
 # The default value is: YES.
 
-GENERATE_BUGLIST       = YES
+GENERATE_BUGLIST       = NO
 
 # The GENERATE_DEPRECATEDLIST tag can be used to enable ( YES) or disable ( NO)
 # the deprecated list. This list is created by putting \deprecated commands in


### PR DESCRIPTION
The [Todo list](http://doc.riot-os.org/todo.html) isn't very helpful (things are duplicate due to name clashes in `cpu/` and `boards/` mainly) and we have [other means and workflows](https://github.com/RIOT-OS/RIOT/issues) to collect such TODOs. In the doc themself they are helpful, however.

As a bonus I also removed the bugs list, which we don't use at the moment (and are also already covered by issues, too) and the tests list, which we don't use either. Although, [the latter](https://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdtest) could be useful to model test cases... What do you thing @A-Paul?