### PR TITLE
ccn-lite: shell: remove leaks

### DIFF
--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -120,6 +120,8 @@ int _ccnl_content(int argc, char **argv)
 
     arg_len = ccnl_ndntlv_prependContent(prefix, (unsigned char*) body, arg_len, NULL, NULL, &offs, _out);
 
+    free_prefix(prefix);
+
     unsigned char *olddata;
     unsigned char *data = olddata = _out + offs;
 

--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -226,7 +226,7 @@ int _ccnl_interest(int argc, char **argv)
             printf("Content received: %s\n", _cont_buf);
             return 0;
         }
-        ccnl_free(prefix);
+        free_prefix(prefix);
         gnrc_netreg_unregister(GNRC_NETTYPE_CCN_CHUNK, &_ne);
     }
     printf("Timeout! No content received in response to the Interest for %s.\n", argv[1]);


### PR DESCRIPTION
1. free the temporary `prefix` after `ccnl_ndntlv_prependContent()` (the prefix is `memcpy`'ed into a buffer in this function)
2. A prefix must be free'd with `free_prefix()`, otherwise just the memory for the struct is free'd, but not all conntected other memory blocks. `free_prefix()` frees all memory blocks explicitely.