### PR TITLE
drivers: add GPS API

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -172,9 +172,23 @@ ifneq (,$(filter grove_ledbar,$(USEMODULE)))
   USEMODULE += my9221
 endif
 
+ifneq (,$(filter gps_%,$(USEMODULE)))
+  USEMODULE += gps
+endif
+
+ifneq (,$(filter gps,$(USEMODULE)))
+  USEMODULE += fmt
+  USEPKG += minmea
+endif
+
+ifneq (,$(filter gps_serial,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_uart
+  USEMODULE += isrpipe
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter hd44780,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
-  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter hdc1000,$(USEMODULE)))

--- a/drivers/gps/Makefile
+++ b/drivers/gps/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/gps/Makefile
+++ b/drivers/gps/Makefile
@@ -1,1 +1,4 @@
+SRC := gps.c
+SUBMODULES := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/drivers/gps/gps.c
+++ b/drivers/gps/gps.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <stdint.h>
+
+#include "minmea.h"
+#include "gps.h"
+
+#ifndef GPS_USE_FMT
+#define GPS_USE_FMT 1
+#endif
+
+#if GPS_USE_FMT
+#include "fmt.h"
+#else
+#include <stdio.h>
+#endif
+
+int gps_parse_gll(const uint8_t *buf, char *lat, char *lon)
+{
+    struct minmea_sentence_gll frame;
+
+    if (minmea_parse_gll(&frame, (const char*)buf)) {
+        if (frame.status != 'A') {
+            return -1;
+        }
+        if (lat) {
+            if (GPS_USE_FMT) {
+                size_t res = fmt_float(lat, minmea_tocoord(&frame.latitude), 5);
+                lat[res] = '\0';
+            }
+            else {
+                sprintf(lat, "%f", minmea_tocoord(&frame.latitude));
+            }
+        }
+        if (lon) {
+            if (GPS_USE_FMT) {
+                size_t res = fmt_float(lon, minmea_tocoord(&frame.longitude), 5);
+                lon[res] = '\0';
+            }
+            else {
+                sprintf(lon, "%f", minmea_tocoord(&frame.longitude));
+            }
+        }
+        return 0;
+    }
+
+    return -1;
+}

--- a/drivers/gps/serial.c
+++ b/drivers/gps/serial.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include "gps.h"
+#include "gps/serial.h"
+#include "periph/uart.h"
+#include "isrpipe.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static ssize_t _readline(isrpipe_t *isrpipe, char *resp_buf, size_t len, uint32_t timeout)
+{
+    ssize_t res = -1;
+    char *resp_pos = resp_buf;
+
+    tsrb_empty(&isrpipe->tsrb);
+
+    memset(resp_buf, 0, len);
+
+    while (len) {
+        int read_res;
+        if ((read_res = isrpipe_read_timeout(isrpipe, resp_pos, 1, timeout)) == 1) {
+            if (*resp_pos == '\r') {
+                continue;
+            }
+            if (*resp_pos == '\n') {
+                *resp_pos = '\0';
+                res = resp_pos - resp_buf;
+                goto out;
+            }
+
+            resp_pos += read_res;
+            len -= read_res;
+        }
+        else if (read_res == -ETIMEDOUT) {
+            res = -ETIMEDOUT;
+            break;
+        }
+    }
+
+out:
+    return res;
+}
+
+static int _get_loc(gps_t *dev, char *lat, char *lon, uint32_t maxwait)
+{
+    gps_serial_t *gps_serial = (gps_serial_t*) dev;
+
+    char linebuf[128];
+    uint64_t before = xtimer_now_usec64();
+
+    while ((maxwait == 0) || ((xtimer_now_usec64() - before) < maxwait)) {
+        ssize_t res = _readline(&gps_serial->isrpipe, linebuf, sizeof(linebuf), maxwait);
+        if (res >= 6 /* $GPGLL */) {
+            DEBUG("gps: %s\n", linebuf);
+            if (gps_parse_gll((uint8_t*) (linebuf), lat, lon) == 0) {
+                return 0;
+            }
+        }
+    }
+
+    return -ETIMEDOUT;
+}
+
+static int _power(gps_t *dev, gps_powermode_t mode)
+{
+    (void)dev;
+    (void)mode;
+
+    return -ENOTSUP;
+}
+
+static const gps_driver_t _gps_serial_driver = {
+    .get_loc=_get_loc,
+    .power=_power,
+};
+
+int gps_serial_init(gps_serial_t *dev, const gps_serial_params_t *params)
+{
+    isrpipe_init(&dev->isrpipe, dev->buf, sizeof(dev->buf));
+    uart_init(params->uart, params->baudrate, (uart_rx_cb_t) isrpipe_write_one,
+              &dev->isrpipe);
+
+    dev->super.driver = &_gps_serial_driver;
+
+    return 0;
+}

