### PR TITLE
sys,phydat: add missing prefix, and string conversions

### DIFF
--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -86,6 +86,7 @@ char phydat_scale_to_str(int8_t scale)
         case -9:    return 'n';
         case -12:   return 'p';
         case -15:   return 'f';
+        case 2:     return 'h';
         case 3:     return 'k';
         case 6:     return 'M';
         case 9:     return 'G';

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -64,6 +64,8 @@ const char *phydat_unit_to_str(uint8_t unit)
         case UNIT_TEMP_K:   return "K";
         case UNIT_LUX:      return "lx";
         case UNIT_M:        return "m";
+        case UNIT_M2:       return "m^2";
+        case UNIT_M3:       return "m^3";
         case UNIT_G:        return "g";
         case UNIT_DPS:      return "dps";
         case UNIT_GR:       return "G";


### PR DESCRIPTION
minor addition, specifically to allow for nice printing of air pressure measurements with `UNIT_PA` and `scale = 2` as `hPa` (hectoPascal).