### PR TITLE
enhance schedule statistics

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -179,10 +179,10 @@ NORETURN void sched_task_exit(void);
  *  Scheduler statistics
  */
 typedef struct {
-    unsigned int laststart;         /**< Time stamp of the last time this thread was
+    uint64_t laststart;         /**< Time stamp of the last time this thread was
                                          scheduled to run */
     unsigned int schedules;         /**< How often the thread was scheduled to run */
-    unsigned long runtime_ticks;    /**< The total runtime of this thread in ticks */
+    uint64_t runtime_ticks;    /**< The total runtime of this thread in ticks */
 } schedstat;
 
 /**
@@ -195,7 +195,7 @@ extern schedstat sched_pidlist[KERNEL_PID_LAST + 1];
  *
  *  @param[in] callback The callback functions the will be called
  */
-void sched_register_cb(void (*callback)(uint32_t, uint32_t));
+void sched_register_cb(void (*callback)(uint64_t, uint32_t));
 #endif /* MODULE_SCHEDSTATISTICS */
 
 #ifdef __cplusplus

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -15,9 +15,6 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT
 
-# Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
-
 # If you want to use native with valgrind, you should recompile native
 # with the target all-valgrind instead of all:
 # make -B clean all-valgrind
@@ -35,6 +32,9 @@ QUIET ?= 1
 #USEMODULE += shell
 #USEMODULE += posix
 #USEMODULE += xtimer
+
+# Uncomment this to enable scheduler statistics for ps:
+#USEMODULE += schedstatistics
 
 # If your application is very simple and doesn't use modules that use
 # messaging, it can be disabled to save some memory:

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -31,7 +31,7 @@ USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 # Uncomment this to enable scheduler statistics for ps:
-#USEMODULE += schedstatistics
+USEMODULE += schedstatistics
 
 BOARD_PROVIDES_NETIF := airfy-beacon cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
         microbit native nrf51dongle nrf52dk nrf6310 openmote-cc2538 pba-d-01-kw2x \

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -12,9 +12,6 @@ RIOTBASE ?= $(CURDIR)/../..
 #RIOTCPU ?= $(CURDIR)/../../RIOT/thirdparty_cpu
 #RIOTBOARD ?= $(CURDIR)/../../RIOT/thirdparty_boards
 
-# Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
-
 # If you want to use native with valgrind, you should recompile native
 # with the target all-valgrind instead of all:
 # make -B clean all-valgrind
@@ -33,6 +30,8 @@ USEMODULE += shell_commands
 USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
+# Uncomment this to enable scheduler statistics for ps:
+#USEMODULE += schedstatistics
 
 BOARD_PROVIDES_NETIF := airfy-beacon cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
         microbit native nrf51dongle nrf52dk nrf6310 openmote-cc2538 pba-d-01-kw2x \

--- a/examples/riot_and_cpp/Makefile
+++ b/examples/riot_and_cpp/Makefile
@@ -16,9 +16,6 @@ RIOTBASE ?= $(CURDIR)/../..
 #RIOTCPU ?= $(CURDIR)/../../../thirdparty_cpu
 #RIOTBOARD ?= $(CURDIR)/../../../thirdparty_boards
 
-# Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
-
 # If you want to use native with valgrind, you should recompile native
 # with the target all-valgrind instead of all:
 # make -B clean all-valgrind
@@ -33,6 +30,9 @@ QUIET ?= 1
 
 # Features required
 FEATURES_REQUIRED += cpp
+
+# Uncomment this to enable scheduler statistics for ps:
+#USEMODULE += schedstatistics
 
 # If you want to add some extra flags when compile c++ files, add these flags
 # to CXXEXFLAGS variable

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -61,10 +61,10 @@ void ps(void)
 #endif
             "%-9sQ | pri "
 #ifdef DEVELHELP
-           "| stack ( used) | base       | current    "
+           "| stack  ( used) | base addr  | current     "
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
-           "| runtime | switches"
+           "| runtime ticks | switches"
 #endif
            "\n",
 #ifdef DEVELHELP
@@ -98,8 +98,13 @@ void ps(void)
             overall_used += stacksz;
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
-            double runtime_ticks =  sched_pidlist[i].runtime_ticks / (double) _xtimer_now() * 100;
-            int switches = sched_pidlist[i].schedules;
+            uint64_t now = _xtimer_now64();
+            uint64_t runtime_ticks = sched_pidlist[i].runtime_ticks;
+            /* add ticks since laststart not accounted for yet */
+            if (thread_getpid() == i) {
+                runtime_ticks += now - sched_pidlist[i].laststart;
+            }
+            unsigned switches = sched_pidlist[i].schedules;
 #endif
             printf("\t%3" PRIkernel_pid
 #ifdef DEVELHELP
@@ -110,7 +115,7 @@ void ps(void)
                    " | %5i (%5i) | %10p | %10p "
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
-                   " | %6.3f%% |  %8d"
+                   " | %13" PRIu64 " |  %8u"
 #endif
                    "\n",
                    p->pid,

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -98,7 +98,7 @@ void ps(void)
             overall_used += stacksz;
 #endif
 #ifdef MODULE_SCHEDSTATISTICS
-            double runtime_ticks =  sched_pidlist[i].runtime_ticks / (double) xtimer_now() * 100;
+            double runtime_ticks =  sched_pidlist[i].runtime_ticks / (double) _xtimer_now() * 100;
             int switches = sched_pidlist[i].schedules;
 #endif
             printf("\t%3" PRIkernel_pid


### PR DESCRIPTION
 ps, schedstats: change stats to ticks

    - change from runtime percentage to absolute ticks
    - use xtimer_now64() instead of xtimer_now()
    - add check to ensure correct runtime ticks sum

the latter is necessary, as I oberved a _jump_ in number of ticks after boot - at least on native.

See following boot log and compare lines starting with `sched_run: now` ...

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

sched_run: active thread: 0, next thread: 2
sched_run: now 823489813
sched_run: done, changed sched_active_thread.
sched_switch: active pid=2 prio=7 on_runqueue=1 , other_prio=6
sched_switch: yielding immediately.
sched_run: active thread: 2, next thread: 3
sched_run: now 303
sched_run: done, changed sched_active_thread.
sched_run: active thread: 3, next thread: 2
sched_run: now 318
sched_run: done, changed sched_active_thread.
sched_switch: active pid=2 prio=7 on_runqueue=1 , other_prio=4
sched_switch: yielding immediately.
sched_run: active thread: 2, next thread: 4
sched_run: now 513
sched_run: done, changed sched_active_thread.
sched_run: active thread: 4, next thread: 2
sched_run: now 5695
sched_run: done, changed sched_active_thread.
main(): This is RIOT! (Version: 2017.04-devel-985-g0f7ab-iMac-fix/ps/schedstats)
Native RTC initialized.
Welcome to RIOT!
```

requires #7043