### PR TITLE
core: byteorder.h: rename NTOH* -> ntoh*, HTON* -> hton*

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -230,7 +230,7 @@ static inline uint64_t byteorder_swapll(uint64_t v);
  * @param[in]      v   The integer to convert.
  * @returns        Converted integer.
  */
-static inline uint16_t HTONS(uint16_t v);
+static inline uint16_t htons(uint16_t v);
 
 /**
  * @brief          Convert from host byte order to network byte order, 32 bit.
@@ -238,7 +238,7 @@ static inline uint16_t HTONS(uint16_t v);
  * @param[in]      v   The integer to convert.
  * @returns        Converted integer.
  */
-static inline uint32_t HTONL(uint32_t v);
+static inline uint32_t htonl(uint32_t v);
 
 /**
  * @brief          Convert from host byte order to network byte order, 64 bit.
@@ -246,7 +246,7 @@ static inline uint32_t HTONL(uint32_t v);
  * @param[in]      v   The integer to convert.
  * @returns        Converted integer.
  */
-static inline uint64_t HTONLL(uint64_t v);
+static inline uint64_t htonll(uint64_t v);
 
 /**
  * @brief          Convert from network byte order to host byte order, 16 bit.
@@ -254,7 +254,7 @@ static inline uint64_t HTONLL(uint64_t v);
  * @param[in]      v   The integer to convert.
  * @returns        Converted integer.
  */
-static inline uint16_t NTOHS(uint16_t v);
+static inline uint16_t ntohs(uint16_t v);
 
 /**
  * @brief          Convert from network byte order to host byte order, 32 bit.
@@ -262,7 +262,7 @@ static inline uint16_t NTOHS(uint16_t v);
  * @param[in]      v   The integer to convert.
  * @returns        Converted integer.
  */
-static inline uint32_t NTOHL(uint32_t v);
+static inline uint32_t ntohl(uint32_t v);
 
 /**
  * @brief          Convert from network byte order to host byte order, 64 bit.
@@ -270,7 +270,7 @@ static inline uint32_t NTOHL(uint32_t v);
  * @param[in]      v   The integer to convert.
  * @returns        Converted integer.
  */
-static inline uint64_t NTOHLL(uint64_t v);
+static inline uint64_t ntohll(uint64_t v);
 
 
 /* **************************** IMPLEMENTATION ***************************** */
@@ -385,34 +385,34 @@ static inline uint64_t byteorder_ntohll(network_uint64_t v)
     return _byteorder_swap(v.u64, ll);
 }
 
-static inline uint16_t HTONS(uint16_t v)
+static inline uint16_t htons(uint16_t v)
 {
     return byteorder_htons(v).u16;
 }
 
-static inline uint32_t HTONL(uint32_t v)
+static inline uint32_t htonl(uint32_t v)
 {
     return byteorder_htonl(v).u32;
 }
 
-static inline uint64_t HTONLL(uint64_t v)
+static inline uint64_t htonll(uint64_t v)
 {
     return byteorder_htonll(v).u64;
 }
 
-static inline uint16_t NTOHS(uint16_t v)
+static inline uint16_t ntohs(uint16_t v)
 {
     network_uint16_t input = { v };
     return byteorder_ntohs(input);
 }
 
-static inline uint32_t NTOHL(uint32_t v)
+static inline uint32_t ntohl(uint32_t v)
 {
     network_uint32_t input = { v };
     return byteorder_ntohl(input);
 }
 
-static inline uint64_t NTOHLL(uint64_t v)
+static inline uint64_t ntohll(uint64_t v)
 {
     network_uint64_t input = { v };
     return byteorder_ntohll(input);

--- a/cpu/native/include/clang_compat.h
+++ b/cpu/native/include/clang_compat.h
@@ -15,12 +15,12 @@
 extern "C" {
 #endif
 
-#undef HTONS
-#undef HTONL
-#undef HTONLL
-#undef NTOHS
-#undef NTOHL
-#undef NTOHLL
+#undef htons
+#undef htonl
+#undef htonll
+#undef ntohs
+#undef ntohl
+#undef ntohll
 
 #ifdef __cplusplus
 }

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -28,6 +28,9 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+/* needs to be included before native's declarations of ntohl etc. */
+#include "byteorder.h"
+
 #ifdef __MACH__
 #include <net/if.h>
 #include <sys/types.h>
@@ -55,7 +58,6 @@
 #include "net/ethernet/hdr.h"
 #include "netdev_tap.h"
 #include "net/netopt.h"
-#include "net/eui64.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -22,7 +22,7 @@
 #else
 #include <dlfcn.h>
 #endif
-
+#include "byteorder.h"
 #include <assert.h>
 #include <getopt.h>
 #include <stdbool.h>

--- a/drivers/adt7310/adt7310.c
+++ b/drivers/adt7310/adt7310.c
@@ -151,7 +151,7 @@ int adt7310_init(adt7310_t *dev, spi_t spi, spi_clk_t clk, gpio_t cs)
         if (status != 0) {
             printf("Error reading address 0x%02x", i);
         }
-        dbg_reg = HTONS(dbg_reg);
+        dbg_reg = htons(dbg_reg);
         printf("%02x: %04" PRIx16 "\n", i, dbg_reg);
     }
 #endif
@@ -197,7 +197,7 @@ int16_t adt7310_read_raw(adt7310_t *dev)
         return INT16_MIN;
     }
     /* The temperature value is sent big endian (network byte order) */
