### PR TITLE
cpu/kinetis: prevent use of symlinks for ld-scripts

### DIFF
--- a/cpu/k60/Makefile.include
+++ b/cpu/k60/Makefile.include
@@ -1,6 +1,10 @@
 # define the CPU architecture for the k60
 export CPU_ARCH = cortex-m4
 
+# map CPU models to generic Kinetis linkerscript
+LD_MK60DN256VLL10 = kinetis_f256l16u16.ld
+LD_MK60DN512VLL10 = kinetis_f512l64u64.ld
+
 # tell the build system that the CPU depends on the Kinetis common files
 export USEMODULE += kinetis_common
 

--- a/cpu/k60/ldscripts/mk60dn256vll10.ld
+++ b/cpu/k60/ldscripts/mk60dn256vll10.ld
@@ -1,1 +1,0 @@
-../../kinetis_common/ldscripts/kinetis_f256l32u32.ld

--- a/cpu/k60/ldscripts/mk60dn512vll10.ld
+++ b/cpu/k60/ldscripts/mk60dn512vll10.ld
@@ -1,1 +1,0 @@
-../../kinetis_common/ldscripts/kinetis_f512l64u64.ld

--- a/cpu/k64f/Makefile.include
+++ b/cpu/k64f/Makefile.include
@@ -1,6 +1,9 @@
 # define the CPU architecture for the k64f
 export CPU_ARCH = cortex-m4
 
+# map CPU models to generic Kinetis linkerscript
+LD_MK64FN1M0VLL12 = kinetis_f1024l64u192.ld
+
 # tell the build system that the CPU depends on the Kinetis common files
 export USEMODULE += kinetis_common
 

--- a/cpu/k64f/ldscripts/mk64fn1m0vll12.ld
+++ b/cpu/k64f/ldscripts/mk64fn1m0vll12.ld
@@ -1,1 +1,0 @@
-../../kinetis_common/ldscripts/kinetis_f1024l64u192.ld

--- a/cpu/kinetis_common/Makefile.include
+++ b/cpu/kinetis_common/Makefile.include
@@ -4,6 +4,9 @@ export INCLUDES += -I$(RIOTCPU)/kinetis_common/include
 # Add search path for linker scripts
 export LINKFLAGS += -L$(RIOTCPU)/kinetis_common/ldscripts
 
+# Use generic linkerscripts for all Kinetis based CPUs
+export LINKER_SCRIPT ?= $(LD_$(shell echo $(CPU_MODEL) | tr a-z A-Z))
+
 # add the CPU specific code for the linker
 export UNDEF += $(BINDIR)/kinetis_common/fcfield.o
 

--- a/cpu/kw2xd/Makefile.include
+++ b/cpu/kw2xd/Makefile.include
@@ -1,6 +1,11 @@
 # define the CPU architecture for the kw2xd
 export CPU_ARCH = cortex-m4
 
+# map CPU models to generic Kinetis linkerscript
+LD_KW21D256 = kinetis_f256l16u16.ld
+LD_KW21D512 = kinetis_f512l32u32.ld
+LD_KW22D512 = kinetis_f512l32u32.ld
+
 # tell the build system that the CPU depends on the Kinetis common files
 export USEMODULE += kinetis_common
 

--- a/cpu/kw2xd/ldscripts/kw21d256.ld
+++ b/cpu/kw2xd/ldscripts/kw21d256.ld
@@ -1,1 +1,0 @@
-../../kinetis_common/ldscripts/kinetis_f256l16u16.ld

--- a/cpu/kw2xd/ldscripts/kw21d512.ld
+++ b/cpu/kw2xd/ldscripts/kw21d512.ld
@@ -1,1 +1,0 @@
-../../kinetis_common/ldscripts/kinetis_f512l32u32.ld

--- a/cpu/kw2xd/ldscripts/kw22d512.ld
+++ b/cpu/kw2xd/ldscripts/kw22d512.ld
@@ -1,1 +1,0 @@
-../../kinetis_common/ldscripts/kinetis_f512l32u32.ld


### PR DESCRIPTION
The use of symbolic links leads to trouble in certain environments (e.g. vagrant under Win). This PR gets rid of symlinks and uses variables in the Makefiles to map to the correct linkerscripts instead.