### PR TITLE
ps, schedstats: fix stats and adapt Makefiles

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -15,9 +15,6 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
-
 # If you want to use native with valgrind, you should recompile native
 # with the target all-valgrind instead of all:
 # make -B clean all-valgrind
@@ -35,6 +32,9 @@ QUIET ?= 1
 #USEMODULE += shell
 #USEMODULE += posix
 #USEMODULE += xtimer
+
+# Uncomment this to enable scheduler statistics for ps:
+#USEMODULE += schedstatistics
 
 # If your application is very simple and doesn't use modules that use
 # messaging, it can be disabled to save some memory:

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -12,9 +12,6 @@ RIOTBASE ?= $(CURDIR)/../..
 #RIOTCPU ?= $(CURDIR)/../../RIOT/thirdparty_cpu
 #RIOTBOARD ?= $(CURDIR)/../../RIOT/thirdparty_boards
 
-# Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
-
 # If you want to use native with valgrind, you should recompile native
 # with the target all-valgrind instead of all:
 # make -B clean all-valgrind
@@ -33,6 +30,8 @@ USEMODULE += shell_commands
 USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
+# Uncomment this to enable scheduler statistics for ps:
+#USEMODULE += schedstatistics
 
 BOARD_PROVIDES_NETIF := airfy-beacon cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
         microbit native nrf51dongle nrf52dk nrf6310 openmote-cc2538 pba-d-01-kw2x \

--- a/examples/riot_and_cpp/Makefile
+++ b/examples/riot_and_cpp/Makefile
@@ -16,9 +16,6 @@ RIOTBASE ?= $(CURDIR)/../..
 #RIOTCPU ?= $(CURDIR)/../../../thirdparty_cpu
 #RIOTBOARD ?= $(CURDIR)/../../../thirdparty_boards
 
-# Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
-
 # If you want to use native with valgrind, you should recompile native
 # with the target all-valgrind instead of all:
 # make -B clean all-valgrind
@@ -33,6 +30,9 @@ QUIET ?= 1
 
 # Features required
 FEATURES_REQUIRED += cpp
+
+# Uncomment this to enable scheduler statistics for ps:
+#USEMODULE += schedstatistics
 
 # If you want to add some extra flags when compile c++ files, add these flags
 # to CXXEXFLAGS variable

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -98,7 +98,7 @@ void ps(void)
             overall_used += stacksz;
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
-            double runtime_ticks =  sched_pidlist[i].runtime_ticks / (double) xtimer_now() * 100;
+            double runtime_ticks =  sched_pidlist[i].runtime_ticks / (double) _xtimer_now() * 100;
             int switches = sched_pidlist[i].schedules;
 #endif
             printf("\t%3" PRIkernel_pid


### PR DESCRIPTION
seems nobody ever used schedstatistics in a while 😉 Its not activated by CFLAGS anymore but as a pseudomodule, further its fixes a missing adaption to the new xtimer calls.