### PR TITLE
unittest/Makefile: make merging easier

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,20 +1,62 @@
 APPLICATION = unittests
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
-                             arduino-uno arduino-zero calliope-mini cc2538dk \
-                             cc2650stk chronos ek-lm4f120xl limifrog-v1 maple-mini \
-                             mbed_lpc1768 microbit msb-430 msb-430h nrf51dongle \
-                             nrf6310 nucleo32-f031 nucleo32-f042 nucleo32-f303 \
-                             nucleo32-l031 nucleo32-l432 nucleo-f030 nucleo-f070 \
-                             nucleo-f072 nucleo-f091 nucleo-f103 nucleo-f302 nucleo-f334 \
-                             nucleo-f410 nucleo-l053 nucleo-l073 opencm904 openmote \
-                             openmote-cc2538 pba-d-01-kw2x pca10000 pca10005 \
-                             remote-pa remote-reva remote-revb saml21-xpro \
-                             samd21-xpro samr21-xpro seeeduino_arch-pro slwstk6220a \
-                             sodaq-autonomo spark-core stm32f0discovery \
-                             stm32f3discovery telosb waspmote-pro weio wsn430-v1_3b \
-                             wsn430-v1_4 yunjia-nrf51822 z1
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
+                             arduino-duemilanove \
+                             arduino-mega2560 \
+                             arduino-uno \
+                             arduino-zero \
+                             calliope-mini \
+                             cc2538dk \
+                             cc2650stk \
+                             chronos \
+                             ek-lm4f120xl \
+                             limifrog-v1 maple-mini \
+                             mbed_lpc1768 \
+                             microbit \
+                             msb-430 \
+                             msb-430h \
+                             nrf51dongle \
+                             nrf6310 \
+                             nucleo32-f031 \
+                             nucleo32-f042 \
+                             nucleo32-f303 \
+                             nucleo32-l031 \
+                             nucleo32-l432 \
+                             nucleo-f030 \
+                             nucleo-f070 \
+                             nucleo-f072 \
+                             nucleo-f091 \
+                             nucleo-f103 \
+                             nucleo-f302 \
+                             nucleo-f334 \
+                             nucleo-f410 \
+                             nucleo-l053 \
+                             nucleo-l073 \
+                             opencm904 \
+                             openmote \
+                             openmote-cc2538 \
+                             pba-d-01-kw2x \
+                             pca10000 \
+                             pca10005 \
+                             remote-pa \
+                             remote-reva \
+                             remote-revb \
+                             saml21-xpro \
+                             samd21-xpro \
+                             samr21-xpro \
+                             seeeduino_arch-pro \
+                             slwstk6220a \
+                             sodaq-autonomo \
+                             spark-core \
+                             stm32f0discovery \
+                             stm32f3discovery \
+                             telosb \
+                             waspmote-pro \
+                             weio \
+                             wsn430-v1_3b \
+                             wsn430-v1_4 \
+                             yunjia-nrf51822 z1
 
 USEMODULE += embunit
 
@@ -29,16 +71,61 @@ endif
 ARM7_BOARDS := msba2 avrextrem
 DISABLE_TEST_FOR_ARM7 := tests-relic tests-cpp_%
 
-ARM_CORTEX_M_BOARDS := airfy-beacon arduino-due arduino-zero cc2538dk ek-lm4f120xl \
-                       f4vi1 fox frdm-k64f iotlab-m3 limifrog-v1 mbed_lpc1768 msbiot \
-                       mulle nrf51dongle nrf52840dk nrf6310 nucleo144-f303 nucleo144-f429 \
-                       nucleo144-f446 nucleo32-f031 nucleo32-f303 nucleo32-l031 nucleo32-l432 \
-                       nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f091 nucleo-f302 \
-                       nucleo-f303 nucleo-f334 nucleo-f401 nucleo-f410 nucleo-f411 \
-                       nucleo-l053 nucleo-l073 nucleo-l1 nucleo-l476 opencm904 openmote-cc2538 \
-                       pba-d-01-kw2x pca10000 pca10005 remote samd21-xpro saml21-xpro \
-                       samr21-xpro slwstk6220a sodaq-autonomo spark-core stm32f0discovery \
-                       stm32f3discovery stm32f4discovery udoo weio yunjia-nrf51822
+ARM_CORTEX_M_BOARDS := airfy-beacon \
+                       arduino-due \
+                       arduino-zero \
+                       cc2538dk \
+                       ek-lm4f120xl \
+                       f4vi1 \
+                       fox \
+                       frdm-k64f \
+                       iotlab-m3 \
+                       limifrog-v1 \
+                       mbed_lpc1768 \
+                       msbiot \
+                       mulle \
+                       nrf51dongle \
+                       nrf52840dk \
+                       nrf6310 \
+                       nucleo144-f303 \
+                       nucleo144-f429 \
+                       nucleo144-f446 \
+                       nucleo32-f031 \
+                       nucleo32-f303 \
+                       nucleo32-l031 \
+                       nucleo32-l432 \
+                       nucleo-f030 \
+                       nucleo-f070 \
+                       nucleo-f072 \
+                       nucleo-f091 \
+                       nucleo-f302 \
+                       nucleo-f303 \
+                       nucleo-f334 \
+                       nucleo-f401 \
+                       nucleo-f410 \
+                       nucleo-f411 \
+                       nucleo-l053 \
+                       nucleo-l073 \
+                       nucleo-l1 \
+                       nucleo-l476 \
+                       opencm904 \
+                       openmote-cc2538 \
+                       pba-d-01-kw2x \
+                       pca10000 \
+                       pca10005 \
+                       remote \
+                       samd21-xpro \
+                       saml21-xpro \
+                       samr21-xpro \
+                       slwstk6220a \
+                       sodaq-autonomo \
+                       spark-core \
+                       stm32f0discovery \
+                       stm32f3discovery \
+                       stm32f4discovery \
+                       udoo \
+                       weio \
+                       yunjia-nrf51822
 
 DISABLE_TEST_FOR_ARM_CORTEX_M := tests-relic
 


### PR DESCRIPTION
Doing my first PR to add samd21-xpro board, the thing that kept conflicting again and again as it went through the review process was these lists in unittests/Makefile. By simply unrolling them to one board per line (I noticed precedence for this pattern in some of the other test files), merging would proceed without conflict much easier.