### PR TITLE
lwip: port to v2.0.2

### DIFF
--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=lwip
 PKG_URL=git://git.savannah.nongnu.org/lwip.git
-PKG_VERSION=fd4a109ffa6513b28a0c780a952cef1110423717
+PKG_VERSION=STABLE-2_0_2_RELEASE_VER
 PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -249,6 +249,11 @@ static int _create(int type, int proto, uint16_t flags, struct netconn **out)
     if ((*out = netconn_new_with_proto_and_callback(type, proto, NULL)) == NULL) {
         return -ENOMEM;
     }
+#if LWIP_IPV4 && LWIP_IPV6
+    if (type & NETCONN_TYPE_IPV6) {
+        netconn_set_ipv6only(*out, 1);
+    }
+#endif
 #if SO_REUSE
     if (flags & SOCK_FLAGS_REUSE_EP) {
         ip_set_option((*out)->pcb.ip, SOF_REUSEADDR);

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -27,7 +27,6 @@ static inline void _tcp_sock_init(sock_tcp_t *sock, struct netconn *conn,
 {
     mutex_init(&sock->mutex);
     mutex_lock(&sock->mutex);
-    netconn_set_noautorecved(conn, 1);
     sock->conn = conn;
     sock->queue = queue;
     sock->last_buf = NULL;
@@ -340,8 +339,6 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
         }
     }
     if (offset > 0) {
-        /* inform lwIP how much we receive*/
-        netconn_recved(sock->conn, (u32_t)offset);
         res = offset;   /* we received data so return it */
     }
     /* unset flags */

--- a/pkg/lwip/contrib/sys_arch.c
+++ b/pkg/lwip/contrib/sys_arch.c
@@ -36,6 +36,11 @@ void sys_init(void)
     return;
 }
 
