### PR TITLE
cleanup: add atoi_cast_removal.cocci, apply to codebase (coccinelle)

### DIFF
--- a/cpu/kinetis_common/dist/calc_spi_scalers/calc_spi_scalers.c
+++ b/cpu/kinetis_common/dist/calc_spi_scalers/calc_spi_scalers.c
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    modclk = (uint32_t)atoi(argv[1]);
+    modclk = atoi(argv[1]);
     if (modclk == 0) {
         printf("error: invalid input value\n");
         return 1;

--- a/dist/tools/coccinelle/warn/remove_atoi_cast.cocci
+++ b/dist/tools/coccinelle/warn/remove_atoi_cast.cocci
@@ -1,0 +1,11 @@
+// removes not needed casts like "e = (uint16_t) atoi(e2)"
+
+@@
+expression e;
+expression e2;
+type t;
+@@
+
+e =
+- (t)
+atoi(e2)

--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -509,7 +509,7 @@ int udp_client_cmd(int argc, char **argv)
         return 1;
     }
     else if (argc > 3) {
-        delay = (uint32_t)atoi(argv[3]);
+        delay = atoi(argv[3]);
     }
     client_send(argv[1], argv[2],  delay);
 

--- a/examples/emcute/main.c
+++ b/examples/emcute/main.c
@@ -89,7 +89,7 @@ static int cmd_con(int argc, char **argv)
     }
 
     if (argc >= 3) {
-        gw.port = (uint16_t)atoi(argv[2]);
+        gw.port = atoi(argv[2]);
     }
     if (argc >= 5) {
         topic = argv[3];

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -110,7 +110,7 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
     memcpy(&remote.addr.ipv6[0], &addr.u8[0], sizeof(addr.u8));
 
     /* parse port */
-    remote.port = (uint16_t)atoi(port_str);
+    remote.port = atoi(port_str);
     if (remote.port == 0) {
         puts("gcoap_cli: unable to parse destination port");
         return 0;

--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -44,7 +44,7 @@ static void send(char *addr_str, char *port_str, char *data, unsigned int num,
         return;
     }
     /* parse port */
-    port = (uint16_t)atoi(port_str);
+    port = atoi(port_str);
     if (port == 0) {
         puts("Error: unable to parse destination port");
         return;
@@ -100,7 +100,7 @@ static void start_server(char *port_str)
         return;
     }
     /* parse port */
-    port = (uint16_t)atoi(port_str);
+    port = atoi(port_str);
     if (port == 0) {
         puts("Error: invalid port specified");
         return;
@@ -141,10 +141,10 @@ int udp_cmd(int argc, char **argv)
             return 1;
         }
         if (argc > 5) {
-            num = (uint32_t)atoi(argv[5]);
+            num = atoi(argv[5]);
         }
         if (argc > 6) {
-            delay = (uint32_t)atoi(argv[6]);
+            delay = atoi(argv[6]);
         }
         send(argv[2], argv[3], argv[4], num, delay);
     }

--- a/examples/posix_sockets/udp.c
+++ b/examples/posix_sockets/udp.c
@@ -45,7 +45,7 @@ static void *_server_thread(void *args)
     msg_init_queue(server_msg_queue, SERVER_MSG_QUEUE_SIZE);
     server_socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
     /* parse port */
-    port = (uint16_t)atoi((char *)args);
+    port = atoi((char *)args);
     if (port == 0) {
         puts("Error: invalid port specified");
         return NULL;
@@ -99,7 +99,7 @@ static int udp_send(char *addr_str, char *port_str, char *data, unsigned int num
         return 1;
     }
     /* parse port */
-    port = (uint16_t)atoi(port_str);
+    port = atoi(port_str);
     dst.sin6_port = htons(port);
     src.sin6_port = htons(port);
     s = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
@@ -155,10 +155,10 @@ int udp_cmd(int argc, char **argv)
             return 1;
         }
         if (argc > 5) {
-            num = (uint32_t)atoi(argv[5]);
+            num = atoi(argv[5]);
         }
         if (argc > 6) {
-            delay = (uint32_t)atoi(argv[6]);
+            delay = atoi(argv[6]);
         }
         return udp_send(argv[2], argv[3], argv[4], num, delay);
     }

