### PR TITLE
boards/nucleo144: rework UART and PWM conf to match Arduino pinout

### DIFF
--- a/boards/nucleo144-f207/include/periph_conf.h
+++ b/boards/nucleo144-f207/include/periph_conf.h
@@ -56,15 +56,25 @@ extern "C" {
  */
 static const pwm_conf_t pwm_config[] = {
     {
-        .dev      = TIM3,
-        .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0 },
-                      { .pin = GPIO_PIN(PORT_C, 7), .cc_chan = 1 },
-                      { .pin = GPIO_PIN(PORT_C, 8), .cc_chan = 2 },
-                      { .pin = GPIO_PIN(PORT_C, 9), .cc_chan = 3 } },
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_E,  9) /* D6 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 11) /* D5 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13) /* D3 */, .cc_chan = 2},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
+        .af       = GPIO_AF1,
+        .bus      = APB2
+    },
+    {
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 15) /* D9 */, .cc_chan = 3},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
         .af       = GPIO_AF2,
         .bus      = APB1
-    }
+    },
 };
 
 #define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
@@ -88,20 +98,11 @@ static const timer_conf_t timer_config[] = {
         .rcc_mask = RCC_APB1ENR_TIM5EN,
         .bus      = APB1,
         .irqn     = TIM5_IRQn
-    },
-    {
-        .dev      = TIM4,
-        .max      = 0xffffffff,
-        .rcc_mask = RCC_APB1ENR_TIM4EN,
-        .bus      = APB1,
-        .irqn     = TIM4_IRQn
     }
 };
 
 #define TIMER_0_ISR         isr_tim2
 #define TIMER_1_ISR         isr_tim5
-#define TIMER_2_ISR         isr_tim3
-#define TIMER_3_ISR         isr_tim4
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
@@ -126,6 +127,20 @@ static const uart_conf_t uart_config[] = {
 #endif
     },
     {
+        .dev        = USART6,
+        .rcc_mask   = RCC_APB2ENR_USART6EN,
+        .rx_pin     = GPIO_PIN(PORT_G, 9),
+        .tx_pin     = GPIO_PIN(PORT_G, 14),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB2,
+        .irqn       = USART6_IRQn,
+#ifdef UART_USE_DMA
+        .dma_stream = 6,
+        .dma_chan   = 4
+#endif
+    },
+    {
         .dev        = USART2,
         .rcc_mask   = RCC_APB1ENR_USART2EN,
         .rx_pin     = GPIO_PIN(PORT_D, 6),
@@ -135,33 +150,19 @@ static const uart_conf_t uart_config[] = {
         .bus        = APB1,
         .irqn       = USART2_IRQn,
 #ifdef UART_USE_DMA
-        .dma_stream = 6,
-        .dma_chan   = 4
-#endif
-    },
-    {
-        .dev        = USART1,
-        .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 10),
-        .tx_pin     = GPIO_PIN(PORT_A,  9),
-        .rx_af      = GPIO_AF7,
-        .tx_af      = GPIO_AF7,
-        .bus        = APB2,
-        .irqn       = USART1_IRQn,
-#ifdef UART_USE_DMA
         .dma_stream = 7,
         .dma_chan   = 4
 #endif
-    }
+    },
 };
 
 #define UART_0_ISR          (isr_usart3)
 #define UART_0_DMA_ISR      (isr_dma1_stream3)
 
-#define UART_1_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart6)
 #define UART_1_DMA_ISR      (isr_dma1_stream6)
 
-#define UART_2_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream7)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))

--- a/boards/nucleo144-f303/include/periph_conf.h
+++ b/boards/nucleo144-f303/include/periph_conf.h
@@ -84,28 +84,28 @@ static const uart_conf_t uart_config[] = {
 #endif
     },
     {
-        .dev        = USART2,
-        .rcc_mask   = RCC_APB1ENR_USART2EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 3),
-        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_C, 5),
+        .tx_pin     = GPIO_PIN(PORT_C, 4),
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
-        .bus        = APB1,
-        .irqn       = USART2_IRQn,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 5,
         .dma_chan   = 4
 #endif
     },
     {
-        .dev        = USART1,
-        .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_B, 7),
-        .tx_pin     = GPIO_PIN(PORT_B, 6),
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 6),
+        .tx_pin     = GPIO_PIN(PORT_D, 5),
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
-        .bus        = APB2,
-        .irqn       = USART1_IRQn,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 4,
         .dma_chan   = 4
@@ -115,9 +115,9 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart3)
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
-#define UART_1_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart1)
 #define UART_1_DMA_ISR      (isr_dma1_stream5)
-#define UART_2_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
@@ -131,12 +131,22 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM1,
         .rcc_mask = RCC_APB2ENR_TIM1EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_A, 8),  .cc_chan = 0},
-                      { .pin = GPIO_PIN(PORT_A, 9),  .cc_chan = 1},
-                      { .pin = GPIO_PIN(PORT_A, 10), .cc_chan = 2},
+        .chan     = { { .pin = GPIO_PIN(PORT_E,  9) /* D6 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 11) /* D5 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13) /* D3 */, .cc_chan = 2},
                       { .pin = GPIO_UNDEF,           .cc_chan = 0} },
