### PR TITLE
gnrc_pktbuf: move common auxiliary functions to common module

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -8,7 +8,6 @@ PSEUDOMODULES += gnrc_netdev_default
 PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
-PSEUDOMODULES += gnrc_pktbuf
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default
 PSEUDOMODULES += gnrc_sixlowpan_iphc_nhc

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -70,6 +70,9 @@ endif
 ifneq (,$(filter gnrc_pktbuf_static,$(USEMODULE)))
     DIRS += pktbuf_static
 endif
+ifneq (,$(filter gnrc_pktbuf,$(USEMODULE)))
+    DIRS += pktbuf
+endif
 ifneq (,$(filter gnrc_priority_pktqueue,$(USEMODULE)))
     DIRS += priority_pktqueue
 endif

--- a/sys/net/gnrc/pktbuf/Makefile
+++ b/sys/net/gnrc/pktbuf/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_pktbuf
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
+++ b/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
@@ -13,6 +13,8 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <sys/uio.h>
+
 #include "net/gnrc/pktbuf.h"
 
 gnrc_pktsnip_t *gnrc_pktbuf_get_iovec(gnrc_pktsnip_t *pkt, size_t *len)

--- a/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
+++ b/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "net/gnrc/pktbuf.h"
+
+gnrc_pktsnip_t *gnrc_pktbuf_get_iovec(gnrc_pktsnip_t *pkt, size_t *len)
+{
+    size_t length;
+    gnrc_pktsnip_t *head;
+    struct iovec *vec;
+
+    assert(len != NULL);
+    if (pkt == NULL) {
+        *len = 0;
+        return NULL;
+    }
+
+    /* count the number of snips in the packet and allocate the IOVEC */
+    length = gnrc_pkt_count(pkt);
+    head = gnrc_pktbuf_add(pkt, NULL, (length * sizeof(struct iovec)),
+                           GNRC_NETTYPE_IOVEC);
+    if (head == NULL) {
+        *len = 0;
+        return NULL;
+    }
+
+    assert(head->data != NULL);
+    vec = (struct iovec *)(head->data);
+    /* fill the IOVEC */
+    while (pkt != NULL) {
+        vec->iov_base = pkt->data;
+        vec->iov_len = pkt->size;
+        ++vec;
+        pkt = pkt->next;
+    }
+    *len = length;
+    return head;
+}
+
+gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt,
+                                        gnrc_pktsnip_t *snip)
+{
+    LL_DELETE(pkt, snip);
+    snip->next = NULL;
+    gnrc_pktbuf_release(snip);
+
+    return pkt;
+}
+
+gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt,
+                                         gnrc_pktsnip_t *old,
+                                         gnrc_pktsnip_t *add)
+{
+    /* If add is a list we need to preserve its tail */
+    if (add->next != NULL) {
+        gnrc_pktsnip_t *tail = add->next;
+        gnrc_pktsnip_t *back;
+        LL_SEARCH_SCALAR(tail, back, next, NULL); /* find the last snip in add */
+        /* Replace old */
+        LL_REPLACE_ELEM(pkt, old, add);
+        /* and wire in the tail between */
+        back->next = add->next;
+        add->next = tail;
+    }
+    else {
+        /* add is a single element, has no tail, simply replace */
+        LL_REPLACE_ELEM(pkt, old, add);
+    }
+    old->next = NULL;
+    gnrc_pktbuf_release(old);
+
+    return pkt;
+}
+
+
+/** @} */

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -22,7 +22,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <sys/uio.h>
 
 #include "mutex.h"
 #include "od.h"

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -270,40 +270,6 @@ gnrc_pktsnip_t *gnrc_pktbuf_start_write(gnrc_pktsnip_t *pkt)
     return pkt;
 }
 
-gnrc_pktsnip_t *gnrc_pktbuf_get_iovec(gnrc_pktsnip_t *pkt, size_t *len)
-{
-    size_t length;
-    gnrc_pktsnip_t *head;
-    struct iovec *vec;
-
-    assert(len != NULL);
-    if (pkt == NULL) {
-        *len = 0;
-        return NULL;
-    }
-
-    /* count the number of snips in the packet and allocate the IOVEC */
-    length = gnrc_pkt_count(pkt);
-    head = gnrc_pktbuf_add(pkt, NULL, (length * sizeof(struct iovec)),
-                           GNRC_NETTYPE_IOVEC);
-    if (head == NULL) {
-        *len = 0;
-        return NULL;
-    }
-
-    assert(head->data != NULL);
-    vec = (struct iovec *)(head->data);
-    /* fill the IOVEC */
-    while (pkt != NULL) {
-        vec->iov_base = pkt->data;
-        vec->iov_len = pkt->size;
-        ++vec;
-        pkt = pkt->next;
-    }
-    *len = length;
-    return head;
-}
-
 #ifdef DEVELHELP
 #ifdef MODULE_OD
 static inline void _print_chunk(void *chunk, size_t size, int num)
@@ -523,38 +489,6 @@ static void _pktbuf_free(void *data, size_t size)
     }
 }
 
-
-gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *snip)
-{
-    LL_DELETE(pkt, snip);
-    snip->next = NULL;
-    gnrc_pktbuf_release(snip);
-
-    return pkt;
-}
-
-gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *old, gnrc_pktsnip_t *add)
-{
-    /* If add is a list we need to preserve its tail */
-    if (add->next != NULL) {
-        gnrc_pktsnip_t *tail = add->next;
-        gnrc_pktsnip_t *back;
-        LL_SEARCH_SCALAR(tail, back, next, NULL); /* find the last snip in add */
-        /* Replace old */
-        LL_REPLACE_ELEM(pkt, old, add);
-        /* and wire in the tail between */
-        back->next = add->next;
-        add->next = tail;
-    }
-    else {
-        /* add is a single element, has no tail, simply replace */
-        LL_REPLACE_ELEM(pkt, old, add);
-    }
-    old->next = NULL;
-    gnrc_pktbuf_release(old);
-
-    return pkt;
-}
 
 gnrc_pktsnip_t *gnrc_pktbuf_duplicate_upto(gnrc_pktsnip_t *pkt, gnrc_nettype_t type)
 {


### PR DESCRIPTION
The packet buffer was originally designed to have a replaceable
back-end. This is why the actual module is called `gnrc_pktbuf_static`.
However, since than some auxiliary functions snuck into the static
back-end, which should go into the common module (which is a
pseudo-module at the moment).

This fix makes the `gnrc_pktbuf` pseudo-module an actual module and
moves the auxiliary functions to that module.