### PR TITLE
drivers: use saul_notsup

### DIFF
--- a/drivers/adxl345/adxl345_saul.c
+++ b/drivers/adxl345/adxl345_saul.c
@@ -31,13 +31,8 @@ static int read_acc(void *dev, phydat_t *res)
     return 3;
 }
 
-static int write(void *dev, phydat_t *state)
-{
-    return -ENOTSUP;
-}
-
 const saul_driver_t adxl345_saul_driver = {
     .read = read_acc,
-    .write = write,
+    .write = saul_notsup,
     .type = SAUL_SENSE_ACCEL,
 };

--- a/drivers/isl29020/isl29020_saul.c
+++ b/drivers/isl29020/isl29020_saul.c
@@ -33,13 +33,8 @@ static int read(void *dev, phydat_t *res)
     return 1;
 }
 
-static int write(void *dev, phydat_t *state)
-{
-    return -ENOTSUP;
-}
-
 const saul_driver_t isl29020_saul_driver = {
     .read = read,
-    .write = write,
+    .write = saul_notsup,
     .type = SAUL_SENSE_LIGHT,
 };

--- a/drivers/l3g4200d/l3g4200d_saul.c
+++ b/drivers/l3g4200d/l3g4200d_saul.c
@@ -32,13 +32,8 @@ static int read(void *dev, phydat_t *res)
     return 3;
 }
 
-static int write(void *dev, phydat_t *state)
-{
-    return -ENOTSUP;
-}
-
 const saul_driver_t l3g4200d_saul_driver = {
     .read = read,
-    .write = write,
+    .write = saul_notsup,
     .type = SAUL_SENSE_GYRO,
 };

--- a/drivers/lis3dh/lis3dh_saul.c
+++ b/drivers/lis3dh/lis3dh_saul.c
@@ -45,15 +45,8 @@ static int read_acc(void *dev, phydat_t *res)
     return 3;
 }
 
-static int write(void *dev, phydat_t *state)
-{
-    (void) dev;
-    (void) state;
-    return -ENOTSUP;
-}
-
 const saul_driver_t lis3dh_saul_driver = {
     .read = read_acc,
-    .write = write,
+    .write = saul_notsup,
     .type = SAUL_SENSE_ACCEL,
 };

--- a/drivers/lps331ap/lps331ap_saul.c
+++ b/drivers/lps331ap/lps331ap_saul.c
@@ -33,13 +33,8 @@ static int read(void *dev, phydat_t *res)
     return 1;
 }
 
-static int write(void *dev, phydat_t *state)
-{
-    return -ENOTSUP;
-}
-
 const saul_driver_t lps331ap_saul_driver = {
     .read = read,
-    .write = write,
+    .write = saul_notsup,
     .type = SAUL_SENSE_PRESS,
 };

--- a/drivers/lsm303dlhc/lsm303dlhc_saul.c
+++ b/drivers/lsm303dlhc/lsm303dlhc_saul.c
@@ -67,19 +67,14 @@ static int read_mag(void *dev, phydat_t *res)
     return 3;
 }
 
-static int write(void *dev, phydat_t *state)
-{
-    return -ENOTSUP;
-}
-
 const saul_driver_t lsm303dlhc_saul_acc_driver = {
     .read = read_acc,
-    .write = write,
+    .write = saul_notsup,
     .type = SAUL_SENSE_ACCEL,
 };
 
 const saul_driver_t lsm303dlhc_saul_mag_driver = {
     .read = read_mag,
-    .write = write,
+    .write = saul_notsup,
     .type = SAUL_SENSE_MAG,
 };


### PR DESCRIPTION
the SAUL mapping of some drivers were not using the shared `saul_notsup` function but were duplicating trivial code...