### PR TITLE
doc: document -EINTR return code

### DIFF
--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -404,7 +404,7 @@ int sock_ip_get_remote(sock_ip_t *sock, sock_ip_ep_t *ep);
  * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
  * @return  -EINTR, receive was interrupted by an illegal networking state
- *          (most likely due to wrong initialization of a parameter or @p sock
+ *          (most likely due to wrong initialization of @p sock or with @p sock
  *          being closed before this function was called)
  * @return  -ENOBUFS, if buffer space is not large enough to store received
  *          data.

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -403,6 +403,8 @@ int sock_ip_get_remote(sock_ip_t *sock, sock_ip_ep_t *ep);
  * @return  0, if no received data is available, but everything is in order.
  * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINTR, receive was interrupted by an illegal networking state
+ *          (most likely due to wrong initialization of a parameter)
  * @return  -ENOBUFS, if buffer space is not large enough to store received
  *          data.
  * @return  -ENOMEM, if no memory was available to receive @p data.

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -405,7 +405,7 @@ int sock_ip_get_remote(sock_ip_t *sock, sock_ip_ep_t *ep);
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
  * @return  -EINTR, receive was interrupted by an illegal networking state
  *          (most likely due to wrong initialization of @p sock or with @p sock
- *          being closed before this function was called)
+ *          being closed before or while this function was called)
  * @return  -ENOBUFS, if buffer space is not large enough to store received
  *          data.
  * @return  -ENOMEM, if no memory was available to receive @p data.

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -404,7 +404,8 @@ int sock_ip_get_remote(sock_ip_t *sock, sock_ip_ep_t *ep);
  * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
  * @return  -EINTR, receive was interrupted by an illegal networking state
- *          (most likely due to wrong initialization of a parameter)
+ *          (most likely due to wrong initialization of a parameter or @p sock
+ *          being closed before this function was called)
  * @return  -ENOBUFS, if buffer space is not large enough to store received
  *          data.
  * @return  -ENOMEM, if no memory was available to receive @p data.

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -390,7 +390,8 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
  * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
  * @return  -EINTR, receive was interrupted by an illegal networking state
- *          (most likely due to wrong initialization of a parameter)
+ *          (most likely due to wrong initialization of a parameter or @p sock
+ *          being closed before this function was called)
  * @return  -ENOBUFS, if buffer space is not large enough to store received
  *          data.
  * @return  -ENOMEM, if no memory was available to receive @p data.

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -389,6 +389,8 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
  * @return  0, if no received data is available, but everything is in order.
  * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINTR, receive was interrupted by an illegal networking state
+ *          (most likely due to wrong initialization of a parameter)
  * @return  -ENOBUFS, if buffer space is not large enough to store received
  *          data.
  * @return  -ENOMEM, if no memory was available to receive @p data.

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -391,7 +391,7 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
  * @return  -EINTR, receive was interrupted by an illegal networking state
  *          (most likely due to wrong initialization of @p sock or with @p sock
- *          being closed before this function was called)
+ *          being closed before or while this function was called)
  * @return  -ENOBUFS, if buffer space is not large enough to store received
  *          data.
  * @return  -ENOMEM, if no memory was available to receive @p data.

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -390,7 +390,7 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
  * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
  * @return  -EINTR, receive was interrupted by an illegal networking state
- *          (most likely due to wrong initialization of a parameter or @p sock
+ *          (most likely due to wrong initialization of @p sock or with @p sock
  *          being closed before this function was called)
  * @return  -ENOBUFS, if buffer space is not large enough to store received
  *          data.


### PR DESCRIPTION
I was asked this week multiple times, why `EINTR` is returned on `sock_recv_udp()`, since the GNRC implementation returns it, if an IPC message of wrong type is received. This happens in most cases due to wrong initialization of `sock` (the other would be broken IPC). Since other stacks might also benefit from this error message, I thought it fitting to document it.