### PR TITLE
sys/drivers: guard l2filter.h, netstats.h includes

### DIFF
--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -22,10 +22,6 @@
 #include <assert.h>
 #include <errno.h>
 
-#ifdef MODULE_NETSTATS_L2
-#include <string.h>
-#endif
-
 #include "mutex.h"
 #include "encx24j600.h"
 #include "encx24j600_internal.h"
@@ -36,7 +32,11 @@
 #include "net/netdev/eth.h"
 #include "net/eui64.h"
 #include "net/ethernet.h"
+
+#ifdef MODULE_NETSTATS_L2
+#include <string.h>
 #include "net/netstats.h"
+#endif
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -53,9 +53,14 @@ extern "C" {
 #include <stdint.h>
 #include <sys/uio.h>
 
-#include "net/netstats.h"
-#include "net/l2filter.h"
 #include "net/netopt.h"
+
+#ifdef MODULE_NETSTATS_L2
+#include "net/netstats.h"
+#endif
+#ifdef MODULE_L2FILTER
+#include "net/l2filter.h"
+#endif
 
 enum {
     NETDEV_TYPE_UNKNOWN,

--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -30,8 +30,11 @@
 #include "mutex.h"
 #include "net/ipv6.h"
 #include "net/ipv6/addr.h"
-#include "net/netstats.h"
 #include "xtimer.h"
+
+#ifdef MODULE_NETSTATS_IPV6
+#include "net/netstats.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -605,7 +608,9 @@ void gnrc_ipv6_netif_init_by_dev(void);
  * @return  A @ref netstats_t pointer to the statistics.
  * @return  NULL if no statistics are available.
  */
+#if defined(MODULE_NETSTATS_IPV6) || DOXYGEN
 netstats_t *gnrc_ipv6_netif_get_stats(kernel_pid_t pid);
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -26,8 +26,6 @@
 #include <inttypes.h>
 
 #include "thread.h"
-#include "net/netstats.h"
-#include "net/l2filter.h"
 #include "net/ipv6/addr.h"
 #include "net/gnrc/ipv6/netif.h"
 #include "net/gnrc/netif.h"
@@ -37,6 +35,13 @@
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/sixlowpan/netif.h"
+
+#ifdef MODULE_NETSTATS
+#include "net/netstats.h"
+#endif
+#ifdef MODULE_L2FILTER
+#include "net/l2filter.h"
+#endif
 
 /**
  * @brief   The maximal expected link layer address length in byte


### PR DESCRIPTION
as discussed in #7066, it does not hurt to include `netstats.h` and `l2filter.h` only if their modules are actually being build.