### PR TITLE
trace: initial import of a stack backtrace function for native

### DIFF
--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -22,6 +22,9 @@ endif
 ifneq (,$(filter can_linux,$(USEMODULE)))
   DIRS += can
 endif
+ifneq (,$(filter trace,$(USEMODULE)))
+	DIRS += trace
+endif
 
 include $(RIOTBASE)/Makefile.base
 

--- a/cpu/native/include/trace.h
+++ b/cpu/native/include/trace.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    trace       Stack traceback (only under native)
+ * @ingroup     core_util
+ * @brief       Address-trace back.
+ *
+ * If you call the @ref trace_print() function a stack traceback of all return
+ * addresses up to @ref TRACE_SIZE will be printed from the point of execution.
+ *
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef TRACE_H
+#define TRACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Maximum number of return addresses to print
+ */
+#ifndef TRACE_SIZE
+#define TRACE_SIZE  (4U)
+#endif
+
+/**
+ * @brief   Print the last @ref TRACE_SIZE return addresses from call of this
+ *          function
+ */
+void trace_print(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TRACE_H */
+/** @} */

--- a/cpu/native/trace/Makefile
+++ b/cpu/native/trace/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/cpu/native/trace/trace.c
+++ b/cpu/native/trace/trace.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include <execinfo.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "trace.h"
+
+void trace_print(void)
+{
+    void *array[TRACE_SIZE + 1];
+    size_t size;
+
+    size = backtrace(array, TRACE_SIZE + 1);
+
+    /* skip above line's return address and start with 1 */
+    for (size_t i = 1; i < size; i++) {
+        printf("%p\n", array[i]);
+    }
+}
+
+/** @} */

--- a/tests/trace/Makefile
+++ b/tests/trace/Makefile
@@ -1,0 +1,14 @@
+# name of your application
+APPLICATION = trace
+include ../Makefile.tests_common
+
+USEMODULE += trace
+
+BOARD_WHITELIST := native
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
+# So clears `TERMFLAGS` before run.
+	TERMFLAGS= tests/01-run.py

--- a/tests/trace/main.c
+++ b/tests/trace/main.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Tests od module.
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "trace.h"
+
+int main(void)
+{
+    printf("TRACE_SIZE: %u\n", TRACE_SIZE);
+    trace_print();
+    return 0;
+}

--- a/tests/trace/tests/01-run.py
+++ b/tests/trace/tests/01-run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect(r"TRACE_SIZE: (\d+)")
+    trace_size = int(child.match.group(1))
+    for i in range(trace_size):
+        child.expect("0x[0-9a-f]{7,8}")
+
+    print("All tests successful")
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'],
+                    'dist/tools/testrunner'))
+    import testrunner
+    sys.exit(testrunner.run(testfunc, timeout=1, echo=True, traceback=True))


### PR DESCRIPTION
Sometimes the debugger just isn't fast enough to debug that pesky race conditions. This module provides at least a little help.

If one wants this for other architectures, the [backtrace](https://www.gnu.org/software/libc/manual/html_node/Backtraces.html) function needs to be implemented.