-    raw = (int16_t)NTOHS((uint16_t)raw);
+    raw = (int16_t)ntohs((uint16_t)raw);
     return raw;
 }
 

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -67,8 +67,8 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     addr_long.uint8[0] &= ~(0x01);
     addr_long.uint8[0] |=  (0x02);
     /* set short and long address */
-    at86rf2xx_set_addr_long(dev, NTOHLL(addr_long.uint64.u64));
-    at86rf2xx_set_addr_short(dev, NTOHS(addr_long.uint16[0].u16));
+    at86rf2xx_set_addr_long(dev, ntohll(addr_long.uint64.u64));
+    at86rf2xx_set_addr_short(dev, ntohs(addr_long.uint16[0].u16));
 
     /* set default PAN id */
     at86rf2xx_set_pan(dev, AT86RF2XX_DEFAULT_PANID);

--- a/drivers/feetech/feetech.c
+++ b/drivers/feetech/feetech.c
@@ -81,7 +81,7 @@ int feetech_write8(feetech_t *device, feetech_addr_t reg, uint8_t value)
 
 int feetech_write16(feetech_t *device, feetech_addr_t reg, uint16_t value)
 {
-    value = HTONS(value);
+    value = htons(value);
     return feetech_write(device, reg, (uint8_t*)&value, 2);
 }
 
@@ -127,7 +127,7 @@ int feetech_read16(feetech_t *device, feetech_addr_t reg, uint16_t *value)
 {
     const int ret = feetech_read(device, reg, (uint8_t*)value, 2);
     if (ret == FEETECH_OK) {
-        *value = NTOHS(*value);
+        *value = ntohs(*value);
     }
     return ret;
 }

--- a/drivers/ina220/ina220.c
+++ b/drivers/ina220/ina220.c
@@ -45,7 +45,7 @@ static int ina220_read_reg(ina220_t *dev, uint8_t reg, uint16_t *out)
         return -1;
     }
 
-    *out = NTOHS(tmp.u16);
+    *out = ntohs(tmp.u16);
     return 0;
 }
 
@@ -58,7 +58,7 @@ static int ina220_write_reg(ina220_t *dev, uint8_t reg, uint16_t in)
     } tmp = { .u16 = 0 };
     int status = 0;
 
-    tmp.u16 = HTONS(in);
+    tmp.u16 = htons(in);
 
     status = i2c_write_regs(dev->i2c, dev->addr, reg, &tmp.c[0], 2);
 

--- a/drivers/jc42/jc42.c
+++ b/drivers/jc42/jc42.c
@@ -72,7 +72,7 @@ int jc42_get_temperature(jc42_t* dev, int16_t* temperature)
     if (jc42_get_register(dev, JC42_REG_TEMP, &tmp) != 0) {
         return JC42_NODEV;
     }
-    tmp = NTOHS(tmp);
+    tmp = ntohs(tmp);
     /* Convert fixed point to uint16_t */
     *temperature = ((s.x = tmp)*100)>>4;
     return JC42_OK;

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -50,8 +50,8 @@ static void kw2xrf_set_address(kw2xrf_t *dev)
     addr_long.uint8[0] &= ~(0x01);
     addr_long.uint8[0] |=  (0x02);
     /* set short and long address */
-    kw2xrf_set_addr_long(dev, NTOHLL(addr_long.uint64.u64));
-    kw2xrf_set_addr_short(dev, NTOHS(addr_long.uint16[0].u16));
+    kw2xrf_set_addr_long(dev, ntohll(addr_long.uint64.u64));
+    kw2xrf_set_addr_short(dev, ntohs(addr_long.uint16[0].u16));
 }
 
 void kw2xrf_setup(kw2xrf_t *dev, const kw2xrf_params_t *params)

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -55,8 +55,8 @@ void mrf24j40_reset(mrf24j40_t *dev)
     addr_long.uint8[0] &= ~(0x01);
     addr_long.uint8[0] |=  (0x02);
     /* set short and long address */
-    mrf24j40_set_addr_long(dev, NTOHLL(addr_long.uint64.u64));
-    mrf24j40_set_addr_short(dev, NTOHS(addr_long.uint16[0].u16));
+    mrf24j40_set_addr_long(dev, ntohll(addr_long.uint64.u64));
+    mrf24j40_set_addr_short(dev, ntohs(addr_long.uint16[0].u16));
 
     /* set default PAN id */
     mrf24j40_set_pan(dev, IEEE802154_DEFAULT_PANID);

--- a/drivers/nvram_spi/nvram-spi.c
+++ b/drivers/nvram_spi/nvram-spi.c
@@ -133,7 +133,7 @@ static int nvram_spi_write(nvram_t *dev, const uint8_t *src, uint32_t dst, size_
 
     /* Address is expected by the device as big-endian, i.e. network byte order,
      * we utilize the network byte order macros here. */
-    addr.u32 = HTONL(dst);
+    addr.u32 = htonl(dst);
 
     /* Acquire exclusive bus access while configuring clock and mode */
     spi_acquire(spi_dev->spi, spi_dev->cs, SPI_MODE_0, spi_dev->clk);
@@ -163,7 +163,7 @@ static int nvram_spi_read(nvram_t *dev, uint8_t *dst, uint32_t src, size_t len)
     } addr;
     /* Address is expected by the device as big-endian, i.e. network byte order,
      * we utilize the network byte order macros here. */
-    addr.u32 = HTONL(src);
+    addr.u32 = htonl(src);
 
     /* Acquire exclusive bus access while configuring clock and mode */
     spi_acquire(spi_dev->spi, spi_dev->cs, SPI_MODE_0, spi_dev->clk);

