### PR TITLE
examples/tests: remove redundant xbee config

### DIFF
--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -9,15 +9,6 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031
 
-## Uncomment to support the XBee module
-#USEMODULE += xbee
-
-## set default UART to use in case none was defined
-#XBEE_UART ?= "1"
-
-## export UART to params file
-#CFLAGS += -DXBEE_UART=$(XBEE_UART)
-
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -15,12 +15,6 @@ USEMODULE += gnrc_pktdump
 USEMODULE += shell
 USEMODULE += shell_commands
 
-# set default UART to use in case none was defined
-XBEE_UART ?= "1"
-
-# export UART to params file
-CFLAGS += -DXBEE_PARAM_UART=$(XBEE_UART)
-
 # No need of big buffer for this test
 CFLAGS += -DGNRC_PKTBUF_SIZE=512
 


### PR DESCRIPTION
Alternative to #6971

There is no need in configuring the xbee to use `UART_DEV(1)` in these Makefiles, as it is configured to use this UART per default -> see `drivers/xbee/include/xbee_params.h`.