### PR TITLE
dist/tools: add firmware metadata generator

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -12,6 +12,7 @@ RIOTMAKE       ?= $(RIOTBASE)/makefiles
 RIOTPKG        ?= $(RIOTBASE)/pkg
 RIOTPROJECT    ?= $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
 GITCACHE       ?= $(RIOTBASE)/dist/tools/git/git-cache
+FW_METADATA    ?= $(RIOTBASE)/dist/tools/firmware_metadata
 APPDIR         ?= $(CURDIR)
 BINDIRBASE     ?= $(APPDIR)/bin
 BINDIR         ?= $(BINDIRBASE)/$(BOARD)
@@ -41,6 +42,7 @@ override RIOTMAKE       := $(abspath $(RIOTMAKE))
 override RIOTPKG        := $(abspath $(RIOTPKG))
 override RIOTPROJECT    := $(abspath $(RIOTPROJECT))
 override GITCACHE       := $(abspath $(GITCACHE))
+override FW_METADATA    := $(abspath $(FW_METADATA))
 override APPDIR         := $(abspath $(APPDIR))
 override BINDIRBASE     := $(abspath $(BINDIRBASE))
 override BINDIR         := $(abspath $(BINDIR))
@@ -280,6 +282,7 @@ BASELIBS += $(APPDEPS)
 
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
+BINFILE ?= $(ELFFILE:.elf=.bin)
 
 # variables used to compile and link c++
 CPPMIX ?= $(if $(wildcard *.cpp),1,)
@@ -303,8 +306,17 @@ else
 endif
 	$(Q)$(SIZE) $(ELFFILE)
 	$(Q)$(OBJCOPY) $(OFLAGS) $(ELFFILE) $(HEXFILE)
+	$(Q)$(OBJCOPY) -O binary $(ELFFILE) $(BINFILE)
 endif
 endif # BUILD_IN_DOCKER
+
+firmware-metadata: all generate-metadata
+	$(Q)$(FW_METADATA)/bin/generate-metadata $(BINFILE) $(VERSION) $(APPID) $(BINDIR)/firmware-metadata.bin
+
+generate-metadata: $(FW_METADATA)/bin/generate-metadata
+
+$(FW_METADATA)/bin/generate-metadata:
+	$(Q)env -i make -C $(FW_METADATA)
 
 ..compiler-check:
 	@command -v $(CC) >/dev/null 2>&1 || \

--- a/Makefile.include
+++ b/Makefile.include
@@ -282,7 +282,6 @@ BASELIBS += $(APPDEPS)
 
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
-BINFILE ?= $(ELFFILE:.elf=.bin)
 
 # variables used to compile and link c++
 CPPMIX ?= $(if $(wildcard *.cpp),1,)
@@ -306,11 +305,12 @@ else
 endif
 	$(Q)$(SIZE) $(ELFFILE)
 	$(Q)$(OBJCOPY) $(OFLAGS) $(ELFFILE) $(HEXFILE)
-	$(Q)$(OBJCOPY) -O binary $(ELFFILE) $(BINFILE)
 endif
 endif # BUILD_IN_DOCKER
 
 firmware-metadata: all generate-metadata
+	BINFILE ?= $(ELFFILE:.elf=.bin)
+	$(Q)$(OBJCOPY) -O binary $(ELFFILE) $(BINFILE)
 	$(Q)$(FW_METADATA)/bin/generate-metadata $(BINFILE) $(VERSION) $(APPID) $(BINDIR)/firmware-metadata.bin
 
 generate-metadata: $(FW_METADATA)/bin/generate-metadata

--- a/dist/tools/firmware_metadata/Makefile
+++ b/dist/tools/firmware_metadata/Makefile
@@ -1,0 +1,19 @@
+RIOTBASE := ../../..
+RIOT_INCLUDE = $(RIOTBASE)/sys/include
+SHA256_DIR := $(RIOTBASE)/sys/hashes
+SHA256_INCLUDE := $(RIOT_INCLUDE)/hashes
+METADATA_SRC := generate-metadata.c $(SHA256_DIR)/sha256.c
+METADATA_HDR := $(RIOT_INCLUDE)/hashes/sha256.h
+
+CFLAGS += -g -O3 -Wall -Wextra -pedantic -std=c99
+
+all: bin/generate-metadata
+
+bin/:
+	mkdir -p bin
+
+bin/generate-metadata: $(METADATA_HDR) $(METADATA_SRC) | bin/
+	$(CC) $(CFLAGS) -I$(RIOT_INCLUDE) $(METADATA_SRC) -o $@
+
+clean:
+	rm -rf bin/generate-metadata

