### PR TITLE
gnrc_ipv6_nib: fix caching mechanism of neighbor cache

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -123,19 +123,18 @@ static inline _nib_onl_entry_t *_cache_out_onl_entry(const ipv6_addr_t *addr,
             res = tmp;
             res->mode = _EMPTY;
             _override_node(addr, iface, res);
-            /* cstate masked above already */
-            res->info = cstate;
+            /* cstate masked in _nib_nc_add() already */
+            res->info |= cstate;
             res->mode = _NC;
-            break;
         }
-        /* requeue if not garbage collectible at the moment */
-        DEBUG("nib: Requeing (addr = %s, iface = %u)\n",
-              ipv6_addr_to_str(addr_str, &tmp->ipv6,
-                               sizeof(addr_str)),
-              _nib_onl_get_if(tmp));
+        /* requeue if not garbage collectible at the moment or queueing
+         * newly created NCE */
         clist_rpush(&_next_removable, (clist_node_t *)tmp);
-        tmp = (_nib_onl_entry_t *)clist_lpop(&_next_removable);
-    } while (tmp != first);
+        if (res == NULL) {
+            /* no new entry created yet, get next entry in FIFO */
+            tmp = (_nib_onl_entry_t *)clist_lpop(&_next_removable);
+        }
+    } while ((tmp != first) && (res != NULL));
     return res;
 }
 

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
@@ -464,23 +464,15 @@ static void test_nib_nc_add__success_full_but_garbage_collectible(void)
     ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
                                   { .u64 = TEST_UINT64 } } };
 
-    for (int i = 0; i < GNRC_IPV6_NIB_NUMOF; i++) {
+    for (int i = 0; i < (3 * GNRC_IPV6_NIB_NUMOF); i++) {
         TEST_ASSERT_NOT_NULL((node = _nib_nc_add(&addr, IFACE,
                                                  GNRC_IPV6_NIB_NC_INFO_NUD_STATE_REACHABLE)));
         TEST_ASSERT(last != node);
+        TEST_ASSERT(ipv6_addr_equal(&addr, &node->ipv6));
+        TEST_ASSERT_EQUAL_INT(IFACE, _nib_onl_get_if(node));
         addr.u64[1].u64++;
         last = node;
     }
-    TEST_ASSERT_NOT_NULL((last = _nib_nc_add(&addr, IFACE,
-                                             GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNMANAGED)));
-    addr.u64[1].u64++;
-    TEST_ASSERT_NOT_NULL((node = _nib_nc_add(&addr, IFACE,
-                                             GNRC_IPV6_NIB_NC_INFO_NUD_STATE_INCOMPLETE)));
-    TEST_ASSERT(last != node);
-    addr.u64[1].u64++;
-    TEST_ASSERT_NOT_NULL((node = _nib_nc_add(&addr, IFACE,
-                                            GNRC_IPV6_NIB_NC_INFO_NUD_STATE_STALE)));
-    TEST_ASSERT(last != node);
 }
 
 /*


### PR DESCRIPTION
While testing #7014 under high load (7 neighbors to a node with just 4 maximum neighbor cache entries) I noticed, that the caching mechanism doesn't quite work as expected, since two bugs exist:

1. the interface of the new neighbor cache entry after a cache miss is overwritten, since it is contained in `nib->info` and directly after the setting function is called it is set (not OR'd) to `cstate`.
2. The newly created neighbor cache entry after a cache miss isn't added to the cache FIFO, resulting in the cache to overflow in its second iteration.

The PR also adapts the unittests for the NIB accordingly so the bug isn't reintroduced.