### PR TITLE
doc: fix grouping of SPIFFS

### DIFF
--- a/sys/include/fs/spiffs_fs.h
+++ b/sys/include/fs/spiffs_fs.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @ingroup     fs
- * @defgroup    spiffs  SPIFFS integration
+ * @defgroup    sys_spiffs  SPIFFS integration
+ * @ingroup     sys_fs
  * @{
  *
  * @file


### PR DESCRIPTION
This was in the wrong (not existing) group.