### PR TITLE
dist: tools: add headerguard check script

### DIFF
--- a/boards/avsextrem/include/board.h
+++ b/boards/avsextrem/include/board.h
@@ -22,8 +22,8 @@
  */
 
 
-#ifndef BOARDCONF_H
-#define BOARDCONF_H
+#ifndef BOARD_H
+#define BOARD_H
 #include "bitarithm.h"
 #include "msba2_common.h"
 
@@ -60,4 +60,4 @@ void init_clks1(void);
 #endif
 
 /** @} */
-#endif /* BOARDCONF_H */
+#endif /* BOARD_H */

--- a/boards/calliope-mini/include/board.h
+++ b/boards/calliope-mini/include/board.h
@@ -73,5 +73,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/chronos/include/board.h
+++ b/boards/chronos/include/board.h
@@ -18,8 +18,8 @@
  * @author      unknown
  */
 
-#ifndef CHRONOS_BOARD_H
-#define CHRONOS_BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include <stdint.h>
 
@@ -59,5 +59,5 @@ extern "C" {
 }
 #endif
 
-#endif /* CHRONOS_BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/ek-lm4f120xl/include/board.h
+++ b/boards/ek-lm4f120xl/include/board.h
@@ -64,5 +64,5 @@ extern void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -64,5 +64,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/microbit/include/board.h
+++ b/boards/microbit/include/board.h
@@ -89,5 +89,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/mips-malta/include/board.h
+++ b/boards/mips-malta/include/board.h
@@ -20,8 +20,8 @@
  * @author      Neil Jones <neil.jones@imgtec.com>
  */
 
-#ifndef _BOARD_H_
-#define _BOARD_H_
+#ifndef BOARD_H
+#define BOARD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,5 +42,5 @@ void board_init(void);
 }
 #endif
 
-#endif /* _BOARD_H_ */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/mips-malta/include/periph_conf.h
+++ b/boards/mips-malta/include/periph_conf.h
@@ -20,8 +20,8 @@
  * @author      Neil Jones <neil.jones@imgtec.com>
  */
 
-#ifndef _PERIPH_CONF_H_
-#define _PERIPH_CONF_H_
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,5 +55,5 @@ extern "C" {
 }
 #endif
 
-#endif /*_PERIPH_CONF_H_*/
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/msb-430-common/drivers/include/sht11-board.h
+++ b/boards/msb-430-common/drivers/include/sht11-board.h
@@ -6,8 +6,8 @@
  * directory for more details.
  */
 
-#ifndef SHT11BOARD_H
-#define SHT11BOARD_H
+#ifndef SHT11_BOARD_H
+#define SHT11_BOARD_H
 
 /**
  * @ingroup     msb_430h
@@ -46,4 +46,4 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* SHT11BOARD_H */
+#endif /* SHT11_BOARD_H */

--- a/boards/msb-430/include/board.h
+++ b/boards/msb-430/include/board.h
@@ -31,8 +31,8 @@
  * @author      Freie Universität Berlin, Computer Systems & Telematics, FeuerWhere project
  */
 
-#ifndef MSB_BOARD_H
-#define MSB_BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "board_common.h"
 
@@ -64,4 +64,4 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /*  MSB_BOARD_H */
+#endif /* BOARD_H */

--- a/boards/msb-430h/include/board.h
+++ b/boards/msb-430h/include/board.h
@@ -19,8 +19,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef MSB_BOARD_H
-#define MSB_BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "board_common.h"
 
@@ -52,4 +52,4 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* MSB_BOARD_H */
+#endif /* BOARD_H */

--- a/boards/msba2-common/drivers/include/sht11-board.h
+++ b/boards/msba2-common/drivers/include/sht11-board.h
@@ -6,8 +6,8 @@
  * directory for more details.
  */
 
-#ifndef SHT11BOARD_H
-#define SHT11BOARD_H
+#ifndef SHT11_BOARD_H
+#define SHT11_BOARD_H
 
 /**
  * @ingroup     lpc2387
@@ -53,4 +53,4 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* SHT11BOARD_H */
+#endif /* SHT11_BOARD_H */

--- a/boards/msba2-common/include/msba2_common.h
+++ b/boards/msba2-common/include/msba2_common.h
@@ -43,4 +43,4 @@ static inline void pllfeed(void)
 #endif
 
 /** @} */
-#endif /*  MSBA2_COMMON_H */
+#endif /* MSBA2_COMMON_H */

--- a/boards/msba2-common/tools/src/control_2xxx.h
+++ b/boards/msba2-common/tools/src/control_2xxx.h
@@ -22,4 +22,4 @@
 void hard_reset_to_bootloader(void);
 void hard_reset_to_user_code(void);
 
-#endif /*  CONTROL_2XXX_H */
+#endif /* CONTROL_2XXX_H */

--- a/boards/msba2-common/tools/src/lpc2k_pgm.h
+++ b/boards/msba2-common/tools/src/lpc2k_pgm.h
@@ -27,4 +27,4 @@ void change_baud(const char *baud_name);
 */
 void signal_terminal(void);
 
-#endif /*  LPC2K_PGM_H */
+#endif /* LPC2K_PGM_H */

--- a/boards/msba2-common/tools/src/serial.h
+++ b/boards/msba2-common/tools/src/serial.h
@@ -34,4 +34,4 @@ void set_rts(int val);
 void set_dtr(int val);
 void change_baud(const char *baud_name);
 
-#endif /*  SERIAL_H */
+#endif /* SERIAL_H */

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -19,8 +19,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef MULLE_PERIPH_CONF_H
-#define MULLE_PERIPH_CONF_H
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #include "periph_cpu.h"
 
@@ -374,5 +374,5 @@ static const spi_conf_t spi_config[] = {
 }
 #endif
 
-#endif /* MULLE_PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/nrf51dongle/include/board.h
+++ b/boards/nrf51dongle/include/board.h
@@ -72,5 +72,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/nrf52840dk/include/board.h
+++ b/boards/nrf52840dk/include/board.h
@@ -78,5 +78,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/nrf52840dk/include/periph_conf.h
+++ b/boards/nrf52840dk/include/periph_conf.h
@@ -98,4 +98,4 @@ static const spi_conf_t spi_config[] = {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */

--- a/boards/nrf52dk/include/board.h
+++ b/boards/nrf52dk/include/board.h
@@ -77,5 +77,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/nrf52dk/include/periph_conf.h
+++ b/boards/nrf52dk/include/periph_conf.h
@@ -98,4 +98,4 @@ static const spi_conf_t spi_config[] = {
 }
 #endif
 
-#endif /* __PERIPH_CONF_H */
+#endif /* PERIPH_CONF_H */

--- a/boards/nrf6310/include/board.h
+++ b/boards/nrf6310/include/board.h
@@ -63,5 +63,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/nucleo-f411/include/board.h
+++ b/boards/nucleo-f411/include/board.h
@@ -18,8 +18,8 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef BOARD_H_
-#define BOARD_H_
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "board_common.h"
 
@@ -41,5 +41,5 @@ extern "C" {
 }
 #endif
 
-#endif /* BOARD_H_ */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/nucleo-f411/include/periph_conf.h
+++ b/boards/nucleo-f411/include/periph_conf.h
@@ -16,8 +16,8 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef PERIPH_CONF_H_
-#define PERIPH_CONF_H_
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #include "periph_cpu.h"
 
@@ -244,5 +244,5 @@ static const spi_conf_t spi_config[] = {
 }
 #endif
 
-#endif /* PERIPH_CONF_H_ */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/nucleo32-f031/include/board.h
+++ b/boards/nucleo32-f031/include/board.h
@@ -20,8 +20,8 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef BOARD_H_
-#define BOARD_H_
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "board_common.h"
 
@@ -33,5 +33,5 @@ extern "C" {
 }
 #endif
 
-#endif /* BOARD_H_ */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/nucleo32-f031/include/periph_conf.h
+++ b/boards/nucleo32-f031/include/periph_conf.h
@@ -17,8 +17,8 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CONF_H_
-#define PERIPH_CONF_H_
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #include "periph_cpu.h"
 
@@ -200,5 +200,5 @@ static const spi_conf_t spi_config[] = {
 }
 #endif
 
-#endif /* PERIPH_CONF_H_ */
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/pca10000/include/board.h
+++ b/boards/pca10000/include/board.h
@@ -72,5 +72,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/pic32-wifire/include/board.h
+++ b/boards/pic32-wifire/include/board.h
@@ -25,8 +25,8 @@
  * @author      Neil Jones <Neil.Jones@imgtec.com>
  */
 
-#ifndef _BOARD_H_
-#define _BOARD_H_
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "periph_conf.h"
 
@@ -56,5 +56,5 @@ void board_init(void);
 }
 #endif
 
-#endif /* _BOARD_H_ */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/pic32-wifire/include/periph_conf.h
+++ b/boards/pic32-wifire/include/periph_conf.h
@@ -19,8 +19,8 @@
  *
  * @author       Neil Jones <Neil.Jones@imgtec.com>
  */
-#ifndef _PERIPH_CONF_H_
-#define _PERIPH_CONF_H_
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
 
 #include "periph_cpu.h"
 
@@ -60,5 +60,5 @@ extern "C" {
 }
 #endif
 
-#endif
+#endif /* PERIPH_CONF_H */
 /** @} */

--- a/boards/qemu-i386/include/board.h
+++ b/boards/qemu-i386/include/board.h
@@ -18,8 +18,8 @@
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef QEMU_I386_BOARD_H
-#define QEMU_I386_BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,7 +37,7 @@ extern "C" {
 }
 #endif
 
-#endif /* QEMU_I386_BOARD_H */
+#endif /* BOARD_H */
 
 /**
  * @}

--- a/boards/qemu-i386/include/cpu_conf.h
+++ b/boards/qemu-i386/include/cpu_conf.h
@@ -16,8 +16,8 @@
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef QEMU_I386_CPU_CONF_H
-#define QEMU_I386_CPU_CONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,6 +35,6 @@ extern "C" {
 }
 #endif
 
-#endif /* QEMU_I386_CPU_CONF_H */
+#endif /* CPU_CONF_H */
 
 /** @} */

--- a/boards/saml21-xpro/include/board.h
+++ b/boards/saml21-xpro/include/board.h
@@ -55,5 +55,5 @@ void board_init(void);
 }
 #endif
 
-#endif /** BOARD_H */
+#endif /* BOARD_H */
 /** @} */

--- a/boards/telosb/include/board.h
+++ b/boards/telosb/include/board.h
@@ -25,8 +25,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef TELOSB_BOARD_H
-#define TELOSB_BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "cpu.h"
 
@@ -116,4 +116,4 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /*  TELOSB_BOARD_H */
+#endif /* BOARD_H */

--- a/boards/wsn430-v1_3b/include/board.h
+++ b/boards/wsn430-v1_3b/include/board.h
@@ -25,8 +25,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef WSN_BOARD_H
-#define WSN_BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "board_common.h"
 
@@ -60,4 +60,4 @@ extern "C" {
 #include <msp430x16x.h>
 
 /** @} */
-#endif /* WSN_BOARD_H */
+#endif /* BOARD_H */

--- a/boards/wsn430-v1_4/include/board.h
+++ b/boards/wsn430-v1_4/include/board.h
@@ -25,8 +25,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef WSN_BOARD_H
-#define WSN_BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 #include "board_common.h"
 
@@ -60,4 +60,4 @@ extern "C" {
 #include <msp430x16x.h>
 
 /** @} */
-#endif /*  WSN_BOARD_H */
+#endif /* BOARD_H */

--- a/boards/x86-multiboot-common/include/multiboot.h
+++ b/boards/x86-multiboot-common/include/multiboot.h
@@ -234,5 +234,5 @@ typedef struct multiboot_mod_list multiboot_module_t;
 }
 #endif
 
-#endif  /** ! MULTIBOOT_H */
+#endif /* MULTIBOOT_H */
 /** @} */

--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -7,8 +7,8 @@
  * directory for more details.
  */
 
-#ifndef Z1_BOARD_H
-#define Z1_BOARD_H
+#ifndef BOARD_H
+#define BOARD_H
 
 /**
  * @defgroup    boards_z1 Zolertia Z1
@@ -123,4 +123,4 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /*  Z1_BOARD_H */
+#endif /* BOARD_H */

--- a/core/include/arch/irq_arch.h
+++ b/core/include/arch/irq_arch.h
@@ -22,8 +22,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef IRQ_ARCH_H
-#define IRQ_ARCH_H
+#ifndef ARCH_IRQ_ARCH_H
+#define ARCH_IRQ_ARCH_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -77,5 +77,5 @@ int irq_arch_in(void);
 }
 #endif
 
-#endif /* IRQ_ARCH_H */
+#endif /* ARCH_IRQ_ARCH_H */
 /** @} */

--- a/core/include/arch/panic_arch.h
+++ b/core/include/arch/panic_arch.h
@@ -16,8 +16,8 @@
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
 
-#ifndef PANIC_ARCH_H
-#define PANIC_ARCH_H
+#ifndef ARCH_PANIC_ARCH_H
+#define ARCH_PANIC_ARCH_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -35,5 +35,5 @@ void panic_arch(void);
 }
 #endif
 
-#endif /* REBOOT_ARCH_H */
+#endif /* ARCH_PANIC_ARCH_H */
 /** @} */

--- a/core/include/arch/thread_arch.h
+++ b/core/include/arch/thread_arch.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef THREAD_ARCH_H
-#define THREAD_ARCH_H
+#ifndef ARCH_THREAD_ARCH_H
+#define ARCH_THREAD_ARCH_H
 
 #include "kernel_defines.h"
 
@@ -92,5 +92,5 @@ void thread_arch_yield(void);
 }
 #endif
 
-#endif /* THREAD_ARCH_H */
+#endif /* ARCH_THREAD_ARCH_H */
 /** @} */

--- a/core/include/native_sched.h
+++ b/core/include/native_sched.h
@@ -20,8 +20,8 @@
  * @author      Raphael Hiesgen <raphael.hiesgen@haw-hamburg.de>
  */
 
-#ifndef NATIVE_SCHEDULER_H
-#define NATIVE_SCHEDULER_H
+#ifndef NATIVE_SCHED_H
+#define NATIVE_SCHED_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,5 +54,5 @@ inline int sched_yield(void)
 }
 #endif
 
-#endif /* NATIVE_SCHEDULER_H */
+#endif /* NATIVE_SCHED_H */
 /** @} */

--- a/core/include/priority_queue.h
+++ b/core/include/priority_queue.h
@@ -16,8 +16,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef QUEUE_H
-#define QUEUE_H
+#ifndef PRIORITY_QUEUE_H
+#define PRIORITY_QUEUE_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -132,4 +132,4 @@ void priority_queue_print_node(priority_queue_t *root);
 #endif
 
 /** @} */
-#endif /* QUEUE_H */
+#endif /* PRIORITY_QUEUE_H */

--- a/core/include/rmutex.h
+++ b/core/include/rmutex.h
@@ -18,8 +18,8 @@
  *
  */
 
-#ifndef RMUTEX_H_
-#define RMUTEX_H_
+#ifndef RMUTEX_H
+#define RMUTEX_H
 
 #include <stdatomic.h>
 
@@ -106,5 +106,5 @@ void rmutex_unlock(rmutex_t *rmutex);
 }
 #endif
 
-#endif /* RMUTEX_H_ */
+#endif /* RMUTEX_H */
 /** @} */

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -77,8 +77,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef SCHEDULER_H
-#define SCHEDULER_H
+#ifndef SCHED_H
+#define SCHED_H
 
 #include <stddef.h>
 #include "kernel_defines.h"
@@ -202,5 +202,5 @@ void sched_register_cb(void (*callback)(uint32_t, uint32_t));
 }
 #endif
 
-#endif /* SCHEDULER_H */
+#endif /* SCHED_H */
 /** @} */

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -47,8 +47,8 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef THREAD_FLAG_H
-#define THREAD_FLAG_H
+#ifndef THREAD_FLAGS_H
+#define THREAD_FLAGS_H
 
 #include "kernel_types.h"
 #include "sched.h"  /* for thread_t typedef */
@@ -152,4 +152,4 @@ int thread_flags_wake(thread_t *thread);
 #endif
 
 /** @} */
-#endif /* THREAD_FLAG_H */
+#endif /* THREAD_FLAGS_H */

--- a/cpu/atmega_common/avr-libc-extra/inttypes.h
+++ b/cpu/atmega_common/avr-libc-extra/inttypes.h
@@ -15,8 +15,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef RIOT_INTTYPES_H
-#define RIOT_INTTYPES_H
+#ifndef INTTYPES_H
+#define INTTYPES_H
 
 #include_next <inttypes.h>
 
@@ -33,5 +33,5 @@ extern "C" {
 }
 #endif
 
-#endif /* RIOT_INTTYPES_H */
+#endif /* INTTYPES_H */
 /** @} */

--- a/cpu/atmega_common/avr-libc-extra/time.h
+++ b/cpu/atmega_common/avr-libc-extra/time.h
@@ -524,7 +524,7 @@ extern "C" {
 }
 #endif
 
-#endif              /* TIME_H  */
+#endif /* TIME_H */
 
 /**
 \endcond

--- a/cpu/atmega_common/include/cpu.h
+++ b/cpu/atmega_common/include/cpu.h
@@ -24,8 +24,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef ATMEGA_COMMON_H
-#define ATMEGA_COMMON_H
+#ifndef CPU_H
+#define CPU_H
 
 #include <stdio.h>
 #include <stdint.h>
@@ -83,5 +83,5 @@ static inline void cpu_print_last_instruction(void)
 }
 #endif
 
-#endif /* ATMEGA_COMMON_H */
+#endif /* CPU_H */
 /** @} */

--- a/cpu/atmega_common/include/sys/stat.h
+++ b/cpu/atmega_common/include/sys/stat.h
@@ -12,8 +12,8 @@
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef SYS_STAT_H_
-#define SYS_STAT_H_
+#ifndef SYS_STAT_H
+#define SYS_STAT_H
 
 #include <time.h> /* for struct timespec */
 #include <sys/types.h> /* for fsblkcnt_t, fsfilcnt_t */
@@ -115,6 +115,6 @@ int    utimensat(int, const char *, const struct timespec [2], int);
 }
 #endif
 
-#endif /* SYS_STAT_H_ */
+#endif /* SYS_STAT_H */
 
 /** @} */

--- a/cpu/atmega_common/include/sys/time.h
+++ b/cpu/atmega_common/include/sys/time.h
@@ -6,8 +6,8 @@
  * directory for more details.
  */
 
-#ifndef ATMEGA_TIME_H
-#define ATMEGA_TIME_H
+#ifndef SYS_TIME_H
+#define SYS_TIME_H
 
 #include <sys/types.h>
 #include <time.h>
@@ -29,4 +29,4 @@ struct timeval {
 }
 #endif
 
-#endif /* ATMEGA_TIME_H */
+#endif /* SYS_TIME_H */

--- a/cpu/atmega_common/include/sys/types.h
+++ b/cpu/atmega_common/include/sys/types.h
@@ -7,8 +7,8 @@
  * directory for more details.
  */
 
-#ifndef SYS_TYPES_H_
-#define SYS_TYPES_H_
+#ifndef SYS_TYPES_H
+#define SYS_TYPES_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -44,4 +44,4 @@ typedef     uint32_t useconds_t;  /**< Used for time in microseconds */
 }
 #endif
 
-#endif /* SYS_TYPES_H_ */
+#endif /* SYS_TYPES_H */

--- a/cpu/cc2538/include/cc2538.h
+++ b/cpu/cc2538/include/cc2538.h
@@ -16,8 +16,8 @@
  * @author          Ian Martin <ian@locicontrols.com>
  */
 
-#ifndef _CC2538_
-#define _CC2538_
+#ifndef CC2538_H
+#define CC2538_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -815,6 +815,6 @@ typedef volatile uint32_t cc2538_reg_t; /**< Least-significant 32 bits of the IE
 }
 #endif
 
-#endif /* _CC2538_ */
+#endif /* CC2538_H */
 
 /*@}*/

--- a/cpu/cc2538/include/cc2538_gptimer.h
+++ b/cpu/cc2538/include/cc2538_gptimer.h
@@ -17,8 +17,8 @@
  * @author          Ian Martin <ian@locicontrols.com>
  */
 
-#ifndef GPTIMER_H
-#define GPTIMER_H
+#ifndef CC2538_GPTIMER_H
+#define CC2538_GPTIMER_H
 
 #include <stdint.h>
 
@@ -180,6 +180,6 @@ void isr_timer3_chan1(void);                /**< RIOT Timer 3 Channel 1 Interrup
 } /* end extern "C" */
 #endif
 
-#endif /* GPTIMER_H */
+#endif /* CC2538_GPTIMER_H */
 
 /* @} */

--- a/cpu/cc26x0/include/cc26x0.h
+++ b/cpu/cc26x0/include/cc26x0.h
@@ -16,8 +16,8 @@
  * @author          Leon M. George <leon@georgemail.eu>
  */
 
-#ifndef CC26x0_H
-#define CC26x0_H
+#ifndef CC26X0_H
+#define CC26X0_H
 
 #include <stdint.h>
 
@@ -112,6 +112,6 @@ typedef enum IRQn
 }
 #endif
 
-#endif /* CC26x0_H */
+#endif /* CC26X0_H */
 
 /*@}*/

--- a/cpu/cc26x0/include/cc26x0_aux.h
+++ b/cpu/cc26x0/include/cc26x0_aux.h
@@ -13,8 +13,8 @@
  * @brief           CC26x0 AUX register definitions
  */
 
-#ifndef CC26x0_AUX_H
-#define CC26x0_AUX_H
+#ifndef CC26X0_AUX_H
+#define CC26X0_AUX_H
 
 #include <stdbool.h>
 
@@ -253,6 +253,6 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26x0_AUX_H */
+#endif /* CC26X0_AUX_H */
 
 /** @}*/

--- a/cpu/cc26x0/include/cc26x0_ccfg.h
+++ b/cpu/cc26x0/include/cc26x0_ccfg.h
@@ -13,8 +13,8 @@
  * @brief           CC26x0 CCFG register definitions
  */
 
-#ifndef CC26x0_CCFG_H
-#define CC26x0_CCFG_H
+#ifndef CC26X0_CCFG_H
+#define CC26X0_CCFG_H
 
 #include <cc26x0.h>
 
@@ -65,6 +65,6 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26x0_CCFG_H */
+#endif /* CC26X0_CCFG_H */
 
 /*@}*/

--- a/cpu/cc26x0/include/cc26x0_fcfg.h
+++ b/cpu/cc26x0/include/cc26x0_fcfg.h
@@ -13,8 +13,8 @@
  * @brief           CC26x0 FCFG register definitions
  */
 
-#ifndef CC26x0_FCFG_H
-#define CC26x0_FCFG_H
+#ifndef CC26X0_FCFG_H
+#define CC26X0_FCFG_H
 
 #include <cc26x0.h>
 
@@ -134,6 +134,6 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26x0_FCFG_H */
+#endif /* CC26X0_FCFG_H */
 
 /*@}*/

--- a/cpu/cc26x0/include/cc26x0_gpio.h
+++ b/cpu/cc26x0/include/cc26x0_gpio.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef CC26x0_GPIO_H
-#define CC26x0_GPIO_H
+#ifndef CC26X0_GPIO_H
+#define CC26X0_GPIO_H
 
 #include "cc26x0.h"
 
@@ -58,6 +58,6 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26x0_GPIO_H */
+#endif /* CC26X0_GPIO_H */
 
 /** @} */

