### PR TITLE
gnrc, tcp: set param THREAD_CREATE_STACKTEST for mem stats in ps

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -189,7 +189,8 @@ int gnrc_tcp_init(void)
     _rcvbuf_init();
 
     /* Start TCP processing thread */
-    return thread_create(_stack, sizeof(_stack), TCP_EVENTLOOP_PRIO, 0, _event_loop, NULL,
+    return thread_create(_stack, sizeof(_stack), TCP_EVENTLOOP_PRIO,
+                         THREAD_CREATE_STACKTEST, _event_loop, NULL,
                          "gnrc_tcp");
 }
 


### PR DESCRIPTION
this adds the missing `THREAD_CREATE_STACKTEST` in the tcp event loop thread creation, to enable proper output in ps and proper memory stats.