### PR TITLE
ipv6_addr: provide fix for off-by-x error

### DIFF
--- a/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr_from_str.c
@@ -96,7 +96,7 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
                 continue;
             }
 
-            if (i > sizeof(ipv6_addr_t)) {
+            if ((i + sizeof(uint16_t)) > sizeof(ipv6_addr_t)) {
                 return NULL;
             }
 
@@ -108,7 +108,7 @@ ipv6_addr_t *ipv6_addr_from_str(ipv6_addr_t *result, const char *addr)
         }
 
 #ifdef MODULE_IPV4_ADDR
-        if (ch == '.' && (i <= sizeof(ipv6_addr_t)) &&
+        if (ch == '.' && ((i + sizeof(ipv4_addr_t)) <= sizeof(ipv6_addr_t)) &&
             ipv4_addr_from_str((ipv4_addr_t *)(&(result->u8[i])),
                                curtok) != NULL) {
             i += sizeof(ipv4_addr_t);

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -896,6 +896,21 @@ static void test_ipv6_addr_from_str__one_colon_start(void)
     TEST_ASSERT_NULL(ipv6_addr_from_str(&result, ":ff::1"));
 }
 
+#define CANARY_DATA     0xc2, 0x8c, 0x36, 0x26, 0x24, 0x16, 0xd1, 0xd6
+
+static void test_ipv6_addr_from_str__overflow(void)
+{
+    uint8_t result[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                         CANARY_DATA };
+    static const uint8_t canary_exp[] = { CANARY_DATA };
+    ipv6_addr_t *addr = (ipv6_addr_t *)&result[0];
+    uint8_t *canary = &result[sizeof(ipv6_addr_t)];
+
+    TEST_ASSERT_NULL(ipv6_addr_from_str(addr, "::A:A:A:A:A:A:A:A:A:A"));
+    TEST_ASSERT_EQUAL_INT(0, memcmp(canary, canary_exp, sizeof(canary_exp)));
+}
+
 static void test_ipv6_addr_from_str__three_colons(void)
 {
     ipv6_addr_t result;
@@ -1086,6 +1101,7 @@ Test *tests_ipv6_addr_tests(void)
         new_TestFixture(test_ipv6_addr_to_str__success4),
         new_TestFixture(test_ipv6_addr_to_str__success5),
         new_TestFixture(test_ipv6_addr_from_str__one_colon_start),
+        new_TestFixture(test_ipv6_addr_from_str__overflow),
         new_TestFixture(test_ipv6_addr_from_str__three_colons),
         new_TestFixture(test_ipv6_addr_from_str__string_too_long),
         new_TestFixture(test_ipv6_addr_from_str__illegal_chars),


### PR DESCRIPTION
Provides a fix and test cases for an off-by-one (actually an off-by-2 and off-by-4) error in the string-to-ipv6-address-conversion.