--- a/cpu/cc26x0/include/cc26x0_gpt.h
+++ b/cpu/cc26x0/include/cc26x0_gpt.h
@@ -16,8 +16,8 @@
  * @author          Leon George <leon@georgemail.eu>
  */
 
-#ifndef CC26x0_GPT_H
-#define CC26x0_GPT_H
+#ifndef CC26X0_GPT_H
+#define CC26X0_GPT_H
 
 #include "cc26x0.h"
 
@@ -207,5 +207,5 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26x0_GPT_H */
+#endif /* CC26X0_GPT_H */
 /** @} */

--- a/cpu/cc26x0/include/cc26x0_i2c.h
+++ b/cpu/cc26x0/include/cc26x0_i2c.h
@@ -16,8 +16,8 @@
  * @author          Leon George <leon@georgemail.eu>
  */
 
-#ifndef CC26x0_I2C_H
-#define CC26x0_I2C_H
+#ifndef CC26X0_I2C_H
+#define CC26X0_I2C_H
 
 #include "cc26x0.h"
 
@@ -67,6 +67,6 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26x0_I2C_H */
+#endif /* CC26X0_I2C_H */
 
 /*@}*/

--- a/cpu/cc26x0/include/cc26x0_ioc.h
+++ b/cpu/cc26x0/include/cc26x0_ioc.h
@@ -16,8 +16,8 @@
  * @author          Leon George <leon@georgemail.eu>
  */
 
-#ifndef CC26x0_IOC_H
-#define CC26x0_IOC_H
+#ifndef CC26X0_IOC_H
+#define CC26X0_IOC_H
 
 #include "cc26x0.h"
 
@@ -159,6 +159,6 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26x0_IOC_H */
+#endif /* CC26X0_IOC_H */
 
 /*@}*/

--- a/cpu/cc26x0/include/cc26x0_prcm.h
+++ b/cpu/cc26x0/include/cc26x0_prcm.h
@@ -14,8 +14,8 @@
  * @brief           CC26x0 PRCM register definitions
  */
 
-#ifndef CC26x0_PRCM_H
-#define CC26x0_PRCM_H
+#ifndef CC26X0_PRCM_H
+#define CC26X0_PRCM_H
 
 #include <cc26x0.h>
 
@@ -317,6 +317,6 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26x0_PRCM_H */
+#endif /* CC26X0_PRCM_H */
 
 /*@}*/

--- a/cpu/cc26x0/include/cc26x0_uart.h
+++ b/cpu/cc26x0/include/cc26x0_uart.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef CC26x0_UART_H
-#define CC26x0_UART_H
+#ifndef CC26X0_UART_H
+#define CC26X0_UART_H
 
 #include "cc26x0.h"
 
@@ -129,5 +129,5 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26x8_UART_H */
+#endif /* CC26X0_UART_H */
 /** @} */

--- a/cpu/cc26x0/include/cc26x0_vims.h
+++ b/cpu/cc26x0/include/cc26x0_vims.h
@@ -14,8 +14,8 @@
  * @brief           CC26x0 VIMS register definitions
  */
 
-#ifndef CC26x0_VIMS_H
-#define CC26x0_VIMS_H
+#ifndef CC26X0_VIMS_H
+#define CC26X0_VIMS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -232,6 +232,6 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26x0_VIMS_H */
+#endif /* CC26X0_VIMS_H */
 
 /*@}*/

--- a/cpu/cc26x0/include/cc26x0_wdt.h
+++ b/cpu/cc26x0/include/cc26x0_wdt.h
@@ -14,8 +14,8 @@
  * @brief           CC26x0 WDT register definitions
  */
 
-#ifndef CC26x0_WDT_H
-#define CC26x0_WDT_H
+#ifndef CC26X0_WDT_H
+#define CC26X0_WDT_H
 
 #include <cc26x0.h>
 
@@ -51,6 +51,6 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26x0_WDT_H */
+#endif /* CC26X0_WDT_H */
 
 /*@}*/

--- a/cpu/cc430/include/cc430-adc.h
+++ b/cpu/cc430/include/cc430-adc.h
@@ -49,4 +49,4 @@ extern uint8_t  adc12_data_ready;
 }
 #endif
 
-#endif
+#endif /* CC430_ADC_H */

--- a/cpu/cc430/include/cc430-rtc.h
+++ b/cpu/cc430/include/cc430-rtc.h
@@ -48,4 +48,4 @@ void rtc_remove_alarm(void);
 }
 #endif
 
-#endif
+#endif /* CC430_RTC_H */

--- a/cpu/cc430/include/periph_cpu.h
+++ b/cpu/cc430/include/periph_cpu.h
@@ -16,8 +16,8 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef CPU_PERIPH_H
-#define CPU_PERIPH_H
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
 
 #include "cpu.h"
 #include "cc430_regs.h"
@@ -32,5 +32,5 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_PERIPH_H */
+#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/cortexm_common/include/vectors_cortexm.h
+++ b/cpu/cortexm_common/include/vectors_cortexm.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef VECTORS_DEFAULT_H
-#define VECTORS_DEFAULT_H
+#ifndef VECTORS_CORTEXM_H
+#define VECTORS_CORTEXM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,5 +122,5 @@ void dummy_handler_default(void);
 }
 #endif
 
-#endif /* VECTORS_DEFAULT_H */
+#endif /* VECTORS_CORTEXM_H */
 /** @} */

--- a/cpu/ezr32wg/include/cpu_conf.h
+++ b/cpu/ezr32wg/include/cpu_conf.h
@@ -46,5 +46,5 @@ extern "C" {
 }
 #endif
 
-#endif /* __CPU_CONF_H */
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/ezr32wg/include/periph_cpu.h
+++ b/cpu/ezr32wg/include/periph_cpu.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef CPU_PERIPH_H
-#define CPU_PERIPH_H
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
 
 #include "cpu.h"
 
@@ -137,5 +137,5 @@ typedef struct {
 }
 #endif
 
-#endif /* CPU_PERIPH_H */
+#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/kinetis_common/include/mcg.h
+++ b/cpu/kinetis_common/include/mcg.h
@@ -97,8 +97,8 @@
  * @author      Johann Fischer <j.fischer@phytec.de>
  */
 
-#ifndef MCG_CPU_H
-#define MCG_CPU_H
+#ifndef MCG_H
+#define MCG_H
 
 #include "periph_conf.h"
 
@@ -133,4 +133,4 @@ int kinetis_mcg_set_mode(kinetis_mcg_mode_t mode);
 #endif /* KINETIS_CPU_USE_MCG */
 /** @} */
 
-#endif /* MCG_CPU_H */
+#endif /* MCG_H */

--- a/cpu/lpc2387/include/cpu_conf.h
+++ b/cpu/lpc2387/include/cpu_conf.h
@@ -7,8 +7,8 @@
  */
 
 
-#ifndef CPUCONF_H
-#define CPUCONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,4 +68,4 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* CPUCONF_H */
+#endif /* CPU_CONF_H */

--- a/cpu/mips32r2_common/include/cpu.h
+++ b/cpu/mips32r2_common/include/cpu.h
@@ -18,8 +18,8 @@
  * @author      Neil Jones <neil.jones@imgtec.com>
  */
 
-#ifndef CPU_H_
-#define CPU_H_
+#ifndef CPU_H
+#define CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,5 +44,5 @@ static inline void cpu_print_last_instruction(void)
 }
 #endif
 
-#endif
+#endif /* CPU_H */
 /** @} */

--- a/cpu/mips32r2_common/include/cpu_conf.h
+++ b/cpu/mips32r2_common/include/cpu_conf.h
@@ -6,8 +6,8 @@
  * directory for more details.
  */
 
-#ifndef _CPU_CONF_H_
-#define _CPU_CONF_H_
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 /**
  * @defgroup    cpu_mips32r2_commom MIPS32R2 Common
@@ -64,5 +64,5 @@ extern "C" {
 }
 #endif
 
-#endif
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/mips32r2_common/include/eic_irq.h
+++ b/cpu/mips32r2_common/include/eic_irq.h
@@ -17,8 +17,8 @@
  * @author      Neil Jones <neil.jones@imgtec.com>
  */
 
-#ifndef EIC_IRQ_H_
-#define EIC_IRQ_H_
+#ifndef EIC_IRQ_H
+#define EIC_IRQ_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,5 +65,5 @@ void eic_irq_ack(int irq_num);
 }
 #endif
 
-#endif
+#endif /* EIC_IRQ_H */
 /** @} */

--- a/cpu/mips_pic32mx/include/cpu.h
+++ b/cpu/mips_pic32mx/include/cpu.h
@@ -20,8 +20,8 @@
  * @author      Neil Jones <neil.jones@imgtec.com>
  */
 
-#ifndef _CPU_H_
-#define _CPU_H_
+#ifndef CPU_H
+#define CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,5 +51,5 @@ static inline void cpu_print_last_instruction(void)
 }
 #endif
 
-#endif
+#endif /* CPU_H */
 /** @} */

--- a/cpu/mips_pic32mx/include/cpu_conf.h
+++ b/cpu/mips_pic32mx/include/cpu_conf.h
@@ -19,8 +19,8 @@
  * @author      Neil Jones <neil.jones@imgtec.com>
  */
 
-#ifndef _CPU_CONF_H_
-#define _CPU_CONF_H_
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,5 +64,5 @@ extern "C" {
 }
 #endif
 
-#endif
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/mips_pic32mx/include/periph_cpu.h
+++ b/cpu/mips_pic32mx/include/periph_cpu.h
@@ -8,6 +8,9 @@
  *
  */
 
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
+
 #include "periph_cpu_common.h"
 
 #ifdef __cplusplus
@@ -17,3 +20,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* PERIPH_CPU_H */

--- a/cpu/mips_pic32mz/include/cpu.h
+++ b/cpu/mips_pic32mz/include/cpu.h
@@ -19,8 +19,8 @@
  * @author      Neil Jones <neil.jones@imgtec.com>
  */
 
-#ifndef CPU_H_
-#define CPU_H_
+#ifndef CPU_H
+#define CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,5 +50,5 @@ static inline void cpu_print_last_instruction(void)
 }
 #endif
 
-#endif
+#endif /* CPU_H */
 /** @} */

--- a/cpu/mips_pic32mz/include/cpu_conf.h
+++ b/cpu/mips_pic32mz/include/cpu_conf.h
@@ -19,8 +19,8 @@
  * @author      Neil Jones <neil.jones@imgtec.com>
  */
 
-#ifndef _CPU_CONF_H_
-#define _CPU_CONF_H_
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,5 +65,5 @@ extern "C" {
 }
 #endif
 
-#endif
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/mips_pic32mz/include/periph_cpu.h
+++ b/cpu/mips_pic32mz/include/periph_cpu.h
@@ -8,6 +8,9 @@
  *
  */
 
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
+
 #include "periph_cpu_common.h"
 
 #ifdef __cplusplus
@@ -17,3 +20,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* PERIPH_CPU_H */

--- a/cpu/msp430_common/include/cpu_conf.h
+++ b/cpu/msp430_common/include/cpu_conf.h
@@ -6,8 +6,8 @@
  * directory for more details.
  */
 
-#ifndef CPUCONF_H
-#define CPUCONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,4 +47,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPUCONF_H */
+#endif /* CPU_CONF_H */

--- a/cpu/msp430_common/include/stdatomic.h
+++ b/cpu/msp430_common/include/stdatomic.h
@@ -29,8 +29,8 @@
 
 /* This file was imported into RIOT from newlib 2.3.0 */
 
-#ifndef STDATOMIC_H_
-#define STDATOMIC_H_
+#ifndef STDATOMIC_H
+#define STDATOMIC_H
 
 #include <sys/cdefs.h>
 #include <sys/_types.h>
@@ -423,4 +423,4 @@ atomic_flag_clear(volatile atomic_flag *__object)
 }
 #endif
 
-#endif /* !_STDATOMIC_H_ */
+#endif /* STDATOMIC_H */

--- a/cpu/msp430_common/include/stdio.h
+++ b/cpu/msp430_common/include/stdio.h
@@ -17,8 +17,8 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se
  */
 
-#ifndef RIOT_MSP430_STDIO_H
-#define RIOT_MSP430_STDIO_H
+#ifndef STDIO_H
+#define STDIO_H
 
 /*
  * The MSP430 toolchain does not provide getchar in stdio.h.
@@ -41,4 +41,4 @@ int getchar(void);
 }
 #endif
 
-#endif /* RIOT_MSP430_STDIO_H */
+#endif /* STDIO_H */

--- a/cpu/msp430_common/include/stdlib.h
+++ b/cpu/msp430_common/include/stdlib.h
@@ -17,8 +17,8 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se
  */
 
-#ifndef RIOT_MSP430_STDLIB_H
-#define RIOT_MSP430_STDLIB_H
+#ifndef STDLIB_H
+#define STDLIB_H
 
 /*
  * The MSP430 toolchain does not provide malloc, free, calloc etc. in stdlib.h.
@@ -37,4 +37,4 @@ extern "C" {
 }
 #endif
 
-#endif /* RIOT_MSP430_STDLIB_H */
+#endif /* STDLIB_H */

--- a/cpu/msp430_common/include/sys/cdefs.h
+++ b/cpu/msp430_common/include/sys/cdefs.h
@@ -39,8 +39,8 @@
 
 /* This file was imported into RIOT from newlib 2.3.0 */
 
-#ifndef _SYS_CDEFS_H_
-#define _SYS_CDEFS_H_
+#ifndef SYS_CDEFS_H
+#define SYS_CDEFS_H
 
 #include <sys/features.h>
 #include <stddef.h>
@@ -708,4 +708,4 @@ extern "C" {
 }
 #endif
 
-#endif /* !_SYS_CDEFS_H_ */
+#endif /* SYS_CDEFS_H */

--- a/cpu/msp430_common/include/sys/features.h
+++ b/cpu/msp430_common/include/sys/features.h
@@ -20,8 +20,8 @@
 
 /* This file was imported into RIOT from newlib 2.3.0 */
 
-#ifndef _SYS_FEATURES_H
-#define _SYS_FEATURES_H
+#ifndef SYS_FEATURES_H
+#define SYS_FEATURES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -511,4 +511,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* _SYS_FEATURES_H */
+#endif /* SYS_FEATURES_H */

--- a/cpu/msp430_common/include/sys/stat.h
+++ b/cpu/msp430_common/include/sys/stat.h
@@ -18,8 +18,8 @@
 /* without the GCC pragma above #include_next will trigger a pedantic error */
 #include_next <sys/stat.h>
 #else
-#ifndef SYS_STAT_H_
-#define SYS_STAT_H_
+#ifndef SYS_STAT_H
+#define SYS_STAT_H
 
 #include <time.h> /* for struct timespec */
 #include <sys/types.h> /* for fsblkcnt_t, fsfilcnt_t */
@@ -121,7 +121,7 @@ int    utimensat(int, const char *, const struct timespec [2], int);
 }
 #endif
 
-#endif /* SYS_STAT_H_ */
+#endif /* SYS_STAT_H */
 
 #endif /* CPU_NATIVE */
 

--- a/cpu/msp430_common/include/sys/time.h
+++ b/cpu/msp430_common/include/sys/time.h
@@ -6,8 +6,8 @@
  * directory for more details.
  */
 
-#ifndef TIME_H
-#define TIME_H
+#ifndef SYS_TIME_H
+#define SYS_TIME_H
 
 #include "msp430_types.h"
 
@@ -19,4 +19,4 @@ extern "C" {
 }
 #endif
 
-#endif /* TIME_H */
+#endif /* SYS_TIME_H */

--- a/cpu/msp430_common/include/time.h
+++ b/cpu/msp430_common/include/time.h
@@ -17,8 +17,8 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef MSPGCC_TIME_H
-#define MSPGCC_TIME_H
+#ifndef TIME_H
+#define TIME_H
 
 #include <sys/types.h>
 #include "msp430_types.h"
@@ -47,5 +47,5 @@ struct tm {
 }
 #endif
 
-#endif
+#endif /* TIME_H */
 /** @} */

--- a/cpu/msp430fxyz/include/periph_cpu.h
+++ b/cpu/msp430fxyz/include/periph_cpu.h
@@ -16,8 +16,8 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef CPU_PERIPH_H
-#define CPU_PERIPH_H
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
 
 #include "cpu.h"
 #include "msp430_regs.h"
@@ -132,5 +132,5 @@ void gpio_periph_mode(gpio_t pin, bool enable);
 }
 #endif
 
-#endif /* CPU_PERIPH_H */
+#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -71,5 +71,5 @@ void native_async_read_add_handler(int fd, void *arg, native_async_read_callback
 }
 #endif
 
-#endif
+#endif /* ASYNC_READ_H */
 /** @} */

--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -17,8 +17,8 @@
  * @author  Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  */
 
-#ifndef _CPU_H
-#define _CPU_H
+#ifndef CPU_H
+#define CPU_H
 
 #include <stdio.h>
 
@@ -42,4 +42,4 @@ __attribute__((always_inline)) static inline void cpu_print_last_instruction(voi
 #endif
 
 /** @} */
-#endif //_CPU_H
+#endif /* CPU_H */

--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -13,8 +13,8 @@
  * @author  Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  * @}
  */
-#ifndef CPUCONF_H
-#define CPUCONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,4 +64,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPUCONF_H */
+#endif /* CPU_CONF_H */

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -16,8 +16,8 @@
  * @author  Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  */
 
-#ifndef _NATIVE_INTERNAL_H
-#define _NATIVE_INTERNAL_H
+#ifndef NATIVE_INTERNAL_H
+#define NATIVE_INTERNAL_H
 
 #include <signal.h>
 #include <stdio.h>
@@ -188,4 +188,4 @@ int unregister_interrupt(int sig);
 #include "sched.h"
 
 /** @} */
-#endif /* _NATIVE_INTERNAL_H */
+#endif /* NATIVE_INTERNAL_H */

--- a/cpu/native/include/netdev_tap_params.h
+++ b/cpu/native/include/netdev_tap_params.h
@@ -16,8 +16,8 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NETDEV_TAP_PARAMS_H_
-#define NETDEV_TAP_PARAMS_H_
+#ifndef NETDEV_TAP_PARAMS_H
+#define NETDEV_TAP_PARAMS_H
 
 #include "netdev_tap.h"
 
@@ -46,5 +46,5 @@ extern netdev_tap_params_t netdev_tap_params[NETDEV_TAP_MAX];
 }
 #endif
 
-#endif /* NETDEV_TAP_PARAMS_H_ */
+#endif /* NETDEV_TAP_PARAMS_H */
 /** @} */

--- a/cpu/native/include/tty_uart.h
+++ b/cpu/native/include/tty_uart.h
@@ -37,5 +37,5 @@ void tty_uart_setup(uart_t uart, const char *name);
 }
 #endif
 
-#endif
+#endif /* TTY_UART_H */
 /** @} */

--- a/cpu/native/osx-libc-extra/malloc.h
+++ b/cpu/native/osx-libc-extra/malloc.h
@@ -63,7 +63,7 @@ extern void free (void *ptr);
 }
 #endif
 
-#endif /* malloc.h */
+#endif /* MALLOC_H */
 
 /**
  * @}

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -16,8 +16,8 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_CPU_
-#define PERIPH_CPU_
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -63,5 +63,5 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_ */
+#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -16,8 +16,8 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_CPU_
-#define PERIPH_CPU_
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -39,5 +39,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_ */
+#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -16,8 +16,8 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef CPU_PERIPH_COMMON_H
-#define CPU_PERIPH_COMMON_H
+#ifndef PERIPH_CPU_COMMON_H
+#define PERIPH_CPU_COMMON_H
 
 #include "cpu.h"
 
@@ -215,5 +215,5 @@ typedef struct {
 }
 #endif
 
-#endif /* CPU_PERIPH_COMMON_H */
+#endif /* PERIPH_CPU_COMMON_H */
 /** @} */

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -16,8 +16,8 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef CPU_PERIPH_H
-#define CPU_PERIPH_H
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
 
 #include <limits.h>
 
@@ -129,5 +129,5 @@ typedef enum {
 }
 #endif
 
-#endif /* CPU_PERIPH_H */
+#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32f0/include/cpu_conf.h
+++ b/cpu/stm32f0/include/cpu_conf.h
@@ -20,8 +20,8 @@
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
 */
 
-#ifndef STM32F0_CPU_CONF_H
-#define STM32F0_CPU_CONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -87,5 +87,5 @@ extern "C" {
 }
 #endif
 
-#endif /* STM32F0_CPU_CONF_H */
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f3/include/cpu_conf.h
+++ b/cpu/stm32f3/include/cpu_conf.h
@@ -19,8 +19,8 @@
  * @author          Katja Kirstein <katja.kirstein@haw-hamburg.de>
  */
 
-#ifndef STM32F3_CPU_CONF_H
-#define STM32F3_CPU_CONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -54,5 +54,5 @@ extern "C" {
 }
 #endif
 
-#endif /* STM32F3_CPU_CONF_H */
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -18,8 +18,8 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef STM32F4_CPU_CONF_H
-#define STM32F4_CPU_CONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -58,5 +58,5 @@ extern "C" {
 }
 #endif
 
-#endif /* STM32F4_CPU_CONF_H */
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/stm32f7/include/cpu_conf.h
+++ b/cpu/stm32f7/include/cpu_conf.h
@@ -18,8 +18,8 @@
  * @author          Hauke Petersen <hauke.pertersen@fu-berlin.de>
 */
 
-#ifndef STM32F7_CPU_CONF_H
-#define STM32F7_CPU_CONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -49,5 +49,5 @@ extern "C" {
 }
 #endif
 
-#endif /* STM32F7_CPU_CONF_H */
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/stm32l0/include/cpu_conf.h
+++ b/cpu/stm32l0/include/cpu_conf.h
@@ -20,8 +20,8 @@
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
 */
 
-#ifndef STM32L0_CPU_CONF_H
-#define STM32L0_CPU_CONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -51,5 +51,5 @@ extern "C" {
 }
 #endif
 
-#endif /* STM32F0_CPU_CONF_H */
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -18,8 +18,8 @@
  * @author          Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
 
-#ifndef CPUCONF_H
-#define CPUCONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -42,6 +42,6 @@ extern "C" {
 }
 #endif
 
-#endif /* CPUCONF_H */
+#endif /* CPU_CONF_H */
 /** @} */
 /** @} */

--- a/cpu/stm32l4/include/cpu_conf.h
+++ b/cpu/stm32l4/include/cpu_conf.h
@@ -20,8 +20,8 @@
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
 */
 
-#ifndef STM32L4_CPU_CONF_H
-#define STM32L4_CPU_CONF_H
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -51,5 +51,5 @@ extern "C" {
 }
 #endif
 
-#endif /* STM32L4_CPU_CONF_H */
+#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/x86/include/cpu.h
+++ b/cpu/x86/include/cpu.h
@@ -26,8 +26,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU_X86_CPU_H
-#define CPU_X86_CPU_H
+#ifndef CPU_H
+#define CPU_H
 
 #include "kernel_defines.h"
 #include "irq.h"
@@ -124,6 +124,6 @@ static inline void cpu_print_last_instruction(void)
 }
 #endif
 
-#endif /* CPU_X86_CPU_H */
+#endif /* CPU_H */
 
 /** @} */

--- a/cpu/x86/include/periph_cpu.h
+++ b/cpu/x86/include/periph_cpu.h
@@ -25,8 +25,8 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef PERIPH_CONF_
-#define PERIPH_CONF_
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,6 +36,6 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CONF_ */
+#endif /* PERIPH_CPU_H */
 
 /** @} */

