### PR TITLE
gnrc: cleanup of gnrc_pkt and enhance unittest

### DIFF
--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -128,7 +128,7 @@ static inline size_t gnrc_pkt_len(gnrc_pktsnip_t *pkt)
 {
     size_t len = 0;
 
-    while (pkt) {
+    while (pkt != NULL) {
         len += pkt->size;
         pkt = pkt->next;
     }
@@ -148,7 +148,7 @@ static inline size_t gnrc_pkt_len_upto(gnrc_pktsnip_t *pkt, gnrc_nettype_t type)
 {
     size_t len = 0;
 
-    while (pkt) {
+    while (pkt != NULL) {
         len += pkt->size;
 
         if (pkt->type == type) {
@@ -172,7 +172,7 @@ static inline size_t gnrc_pkt_count(const gnrc_pktsnip_t *pkt)
 {
     size_t count = 0;
 
-    while (pkt) {
+    while (pkt != NULL) {
         ++count;
         pkt = pkt->next;
     }

--- a/sys/net/gnrc/pkt/gnrc_pkt.c
+++ b/sys/net/gnrc/pkt/gnrc_pkt.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Freie Universität Berlin
+ *               2017 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -11,22 +12,18 @@
  *
  * @file
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Sebastian Meiling <s@mlng.net>
  */
-
-#include <assert.h>
 
 #include "net/gnrc/pkt.h"
 
-gnrc_pktsnip_t *gnrc_pktsnip_search_type(gnrc_pktsnip_t *ptr,
+gnrc_pktsnip_t *gnrc_pktsnip_search_type(gnrc_pktsnip_t *pkt,
                                          gnrc_nettype_t type)
 {
-    while (ptr != NULL) {
-        if (ptr->type == type) {
-            return ptr;
-        }
-        ptr = ptr->next;
+    while ((pkt != NULL) && (pkt->type != type)) {
+        pkt = pkt->next;
     }
-    return NULL;
+    return pkt;
 }
 
 /** @} */

--- a/tests/unittests/tests-pkt/Makefile.include
+++ b/tests/unittests/tests-pkt/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += gnrc_ipv6

--- a/tests/unittests/tests-pkt/tests-pkt.c
+++ b/tests/unittests/tests-pkt/tests-pkt.c
@@ -26,6 +26,9 @@
     { 1, (next), (data), (len), GNRC_NETTYPE_UNDEF }
 #define _INIT_ELEM_STATIC_DATA(data, next) _INIT_ELEM(sizeof(data), data, next)
 
+#define _INIT_ELEM_STATIC_TYPE(type, next) \
+    { 1, (next), NULL, 0, (type) }
+
 static void test_pkt_len__NULL(void)
 {
     TEST_ASSERT_EQUAL_INT(0, gnrc_pkt_len(NULL));
@@ -106,6 +109,26 @@ static void test_pkt_count__null(void)
     TEST_ASSERT_EQUAL_INT(0, gnrc_pkt_count(NULL));
 }
 
+static void test_pktsnip_search_type(void)
+{
+    /* init packet snips */
+    gnrc_pktsnip_t snip1 = _INIT_ELEM_STATIC_TYPE(GNRC_NETTYPE_UNDEF, NULL);
+    gnrc_pktsnip_t snip2 = _INIT_ELEM_STATIC_TYPE(GNRC_NETTYPE_TEST, &snip1);
+    gnrc_pktsnip_t snip3 = _INIT_ELEM_STATIC_TYPE(GNRC_NETTYPE_IPV6, &snip2);
+    /* successfull searches */
+    gnrc_pktsnip_t *res;
+    TEST_ASSERT_NOT_NULL((res = gnrc_pktsnip_search_type(&snip3, GNRC_NETTYPE_UNDEF)));
+    TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_UNDEF, res->type);
+    TEST_ASSERT_NOT_NULL((res = gnrc_pktsnip_search_type(&snip3, GNRC_NETTYPE_TEST)));
+    TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_TEST, res->type);
+    TEST_ASSERT_NOT_NULL((res = gnrc_pktsnip_search_type(&snip3, GNRC_NETTYPE_IPV6)));
+    TEST_ASSERT_EQUAL_INT(GNRC_NETTYPE_IPV6, res->type);
+    /* failing searches  */
+    TEST_ASSERT_NULL(gnrc_pktsnip_search_type(&snip1, GNRC_NETTYPE_TEST));
+    TEST_ASSERT_NULL(gnrc_pktsnip_search_type(&snip2, GNRC_NETTYPE_IPV6));
+    TEST_ASSERT_NULL(gnrc_pktsnip_search_type(&snip3, GNRC_NETTYPE_NUMOF));
+}
+
 Test *tests_pkt_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -119,6 +142,7 @@ Test *tests_pkt_tests(void)
         new_TestFixture(test_pkt_count__1_elem),
         new_TestFixture(test_pkt_count__5_elem),
         new_TestFixture(test_pkt_count__null),
+        new_TestFixture(test_pktsnip_search_type),
     };
 
     EMB_UNIT_TESTCALLER(pkt_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
minor optimization and correction, e.g. `/ptr/pkt/` like in header file.