### PR TITLE
ccn-lite: shell: do not count white space after single word

### DIFF
--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -99,15 +99,17 @@ int _ccnl_content(int argc, char **argv)
 
     if (argc > 2) {
         char buf[BUF_SIZE];
-        memset(buf, ' ', BUF_SIZE);
         char *buf_ptr = buf;
         for (int i = 2; (i < argc) && (buf_ptr < (buf + BUF_SIZE)); i++) {
+            if (i > 2) {
+                *(buf_ptr++) = ' ';
+            }
             arg_len = strlen(argv[i]);
             if ((buf_ptr + arg_len) > (buf + BUF_SIZE)) {
                 arg_len = (buf + BUF_SIZE) - buf_ptr;
             }
             strncpy(buf_ptr, argv[i], arg_len);
-            buf_ptr += arg_len + 1;
+            buf_ptr += arg_len;
         }
         *buf_ptr = '\0';
         body = buf;


### PR DESCRIPTION
If a single word is added to the content cache via `ccnl_cont /TEST
hello`, then the resulting wireshark dump of a successful `ccnl_int
/TEST` will contain a TLV of len(hello) plus 1 (whit space). By
incrementing `buf_ptr` only for loop iterations `> 2` fixes this. As a
bonus, I removed the superfluous `memset` to white space, as the buffer
is correctly terminated with a '\0' character.