### PR TITLE
saul/gpio: add handling of active-low signals + state initialization

### DIFF
--- a/boards/samr21-xpro/include/gpio_params.h
+++ b/boards/samr21-xpro/include/gpio_params.h
@@ -34,14 +34,18 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(orange)",
-        .pin = LED0_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(orange)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .type  = SAUL_GPIO_OUT_INV,
+        .state = SAUL_GPIO_CLEAR
     },
     {
-        .name = "Button(SW0)",
-        .pin = BUTTON_GPIO,
-        .mode = GPIO_IN_PU
+        .name  = "Button(SW0)",
+        .pin   = BUTTON_GPIO,
+        .mode  = GPIO_IN_PU,
+        .type  = SAUL_GPIO_IN_INV,
+        .state = SAUL_GPIO_SKIP
     },
 };
 

--- a/drivers/include/saul/periph.h
+++ b/drivers/include/saul/periph.h
@@ -33,13 +33,54 @@ extern "C" {
 
 #ifdef MODULE_SAUL_GPIO
 /**
+ * @brief   Available SAUL GPIO modes
+ */
+typedef enum {
+    SAUL_GPIO_IN,           /**< pin is used as input */
+    SAUL_GPIO_IN_INV,       /**< pin is used as inverted input */
+    SAUL_GPIO_OUT,          /**< pin is used as output */
+    SAUL_GPIO_OUT_INV,      /**< pin is used as inverted output */
+} saul_gpio_type_t;
+
+/**
+ * @brief   Initial pin state after initialization
+ */
+typedef enum {
+    SAUL_GPIO_CLEAR = 0,    /**< set pin inactive after initialization */
+    SAUL_GPIO_SET   = 1,    /**< set pin active after initialization */
+    SAUL_GPIO_SKIP  = 2     /**< do not touch the pin state */
+} saul_gpio_state_t;
+
+/**
  * @brief   Direct mapped GPIO configuration values
  */
 typedef struct {
     const char *name;       /**< name of the device connected to this pin */
     gpio_t pin;             /**< GPIO pin to initialize and expose */
-    gpio_mode_t mode;       /**< pin mode to use */
+    gpio_mode_t mode;       /**< GPIO mode to use */
+    saul_gpio_type_t type;  /**< usage type for the pin */
+    saul_gpio_state_t state;/**< initial pin state */
 } saul_gpio_params_t;
+
+/**
+ * @brief   SAUL GPIO input driver
+ */
+extern const saul_driver_t gpio_in_saul_driver;
+
+/**
+ * @brief   SAUL GPIO inverted input driver
+ */
+extern const saul_driver_t gpio_in_inv_saul_driver;
+
+/**
+ * @brief   SAUL GPIO output driver
+ */
+extern const saul_driver_t gpio_out_saul_driver;
+
+/**
+ * @brief   SAUL GPIO inverted output driver
+ */
+extern const saul_driver_t gpio_out_inv_saul_driver;
 #endif /* MODULE_SAUL_GPIO */
 
 #ifdef MODULE_SAUL_ADC


### PR DESCRIPTION
motivated by #7148

The SAUL GPIO driver can now handle inverted logic (active-low pins) and the initial state can be configured on a per-pin basis.

This costs us on the `samr21-xpro` with two configured SAUL GPIOs ~100 byte, so it doesn't come cheap...

I have not yet adapted other boards than the `samr21-xpro`, wanted to get opinions first.