### PR TITLE
drivers/sdcard_spi: remove xtimer_init

### DIFF
--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -94,7 +94,6 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
                   (gpio_init(card->params.power, GPIO_OUT) == 0)) ) {
 
                 DEBUG("gpio_init(): [OK]\n");
-                xtimer_init();
                 return SD_INIT_SPI_POWER_SEQ;
             }
 


### PR DESCRIPTION
a call to `xtimer_init()` does not belong into any device driver and is not a good idea...