### PR TITLE
sys/cpp11-compat: fixed doxygen warnings

### DIFF
--- a/sys/cpp11-compat/include/riot/thread.hpp
+++ b/sys/cpp11-compat/include/riot/thread.hpp
@@ -240,6 +240,10 @@ public:
    */
   template <class F, class... Args>
   explicit thread(F&& f, Args&&... args);
+
+  /**
+   * @brief Disallow copy constructor for constant objects.
+   */
   thread(const thread&) = delete;
   /**
    * @brief Move constructor.
@@ -251,6 +255,9 @@ public:
 
   ~thread();
 
+  /**
+   * @brief Disallow the assignment operator for constant objects.
+   */
   thread& operator=(const thread&) = delete;
   /**
    * @brief Move assignment operator.

--- a/sys/cpp11-compat/include/riot/thread.hpp
+++ b/sys/cpp11-compat/include/riot/thread.hpp
@@ -242,9 +242,10 @@ public:
   explicit thread(F&& f, Args&&... args);
 
   /**
-   * @brief Disallow copy constructor for constant objects.
+   * @brief Disallow copy constructor.
    */
   thread(const thread&) = delete;
+
   /**
    * @brief Move constructor.
    */
@@ -256,9 +257,10 @@ public:
   ~thread();
 
   /**
-   * @brief Disallow the assignment operator for constant objects.
+   * @brief Disallow copy assignment operator.
    */
   thread& operator=(const thread&) = delete;
+
   /**
    * @brief Move assignment operator.
    */


### PR DESCRIPTION
Running `make doc`, before:
```
"make" -BC doc/doxygen
make[1]: Entering directory `/home/hauke/dev/riot/RIOT/doc/doxygen'
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
Warning: ignoring unsupported tag `DOCBOOK_PROGRAMLISTING =' at line 1899, file -
Warning: ignoring unsupported tag `PLANTUML_JAR_PATH      =' at line 2347, file -
/home/hauke/dev/riot/RIOT/sys/cpp11-compat/include/riot/thread.hpp:243: warning: Member thread(const thread &)=delete (function) of class riot::thread is not documented.
/home/hauke/dev/riot/RIOT/sys/cpp11-compat/include/riot/thread.hpp:254: warning: Member operator=(const thread &)=delete (function) of class riot::thread is not documented.
make[1]: Leaving directory `/home/hauke/dev/riot/RIOT/doc/doxygen'
```
and after:
```
"make" -BC doc/doxygen
make[1]: Entering directory `/home/hauke/dev/riot/RIOT/doc/doxygen'
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
Warning: ignoring unsupported tag `DOCBOOK_PROGRAMLISTING =' at line 1899, file -
Warning: ignoring unsupported tag `PLANTUML_JAR_PATH      =' at line 2347, file -
make[1]: Leaving directory `/home/hauke/dev/riot/RIOT/doc/doxygen'
gen'
```

Although I must say, I am not hundred percent sure if my added comments make sense...