### PR TITLE
sys: shell: gnrc_6ctx: further fix gnrc_6ctx_add error handling

### DIFF
--- a/sys/shell/commands/sc_gnrc_6ctx.c
+++ b/sys/shell/commands/sc_gnrc_6ctx.c
@@ -91,7 +91,7 @@ int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_s
         return 1;
     }
     prefix_len_str = strtok_r(NULL, "/", &save_ptr);
-    if (prefix_len_str == 0) {
+    if (prefix_len_str == NULL) {
         _usage(cmd_str);
         return 1;
     }


### PR DESCRIPTION
this PR adds further correction to #6948, because `strtok_r` returns `NULL` if delim not found and not `0`. Maybe the destination variable of `prefix_len_str` is misleadingly named, as it suggests a length but actually is a `char *` 😉 