### PR TITLE
cpu/sam0: enable PD for MISO pin to save energy

### DIFF
--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -102,7 +102,9 @@ void spi_init(spi_t bus)
 
 void spi_init_pins(spi_t bus)
 {
-    gpio_init(spi_config[bus].miso_pin, GPIO_IN);
+    /* enabling the pull-down for the MISO pin saves (significant) energy -> see
+     * [issue #5868](https://github.com/RIOT-OS/RIOT/pull/5868) */
+    gpio_init(spi_config[bus].miso_pin, GPIO_IN_PD);
     gpio_init(spi_config[bus].mosi_pin, GPIO_OUT);
     gpio_init(spi_config[bus].clk_pin, GPIO_OUT);
     gpio_init_mux(spi_config[bus].miso_pin, spi_config[bus].miso_mux);


### PR DESCRIPTION
Factored out from #6652 to get this merged quickly (credits go to @immesys). Seems like I lost this (previously already merged change: #5868) when doing the SPI remodeling. Sorry for that...