### PR TITLE
trickle: adjust old_interval to max / 2 in case of I > Imax

### DIFF
--- a/sys/trickle/trickle.c
+++ b/sys/trickle/trickle.c
@@ -41,6 +41,7 @@ void trickle_interval(trickle_t *trickle)
 
     if ((trickle->I == 0) || (trickle->I > max_interval)) {
         trickle->I = max_interval;
+        old_interval = max_interval / 2;
     }
 
     DEBUG("trickle: I == %" PRIu32 ", diff == %" PRIu32 "\n", trickle->I, diff);


### PR DESCRIPTION
After off-github discussions with @smlng we realised that `old_interval` should be ~~divided by two~~ set to `max/2` in case `I >= Imax`. Otherwise `t` would always be calculated as `Imax`.