### PR TITLE
cpu/stm32f1: remove unused cpu_clock_scale

### DIFF
--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -59,15 +59,6 @@ extern "C" {
 #endif
 /** @} */
 
-/**
- * @brief Configure the CPU's clock system
- *
- * @param[in] source    source clock frequency
- * @param[in] target    target clock frequency
- * @param[in] prescale  prescaler to use
- */
-void cpu_clock_scale(uint32_t source, uint32_t target, uint32_t *prescale);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
this function def was a leftover from old times... No need to have it anymore...