### PR TITLE
murdock: enable dlcache

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -3,6 +3,7 @@
 export RIOT_CI_BUILD=1
 export STATIC_TESTS=${STATIC_TESTS:-1}
 export CFLAGS_DBG=""
+export DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
 
 error() {
     echo "$@"


### PR DESCRIPTION
This PR makes a worker's home directory the default for dlcache, for Murdock builds.