### PR TITLE
cpu/stm32f1: fix build issue with iotlab-m3 (arm-none-eabi-gcc 4.9.3)

### DIFF
--- a/cpu/stm32f1/stmclk.c
+++ b/cpu/stm32f1/stmclk.c
@@ -103,7 +103,7 @@
 #elif CLK_HSE
 #define SYSCLK_SRC              RCC_CFGR_SW_HSE
 #define SYSCLK_BSY              RCC_CFGR_SWS_HSE
-#elif
+#else
 #define SYSCLK_SRC              RCC_CFGR_SW_HSI
 #define SYSCLK_BSY              RCC_CFGR_SWS_HSI
 #endif


### PR DESCRIPTION
```
    make BOARD=iotlab-m3 -C examples/default
````
is generating `error: #elif with no expression`