### PR TITLE
native: add break to satisfy compiler gcc-7.1.1

### DIFF
--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -290,6 +290,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
             case 0:
             case 'h':
                 usage_exit(EXIT_SUCCESS);
+                break;
             case 'i':
                 _native_id = atol(optarg);
                 break;


### PR DESCRIPTION
Building any application with gcc 7.1.1 fails with the following error:

```
~/RIOT % make -C examples/hello-world
make: Entering directory 'RIOT/examples/hello-world'
Building application "hello-world" for "native" with MCU "native".

"make" -C RIOT/boards/native
"make" -C RIOT/boards/native/drivers
"make" -C RIOT/core
"make" -C RIOT/cpu/native
RIOT/cpu/native/startup.c: In function ‘startup’:
RIOT/cpu/native/startup.c:292:17: error: this statement may fall through [-Werror=implicit-fallthrough=]
       usage_exit(EXIT_SUCCESS);
       ^~~~~~~~~~~~~~~~~~~~~~~~
RIOT/cpu/native/startup.c:293:13: note: here
   case 'i':
   ^~~~
cc1: all warnings being treated as errors
make[2]: *** [RIOT/Makefile.base:81: RIOT/examples/hello-world/bin/native/cpu/startup.o] Error 1
make[1]: *** [RIOT/Makefile.base:20: ALL--RIOT/cpu/native] Error 2
make: *** [RIOT/examples/hello-world/../../Makefile.include:297: all] Error 2
make: Leaving directory 'RIOT/examples/hello-world'
```

```
% gcc --version
gcc (GCC) 7.1.1 20170528
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

fixed by adding a `break` statement after `usage_exit()`