### PR TITLE
cpu/gpio: adapt GPIO implementations to #7173

### DIFF
--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -55,8 +55,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     else {
         gpio(pin)->DIR &= ~gpio_pin_mask(pin);
     }
-    /* clear pin */
-    gpio(pin)->DATA &= ~gpio_pin_mask(pin);
 
     return 0;
 }

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -47,7 +47,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     IOC->CFG[pin] = mode;
     GPIO->DOE &= ~(1 << pin);
     GPIO->DOE |= ((~(mode >> DOE_SHIFT) & 0x1) << pin);
-    GPIO->DOUTCLR = (1 << pin);
 
     return 0;
 }

--- a/cpu/ezr32wg/periph/gpio.c
+++ b/cpu/ezr32wg/periph/gpio.c
@@ -60,17 +60,21 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     GPIO_P_TypeDef *port = _port(pin);
     uint32_t pin_pos = _pin_pos(pin);
 
+    if (mode == GPIO_IN_PD) {
+        return -1;
+    }
+
     /* enable power for the GPIO module */
     CMU->HFPERCLKEN0 |= CMU_HFPERCLKEN0_GPIO;
 
     /* configure the mode */
     port->MODE[pin_pos >> 3] &= ~(0xf << ((pin_pos & 0x7) * 4));
     port->MODE[pin_pos >> 3] |= (mode << ((pin_pos & 0x7) * 4));
-    /* reset output register */
-    port->DOUTCLR = (1 << pin_pos);
     /* if input with pull-up, set the data out register */
     if (mode == GPIO_IN_PU) {
         port->DOUTSET = (1 << pin_pos);
+    } else if (mode == GPIO_IN) {
+        port->DOUTCLR = (1 << pin_pos);
     }
 
     return 0;

--- a/cpu/kinetis_common/periph/gpio.c
+++ b/cpu/kinetis_common/periph/gpio.c
@@ -181,7 +181,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     /* set pin direction */
     if (mode & MODE_OUT) {
         gpio(pin)->PDDR |=  (1 << pin_num(pin));
-        gpio(pin)->PCOR = (1 << pin_num(pin));
     }
     else {
         gpio(pin)->PDDR &= ~(1 << pin_num(pin));

--- a/cpu/msp430fxyz/periph/gpio.c
+++ b/cpu/msp430fxyz/periph/gpio.c
@@ -88,14 +88,13 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
         return -1;
     }
 
-    /* reset pin and output value */
+    /* set pin direction */
     if (mode == GPIO_OUT) {
         port->DIR |= _pin(pin);
     }
     else {
         port->DIR &= ~(_pin(pin));
     }
-    port->OD &= ~(_pin(pin));
 
     return 0;
 }

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -97,9 +97,8 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
         port->DIRSET.reg = pin_mask;
     }
 
-    /* configure the pin cfg and clear output register */
+    /* configure the pin cfg */
     port->PINCFG[pin_pos].reg = (mode & MODE_PINCFG_MASK);
-    port->OUTCLR.reg = pin_mask;
 
     /* and set pull-up/pull-down if applicable */
     if (mode == 0x7) {

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -94,9 +94,8 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     /* set output mode */
     port->OTYPER &= ~(1 << pin_num);
     port->OTYPER |=  (((mode >> 4) & 0x1) << pin_num);
-    /* finally set pin speed to maximum and reset output */
+    /* set pin speed to maximum */
     port->OSPEEDR |= (3 << (2 * pin_num));
-    port->BSRR = (1 << (pin_num + 16));
 
     return 0;
 }

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -89,9 +89,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     /* set pin mode */
     port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
     port->CR[pin_num >> 3] |=  ((mode & MODE_MASK) << ((pin_num & 0x7) * 4));
-    /* set initial state of output register */
-    port->BRR = (1 << pin_num);
-    port->BSRR = ((mode >> ODR_POS) << pin_num);
 
     return 0; /* all OK */
 }


### PR DESCRIPTION
Adapted effected GPIO implementations according to the discussion in #7173.

Touched CPUs (to be tested):
 - [x] stm32_common
 - [x] stm32f1
 - [x] samd21
 - [x] saml21
 - [x] msp430fxyz
 - [x] kinetis_common
 - [x] ezr32wg
 - [x] cc26x0
 - [x] cc2538