--- a/pkg/emb6/contrib/conn/udp/emb6_conn_udp.c
+++ b/pkg/emb6/contrib/conn/udp/emb6_conn_udp.c
@@ -109,7 +109,7 @@ int conn_udp_getlocaladdr(conn_udp_t *conn, void *addr, uint16_t *port)
     if (conn->sock.input_callback != NULL) {
         mutex_lock(&conn->mutex);
         memset(addr, 0, sizeof(ipv6_addr_t));
-        *port = NTOHS(conn->sock.udp_conn->lport);
+        *port = ntohs(conn->sock.udp_conn->lport);
         mutex_unlock(&conn->mutex);
         return sizeof(ipv6_addr_t);
     }

--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -118,7 +118,7 @@ static uint32_t htonf(float x)
         float f;
         uint32_t i;
     } u = { .f = x };
-    return HTONL(u.i);
+    return htonl(u.i);
 }
 
 /**
@@ -129,7 +129,7 @@ static float ntohf(uint32_t x)
     union u {
         float f;
         uint32_t i;
-    } u = { .i = NTOHL(x) };
+    } u = { .i = ntohl(x) };
     return u.f;
 }
 
@@ -142,7 +142,7 @@ static uint64_t htond(double x)
         double d;
         uint64_t i;
     } u = { .d = x };
-    return HTONLL(u.i);
+    return htonll(u.i);
 }
 
 /**
@@ -153,7 +153,7 @@ static double ntohd(uint64_t x)
     union u {
         double d;
         uint64_t i;
-    } u = { .i = HTONLL(x) };
+    } u = { .i = htonll(x) };
     return u.d;
 }
 
@@ -358,15 +358,15 @@ static size_t decode_int(const cbor_stream_t *s, size_t offset, uint64_t *val)
             break;
 
         case 2:
-            *val = HTONS(((cast_align_u8_t *)in)->u.u16);
+            *val = htons(((cast_align_u8_t *)in)->u.u16);
             break;
 
         case 4:
-            *val = HTONL(((cast_align_u8_t *)in)->u.u32);
+            *val = htonl(((cast_align_u8_t *)in)->u.u32);
             break;
 
         default:
-            *val = HTONLL(((cast_align_u8_t *)in)->u.u64);
+            *val = htonll(((cast_align_u8_t *)in)->u.u64);
             break;
     }
 
@@ -563,7 +563,7 @@ size_t cbor_serialize_float_half(cbor_stream_t *s, float val)
 {
     CBOR_ENSURE_SIZE(s, 3);
     s->data[s->pos++] = CBOR_FLOAT16;
-    uint16_t encoded_val = HTONS(encode_float_half(val));
+    uint16_t encoded_val = htons(encode_float_half(val));
     memcpy(s->data + s->pos, &encoded_val, 2);
     s->pos += 2;
     return 3;

--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -23,8 +23,6 @@
 
 #ifdef RIOT_VERSION
 #include "byteorder.h"
-#define ntohs NTOHS
-#define htons HTONS
 #endif
 
 /* min domain name length is 1, so minimum record length is 7 */

--- a/sys/posix/include/sys/bytes.h
+++ b/sys/posix/include/sys/bytes.h
@@ -26,66 +26,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief   Convert values between host and network byte order.
- *
- * @see <a href="http://pubs.opengroup.org/onlinepubs/9699919799/functions/htonl.html">
- *          The Open Group Base Specification Issue 7, htonl
- *      </a>
- *
- * @param[in] hostlong  A 32 bit number.
- * @return              The argument value converted from host to network byte
- *                      order.
- */
-#ifndef htonl
-#define htonl(hostlong)     HTONL(hostlong)
-#endif
-
-/**
- * @brief   Convert values between host and network byte order.
- *
- * @see <a href="http://pubs.opengroup.org/onlinepubs/9699919799/functions/htons.html">
- *          The Open Group Base Specification Issue 7, htons
- *      </a>
- *
- * @param[in] hostshort A 16 bit number.
- * @return              The argument value converted from host to network byte
- *                      order.
- */
-#ifndef htons
-#define htons(hostshort)    HTONS(hostshort)
-#endif
-
-/**
- * @brief   Convert values between host and network byte order.
- *
- * @see <a href="http://pubs.opengroup.org/onlinepubs/9699919799/functions/ntohl.html">
- *          The Open Group Base Specification Issue 7, ntohl
- *      </a>
- *
- * @param[in] netlong   A 32-bit integer number.
- * @return              The argument value converted from network to host byte
- *                      order.
- */
-#ifndef ntohl
-#define ntohl(netlong)      NTOHL(netlong)
-#endif
-
-/**
- * @brief   Convert values between host and network byte order.
- *
- * @see <a href="http://pubs.opengroup.org/onlinepubs/9699919799/functions/ntohs.html">
- *          The Open Group Base Specification Issue 7, ntohs
- *      </a>
- *
- * @param[in] netshort  A 16-bit integer number.
- * @return              The argument value converted from network to host byte
- *                      order.
- */
-#ifndef ntohs
-#define ntohs(netshort)     NTOHS(netshort)
-#endif
-
 typedef size_t socklen_t;           /**< socket address length */
 
 #ifdef __cplusplus

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -68,7 +68,7 @@ static void test_sock_ip_create4__EINVAL_netif(void)
     static const sock_ip_ep_t local = { .family = AF_INET, .netif = _TEST_NETIF };
     const sock_ip_ep_t remote = { .family = AF_INET,
                                          .netif = (_TEST_NETIF + 1),
-                                         .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) } };
+                                         .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) } };
 
     assert(-EINVAL == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                      SOCK_FLAGS_REUSE_EP));
