### PR TITLE
cleanup: remove unused in-function static variable properties (coccinelle)

### DIFF
--- a/dist/tools/uhcpd/uhcpd.c
+++ b/dist/tools/uhcpd/uhcpd.c
@@ -41,8 +41,8 @@ int ipv6_addr_split(char *addr_str, char seperator, int _default)
 
 int main(int argc, char *argv[])
 {
-    static unsigned ifindex;
-    static unsigned _bind_to_device = 0;
+    unsigned ifindex;
+    unsigned _bind_to_device = 0;
 
     if (argc < 3) {
         fprintf(stderr, "usage: uhcpd <interface> <prefix/prefix_length> [%s]\n",

--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -410,7 +410,7 @@ static void init_dtls(session_t *dst, char *addr_str)
  */
 static void client_send(char *addr_str, char *data, unsigned int delay)
 {
-    static int8_t iWatch;
+    int8_t iWatch;
     static session_t dst;
     static int connected = 0;
     msg_t msg;


### PR DESCRIPTION
Found by static.cocci.

```_bind_to_device``` fixed manually, as the enclosing function (main) is only executed once anyways.

Thanks to Julia for providing the semantic patch!