### PR TITLE
kinetis: MCG improvements

### DIFF
--- a/cpu/kinetis_common/include/mcg.h
+++ b/cpu/kinetis_common/include/mcg.h
@@ -10,7 +10,8 @@
  * @defgroup    cpu_kinetis_common_mcg Kinetis MCG
  * @ingroup     cpu_kinetis_common
  * @brief       Implementation of the Kinetis Multipurpose Clock Generator
- *              (MCG) driver.
+ *              (MCG) driver
+ *
  *              Please add mcg.h in cpu conf.h
  *              and MCG configuration to periph_conf.h
  *
@@ -36,6 +37,30 @@
  *              -  FEE -> BLPI
  *              -  BLPE -> FEE
  *              -  BLPI -> FEE
+ *
+ *              \dot
+ *              digraph states {
+ *                layout=dot
+ *                nodesep=0.5
+ *                {rank=same Reset [shape=none] FEI FEE}
+ *                {rank=same FBI FBE}
+ *                {rank=same BLPI BLPE}
+ *                Reset -> FEI
+ *                FEI -> FEE [dir="both"]
+ *                FEI -> FBE [dir="both"]
+ *                FEI -> FBI [dir="both"]
+ *                FEE -> FBI [dir="both"]
+ *                FEE -> FBE [dir="both"]
+ *                FBI -> FBE [dir="both"]
+ *                FBI -> BLPI [dir="both"]
+ *                FBE -> BLPE [dir="both"]
+ *                PBE
+ *                PEE
+ *                FBE -> PBE [dir="both"]
+ *                BLPE -> PBE [dir="both"]
+ *                PBE -> PEE [dir="both"]
+ *              }
+ *              \enddot
  *
  *              ### MCG Configuration Examples (for periph_conf.h) ###
  *

--- a/cpu/kinetis_common/periph/mcg.c
+++ b/cpu/kinetis_common/periph/mcg.c
@@ -25,6 +25,12 @@
 
 #if KINETIS_CPU_USE_MCG
 
+#if defined(MCG_C6_PLLS_MASK)
+#define KINETIS_HAVE_PLL 1
+#else
+#define KINETIS_HAVE_PLL 0
+#endif
+
 /* Pathfinding for the clocking modes, this table lists the next mode in the
  * chain when moving from mode <first> to mode <second> */
 static const uint8_t mcg_mode_routing[8][8] = {
@@ -109,6 +115,7 @@ static uint8_t current_mode = KINETIS_MCG_FEI;
 #error "KINETIS_MCG_ERC_RANGE not defined in periph_conf.h"
 #endif
 
+#if KINETIS_HAVE_PLL
 #ifndef KINETIS_MCG_PLL_PRDIV
 #error "KINETIS_MCG_PLL_PRDIV not defined in periph_conf.h"
 #endif
@@ -130,6 +137,9 @@ static inline void kinetis_mcg_disable_pll(void)
     MCG->C5 = (uint8_t)0;
     MCG->C6 = (uint8_t)0;
 }
+#else
+static inline void kinetis_mcg_disable_pll(void) {}
+#endif /* KINETIS_HAVE_PLL */
 
 /**
  * @brief Set Frequency Locked Loop (FLL) factor.
@@ -311,6 +321,7 @@ static void kinetis_mcg_set_blpe(void)
     current_mode = KINETIS_MCG_BLPE;
 }
 
+#if KINETIS_HAVE_PLL
 /**
  * @brief Initialize the PLL Bypassed External Mode.
  *
@@ -366,7 +377,7 @@ static void kinetis_mcg_set_pee(void)
 
     current_mode = KINETIS_MCG_PEE;
 }
-
+#endif /* KINETIS_HAVE_PLL */
 
 int kinetis_mcg_set_mode(kinetis_mcg_mode_t mode)
 {
@@ -375,12 +386,14 @@ int kinetis_mcg_set_mode(kinetis_mcg_mode_t mode)
     }
     while (current_mode != mode) {
         switch(mcg_mode_routing[current_mode][mode]) {
+#if KINETIS_HAVE_PLL
             case KINETIS_MCG_PEE:
                 kinetis_mcg_set_pee();
                 break;
             case KINETIS_MCG_PBE:
                 kinetis_mcg_set_pbe();
                 break;
+#endif /* KINETIS_HAVE_PLL */
             case KINETIS_MCG_BLPE:
                 kinetis_mcg_set_blpe();
                 break;

--- a/cpu/kinetis_common/periph/mcg.c
+++ b/cpu/kinetis_common/periph/mcg.c
@@ -183,7 +183,7 @@ static void kinetis_mcg_enable_osc(void)
         MCG->C2 |= (uint8_t)(MCG_C2_EREFS0_MASK);
 
         /* wait fo OSC initialization */
-        while ((MCG->S & MCG_S_OSCINIT0_MASK) == 0);
+        while ((MCG->S & MCG_S_OSCINIT0_MASK) == 0) {}
     }
 }
 
