### PR TITLE
can: add ncv7356 SW transceiver driver

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -357,6 +357,11 @@ ifneq (,$(filter my9221,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter nvc7356,$(USEMODULE)))
+  USEMODULE += can_trx
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 ifneq (,$(filter nrfmin,$(USEMODULE)))
   FEATURES_REQUIRED += radio_nrfmin
   FEATURES_REQUIRED += periph_cpuid

--- a/drivers/include/ncv7356.h
+++ b/drivers/include/ncv7356.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2016-2018  OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_ncv7356 NCV7356
+ * @ingroup     drivers_can
+ * @ingroup     drivers_can_trx
+ * @brief       ncv7356 Single Wire CAN transceiver driver
+ *
+ * @{
+ *
+ * @file
+ * @brief       ncv7356 generic CAN transceiver interface initialization
+ *
+ * @author      Aurelien Gonce <aurelien.gonce@altran.com>
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ */
+#ifndef NCV7356_H
+#define NCV7356_H
+
+#include <stdio.h>
+
+#include "periph/gpio.h"
+#include "can/can_trx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   ncv7356 trx descriptor
+ */
+typedef struct ncv7356_trx {
+    /**
+     *  set mode interface
+     */
+    can_trx_t trx;
+
+    /**
+     *  Mode 0 pin of ncv7356 device
+     */
+    gpio_t mode0_pin;
+
+    /**
+     *  Mode 1 pin of ncv7356 device
+     */
+    gpio_t mode1_pin;
+
+} ncv7356_trx_t;
+
+/**
+ * @brief   Set mode interface
+ *
+ * @param[in] dev      Pointer to the ncv7356 descriptor
+ * @param[in] mode     mode to set
+ *
+ * @return  0 on success
+ * @return -1 on error
+ */
+int ncv7356_trx_set_mode(can_trx_t *dev, can_trx_mode_t mode);
+
+/**
+ * @brief   Initialize the given ncv7356
+ *
+ * @param[in] dev      Pointer to the ncv7356 descriptor
+ *
+ * @return  0 on success
+ * @return -1 on error
+ */
+int ncv7356_trx_init(can_trx_t *dev);
+
+/**
+ * @brief   ncv7356 driver
+ */
+extern const trx_driver_t ncv7356_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NCV7356_H */
+/** @} */

--- a/drivers/ncv7356/Makefile
+++ b/drivers/ncv7356/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ncv7356/ncv7356.c
+++ b/drivers/ncv7356/ncv7356.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2016-2018  OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ncv7356
+ * @{
+ *
+ * @file
+ * @brief       generic can transceiver implementation for ncv7356
+ *
+ * @author      Aurelien GONCE <aurelien.gonce@altran.com>
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include "ncv7356.h"
+
+int ncv7356_trx_set_mode(can_trx_t *dev, can_trx_mode_t mode)
+{
+    ncv7356_trx_t *ncv7356 = (ncv7356_trx_t *)dev;
+    int ret;
+
+    switch (mode) {
+    case TRX_NORMAL_MODE:
+    case TRX_SILENT_MODE:
+        gpio_set(ncv7356->mode0_pin);
+        gpio_set(ncv7356->mode1_pin);
+        ret = 0;
+        break;
+
+    case TRX_HIGH_SPEED_MODE:
+        gpio_set(ncv7356->mode0_pin);
+        gpio_clear(ncv7356->mode1_pin);
+        ret = 0;
+        break;
+
+    case TRX_HIGH_VOLTAGE_WAKE_UP_MODE:
+        gpio_clear(ncv7356->mode0_pin);
+        gpio_set(ncv7356->mode1_pin);
+        ret = 0;
+        break;
+
+    case TRX_SLEEP_MODE:
+        gpio_clear(ncv7356->mode0_pin);
+        gpio_clear(ncv7356->mode1_pin);
+        ret = 0;
+        break;
+
+    default:
+        ret = -1;
+        break;
+    }
+
+    return ret;
+}
+
+int ncv7356_trx_init(can_trx_t *dev)
+{
+    ncv7356_trx_t *ncv7356 = (ncv7356_trx_t *)dev;
+
+    gpio_init(ncv7356->mode0_pin, GPIO_OUT);
+    gpio_init(ncv7356->mode1_pin, GPIO_OUT);
+    ncv7356_trx_set_mode((can_trx_t *)dev, TRX_NORMAL_MODE);
+
+    return 0;
+}
+
+const trx_driver_t ncv7356_driver = {
+    .init = ncv7356_trx_init,
+    .set_mode = ncv7356_trx_set_mode,
+};

--- a/tests/can_trx/Makefile
+++ b/tests/can_trx/Makefile
@@ -10,10 +10,14 @@ USEMODULE += ps
 
 USEMODULE += can_trx
 
-TRX_TO_BUILD ?= tja1042
+TRX_TO_BUILD ?= tja1042 ncv7356
 
 ifneq (,$(filter tja1042,$(TRX_TO_BUILD)))
-    USEMODULE += tja1042
+  USEMODULE += tja1042
+endif
+
+ifneq (,$(filter ncv7356,$(TRX_TO_BUILD)))
+  USEMODULE += ncv7356
 endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/can_trx/main.c
+++ b/tests/can_trx/main.c
@@ -32,9 +32,19 @@ static can_trx_t tja1042 = {
 };
 #endif
 
+#ifdef MODULE_NCV7356
+#include "ncv7356.h"
+static can_trx_t ncv7356 = {
+    .driver = &ncv7356_driver,
+};
+#endif
+
 static can_trx_t *devs[] = {
 #ifdef MODULE_TJA1042
     &tja1042,
+#endif
+#ifdef MODULE_NCV7356
+    &ncv7356,
 #endif
     NULL,
 };


### PR DESCRIPTION
Follow up, based on #5793

This is the NCV7356 (https://www.onsemi.com/pub/Collateral/NCV7356-D.PDF) single wire CAN transceiver driver.