### PR TITLE
cpu: k60: remove dangling symlink

### DIFF
--- a/cpu/k60/include/system_MK60DZ10.h
+++ b/cpu/k60/include/system_MK60DZ10.h
@@ -1,1 +1,0 @@
-system_MK60D10.h


### PR DESCRIPTION
Seems to be a leftover, I didn't find any reference, and anyway the target of the symlink is missing.