### PR TITLE
periph/rtc: move init from auto_init to periph_init

### DIFF
--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -23,6 +23,9 @@
 #ifdef MODULE_PERIPH_SPI
 #include "periph/spi.h"
 #endif
+#ifdef MODULE_PERIPH_RTC
+#include "periph/rtc.h"
+#endif
 
 void periph_init(void)
 {
@@ -31,5 +34,10 @@ void periph_init(void)
     for (unsigned i = 0; i < SPI_NUMOF; i++) {
         spi_init(SPI_DEV(i));
     }
+#endif
+
+    /* Initialize RTC */
+#ifdef MODULE_PERIPH_RTC
+    rtc_init();
 #endif
 }

--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -29,10 +29,6 @@
 #include "shell.h"
 #include "shell_commands.h"
 
-#if FEATURE_PERIPH_RTC
-#include "periph/rtc.h"
-#endif
-
 #ifdef MODULE_NETIF
 #include "net/gnrc/pktdump.h"
 #include "net/gnrc.h"
@@ -40,10 +36,6 @@
 
 int main(void)
 {
-#ifdef FEATURE_PERIPH_RTC
-    rtc_init();
-#endif
-
 #ifdef MODULE_NETIF
     gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                           gnrc_pktdump_pid);

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -32,10 +32,6 @@
 #include "xtimer.h"
 #endif
 
-#ifdef MODULE_RTC
-#include "periph/rtc.h"
-#endif
-
 #ifdef MODULE_GNRC_SIXLOWPAN
 #include "net/gnrc/sixlowpan.h"
 #endif
@@ -104,10 +100,6 @@ void auto_init(void)
 #ifdef MODULE_XTIMER
     DEBUG("Auto init xtimer module.\n");
     xtimer_init();
-#endif
-#ifdef MODULE_RTC
-    DEBUG("Auto init rtc module.\n");
-    rtc_init();
 #endif
 #ifdef MODULE_SHT11
     DEBUG("Auto init SHT11 module.\n");

--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -139,7 +139,6 @@ static int _rtc_usage(void)
 {
     puts("usage: rtc <command> [arguments]");
     puts("commands:");
-    puts("\tinit\t\tinitialize the interface");
     puts("\tpoweron\t\tpower the interface on");
     puts("\tpoweroff\tpower the interface off");
     puts("\tclearalarm\tdeactivate the current alarm");
@@ -155,9 +154,6 @@ int _rtc_handler(int argc, char **argv)
     if (argc < 2) {
         _rtc_usage();
         return 1;
-    }
-    else if (strncmp(argv[1], "init", 4) == 0) {
-        rtc_init();
     }
     else if (strncmp(argv[1], "poweron", 7) == 0) {
         rtc_poweron();

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -57,7 +57,7 @@ extern int _at30tse75x_handler(int argc, char **argv);
 extern int _saul(int argc, char **argv);
 #endif
 
-#if FEATURE_PERIPH_RTC
+#ifdef MODULE_PERIPH_RTC
 extern int _rtc_handler(int argc, char **argv);
 #endif
 
@@ -187,7 +187,7 @@ const shell_command_t _shell_command_list[] = {
     { "random_init", "initializes the PRNG", _random_init },
     { "random_get", "returns 32 bit of pseudo randomness", _random_get },
 #endif
-#if FEATURE_PERIPH_RTC
+#ifdef MODULE_PERIPH_RTC
     {"rtc", "control RTC peripheral interface",  _rtc_handler},
 #endif
 #ifdef CPU_X86

--- a/tests/periph_rtc/main.c
+++ b/tests/periph_rtc/main.c
@@ -83,9 +83,6 @@ int main(void)
     printf("This test will display 'Alarm!' every %u seconds for %u times\n",
             PERIOD, REPEAT);
 
-    /* initialize RTC */
-    rtc_init();
-
     /* set RTC */
     print_time("  Setting clock to ", &time);
     rtc_set_time(&time);

--- a/tests/pkg_fatfs/main.c
+++ b/tests/pkg_fatfs/main.c
@@ -354,7 +354,6 @@ int main(void)
     /* the rtc is used in diskio.c for timestamps of files */
     puts("Initializing the RTC driver");
     rtc_poweron();
-    rtc_init();
 
     struct tm time;
     time.tm_year = TEST_FATFS_RTC_YEAR - RTC_YEAR_OFFSET;  /* years are counted from 1900 */


### PR DESCRIPTION
It seems that the auto_init code used to initialize rtc was not working. 

Using the periph_init seems better.