--- a/cpu/x86/include/ucontext.h
+++ b/cpu/x86/include/ucontext.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__UCONTEXT__HPP__
-#define CPU__X86__UCONTEXT__HPP__
+#ifndef UCONTEXT_H
+#define UCONTEXT_H
 
 #include <stdlib.h>
 #include <unistd.h>
@@ -169,6 +169,6 @@ int swapcontext(ucontext_t *oucp, const ucontext_t *ucp);
 }
 #endif
 
-#endif
+#endif /* UCONTEXT_H */
 
 /** @} */

--- a/cpu/x86/include/x86_cmos.h
+++ b/cpu/x86/include/x86_cmos.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__CMOS__H__
-#define CPU__X86__CMOS__H__
+#ifndef X86_CMOS_H
+#define X86_CMOS_H
 
 #include "x86_ports.h"
 
@@ -66,6 +66,6 @@ void x86_cmos_serial(uint8_t (*serial)[CMOS_SERIAL_LEN]);
 }
 #endif
 
-#endif
+#endif /* X86_CMOS_H */
 
 /** @} */

--- a/cpu/x86/include/x86_interrupts.h
+++ b/cpu/x86/include/x86_interrupts.h
@@ -26,8 +26,8 @@
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__INTERRUPTS__H__
-#define CPU__X86__INTERRUPTS__H__
+#ifndef X86_INTERRUPTS_H
+#define X86_INTERRUPTS_H
 
 #include "ucontext.h"
 
@@ -160,6 +160,6 @@ void x86_print_registers(struct x86_pushad *orig_ctx, unsigned long error_code);
 }
 #endif
 
-#endif
+#endif /* X86_INTERRUPTS_H */
 
 /** @} */

--- a/cpu/x86/include/x86_kernel_memory.h
+++ b/cpu/x86/include/x86_kernel_memory.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef KERNEL_MEMORY_H__
-#define KERNEL_MEMORY_H__
+#ifndef X86_KERNEL_MEMORY_H
+#define X86_KERNEL_MEMORY_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -119,6 +119,6 @@ extern char _heap_start;
 }
 #endif
 
-#endif
+#endif /* X86_KERNEL_MEMORY_H */
 
 /** @} */

--- a/cpu/x86/include/x86_memory.h
+++ b/cpu/x86/include/x86_memory.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__MEMORY__H__
-#define CPU__X86__MEMORY__H__
+#ifndef X86_MEMORY_H
+#define X86_MEMORY_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -178,6 +178,6 @@ void x86_init_gdt(void);
 }
 #endif
 
-#endif
+#endif /* X86_MEMORY_H */
 
 /** @} */

--- a/cpu/x86/include/x86_pci.h
+++ b/cpu/x86/include/x86_pci.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__PCI__H__
-#define CPU__X86__PCI__H__
+#ifndef X86_PCI_H
+#define X86_PCI_H
 
 #include "x86_pci_init.h"
 #include "x86_pic.h"
@@ -418,6 +418,6 @@ void x86_pci_set_irq(struct x86_known_pci_device *d, uint8_t irq_num);
 }
 #endif
 
-#endif
+#endif /* X86_PCI_H */
 
 /** @} */

--- a/cpu/x86/include/x86_pci_strings.h
+++ b/cpu/x86/include/x86_pci_strings.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__PCI_NAMES__H__
-#define CPU__X86__PCI_NAMES__H__
+#ifndef X86_PCI_STRINGS_H
+#define X86_PCI_STRINGS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,6 +56,6 @@ const char *x86_pci_device_id_to_string(unsigned vendor_id, unsigned device_id, 
 }
 #endif
 
-#endif
+#endif /* X86_PCI_STRINGS_H */
 
 /** @} */

--- a/cpu/x86/include/x86_pic.h
+++ b/cpu/x86/include/x86_pic.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__PIC__H__
-#define CPU__X86__PIC__H__
+#ifndef X86_PIC_H
+#define X86_PIC_H
 
 #include <stdint.h>
 
@@ -171,6 +171,6 @@ void x86_pic_disable_irq(unsigned num);
 }
 #endif
 
-#endif
+#endif /* X86_PIC_H */
 
 /** @} */

--- a/cpu/x86/include/x86_pit.h
+++ b/cpu/x86/include/x86_pit.h
@@ -31,8 +31,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__PIT__H__
-#define CPU__X86__PIT__H__
+#ifndef X86_PIT_H
+#define X86_PIT_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -117,6 +117,6 @@ bool x86_pit_set(unsigned channel, unsigned mode, unsigned hz);
 }
 #endif
 
-#endif
+#endif /* X86_PIT_H */
 
 /** @} */

--- a/cpu/x86/include/x86_ports.h
+++ b/cpu/x86/include/x86_ports.h
@@ -23,8 +23,8 @@
 
 // Copy of Pintos' threads/io.h, license header extracted from Pintos' LICENSE file.
 
-#ifndef CPU__X86__PORTS_H__
-#define CPU__X86__PORTS_H__
+#ifndef X86_PORTS_H
+#define X86_PORTS_H
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -191,4 +191,4 @@ static inline void  __attribute__((always_inline)) io_wait(void)
 }
 #endif
 
-#endif
+#endif /* X86_PORTS_H */

--- a/cpu/x86/include/x86_reboot.h
+++ b/cpu/x86/include/x86_reboot.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__REBOOT__H__
-#define CPU__X86__REBOOT__H__
+#ifndef X86_REBOOT_H
+#define X86_REBOOT_H
 
 #include <stdbool.h>
 #include "kernel_defines.h"
@@ -93,6 +93,6 @@ void x86_set_shutdown_fun(x86_shutdown_t fun);
 }
 #endif
 
-#endif
+#endif /* X86_REBOOT_H */
 
 /** @} */

--- a/cpu/x86/include/x86_registers.h
+++ b/cpu/x86/include/x86_registers.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__REGISTERS__H__
-#define CPU__X86__REGISTERS__H__
+#ifndef X86_REGISTERS_H
+#define X86_REGISTERS_H
 
 #include <stdint.h>
 
@@ -258,6 +258,6 @@ static inline uint64_t X86_CR_ATTR cpuid_caps(void)
 }
 #endif
 
-#endif
+#endif /* X86_REGISTERS_H */
 
 /** @} */

--- a/cpu/x86/include/x86_rtc.h
+++ b/cpu/x86/include/x86_rtc.h
@@ -28,8 +28,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__RTC__H__
-#define CPU__X86__RTC__H__
+#ifndef X86_RTC_H
+#define X86_RTC_H
 
 #include "msg.h"
 #include "x86_cmos.h"
@@ -215,6 +215,6 @@ void x86_rtc_set_update_callback(x86_rtc_callback_t cb);
 }
 #endif
 
-#endif
+#endif /* X86_RTC_H */
 
 /** @} */

--- a/cpu/x86/include/x86_threading.h
+++ b/cpu/x86/include/x86_threading.h
@@ -26,8 +26,8 @@
  * @author     René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__THREADING__H__
-#define CPU__X86__THREADING__H__
+#ifndef X86_THREADING_H
+#define X86_THREADING_H
 
 #include <stdbool.h>
 
@@ -52,6 +52,6 @@ extern bool x86_in_isr;
 }
 #endif
 
-#endif
+#endif /* X86_THREADING_H */
 
 /** @} */

--- a/cpu/x86/include/x86_uart.h
+++ b/cpu/x86/include/x86_uart.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__UART__H__
-#define CPU__X86__UART__H__
+#ifndef X86_UART_H
+#define X86_UART_H
 
 #include "x86_pic.h"
 
@@ -179,6 +179,6 @@ enum iir_t {
 }
 #endif
 
-#endif
+#endif /* X86_UART_H */
 
 /** @} */

--- a/cpu/x86/include/x86_videoram.h
+++ b/cpu/x86/include/x86_videoram.h
@@ -25,8 +25,8 @@
  * @author  René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef CPU__X86__VIDEORAM_H__
-#define CPU__X86__VIDEORAM_H__
+#ifndef X86_VIDEORAM_H
+#define X86_VIDEORAM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,6 +65,6 @@ void videoram_put_hex(unsigned long v);
 }
 #endif
 
-#endif
+#endif /* X86_VIDEORAM_H */
 
 /** @} */

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -90,6 +90,7 @@ then
         run ./dist/tools/cppcheck/check.sh
         run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/coccinelle/check.sh
+        QUIET=1 run ./dist/tools/headerguards/check.sh
         exit $RESULT
     fi
 

--- a/dist/tools/ci/changed_files.sh
+++ b/dist/tools/ci/changed_files.sh
@@ -8,7 +8,7 @@
 
 changed_files() {
     : ${FILEREGEX:='\.([CcHh]|[ch]pp)$'}
-    : ${EXCLUDE:='^(.+/include/vendor/|dist/tools/coccinelle/include)'}
+    : ${EXCLUDE:='^(.+/include/vendor/|dist/tools/coccinelle/include|boards/msba2-common/tools/src)'}
     : ${DIFFFILTER:='ACMR'}
 
     DIFFFILTER="--diff-filter=${DIFFFILTER}"

--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Copyright 2017 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+: ${RIOTBASE:=$(pwd)}
+
+. ${RIOTBASE}/dist/tools/ci/changed_files.sh
+
+EXIT_CODE=0
+
+filter() {
+    if [ $QUIET -eq 0 ]; then
+        cat
+    else
+        grep '^---' | cut -f 2 -d ' '
+    fi
+}
+
+_headercheck() {
+    OUT="$(${RIOTBASE}/dist/tools/headerguards/headerguards.py ${FILES} | filter)"
+
+    if [ -n "$OUT" ]; then
+        EXIT_CODE=1
+        echo "$OUT"
+    fi
+}
+
+: ${FILES:=$(FILEREGEX='\.h$' changed_files)}
+
+if [ -z "${FILES}" ]; then
+    exit
+fi
+
+: ${QUIET:=0}
+
+if [ -z "$*" ]; then
+    _headercheck
+fi
+
+exit $EXIT_CODE

--- a/dist/tools/headerguards/headerguards.py
+++ b/dist/tools/headerguards/headerguards.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import os, sys
+import difflib
+#from string import maketrans
+from io import BytesIO, TextIOWrapper
+
+_in = "/-."
+_out = "___"
+
+transtab = str.maketrans(_in, _out)
+
+def path_to_guardname(filepath):
+    res = filepath.upper().translate(transtab)
+    if res.startswith("_"):
+        res = "PRIV" + res
+    return res
+
+def get_guard_name(filepath):
+    parts = filepath.split(os.sep)
+    start = 0
+    found = False
+    for i, part in enumerate(parts):
+        if part == "include":
+            found = True
+            start = i+1
+            break
+
+    if not found:
+        start = len(parts) -1
+
+    return path_to_guardname(os.path.join(*parts[start:]))
+
+def fix_headerguard(filename):
+    supposed = get_guard_name(filename)
+    with open(filename, "r",encoding='utf-8', errors='ignore') as f:
+        inlines = f.readlines()
+
+    tmp = TextIOWrapper(BytesIO(), encoding="utf-8", errors="ignore")
+    tmp.seek(0)
+
+    guard_found = 0
+    guard_name = ""
+    ifstack = 0
+    for n, line in enumerate(inlines):
+        if guard_found == 0:
+            if line.startswith("#ifndef"):
+                guard_found += 1
+                guard_name = line[8:].rstrip()
+                line = "#ifndef %s\n" % (supposed)
+        elif guard_found == 1:
+            if line.startswith("#define") and line[8:].rstrip() == guard_name:
+                line = "#define %s\n" % (supposed)
+                guard_found += 1
+            else:
+                break
+        elif guard_found == 2:
+            if line.startswith("#if"):
+                ifstack += 1
+            elif line.startswith("#endif"):
+                if ifstack > 0:
+                    ifstack -= 1
+                else:
+                    guard_found += 1
+                    line = "#endif /* %s */\n" % supposed
+
+        tmp.write(line)
+
+    tmp.seek(0)
+    if guard_found == 3:
+        for line in difflib.unified_diff(inlines, tmp.readlines(), "%s" % filename, "%s" % filename):
+            sys.stdout.write(line)
+    else:
+        print("%s: no / broken header guard" % filename, file=sys.stderr)
+        return False
+
+if __name__=="__main__":
+    error = False
+    for filename in sys.argv[1:]:
+        if fix_headerguard(filename) == False:
+            error = True
+
+    if error:
+        sys.exit(1)

--- a/drivers/bh1750fvi/include/bh1750fvi_internal.h
+++ b/drivers/bh1750fvi/include/bh1750fvi_internal.h
@@ -16,8 +16,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef BH1750FVI_REGS_H
-#define BH1750FVI_REGS_H
+#ifndef BH1750FVI_INTERNAL_H
+#define BH1750FVI_INTERNAL_H
 
 
 #ifdef __cplusplus
@@ -63,5 +63,5 @@ extern "C" {
 }
 #endif
 
-#endif /* BH1750FVI_REGS_H */
+#endif /* BH1750FVI_INTERNAL_H */
 /** @} */

--- a/drivers/bmp180/include/bmp180_internals.h
+++ b/drivers/bmp180/include/bmp180_internals.h
@@ -18,8 +18,8 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef BMP180_REGS_H
-#define BMP180_REGS_H
+#ifndef BMP180_INTERNALS_H
+#define BMP180_INTERNALS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,5 +58,5 @@ extern "C" {
 }
 #endif
 
-#endif /* BMP180_REGS_H */
+#endif /* BMP180_INTERNALS_H */
 /** @} */

--- a/drivers/cc110x/include/cc110x-defines.h
+++ b/drivers/cc110x/include/cc110x-defines.h
@@ -204,4 +204,4 @@ extern "C" {
 #endif
 
 /** @} */
-#endif
+#endif /* CC110X_DEFINES_H */

--- a/drivers/cc110x/include/gnrc_netdev_cc110x.h
+++ b/drivers/cc110x/include/gnrc_netdev_cc110x.h
@@ -19,8 +19,8 @@
 #include "net/gnrc/netdev.h"
 #include "cc110x-netdev.h"
 
-#ifndef GNRC_CC110X_H
-#define GNRC_CC110X_H
+#ifndef GNRC_NETDEV_CC110X_H
+#define GNRC_NETDEV_CC110X_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,5 +41,5 @@ int gnrc_netdev_cc110x_init(gnrc_netdev_t *gnrc_netdev, netdev_cc110x_t *dev);
 }
 #endif
 
-#endif /* GNRC_CC110X_H */
+#endif /* GNRC_NETDEV_CC110X_H */
 /** @} */

--- a/drivers/dynamixel/include/dynamixel_crc.h
+++ b/drivers/dynamixel/include/dynamixel_crc.h
@@ -33,5 +33,5 @@ uint16_t dynamixel_crc_update(uint16_t crc_accum, const uint8_t *buffer, size_t 
 }
 #endif
 
-#endif
+#endif /* DYNAMIXEL_CRC_H */
 /** @} */

--- a/drivers/dynamixel/include/dynamixel_protocol.h
+++ b/drivers/dynamixel/include/dynamixel_protocol.h
@@ -91,5 +91,5 @@ typedef enum {
 }
 #endif
 
-#endif
+#endif /* DYNAMIXEL_PROTOCOL_H */
 /** @} */

--- a/drivers/dynamixel/include/dynamixel_reader.h
+++ b/drivers/dynamixel/include/dynamixel_reader.h
@@ -146,5 +146,5 @@ static inline size_t dynamixel_reader_status_get_payload_size(const dynamixel_re
 }
 #endif
 
-#endif
+#endif /* DYNAMIXEL_READER_H */
 /** @} */

--- a/drivers/dynamixel/include/dynamixel_writer.h
+++ b/drivers/dynamixel/include/dynamixel_writer.h
@@ -98,5 +98,5 @@ void dynamixel_writer_read_make(dynamixel_writer_t *writer, uint8_t id, uint16_t
 }
 #endif
 
-#endif
+#endif /* DYNAMIXEL_WRITER_H */
 /** @} */

--- a/drivers/encx24j600/include/encx24j600_defines.h
+++ b/drivers/encx24j600/include/encx24j600_defines.h
@@ -17,8 +17,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef ENCX24J600_REGS_H
-#define ENCX24J600_REGS_H
+#ifndef ENCX24J600_DEFINES_H
+#define ENCX24J600_DEFINES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -202,5 +202,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* ENCX24J600_REGS_H */
+#endif /* ENCX24J600_DEFINES_H */
 /** @} */

--- a/drivers/feetech/include/feetech_protocol.h
+++ b/drivers/feetech/include/feetech_protocol.h
@@ -95,5 +95,5 @@ typedef enum {
 }
 #endif
 
-#endif
+#endif /* FEETECH_PROTOCOL_H */
 /** @} */

--- a/drivers/feetech/include/feetech_reader.h
+++ b/drivers/feetech/include/feetech_reader.h
@@ -293,5 +293,5 @@ const uint8_t *feetech_reader_sync_write_item_get_payload(const feetech_reader_t
 }
 #endif
 
-#endif
+#endif /* FEETECH_READER_H */
 /** @} */

--- a/drivers/feetech/include/feetech_writer.h
+++ b/drivers/feetech/include/feetech_writer.h
@@ -181,5 +181,5 @@ void feetech_writer_sync_write_add_16bits(feetech_writer_t *writer, uint8_t id, 
 }
 #endif
 
-#endif
+#endif /* FEETECH_WRITER_H */
 /** @} */

--- a/drivers/ina220/include/ina220-regs.h
+++ b/drivers/ina220/include/ina220-regs.h
@@ -46,5 +46,5 @@ typedef enum ina220_reg {
 }
 #endif
 
-#endif /* __L3G4200D_REGS_H */
+#endif /* INA220_REGS_H */
 /** @} */

--- a/drivers/include/dynamixel.h
+++ b/drivers/include/dynamixel.h
@@ -167,5 +167,5 @@ int dynamixel_read(dynamixel_t *device, dynamixel_addr_t reg, uint8_t *data, siz
 }
 #endif
 
-#endif
+#endif /* DYNAMIXEL_H */
 /** @} */

--- a/drivers/include/feetech.h
+++ b/drivers/include/feetech.h
@@ -166,5 +166,5 @@ int feetech_read(feetech_t *device, feetech_addr_t addr, uint8_t *data, size_t l
 }
 #endif
 
-#endif
+#endif /* FEETECH_H */
 /** @} */

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -157,5 +157,5 @@ int hdc1000_read(hdc1000_t *dev, int16_t *temp, int16_t *hum);
 }
 #endif
 
-#endif
+#endif /* HDC1000_H */
 /** @} */

--- a/drivers/include/jc42.h
+++ b/drivers/include/jc42.h
@@ -28,8 +28,8 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef JC42_TEMP_H
-#define JC42_TEMP_H
+#ifndef JC42_H
+#define JC42_H
 
 #include "periph/i2c.h"
 #include "saul.h"
@@ -122,4 +122,4 @@ int jc42_get_temperature(jc42_t* dev, int16_t* temperature);
 #endif
 
 /** @} */
-#endif /* JC42_TEMP_H */
+#endif /* JC42_H */

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -20,8 +20,8 @@
  * @author      Sebastian Meiling <s@mlng.net>
  */
 
-#ifndef KW2XDRF_H
-#define KW2XDRF_H
+#ifndef KW2XRF_H
+#define KW2XRF_H
 
 #include <stdint.h>
 
@@ -170,5 +170,5 @@ void kw2xrf_reset_phy(kw2xrf_t *dev);
 }
 #endif
 
-#endif /* KW2XDRF_H */
+#endif /* KW2XRF_H */
 /** @} */

--- a/drivers/include/mag3110.h
+++ b/drivers/include/mag3110.h
@@ -202,5 +202,5 @@ int mag3110_read_dtemp(mag3110_t *dev, int8_t *dtemp);
 }
 #endif
 
-#endif
+#endif /* MAG3110_H */
 /** @} */

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -161,5 +161,5 @@ int mpl3115a2_read_temp(mpl3115a2_t *dev, int16_t *temp);
 }
 #endif
 
-#endif
+#endif /* MPL3115A2_H */
 /** @} */

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -21,8 +21,8 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef MTD_SPI_NOR_H_
-#define MTD_SPI_NOR_H_
+#ifndef MTD_SPI_NOR_H
+#define MTD_SPI_NOR_H
 
 #include <stdint.h>
 
@@ -144,5 +144,5 @@ extern const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default;
 }
 #endif
 
-#endif /* MTD_SPI_NOR_H_ */
+#endif /* MTD_SPI_NOR_H */
 /** @} */

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -43,8 +43,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef NETDEV_H
-#define NETDEV_H
+#ifndef NET_NETDEV_H
+#define NET_NETDEV_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -234,4 +234,4 @@ typedef struct netdev_driver {
 }
 #endif
 /** @} */
-#endif /* NETDEV_H */
+#endif /* NET_NETDEV_H */

--- a/drivers/include/net/netdev/eth.h
+++ b/drivers/include/net/netdev/eth.h
@@ -16,8 +16,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef NETDEV_ETH_H
-#define NETDEV_ETH_H
+#ifndef NET_NETDEV_ETH_H
+#define NET_NETDEV_ETH_H
 
 #include <stdint.h>
 
@@ -62,4 +62,4 @@ int netdev_eth_set(netdev_t *dev, netopt_t opt, void *value, size_t value_len);
 }
 #endif
 /** @} */
-#endif /* NETDEV_ETH_H */
+#endif /* NET_NETDEV_ETH_H */

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -16,8 +16,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NETDEV_IEEE802154_H
-#define NETDEV_IEEE802154_H
+#ifndef NET_NETDEV_IEEE802154_H
+#define NET_NETDEV_IEEE802154_H
 
 #include "net/ieee802154.h"
 #include "net/gnrc/nettype.h"
@@ -164,5 +164,5 @@ int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, void *value,
 }
 #endif
 
-#endif /* NETDEV_IEEE802154_H */
+#endif /* NET_NETDEV_IEEE802154_H */
 /** @} */

--- a/drivers/include/nvram-spi.h
+++ b/drivers/include/nvram-spi.h
@@ -20,8 +20,8 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef DRIVERS_NVRAM_SPI_H
-#define DRIVERS_NVRAM_SPI_H
+#ifndef NVRAM_SPI_H
+#define NVRAM_SPI_H
 
 #include <stdint.h>
 #include "nvram.h"
@@ -64,5 +64,5 @@ int nvram_spi_init(nvram_t *dev, nvram_spi_params_t *spi_params, size_t size);
 }
 #endif
 
-#endif /* DRIVERS_NVRAM_SPI_H */
+#endif /* NVRAM_SPI_H */
 /** @} */

--- a/drivers/include/nvram.h
+++ b/drivers/include/nvram.h
@@ -24,8 +24,8 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef DRIVERS_NVRAM_H
-#define DRIVERS_NVRAM_H
+#ifndef NVRAM_H
+#define NVRAM_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -91,5 +91,5 @@ extern const vfs_file_ops_t nvram_vfs_ops;
 }
 #endif
 
-#endif /* DRIVERS_NVRAM_H */
+#endif /* NVRAM_H */
 /** @} */

--- a/drivers/include/pcd8544.h
+++ b/drivers/include/pcd8544.h
@@ -19,8 +19,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PDC8544_H
-#define PDC8544_H
+#ifndef PCD8544_H
+#define PCD8544_H
 
 #include <stdint.h>
 
@@ -198,5 +198,5 @@ void pcd8544_riot(pcd8544_t *dev);
 }
 #endif
 
-#endif /* PDC8544_H */
+#endif /* PCD8544_H */
 /** @} */

