### PR TITLE
dist/edbg: forward commit hash to added samr21-xpro (rev D)

### DIFF
--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=edbg
 PKG_URL=https://github.com/ataradov/edbg
-PKG_VERSION=d499ffd8297233b65dd91fd58fb98b9f9a03fec1
+PKG_VERSION=935bb4b1efd0e2f8434cf97443e0d95b9e02ec1d
 PKG_LICENSE=BSD-3-Clause
 PKG_BUILDDIR=$(CURDIR)/bin
 


### PR DESCRIPTION
@ataradov just updated edbg and included the ID for samr21-xpro (rev D),
which resolves our problem flashing it [1]

[1] https://lists.riot-os.org/pipermail/devel/2017-May/005177.html