@@ -123,7 +123,7 @@ static void test_sock_ip_create4__only_local_reuse_ep(void)
 static void test_sock_ip_create4__only_remote(void)
 {
     const sock_ip_ep_t remote = { .family = AF_INET,
-                                         .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) } };
+                                         .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) } };
     sock_ip_ep_t ep;
 
     assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
@@ -132,7 +132,7 @@ static void test_sock_ip_create4__only_remote(void)
     assert(0 == sock_ip_get_local(&_sock, &ep));
     assert(0 == sock_ip_get_remote(&_sock, &ep));
     assert(AF_INET == ep.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
     assert(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
@@ -140,7 +140,7 @@ static void test_sock_ip_create4__full(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET, .netif = _TEST_NETIF };
     const sock_ip_ep_t remote = { .family = AF_INET,
-                                         .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) } };
+                                         .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) } };
     sock_ip_ep_t ep;
 
     assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
@@ -152,7 +152,7 @@ static void test_sock_ip_create4__full(void)
     assert(_TEST_NETIF == ep.netif);
     assert(0 == sock_ip_get_remote(&_sock, &ep));
     assert(AF_INET == ep.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
     assert(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
@@ -205,7 +205,7 @@ static void test_sock_ip_recv4__ETIMEDOUT(void)
 static void test_sock_ip_recv4__socketed(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET };
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
 
     assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
@@ -220,7 +220,7 @@ static void test_sock_ip_recv4__socketed(void)
 static void test_sock_ip_recv4__socketed_with_remote(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET };
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
     sock_ip_ep_t result;
 
@@ -231,14 +231,14 @@ static void test_sock_ip_recv4__socketed_with_remote(void)
     assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
     assert(AF_INET == result.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
     assert(_TEST_NETIF == result.netif);
     assert(_check_net());
 }
 
 static void test_sock_ip_recv4__unsocketed(void)
 {
-    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                         .family = AF_INET };
 
     assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
@@ -262,7 +262,7 @@ static void test_sock_ip_recv4__unsocketed_with_remote(void)
     assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
     assert(AF_INET == result.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
     assert(_TEST_NETIF == result.netif);
     assert(_check_net());
 }
@@ -280,7 +280,7 @@ static void test_sock_ip_recv4__with_timeout(void)
                                           sizeof(_test_buffer), _TEST_TIMEOUT,
                                           &result));
     assert(AF_INET == result.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
     assert(_TEST_NETIF == result.netif);
     assert(_check_net());
 }
