### PR TITLE
saul: add missing headers in auto_init

### DIFF
--- a/sys/auto_init/saul/auto_init_adc.c
+++ b/sys/auto_init/saul/auto_init_adc.c
@@ -25,7 +25,7 @@
 #include "saul_reg.h"
 #include "saul/periph.h"
 #include "adc_params.h"
-#include "periph/gpio.h"
+#include "periph/adc.h"
 
 /**
  * @brief   Define the number of configured sensors

--- a/sys/auto_init/saul/auto_init_bme280.c
+++ b/sys/auto_init/saul/auto_init_bme280.c
@@ -22,9 +22,8 @@
 
 #include "log.h"
 #include "saul_reg.h"
-
-#include "bme280_params.h"
 #include "bme280.h"
+#include "bme280_params.h"
 
 /**
  * @brief   Allocation of memory for device descriptors

--- a/sys/auto_init/saul/auto_init_bmp180.c
+++ b/sys/auto_init/saul/auto_init_bmp180.c
@@ -22,7 +22,7 @@
 
 #include "log.h"
 #include "saul_reg.h"
-
+#include "bmp180.h"
 #include "bmp180_params.h"
 
 /**

--- a/sys/auto_init/saul/auto_init_hdc1000.c
+++ b/sys/auto_init/saul/auto_init_hdc1000.c
@@ -23,7 +23,6 @@
 
 #include "log.h"
 #include "saul_reg.h"
-
 #include "hdc1000.h"
 #include "hdc1000_params.h"
 

--- a/sys/auto_init/saul/auto_init_io1_xplained.c
+++ b/sys/auto_init/saul/auto_init_io1_xplained.c
@@ -22,7 +22,6 @@
 
 #include "log.h"
 #include "saul_reg.h"
-
 #include "io1_xplained.h"
 #include "io1_xplained_params.h"
 

--- a/sys/auto_init/saul/auto_init_jc42.c
+++ b/sys/auto_init/saul/auto_init_jc42.c
@@ -22,7 +22,6 @@
 
 #include "log.h"
 #include "saul_reg.h"
-
 #include "jc42.h"
 #include "jc42_params.h"
 

--- a/sys/auto_init/saul/auto_init_mma8x5x.c
+++ b/sys/auto_init/saul/auto_init_mma8x5x.c
@@ -24,7 +24,6 @@
 
 #include "log.h"
 #include "saul_reg.h"
-
 #include "mma8x5x.h"
 #include "mma8x5x_params.h"
 

--- a/sys/auto_init/saul/auto_init_si70xx.c
+++ b/sys/auto_init/saul/auto_init_si70xx.c
@@ -22,9 +22,8 @@
 
 #include "log.h"
 #include "saul_reg.h"
-
-#include "si70xx_params.h"
 #include "si70xx.h"
+#include "si70xx_params.h"
 
 /**
  * @brief   Define the number of configured sensors

--- a/sys/auto_init/saul/auto_init_tsl2561.c
+++ b/sys/auto_init/saul/auto_init_tsl2561.c
@@ -22,7 +22,7 @@
 
 #include "log.h"
 #include "saul_reg.h"
-
+#include "tsl2561.h"
 #include "tsl2561_params.h"
 
 /**

--- a/sys/auto_init/saul/auto_init_veml6070.c
+++ b/sys/auto_init/saul/auto_init_veml6070.c
@@ -22,7 +22,7 @@
 
 #include "log.h"
 #include "saul_reg.h"
-
+#include "veml6070.h"
 #include "veml6070_params.h"
 
 /**


### PR DESCRIPTION
make includes in saul auto_init function consistent, i.e., fixes missing includes.