### PR TITLE
gnrc_netreg: make message queue requirement more visible

### DIFF
--- a/tests/sntp/Makefile
+++ b/tests/sntp/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
-                             telosb z1
+                             telosb wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += sntp
 USEMODULE += gnrc_sock_udp


### PR DESCRIPTION
I'm a little bit fed up about always answering the same question. @haukepetersen suggested this as a solution.