### PR TITLE
net/gcoap: add table of contents to module doc

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -30,6 +30,14 @@
  * provides functions to generate and send an observe notification that are
  * similar to the functions to send a client request.
  *
+ * *Contents*
+ *
+ * - Server Operation
+ * - Client Operation
+ * - Observe Server Operation
+ * - Implementation Notes
+ * - Implementation Status
+ *
  * ## Server Operation ##
  *
  * gcoap listens for requests on GCOAP_PORT, 5683 by default. You can redefine


### PR DESCRIPTION
Depends on #7097.

Adds a TOC list with the main headings of the module documentation. #7097 moved the implementation status documentation to the end of this page. We want a new user to be sure to see that status information is available, and just generally see at a glance what is in the documentation.

I wanted to create links to the headings, but due to limitations in doxygen, it would have required explicit 'h2' tags with an 'id' attribute. Since the main idea is just to alert the user to the headings, I think it's better to keep the markdown clean.

The result is:

 *Contents*
 
 - Server Operation
 - Client Operation
 - Observe Server Operation
 - Implementation Notes
 - Implementation Status