### PR TITLE
frdm-k64f: add Darwin serial port

### DIFF
--- a/boards/frdm-k64f/Makefile.include
+++ b/boards/frdm-k64f/Makefile.include
@@ -4,6 +4,7 @@ export CPU_MODEL = mk64fn1m0vll12
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 .PHONY: flash
 flash: $(RIOTCPU)/kinetis_common/dist/wdog-disable.bin


### PR DESCRIPTION
Small addition to support `make term` natively on OS X.