### PR TITLE
cpu/stm32l4/ldscripts: fix stm32l476rg cpuid base address

### DIFF
--- a/cpu/stm32l4/ldscripts/stm32l476rg.ld
+++ b/cpu/stm32l4/ldscripts/stm32l476rg.ld
@@ -22,7 +22,7 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)   : ORIGIN = 0x1ff80050, LENGTH = 12
+    cpuid (r)   : ORIGIN = 0x1fff7590, LENGTH = 12
 }
 
 _cpuid_address = ORIGIN(cpuid);


### PR DESCRIPTION
According to this [MCU datasheet](http://www.st.com/content/ccc/resource/technical/document/reference_manual/02/35/09/0c/4f/f7/40/03/DM00083560.pdf/files/DM00083560.pdf/jcr:content/translations/en.DM00083560.pdf), the cpu unique id base address should be `0x1FFF 7590`.

Seems to be a copy-paste mistake.