### PR TITLE
kinetis: Unify default ISR definitions

### DIFF
--- a/cpu/k60/vectors.c
+++ b/cpu/k60/vectors.c
@@ -27,398 +27,273 @@
  * @{
  */
 
-#include "cpu.h"
-#include "vectors_cortexm.h"
-#include "wdog.h"
-
-/**
- * memory markers as defined in the linker script
- */
-extern uint32_t _estack;
-
-void pre_startup(void)
-{
-    /* disable the WDOG */
-    wdog_disable();
-
-    /*
-     * Workaround for hardware errata e4218: "SIM/FLEXBUS: SIM_SCGC7[FLEXBUS]
-     * bit should be cleared when the FlexBus is not being used."
-     */
-    BITBAND_REG32(SIM->SCGC7, SIM_SCGC7_FLEXBUS_SHIFT) = 0;
-}
-
-void dummy_handler(void)
-{
-    dummy_handler_default();
-}
-
-/* Cortex-M specific interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
-/* K60 specific interrupt vector */
-WEAK_DEFAULT void isr_dma0_complete(void);
-WEAK_DEFAULT void isr_dma1_complete(void);
-WEAK_DEFAULT void isr_dma2_complete(void);
-WEAK_DEFAULT void isr_dma3_complete(void);
-WEAK_DEFAULT void isr_dma4_complete(void);
-WEAK_DEFAULT void isr_dma5_complete(void);
-WEAK_DEFAULT void isr_dma6_complete(void);
-WEAK_DEFAULT void isr_dma7_complete(void);
-WEAK_DEFAULT void isr_dma8_complete(void);
-WEAK_DEFAULT void isr_dma9_complete(void);
-WEAK_DEFAULT void isr_dma10_complete(void);
-WEAK_DEFAULT void isr_dma11_complete(void);
-WEAK_DEFAULT void isr_dma12_complete(void);
-WEAK_DEFAULT void isr_dma13_complete(void);
-WEAK_DEFAULT void isr_dma14_complete(void);
-WEAK_DEFAULT void isr_dma15_complete(void);
-WEAK_DEFAULT void isr_dma_error(void);
-WEAK_DEFAULT void isr_mcm(void);
-WEAK_DEFAULT void isr_flash_command_complete(void);
-WEAK_DEFAULT void isr_flash_read_collision(void);
-WEAK_DEFAULT void isr_low_voltage(void);
-WEAK_DEFAULT void isr_llwu(void);
-WEAK_DEFAULT void isr_watchdog(void);
-WEAK_DEFAULT void isr_random_number_generator(void);
-WEAK_DEFAULT void isr_i2c0(void);
-WEAK_DEFAULT void isr_i2c1(void);
-WEAK_DEFAULT void isr_spi0(void);
-WEAK_DEFAULT void isr_spi1(void);
-WEAK_DEFAULT void isr_spi2(void);
-WEAK_DEFAULT void isr_can0_ored_msg_buffer(void);
-WEAK_DEFAULT void isr_can0_bus_off(void);
-WEAK_DEFAULT void isr_can0_error(void);
-WEAK_DEFAULT void isr_can0_tx_warn(void);
-WEAK_DEFAULT void isr_can0_rx_warn(void);
-WEAK_DEFAULT void isr_can0_wake_up(void);
-WEAK_DEFAULT void isr_i2s0_tx(void);
-WEAK_DEFAULT void isr_i2s0_rx(void);
-WEAK_DEFAULT void isr_can1_ored_msg_buffer(void);
-WEAK_DEFAULT void isr_can1_bus_off(void);
-WEAK_DEFAULT void isr_can1_error(void);
-WEAK_DEFAULT void isr_can1_tx_warn(void);
-WEAK_DEFAULT void isr_can1_rx_warn(void);
-WEAK_DEFAULT void isr_can1_wake_up(void);
-/* void dummy_handler(void); */
-WEAK_DEFAULT void isr_uart0_lon(void);
-WEAK_DEFAULT void isr_uart0_rx_tx(void);
-WEAK_DEFAULT void isr_uart0_error(void);
-WEAK_DEFAULT void isr_uart1_rx_tx(void);
-WEAK_DEFAULT void isr_uart1_error(void);
-WEAK_DEFAULT void isr_uart2_rx_tx(void);
-WEAK_DEFAULT void isr_uart2_error(void);
-WEAK_DEFAULT void isr_uart3_rx_tx(void);
-WEAK_DEFAULT void isr_uart3_error(void);
-WEAK_DEFAULT void isr_uart4_rx_tx(void);
-WEAK_DEFAULT void isr_uart4_error(void);
-/* void dummy_handler(void); */
-/* void dummy_handler(void); */
-WEAK_DEFAULT void isr_adc0(void);
-WEAK_DEFAULT void isr_adc1(void);
-WEAK_DEFAULT void isr_cmp0(void);
-WEAK_DEFAULT void isr_cmp1(void);
-WEAK_DEFAULT void isr_cmp2(void);
-WEAK_DEFAULT void isr_ftm0(void);
-WEAK_DEFAULT void isr_ftm1(void);
-WEAK_DEFAULT void isr_ftm2(void);
-WEAK_DEFAULT void isr_cmt(void);
-WEAK_DEFAULT void isr_rtc_alarm(void);
-WEAK_DEFAULT void isr_rtc_seconds(void);
-WEAK_DEFAULT void isr_pit0(void);
-WEAK_DEFAULT void isr_pit1(void);
-WEAK_DEFAULT void isr_pit2(void);
-WEAK_DEFAULT void isr_pit3(void);
-WEAK_DEFAULT void isr_pdb(void);
-WEAK_DEFAULT void isr_usb_otg(void);
-WEAK_DEFAULT void isr_usb_charger_detect(void);
-WEAK_DEFAULT void isr_enet_1588_timer(void);
-WEAK_DEFAULT void isr_enet_tx(void);
-WEAK_DEFAULT void isr_enet_rx(void);
-WEAK_DEFAULT void isr_enet_error_misc(void);
-/* void dummy_handler(void); */
-WEAK_DEFAULT void isr_sdhc(void);
-WEAK_DEFAULT void isr_dac0(void);
-/* void dummy_handler(void); */
-WEAK_DEFAULT void isr_tsi(void);
-WEAK_DEFAULT void isr_mcg(void);
-WEAK_DEFAULT void isr_lptmr0(void);
-/* void dummy_handler(void); */
-WEAK_DEFAULT void isr_porta(void);
-WEAK_DEFAULT void isr_portb(void);
-WEAK_DEFAULT void isr_portc(void);
-WEAK_DEFAULT void isr_portd(void);
-WEAK_DEFAULT void isr_porte(void);
-/* void dummy_handler(void); */
-/* void dummy_handler(void); */
-WEAK_DEFAULT void isr_software(void);
+#include "vectors_kinetis.h"
 
 /**
  * @brief Interrupt vector definition
  */
-ISR_VECTORS const void *interrupt_vector[] = {
+ISR_VECTORS const isr_func_t interrupt_vector[] = {
     /* Stack pointer */
-    (void *)(&_estack),             /* pointer to the top of the empty stack */
+    (isr_func_t)(&_estack),     /* pointer to the top of the empty stack */
     /* Cortex-M4 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    reset_handler_default,  /* entry point of the program */
+    nmi_default,            /* non maskable interrupt handler */
+    hard_fault_default,     /* hard fault exception */
+    mem_manage_default,     /* memory manage exception */
+    bus_fault_default,      /* bus fault exception */
+    usage_fault_default,    /* usage fault exception */
+    dummy_handler,          /* Reserved */
+    dummy_handler,          /* Reserved */
+    dummy_handler,          /* Reserved */
+    dummy_handler,          /* Reserved */
+    isr_svc,                /* system call interrupt, in RIOT used for
+                             * switching into thread context on boot */
+    debug_mon_default,      /* debug monitor exception */
+    dummy_handler,          /* Reserved */
+    isr_pendsv,             /* pendSV interrupt, in RIOT the actual
+                             * context switching is happening here */
+    isr_systick,            /* SysTick interrupt, not used in RIOT */
     /* K60 specific peripheral handlers */
-    (void*) isr_dma0_complete,
-    (void*) isr_dma1_complete,
-    (void*) isr_dma2_complete,
-    (void*) isr_dma3_complete,
-    (void*) isr_dma4_complete,
-    (void*) isr_dma5_complete,
-    (void*) isr_dma6_complete,
-    (void*) isr_dma7_complete,
-    (void*) isr_dma8_complete,
-    (void*) isr_dma9_complete,
-    (void*) isr_dma10_complete,
-    (void*) isr_dma11_complete,
-    (void*) isr_dma12_complete,
-    (void*) isr_dma13_complete,
-    (void*) isr_dma14_complete,
-    (void*) isr_dma15_complete,
-    (void*) isr_dma_error,
-    (void*) isr_mcm,
-    (void*) isr_flash_command_complete,
-    (void*) isr_flash_read_collision,
-    (void*) isr_low_voltage,
-    (void*) isr_llwu,
-    (void*) isr_watchdog,
-    (void*) isr_random_number_generator,
-    (void*) isr_i2c0,
-    (void*) isr_i2c1,
-    (void*) isr_spi0,
-    (void*) isr_spi1,
-    (void*) isr_spi2,
-    (void*) isr_can0_ored_msg_buffer,
-    (void*) isr_can0_bus_off,
-    (void*) isr_can0_error,
-    (void*) isr_can0_tx_warn,
-    (void*) isr_can0_rx_warn,
-    (void*) isr_can0_wake_up,
-    (void*) isr_i2s0_tx,
-    (void*) isr_i2s0_rx,
-    (void*) isr_can1_ored_msg_buffer,
-    (void*) isr_can1_bus_off,
-    (void*) isr_can1_error,
-    (void*) isr_can1_tx_warn,
-    (void*) isr_can1_rx_warn,
-    (void*) isr_can1_wake_up,
-    (void*) dummy_handler,
-    (void*) isr_uart0_lon,
-    (void*) isr_uart0_rx_tx,
-    (void*) isr_uart0_error,
-    (void*) isr_uart1_rx_tx,
-    (void*) isr_uart1_error,
-    (void*) isr_uart2_rx_tx,
-    (void*) isr_uart2_error,
-    (void*) isr_uart3_rx_tx,
-    (void*) isr_uart3_error,
-    (void*) isr_uart4_rx_tx,
-    (void*) isr_uart4_error,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) isr_adc0,
-    (void*) isr_adc1,
-    (void*) isr_cmp0,
-    (void*) isr_cmp1,
-    (void*) isr_cmp2,
-    (void*) isr_ftm0,
-    (void*) isr_ftm1,
-    (void*) isr_ftm2,
-    (void*) isr_cmt,
-    (void*) isr_rtc_alarm,
-    (void*) isr_rtc_seconds,
-    (void*) isr_pit0,
-    (void*) isr_pit1,
-    (void*) isr_pit2,
-    (void*) isr_pit3,
-    (void*) isr_pdb,
-    (void*) isr_usb_otg,
-    (void*) isr_usb_charger_detect,
-    (void*) isr_enet_1588_timer,
-    (void*) isr_enet_tx,
-    (void*) isr_enet_rx,
-    (void*) isr_enet_error_misc,
-    (void*) dummy_handler,
-    (void*) isr_sdhc,
-    (void*) isr_dac0,
-    (void*) dummy_handler,
-    (void*) isr_tsi,
-    (void*) isr_mcg,
-    (void*) isr_lptmr0,
-    (void*) dummy_handler,
-    (void*) isr_porta,
-    (void*) isr_portb,
-    (void*) isr_portc,
-    (void*) isr_portd,
-    (void*) isr_porte,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) isr_software, /* Vector 110 */
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler,
-    (void*) dummy_handler /* vector 255 */
+    isr_dma0,
+    isr_dma1,
+    isr_dma2,
+    isr_dma3,
+    isr_dma4,
+    isr_dma5,
+    isr_dma6,
+    isr_dma7,
+    isr_dma8,
+    isr_dma9,
+    isr_dma10,
+    isr_dma11,
+    isr_dma12,
+    isr_dma13,
+    isr_dma14,
+    isr_dma15,
+    isr_dma_error,
+    isr_mcm,
+    isr_ftfl,
+    isr_ftfl_collision,
+    isr_pmc,
+    isr_llwu,
+    isr_wdog_ewm,
+    isr_rng,
+    isr_i2c0,
+    isr_i2c1,
+    isr_spi0,
+    isr_spi1,
+    isr_spi2,
+    isr_can0_mb,
+    isr_can0_bus_off,
+    isr_can0_error,
+    isr_can0_tx_warn,
+    isr_can0_rx_warn,
+    isr_can0_wake_up,
+    isr_i2s0_tx,
+    isr_i2s0_rx,
+    isr_can1_mb,
+    isr_can1_bus_off,
+    isr_can1_error,
+    isr_can1_tx_warn,
+    isr_can1_rx_warn,
+    isr_can1_wake_up,
+    dummy_handler,
+    isr_uart0_lon,
+    isr_uart0_rx_tx,
+    isr_uart0_error,
+    isr_uart1_rx_tx,
+    isr_uart1_error,
+    isr_uart2_rx_tx,
+    isr_uart2_error,
+    isr_uart3_rx_tx,
+    isr_uart3_error,
+    isr_uart4_rx_tx,
+    isr_uart4_error,
+    dummy_handler,
+    dummy_handler,
+    isr_adc0,
+    isr_adc1,
+    isr_cmp0,
+    isr_cmp1,
+    isr_cmp2,
+    isr_ftm0,
+    isr_ftm1,
+    isr_ftm2,
+    isr_cmt,
+    isr_rtc,
+    isr_rtc_seconds,
+    isr_pit0,
+    isr_pit1,
+    isr_pit2,
+    isr_pit3,
+    isr_pdb0,
+    isr_usb0,
+    isr_usbdcd,
+    isr_enet_1588_timer,
+    isr_enet_tx,
+    isr_enet_rx,
+    isr_enet_error,
+    dummy_handler,
+    isr_sdhc,
+    isr_dac0,
+    dummy_handler,
+    isr_tsi,
+    isr_mcg,
+    isr_lptmr0,
+    dummy_handler,
+    isr_porta,
+    isr_portb,
+    isr_portc,
+    isr_portd,
+    isr_porte,
+    dummy_handler,
+    dummy_handler,
+    isr_swi, /* Vector 110 */
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler,
+    dummy_handler /* vector 255 */
 };
 
 /** @} */

