### PR TITLE
cpu/stm32f4: add stm32f413vg support

### DIFF
--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -33,7 +33,7 @@
 #include "vendor/stm32f411xe.h"
 #elif defined(CPU_MODEL_STM32F412ZG)
 #include "vendor/stm32f412zx.h"
-#elif defined(CPU_MODEL_STM32F413ZH)
+#elif defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
 #include "vendor/stm32f413xx.h"
 #elif defined(CPU_MODEL_STM32F415RG)
 #include "vendor/stm32f415xx.h"
@@ -52,7 +52,11 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
+#if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
+#define CPU_IRQ_NUMOF                   (102U)
+#else
 #define CPU_IRQ_NUMOF                   (82U)
+#endif
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 

--- a/cpu/stm32f4/ldscripts/stm32f413vg.ld
+++ b/cpu/stm32f4/ldscripts/stm32f413vg.ld
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief           Memory definitions for the STM32F413ZH
+ * @brief           Memory definitions for the STM32F413VG
  *
  * @author          Vincent Dupont <vincent@otakeys.com>
  *
@@ -20,7 +20,7 @@
 
 MEMORY
 {
-    rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1536K
+    rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1M
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 320K
     cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }

--- a/cpu/stm32f4/vectors.c
+++ b/cpu/stm32f4/vectors.c
@@ -105,13 +105,28 @@ WEAK_DEFAULT void isr_dma2_stream7(void);
 WEAK_DEFAULT void isr_usart6(void);
 WEAK_DEFAULT void isr_i2c3_ev(void);
 WEAK_DEFAULT void isr_i2c3_er(void);
-#if defined(CPU_MODEL_STM32F413ZH)
-/* STM32F413 specific interrupt vectors (CAN3)
+#if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
+/* STM32F413 specific interrupt vectors
  * See RM0430, part 10.2 */
 WEAK_DEFAULT void isr_can3_tx(void);
 WEAK_DEFAULT void isr_can3_rx0(void);
 WEAK_DEFAULT void isr_can3_rx1(void);
 WEAK_DEFAULT void isr_can3_sce(void);
+WEAK_DEFAULT void isr_usart7(void);
+WEAK_DEFAULT void isr_usart8(void);
+WEAK_DEFAULT void isr_spi4(void);
+WEAK_DEFAULT void isr_spi5(void);
+WEAK_DEFAULT void isr_sai1(void);
+WEAK_DEFAULT void isr_uart9(void);
+WEAK_DEFAULT void isr_uart10(void);
+WEAK_DEFAULT void isr_quadspi(void);
+WEAK_DEFAULT void isr_fmpi2c1_ev(void);
+WEAK_DEFAULT void isr_fmpi2c1_er(void);
+WEAK_DEFAULT void isr_lptim1(void);
+WEAK_DEFAULT void isr_dfsdm2_flt0(void);
+WEAK_DEFAULT void isr_dfsdm2_flt1(void);
+WEAK_DEFAULT void isr_dfsdm2_flt2(void);
+WEAK_DEFAULT void isr_dfsdm2_flt3(void);
 #else
 WEAK_DEFAULT void isr_otg_hs_ep1_out(void);
 WEAK_DEFAULT void isr_otg_hs_ep1_in(void);
@@ -220,11 +235,12 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) isr_usart6,             /* USART6 */
     (void*) isr_i2c3_ev,            /* I2C3 event */
     (void*) isr_i2c3_er,            /* I2C3 error */
-#if defined(CPU_MODEL_STM32F413ZH)
+#if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
     (void*) isr_can3_tx,            /* CAN3 TX */
     (void*) isr_can3_rx0,           /* CAN3 RX0 */
     (void*) isr_can3_rx1,           /* CAN3 RX1 */
     (void*) isr_can3_sce,           /* CAN3 SCE */
+    (void*) (0UL),                  /* Reserved */
     (void*) (0UL),                  /* Reserved */
 #else
     (void*) isr_otg_hs_ep1_out,     /* USB OTG HS End Point 1 Out */
@@ -232,8 +248,30 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) isr_otg_hs_wkup,        /* USB OTG HS Wakeup through EXTI */
     (void*) isr_otg_hs,             /* USB OTG HS */
     (void*) isr_dcmi,               /* DCMI */
-#endif
     (void*) isr_cryp,               /* CRYP crypto */
+#endif
     (void*) isr_hash_rng,           /* Hash and Rng */
     (void*) isr_fpu,                /* FPU */
+#if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
+    (void*) isr_usart7,             /* USART7 */
+    (void*) isr_usart8,             /* USART8 */
+    (void*) isr_spi4,               /* SPI4 */
+    (void*) isr_spi5,               /* SPI5 */
+    (void*) (0UL),                  /* Reserved */
+    (void*) isr_sai1,               /* SAI1 */
+    (void*) isr_uart9,              /* UART9 */
+    (void*) isr_uart10,             /* UART10 */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) isr_quadspi,            /* QuadSPI */
+    (void*) (0UL),                  /* Reserved */
+    (void*) (0UL),                  /* Reserved */
+    (void*) isr_fmpi2c1_ev,         /* FMPI2C1 Event */
+    (void*) isr_fmpi2c1_er,         /* FMPI2C1 Error */
+    (void*) isr_lptim1,             /* LP TIM1 */
+    (void*) isr_dfsdm2_flt0,        /* DFSDM2 Filter 0 */
+    (void*) isr_dfsdm2_flt1,        /* DFSDM2 Filter 1 */
+    (void*) isr_dfsdm2_flt2,        /* DFSDM2 Filter 2 */
+    (void*) isr_dfsdm2_flt3,        /* DFSDM2 Filter 3 */
+#endif
 };


### PR DESCRIPTION
Adds stm32f413vg support ad fixes the number of IRQ for stm32f413