### PR TITLE
driver, encx24j600: fix possible buffer overflow

### DIFF
--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -369,7 +369,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         }
 #ifdef MODULE_NETSTATS_L2
         netdev->stats.rx_count++;
-        netdev->stats.rx_bytes += len;
+        netdev->stats.rx_bytes += payload_len;
 #endif
         /* read packet (without 4 bytes checksum) */
         sram_op(dev, ENC_RRXDATA, 0xFFFF, buf, payload_len);

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -360,7 +360,13 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     /* hdr.frame_len given by device contains 4 bytes checksum */
     size_t payload_len = hdr.frame_len - 4;
 
+
     if (buf) {
+        if (payload_len > len) {
+            /* payload exceeds buffer size */
+            unlock(dev);
+            return -ENOBUFS;
+        }
 #ifdef MODULE_NETSTATS_L2
         netdev->stats.rx_count++;
         netdev->stats.rx_bytes += len;


### PR DESCRIPTION
    overflow if len < payload_len, that is packet too big