--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -20,8 +20,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_COMPAT_H
-#define PERIPH_COMPAT_H
+#ifndef PERIPH_DEV_ENUMS_H
+#define PERIPH_DEV_ENUMS_H
 
 #include "periph_conf.h"
 
@@ -99,5 +99,5 @@ enum {
 }
 #endif
 
-#endif /* PERIPH_COMPAT_H */
+#endif /* PERIPH_DEV_ENUMS_H */
 /** @} */

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -30,8 +30,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef FLASHPAGE_H
-#define FLASHPAGE_H
+#ifndef PERIPH_FLASHPAGE_H
+#define PERIPH_FLASHPAGE_H
 
 #include <stdint.h>
 
@@ -145,5 +145,5 @@ int flashpage_write_and_verify(int page, void *data);
 }
 #endif
 
-#endif /* FLASHPAGE_H */
+#endif /* PERIPH_FLASHPAGE_H */
 /** @} */

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -50,8 +50,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef GPIO_H
-#define GPIO_H
+#ifndef PERIPH_GPIO_H
+#define PERIPH_GPIO_H
 
 #include <limits.h>
 
@@ -223,5 +223,5 @@ void gpio_write(gpio_t pin, int value);
 }
 #endif
 
-#endif /* GPIO_H */
+#endif /* PERIPH_GPIO_H */
 /** @} */

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -51,8 +51,8 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
 
-#ifndef I2C_H
-#define I2C_H
+#ifndef PERIPH_I2C_H
+#define PERIPH_I2C_H
 
 #include <stdint.h>
 #include <limits.h>
@@ -283,5 +283,5 @@ void i2c_poweroff(i2c_t dev);
 }
 #endif
 
-#endif /* I2C_H */
+#endif /* PERIPH_I2C_H */
 /** @} */

--- a/drivers/include/periph/pm.h
+++ b/drivers/include/periph/pm.h
@@ -20,8 +20,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef PM_H
-#define PM_H
+#ifndef PERIPH_PM_H
+#define PERIPH_PM_H
 
 #include "assert.h"
 #include "periph_cpu.h"
@@ -51,5 +51,5 @@ void pm_set_lowest(void);
 }
 #endif
 
-#endif /* __PM_H */
+#endif /* PERIPH_PM_H */
 /** @} */

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -23,8 +23,8 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  */
 
-#ifndef RTC_H
-#define RTC_H
+#ifndef PERIPH_RTC_H
+#define PERIPH_RTC_H
 
 #include <time.h>
 #include "periph_conf.h"
@@ -114,5 +114,5 @@ void rtc_poweroff(void);
 }
 #endif
 
-#endif /* RTC_H */
+#endif /* PERIPH_RTC_H */
 /** @} */

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -20,8 +20,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef RTT_H
-#define RTT_H
+#ifndef PERIPH_RTT_H
+#define PERIPH_RTT_H
 
 #include "periph_conf.h"
 
@@ -172,5 +172,5 @@ void rtt_poweroff(void);
 }
 #endif
 
-#endif /* RTT_H */
+#endif /* PERIPH_RTT_H */
 /** @} */

--- a/drivers/include/pn532.h
+++ b/drivers/include/pn532.h
@@ -18,8 +18,8 @@
  * @author      Víctor Ariño <victor.arino@triagnosys.com>
  */
 
-#ifndef NFC_READER_INCLUDE_PN532_H
-#define NFC_READER_INCLUDE_PN532_H
+#ifndef PN532_H
+#define PN532_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -383,5 +383,5 @@ void pn532_release_passive(pn532_t *dev, unsigned target_id);
 }
 #endif
 
-#endif /* NFC_READER_INCLUDE_PN532_H */
+#endif /* PN532_H */
 /** @} */

--- a/drivers/include/tcs37727.h
+++ b/drivers/include/tcs37727.h
@@ -139,5 +139,5 @@ void tcs37727_read(tcs37727_t *dev, tcs37727_data_t *data);
 }
 #endif
 
-#endif
+#endif /* TCS37727_H */
 /** @} */

--- a/drivers/include/tmp006.h
+++ b/drivers/include/tmp006.h
@@ -205,5 +205,5 @@ void tmp006_convert(int16_t rawv, int16_t rawt,  float *tamb, float *tobj);
 }
 #endif
 
-#endif
+#endif /* TMP006_H */
 /** @} */

--- a/drivers/include/tsl2561.h
+++ b/drivers/include/tsl2561.h
@@ -18,8 +18,8 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef TSL2561_H_
-#define TSL2561_H_
+#ifndef TSL2561_H
+#define TSL2561_H
 
 #include "saul.h"
 #include "periph/i2c.h"
@@ -109,5 +109,5 @@ uint16_t tsl2561_read_illuminance(tsl2561_t *dev);
 }
 #endif
 
-#endif /* TSL2561_H_ */
+#endif /* TSL2561_H */
 /** @} */

--- a/drivers/include/w5100.h
+++ b/drivers/include/w5100.h
@@ -81,5 +81,5 @@ void w5100_setup(w5100_t *dev, const w5100_params_t *params);
 }
 #endif
 
-#endif /* W5100_h */
+#endif /* W5100_H */
 /* @} */

--- a/drivers/kw2xrf/include/kw2xrf_reg.h
+++ b/drivers/kw2xrf/include/kw2xrf_reg.h
@@ -50,8 +50,8 @@
  * @author      Johann Fischer <j.fischer@phytec.de>
  */
 
-#ifndef MKW2XD_MODEM_REG_H
-#define MKW2XD_MODEM_REG_H
+#ifndef KW2XRF_REG_H
+#define KW2XRF_REG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -564,5 +564,5 @@ enum mkw2xdrf_iregister {
 }
 #endif
 
-#endif /* MKW2XD_MODEM_REG_H */
+#endif /* KW2XRF_REG_H */
 /** @} */

--- a/drivers/kw2xrf/include/overwrites.h
+++ b/drivers/kw2xrf/include/overwrites.h
@@ -31,8 +31,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef OVERWRITES_H_
-#define OVERWRITES_H_
+#ifndef OVERWRITES_H
+#define OVERWRITES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -311,4 +311,4 @@ end of deprecated versions */
 #ifdef __cplusplus
 }
 #endif
-#endif  //OVERWRITES_H_
+#endif /* OVERWRITES_H */

--- a/drivers/lsm6dsl/include/lsm6dsl_internal.h
+++ b/drivers/lsm6dsl/include/lsm6dsl_internal.h
@@ -153,5 +153,5 @@ extern "C" {
 }
 #endif
 
-#endif /* LSM6DS_LINTERNAL_H */
+#endif /* LSM6DSL_INTERNAL_H */
 /** @} */

--- a/drivers/mag3110/include/mag3110_reg.h
+++ b/drivers/mag3110/include/mag3110_reg.h
@@ -76,5 +76,5 @@ extern "C"
 }
 #endif
 
-#endif
+#endif /* MAG3110_REG_H */
 /** @} */

--- a/drivers/mma8x5x/include/mma8x5x_regs.h
+++ b/drivers/mma8x5x/include/mma8x5x_regs.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef MMA8X5X_REG_H
-#define MMA8X5X_REG_H
+#ifndef MMA8X5X_REGS_H
+#define MMA8X5X_REGS_H
 
 #ifdef __cplusplus
 extern "C"
@@ -258,5 +258,5 @@ extern "C"
 }
 #endif
 
-#endif
+#endif /* MMA8X5X_REGS_H */
 /** @} */

--- a/drivers/mpl3115a2/include/mpl3115a2_reg.h
+++ b/drivers/mpl3115a2/include/mpl3115a2_reg.h
@@ -130,5 +130,5 @@ extern "C"
 }
 #endif
 
-#endif
+#endif /* MPL3115A2_REG_H */
 /** @} */

--- a/drivers/pcd8544/include/pcd8544_internal.h
+++ b/drivers/pcd8544/include/pcd8544_internal.h
@@ -17,8 +17,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PDC8544_INTERNAL_H
-#define PDC8544_INTERNAL_H
+#ifndef PCD8544_INTERNAL_H
+#define PCD8544_INTERNAL_H
 
 #ifdef __cplusplus
  extern "C" {
@@ -72,5 +72,5 @@
 }
 #endif
 
-#endif /* PDC8544_INTERNAL_H */
+#endif /* PCD8544_INTERNAL_H */
 /** @} */

--- a/drivers/tcs37727/include/tcs37727-internal.h
+++ b/drivers/tcs37727/include/tcs37727-internal.h
@@ -131,5 +131,5 @@ extern "C"
 }
 #endif
 
-#endif
+#endif /* TCS37727_INTERNAL_H */
 /** @} */

--- a/drivers/tsl2561/include/tsl2561_internals.h
+++ b/drivers/tsl2561/include/tsl2561_internals.h
@@ -17,8 +17,8 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef TSL2561_REGS_H_
-#define TSL2561_REGS_H_
+#ifndef TSL2561_INTERNALS_H
+#define TSL2561_INTERNALS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -104,5 +104,5 @@ extern "C" {
 }
 #endif
 
-#endif /* TSL2561_REGS_H_ */
+#endif /* TSL2561_INTERNALS_H */
 /** @} */

--- a/drivers/tsl2561/include/tsl2561_params.h
+++ b/drivers/tsl2561/include/tsl2561_params.h
@@ -75,5 +75,5 @@ saul_reg_info_t tsl2561_saul_reg_info[] =
 }
 #endif
 
-#endif // TSL2561_PARAMS_H
+#endif /* TSL2561_PARAMS_H */
 /** @} */

--- a/drivers/uart_half_duplex/include/uart_half_duplex.h
+++ b/drivers/uart_half_duplex/include/uart_half_duplex.h
@@ -140,5 +140,5 @@ size_t uart_half_duplex_recv(uart_half_duplex_t *dev, size_t size);
 }
 #endif
 
-#endif
+#endif /* UART_HALF_DUPLEX_H */
 /** @} */

--- a/pkg/emb6/include/board_conf.h
+++ b/pkg/emb6/include/board_conf.h
@@ -18,8 +18,8 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef EMB6_BOARD_CONF_H
-#define EMB6_BOARD_CONF_H
+#ifndef BOARD_CONF_H
+#define BOARD_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,6 +41,6 @@ uint8_t board_conf(s_ns_t *ps_nStack);
 }
 #endif
 
-#endif /* EMB6_BOARD_CONF_H */
+#endif /* BOARD_CONF_H */
 /** @} */
 /** @} */

--- a/pkg/emb6/include/sock_types.h
+++ b/pkg/emb6/include/sock_types.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef SOCK_TYPES_H_
-#define SOCK_TYPES_H_
+#ifndef SOCK_TYPES_H
+#define SOCK_TYPES_H
 
 #include <stdatomic.h>
 
@@ -62,5 +62,5 @@ struct sock_udp {
 }
 #endif
 
-#endif /* SOCK_TYPES_H_ */
+#endif /* SOCK_TYPES_H */
 /** @} */

--- a/pkg/lwip/include/arch/cc.h
+++ b/pkg/lwip/include/arch/cc.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef LWIP_ARCH_CC_H
-#define LWIP_ARCH_CC_H
+#ifndef ARCH_CC_H
+#define ARCH_CC_H
 
 #include <assert.h>
 #include <inttypes.h>
@@ -111,5 +111,5 @@ extern "C" {
 }
 #endif
 
-#endif /* LWIP_ARCH_CC_H */
+#endif /* ARCH_CC_H */
 /** @} */

--- a/pkg/lwip/include/arch/sys_arch.h
+++ b/pkg/lwip/include/arch/sys_arch.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef LWIP_ARCH_SYS_ARCH_H
-#define LWIP_ARCH_SYS_ARCH_H
+#ifndef ARCH_SYS_ARCH_H
+#define ARCH_SYS_ARCH_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -84,5 +84,5 @@ static inline void sys_mbox_set_invalid(sys_mbox_t *mbox)
 }
 #endif
 
-#endif /* LWIP_ARCH_SYS_ARCH_H */
+#endif /* ARCH_SYS_ARCH_H */
 /** @} */

--- a/pkg/lwip/include/lwip/netif/netdev.h
+++ b/pkg/lwip/include/lwip/netif/netdev.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef LWIP_NETDEV_H
-#define LWIP_NETDEV_H
+#ifndef LWIP_NETIF_NETDEV_H
+#define LWIP_NETIF_NETDEV_H
 
 #include "net/ethernet.h"
 #include "net/netdev.h"
@@ -58,5 +58,5 @@ err_t lwip_netdev_init(struct netif *netif);
 }
 #endif
 
-#endif /* LWIP_NETDEV_H */
+#endif /* LWIP_NETIF_NETDEV_H */
 /** @} */

--- a/pkg/lwip/include/lwip/sock_internal.h
+++ b/pkg/lwip/include/lwip/sock_internal.h
@@ -18,8 +18,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef SOCK_INTERNAL_H
-#define SOCK_INTERNAL_H
+#ifndef LWIP_SOCK_INTERNAL_H
+#define LWIP_SOCK_INTERNAL_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -65,5 +65,5 @@ ssize_t lwip_sock_send(struct netconn **conn, const void *data, size_t len,
 }
 #endif
 
-#endif /* SOCK_INTERNAL_H */
+#endif /* LWIP_SOCK_INTERNAL_H */
 /** @} */

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef LWIP_LWIPOPTS_H
-#define LWIP_LWIPOPTS_H
+#ifndef LWIPOPTS_H
+#define LWIPOPTS_H
 
 #include "thread.h"
 #include "net/gnrc/netif/hdr.h"
@@ -155,5 +155,5 @@ extern "C" {
 }
 #endif
 
-#endif /* LWIP_LWIPOPTS_H */
+#endif /* LWIPOPTS_H */
 /** @} */

--- a/pkg/nordic_softdevice_ble/src/ble-core.h
+++ b/pkg/nordic_softdevice_ble/src/ble-core.h
@@ -43,8 +43,8 @@
  *
  * @author  Wojciech Bober <wojciech.bober@nordicsemi.no>
  */
-#ifndef DEV_BLE_H
-#define DEV_BLE_H
+#ifndef BLE_CORE_H
+#define BLE_CORE_H
 
 #include <stdint.h>
 
@@ -80,7 +80,7 @@ void ble_get_mac(uint8_t addr[8]);
 }
 #endif
 
-#endif /* DEV_BLE_H */
+#endif /* BLE_CORE_H */
 
 /**
  * @}

--- a/pkg/spiffs/include/spiffs_config.h
+++ b/pkg/spiffs/include/spiffs_config.h
@@ -28,8 +28,8 @@
  *      Author: petera
  */
 
-#ifndef SPIFFS_CONFIG_H_
-#define SPIFFS_CONFIG_H_
+#ifndef SPIFFS_CONFIG_H
+#define SPIFFS_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -298,4 +298,4 @@ typedef int16_t s16_t;
 }
 #endif
 
-#endif /* SPIFFS_CONFIG_H_ */
+#endif /* SPIFFS_CONFIG_H */

--- a/sys/embunit/ColorTextColors.h
+++ b/sys/embunit/ColorTextColors.h
@@ -13,8 +13,8 @@
  *
  * @author Janos Kutscherauer <noshky@gmail.com>
  */
-#ifndef EMBUNIT_COLORTEXTCOLORS_H
-#define EMBUNIT_COLORTEXTCOLORS_H
+#ifndef COLORTEXTCOLORS_H
+#define COLORTEXTCOLORS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,5 +53,5 @@ extern "C" {
 }
 #endif
 
-#endif/* EMBUNIT_COLORTEXTCOLORS_H */
+#endif /* COLORTEXTCOLORS_H */
 /** @} */

--- a/sys/include/base64.h
+++ b/sys/include/base64.h
@@ -17,8 +17,8 @@
  * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
  */
 
-#ifndef BASE64_ENCODER_DECODER_H
-#define BASE64_ENCODER_DECODER_H
+#ifndef BASE64_H
+#define BASE64_H
 
 #include <stddef.h> /* for size_t */
 
@@ -79,4 +79,4 @@ int base64_decode(unsigned char *base64_in, size_t base64_in_size, \
 #endif
 
 /** @} */
-#endif /* BASE64_ENCODER_DECODER_H */
+#endif /* BASE64_H */

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -120,8 +120,8 @@
  * @author Christian Mehlis <mehlis@inf.fu-berlin.de>
  */
 
-#ifndef _BLOOM_FILTER_H
-#define _BLOOM_FILTER_H
+#ifndef BLOOM_H
+#define BLOOM_H
 
 #include <stdlib.h>
 #include <stdbool.h>
@@ -233,4 +233,4 @@ bool bloom_check(bloom_t *bloom, const uint8_t *buf, size_t len);
 #endif
 
 /** @} */
-#endif /* _BLOOM_FILTER_H */
+#endif /* BLOOM_H */

--- a/sys/include/cbor.h
+++ b/sys/include/cbor.h
@@ -706,6 +706,6 @@ bool cbor_at_end(const cbor_stream_t *stream, size_t offset);
 }
 #endif
 
-#endif
+#endif /* CBOR_H */
 
 /** @} */

--- a/sys/include/checksum/crc16_ccitt.h
+++ b/sys/include/checksum/crc16_ccitt.h
@@ -27,8 +27,8 @@
  * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  */
 
-#ifndef CRC16_CCITT_H
-#define CRC16_CCITT_H
+#ifndef CHECKSUM_CRC16_CCITT_H
+#define CHECKSUM_CRC16_CCITT_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -66,6 +66,6 @@ uint16_t crc16_ccitt_calc(const unsigned char *buf, size_t len);
 }
 #endif
 
-#endif /* CRC16_CCITT_H */
+#endif /* CHECKSUM_CRC16_CCITT_H */
 
 /** @} */

--- a/sys/include/checksum/fletcher16.h
+++ b/sys/include/checksum/fletcher16.h
@@ -17,8 +17,8 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef FLETCHER16_H
-#define FLETCHER16_H
+#ifndef CHECKSUM_FLETCHER16_H
+#define CHECKSUM_FLETCHER16_H
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -46,6 +46,6 @@ uint16_t fletcher16(const uint8_t *buf, size_t bytes);
 }
 #endif
 
-#endif /* FLETCHER16_H */
+#endif /* CHECKSUM_FLETCHER16_H */
 
 /** @} */

--- a/sys/include/checksum/fletcher32.h
+++ b/sys/include/checksum/fletcher32.h
@@ -17,8 +17,8 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef FLETCHER32_H
-#define FLETCHER32_H
+#ifndef CHECKSUM_FLETCHER32_H
+#define CHECKSUM_FLETCHER32_H
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -47,6 +47,6 @@ uint32_t fletcher32(const uint16_t *buf, size_t words);
 }
 #endif
 
-#endif /* FLETCHER32_H */
+#endif /* CHECKSUM_FLETCHER32_H */
 
 /** @} */

--- a/sys/include/checksum/ucrc16.h
+++ b/sys/include/checksum/ucrc16.h
@@ -26,8 +26,8 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef UCRC16_H
-#define UCRC16_H
+#ifndef CHECKSUM_UCRC16_H
+#define CHECKSUM_UCRC16_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -78,5 +78,5 @@ uint16_t ucrc16_calc_le(const uint8_t *buf, size_t len, uint16_t poly,
 }
 #endif
 
-#endif /* UCRC16_H */
+#endif /* CHECKSUM_UCRC16_H */
 /** @} */

--- a/sys/include/crypto/aes.h
+++ b/sys/include/crypto/aes.h
@@ -19,8 +19,8 @@
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  */
 
-#ifndef AES_H
-#define AES_H
+#ifndef CRYPTO_AES_H
+#define CRYPTO_AES_H
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -128,4 +128,4 @@ int aes_decrypt(const cipher_context_t *context, const uint8_t *cipher_block,
 #endif
 
 /** @} */
-#endif /* AES_H */
+#endif /* CRYPTO_AES_H */

--- a/sys/include/crypto/chacha.h
+++ b/sys/include/crypto/chacha.h
@@ -137,7 +137,7 @@ uint32_t chacha_prng_next(void);
 }
 #endif
 
-#endif /* ifndef CRYPTO_CHACHA_H */
+#endif /* CRYPTO_CHACHA_H */
 
 /**
  * @}

--- a/sys/include/crypto/helper.h
+++ b/sys/include/crypto/helper.h
@@ -17,8 +17,8 @@
  * @author      Nico von Geyso <nico.geyso@fu-berlin.de>
  */
 
-#ifndef CRYPTO_MODES_HELPER_H
-#define CRYPTO_MODES_HELPER_H
+#ifndef CRYPTO_HELPER_H
+#define CRYPTO_HELPER_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -53,4 +53,4 @@ int crypto_equals(uint8_t *a, uint8_t *b, size_t len);
 }
 #endif
 
-#endif /* CRYPTO_MODES_HELPER_H */
+#endif /* CRYPTO_HELPER_H */

--- a/sys/include/ecc/hamming256.h
+++ b/sys/include/ecc/hamming256.h
@@ -15,8 +15,8 @@
  * @author      Lucas Jenß <lucas@x3ro.de>
  */
 
-#ifndef _HAMMING256_H
-#define _HAMMING256_H
+#ifndef ECC_HAMMING256_H
+#define ECC_HAMMING256_H
 
 #include <stdint.h>
 
@@ -68,5 +68,5 @@ uint8_t hamming_verify256x( uint8_t *data, uint32_t size, const uint8_t *code );
 }
 #endif
 
-#endif
+#endif /* ECC_HAMMING256_H */
 /** @} */

--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -16,8 +16,8 @@
  * @author Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef SYS_EMB_UNIT_H
-#define SYS_EMB_UNIT_H
+#ifndef EMBUNIT_H
+#define EMBUNIT_H
 
 #include "embUnit/embUnit.h"
 
@@ -64,4 +64,4 @@ extern "C" {
 }
 #endif
 
-#endif /* SYS_EMB_UNIT_H */
+#endif /* EMBUNIT_H */

--- a/sys/include/embUnit/AssertImpl.h
+++ b/sys/include/embUnit/AssertImpl.h
@@ -100,4 +100,4 @@ void assertImplementationCStr(const char *expected,const char *actual, long line
 }
 #endif
 
-#endif/* EMBUNIT_ASSERTIMPL_H */
+#endif /* EMBUNIT_ASSERTIMPL_H */

--- a/sys/include/embUnit/ColorOutputter.h
+++ b/sys/include/embUnit/ColorOutputter.h
@@ -41,5 +41,5 @@ void ColorOutputter_printStatistics(OutputterRef self, TestResultRef result);
 }
 #endif
 
-#endif/* EMBUNIT_COLOROUTPUTTER_H */
+#endif /* EMBUNIT_COLOROUTPUTTER_H */
 /** @} */

--- a/sys/include/embUnit/ColorTextOutputter.h
+++ b/sys/include/embUnit/ColorTextOutputter.h
@@ -26,5 +26,5 @@ OutputterRef ColorTextOutputter_outputter(void);
 }
 #endif
 
-#endif/* EMBUNIT_COLORTEXTOUTPUTTER_H */
+#endif /* EMBUNIT_COLORTEXTOUTPUTTER_H */
 /** @} */

--- a/sys/include/embUnit/CompilerOutputter.h
+++ b/sys/include/embUnit/CompilerOutputter.h
@@ -47,4 +47,4 @@ OutputterRef CompilerOutputter_outputter(void);
 }
 #endif
 
-#endif/* EMBUNIT_COMPILEROUTPUTTER_H */
+#endif /* EMBUNIT_COMPILEROUTPUTTER_H */

