### PR TITLE
doc: boards: unify board names

### DIFF
--- a/boards/frdm-k64f/board.c
+++ b/boards/frdm-k64f/board.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     board_frdm-k64f
+ * @ingroup     boards_frdm-k64f
  * @{
  *
  * @file

--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @defgroup    board_frdm-k64f Freescale FRDM-K64F Board
+ * @defgroup    boards_frdm-k64f Freescale FRDM-K64F Board
  * @ingroup     boards
  * @brief       Board specific implementations for the FRDM-K64F
  * @{

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     board_frdm-k64f
+ * @ingroup     boards_frdm-k64f
  * @{
  *
  * @file

--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     board_mulle
+ * @ingroup     boards_mulle
  * @{
  *
  * @file

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    board_mulle Eistec Mulle
+ * @defgroup    boards_mulle Eistec Mulle
  * @ingroup     boards
  * @brief       Board specific files for Eistec Mulle IoT boards
  * @{

--- a/boards/mulle/include/mulle-nvram.h
+++ b/boards/mulle/include/mulle-nvram.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 /**
- * @ingroup     board_mulle
+ * @ingroup     boards_mulle
  * @{
  *
  * @file

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -9,7 +9,7 @@
 
 
 /**
- * @ingroup     board_mulle
+ * @ingroup     boards_mulle
  * @{
  *
  * @file

--- a/boards/nrf6310/board.c
+++ b/boards/nrf6310/board.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     board_nrf6310
+ * @ingroup     boards_nrf6310
  * @{
  *
  * @file        board.c

--- a/boards/nrf6310/include/board.h
+++ b/boards/nrf6310/include/board.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    board_nrf6310 NRF6310 (Nordic NRF Hardware Development Kit)
+ * @defgroup    boards_nrf6310 NRF6310 (Nordic NRF Hardware Development Kit)
  * @ingroup     boards
  * @brief       Board specific files for the nRF51 boards nrf6310 or MOMMOSOFT BLE DEVKIT.N
  * @{

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     board_nrf6310
+ * @ingroup     boards_nrf6310
  * @{
  *
  * @file

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @defgroup    board_phywave_eval phyWAVE-KW22 Board
+ * @defgroup    boards_pba-d-01-kw2x phyWAVE-KW22 Board
  * @ingroup     boards
  * @brief       Board specific implementations for the phyWAVE evaluation board
  * @{

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     board_pba-d-01-kw2x
+ * @ingroup     boards_pba-d-01-kw2x
  * @{
  *
  * @file


### PR DESCRIPTION
The majority of boards are prefixed with "boards_", following the convention for group names. A few are prefixed with `board_*`. This PR fixes that.