### PR TITLE
cpu/mips: Integrate better with RIOT newlib layer (v2)

### DIFF
--- a/boards/mips-malta/Makefile.include
+++ b/boards/mips-malta/Makefile.include
@@ -1,4 +1,5 @@
 export CPU = mips32r2_common
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
-export USE_HARD_FLOAT = 1
+#export USE_HARD_FLOAT = 1
 export USE_DSP = 1
+export USE_UHI_SYSCALLS = 1

--- a/boards/mips-malta/include/periph_conf.h
+++ b/boards/mips-malta/include/periph_conf.h
@@ -41,16 +41,6 @@ extern "C" {
  */
 #define UART_NUMOF          (0)
 
-/**
- * @brief   Enable DSP context save + restore.
- */
-#define MIPS_DSP            (1)
-
-/**
- * @brief   Enable FPU context save + restore.
- */
-#define MIPS_HARD_FLOAT     (1)
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/pic32-clicker/Makefile.include
+++ b/boards/pic32-clicker/Makefile.include
@@ -2,3 +2,4 @@ export CPU = mips_pic32mx
 export CPU_MODEL=p32mx470f512h
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
+export USE_UHI_SYSCALLS = 1

--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -2,3 +2,4 @@ export CPU = mips_pic32mz
 export CPU_MODEL=p32mz2048efg100
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
+export USE_UHI_SYSCALLS = 1

--- a/cpu/mips32r2_common/Makefile
+++ b/cpu/mips32r2_common/Makefile
@@ -1,4 +1,4 @@
 MODULE = cpu
-DIRS = periph
+DIRS = periph newlib_syscalls_mips_uhi
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -4,7 +4,6 @@ export APP_START=0x80000000
 
 include $(RIOTMAKE)/arch/mips.inc.mk
 
-export LINKFLAGS += -Tuhi32.ld
 export USEMODULE += periph
 export USEMODULE += newlib
 

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -6,3 +6,5 @@ include $(RIOTMAKE)/arch/mips.inc.mk
 
 export LINKFLAGS += -Tuhi32.ld
 export USEMODULE += periph
+export USEMODULE += newlib
+export USEMODULE += newlib_syscalls_mips_uhi

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -7,4 +7,13 @@ include $(RIOTMAKE)/arch/mips.inc.mk
 export LINKFLAGS += -Tuhi32.ld
 export USEMODULE += periph
 export USEMODULE += newlib
-export USEMODULE += newlib_syscalls_mips_uhi
+
+ifeq ($(USE_UHI_SYSCALLS),1)
+  #Use UHI to handle syscalls
+  export LINKFLAGS += -luhi -Tuhi32.ld
+  export USEMODULE += newlib_syscalls_mips_uhi
+else
+  #Use RIOT to handle syscalls (default)
+  export LINKFLAGS += -Tuhi32.ld
+  export USEMODULE += newlib_syscalls_default
+endif

--- a/cpu/mips32r2_common/cpu.c
+++ b/cpu/mips32r2_common/cpu.c
@@ -60,10 +60,6 @@ void mips_start(void)
 {
     board_init();
 
-#if MODULE_NEWLIB
-#error "This Port is designed to work with the (newlib) C library provided with the mips sdk toolchain"
-#endif
-
     /* kernel_init */
     kernel_init();
 }

--- a/cpu/mips32r2_common/newlib_syscalls_mips_uhi/Makefile
+++ b/cpu/mips32r2_common/newlib_syscalls_mips_uhi/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
+++ b/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2017 whoever implements this
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @todo Here there should be a syscall implementation for use with the mips-mti-elf toolchain newlib
+ */
+typedef int dont_be_pedantic;

--- a/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
+++ b/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
@@ -12,7 +12,7 @@
   *
   * @file
   * @brief Newlib system call implementation for use with the mips-mti-elf
-  * toolchain newlib incoporating as sem-hosting interface caled 'UHI'
+  * toolchain newlib incorporating as semi-hosting interface called 'UHI'
   *
   * @author Neil Jones <neil.jones@imgtec.com>
   *
@@ -49,7 +49,7 @@ char *heap_top = &_sheap + 4;
 /**
  * @brief Free resources on NewLib de-initialization, not used for RIOT
  */
- 
+
 /* __attribute__((used)) fixes linker errors when building with LTO, but without nano.specs */
 __attribute__((used)) void _fini(void)
 {
@@ -69,7 +69,6 @@ void _exit(int n)
 {
     exit(n);
     pm_off();
-    while(1);
 }
 
 /**

--- a/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
+++ b/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
@@ -1,11 +1,328 @@
 /*
- * Copyright (C) 2017 whoever implements this
+ * Copyright (C) 2017 Imagination Technologies
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+
 /**
- * @todo Here there should be a syscall implementation for use with the mips-mti-elf toolchain newlib
+  * @ingroup sys_newlib
+  * @{
+  *
+  * @file
+  * @brief Newlib system call implementation for use with the mips-mti-elf
+  * toolchain newlib incoporating as sem-hosting interface caled 'UHI'
+  *
+  * @author Neil Jones <neil.jones@imgtec.com>
+  *
+  * @}
+  */
+
+#include <unistd.h>
+#include <reent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/unistd.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <mips/hal.h>
+
+#include "cpu.h"
+#include "board.h"
+#include "sched.h"
+#include "thread.h"
+#include "irq.h"
+#include "log.h"
+#include "periph/pm.h"
+
+/**
+ * * @brief manage the heap
+ * */
+extern char _sheap; /* start of the heap */
+extern char _eheap; /* end of the heap */
+char *heap_top = &_sheap + 4;
+
+/**
+ * @brief Free resources on NewLib de-initialization, not used for RIOT
  */
-typedef int dont_be_pedantic;
+ 
+/* __attribute__((used)) fixes linker errors when building with LTO, but without nano.specs */
+__attribute__((used)) void _fini(void)
+{
+    /* nothing to do here */
+}
+
+/**
+* @brief Exit a program without cleaning up files
+*
+* If your system doesn't provide this, it is best to avoid linking with subroutines that
+* require it (exit, system).
+*
+* @param n the exit code, 0 for all OK, >0 for not OK
+*/
+
+void _exit(int n)
+{
+    exit(n);
+    pm_off();
+    while(1);
+}
+
+/**
+* @brief Allocate memory from the heap.
+*
+* The current heap implementation is very rudimentary, it is only able to allocate
+* memory. But it does not have any means to free memory again
+*
+* @return pointer to the newly allocated memory on success
+* @return pointer set to address `-1` on failure
+*/
+
+void *_sbrk_r(struct _reent *r, ptrdiff_t incr)
+{
+    unsigned int state = irq_disable();
+    void *res = heap_top;
+    if ((heap_top + incr > &_eheap) || (heap_top + incr < &_sheap)) {
+        r->_errno = ENOMEM;
+        res = (void *)-1;
+    } else {
+        heap_top += incr;
+    }
+    irq_restore(state);
+    return res;
+}
+
+/**
+* @brief Get the process-ID of the current thread
+*
+* @return the process ID of the current thread
+*/
+pid_t _getpid(void)
+{
+    return sched_active_pid;
+}
+
+/**
+* @brief Get the process-ID of the current thread
+*
+* @return the process ID of the current thread
+*/
+pid_t _getpid_r(struct _reent *ptr)
+{
+    (void) ptr;
+    return sched_active_pid;
+}
+
+/**
+* @brief Send a signal to a given thread
+*
+* @param r pointer to reent structure
+* @param pid process ID to kill
+* @param sig signal number to pass to process
+*
+* @return -1 on error
+* @return 0 on sucess
+*/
+__attribute__ ((weak))
+int _kill_r(struct _reent *r, pid_t pid, int sig)
+{
+    (void) pid;
+    (void) sig;
+    r->_errno = ESRCH; /* not implemented yet */
+    return -1;
+}
+
+/**
+* @brief Open a file
+*
+* This is a wrapper around @c _open
+*
+* @param r pointer to reent structure
+* @param name file name to open
+* @param flags flags, see man 3p open
+* @param mode mode, file creation mode if the file is created when opening
+*
+* @return fd number (>= 0) on success
+* @return -1 on error
+*/
+int _open_r(struct _reent *r, const char *name, int flags, int mode)
+{
+    return open(name, flags, mode);
+}
+
+/**
+* @brief Read bytes from an open file
+*
+* This is a wrapper around @c _read
+*
+* @param[in] r pointer to reent structure
+* @param[in] fd open file descriptor obtained from @c open()
+* @param[out] dest destination buffer
+* @param[in] count maximum number of bytes to read
+*
+* @return number of bytes read on success
+* @return -1 on error,
+*/
+_ssize_t _read_r(struct _reent *r, int fd, void *dest, size_t count)
+{
+    return read(fd,dest,count);
+}
+
+/**
+* @brief Write bytes to an open file
+*
+* This is a wrapper around @c _write
+*
+* @param[in] r pointer to reent structure
+* @param[in] fd open file descriptor obtained from @c open()
+* @param[in] src source data buffer
+* @param[in] count maximum number of bytes to write
+*
+* @return number of bytes written on success
+* @return -1 on error
+*/
+_ssize_t _write_r(struct _reent *r, int fd, const void *src, size_t count)
+{
+    int res = write(fd, src, count);
+    return res;
+}
+
+/**
+* @brief Close an open file
+*
+* This is a wrapper around @c _close
+*
+* If this call returns an error, the fd should still be considered invalid and
+* no further attempt to use it shall be made, not even to retry @c close()
+*
+* @param[in] r pointer to reent structure
+* @param[in] fd open file descriptor obtained from @c open()
+*
+* @return 0 on success
+* @return -1 on error
+*/
+int _close_r(struct _reent *r, int fd)
+{
+    int res = close(fd);
+    return res;
+}
+
+/**
+* @brief Query or set options on an open file
+*
+* This is a wrapper around @c _fcntl
+*
+* @param[in] r pointer to reent structure
+* @param[in] fd open file descriptor obtained from @c open()
+* @param[in] cmd fcntl command, see man 3p fcntl
+* @param[in] arg argument to fcntl command, see man 3p fcntl
+*
+* @return 0 on success
+* @return -1 on error
+*/
+int _fcntl_r (struct _reent *r, int fd, int cmd, int arg)
+{
+    int res = fcntl(fd, cmd, arg);
+    return res;
+}
+
+/**
+* @brief Seek to position in file
+*
+* This is a wrapper around @c _lseek
+*
+* @p whence determines the function of the seek and should be set to one of
+* the following values:
+*
+* - @c SEEK_SET: Seek to absolute offset @p off
+* - @c SEEK_CUR: Seek to current location + @p off
+* - @c SEEK_END: Seek to end of file + @p off
+*
+* @param[in] r pointer to reent structure
+* @param[in] fd open file descriptor obtained from @c open()
+* @param[in] off seek offset
+* @param[in] whence determines the seek method, see detailed description
+*
+* @return the new seek location in the file on success
+* @return -1 on error
+*/
+_off_t _lseek_r(struct _reent *r, int fd, _off_t off, int whence)
+{
+    int res = lseek(fd, off, whence);
+    return res;
+}
+
+/**
+* @brief Get status of an open file
+*
+* This is a wrapper around @c _fstat
+*
+* @param[in] r pointer to reent structure
+* @param[in] fd open file descriptor obtained from @c open()
+* @param[out] buf pointer to stat struct to fill
+*
+* @return 0 on success
+* @return -1 on error
+*/
+int _fstat_r(struct _reent *r, int fd, struct stat *buf)
+{
+    int res = fstat(fd, buf);
+    return res;
+}
+
+/*
+* @brief Unlink (delete) a file
+*
+* @param[in] r pointer to reent structure
+* @param[in] path path to file to be deleted
+*
+* @return 0 on success
+* @return -1 on error
+*/
+int _unlink_r(struct _reent *r, const char *path)
+{
+    int res = unlink(path);
+    return res;
+}
+
+/**
+* @brief Query whether output stream is a terminal
+*
+* @param r pointer to reent structure
+* @param fd descriptor of stream to query
+*
+* @return 0 for none tty
+* @return 1 for tty
+*
+*/
+int _isatty_r(struct _reent *r, int fd)
+{
+    r->_errno = 0;
+    if(fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO) {
+        return 1;
+    }
+    return 0;
+}
+
+/**
+* @brief Send a signal to a thread
+*
+* @param[in] pid the pid to send to
+* @param[in] sig the signal to send
+*
+* @return 0 on success
+* @return -1 on error
+*
+*/
+__attribute__ ((weak))
+int _kill(pid_t pid, int sig)
+{
+    (void) pid;
+    (void) sig;
+    errno = ESRCH; /* not implemented yet */
+    return -1;
+}

--- a/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
+++ b/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
@@ -68,6 +68,12 @@ __attribute__((used)) void _fini(void)
 void _exit(int n)
 {
     exit(n);
+
+    /*
+     * Disable unreachableCode cppcheck as pm_off spins indefinately after
+     * pulling the plug
+     */
+    /* cppcheck-suppress unreachableCode */
     pm_off();
 }
 

--- a/cpu/mips32r2_common/thread_arch.c
+++ b/cpu/mips32r2_common/thread_arch.c
@@ -165,7 +165,11 @@ struct linkctx* exctx_find(reg_t id, struct gpctx *gp)
 }
 
 /* unaligned access helper */
-static inline uint32_t __attribute__((optimize("-O3")))
+static inline uint32_t
+#ifndef __clang__
+/* Clang does not support attribute optimize */
+__attribute__((optimize("-O3")))
+#endif
 mem_rw(const void *vaddr)
 {
     uint32_t v;

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -1,6 +1,3 @@
-export MEMORY_BASE=0x80000000
-export MEMORY_SIZE=128K
-export APP_START=0x80000000
 export ROMABLE = 1
 
 include $(RIOTMAKE)/arch/mips.inc.mk
@@ -9,7 +6,18 @@ include $(RIOTCPU)/mips_pic32_common/Makefile.include
 # define build specific options
 export CFLAGS += -march=m4k -DSKIP_COPY_TO_RAM
 
+export USEMODULE += mips_pic32_common
 export USEMODULE += periph
+export USEMODULE += newlib
+
+ifeq ($(USE_UHI_SYSCALLS),1)
+  #Use UHI to handle syscalls
+  export LINKFLAGS += -luhi
+  export USEMODULE += newlib_syscalls_mips_uhi
+else
+  #Use RIOT to handle syscalls (default)
+  export USEMODULE += newlib_syscalls_default
+endif
 
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
 export LINKFLAGS += -Tpic32mx512_12_128_uhi.ld

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -12,7 +12,7 @@ export CFLAGS += -march=m4k -DSKIP_COPY_TO_RAM
 export USEMODULE += periph
 
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
-export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/pic32mx512_12_128_uhi.ld
+export LINKFLAGS += -Tpic32mx512_12_128_uhi.ld
 
 # the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
 export OBJCOPY = objcopy #use system objcopy as toolchain one is broken.

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -1,6 +1,3 @@
-export MEMORY_BASE=0x80000000
-export MEMORY_SIZE=512K
-export APP_START=0x80000000
 export ROMABLE = 1
 
 include $(RIOTMAKE)/arch/mips.inc.mk
@@ -10,7 +7,19 @@ include $(RIOTCPU)/mips_pic32_common/Makefile.include
 export CFLAGS += -march=m5101 -mmicromips -DSKIP_COPY_TO_RAM
 export CFLAGS += -DMIPS_MICROMIPS
 
+export USEMODULE += mips_pic32_common
 export USEMODULE += periph
+export USEMODULE += newlib
+
+ifeq ($(USE_UHI_SYSCALLS),1)
+  #Use UHI to handle syscalls
+  export LINKFLAGS += -luhi
+  export USEMODULE += newlib_syscalls_mips_uhi
+else
+  #Use RIOT to handle syscalls (default)
+  export USEMODULE += newlib_syscalls_default
+endif
+
 
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
 export LINKFLAGS += -Tpic32mz2048_uhi.ld

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -13,7 +13,7 @@ export CFLAGS += -DMIPS_MICROMIPS
 export USEMODULE += periph
 
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
-export LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ldscripts/pic32mz2048_uhi.ld
+export LINKFLAGS += -Tpic32mz2048_uhi.ld
 
 # the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
 export OBJCOPY = objcopy #use system objcopy as toolchain one is broken.

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -49,6 +49,12 @@ ifeq ($(USE_DSP),1)
     export CFLAGS += -mdsp
 endif
 
+ifeq ($(TOOLCHAIN),llvm)
+# The MIPS toolchain headers in assembly mode are not compatible with Clang
+export CCAS = $(PREFIX)gcc
+export CCASUWFLAGS += -target $(TARGET_ARCH)
+endif
+
 export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_OPT) $(CFLAGS_DBG)
 
 export LINKFLAGS += $(MIPS_HAL_LDFLAGS)

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -1,31 +1,47 @@
-ifndef MIPS_ELF_ROOT
-ifneq ($(BUILD_IN_DOCKER),1) #Don't error when BUILD_IN_DOCKER=1 as it _is_ set in DOCKER
-    $(error "Please set $$(MIPS_ELF_ROOT) and ensure $$(MIPS_ELF_ROOT)/bin is on your PATH")
-endif
-endif
-
 # Target triple for the build.
 export TARGET_ARCH ?= mips-mti-elf
 
 export ABI=32
 
-ifneq ($(BUILD_IN_DOCKER),1) #Don't error when BUILD_IN_DOCKER=1 as MIPS_ELF_ROOT _is_ set in DOCKER
-include $(MIPS_ELF_ROOT)/share/mips/rules/mipshal.mk
-endif
+# Portable 'lowercase' func.
+lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
+
+# Default values for the linker script symbols listed below are
+# defined in the linker script.
+
+# These are linker script symbols that are prefixed with '__"
+priv_symbols = MEMORY_BASE MEMORY_SIZE STACK
+priv_symbols += ENABLE_XPA
+priv_symbols += FLUSH_TO_ZERO
+priv_symbols += FLASH_START APP_START FLASH_APP_START
+priv_symbols += ISR_VEC_SPACE ISR_VECTOR_COUNT
+
+comma := ,
+
+# A bit of makefile magic:
+# foreach symbol in overridable ld-symbols :
+#   If symbol has a value, produce a linker argument for that symbol.
+MIPS_HAL_LDFLAGS = $(foreach a,$(priv_symbols),$(if $($a),-Wl$(comma)--defsym$(comma)__$(call lc,$(a))=$($a)))
 
 # define build specific options
-export CFLAGS_CPU   = -EL -std=gnu99
+# Remove -std=gnu99 once the MIPS toolchain headers are updated to include upstream
+# newlib commit 81c17949f0419d1c4fee421c60987ea1149522ae
+# https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=commitdiff;h=81c17949f0419d1c4fee421c60987ea1149522ae
+# Otherwise we get an error about a missing declaration of strnlen in some parts.
+export CFLAGS += -std=gnu99
+export CFLAGS_CPU   = -EL -mabi=$(ABI)
+# Why not -fdata-sections?? /JN
 export CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums #-fdata-sections
-export CFLAGS_DBG = -O0 -g2
-export CFLAGS_OPT = -Os -g2
+export CFLAGS_DBG   = -g3
+export CFLAGS_OPT   = -Os
 
-export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_OPT)
-#$(CFLAGS_DBG)
+export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_OPT) $(CFLAGS_DBG)
 
 ifeq ($(USE_HARD_FLOAT),1)
     export CFLAGS += -mhard-float
 else
