### PR TITLE
gnrc_mac: use csma_sender API when needed for csma transmission

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -13,6 +13,11 @@ ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter gnrc_mac,$(USEMODULE)))
+  USEMODULE += gnrc_priority_pktqueue
+  USEMODULE += csma_sender
+endif
+
 ifneq (,$(filter nhdp,$(USEMODULE)))
   USEMODULE += sock_udp
   USEMODULE += xtimer

--- a/sys/include/net/gnrc/netdev.h
+++ b/sys/include/net/gnrc/netdev.h
@@ -38,6 +38,9 @@
 #include "net/gnrc/mac/types.h"
 #include "net/ieee802154.h"
 #include "net/gnrc/mac/mac.h"
+#ifdef MODULE_GNRC_MAC
+#include "net/csma_sender.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,6 +68,17 @@ extern "C" {
  *          packet
  */
 #define GNRC_NETDEV_MAC_INFO_RX_STARTED         (0x0004U)
+
+/**
+ * @brief   Flag to track if a device has enabled CSMA for transmissions
+ *
+ * If `gnrc_mac` is used, the user should be noticed that the `send()`
+ * function of gnrc_netdev will be affected with the state of this flag, since
+ * `gnrc_mac` accordingly adapts the `send()` function. If the device doesn't
+ * support on-chip CSMA and this flag is set for requiring CSMA transmission,
+ * then, the device will run software CSMA using `csma_sender` APIs.
+ */
+#define GNRC_NETDEV_MAC_INFO_CSMA_ENABLED       (0x0100U)
 
 /**
  * @brief Structure holding GNRC netdev adapter state
@@ -117,6 +131,11 @@ typedef struct gnrc_netdev {
      * @brief device's l2 address length
      */
     uint8_t  l2_addr_len;
+
+    /**
+     * @brief device's software CSMA configuration
+     */
+    csma_sender_conf_t csma_conf;
 
 #if ((GNRC_MAC_RX_QUEUE_SIZE != 0) || (GNRC_MAC_DISPATCH_BUFFER_SIZE != 0)) || defined(DOXYGEN)
     /**

--- a/sys/net/gnrc/link_layer/netdev/gnrc_netdev_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev/gnrc_netdev_ieee802154.c
@@ -221,7 +221,16 @@ static int _send(gnrc_netdev_t *gnrc_netdev, gnrc_pktsnip_t *pkt)
             gnrc_netdev->dev->stats.tx_unicast_count++;
         }
 #endif
+#ifdef MODULE_GNRC_MAC
+        if (gnrc_netdev->mac_info & GNRC_NETDEV_MAC_INFO_CSMA_ENABLED) {
+            res = csma_sender_csma_ca_send(netdev, vector, n, &gnrc_netdev->csma_conf);
+        }
+        else {
+            res = netdev->driver->send(netdev, vector, n);
+        }
+#else
         res = netdev->driver->send(netdev, vector, n);
+#endif
     }
     else {
         return -ENOBUFS;


### PR DESCRIPTION
This PR adds `csma_sender` to gnrc_mac for enabling software CSMA transmission when needed (for devices that don't support hardware CSMA).
Related operations are based on the corresponding flags that indicate whether the device wants CSMA transmissions.

@miri64 @gebart Could you check whether you are happy with this PR. :-)

Once this PR would be merged, I will immediately adapt [Lw-MAC](https://github.com/RIOT-OS/RIOT/pull/6554) to use it.