### PR TITLE
pkg/jerryscript: update jerryscript package with the latest version (56802c22)

### DIFF
--- a/examples/javascript/main.c
+++ b/examples/javascript/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <stdio.h>
 #include <string.h>
 #include "shell.h"
 #include "jerryscript.h"

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=jerryscript
 PKG_URL=https://github.com/jerryscript-project/jerryscript.git
-PKG_VERSION=b140158104064ef082ddb58052f8c7c7cee9675c
+PKG_VERSION=56802c22a10b0d684ac93921ac28df891e320b4a
 PKG_LICENSE=Apache-2.0
 
 .PHONY: all
@@ -8,6 +8,5 @@ PKG_LICENSE=Apache-2.0
 all: git-download
 	@cp Makefile.jerryscript $(PKG_BUILDDIR)/Makefile
 	$(MAKE) -C $(PKG_BUILDDIR)
-	cp $(PKG_BUILDDIR)/riot/lib/libjerry-core.a ${BINDIR}/libjerrycore.a
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile.dep
+++ b/pkg/jerryscript/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter jerryscript,$(USEPKG)))
+    USEMODULE += jerryport-minimal
+endif

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -18,6 +18,7 @@ libjerry:
 	 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain_external.cmake \
 	 -DJERRY_LIBC=OFF \
 	 -DJERRY_CMDLINE=OFF \
+	 -DJERRY_LIBM=OFF \
 	 -DENABLE_ALL_IN_ONE=OFF \
 	 -DEXTERNAL_CMAKE_SYSTEM_PROCESSOR="$(MCPU)" \
 	 -DEXTERNAL_CMAKE_C_COMPILER=$(CC) \
@@ -25,7 +26,8 @@ libjerry:
 	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP)
 
-	make -C $(BUILD_DIR) jerry-core
+	make -C $(BUILD_DIR) jerry-core jerry-port-default-minimal
 	cp $(BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
+	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
Also disabled to build jerry-libm because it is unused.