### PR TITLE
posix: fix redefined clockid_t on macOS

### DIFF
--- a/sys/posix/pthread/include/pthread_cond.h
+++ b/sys/posix/pthread/include/pthread_cond.h
@@ -25,7 +25,12 @@
 #   include "msp430_types.h"
 #endif
 
-#if defined(__MACH__) || defined(__WITH_AVRLIBC__)
+#ifdef __MACH__
+/* needed for AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER */
+#include <AvailabilityMacros.h>
+#endif
+
+#if defined(__WITH_AVRLIBC__) || (defined(__MACH__) && !defined(AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER))
 typedef int clockid_t;
 #endif
 


### PR DESCRIPTION
fixes the following compile error on macOS (10.12.5), found in posix related tests such as `tests/pthread`, `tests/pthread_barrier`, `tests/pthread_cleanup` ...:

```
/RIOT/sys/posix/pthread/include/pthread_cond.h:29:13: error: typedef redefinition with different types
      ('int' vs 'enum clockid_t')
typedef int clockid_t;
            ^
/usr/include/time.h:171:3: note: previous definition is here
} clockid_t;
  ^
1 error generated.
```
