### PR TITLE
ndp: warn gcc-7 about intentional fall-through

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -105,7 +105,8 @@ void gnrc_ndp_internal_set_state(gnrc_ipv6_nc_t *nc_entry, uint8_t state)
             DEBUG("REACHABLE (reachable time = %" PRIu32 " us)\n", ipv6_iface->reach_time);
             t = ipv6_iface->reach_time;
 
-            /* we intentionally fall through here to set the desired timeout t */
+            /* Falls through. */
+            /* this is intentional to set the desired timeout t */
         case GNRC_IPV6_NC_STATE_DELAY:
 #if ENABLE_DEBUG
             if (state == GNRC_IPV6_NC_STATE_DELAY) {


### PR DESCRIPTION
Since gcc-7 `Wimplicit-fallthrough` is activated by using `-Wextra`.
This leads to the following problem when compiling `gnrc_networking`:

```
RIOT/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c: In function ‘gnrc_ndp_internal_set_state’:
RIOT/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c:106:15: error: this statement may fall through [-Werror=implicit-fallthrough=]
   t = ipv6_iface->reach_time;
  ~~^~~~~~~~~~~~~~~~~~~~~~~~
RIOT/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c:109:9: note: here
case GNRC_IPV6_NC_STATE_DELAY:
         ^~~~
```

The fall-through in this code is intentional. There are several ways to
warn the comiler about such intentional fall-throughs, which include
e.g. attributed empty statements (`__attribute__ ((fallthrough));`).
I don't like tis approach however. The best way would probably be to
remove this fall-through from the code. However, to keep the diff
minimal, and since ndp will change in the future, I went for warning
the compiler using comments.

The compiler checks comments for several *fall through* regexs to
decide whether a fallthrough was intentional or not.

You can read more about this gcc option in [1]. A note about
fallthrough comment regexs is at the bottom of this article.

[1] https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/