### PR TITLE
boards/st-l072z-lrwan1: add sx1276 configuration

### DIFF
--- a/boards/b-l072z-lrwan1/board.c
+++ b/boards/b-l072z-lrwan1/board.c
@@ -27,6 +27,12 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
+#if defined(MODULE_SX1276)
+    /* Enable TCXO */
+    gpio_init(RADIO_TCXO_VCC_PIN, GPIO_OUT);
+    gpio_set(RADIO_TCXO_VCC_PIN);
+#endif
+
 #ifdef AUTO_INIT_LED0
     /* The LED pin is also used for SPI, so we enable it
        only if explicitly wanted by the user */

--- a/boards/b-l072z-lrwan1/include/board.h
+++ b/boards/b-l072z-lrwan1/include/board.h
@@ -39,6 +39,22 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    sx1276 configuration
+ * @{
+ */
+#define SX127X_PARAM_SPI                    (SPI_DEV(1))
+#define SX127X_PARAM_SPI_NSS                GPIO_PIN(PORT_A, 15)
+
+#define SX127X_PARAM_RESET                  GPIO_PIN(PORT_C, 0)
+#define SX127X_PARAM_DIO0                   GPIO_PIN(PORT_B, 4)
+#define SX127X_PARAM_DIO1                   GPIO_PIN(PORT_B, 1)
+#define SX127X_PARAM_DIO2                   GPIO_PIN(PORT_B, 0)
+#define SX127X_PARAM_DIO3                   GPIO_PIN(PORT_C, 13)
+
+#define RADIO_TCXO_VCC_PIN                  GPIO_PIN(PORT_A, 12)
+/** @} */
+
+/**
  * @name    LED pin definitions and handlers
  * @{
  */


### PR DESCRIPTION
This adds the basic configuration for controlling the SX1276 LoRa radio available on this board.
Just tested it with #6797 and the configuration works: I could exchange packet with another [sx1276](https://developer.mbed.org/components/SX1276MB1xAS/) plugged on a Nucleo board.

This PR depends on ~~#6951~~ and ~~#6797~~.