+u32_t sys_now(void)
+{
+    return (uint32_t)(xtimer_now_usec64() / US_PER_MS);
+}
+
 err_t sys_mutex_new(sys_mutex_t *mutex)
 {
     mutex_init((mutex_t *)mutex);

--- a/pkg/lwip/include/arch/cc.h
+++ b/pkg/lwip/include/arch/cc.h
@@ -44,23 +44,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Generic types for lwIP
- * @{
- */
-typedef uint8_t u8_t;                   /**< unsigned 8-bit type */
-typedef int8_t  s8_t;                   /**< signed 8-bit type */
-typedef uint16_t u16_t;                 /**< unsigned 16-bit type */
-typedef int16_t  s16_t;                 /**< signed 16-bit type */
-typedef uint32_t u32_t;                 /**< unsigned 32-bit type */
-typedef int32_t  s32_t;                 /**< signed 32-bit type */
-
-typedef unsigned long mem_ptr_t;        /**< A generic pointer type. It has to be an integer type
-                                         *   (not void*, due to some pointer arithmetics). */
-/**
- * @}
- */
-
-/**
  * @brief   (sn)printf formatters for the generic lwIP types
  * @{
  */

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -136,6 +136,8 @@ extern "C" {
 #endif
 
 #define LWIP_SOCKET             (0)
+
+#define LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS
 #define MEMP_MEM_MALLOC         (1)
 #define NETIF_MAX_HWADDR_LEN    (GNRC_NETIF_HDR_L2ADDR_MAX_LEN)
 

--- a/pkg/lwip/patches/0001-Fix-warnings.patch
+++ b/pkg/lwip/patches/0001-Fix-warnings.patch
@@ -1,29 +1,39 @@
-From 0e28e1cd26c1de2ccf48bea9013676ef1d4d69b7 Mon Sep 17 00:00:00 2001
+From f732fca2cd91553aa6f14ed851f84572d374aaa6 Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mail@martine-lenders.eu>
 Date: Thu, 12 Nov 2015 16:36:00 +0100
 Subject: [PATCH 1/2] Fix warnings
 
 ---
- src/include/lwip/debug.h | 6 ++++--
- 1 file changed, 4 insertions(+), 2 deletions(-)
+ src/core/ipv6/nd6.c | 2 +-
+ src/core/netif.c    | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/src/include/lwip/debug.h b/src/include/lwip/debug.h
-index 973a633..c7b3c9c 100644
---- a/src/include/lwip/debug.h
-+++ b/src/include/lwip/debug.h
-@@ -67,8 +67,10 @@
-  * -- To disable assertions define LWIP_NOASSERT in arch/cc.h.
-  */
- #ifndef LWIP_NOASSERT
--#define LWIP_ASSERT(message, assertion) do { if(!(assertion)) \
--  LWIP_PLATFORM_ASSERT(message); } while(0)
-+#define LWIP_ASSERT(message, assertion) \
-+    if(!(assertion)) { \
-+        LWIP_PLATFORM_ASSERT(message); \
-+    }
- #ifndef LWIP_PLATFORM_ASSERT
- #error "If you want to use LWIP_ASSERT, LWIP_PLATFORM_ASSERT(message) needs to be defined in your arch/cc.h"
- #endif
+diff --git a/src/core/ipv6/nd6.c b/src/core/ipv6/nd6.c
+index 0b36718..b63a9b5 100644
+--- a/src/core/ipv6/nd6.c
++++ b/src/core/ipv6/nd6.c
+@@ -635,7 +635,7 @@ nd6_input(struct pbuf *p, struct netif *inp)
+           if (i >= 0) {
+             neighbor_cache[i].netif = inp;
+             MEMCPY(neighbor_cache[i].lladdr, lladdr_opt->addr, inp->hwaddr_len);
+-            ip6_addr_set(&(neighbor_cache[i].next_hop_address), &tmp);
++            ip6_addr_copy(neighbor_cache[i].next_hop_address, tmp);
+ 
+             /* Receiving a message does not prove reachability: only in one direction.
+              * Delay probe in case we get confirmation of reachability from upper layer (TCP). */
+diff --git a/src/core/netif.c b/src/core/netif.c
+index 428b148..f7c18e9 100644
+--- a/src/core/netif.c
++++ b/src/core/netif.c
+@@ -1042,7 +1042,7 @@ netif_ip6_addr_set_parts(struct netif *netif, s8_t addr_idx, u32_t i0, u32_t i1,
+     LWIP_DEBUGF(NETIF_DEBUG | LWIP_DBG_STATE, ("netif_ip6_addr_set: netif address being changed\n"));
+ 
+     if (netif_ip6_addr_state(netif, addr_idx) & IP6_ADDR_VALID) {
+-#if LWIP_TCP || LWIP_UDP
++#if LWIP_TCP || LWIP_UDP || LWIP_RAW
+       ip_addr_t new_ipaddr;
+       IP_ADDR6(&new_ipaddr, i0, i1, i2, i3);
+ #endif /* LWIP_TCP || LWIP_UDP */
 -- 
-1.9.1
+2.7.4
 

--- a/pkg/lwip/patches/0002-Add-RIOT-Makefiles.patch
+++ b/pkg/lwip/patches/0002-Add-RIOT-Makefiles.patch
@@ -1,4 +1,4 @@
-From 4f1f9c53db7ffeece81253d9b39d78296e5b68a8 Mon Sep 17 00:00:00 2001
+From 1111daabb54619247649a5d065ce031edd3a968f Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mail@martine-lenders.eu>
 Date: Thu, 12 Nov 2015 15:43:31 +0100
 Subject: [PATCH 2/2] Add RIOT Makefiles
@@ -115,5 +115,5 @@ index 0000000..6030171
 +
 +include $(RIOTBASE)/Makefile.base
 -- 
-1.9.1
+2.7.4
 

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -868,10 +868,8 @@ static void test_sock_ip_send6__EHOSTUNREACH(void)
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR6_WRONG },
                                          .family = AF_INET6 };
 
-    /* lwIP returns ENOMEM on failed neighbor cache lookup, since it "tries" to
-     * create one so we have to live with this weird behavior */
-    assert(-ENOMEM == sock_ip_send(NULL, "ABCD", sizeof("ABCD"), _TEST_PROTO,
-                                   &remote));
+    assert(-EHOSTUNREACH == sock_ip_send(NULL, "ABCD", sizeof("ABCD"), _TEST_PROTO,
+                                         &remote));
 }
 
 static void test_sock_ip_send6__ENOTCONN(void)

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -27,6 +27,7 @@
 #include "lwip/ip4.h"
 #include "lwip/inet_chksum.h"
 #include "lwip/nd6.h"
+#include "lwip/priv/nd6_priv.h"
 #include "lwip/netif.h"
 #include "lwip/netif/netdev.h"
 #include "lwip/tcpip.h"
@@ -35,7 +36,7 @@
 #include "constants.h"
 #include "stack.h"
 
-#define _MSG_QUEUE_SIZE     (1)
+#define _MSG_QUEUE_SIZE     (4)
 #define _SEND_DONE  (0x92d7)
 #define _NETDEV_BUFFER_SIZE     (128)
 
@@ -197,7 +198,9 @@ void _net_init(void)
     static const uint8_t local6[] = _TEST_ADDR6_LOCAL;
     s8_t idx;
     netif_add_ip6_address(&netif, (ip6_addr_t *)&local6, &idx);
-    netif_ip6_addr_set_state(&netif, idx, IP6_ADDR_VALID);
+    for (int i = 0; i <= idx; i++) {
+        netif.ip6_addr_state[i] |= IP6_ADDR_VALID;
+    }
 #endif
     netif_set_default(&netif);
     lwip_bootstrap();

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -995,10 +995,8 @@ static void test_sock_udp_send6__EHOSTUNREACH(void)
                                           .family = AF_INET6,
                                           .port = _TEST_PORT_REMOTE };
 
-    /* lwIP returns ENOMEM on failed neighbor cache lookup, since it "tries" to
-     * create one so we have to live with this weird behavior */
-    assert(-ENOMEM == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
-                                    &remote));
+    assert(-EHOSTUNREACH == sock_udp_send(NULL, "ABCD", sizeof("ABCD"),
+                                          &remote));
 }
 
 static void test_sock_udp_send6__EINVAL_port(void)

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -28,6 +28,7 @@
 #include "lwip/ip4.h"
 #include "lwip/inet_chksum.h"
 #include "lwip/nd6.h"
+#include "lwip/priv/nd6_priv.h"
 #include "lwip/netif.h"
 #include "lwip/netif/netdev.h"
 #include "lwip/opt.h"
@@ -200,7 +201,9 @@ void _net_init(void)
     static const uint8_t local6[] = _TEST_ADDR6_LOCAL;
     s8_t idx;
     netif_add_ip6_address(&netif, (ip6_addr_t *)&local6, &idx);
-    netif_ip6_addr_set_state(&netif, idx, IP6_ADDR_VALID);
+    for (int i = 0; i <= idx; i++) {
+        netif.ip6_addr_state[i] |= IP6_ADDR_VALID;
+    }
 #endif
     netif_set_default(&netif);
     lwip_bootstrap();


### PR DESCRIPTION
Finally came around to do that.

`tests/lwip_sock_ip` hangs with `LWIP_IPV4=1` and `LWIP_IPV6=1`, but there is strong evidence that this is related to #7035.