### PR TITLE
xtimer: improve performance

### DIFF
--- a/cpu/samd21/periph/pm.c
+++ b/cpu/samd21/periph/pm.c
@@ -24,6 +24,7 @@
  */
 
 #include "periph/pm.h"
+#include "xtimer.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -54,6 +55,9 @@ enum system_sleepmode {
 void pm_set(unsigned mode)
 {
     int deep = 0;
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+    xtimer_sync = false;
+#endif
 
     switch (mode) {
         case 0:

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -127,7 +127,7 @@ void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period) {
         }
         mutex_lock(&mutex);
         DEBUG("xps, abs: %" PRIu32 "\n", target);
-        _xtimer_set_absolute(&timer, target);
+        _xtimer_set_absolute(&timer, target, now);
         mutex_lock(&mutex);
     }
 out:

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -12,6 +12,7 @@
  * @brief xtimer core functionality
  * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @author Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author Hyung-Sin Kim <hs.kim@cs.berkeley.edu>
  * @}
  */
 
@@ -35,6 +36,12 @@ static volatile uint32_t _long_cnt = 0;
 volatile uint32_t _xtimer_high_cnt = 0;
 #endif
 
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+volatile uint32_t prev_s = 0xffffffff;
+volatile uint32_t prev_x = 0xffffffff;
+volatile bool xtimer_sync = false;
+#endif
+
 static inline void xtimer_spin_until(uint32_t value);
 
 static xtimer_t *timer_list_head = NULL;
@@ -46,7 +53,7 @@ static void _add_timer_to_long_list(xtimer_t **list_head, xtimer_t *timer);
 static void _shoot(xtimer_t *timer);
 static void _remove(xtimer_t *timer);
 static inline void _lltimer_set(uint32_t target);
-static uint32_t _time_left(uint32_t target, uint32_t reference);
+static uint32_t _time_left(uint32_t target, uint32_t reference, uint32_t now);
 
 static void _timer_callback(void);
 static void _periph_timer_callback(void *arg, int chan);
@@ -64,27 +71,52 @@ static inline void xtimer_spin_until(uint32_t target) {
 #endif
     while (_xtimer_lltimer_now() > target);
     while (_xtimer_lltimer_now() < target);
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+    prev_s = _stimer_lltimer_now();
+    prev_x = _xtimer_lltimer_now();
+    xtimer_sync = true;
+#endif
 }
 
 void xtimer_init(void)
 {
     /* initialize low-level timer */
     timer_init(XTIMER_DEV, XTIMER_HZ, _periph_timer_callback, NULL);
-
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+    /* initialize low-level timer for STIMER to support slow XTIMER operation.
+     * for this setup, XTIMER is expected to slow (e.g., 32 kHz) and
+     * STIMER must be faster than XTIMER (e.g., 8 MHz or 48 MHz).
+     */
+    timer_init(STIMER_DEV, STIMER_HZ, _periph_timer_callback, NULL);
+    prev_s = _stimer_lltimer_now();
+    prev_x = _xtimer_lltimer_now();
+    xtimer_sync = true;
+#endif
     /* register initial overflow tick */
     _lltimer_set(0xFFFFFFFF);
 }
 
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+/**
+ * @brief time difference of STIMER
+ */
+static uint32_t _stimer_diff(uint32_t prev, uint32_t now) {
+    if (now >= prev) {
+        return now - prev;
+    } else { 
+        return (0xFFFFFFFF-prev) + now;
+    }	
+}
+#endif
+
 static void _xtimer_now_internal(uint32_t *short_term, uint32_t *long_term)
 {
     uint32_t before, after, long_value;
-
     /* loop to cope with possible overflow of _xtimer_now() */
     do {
         before = _xtimer_now();
         long_value = _long_cnt;
         after = _xtimer_now();
-
     } while(before > after);
 
     *short_term = after;
@@ -142,8 +174,9 @@ void _xtimer_set(xtimer_t *timer, uint32_t offset)
         _shoot(timer);
     }
     else {
-        uint32_t target = _xtimer_now() + offset;
-        _xtimer_set_absolute(timer, target);
+        uint32_t now = _xtimer_now();
+        uint32_t target = now + offset;
+        _xtimer_set_absolute(timer, target, now);
     }
 }
 
@@ -168,13 +201,15 @@ static inline void _lltimer_set(uint32_t target)
     timer_set_absolute(XTIMER_DEV, XTIMER_CHAN, _xtimer_lltimer_mask(target));
 }
 