@@ -297,14 +297,14 @@ static void test_sock_ip_recv4__non_blocking(void)
     assert(sizeof("ABCD") == sock_ip_recv(&_sock, _test_buffer,
                                           sizeof(_test_buffer), 0, &result));
     assert(AF_INET == result.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
     assert(_TEST_NETIF == result.netif);
     assert(_check_net());
 }
 
 static void test_sock_ip_send4__EAFNOSUPPORT(void)
 {
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_UNSPEC };
 
     assert(-EAFNOSUPPORT == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
@@ -314,7 +314,7 @@ static void test_sock_ip_send4__EAFNOSUPPORT(void)
 
 static void test_sock_ip_send4__EINVAL_addr(void)
 {
-    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                         .family = AF_INET,
                                         .netif = _TEST_NETIF };
     static const sock_ip_ep_t remote = { .family = AF_INET,
@@ -329,10 +329,10 @@ static void test_sock_ip_send4__EINVAL_addr(void)
 
 static void test_sock_ip_send4__EINVAL_netif(void)
 {
-    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                         .family = AF_INET,
                                         .netif = _TEST_NETIF };
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET,
                                          .netif = _TEST_NETIF + 1 };
 
@@ -345,7 +345,7 @@ static void test_sock_ip_send4__EINVAL_netif(void)
 
 static void test_sock_ip_send4__EHOSTUNREACH(void)
 {
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_WRONG) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_WRONG) },
                                          .family = AF_INET };
 
     assert(-EHOSTUNREACH == sock_ip_send(NULL, "ABCD", sizeof("ABCD"), _TEST_PROTO,
@@ -363,7 +363,7 @@ static void test_sock_ip_send4__ENOTCONN(void)
 
 static void test_sock_ip_send4__socketed_no_local_no_netif(void)
 {
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
 
     assert(0 == sock_ip_create(&_sock, NULL, &remote, _TEST_PROTO,
@@ -378,9 +378,9 @@ static void test_sock_ip_send4__socketed_no_local_no_netif(void)
 
 static void test_sock_ip_send4__socketed_no_netif(void)
 {
-    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                         .family = AF_INET };
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
 
     assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
@@ -395,7 +395,7 @@ static void test_sock_ip_send4__socketed_no_netif(void)
 
 static void test_sock_ip_send4__socketed_no_local(void)
 {
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET,
                                          .netif = _TEST_NETIF };
 
@@ -411,10 +411,10 @@ static void test_sock_ip_send4__socketed_no_local(void)
 
 static void test_sock_ip_send4__socketed(void)
 {
-    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                         .family = AF_INET,
                                         .netif = _TEST_NETIF };
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
 
     assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
@@ -429,12 +429,12 @@ static void test_sock_ip_send4__socketed(void)
 
 static void test_sock_ip_send4__socketed_other_remote(void)
 {
-    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                         .family = AF_INET,
                                         .netif = _TEST_NETIF };
-    const sock_ip_ep_t sock_remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_WRONG) },
+    const sock_ip_ep_t sock_remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_WRONG) },
                                               .family = AF_INET };
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
 
     assert(0 == sock_ip_create(&_sock, &local, &sock_remote, _TEST_PROTO,
@@ -449,7 +449,7 @@ static void test_sock_ip_send4__socketed_other_remote(void)
 
 static void test_sock_ip_send4__unsocketed_no_local_no_netif(void)
 {
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
 
     assert(0 == sock_ip_create(&_sock, NULL, NULL, _TEST_PROTO,
@@ -464,9 +464,9 @@ static void test_sock_ip_send4__unsocketed_no_local_no_netif(void)
 
 static void test_sock_ip_send4__unsocketed_no_netif(void)
 {
-    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                         .family = AF_INET };
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
 
     assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
@@ -481,7 +481,7 @@ static void test_sock_ip_send4__unsocketed_no_netif(void)
 
 static void test_sock_ip_send4__unsocketed_no_local(void)
 {
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET,
                                          .netif = _TEST_NETIF };
 
@@ -497,10 +497,10 @@ static void test_sock_ip_send4__unsocketed_no_local(void)
 
 static void test_sock_ip_send4__unsocketed(void)
 {
-    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_ip_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                         .family = AF_INET,
                                         .netif = _TEST_NETIF };
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
 
     assert(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
@@ -515,7 +515,7 @@ static void test_sock_ip_send4__unsocketed(void)
 
 static void test_sock_ip_send4__no_sock_no_netif(void)
 {
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET };
 
     assert(sizeof("ABCD") == sock_ip_send(NULL, "ABCD", sizeof("ABCD"),
@@ -528,7 +528,7 @@ static void test_sock_ip_send4__no_sock_no_netif(void)
 
 static void test_sock_ip_send4__no_sock(void)
 {
-    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_ip_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                          .family = AF_INET,
                                          .netif = _TEST_NETIF };
 

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -186,9 +186,9 @@ void _net_init(void)
     assert(netdev.netdev.driver);
 #if LWIP_IPV4
     ip4_addr_t local4, mask4, gw4;
-    local4.addr = HTONL(_TEST_ADDR4_LOCAL);
-    mask4.addr = HTONL(_TEST_ADDR4_MASK);
-    gw4.addr = HTONL(_TEST_ADDR4_GW);
+    local4.addr = htonl(_TEST_ADDR4_LOCAL);
+    mask4.addr = htonl(_TEST_ADDR4_MASK);
+    gw4.addr = htonl(_TEST_ADDR4_GW);
     netif_add(&netif, &local4, &mask4, &gw4, &netdev, lwip_netdev_init, tcpip_input);
 #else
     netif_add(&netif, &netdev, lwip_netdev_init, tcpip_input);
@@ -217,7 +217,7 @@ void _prepare_send_checks(void)
 
     netdev_test_set_send_cb(&netdev, _netdev_send);
 #if LWIP_ARP
-    const ip4_addr_t remote4 = { .addr = HTONL(_TEST_ADDR4_REMOTE) };
+    const ip4_addr_t remote4 = { .addr = htonl(_TEST_ADDR4_REMOTE) };
     assert(ERR_OK == etharp_add_static_entry(&remote4, (struct eth_addr *)mac));
 #endif
 #if LWIP_IPV6
@@ -253,11 +253,11 @@ bool _inject_4packet(uint32_t src, uint32_t dst, uint8_t proto, void *data,
     eth_hdr->type = byteorder_htons(ETHERTYPE_IPV4);
     IPH_VHL_SET(ip_hdr, 4, 5);
     IPH_TOS_SET(ip_hdr, 0);
-    IPH_LEN_SET(ip_hdr, HTONS(sizeof(struct ip_hdr) + data_len));
+    IPH_LEN_SET(ip_hdr, htons(sizeof(struct ip_hdr) + data_len));
     IPH_TTL_SET(ip_hdr, 64);
     IPH_PROTO_SET(ip_hdr, proto);
-    ip_hdr->src.addr = HTONL(src);
-    ip_hdr->dest.addr = HTONL(dst);
+    ip_hdr->src.addr = htonl(src);
+    ip_hdr->dest.addr = htonl(dst);
     IPH_CHKSUM_SET(ip_hdr, 0);
     IPH_CHKSUM_SET(ip_hdr, inet_chksum(ip_hdr, sizeof(struct ip_hdr)));
 
@@ -326,7 +326,7 @@ bool _check_4packet(uint32_t src, uint32_t dst, uint8_t proto,
     ethernet_hdr_t *eth_hdr = (ethernet_hdr_t *)_netdev_buffer;
     struct ip_hdr *ip_hdr = (struct ip_hdr *)(eth_hdr + 1);
     uint8_t *payload = (uint8_t *)(ip_hdr + 1);
-    uint16_t payload_len = HTONS(IPH_LEN(ip_hdr)) - sizeof(struct ip_hdr);
+    uint16_t payload_len = htons(IPH_LEN(ip_hdr)) - sizeof(struct ip_hdr);
     const bool ip_correct = ((src == 0) || (src = ip_hdr->src.addr)) &&
                             (dst = ip_hdr->dest.addr) &&
                             (IPH_PROTO(ip_hdr) == proto);

--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -88,7 +88,7 @@ static void tear_down(void)
 #ifdef SO_REUSE
 static void test_tcp_connect4__EADDRINUSE(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
@@ -107,7 +107,7 @@ static void test_tcp_connect4__EADDRINUSE(void)
 
 static void test_tcp_connect4__EAFNOSUPPORT(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
 
@@ -129,7 +129,7 @@ static void test_tcp_connect4__EINVAL_addr(void)
 
 static void test_tcp_connect4__EINVAL_netif(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = (_TEST_NETIF + 1) };
@@ -142,7 +142,7 @@ static void test_tcp_connect4__EINVAL_netif(void)
 
 static void test_tcp_connect4__success_without_port(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = _TEST_NETIF };
@@ -158,13 +158,13 @@ static void test_tcp_connect4__success_without_port(void)
     assert(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     assert(0 == sock_tcp_get_remote(&_sock, &ep));
     assert(AF_INET == ep.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
     assert(SOCK_ADDR_ANY_NETIF == ep.netif);
     assert(_TEST_PORT_REMOTE == ep.port);
 }
 static void test_tcp_connect4__success_local_port(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
@@ -184,7 +184,7 @@ static void test_tcp_connect4__success_local_port(void)
     assert(_TEST_PORT_LOCAL == ep.port);
     assert(0 == sock_tcp_get_remote(&_sock, &ep));
     assert(AF_INET == ep.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
     assert(SOCK_ADDR_ANY_NETIF == ep.netif);
     assert(_TEST_PORT_REMOTE == ep.port);
 }
@@ -192,7 +192,7 @@ static void test_tcp_connect4__success_local_port(void)
 #ifdef SO_REUSE
 static void test_tcp_listen4__EADDRINUSE(void)
 {
-    const sock_tcp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_tcp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                          .family = AF_INET,
                                          .port = _TEST_PORT_LOCAL,
                                          .netif = SOCK_ADDR_ANY_NETIF };
@@ -211,7 +211,7 @@ static void test_tcp_listen4__EADDRINUSE(void)
 
 static void test_tcp_listen4__EAFNOSUPPORT(void)
 {
-    const sock_tcp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_tcp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                          .port = _TEST_PORT_LOCAL,
                                          .netif = SOCK_ADDR_ANY_NETIF };
 
@@ -221,7 +221,7 @@ static void test_tcp_listen4__EAFNOSUPPORT(void)
 
 static void test_tcp_listen4__EINVAL(void)
 {
-    const sock_tcp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_tcp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                          .family = AF_INET,
                                          .port = _TEST_PORT_LOCAL,
                                          .netif = (_TEST_NETIF + 1) };
@@ -232,7 +232,7 @@ static void test_tcp_listen4__EINVAL(void)
 
 static void test_tcp_listen4__success_any_netif(void)
 {
-    const sock_tcp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_tcp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                          .family = AF_INET,
                                          .port = _TEST_PORT_LOCAL,
                                          .netif = SOCK_ADDR_ANY_NETIF };
@@ -242,7 +242,7 @@ static void test_tcp_listen4__success_any_netif(void)
                                 _QUEUE_SIZE, 0));
     assert(0 == sock_tcp_queue_get_local(&_queue, &ep));
     assert(AF_INET == ep.family);
-    assert(HTONL(_TEST_ADDR4_LOCAL) == ep.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_LOCAL) == ep.addr.ipv4_u32);
     assert(SOCK_ADDR_ANY_NETIF == ep.netif);
     assert(_TEST_PORT_LOCAL == ep.port);
 }
@@ -304,7 +304,7 @@ static void test_tcp_accept4__success(void)
     sock_tcp_ep_t ep;
     sock_tcp_t *sock;
 
-    _server_addr.addr.ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE);  /* loopback */
+    _server_addr.addr.ipv4_u32 = htonl(_TEST_ADDR4_REMOTE);  /* loopback */
     _server_addr.family = AF_INET;
     _server_addr.port = _TEST_PORT_LOCAL;
     _server_addr.netif = SOCK_ADDR_ANY_NETIF;
@@ -319,7 +319,7 @@ static void test_tcp_accept4__success(void)
     assert(_TEST_PORT_LOCAL == ep.port);
     assert(0 == sock_tcp_get_remote(sock, &ep));
     assert(AF_INET == ep.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
     assert(SOCK_ADDR_ANY_NETIF == ep.netif);
     assert(_TEST_PORT_REMOTE == ep.port);
 }
@@ -328,7 +328,7 @@ static void test_tcp_accept4__success(void)
 
 static void test_tcp_read4__EAGAIN(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
@@ -348,7 +348,7 @@ static void test_tcp_read4__EAGAIN(void)
 
 static void test_tcp_read4__ECONNRESET(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
@@ -378,7 +378,7 @@ static void test_tcp_read4__ENOTCONN(void)
 
 static void test_tcp_read4__ETIMEDOUT(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
@@ -401,7 +401,7 @@ static void test_tcp_read4__ETIMEDOUT(void)
 
 static void test_tcp_read4__success(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
@@ -429,7 +429,7 @@ static void test_tcp_read4__success(void)
 
 static void test_tcp_read4__success_with_timeout(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
@@ -457,7 +457,7 @@ static void test_tcp_read4__success_with_timeout(void)
 
 static void test_tcp_read4__success_non_blocking(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };
@@ -492,7 +492,7 @@ static void test_tcp_write4__ENOTCONN(void)
 
 static void test_tcp_write4__success(void)
 {
-    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_tcp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                           .family = AF_INET,
                                           .port = _TEST_PORT_REMOTE,
                                           .netif = SOCK_ADDR_ANY_NETIF };

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -88,7 +88,7 @@ static void test_sock_udp_create4__EINVAL_netif(void)
     const sock_udp_ep_t remote = { .family = AF_INET,
                                    .netif = (_TEST_NETIF + 1),
                                    .port = _TEST_PORT_REMOTE,
-                                   .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) } };
+                                   .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) } };
 
     assert(-EINVAL == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
 }
@@ -144,7 +144,7 @@ static void test_sock_udp_create4__only_remote(void)
 {
     const sock_udp_ep_t remote = { .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE,
-                                   .addr =  { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) } };
+                                   .addr =  { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) } };
     sock_udp_ep_t ep;
 
     assert(0 == sock_udp_create(&_sock, NULL, &remote, SOCK_FLAGS_REUSE_EP));
@@ -152,7 +152,7 @@ static void test_sock_udp_create4__only_remote(void)
     assert(0 == sock_udp_get_local(&_sock, &ep));
     assert(0 == sock_udp_get_remote(&_sock, &ep));
     assert(AF_INET == ep.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
     assert(SOCK_ADDR_ANY_NETIF == ep.netif);
     assert(_TEST_PORT_REMOTE == ep.port);
 }
@@ -163,7 +163,7 @@ static void test_sock_udp_create4__full(void)
                                          .port = _TEST_PORT_LOCAL };
     const sock_udp_ep_t remote = { .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE,
-                                   .addr =  { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) } };
+                                   .addr =  { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) } };
     sock_udp_ep_t ep;
 
     assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
@@ -175,7 +175,7 @@ static void test_sock_udp_create4__full(void)
     assert(_TEST_PORT_LOCAL == ep.port);
     assert(0 == sock_udp_get_remote(&_sock, &ep));
     assert(AF_INET == ep.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == ep.addr.ipv4_u32);
     assert(SOCK_ADDR_ANY_NETIF == ep.netif);
     assert(_TEST_PORT_REMOTE == ep.port);
 }
@@ -231,7 +231,7 @@ static void test_sock_udp_recv4__socketed(void)
 {
     static const sock_udp_ep_t local = { .family = AF_INET,
                                          .port = _TEST_PORT_LOCAL };
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -249,7 +249,7 @@ static void test_sock_udp_recv4__socketed_with_remote(void)
 {
     static const sock_udp_ep_t local = { .family = AF_INET,
                                          .port = _TEST_PORT_LOCAL };
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
     sock_udp_ep_t result;
@@ -262,7 +262,7 @@ static void test_sock_udp_recv4__socketed_with_remote(void)
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
     assert(AF_INET == result.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
     assert(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
     assert(_TEST_NETIF == result.netif);
@@ -272,7 +272,7 @@ static void test_sock_udp_recv4__socketed_with_remote(void)
 
 static void test_sock_udp_recv4__unsocketed(void)
 {
-    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                   .family = AF_INET,
                                   .port = _TEST_PORT_LOCAL };
 
@@ -300,7 +300,7 @@ static void test_sock_udp_recv4__unsocketed_with_remote(void)
                                            sizeof(_test_buffer),
                                            SOCK_NO_TIMEOUT, &result));
     assert(AF_INET == result.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
     assert(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
     assert(_TEST_NETIF == result.netif);
@@ -322,7 +322,7 @@ static void test_sock_udp_recv4__with_timeout(void)
                                            sizeof(_test_buffer), _TEST_TIMEOUT,
                                            &result));
     assert(AF_INET == result.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
     assert(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
     assert(_TEST_NETIF == result.netif);
@@ -343,7 +343,7 @@ static void test_sock_udp_recv4__non_blocking(void)
     assert(sizeof("ABCD") == sock_udp_recv(&_sock, _test_buffer,
                                            sizeof(_test_buffer), 0, &result));
     assert(AF_INET == result.family);
-    assert(HTONL(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
+    assert(htonl(_TEST_ADDR4_REMOTE) == result.addr.ipv4_u32);
     assert(_TEST_PORT_REMOTE == result.port);
 #if LWIP_NETBUF_RECVINFO
     assert(_TEST_NETIF == result.netif);
@@ -353,7 +353,7 @@ static void test_sock_udp_recv4__non_blocking(void)
 
 static void test_sock_udp_send4__EAFNOSUPPORT(void)
 {
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_UNSPEC,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -364,7 +364,7 @@ static void test_sock_udp_send4__EAFNOSUPPORT(void)
 
 static void test_sock_udp_send4__EINVAL_addr(void)
 {
-    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                   .family = AF_INET,
                                   .port = _TEST_PORT_REMOTE,
                                   .netif = _TEST_NETIF };
@@ -379,11 +379,11 @@ static void test_sock_udp_send4__EINVAL_addr(void)
 
 static void test_sock_udp_send4__EINVAL_netif(void)
 {
-    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                   .family = AF_INET,
                                   .port = _TEST_PORT_REMOTE,
                                   .netif = _TEST_NETIF };
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE,
                                    .netif = _TEST_NETIF + 1 };
@@ -395,7 +395,7 @@ static void test_sock_udp_send4__EINVAL_netif(void)
 
 static void test_sock_udp_send4__EHOSTUNREACH(void)
 {
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_WRONG) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_WRONG) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -405,7 +405,7 @@ static void test_sock_udp_send4__EHOSTUNREACH(void)
 
 static void test_sock_udp_send4__EINVAL_port(void)
 {
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET };
 
     assert(-EINVAL == sock_udp_send(NULL, "ABCD", sizeof("ABCD"), &remote));
@@ -421,7 +421,7 @@ static void test_sock_udp_send4__ENOTCONN(void)
 
 static void test_sock_udp_send4__socketed_no_local_no_netif(void)
 {
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -436,10 +436,10 @@ static void test_sock_udp_send4__socketed_no_local_no_netif(void)
 
 static void test_sock_udp_send4__socketed_no_netif(void)
 {
-    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                   .family = AF_INET,
                                   .port = _TEST_PORT_LOCAL };
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -455,7 +455,7 @@ static void test_sock_udp_send4__socketed_no_netif(void)
 
 static void test_sock_udp_send4__socketed_no_local(void)
 {
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .netif = _TEST_NETIF,
                                    .port = _TEST_PORT_REMOTE };
@@ -472,11 +472,11 @@ static void test_sock_udp_send4__socketed_no_local(void)
 
 static void test_sock_udp_send4__socketed(void)
 {
-    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                   .family = AF_INET,
                                   .netif = _TEST_NETIF,
                                   .port = _TEST_PORT_LOCAL };
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -492,14 +492,14 @@ static void test_sock_udp_send4__socketed(void)
 
 static void test_sock_udp_send4__socketed_other_remote(void)
 {
-    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                   .family = AF_INET,
                                   .netif = _TEST_NETIF,
                                   .port = _TEST_PORT_LOCAL };
-    const sock_udp_ep_t sock_remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_WRONG) },
+    const sock_udp_ep_t sock_remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_WRONG) },
                                         .family = AF_INET,
                                         .port = _TEST_PORT_REMOTE + _TEST_PORT_LOCAL };
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -515,7 +515,7 @@ static void test_sock_udp_send4__socketed_other_remote(void)
 
 static void test_sock_udp_send4__unsocketed_no_local_no_netif(void)
 {
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -531,10 +531,10 @@ static void test_sock_udp_send4__unsocketed_no_local_no_netif(void)
 
 static void test_sock_udp_send4__unsocketed_no_netif(void)
 {
-    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                   .family = AF_INET,
                                   .port = _TEST_PORT_LOCAL };
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -550,7 +550,7 @@ static void test_sock_udp_send4__unsocketed_no_netif(void)
 
 static void test_sock_udp_send4__unsocketed_no_local(void)
 {
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .netif = _TEST_NETIF,
                                    .port = _TEST_PORT_REMOTE };
@@ -567,11 +567,11 @@ static void test_sock_udp_send4__unsocketed_no_local(void)
 
 static void test_sock_udp_send4__unsocketed(void)
 {
-    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_LOCAL) },
+    const sock_udp_ep_t local = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_LOCAL) },
                                   .family = AF_INET,
                                   .netif = _TEST_NETIF,
                                   .port = _TEST_PORT_LOCAL };
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -587,7 +587,7 @@ static void test_sock_udp_send4__unsocketed(void)
 
 static void test_sock_udp_send4__no_sock_no_netif(void)
 {
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .port = _TEST_PORT_REMOTE };
 