-    export CFLAGS += -msoft-float #hard-float is the default so we must set soft-float
+    #hard-float is the default so we must set soft-float
+    export CFLAGS += -msoft-float
     export LINKFLAGS += -msoft-float
 endif
 
@@ -33,9 +49,10 @@ ifeq ($(USE_DSP),1)
     export CFLAGS += -mdsp
 endif
 
-export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_OPT) #$(CFLAGS_DBG)
+export ASFLAGS += $(CFLAGS_CPU) $(CFLAGS_OPT) $(CFLAGS_DBG)
 
-export LINKFLAGS += $(MIPS_HAL_LDFLAGS) -mabi=$(ABI)
+export LINKFLAGS += $(MIPS_HAL_LDFLAGS)
+export LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts
 export LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT)
 export LINKFLAGS += -Wl,--gc-sections
 

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -23,6 +23,10 @@ comma := ,
 #   If symbol has a value, produce a linker argument for that symbol.
 MIPS_HAL_LDFLAGS = $(foreach a,$(priv_symbols),$(if $($a),-Wl$(comma)--defsym$(comma)__$(call lc,$(a))=$($a)))
 
+ifeq ($(ROMABLE),1)
+MIPS_HAL_LDFLAGS += -T bootcode.ld
+endif
+
 # define build specific options
 # Remove -std=gnu99 once the MIPS toolchain headers are updated to include upstream
 # newlib commit 81c17949f0419d1c4fee421c60987ea1149522ae

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -34,8 +34,7 @@ endif
 # Otherwise we get an error about a missing declaration of strnlen in some parts.
 export CFLAGS += -std=gnu99
 export CFLAGS_CPU   = -EL -mabi=$(ABI)
