### PR TITLE
kinetis: Use 9 bit UART config for 8E1, 8O1 modes

### DIFF
--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -205,9 +205,9 @@ typedef enum {
 /** @brief 8 data bits, no parity, 1 stop bit */
 #define UART_MODE_8N1       (0)
 /** @brief 8 data bits, even parity, 1 stop bit */
-#define UART_MODE_8E1       (UART_C1_PE_MASK)
+#define UART_MODE_8E1       (UART_C1_PE_MASK | UART_C1_M_MASK)
 /** @brief 8 data bits, odd parity, 1 stop bit */
-#define UART_MODE_8O1       (UART_C1_PE_MASK | UART_C1_PT_MASK)
+#define UART_MODE_8O1       (UART_C1_PE_MASK | UART_C1_M_MASK | UART_C1_PT_MASK)
 /** @} */
 
 #ifndef DOXYGEN


### PR DESCRIPTION
Pull request GH-7098 introduced the "8 data bits, even parity, 1 stop bit" mode to the Kinetis UART configuration. Unfortunately, the configuration misses the correct configuration since the current setting reduces the number of actual data bits to 7. Hence, the 9 bit mode needs to be enabled (so it becomes 8 data bits + 1 parity bit).

The following snippet is from the [MKW2xD Reference Manual](http://www.nxp.com/assets/documents/data/en/reference-manuals/MKW2xDxxxRM.pdf) and specifies the required changes.
![image](https://user-images.githubusercontent.com/237157/26976535-7a4276f4-4d24-11e7-86d7-d63dcacff2d3.png)
