### PR TITLE
doc: unify RE-Mote grouping with grouping of other boards

### DIFF
--- a/boards/remote-pa/board.c
+++ b/boards/remote-pa/board.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     board_remote
+ * @ingroup     board_remote-pa
  * @{
  *
  * @file

--- a/boards/remote-pa/include/board.h
+++ b/boards/remote-pa/include/board.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @defgroup    board_remote Re-Mote
+ * @defgroup    boards_remote-pa Re-Mote Prototype A
  * @ingroup     boards
  * @brief       Support for the Re-Mote board prototype A
  * @{

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     board_remote
+ * @ingroup     boards_remote-pa
  * @{
  *
  * @file

--- a/boards/remote-reva/include/board.h
+++ b/boards/remote-reva/include/board.h
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     boards_remote
+ * @defgroup    boards_reva RE-Mote Revision A
+ * @ingroup     boards
  * @brief       Support for the RE-Mote board Revision A
  * @{
  *

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     board_remote
+ * @ingroup     boards_remote-reva
  * @{
  *
  * @file

--- a/boards/remote-revb/include/board.h
+++ b/boards/remote-revb/include/board.h
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     boards_remote
+ * @defgroup    boards_remote-revb RE-Mote Revision B
+ * @ingroup     boards
  * @brief       Support for the RE-Mote board Revision B
  * @{
  *

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     board_remote
+ * @ingroup     boards_remote-revb
  * @{
  *
  * @file


### PR DESCRIPTION
Most other board families are grouped flat (like i.e. Nucleo), so the same flat hierarchie for the RE-Mote boards should be applied (moreover it gives a nice overview at the [`boards` module page in the documentation](http://doc.riot-os.org/group__boards.html)).