### PR TITLE
frdm-k64f: Move clock initialization to board_init

### DIFF
--- a/boards/frdm-k64f/board.c
+++ b/boards/frdm-k64f/board.c
@@ -19,11 +19,23 @@
  * @}
  */
 
+#include <stdint.h>
 #include "board.h"
+#include "mcg.h"
 #include "periph/gpio.h"
+
+/* Clock dividers used to keep the module clocks within their allowed range */
+#define SIM_CLKDIV1_60MHZ      (SIM_CLKDIV1_OUTDIV1(0) | \
+                                SIM_CLKDIV1_OUTDIV2(0) | \
+                                SIM_CLKDIV1_OUTDIV3(1) | \
+                                SIM_CLKDIV1_OUTDIV4(2))
+
+static inline void board_clock_init(void);
 
 void board_init(void)
 {
+    /* initialize the CPU clock source */
+    board_clock_init();
     /* initialize the CPU core */
     cpu_init();
 
@@ -34,4 +46,27 @@ void board_init(void)
     gpio_set(LED0_PIN);
     gpio_set(LED1_PIN);
     gpio_set(LED2_PIN);
+}
+
+/**
+ * @brief Configure the clock source and clock prescalers for the system
+ *
+ * | Clock name | Run mode frequency (max) | VLPR mode frequency (max) |
+ *
+ * | Core       | 120 MHz                  |   4 MHz                   |
+ * | System     | 120 MHz                  |   4 MHz                   |
+ * | Bus        |  60 MHz                  |   4 MHz                   |
+ * | FlexBus    |  50 MHz                  | 800 kHz                   |
+ * | Flash      |  25 MHz                  |   4 MHz                   |
+ */
+static inline void board_clock_init(void)
+{
+    /* setup system prescalers */
+    SIM->CLKDIV1 = (uint32_t)SIM_CLKDIV1_60MHZ;
+
+    /* RMII RXCLK */
+    SIM->SCGC5 |= SIM_SCGC5_PORTA_MASK;
+    PORTA->PCR[18] &= ~(PORT_PCR_ISF_MASK | PORT_PCR_MUX(0x07));
+
+    kinetis_mcg_set_mode(KINETIS_MCG_PEE);
 }

--- a/cpu/k64f/cpu.c
+++ b/cpu/k64f/cpu.c
@@ -19,18 +19,8 @@
  * @}
  */
 
-#include <stdint.h>
 #include "cpu.h"
-#include "mcg.h"
-#include "cpu_conf.h"
 #include "periph/init.h"
-
-#define SIM_CLKDIV1_60MHZ      (SIM_CLKDIV1_OUTDIV1(0) | \
-                                SIM_CLKDIV1_OUTDIV2(0) | \
-                                SIM_CLKDIV1_OUTDIV3(1) | \
-                                SIM_CLKDIV1_OUTDIV4(2))
-
-static void cpu_clock_init(void);
 
 /**
  * @brief Initialize the CPU, set IRQ priorities
@@ -39,31 +29,6 @@ void cpu_init(void)
 {
     /* initialize the Cortex-M core */
     cortexm_init();
-    /* initialize the clock system */
-    cpu_clock_init();
     /* trigger static peripheral initialization */
     periph_init();
-}
-
-/**
- * @brief Configure the controllers clock system
- *
- * | Clock name | Run mode frequency (max) | VLPR mode frequency (max) |
- *
- * | Core       | 120 MHz                  |   4 MHz                   |
- * | System     | 120 MHz                  |   4 MHz                   |
- * | Bus        |  60 MHz                  |   4 MHz                   |
- * | FlexBus    |  50 MHz                  | 800 kHz                   |
- * | Flash      |  25 MHz                  |   4 MHz                   |
- */
-static void cpu_clock_init(void)
-{
-    /* setup system prescalers */
-    SIM->CLKDIV1 = (uint32_t)SIM_CLKDIV1_60MHZ;
-
-    /* RMII RXCLK */
-    SIM->SCGC5 |= SIM_SCGC5_PORTA_MASK;
-    PORTA->PCR[18] &= ~(PORT_PCR_ISF_MASK | PORT_PCR_MUX(0x07));
-
-    kinetis_mcg_set_mode(KINETIS_MCG_PEE);
 }


### PR DESCRIPTION
The clock setting on this board depends on the existence of an external RMII crystal, which is not mandatory for the CPU itself.

The clock settings in general should be deferred to board_init IMO, there are so many different settings possible that it makes no sense to default the CPU into any particular mode other than the hardware defaults.