### PR TITLE
boards/nucleo-f401: Provide Nucleo F401 specific Arduino pinmap

### DIFF
--- a/boards/nucleo-f401/include/arduino_pinmap.h
+++ b/boards/nucleo-f401/include/arduino_pinmap.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C)  2016 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo-common
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PORT_A, 3)
+#define ARDUINO_PIN_1           GPIO_PIN(PORT_A, 2)
+#define ARDUINO_PIN_2           GPIO_PIN(PORT_A, 10)
+#define ARDUINO_PIN_3           GPIO_PIN(PORT_B, 3)
+#define ARDUINO_PIN_4           GPIO_PIN(PORT_B, 5)
+#define ARDUINO_PIN_5           GPIO_PIN(PORT_B, 4)
+#define ARDUINO_PIN_6           GPIO_PIN(PORT_B, 10)
+#define ARDUINO_PIN_7           GPIO_PIN(PORT_A, 8)
+
+#define ARDUINO_PIN_8           GPIO_PIN(PORT_A, 9)
+#define ARDUINO_PIN_9           GPIO_PIN(PORT_C, 7)
+#define ARDUINO_PIN_10          GPIO_PIN(PORT_B, 6)
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_A, 7)
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_A, 6)
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_A, 5) /* on-board LED */
+
+#define ARDUINO_PIN_A0          GPIO_PIN(PORT_A, 0)
+#define ARDUINO_PIN_A1          GPIO_PIN(PORT_A, 1)
+#define ARDUINO_PIN_A2          GPIO_PIN(PORT_A, 4)
+#define ARDUINO_PIN_A3          GPIO_PIN(PORT_B, 0)
+#ifdef NUCLEO_SB46_ON       
+#define ARDUINO_PIN_A4          GPIO_PIN(PORT_B, 9) /* See Table 9: Solder bridges to enable */
+#else
+#define ARDUINO_PIN_A4          GPIO_PIN(PORT_C, 1) /* Default for A4 */
+#endif
+#ifdef NUCLEO_SB52_ON
+#define ARDUINO_PIN_A5          GPIO_PIN(PORT_B, 8) /* See Table 9: Solder bridges to enable */
+#else
+#define ARDUINO_PIN_A5          GPIO_PIN(PORT_C, 0) /* Default for A5 */
+#endif
+/** @ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */


### PR DESCRIPTION
This provides a Nucleo F401 specific Arduino pinmap, as F401 has some solder bridges.

Please note that apparently the generic Nucleo Arduino Pinmap in `boards/nucleo-common/arduino_pinmap.h` lists the analog `ARDUINO_PIN_Ax` in reverse order.  That was the case at least for F401, but I did not check it for others.

Also, IIRC, F334 has a completely different pinmap.  Hence, if you fix the common pinmap, it may be useful to add there also an `#ifdef`d `#error` for F334, since the pinmap won't work.