### PR TITLE
drivers/mrf24j40 remove obsolete RSSI_BASE_VALUE define

### DIFF
--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -76,11 +76,6 @@ extern "C" {
  */
 
 /**
- * @brief   Base (minimal) RSSI value in dBm
- */
-#define RSSI_BASE_VAL                   (-91)
-
-/**
  * @brief   Flags for PSEUDO DEVICE INTERNAL STATES
  * @{
  */


### PR DESCRIPTION
Probably a leftover from the at86rf2xx driver which was used as a base for this driver