--- a/drivers/include/gps.h
+++ b/drivers/include/gps.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_gps GPS
+ * @ingroup     drivers
+ * @brief       API for accessing GPS modules
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for GPS
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef GPS_H
+#define GPS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct gps_driver gps_driver_t; /**< gps_driver_t forward declaration */
+
+/**
+ * @brief base GPS context structure
+ */
+typedef struct {
+    const gps_driver_t *driver;         /**< pointer to gps driver structure */
+} gps_t;
+
+/**
+ * @brief enum holding possible GPS power saving modes
+ */
+typedef enum {
+    GPS_OFF,                            /**< GPS hardware turned off */
+    GPS_SLEEP,                          /**< GPS hardware in sleep mode */
+    GPS_POWERSAVE,                      /**< GPS in low power mode */
+    GPS_ON,                             /**< GPS active */
+} gps_powermode_t;
+
+/**
+ * @brief Structure for GPS backend function pointers
+ */
+struct gps_driver {
+    /** ptr to get_loc implementation */
+    int(*get_loc)(gps_t *dev, char *lat, char *lon, uint32_t wait_fix);
+
+    /** ptr to power implementation */
+    int(*power)(gps_t *dev, gps_powermode_t mode);
+};
+
+/**
+ * @brief   Get GPS location
+ *
+ * Gets the current location from GPS. Waits at most @p maxwait usec until a
+ * location fix has been acquired.
+ * Location will be stored in decimal degree (DD.DDDDDD) format as text.
+ * Both @p and @p lon can be NULL. In that case, the corresponding value will
+ * not be stored.
+ *
+ * @note If not NULL, both @p lat and @p lon must point to buffers holding the
+ *       result (10 bytes)!
+ *
+ * @note allow for enough time to read out the fix. E.g., serial NMEA0183
+ *       devices report every second.
+ *
+ * @param[in]   gpsdev  GPS device to operate on
+ * @param[in]   lat     buffer for storing latitude
+ * @param[in]   lon     buffer for storing lontitide
+ * @param[in]   maxwait maximum wait time in usec
+ *
+ * @returns     0 on success
+ * @returns     -ETIMEOUT on timeout
+ * @returns     <0 on other errors
+ */
+static inline int gps_get_loc(gps_t *gpsdev, char *lat, char *lon, uint32_t maxwait)
+{
+    return gpsdev->driver->get_loc(gpsdev, lat, lon, maxwait);
+}
+
+/**
+ * @brief Set power mode of GPS device
+ *
+ * @param[in]   gpsdev  GPS device to operate on
+ * @param[in]   mode    low-power mode to set
+ *
+ * @returns     0 on success
+ * @return      <0 on error
+ */
+static inline int gps_power(gps_t *gpsdev, gps_powermode_t mode)
+{
+    return gpsdev->driver->power(gpsdev, mode);
+}
+
+/**
+ * @brief   parse raw GPS GLL sentence
+ *
+ * Used internally by backend drivers.
+ *
+ * @param[in]   buf buffer containing sentence
+ * @param[in]   lat buffer to store latitude
+ * @param[in]   lon buffer to store lontitude
+ *
+ * @returns 0 on success
+ * @returns <0 on error
+ */
+int gps_parse_gll(const uint8_t *buf, char *lat, char *lon);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */
+#endif /* GPS_H */

