### PR TITLE
examples/gnrc_border_router: remove `make term` warnings

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -370,7 +370,7 @@ flash: all $(FLASHDEPS)
 preflash: all
 	$(PREFLASHER) $(PREFFLAGS)
 
-term: $(filter flash, $(MAKECMDGOALS))
+term: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
 	@command -v $(TERMPROG) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \
 		'${COLOR_RED}Terminal program $(TERMPROG) not found. Aborting.${COLOR_RESET}'; \

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -76,12 +76,17 @@ QUIET ?= 1
 TAP ?= tap0
 IPV6_PREFIX ?= 2001:db8::/64
 
+# We override the `make term` command to use ethos
+TERMPROG ?= sudo sh $(RIOTBASE)/dist/tools/ethos/start_network.sh
+TERMFLAGS ?= $(PORT) $(TAP) $(IPV6_PREFIX)
+
+# We depend on the ethos host tools to run the border router, we build them
+# if necessary
+TERMDEPS += host-tools
+
 include $(RIOTBASE)/Makefile.include
 
 .PHONY: host-tools
-
-term: host-tools
-	$(Q)sudo sh $(RIOTBASE)/dist/tools/ethos/start_network.sh $(PORT) $(TAP) $(IPV6_PREFIX)
 
 host-tools:
 	$(Q)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -11,7 +11,7 @@ ifeq ($(PORT),)
 endif
 
 export BAUD ?= 115200
-export TERMFLAGS += -p "$(PORT)" -b "$(BAUD)"
-export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
+export TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
+export TERMPROG ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
 
 export PORT


### PR DESCRIPTION
Calling `make term` (or more precisely on any target...) caused the `gnrc_border_router` example to throw a warning about re-definition of the term target:

```
Makefile:84: warning: overriding commands for target `term'
/home/hauke/dev/riot/RIOT/examples/gnrc_border_router/../../Makefile.include:371: warning: ignoring old commands for target `term'
```

This should be fixed with this PR.