### PR TITLE
cpu/kintis+boards: fixed UART configuration

### DIFF
--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -91,6 +91,9 @@ static const uart_conf_t uart_config[] = {
         .irqn   = UART0_RX_TX_IRQn,
     },
 };
+
+#define UART_0_ISR          (uart_0_rx_tx)
+
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -118,8 +118,11 @@ static const uart_conf_t uart_config[] = {
         .irqn   = UART1_RX_TX_IRQn,
     },
 };
-#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 
+#define UART_0_ISR          (isr_uart0_rx_tx)
+#define UART_1_ISR          (isr_uart1_rx_tx)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 
 /**

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -31,11 +31,6 @@ extern "C"
 #endif
 
 /**
- * @brief Use the UART2 for STDIO on this board
- */
-#define UART_STDIO_DEV      UART_DEV(2)
-
-/**
  * @name    LED pin definitions and handlers
  * @{
  */

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -83,26 +83,6 @@ extern "C"
  */
 static const uart_conf_t uart_config[] = {
     {
-        .dev    = UART0,
-        .clken  = (volatile uint32_t*)(BITBAND_REGADDR(SIM->SCGC4, SIM_SCGC4_UART0_SHIFT)),
-        .freq   = CLOCK_CORECLOCK,
-        .pin_rx = GPIO_PIN(PORT_D, 6),
-        .pin_tx = GPIO_PIN(PORT_D, 7),
-        .pcr_rx = PORT_PCR_MUX(3),
-        .pcr_tx = PORT_PCR_MUX(3),
-        .irqn   = UART0_RX_TX_IRQn,
-    },
-    {
-        .dev    = UART1,
-        .clken  = (volatile uint32_t*)(BITBAND_REGADDR(SIM->SCGC4, SIM_SCGC4_UART1_SHIFT)),
-        .freq   = CLOCK_CORECLOCK,
-        .pin_rx = GPIO_UNDEF,
-        .pin_tx = GPIO_UNDEF,
-        .pcr_rx = PORT_PCR_MUX(3),
-        .pcr_tx = PORT_PCR_MUX(3),
-        .irqn   = UART1_RX_TX_IRQn,
-    },
-    {
         .dev    = UART2,
         .clken  = (volatile uint32_t*)(BITBAND_REGADDR(SIM->SCGC4, SIM_SCGC4_UART2_SHIFT)),
         .freq   = CLOCK_BUSCLOCK,
@@ -112,7 +92,21 @@ static const uart_conf_t uart_config[] = {
         .pcr_tx = PORT_PCR_MUX(3),
         .irqn   = UART2_RX_TX_IRQn,
     },
+    {
+        .dev    = UART0,
+        .clken  = (volatile uint32_t*)(BITBAND_REGADDR(SIM->SCGC4, SIM_SCGC4_UART0_SHIFT)),
+        .freq   = CLOCK_CORECLOCK,
+        .pin_rx = GPIO_PIN(PORT_D, 6),
+        .pin_tx = GPIO_PIN(PORT_D, 7),
+        .pcr_rx = PORT_PCR_MUX(3),
+        .pcr_tx = PORT_PCR_MUX(3),
+        .irqn   = UART0_RX_TX_IRQn,
+    }
 };
+
+#define UART_0_ISR          (isr_uart2_rx_tx)
+#define UART_1_ISR          (isr_uart0_rx_tx)
+
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */
 

--- a/cpu/kinetis_common/periph/uart.c
+++ b/cpu/kinetis_common/periph/uart.c
@@ -178,27 +178,37 @@ static inline void irq_handler(uart_t uart)
     cortexm_isr_end();
 }
 
-void isr_uart0_rx_tx(void)
+#ifdef UART_0_ISR
+void UART_0_ISR(void)
 {
     irq_handler(UART_DEV(0));
 }
+#endif
 
-void isr_uart1_rx_tx(void)
+#ifdef UART_1_ISR
+void UART_1_ISR(void)
 {
     irq_handler(UART_DEV(1));
 }
+#endif
 
-void isr_uart2_rx_tx(void)
+#ifdef UART_2_ISR
+void UART_2_ISR(void)
 {
     irq_handler(UART_DEV(2));
 }
+#endif
 
-void isr_uart3_rx_tx(void)
+#ifdef UART_3_ISR
+void UART_3_ISR(void)
 {
     irq_handler(UART_DEV(3));
 }
+#endif
 
-void isr_uart4_rx_tx(void)
+#ifdef UART_4_ISR
+void UART_4_ISR(void)
 {
     irq_handler(UART_DEV(4));
 }
+#endif


### PR DESCRIPTION
In #6868 I overlooked a sub-optimal UART configuration. This PR enables to arbitrarily order the (logical) UART devices for Kinetis CPUs (as done for other platforms), so no need to configure unused UART devices anymore -> saves ROM on e.g. phyNODE

tested on `mulle` and `phyNODE`