-int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
+int _xtimer_set_absolute(xtimer_t *timer, uint32_t target, uint32_t now)
 {
-    uint32_t now = _xtimer_now();
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+#else 
+    now = _xtimer_now();
+#endif
     int res = 0;
 
     DEBUG("timer_set_absolute(): now=%" PRIu32 " target=%" PRIu32 "\n", now, target);
-
     timer->next = NULL;
     if ((target >= now) && ((target - XTIMER_BACKOFF) < now)) {
         /* backoff */
@@ -197,11 +232,17 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
     if ( (timer->long_target > _long_cnt) || !_this_high_period(target) ) {
         DEBUG("xtimer_set_absolute(): the timer doesn't fit into the low-level timer's mask.\n");
         _add_timer_to_long_list(&long_list_head, timer);
+        if (!timer_list_head) {
+            _lltimer_set(0xFFFFFFFF);
+        }
     }
     else {
         if (_xtimer_lltimer_mask(now) >= target) {
             DEBUG("xtimer_set_absolute(): the timer will expire in the next timer period\n");
             _add_timer_to_list(&overflow_list_head, timer);
+            if (!timer_list_head) {
+                _lltimer_set(0xFFFFFFFF);
+            }
         }
         else {
             DEBUG("timer_set_absolute(): timer will expire in this timer period.\n");
@@ -213,7 +254,6 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
             }
         }
     }
-
     irq_restore(state);
 
     return res;
@@ -286,10 +326,8 @@ void xtimer_remove(xtimer_t *timer)
     irq_restore(state);
 }
 
-static uint32_t _time_left(uint32_t target, uint32_t reference)
+static uint32_t _time_left(uint32_t target, uint32_t reference, uint32_t now)
 {
-    uint32_t now = _xtimer_lltimer_now();
-
     if (now < reference) {
         return 0;
     }
@@ -425,6 +463,7 @@ static void _next_period(void)
     _select_long_timers();
 }
 
+
 /**
  * @brief main xtimer callback function
  */
@@ -432,6 +471,11 @@ static void _timer_callback(void)
 {
     uint32_t next_target;
     uint32_t reference;
+    uint32_t now;
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+    uint32_t now_s;
+    uint32_t diff_s;
+#endif
 
     _in_handler = 1;
 
@@ -452,21 +496,43 @@ static void _timer_callback(void)
 
         /* make sure the timer counter also arrived
          * in the next timer period */
-        while (_xtimer_lltimer_now() == _xtimer_lltimer_mask(0xFFFFFFFF)) {}
+        while ((reference = _xtimer_lltimer_now()) == _xtimer_lltimer_mask(0xFFFFFFFF)) {}
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+        prev_s = _stimer_lltimer_now();
+#endif
     }
     else {
         /* we ended up in _timer_callback and there is
          * a timer waiting.
          */
         /* set our period reference to the current time. */
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+        prev_s = _stimer_lltimer_now();
+#endif
         reference = _xtimer_lltimer_now();
     }
+    now = reference;
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+    prev_x = now;
+    xtimer_sync = true;
+#endif
 
 overflow:
     /* check if next timers are close to expiring */
-    while (timer_list_head && (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference) < XTIMER_ISR_BACKOFF)) {
+    while (timer_list_head && (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference, now) < XTIMER_ISR_BACKOFF)) {
         /* make sure we don't fire too early */
-        while (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference)) {}
+        while (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference, now)) {
+            /* update current time */
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+            do {
+                now_s = _stimer_lltimer_now();
+                diff_s = _stimer_diff(prev_s, now_s);
+            } while (diff_s < STIMER_HZ/XTIMER_HZ);
+            now = now + (uint32_t)((uint64_t)diff_s*XTIMER_HZ/STIMER_HZ);
+#else
+            now = _xtimer_lltimer_now();
+#endif
+        }
 
         /* pick first timer in list */
         xtimer_t *timer = timer_list_head;
@@ -480,17 +546,36 @@ overflow:
 
         /* fire timer */
         _shoot(timer);
+
+        /* update current time after executing callback */
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+        now_s = _stimer_lltimer_now();
+        diff_s = _stimer_diff(prev_s, now_s);
+        if (diff_s >= STIMER_HZ/XTIMER_HZ) {
+            now = now + (uint32_t)((uint64_t)diff_s*XTIMER_HZ/STIMER_HZ);
+        }
+#else
+        now = _xtimer_lltimer_now();
+#endif
     }
 
     /* possibly executing all callbacks took enough
      * time to overflow.  In that case we advance to
      * next timer period and check again for expired
      * timers.*/