--- a/sys/include/embUnit/HelperMacro.h
+++ b/sys/include/embUnit/HelperMacro.h
@@ -64,4 +64,4 @@ extern "C" {
 }
 #endif
 
-#endif/* EMBUNIT_HELPERMACRO_H */
+#endif /* EMBUNIT_HELPERMACRO_H */

--- a/sys/include/embUnit/Outputter.h
+++ b/sys/include/embUnit/Outputter.h
@@ -79,4 +79,4 @@ struct __Outputter {
 }
 #endif
 
-#endif/* EMBUNIT_OUTPUTTER_H */
+#endif /* EMBUNIT_OUTPUTTER_H */

--- a/sys/include/embUnit/RepeatedTest.h
+++ b/sys/include/embUnit/RepeatedTest.h
@@ -61,4 +61,4 @@ extern const TestImplement RepeatedTestImplement;
 }
 #endif
 
-#endif/* EMBUNIT_REPEATEDTEST_H */
+#endif /* EMBUNIT_REPEATEDTEST_H */

--- a/sys/include/embUnit/Test.h
+++ b/sys/include/embUnit/Test.h
@@ -70,4 +70,4 @@ struct __Test {
 }
 #endif
 
-#endif/* EMBUNIT_TEST_H */
+#endif /* EMBUNIT_TEST_H */

--- a/sys/include/embUnit/TestCaller.h
+++ b/sys/include/embUnit/TestCaller.h
@@ -77,4 +77,4 @@ extern const TestImplement TestCallerImplement;
 }
 #endif
 
-#endif/* EMBUNIT_TESTCALLER_H */
+#endif /* EMBUNIT_TESTCALLER_H */

--- a/sys/include/embUnit/TestCase.h
+++ b/sys/include/embUnit/TestCase.h
@@ -65,4 +65,4 @@ extern const TestImplement TestCaseImplement;
 }
 #endif
 
-#endif/* EMBUNIT_TESTCASE_H */
+#endif /* EMBUNIT_TESTCASE_H */

--- a/sys/include/embUnit/TestListener.h
+++ b/sys/include/embUnit/TestListener.h
@@ -67,4 +67,4 @@ struct __TestListner {
 }
 #endif
 
-#endif/* EMBUNIT_TESTLISTENER_H */
+#endif /* EMBUNIT_TESTLISTENER_H */

--- a/sys/include/embUnit/TestResult.h
+++ b/sys/include/embUnit/TestResult.h
@@ -67,4 +67,4 @@ void TestResult_addFailure(TestResult* self,Test* test,const char* msg,int line,
 }
 #endif
 
-#endif/* EMBUNIT_TESTRESULT_H */
+#endif /* EMBUNIT_TESTRESULT_H */

--- a/sys/include/embUnit/TestRunner.h
+++ b/sys/include/embUnit/TestRunner.h
@@ -49,4 +49,4 @@ extern int TestRunnerHadErrors;
 }
 #endif
 
-#endif/* EMBUNIT_TESTRUNNER_H */
+#endif /* EMBUNIT_TESTRUNNER_H */

--- a/sys/include/embUnit/TestSuite.h
+++ b/sys/include/embUnit/TestSuite.h
@@ -63,4 +63,4 @@ extern const TestImplement TestSuiteImplement;
 }
 #endif
 
-#endif/* EMBUNIT_TESTSUITE_H */
+#endif /* EMBUNIT_TESTSUITE_H */

--- a/sys/include/embUnit/TextOutputter.h
+++ b/sys/include/embUnit/TextOutputter.h
@@ -47,4 +47,4 @@ OutputterRef TextOutputter_outputter(void);
 }
 #endif
 
-#endif/* EMBUNIT_TEXTOUTPUTTER_H */
+#endif /* EMBUNIT_TEXTOUTPUTTER_H */

--- a/sys/include/embUnit/TextUIRunner.h
+++ b/sys/include/embUnit/TextUIRunner.h
@@ -53,4 +53,4 @@ void TextUIRunner_end(void);
 }
 #endif
 
-#endif/* EMBUNIT_TEXTUIRUNNER_H */
+#endif /* EMBUNIT_TEXTUIRUNNER_H */

--- a/sys/include/embUnit/XMLOutputter.h
+++ b/sys/include/embUnit/XMLOutputter.h
@@ -48,4 +48,4 @@ OutputterRef XMLOutputter_outputter(void);
 }
 #endif
 
-#endif/* EMBUNIT_XMLOUTPUTTER_H */
+#endif /* EMBUNIT_XMLOUTPUTTER_H */

--- a/sys/include/embUnit/embUnit.h
+++ b/sys/include/embUnit/embUnit.h
@@ -55,4 +55,4 @@ extern "C" {
 }
 #endif
 
-#endif/* EMBUNIT_EMBUNIT_H */
+#endif /* EMBUNIT_EMBUNIT_H */

--- a/sys/include/embUnit/embUnit_config.h
+++ b/sys/include/embUnit/embUnit_config.h
@@ -32,8 +32,8 @@
  *
  * $Id: config.h,v 1.7 2004/02/10 16:17:07 arms22 Exp $
  */
-#ifndef EMBUNIT_CONFIG_H
-#define EMBUNIT_CONFIG_H
+#ifndef EMBUNIT_EMBUNIT_CONFIG_H
+#define EMBUNIT_EMBUNIT_CONFIG_H
 
 #ifdef  __cplusplus
 extern "C" {
@@ -53,4 +53,4 @@ extern "C" {
 }
 #endif
 
-#endif/* EMBUNIT_CONFIG_H */
+#endif /* EMBUNIT_EMBUNIT_CONFIG_H */

--- a/sys/include/embUnit/stdImpl.h
+++ b/sys/include/embUnit/stdImpl.h
@@ -59,4 +59,4 @@ static inline char* stdimpl_itoa(int v,char *string,int r)
 }
 #endif
 
-#endif/* EMBUNIT_STDIMPL_H */
+#endif /* EMBUNIT_STDIMPL_H */

--- a/sys/include/fs/constfs.h
+++ b/sys/include/fs/constfs.h
@@ -21,8 +21,8 @@
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef CONSTFS_H_
-#define CONSTFS_H_
+#ifndef FS_CONSTFS_H
+#define FS_CONSTFS_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -61,6 +61,6 @@ extern const vfs_file_system_t constfs_file_system;
 }
 #endif
 
-#endif
+#endif /* FS_CONSTFS_H */
 
 /** @} */

--- a/sys/include/fs/devfs.h
+++ b/sys/include/fs/devfs.h
@@ -22,8 +22,8 @@
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef DEVFS_H_
-#define DEVFS_H_
+#ifndef FS_DEVFS_H
+#define FS_DEVFS_H
 
 #include "clist.h"
 #include "vfs.h"
@@ -89,6 +89,6 @@ int devfs_unregister(devfs_t *node);
 }
 #endif
 
-#endif
+#endif /* FS_DEVFS_H */
 
 /** @} */

--- a/sys/include/fs/spiffs_fs.h
+++ b/sys/include/fs/spiffs_fs.h
@@ -17,8 +17,8 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef SPIFFS_FS_H
-#define SPIFFS_FS_H
+#ifndef FS_SPIFFS_FS_H
+#define FS_SPIFFS_FS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,6 +81,6 @@ extern const vfs_file_system_t spiffs_file_system;
 }
 #endif
 
-#endif /* SPIFFS_FS_H */
+#endif /* FS_SPIFFS_FS_H */
 
 /** @} */

--- a/sys/include/hashes/sha1.h
+++ b/sys/include/hashes/sha1.h
@@ -23,8 +23,8 @@
 /* This code is public-domain - it is based on libcrypt
  * placed in the public domain by Wei Dai and other contributors. */
 
-#ifndef _SHA1_H
-#define _SHA1_H
+#ifndef HASHES_SHA1_H
+#define HASHES_SHA1_H
 
 #include <stdint.h>
 
@@ -118,5 +118,5 @@ void sha1_final_hmac(sha1_context *ctx, void *digest);
 }
 #endif
 
-#endif /* _SHA1_H */
+#endif /* HASHES_SHA1_H */
 /** @} */

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -43,8 +43,8 @@
  * @author      Hermann Lelong
  */
 
-#ifndef _SHA256_H
-#define _SHA256_H
+#ifndef HASHES_SHA256_H
+#define HASHES_SHA256_H
 
 #include <inttypes.h>
 
@@ -240,4 +240,4 @@ int sha256_chain_verify_element(void *element,
 #endif
 
 /** @} */
-#endif /* _SHA256_H */
+#endif /* HASHES_SHA256_H */

--- a/sys/include/luid.h
+++ b/sys/include/luid.h
@@ -50,8 +50,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef LUID_H_
-#define LUID_H_
+#ifndef LUID_H
+#define LUID_H
 
 #include <stddef.h>
 
@@ -115,5 +115,5 @@ void luid_base(void *buf, size_t len);
 }
 #endif
 
-#endif /* LUID_H_ */
+#endif /* LUID_H */
 /** @} */

--- a/sys/include/net/af.h
+++ b/sys/include/net/af.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef AF_H
-#define AF_H
+#ifndef NET_AF_H
+#define NET_AF_H
 
 
 
@@ -47,5 +47,5 @@ enum {
 }
 #endif
 
-#endif /* AF_H */
+#endif /* NET_AF_H */
 /** @} */

--- a/sys/include/net/csma_sender.h
+++ b/sys/include/net/csma_sender.h
@@ -22,8 +22,8 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef CSMA_SENDER_H
-#define CSMA_SENDER_H
+#ifndef NET_CSMA_SENDER_H
+#define NET_CSMA_SENDER_H
 
 #include <stdint.h>
 
@@ -140,6 +140,6 @@ int csma_sender_cca_send(netdev_t *dev, struct iovec *vector, unsigned count);
 }
 #endif
 
-#endif /* CSMA_SENDER_H */
+#endif /* NET_CSMA_SENDER_H */
 
 /** @} */

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -82,8 +82,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef MQTTSN_H
-#define MQTTSN_H
+#ifndef NET_EMCUTE_H
+#define NET_EMCUTE_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -377,5 +377,5 @@ const char *emcute_type_str(uint8_t type);
 }
 #endif
 
-#endif /* MQTTSN_H */
+#endif /* NET_EMCUTE_H */
 /** @} */

--- a/sys/include/net/ethernet.h
+++ b/sys/include/net/ethernet.h
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef ETHERNET_H
-#define ETHERNET_H
+#ifndef NET_ETHERNET_H
+#define NET_ETHERNET_H
 
 #include <stdint.h>
 
@@ -74,7 +74,7 @@ static inline void ethernet_get_iid(eui64_t *eui64, uint8_t *mac)
 }
 #endif
 
-#endif /* ETHERNET_H */
+#endif /* NET_ETHERNET_H */
 /**
  * @}
  */

--- a/sys/include/net/ethernet/hdr.h
+++ b/sys/include/net/ethernet/hdr.h
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef ETHERNET_HDR_H
-#define ETHERNET_HDR_H
+#ifndef NET_ETHERNET_HDR_H
+#define NET_ETHERNET_HDR_H
 
 #include <inttypes.h>
 
@@ -51,7 +51,7 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* ETHERNET_HDR_H */
+#endif /* NET_ETHERNET_HDR_H */
 /**
  * @}
  */

--- a/sys/include/net/ethertype.h
+++ b/sys/include/net/ethertype.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef ETHERTYPE_H
-#define ETHERTYPE_H
+#ifndef NET_ETHERTYPE_H
+#define NET_ETHERTYPE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,7 +42,7 @@ extern "C" {
 }
 #endif
 
-#endif /* ETHERTYPE_H */
+#endif /* NET_ETHERTYPE_H */
 /**
  * @}
  */

--- a/sys/include/net/eui64.h
+++ b/sys/include/net/eui64.h
@@ -21,8 +21,8 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  */
-#ifndef EUI64_H
-#define EUI64_H
+#ifndef NET_EUI64_H
+#define NET_EUI64_H
 
 #include <stdint.h>
 #include "byteorder.h"
@@ -44,5 +44,5 @@ typedef union {
 }
 #endif
 
-#endif /* EUI64_H */
+#endif /* NET_EUI64_H */
 /** @} */

--- a/sys/include/net/fib.h
+++ b/sys/include/net/fib.h
@@ -22,8 +22,8 @@
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  */
 
-#ifndef FIB_H
-#define FIB_H
+#ifndef NET_FIB_H
+#define NET_FIB_H
 
 #include <stdint.h>
 
@@ -513,5 +513,5 @@ int fib_devel_get_lifetime(fib_table_t *table, uint64_t *lifetime, uint8_t *dst,
 }
 #endif
 
-#endif /* FIB_H */
+#endif /* NET_FIB_H */
 /** @} */

--- a/sys/include/net/fib/table.h
+++ b/sys/include/net/fib/table.h
@@ -16,8 +16,8 @@
  * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>
  */
 
-#ifndef FIB_TABLE_H
-#define FIB_TABLE_H
+#ifndef NET_FIB_TABLE_H
+#define NET_FIB_TABLE_H
 
 #include <stdint.h>
 
@@ -139,5 +139,5 @@ typedef struct {
 }
 #endif
 
-#endif /* FIB_TABLE_H */
+#endif /* NET_FIB_TABLE_H */
 /** @} */

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -138,8 +138,8 @@
  * @author      Ken Bannister <kb2ma@runbox.com>
  */
 
-#ifndef GCOAP_H
-#define GCOAP_H
+#ifndef NET_GCOAP_H
+#define NET_GCOAP_H
 
 #include "net/sock/udp.h"
 #include "nanocoap.h"
@@ -415,5 +415,5 @@ uint8_t gcoap_op_state(void);
 }
 #endif
 
-#endif /* GCOAP_H */
+#endif /* NET_GCOAP_H */
 /** @} */

--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -280,8 +280,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef GNRC_NETBASE_H
-#define GNRC_NETBASE_H
+#ifndef NET_GNRC_H
+#define NET_GNRC_H
 
 #include "net/netopt.h"
 #include "net/gnrc/netapi.h"
@@ -302,5 +302,5 @@ extern "C" {
 }
 #endif
 
-#endif /* GNRC_NETBASE_H */
+#endif /* NET_GNRC_H */
 /** @} */

--- a/sys/include/net/gnrc/icmpv6.h
+++ b/sys/include/net/gnrc/icmpv6.h
@@ -24,8 +24,8 @@
  * @todo build error messages
  */
 
-#ifndef GNRC_ICMPV6_H
-#define GNRC_ICMPV6_H
+#ifndef NET_GNRC_ICMPV6_H
+#define NET_GNRC_ICMPV6_H
 
 #include "kernel_types.h"
 #include "net/icmpv6.h"
@@ -79,7 +79,7 @@ int gnrc_icmpv6_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr);
 }
 #endif
 
-#endif /* GNRC_ICMPV6_H */
+#endif /* NET_GNRC_ICMPV6_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/icmpv6/echo.h
+++ b/sys/include/net/gnrc/icmpv6/echo.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_ICMPV6_ECHO_H
-#define GNRC_ICMPV6_ECHO_H
+#ifndef NET_GNRC_ICMPV6_ECHO_H
+#define NET_GNRC_ICMPV6_ECHO_H
 
 #include <inttypes.h>
 
@@ -62,5 +62,5 @@ void gnrc_icmpv6_echo_req_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6_hdr,
 }
 #endif
 
-#endif /* GNRC_ICMPV6_ECHO_H */
+#endif /* NET_GNRC_ICMPV6_ECHO_H */
 /** @} */

--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_ICMPV6_ERROR_H
-#define GNRC_ICMPV6_ERROR_H
+#ifndef NET_GNRC_ICMPV6_ERROR_H
+#define NET_GNRC_ICMPV6_ERROR_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -165,5 +165,5 @@ static inline void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
 }
 #endif
 
-#endif /* GNRC_ICMPV6_ERROR_H */
+#endif /* NET_GNRC_ICMPV6_ERROR_H */
 /** @} */

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -26,8 +26,8 @@
  */
 
 
-#ifndef GNRC_IPV6_H
-#define GNRC_IPV6_H
+#ifndef NET_GNRC_IPV6_H
+#define NET_GNRC_IPV6_H
 
 #include "kernel_types.h"
 #include "net/gnrc.h"
@@ -170,7 +170,7 @@ ipv6_hdr_t *gnrc_ipv6_get_header(gnrc_pktsnip_t *pkt);
 }
 #endif
 
-#endif /* GNRC_IPV6_H */
+#endif /* NET_GNRC_IPV6_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/ipv6/blacklist.h
+++ b/sys/include/net/gnrc/ipv6/blacklist.h
@@ -19,8 +19,8 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Martin Landsmann <martin.landsmann@haw-hamburg.de>
  */
-#ifndef GNRC_IPV6_BLACKLIST_H
-#define GNRC_IPV6_BLACKLIST_H
+#ifndef NET_GNRC_IPV6_BLACKLIST_H
+#define NET_GNRC_IPV6_BLACKLIST_H
 
 #include <stdbool.h>
 
@@ -75,5 +75,5 @@ void gnrc_ipv6_blacklist_print(void);
 }
 #endif
 
-#endif /* GNRC_IPV6_BLACKLIST_H */
+#endif /* NET_GNRC_IPV6_BLACKLIST_H */
 /** @} */

--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -22,8 +22,8 @@
  */
 
 
-#ifndef GNRC_IPV6_EXT_H
-#define GNRC_IPV6_EXT_H
+#ifndef NET_GNRC_IPV6_EXT_H
+#define NET_GNRC_IPV6_EXT_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -81,7 +81,7 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_build(gnrc_pktsnip_t *ipv6, gnrc_pktsnip_t *next,
 }
 #endif
 
-#endif /* GNRC_IPV6_EXT_H */
+#endif /* NET_GNRC_IPV6_EXT_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/ipv6/hdr.h
+++ b/sys/include/net/gnrc/ipv6/hdr.h
@@ -16,8 +16,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_IPV6_HDR_H
-#define GNRC_IPV6_HDR_H
+#ifndef NET_GNRC_IPV6_HDR_H
+#define NET_GNRC_IPV6_HDR_H
 
 #include <stdint.h>
 
@@ -50,5 +50,5 @@ gnrc_pktsnip_t *gnrc_ipv6_hdr_build(gnrc_pktsnip_t *payload, const ipv6_addr_t *
 }
 #endif
 
-#endif /* GNRC_IPV6_HDR_H */
+#endif /* NET_GNRC_IPV6_HDR_H */
 /** @} */

--- a/sys/include/net/gnrc/ipv6/nc.h
+++ b/sys/include/net/gnrc/ipv6/nc.h
@@ -18,8 +18,8 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef GNRC_IPV6_NC_H
-#define GNRC_IPV6_NC_H
+#ifndef NET_GNRC_IPV6_NC_H
+#define NET_GNRC_IPV6_NC_H
 
 #include <assert.h>
 #include <stdbool.h>
@@ -313,7 +313,7 @@ kernel_pid_t gnrc_ipv6_nc_get_l2_addr(uint8_t *l2_addr, uint8_t *l2_addr_len,
 }
 #endif
 
-#endif /* GNRC_IPV6_NC_H */
+#endif /* NET_GNRC_IPV6_NC_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/ipv6/netif.h
+++ b/sys/include/net/gnrc/ipv6/netif.h
@@ -18,8 +18,8 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef GNRC_IPV6_NETIF_H
-#define GNRC_IPV6_NETIF_H
+#ifndef NET_GNRC_IPV6_NETIF_H
+#define NET_GNRC_IPV6_NETIF_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -611,7 +611,7 @@ netstats_t *gnrc_ipv6_netif_get_stats(kernel_pid_t pid);
 }
 #endif
 
-#endif /* NETIF_H */
+#endif /* NET_GNRC_IPV6_NETIF_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/ipv6/whitelist.h
+++ b/sys/include/net/gnrc/ipv6/whitelist.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_IPV6_WHITELIST_H
-#define GNRC_IPV6_WHITELIST_H
+#ifndef NET_GNRC_IPV6_WHITELIST_H
+#define NET_GNRC_IPV6_WHITELIST_H
 
 #include <stdbool.h>
 
@@ -73,5 +73,5 @@ void gnrc_ipv6_whitelist_print(void);
 }
 #endif
 
-#endif /* GNRC_IPV6_WHITELIST_H */
+#endif /* NET_GNRC_IPV6_WHITELIST_H */
 /** @} */

--- a/sys/include/net/gnrc/mac/internal.h
+++ b/sys/include/net/gnrc/mac/internal.h
@@ -18,8 +18,8 @@
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
 
-#ifndef GNRC_MAC_INTERNAL_H
-#define GNRC_MAC_INTERNAL_H
+#ifndef NET_GNRC_MAC_INTERNAL_H
+#define NET_GNRC_MAC_INTERNAL_H
 
 #include <stdint.h>
 #include <net/ieee802154.h>
@@ -76,5 +76,5 @@ void gnrc_mac_dispatch(gnrc_mac_rx_t* rx);
 }
 #endif
 
-#endif /* GNRC_MAC_INTERNAL_H */
+#endif /* NET_GNRC_MAC_INTERNAL_H */
 /** @} */

--- a/sys/include/net/gnrc/mac/mac.h
+++ b/sys/include/net/gnrc/mac/mac.h
@@ -21,8 +21,8 @@
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
 
-#ifndef GNRC_MAC_H
-#define GNRC_MAC_H
+#ifndef NET_GNRC_MAC_MAC_H
+#define NET_GNRC_MAC_MAC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,5 +60,5 @@ extern "C" {
 }
 #endif
 
-#endif /* GNRC_MAC_H */
+#endif /* NET_GNRC_MAC_MAC_H */
 /** @} */

--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -18,8 +18,8 @@
  * @author      Shuguo Zhuo  <shuguo.zhuo@inria.fr>
  */
 
-#ifndef GNRC_MAC_TYPES_H
-#define GNRC_MAC_TYPES_H
+#ifndef NET_GNRC_MAC_TYPES_H
+#define NET_GNRC_MAC_TYPES_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -186,5 +186,5 @@ typedef struct {
 }
 #endif
 
-#endif /* GNRC_MAC_TYPES_H */
+#endif /* NET_GNRC_MAC_TYPES_H */
 /** @} */

--- a/sys/include/net/gnrc/ndp.h
+++ b/sys/include/net/gnrc/ndp.h
@@ -18,8 +18,8 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef GNRC_NDP_H
-#define GNRC_NDP_H
+#ifndef NET_GNRC_NDP_H
+#define NET_GNRC_NDP_H
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -557,7 +557,7 @@ gnrc_pktsnip_t *gnrc_ndp_opt_mtu_build(uint32_t mtu, gnrc_pktsnip_t *next);
 }
 #endif
 
-#endif /* GNRC_NDP_H */
+#endif /* NET_GNRC_NDP_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/ndp/host.h
+++ b/sys/include/net/gnrc/ndp/host.h
@@ -18,8 +18,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_NDP_HOST_H
-#define GNRC_NDP_HOST_H
+#ifndef NET_GNRC_NDP_HOST_H
+#define NET_GNRC_NDP_HOST_H
 
 #include "net/gnrc/ipv6/netif.h"
 
@@ -50,5 +50,5 @@ void gnrc_ndp_host_retrans_rtr_sol(gnrc_ipv6_netif_t *iface);
 }
 #endif
 
-#endif /* GNRC_NDP_HOST_H */
+#endif /* NET_GNRC_NDP_HOST_H */
 /** @} */

