### PR TITLE
gcoap: make stack size configurable

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -387,6 +387,13 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief Stack size for module thread
+ */
+#ifndef GCOAP_STACK_SIZE
+#define GCOAP_STACK_SIZE (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#endif
+
+/**
  * @brief   A modular collection of resources for a server
  */
 typedef struct gcoap_listener {

--- a/sys/net/application_layer/coap/gcoap.c
+++ b/sys/net/application_layer/coap/gcoap.c
@@ -26,9 +26,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/** @brief Stack size for module thread */
-#define GCOAP_STACK_SIZE (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
-
 /* Internal functions */
 static void *_event_loop(void *arg);
 static void _listen(sock_udp_t *sock);


### PR DESCRIPTION
At the moment it is not possible to change `gcoap`'s stack size. Correct me if I am wrong, but AFAIK, functions for resources are executed in `gcoap`'s thread context (?), so it might be helpful for a user to vary the size of the stack on compile time.