### PR TITLE
tests, periph_spi: fix unused variable

### DIFF
--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -219,6 +219,9 @@ int cmd_transfer(int argc, char **argv)
 
 int cmd_bench(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
+
     uint32_t start, stop;
     uint32_t sum = 0;
     uint8_t in;


### PR DESCRIPTION
fixes:

```
/RIOT/tests/periph_spi/main.c:220:19: error: unused parameter 'argc' [-Werror,-Wunused-parameter]
int cmd_bench(int argc, char **argv)
                  ^
/RIOT/tests/periph_spi/main.c:220:32: error: unused parameter 'argv' [-Werror,-Wunused-parameter]
int cmd_bench(int argc, char **argv)
```