### PR TITLE
netopt: add NETOPT_SRC_ADDR convenience function

### DIFF
--- a/drivers/netdev_eth/netdev_eth.c
+++ b/drivers/netdev_eth/netdev_eth.c
@@ -62,6 +62,10 @@ int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
                 res = sizeof(uint16_t);
                 break;
             }
+        case NETOPT_SRC_ADDR:
+            res = netdev->driver->get(netdev, NETOPT_ADDRESS, addr,
+                                      ETHERNET_ADDR_LEN);
+            break;
         case NETOPT_MAX_PACKET_SIZE:
             {
                 assert(max_len >= 2);

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -47,6 +47,20 @@ static int _get_iid(netdev_ieee802154_t *dev, eui64_t *value, size_t max_len)
     return sizeof(eui64_t);
 }
 
+static inline int _get_short_addr(netdev_ieee802154_t *dev, void *value)
+{
+    assert(max_len >= sizeof(dev->short_addr));
+    memcpy(value, dev->short_addr, sizeof(dev->short_addr));
+    return sizeof(dev->short_addr);
+}
+
+static inline int _get_long_addr(netdev_ieee802154_t *dev, void *value)
+{
+    assert(max_len >= sizeof(dev->long_addr));
+    memcpy(value, dev->long_addr, sizeof(dev->long_addr));
+    return sizeof(dev->long_addr);
+}
+
 int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
                            size_t max_len)
 {
@@ -54,14 +68,10 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
 
     switch (opt) {
         case NETOPT_ADDRESS:
-            assert(max_len >= sizeof(dev->short_addr));
-            memcpy(value, dev->short_addr, sizeof(dev->short_addr));
-            res = sizeof(dev->short_addr);
+            res = _get_short_addr(dev, value);
             break;
         case NETOPT_ADDRESS_LONG:
-            assert(max_len >= sizeof(dev->long_addr));
-            memcpy(value, dev->long_addr, sizeof(dev->long_addr));
-            res = sizeof(dev->long_addr);
+            res = _get_long_addr(dev, value);
             break;
         case NETOPT_ADDR_LEN:
         case NETOPT_SRC_LEN:
@@ -73,6 +83,15 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
                 *((uint16_t *)value) = IEEE802154_SHORT_ADDRESS_LEN;
             }
             res = sizeof(uint16_t);
+            break;
+        case NETOPT_SRC_ADDR:
+            assert(max_len >= sizeof(dev->long_addr));
+            if (dev->flags & NETDEV_IEEE802154_SRC_MODE_LONG) {
+                res = _get_long_addr(dev, value);
+            }
+            else {
+                res = _get_short_addr(dev, value);
+            }
             break;
         case NETOPT_NID:
             assert(max_len == sizeof(dev->pan));

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -48,6 +48,19 @@ typedef enum {
     NETOPT_ADDR_LEN,            /**< get the default address length a
                                  *   network device expects as uint16_t in
                                  *   host byte order */
+    /**
+     * @brief   get the currently configured source address as an array in host
+     *          byte order
+     *
+     * Expects the return parameter array to at least be as long as the length
+     * of the address returned by getting NETOPT_ADDRESS_LONG. Returns the
+     * actual length of the address on success.
+     *
+     * @note Setting this option should always return -ENOTSUP.
+     *       @ref NETOPT_ADDRESS and @ref NETOPT_ADDRESS_LONG shall be used for
+     *       setting the specific address.
+     */
+    NETOPT_SRC_ADDR,
     NETOPT_SRC_LEN,             /**< get/set the address length to choose
                                  *   for the network device's source address
                                  *   as uint16_t in host byte order */


### PR DESCRIPTION
Introduces a new option to simplify address getting a bit. If implemented, instead of 

```C
    if ((gnrc_netapi_get(iface, NETOPT_SRC_LEN, 0, &l2src_len,
                         sizeof(l2src_len)) >= 0) &&
        (l2src_len > max_short_len)) {
        try_long = true;
    }

    if (try_long && ((res = gnrc_netapi_get(iface, NETOPT_ADDRESS_LONG, 0,
                                            l2src, l2src_maxlen)) > max_short_len)) {
        l2src_len = (uint16_t)res;
    }
    else if ((res = gnrc_netapi_get(iface, NETOPT_ADDRESS, 0, l2src,
                                    l2src_maxlen)) >= 0) {
        l2src_len = (uint16_t)res;
    }
    else {
        DEBUG("nib: No link-layer address found.\n");
        l2src_len = 0;
    }
```

to get the current IEEE 802.15.4 source address of a device, we can if implemented just

```C
l2src_len = gnrc_netapi_get(iface, NETOPT_SRC_ADDR, 0, l2src, sizeof(l2src));
```

I added this as an additional option to keep the change to the API minimal for now, but I'm not opposed to merge `NETOPT_ADDRESS`, `NETOPT_ADDRESS_LONG`, and `NETOPT_SRC_LEN`, if possible without destroying their semantics.