-# Why not -fdata-sections?? /JN
-export CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums #-fdata-sections
+export CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums -fdata-sections
 export CFLAGS_DBG   = -g3
 export CFLAGS_OPT   = -Os
 

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -41,7 +41,7 @@ export CFLAGS_OPT   = -Os
 export CFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_OPT) $(CFLAGS_DBG)
 
 ifeq ($(USE_HARD_FLOAT),1)
-    export CFLAGS += -mhard-float
+    export CFLAGS += -mhard-float -DMIPS_HARD_FLOAT
 else
     #hard-float is the default so we must set soft-float
     export CFLAGS += -msoft-float
@@ -49,7 +49,7 @@ else
 endif
 
 ifeq ($(USE_DSP),1)
-    export CFLAGS += -mdsp
+    export CFLAGS += -mdsp -DMIPS_DSP
 endif
 
 ifeq ($(TOOLCHAIN),llvm)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -13,7 +13,11 @@ ifeq (1,$(USE_NEWLIB_NANO))
   export LINKFLAGS += -specs=nano.specs
 endif
 
-export LINKFLAGS += -lc -lnosys
+ifeq ($(TARGET_ARCH),mips-mti-elf)
+ export LINKFLAGS += -lc
+else
+ export LINKFLAGS += -lc -lnosys
+endif
 
 # Search for Newlib include directories
 

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -58,6 +58,8 @@ extern char _sheap;                 /* start of the heap */
 extern char _eheap;                 /* end of the heap */
 char *heap_top = &_sheap + 4;
 
