### PR TITLE
boards/arduino-mkrfox1200: add initial implementation (without SigFox)

### DIFF
--- a/boards/arduino-mkrfox1200/Makefile
+++ b/boards/arduino-mkrfox1200/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/arduino-mkr
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-mkrfox1200/Makefile.dep
+++ b/boards/arduino-mkrfox1200/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/arduino-mkr/Makefile.dep

--- a/boards/arduino-mkrfox1200/Makefile.features
+++ b/boards/arduino-mkrfox1200/Makefile.features
@@ -1,0 +1,3 @@
+include $(RIOTBOARD)/common/arduino-mkr/Makefile.features
+
+-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/arduino-mkrfox1200/Makefile.include
+++ b/boards/arduino-mkrfox1200/Makefile.include
@@ -1,0 +1,10 @@
+USEMODULE += boards_common_arduino-mkr
+
+ifeq ($(PROGRAMMER),jlink)
+  export MKR_JLINK_DEVICE = atsamd21
+endif
+
+include $(RIOTBOARD)/common/arduino-mkr/Makefile.include
+
+# add arduino-mkrfox1200 include path
+INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/arduino-mkrfox1200/doc.txt
+++ b/boards/arduino-mkrfox1200/doc.txt
@@ -1,0 +1,34 @@
+/**
+ * @defgroup    boards_arduino-mkrfox1200 Arduino MKRFOX1200
+ * @ingroup     boards
+ * @brief       Support for the Arduino MKRFOX1200 board.
+ *
+ * ### General information
+ *
+ * The [Arduino MKRFOX1200](https://www.arduino.cc/en/Main.ArduinoBoardMKRFox1200) board is
+ * a learning and development board that provides Sigfox connectivity and is
+ * powered by an Atmel SAMD21 microcontroller.
+ *
+ * ### Pinout
+ *
+ * <img src="https://www.arduino.cc/en/uploads/Main/MKR1000_pinout.png"
+ *      alt="Arduino MKRFOX1200 pinout" style="height:800px;"/>
+ *
+ * ### Flash the board
+ *
+ * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
+ *    When the board is in bootloader mode, the user led (green) oscillates
+ *    smoothly.
+ *
+ *
+ * 2. Use `BOARD=arduino-mkrfox1200` with the `make` command.<br/>
+ *    Example with `hello-world` application:
+ * ```
+ *      make BOARD=arduino-mkrfox1200 -C examples/hello-world flash
+ * ```
+ *
+ * ### Accessing STDIO via UART
+ *
+ * To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
+ * the RX/TX pins on the board.
+ */

--- a/boards/arduino-mkrfox1200/include/board.h
+++ b/boards/arduino-mkrfox1200/include/board.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-mkrfox1200
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Arduino MKRFOX1200
+ *              board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "board_common.h"
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 6 on this board
+ */
+#define ARDUINO_LED         (6U)
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 20)
+
+#define LED_PORT            PORT->Group[PA]
+#define LED0_MASK           (1 << 20)
+
+#define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-duemilanove \
                              arduino-mega2560 \
                              arduino-mkr1000 \
+                             arduino-mkrfox1200 \
                              arduino-mkrzero \
                              arduino-uno \
                              arduino-zero \
@@ -82,6 +83,7 @@ DISABLE_TEST_FOR_ARM7 := tests-relic tests-cpp_%
 ARM_CORTEX_M_BOARDS := airfy-beacon \
                        arduino-due \
                        arduino-mkr1000 \
+                       arduino-mkrfox1200 \
                        arduino-mkrzero \
                        arduino-zero \
                        b-l072z-lrwan1 \


### PR DESCRIPTION
This PR adds support for the mkrfox1200 board. It will be possible to use SigFox with it when #7087 is merged.

~~Since #6881 factorize the ports with mkr1000, this PR is based on it.~~