### PR TITLE
can: add tja1042 transceiver driver

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -245,3 +245,8 @@ ifneq (,$(filter adc%1c,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += adcxx1c
 endif
+
+ifneq (,$(filter tja1042,$(USEMODULE)))
+  USEMODULE += can_trx
+  FEATURES_REQUIRED += periph_gpio
+endif

--- a/drivers/include/tja1042.h
+++ b/drivers/include/tja1042.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016-2018  OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_tja1042 TJA1042
+ * @ingroup     drivers
+ * @ingroup     trx_can
+ * @brief       tja1042 High Speed CAN transceiver driver
+ *
+ * @{
+ *
+ * @file
+ * @brief       tja1042 generic CAN transceiver interface initialization
+ *
+ * @author      Aurelien Gonce <aurelien.gonce@altran.com>
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ */
+#ifndef TJA1042_H
+#define TJA1042_H
+
+#include <stdio.h>
+
+#include "periph/gpio.h"
+#include "can/can_trx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   tja1042 CAN trx descriptor
+ */
+typedef struct tja1042_trx {
+    /**
+     *  set mode interface
+     */
+    can_trx_t trx;
+
+    /**
+     *  Mode pin of tja1042 device
+     */
+    gpio_t stb_pin;
+
+} tja1042_trx_t;
+
+/**
+ * @brief   Set mode interface
+ *
+ * @param[in] dev      Pointer to the tja1042 descriptor
+ * @param[in] mode     mode to set
+ *
+ * @return  0 on success
+ * @return -1 on error
+ */
+int tja1042_trx_set_mode(can_trx_t *dev, can_trx_mode_t mode);
+
+/**
+ * @brief   Initialize the given tja1042
+ *
+ * @param[in] dev      Pointer to the tja1042 descriptor
+ *
+ * @return  0 on success
+ * @return -1 on error
+ */
+int tja1042_trx_init(can_trx_t *dev);
+
+/**
+ * @brief   tja1042 driver
+ */
+extern const trx_driver_t tja1042_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TJA1042_H */
+/** @} */

--- a/drivers/tja1042/Makefile
+++ b/drivers/tja1042/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/tja1042/tja1042.c
+++ b/drivers/tja1042/tja1042.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016-2018  OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_tja1042
+ * @{
+ *
+ * @file
+ * @brief       generic CAN transceiver implementation for tja1042
+ *
+ * @author      Aurelien Gonce <aurelien.gonce@altran.com>
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include <assert.h>
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#include "tja1042.h"
+
+int tja1042_trx_set_mode(can_trx_t *dev, can_trx_mode_t mode)
+{
+    tja1042_trx_t *tja1042 = (tja1042_trx_t *)dev;
+    int ret;
+
+    DEBUG("tja1042_trx_set_mode: dev=%p, mode=%d\n", (void *)dev, (int)mode);
+
+    switch (mode) {
+    case TRX_NORMAL_MODE:
+    case TRX_SILENT_MODE:
+        gpio_clear(tja1042->stb_pin);
+        ret = 0;
+        break;
+
+    case TRX_SLEEP_MODE:
+        gpio_set(tja1042->stb_pin);
+        ret = 0;
+        break;
+
+    default:
+        ret = -1;
+        break;
+    }
+
+    return ret;
+}
+
+int tja1042_trx_init(can_trx_t *dev)
+{
+    assert(dev != NULL);
+
+    tja1042_trx_t *tja1042 = (tja1042_trx_t *)dev;
+
+    gpio_init(tja1042->stb_pin, GPIO_OUT);
+    tja1042_trx_set_mode(dev, TRX_NORMAL_MODE);
+
+    return 0;
+}
+
+const trx_driver_t tja1042_driver = {
+    .init = tja1042_trx_init,
+    .set_mode = tja1042_trx_set_mode,
+};

--- a/tests/can_trx/Makefile
+++ b/tests/can_trx/Makefile
@@ -1,0 +1,16 @@
+export APPLICATION = can_trx
+include ../Makefile.tests_common
+
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+USEMODULE += can_trx
+
+TRX_TO_BUILD ?= tja1042
+
+ifneq (,$(filter tja1042,$(TRX_TO_BUILD)))
+    USEMODULE += tja1042
+endif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/can_trx/main.c
+++ b/tests/can_trx/main.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2017 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       test a CAN transceiver through can_trx interface
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "can/can_trx.h"
+
+#include "shell.h"
+
+#ifdef MODULE_TJA1042
+#include "tja1042.h"
+static can_trx_t tja1042 = {
+        .driver = &tja1042_driver,
+};
+#endif
+
+static can_trx_t *devs[] = {
+#ifdef MODULE_TJA1042
+    &tja1042,
+#endif
+    NULL,
+};
+
+static int help(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    puts("Help:");
+    puts("\tinit [trx_id] - initialize a trx");
+    puts("\tset_mode [trx_id] [mode] - set a mode on the trx");
+    printf("trx_id: 0..%u\n", (unsigned)(sizeof(devs) / sizeof(devs[0])));
+    puts("modes:");
+    puts("\t0: normal mode");
+    puts("\t1: silent mode");
+    puts("\t2: standby mode");
+    puts("\t3: high-speed mode (SW CAN only)");
+    puts("\t4: high-voltage wakeup mode (SW CAN only)");
+
+    return 0;
+}
+
+static int init(int argc, char **argv) {
+
+    if (argc < 2) {
+        puts("trx_id needed");
+        help(0, NULL);
+        return 1;
+    }
+
+    unsigned trx = atoi(argv[1]);
+    if (trx < (sizeof(devs) / sizeof(devs[0]))) {
+        int res = can_trx_init(devs[trx]);
+        if (res >= 0) {
+            puts("Trx successfully initialized");
+            return 0;
+        }
+        else {
+            printf("Error when initializing trx: %d\n", res);
+        }
+    }
+    else {
+        puts("Invalid trx_id");
+    }
+
+    return 1;
+}
+
+static int set_mode(int argc, char **argv) {
+
+    if (argc < 3) {
+        puts("trx_id and mode needed");
+        help(0, NULL);
+        return 1;
+    }
+    unsigned trx = atoi(argv[1]);
+    unsigned mode = atoi(argv[2]);
+    if ((trx < (sizeof(devs) / sizeof(devs[0]))) &&
+            (mode <= TRX_HIGH_VOLTAGE_WAKE_UP_MODE)) {
+        int res = can_trx_set_mode(devs[trx], mode);
+        if (res >= 0) {
+            puts("Mode successfully set");
+            return 0;
+        }
+        else {
+            printf("Error when setting mode: %d\n", res);
+        }
+    }
+    else {
+        puts("Invalid trx_id or mode");
+    }
+
+    return 1;
+}
+
+static const shell_command_t cmds[] = {
+        { "help", "help", help },
+        { "init", "initialize a can trx", init },
+        { "set_mode", "set a can trx mode", set_mode },
+        { NULL, NULL, NULL },
+};
+
+int main(void)
+{
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(cmds, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
Follow up, based on #5793 

This is the TJA1042 (http://www.nxp.com/documents/data_sheet/TJA1042.pdf) HS CAN transceiver driver.