### PR TITLE
boards/frdm-k64f: fix typo on UART_0_ISR

### DIFF
--- a/boards/frdm-k64f/Makefile.include
+++ b/boards/frdm-k64f/Makefile.include
@@ -4,6 +4,7 @@ export CPU_MODEL = mk64fn1m0vll12
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 .PHONY: flash
 flash: $(RIOTCPU)/kinetis_common/dist/wdog-disable.bin

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -92,7 +92,7 @@ static const uart_conf_t uart_config[] = {
     },
 };
 
-#define UART_0_ISR          (uart_0_rx_tx)
+#define UART_0_ISR          (isr_uart0_rx_tx)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */


### PR DESCRIPTION
A typo on the periph_conf.h definition of UART_0_ISR led to a kernel panic.

Rebased on top of #6983.