--- a/dist/tools/firmware_metadata/README.md
+++ b/dist/tools/firmware_metadata/README.md
@@ -1,0 +1,36 @@
+# Metadata generator for firmware verification
+This program generates a binary file containing a metadata structure as
+follows:
+
+```c
+typedef struct firmware_metadata {
+    uint8_t hash[SHA256_DIGEST_LENGTH]; /**< SHA256 Hash of firmware image */
+    uint8_t shash[SIGN_LEN];            /**< Signed SHA256 */
+    uint16_t version;                   /**< Integer representing firmware version */
+    uint32_t size;                      /**< Size of firmware image */
+    uint32_t appid;                     /**< Integer representing the application ID */
+} firmware_metadata_t;
+```
+
+This structure is filled with the data obtained from the firmware.
+
+## Usage
+To use, you should call `generate-metadata` with the following arguments:
+
+```console
+./generate-metadata <firmware.bin> <version> <appid> <output-path>
+```
+
+Where:
+
+_\<firmware.bin\>\:_ The firmware in binary format
+
+_\<version\>\:_ The firmware version in 16-bit HEX
+
+_\<appid\>_\: ID for the application in 32-bit HEX
+
+_\<output-path\>_\: The path for fimrware_metadata.bin
+
+If the operation succeeds, the results are printed out and a binary called
+"firmware-metadata.bin" is written, if no _output-path_ option is specified,
+in which case the file is written to the given path with the given name.

--- a/dist/tools/firmware_metadata/README.md
+++ b/dist/tools/firmware_metadata/README.md
@@ -25,12 +25,12 @@ Where:
 
 _\<firmware.bin\>\:_ The firmware in binary format
 
-_\<version\>\:_ The firmware version in 16-bit HEX
+_\<version\>\:_ The firmware version in 16-bit HEX format
 
-_\<appid\>_\: ID for the application in 32-bit HEX
+_\<appid\>_\: ID for the application in 32-bit HEX format
 
-_\<output-path\>_\: The path for fimrware_metadata.bin
+_\<output-path/filename.bin\>_\: The path and name of the metadata binary file
 
 If the operation succeeds, the results are printed out and a binary called
-"firmware-metadata.bin" is written, if no _output-path_ option is specified,
-in which case the file is written to the given path with the given name.
+"firmware-metadata.bin" is written, if no _output-path_ option is specified.
+Otherwise, the file is written to the given path with the given name.

