### PR TITLE
doccheck: actually show warning, not just file

### DIFF
--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -6,11 +6,13 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-ERRORS=$(make doc 2>&1 | grep '.*warning' | sed "s#.*${PWD}/\([^:]*\).*#\1#" | sort | uniq)
+RIOTBASE=$(readlink -f "$(dirname $(realpath $0))/../../..")
+
+ERRORS=$(make doc 2>&1 | grep '.*warning' | sed "s#${PWD}/\([^:]*\)#\1#g")
 
 if [ -n "${ERRORS}" ]
 then
-    echo "ERROR: The following files generate doxygen warnings:"
+    echo "ERROR: Doxygen generates the following warnings:"
     echo "${ERRORS}"
     exit 2
 else


### PR DESCRIPTION
Now that there are no doc warnings in master anymore I think it is a great help for contributors to actually see *what* errors the CI in the documentation is reporting.