--- a/cpu/k64f/vectors.c
+++ b/cpu/k64f/vectors.c
@@ -20,378 +20,269 @@
  * @}
  */
 
-#include <stdint.h>
-#include "vectors_cortexm.h"
-#include "wdog.h"
-
-/**
- * memory markers as defined in the linker script
- */
-extern uint32_t _estack;
-
-void pre_startup (void)
-{
-    /* disable the WDOG */
-    wdog_disable();
-}
-
-void dummy_handler(void)
-{
-    dummy_handler_default();
-}
-
-/* Cortex-M specific interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
-/* K64F specific interrupt vector */
-WEAK_DEFAULT void isr_dma0(void);
-WEAK_DEFAULT void isr_dma1(void);
-WEAK_DEFAULT void isr_dma2(void);
-WEAK_DEFAULT void isr_dma3(void);
-WEAK_DEFAULT void isr_dma4(void);
-WEAK_DEFAULT void isr_dma5(void);
-WEAK_DEFAULT void isr_dma6(void);
-WEAK_DEFAULT void isr_dma7(void);
-WEAK_DEFAULT void isr_dma8(void);
-WEAK_DEFAULT void isr_dma9(void);
-WEAK_DEFAULT void isr_dma10(void);
-WEAK_DEFAULT void isr_dma11(void);
-WEAK_DEFAULT void isr_dma12(void);
-WEAK_DEFAULT void isr_dma13(void);
-WEAK_DEFAULT void isr_dma14(void);
-WEAK_DEFAULT void isr_dma15(void);
-WEAK_DEFAULT void isr_dma_error(void);
-WEAK_DEFAULT void isr_mcm(void);
-WEAK_DEFAULT void isr_ftfl(void);
-WEAK_DEFAULT void isr_ftfl_collision(void);
-WEAK_DEFAULT void isr_pmc(void);
-WEAK_DEFAULT void isr_llwu(void);
-WEAK_DEFAULT void isr_wdog_ewm(void);
-WEAK_DEFAULT void isr_rng(void);
-WEAK_DEFAULT void isr_i2c0(void);
-WEAK_DEFAULT void isr_i2c1(void);
-WEAK_DEFAULT void isr_spi0(void);
-WEAK_DEFAULT void isr_spi1(void);
-WEAK_DEFAULT void isr_i2s0_tx(void);
-WEAK_DEFAULT void isr_i2s0_rx(void);
-WEAK_DEFAULT void isr_uart0_lon(void);
-WEAK_DEFAULT void isr_uart0_rx_tx(void);
-WEAK_DEFAULT void isr_uart0_err(void);
-WEAK_DEFAULT void isr_uart1_rx_tx(void);
-WEAK_DEFAULT void isr_uart1_err(void);
-WEAK_DEFAULT void isr_uart2_rx_tx(void);
-WEAK_DEFAULT void isr_uart2_err(void);
-WEAK_DEFAULT void isr_uart3_rx_tx(void);
-WEAK_DEFAULT void isr_uart3_err(void);
-WEAK_DEFAULT void isr_adc0(void);
-WEAK_DEFAULT void isr_cmp0(void);
-WEAK_DEFAULT void isr_cmp1(void);
-WEAK_DEFAULT void isr_ftm0(void);
-WEAK_DEFAULT void isr_ftm1(void);
-WEAK_DEFAULT void isr_ftm2(void);
-WEAK_DEFAULT void isr_cmt(void);
-WEAK_DEFAULT void isr_rtc(void);
-WEAK_DEFAULT void isr_rtc_seconds(void);
-WEAK_DEFAULT void isr_pit0(void);
-WEAK_DEFAULT void isr_pit1(void);
-WEAK_DEFAULT void isr_pit2(void);
-WEAK_DEFAULT void isr_pit3(void);
-WEAK_DEFAULT void isr_pdb0(void);
-WEAK_DEFAULT void isr_usb0(void);
-WEAK_DEFAULT void isr_usbdcd(void);
-WEAK_DEFAULT void isr_dac0(void);
-WEAK_DEFAULT void isr_mcg(void);
-WEAK_DEFAULT void isr_lptmr0(void);
-WEAK_DEFAULT void isr_porta(void);
-WEAK_DEFAULT void isr_portb(void);
-WEAK_DEFAULT void isr_portc(void);
-WEAK_DEFAULT void isr_portd(void);
-WEAK_DEFAULT void isr_porte(void);
-WEAK_DEFAULT void isr_swi(void);
-WEAK_DEFAULT void isr_spi2(void);
-WEAK_DEFAULT void isr_uart4_rx_tx(void);
-WEAK_DEFAULT void isr_uart4_err(void);
-WEAK_DEFAULT void isr_uart5_rx_tx(void);
-WEAK_DEFAULT void isr_uart5_err(void);
-WEAK_DEFAULT void isr_cmp2(void);
-WEAK_DEFAULT void isr_ftm3(void);
-WEAK_DEFAULT void isr_dac1(void);
-WEAK_DEFAULT void isr_adc1(void);
-WEAK_DEFAULT void isr_i2c2(void);
-WEAK_DEFAULT void isr_can0_mb(void);
-WEAK_DEFAULT void isr_can0_bus_off(void);
-WEAK_DEFAULT void isr_can0_error(void);
-WEAK_DEFAULT void isr_can0_tx_warning(void);
-WEAK_DEFAULT void isr_can0_rx_warning(void);
-WEAK_DEFAULT void isr_can0_wake_up(void);
-WEAK_DEFAULT void isr_sdhc(void);
-WEAK_DEFAULT void isr_enet_1588_timer(void);
-WEAK_DEFAULT void isr_enet_transmit(void);
-WEAK_DEFAULT void isr_enet_receive(void);
-WEAK_DEFAULT void isr_enet_error(void);
+#include "vectors_kinetis.h"
 
 /* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
+ISR_VECTORS const isr_func_t interrupt_vector[] = {
     /* Stack pointer */
-    (void *)(&_estack),             /* pointer to the top of the empty stack */
+    (isr_func_t)(&_estack),     /* pointer to the top of the empty stack */
     /* Cortex-M4 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    reset_handler_default,  /* entry point of the program */
+    nmi_default,            /* non maskable interrupt handler */
+    hard_fault_default,     /* hard fault exception */
+    mem_manage_default,     /* memory manage exception */
+    bus_fault_default,      /* bus fault exception */
+    usage_fault_default,    /* usage fault exception */
+    dummy_handler,          /* Reserved */
+    dummy_handler,          /* Reserved */
+    dummy_handler,          /* Reserved */
+    dummy_handler,          /* Reserved */
+    isr_svc,                /* system call interrupt, in RIOT used for
+                             * switching into thread context on boot */
+    debug_mon_default,      /* debug monitor exception */
+    dummy_handler,          /* Reserved */
+    isr_pendsv,             /* pendSV interrupt, in RIOT the actual
+                             * context switching is happening here */
+    isr_systick,            /* SysTick interrupt, not used in RIOT */
     /* K64F specific peripheral handlers */
