### PR TITLE
gnrc_tcp: fix return on closed state

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -525,7 +525,7 @@ void gnrc_tcp_close(gnrc_tcp_tcb_t *tcb)
     /* Return if connection is closed */
     if (tcb->state == FSM_STATE_CLOSED) {
         mutex_unlock(&(tcb->function_lock));
-        return 0;
+        return;
     }
 
     /* Mark TCB as waiting for incomming messages */


### PR DESCRIPTION
#6969 and #6997 were merged in rapid succession. However, #6969 introduced a new code path were `gnrc_tcp_close()` would return early (with a value), while #6997 set the return type of that function to `void`. Because of this master is currently broken (I guess someone owes the community a box of beer ;-)). Murdock wasn't able to detect this because at build time neither of the PRs was merged into master. I guess it's high time for nightly builds, @kaspar030 ;-).