### PR TITLE
sam0: fix edbg flash with serial number

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -10,7 +10,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 #   Usage: SERIAL="ATML..." BOARD=<board> make flash
 ifneq (,$(SERIAL))
     export OPENOCD_EXTRA_INIT += "-c cmsis_dap_serial $(SERIAL)"
-    EDBG_ARGS += "--serial $(SERIAL)"
+    EDBG_ARGS += --serial $(SERIAL)
     SERIAL_TTY = $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL)))
     ifeq (,$(SERIAL_TTY))
         $(error Did not find a device with serial $(SERIAL))


### PR DESCRIPTION
We couldn't flash anymore if a SERIAL number was specified, arg was not understood anymore by edbg because of quotes