### PR TITLE
boards/nrf6310: del redundant TERMFLAGS assignemt

### DIFF
--- a/boards/nrf6310/Makefile.include
+++ b/boards/nrf6310/Makefile.include
@@ -14,7 +14,6 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 
 export OFLAGS = -O binary
 export HEXFILE = $(ELFFILE:.elf=.bin)
-export TERMFLAGS += -p "$(PORT)"
 export FFLAGS = $(BINDIR) $(HEXFILE)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)


### PR DESCRIPTION
The port for the TERMPROG is assingned in serial.inc.mk...