### PR TITLE
examples/emcute: add possibility to set DEFAULT_CHANNEL when building

### DIFF
--- a/examples/emcute/Makefile
+++ b/examples/emcute/Makefile
@@ -43,3 +43,17 @@ CFLAGS += -DDEVELHELP
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+ifneq (,$(filter cc110x,$(USEMODULE)))          # radio is cc110x sub-GHz
+  DEFAULT_CHANNEL ?= 0
+  CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+else
+  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
+    DEFAULT_CHANNEL ?= 5
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+  else                                          # radio is IEEE 802.15.4 2.4 GHz
+    DEFAULT_CHANNEL ?= 26
+    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+  endif
+endif


### PR DESCRIPTION
While testing emcute example yesterday with a border router configured on a different 802.15.4 channel than 26, I noticed it was not 'possible' to change that at build time.
This PR applies the same configuration available in gnrc_networking and other networking applications.