### PR TITLE
gnrc_tcp: cleanup: shortend gnrc_tcp_tcb_init()

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -199,16 +199,11 @@ void gnrc_tcp_tcb_init(gnrc_tcp_tcb_t *tcb)
 #ifdef MODULE_GNRC_IPV6
     tcb->address_family = AF_INET6;
 #else
-    tcb->address_family = AF_UNSPEC;
     DEBUG("gnrc_tcp.c : gnrc_tcp_tcb_init() : Address unspec, add netlayer module to makefile\n");
 #endif
-    tcb->local_port = PORT_UNSPEC;
-    tcb->peer_port = PORT_UNSPEC;
-    tcb->state = FSM_STATE_CLOSED;
     tcb->rtt_var = RTO_UNINITIALIZED;
     tcb->srtt = RTO_UNINITIALIZED;
     tcb->rto = RTO_UNINITIALIZED;
-    tcb->owner = KERNEL_PID_UNDEF;
     mutex_init(&(tcb->fsm_lock));
     mutex_init(&(tcb->function_lock));
 }

--- a/sys/net/gnrc/transport_layer/tcp/internal/fsm.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/fsm.h
@@ -34,7 +34,7 @@ extern "C" {
  *  @brief The TCP FSM states.
  */
 typedef enum {
-    FSM_STATE_CLOSED,
+    FSM_STATE_CLOSED = 0,
     FSM_STATE_LISTEN,
     FSM_STATE_SYN_SENT,
     FSM_STATE_SYN_RCVD,


### PR DESCRIPTION
Tiny PR in reaction to the discussion in  #6476.

This removes redundant assignments after memset.