### PR TITLE
cpu/cortexm: set VTOR for selected M0+ CPUs

### DIFF
--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -41,7 +41,8 @@ void cortexm_init(void)
 
     /* configure the vector table location to internal flash */
 #if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
-    defined(CPU_ARCH_CORTEX_M4F) || defined(CPU_ARCH_CORTEX_M7)
+    defined(CPU_ARCH_CORTEX_M4F) || defined(CPU_ARCH_CORTEX_M7) || \
+    (defined(CPU_ARCH_CORTEX_M0PLUS) && (__VTOR_PRESENT == 1))
     SCB->VTOR = (uint32_t)&_isr_vectors;
 #endif
 


### PR DESCRIPTION
Selected Cortex-M0+ CPUs are actually capable of relocating their vector table, e.g. the `sam0` familiy of devices. This is(interesting when jumping between multiple firmwares.

This PR adds the initialization of that register (if present) to for these CPUs to the cortexm startup code.