--- a/sys/shell/commands/sc_gnrc_6ctx.c
+++ b/sys/shell/commands/sc_gnrc_6ctx.c
@@ -80,7 +80,7 @@ int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_s
     char *addr_str, *prefix_len_str, *save_ptr;
     unsigned prefix_len;
     unsigned ltime;
-    unsigned ctx = (unsigned)atoi(ctx_str);
+    unsigned ctx = atoi(ctx_str);
     if (ctx >= GNRC_SIXLOWPAN_CTX_SIZE) {
         _usage(cmd_str);
         return 1;
@@ -95,7 +95,7 @@ int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_s
         _usage(cmd_str);
         return 1;
     }
-    prefix_len = (unsigned)atoi(prefix_len_str);
+    prefix_len = atoi(prefix_len_str);
     if ((prefix_len - 1U) > 128U) {
         puts("ERROR: prefix_len < 1 || prefix_len > 128");
         return 1;
@@ -112,7 +112,7 @@ int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_s
         puts("ERROR: can not add context");
         return 1;
     }
-    ltime = (unsigned)atoi(ltime_str);
+    ltime = atoi(ltime_str);
     if (gnrc_sixlowpan_ctx_update((uint8_t)ctx, &prefix, (uint8_t)prefix_len, ltime,
                                   true) == NULL) {
         puts("ERROR: can not add context");
@@ -126,7 +126,7 @@ int _gnrc_6ctx_add(char *cmd_str, char *ctx_str, char *prefix_str, char *ltime_s
 int _gnrc_6ctx_del(char *cmd_str, char *ctx_str)
 {
     gnrc_sixlowpan_ctx_t *ctx;
-    unsigned cid = (unsigned)atoi(ctx_str);
+    unsigned cid = atoi(ctx_str);
     if (cid >= GNRC_SIXLOWPAN_CTX_SIZE) {
         _usage(cmd_str);
         return 1;

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -31,7 +31,7 @@
 
 int _gnrc_rpl_init(char *arg)
 {
-    kernel_pid_t iface_pid = (kernel_pid_t) atoi(arg);
+    kernel_pid_t iface_pid = atoi(arg);
     gnrc_ipv6_netif_t *entry = gnrc_ipv6_netif_get(iface_pid);
 
     if (entry == NULL) {
@@ -46,7 +46,7 @@ int _gnrc_rpl_init(char *arg)
 
 int _gnrc_rpl_dodag_root(char *arg1, char *arg2)
 {
-    uint8_t instance_id = (uint8_t) atoi(arg1);
+    uint8_t instance_id = atoi(arg1);
     ipv6_addr_t dodag_id;
 
     if (ipv6_addr_from_str(&dodag_id, arg2) == NULL) {
@@ -69,7 +69,7 @@ int _gnrc_rpl_dodag_root(char *arg1, char *arg2)
 #ifdef MODULE_GNRC_RPL_P2P
 int _gnrc_rpl_find(char *arg1, char *arg2)
 {
-    uint8_t instance_id = (uint8_t) atoi(arg1);
+    uint8_t instance_id = atoi(arg1);
     ipv6_addr_t dodag_id;
     ipv6_addr_t target;
 
@@ -97,7 +97,7 @@ int _gnrc_rpl_find(char *arg1, char *arg2)
 
 int _gnrc_rpl_instance_remove(char *arg1)
 {
-    uint8_t instance_id = (uint8_t) atoi(arg1);
+    uint8_t instance_id = atoi(arg1);
     gnrc_rpl_instance_t *inst;
 
     if ((inst = gnrc_rpl_instance_get(instance_id)) == NULL) {
@@ -116,7 +116,7 @@ int _gnrc_rpl_instance_remove(char *arg1)
 
 int _gnrc_rpl_trickle_reset(char *arg1)
 {
-    uint8_t instance_id = (uint8_t) atoi(arg1);
+    uint8_t instance_id = atoi(arg1);
     gnrc_rpl_instance_t *inst;
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
@@ -135,7 +135,7 @@ int _gnrc_rpl_trickle_reset(char *arg1)
 
 int _gnrc_rpl_trickle_stop(char *arg1)
 {
-    uint8_t instance_id = (uint8_t) atoi(arg1);
+    uint8_t instance_id = atoi(arg1);
     gnrc_rpl_instance_t *inst;
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
@@ -153,7 +153,7 @@ int _gnrc_rpl_trickle_stop(char *arg1)
 
 int _gnrc_rpl_trickle_start(char *arg1)
 {
-    uint8_t instance_id = (uint8_t) atoi(arg1);
+    uint8_t instance_id = atoi(arg1);
     gnrc_rpl_instance_t *inst;
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
@@ -312,7 +312,7 @@ int _gnrc_rpl_dodag_show(void)
 
 int _gnrc_rpl_operation(bool leaf, char *arg1)
 {
-    uint8_t instance_id = (uint8_t) atoi(arg1);
+    uint8_t instance_id = atoi(arg1);
     gnrc_rpl_instance_t *inst;
 
     if ((inst = gnrc_rpl_instance_get(instance_id)) == NULL) {
@@ -334,7 +334,7 @@ int _gnrc_rpl_operation(bool leaf, char *arg1)
 #ifndef GNRC_RPL_WITHOUT_PIO
 int _gnrc_rpl_set_pio(char *inst_id, bool status)
 {
-    uint8_t instance_id = (uint8_t) atoi(inst_id);
+    uint8_t instance_id = atoi(inst_id);
     gnrc_rpl_instance_t *inst;
 
     if ((inst = gnrc_rpl_instance_get(instance_id)) == NULL) {

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -560,7 +560,7 @@ static int _netif_set_u16(kernel_pid_t dev, netopt_t opt, char *u16_str)
 
 static int _netif_set_i16(kernel_pid_t dev, netopt_t opt, char *i16_str)
 {
-    int16_t val = (int16_t)atoi(i16_str);
+    int16_t val = atoi(i16_str);
 
     if (gnrc_netapi_set(dev, opt, 0, (int16_t *)&val, sizeof(int16_t)) < 0) {
         printf("error: unable to set ");
@@ -578,7 +578,7 @@ static int _netif_set_i16(kernel_pid_t dev, netopt_t opt, char *i16_str)
 
 static int _netif_set_u8(kernel_pid_t dev, netopt_t opt, char *u8_str)
 {
-    uint8_t val = (uint8_t)atoi(u8_str);
+    uint8_t val = atoi(u8_str);
 
     if (gnrc_netapi_set(dev, opt, 0, (uint8_t *)&val, sizeof(uint8_t)) < 0) {
         printf("error: unable to set ");
@@ -1056,7 +1056,7 @@ int _netif_send(int argc, char **argv)
     }
 
     /* parse interface */
-    dev = (kernel_pid_t)atoi(argv[1]);
+    dev = atoi(argv[1]);
 
     if (!_is_iface(dev)) {
         puts("error: invalid interface given");
@@ -1114,7 +1114,7 @@ int _netif_config(int argc, char **argv)
         return 0;
     }
     else if (_is_number(argv[1])) {
-        kernel_pid_t dev = (kernel_pid_t)atoi(argv[1]);
+        kernel_pid_t dev = atoi(argv[1]);
 
         if (_is_iface(dev)) {
             if (argc < 3) {

--- a/sys/shell/commands/sc_saul_reg.c
+++ b/sys/shell/commands/sc_saul_reg.c
@@ -116,7 +116,7 @@ static void write(int argc, char **argv)
     memset(&data, 0, sizeof(data));
     dim = ((argc - 3) > (int)PHYDAT_DIM) ? (int)PHYDAT_DIM : (argc - 3);
     for (int i = 0; i < dim; i++) {
-        data.val[i] = (int16_t)atoi(argv[i + 3]);
+        data.val[i] = atoi(argv[i + 3]);
     }
     /* print values before writing */
     printf("Writing to device #%i - %s\n", num, dev->name);

--- a/tests/driver_dynamixel/main.c
+++ b/tests/driver_dynamixel/main.c
@@ -90,7 +90,7 @@ static void dir_disable_tx(uart_t uart) {
 
 static int parse_uart(char *arg)
 {
-    unsigned uart = (unsigned)atoi(arg);
+    unsigned uart = atoi(arg);
     if (uart >= UART_NUMOF) {
         printf("Error: Invalid UART_DEV device specified (%u).\n", uart);
         return -1;
@@ -104,7 +104,7 @@ static int parse_uart(char *arg)
 
 static int32_t parse_baud(char *arg)
 {
-    int32_t baud = (int32_t)atoi(arg);
+    int32_t baud = atoi(arg);
 
     for (size_t i = 0 ; i < ARRAY_LEN(baudrates) ; i++) {
         if (baud == baudrates[i]) {
@@ -118,7 +118,7 @@ static int32_t parse_baud(char *arg)
 
 static int parse_dev(char *arg)
 {
-    int dev = (int)atoi(arg);
+    int dev = atoi(arg);
     if (dev < 0 || 254 < dev) {
         printf("Error: Invalid device id (%s)\n", arg);
         return -1;

--- a/tests/driver_feetech/main.c
+++ b/tests/driver_feetech/main.c
@@ -81,7 +81,7 @@ static uart_half_duplex_t stream;
 
 static int parse_uart(char *arg)
 {
-    unsigned uart = (unsigned)atoi(arg);
+    unsigned uart = atoi(arg);
     if (uart >= UART_NUMOF) {
         printf("Error: Invalid UART_DEV device specified (%u).\n", uart);
         return -1;
@@ -95,7 +95,7 @@ static int parse_uart(char *arg)
 
 static int32_t parse_baud(char *arg)
 {
-    int32_t baud = (int32_t)atoi(arg);
+    int32_t baud = atoi(arg);
 
     for (size_t i = 0 ; i < ARRAY_LEN(baudrates) ; i++) {
         if (baud == baudrates[i]) {
@@ -109,7 +109,7 @@ static int32_t parse_baud(char *arg)
 
 static int parse_dev(char *arg)
 {
-    int dev = (int)atoi(arg);
+    int dev = atoi(arg);
     if (dev < 0 || 254 < dev) {
         printf("Error: Invalid device id (%s)\n", arg);
         return -1;

--- a/tests/driver_kw2xrf/main.c
+++ b/tests/driver_kw2xrf/main.c
@@ -62,7 +62,7 @@ static void _set_test_mode(int argc, char **argv, uint8_t mode)
 {
     (void) argc;
     if (_is_number(argv[1])) {
-        kernel_pid_t dev = (kernel_pid_t)atoi(argv[1]);
+        kernel_pid_t dev = atoi(argv[1]);
 
         if (_is_iface(dev)) {
             gnrc_netapi_set(dev, NETOPT_RF_TESTMODE, 0, (void *)&mode, sizeof(mode));

--- a/tests/driver_pcd8544/main.c
+++ b/tests/driver_pcd8544/main.c
@@ -48,7 +48,7 @@ static int _contrast(int argc, char **argv)
         printf("usage: %s VAL [0-127]\n", argv[0]);
         return 1;
     }
-    val = (uint8_t)atoi(argv[1]);
+    val = atoi(argv[1]);
     pcd8544_set_contrast(&dev, val);
     return 0;
 }
@@ -61,7 +61,7 @@ static int _temp(int argc, char **argv)
         printf("usage: %s VAL [0-3]\n", argv[0]);
         return 1;
     }
-    val = (uint8_t)atoi(argv[1]);
+    val = atoi(argv[1]);
     pcd8544_set_tempcoef(&dev, val);
     return 0;
 }
@@ -74,7 +74,7 @@ static int _bias(int argc, char **argv)
         printf("usage: %s VAL [0-7]\n", argv[0]);
         return 1;
     }
-    val = (uint8_t)atoi(argv[1]);
+    val = atoi(argv[1]);
     pcd8544_set_bias(&dev, val);
     return 0;
 }
@@ -132,8 +132,8 @@ static int _write(int argc, char **argv)
         return -1;
     }
 
-    x = (uint8_t)atoi(argv[1]);
-    y = (uint8_t)atoi(argv[2]);
+    x = atoi(argv[1]);
+    y = atoi(argv[2]);
 
     pcd8544_write_s(&dev, x, y, argv[3]);
     return 0;

--- a/tests/driver_sdcard_spi/main.c
+++ b/tests/driver_sdcard_spi/main.c
@@ -189,8 +189,8 @@ static int _read(int argc, char **argv)
     bool print_as_char = false;
 
     if ((argc == 3) || (argc == 4)) {
-        blockaddr = (uint32_t)atoi(argv[1]);
-        cnt = (uint32_t)atoi(argv[2]);
+        blockaddr = atoi(argv[1]);
+        cnt = atoi(argv[2]);
         if (argc == 4 && (strcmp("-c", argv[3]) == 0)) {
             print_as_char = true;
         }
@@ -254,7 +254,7 @@ static int _write(int argc, char **argv)
     bool repeat_data = false;
 
     if (argc == 3 || argc == 4) {
-        bladdr = (int)atoi(argv[1]);
+        bladdr = atoi(argv[1]);
         data = argv[2];
         size = strlen(argv[2]);
         printf("will write '%s' (%d chars) at start of block %d\n", data, size, bladdr);
@@ -310,8 +310,8 @@ static int _copy(int argc, char **argv)
         return -1;
     }
 
-    src_block = (uint32_t)atoi(argv[1]);
-    dst_block = (uint32_t)atoi(argv[2]);
+    src_block = atoi(argv[1]);
+    dst_block = atoi(argv[2]);
 
     sd_rw_response_t rd_state;
     sdcard_spi_read_blocks(card, src_block, tmp_copy, SD_HC_BLOCK_SIZE, 1, &rd_state);

--- a/tests/driver_srf02/main.c
+++ b/tests/driver_srf02/main.c
@@ -56,7 +56,7 @@ static int cmd_init(int argc, char **argv)
         return 1;
     }
 
-    uint8_t addr = (uint8_t)atoi(argv[1]);
+    uint8_t addr = atoi(argv[1]);
 
     printf("Initializing SRF02 sensor at I2C_DEV(%i), address is %i\n... ",
            TEST_SRF02_I2C, (int)addr);
@@ -103,7 +103,7 @@ static int cmd_set_addr(int argc, char **argv)
         return 1;
     }
 
-    new_addr = (uint8_t)atoi(argv[1]);
+    new_addr = atoi(argv[1]);
     srf02_set_addr(&dev, new_addr);
     printf("Set address to %i\n", (int)new_addr);
     return 0;

--- a/tests/emb6/udp.c
+++ b/tests/emb6/udp.c
@@ -126,10 +126,10 @@ int udp_cmd(int argc, char **argv)
             return 1;
         }
         if (argc > 5) {
-            num = (uint32_t)atoi(argv[5]);
+            num = atoi(argv[5]);
         }
         if (argc > 6) {
-            delay = (uint32_t)atoi(argv[6]);
+            delay = atoi(argv[6]);
         }
         return udp_send(argv[2], argv[3], argv[4], num, delay);
     }

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -52,7 +52,7 @@ static char printer_stack[THREAD_STACKSIZE_MAIN];
 
 static int parse_dev(char *arg)
 {
-    unsigned dev = (unsigned)atoi(arg);
+    unsigned dev = atoi(arg);
     if (dev >= UART_NUMOF) {
         printf("Error: Invalid UART_DEV device specified (%u).\n", dev);
         return -1;
@@ -121,7 +121,7 @@ static int cmd_init(int argc, char **argv)
     if (dev < 0) {
         return 1;
     }
-    baud = (uint32_t)atoi(argv[2]);
+    baud = atoi(argv[2]);
 
     /* initialize UART */
     res = uart_init(UART_DEV(dev), baud, rx_cb, (void *)dev);


### PR DESCRIPTION
AFAIK casting atoi() on assignment like this:

    uint8_t e = (uint8_t) atoi(e2);

is done implicitly as per C spec:

```
Conversion as if by assignment

- In the assignment operator, the value of the right-hand operand is converted to the unqualified type of the left-hand operand.
- In scalar initialization, the value of the initializer expression is converted to the unqualified type of the object being initialized
- In a function-call expression, to a function that has a prototype, the value of each argument expression is converted to the type of the unqualified declared types of the corresponding parameter
- In a return statement, the value of the operand of return is converted to an object having the return type of the function

Note that actual assignment, in addition to the conversion, also removes extra range and precision from floating-point types and prohibits overlaps; those characteristics do not apply to conversion as if by assignment.
```

(from http://en.cppreference.com/w/c/language/conversion)

This PR adds a coccinelle patch removing the casts for assignments of the form ``` e = (type) atoi(e2)```, and also adds a commit with the patch's output applied to the tree.

~~(waiting for #6946)~~