### PR TITLE
boards: make use of `serial.inc.mk`

### DIFF
--- a/boards/arduino-atmega-common/Makefile.include
+++ b/boards/arduino-atmega-common/Makefile.include
@@ -3,21 +3,11 @@ include $(RIOTBOARD)/arduino-atmega-common/Makefile.dep
 
 INCLUDES += -I$(RIOTBOARD)/arduino-atmega-common/include
 
-# define port used to flash the board
-OS = $(shell uname)
-ifeq ($(OS),Linux)
-  PORT = $(PORT_LINUX)
-else ifeq ($(OS),Darwin)
-  PORT ?= $(PORT_DARWIN)
-else
-  $(info CAUTION: No flash tool for your host system found!)
-  # TODO: fix for building under windows
-endif
+# refine serial port information
+export BAUD ?= 9600
+include $(RIOTMAKE)/tools/serial.inc.mk
 
-export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
-export TERMFLAGS ?= -b 9600 -p $(PORT)
 export FLASHER = avrdude
-export PORT
 export DIST_PATH = $(RIOTBOARD)/$(BOARD)/dist
 export DEBUGSERVER_PORT = 4242
 export DEBUGSERVER = $(DIST_PATH)/debug_srv.sh

--- a/boards/msba2-common/Makefile.include
+++ b/boards/msba2-common/Makefile.include
@@ -2,7 +2,10 @@
 export CPU = lpc2387
 
 FLASHER = lpc2k_pgm
-TERMPROG ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
+
+# configure serial interface
+export TERMFLAGS += -tg -p "$(PORT)"
+include $(RIOTMAKE)/tools/serial.inc.mk
 
 export CFLAGS_CPU   = -mcpu=arm7tdmi-s
 export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
@@ -22,7 +25,6 @@ ifeq ($(PORT),)
 	export PORT = /dev/ttyUSB0
 endif
 export FFLAGS = $(PORT) $(HEXFILE)
-export TERMFLAGS += -tg -p "$(PORT)"
 
 export INCLUDES += -I$(RIOTBOARD)/msba2-common/include -I$(RIOTBOARD)/msba2-common/drivers/include
 

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -5,10 +5,11 @@ export CPU_MODEL = stm32f103cb
 # the spark-core uses its own custom linkerscript...
 export LINKER_SCRIPT = stm32f103cb_sparkcore.ld
 
-# set the default port
-export PORT ?= /dev/ttyUSB0
+# configure the serial interface
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+include $(RIOTMAKE)/tools/serial.inc.mk
 
-#
 export BINFILE = $(patsubst %.elf,%.bin,$(ELFFILE))
 
 export FLASHER = dfu-util
@@ -17,12 +18,8 @@ export RESET = # dfu-util has no support for resetting the device
 
 export OFLAGS = -O binary
 export FFLAGS = -d 1d50:607f -a 0 -s 0x08005000:leave -D "$(HEXFILE)"
-export TERMFLAGS = -p $(PORT)
 
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include/
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -1,6 +1,12 @@
 # define the cpu used by the waspmote pro board
 export CPU = atmega1281
 
+# configure the terminal program
+PORT_LINUX  ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+BAUD        ?= 9600
+include $(RIOTMAKE)/tools/serial.inc.mk
+
 # define tools used for building the project
 export PREFIX = avr-
 export CC = $(PREFIX)gcc
@@ -10,24 +16,8 @@ export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-export TERMPROG = $(RIOTBASE)/dist/tools/pyterm/pyterm
-export TERMFLAGS = -b 9600 -p $(PORT)
 
-#define the flash-tool and default port depending on the host operating system
-OS = $(shell uname)
-ifeq ($(OS),Linux)
-  PORT ?= /dev/ttyACM0
-  FLASHER = avrdude
-else ifeq ($(OS),Darwin)
-  PORT ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
-  FLASHER = avrdude
-else
-  $(info CAUTION: No flash tool for your host system found!)
-  # TODO: fix for building under windows
-endif
-
-export FLASHER
-export PORT
+export FLASHER = avrdude
 export DIST_PATH = $(RIOTBOARD)/$(BOARD)/dist
 export DEBUGSERVER_PORT = 4242
 export DEBUGSERVER = $(DIST_PATH)/debug_srv.sh


### PR DESCRIPTION
This PR removes some redundancies w.r.t. to the definition of the default terminal program and its parameters.