### PR TITLE
grnc, tcp: fix assert

### DIFF
--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -66,7 +66,7 @@ void gnrc_tcp_tcb_init(gnrc_tcp_tcb_t *tcb);
   * @param[in]     address_family   Address family of @p target_addr.
   * @param[in]     target_addr      Pointer to target address.
   * @param[in]     target_port      Target port number.
-  * @param[in]     local_port       If zero or GNRC_TCP_PORT_UNSPEC, the connections
+  * @param[in]     local_port       If zero or PORT_UNSPEC, the connections
   *                                 source port is randomly chosen. If local_port is non-zero
   *                                 the local_port is used as source port.
   *

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -237,7 +237,7 @@ int gnrc_tcp_open_passive(gnrc_tcp_tcb_t *tcb,  const uint8_t address_family,
                           const uint8_t *local_addr, const uint16_t local_port)
 {
     assert(tcb != NULL);
-    assert(local_port != GNRC_TCP_PORT_UNSPEC);
+    assert(local_port != PORT_UNSPEC);
 
     /* Check AF-Family support if local address was supplied */
     if (local_addr != NULL) {


### PR DESCRIPTION
Found usage of an old define in assert when compiling with `DEVHELP`,  its name has changed, but wasn't adapted here.