### PR TITLE
gnrc_netdev: port to generalized netif auto-initialization

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -510,6 +510,10 @@ ifneq (,$(filter gnrc_netdev,$(USEMODULE)))
   USEMODULE += netopt
 endif
 
+ifneq (,$(filter gnrc_netif,$(USEMODULE)))
+  USEMODULE += netif
+endif
+
 ifneq (,$(filter netstats_%, $(USEMODULE)))
   USEMODULE += netstats
 endif

--- a/cpu/native/include/netif_params.h
+++ b/cpu/native/include/netif_params.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_netif
+ * @brief
+ * @{
+ *
+ * @file
+ * @brief       Network interface parameter file.
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NETIF_PARAMS_H
+#define NETIF_PARAMS_H
+
+#include "net/netif.h"
+#include "netdev_tap_params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static const netif_params_t netif_params[] =
+{
+    { &netdev_tap_params[0],
+#ifdef MODULE_GNRC
+      NETIF_TYPE_GNRC_DEFAULT,
+#endif
+      "ET0"
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NETIF_PARAMS_H */
+/** @} */

--- a/drivers/at86rf2xx/include/at86rf2xx_params.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_params.h
@@ -22,6 +22,7 @@
 #define AT86RF2XX_PARAMS_H
 
 #include "board.h"
+#include "at86rf2xx.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/at86rf2xx/include/netif_params.h
+++ b/drivers/at86rf2xx/include/netif_params.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_netif
+ * @brief
+ * @{
+ *
+ * @file
+ * @brief       Network interface parameter file.
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NETIF_PARAMS_H
+#define NETIF_PARAMS_H
+
+#include "net/netif.h"
+#include "at86rf2xx_params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static const netif_params_t netif_params[] =
+{
+    { &at86rf2xx_params[0],
+#ifdef MODULE_GNRC
+      NETIF_TYPE_GNRC_DEFAULT,
+#endif
+      "WP0"
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NETIF_PARAMS_H */
+/** @} */

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -36,7 +36,6 @@ PSEUDOMODULES += lwip_udp
 PSEUDOMODULES += lwip_udplite
 PSEUDOMODULES += mpu_stack_guard
 PSEUDOMODULES += netdev_default
-PSEUDOMODULES += netif
 PSEUDOMODULES += netstats
 PSEUDOMODULES += netstats_l2
 PSEUDOMODULES += netstats_ipv6

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -28,6 +28,9 @@ endif
 ifneq (,$(filter netdev_test,$(USEMODULE)))
     DIRS += net/netdev_test
 endif
+ifneq (,$(filter netif,$(USEMODULE)))
+    DIRS += net/link_layer/netif
+endif
 ifneq (,$(filter icmpv6,$(USEMODULE)))
     DIRS += net/network_layer/icmpv6
 endif

--- a/sys/auto_init/netif/auto_init_netdev_tap.c
+++ b/sys/auto_init/netif/auto_init_netdev_tap.c
@@ -22,29 +22,37 @@
 #include "log.h"
 #include "debug.h"
 #include "netdev_tap_params.h"
+#include "netif_params.h"
 #include "net/gnrc/netdev/eth.h"
 
 #define TAP_MAC_STACKSIZE           (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
 #define TAP_MAC_PRIO                (THREAD_PRIORITY_MAIN - 3)
 
 static netdev_tap_t netdev_tap[NETDEV_TAP_MAX];
+#ifdef MODULE_GNRC
 static char _netdev_eth_stack[NETDEV_TAP_MAX][TAP_MAC_STACKSIZE + DEBUG_EXTRA_STACKSIZE];
 static gnrc_netdev_t _gnrc_netdev_tap[NETDEV_TAP_MAX];
+#endif
 
 void auto_init_netdev_tap(void)
 {
     for (unsigned i = 0; i < NETDEV_TAP_MAX; i++) {
         const netdev_tap_params_t *p = &netdev_tap_params[i];
+        const netif_params_t *_netif_params = netif_params_get_by_dev(
+                                                        netif_params, p);
 
-        LOG_DEBUG("[auto_init_netif] initializing netdev_tap #%u on TAP %s\n",
-                  i, *(p->tap_name));
+        LOG_DEBUG("[auto_init_netif] initializing netdev_tap #%s on TAP %s\n",
+                  _netif_params->name, *(p->tap_name));
 
         netdev_tap_setup(&netdev_tap[i], p);
-        gnrc_netdev_eth_init(&_gnrc_netdev_tap[i], (netdev_t*)&netdev_tap[i]);
-
-        gnrc_netdev_init(_netdev_eth_stack[i], TAP_MAC_STACKSIZE,
-                         TAP_MAC_PRIO, "gnrc_netdev_tap",
-                         &_gnrc_netdev_tap[i]);
+#ifdef MODULE_GNRC
+        /* XXX super hacky way to provide the stack without requiring additional
+         * fields in gnrc_netdev_t just for initialization */
+        _gnrc_netdev_tap[i].dev = (netdev_t *)_netdev_eth_stack[i];
+        _gnrc_netdev_tap[i].pid = TAP_MAC_STACKSIZE + DEBUG_EXTRA_STACKSIZE;
+#endif
+        netif_setup(_netif_params, GNRC_NETDEV_TYPE_ETH,
+                    (netdev_t *)&netdev_tap[i], &_gnrc_netdev_tap[i]);
     }
 }
 

--- a/sys/include/net/gnrc/netdev.h
+++ b/sys/include/net/gnrc/netdev.h
@@ -38,6 +38,7 @@
 #include "net/gnrc/mac/types.h"
 #include "net/ieee802154.h"
 #include "net/gnrc/mac/mac.h"
+#include "net/netif.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,6 +66,21 @@ extern "C" {
  *          packet
  */
 #define GNRC_NETDEV_MAC_INFO_RX_STARTED         (0x0004U)
+
+/**
+ * @brief   Sub-types for interface initialization
+ * @anchor  net_gnrc_netif_type
+ */
+enum {
+    GNRC_NETDEV_TYPE_NONE = 0,      /**< No specified type */
+    GNRC_NETDEV_TYPE_ETH,           /**< Use Ethernet adaptation layer
+                                     *   (see net/gnrc/netdev/eth.h) */
+    GNRC_NETDEV_TYPE_IEEE802154,    /**< Use IEEE 802.15.4 adaptation layer
+                                     *   (see net/gnrc/netdev/ieee802154.h) */
+    GNRC_NETDEV_TYPE_CC110X,        /**< Use CC110X adaptation layer (see gnrc_netdev_cc110x.h) */
+    GNRC_NETDEV_TYPE_XBEE,          /**< Use XBEE adaptation layer (see xbee_adpt.h) */
+    /* extend if needed */
+};
 
 /**
  * @brief Structure holding GNRC netdev adapter state
@@ -204,19 +220,21 @@ static inline void gnrc_netdev_set_tx_feedback(gnrc_netdev_t *dev,
 #endif
 
 /**
- * @brief Initialize GNRC netdev handler thread
+ * @brief   Setup GNRC network interface (== GNRC netdev handler thread) from
+ *          network interface parameters
  *
- * @param[in] stack         ptr to preallocated stack buffer
- * @param[in] stacksize     size of stack buffer
- * @param[in] priority      priority of thread
- * @param[in] name          name of thread
- * @param[in] gnrc_netdev  ptr to netdev device to handle in created thread
+ * @param[in] params    Initialization parameters of the interface
+ * @param[in] subtype   See @ref net_gnrc_netif_type "GNRC netif subtypes"
+ * @param[in] netdev    The set-up'd (but not initialized) network device, based
+ *                      on device specific parameters netif_params_t::dev_params
+ *
+ * @note    Called by @ref netif_setup() with `auto_init`.
  *
  * @return pid of created thread
  * @return KERNEL_PID_UNDEF on error
  */
-kernel_pid_t gnrc_netdev_init(char *stack, int stacksize, char priority,
-                               const char *name, gnrc_netdev_t *gnrc_netdev);
+kernel_pid_t gnrc_netdev_setup(const netif_params_t *params, unsigned subtype,
+                               netdev_t *netdev, gnrc_netdev_t *iface);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -35,6 +35,39 @@ extern "C" {
 #define NETIF_NAMELENMAX    (8U)
 #endif
 
+typedef enum {
+    NETIF_TYPE_UNDEF = 0;
+#ifdef MODULE_GNRC
+    NETIF_TYPE_GNRC_NETIF,
+#endif
+#ifdef MODULE_GNRC_LWMAC
+    NETIF_TYPE_GNRC_NETIF_LWMAC,
+#ifdef MODULE_LWIP
+    NETIF_TYPE_LWIP,
+#endif /* MODULE_LWIP */
+#ifdef MODUE_LWIP_SIXLOWPAN
+    NETIF_TYPE_LWIP_6LO,
+#endif /* MODULE_LWIP */
+#ifdef MODULE_EMB6
+    NETIF_TYPE_EMB6,
+#endif
+#ifdef MODULE_OPENTHREAD
+    NETIF_TYPE_OPENTHREAD,
+#endif
+    /* extend list if needed */
+} netif_type_t;
+
+typedef struct {
+    const void *dev_params;
+    netif_type_t type;
+    const char *name;
+} netif_params_t;
+
+extern const void *netif_netdev_default_params;
+
+netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
+                                        const void *dev_pararms);
+
 /**
  * @brief   Network interface enumeration type
  */

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -31,42 +31,67 @@ extern "C" {
  */
 #define NETIF_INVALID       (0x0-1)
 
+/**
+ * @brief   Maximum length for an interface name
+ */
 #ifndef NETIF_NAMELENMAX
 #define NETIF_NAMELENMAX    (8U)
 #endif
 
+/**
+ * @brief   Type of the interface
+ */
 typedef enum {
-    NETIF_TYPE_UNDEF = 0;
-#ifdef MODULE_GNRC
+    NETIF_TYPE_UNDEF = 0;       /**< Interface is of no specific type (raw @ref drivers_netdev) */
+#if defined(MODULE_GNRC) || DOXYGEN
+    /**
+     * @brief   Default GNRC network interface (without software MAC)
+     *
+     * @note only available with @ref net_gnrc "GNRC" module.
+     */
     NETIF_TYPE_GNRC_NETIF,
 #endif
-#ifdef MODULE_GNRC_LWMAC
-    NETIF_TYPE_GNRC_NETIF_LWMAC,
-#ifdef MODULE_LWIP
-    NETIF_TYPE_LWIP,
+#if defined(MODULE_LWIP_ETHERNET) || DOXYGEN
+    /**
+     * @brief   lwIP Ethernet network interface
+     *
+     * @note only available with `lwip_ethernet` module of the @ref pkg_lwip package.
+     */
+    NETIF_TYPE_LWIP_ETHERNET,
 #endif /* MODULE_LWIP */
-#ifdef MODUE_LWIP_SIXLOWPAN
+#if defined(MODUE_LWIP_SIXLOWPAN) || DOXYGEN
+    /**
+     * @brief   lwIP 6LoWPAN network interface
+     *
+     * @note only available with `lwip_sixlowpan` module of the @ref pkg_lwip package.
+     */
     NETIF_TYPE_LWIP_6LO,
 #endif /* MODULE_LWIP */
-#ifdef MODULE_EMB6
+#if defined(MODULE_EMB6) || DOXYGEN
+    /**
+     * @brief   emb6 interface
+     *
+     * @note only available with @ref pkg_emb6
+     */
     NETIF_TYPE_EMB6,
-#endif
-#ifdef MODULE_OPENTHREAD
-    NETIF_TYPE_OPENTHREAD,
 #endif
     /* extend list if needed */
 } netif_type_t;
 
+/**
+ * @brief struct holding all parameters needed for interface initialization
+ */
 typedef struct {
+    /**
+     * @brief Network device parameters
+     *
+     * The network device parameters are used to associate a network device to
+     * the network interface.
+     */
     const void *dev_params;
-    netif_type_t type;
-    const char *name;
+    netif_type_t type;      /**< type of the interface */
+    const char *name;       /**< name of the interface */
 } netif_params_t;
-
-extern const void *netif_netdev_default_params;
-
-netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
-                                        const void *dev_pararms);
 
 /**
  * @brief   Network interface enumeration type
@@ -74,9 +99,34 @@ netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
 typedef intptr_t netif_t;
 
 /**
+ * @brief   Gets a network interface parameter struct from an array of parameter
+ *          structs by network device parameters
+ *
+ * @param[in] netif_params  Array of network interface parameters.
+ * @param[in] dev_pararms   A struct of network device parameters.
+ *
+ * @return  The parameters with netif_params_t::dev_params == @p dev_params
+ * @return  NULL, if there are no such parameters in @p netif_params
+ */
+netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
+                                        const void *dev_params);
+
+/**
+ * @brief   Initialize interface
+ *
+ * @param[in] params    Initialization parameters of the interface
+ *
+ * @return  The interface enumerator on success
+ * @return  @ref NETIF_INVALID on error.
+ */
+netif_t netif_init(const netif_params_t *params);
+
+/**
  * @brief   Iterator for the interfaces
  *
  * Returns interface after @p last. To start use `last == NETIF_INVALID`.
+ *
+ * @note    Supposed to be implemented by the networking module
  *
  * @return next network interface.
  * @return @ref NETIF_INVALID, if there is no interface after @p last
@@ -88,6 +138,8 @@ netif_t netif_iter(netif_t last);
  *
  * @pre `name != NULL`
  * @pre name holds at least @ref NETIF_NAMELENMAX characters
+ *
+ * @note    Supposed to be implemented by the networking module
  *
  * @param[in] netif A network interface.
  * @param[out] name The name of the interface. Must not be `NULL`. Must at least
@@ -102,6 +154,8 @@ int netif_get_name(netif_t netif, char *name);
  * @brief   Gets interface by name
  *
  * @pre `name != NULL`
+ *
+ * @note    Supposed to be implemented by the networking module
  *
  * @param[in] name  The name of an interface. Must not be `NULL`.
  *

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -22,6 +22,8 @@
 #ifndef NETIF_H_
 #define NETIF_H_
 
+#include "net/netdev.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -39,33 +41,32 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Maximum number of network interfaces
+ */
+#ifndef NETIF_NUMOF
+#define NETIF_NUMOF         (1U)
+#endif
+
+/**
  * @brief   Type of the interface
  */
 typedef enum {
-    NETIF_TYPE_UNDEF = 0;       /**< Interface is of no specific type (raw @ref drivers_netdev) */
+    NETIF_TYPE_INVALID = 0;     /**< Interface is of no specific type (should not be used) */
 #if defined(MODULE_GNRC) || DOXYGEN
     /**
      * @brief   Default GNRC network interface (without software MAC)
      *
      * @note only available with @ref net_gnrc "GNRC" module.
      */
-    NETIF_TYPE_GNRC_NETIF,
+    NETIF_TYPE_GNRC_DEFAULT,
 #endif
 #if defined(MODULE_LWIP_ETHERNET) || DOXYGEN
     /**
-     * @brief   lwIP Ethernet network interface
+     * @brief   lwIP network interface
      *
-     * @note only available with `lwip_ethernet` module of the @ref pkg_lwip package.
+     * @note only available with @ref pkg_lwip.
      */
-    NETIF_TYPE_LWIP_ETHERNET,
-#endif /* MODULE_LWIP */
-#if defined(MODUE_LWIP_SIXLOWPAN) || DOXYGEN
-    /**
-     * @brief   lwIP 6LoWPAN network interface
-     *
-     * @note only available with `lwip_sixlowpan` module of the @ref pkg_lwip package.
-     */
-    NETIF_TYPE_LWIP_6LO,
+    NETIF_TYPE_LWIP,
 #endif /* MODULE_LWIP */
 #if defined(MODULE_EMB6) || DOXYGEN
     /**
@@ -112,14 +113,21 @@ netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
                                         const void *dev_params);
 
 /**
- * @brief   Initialize interface
+ * @brief   Set-up interface
  *
  * @param[in] params    Initialization parameters of the interface
+ * @param[in] subtype   netif_params_t:: specific sub-type based on the nature
+ *                      of @p netdev (e.g. specifies that the device is an
+ *                      Ethernet or IEEE 802.15.4 device). May be 0 and ignored
+ *                      if not required by network stack.
+ * @param[in] netdev    The set-up'd (but not initialized) network device, based
+ *                      on device specific parameters netif_params_t::dev_params
  *
  * @return  The interface enumerator on success
  * @return  @ref NETIF_INVALID on error.
  */
-netif_t netif_init(const netif_params_t *params);
+netif_t netif_init(const netif_params_t *params, unsigned subtype,
+                   netdev_t *netdev);
 
 /**
  * @brief   Iterator for the interfaces

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -182,6 +182,8 @@ netif_t netif_get_by_name(const char *name);
 /**
  * @brief   Gets option from an interface
  *
+ * @note    Supposed to be implemented by the networking module
+ *
  * @param[in]   netif   A network interface.
  * @param[in]   opt     Option type.
  * @param[out]  value   Pointer to store the option's value in.
@@ -194,6 +196,8 @@ int netif_get_opt(netif_t netif, netopt_t opt, void *value, size_t max_len);
 
 /**
  * @brief   Sets option to an interface
+ *
+ * @note    Supposed to be implemented by the networking module
  *
  * @param[in] netif     A network interface.
  * @param[in] opt       Option type.

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -42,13 +42,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Maximum number of network interfaces
- */
-#ifndef NETIF_NUMOF
-#define NETIF_NUMOF         (1U)
-#endif
-
-/**
  * @brief   Type of the interface
  */
 typedef enum {
@@ -95,15 +88,19 @@ typedef struct {
     const char *name;       /**< name of the interface */
 } netif_params_t;
 
+#include "netif_params.h"
+
+/**
+ * @brief   Maximum number of network interfaces
+ */
+#ifndef NETIF_NUMOF
+#define NETIF_NUMOF         (sizeof(netif_params) / sizeof(netif_params[0]))
+#endif
+
 /**
  * @brief   Network interface enumeration type
  */
 typedef intptr_t netif_t;
-
-/**
- * @brief   Parameters for the default network device of the @ref boards
- */
-extern void *netdev_params_default;
 
 /**
  * @brief   Gets a network interface parameter struct from an array of parameter
@@ -115,14 +112,14 @@ extern void *netdev_params_default;
  * @return  The parameters with netif_params_t::dev_params == @p dev_params
  * @return  NULL, if there are no such parameters in @p netif_params
  */
-netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
-                                        const void *dev_params);
+const netif_params_t *netif_params_get_by_dev(const netif_params_t *netif_params,
+                                              const void *dev_params);
 
 /**
  * @brief   Set-up interface
  *
  * @param[in] params    Initialization parameters of the interface
- * @param[in] subtype   netif_params_t:: specific sub-type based on the nature
+ * @param[in] subtype   netif_params_t::type specific sub-type based on the nature
  *                      of @p netdev (e.g. specifies that the device is an
  *                      Ethernet or IEEE 802.15.4 device). May be 0 and ignored
  *                      if not required by network stack.

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @defgroup    Network interfaces
+ * @defgroup    net_netif   Network interfaces
  * @ingroup     net
  * @brief       Common network interface API
  * @{

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -23,6 +23,7 @@
 #define NETIF_H_
 
 #include "net/netdev.h"
+#include "net/netopt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,11 +101,16 @@ typedef struct {
 typedef intptr_t netif_t;
 
 /**
+ * @brief   Parameters for the default network device of the @ref boards
+ */
+extern void *netdev_params_default;
+
+/**
  * @brief   Gets a network interface parameter struct from an array of parameter
  *          structs by network device parameters
  *
  * @param[in] netif_params  Array of network interface parameters.
- * @param[in] dev_pararms   A struct of network device parameters.
+ * @param[in] dev_params    A struct of network device parameters.
  *
  * @return  The parameters with netif_params_t::dev_params == @p dev_params
  * @return  NULL, if there are no such parameters in @p netif_params
@@ -122,12 +128,13 @@ netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
  *                      if not required by network stack.
  * @param[in] netdev    The set-up'd (but not initialized) network device, based
  *                      on device specific parameters netif_params_t::dev_params
+ * @param[in] priv_data Private, stack-dependent data.
  *
  * @return  The interface enumerator on success
  * @return  @ref NETIF_INVALID on error.
  */
 netif_t netif_init(const netif_params_t *params, unsigned subtype,
-                   netdev_t *netdev);
+                   netdev_t *netdev, void *priv_data);
 
 /**
  * @brief   Iterator for the interfaces
@@ -171,6 +178,32 @@ int netif_get_name(netif_t netif, char *name);
  * @return  @ref NETIF_INVALID if no interface is named @p name.
  */
 netif_t netif_get_by_name(const char *name);
+
+/**
+ * @brief   Gets option from an interface
+ *
+ * @param[in]   netif   A network interface.
+ * @param[in]   opt     Option type.
+ * @param[out]  value   Pointer to store the option's value in.
+ * @param[in]   max_len Maximal amount of byte that fit into @p value.
+ *
+ * @return  Number of bytes written to @p value.
+ * @return  `< 0` on error, 0 on success.
+ */
+int netif_get_opt(netif_t netif, netopt_t opt, void *value, size_t max_len);
+
+/**
+ * @brief   Sets option to an interface
+ *
+ * @param[in] netif     A network interface.
+ * @param[in] opt       Option type.
+ * @param[in] value     Pointer to store the option's value in.
+ * @param[in] value_len The length of @p value.
+ *
+ * @return Number of bytes used from @p value.
+ * @return `< 0` on error, 0 on success.
+ */
+int netif_set_opt(netif_t netif, netopt_t opt, void *value, size_t value_len);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -52,7 +52,7 @@ extern "C" {
  * @brief   Type of the interface
  */
 typedef enum {
-    NETIF_TYPE_INVALID = 0;     /**< Interface is of no specific type (should not be used) */
+    NETIF_TYPE_INVALID = 0,     /**< Interface is of no specific type (should not be used) */
 #if defined(MODULE_GNRC) || DOXYGEN
     /**
      * @brief   Default GNRC network interface (without software MAC)
@@ -133,8 +133,8 @@ netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
  * @return  The interface enumerator on success
  * @return  @ref NETIF_INVALID on error.
  */
-netif_t netif_init(const netif_params_t *params, unsigned subtype,
-                   netdev_t *netdev, void *priv_data);
+netif_t netif_setup(const netif_params_t *params, unsigned subtype,
+                    netdev_t *netdev, void *priv_data);
 
 /**
  * @brief   Iterator for the interfaces

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    Network interfaces
+ * @ingroup     net
+ * @brief       Common network interface API
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ */
+#ifndef NETIF_H_
+#define NETIF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Identifier for an invalid network interface
+ */
+#define NETIF_INVALID       (0x0-1)
+
+#ifndef NETIF_NAMELENMAX
+#define NETIF_NAMELENMAX    (8U)
+#endif
+
+/**
+ * @brief   Network interface enumeration type
+ */
+typedef intptr_t netif_t;
+
+/**
+ * @brief   Iterator for the interfaces
+ *
+ * Returns interface after @p last. To start use `last == NETIF_INVALID`.
+ *
+ * @return next network interface.
+ * @return @ref NETIF_INVALID, if there is no interface after @p last
+ */
+netif_t netif_iter(netif_t last);
+
+/**
+ * @brief   Gets name of an interface
+ *
+ * @pre `name != NULL`
+ * @pre name holds at least @ref NETIF_NAMELENMAX characters
+ *
+ * @param[in] netif A network interface.
+ * @param[out] name The name of the interface. Must not be `NULL`. Must at least
+ *                  hold @ref NETIF_NAMELENMAX bytes.
+ *
+ * @return  length of @p name on success
+ * @return  0, if @p netif was not a valid interface.
+ */
+int netif_get_name(netif_t netif, char *name);
+
+/**
+ * @brief   Gets interface by name
+ *
+ * @pre `name != NULL`
+ *
+ * @param[in] name  The name of an interface. Must not be `NULL`.
+ *
+ * @return  The identifier of the interface on success.
+ * @return  @ref NETIF_INVALID if no interface is named @p name.
+ */
+netif_t netif_get_by_name(const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NETIF_H_ */
+/** @} */

--- a/sys/net/link_layer/netif/Makefile
+++ b/sys/net/link_layer/netif/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/link_layer/netif/netif.c
+++ b/sys/net/link_layer/netif/netif.c
@@ -40,7 +40,17 @@ netif_t netif_setup(const netif_params_t *params, unsigned subtype,
                     netdev_t *netdev, void *priv_data)
 {
     switch (params->type) {
-        /* TODO: type specific calls */
+#ifdef MODULE_GNRC
+        case NETIF_TYPE_GNRC_DEFAULT: {
+            kernel_pid_t res;
+            DEBUG("netif: Initialize %s as GNRC interface\n", params->name);
+            if ((res = gnrc_netdev_setup(params, subtype, netdev,
+                                         priv_data)) == KERNEL_PID_UNDEF) {
+                return NETIF_INVALID;
+            }
+            return (netif_t)res;
+        }
+#endif
         default:
             (void)subtype;
             (void)netdev;

--- a/sys/net/link_layer/netif/netif.c
+++ b/sys/net/link_layer/netif/netif.c
@@ -13,21 +13,26 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#ifdef MODULE_GNRC
+#include "net/gnrc/netdev.h"
+#endif
+
 #include "net/netif.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-netif_params_t *netif_params_default = NULL;
-
-netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
-                                        const void *dev_params)
+/* XXX: rename parameters locally to not conflict with global names in
+ * NETIF_NUMOF macro*/
+const netif_params_t *netif_params_get_by_dev(const netif_params_t *nparams,
+                                              const void *dparams)
 {
-    for (int i = 0; i < NETIF_NUMOF; i++) {
-        if (netif_params[i].dev_params == dev_params) {
-            return &netif_params[i];
+    for (unsigned i = 0; i < NETIF_NUMOF; i++) {
+        if (nparams[i].dev_params == dparams) {
+            return &nparams[i];
         }
     }
+    DEBUG("netif: found no fitting netif parameters for dev %p\n", dparams);
     return NULL;
 }
 

--- a/sys/net/link_layer/netif/netif.c
+++ b/sys/net/link_layer/netif/netif.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "net/netif.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
+                                        const void *dev_params)
+{
+    for (int i = 0; i < NETIF_NUMOF; i++) {
+        if (netif_params[i].dev_params == dev_params) {
+            return &netif_params[i];
+        }
+    }
+    return NULL;
+}
+
+netif_t netif_setup(const netif_params_t *params, unsigned subtype,
+                    netdev_t *netdev)
+{
+    switch (params->type) {
+        /* TODO: type specific calls */
+        default:
+            (void)subtype;
+            (void)netdev;
+            return NETIF_INVALID;
+    }
+}
+
+/** @} */

--- a/sys/net/link_layer/netif/netif.c
+++ b/sys/net/link_layer/netif/netif.c
@@ -18,6 +18,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+netif_params_t *netif_params_default = NULL;
+
 netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
                                         const void *dev_params)
 {
@@ -30,13 +32,14 @@ netif_params_t *netif_params_get_by_dev(netif_params_t *netif_params,
 }
 
 netif_t netif_setup(const netif_params_t *params, unsigned subtype,
-                    netdev_t *netdev)
+                    netdev_t *netdev, void *priv_data)
 {
     switch (params->type) {
         /* TODO: type specific calls */
         default:
             (void)subtype;
             (void)netdev;
+            (void)priv_data;
             return NETIF_INVALID;
     }
 }


### PR DESCRIPTION
This implements the generalized auto-initialization in #6413 for GNRC and examplifies it for `at86rf2xx` and `netdev_tap` (other netdevs might not at the moment, I will port them if you are okay with the concept).

Depends on #6413.