### PR TITLE
saul/gpio: differentiate SENSE_BTN and ACT_SWITCH

### DIFF
--- a/drivers/saul/gpio_saul.c
+++ b/drivers/saul/gpio_saul.c
@@ -42,8 +42,14 @@ static int write(void *dev, phydat_t *state)
     return 1;
 }
 
-const saul_driver_t gpio_saul_driver = {
+const saul_driver_t gpio_out_saul_driver = {
     .read = read,
     .write = write,
-    .type = SAUL_ACT_SWITCH,
+    .type = SAUL_ACT_SWITCH
+};
+
+const saul_driver_t gpio_in_saul_driver = {
+    .read = read,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_BTN
 };

--- a/sys/auto_init/saul/auto_init_gpio.c
+++ b/sys/auto_init/saul/auto_init_gpio.c
@@ -43,9 +43,14 @@ static gpio_t saul_gpios[SAUL_GPIO_NUMOF];
 static saul_reg_t saul_reg_entries[SAUL_GPIO_NUMOF];
 
 /**
- * @brief   Reference the driver struct
+ * @brief   Reference the input mode driver struct
  */
-extern saul_driver_t gpio_saul_driver;
+extern saul_driver_t gpio_in_saul_driver;
+
+/**
+ * @brief   Reference to the output mode driver struct
+ */
+extern saul_driver_t gpio_out_saul_driver;
 
 
 void auto_init_gpio(void)
@@ -58,7 +63,13 @@ void auto_init_gpio(void)
         saul_gpios[i] = p->pin;
         saul_reg_entries[i].dev = &(saul_gpios[i]);
         saul_reg_entries[i].name = p->name;
-        saul_reg_entries[i].driver = &gpio_saul_driver;
+        if ((p->mode == GPIO_IN) || (p->mode == GPIO_IN_PD) ||
+            (p->mode == GPIO_IN_PU)) {
+            saul_reg_entries[i].driver = &gpio_in_saul_driver;
+        }
+        else {
+            saul_reg_entries[i].driver = &gpio_out_saul_driver;
+        }
         /* initialize the GPIO pin */
         gpio_init(p->pin, p->mode);
         /* add to registry */


### PR DESCRIPTION
GPIO mapped (input) buttons were falsely identified for SAUL as `ACT_SWITCH`. This PR enables the SAUL GPIO driver to differentiate between output pins (`ACT_SWITCH`) and input pins (`SENSE_BTN`).