@@ -602,7 +602,7 @@ static void test_sock_udp_send4__no_sock_no_netif(void)
 
 static void test_sock_udp_send4__no_sock(void)
 {
-    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = HTONL(_TEST_ADDR4_REMOTE) },
+    const sock_udp_ep_t remote = { .addr = { .ipv4_u32 = htonl(_TEST_ADDR4_REMOTE) },
                                    .family = AF_INET,
                                    .netif = _TEST_NETIF,
                                    .port = _TEST_PORT_REMOTE };

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -189,9 +189,9 @@ void _net_init(void)
     assert(netdev.netdev.driver);
 #if LWIP_IPV4
     ip4_addr_t local4, mask4, gw4;
-    local4.addr = HTONL(_TEST_ADDR4_LOCAL);
-    mask4.addr = HTONL(_TEST_ADDR4_MASK);
-    gw4.addr = HTONL(_TEST_ADDR4_GW);
+    local4.addr = htonl(_TEST_ADDR4_LOCAL);
+    mask4.addr = htonl(_TEST_ADDR4_MASK);
+    gw4.addr = htonl(_TEST_ADDR4_GW);
     netif_add(&netif, &local4, &mask4, &gw4, &netdev, lwip_netdev_init, tcpip_input);
 #else
     netif_add(&netif, &netdev, lwip_netdev_init, tcpip_input);