@@ -204,10 +204,10 @@ static void kinetis_mcg_set_fei(void)
     MCG->C2 = (uint8_t)0;
 
     /* source of the FLL reference clock shall be internal reference clock */
-    while ((MCG->S & MCG_S_IREFST_MASK) == 0);
+    while ((MCG->S & MCG_S_IREFST_MASK) == 0) {}
 
     /* Wait until output of the FLL is selected */
-    while (MCG->S & (MCG_S_CLKST_MASK));
+    while (MCG->S & (MCG_S_CLKST_MASK)) {}
 
     kinetis_mcg_disable_pll();
     current_mode = KINETIS_MCG_FEI;
@@ -229,7 +229,7 @@ static void kinetis_mcg_set_fee(void)
     MCG->C1 = (uint8_t)(MCG_C1_CLKS(0) | MCG_C1_FRDIV(KINETIS_MCG_ERC_FRDIV));
 
     /* Wait until output of FLL is selected */
-    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(0));
+    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(0)) {}
 
     kinetis_mcg_disable_pll();
     current_mode = KINETIS_MCG_FEE;
@@ -259,10 +259,10 @@ static void kinetis_mcg_set_fbi(void)
     MCG->C1 = (uint8_t)(MCG_C1_CLKS(1) | MCG_C1_IREFS_MASK);
 
     /* Wait until output of IRC is selected */
-    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(1));
+    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(1)) {}
 
     /* source of the FLL reference clock shall be internal reference clock */
-    while ((MCG->S & MCG_S_IREFST_MASK) == 0);
+    while ((MCG->S & MCG_S_IREFST_MASK) == 0) {}
 
     kinetis_mcg_disable_pll();
     current_mode = KINETIS_MCG_FBI;
@@ -288,7 +288,7 @@ static void kinetis_mcg_set_fbe(void)
     MCG->C1 = (uint8_t)(MCG_C1_CLKS(2) | MCG_C1_FRDIV(KINETIS_MCG_ERC_FRDIV));
 
     /* Wait until ERC is selected */
-    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(2));
+    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(2)) {}
 
     kinetis_mcg_disable_pll();
     current_mode = KINETIS_MCG_FBE;
@@ -338,7 +338,7 @@ static void kinetis_mcg_set_pbe(void)
     MCG->C1 = (uint8_t)(MCG_C1_CLKS(2) | MCG_C1_FRDIV(KINETIS_MCG_ERC_FRDIV));
 
     /* Wait until ERC is selected */
-    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(2));
+    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(2)) {}
 
     /* PLL is not disabled in bypass mode */
     MCG->C2 &= ~(uint8_t)(MCG_C2_LP_MASK);
@@ -353,10 +353,10 @@ static void kinetis_mcg_set_pbe(void)
     MCG->C6 |= (uint8_t)(MCG_C6_PLLS_MASK);
 
     /* Wait until the source of the PLLS clock is PLL */
-    while ((MCG->S & MCG_S_PLLST_MASK) == 0);
+    while ((MCG->S & MCG_S_PLLST_MASK) == 0) {}
 
     /* Wait until PLL locked */
-    while ((MCG->S & MCG_S_LOCK0_MASK) == 0);
+    while ((MCG->S & MCG_S_LOCK0_MASK) == 0) {}
 
     current_mode = KINETIS_MCG_PBE;
 }
@@ -373,7 +373,7 @@ static void kinetis_mcg_set_pee(void)
     MCG->C1 &= ~(uint8_t)(MCG_C1_CLKS_MASK);
 
     /* Wait until output of the PLL is selected */
-    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(3));
+    while ((MCG->S & MCG_S_CLKST_MASK) != MCG_S_CLKST(3)) {}
 
     current_mode = KINETIS_MCG_PEE;
 }


### PR DESCRIPTION
A collection of improvements for the multipurpose clock generator (MCG) driver, including:

 - Add state transition graph to MCG documentation
 - Simplify MCG state traversal algorithm 
The new implementation uses a precalculated map of which mode to switch
to next if going from mode A to mode B. This simplifies the
implementation for moving between modes which are not direct neighbors.
See mcg.h documentation for a diagram of the state machine for the
clocking modes. Also found in the CPU reference manual of all Kinetis
CPUs, MCG chapter, MCG mode state diagram.
 - Add support for low-end MCG without PLL
 - Use {} for empty while loops

Tested on Mulle/K60, FRDM-K22F (in #6994), FRDM-KW41Z (in #6995)

Will be required for future support of Kinetis L series CPUs and KW41Z