### PR TITLE
nanocoap: fix byte order of request message ID, and add test application

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -207,7 +207,8 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
     /* if code is COAP_CODE_EMPTY (zero), use RST as type, else RESP */
     unsigned type = code ? COAP_RESP : COAP_RST;
 
-    coap_build_hdr((coap_hdr_t *)rbuf, type, pkt->token, tkl, code, pkt->hdr->id);
+    coap_build_hdr((coap_hdr_t *)rbuf, type, pkt->token, tkl, code,
+                   ntohs(pkt->hdr->id));
     coap_hdr_set_type((coap_hdr_t *)rbuf, type);
     coap_hdr_set_code((coap_hdr_t *)rbuf, code);
 
@@ -224,7 +225,7 @@ ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t to
     memset(hdr, 0, sizeof(coap_hdr_t));
     hdr->ver_t_tkl = (0x1 << 6) | (type << 4) | token_len;
     hdr->code = code;
-    hdr->id = id;
+    hdr->id = htons(id);
 
     if (token_len) {
         memcpy(hdr->data, token, token_len);

--- a/tests/unittests/tests-nanocoap/Makefile
+++ b/tests/unittests/tests-nanocoap/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-nanocoap/Makefile.include
+++ b/tests/unittests/tests-nanocoap/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += nanocoap

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 Ken Bannister. All rights reserved.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+#include <errno.h>
+#include <stdint.h>
+
+#include "embUnit.h"
+
+#include "net/nanocoap.h"
+
+#include "unittests-constants.h"
+#include "tests-nanocoap.h"
+
+/*
+ * Validates encoded message ID byte order.
+ */
+static void test_nanocoap__req_msgid(void)
+{
+    uint8_t buf[128];
+    uint16_t msgid = 0xABCD;
+    char path[] = "/test";
+
+    uint8_t *pktpos = &buf[0];
+    pktpos += coap_build_hdr((coap_hdr_t *)pktpos, COAP_REQ, NULL, 0, COAP_METHOD_GET, msgid);
+    pktpos += coap_put_option_uri(pktpos, 0, path, COAP_OPT_URI_PATH);
+
+    coap_pkt_t pkt;
+    coap_parse(&pkt, &buf[0], pktpos - &buf[0]);
+
+    TEST_ASSERT_EQUAL_INT(msgid, coap_get_id(&pkt));
+}
+
+Test *tests_nanocoap_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_nanocoap__req_msgid),
+    };
+
+    EMB_UNIT_TESTCALLER(nanocoap_tests, NULL, NULL, fixtures);
+
+    return (Test *)&nanocoap_tests;
+}
+
+void tests_nanocoap(void)
+{
+    TESTS_RUN(tests_nanocoap_tests());
+}
+/** @} */

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.h
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Ken Bannister. All rights reserved.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unit tests for the nanocoap module
+ *
+ * @author      Ken Bannister <kb2ma@runbox.com>
+ */
+#ifndef TESTS_NANOCOAP_H
+#define TESTS_NANOCOAP_H
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_nanocoap(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_NANOCOAP_H */
+/** @} */


### PR DESCRIPTION
nanocoap was inconsistent in its public interface to the message ID for a request. For details, see the [issue](https://github.com/kaspar030/sock/issues/13) and the [PR](https://github.com/kaspar030/sock/issues/14) for the fix. This PR updates RIOT's package to include the fix. I also added a gcoap unit test to verify.

This PR uses the nanocoap from my fork, and I hope/expect @kaspar030 will accept the fix into his repository. Until that happens, RIOT can use the commits from the kb2ma nanocoap (sock) repository.