### PR TITLE
shell: add param checks to rtc commands settime and setalarm

### DIFF
--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -173,17 +173,18 @@ int _rtc_handler(int argc, char **argv)
     else if (strncmp(argv[1], "getalarm", 8) == 0) {
         _rtc_getalarm();
     }
-    else if (strncmp(argv[1], "setalarm", 8) == 0) {
+    else if ((strncmp(argv[1], "setalarm", 8) == 0) && (argc == 4)) {
         _rtc_setalarm(argv + 2);
     }
     else if (strncmp(argv[1], "gettime", 7) == 0) {
         _rtc_gettime();
     }
-    else if (strncmp(argv[1], "settime", 7) == 0) {
+    else if ((strncmp(argv[1], "settime", 7) == 0)  && (argc == 4)) {
         _rtc_settime(argv + 2);
     }
     else {
-        printf("unknown command: %s\n", argv[1]);
+        printf("unknown command or missing parameters: %s\n\n", argv[1]);
+        _rtc_usage();
         return 1;
     }
     return 0;


### PR DESCRIPTION
this PR fixes undefined behavior of shell commands `rtc settime` and `rtc setalarm` when no date and time are given.