### PR TITLE
pkg: ccn-lite: update to latest commit

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=ccn-lite
 PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
-PKG_VERSION=10119ca8173457e8a26b28fc9f30fe0d97d17857
+PKG_VERSION=7b973a737dba47fe6c1ee2d58e06dd9a22209fde
 PKG_LICENSE=ISC
 
 .PHONY: all

--- a/pkg/ccn-lite/ccn-lite-riot.h
+++ b/pkg/ccn-lite/ccn-lite-riot.h
@@ -213,11 +213,11 @@ int ccnl_open_netif(kernel_pid_t if_pid, gnrc_nettype_t netreg_type);
  * @param[out] buf      Buffer to write the content chunk to
  * @param[in] buf_len   Size of @p buf
  *
- * @return pointer to the successfully sent Interest
- * @return NULL if Interest couldn't be sent
+ * @return 0 on success
+ * @return -1 on failure
  */
-struct ccnl_interest_s *ccnl_send_interest(struct ccnl_prefix_s *prefix,
-                                           unsigned char *buf, size_t buf_len);
+int ccnl_send_interest(struct ccnl_prefix_s *prefix,
+                       unsigned char *buf, size_t buf_len);
 
 /**
  * @brief Wait for incoming content chunk


### PR DESCRIPTION
The latest commit of the ccn-lite repository contains some mem leak fixes. This PR updates our package to point to the latest ccn-lite commit.