### PR TITLE
netdev.h: remove indirect reference to netdev2 from doc

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -12,8 +12,7 @@
 /**
  * @defgroup    drivers_netdev_api Network Device Driver API
  * @ingroup     drivers_netdev
- * @brief       This is the second version of a generic low-level network
- *              driver interface
+ * @brief       This is a generic low-level network driver interface
  * @{
  *
  * This interface is supposed to be a low-level interface for network drivers.


### PR DESCRIPTION
IMO there's no need to mention that the current `netdev` implementation is a second iteration. It just confuses and raises questions about the first iteration. So I propose to remove that line.