-    (void *) isr_dma0,              /* DMA channel 0 transfer complete */
-    (void *) isr_dma1,              /* DMA channel 1 transfer complete */
-    (void *) isr_dma2,              /* DMA channel 2 transfer complete */
-    (void *) isr_dma3,              /* DMA channel 3 transfer complete */
-    (void *) isr_dma4,              /* DMA channel 4 transfer complete */
-    (void *) isr_dma5,              /* DMA channel 5 transfer complete */
-    (void *) isr_dma6,              /* DMA channel 6 transfer complete */
-    (void *) isr_dma7,              /* DMA channel 7 transfer complete */
-    (void *) isr_dma8,              /* DMA channel 8 transfer complete */
-    (void *) isr_dma9,              /* DMA channel 9 transfer complete */
-    (void *) isr_dma10,             /* DMA channel 10 transfer complete */
-    (void *) isr_dma11,             /* DMA channel 11 transfer complete */
-    (void *) isr_dma12,             /* DMA channel 12 transfer complete */
-    (void *) isr_dma13,             /* DMA channel 13 transfer complete */
-    (void *) isr_dma14,             /* DMA channel 14 transfer complete */
-    (void *) isr_dma15,             /* DMA channel 15 transfer complete */
-    (void *) isr_dma_error,         /* DMA channel 0 - 15 error */
-    (void *) isr_mcm,               /* MCM normal interrupt */
-    (void *) isr_ftfl,              /* FTFL command complete */
-    (void *) isr_ftfl_collision,    /* FTFL read collision */
-    (void *) isr_pmc,               /* PMC controller low-voltage detect low-voltage warning */
-    (void *) isr_llwu,              /* Low leakage wakeup */
-    (void *) isr_wdog_ewm,          /* Single interrupt vector for  WDOG and EWM */
-    (void *) isr_rng,               /* Randon number generator */
-    (void *) isr_i2c0,              /* Inter-integrated circuit 0 */
-    (void *) isr_i2c1,              /* Inter-integrated circuit 1 */
-    (void *) isr_spi0,              /* Serial peripheral Interface 0 */
-    (void *) isr_spi1,              /* Serial peripheral Interface 1 */
-    (void *) isr_i2s0_tx,           /* Integrated interchip sound 0 transmit interrupt */
-    (void *) isr_i2s0_rx,           /* Integrated interchip sound 0 receive interrupt */
-    (void *) isr_uart0_lon,         /* UART0 LON interrupt */
-    (void *) isr_uart0_rx_tx,       /* UART0 receive/transmit interrupt */
-    (void *) isr_uart0_err,         /* UART0 error interrupt */
-    (void *) isr_uart1_rx_tx,       /* UART1 receive/transmit interrupt */
-    (void *) isr_uart1_err,         /* UART1 error interrupt */
-    (void *) isr_uart2_rx_tx,       /* UART2 receive/transmit interrupt */
-    (void *) isr_uart2_err,         /* UART2 error interrupt */
-    (void *) isr_uart3_rx_tx,       /* UART3 receive/transmit interrupt */
-    (void *) isr_uart3_err,         /* UART3 error interrupt */
-    (void *) isr_adc0,              /* Analog-to-digital converter 0 */
-    (void *) isr_cmp0,              /* Comparator 0 */
-    (void *) isr_cmp1,              /* Comparator 1 */
-    (void *) isr_ftm0,              /* FlexTimer module 0 fault overflow and channels interrupt */
-    (void *) isr_ftm1,              /* FlexTimer module 1 fault overflow and channels interrupt */
-    (void *) isr_ftm2,              /* FlexTimer module 2 fault overflow and channels interrupt */
-    (void *) isr_cmt,               /* Carrier modulator transmitter */
-    (void *) isr_rtc,               /* Real time clock */
-    (void *) isr_rtc_seconds,       /* Real time clock seconds */
-    (void *) isr_pit0,              /* Periodic interrupt timer channel 0 */
-    (void *) isr_pit1,              /* Periodic interrupt timer channel 1 */
-    (void *) isr_pit2,              /* Periodic interrupt timer channel 2 */
-    (void *) isr_pit3,              /* Periodic interrupt timer channel 3 */
-    (void *) isr_pdb0,              /* Programmable delay block */
-    (void *) isr_usb0,              /* USB OTG interrupt */
-    (void *) isr_usbdcd,            /* USB charger detect */
-    (void *) dummy_handler,         /* Reserved interrupt */
-    (void *) isr_dac0,              /* Digital-to-analog converter 0 */
-    (void *) isr_mcg,               /* Multipurpose clock generator */
-    (void *) isr_lptmr0,            /* Low power timer interrupt */
-    (void *) isr_porta,             /* Port A pin detect interrupt */
-    (void *) isr_portb,             /* Port B pin detect interrupt */
-    (void *) isr_portc,             /* Port C pin detect interrupt */
-    (void *) isr_portd,             /* Port D pin detect interrupt */
-    (void *) isr_porte,             /* Port E pin detect interrupt */
-    (void *) isr_swi,               /* Software interrupt */
-    (void *) isr_spi2,              /* Serial peripheral Interface 2 */
-    (void *) isr_uart4_rx_tx,       /* UART4 receive/transmit interrupt */
-    (void *) isr_uart4_err,         /* UART4 error interrupt */
-    (void *) isr_uart5_rx_tx,       /* UART5 receive/transmit interrupt */
-    (void *) isr_uart5_err,         /* UART5 error interrupt */
-    (void *) isr_cmp2,              /* Comparator 2 */
-    (void *) isr_ftm3,              /* FlexTimer module 3 fault overflow and channels interrupt */
-    (void *) isr_dac1,              /* Digital-to-analog converter 1 */
-    (void *) isr_adc1,              /* Analog-to-digital converter 1 */
-    (void *) isr_i2c2,              /* Inter-integrated circuit 2 */
-    (void *) isr_can0_mb,           /* CAN0 OR'd message buffers interrupt */
-    (void *) isr_can0_bus_off,      /* CAN0 bus off interrupt */
-    (void *) isr_can0_error,        /* CAN0 error interrupt */
-    (void *) isr_can0_tx_warning,   /* CAN0 tx warning interrupt */
-    (void *) isr_can0_rx_warning,   /* CAN0 rx warning interrupt */
-    (void *) isr_can0_wake_up,      /* CAN0 wake up interrupt */
-    (void *) isr_sdhc,              /* SDHC interrupt */
-    (void *) isr_enet_1588_timer,   /* Ethernet MAC IEEE 1588 Timer interrupt */
-    (void *) isr_enet_transmit,     /* Ethernet MAC transmit interrupt */
-    (void *) isr_enet_receive,      /* Ethernet MAC receive interrupt */
-    (void *) isr_enet_error,        /* Ethernet MAC error interrupt */
-    (void *) dummy_handler,         /* reserved 102 */
-    (void *) dummy_handler,         /* reserved 103 */
-    (void *) dummy_handler,         /* reserved 104 */
-    (void *) dummy_handler,         /* reserved 105 */
-    (void *) dummy_handler,         /* reserved 106 */
-    (void *) dummy_handler,         /* reserved 107 */
-    (void *) dummy_handler,         /* reserved 108 */
-    (void *) dummy_handler,         /* reserved 109 */
-    (void *) dummy_handler,         /* reserved 110 */
-    (void *) dummy_handler,         /* reserved 111 */
-    (void *) dummy_handler,         /* reserved 112 */
-    (void *) dummy_handler,         /* reserved 113 */
-    (void *) dummy_handler,         /* reserved 114 */
-    (void *) dummy_handler,         /* reserved 115 */
-    (void *) dummy_handler,         /* reserved 116 */
-    (void *) dummy_handler,         /* reserved 117 */
-    (void *) dummy_handler,         /* reserved 118 */
-    (void *) dummy_handler,         /* reserved 119 */
-    (void *) dummy_handler,         /* reserved 120 */
-    (void *) dummy_handler,         /* reserved 121 */
-    (void *) dummy_handler,         /* reserved 122 */
-    (void *) dummy_handler,         /* reserved 123 */
-    (void *) dummy_handler,         /* reserved 124 */
-    (void *) dummy_handler,         /* reserved 125 */
-    (void *) dummy_handler,         /* reserved 126 */
-    (void *) dummy_handler,         /* reserved 127 */
-    (void *) dummy_handler,         /* reserved 128 */
-    (void *) dummy_handler,         /* reserved 129 */
-    (void *) dummy_handler,         /* reserved 130 */
-    (void *) dummy_handler,         /* reserved 131 */
-    (void *) dummy_handler,         /* reserved 132 */
-    (void *) dummy_handler,         /* reserved 133 */
-    (void *) dummy_handler,         /* reserved 134 */
-    (void *) dummy_handler,         /* reserved 135 */
-    (void *) dummy_handler,         /* reserved 136 */
-    (void *) dummy_handler,         /* reserved 137 */
-    (void *) dummy_handler,         /* reserved 138 */
-    (void *) dummy_handler,         /* reserved 139 */
-    (void *) dummy_handler,         /* reserved 140 */
-    (void *) dummy_handler,         /* reserved 141 */
-    (void *) dummy_handler,         /* reserved 142 */
-    (void *) dummy_handler,         /* reserved 143 */
-    (void *) dummy_handler,         /* reserved 144 */
-    (void *) dummy_handler,         /* reserved 145 */
-    (void *) dummy_handler,         /* reserved 146 */
-    (void *) dummy_handler,         /* reserved 147 */
-    (void *) dummy_handler,         /* reserved 148 */
-    (void *) dummy_handler,         /* reserved 149 */
-    (void *) dummy_handler,         /* reserved 150 */
-    (void *) dummy_handler,         /* reserved 151 */
-    (void *) dummy_handler,         /* reserved 152 */
-    (void *) dummy_handler,         /* reserved 153 */
-    (void *) dummy_handler,         /* reserved 154 */
-    (void *) dummy_handler,         /* reserved 155 */
-    (void *) dummy_handler,         /* reserved 156 */
-    (void *) dummy_handler,         /* reserved 157 */
-    (void *) dummy_handler,         /* reserved 158 */
-    (void *) dummy_handler,         /* reserved 159 */
-    (void *) dummy_handler,         /* reserved 160 */
-    (void *) dummy_handler,         /* reserved 161 */
-    (void *) dummy_handler,         /* reserved 162 */
-    (void *) dummy_handler,         /* reserved 163 */
-    (void *) dummy_handler,         /* reserved 164 */
-    (void *) dummy_handler,         /* reserved 165 */
-    (void *) dummy_handler,         /* reserved 166 */
-    (void *) dummy_handler,         /* reserved 167 */
-    (void *) dummy_handler,         /* reserved 168 */
-    (void *) dummy_handler,         /* reserved 169 */
-    (void *) dummy_handler,         /* reserved 170 */
-    (void *) dummy_handler,         /* reserved 171 */
-    (void *) dummy_handler,         /* reserved 172 */
-    (void *) dummy_handler,         /* reserved 173 */
-    (void *) dummy_handler,         /* reserved 174 */
-    (void *) dummy_handler,         /* reserved 175 */
-    (void *) dummy_handler,         /* reserved 176 */
-    (void *) dummy_handler,         /* reserved 177 */
-    (void *) dummy_handler,         /* reserved 178 */
-    (void *) dummy_handler,         /* reserved 179 */
-    (void *) dummy_handler,         /* reserved 180 */
-    (void *) dummy_handler,         /* reserved 181 */
-    (void *) dummy_handler,         /* reserved 182 */
-    (void *) dummy_handler,         /* reserved 183 */
-    (void *) dummy_handler,         /* reserved 184 */
-    (void *) dummy_handler,         /* reserved 185 */
-    (void *) dummy_handler,         /* reserved 186 */
-    (void *) dummy_handler,         /* reserved 187 */
-    (void *) dummy_handler,         /* reserved 188 */
-    (void *) dummy_handler,         /* reserved 189 */
-    (void *) dummy_handler,         /* reserved 190 */
-    (void *) dummy_handler,         /* reserved 191 */
-    (void *) dummy_handler,         /* reserved 192 */
-    (void *) dummy_handler,         /* reserved 193 */
-    (void *) dummy_handler,         /* reserved 194 */
-    (void *) dummy_handler,         /* reserved 195 */
-    (void *) dummy_handler,         /* reserved 196 */
-    (void *) dummy_handler,         /* reserved 197 */
-    (void *) dummy_handler,         /* reserved 198 */
-    (void *) dummy_handler,         /* reserved 199 */
-    (void *) dummy_handler,         /* reserved 200 */
-    (void *) dummy_handler,         /* reserved 201 */
-    (void *) dummy_handler,         /* reserved 202 */
-    (void *) dummy_handler,         /* reserved 203 */
-    (void *) dummy_handler,         /* reserved 204 */
-    (void *) dummy_handler,         /* reserved 205 */
-    (void *) dummy_handler,         /* reserved 206 */
-    (void *) dummy_handler,         /* reserved 207 */
-    (void *) dummy_handler,         /* reserved 208 */
-    (void *) dummy_handler,         /* reserved 209 */
-    (void *) dummy_handler,         /* reserved 210 */
-    (void *) dummy_handler,         /* reserved 211 */
-    (void *) dummy_handler,         /* reserved 212 */
-    (void *) dummy_handler,         /* reserved 213 */
-    (void *) dummy_handler,         /* reserved 214 */
-    (void *) dummy_handler,         /* reserved 215 */
-    (void *) dummy_handler,         /* reserved 216 */
-    (void *) dummy_handler,         /* reserved 217 */
-    (void *) dummy_handler,         /* reserved 218 */
-    (void *) dummy_handler,         /* reserved 219 */
-    (void *) dummy_handler,         /* reserved 220 */
-    (void *) dummy_handler,         /* reserved 221 */
-    (void *) dummy_handler,         /* reserved 222 */
-    (void *) dummy_handler,         /* reserved 223 */
-    (void *) dummy_handler,         /* reserved 224 */
-    (void *) dummy_handler,         /* reserved 225 */
-    (void *) dummy_handler,         /* reserved 226 */
-    (void *) dummy_handler,         /* reserved 227 */
-    (void *) dummy_handler,         /* reserved 228 */
-    (void *) dummy_handler,         /* reserved 229 */
-    (void *) dummy_handler,         /* reserved 230 */
-    (void *) dummy_handler,         /* reserved 231 */
-    (void *) dummy_handler,         /* reserved 232 */
-    (void *) dummy_handler,         /* reserved 233 */
-    (void *) dummy_handler,         /* reserved 234 */
-    (void *) dummy_handler,         /* reserved 235 */
-    (void *) dummy_handler,         /* reserved 236 */
-    (void *) dummy_handler,         /* reserved 237 */
-    (void *) dummy_handler,         /* reserved 238 */
-    (void *) dummy_handler,         /* reserved 239 */
-    (void *) dummy_handler,         /* reserved 240 */
-    (void *) dummy_handler,         /* reserved 241 */
-    (void *) dummy_handler,         /* reserved 242 */
-    (void *) dummy_handler,         /* reserved 243 */
-    (void *) dummy_handler,         /* reserved 244 */
-    (void *) dummy_handler,         /* reserved 245 */
-    (void *) dummy_handler,         /* reserved 246 */
-    (void *) dummy_handler,         /* reserved 247 */
-    (void *) dummy_handler,         /* reserved 248 */
-    (void *) dummy_handler,         /* reserved 249 */
-    (void *) dummy_handler,         /* reserved 250 */
-    (void *) dummy_handler,         /* reserved 251 */
-    (void *) dummy_handler,         /* reserved 252 */
-    (void *) dummy_handler,         /* reserved 253 */
-    (void *) dummy_handler,         /* reserved 254 */
-    (void *) dummy_handler,         /* reserved 255 */
+    isr_dma0,              /* DMA channel 0 transfer complete */
+    isr_dma1,              /* DMA channel 1 transfer complete */
+    isr_dma2,              /* DMA channel 2 transfer complete */
+    isr_dma3,              /* DMA channel 3 transfer complete */
+    isr_dma4,              /* DMA channel 4 transfer complete */
+    isr_dma5,              /* DMA channel 5 transfer complete */
+    isr_dma6,              /* DMA channel 6 transfer complete */
+    isr_dma7,              /* DMA channel 7 transfer complete */
+    isr_dma8,              /* DMA channel 8 transfer complete */
+    isr_dma9,              /* DMA channel 9 transfer complete */
+    isr_dma10,             /* DMA channel 10 transfer complete */
+    isr_dma11,             /* DMA channel 11 transfer complete */
+    isr_dma12,             /* DMA channel 12 transfer complete */
+    isr_dma13,             /* DMA channel 13 transfer complete */
+    isr_dma14,             /* DMA channel 14 transfer complete */
+    isr_dma15,             /* DMA channel 15 transfer complete */
+    isr_dma_error,         /* DMA channel 0 - 15 error */
+    isr_mcm,               /* MCM normal interrupt */
+    isr_ftfl,              /* FTFL command complete */
+    isr_ftfl_collision,    /* FTFL read collision */
+    isr_pmc,               /* PMC controller low-voltage detect low-voltage warning */
+    isr_llwu,              /* Low leakage wakeup */
+    isr_wdog_ewm,          /* Single interrupt vector for  WDOG and EWM */
+    isr_rng,               /* Randon number generator */
+    isr_i2c0,              /* Inter-integrated circuit 0 */
+    isr_i2c1,              /* Inter-integrated circuit 1 */
+    isr_spi0,              /* Serial peripheral Interface 0 */
+    isr_spi1,              /* Serial peripheral Interface 1 */
+    isr_i2s0_tx,           /* Integrated interchip sound 0 transmit interrupt */
+    isr_i2s0_rx,           /* Integrated interchip sound 0 receive interrupt */
+    isr_uart0_lon,         /* UART0 LON interrupt */
+    isr_uart0_rx_tx,       /* UART0 receive/transmit interrupt */
+    isr_uart0_error,       /* UART0 error interrupt */
+    isr_uart1_rx_tx,       /* UART1 receive/transmit interrupt */
+    isr_uart1_error,       /* UART1 error interrupt */
+    isr_uart2_rx_tx,       /* UART2 receive/transmit interrupt */
+    isr_uart2_error,       /* UART2 error interrupt */
+    isr_uart3_rx_tx,       /* UART3 receive/transmit interrupt */
+    isr_uart3_error,       /* UART3 error interrupt */
+    isr_adc0,              /* Analog-to-digital converter 0 */
+    isr_cmp0,              /* Comparator 0 */
+    isr_cmp1,              /* Comparator 1 */
+    isr_ftm0,              /* FlexTimer module 0 fault overflow and channels interrupt */
+    isr_ftm1,              /* FlexTimer module 1 fault overflow and channels interrupt */
+    isr_ftm2,              /* FlexTimer module 2 fault overflow and channels interrupt */
+    isr_cmt,               /* Carrier modulator transmitter */
+    isr_rtc,               /* Real time clock */
+    isr_rtc_seconds,       /* Real time clock seconds */
+    isr_pit0,              /* Periodic interrupt timer channel 0 */
+    isr_pit1,              /* Periodic interrupt timer channel 1 */
+    isr_pit2,              /* Periodic interrupt timer channel 2 */
+    isr_pit3,              /* Periodic interrupt timer channel 3 */
+    isr_pdb0,              /* Programmable delay block */
+    isr_usb0,              /* USB OTG interrupt */
+    isr_usbdcd,            /* USB charger detect */
+    dummy_handler,         /* Reserved interrupt */
+    isr_dac0,              /* Digital-to-analog converter 0 */
+    isr_mcg,               /* Multipurpose clock generator */
+    isr_lptmr0,            /* Low power timer interrupt */
+    isr_porta,             /* Port A pin detect interrupt */
+    isr_portb,             /* Port B pin detect interrupt */
+    isr_portc,             /* Port C pin detect interrupt */
+    isr_portd,             /* Port D pin detect interrupt */
+    isr_porte,             /* Port E pin detect interrupt */
+    isr_swi,               /* Software interrupt */
+    isr_spi2,              /* Serial peripheral Interface 2 */
+    isr_uart4_rx_tx,       /* UART4 receive/transmit interrupt */
+    isr_uart4_error,       /* UART4 error interrupt */
+    isr_uart5_rx_tx,       /* UART5 receive/transmit interrupt */
+    isr_uart5_error,       /* UART5 error interrupt */
+    isr_cmp2,              /* Comparator 2 */
+    isr_ftm3,              /* FlexTimer module 3 fault overflow and channels interrupt */
+    isr_dac1,              /* Digital-to-analog converter 1 */
+    isr_adc1,              /* Analog-to-digital converter 1 */
+    isr_i2c2,              /* Inter-integrated circuit 2 */
+    isr_can0_mb,           /* CAN0 OR'd message buffers interrupt */
+    isr_can0_bus_off,      /* CAN0 bus off interrupt */
+    isr_can0_error,        /* CAN0 error interrupt */
+    isr_can0_tx_warn,      /* CAN0 tx warning interrupt */
+    isr_can0_rx_warn,      /* CAN0 rx warning interrupt */
+    isr_can0_wake_up,      /* CAN0 wake up interrupt */
+    isr_sdhc,              /* SDHC interrupt */
+    isr_enet_1588_timer,   /* Ethernet MAC IEEE 1588 Timer interrupt */
+    isr_enet_tx,           /* Ethernet MAC transmit interrupt */
+    isr_enet_rx,           /* Ethernet MAC receive interrupt */
+    isr_enet_error,        /* Ethernet MAC error interrupt */
+    dummy_handler,         /* reserved 102 */
+    dummy_handler,         /* reserved 103 */
+    dummy_handler,         /* reserved 104 */
+    dummy_handler,         /* reserved 105 */
+    dummy_handler,         /* reserved 106 */
+    dummy_handler,         /* reserved 107 */
+    dummy_handler,         /* reserved 108 */
+    dummy_handler,         /* reserved 109 */
+    dummy_handler,         /* reserved 110 */
+    dummy_handler,         /* reserved 111 */
+    dummy_handler,         /* reserved 112 */
+    dummy_handler,         /* reserved 113 */
+    dummy_handler,         /* reserved 114 */
+    dummy_handler,         /* reserved 115 */
+    dummy_handler,         /* reserved 116 */
+    dummy_handler,         /* reserved 117 */
+    dummy_handler,         /* reserved 118 */
+    dummy_handler,         /* reserved 119 */
+    dummy_handler,         /* reserved 120 */
+    dummy_handler,         /* reserved 121 */
+    dummy_handler,         /* reserved 122 */
+    dummy_handler,         /* reserved 123 */
+    dummy_handler,         /* reserved 124 */
+    dummy_handler,         /* reserved 125 */
+    dummy_handler,         /* reserved 126 */
+    dummy_handler,         /* reserved 127 */
+    dummy_handler,         /* reserved 128 */
+    dummy_handler,         /* reserved 129 */
+    dummy_handler,         /* reserved 130 */
+    dummy_handler,         /* reserved 131 */
+    dummy_handler,         /* reserved 132 */
+    dummy_handler,         /* reserved 133 */
+    dummy_handler,         /* reserved 134 */
+    dummy_handler,         /* reserved 135 */
+    dummy_handler,         /* reserved 136 */
+    dummy_handler,         /* reserved 137 */
+    dummy_handler,         /* reserved 138 */
+    dummy_handler,         /* reserved 139 */
+    dummy_handler,         /* reserved 140 */
+    dummy_handler,         /* reserved 141 */
+    dummy_handler,         /* reserved 142 */
+    dummy_handler,         /* reserved 143 */
+    dummy_handler,         /* reserved 144 */
+    dummy_handler,         /* reserved 145 */
+    dummy_handler,         /* reserved 146 */
+    dummy_handler,         /* reserved 147 */
+    dummy_handler,         /* reserved 148 */
+    dummy_handler,         /* reserved 149 */
+    dummy_handler,         /* reserved 150 */
+    dummy_handler,         /* reserved 151 */
+    dummy_handler,         /* reserved 152 */
+    dummy_handler,         /* reserved 153 */
+    dummy_handler,         /* reserved 154 */
+    dummy_handler,         /* reserved 155 */
+    dummy_handler,         /* reserved 156 */
+    dummy_handler,         /* reserved 157 */
+    dummy_handler,         /* reserved 158 */
+    dummy_handler,         /* reserved 159 */
+    dummy_handler,         /* reserved 160 */
+    dummy_handler,         /* reserved 161 */
+    dummy_handler,         /* reserved 162 */
+    dummy_handler,         /* reserved 163 */
+    dummy_handler,         /* reserved 164 */
+    dummy_handler,         /* reserved 165 */
+    dummy_handler,         /* reserved 166 */
+    dummy_handler,         /* reserved 167 */
+    dummy_handler,         /* reserved 168 */
+    dummy_handler,         /* reserved 169 */
+    dummy_handler,         /* reserved 170 */
+    dummy_handler,         /* reserved 171 */
+    dummy_handler,         /* reserved 172 */
+    dummy_handler,         /* reserved 173 */
+    dummy_handler,         /* reserved 174 */
+    dummy_handler,         /* reserved 175 */
+    dummy_handler,         /* reserved 176 */
+    dummy_handler,         /* reserved 177 */
+    dummy_handler,         /* reserved 178 */
+    dummy_handler,         /* reserved 179 */
+    dummy_handler,         /* reserved 180 */
+    dummy_handler,         /* reserved 181 */
+    dummy_handler,         /* reserved 182 */
+    dummy_handler,         /* reserved 183 */
+    dummy_handler,         /* reserved 184 */
+    dummy_handler,         /* reserved 185 */
+    dummy_handler,         /* reserved 186 */
+    dummy_handler,         /* reserved 187 */
+    dummy_handler,         /* reserved 188 */
+    dummy_handler,         /* reserved 189 */
+    dummy_handler,         /* reserved 190 */
+    dummy_handler,         /* reserved 191 */
+    dummy_handler,         /* reserved 192 */
+    dummy_handler,         /* reserved 193 */
+    dummy_handler,         /* reserved 194 */
+    dummy_handler,         /* reserved 195 */
+    dummy_handler,         /* reserved 196 */
+    dummy_handler,         /* reserved 197 */
+    dummy_handler,         /* reserved 198 */
+    dummy_handler,         /* reserved 199 */
+    dummy_handler,         /* reserved 200 */
+    dummy_handler,         /* reserved 201 */
+    dummy_handler,         /* reserved 202 */
+    dummy_handler,         /* reserved 203 */
+    dummy_handler,         /* reserved 204 */
+    dummy_handler,         /* reserved 205 */
+    dummy_handler,         /* reserved 206 */
+    dummy_handler,         /* reserved 207 */
+    dummy_handler,         /* reserved 208 */
+    dummy_handler,         /* reserved 209 */
+    dummy_handler,         /* reserved 210 */
+    dummy_handler,         /* reserved 211 */
+    dummy_handler,         /* reserved 212 */
+    dummy_handler,         /* reserved 213 */
+    dummy_handler,         /* reserved 214 */
+    dummy_handler,         /* reserved 215 */
+    dummy_handler,         /* reserved 216 */
+    dummy_handler,         /* reserved 217 */
+    dummy_handler,         /* reserved 218 */
+    dummy_handler,         /* reserved 219 */
+    dummy_handler,         /* reserved 220 */
+    dummy_handler,         /* reserved 221 */
+    dummy_handler,         /* reserved 222 */
+    dummy_handler,         /* reserved 223 */
+    dummy_handler,         /* reserved 224 */
+    dummy_handler,         /* reserved 225 */
+    dummy_handler,         /* reserved 226 */
+    dummy_handler,         /* reserved 227 */
+    dummy_handler,         /* reserved 228 */
+    dummy_handler,         /* reserved 229 */
+    dummy_handler,         /* reserved 230 */
+    dummy_handler,         /* reserved 231 */
+    dummy_handler,         /* reserved 232 */
+    dummy_handler,         /* reserved 233 */
+    dummy_handler,         /* reserved 234 */
+    dummy_handler,         /* reserved 235 */
+    dummy_handler,         /* reserved 236 */
+    dummy_handler,         /* reserved 237 */
+    dummy_handler,         /* reserved 238 */
+    dummy_handler,         /* reserved 239 */
+    dummy_handler,         /* reserved 240 */
+    dummy_handler,         /* reserved 241 */
+    dummy_handler,         /* reserved 242 */
+    dummy_handler,         /* reserved 243 */
+    dummy_handler,         /* reserved 244 */
+    dummy_handler,         /* reserved 245 */
+    dummy_handler,         /* reserved 246 */
+    dummy_handler,         /* reserved 247 */
+    dummy_handler,         /* reserved 248 */
+    dummy_handler,         /* reserved 249 */
+    dummy_handler,         /* reserved 250 */
+    dummy_handler,         /* reserved 251 */
+    dummy_handler,         /* reserved 252 */
+    dummy_handler,         /* reserved 253 */
+    dummy_handler,         /* reserved 254 */
+    dummy_handler,         /* reserved 255 */
 };