-        .af       = GPIO_AF6,
+        .af       = GPIO_AF2,
         .bus      = APB2
+    },
+    {
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 15) /* D9 */, .cc_chan = 3},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
     }
 };
 
@@ -173,7 +183,7 @@ static const spi_conf_t spi_config[] = {
         .mosi_pin = GPIO_PIN(PORT_A, 7),
         .miso_pin = GPIO_PIN(PORT_A, 6),
         .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
+        .cs_pin   = GPIO_UNDEF,
         .af       = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
         .apbbus   = APB2

--- a/boards/nucleo144-f413/include/periph_conf.h
+++ b/boards/nucleo144-f413/include/periph_conf.h
@@ -89,28 +89,28 @@ static const uart_conf_t uart_config[] = {
 #endif
     },
     {
-        .dev        = USART2,
-        .rcc_mask   = RCC_APB1ENR_USART2EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 3),
-        .tx_pin     = GPIO_PIN(PORT_A, 2),
-        .rx_af      = GPIO_AF7,
-        .tx_af      = GPIO_AF7,
-        .bus        = APB1,
-        .irqn       = USART2_IRQn,
+        .dev        = USART6,
+        .rcc_mask   = RCC_APB2ENR_USART6EN,
+        .rx_pin     = GPIO_PIN(PORT_G, 9),
+        .tx_pin     = GPIO_PIN(PORT_G, 14),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB2,
+        .irqn       = USART6_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 5,
         .dma_chan   = 4
 #endif
     },
     {
-        .dev        = USART1,
-        .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 10),
-        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 6),
+        .tx_pin     = GPIO_PIN(PORT_D, 5),
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
-        .bus        = APB2,
-        .irqn       = USART1_IRQn,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 4,
         .dma_chan   = 4
@@ -120,9 +120,9 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart3)
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
-#define UART_1_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart6)
 #define UART_1_DMA_ISR      (isr_dma1_stream5)
-#define UART_2_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
@@ -134,34 +134,24 @@ static const uart_conf_t uart_config[] = {
  */
 static const pwm_conf_t pwm_config[] = {
     {
-        .dev      = TIM2,
-        .rcc_mask = RCC_APB1ENR_TIM2EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_A, 15), .cc_chan = 0},
-                      { .pin = GPIO_PIN(PORT_B,  3), .cc_chan = 1},
-                      { .pin = GPIO_PIN(PORT_B, 10), .cc_chan = 2},
-                      { .pin = GPIO_PIN(PORT_B,  2), .cc_chan = 3} },
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_E,  9) /* D6 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 11) /* D5 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13) /* D3 */, .cc_chan = 2},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
         .af       = GPIO_AF1,
-        .bus      = APB1
+        .bus      = APB2
     },
     {
-        .dev      = TIM3,
-        .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_B, 4), .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 } },
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 15) /* D9 */, .cc_chan = 3},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
         .af       = GPIO_AF2,
         .bus      = APB1
-    },
-    {
-        .dev      = TIM8,
-        .rcc_mask = RCC_APB2ENR_TIM8EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0},
-                      { .pin = GPIO_PIN(PORT_C, 7), .cc_chan = 1},
-                      { .pin = GPIO_PIN(PORT_C, 8), .cc_chan = 2},
-                      { .pin = GPIO_PIN(PORT_C, 9), .cc_chan = 3} },
-        .af       = GPIO_AF3,
-        .bus      = APB2
     },
 };
 

--- a/boards/nucleo144-f429/include/periph_conf.h
+++ b/boards/nucleo144-f429/include/periph_conf.h
@@ -87,28 +87,28 @@ static const uart_conf_t uart_config[] = {
 #endif
     },
     {
-        .dev        = USART2,
-        .rcc_mask   = RCC_APB1ENR_USART2EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 3),
-        .tx_pin     = GPIO_PIN(PORT_A, 2),
-        .rx_af      = GPIO_AF7,
-        .tx_af      = GPIO_AF7,
-        .bus        = APB1,
-        .irqn       = USART2_IRQn,
+        .dev        = USART6,
+        .rcc_mask   = RCC_APB2ENR_USART6EN,
+        .rx_pin     = GPIO_PIN(PORT_G, 9),
+        .tx_pin     = GPIO_PIN(PORT_G, 14),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB2,
+        .irqn       = USART6_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 5,
         .dma_chan   = 4
 #endif
     },
     {
-        .dev        = USART1,
-        .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 10),
-        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 6),
+        .tx_pin     = GPIO_PIN(PORT_D, 5),
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
-        .bus        = APB2,
-        .irqn       = USART1_IRQn,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 4,
         .dma_chan   = 4
@@ -118,9 +118,9 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart3)
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
-#define UART_1_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart6)
 #define UART_1_DMA_ISR      (isr_dma1_stream5)
