### PR TITLE
sys/shell: fix build when SHELL_NO_ECHO is defined (Backport of #7005)

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -32,7 +32,7 @@
 #include "shell.h"
 #include "shell_commands.h"
 
-#ifndef SHELL_NO_ECHO
+#if !defined(SHELL_NO_ECHO) || !defined(SHELL_NO_PROMPT)
 #ifdef MODULE_NEWLIB
 /* use local copy of putchar, as it seems to be inlined,
  * enlarging code by 50% */


### PR DESCRIPTION
When SHELL_NO_ECHO was defined and not SHELL_NO_PROMPT build was broken
because _putchar was not defined.
This define _putchar when one of SHELL_NO_PROMPT or SHELL_NO_ECHO is not
defined.