### PR TITLE
examples/gnrc_{minimal,networking}: simplify XBee setup

### DIFF
--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -9,14 +9,16 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031
 
-## Uncomment to support the XBee module
-#USEMODULE += xbee
+ifneq (,$(filter xbee,$(USEMODULE)))
+  # Prepend your build command with USEMODULE = xbee in order to
+  # use a XBee radio and apply the following configuration
 
-## set default UART to use in case none was defined
-#XBEE_UART ?= "1"
+  # set default UART to use in case none was defined
+  XBEE_UART ?= "1"
 
-## export UART to params file
-#CFLAGS += -DXBEE_UART=$(XBEE_UART)
+  # export UART to params file
+  CFLAGS += -DXBEE_PARAM_UART=$(XBEE_UART)
+endif
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -13,6 +13,17 @@ BOARD_INSUFFICIENT_MEMORY := calliope-mini chronos microbit msb-430 msb-430h \
                              nucleo-f334 nucleo-l053 spark-core stm32f0discovery telosb \
                              weio wsn430-v1_3b wsn430-v1_4 z1
 
+ifneq (,$(filter xbee,$(USEMODULE)))
+  # Prepend your build command with USEMODULE=xbee in order to
+  # use a XBee radio and apply the following configurations
+
+  # set default UART to use in case none was defined
+  XBEE_UART ?= "1"
+
+  # export UART to params file
+  CFLAGS += -DXBEE_PARAM_UART=$(XBEE_UART)
+endif
+
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default


### PR DESCRIPTION
This PR is an attempt to simplify the configuration of an XBee with networking examples. The idea is to apply the XBee UART flag only when xbee module is loaded.

As a consequence, one can simply build a networking firmware using a XBee with the following command:
```
USEMODULE=xbee make BOARD=<board> -C examples/gnrc_minimal flash term
```

If you think this PR is worth, it can also be applied to other networking examples: emcute, microcoap, nanocoap, gcoap, dtls ?