-#define UART_2_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
@@ -132,25 +132,25 @@ static const uart_conf_t uart_config[] = {
  */
 static const pwm_conf_t pwm_config[] = {
     {
-        .dev      = TIM2,
-        .rcc_mask = RCC_APB1ENR_TIM2EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_A, 15), .cc_chan = 0},
-                      { .pin = GPIO_PIN(PORT_B,  3), .cc_chan = 1},
-                      { .pin = GPIO_PIN(PORT_B, 10), .cc_chan = 2},
-                      { .pin = GPIO_UNDEF,           .cc_chan = 0} },
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_E,  9) /* D6 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 11) /* D5 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13) /* D3 */, .cc_chan = 2},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
         .af       = GPIO_AF1,
-        .bus      = APB1
+        .bus      = APB2
     },
     {
-        .dev      = TIM3,
-        .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_B, 4), .cc_chan = 0 },
-                      { .pin = GPIO_PIN(PORT_B, 5), .cc_chan = 1 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 } },
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 15) /* D9 */, .cc_chan = 3},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
         .af       = GPIO_AF2,
         .bus      = APB1
-    }
+    },
 };
 
 #define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
@@ -186,7 +186,7 @@ static const spi_conf_t spi_config[] = {
         .mosi_pin = GPIO_PIN(PORT_A, 7),
         .miso_pin = GPIO_PIN(PORT_A, 6),
         .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
+        .cs_pin   = GPIO_UNDEF,
         .af       = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
         .apbbus   = APB2

--- a/boards/nucleo144-f446/include/periph_conf.h
+++ b/boards/nucleo144-f446/include/periph_conf.h
@@ -87,28 +87,28 @@ static const uart_conf_t uart_config[] = {
 #endif
     },
     {
-        .dev        = USART2,
-        .rcc_mask   = RCC_APB1ENR_USART2EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 3),
-        .tx_pin     = GPIO_PIN(PORT_A, 2),
-        .rx_af      = GPIO_AF7,
-        .tx_af      = GPIO_AF7,
-        .bus        = APB1,
-        .irqn       = USART2_IRQn,
+        .dev        = USART6,
+        .rcc_mask   = RCC_APB2ENR_USART6EN,
+        .rx_pin     = GPIO_PIN(PORT_G, 9),
+        .tx_pin     = GPIO_PIN(PORT_G, 14),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB2,
+        .irqn       = USART6_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 5,
         .dma_chan   = 4
 #endif
     },
     {
-        .dev        = USART1,
-        .rcc_mask   = RCC_APB2ENR_USART1EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 10),
-        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 6),
+        .tx_pin     = GPIO_PIN(PORT_D, 5),
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
-        .bus        = APB2,
-        .irqn       = USART1_IRQn,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 4,
         .dma_chan   = 4
@@ -118,9 +118,9 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_0_ISR          (isr_usart3)
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
-#define UART_1_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart6)
 #define UART_1_DMA_ISR      (isr_dma1_stream5)
-#define UART_2_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart2)
 #define UART_2_DMA_ISR      (isr_dma1_stream4)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
@@ -132,34 +132,24 @@ static const uart_conf_t uart_config[] = {
  */
 static const pwm_conf_t pwm_config[] = {
     {
-        .dev      = TIM2,
-        .rcc_mask = RCC_APB1ENR_TIM2EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_A, 15), .cc_chan = 0},
-                      { .pin = GPIO_PIN(PORT_B,  3), .cc_chan = 1},
-                      { .pin = GPIO_PIN(PORT_B, 10), .cc_chan = 2},
-                      { .pin = GPIO_PIN(PORT_B,  2), .cc_chan = 3} },
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_E,  9) /* D6 */, .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 11) /* D5 */, .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13) /* D3 */, .cc_chan = 2},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
         .af       = GPIO_AF1,
-        .bus      = APB1
+        .bus      = APB2
     },
     {
-        .dev      = TIM3,
-        .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_B, 4), .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 } },
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 15) /* D9 */, .cc_chan = 3},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0},
+                      { .pin = GPIO_UNDEF,                    .cc_chan = 0} },
         .af       = GPIO_AF2,
         .bus      = APB1
-    },
-    {
-        .dev      = TIM8,
-        .rcc_mask = RCC_APB2ENR_TIM8EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0},
-                      { .pin = GPIO_PIN(PORT_C, 7), .cc_chan = 1},
-                      { .pin = GPIO_PIN(PORT_C, 8), .cc_chan = 2},
-                      { .pin = GPIO_PIN(PORT_C, 9), .cc_chan = 3} },
-        .af       = GPIO_AF3,
-        .bus      = APB2
     },
 };
 
@@ -196,7 +186,7 @@ static const spi_conf_t spi_config[] = {
         .mosi_pin = GPIO_PIN(PORT_A, 7),
         .miso_pin = GPIO_PIN(PORT_A, 6),
         .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
+        .cs_pin   = GPIO_UNDEF,
         .af       = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
         .apbbus   = APB2


### PR DESCRIPTION
This PR adapt UART and PWM configuration in order to match the Arduino pinout available on the nucleo144 boards.
The good thing is that it's possible to plug an Xbee shield and use it as is since the RX/TX Arduino pins are connected to the second UART and not shared with the STLink.
The boards equipped with an Ethernet port could then be used a as BR ?

This PR replaces #6926.