### PR TITLE
ndp: doc: fix RFC link

### DIFF
--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -66,7 +66,7 @@ extern "C" {
 
 /**
  * @name    Neighbor advertisement flags
- * @see     [RFC 4861, section 4.2](https://tools.ietf.org/html/rfc4861#section-4.2)
+ * @see     [RFC 4861, section 4.4](https://tools.ietf.org/html/rfc4861#section-4.4)
  * @{
  */
 #define NDP_NBR_ADV_FLAGS_MASK      (0xe0)


### PR DESCRIPTION
The RFC link for the neighbor advertisement flags in the doc was wrong (it linked to the *router* advertisement format, not the *neighbor* advertisement format). This PR fixes that.