### PR TITLE
pkg/spiffs: fix unittests

### DIFF
--- a/pkg/spiffs/include/spiffs_config.h
+++ b/pkg/spiffs/include/spiffs_config.h
@@ -208,7 +208,7 @@ void spiffs_unlock(struct spiffs_t *fs);
 
 // Enable this if your target needs aligned data for index tables
 #ifndef SPIFFS_ALIGNED_OBJECT_INDEX_TABLES
-#define SPIFFS_ALIGNED_OBJECT_INDEX_TABLES       0
+#define SPIFFS_ALIGNED_OBJECT_INDEX_TABLES       1
 #endif
 
 // Enable this if you want the HAL callbacks to be called with the spiffs struct

--- a/tests/unittests/tests-spiffs/tests-spiffs.c
+++ b/tests/unittests/tests-spiffs/tests-spiffs.c
@@ -29,10 +29,10 @@
 #else
 /* Test mock object implementing a simple RAM-based mtd */
 #ifndef SECTOR_COUNT
-#define SECTOR_COUNT 8
+#define SECTOR_COUNT 4
 #endif
 #ifndef PAGE_PER_SECTOR
-#define PAGE_PER_SECTOR 4
+#define PAGE_PER_SECTOR 8
 #endif
 #ifndef PAGE_SIZE
 #define PAGE_SIZE 128


### PR DESCRIPTION
Fixes #7011

- enforce memory alignment of object index tables to avoid unaligned access leading to hard fault (at least on Cortex-M0)
- update dummy memory from unittests to comply with spiffs requirements (page_size must be block_size / (2^y) where y > 2)