### PR TITLE
boards/nucleo-f411: add ADC pin config

### DIFF
--- a/boards/nucleo-f411/Makefile.features
+++ b/boards/nucleo-f411/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio

--- a/boards/nucleo-f411/include/periph_conf.h
+++ b/boards/nucleo-f411/include/periph_conf.h
@@ -226,10 +226,24 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
+ * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F411 order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
  * @{
  */
-#define ADC_NUMOF          (0)
+#define ADC_NUMOF          (6U)
+#define ADC_CONFIG {             \
+    {GPIO_PIN(PORT_A, 0), 0, 0}, \
+    {GPIO_PIN(PORT_A, 1), 0, 1}, \
+    {GPIO_PIN(PORT_A, 4), 0, 4}, \
+    {GPIO_PIN(PORT_B, 0), 0, 8}, \
+    {GPIO_PIN(PORT_C, 1), 0, 11}, \
+    {GPIO_PIN(PORT_C, 0), 0, 10}, \
+}
 /** @} */
 
 /**


### PR DESCRIPTION
Most likely other stm32f4 based MCUs lack a proper ADC configuration as well. However, I just tested on the f411.