@@ -220,7 +220,7 @@ void _prepare_send_checks(void)
 
     netdev_test_set_send_cb(&netdev, _netdev_send);
 #if LWIP_ARP
-    const ip4_addr_t remote4 = { .addr = HTONL(_TEST_ADDR4_REMOTE) };
+    const ip4_addr_t remote4 = { .addr = htonl(_TEST_ADDR4_REMOTE) };
     assert(ERR_OK == etharp_add_static_entry(&remote4, (struct eth_addr *)mac));
 #endif
 #if LWIP_IPV6
@@ -259,11 +259,11 @@ bool _inject_4packet(uint32_t src, uint32_t dst, uint16_t src_port,
     eth_hdr->type = byteorder_htons(ETHERTYPE_IPV4);
     IPH_VHL_SET(ip_hdr, 4, 5);
     IPH_TOS_SET(ip_hdr, 0);
-    IPH_LEN_SET(ip_hdr, HTONS(sizeof(struct ip_hdr) + udp_len));
+    IPH_LEN_SET(ip_hdr, htons(sizeof(struct ip_hdr) + udp_len));
     IPH_TTL_SET(ip_hdr, 64);
     IPH_PROTO_SET(ip_hdr, PROTNUM_UDP);
-    ip_hdr->src.addr = HTONL(src);
-    ip_hdr->dest.addr = HTONL(dst);
+    ip_hdr->src.addr = htonl(src);
+    ip_hdr->dest.addr = htonl(dst);
     IPH_CHKSUM_SET(ip_hdr, 0);
     IPH_CHKSUM_SET(ip_hdr, inet_chksum(ip_hdr, sizeof(struct ip_hdr)));
 


### PR DESCRIPTION
Fixes #5959.