### PR TITLE
samd21-xpro:missing r in periph_flashpage

### DIFF
--- a/boards/samd21-xpro/Makefile.features
+++ b/boards/samd21-xpro/Makefile.features
@@ -1,7 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += peiph_flashpage
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm


### PR DESCRIPTION
Minor typo in the samd21-xpro Makefile.features.