### PR TITLE
sys: shell: gnrc_6ctx: fix gnrc_6ctx_add error handling (coccinelle)

### DIFF
--- a/sys/shell/commands/sc_gnrc_6ctx.c
+++ b/sys/shell/commands/sc_gnrc_6ctx.c
@@ -91,7 +91,7 @@ int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_s
         return 1;
     }
     prefix_len_str = strtok_r(NULL, "/", &save_ptr);
-    if (addr_str == NULL) {
+    if (prefix_len_str == 0) {
         _usage(cmd_str);
         return 1;
     }


### PR DESCRIPTION
The error check tested for the wrong condition.

(indirectly found by notnull.cocci)