### PR TITLE
netopt: Add NETOPT_LAST_ED_LEVEL

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -260,6 +260,15 @@ typedef enum {
      */
     NETOPT_L2FILTER_RM,
 
+    /**
+     * @brief   Energy level during the last performed CCA or RX frame
+     *
+     * Get the last ED level available as an int8_t. The source of the
+     * measurement is unspecified and may come from the latest CCA
+     * measurement (CCA mode 1), or from the last received frame.
+     */
+    NETOPT_LAST_ED_LEVEL,
+
     /* add more options if needed */
 
     /**

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -60,6 +60,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_RF_TESTMODE]     = "NETOPT_RF_TESTMODE",
     [NETOPT_L2FILTER]        = "NETOPT_L2FILTER",
     [NETOPT_L2FILTER_RM]     = "NETOPT_L2FILTER_RM",
+    [NETOPT_LAST_ED_LEVEL]   = "NETOPT_LAST_ED_LEVEL",
     [NETOPT_NUMOF]           = "NETOPT_NUMOF",
 };
 


### PR DESCRIPTION
This netopt option provides a way for an application to request the latest ED measurement from the radio. Used by the spectrum-scanner application in https://github.com/RIOT-OS/applications/pull/30