### PR TITLE
boards: wifire/clicker: Fix UART configuration

### DIFF
--- a/boards/pic32-clicker/clicker.c
+++ b/boards/pic32-clicker/clicker.c
@@ -22,7 +22,7 @@ void board_init(void)
      * Setup pin mux for UART3 this is the one connected
      * to the mickroBUS
      */
-    U3RXREG =  0x2;          /*connect pin RPF5 to UART3 RX*/
+    U3RXR =    0x2;          /*connect pin RPF5 to UART3 RX*/
     RPF4R =    0x1;          /*connect pin RPF4 to UART3 TX*/
 
     /* intialise UART used for debug (printf) */

--- a/boards/pic32-clicker/clicker.c
+++ b/boards/pic32-clicker/clicker.c
@@ -24,10 +24,6 @@ void board_init(void)
      */
     U3RXREG =  0x2;          /*connect pin RPF5 to UART3 RX*/
     RPF4R =    0x1;          /*connect pin RPF4 to UART3 TX*/
-    PORTFCLR = BIT5 | BIT4;  /*set '0' on Porf F pins 4 and 5 */
-    TRISFCLR = BIT4;         /*set PortF pin 4 for output */
-    TRISFSET = BIT5;         /*set PortF pin 5 for input */
-    ODCFCLR =  BIT5 | BIT4;  /*set PortF pin 4 and 5 as not open-drain */
 
     /* intialise UART used for debug (printf) */
 #ifdef DEBUG_VIA_UART

--- a/boards/pic32-wifire/wifire.c
+++ b/boards/pic32-wifire/wifire.c
@@ -25,10 +25,6 @@ void board_init(void)
      */
     U4RXREG = 0xb;            /* connect pin RPF2 to UART 4 RX */
     RPF8R =   0x2;            /* connect pin RPF8 to UART 4 TX */
-    PORTFCLR =  BIT8 | BIT2;  /* clear down port F pins 2 and 8 */
-    TRISFCLR =  BIT2;         /* set portf pin 2 as input */
-    TRISFSET =  BIT8;         /* set portf pin 8 as output */
-    ODCFCLR =   BIT8 | BIT2;  /* set portf pint 2 and 8 as not open-drain */
 
     /* intialise UART used for debug (printf) */
 #ifdef DEBUG_VIA_UART

--- a/boards/pic32-wifire/wifire.c
+++ b/boards/pic32-wifire/wifire.c
@@ -23,7 +23,7 @@ void board_init(void)
      * Setup pin mux for UART4 this is the one connected
      * to the ftdi chip (usb<->uart)
      */
-    U4RXREG = 0xb;            /* connect pin RPF2 to UART 4 RX */
+    U4RXR =   0xb;            /* connect pin RPF2 to UART 4 RX */
     RPF8R =   0x2;            /* connect pin RPF8 to UART 4 TX */
 
     /* intialise UART used for debug (printf) */


### PR DESCRIPTION
This pull request implements the following changes to the pic32-wifire and pic32-clicker boards:
- Remove UART pin configuration. This is not needed since the UART module takes over the pin.
- Fix UART RX pinmux register