### PR TITLE
tests, emb6: fix unused var

### DIFF
--- a/tests/emb6/main.c
+++ b/tests/emb6/main.c
@@ -72,6 +72,8 @@ static int ifconfig(int argc, char **argv)
 
 static void *_emb6_thread(void *args)
 {
+    (void)args;
+
     emb6_process(500);  /* never stops */
     return NULL;
 }


### PR DESCRIPTION
fixes:

```
/RIOT/tests/emb6/main.c:73:33: error: unused parameter 'args' [-Werror,-Wunused-parameter]
static void *_emb6_thread(void *args)
                                ^
1 error generated.
```