### PR TITLE
gcoap: move dependencies to actual module

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -598,6 +598,11 @@ ifneq (,$(filter l2filter_%,$(USEMODULE)))
   USEMODULE += l2filter
 endif
 
+ifneq (,$(filter gcoap,$(USEMODULE)))
+USEPKG += nanocoap
+USEMODULE += gnrc_sock_udp
+endif
+
 # include package dependencies
 -include $(USEPKG:%=$(RIOTPKG)/%/Makefile.dep)
 

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -26,17 +26,12 @@ BOARD_BLACKLIST := nrf52dk
 #GCOAP_TOKENLEN = 2
 #CFLAGS += -DGCOAP_TOKENLEN=$(GCOAP_TOKENLEN)
 
-USEPKG += nanocoap
-# Required by nanocoap, but only due to issue #5959.
-USEMODULE += posix
-
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_sock_udp
 USEMODULE += gcoap
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo

--- a/examples/gcoap/Makefile.slip
+++ b/examples/gcoap/Makefile.slip
@@ -42,16 +42,11 @@ INCLUDES += -I$(CURDIR)
 CFLAGS += -DSLIP_UART=$(SLIP_UART)
 CFLAGS += -DSLIP_BAUDRATE=$(SLIP_BAUDRATE)
 
-USEPKG += nanocoap
-# Required by nanocoap, but only due to issue #5959.
-USEMODULE += posix
-
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules
-USEMODULE += gnrc_sock_udp
 USEMODULE += gcoap
 # Add a routing protocol
 USEMODULE += gnrc_rpl

--- a/tests/unittests/tests-gcoap/Makefile.include
+++ b/tests/unittests/tests-gcoap/Makefile.include
@@ -1,8 +1,5 @@
-USEPKG += nanocoap
-
 # Specify the mandatory networking modules
 USEMODULE += gcoap
-USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6
 
 USEMODULE += random


### PR DESCRIPTION
By using gcoap a bit I noticed that the actual dependencies for gcoap were declared for the example rather than for the actual module.

As far as I can see, the example doesn't even include `nanocoap.h`, which is the main dependency.

Thus, this PR proposes to declare such dependencies in Makefile.dep