### PR TITLE
examples/gnrc_border_router: add commented SLIP compatibility

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -29,6 +29,25 @@ CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ET
 FEATURES_REQUIRED += periph_uart
 endif
 
+# SLIP legacy compatibility
+# Uncomment the lines below if you want to use SLIP with this example and don't
+# forget to comment the lines above for ethos.
+#ifeq (,$(SLIP_UART))
+# set default (last available UART)
+#SLIP_UART="UART_DEV(UART_NUMOF-1)"
+#endif
+#ifeq (,$(SLIP_BAUDRATE))
+# set default
+#SLIP_BAUDRATE=115200
+#endif
+
+#GNRC_NETIF_NUMOF := 2
+#INCLUDES += -I$(CURDIR)
+#CFLAGS += -DSLIP_UART=$(SLIP_UART)
+#CFLAGS += -DSLIP_BAUDRATE=$(SLIP_BAUDRATE)
+# Include SLIP package for IP over Serial communication
+#USEMODULE += gnrc_slip
+
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default

--- a/examples/gnrc_border_router/README.md
+++ b/examples/gnrc_border_router/README.md
@@ -181,7 +181,7 @@ example on any RIOT supported platform that offers either more than one UART or
 be equipped with an IPv6 capable network device. In this case only the Makefile
 of this application has to be slightly modified, e.g. by replacing the line
 ```
-USEMODULE += gnrc_slip
+USEMODULE += ethos gnrc_netdev
 ```
 with something like
 ```
@@ -217,7 +217,7 @@ USEMODULE += gnrc_slip
 ## Configuration
 
 In order to connect a RIOT 6LoWPAN border router over SLIP you run a small
-program called tunslip (imported from Contiki) [2] on the Linux host. The
+program called tunslip6 (imported from Contiki) [2] on the Linux host. The
 program can be found in the `dist/tools/tunslip` folder and has to be compiled
 before first use (simple calling `make` should be enough). Now, one can start
 the program by calling something like:


### PR DESCRIPTION
A trial to solve #6354 