### PR TITLE
drivers: remove useless suffix from saul name

### DIFF
--- a/drivers/bmp180/include/bmp180_params.h
+++ b/drivers/bmp180/include/bmp180_params.h
@@ -64,12 +64,9 @@ static const bmp180_params_t bmp180_params[] =
 /**
  * @brief   Configure SAUL registry entries
  */
-static const saul_reg_info_t bmp180_saul_reg_info[][2] =
+static const saul_reg_info_t bmp180_saul_reg_info[] =
 {
-    {
-        { .name = "bmp180-temp" },
-        { .name = "bmp180-press" }
-    }
+    { .name = "bmp180" }
 };
 
 #ifdef __cplusplus

--- a/drivers/bmx280/include/bmx280_params.h
+++ b/drivers/bmx280/include/bmx280_params.h
@@ -77,19 +77,13 @@ static const bmx280_params_t bmx280_params[] =
  * for each device. Please be awar that the indexes are used in
  * auto_init_bmx280, so make sure the indexes match.
  */
-#if defined(MODULE_BME280)
-static const saul_reg_info_t bmx280_saul_reg_info[BMX280_NUMOF][3] =
-#else
-static const saul_reg_info_t bmx280_saul_reg_info[BMX280_NUMOF][2] =
-#endif
+static const saul_reg_info_t bmx280_saul_reg_info[BMX280_NUMOF] =
 {
-    {
-        { .name = "bmx280-temp" },
-        { .name = "bmx280-press" },
 #if defined(MODULE_BME280)
-        { .name = "bme280-humidity" },
+        { .name = "bme280" }
+#else
+        { .name = "bmp280" }
 #endif
-    },
 };
 
 #ifdef __cplusplus

--- a/drivers/si70xx/include/si70xx_params.h
+++ b/drivers/si70xx/include/si70xx_params.h
@@ -59,12 +59,9 @@ static const si70xx_params_t si70xx_params[] =
 /**
  * @brief   Configure SAUL registry entries
  */
-static const saul_reg_info_t si70xx_saul_reg_info[][2] =
+static const saul_reg_info_t si70xx_saul_reg_info[] =
 {
-    {
-        { .name = "si70xx-temp" },
-        { .name = "si70xx-hum" }
-    }
+    { .name = "si70xx" }
 };
 
 #ifdef __cplusplus

--- a/drivers/tsl2561/include/tsl2561_params.h
+++ b/drivers/tsl2561/include/tsl2561_params.h
@@ -66,9 +66,7 @@ static const tsl2561_params_t tsl2561_params[] =
  */
 saul_reg_info_t tsl2561_saul_reg_info[] =
 {
-    {
-        .name= "tsl2561-illuminance"
-    }
+    { .name= "tsl2561" }
 };
 
 #ifdef __cplusplus

--- a/drivers/veml6070/include/veml6070_params.h
+++ b/drivers/veml6070/include/veml6070_params.h
@@ -59,9 +59,7 @@ static const veml6070_params_t veml6070_params[] =
  */
 static const saul_reg_info_t veml6070_saul_reg_info[] =
 {
-    {
-        .name = "veml6070-uv"
-    }
+    { .name = "veml6070" }
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_bmp180.c
+++ b/sys/auto_init/saul/auto_init_bmp180.c
@@ -61,12 +61,12 @@ void auto_init_bmp180(void)
 
         /* temperature */
         saul_entries[(i * 2)].dev = &(bmp180_devs[i]);
-        saul_entries[(i * 2)].name = bmp180_saul_reg_info[i][0].name;
+        saul_entries[(i * 2)].name = bmp180_saul_reg_info[i].name;
         saul_entries[(i * 2)].driver = &bmp180_temperature_saul_driver;
 
         /* atmospheric pressure */
         saul_entries[(i * 2) + 1].dev = &(bmp180_devs[i]);
-        saul_entries[(i * 2) + 1].name = bmp180_saul_reg_info[i][1].name;
+        saul_entries[(i * 2) + 1].name = bmp180_saul_reg_info[i].name;
         saul_entries[(i * 2) + 1].driver = &bmp180_pressure_saul_driver;
 
         /* register to saul */

--- a/sys/auto_init/saul/auto_init_bmx280.c
+++ b/sys/auto_init/saul/auto_init_bmx280.c
@@ -67,14 +67,14 @@ void auto_init_bmx280(void)
 
         /* temperature */
         saul_entries[se_ix].dev = &bmx280_devs[i];
-        saul_entries[se_ix].name = bmx280_saul_reg_info[i][0].name;
+        saul_entries[se_ix].name = bmx280_saul_reg_info[i].name;
         saul_entries[se_ix].driver = &bmx280_temperature_saul_driver;
         saul_reg_add(&saul_entries[se_ix]);
         se_ix++;
 
         /* pressure */
         saul_entries[se_ix].dev = &bmx280_devs[i];
-        saul_entries[se_ix].name = bmx280_saul_reg_info[i][1].name;
+        saul_entries[se_ix].name = bmx280_saul_reg_info[i].name;
         saul_entries[se_ix].driver = &bmx280_pressure_saul_driver;
         saul_reg_add(&saul_entries[se_ix]);
         se_ix++;
@@ -82,7 +82,7 @@ void auto_init_bmx280(void)
 #if defined(MODULE_BME280)
         /* relative humidity */
         saul_entries[se_ix].dev = &bmx280_devs[i];
-        saul_entries[se_ix].name = bmx280_saul_reg_info[i][2].name;
+        saul_entries[se_ix].name = bmx280_saul_reg_info[i].name;
         saul_entries[se_ix].driver = &bme280_relative_humidity_saul_driver;
         saul_reg_add(&saul_entries[se_ix]);
         se_ix++;

--- a/sys/auto_init/saul/auto_init_si70xx.c
+++ b/sys/auto_init/saul/auto_init_si70xx.c
@@ -63,12 +63,12 @@ void auto_init_si70xx(void)
 
         /* temperature */
         saul_entries[i * 2].dev = &si70xx_devs[i];
-        saul_entries[i * 2].name = si70xx_saul_reg_info[i][0].name;
+        saul_entries[i * 2].name = si70xx_saul_reg_info[i].name;
         saul_entries[i * 2].driver = &si70xx_temperature_saul_driver;
 
         /* relative humidity */
         saul_entries[(i * 2) + 1].dev = &si70xx_devs[i];
-        saul_entries[(i * 2) + 1].name = si70xx_saul_reg_info[i][1].name;
+        saul_entries[(i * 2) + 1].name = si70xx_saul_reg_info[i].name;
         saul_entries[(i * 2) + 1].driver = \
                 &si70xx_relative_humidity_saul_driver;
 


### PR DESCRIPTION
According to requested changes in #6712, this PR adapts the other drivers that have the same problem.