--- a/cpu/kinetis_common/include/vectors_kinetis.h
+++ b/cpu/kinetis_common/include/vectors_kinetis.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2017 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_k22f
+ * @{
+ *
+ * @file
+ * @brief       Interrupt service routine declarations for Kinetis MCUs
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#ifndef VECTORS_KINETIS_H
+#define VECTORS_KINETIS_H
+
+#include <stdint.h>
+#include "vectors_cortexm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief memory markers as defined in the linker script
+ */
+extern uint32_t _estack;
+
+/**
+ * @brief Dummy handler
+ */
+void dummy_handler(void);
+
+/* Cortex-M specific interrupt vectors */
+void isr_svc(void);          /**< Supervisor call */
+void isr_pendsv(void);       /**< Pending SVC */
+void isr_systick(void);      /**< System tick interrupt */
+/* Kinetis specific interrupt vectors */
+void isr_adc0(void);         /**< ADC0 interrupt handler */
+void isr_adc1(void);         /**< ADC1 interrupt handler */
+void isr_can0_bus_off(void); /**< CAN0 bus off interrupt handler */
+void isr_can0_error(void);   /**< CAN0 error interrupt handler */
+void isr_can0_mb(void);      /**< CAN0 message buffer interrupt handler */
+void isr_can0_rx_warn(void); /**< CAN0 receive warning interrupt handler */
+void isr_can0_tx_warn(void); /**< CAN0 transmit warning interrupt handler */
+void isr_can0_wake_up(void); /**< CAN0 wake up interrupt handler */
+void isr_can1_bus_off(void); /**< CAN1 bus off interrupt handler */
+void isr_can1_error(void);   /**< CAN1 error interrupt handler */
+void isr_can1_mb(void);      /**< CAN1 message buffer interrupt handler */
+void isr_can1_rx_warn(void); /**< CAN1 receive warning interrupt handler */
+void isr_can1_tx_warn(void); /**< CAN1 transmit warning interrupt handler */
+void isr_can1_wake_up(void); /**< CAN1 wake up interrupt handler */
+void isr_cmp0(void);         /**< CMP0 interrupt handler */
+void isr_cmp1(void);         /**< CMP1 interrupt handler */
+void isr_cmp2(void);         /**< CMP2 interrupt handler */
+void isr_cmt(void);          /**< CMT interrupt handler */
+void isr_dac0(void);         /**< DAC0 interrupt handler */
+void isr_dac1(void);         /**< DAC1 interrupt handler */
+void isr_dma0(void);         /**< DMA channel 0 interrupt handler */
+void isr_dma1(void);         /**< DMA channel 1 interrupt handler */
+void isr_dma2(void);         /**< DMA channel 2 interrupt handler */
+void isr_dma3(void);         /**< DMA channel 3 interrupt handler */
+void isr_dma4(void);         /**< DMA channel 4 interrupt handler */
+void isr_dma5(void);         /**< DMA channel 5 interrupt handler */
+void isr_dma6(void);         /**< DMA channel 6 interrupt handler */
+void isr_dma7(void);         /**< DMA channel 7 interrupt handler */
+void isr_dma8(void);         /**< DMA channel 8 interrupt handler */
+void isr_dma9(void);         /**< DMA channel 9 interrupt handler */
+void isr_dma10(void);        /**< DMA channel 10 interrupt handler */
+void isr_dma11(void);        /**< DMA channel 11 interrupt handler */
+void isr_dma12(void);        /**< DMA channel 12 interrupt handler */
+void isr_dma13(void);        /**< DMA channel 13 interrupt handler */
+void isr_dma14(void);        /**< DMA channel 14 interrupt handler */
+void isr_dma15(void);        /**< DMA channel 15 interrupt handler */
+void isr_dma_error(void);    /**< DMA error interrupt handler */
+void isr_enet_1588_timer(void); /**< ENET 1588 timer interrupt handler */
+void isr_enet_error(void);   /**< ENET error interrupt handler */
+void isr_enet_rx(void);      /**< ENET receive interrupt handler */
+void isr_enet_tx(void);      /**< ENET transmit interrupt handler */
+void isr_ftfl(void);         /**< FTFL command complete interrupt handler */
+void isr_ftfl_collision(void); /**< FTFL collision interrupt handler */
+void isr_ftm0(void);         /**< FTM0 interrupt handler */
+void isr_ftm1(void);         /**< FTM1 interrupt handler */
+void isr_ftm2(void);         /**< FTM2 interrupt handler */
+void isr_ftm3(void);         /**< FTM3 interrupt handler */
+void isr_i2c0(void);         /**< I2C0 interrupt handler */
+void isr_i2c1(void);         /**< I2C1 interrupt handler */
+void isr_i2c2(void);         /**< I2C2 interrupt handler */
+void isr_i2s0_rx(void);      /**< I2S0 receive interrupt handler */
+void isr_i2s0_tx(void);      /**< I2S0 transmit interrupt handler */
+void isr_llwu(void);         /**< LLWU interrupt handler */
+void isr_lptmr0(void);       /**< LPTMR0 interrupt handler */
+void isr_mcg(void);          /**< MCG interrupt handler */
+void isr_mcm(void);          /**< MCM interrupt handler */
+void isr_pdb0(void);         /**< PDB0 interrupt handler */
+void isr_pit0(void);         /**< PIT channel 0 interrupt handler */
+void isr_pit1(void);         /**< PIT channel 1 interrupt handler */
+void isr_pit2(void);         /**< PIT channel 2 interrupt handler */
+void isr_pit3(void);         /**< PIT channel 3 interrupt handler */
+void isr_pmc(void);          /**< PMC interrupt handler */
+void isr_porta(void);        /**< PORTA interrupt handler */
+void isr_portb(void);        /**< PORTB interrupt handler */
+void isr_portc(void);        /**< PORTC interrupt handler */
+void isr_portd(void);        /**< PORTD interrupt handler */
+void isr_porte(void);        /**< PORTE interrupt handler */
+void isr_rng(void);          /**< Random number generator interrupt handler */
+void isr_rtc(void);          /**< RTC alarm interrupt handler */
+void isr_rtc_seconds(void);  /**< RTC seconds interrupt handler */
+void isr_sdhc(void);         /**< SDHC interrupt handler */
+void isr_spi0(void);         /**< SPI0 interrupt handler */
+void isr_spi1(void);         /**< SPI1 interrupt handler */
+void isr_spi2(void);         /**< SPI2 interrupt handler */
+void isr_swi(void);          /**< Software interrupt handler */
+void isr_tsi(void);          /**< TSI interrupt handler */
+void isr_uart0_lon(void);    /**< UART0 LON sources interrupt handler */
+void isr_uart0_error(void);  /**< UART0 error interrupt handler */
+void isr_uart0_rx_tx(void);  /**< UART0 receive/transmit interrupt handler */
+void isr_uart1_error(void);  /**< UART1 error interrupt handler */
+void isr_uart1_rx_tx(void);  /**< UART1 receive/transmit interrupt handler */
+void isr_uart2_error(void);  /**< UART2 error interrupt handler */
+void isr_uart2_rx_tx(void);  /**< UART2 receive/transmit interrupt handler */
+void isr_uart3_error(void);  /**< UART3 error interrupt handler */
+void isr_uart3_rx_tx(void);  /**< UART3 receive/transmit interrupt handler */
+void isr_uart4_error(void);  /**< UART4 error interrupt handler */
+void isr_uart4_rx_tx(void);  /**< UART4 receive/transmit interrupt handler */
+void isr_uart5_error(void);  /**< UART5 error interrupt handler */
+void isr_uart5_rx_tx(void);  /**< UART5 receive/transmit interrupt handler */
+void isr_usb0(void);         /**< USB OTG interrupt handler */
+void isr_usbdcd(void);       /**< USB charger detection interrupt handler */
+void isr_wdog_ewm(void);     /**< WDOG and EWM interrupt handler */
+
+/**
+ * @brief Interrupt vector pointer type
+ */
+typedef void (*isr_func_t)(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* VECTORS_KINETIS_H */

--- a/cpu/kinetis_common/isr_kinetis.c
+++ b/cpu/kinetis_common/isr_kinetis.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2017 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_kinetis_common
+ * @{
+ *
+ * @file
+ * @brief       Default interrupt service routine definitions for Kinetis CPUs
+ *
+ * This file defines weak defaults for all available ISRs in Kinetis CPUs, these
+ * weak defaults will act as fallback definitions if no driver defines a
+ * specific handler for any interrupt.
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include "cpu.h"
+#include "vectors_cortexm.h"
+#include "vectors_kinetis.h"
+#include "wdog.h"
+
+void pre_startup(void)
+{
+    /* disable the WDOG */
+    wdog_disable();
+#ifdef SIM_SCGC7_FLEXBUS_SHIFT
+    /*
+     * Workaround for hardware errata e4218: "SIM/FLEXBUS: SIM_SCGC7[FLEXBUS]
+     * bit should be cleared when the FlexBus is not being used."
+     */
+    BITBAND_REG32(SIM->SCGC7, SIM_SCGC7_FLEXBUS_SHIFT) = 0;
+#endif
+}
+
+void dummy_handler(void)
+{
+    dummy_handler_default();
+}
+
+/* Cortex-M specific interrupt vectors */
+WEAK_DEFAULT void isr_svc(void);
+WEAK_DEFAULT void isr_pendsv(void);
+WEAK_DEFAULT void isr_systick(void);
+/* Kinetis specific interrupt vector */
+WEAK_DEFAULT void isr_adc0(void);
+WEAK_DEFAULT void isr_adc1(void);
+WEAK_DEFAULT void isr_can0_bus_off(void);
+WEAK_DEFAULT void isr_can0_error(void);
+WEAK_DEFAULT void isr_can0_mb(void);
+WEAK_DEFAULT void isr_can0_rx_warn(void);
+WEAK_DEFAULT void isr_can0_tx_warn(void);
+WEAK_DEFAULT void isr_can0_wake_up(void);
+WEAK_DEFAULT void isr_can1_bus_off(void);
+WEAK_DEFAULT void isr_can1_error(void);
+WEAK_DEFAULT void isr_can1_mb(void);
+WEAK_DEFAULT void isr_can1_rx_warn(void);
+WEAK_DEFAULT void isr_can1_tx_warn(void);
+WEAK_DEFAULT void isr_can1_wake_up(void);
+WEAK_DEFAULT void isr_cmp0(void);
+WEAK_DEFAULT void isr_cmp1(void);
+WEAK_DEFAULT void isr_cmp2(void);
+WEAK_DEFAULT void isr_cmt(void);
+WEAK_DEFAULT void isr_dac0(void);
+WEAK_DEFAULT void isr_dac1(void);
+WEAK_DEFAULT void isr_dma0(void);
+WEAK_DEFAULT void isr_dma1(void);
+WEAK_DEFAULT void isr_dma2(void);
+WEAK_DEFAULT void isr_dma3(void);
+WEAK_DEFAULT void isr_dma4(void);
+WEAK_DEFAULT void isr_dma5(void);
+WEAK_DEFAULT void isr_dma6(void);
+WEAK_DEFAULT void isr_dma7(void);
+WEAK_DEFAULT void isr_dma8(void);
+WEAK_DEFAULT void isr_dma9(void);
+WEAK_DEFAULT void isr_dma10(void);
+WEAK_DEFAULT void isr_dma11(void);
+WEAK_DEFAULT void isr_dma12(void);
+WEAK_DEFAULT void isr_dma13(void);
+WEAK_DEFAULT void isr_dma14(void);
+WEAK_DEFAULT void isr_dma15(void);
+WEAK_DEFAULT void isr_dma_error(void);
+WEAK_DEFAULT void isr_enet_1588_timer(void);
+WEAK_DEFAULT void isr_enet_error(void);
+WEAK_DEFAULT void isr_enet_rx(void);
+WEAK_DEFAULT void isr_enet_tx(void);
+WEAK_DEFAULT void isr_ftfl(void);
+WEAK_DEFAULT void isr_ftfl_collision(void);
+WEAK_DEFAULT void isr_ftm0(void);
+WEAK_DEFAULT void isr_ftm1(void);
+WEAK_DEFAULT void isr_ftm2(void);
+WEAK_DEFAULT void isr_ftm3(void);
+WEAK_DEFAULT void isr_i2c0(void);
+WEAK_DEFAULT void isr_i2c1(void);
+WEAK_DEFAULT void isr_i2c2(void);
+WEAK_DEFAULT void isr_i2s0_rx(void);
+WEAK_DEFAULT void isr_i2s0_tx(void);
+WEAK_DEFAULT void isr_llwu(void);
+WEAK_DEFAULT void isr_lptmr0(void);
+WEAK_DEFAULT void isr_mcg(void);
+WEAK_DEFAULT void isr_mcm(void);
+WEAK_DEFAULT void isr_pdb0(void);
+WEAK_DEFAULT void isr_pit0(void);
+WEAK_DEFAULT void isr_pit1(void);
+WEAK_DEFAULT void isr_pit2(void);
+WEAK_DEFAULT void isr_pit3(void);
+WEAK_DEFAULT void isr_pmc(void);
+WEAK_DEFAULT void isr_porta(void);
+WEAK_DEFAULT void isr_portb(void);
+WEAK_DEFAULT void isr_portc(void);
+WEAK_DEFAULT void isr_portd(void);
+WEAK_DEFAULT void isr_porte(void);
+WEAK_DEFAULT void isr_rng(void);
+WEAK_DEFAULT void isr_rtc_seconds(void);
+WEAK_DEFAULT void isr_rtc(void);
+WEAK_DEFAULT void isr_sdhc(void);
+WEAK_DEFAULT void isr_spi0(void);
+WEAK_DEFAULT void isr_spi1(void);
+WEAK_DEFAULT void isr_spi2(void);
+WEAK_DEFAULT void isr_swi(void);
+WEAK_DEFAULT void isr_tsi(void);
+WEAK_DEFAULT void isr_uart0_error(void);
+WEAK_DEFAULT void isr_uart0_lon(void);
+WEAK_DEFAULT void isr_uart0_rx_tx(void);
+WEAK_DEFAULT void isr_uart1_error(void);
+WEAK_DEFAULT void isr_uart1_rx_tx(void);
+WEAK_DEFAULT void isr_uart2_error(void);
+WEAK_DEFAULT void isr_uart2_rx_tx(void);
+WEAK_DEFAULT void isr_uart3_error(void);
+WEAK_DEFAULT void isr_uart3_rx_tx(void);
+WEAK_DEFAULT void isr_uart4_error(void);
+WEAK_DEFAULT void isr_uart4_rx_tx(void);
+WEAK_DEFAULT void isr_uart5_error(void);
+WEAK_DEFAULT void isr_uart5_rx_tx(void);
+WEAK_DEFAULT void isr_usb0(void);
+WEAK_DEFAULT void isr_usbdcd(void);
+WEAK_DEFAULT void isr_wdog_ewm(void);

--- a/cpu/kw2xd/vectors.c
+++ b/cpu/kw2xd/vectors.c
@@ -20,354 +20,269 @@
  * @}
  */
 
-#include <stdint.h>
-#include "vectors_cortexm.h"
-#include "wdog.h"
-
-/**
- * memory markers as defined in the linker script
- */
-extern uint32_t _estack;
-
-void pre_startup (void)
-{
-    /* disable the WDOG */
-    wdog_disable();
-}
-
-void dummy_handler(void)
-{
-    dummy_handler_default();
-}
-
-/* Cortex-M specific interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
-/* MKW22D512 specific interrupt vector */
-WEAK_DEFAULT void isr_dma0(void);
-WEAK_DEFAULT void isr_dma1(void);
-WEAK_DEFAULT void isr_dma2(void);
-WEAK_DEFAULT void isr_dma3(void);
-WEAK_DEFAULT void isr_dma4(void);
-WEAK_DEFAULT void isr_dma5(void);
-WEAK_DEFAULT void isr_dma6(void);
-WEAK_DEFAULT void isr_dma7(void);
-WEAK_DEFAULT void isr_dma8(void);
-WEAK_DEFAULT void isr_dma9(void);
-WEAK_DEFAULT void isr_dma10(void);
-WEAK_DEFAULT void isr_dma11(void);
-WEAK_DEFAULT void isr_dma12(void);
-WEAK_DEFAULT void isr_dma13(void);
-WEAK_DEFAULT void isr_dma14(void);
-WEAK_DEFAULT void isr_dma15(void);
-WEAK_DEFAULT void isr_dma_error(void);
-WEAK_DEFAULT void isr_mcm(void);
-WEAK_DEFAULT void isr_ftfl(void);
-WEAK_DEFAULT void isr_ftfl_collision(void);
-WEAK_DEFAULT void isr_pmc(void);
-WEAK_DEFAULT void isr_llwu(void);
-WEAK_DEFAULT void isr_wdog_ewm(void);
-WEAK_DEFAULT void isr_rng(void);
-WEAK_DEFAULT void isr_i2c0(void);
-WEAK_DEFAULT void isr_i2c1(void);
-WEAK_DEFAULT void isr_spi0(void);
-WEAK_DEFAULT void isr_spi1(void);
-WEAK_DEFAULT void isr_i2s0_tx(void);
-WEAK_DEFAULT void isr_i2s0_rx(void);
-WEAK_DEFAULT void isr_uart0_rx_tx(void);
-WEAK_DEFAULT void isr_uart0_err(void);
-WEAK_DEFAULT void isr_uart1_rx_tx(void);
-WEAK_DEFAULT void isr_uart1_err(void);
-WEAK_DEFAULT void isr_uart2_rx_tx(void);
-WEAK_DEFAULT void isr_uart2_err(void);
-WEAK_DEFAULT void isr_adc0(void);
-WEAK_DEFAULT void isr_cmp0(void);
-WEAK_DEFAULT void isr_cmp1(void);
-WEAK_DEFAULT void isr_ftm0(void);
-WEAK_DEFAULT void isr_ftm1(void);
-WEAK_DEFAULT void isr_ftm2(void);
-WEAK_DEFAULT void isr_cmt(void);
-WEAK_DEFAULT void isr_rtc(void);
-WEAK_DEFAULT void isr_rtc_seconds(void);
-WEAK_DEFAULT void isr_pit0(void);
-WEAK_DEFAULT void isr_pit1(void);
-WEAK_DEFAULT void isr_pit2(void);
-WEAK_DEFAULT void isr_pit3(void);
-WEAK_DEFAULT void isr_pdb0(void);
-WEAK_DEFAULT void isr_usb0(void);
-WEAK_DEFAULT void isr_usbdcd(void);
-WEAK_DEFAULT void isr_dac0(void);
-WEAK_DEFAULT void isr_mcg(void);
-WEAK_DEFAULT void isr_lptmr0(void);
-WEAK_DEFAULT void isr_porta(void);
-WEAK_DEFAULT void isr_portb(void);
-WEAK_DEFAULT void isr_portc(void);
-WEAK_DEFAULT void isr_portd(void);
-WEAK_DEFAULT void isr_porte(void);
-WEAK_DEFAULT void isr_swi(void);
+#include "vectors_kinetis.h"
 
 /* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
+ISR_VECTORS const isr_func_t interrupt_vector[] = {
     /* Stack pointer */
-    (void *)(&_estack),             /* pointer to the top of the empty stack */
+    (isr_func_t)(&_estack),     /* pointer to the top of the empty stack */
     /* Cortex-M4 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    reset_handler_default,  /* entry point of the program */
+    nmi_default,            /* non maskable interrupt handler */
+    hard_fault_default,     /* hard fault exception */
+    mem_manage_default,     /* memory manage exception */
+    bus_fault_default,      /* bus fault exception */
+    usage_fault_default,    /* usage fault exception */
+    dummy_handler,          /* Reserved */
+    dummy_handler,          /* Reserved */
+    dummy_handler,          /* Reserved */
+    dummy_handler,          /* Reserved */
+    isr_svc,                /* system call interrupt, in RIOT used for
+                             * switching into thread context on boot */
+    debug_mon_default,      /* debug monitor exception */
+    dummy_handler,          /* Reserved */
+    isr_pendsv,             /* pendSV interrupt, in RIOT the actual
+                             * context switching is happening here */
+    isr_systick,            /* SysTick interrupt, not used in RIOT */
     /* MKW22D512 specific peripheral handlers */
-    (void *) isr_dma0,              /* DMA channel 0 transfer complete */
-    (void *) isr_dma1,              /* DMA channel 1 transfer complete */
-    (void *) isr_dma2,              /* DMA channel 2 transfer complete */
-    (void *) isr_dma3,              /* DMA channel 3 transfer complete */
-    (void *) isr_dma4,              /* DMA channel 4 transfer complete */
-    (void *) isr_dma5,              /* DMA channel 5 transfer complete */
-    (void *) isr_dma6,              /* DMA channel 6 transfer complete */
-    (void *) isr_dma7,              /* DMA channel 7 transfer complete */
-    (void *) isr_dma8,              /* DMA channel 8 transfer complete */
-    (void *) isr_dma9,              /* DMA channel 9 transfer complete */
-    (void *) isr_dma10,             /* DMA channel 10 transfer complete */
-    (void *) isr_dma11,             /* DMA channel 11 transfer complete */
-    (void *) isr_dma12,             /* DMA channel 12 transfer complete */
-    (void *) isr_dma13,             /* DMA channel 13 transfer complete */
-    (void *) isr_dma14,             /* DMA channel 14 transfer complete */
-    (void *) isr_dma15,             /* DMA channel 15 transfer complete */
-    (void *) isr_dma_error,         /* DMA channel 0 - 15 error */
-    (void *) isr_mcm,               /* MCM normal interrupt */
-    (void *) isr_ftfl,              /* FTFL command complete */
-    (void *) isr_ftfl_collision,    /* FTFL read collision */
-    (void *) isr_pmc,               /* PMC controller low-voltage detect low-voltage warning */
-    (void *) isr_llwu,              /* Low leakage wakeup */
-    (void *) isr_wdog_ewm,          /* Single interrupt vector for  WDOG and EWM */
-    (void *) isr_rng,               /* Randon number generator */
-    (void *) isr_i2c0,              /* Inter-integrated circuit 0 */
-    (void *) isr_i2c1,              /* Inter-integrated circuit 1 */
-    (void *) isr_spi0,              /* Serial peripheral Interface 0 */
-    (void *) isr_spi1,              /* Serial peripheral Interface 1 */
-    (void *) isr_i2s0_tx,           /* Integrated interchip sound 0 transmit interrupt */
-    (void *) isr_i2s0_rx,           /* Integrated interchip sound 0 receive interrupt */
-    (void *) dummy_handler,         /* Reserved interrupt */
-    (void *) isr_uart0_rx_tx,       /* UART0 receive/transmit interrupt */
-    (void *) isr_uart0_err,         /* UART0 error interrupt */
-    (void *) isr_uart1_rx_tx,       /* UART1 receive/transmit interrupt */
-    (void *) isr_uart1_err,         /* UART1 error interrupt */
-    (void *) isr_uart2_rx_tx,       /* UART2 receive/transmit interrupt */
-    (void *) isr_uart2_err,         /* UART2 error interrupt */
-    (void *) dummy_handler,         /* Reserved interrupt */
-    (void *) dummy_handler,         /* Reserved interrupt */
-    (void *) isr_adc0,              /* Analog-to-digital converter 0 */
-    (void *) isr_cmp0,              /* Comparator 0 */
-    (void *) isr_cmp1,              /* Comparator 1 */
-    (void *) isr_ftm0,              /* FlexTimer module 0 fault overflow and channels interrupt */
-    (void *) isr_ftm1,              /* FlexTimer module 1 fault overflow and channels interrupt */
-    (void *) isr_ftm2,              /* FlexTimer module 2 fault overflow and channels interrupt */
-    (void *) isr_cmt,               /* Carrier modulator transmitter */
-    (void *) isr_rtc,               /* Real time clock */
-    (void *) isr_rtc_seconds,       /* Real time clock seconds */
-    (void *) isr_pit0,              /* Periodic interrupt timer channel 0 */
-    (void *) isr_pit1,              /* Periodic interrupt timer channel 1 */
-    (void *) isr_pit2,              /* Periodic interrupt timer channel 2 */
-    (void *) isr_pit3,              /* Periodic interrupt timer channel 3 */
-    (void *) isr_pdb0,              /* Programmable delay block */
-    (void *) isr_usb0,              /* USB OTG interrupt */
-    (void *) isr_usbdcd,            /* USB charger detect */
-    (void *) dummy_handler,         /* Reserved interrupt */
-    (void *) isr_dac0,              /* Digital-to-analog converter 0 */
-    (void *) isr_mcg,               /* Multipurpose clock generator */
-    (void *) isr_lptmr0,            /* Low power timer interrupt */
-    (void *) isr_porta,             /* Port A pin detect interrupt */
-    (void *) isr_portb,             /* Port B pin detect interrupt */
-    (void *) isr_portc,             /* Port C pin detect interrupt */
-    (void *) isr_portd,             /* Port D pin detect interrupt */
-    (void *) isr_porte,             /* Port E pin detect interrupt */
-    (void *) isr_swi,               /* Software interrupt */
-    (void *) dummy_handler,         /* reserved 81 */
-    (void *) dummy_handler,         /* reserved 82 */
-    (void *) dummy_handler,         /* reserved 83 */
-    (void *) dummy_handler,         /* reserved 84 */
-    (void *) dummy_handler,         /* reserved 85 */
-    (void *) dummy_handler,         /* reserved 86 */
-    (void *) dummy_handler,         /* reserved 87 */
-    (void *) dummy_handler,         /* reserved 88 */
-    (void *) dummy_handler,         /* reserved 89 */
-    (void *) dummy_handler,         /* reserved 90 */
-    (void *) dummy_handler,         /* reserved 91 */
-    (void *) dummy_handler,         /* reserved 92 */
-    (void *) dummy_handler,         /* reserved 93 */
-    (void *) dummy_handler,         /* reserved 94 */
-    (void *) dummy_handler,         /* reserved 95 */
-    (void *) dummy_handler,         /* reserved 96 */
-    (void *) dummy_handler,         /* reserved 97 */
-    (void *) dummy_handler,         /* reserved 98 */
-    (void *) dummy_handler,         /* reserved 99 */
-    (void *) dummy_handler,         /* reserved 100 */
-    (void *) dummy_handler,         /* reserved 101 */
-    (void *) dummy_handler,         /* reserved 102 */
-    (void *) dummy_handler,         /* reserved 103 */
-    (void *) dummy_handler,         /* reserved 104 */
-    (void *) dummy_handler,         /* reserved 105 */
-    (void *) dummy_handler,         /* reserved 106 */
-    (void *) dummy_handler,         /* reserved 107 */
-    (void *) dummy_handler,         /* reserved 108 */
-    (void *) dummy_handler,         /* reserved 109 */
-    (void *) dummy_handler,         /* reserved 110 */
-    (void *) dummy_handler,         /* reserved 111 */
-    (void *) dummy_handler,         /* reserved 112 */
-    (void *) dummy_handler,         /* reserved 113 */
-    (void *) dummy_handler,         /* reserved 114 */
-    (void *) dummy_handler,         /* reserved 115 */
-    (void *) dummy_handler,         /* reserved 116 */
-    (void *) dummy_handler,         /* reserved 117 */
-    (void *) dummy_handler,         /* reserved 118 */
-    (void *) dummy_handler,         /* reserved 119 */
-    (void *) dummy_handler,         /* reserved 120 */
-    (void *) dummy_handler,         /* reserved 121 */
-    (void *) dummy_handler,         /* reserved 122 */
-    (void *) dummy_handler,         /* reserved 123 */
-    (void *) dummy_handler,         /* reserved 124 */
-    (void *) dummy_handler,         /* reserved 125 */
-    (void *) dummy_handler,         /* reserved 126 */
-    (void *) dummy_handler,         /* reserved 127 */
-    (void *) dummy_handler,         /* reserved 128 */
-    (void *) dummy_handler,         /* reserved 129 */
-    (void *) dummy_handler,         /* reserved 130 */
-    (void *) dummy_handler,         /* reserved 131 */
-    (void *) dummy_handler,         /* reserved 132 */
-    (void *) dummy_handler,         /* reserved 133 */
-    (void *) dummy_handler,         /* reserved 134 */
-    (void *) dummy_handler,         /* reserved 135 */
-    (void *) dummy_handler,         /* reserved 136 */
-    (void *) dummy_handler,         /* reserved 137 */
-    (void *) dummy_handler,         /* reserved 138 */
-    (void *) dummy_handler,         /* reserved 139 */
-    (void *) dummy_handler,         /* reserved 140 */
-    (void *) dummy_handler,         /* reserved 141 */
-    (void *) dummy_handler,         /* reserved 142 */
-    (void *) dummy_handler,         /* reserved 143 */
-    (void *) dummy_handler,         /* reserved 144 */
-    (void *) dummy_handler,         /* reserved 145 */
-    (void *) dummy_handler,         /* reserved 146 */
-    (void *) dummy_handler,         /* reserved 147 */
-    (void *) dummy_handler,         /* reserved 148 */
-    (void *) dummy_handler,         /* reserved 149 */
-    (void *) dummy_handler,         /* reserved 150 */
-    (void *) dummy_handler,         /* reserved 151 */
-    (void *) dummy_handler,         /* reserved 152 */
-    (void *) dummy_handler,         /* reserved 153 */
-    (void *) dummy_handler,         /* reserved 154 */
-    (void *) dummy_handler,         /* reserved 155 */
-    (void *) dummy_handler,         /* reserved 156 */
-    (void *) dummy_handler,         /* reserved 157 */
-    (void *) dummy_handler,         /* reserved 158 */
-    (void *) dummy_handler,         /* reserved 159 */
-    (void *) dummy_handler,         /* reserved 160 */
-    (void *) dummy_handler,         /* reserved 161 */
-    (void *) dummy_handler,         /* reserved 162 */
-    (void *) dummy_handler,         /* reserved 163 */
-    (void *) dummy_handler,         /* reserved 164 */
-    (void *) dummy_handler,         /* reserved 165 */
-    (void *) dummy_handler,         /* reserved 166 */
-    (void *) dummy_handler,         /* reserved 167 */
-    (void *) dummy_handler,         /* reserved 168 */
-    (void *) dummy_handler,         /* reserved 169 */
-    (void *) dummy_handler,         /* reserved 170 */
-    (void *) dummy_handler,         /* reserved 171 */
-    (void *) dummy_handler,         /* reserved 172 */
-    (void *) dummy_handler,         /* reserved 173 */
-    (void *) dummy_handler,         /* reserved 174 */
-    (void *) dummy_handler,         /* reserved 175 */
-    (void *) dummy_handler,         /* reserved 176 */
-    (void *) dummy_handler,         /* reserved 177 */
-    (void *) dummy_handler,         /* reserved 178 */
-    (void *) dummy_handler,         /* reserved 179 */
-    (void *) dummy_handler,         /* reserved 180 */
-    (void *) dummy_handler,         /* reserved 181 */
-    (void *) dummy_handler,         /* reserved 182 */
-    (void *) dummy_handler,         /* reserved 183 */
-    (void *) dummy_handler,         /* reserved 184 */
-    (void *) dummy_handler,         /* reserved 185 */
-    (void *) dummy_handler,         /* reserved 186 */
-    (void *) dummy_handler,         /* reserved 187 */
-    (void *) dummy_handler,         /* reserved 188 */
-    (void *) dummy_handler,         /* reserved 189 */
-    (void *) dummy_handler,         /* reserved 190 */
-    (void *) dummy_handler,         /* reserved 191 */
-    (void *) dummy_handler,         /* reserved 192 */
-    (void *) dummy_handler,         /* reserved 193 */
-    (void *) dummy_handler,         /* reserved 194 */
-    (void *) dummy_handler,         /* reserved 195 */
-    (void *) dummy_handler,         /* reserved 196 */
-    (void *) dummy_handler,         /* reserved 197 */
-    (void *) dummy_handler,         /* reserved 198 */
-    (void *) dummy_handler,         /* reserved 199 */
-    (void *) dummy_handler,         /* reserved 200 */
-    (void *) dummy_handler,         /* reserved 201 */
-    (void *) dummy_handler,         /* reserved 202 */
-    (void *) dummy_handler,         /* reserved 203 */
-    (void *) dummy_handler,         /* reserved 204 */
-    (void *) dummy_handler,         /* reserved 205 */
-    (void *) dummy_handler,         /* reserved 206 */
-    (void *) dummy_handler,         /* reserved 207 */
-    (void *) dummy_handler,         /* reserved 208 */
-    (void *) dummy_handler,         /* reserved 209 */
-    (void *) dummy_handler,         /* reserved 210 */
-    (void *) dummy_handler,         /* reserved 211 */
-    (void *) dummy_handler,         /* reserved 212 */
-    (void *) dummy_handler,         /* reserved 213 */
-    (void *) dummy_handler,         /* reserved 214 */
-    (void *) dummy_handler,         /* reserved 215 */
-    (void *) dummy_handler,         /* reserved 216 */
-    (void *) dummy_handler,         /* reserved 217 */
-    (void *) dummy_handler,         /* reserved 218 */
-    (void *) dummy_handler,         /* reserved 219 */
-    (void *) dummy_handler,         /* reserved 220 */
-    (void *) dummy_handler,         /* reserved 221 */
-    (void *) dummy_handler,         /* reserved 222 */
-    (void *) dummy_handler,         /* reserved 223 */
-    (void *) dummy_handler,         /* reserved 224 */
-    (void *) dummy_handler,         /* reserved 225 */
-    (void *) dummy_handler,         /* reserved 226 */
-    (void *) dummy_handler,         /* reserved 227 */
-    (void *) dummy_handler,         /* reserved 228 */
-    (void *) dummy_handler,         /* reserved 229 */
-    (void *) dummy_handler,         /* reserved 230 */
-    (void *) dummy_handler,         /* reserved 231 */
-    (void *) dummy_handler,         /* reserved 232 */
-    (void *) dummy_handler,         /* reserved 233 */
-    (void *) dummy_handler,         /* reserved 234 */
-    (void *) dummy_handler,         /* reserved 235 */
-    (void *) dummy_handler,         /* reserved 236 */
-    (void *) dummy_handler,         /* reserved 237 */
-    (void *) dummy_handler,         /* reserved 238 */
-    (void *) dummy_handler,         /* reserved 239 */
-    (void *) dummy_handler,         /* reserved 240 */
-    (void *) dummy_handler,         /* reserved 241 */
-    (void *) dummy_handler,         /* reserved 242 */
-    (void *) dummy_handler,         /* reserved 243 */
-    (void *) dummy_handler,         /* reserved 244 */
-    (void *) dummy_handler,         /* reserved 245 */
-    (void *) dummy_handler,         /* reserved 246 */
-    (void *) dummy_handler,         /* reserved 247 */
-    (void *) dummy_handler,         /* reserved 248 */
-    (void *) dummy_handler,         /* reserved 249 */
-    (void *) dummy_handler,         /* reserved 250 */
-    (void *) dummy_handler,         /* reserved 251 */
-    (void *) dummy_handler,         /* reserved 252 */
-    (void *) dummy_handler,         /* reserved 253 */
-    (void *) dummy_handler,         /* reserved 254 */
-    (void *) dummy_handler,         /* reserved 255 */
+    isr_dma0,              /* DMA channel 0 transfer complete */
+    isr_dma1,              /* DMA channel 1 transfer complete */
+    isr_dma2,              /* DMA channel 2 transfer complete */
+    isr_dma3,              /* DMA channel 3 transfer complete */
+    isr_dma4,              /* DMA channel 4 transfer complete */
+    isr_dma5,              /* DMA channel 5 transfer complete */
+    isr_dma6,              /* DMA channel 6 transfer complete */
+    isr_dma7,              /* DMA channel 7 transfer complete */
+    isr_dma8,              /* DMA channel 8 transfer complete */
+    isr_dma9,              /* DMA channel 9 transfer complete */
+    isr_dma10,             /* DMA channel 10 transfer complete */
+    isr_dma11,             /* DMA channel 11 transfer complete */
+    isr_dma12,             /* DMA channel 12 transfer complete */
+    isr_dma13,             /* DMA channel 13 transfer complete */
+    isr_dma14,             /* DMA channel 14 transfer complete */
+    isr_dma15,             /* DMA channel 15 transfer complete */
+    isr_dma_error,         /* DMA channel 0 - 15 error */
+    isr_mcm,               /* MCM normal interrupt */
+    isr_ftfl,              /* FTFL command complete */
+    isr_ftfl_collision,    /* FTFL read collision */
+    isr_pmc,               /* PMC controller low-voltage detect low-voltage warning */
+    isr_llwu,              /* Low leakage wakeup */
+    isr_wdog_ewm,          /* Single interrupt vector for  WDOG and EWM */
+    isr_rng,               /* Randon number generator */
+    isr_i2c0,              /* Inter-integrated circuit 0 */
+    isr_i2c1,              /* Inter-integrated circuit 1 */
+    isr_spi0,              /* Serial peripheral Interface 0 */
+    isr_spi1,              /* Serial peripheral Interface 1 */
+    isr_i2s0_tx,           /* Integrated interchip sound 0 transmit interrupt */
+    isr_i2s0_rx,           /* Integrated interchip sound 0 receive interrupt */
+    dummy_handler,         /* Reserved interrupt */
+    isr_uart0_rx_tx,       /* UART0 receive/transmit interrupt */
+    isr_uart0_error,       /* UART0 error interrupt */
+    isr_uart1_rx_tx,       /* UART1 receive/transmit interrupt */
+    isr_uart1_error,       /* UART1 error interrupt */
+    isr_uart2_rx_tx,       /* UART2 receive/transmit interrupt */
+    isr_uart2_error,       /* UART2 error interrupt */
+    dummy_handler,         /* Reserved interrupt */
+    dummy_handler,         /* Reserved interrupt */
+    isr_adc0,              /* Analog-to-digital converter 0 */
+    isr_cmp0,              /* Comparator 0 */
+    isr_cmp1,              /* Comparator 1 */
+    isr_ftm0,              /* FlexTimer module 0 fault overflow and channels interrupt */
+    isr_ftm1,              /* FlexTimer module 1 fault overflow and channels interrupt */
+    isr_ftm2,              /* FlexTimer module 2 fault overflow and channels interrupt */
+    isr_cmt,               /* Carrier modulator transmitter */
+    isr_rtc,               /* Real time clock */
+    isr_rtc_seconds,       /* Real time clock seconds */
+    isr_pit0,              /* Periodic interrupt timer channel 0 */
+    isr_pit1,              /* Periodic interrupt timer channel 1 */
+    isr_pit2,              /* Periodic interrupt timer channel 2 */
+    isr_pit3,              /* Periodic interrupt timer channel 3 */
+    isr_pdb0,              /* Programmable delay block */
+    isr_usb0,              /* USB OTG interrupt */
+    isr_usbdcd,            /* USB charger detect */
+    dummy_handler,         /* Reserved interrupt */
+    isr_dac0,              /* Digital-to-analog converter 0 */
+    isr_mcg,               /* Multipurpose clock generator */
+    isr_lptmr0,            /* Low power timer interrupt */
+    isr_porta,             /* Port A pin detect interrupt */
+    isr_portb,             /* Port B pin detect interrupt */
+    isr_portc,             /* Port C pin detect interrupt */
+    isr_portd,             /* Port D pin detect interrupt */
+    isr_porte,             /* Port E pin detect interrupt */
+    isr_swi,               /* Software interrupt */
+    dummy_handler,         /* reserved 81 */
+    dummy_handler,         /* reserved 82 */
+    dummy_handler,         /* reserved 83 */
+    dummy_handler,         /* reserved 84 */
+    dummy_handler,         /* reserved 85 */
+    dummy_handler,         /* reserved 86 */
+    dummy_handler,         /* reserved 87 */
+    dummy_handler,         /* reserved 88 */
+    dummy_handler,         /* reserved 89 */
+    dummy_handler,         /* reserved 90 */
+    dummy_handler,         /* reserved 91 */
+    dummy_handler,         /* reserved 92 */
+    dummy_handler,         /* reserved 93 */
+    dummy_handler,         /* reserved 94 */
+    dummy_handler,         /* reserved 95 */
+    dummy_handler,         /* reserved 96 */
+    dummy_handler,         /* reserved 97 */
+    dummy_handler,         /* reserved 98 */
+    dummy_handler,         /* reserved 99 */
+    dummy_handler,         /* reserved 100 */
+    dummy_handler,         /* reserved 101 */
+    dummy_handler,         /* reserved 102 */
+    dummy_handler,         /* reserved 103 */
+    dummy_handler,         /* reserved 104 */
+    dummy_handler,         /* reserved 105 */
+    dummy_handler,         /* reserved 106 */
+    dummy_handler,         /* reserved 107 */
+    dummy_handler,         /* reserved 108 */
+    dummy_handler,         /* reserved 109 */
+    dummy_handler,         /* reserved 110 */
+    dummy_handler,         /* reserved 111 */
+    dummy_handler,         /* reserved 112 */
+    dummy_handler,         /* reserved 113 */
+    dummy_handler,         /* reserved 114 */
+    dummy_handler,         /* reserved 115 */
+    dummy_handler,         /* reserved 116 */
+    dummy_handler,         /* reserved 117 */
+    dummy_handler,         /* reserved 118 */
+    dummy_handler,         /* reserved 119 */
+    dummy_handler,         /* reserved 120 */
+    dummy_handler,         /* reserved 121 */
+    dummy_handler,         /* reserved 122 */
+    dummy_handler,         /* reserved 123 */
+    dummy_handler,         /* reserved 124 */
+    dummy_handler,         /* reserved 125 */
+    dummy_handler,         /* reserved 126 */
+    dummy_handler,         /* reserved 127 */
+    dummy_handler,         /* reserved 128 */
+    dummy_handler,         /* reserved 129 */
+    dummy_handler,         /* reserved 130 */
+    dummy_handler,         /* reserved 131 */
+    dummy_handler,         /* reserved 132 */
+    dummy_handler,         /* reserved 133 */
+    dummy_handler,         /* reserved 134 */
+    dummy_handler,         /* reserved 135 */
+    dummy_handler,         /* reserved 136 */
+    dummy_handler,         /* reserved 137 */
+    dummy_handler,         /* reserved 138 */
+    dummy_handler,         /* reserved 139 */
+    dummy_handler,         /* reserved 140 */
+    dummy_handler,         /* reserved 141 */
+    dummy_handler,         /* reserved 142 */
+    dummy_handler,         /* reserved 143 */
+    dummy_handler,         /* reserved 144 */
+    dummy_handler,         /* reserved 145 */
+    dummy_handler,         /* reserved 146 */
+    dummy_handler,         /* reserved 147 */
+    dummy_handler,         /* reserved 148 */
+    dummy_handler,         /* reserved 149 */
+    dummy_handler,         /* reserved 150 */
+    dummy_handler,         /* reserved 151 */
+    dummy_handler,         /* reserved 152 */
+    dummy_handler,         /* reserved 153 */
+    dummy_handler,         /* reserved 154 */
+    dummy_handler,         /* reserved 155 */
+    dummy_handler,         /* reserved 156 */
+    dummy_handler,         /* reserved 157 */
+    dummy_handler,         /* reserved 158 */
+    dummy_handler,         /* reserved 159 */
+    dummy_handler,         /* reserved 160 */
+    dummy_handler,         /* reserved 161 */
+    dummy_handler,         /* reserved 162 */
+    dummy_handler,         /* reserved 163 */
+    dummy_handler,         /* reserved 164 */
+    dummy_handler,         /* reserved 165 */
+    dummy_handler,         /* reserved 166 */
+    dummy_handler,         /* reserved 167 */
+    dummy_handler,         /* reserved 168 */
+    dummy_handler,         /* reserved 169 */
+    dummy_handler,         /* reserved 170 */
+    dummy_handler,         /* reserved 171 */
+    dummy_handler,         /* reserved 172 */
+    dummy_handler,         /* reserved 173 */
+    dummy_handler,         /* reserved 174 */
+    dummy_handler,         /* reserved 175 */
+    dummy_handler,         /* reserved 176 */
+    dummy_handler,         /* reserved 177 */
+    dummy_handler,         /* reserved 178 */
+    dummy_handler,         /* reserved 179 */
+    dummy_handler,         /* reserved 180 */
+    dummy_handler,         /* reserved 181 */
+    dummy_handler,         /* reserved 182 */
+    dummy_handler,         /* reserved 183 */
+    dummy_handler,         /* reserved 184 */
+    dummy_handler,         /* reserved 185 */
+    dummy_handler,         /* reserved 186 */
+    dummy_handler,         /* reserved 187 */
+    dummy_handler,         /* reserved 188 */
+    dummy_handler,         /* reserved 189 */
+    dummy_handler,         /* reserved 190 */
+    dummy_handler,         /* reserved 191 */
+    dummy_handler,         /* reserved 192 */
+    dummy_handler,         /* reserved 193 */
+    dummy_handler,         /* reserved 194 */
+    dummy_handler,         /* reserved 195 */
+    dummy_handler,         /* reserved 196 */
+    dummy_handler,         /* reserved 197 */
+    dummy_handler,         /* reserved 198 */
+    dummy_handler,         /* reserved 199 */
+    dummy_handler,         /* reserved 200 */
+    dummy_handler,         /* reserved 201 */
+    dummy_handler,         /* reserved 202 */
+    dummy_handler,         /* reserved 203 */
+    dummy_handler,         /* reserved 204 */
+    dummy_handler,         /* reserved 205 */
+    dummy_handler,         /* reserved 206 */
+    dummy_handler,         /* reserved 207 */
+    dummy_handler,         /* reserved 208 */
+    dummy_handler,         /* reserved 209 */
+    dummy_handler,         /* reserved 210 */
+    dummy_handler,         /* reserved 211 */
+    dummy_handler,         /* reserved 212 */
+    dummy_handler,         /* reserved 213 */
+    dummy_handler,         /* reserved 214 */
+    dummy_handler,         /* reserved 215 */
+    dummy_handler,         /* reserved 216 */
+    dummy_handler,         /* reserved 217 */
+    dummy_handler,         /* reserved 218 */
+    dummy_handler,         /* reserved 219 */
+    dummy_handler,         /* reserved 220 */
+    dummy_handler,         /* reserved 221 */
+    dummy_handler,         /* reserved 222 */
+    dummy_handler,         /* reserved 223 */
+    dummy_handler,         /* reserved 224 */
+    dummy_handler,         /* reserved 225 */
+    dummy_handler,         /* reserved 226 */
+    dummy_handler,         /* reserved 227 */
+    dummy_handler,         /* reserved 228 */
+    dummy_handler,         /* reserved 229 */
+    dummy_handler,         /* reserved 230 */
+    dummy_handler,         /* reserved 231 */
+    dummy_handler,         /* reserved 232 */
+    dummy_handler,         /* reserved 233 */
+    dummy_handler,         /* reserved 234 */
+    dummy_handler,         /* reserved 235 */
+    dummy_handler,         /* reserved 236 */
+    dummy_handler,         /* reserved 237 */
+    dummy_handler,         /* reserved 238 */
+    dummy_handler,         /* reserved 239 */
+    dummy_handler,         /* reserved 240 */
+    dummy_handler,         /* reserved 241 */
+    dummy_handler,         /* reserved 242 */
+    dummy_handler,         /* reserved 243 */
+    dummy_handler,         /* reserved 244 */
+    dummy_handler,         /* reserved 245 */
+    dummy_handler,         /* reserved 246 */
+    dummy_handler,         /* reserved 247 */
+    dummy_handler,         /* reserved 248 */
+    dummy_handler,         /* reserved 249 */
+    dummy_handler,         /* reserved 250 */
+    dummy_handler,         /* reserved 251 */
+    dummy_handler,         /* reserved 252 */
+    dummy_handler,         /* reserved 253 */
+    dummy_handler,         /* reserved 254 */
+    dummy_handler,         /* reserved 255 */
 };


### PR DESCRIPTION
This moves the instantiation of the weak aliases for the dummy handler into a separate file that is shared between Kinetis CPUs in kinetis_common. A shared header vectors_kinetis.h is used to provide the declarations and documentation for all CPU specific ISRs. This makes it easier to keep the names of the ISR functions unified when the same hardware module is used in multiple CPUs.