### PR TITLE
drivers: fix doxygen for hd44780

### DIFF
--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -16,6 +16,8 @@
  * @note        The display is also known as LCM1602C from Arduino kits
  *
  * @author      Sebastian Meiling <s@mlng.net>
+ *
+ * @}
  */
 
 #include <assert.h>

--- a/drivers/hd44780/include/hd44780_internal.h
+++ b/drivers/hd44780/include/hd44780_internal.h
@@ -35,7 +35,7 @@ extern "C" {
 #define HD44780_FUNCTIONSET             (0x20)
 #define HD44780_SETCGRAMADDR            (0x40)
 #define HD44780_SETDDRAMADDR            (0x80)
-/**@}*/
+/** @} */
 
 /**
  * @brief   HD44780 LCD entry modes flags
@@ -45,7 +45,7 @@ extern "C" {
 #define HD44780_ENTRYLEFT               (0x02)
 #define HD44780_ENTRYSHIFTINCREMENT     (0x01)
 #define HD44780_ENTRYSHIFTDECREMENT     (0x00)
-/**@}*/
+/** @} */
 
 /**
  * @brief   HD44780 LCD control flags
@@ -57,7 +57,7 @@ extern "C" {
 #define HD44780_CURSOROFF               (0x00)
 #define HD44780_BLINKON                 (0x01)
 #define HD44780_BLINKOFF                (0x00)
-/**@}*/
+/** @} */
 
 /**
  * @brief   HD44780 display and cursor shift flags
@@ -79,7 +79,7 @@ extern "C" {
 #define HD44780_1LINE                   (0x00)
 #define HD44780_5x10DOTS                (0x04)
 #define HD44780_5x8DOTS                 (0x00)
-/**@}*/
+/** @} */
 
 /**
  * @brief   HD44780 LCD timings
@@ -98,3 +98,4 @@ extern "C" {
 #endif
 
 #endif /* HD44780_INTERNAL_H */
+/** @} */

--- a/drivers/include/hd44780.h
+++ b/drivers/include/hd44780.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_hd44780 HD44780 LCD driver
+ * @defgroup    drivers_hd44780 HD44780 LCD driver
  * @ingroup     drivers_actuators
  * @brief       Driver for the Hitachi HD44780 LCD driver
  *


### PR DESCRIPTION
minor corrections, i.e, fix group name and closing brackets of groups.