--- a/dist/tools/firmware_metadata/README.md
+++ b/dist/tools/firmware_metadata/README.md
@@ -15,7 +15,7 @@ typedef struct firmware_metadata {
 This structure is filled with the data obtained from the firmware.
 
 ## Usage
-To use, you should call `generate-metadata` with the following arguments:
+To use it, call `generate-metadata` with the following arguments:
 
 ```console
 ./generate-metadata <firmware.bin> <version> <appid> <output-path>

--- a/dist/tools/firmware_metadata/generate-metadata.c
+++ b/dist/tools/firmware_metadata/generate-metadata.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2016, Mark Solters <msolters@gmail.com>.
+ *               2016, Inria
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/**
+ * @ingroup     FW
+ * @file
+ * @brief       Meta-data generation for FW images
+ *
+ * @author      Mark Solters <msolters@gmail.com>
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/resource.h>
+
+#include "hashes/sha256.h"
+
+#define FW_METADATA_BIN "firmware-metadata.bin"
+
+typedef struct firmware_metadata {
+    uint8_t hash[SHA256_DIGEST_LENGTH];  /**< SHA256 Hash of firmware image */
+    uint8_t shash[SHA256_DIGEST_LENGTH]; /**< Signed SHA256 */
+    uint16_t version;                    /**< Integer representing firmware version */
+    uint32_t size;                       /**< Size of firmware image */
+    uint32_t appid;                      /**< Integer representing the application ID */
+} firmware_metadata_t;
+
+/* Input firmware .bin file */
+FILE *firmware_bin;
+
+/* Output metadata .bin file */
+FILE *metadata_bin;
+
+uint32_t firmware_size = 0;
+
+int main(int argc, char *argv[])
+{
+    firmware_metadata_t metadata;
+    sha256_context_t firmware_sha256;
+    uint8_t output_buffer[sizeof(firmware_metadata_t)];
+    int bytes_read = 0;
+    uint8_t firmware_buffer[1024];
+    char firmware_metadata_path[128];
+
+    if (argc < 4) {
+        puts("Usage: generate-metadata <BINFILE> <VERSION> <APPID> [output path]");
+        return -1;
+    }
+
+    if (argv[4]) {
+        strcpy(firmware_metadata_path, argv[4]);
+    }
+    else {
+        strcpy(firmware_metadata_path, "firmware-metadata.bin");
+    }
+
+    /* Open the firmware .bin file */
+    if (!(firmware_bin = fopen(argv[1], "r"))) {
+        printf("Error: No binary file found!\n");
+        return -1;
+    }
+
+    sha256_init(&firmware_sha256);
+
+    while((bytes_read = fread(firmware_buffer, 1, sizeof(firmware_buffer), firmware_bin))) {
+        sha256_update(&firmware_sha256, firmware_buffer, bytes_read);
+        firmware_size += bytes_read;
+    }
+    sha256_final(&firmware_sha256, metadata.hash);
+
+    printf("Firmware bytes read: %u\n", firmware_size);
+
+    /* Close the .bin file. */
+    fclose(firmware_bin);
+
+    /*
+     * Fill with 0 the signed hash, as it's not yet implemented
+     */
+    for (unsigned long i = 0; i < sizeof(metadata.shash); i++) {
+        metadata.shash[i] = 0;
+    }
+
+    /* Generate FW image metadata */
+    metadata.size = firmware_size;
+    sscanf(argv[2], "%xu", (unsigned int *)&(metadata.version));
+    sscanf(argv[3], "%xu", &(metadata.appid));
+    memcpy(output_buffer, (uint8_t*)&metadata, sizeof(firmware_metadata_t));
+
+    printf("Firmware Size: %d\n", metadata.size);
+    printf("Firmware Version: %#x\n", metadata.version);
+    printf("Firmware APPID: %#x\n", metadata.appid);
+    printf("Firmware HASH: ");
+    for (unsigned long i = 0; i < sizeof(metadata.hash); i++) {
+        printf("%02x ", metadata.hash[i]);
+    }
+    printf("\n");
+    printf("Firmware signed HASH: ");
+    for (unsigned long i = 0; i < sizeof(metadata.shash); i++) {
+        printf("%02x ", metadata.shash[i]);
+    }
+    printf("\n");
+
+    /* Open the output firmware .bin file */
+    metadata_bin = fopen(firmware_metadata_path, "w");
+
+    /* Write the metadata */
+    printf("Metadata size: %lu\n", sizeof(firmware_metadata_t));
+    fwrite(output_buffer, sizeof(output_buffer), 1, metadata_bin);
+
+    /* 0xff spacing until firmware binary starts */
+    uint8_t blank_buffer[256 - sizeof(firmware_metadata_t)];
+
+    for (unsigned long b = 0; b < sizeof(blank_buffer); b++) {
+        blank_buffer[b] = 0xff;
+    }
+
+    fwrite(blank_buffer, sizeof(blank_buffer), 1, metadata_bin);
+
+    /* Close the metadata file */
+    fclose(metadata_bin);
+
+    return 0;
+}

--- a/dist/tools/firmware_metadata/generate-metadata.c
+++ b/dist/tools/firmware_metadata/generate-metadata.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 
     sha256_init(&firmware_sha256);
 
-    while((bytes_read = fread(firmware_buffer, 1, sizeof(firmware_buffer), firmware_bin))) {
+    while ((bytes_read = fread(firmware_buffer, 1, sizeof(firmware_buffer), firmware_bin))) {
         sha256_update(&firmware_sha256, firmware_buffer, bytes_read);
         firmware_size += bytes_read;
     }


### PR DESCRIPTION
Since #6450 became a bit complicated to manage, I'll start to split the work in several PRs, with the aim to ease review and have a better picture of the approach.

This PR adds a firmware metadata generator, which will produce a binary file representing a structure of this kind:

```c
typedef struct FW_metadata {
    uint8_t hash[SHA256_DIGEST_LENGTH]; /**< SHA256 Hash of firmware image */
    uint8_t shash[SIGN_LEN];            /**< Signed SHA256 */
    uint16_t version;                   /**< Integer representing firmware version */
    uint32_t size;                      /**< Size of firmware image */
    uint32_t appid;                     /**< Integer representing the application ID */
} FW_metadata_t;
```

as a simplified way to characterise the contents of a firmware, while adding some security features as the sha256 hash for integrity check, as well as a field for a signed hash, which will come in a following PR.

This approach will use the current RIOT implementation of sha256 to allow portability.

To test the firmware generator, you can run the following command for any RIOT example or application:

`make firmware-metadata VERSION=0x1 APPID=0xabcd1234`

using `VERSION=0x1` and `APPID=0xabcd1234` as examples.

The ultimate goal is to put this metadata at the beginning of any firmware, to use it e.g. for a firmware update. This feature will come in an upcoming PR, stay tuned.