### PR TITLE
make: fix link to quickstart guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ welcome:
 	@echo "You should run 'make' in your application's directory instead."
 	@echo ""
 	@echo "Please see our Quick Start Guide at:"
-	@echo "    https://github.com/RIOT-OS/RIOT/wiki/Quick-Start-Guide"
+	@echo "    https://doc.riot-os.org/getting-started.html"
 	@echo "Or ask questions on our mailing list:"
 	@echo "    users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)"
 


### PR DESCRIPTION
Our Makefiles link to a quickstart guide long gone.