### PR TITLE
doc: arduino: unify arduino include path and doc with rest of codebase

### DIFF
--- a/boards/arduino-atmega-common/Makefile.include
+++ b/boards/arduino-atmega-common/Makefile.include
@@ -1,6 +1,8 @@
 # include optional dependencies
 include $(RIOTBOARD)/arduino-atmega-common/Makefile.dep
 
+INCLUDES += -I$(RIOTBOARD)/arduino-atmega-common/include
+
 # define port used to flash the board
 OS = $(shell uname)
 ifeq ($(OS),Linux)

--- a/boards/arduino-atmega-common/include/board_common.h
+++ b/boards/arduino-atmega-common/include/board_common.h
@@ -22,8 +22,8 @@
  * @author      Laurent Navet <laurent.navet@gmail.com>
  */
 
-#ifndef BOARD_H
-#define BOARD_H
+#ifndef BOARD_COMMON_H
+#define BOARD_COMMON_H
 
 #include "cpu.h"
 #include "arduino_pinmap.h"
@@ -106,5 +106,5 @@ void board_init(void);
 }
 #endif
 
-#endif /* BOARD_H */
+#endif /* BOARD_COMMON_H */
 /** @} */

--- a/boards/arduino-duemilanove/Makefile.include
+++ b/boards/arduino-duemilanove/Makefile.include
@@ -3,9 +3,6 @@ export CPU = atmega328p
 
 USEMODULE += arduino-atmega-common
 
-# add arduino-atmega-common include path
-INCLUDES += -I$(RIOTBOARD)/arduino-atmega-common/include
-
 #export needed for flash rule
 export PORT_LINUX ?= /dev/ttyUSB0
 export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/arduino-duemilanove/include/board.h
+++ b/boards/arduino-duemilanove/include/board.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017   Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_arduino-duemilanove Arduino Duemilanove
+ * @ingroup     boards
+ * @brief       Support for the Arduino Duemilanove board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Arduino Duemilanove board
+ *
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -3,9 +3,6 @@ export CPU = atmega2560
 
 USEMODULE += arduino-atmega-common
 
-# add arduino-atmega-common include path
-INCLUDES += -I$(RIOTBOARD)/arduino-atmega-common/include
-
 #export needed for flash rule
 export PORT_LINUX ?= /dev/ttyACM0
 export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017   Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_arduino-mega2560 Arduino Mega 2560
+ * @ingroup     boards
+ * @brief       Support for the Arduino Mega 2560 board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Arduino Mega 2560 board
+ *
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/arduino-uno/Makefile.include
+++ b/boards/arduino-uno/Makefile.include
@@ -3,9 +3,6 @@ export CPU = atmega328p
 
 USEMODULE += arduino-atmega-common
 
-# add arduino-atmega-common include path
-INCLUDES += -I$(RIOTBOARD)/arduino-atmega-common/include
-
 # export needed for flash rule
 export PORT_LINUX ?= /dev/ttyACM0
 export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/arduino-uno/include/board.h
+++ b/boards/arduino-uno/include/board.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017   Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_arduino-uno Arduino Uno
+ * @ingroup     boards
+ * @brief       Support for the Arduino Uno board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Arduino Uno board
+ *
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */


### PR DESCRIPTION
This unifies the include path of ATMega-based platforms to the scheme used by other platform families (e.g. Nucleo). This way all the Arduino flavors we support show up in http://doc.riot-os.org/group__boards.html.