--- a/sys/include/net/gnrc/ndp/internal.h
+++ b/sys/include/net/gnrc/ndp/internal.h
@@ -19,8 +19,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_NDP_INTERNAL_H
-#define GNRC_NDP_INTERNAL_H
+#ifndef NET_GNRC_NDP_INTERNAL_H
+#define NET_GNRC_NDP_INTERNAL_H
 
 #include "kernel_types.h"
 #include "net/gnrc/ipv6/nc.h"
@@ -211,5 +211,5 @@ static inline void gnrc_ndp_internal_reset_nbr_sol_timer(gnrc_ipv6_nc_t *nc_entr
 }
 #endif
 
-#endif /* GNRC_NDP_INTERNAL_H */
+#endif /* NET_GNRC_NDP_INTERNAL_H */
 /** @} */

--- a/sys/include/net/gnrc/ndp/node.h
+++ b/sys/include/net/gnrc/ndp/node.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_NDP_NODE_H
-#define GNRC_NDP_NODE_H
+#ifndef NET_GNRC_NDP_NODE_H
+#define NET_GNRC_NDP_NODE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,5 +49,5 @@ kernel_pid_t gnrc_ndp_node_next_hop_l2addr(uint8_t *l2addr, uint8_t *l2addr_len,
 }
 #endif
 
-#endif /* GNRC_NDP_NODE_H */
+#endif /* NET_GNRC_NDP_NODE_H */
 /** @} */

--- a/sys/include/net/gnrc/ndp/router.h
+++ b/sys/include/net/gnrc/ndp/router.h
@@ -18,8 +18,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_NDP_ROUTER_H
-#define GNRC_NDP_ROUTER_H
+#ifndef NET_GNRC_NDP_ROUTER_H
+#define NET_GNRC_NDP_ROUTER_H
 
 #include <stdbool.h>
 
@@ -84,5 +84,5 @@ void gnrc_ndp_router_send_rtr_adv(gnrc_ipv6_nc_t *neighbor);
 }
 #endif
 
-#endif /* GNRC_NDP_ROUTER_H */
+#endif /* NET_GNRC_NDP_ROUTER_H */
 /** @} */

--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -55,8 +55,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef GNRC_NETAPI_H
-#define GNRC_NETAPI_H
+#ifndef NET_GNRC_NETAPI_H
+#define NET_GNRC_NETAPI_H
 
 #include "thread.h"
 #include "net/netopt.h"
@@ -210,7 +210,7 @@ int gnrc_netapi_set(kernel_pid_t pid, netopt_t opt, uint16_t context,
 }
 #endif
 
-#endif /* GNRC_NETAPI_H */
+#endif /* NET_GNRC_NETAPI_H */
 /**
  * @}^
  */

--- a/sys/include/net/gnrc/netdev.h
+++ b/sys/include/net/gnrc/netdev.h
@@ -26,8 +26,8 @@
  * @author    Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef GNRC_NETDEV_H
-#define GNRC_NETDEV_H
+#ifndef NET_GNRC_NETDEV_H
+#define NET_GNRC_NETDEV_H
 
 #include <assert.h>
 #include <stdint.h>
@@ -222,5 +222,5 @@ kernel_pid_t gnrc_netdev_init(char *stack, int stacksize, char priority,
 }
 #endif
 
-#endif /* GNRC_NETDEV_H */
+#endif /* NET_GNRC_NETDEV_H */
 /** @} */

--- a/sys/include/net/gnrc/netdev/eth.h
+++ b/sys/include/net/gnrc/netdev/eth.h
@@ -16,8 +16,8 @@
  * @author    Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef GNRC_NETDEV_ETH_H
-#define GNRC_NETDEV_ETH_H
+#ifndef NET_GNRC_NETDEV_ETH_H
+#define NET_GNRC_NETDEV_ETH_H
 
 #include "net/gnrc/netdev.h"
 
@@ -40,5 +40,5 @@ int gnrc_netdev_eth_init(gnrc_netdev_t *gnrc_netdev, netdev_t *dev);
 }
 #endif
 
-#endif /* GNRC_NETDEV_ETH_H */
+#endif /* NET_GNRC_NETDEV_ETH_H */
 /** @} */

--- a/sys/include/net/gnrc/netdev/ieee802154.h
+++ b/sys/include/net/gnrc/netdev/ieee802154.h
@@ -16,8 +16,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_NETDEV_IEEE802154_H
-#define GNRC_NETDEV_IEEE802154_H
+#ifndef NET_GNRC_NETDEV_IEEE802154_H
+#define NET_GNRC_NETDEV_IEEE802154_H
 
 #include "net/netdev/ieee802154.h"
 #include "net/gnrc/netdev.h"
@@ -42,5 +42,5 @@ int gnrc_netdev_ieee802154_init(gnrc_netdev_t *gnrc_netdev,
 }
 #endif
 
-#endif /* GNRC_IEEE802154_H */
+#endif /* NET_GNRC_NETDEV_IEEE802154_H */
 /** @} */

--- a/sys/include/net/gnrc/netdev/xbee_adpt.h
+++ b/sys/include/net/gnrc/netdev/xbee_adpt.h
@@ -25,8 +25,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef GNRC_NETDEV_XBEE_ADPT_H
-#define GNRC_NETDEV_XBEE_ADPT_H
+#ifndef NET_GNRC_NETDEV_XBEE_ADPT_H
+#define NET_GNRC_NETDEV_XBEE_ADPT_H
 
 #include "xbee.h"
 #include "net/gnrc/netdev.h"
@@ -48,5 +48,5 @@ void gnrc_netdev_xbee_init(gnrc_netdev_t *gnrc_netdev, xbee_t *dev);
 }
 #endif
 
-#endif /* GNRC_NETDEV_XBEE_ADPT_H */
+#endif /* NET_GNRC_NETDEV_XBEE_ADPT_H */
 /** @} */

--- a/sys/include/net/gnrc/neterr.h
+++ b/sys/include/net/gnrc/neterr.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_NETERR_H
-#define GNRC_NETERR_H
+#ifndef NET_GNRC_NETERR_H
+#define NET_GNRC_NETERR_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -89,5 +89,5 @@ static inline int gnrc_neterr_reg(gnrc_pktsnip_t *pkt)
 }
 #endif
 
-#endif /* GNRC_NETERR_H */
+#endif /* NET_GNRC_NETERR_H */
 /** @} */

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -22,8 +22,8 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  */
-#ifndef GNRC_NETIF_H
-#define GNRC_NETIF_H
+#ifndef NET_GNRC_NETIF_H
+#define NET_GNRC_NETIF_H
 
 #include <stdlib.h>
 #include <stdbool.h>
@@ -142,5 +142,5 @@ size_t gnrc_netif_addr_from_str(uint8_t *out, size_t out_len, const char *str);
 }
 #endif
 
-#endif /* GNRC_NETIF_H */
+#endif /* NET_GNRC_NETIF_H */
 /** @} */

--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -18,8 +18,8 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef NETIF_HDR_H
-#define NETIF_HDR_H
+#ifndef NET_GNRC_NETIF_HDR_H
+#define NET_GNRC_NETIF_HDR_H
 
 #include <string.h>
 #include <stdint.h>
@@ -242,5 +242,5 @@ int gnrc_netif_hdr_get_srcaddr(gnrc_pktsnip_t* pkt, uint8_t** pointer_to_addr);
 }
 #endif
 
-#endif /* NETIF_HDR_H */
+#endif /* NET_GNRC_NETIF_HDR_H */
 /** @} */

--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -18,8 +18,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NETREG_H
-#define NETREG_H
+#ifndef NET_GNRC_NETREG_H
+#define NET_GNRC_NETREG_H
 
 #include <inttypes.h>
 
@@ -345,5 +345,5 @@ int gnrc_netreg_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr);
 }
 #endif
 
-#endif /* NETREG_H */
+#endif /* NET_GNRC_NETREG_H */
 /** @} */

--- a/sys/include/net/gnrc/nettest.h
+++ b/sys/include/net/gnrc/nettest.h
@@ -18,8 +18,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_NETTEST_H
-#define GNRC_NETTEST_H
+#ifndef NET_GNRC_NETTEST_H
+#define NET_GNRC_NETTEST_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -264,5 +264,5 @@ void gnrc_nettest_reset(void);
 }
 #endif
 
-#endif /* GNRC_NETTEST_H */
+#endif /* NET_GNRC_NETTEST_H */
 /** @} */

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -22,8 +22,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_NETTYPE_H
-#define GNRC_NETTYPE_H
+#ifndef NET_GNRC_NETTYPE_H
+#define NET_GNRC_NETTYPE_H
 
 #include <inttypes.h>
 
@@ -245,5 +245,5 @@ static inline uint8_t gnrc_nettype_to_protnum(gnrc_nettype_t type)
 }
 #endif
 
-#endif /* GNRC_NETTYPE_H */
+#endif /* NET_GNRC_NETTYPE_H */
 /** @} */

--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -19,8 +19,8 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-#ifndef GNRC_PKT_H
-#define GNRC_PKT_H
+#ifndef NET_GNRC_PKT_H
+#define NET_GNRC_PKT_H
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -196,5 +196,5 @@ gnrc_pktsnip_t *gnrc_pktsnip_search_type(gnrc_pktsnip_t *pkt,
 }
 #endif
 
-#endif /* GNRC_PKT_H */
+#endif /* NET_GNRC_PKT_H */
 /** @} */

--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -27,8 +27,8 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-#ifndef GNRC_PKTBUF_H
-#define GNRC_PKTBUF_H
+#ifndef NET_GNRC_PKTBUF_H
+#define NET_GNRC_PKTBUF_H
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -309,5 +309,5 @@ bool gnrc_pktbuf_is_sane(void);
 }
 #endif
 
-#endif /* GNRC_PKTBUF_H */
+#endif /* NET_GNRC_PKTBUF_H */
 /** @} */

--- a/sys/include/net/gnrc/pktdump.h
+++ b/sys/include/net/gnrc/pktdump.h
@@ -19,8 +19,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef GNRC_PKTDUMP_H
-#define GNRC_PKTDUMP_H
+#ifndef NET_GNRC_PKTDUMP_H
+#define NET_GNRC_PKTDUMP_H
 
 #include "kernel_types.h"
 
@@ -66,5 +66,5 @@ kernel_pid_t gnrc_pktdump_init(void);
 }
 #endif
 
-#endif /* GNRC_PKTDUMP_H */
+#endif /* NET_GNRC_PKTDUMP_H */
 /** @} */

--- a/sys/include/net/gnrc/pktqueue.h
+++ b/sys/include/net/gnrc/pktqueue.h
@@ -18,8 +18,8 @@
  * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#ifndef GNRC_PKTQUEUE_H
-#define GNRC_PKTQUEUE_H
+#ifndef NET_GNRC_PKTQUEUE_H
+#define NET_GNRC_PKTQUEUE_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -84,7 +84,7 @@ static inline gnrc_pktqueue_t *gnrc_pktqueue_remove_head(gnrc_pktqueue_t **queue
 }
 #endif
 
-#endif /* GNRC_PKTQUEUE_H */
+#endif /* NET_GNRC_PKTQUEUE_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/priority_pktqueue.h
+++ b/sys/include/net/gnrc/priority_pktqueue.h
@@ -20,8 +20,8 @@
  * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>
  */
 
-#ifndef GNRC_PRIORITY_PKTQUEUE_H
-#define GNRC_PRIORITY_PKTQUEUE_H
+#ifndef NET_GNRC_PRIORITY_PKTQUEUE_H
+#define NET_GNRC_PRIORITY_PKTQUEUE_H
 
 #include <stdint.h>
 #include <priority_queue.h>
@@ -133,5 +133,5 @@ void gnrc_priority_pktqueue_push(gnrc_priority_pktqueue_t* queue,
 }
 #endif
 
-#endif /* GNRC_PRIORITY_PKTQUEUE_H */
+#endif /* NET_GNRC_PRIORITY_PKTQUEUE_H */
 /** @} */

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -95,8 +95,8 @@
  * @author      Cenk Gündoğan <cnkgndgn@gmail.com>
  */
 
-#ifndef GNRC_RPL_H
-#define GNRC_RPL_H
+#ifndef NET_GNRC_RPL_H
+#define NET_GNRC_RPL_H
 
 #include <string.h>
 #include <stdint.h>
@@ -634,5 +634,5 @@ static inline void gnrc_rpl_config_pio(gnrc_rpl_dodag_t *dodag, bool status)
 }
 #endif
 
-#endif /* GNRC_RPL_H */
+#endif /* NET_GNRC_RPL_H */
 /** @} */

--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -20,8 +20,8 @@
  * @author      Cenk Gündoğan <cnkgndgn@gmail.com>
  */
 
-#ifndef GNRC_RPL_DODAG_H
-#define GNRC_RPL_DODAG_H
+#ifndef NET_GNRC_RPL_DODAG_H
+#define NET_GNRC_RPL_DODAG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -173,7 +173,7 @@ void gnrc_rpl_router_operation(gnrc_rpl_dodag_t *dodag);
 }
 #endif
 
-#endif /* GNRC_RPL_DODAG_H */
+#endif /* NET_GNRC_RPL_DODAG_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/rpl/of_manager.h
+++ b/sys/include/net/gnrc/rpl/of_manager.h
@@ -16,8 +16,8 @@
  * @author  Fabian Brandt <fabianbr@zedat.fu-berlin.de>
  */
 
-#ifndef RPL_OFM_H
-#define RPL_OFM_H
+#ifndef NET_GNRC_RPL_OF_MANAGER_H
+#define NET_GNRC_RPL_OF_MANAGER_H
 
 #include "structs.h"
 
@@ -41,5 +41,5 @@ gnrc_rpl_of_t *gnrc_rpl_get_of_for_ocp(uint16_t ocp);
 }
 #endif
 
-#endif /* RPL_OFM_H */
+#endif /* NET_GNRC_RPL_OF_MANAGER_H */
 /** @} */

--- a/sys/include/net/gnrc/rpl/p2p.h
+++ b/sys/include/net/gnrc/rpl/p2p.h
@@ -20,8 +20,8 @@
  *
  * @author  Cenk Gündoğan <mail@cgundogan.de>
  */
-#ifndef GNRC_RPL_P2P_H
-#define GNRC_RPL_P2P_H
+#ifndef NET_GNRC_RPL_P2P_H
+#define NET_GNRC_RPL_P2P_H
 
 #include "net/ipv6/addr.h"
 #include "net/gnrc.h"
@@ -176,5 +176,5 @@ void gnrc_rpl_p2p_update(void);
 }
 #endif
 
-#endif /* GNRC_RPL_P2P_H */
+#endif /* NET_GNRC_RPL_P2P_H */
 /** @} */

--- a/sys/include/net/gnrc/rpl/p2p_dodag.h
+++ b/sys/include/net/gnrc/rpl/p2p_dodag.h
@@ -18,8 +18,8 @@
  * @author      Cenk Gündoğan <mail@cgundogan.de>
  */
 
-#ifndef GNRC_RPL_P2P_DODAG_H
-#define GNRC_RPL_P2P_DODAG_H
+#ifndef NET_GNRC_RPL_P2P_DODAG_H
+#define NET_GNRC_RPL_P2P_DODAG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,7 +68,7 @@ gnrc_rpl_p2p_ext_t *gnrc_rpl_p2p_ext_get(gnrc_rpl_dodag_t *dodag);
 }
 #endif
 
-#endif /* GNRC_RPL_P2P_DODAG_H */
+#endif /* NET_GNRC_RPL_P2P_DODAG_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/rpl/p2p_structs.h
+++ b/sys/include/net/gnrc/rpl/p2p_structs.h
@@ -18,8 +18,8 @@
  * @author      Cenk Gündoğan <mail@cgundogan.de>
  */
 
-#ifndef GNRC_RPL_P2P_STRUCTS_H
-#define GNRC_RPL_P2P_STRUCTS_H
+#ifndef NET_GNRC_RPL_P2P_STRUCTS_H
+#define NET_GNRC_RPL_P2P_STRUCTS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,7 +100,7 @@ typedef struct {
 }
 #endif
 
-#endif /* GNRC_RPL_P2P_STRUCTS_H */
+#endif /* NET_GNRC_RPL_P2P_STRUCTS_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/rpl/srh.h
+++ b/sys/include/net/gnrc/rpl/srh.h
@@ -20,8 +20,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_RPL_SRH_H
-#define GNRC_RPL_SRH_H
+#ifndef NET_GNRC_RPL_SRH_H
+#define NET_GNRC_RPL_SRH_H
 
 #include "net/ipv6/hdr.h"
 #include "net/ipv6/addr.h"
@@ -70,5 +70,5 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh);
 }
 #endif
 
-#endif /* GNRC_RPL_SRH_H */
+#endif /* NET_GNRC_RPL_SRH_H */
 /** @} */

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -20,8 +20,8 @@
  * @author      Cenk Gündoğan <cnkgndgn@gmail.com>
  */
 
-#ifndef GNRC_RPL_STRUCTS_H
-#define GNRC_RPL_STRUCTS_H
+#ifndef NET_GNRC_RPL_STRUCTS_H
+#define NET_GNRC_RPL_STRUCTS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -293,7 +293,7 @@ struct gnrc_rpl_instance {
 }
 #endif
 
-#endif /* GNRC_RPL_STRUCTS_H */
+#endif /* NET_GNRC_RPL_STRUCTS_H */
 /**
  * @}
  */

--- a/sys/include/net/gnrc/sixlowpan.h
+++ b/sys/include/net/gnrc/sixlowpan.h
@@ -97,8 +97,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_SIXLOWPAN_H
-#define GNRC_SIXLOWPAN_H
+#ifndef NET_GNRC_SIXLOWPAN_H
+#define NET_GNRC_SIXLOWPAN_H
 
 #include <stdbool.h>
 
@@ -150,5 +150,5 @@ kernel_pid_t gnrc_sixlowpan_init(void);
 }
 #endif
 
-#endif /* GNRC_SIXLOWPAN_H */
+#endif /* NET_GNRC_SIXLOWPAN_H */
 /** @} */

--- a/sys/include/net/gnrc/sixlowpan/ctx.h
+++ b/sys/include/net/gnrc/sixlowpan/ctx.h
@@ -23,8 +23,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_SIXLOWPAN_CTX_H
-#define GNRC_SIXLOWPAN_CTX_H
+#ifndef NET_GNRC_SIXLOWPAN_CTX_H
+#define NET_GNRC_SIXLOWPAN_CTX_H
 
 #include <inttypes.h>
 #include <stdbool.h>
@@ -136,5 +136,5 @@ void gnrc_sixlowpan_ctx_reset(void);
 }
 #endif
 
-#endif /* GNRC_SIXLOWPAN_CTX_H */
+#endif /* NET_GNRC_SIXLOWPAN_CTX_H */
 /** @} */

--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -22,8 +22,8 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  * @author  Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  */
-#ifndef GNRC_SIXLOWPAN_FRAG_H
-#define GNRC_SIXLOWPAN_FRAG_H
+#ifndef NET_GNRC_SIXLOWPAN_FRAG_H
+#define NET_GNRC_SIXLOWPAN_FRAG_H
 
 #include <inttypes.h>
 #include <stdbool.h>
@@ -72,5 +72,5 @@ void gnrc_sixlowpan_frag_handle_pkt(gnrc_pktsnip_t *pkt);
 }
 #endif
 
-#endif /* GNRC_SIXLOWPAN_FRAG_H */
+#endif /* NET_GNRC_SIXLOWPAN_FRAG_H */
 /** @} */

--- a/sys/include/net/gnrc/sixlowpan/iphc.h
+++ b/sys/include/net/gnrc/sixlowpan/iphc.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_SIXLOWPAN_IPHC_H
-#define GNRC_SIXLOWPAN_IPHC_H
+#ifndef NET_GNRC_SIXLOWPAN_IPHC_H
+#define NET_GNRC_SIXLOWPAN_IPHC_H
 
 #include <stdbool.h>
 
@@ -65,5 +65,5 @@ bool gnrc_sixlowpan_iphc_encode(gnrc_pktsnip_t *pkt);
 }
 #endif
 
-#endif /* GNRC_SIXLOWPAN_IPHC_H */
+#endif /* NET_GNRC_SIXLOWPAN_IPHC_H */
 /** @} */

--- a/sys/include/net/gnrc/sixlowpan/nd.h
+++ b/sys/include/net/gnrc/sixlowpan/nd.h
@@ -20,8 +20,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_SIXLOWPAN_ND_H
-#define GNRC_SIXLOWPAN_ND_H
+#ifndef NET_GNRC_SIXLOWPAN_ND_H
+#define NET_GNRC_SIXLOWPAN_ND_H
 
 #include <stdint.h>
 
@@ -282,5 +282,5 @@ gnrc_pktsnip_t *gnrc_sixlowpan_nd_opt_abr_build(uint32_t version, uint16_t ltime
 }
 #endif
 
-#endif /* GNRC_SIXLOWPAN_ND_H */
+#endif /* NET_GNRC_SIXLOWPAN_ND_H */
 /** @} */

--- a/sys/include/net/gnrc/sixlowpan/nd/border_router.h
+++ b/sys/include/net/gnrc/sixlowpan/nd/border_router.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_SIXLOWPAN_BORDER_ROUTER_H
-#define GNRC_SIXLOWPAN_BORDER_ROUTER_H
+#ifndef NET_GNRC_SIXLOWPAN_ND_BORDER_ROUTER_H
+#define NET_GNRC_SIXLOWPAN_ND_BORDER_ROUTER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,5 +39,5 @@ extern "C" {
 }
 #endif
 
-#endif /* GNRC_SIXLOWPAN_BORDER_ROUTER_H */
+#endif /* NET_GNRC_SIXLOWPAN_ND_BORDER_ROUTER_H */
 /** @} */

--- a/sys/include/net/gnrc/sixlowpan/nd/router.h
+++ b/sys/include/net/gnrc/sixlowpan/nd/router.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_SIXLOWPAN_ND_ROUTER_H
-#define GNRC_SIXLOWPAN_ND_ROUTER_H
+#ifndef NET_GNRC_SIXLOWPAN_ND_ROUTER_H
+#define NET_GNRC_SIXLOWPAN_ND_ROUTER_H
 
 #include <stdbool.h>
 
@@ -222,5 +222,5 @@ void gnrc_sixlowpan_nd_router_abr_rem_ctx(gnrc_sixlowpan_nd_router_abr_t *abr, u
 }
 #endif
 
-#endif /* GNRC_SIXLOWPAN_ND_ROUTER_H */
+#endif /* NET_GNRC_SIXLOWPAN_ND_ROUTER_H */
 /** @} */

--- a/sys/include/net/gnrc/sixlowpan/netif.h
+++ b/sys/include/net/gnrc/sixlowpan/netif.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_SIXLOWPAN_NETIF_H
-#define GNRC_SIXLOWPAN_NETIF_H
+#ifndef NET_GNRC_SIXLOWPAN_NETIF_H
+#define NET_GNRC_SIXLOWPAN_NETIF_H
 
 #include <stdbool.h>
 
@@ -73,5 +73,5 @@ gnrc_sixlowpan_netif_t *gnrc_sixlowpan_netif_get(kernel_pid_t pid);
 }
 #endif
 
-#endif /* GNRC_SIXLOWPAN_NETIF_H */
+#endif /* NET_GNRC_SIXLOWPAN_NETIF_H */
 /** @} */

--- a/sys/include/net/gnrc/slip.h
+++ b/sys/include/net/gnrc/slip.h
@@ -21,8 +21,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef GNRC_SLIP_H
-#define GNRC_SLIP_H
+#ifndef NET_GNRC_SLIP_H
+#define NET_GNRC_SLIP_H
 
 #include <inttypes.h>
 
