### PR TITLE
boards/nucleo-l073: add third UART (USART1) configuration

### DIFF
--- a/boards/nucleo-l073/include/periph_conf.h
+++ b/boards/nucleo-l073/include/periph_conf.h
@@ -86,6 +86,16 @@ static const uart_conf_t uart_config[] = {
         .irqn       = USART2_IRQn
     },
     {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF4,
+        .tx_af      = GPIO_AF4,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn
+    },
+    {
         .dev        = USART4,
         .rcc_mask   = RCC_APB1ENR_USART4EN,
         .rx_pin     = GPIO_PIN(PORT_C, 11),
@@ -98,7 +108,8 @@ static const uart_conf_t uart_config[] = {
 };
 
 #define UART_0_ISR          (isr_usart2)
-#define UART_1_ISR          (isr_usart4_5)
+#define UART_1_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart4_5)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */


### PR DESCRIPTION
UART1 definition has been added to the nucleo-l073 board definition. The UART has been tested with a WISOL module (Sigfox) that runs at 9600 bauds. All is working fine. The RX and TX signals have also been observed adn decoded with a logic analyzer.