### PR TITLE
examples/nanocoap_server: FIX Configuration of the node as an IPv6 node

### DIFF
--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -19,12 +19,11 @@ BOARD_BLACKLIST := nrf52dk
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
+USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_udp
+USEMODULE += gnrc_sock_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
-
-#
-USEMODULE += gnrc_sock_udp
 
 USEPKG += nanocoap
 # optionally enable nanocoap's debug output


### PR DESCRIPTION
Added the proper module for configuring the node as an IPv6 node.

The node was originally configured as an IPv6 router node.
But, in the commit https://github.com/RIOT-OS/RIOT/commit/74342ee4dfd07816301a21bcf5960d022353dedf#diff-5e0ca2b1ef1a4406b914f753a8f8a2f6L24 it was
removed this behavior. Yet, a configuration for standard IPv6 node
was missed.

Seems that the default behavior until the release 2016.10 was as
`USEMODULE += gnrc_ipv6_default`. Yet, after this release, the
behavior changed to `USEMODULE += gnrc_ipv6`, which made impossible
to  communicate with the node.