### PR TITLE
driver/nrfmin: add get MAX_PACKET_SIZE option

### DIFF
--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -477,6 +477,9 @@ static int nrfmin_get(netdev_t *dev, netopt_t opt, void *val, size_t max_len)
             assert(max_len >= sizeof(int16_t));
             *((int16_t *)val) = nrfmin_get_txpower();
             return sizeof(int16_t);
+        case NETOPT_MAX_PACKET_SIZE:
+            assert(max_len >= sizeof(uint16_t));
+            *((uint16_t *)val) = NRFMIN_PAYLOAD_MAX;
         case NETOPT_ADDRESS_LONG:
             assert(max_len >= sizeof(uint64_t));
             nrfmin_get_pseudo_long_addr((uint16_t *)val);


### PR DESCRIPTION
The nrfmin driver did not return this value, this leads to problems when trying to run 6lowpan on top of it (although this is not the only problem :-) ).