--- a/drivers/include/gps/serial.h
+++ b/drivers/include/gps/serial.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_gps
+ * @brief       Driver for NMEA 0183 GPS devices
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for NMEA 0183 device driver
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef GPS_SERIAL_H
+#define GPS_SERIAL_H
+
+#include <stdint.h>
+
+#include "isrpipe.h"
+#include "periph/uart.h"
+#include "gps.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef GPS_SERIAL_BUFSIZE
+#define GPS_SERIAL_BUFSIZE  (512U)      /**< buffer for NMEA sentences */
+#endif
+
+/**
+ * @brief gps_serial parameter struct
+ */
+typedef struct {
+    uart_t uart;        /**< UART device the GPS module is connected to */
+    uint32_t baudrate;  /**< baudrate of GPS module */
+} gps_serial_params_t;
+
+/**
+ * @brief gps_serial context struct
+ * @extends gps_t
+ */
+typedef struct {
+    gps_t super;                    /**< parent struct */
+    char buf[GPS_SERIAL_BUFSIZE];   /**< GPS input buffer */
+    isrpipe_t isrpipe;              /**< isrpipe object used for serial IO */
+} gps_serial_t;
+
+/**
+ * @brief   GPS serial initialization function
+ *
+ * @param[in]   dev     device struct to initialize
+ * @param[in]   params  pointer to parameter struct
+ *
+ * @returns     0 on success
+ * @returns     <0 otherwise
+ */
+int gps_serial_init(gps_serial_t *dev, const gps_serial_params_t *params);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPS_SERIAL_H */

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -34,6 +34,7 @@ PSEUDOMODULES += gnrc_sixlowpan_router
 PSEUDOMODULES += gnrc_sixlowpan_router_default
 PSEUDOMODULES += gnrc_sock_check_reuse
 PSEUDOMODULES += gnrc_txtsnd
+PSEUDOMODULES += gps_%
 PSEUDOMODULES += l2filter_blacklist
 PSEUDOMODULES += l2filter_whitelist
 PSEUDOMODULES += lis2dh12_spi

--- a/tests/gps/Makefile
+++ b/tests/gps/Makefile
@@ -1,0 +1,14 @@
+# name of your application
+APPLICATION = gps
+
+include ../Makefile.tests_common
+
+USEMODULE += gps_serial
+
+# The MSP-430 toolchain lacks mktime and NAN
+BOARD_BLACKLIST += chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+
+# mips-malta is missing uart_init()
+BOARD_BLACKLIST += mips-malta
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/gps/main.c
+++ b/tests/gps/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     test
+ * @{
+ *
+ * @file
+ * @brief       RIOT GPS test application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+
+#include <stdio.h>
+
+#include "gps.h"
+#include "gps/serial.h"
+#include "periph/uart.h"
+
+static gps_serial_t gps;
+static const gps_serial_params_t gps_serial_params = { .uart=UART_DEV(1), .baudrate=9600 };
+
+int main(void)
+{
+    gps_serial_init(&gps, &gps_serial_params);
+
+    char lat[16];
+    char lon[16];
+
+    while(1) {
+        int res = gps_get_loc((gps_t*)&gps, lat, lon, 2000000LLU);
+        if (!res) {
+            printf("lat=%s lon=%s\n", lat, lon);
+        }
+        else {
+            printf("res=%i\n", res);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds a generic GPS API, and a driver for NMEW 0183 serial GPS receivers.

Tested with both the Microstack GPS module and an Quectel MC60 in stand-alone mode.

Waiting for ~#6772~.