### PR TITLE
rpl: make parent lifetime consistent with other timers

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -265,8 +265,7 @@ void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent)
 {
     /* update Parent lifetime */
     if (parent != NULL) {
-        uint32_t now = xtimer_now_usec();
-        parent->lifetime = (now / US_PER_SEC) + (dodag->default_lifetime * dodag->lifetime_unit);
+        parent->lifetime = dodag->default_lifetime * dodag->lifetime_unit;
 #ifdef MODULE_GNRC_RPL_P2P
         if (dodag->instance->mop != GNRC_RPL_P2P_MOP) {
 #endif

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -304,8 +304,7 @@ int _gnrc_rpl_dodag_show(void)
         LL_FOREACH(gnrc_rpl_instances[i].dodag.parents, parent) {
             printf("\t\tparent [addr: %s | rank: %d | lifetime: %" PRIu32 "s]\n",
                     ipv6_addr_to_str(addr_str, &parent->addr, sizeof(addr_str)),
-                    parent->rank, ((int32_t) (parent->lifetime - (((uint32_t) xnow / US_PER_SEC))))
-                    < 0 ? 0 : (parent->lifetime - ((uint32_t) xnow / US_PER_SEC)));
+                    parent->rank, parent->lifetime);
         }
     }
     return 0;


### PR DESCRIPTION
fixes #6229 