### PR TITLE
ps: fix schedstatistics

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -179,10 +179,10 @@ NORETURN void sched_task_exit(void);
  *  Scheduler statistics
  */
 typedef struct {
-    unsigned int laststart;         /**< Time stamp of the last time this thread was
-                                         scheduled to run */
-    unsigned int schedules;         /**< How often the thread was scheduled to run */
-    unsigned long runtime_ticks;    /**< The total runtime of this thread in ticks */
+    uint64_t laststart;      /**< Time stamp of the last time this thread was
+                                  scheduled to run */
+    unsigned int schedules;  /**< How often the thread was scheduled to run */
+    uint64_t runtime_ticks;  /**< The total runtime of this thread in ticks */
 } schedstat;
 
 /**

--- a/core/sched.c
+++ b/core/sched.c
@@ -101,7 +101,7 @@ int __attribute__((used)) sched_run(void)
     }
 
 #ifdef MODULE_SCHEDSTATISTICS
-    unsigned long time = _xtimer_now();
+    uint64_t now = _xtimer_now64();
 #endif
 
     if (active_thread) {
@@ -118,17 +118,17 @@ int __attribute__((used)) sched_run(void)
 #ifdef MODULE_SCHEDSTATISTICS
         schedstat *active_stat = &sched_pidlist[active_thread->pid];
         if (active_stat->laststart) {
-            active_stat->runtime_ticks += time - active_stat->laststart;
+            active_stat->runtime_ticks += now - active_stat->laststart;
         }
 #endif
     }
 
 #ifdef MODULE_SCHEDSTATISTICS
     schedstat *next_stat = &sched_pidlist[next_thread->pid];
-    next_stat->laststart = time;
+    next_stat->laststart = now;
     next_stat->schedules++;
     if (sched_cb) {
-        sched_cb(time, next_thread->pid);
+        sched_cb(now, next_thread->pid);
     }
 #endif
 

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -13,7 +13,7 @@ RIOTBASE ?= $(CURDIR)/../..
 #RIOTBOARD ?= $(CURDIR)/../../RIOT/thirdparty_boards
 
 # Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
+#USEMODULE += schedstatistics
 
 # If you want to use native with valgrind, you should recompile native
 # with the target all-valgrind instead of all:

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -61,7 +61,7 @@ void ps(void)
 #endif
             "%-9sQ | pri "
 #ifdef DEVELHELP
-           "| stack ( used) | base       | current    "
+           "| stack ( used) | base       | current     "
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
            "| runtime | switches"
@@ -98,7 +98,8 @@ void ps(void)
             overall_used += stacksz;
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
-            double runtime_ticks =  sched_pidlist[i].runtime_ticks / (double) xtimer_now() * 100;
+            double runtime_ticks = sched_pidlist[i].runtime_ticks /
+                                   (double) _xtimer_now64() * 100;
             int switches = sched_pidlist[i].schedules;
 #endif
             printf("\t%3" PRIkernel_pid

--- a/tests/ps_schedstatistics/Makefile
+++ b/tests/ps_schedstatistics/Makefile
@@ -1,0 +1,16 @@
+APPLICATION = ps_schedstatistics
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo-l053 \
+                             nucleo32-f031 nucleo32-f042 nucleo32-l031 \
+                             stm32f0discovery telosb weio wsn430-v1_3b \
+                             wsn430-v1_4 z1
+
+CFLAGS += -DDEVELHELP
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+USEMODULE += schedstatistics
+USEMODULE += printf_float
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/ps_schedstatistics/main.c
+++ b/tests/ps_schedstatistics/main.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief ps schedstatistics test app
+ *
+ * @author Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include <shell.h>
+#include <thread.h>
+#include <xtimer.h>
+
+#define NB_THREADS 5
+
+static char stacks[NB_THREADS][THREAD_STACKSIZE_DEFAULT];
+static kernel_pid_t pids[NB_THREADS];
+
+static void *_thread_fn(void *arg)
+{
+    int next = (int)arg < NB_THREADS - 1 ? (int)arg + 1 : 0;
+    msg_t msg;
+
+    printf("Creating thread #%d, next=%d\n", (int)arg, next);
+
+    while (1) {
+        msg_receive(&msg);
+        xtimer_usleep(XTIMER_BACKOFF - 1);
+        xtimer_usleep(2 * XTIMER_BACKOFF);
+        msg_send(&msg, pids[next]);
+    }
+
+    return NULL;
+}
+
+int main(void)
+{
+    for (int i = 0; i < NB_THREADS; i++) {
+        pids[i] = thread_create(stacks[i], sizeof(stacks[i]),
+                                THREAD_PRIORITY_MAIN + 1,
+                                THREAD_CREATE_STACKTEST,
+                                _thread_fn, (void *)i, "thread");
+    }
+
+
+    msg_t msg;
+    msg_send(&msg, pids[0]);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+}


### PR DESCRIPTION
Fix xtimer_now() usage and fix columns alignment in ps command when
module schedstatistics is used.