-    if (reference > _xtimer_lltimer_now()) {
+    if (reference > now) {
         DEBUG("_timer_callback: overflowed while executing callbacks. %i\n",
               timer_list_head != NULL);
         _next_period();
         reference = 0;
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+        prev_s = _stimer_lltimer_now();
+#endif
+        now = _xtimer_lltimer_now();
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+        prev_x = now;
+        xtimer_sync = true;
+#endif
         goto overflow;
     }
 
@@ -499,20 +584,44 @@ overflow:
         next_target = timer_list_head->target - XTIMER_OVERHEAD;
 
         /* make sure we're not setting a time in the past */
-        if (next_target < (_xtimer_lltimer_now() + XTIMER_ISR_BACKOFF)) {
+        if (next_target < (now + XTIMER_ISR_BACKOFF)) {
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+            prev_s = _stimer_lltimer_now();
+#endif
+            now = _xtimer_lltimer_now();
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+            prev_x = now;
+            xtimer_sync = true;
+#endif
             goto overflow;
         }
+        _in_handler = 0;
+
+        /* set low level timer */
+        _lltimer_set(next_target);
     }
     else {
         /* there's no timer planned for this timer period */
-        /* schedule callback on next overflow */
-        next_target = _xtimer_lltimer_mask(0xFFFFFFFF);
-        uint32_t now = _xtimer_lltimer_now();
-
+        /* update current time */
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+        now_s = _stimer_lltimer_now();
+        diff_s = _stimer_diff(prev_s, now_s);
+        now = now + (uint32_t)((uint64_t)diff_s*XTIMER_HZ/STIMER_HZ);
+#else
+        now = _xtimer_lltimer_now();
+#endif
         /* check for overflow again */
         if (now < reference) {
             _next_period();
             reference = 0;
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+            prev_s = _stimer_lltimer_now();
+#endif
+            now = _xtimer_lltimer_now();
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+            prev_x = now;
+            xtimer_sync = true;
+#endif
             goto overflow;
         }
         else {
@@ -522,13 +631,22 @@ overflow:
                 while (_xtimer_lltimer_now() >= now) {}
                 _next_period();
                 reference = 0;
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+                prev_s = _stimer_lltimer_now();
+#endif        
+                now = _xtimer_lltimer_now();
+#if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
+                prev_x = now;
+                xtimer_sync = true;
+#endif
                 goto overflow;
             }
         }
+        _in_handler = 0;
+
+        if (overflow_list_head || long_list_head) {
+            /* schedule callback on next overflow */  
+            _lltimer_set(0xFFFFFFFF);
+        }
     }
-
-    _in_handler = 0;
-
-    /* set low level timer */
-    _lltimer_set(next_target);
 }


### PR DESCRIPTION
This PR is @Hyungsin's work, I just cleaned it up and rebased it for pushing upstream.

The PR attempts to minimize the number of times that xtimer_now is called, as this operation is far more expensive than you would expect.

On SAMR21, as part of their energy saving design, Atmel has the timer counter registers on a different clock domain in the chip, it is necessary to perform a synchronized read to get the current value of the counter (e.g [here](https://github.com/RIOT-OS/RIOT/blob/master/cpu/samd21/periph/timer.c#L239-L240) ). The nature of this clock sync is that it takes a few cycles of the clock driving the counter to synchronize. We are using a 32768 hz clock for xtimer as it operates during sleep (OSCULP) and in practice it takes _several hundred_ microseconds to read the timer counter register. This does not appear to be a bug, it is just the cost of reading a register that is on a different clock domain (likely some metastability fix in the silicon). 

What this means is that a program that simply wakes up and immediately sleeps takes roughly 2ms to do so. Initially we attributed this to PLL startup etc, but after digging in we found that is actually all negligible, the real cost is reading the timer register six times (four on wakeup, two on setting a new timer when going to sleep). A simple refactor of the xtimer code allows this to happen only three times (two on wakeup, one to set a new timer when going to sleep). Certain xtimer callbacks like unlocking a mutex can be assumed to take negligable time, so we allow them to be flagged as being trivial, so that _now_ after the callback can be assumed to be within XTIMER_ISR_BACKOFF of _now_ before the callback, removing a register read. Other changes include passing now as a parameter to internal functions instead of re-reading from the timer register.

To illustrate, look at this plot of a program just waking up and immediately going to sleep again using xtimer_usleep in a loop.

![image](https://cloud.githubusercontent.com/assets/4234131/26020158/2e214be2-3730-11e7-85de-0117c8c8fcc9.png)

The first thing to note is that the overhead of xtimer_now is not affected by the primary CPU clock frequency, because it is on the timer's clock domain (both 8Mhz and 48Mhz take the same amount of time). This also confirms that the delay is not PLL, because the 8Mhz is a direct RC with no startup delay.

Secondly you can see with this PR the time is reduced from ~1.9ms to ~0.8ms. This is very useful for low power applications wanting to spend as little time as possible in high-power modes, and brings RIOT-OS more in line with Contiki and TinyOS in timer overhead.