+/* MIPS newlib crt implements _init,_fini and _exit and manages the heap */
+#ifndef __mips__
 /**
  * @brief Initialize NewLib, called by __libc_init_array() from the startup script
  */
@@ -115,6 +117,8 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t incr)
     irq_restore(state);
     return res;
 }
+
+#endif /*__mips__*/
 
 /**
  * @brief Get the process-ID of the current thread

--- a/sys/posix/include/fcntl.h
+++ b/sys/posix/include/fcntl.h
@@ -15,10 +15,8 @@
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/fcntl.h.html
  */
 
-/** @todo Remove ifdef __mips__ special case after
- * [#6639](https://github.com/RIOT-OS/RIOT/pull/6639) is merged */
 #ifndef DOXYGEN
-#if defined(CPU_NATIVE) || MODULE_NEWLIB || defined(__mips__)
+#if defined(CPU_NATIVE) || MODULE_NEWLIB
 /* If building on native or newlib we need to use the system header instead */
 #pragma GCC system_header
 /* without the GCC pragma above #include_next will trigger a pedantic error */

--- a/sys/posix/include/sys/statvfs.h
+++ b/sys/posix/include/sys/statvfs.h
@@ -22,9 +22,7 @@
 #define SYS_STATVFS_H
 
 #include <sys/types.h> /* for fsblkcnt_t, fsfilcnt_t */
-/** @todo Remove ifdef __mips__ special case after
- * [#6639](https://github.com/RIOT-OS/RIOT/pull/6639) is merged */
-#if MODULE_NEWLIB || defined(__mips__)
+#if MODULE_NEWLIB
 /* newlib support for fsblkcnt_t was only recently added to the newlib git
  * repository, commit f3e587d30a9f65d0c6551ad14095300f6e81672e, 15 apr 2016.
  * Will be included in release 2.5.0, around new year 2016/2017.


### PR DESCRIPTION
This is an update to #6639 as contributed by @gebart .
Depends on ~~#6670~~

- Copied the relevant parts of mipshal.mk from the toolchain
- Cleaned up CFLAGS and more in Makefile.include
- Added syscalls implementation which can be used to interface with the UHI system, in reference to #6588 (comment)
- Added a note on why -std=gnu99 is necessary for this CPU presently, should be removed once the toolchain is updated to a more recent newlib version.
- Various other makefile clean-up for MIPS
