### PR TITLE
saml21/gpio: Allow multiple EXTI at the same time

### DIFF
--- a/cpu/saml21/periph/gpio.c
+++ b/cpu/saml21/periph/gpio.c
@@ -137,6 +137,9 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     /* enable clocks for the EIC module */
     MCLK->APBAMASK.reg |= MCLK_APBAMASK_EIC;
     GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
+    /* disable the EIC module*/
+    EIC->CTRLA.reg = 0;
+    while (EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
     /* configure the active flank */
     EIC->CONFIG[exti >> 3].reg &= ~(0xf << ((exti & 0x7) * 4));
     EIC->CONFIG[exti >> 3].reg |=  (flank << ((exti & 0x7) * 4));


### PR DESCRIPTION
This PR proposes a fix for #6904 
To sum up, having one EXTI on saml21 works fine but if you try to enable several exti only the first one works.( all init said it's ok but only the first works)
The problem is any attempt to write into `EIC->CONFIG` failed after EIC is enabled (`EIC->CTRLA.reg = EIC_CTRLA_ENABLE;`)
[SAML21 datasheet](http://www.atmel.com/Images/Atmel-42385-SAM-L21-Datasheet.pdf) said that `EIC->CONFIG` registers are protected after EIC is enable. (27.6.2.1. Initialization -> page 473 of saml21 datasheet)

Another solution would be (disable EIC at the end of the function, change `EIC->CONFIG` reg and re-enable it): 
```
    /* enable clocks for the EIC module */
    MCLK->APBAMASK.reg |= MCLK_APBAMASK_EIC;
    GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
    /* enable the global EIC interrupt */
    NVIC_EnableIRQ(EIC_IRQn);
    /*Enable pin interrupt */
    EIC->INTFLAG.reg = (1 << exti);
    EIC->INTENSET.reg = (1 << exti);
    /* disable the EIC module*/
    EIC->CTRLA.reg = 0;
    while (EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
    /* configure the active flank */
    EIC->CONFIG[exti >> 3].reg &= ~(0xf << ((exti & 0x7) * 4));
    EIC->CONFIG[exti >> 3].reg |=  (flank << ((exti & 0x7) * 4));
    /* enable the EIC module*/
    EIC->CTRLA.reg = EIC_CTRLA_ENABLE;
    while (EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE) {}
    return 0;
```

Let me know what you think about it.



