### PR TITLE
boards/nucleo144-f303: reconfigure PWM and UART to match Arduino pinout

### DIFF
--- a/boards/nucleo144-f303/include/periph_conf.h
+++ b/boards/nucleo144-f303/include/periph_conf.h
@@ -84,28 +84,28 @@ static const uart_conf_t uart_config[] = {
 #endif
     },
     {
-        .dev        = USART2,
-        .rcc_mask   = RCC_APB1ENR_USART2EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 3),
-        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_C, 5),
+        .tx_pin     = GPIO_PIN(PORT_C, 4),
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
-        .bus        = APB1,
-        .irqn       = USART2_IRQn,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 5,
         .dma_chan   = 4
 #endif
     },
     {
-        .dev        = USART1,
-        .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_B, 7),
-        .tx_pin     = GPIO_PIN(PORT_B, 6),
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 6),
+        .tx_pin     = GPIO_PIN(PORT_D, 5),
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
-        .bus        = APB2,
-        .irqn       = USART1_IRQn,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 4,
         .dma_chan   = 4
@@ -115,9 +115,9 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart3)
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
-#define UART_1_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart1)
 #define UART_1_DMA_ISR      (isr_dma1_stream5)
-#define UART_2_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
@@ -131,12 +131,22 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM1,
         .rcc_mask = RCC_APB2ENR_TIM1EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_A, 8),  .cc_chan = 0},
-                      { .pin = GPIO_PIN(PORT_A, 9),  .cc_chan = 1},
-                      { .pin = GPIO_PIN(PORT_A, 10), .cc_chan = 2},
+        .chan     = { { .pin = GPIO_PIN(PORT_E, 9),  .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 11), .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13), .cc_chan = 2},
                       { .pin = GPIO_UNDEF,           .cc_chan = 0} },
-        .af       = GPIO_AF6,
+        .af       = GPIO_AF2,
         .bus      = APB2
+    },
+    {
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 15), .cc_chan = 3},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
     }
 };
 
@@ -173,7 +183,7 @@ static const spi_conf_t spi_config[] = {
         .mosi_pin = GPIO_PIN(PORT_A, 7),
         .miso_pin = GPIO_PIN(PORT_A, 6),
         .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
+        .cs_pin   = GPIO_UNDEF,
         .af       = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
         .apbbus   = APB2


### PR DESCRIPTION
This PR reworks the periph configuration of the nucleo144-f303.
Note that the second UART is mapped to RX/TX pins of the Arduino pinout making this board a good candidate for an Arduino Xbee shield.
When this PR is merged, we can safely merge #6880 as it solves the reported pin clashes.