### PR TITLE
dist: tools: revert "dist: cppcheck: switch back to 8 jobs"

### DIFF
--- a/dist/tools/cppcheck/check.sh
+++ b/dist/tools/cppcheck/check.sh
@@ -53,6 +53,7 @@ if [ -z "${FILES}" ]; then
     exit
 fi
 
-cppcheck --std=c99 --enable=style --force --error-exitcode=2 --quiet -j 8 \
+# TODO: switch back to 8 jobs when/if cppcheck issue is resolved
+cppcheck --std=c99 --enable=style --force --error-exitcode=2 --quiet -j 1 \
          --template "{file}:{line}: {severity} ({id}): {message}"         \
          --inline-suppr ${DEFAULT_SUPPRESSIONS} ${@} ${FILES}


### PR DESCRIPTION
This reverts commit ec97a94626baa8a8843a0aa00e17213fac08696f.

The commit seems to cause exit with error code != 0, even if there's no error, on cppcheck 1.72, which is our current CI version.
Furthermore, there's no reference to either the issue or how it was resolved in the original commit message.

