### PR TITLE
dist: tools: coccinelle: add enable_debug_false.cocci

### DIFF
--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -15,7 +15,7 @@
 #include "periph_conf.h"
 #include "mutex.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 /* Only if we actually have any ADCs */

--- a/cpu/samd21/periph/pm.c
+++ b/cpu/samd21/periph/pm.c
@@ -24,7 +24,7 @@
 
 #include "periph/pm.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 enum system_sleepmode {

--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -25,7 +25,7 @@
 #include "irq.h"
 #include "periph/pm.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 void pm_set(unsigned mode)

--- a/dist/tools/coccinelle/warn/enable_debug_false.cocci
+++ b/dist/tools/coccinelle/warn/enable_debug_false.cocci
@@ -1,0 +1,5 @@
+@@
+@@
+
+- #define ENABLE_DEBUG (1)
++ #define ENABLE_DEBUG (0)

--- a/drivers/lsm6dsl/lsm6dsl.c
+++ b/drivers/lsm6dsl/lsm6dsl.c
@@ -19,7 +19,7 @@
 #include "lsm6dsl.h"
 #include "lsm6dsl_internal.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -30,7 +30,7 @@
 #include "timex.h"
 #include "xtimer.h"
 
-#define ENABLE_DEBUG  (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 /* TinyDTLS */

--- a/examples/dtls-echo/dtls-server.c
+++ b/examples/dtls-echo/dtls-server.c
@@ -37,7 +37,7 @@
 #include "dtls_debug.h"
 #include "tinydtls.h"
 
-#define ENABLE_DEBUG  (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 //#define DEFAULT_PORT 20220    /* DTLS default port  */


### PR DESCRIPTION
This PR adds a coccinelle patch that finds occurrences of

    #define ENABLE_DEBUG (1)

... which are usually test leftovers.

The patch is added to "warn/", as we've two files where the #define is guarded with other defines, but coccinelle cannot (yet) parse ifdefs.

Second commit applys the output of the patch to the codebase. The two 'weird' files have been left alone.