### PR TITLE
saul: add support for LEDs and buttons on pba-d-01-kw2x

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.dep
+++ b/boards/pba-d-01-kw2x/Makefile.dep
@@ -3,6 +3,7 @@ ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
   USEMODULE += mag3110
   USEMODULE += mma8x5x
   USEMODULE += hdc1000

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -65,6 +65,15 @@ extern "C"
 /** @} */
 
 /**
+ * @name Macro for capacitive sensor button.
+ * @{
+ */
+#define CS_BUTTON_PORT         PORTC
+#define CS_BUTTON_PIN          6
+#define CS_BUTTON_GPIO         GPIO_PIN(PORT_C, CS_BUTTON_PIN)
+/** @} */
+
+/**
  * @name KW2XRF configuration
  *
  * {spi bus, cs pin, int pin, spi speed,}

--- a/boards/pba-d-01-kw2x/include/gpio_params.h
+++ b/boards/pba-d-01-kw2x/include/gpio_params.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017   HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup boards_pba-d-01-kw2x
+ * @{
+ *
+ * @file
+ * @brief   Board specific configuration of direct mapped GPIOs
+ *
+ * @author  Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GPIO pin configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(blue)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Button(SW0)",
+        .pin = BUTTON_GPIO,
+        .mode = GPIO_IN_PU
+    },
+    {
+        .name = "Button(CS0)",
+        .pin = CS_BUTTON_GPIO,
+        .mode = GPIO_IN
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
add SAUL support for RGB LED, user button, and capacitive sensor button on board `pba-d-01-kw2x`