@@ -88,5 +88,5 @@ kernel_pid_t gnrc_slip_init(gnrc_slip_dev_t *dev, uart_t uart, uint32_t baudrate
 }
 #endif
 
-#endif /* __SLIP_H */
+#endif /* NET_GNRC_SLIP_H */
 /** @} */

--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -19,8 +19,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef GNRC_TCP_H
-#define GNRC_TCP_H
+#ifndef NET_GNRC_TCP_H
+#define NET_GNRC_TCP_H
 
 #include <stdint.h>
 #include "net/gnrc/pkt.h"
@@ -216,5 +216,5 @@ gnrc_pktsnip_t *gnrc_tcp_hdr_build(gnrc_pktsnip_t *payload, uint16_t src, uint16
 }
 #endif
 
-#endif /* GNRC_TCP_H */
+#endif /* NET_GNRC_TCP_H */
 /** @} */

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -19,8 +19,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef GNRC_TCP_CONFIG_H
-#define GNRC_TCP_CONFIG_H
+#ifndef NET_GNRC_TCP_CONFIG_H
+#define NET_GNRC_TCP_CONFIG_H
 
 #include "timex.h"
 
@@ -141,5 +141,5 @@ extern "C" {
 }
 #endif
 
-#endif /* GNRC_TCP_CONFIG_H */
+#endif /* NET_GNRC_TCP_CONFIG_H */
 /** @} */

--- a/sys/include/net/gnrc/tcp/tcb.h
+++ b/sys/include/net/gnrc/tcp/tcb.h
@@ -19,8 +19,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef GNRC_TCP_TCB_H
-#define GNRC_TCP_TCB_H
+#ifndef NET_GNRC_TCP_TCB_H
+#define NET_GNRC_TCP_TCB_H
 
 #include <stdint.h>
 #include "kernel_types.h"
@@ -88,5 +88,5 @@ typedef struct _transmission_control_block {
 #ifdef __cplusplus
 }
 #endif
-#endif /* GNRC_TCP_TCB_H */
+#endif /* NET_GNRC_TCP_TCB_H */
 /** @} */

--- a/sys/include/net/gnrc/tftp.h
+++ b/sys/include/net/gnrc/tftp.h
@@ -32,8 +32,8 @@
  * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
  */
 
-#ifndef GNRC_TFTP_H
-#define GNRC_TFTP_H
+#ifndef NET_GNRC_TFTP_H
+#define NET_GNRC_TFTP_H
 
 #include <inttypes.h>
 
@@ -199,7 +199,7 @@ int gnrc_tftp_client_write(ipv6_addr_t *addr, const char *file_name, tftp_mode_t
 }
 #endif
 
-#endif /* GNRC_TFTP_H */
+#endif /* NET_GNRC_TFTP_H */
 
 /**
  * @}

--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -19,8 +19,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef GNRC_UDP_H
-#define GNRC_UDP_H
+#ifndef NET_GNRC_UDP_H
+#define NET_GNRC_UDP_H
 
 #include <stdint.h>
 
@@ -92,5 +92,5 @@ int gnrc_udp_init(void);
 }
 #endif
 
-#endif /* GNRC_UDP_H */
+#endif /* NET_GNRC_UDP_H */
 /** @} */

--- a/sys/include/net/iana/portrange.h
+++ b/sys/include/net/iana/portrange.h
@@ -17,8 +17,8 @@
  *
  * @author  smlng <s@mlng.net>,
  */
-#ifndef IANA_H
-#define IANA_H
+#ifndef NET_IANA_PORTRANGE_H
+#define NET_IANA_PORTRANGE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,5 +43,5 @@ extern "C" {
 }
 #endif
 
-#endif /* IANA_H */
+#endif /* NET_IANA_PORTRANGE_H */
 /** @} */

--- a/sys/include/net/icmp.h
+++ b/sys/include/net/icmp.h
@@ -20,8 +20,8 @@
  *
  * @author  José Ignacio Alamos <jialamos@uc.cl>
  */
-#ifndef ICMP_H
-#define ICMP_H
+#ifndef NET_ICMP_H
+#define NET_ICMP_H
 
 #include "byteorder.h"
 
@@ -50,5 +50,5 @@ typedef struct __attribute__((packed)){
 }
 #endif
 
-#endif /* ICMP_H */
+#endif /* NET_ICMP_H */
 /** @} */

--- a/sys/include/net/icmpv6.h
+++ b/sys/include/net/icmpv6.h
@@ -20,8 +20,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef ICMPV6_H
-#define ICMPV6_H
+#ifndef NET_ICMPV6_H
+#define NET_ICMPV6_H
 
 #include <stdint.h>
 
@@ -228,5 +228,5 @@ void icmpv6_hdr_print(icmpv6_hdr_t *hdr);
 }
 #endif
 
-#endif /* ICMPV6_H */
+#endif /* NET_ICMPV6_H */
 /** @} */

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -18,8 +18,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef IEEE802154_H
-#define IEEE802154_H
+#ifndef NET_IEEE802154_H
+#define NET_IEEE802154_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -295,5 +295,5 @@ static inline eui64_t *ieee802154_get_iid(eui64_t *eui64, const uint8_t *addr,
 }
 #endif
 
-#endif /* IEEE802154_H */
+#endif /* NET_IEEE802154_H */
 /** @} */

--- a/sys/include/net/inet_csum.h
+++ b/sys/include/net/inet_csum.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef INET_CSUM_H
-#define INET_CSUM_H
+#ifndef NET_INET_CSUM_H
+#define NET_INET_CSUM_H
 
 #include <inttypes.h>
 #include <stddef.h>
@@ -77,5 +77,5 @@ static inline uint16_t inet_csum(uint16_t sum, const uint8_t *buf, uint16_t len)
 }
 #endif
 
-#endif /* INET_CSUM_H */
+#endif /* NET_INET_CSUM_H */
 /** @} */

--- a/sys/include/net/ipv4.h
+++ b/sys/include/net/ipv4.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef IPV4_H
-#define IPV4_H
+#ifndef NET_IPV4_H
+#define NET_IPV4_H
 
 #include "net/ipv4/addr.h"
 
@@ -31,5 +31,5 @@ extern "C" {
 }
 #endif
 
-#endif /* IPV4_H */
+#endif /* NET_IPV4_H */
 /** @} */

--- a/sys/include/net/ipv4/addr.h
+++ b/sys/include/net/ipv4/addr.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef IPV4_ADDR_H
-#define IPV4_ADDR_H
+#ifndef NET_IPV4_ADDR_H
+#define NET_IPV4_ADDR_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -87,5 +87,5 @@ ipv4_addr_t *ipv4_addr_from_str(ipv4_addr_t *result, const char *addr);
 }
 #endif
 
-#endif /* IPV4_ADDR_H */
+#endif /* NET_IPV4_ADDR_H */
 /** @} */

--- a/sys/include/net/ipv4/hdr.h
+++ b/sys/include/net/ipv4/hdr.h
@@ -17,8 +17,8 @@
  *
  * @author  José Ignacio Alamos <jialamos@uc.cl>
  */
-#ifndef IPV4_HDR_H
-#define IPV4_HDR_H
+#ifndef NET_IPV4_HDR_H
+#define NET_IPV4_HDR_H
 
 #include "byteorder.h"
 #include "net/ipv4/addr.h"
@@ -191,5 +191,5 @@ static inline uint16_t ipv4_hdr_get_fo(ipv4_hdr_t *hdr)
 }
 #endif
 
-#endif /* IPV4_HDR_H */
+#endif /* NET_IPV4_HDR_H */
 /** @} */

--- a/sys/include/net/ipv6.h
+++ b/sys/include/net/ipv6.h
@@ -21,8 +21,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef IPV6_H
-#define IPV6_H
+#ifndef NET_IPV6_H
+#define NET_IPV6_H
 
 #include "net/ipv6/addr.h"
 #include "net/ipv6/ext.h"
@@ -46,5 +46,5 @@ extern "C" {
 #endif
 
 
-#endif /* IPV6_H */
+#endif /* NET_IPV6_H */
 /** @} */

--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -24,8 +24,8 @@
  */
 
 
-#ifndef IPV6_ADDR_H
-#define IPV6_ADDR_H
+#ifndef NET_IPV6_ADDR_H
+#define NET_IPV6_ADDR_H
 
 #include <stdbool.h>
 #include <string.h>
@@ -780,7 +780,7 @@ void ipv6_addr_print(const ipv6_addr_t *addr);
 }
 #endif
 
-#endif /* IPV6_ADDR_H */
+#endif /* NET_IPV6_ADDR_H */
 /**
  * @}
  */

--- a/sys/include/net/ipv6/ext.h
+++ b/sys/include/net/ipv6/ext.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef IPV6_EXT_H
-#define IPV6_EXT_H
+#ifndef NET_IPV6_EXT_H
+#define NET_IPV6_EXT_H
 
 #include <stdint.h>
 
@@ -60,5 +60,5 @@ static inline ipv6_ext_t *ipv6_ext_get_next(ipv6_ext_t *ext)
 }
 #endif
 
-#endif /* IPV6_EXT_H */
+#endif /* NET_IPV6_EXT_H */
 /** @} */

--- a/sys/include/net/ipv6/ext/rh.h
+++ b/sys/include/net/ipv6/ext/rh.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef IPV6_EXT_RH_H
-#define IPV6_EXT_RH_H
+#ifndef NET_IPV6_EXT_RH_H
+#define NET_IPV6_EXT_RH_H
 
 #include <stdint.h>
 
@@ -73,5 +73,5 @@ int ipv6_ext_rh_process(ipv6_hdr_t *ipv6, ipv6_ext_rh_t *ext);
 }
 #endif
 
-#endif /* IPV6_EXT_RH_H */
+#endif /* NET_IPV6_EXT_RH_H */
 /** @} */

--- a/sys/include/net/ipv6/hdr.h
+++ b/sys/include/net/ipv6/hdr.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef IPV6_HDR_H
-#define IPV6_HDR_H
+#ifndef NET_IPV6_HDR_H
+#define NET_IPV6_HDR_H
 
 #include <stdint.h>
 
@@ -308,5 +308,5 @@ void ipv6_hdr_print(ipv6_hdr_t *hdr);
 }
 #endif
 
-#endif /* IPV6_HDR_H */
+#endif /* NET_IPV6_HDR_H */
 /** @} */

--- a/sys/include/net/l2filter.h
+++ b/sys/include/net/l2filter.h
@@ -28,8 +28,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef L2FILTER_H
-#define L2FILTER_H
+#ifndef NET_L2FILTER_H
+#define NET_L2FILTER_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -125,5 +125,5 @@ bool l2filter_pass(const l2filter_t *list, const void *addr, size_t addr_len);
 }
 #endif
 
-#endif /* L2FILTER_H */
+#endif /* NET_L2FILTER_H */
 /** @} */

--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NDP_H
-#define NDP_H
+#ifndef NET_NDP_H
+#define NET_NDP_H
 
 #include <stdint.h>
 
@@ -291,5 +291,5 @@ typedef struct __attribute__((packed)) {
 }
 #endif
 
-#endif /* NDP_H */
+#endif /* NET_NDP_H */
 /** @} */

--- a/sys/include/net/netdev_test.h
+++ b/sys/include/net/netdev_test.h
@@ -76,8 +76,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef NETDEV_TEST_H
-#define NETDEV_TEST_H
+#ifndef NET_NETDEV_TEST_H
+#define NET_NETDEV_TEST_H
 
 #include "mutex.h"
 
@@ -302,5 +302,5 @@ void netdev_test_reset(netdev_test_t *dev);
 }
 #endif
 
-#endif /* NETDEV_TEST_H */
+#endif /* NET_NETDEV_TEST_H */
 /** @} */

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -22,8 +22,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef NETOPT_H
-#define NETOPT_H
+#ifndef NET_NETOPT_H
+#define NET_NETOPT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -323,5 +323,5 @@ const char *netopt2str(netopt_t opt);
 }
 #endif
 
-#endif /* NETOPT_H */
+#endif /* NET_NETOPT_H */
 /** @} */

--- a/sys/include/net/netstats.h
+++ b/sys/include/net/netstats.h
@@ -20,8 +20,8 @@
 
 #include <stdint.h>
 
-#ifndef NETSTATS_H
-#define NETSTATS_H
+#ifndef NET_NETSTATS_H
+#define NET_NETSTATS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,5 +57,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NETSTATS_H */
+#endif /* NET_NETSTATS_H */
 /** @} */

--- a/sys/include/net/ntp_packet.h
+++ b/sys/include/net/ntp_packet.h
@@ -19,8 +19,8 @@
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
  */
 
-#ifndef NTP_PACKET_H
-#define NTP_PACKET_H
+#ifndef NET_NTP_PACKET_H
+#define NET_NTP_PACKET_H
 
 #include <stdint.h>
 #include "byteorder.h"
@@ -169,5 +169,5 @@ static inline ntp_mode_t ntp_packet_get_mode(ntp_packet_t *packet)
 }
 #endif
 
-#endif /* NTP_PACKET_H */
+#endif /* NET_NTP_PACKET_H */
 /** @} */

--- a/sys/include/net/packet.h
+++ b/sys/include/net/packet.h
@@ -18,8 +18,8 @@
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  */
 
-#ifndef PACKET_H
-#define PACKET_H
+#ifndef NET_PACKET_H
+#define NET_PACKET_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,4 +45,4 @@ struct sockaddr_ll {
 /**
  * @}
  */
-#endif /* PACKET_H */
+#endif /* NET_PACKET_H */

--- a/sys/include/net/ppp/hdr.h
+++ b/sys/include/net/ppp/hdr.h
@@ -18,8 +18,8 @@
  * @author  José Ignacio Alamos
  */
 
-#ifndef PPP_HDR_H
-#define PPP_HDR_H
+#ifndef NET_PPP_HDR_H
+#define NET_PPP_HDR_H
 
 #include <inttypes.h>
 
@@ -63,5 +63,5 @@ typedef struct __attribute__((packed)){
 }
 #endif
 
-#endif /* PPP_HDR_H */
+#endif /* NET_PPP_HDR_H */
 /** @} */

--- a/sys/include/net/ppptype.h
+++ b/sys/include/net/ppptype.h
@@ -24,8 +24,8 @@
  */
 
 
-#ifndef PPPTYPE_H
-#define PPPTYPE_H
+#ifndef NET_PPPTYPE_H
+#define NET_PPPTYPE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,7 +44,7 @@ extern "C" {
 }
 #endif
 
-#endif /* PPPTYPE_H */
+#endif /* NET_PPPTYPE_H */
 /**
  * @}
  */

--- a/sys/include/net/protnum.h
+++ b/sys/include/net/protnum.h
@@ -23,8 +23,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef PROTNUM_H
-#define PROTNUM_H
+#ifndef NET_PROTNUM_H
+#define NET_PROTNUM_H
 
 
 #ifdef __cplusplus
@@ -182,5 +182,5 @@ extern "C" {
 }
 #endif
 
-#endif /* PROTNUM_H */
+#endif /* NET_PROTNUM_H */
 /** @} */

--- a/sys/include/net/rpl/rpl_netstats.h
+++ b/sys/include/net/rpl/rpl_netstats.h
@@ -20,8 +20,8 @@
 
 #include <stdint.h>
 
-#ifndef NETSTATS_RPL_H
-#define NETSTATS_RPL_H
+#ifndef NET_RPL_RPL_NETSTATS_H
+#define NET_RPL_RPL_NETSTATS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,5 +73,5 @@ typedef struct {
 }
 #endif
 
-#endif /* NETSTATS_RPL_H */
+#endif /* NET_RPL_RPL_NETSTATS_H */
 /** @} */

--- a/sys/include/net/sixlowpan.h
+++ b/sys/include/net/sixlowpan.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef SIXLOWPAN_H
-#define SIXLOWPAN_H
+#ifndef NET_SIXLOWPAN_H
+#define NET_SIXLOWPAN_H
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -261,5 +261,5 @@ void sixlowpan_print(uint8_t *data, size_t size);
 }
 #endif
 
-#endif /* SIXLOWPAN_H */
+#endif /* NET_SIXLOWPAN_H */
 /** @} */

--- a/sys/include/net/sixlowpan/nd.h
+++ b/sys/include/net/sixlowpan/nd.h
@@ -19,8 +19,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef SIXLOWPAN_ND_H
-#define SIXLOWPAN_ND_H
+#ifndef NET_SIXLOWPAN_ND_H
+#define NET_SIXLOWPAN_ND_H
 
 #include <stdint.h>
 
@@ -227,5 +227,5 @@ static inline void sixlowpan_nd_opt_6ctx_set_cid(sixlowpan_nd_opt_6ctx_t *ctx_op
 }
 #endif
 
-#endif /* SIXLOWPAN_ND_H */
+#endif /* NET_SIXLOWPAN_ND_H */
 /** @} */

--- a/sys/include/net/sntp.h
+++ b/sys/include/net/sntp.h
@@ -20,8 +20,8 @@
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
  */
 
-#ifndef SNTP_H
-#define SNTP_H
+#ifndef NET_SNTP_H
+#define NET_SNTP_H
 
 #include <stdint.h>
 #include <time.h>
@@ -66,5 +66,5 @@ static inline uint64_t sntp_get_unix_usec(void)
 }
 #endif
 
-#endif /* SNTP_H */
+#endif /* NET_SNTP_H */
 /** @} */

--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -20,8 +20,8 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef SOCK_DNS_H
-#define SOCK_DNS_H
+#ifndef NET_SOCK_DNS_H
+#define NET_SOCK_DNS_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -94,5 +94,5 @@ extern sock_udp_ep_t sock_dns_server;
 }
 #endif
 
-#endif /* SOCK_DNS_H */
+#endif /* NET_SOCK_DNS_H */
 /** @} */

--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -20,8 +20,8 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef SOCK_UTIL_H
-#define SOCK_UTIL_H
+#ifndef NET_SOCK_UTIL_H
+#define NET_SOCK_UTIL_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -87,5 +87,5 @@ int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str);
 }
 #endif
 
-#endif /* SOCK_UTIL_H */
+#endif /* NET_SOCK_UTIL_H */
 /** @} */

--- a/sys/include/net/tcp.h
+++ b/sys/include/net/tcp.h
@@ -19,8 +19,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef TCP_H
-#define TCP_H
+#ifndef NET_TCP_H
+#define NET_TCP_H
 
 #include "byteorder.h"
 
@@ -86,5 +86,5 @@ void tcp_hdr_print(tcp_hdr_t *hdr);
 }
 #endif
 
-#endif /* TCP_H */
+#endif /* NET_TCP_H */
 /** @} */

--- a/sys/include/net/udp.h
+++ b/sys/include/net/udp.h
@@ -20,8 +20,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef UDP_H
-#define UDP_H
+#ifndef NET_UDP_H
+#define NET_UDP_H
 
 #include "byteorder.h"
 
@@ -50,5 +50,5 @@ void udp_hdr_print(udp_hdr_t *hdr);
 }
 #endif
 
-#endif /* UDP_H */
+#endif /* NET_UDP_H */
 /** @} */

--- a/sys/include/net/uhcp.h
+++ b/sys/include/net/uhcp.h
@@ -18,8 +18,8 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef UHCP_H
-#define UHCP_H
+#ifndef NET_UHCP_H
+#define NET_UHCP_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -175,5 +175,5 @@ int udp_sendto(uint8_t *buf, size_t len, uint8_t *dst, uint16_t dst_port, uhcp_i
 }
 #endif
 
-#endif /* UHCP_H */
+#endif /* NET_UHCP_H */
 /** @} */

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -32,8 +32,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef SECT_DATA_H
-#define SECT_DATA_H
+#ifndef PHYDAT_H
+#define PHYDAT_H
 
 #include <stdint.h>
 #include <errno.h>
@@ -171,5 +171,5 @@ char phydat_scale_to_str(int8_t scale);
 }
 #endif
 
-#endif /* SECT_DATA_H */
+#endif /* PHYDAT_H */
 /** @} */

--- a/sys/include/pipe.h
+++ b/sys/include/pipe.h
@@ -32,8 +32,8 @@
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef PIPE__H
-#define PIPE__H
+#ifndef PIPE_H
+#define PIPE_H
 
 #include <sys/types.h>
 
@@ -121,7 +121,7 @@ void pipe_free(pipe_t *rp);
 }
 #endif
 
-#endif /* PIPE__H */
+#endif /* PIPE_H */
 /**
  * @}
  */

--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -72,5 +72,5 @@ void pm_set(unsigned mode);
 }
 #endif
 
-#endif /* __PM_LAYERED_H */
+#endif /* PM_LAYERED_H */
 /** @} */

--- a/sys/include/tm.h
+++ b/sys/include/tm.h
@@ -14,8 +14,8 @@
  * @brief       Utility library for `struct tm`.
  */
 
-#ifndef SYS__TIMEX__TM__H
-#define SYS__TIMEX__TM__H
+#ifndef TM_H
+#define TM_H
 
 #include <time.h>
 #include <sys/time.h>
@@ -119,5 +119,5 @@ int tm_is_valid_time(int hour, int min, int sec) CONST;
 }
 #endif
 
-#endif /* SYS__TIMEX__TM__H */
+#endif /* TM_H */
 /** @} */

--- a/sys/include/ubjson.h
+++ b/sys/include/ubjson.h
@@ -28,8 +28,8 @@
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef UBJSON_H__
-#define UBJSON_H__
+#ifndef UBJSON_H
+#define UBJSON_H
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -581,5 +581,5 @@ ssize_t ubjson_close_object(ubjson_cookie_t *__restrict cookie);
 }
 #endif
 
-#endif /* ifndef UBJSON_H__ */
+#endif /* UBJSON_H */
 /** @} */

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -50,8 +50,8 @@
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef VFS_H_
-#define VFS_H_
+#ifndef VFS_H
+#define VFS_H
 
 #include <stdint.h>
 /* The stdatomic.h in GCC gives compilation errors with C++
@@ -830,6 +830,6 @@ const vfs_mount_t *vfs_iterate_mounts(const vfs_mount_t *cur);
 }
 #endif
 
-#endif
+#endif /* VFS_H */
 
 /** @} */

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -135,4 +135,4 @@ inline static uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
 }
 #endif
 
-#endif
+#endif /* XTIMER_TICK_CONVERSION_H */

--- a/sys/libc/include/sys/uio.h
+++ b/sys/libc/include/sys/uio.h
@@ -17,8 +17,8 @@
  *
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef UIO_H
-#define UIO_H
+#ifndef SYS_UIO_H
+#define SYS_UIO_H
 
 #include <stdlib.h>
 #include <sys/types.h>
@@ -39,4 +39,4 @@ struct iovec {
 }
 #endif
 /** @} */
-#endif /* UIO_H */
+#endif /* SYS_UIO_H */

--- a/sys/log/log_printfnoformat/log_module.h
+++ b/sys/log/log_printfnoformat/log_module.h
@@ -20,8 +20,8 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef LOG_FORMAT_H
-#define LOG_FORMAT_H
+#ifndef LOG_MODULE_H
+#define LOG_MODULE_H
 
 #include <stdio.h>
 
@@ -47,4 +47,4 @@ static inline void log_write(unsigned level, const char *format, ...) {
 }
 #endif
 /**@}*/
-#endif /* LOG_FORMAT_H */
+#endif /* LOG_MODULE_H */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -16,8 +16,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef GNRC_SIXLOWPAN_FRAG_RBUF_H
-#define GNRC_SIXLOWPAN_FRAG_RBUF_H
+#ifndef RBUF_H
+#define RBUF_H
 
 #include <inttypes.h>
 
