### PR TITLE
cpu/stm32-common: add RTC support to stm32l0

### DIFF
--- a/boards/nucleo-l053/Makefile.features
+++ b/boards/nucleo-l053/Makefile.features
@@ -3,6 +3,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-l053/include/periph_conf.h
+++ b/boards/nucleo-l053/include/periph_conf.h
@@ -182,7 +182,7 @@ static const spi_conf_t spi_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (0U)
+#define RTC_NUMOF           (1U)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l073/Makefile.features
+++ b/boards/nucleo-l073/Makefile.features
@@ -3,6 +3,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-l073/include/periph_conf.h
+++ b/boards/nucleo-l073/include/periph_conf.h
@@ -182,7 +182,7 @@ static const spi_conf_t spi_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (0U)
+#define RTC_NUMOF           (1U)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo32-l031/Makefile.features
+++ b/boards/nucleo32-l031/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo32-l031/include/periph_conf.h
+++ b/boards/nucleo32-l031/include/periph_conf.h
@@ -167,7 +167,7 @@ static const spi_conf_t spi_config[] = {
  * @name    RTC configuration
  * @{
  */
-#define RTC_NUMOF           (0U)
+#define RTC_NUMOF           (1U)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -27,7 +27,8 @@
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F2) || \
     defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32F4) || \
-    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L1)
+    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
+    defined(CPU_FAM_STM32L1)
 
 /* guard file in case no RTC device was specified */
 #if RTC_NUMOF
@@ -65,7 +66,7 @@ void rtc_init(void)
     PWR->CR |= PWR_CR_DBP;
 #endif
 
-#if defined(CPU_FAM_STM32L1)
+#if defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32L0)
     if (!(RCC->CSR & RCC_CSR_RTCEN)) {
 #else
     if (!(RCC->BDCR & RCC_BDCR_RTCEN)) {
@@ -192,9 +193,15 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
     /* Enable RTC write protection */
     RTC->WPR = 0xFF;
 
+#if defined(CPU_FAM_STM32L0)
+    EXTI->IMR  |= EXTI_IMR_IM17;
+#else
     EXTI->IMR  |= EXTI_IMR_MR17;
+#endif
+
     EXTI->RTSR |= EXTI_RTSR_TR17;
-#if defined(CPU_FAM_STM32F0)
+
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0)
     NVIC_SetPriority(RTC_IRQn, 10);
     NVIC_EnableIRQ(RTC_IRQn);
 #else
@@ -235,7 +242,7 @@ void rtc_clear_alarm(void)
 
 void rtc_poweron(void)
 {
-#if defined(CPU_FAM_STM32L1)
+#if defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32L0)
     /* Reset RTC domain */
     RCC->CSR |= RCC_CSR_RTCRST;
     RCC->CSR &= ~(RCC_CSR_RTCRST);
@@ -274,7 +281,7 @@ void rtc_poweron(void)
 
 void rtc_poweroff(void)
 {
-#if defined(CPU_FAM_STM32L1)
+#if defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32L0)
     /* Reset RTC domain */
     RCC->CSR |= RCC_CSR_RTCRST;
     RCC->CSR &= ~(RCC_CSR_RTCRST);
@@ -293,7 +300,7 @@ void rtc_poweroff(void)
 #endif
 }
 
-#if defined(CPU_FAM_STM32F0)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0)
 void isr_rtc(void)
 #else
 void isr_rtc_alarm(void)
@@ -331,4 +338,5 @@ static uint8_t byte2bcd(uint8_t value)
 
 #endif /* defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F2) || \
           defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32F4) || \
-          defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L1) */
+          defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
+          defined(CPU_FAM_STM32L1) */


### PR DESCRIPTION
Provide rtc feature for nucleo-l0

After a messy push -f here is a new pull request :D

@haukepetersen
@vincent-d
@aabadie