### PR TITLE
at86rf2xx/Check at86rf2xx state before changing phy

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -452,10 +452,6 @@ void at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
         return;
     }
 
-    if (state == AT86RF2XX_STATE_FORCE_TRX_OFF) {
-        _set_state(dev, AT86RF2XX_STATE_TRX_OFF, state);
-        return;
-    }
 
     /* make sure there is no ongoing transmission, or state transition already
      * in progress */
@@ -463,6 +459,11 @@ void at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
            old_state == AT86RF2XX_STATE_BUSY_TX_ARET ||
            old_state == AT86RF2XX_STATE_IN_PROGRESS) {
         old_state = at86rf2xx_get_status(dev);
+    }
+
+    if (state == AT86RF2XX_STATE_FORCE_TRX_OFF) {
+        _set_state(dev, AT86RF2XX_STATE_TRX_OFF, state);
+        return;
     }
 
     if (state == old_state) {

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -147,6 +147,7 @@ void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
 
 void at86rf2xx_configure_phy(at86rf2xx_t *dev)
 {
+    while (AT86RF2XX_STATE_IN_PROGRESS == at86rf2xx_get_status(dev)) {}
     uint8_t state = at86rf2xx_get_status(dev);
 
     /* we must be in TRX_OFF before changing the PHY configuration */


### PR DESCRIPTION
at86rf2xx: Changing phy involve to save current transceiver state, set transceiver to OFF and set it back again to its previous state. This PR avoids to save transceiver state AT86RF2XX_STATE_IN_PROGRESS and wait that transceiver is in stable state