### PR TITLE
rpl: drop DAO-ACK when received via multicast

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -976,7 +976,7 @@ void gnrc_rpl_recv_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack, kernel_pid_t iface, ipv6
     (void)iface;
     (void)src;
     (void)dst;
-    (void) len;
+    (void)len;
 
     gnrc_rpl_instance_t *inst = NULL;
     gnrc_rpl_dodag_t *dodag = NULL;
@@ -986,7 +986,7 @@ void gnrc_rpl_recv_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack, kernel_pid_t iface, ipv6
 #endif
 
 #ifndef GNRC_RPL_WITHOUT_VALIDATION
-    if (!gnrc_rpl_validation_DAO_ACK(dao_ack, len)) {
+    if (!gnrc_rpl_validation_DAO_ACK(dao_ack, len, dst)) {
         return;
     }
 #endif

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/validation.h
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/validation.h
@@ -118,13 +118,21 @@ static inline bool gnrc_rpl_validation_DAO(gnrc_rpl_dao_t *dao, uint16_t len)
  *
  * @param[in]   dao_ack     The DAO-ACK control message
  * @param[in]   len         Length of the DAO-ACK control message
+ * @param[in]   dst         Pointer to the destination address of the IPv6 packet.
  *
  * @return  true, if @p dao_ack is valid
  * @return  false, otherwise
  */
-static inline bool gnrc_rpl_validation_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack, uint16_t len)
+static inline bool gnrc_rpl_validation_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack,
+                                               uint16_t len,
+                                               ipv6_addr_t *dst)
 {
     uint16_t expected_len = sizeof(*dao_ack) + sizeof(icmpv6_hdr_t);
+
+    if (ipv6_addr_is_multicast(dst)) {
+        DEBUG("RPL: received DAO-ACK on multicast address\n");
+        return false;
+    }
 
     if ((dao_ack->d_reserved & GNRC_RPL_DAO_ACK_D_BIT)) {
         expected_len += sizeof(ipv6_addr_t);


### PR DESCRIPTION
* small cleanup (whitespace)
* added check to process DAO-ACKs only when received via unicast, iff validation is active