@@ -104,5 +104,5 @@ void rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *frag,
 }
 #endif
 
-#endif /* GNRC_SIXLOWPAN_FRAG_RBUF_H */
+#endif /* RBUF_H */
 /** @} */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/netstats.h
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/netstats.h
@@ -16,8 +16,8 @@
  * @author      Cenk Gündoğan <mail@cgundogan.de>
  */
 
-#ifndef RPL_NETSTATS_H
-#define RPL_NETSTATS_H
+#ifndef NETSTATS_H
+#define NETSTATS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -187,5 +187,5 @@ static inline void gnrc_rpl_netstats_tx_DAO_ACK(netstats_rpl_t *netstats, size_t
 }
 #endif
 
-#endif /* RPL_NETSTATS_H */
+#endif /* NETSTATS_H */
 /** @} */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/validation.h
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/validation.h
@@ -16,8 +16,8 @@
  * @author      Cenk Gündoğan <mail@cgundogan.de>
  */
 
-#ifndef GNRC_RPL_VALIDATION_H
-#define GNRC_RPL_VALIDATION_H
+#ifndef VALIDATION_H
+#define VALIDATION_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -143,5 +143,5 @@ static inline bool gnrc_rpl_validation_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack, uint
 }
 #endif
 
-#endif /* GNRC_RPL_VALIDATION_H */
+#endif /* VALIDATION_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/internal/common.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/common.h
@@ -19,8 +19,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef GNRC_TCP_INTERNAL_COMMON_H
-#define GNRC_TCP_INTERNAL_COMMON_H
+#ifndef COMMON_H
+#define COMMON_H
 
 #include <stdint.h>
 #include "assert.h"
@@ -136,5 +136,5 @@ extern mutex_t _list_tcb_lock;
 }
 #endif
 
-#endif /* GNRC_TCP_INTERNAL_COMMON_H */
+#endif /* COMMON_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/internal/eventloop.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/eventloop.h
@@ -19,8 +19,8 @@
 * @author       Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef GNRC_TCP_INTERNAL_EVENTLOOP_H
-#define GNRC_TCP_INTERNAL_EVENTLOOP_H
+#ifndef EVENTLOOP_H
+#define EVENTLOOP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,5 +39,5 @@ void *_event_loop(__attribute__((unused)) void *arg);
 }
 #endif
 
-#endif /* GNRC_TCP_INTERNAL_EVENTLOOP_H */
+#endif /* EVENTLOOP_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/internal/fsm.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/fsm.h
@@ -19,8 +19,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef GNRC_TCP_INTERNAL_FSM_H
-#define GNRC_TCP_INTERNAL_FSM_H
+#ifndef FSM_H
+#define FSM_H
 
 #include <stdint.h>
 #include "net/gnrc/pkt.h"
@@ -83,5 +83,5 @@ int _fsm(gnrc_tcp_tcb_t *tcb, fsm_event_t event, gnrc_pktsnip_t *in_pkt, void *b
 }
 #endif
 
-#endif /* GNRC_TCP_INTERNAL_FSM_H */
+#endif /* FSM_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/internal/option.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/option.h
@@ -19,8 +19,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef GNRC_TCP_INTERNAL_OPTION_H
-#define GNRC_TCP_INTERNAL_OPTION_H
+#ifndef OPTION_H
+#define OPTION_H
 
 #include <stdint.h>
 #include "assert.h"
@@ -73,5 +73,5 @@ int _option_parse(gnrc_tcp_tcb_t *tcb, tcp_hdr_t *hdr);
 }
 #endif
 
-#endif /* GNRC_TCP_INTERNAL_OPTION_H*/
+#endif /* OPTION_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/internal/pkt.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/pkt.h
@@ -19,8 +19,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef GNRC_TCP_INTERNAL_PKT_H
-#define GNRC_TCP_INTERNAL_PKT_H
+#ifndef PKT_H
+#define PKT_H
 
 #include <stdint.h>
 #include "net/gnrc/pkt.h"
@@ -148,5 +148,5 @@ uint16_t _pkt_calc_csum(const gnrc_pktsnip_t *hdr, const gnrc_pktsnip_t *pseudo_
 }
 #endif
 
-#endif /* GNRC_TCP_INTERNAL_PKT_H */
+#endif /* PKT_H */
 /** @} */

--- a/sys/net/gnrc/transport_layer/tcp/internal/rcvbuf.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/rcvbuf.h
@@ -19,8 +19,8 @@
  * @author      Simon Brummer <simon.brummer@posteo.de>
  */
 
-#ifndef GNRC_TCP_INTERNAL_RCVBUF_H
-#define GNRC_TCP_INTERNAL_RCVBUF_H
+#ifndef RCVBUF_H
+#define RCVBUF_H
 
 #include <stdint.h>
 #include "mutex.h"
@@ -73,5 +73,5 @@ void _rcvbuf_release_buffer(gnrc_tcp_tcb_t *tcb);
 }
 #endif
 
-#endif /* GNRC_TCP_INTERNAL_RCVBUF_H */
+#endif /* RCVBUF_H */
 /** @} */

--- a/sys/posix/include/netinet/in.h
+++ b/sys/posix/include/netinet/in.h
@@ -20,8 +20,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef _NETINET_IN_H
-#define _NETINET_IN_H
+#ifndef NETINET_IN_H
+#define NETINET_IN_H
 
 #include <inttypes.h>
 #include <sys/socket.h>
@@ -271,4 +271,4 @@ extern const struct in6_addr in6addr_loopback;
 /**
  * @}
  */
-#endif /* _NETINET_IN_H */
+#endif /* NETINET_IN_H */

--- a/sys/posix/include/semaphore.h
+++ b/sys/posix/include/semaphore.h
@@ -22,8 +22,8 @@
  * @author  Víctor Ariño <victor.arino@zii.aero>
  */
 
-#ifndef POSIX_SEMAPHORE_H
-#define POSIX_SEMAPHORE_H
+#ifndef SEMAPHORE_H
+#define SEMAPHORE_H
 
 #include <errno.h>
 #include <time.h>
@@ -294,5 +294,5 @@ static inline int sem_getvalue(sem_t *sem, int *sval)
 }
 #endif
 
-#endif  /* POSIX_SEMAPHORE_H */
+#endif /* SEMAPHORE_H */
 /** @} */

--- a/sys/posix/include/sys/bytes.h
+++ b/sys/posix/include/sys/bytes.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef BYTES_H
-#define BYTES_H
+#ifndef SYS_BYTES_H
+#define SYS_BYTES_H
 
 #include "byteorder.h"
 
@@ -32,5 +32,5 @@ typedef size_t socklen_t;           /**< socket address length */
 }
 #endif
 
-#endif /* BYTES_H */
+#endif /* SYS_BYTES_H */
 /** @} */

--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -26,8 +26,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef _SYS_SOCKET_H
-#define _SYS_SOCKET_H
+#ifndef SYS_SOCKET_H
+#define SYS_SOCKET_H
 
 #ifdef CPU_NATIVE
 /* Ignore Linux definitions in native */

--- a/sys/posix/include/sys/statvfs.h
+++ b/sys/posix/include/sys/statvfs.h
@@ -18,8 +18,8 @@
 /* without the GCC pragma above #include_next will trigger a pedantic error */
 #include_next <sys/statvfs.h>
 #else
-#ifndef SYS_STATVFS_H_
-#define SYS_STATVFS_H_
+#ifndef SYS_STATVFS_H
+#define SYS_STATVFS_H
 
 #include <sys/types.h> /* for fsblkcnt_t, fsfilcnt_t */
 /** @todo Remove ifdef __mips__ special case after
@@ -71,7 +71,7 @@ enum {
 }
 #endif
 
-#endif /* SYS_STATVFS_H_ */
+#endif /* SYS_STATVFS_H */
 
 #endif /* CPU_NATIVE */
 

--- a/sys/posix/pthread/include/pthread.h
+++ b/sys/posix/pthread/include/pthread.h
@@ -17,8 +17,8 @@
  * @see     [The Open Group Base Specifications Issue 7: pthread.h - threads](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/pthread.h.html)
  */
 
-#ifndef SYS__POSIX__PTHREAD__H
-#define SYS__POSIX__PTHREAD__H
+#ifndef PTHREAD_H
+#define PTHREAD_H
 
 #include <time.h>
 
@@ -58,7 +58,7 @@ extern "C" {
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD__H */
+#endif /* PTHREAD_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_barrier.h
+++ b/sys/posix/pthread/include/pthread_barrier.h
@@ -14,8 +14,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_BARRIER__H
-#define SYS__POSIX__PTHREAD_BARRIER__H
+#ifndef PTHREAD_BARRIER_H
+#define PTHREAD_BARRIER_H
 
 #include "mutex.h"
 
@@ -136,7 +136,7 @@ int pthread_barrierattr_setpshared(pthread_barrierattr_t *attr, int pshared);
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_BARRIER__H */
+#endif /* PTHREAD_BARRIER_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_cancellation.h
+++ b/sys/posix/pthread/include/pthread_cancellation.h
@@ -15,8 +15,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_CANCELLCATION__H
-#define SYS__POSIX__PTHREAD_CANCELLCATION__H
+#ifndef PTHREAD_CANCELLATION_H
+#define PTHREAD_CANCELLATION_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,7 +69,7 @@ void pthread_testcancel(void);
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_CANCELLCATION__H */
+#endif /* PTHREAD_CANCELLATION_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_cleanup.h
+++ b/sys/posix/pthread/include/pthread_cleanup.h
@@ -14,8 +14,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_CLEANUP__H
-#define SYS__POSIX__PTHREAD_CLEANUP__H
+#ifndef PTHREAD_CLEANUP_H
+#define PTHREAD_CLEANUP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -95,7 +95,7 @@ void __pthread_cleanup_pop(__pthread_cleanup_datum_t *datum, int execute);
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_CLEANUP__H */
+#endif /* PTHREAD_CLEANUP_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_cond.h
+++ b/sys/posix/pthread/include/pthread_cond.h
@@ -14,8 +14,8 @@
  * @author      Martin Landsmann <martin.landsmann@haw-hamburg.de>
  */
 
-#ifndef SYS__POSIX__PTHREAD_COND__H
-#define SYS__POSIX__PTHREAD_COND__H
+#ifndef PTHREAD_COND_H
+#define PTHREAD_COND_H
 
 #include <time.h>
 #include "mutex.h"
@@ -150,7 +150,7 @@ int pthread_cond_broadcast(pthread_cond_t *cond);
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_COND__H */
+#endif /* PTHREAD_COND_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_mutex.h
+++ b/sys/posix/pthread/include/pthread_mutex.h
@@ -14,8 +14,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_MUTEX__H
-#define SYS__POSIX__PTHREAD_MUTEX__H
+#ifndef PTHREAD_MUTEX_H
+#define PTHREAD_MUTEX_H
 
 #include <time.h>
 
@@ -112,7 +112,7 @@ int pthread_mutex_setprioceiling(pthread_mutex_t *mutex, int prioceiling, int *o
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_MUTEX__H */
+#endif /* PTHREAD_MUTEX_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_mutex_attr.h
+++ b/sys/posix/pthread/include/pthread_mutex_attr.h
@@ -14,8 +14,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_MUTEX_ATTR__H
-#define SYS__POSIX__PTHREAD_MUTEX_ATTR__H
+#ifndef PTHREAD_MUTEX_ATTR_H
+#define PTHREAD_MUTEX_ATTR_H
 
 #include <errno.h>
 
@@ -215,7 +215,7 @@ int pthread_mutexattr_setrobust(pthread_mutexattr_t *attr, int robustness);
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_MUTEX_ATTR__H */
+#endif /* PTHREAD_MUTEX_ATTR_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_once.h
+++ b/sys/posix/pthread/include/pthread_once.h
@@ -14,8 +14,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_ONCE__H
-#define SYS__POSIX__PTHREAD_ONCE__H
+#ifndef PTHREAD_ONCE_H
+#define PTHREAD_ONCE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,7 +48,7 @@ int pthread_once(pthread_once_t *once_control, void (*init_routine)(void));
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_ONCE__H */
+#endif /* PTHREAD_ONCE_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_rwlock.h
+++ b/sys/posix/pthread/include/pthread_rwlock.h
@@ -14,8 +14,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_RWLOCK__H
-#define SYS__POSIX__PTHREAD_RWLOCK__H
+#ifndef PTHREAD_RWLOCK_H
+#define PTHREAD_RWLOCK_H
 
 #include "priority_queue.h"
 #include "thread.h"
@@ -176,7 +176,7 @@ bool __pthread_rwlock_blocked_writingly(const pthread_rwlock_t *rwlock);
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_ONCE__H */
+#endif /* PTHREAD_RWLOCK_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_rwlock_attr.h
+++ b/sys/posix/pthread/include/pthread_rwlock_attr.h
@@ -14,8 +14,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_RWLOCK_ATTR__H
-#define SYS__POSIX__PTHREAD_RWLOCK_ATTR__H
+#ifndef PTHREAD_RWLOCK_ATTR_H
+#define PTHREAD_RWLOCK_ATTR_H
 
 #include <errno.h>
 
@@ -80,7 +80,7 @@ int pthread_rwlockattr_setpshared(pthread_rwlockattr_t *attr, int pshared);
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_RWLOCK_ATTR__H */
+#endif /* PTHREAD_RWLOCK_ATTR_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_scheduling.h
+++ b/sys/posix/pthread/include/pthread_scheduling.h
@@ -15,8 +15,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_SCHEDULING__H
-#define SYS__POSIX__PTHREAD_SCHEDULING__H
+#ifndef PTHREAD_SCHEDULING_H
+#define PTHREAD_SCHEDULING_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,7 +55,7 @@ int pthread_setschedprio(pthread_t target_thread, int prio);
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_SCHEDULING__H */
+#endif /* PTHREAD_SCHEDULING_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_spin.h
+++ b/sys/posix/pthread/include/pthread_spin.h
@@ -17,8 +17,8 @@
  *          Use irq_disable() and irq_restore() for shortterm locks instead.
  */
 
-#ifndef SYS_POSIX_PTHREAD_SPIN_H
-#define SYS_POSIX_PTHREAD_SPIN_H
+#ifndef PTHREAD_SPIN_H
+#define PTHREAD_SPIN_H
 
 #include <stdatomic.h>
 
@@ -91,7 +91,7 @@ int pthread_spin_unlock(pthread_spinlock_t *lock);
 }
 #endif
 
-#endif /* SYS_POSIX_PTHREAD_SPIN_H */
+#endif /* PTHREAD_SPIN_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_threading.h
+++ b/sys/posix/pthread/include/pthread_threading.h
@@ -14,8 +14,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_THREADING__H
-#define SYS__POSIX__PTHREAD_THREADING__H
+#ifndef PTHREAD_THREADING_H
+#define PTHREAD_THREADING_H
 
 #include "kernel_defines.h"
 
@@ -107,7 +107,7 @@ static inline int pthread_equal(pthread_t thread1, pthread_t thread2)
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_THREADING__H */
+#endif /* PTHREAD_THREADING_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_threading_attr.h
+++ b/sys/posix/pthread/include/pthread_threading_attr.h
@@ -14,8 +14,8 @@
  * @note    Do not include this header file directly, but pthread.h.
  */
 
-#ifndef SYS__POSIX__PTHREAD_THREADING_ATTR__H
-#define SYS__POSIX__PTHREAD_THREADING_ATTR__H
+#ifndef PTHREAD_THREADING_ATTR_H
+#define PTHREAD_THREADING_ATTR_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -206,7 +206,7 @@ int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize);
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_THREADING_ATTR__H */
+#endif /* PTHREAD_THREADING_ATTR_H */
 
 /**
  * @}

--- a/sys/posix/pthread/include/pthread_tls.h
+++ b/sys/posix/pthread/include/pthread_tls.h
@@ -15,8 +15,8 @@
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
  */
 
-#ifndef SYS__POSIX__PTHREAD_TLS__H
-#define SYS__POSIX__PTHREAD_TLS__H
+#ifndef PTHREAD_TLS_H
+#define PTHREAD_TLS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -87,7 +87,7 @@ struct __pthread_tls_datum **__pthread_get_tls_head(int self_id) PURE;
 }
 #endif
 
-#endif /* SYS__POSIX__PTHREAD_TLS__H */
+#endif /* PTHREAD_TLS_H */
 
 /**
  * @}

--- a/sys/quad_math/quad.h
+++ b/sys/quad_math/quad.h
@@ -49,6 +49,9 @@
  * with 48-bit ints.
  */
 
+#ifndef QUAD_H
+#define QUAD_H
+
 #include <sys/types.h>
 #include <limits.h>
 
@@ -147,3 +150,5 @@ quad_t __xordi3(quad_t, quad_t);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* QUAD_H */

--- a/sys/random/tinymt32/tinymt32.h
+++ b/sys/random/tinymt32/tinymt32.h
@@ -230,4 +230,4 @@ inline static double tinymt32_generate_32double(tinymt32_t *random)
 }
 #endif
 
-#endif
+#endif /* TINYMT32_H */

--- a/sys/ubjson/ubjson-internal.h
+++ b/sys/ubjson/ubjson-internal.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef UBJSON__INTERNAL_H__
-#define UBJSON__INTERNAL_H__
+#ifndef UBJSON_INTERNAL_H
+#define UBJSON_INTERNAL_H
 
 /* compare http://ubjson.org/type-reference/ */
 
@@ -59,4 +59,4 @@ typedef enum {
 }
 #endif
 
-#endif /* ifndef UBJSON__INTERNAL_H__ */
+#endif /* UBJSON_INTERNAL_H */

--- a/tests/emb6/common.h
+++ b/tests/emb6/common.h
@@ -15,8 +15,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef MAIN_H
-#define MAIN_H
+#ifndef COMMON_H
+#define COMMON_H
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -75,5 +75,5 @@ int udp_cmd(int argc, char **argv);
 }
 #endif
 
-#endif /* MAIN_H */
+#endif /* COMMON_H */
 /** @} */

--- a/tests/lwip/common.h
+++ b/tests/lwip/common.h
@@ -15,8 +15,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef MAIN_H
-#define MAIN_H
+#ifndef COMMON_H
+#define COMMON_H
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -90,5 +90,5 @@ int udp_cmd(int argc, char **argv);
 }
 #endif
 
-#endif /* MAIN_H */
+#endif /* COMMON_H */
 /** @} */

--- a/tests/lwip_sock_tcp/constants.h
+++ b/tests/lwip_sock_tcp/constants.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef CONSTANTS_H_
-#define CONSTANTS_H_
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
 
 
 #ifdef __cplusplus
@@ -45,5 +45,5 @@ extern "C" {
 }
 #endif
 
-#endif /* CONSTANTS_H_ */
+#endif /* CONSTANTS_H */
 /** @} */

--- a/tests/lwip_sock_tcp/stack.h
+++ b/tests/lwip_sock_tcp/stack.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef STACK_H_
-#define STACK_H_
+#ifndef STACK_H
+#define STACK_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,5 +33,5 @@ void _net_init(void);
 }
 #endif
 
-#endif /* STACK_H_ */
+#endif /* STACK_H */
 /** @} */

--- a/tests/lwip_sock_udp/constants.h
+++ b/tests/lwip_sock_udp/constants.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef CONSTANTS_H_
-#define CONSTANTS_H_
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
 
 
 #ifdef __cplusplus
@@ -45,5 +45,5 @@ extern "C" {
 }
 #endif
 
-#endif /* CONSTANTS_H_ */
+#endif /* CONSTANTS_H */
 /** @} */

--- a/tests/lwip_sock_udp/stack.h
+++ b/tests/lwip_sock_udp/stack.h
@@ -17,8 +17,8 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef STACK_H_
-#define STACK_H_
+#ifndef STACK_H
+#define STACK_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -129,5 +129,5 @@ bool _check_6packet(const ipv6_addr_t *src, const ipv6_addr_t *dst,
 }
 #endif
 
-#endif /* STACK_H_ */
+#endif /* STACK_H */
 /** @} */

--- a/tests/unittests/map.h
+++ b/tests/unittests/map.h
@@ -26,8 +26,8 @@
  * prior written authorization from the authors.
  */
 
-#ifndef UNITTESTS_MAP_H
-#define UNITTESTS_MAP_H
+#ifndef MAP_H
+#define MAP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,4 +56,4 @@ extern "C" {
 }
 #endif
 
-#endif /* UNITTESTS_MAP_H */
+#endif /* MAP_H */

--- a/tests/unittests/tests-fib_sr/tests-fib_sr.h
+++ b/tests/unittests/tests-fib_sr/tests-fib_sr.h
@@ -15,8 +15,8 @@
  *
  * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
  */
-#ifndef TESTS_FIB_H
-#define TESTS_FIB_H
+#ifndef TESTS_FIB_SR_H
+#define TESTS_FIB_SR_H
 #include "embUnit/embUnit.h"
 
 #ifdef __cplusplus
@@ -39,5 +39,5 @@ Test *tests_fib_sr_tests(void);
 }
 #endif
 
-#endif /* TESTS_FIB_H */
+#endif /* TESTS_FIB_SR_H */
 /** @} */

--- a/tests/unittests/tests-flashpage/tests-flashpage.h
+++ b/tests/unittests/tests-flashpage/tests-flashpage.h
@@ -15,8 +15,8 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-#ifndef TESTS_FLASHPAGE_H_
-#define TESTS_FLASHPAGE_H_
+#ifndef TESTS_FLASHPAGE_H
+#define TESTS_FLASHPAGE_H
 
 #include "embUnit.h"
 
@@ -33,5 +33,5 @@ void tests_flashpage(void);
 }
 #endif
 
-#endif /* TESTS_FLASHPAGE_H_ */
+#endif /* TESTS_FLASHPAGE_H */
 /** @} */

--- a/tests/unittests/tests-gnrc_mac_internal/tests-gnrc_mac_internal.h
+++ b/tests/unittests/tests-gnrc_mac_internal/tests-gnrc_mac_internal.h
@@ -15,8 +15,8 @@
  *
  * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>
  */
-#ifndef TESTS_PRIORITY_PKTQUEUE_H
-#define TESTS_PRIORITY_PKTQUEUE_H
+#ifndef TESTS_GNRC_MAC_INTERNAL_H
+#define TESTS_GNRC_MAC_INTERNAL_H
 
 #include "embUnit.h"
 
@@ -33,5 +33,5 @@ void tests_gnrc_mac_internal(void);
 }
 #endif
 
-#endif /* TESTS_PRIORITY_PKTQUEUE_H */
+#endif /* TESTS_GNRC_MAC_INTERNAL_H */
 /** @} */

--- a/tests/unittests/tests-hashes/tests-hashes.h
+++ b/tests/unittests/tests-hashes/tests-hashes.h
@@ -76,5 +76,5 @@ Test *tests_hashes_sha256_chain_tests(void);
 }
 #endif
 
-#endif /* TESTS_CRYPTO_H */
+#endif /* TESTS_HASHES_H */
 /** @} */


### PR DESCRIPTION
This PR adds a python script checking for header guards.

Features:
- it outputs diffs that can be directly applied.
- it fixes / adds the commend at the closing ```#endif```
- it adds the file path to the guard, up to ```include/```, or none if there's no ```include``` in the path. (e.g., 'sys/include/a/b/c.h' -> 'A_B_C_H'), 'sys/posix/blah/foo.h' -> 'FOO_H'

One commit  adds some missing header guards (changes made manually),
another commit applies the headercheck output to the codebase.