### PR TITLE
drivers: partial use of constness when accessing device descriptor

### DIFF
--- a/drivers/adt7310/adt7310.c
+++ b/drivers/adt7310/adt7310.c
@@ -185,7 +185,7 @@ int adt7310_set_config(adt7310_t *dev, uint8_t config)
     return adt7310_write_reg(dev, ADT7310_REG_CONFIG, ADT7310_REG_SIZE_CONFIG, &config);
 }
 
-int16_t adt7310_read_raw(adt7310_t *dev)
+int16_t adt7310_read_raw(const adt7310_t *dev)
 {
     int status;
     int16_t raw;
@@ -201,7 +201,7 @@ int16_t adt7310_read_raw(adt7310_t *dev)
     return raw;
 }
 
-int32_t adt7310_read(adt7310_t *dev)
+int32_t adt7310_read(const adt7310_t *dev)
 {
     int16_t raw = adt7310_read_raw(dev);
     if (raw == INT16_MIN) {
@@ -214,7 +214,7 @@ int32_t adt7310_read(adt7310_t *dev)
     return ((((int32_t)raw) * 1000) >> ADT7310_VALUE_FRAC_BITS);
 }
 
-float adt7310_read_float(adt7310_t *dev)
+float adt7310_read_float(const adt7310_t *dev)
 {
     int16_t raw = adt7310_read_raw(dev);
     if (raw == INT16_MIN) {

--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -80,7 +80,7 @@ int adxl345_init(adxl345_t *dev, adxl345_params_t* params)
     return ADXL345_OK;
 }
 
-void adxl345_read(adxl345_t *dev, adxl345_data_t *data)
+void adxl345_read(const adxl345_t *dev, adxl345_data_t *data)
 {
     int8_t result[6];
 
@@ -95,7 +95,7 @@ void adxl345_read(adxl345_t *dev, adxl345_data_t *data)
     data->z = (((result[5] << 8)+result[4]) * dev->scale_factor);
 }
 
-void adxl345_set_interrupt(adxl345_t *dev)
+void adxl345_set_interrupt(const adxl345_t *dev)
 {
     assert(dev);
 
@@ -135,7 +135,7 @@ void adxl345_set_interrupt(adxl345_t *dev)
     i2c_release(BUS);
 }
 
-void adxl345_set_measure(adxl345_t *dev)
+void adxl345_set_measure(const adxl345_t *dev)
 {
     uint8_t reg;
 
@@ -150,7 +150,7 @@ void adxl345_set_measure(adxl345_t *dev)
     i2c_release(BUS);
 }
 
-void adxl345_set_standby(adxl345_t *dev)
+void adxl345_set_standby(const adxl345_t *dev)
 {
     uint8_t reg;
 
@@ -165,7 +165,7 @@ void adxl345_set_standby(adxl345_t *dev)
     i2c_release(BUS);
 }
 
-void adxl345_set_sleep(adxl345_t *dev)
+void adxl345_set_sleep(const adxl345_t *dev)
 {
     uint8_t reg;
 
@@ -180,7 +180,7 @@ void adxl345_set_sleep(adxl345_t *dev)
     i2c_release(BUS);
 }
 
-void adxl345_set_autosleep(adxl345_t *dev)
+void adxl345_set_autosleep(const adxl345_t *dev)
 {
     uint8_t reg;
 
@@ -195,7 +195,7 @@ void adxl345_set_autosleep(adxl345_t *dev)
     i2c_release(BUS);
 }
 
-void adxl345_set_bandwidth_rate(adxl345_t *dev, uint8_t bw_rate)
+void adxl345_set_bandwidth_rate(const adxl345_t *dev, uint8_t bw_rate)
 {
     uint8_t reg;
 
@@ -210,7 +210,7 @@ void adxl345_set_bandwidth_rate(adxl345_t *dev, uint8_t bw_rate)
     i2c_release(BUS);
 }
 
-void adxl345_set_fifo_mode(adxl345_t *dev, uint8_t mode,
+void adxl345_set_fifo_mode(const adxl345_t *dev, uint8_t mode,
                            uint8_t output, uint8_t value)
 {
     uint8_t reg;

--- a/drivers/at30tse75x/at30tse75x.c
+++ b/drivers/at30tse75x/at30tse75x.c
@@ -35,7 +35,7 @@ static inline float temperature_to_float(uint16_t temp)
     return temp_int + (frac_multiplier * AT30TSE75X_FRACTIONAL_BASE);
 }
 
-static int at30tse75x_get_register(at30tse75x_t* dev, uint8_t reg, uint16_t* data)
+static int at30tse75x_get_register(const at30tse75x_t *dev, uint8_t reg, uint16_t* data)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
@@ -49,7 +49,7 @@ static int at30tse75x_get_register(at30tse75x_t* dev, uint8_t reg, uint16_t* dat
     return 0;
 }
 
-static int at30tse75x_set_register(at30tse75x_t* dev, uint8_t reg, uint16_t* data)
+static int at30tse75x_set_register(const at30tse75x_t *dev, uint8_t reg, uint16_t *data)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
@@ -63,7 +63,7 @@ static int at30tse75x_set_register(at30tse75x_t* dev, uint8_t reg, uint16_t* dat
     return 0;
 }
 
-static int at30tse75x_reset(at30tse75x_t* dev)
+static int at30tse75x_reset(const at30tse75x_t *dev)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
@@ -77,7 +77,7 @@ static int at30tse75x_reset(at30tse75x_t* dev)
     return 0;
 }
 
-int at30tse75x_get_config(at30tse75x_t* dev, uint8_t* data)
+int at30tse75x_get_config(const at30tse75x_t *dev, uint8_t *data)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
@@ -91,7 +91,7 @@ int at30tse75x_get_config(at30tse75x_t* dev, uint8_t* data)
     return 0;
 }
 
-int at30tse75x_set_config(at30tse75x_t* dev, uint8_t data)
+int at30tse75x_set_config(const at30tse75x_t *dev, uint8_t data)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
@@ -105,7 +105,7 @@ int at30tse75x_set_config(at30tse75x_t* dev, uint8_t data)
     return 0;
 }
 
-int at30tse75x_set_resolution(at30tse75x_t* dev, at30tse75x_resolution_t resolution)
+int at30tse75x_set_resolution(const at30tse75x_t *dev, at30tse75x_resolution_t resolution)
 {
     uint8_t config;
 
@@ -128,7 +128,7 @@ int at30tse75x_set_resolution(at30tse75x_t* dev, at30tse75x_resolution_t resolut
     return 0;
 }
 
-int at30tse75x_set_mode(at30tse75x_t* dev, at30tse75x_mode_t mode)
+int at30tse75x_set_mode(const at30tse75x_t *dev, at30tse75x_mode_t mode)
 {
     uint8_t config;
     if(at30tse75x_get_config(dev, &config) != 0) {
@@ -159,7 +159,7 @@ int at30tse75x_set_mode(at30tse75x_t* dev, at30tse75x_mode_t mode)
     return 0;
 }
 
-int at30tse75x_set_alarm_polarity(at30tse75x_t* dev, at30tse75x_alarm_polatity_t polarity)
+int at30tse75x_set_alarm_polarity(const at30tse75x_t *dev, at30tse75x_alarm_polatity_t polarity)
 {
     uint8_t config;
     if(at30tse75x_get_config(dev, &config) != 0) {
@@ -184,7 +184,7 @@ int at30tse75x_set_alarm_polarity(at30tse75x_t* dev, at30tse75x_alarm_polatity_t
     return 0;
 }
 
-int at30tse75x_set_fault_tolerance(at30tse75x_t* dev, at30tse75x_fault_tolerance_t tolerance)
+int at30tse75x_set_fault_tolerance(const at30tse75x_t *dev, at30tse75x_fault_tolerance_t tolerance)
 {
     if(tolerance < AT30TSE75X_ALARM_AFTER_1 ||
        tolerance > AT30TSE75X_ALARM_AFTER_6) {
@@ -206,19 +206,19 @@ int at30tse75x_set_fault_tolerance(at30tse75x_t* dev, at30tse75x_fault_tolerance
     return 0;
 }
 
-int at30tse75x_set_limit_low(at30tse75x_t* dev, int8_t t_low)
+int at30tse75x_set_limit_low(const at30tse75x_t *dev, int8_t t_low)
 {
     uint16_t tmp = (t_low << 8) | (0x00);
     return at30tse75x_set_register(dev, AT30TSE75X_REG__LIMIT_LOW, &tmp);
 }
 
-int at30tse75x_set_limit_high(at30tse75x_t* dev, int8_t t_high)
+int at30tse75x_set_limit_high(const at30tse75x_t *dev, int8_t t_high)
 {
     uint16_t tmp = (t_high << 8) | (0x00);
     return at30tse75x_set_register(dev, AT30TSE75X_REG__LIMIT_HIGH, &tmp);
 }
 
-int at30tse75x_save_config(at30tse75x_t* dev)
+int at30tse75x_save_config(const at30tse75x_t *dev)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
@@ -232,7 +232,7 @@ int at30tse75x_save_config(at30tse75x_t* dev)
     return 0;
 }
 
-int at30tse75x_restore_config(at30tse75x_t* dev)
+int at30tse75x_restore_config(const at30tse75x_t *dev)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
@@ -246,7 +246,7 @@ int at30tse75x_restore_config(at30tse75x_t* dev)
     return 0;
 }
 
-int at30tse75x_get_temperature(at30tse75x_t* dev, float* temperature)
+int at30tse75x_get_temperature(const at30tse75x_t *dev, float *temperature)
 {
     uint16_t tmp;
     uint8_t config;
@@ -282,7 +282,7 @@ int at30tse75x_get_temperature(at30tse75x_t* dev, float* temperature)
     return 0;
 }
 
-int at30tse75x_init(at30tse75x_t* dev, i2c_t i2c, i2c_speed_t speed, uint8_t addr)
+int at30tse75x_init(at30tse75x_t *dev, i2c_t i2c, i2c_speed_t speed, uint8_t addr)
 {
     uint8_t config;
 

--- a/drivers/bh1750fvi/bh1750fvi.c
+++ b/drivers/bh1750fvi/bh1750fvi.c
@@ -49,7 +49,7 @@ int bh1750fvi_init(bh1750fvi_t *dev, bh1750fvi_params_t *params)
     return BH1750FVI_OK;
 }
 
-uint16_t bh1750fvi_sample(bh1750fvi_t *dev)
+uint16_t bh1750fvi_sample(const bh1750fvi_t *dev)
 {
     uint32_t tmp;
     uint8_t raw[2];

--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -35,9 +35,9 @@
 #define OVERSAMPLING (dev->params.oversampling)
 
 /* Internal function prototypes */
-static int _read_ut(bmp180_t *dev, int32_t *ut);
-static int _read_up(bmp180_t *dev, int32_t *up);
-static int _compute_b5(bmp180_t *dev, int32_t ut, int32_t *b5);
+static int _read_ut(const bmp180_t *dev, int32_t *ut);
+static int _read_up(const bmp180_t *dev, int32_t *up);
+static int _compute_b5(const bmp180_t *dev, int32_t ut, int32_t *b5);
 
 /*---------------------------------------------------------------------------*
  *                          BMP180 Core API                                 *
@@ -109,7 +109,7 @@ int bmp180_init(bmp180_t *dev, const bmp180_params_t *params)
     return 0;
 }
 
-int16_t bmp180_read_temperature(bmp180_t *dev)
+int16_t bmp180_read_temperature(const bmp180_t *dev)
 {
     int32_t ut, b5;
     /* Acquire exclusive access */
@@ -127,7 +127,7 @@ int16_t bmp180_read_temperature(bmp180_t *dev)
     return (int16_t)((b5 + 8) >> 4);
 }
 
-uint32_t bmp180_read_pressure(bmp180_t *dev)
+uint32_t bmp180_read_pressure(const bmp180_t *dev)
 {
     int32_t ut = 0, up = 0, x1, x2, x3, b3, b5, b6, p;
     uint32_t b4, b7;
@@ -168,14 +168,14 @@ uint32_t bmp180_read_pressure(bmp180_t *dev)
     return (uint32_t)(p + ((x1 + x2 + 3791) >> 4));
 }
 
-int16_t bmp180_altitude(bmp180_t *dev, uint32_t pressure_0)
+int16_t bmp180_altitude(const bmp180_t *dev, uint32_t pressure_0)
 {
     uint32_t p = bmp180_read_pressure(dev);
 
     return (int16_t)(44330.0 * (1.0 - pow((double)p / pressure_0, 0.1903)));;
 }
 
-uint32_t bmp180_sealevel_pressure(bmp180_t *dev, int16_t altitude)
+uint32_t bmp180_sealevel_pressure(const bmp180_t *dev, int16_t altitude)
 {
     uint32_t p = bmp180_read_pressure(dev);
 
@@ -186,7 +186,7 @@ uint32_t bmp180_sealevel_pressure(bmp180_t *dev, int16_t altitude)
 /*                                Internal functions                                  */
 /*------------------------------------------------------------------------------------*/
 
-static int _read_ut(bmp180_t *dev, int32_t *output)
+static int _read_ut(const bmp180_t *dev, int32_t *output)
 {
     /* Read UT (Uncompsensated Temperature value) */
     uint8_t ut[2] = {0};
@@ -205,7 +205,7 @@ static int _read_ut(bmp180_t *dev, int32_t *output)
     return 0;
 }
 
-static int _read_up(bmp180_t *dev, int32_t *output)
+static int _read_up(const bmp180_t *dev, int32_t *output)
 {
     /* Read UP (Uncompsensated Pressure value) */
     uint8_t up[3] = {0};
@@ -241,7 +241,7 @@ static int _read_up(bmp180_t *dev, int32_t *output)
     return 0;
 }
 
-static int _compute_b5(bmp180_t *dev, int32_t ut, int32_t *output)
+static int _compute_b5(const bmp180_t *dev, int32_t ut, int32_t *output)
 {
     int32_t x1, x2;
     x1 = (ut - dev->calibration.ac6) * dev->calibration.ac5 >> 15;

--- a/drivers/bmx280/bmx280.c
+++ b/drivers/bmx280/bmx280.c
@@ -33,11 +33,11 @@
 #include "debug.h"
 
 static int read_calibration_data(bmx280_t* dev);
-static int do_measurement(bmx280_t* dev);
-static uint8_t get_ctrl_meas(bmx280_t* dev);
-static uint8_t get_status(bmx280_t* dev);
-static uint8_t read_u8_reg(bmx280_t* dev, uint8_t reg);
-static void write_u8_reg(bmx280_t* dev, uint8_t reg, uint8_t b);
+static int do_measurement(const bmx280_t* dev);
+static uint8_t get_ctrl_meas(const bmx280_t* dev);
+static uint8_t get_status(const bmx280_t* dev);
+static uint8_t read_u8_reg(const bmx280_t* dev, uint8_t reg);
+static void write_u8_reg(const bmx280_t* dev, uint8_t reg, uint8_t b);
 static uint16_t get_uint16_le(const uint8_t *buffer, size_t offset);
 static int16_t get_int16_le(const uint8_t *buffer, size_t offset);
 
@@ -98,13 +98,13 @@ int bmx280_init(bmx280_t* dev, const bmx280_params_t* params)
  * Returns temperature in DegC, resolution is 0.01 DegC.
  * t_fine carries fine temperature as global value
  */
-int16_t bmx280_read_temperature(bmx280_t* dev)
+int16_t bmx280_read_temperature(const bmx280_t* dev)
 {
     if (do_measurement(dev) < 0) {
         return INT16_MIN;
     }
 
-    bmx280_calibration_t *cal = &dev->calibration;      /* helper variable */
+    const bmx280_calibration_t *cal = &dev->calibration; /* helper variable */
 
     /* Read the uncompensated temperature */
     int32_t adc_T = (((uint32_t)measurement_regs[3 + 0]) << 12) |
@@ -133,9 +133,9 @@ int16_t bmx280_read_temperature(bmx280_t* dev)
 /*
  * Returns pressure in Pa
  */
-uint32_t bmx280_read_pressure(bmx280_t *dev)
+uint32_t bmx280_read_pressure(const bmx280_t *dev)
 {
-    bmx280_calibration_t *cal = &dev->calibration;      /* helper variable */
+    const bmx280_calibration_t *cal = &dev->calibration; /* helper variable */
 
     /* Read the uncompensated pressure */
     int32_t adc_P = (((uint32_t)measurement_regs[0 + 0]) << 12) |
@@ -173,9 +173,9 @@ uint32_t bmx280_read_pressure(bmx280_t *dev)
 }
 
 #if defined(MODULE_BME280)
-uint16_t bme280_read_humidity(bmx280_t *dev)
+uint16_t bme280_read_humidity(const bmx280_t *dev)
 {
-    bmx280_calibration_t *cal = &dev->calibration;      /* helper variable */
+    const bmx280_calibration_t *cal = &dev->calibration; /* helper variable */
 
     /* Read the uncompensated pressure */
     int32_t adc_H = (((uint32_t)measurement_regs[6 + 0]) << 8) |
@@ -293,7 +293,7 @@ static int read_calibration_data(bmx280_t* dev)
 /**
  * @brief Start a measurement and read the registers
  */
-static int do_measurement(bmx280_t* dev)
+static int do_measurement(const bmx280_t* dev)
 {
     /*
      * If settings has FORCED mode, then the device go to sleep after
@@ -330,17 +330,17 @@ static int do_measurement(bmx280_t* dev)
     return 0;
 }
 
-static uint8_t get_ctrl_meas(bmx280_t* dev)
+static uint8_t get_ctrl_meas(const bmx280_t* dev)
 {
     return read_u8_reg(dev, BMX280_CTRL_MEAS_REG);
 }
 
-static uint8_t get_status(bmx280_t* dev)
+static uint8_t get_status(const bmx280_t* dev)
 {
     return read_u8_reg(dev, BMX280_STAT_REG);
 }
 
-static uint8_t read_u8_reg(bmx280_t* dev, uint8_t reg)
+static uint8_t read_u8_reg(const bmx280_t* dev, uint8_t reg)
 {
     uint8_t b;
     /* Assuming device is correct, it should return 1 (nr bytes) */
@@ -348,7 +348,7 @@ static uint8_t read_u8_reg(bmx280_t* dev, uint8_t reg)
     return b;
 }
 
-static void write_u8_reg(bmx280_t* dev, uint8_t reg, uint8_t b)
+static void write_u8_reg(const bmx280_t* dev, uint8_t reg, uint8_t b)
 {
     /* Assuming device is correct, it should return 1 (nr bytes) */
     (void)i2c_write_reg(dev->params.i2c_dev, dev->params.i2c_addr, reg, b);

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -80,7 +80,7 @@ int dht_init(dht_t *dev, const dht_params_t *params)
     return DHT_OK;
 }
 
-int dht_read(dht_t *dev, int16_t *temp, int16_t *hum)
+int dht_read(const dht_t *dev, int16_t *temp, int16_t *hum)
 {
     uint8_t csum, sum;
     uint16_t raw_hum, raw_temp;

--- a/drivers/dsp0401/dsp0401.c
+++ b/drivers/dsp0401/dsp0401.c
@@ -146,7 +146,7 @@ static const uint8_t dsp0401_charmap[][2] = {
     { 0x00, 0x00 },  /* 127:      */
 };
 
-static void _shift_char(dsp0401_t *dev, uint8_t c)
+static void _shift_char(const dsp0401_t *dev, uint8_t c)
 {
     /* Unsupported chars not displayed */
     if ((c < CHAR_MAP_MIN) || (c > CHAR_MAP_MAX)) {
@@ -162,7 +162,7 @@ static void _shift_char(dsp0401_t *dev, uint8_t c)
     }
 }
 
-static void _latch(dsp0401_t *dev)
+static void _latch(const dsp0401_t *dev)
 {
     xtimer_usleep(LATCH_DELAY);
     gpio_set(LAT);
@@ -208,7 +208,7 @@ int dsp0401_init(dsp0401_t *dev, const dsp0401_params_t *params)
     return DSP0401_OK;
 }
 
-void dsp0401_display_text(dsp0401_t *dev, char *text)
+void dsp0401_display_text(const dsp0401_t *dev, char *text)
 {
     unsigned text_len = strlen(text);
     for (unsigned i = 0 ; i < MOD_COUNT * 4; ++i) {
@@ -222,7 +222,7 @@ void dsp0401_display_text(dsp0401_t *dev, char *text)
     _latch(dev);
 }
 
-void dsp0401_clear_text(dsp0401_t *dev)
+void dsp0401_clear_text(const dsp0401_t *dev)
 {
     /* each module has 4 alphanumeric displays */
     for (unsigned i = 0; i < MOD_COUNT * 4; ++i) {
@@ -231,7 +231,7 @@ void dsp0401_clear_text(dsp0401_t *dev)
     _latch(dev);
 }
 
-void dsp0401_scroll_text(dsp0401_t *dev, char *text, uint16_t delay)
+void dsp0401_scroll_text(const dsp0401_t *dev, char *text, uint16_t delay)
 {
     dsp0401_clear_text(dev);
 

--- a/drivers/dynamixel/dynamixel.c
+++ b/drivers/dynamixel/dynamixel.c
@@ -49,7 +49,7 @@ int dynamixel_ping(uart_half_duplex_t *stream, dynamixel_id_t id)
     return DYNAMIXEL_OK;
 }
 
-int dynamixel_write(dynamixel_t *device, dynamixel_addr_t reg, const uint8_t *data, size_t length)
+int dynamixel_write(const dynamixel_t *device, dynamixel_addr_t reg, const uint8_t *data, size_t length)
 {
     uart_half_duplex_set_tx(device->stream);
     if (device->stream->size < length) {
@@ -70,17 +70,17 @@ int dynamixel_write(dynamixel_t *device, dynamixel_addr_t reg, const uint8_t *da
     return DYNAMIXEL_OK;
 }
 
-int dynamixel_write8(dynamixel_t *device, dynamixel_addr_t reg, uint8_t value)
+int dynamixel_write8(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t value)
 {
     return dynamixel_write(device, reg, &value, 1);
 }
 
-int dynamixel_write16(dynamixel_t *device, dynamixel_addr_t reg, uint16_t value)
+int dynamixel_write16(const dynamixel_t *device, dynamixel_addr_t reg, uint16_t value)
 {
     return dynamixel_write(device, reg, (uint8_t*)&value, 2);
 }
 
-int dynamixel_read(dynamixel_t *device, dynamixel_addr_t reg, uint8_t *data, size_t length)
+int dynamixel_read(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t *data, size_t length)
 {
     uart_half_duplex_set_tx(device->stream);
     if (device->stream->size < length) {
@@ -113,12 +113,12 @@ int dynamixel_read(dynamixel_t *device, dynamixel_addr_t reg, uint8_t *data, siz
     return DYNAMIXEL_OK;
 }
 
-int dynamixel_read8(dynamixel_t *device, dynamixel_addr_t reg, uint8_t *value)
+int dynamixel_read8(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t *value)
 {
     return dynamixel_read(device, reg, value, 1);
 }
 
-int dynamixel_read16(dynamixel_t *device, dynamixel_addr_t reg, uint16_t *value)
+int dynamixel_read16(const dynamixel_t *device, dynamixel_addr_t reg, uint16_t *value)
 {
     return dynamixel_read(device, reg, (uint8_t*)value, 2);
 }

--- a/drivers/feetech/feetech.c
+++ b/drivers/feetech/feetech.c
@@ -53,7 +53,7 @@ int feetech_ping(uart_half_duplex_t *stream, feetech_id_t id)
     return FEETECH_OK;
 }
 
-int feetech_write(feetech_t *device, feetech_addr_t reg, const uint8_t *data, size_t length)
+int feetech_write(const feetech_t *device, feetech_addr_t reg, const uint8_t *data, size_t length)
 {
     uart_half_duplex_set_tx(device->stream);
     if (device->stream->size < length) {
@@ -74,18 +74,18 @@ int feetech_write(feetech_t *device, feetech_addr_t reg, const uint8_t *data, si
     return FEETECH_OK;
 }
 
-int feetech_write8(feetech_t *device, feetech_addr_t reg, uint8_t value)
+int feetech_write8(const feetech_t *device, feetech_addr_t reg, uint8_t value)
 {
     return feetech_write(device, reg, &value, 1);
 }
 
-int feetech_write16(feetech_t *device, feetech_addr_t reg, uint16_t value)
+int feetech_write16(const feetech_t *device, feetech_addr_t reg, uint16_t value)
 {
     value = htons(value);
     return feetech_write(device, reg, (uint8_t*)&value, 2);
 }
 
-int feetech_read(feetech_t *device, feetech_addr_t reg, uint8_t *data, size_t length)
+int feetech_read(const feetech_t *device, feetech_addr_t reg, uint8_t *data, size_t length)
 {
     uart_half_duplex_set_tx(device->stream);
     if (device->stream->size < length) {
@@ -118,12 +118,12 @@ int feetech_read(feetech_t *device, feetech_addr_t reg, uint8_t *data, size_t le
     return FEETECH_OK;
 }
 
-int feetech_read8(feetech_t *device, feetech_addr_t reg, uint8_t *value)
+int feetech_read8(const feetech_t *device, feetech_addr_t reg, uint8_t *value)
 {
     return feetech_read(device, reg, value, 1);
 }
 
-int feetech_read16(feetech_t *device, feetech_addr_t reg, uint16_t *value)
+int feetech_read16(const feetech_t *device, feetech_addr_t reg, uint16_t *value)
 {
     const int ret = feetech_read(device, reg, (uint8_t*)value, 2);
     if (ret == FEETECH_OK) {

--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -30,10 +30,10 @@
 #include "hd44780.h"
 #include "hd44780_internal.h"
 
-static inline void _command(hd44780_t *dev, uint8_t value);
-static void _pulse(hd44780_t *dev);
-static void _send(hd44780_t *dev, uint8_t value, uint8_t mode);
-static void _write_bits(hd44780_t *dev, uint8_t bits, uint8_t value);
+static inline void _command(const hd44780_t *dev, uint8_t value);
+static void _pulse(const hd44780_t *dev);
+static void _send(const hd44780_t *dev, uint8_t value, uint8_t mode);
+static void _write_bits(const hd44780_t *dev, uint8_t bits, uint8_t value);
 
 /**
  * @brief   Send a command to the display
@@ -41,7 +41,7 @@ static void _write_bits(hd44780_t *dev, uint8_t bits, uint8_t value);
  * @param[in]  dev          device descriptor of display to initialize
  * @param[in]  value        the command
  */
-static inline void _command(hd44780_t *dev, uint8_t value)
+static inline void _command(const hd44780_t *dev, uint8_t value)
 {
     _send(dev, value, HD44780_OFF);
 }
@@ -51,7 +51,7 @@ static inline void _command(hd44780_t *dev, uint8_t value)
  *
  * @param[in]  dev          device descriptor of display to initialize
  */
-static void _pulse(hd44780_t *dev)
+static void _pulse(const hd44780_t *dev)
 {
     gpio_clear(dev->p.enable);
     xtimer_usleep(HD44780_PULSE_WAIT_SHORT);
@@ -68,7 +68,7 @@ static void _pulse(hd44780_t *dev)
  * @param[in]  value        the data value, either char or command
  * @param[in]  state        send state, to distinguish chars and commands
  */
-static void _send(hd44780_t *dev, uint8_t value, hd44780_state_t state)
+static void _send(const hd44780_t *dev, uint8_t value, hd44780_state_t state)
 {
     (state == HD44780_ON) ? gpio_set(dev->p.rs) : gpio_clear(dev->p.rs);
     /* if RW pin is available, set it to LOW */
@@ -85,7 +85,7 @@ static void _send(hd44780_t *dev, uint8_t value, hd44780_state_t state)
     }
 }
 
-static void _write_bits(hd44780_t *dev, uint8_t bits, uint8_t value)
+static void _write_bits(const hd44780_t *dev, uint8_t bits, uint8_t value)
 {
     for (unsigned i = 0; i < bits; ++i) {
         if ((value >> i) & 0x01) {
@@ -190,19 +190,19 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
     return 0;
 }
 
-void hd44780_clear(hd44780_t *dev)
+void hd44780_clear(const hd44780_t *dev)
 {
     _command(dev, HD44780_CLEARDISPLAY);
     xtimer_usleep(HD44780_CMD_WAIT);
 }
 
-void hd44780_home(hd44780_t *dev)
+void hd44780_home(const hd44780_t *dev)
 {
     _command(dev, HD44780_RETURNHOME);
     xtimer_usleep(HD44780_CMD_WAIT);
 }
 
-void hd44780_set_cursor(hd44780_t *dev, uint8_t col, uint8_t row)
+void hd44780_set_cursor(const hd44780_t *dev, uint8_t col, uint8_t row)
 {
     if (row >= dev->p.rows) {
         row = dev->p.rows - 1;
@@ -243,12 +243,12 @@ void hd44780_blink(hd44780_t *dev, hd44780_state_t state)
     _command(dev, HD44780_DISPLAYCONTROL | dev->ctrl);
 }
 
-void hd44780_scroll_left(hd44780_t *dev)
+void hd44780_scroll_left(const hd44780_t *dev)
 {
     _command(dev, HD44780_CURSORSHIFT | HD44780_DISPLAYMOVE | HD44780_MOVELEFT);
 }
 
-void hd44780_scroll_right(hd44780_t *dev) {
+void hd44780_scroll_right(const hd44780_t *dev) {
     _command(dev, HD44780_CURSORSHIFT | HD44780_DISPLAYMOVE | HD44780_MOVERIGHT);
 }
 
@@ -275,7 +275,7 @@ void hd44780_autoscroll(hd44780_t *dev, hd44780_state_t state)
     _command(dev, HD44780_ENTRYMODESET | dev->mode);
 }
 
-void hd44780_create_char(hd44780_t *dev, uint8_t location, uint8_t charmap[])
+void hd44780_create_char(const hd44780_t *dev, uint8_t location, uint8_t charmap[])
 {
     location &= 0x7; /* 8 locations (0-7) possible */
     _command(dev, HD44780_SETCGRAMADDR | (location << 3));
@@ -284,12 +284,12 @@ void hd44780_create_char(hd44780_t *dev, uint8_t location, uint8_t charmap[])
     }
 }
 
-void hd44780_write(hd44780_t *dev, uint8_t value)
+void hd44780_write(const hd44780_t *dev, uint8_t value)
 {
     _send(dev, value, HD44780_ON);
 }
 
-void hd44780_print(hd44780_t *dev, const char *data )
+void hd44780_print(const hd44780_t *dev, const char *data )
 {
     while (*data != '\0') {
         hd44780_write(dev, *data++);

--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -76,7 +76,7 @@ int hdc1000_init(hdc1000_t *dev, const hdc1000_params_t *params)
     return HDC1000_OK;
 }
 
-int hdc1000_trigger_conversion(hdc1000_t *dev)
+int hdc1000_trigger_conversion(const hdc1000_t *dev)
 {
     int status = HDC1000_OK;
     assert(dev);
@@ -95,7 +95,7 @@ int hdc1000_trigger_conversion(hdc1000_t *dev)
     return status;
 }
 
-int hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum)
+int hdc1000_get_results(const hdc1000_t *dev, int16_t *temp, int16_t *hum)
 {
     int status = HDC1000_OK;
     assert(dev);
@@ -124,7 +124,7 @@ int hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum)
     return status;
 }
 
-int hdc1000_read(hdc1000_t *dev, int16_t *temp, int16_t *hum)
+int hdc1000_read(const hdc1000_t *dev, int16_t *temp, int16_t *hum)
 {
     if (hdc1000_trigger_conversion(dev) != HDC1000_OK) {
         return HDC1000_BUSERR;

--- a/drivers/hih6130/hih6130.c
+++ b/drivers/hih6130/hih6130.c
@@ -55,7 +55,7 @@ enum {
 #define MEASUREMENT_DELAY   (50*1000)
 
 /** @brief Trigger a new measurement on the sensor */
-static inline int hih6130_measurement_request(hih6130_t *dev)
+static inline int hih6130_measurement_request(const hih6130_t *dev)
 {
     i2c_acquire(dev->i2c);
 
@@ -77,7 +77,7 @@ void hih6130_init(hih6130_t *dev, i2c_t i2c, uint8_t address)
     dev->addr = address;
 }
 
-static inline int hih6130_get_humidity_temperature_raw(hih6130_t *dev, uint16_t *humidity_raw, uint16_t *temperature_raw)
+static inline int hih6130_get_humidity_temperature_raw(const hih6130_t *dev, uint16_t *humidity_raw, uint16_t *temperature_raw)
 {
     int status;
     uint8_t buf[HIH6130_FULL_DATA_LENGTH];
@@ -109,7 +109,7 @@ static inline int hih6130_get_humidity_temperature_raw(hih6130_t *dev, uint16_t 
     return status;
 }
 
-int hih6130_get_humidity_temperature_float(hih6130_t *dev,
+int hih6130_get_humidity_temperature_float(const hih6130_t *dev,
     float *relative_humidity_percent, float *temperature_celsius)
 {
     uint16_t hum_raw, temp_raw;

--- a/drivers/ina220/ina220.c
+++ b/drivers/ina220/ina220.c
@@ -31,7 +31,7 @@
 #include "debug.h"
 
 /** @brief Read one 16 bit register from a INA220 device and swap byte order, if necessary. */
-static int ina220_read_reg(ina220_t *dev, uint8_t reg, uint16_t *out)
+static int ina220_read_reg(const ina220_t *dev, uint8_t reg, uint16_t *out)
 {
     union {
         uint8_t c[2];
@@ -50,7 +50,7 @@ static int ina220_read_reg(ina220_t *dev, uint8_t reg, uint16_t *out)
 }
 
 /** @brief Write one 16 bit register to a INA220 device and swap byte order, if necessary. */
-static int ina220_write_reg(ina220_t *dev, uint8_t reg, uint16_t in)
+static int ina220_write_reg(const ina220_t *dev, uint8_t reg, uint16_t in)
 {
     union {
         uint8_t c[2];
@@ -78,32 +78,32 @@ int ina220_init(ina220_t *dev, i2c_t i2c, uint8_t address)
     return 0;
 }
 
-int ina220_set_calibration(ina220_t *dev, uint16_t calibration)
+int ina220_set_calibration(const ina220_t *dev, uint16_t calibration)
 {
     return ina220_write_reg(dev, INA220_REG_CALIBRATION, calibration);
 }
 
-int ina220_set_config(ina220_t *dev, uint16_t config)
+int ina220_set_config(const ina220_t *dev, uint16_t config)
 {
     return ina220_write_reg(dev, INA220_REG_CONFIGURATION, config);
 }
 
-int ina220_read_shunt(ina220_t *dev, int16_t *voltage)
+int ina220_read_shunt(const ina220_t *dev, int16_t *voltage)
 {
     return ina220_read_reg(dev, INA220_REG_SHUNT_VOLTAGE, (uint16_t *)voltage);
 }
 
-int ina220_read_bus(ina220_t *dev, int16_t *voltage)
+int ina220_read_bus(const ina220_t *dev, int16_t *voltage)
 {
     return ina220_read_reg(dev, INA220_REG_BUS_VOLTAGE, (uint16_t *)voltage);
 }
 
-int ina220_read_current(ina220_t *dev, int16_t *current)
+int ina220_read_current(const ina220_t *dev, int16_t *current)
 {
     return ina220_read_reg(dev, INA220_REG_CURRENT, (uint16_t *)current);
 }
 
-int ina220_read_power(ina220_t *dev, int16_t *power)
+int ina220_read_power(const ina220_t *dev, int16_t *power)
 {
     return ina220_read_reg(dev, INA220_REG_POWER, (uint16_t *)power);
 }

--- a/drivers/include/adt7310.h
+++ b/drivers/include/adt7310.h
@@ -139,7 +139,7 @@ int adt7310_init(adt7310_t *dev, spi_t spi, spi_clk_t clk, gpio_t cs);
  * @return                  raw sensor value on success
  * @return                  INT16_MIN on error
  */
-int16_t adt7310_read_raw(adt7310_t *dev);
+int16_t adt7310_read_raw(const adt7310_t *dev);
 
 /**
  * @brief Read temperature value from sensor and convert to milli-degrees Celsius.
@@ -151,7 +151,7 @@ int16_t adt7310_read_raw(adt7310_t *dev);
  * @return                  temperature in milli-degrees Celsius
  * @return                  INT32_MIN on errors
  */
-int32_t adt7310_read(adt7310_t *dev);
+int32_t adt7310_read(const adt7310_t *dev);
 
 /**
  * @brief Read temperature value from sensor and convert to degrees Celsius.
@@ -161,7 +161,7 @@ int32_t adt7310_read(adt7310_t *dev);
  * @return                  floating point representation of temperature in degrees Celsius
  * @return                  NaN on errors
  */
-float adt7310_read_float(adt7310_t *dev);
+float adt7310_read_float(const adt7310_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -181,42 +181,42 @@ int adxl345_init(adxl345_t *dev, adxl345_params_t* params);
  * @param[in]  dev          device descriptor of accelerometer
  * @param[out] data         the current acceleration data [in mg]
  */
-void adxl345_read(adxl345_t *dev, adxl345_data_t *data);
+void adxl345_read(const adxl345_t *dev, adxl345_data_t *data);
 
 /**
  * @brief   set ADXL345's interrupts configuration
  *
  * @param[in]  dev          device descriptor of accelerometer
  */
-void adxl345_set_interrupt(adxl345_t *dev);
+void adxl345_set_interrupt(const adxl345_t *dev);
 
 /**
  * @brief   set ADXL345's measure mode
  *
  * @param[in]  dev          device descriptor of accelerometer
  */
-void adxl345_set_measure(adxl345_t *dev);
+void adxl345_set_measure(const adxl345_t *dev);
 
 /**
  * @brief   Set standby mode
  *
  * @param[in]  dev          device descriptor of accelerometer
  */
-void adxl345_set_standby(adxl345_t *dev);
+void adxl345_set_standby(const adxl345_t *dev);
 
 /**
  * @brief   Set sleep mode
  *
  * @param[in]  dev          device descriptor of accelerometer
  */
-void adxl345_set_sleep(adxl345_t *dev);
+void adxl345_set_sleep(const adxl345_t *dev);
 
 /**
  * @brief   Set autosleep mode
  *
  * @param[in]  dev          device descriptor of accelerometer
  */
-void adxl345_set_autosleep(adxl345_t *dev);
+void adxl345_set_autosleep(const adxl345_t *dev);
 
 /**
  * @brief   Set bandwidth rate
@@ -224,7 +224,7 @@ void adxl345_set_autosleep(adxl345_t *dev);
  * @param[in]  dev          device descriptor of accelerometer
  * @param[in]  bw_rate      new datarate
  */
-void adxl345_set_bandwidth_rate(adxl345_t *dev, uint8_t bw_rate);
+void adxl345_set_bandwidth_rate(const adxl345_t *dev, uint8_t bw_rate);
 
 /**
  * @brief   Set fifo mode with its configuration.
@@ -234,7 +234,7 @@ void adxl345_set_bandwidth_rate(adxl345_t *dev, uint8_t bw_rate);
  * @param[in]  output       set trigger output
  * @param[in]  value        set trigger's value
  */
-void adxl345_set_fifo_mode(adxl345_t *dev, uint8_t mode,
+void adxl345_set_fifo_mode(const adxl345_t *dev, uint8_t mode,
                            uint8_t output, uint8_t value);
 
 #ifdef __cplusplus

--- a/drivers/include/at30tse75x.h
+++ b/drivers/include/at30tse75x.h
@@ -188,7 +188,7 @@ int at30tse75x_init(at30tse75x_t* dev, i2c_t i2c, i2c_speed_t speed, uint8_t add
  * @return                   0 on success
  * @return                  -1 on error
  */
-int at30tse75x_save_config(at30tse75x_t* dev);
+int at30tse75x_save_config(const at30tse75x_t* dev);
 
 /**
  * @brief   Restore configuration register from non-volatile backup register
@@ -198,7 +198,7 @@ int at30tse75x_save_config(at30tse75x_t* dev);
  * @return                   0 on success
  * @return                  -1 on error
  */
-int at30tse75x_restore_config(at30tse75x_t* dev);
+int at30tse75x_restore_config(const at30tse75x_t* dev);
 
 /**
  * @brief   Get content of configuration register
@@ -209,7 +209,7 @@ int at30tse75x_restore_config(at30tse75x_t* dev);
  * @return                   0 on success
  * @return                  -1 on error
  */
-int at30tse75x_get_config(at30tse75x_t* dev, uint8_t* data);
+int at30tse75x_get_config(const at30tse75x_t* dev, uint8_t* data);
 
 /**
  * @brief   Set content of configuration register
@@ -220,7 +220,7 @@ int at30tse75x_get_config(at30tse75x_t* dev, uint8_t* data);
  * @return                   0 on success
  * @return                  -1 on error
  */
-int at30tse75x_set_config(at30tse75x_t* dev, uint8_t data);
+int at30tse75x_set_config(const at30tse75x_t* dev, uint8_t data);
 
 /**
  * @brief   Set temperature resolution
@@ -232,7 +232,7 @@ int at30tse75x_set_config(at30tse75x_t* dev, uint8_t data);
  * @return                  -1 on error
  * @return                  -2 on bad user input
  */
-int at30tse75x_set_resolution(at30tse75x_t* dev, at30tse75x_resolution_t resolution);
+int at30tse75x_set_resolution(const at30tse75x_t* dev, at30tse75x_resolution_t resolution);
 
 /**
  * @brief   Set operation mode
@@ -244,7 +244,7 @@ int at30tse75x_set_resolution(at30tse75x_t* dev, at30tse75x_resolution_t resolut
  * @return                  -1 on device error
  * @return                  -2 on bad user input
  */
-int at30tse75x_set_mode(at30tse75x_t* dev, at30tse75x_mode_t mode);
+int at30tse75x_set_mode(const at30tse75x_t* dev, at30tse75x_mode_t mode);
 
 /**
  * @brief   Set polarity of ALERT pin
@@ -256,7 +256,7 @@ int at30tse75x_set_mode(at30tse75x_t* dev, at30tse75x_mode_t mode);
  * @return                  -1 on device error
  * @return                  -2 on bad user input
  */
-int at30tse75x_set_alarm_polarity(at30tse75x_t* dev, at30tse75x_alarm_polatity_t polarity);
+int at30tse75x_set_alarm_polarity(const at30tse75x_t* dev, at30tse75x_alarm_polatity_t polarity);
 
 /**
  * @brief   Set tolerance to outlying measurements
@@ -268,7 +268,7 @@ int at30tse75x_set_alarm_polarity(at30tse75x_t* dev, at30tse75x_alarm_polatity_t
  * @return                  -1 on device error
  * @return                  -2 on bad user input
  */
-int at30tse75x_set_fault_tolerance(at30tse75x_t* dev, at30tse75x_fault_tolerance_t tolerance);
+int at30tse75x_set_fault_tolerance(const at30tse75x_t* dev, at30tse75x_fault_tolerance_t tolerance);
 
 /**
  * @brief   Set T_Low limit
@@ -280,7 +280,7 @@ int at30tse75x_set_fault_tolerance(at30tse75x_t* dev, at30tse75x_fault_tolerance
  * @return                  -1 on device error
  * @return                  -2 on bad user input
  */
-int at30tse75x_set_limit_low(at30tse75x_t* dev, int8_t t_low);
+int at30tse75x_set_limit_low(const at30tse75x_t* dev, int8_t t_low);
 
 /**
  * @brief   Set T_High limit
@@ -291,7 +291,7 @@ int at30tse75x_set_limit_low(at30tse75x_t* dev, int8_t t_low);
  * @return                   0 on success
  * @return                  -1 on error
  */
-int at30tse75x_set_limit_high(at30tse75x_t* dev, int8_t t_high);
+int at30tse75x_set_limit_high(const at30tse75x_t* dev, int8_t t_high);
 
 /**
  * @brief   Get measured temperature
@@ -302,7 +302,7 @@ int at30tse75x_set_limit_high(at30tse75x_t* dev, int8_t t_high);
  * @return                   0 on success
  * @return                  -1 on error
  */
-int at30tse75x_get_temperature(at30tse75x_t* dev, float* temperature);
+int at30tse75x_get_temperature(const at30tse75x_t* dev, float* temperature);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/bh1750fvi.h
+++ b/drivers/include/bh1750fvi.h
@@ -95,7 +95,7 @@ int bh1750fvi_init(bh1750fvi_t *dev, bh1750fvi_params_t *params);
  *
  * @return      ambient light intensity in LUX
  */
-uint16_t bh1750fvi_sample(bh1750fvi_t *dev);
+uint16_t bh1750fvi_sample(const bh1750fvi_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/bmp180.h
+++ b/drivers/include/bmp180.h
@@ -104,7 +104,7 @@ int bmp180_init(bmp180_t *dev, const bmp180_params_t *params);
  *
  * @return                  Temperature in d°C
  */
-int16_t bmp180_read_temperature(bmp180_t *dev);
+int16_t bmp180_read_temperature(const bmp180_t *dev);
 
 /**
  * @brief Read pressure value from the given BMP180 device, returned in Pa
@@ -113,7 +113,7 @@ int16_t bmp180_read_temperature(bmp180_t *dev);
  *
  * @return                  Pressure in Pa
  */
-uint32_t bmp180_read_pressure(bmp180_t *dev);
+uint32_t bmp180_read_pressure(const bmp180_t *dev);
 
 /**
  * @brief Compute altitude, returned in m.
@@ -123,7 +123,7 @@ uint32_t bmp180_read_pressure(bmp180_t *dev);
  *
  * @return                  Altitude in m
  */
-int16_t bmp180_altitude(bmp180_t *dev, uint32_t pressure_0);
+int16_t bmp180_altitude(const bmp180_t *dev, uint32_t pressure_0);
 
 /**
  * @brief Compute pressure at sea level, returned in Pa.
@@ -133,7 +133,7 @@ int16_t bmp180_altitude(bmp180_t *dev, uint32_t pressure_0);
  *
  * @return                  Pressure at sea level in Pa
  */
-uint32_t bmp180_sealevel_pressure(bmp180_t *dev, int16_t altitude);
+uint32_t bmp180_sealevel_pressure(const bmp180_t *dev, int16_t altitude);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -183,7 +183,7 @@ int bmx280_init(bmx280_t* dev, const bmx280_params_t* params);
  * @returns                 The temperature in centi Celsius. In case of an error
  *                          it returns INT16_MIN.
  */
-int16_t bmx280_read_temperature(bmx280_t* dev);
+int16_t bmx280_read_temperature(const bmx280_t* dev);
 
 /**
  * @brief Read air pressure value from the given BMX280 device, returned in PA
@@ -195,7 +195,7 @@ int16_t bmx280_read_temperature(bmx280_t* dev);
  *
  * @returns                 The air pressure in Pa
  */
-uint32_t bmx280_read_pressure(bmx280_t *dev);
+uint32_t bmx280_read_pressure(const bmx280_t *dev);
 
 #if defined(MODULE_BME280)
 /**
@@ -208,7 +208,7 @@ uint32_t bmx280_read_pressure(bmx280_t *dev);
  *
  * @returns                 Humidity in centi %RH (i.e. the percentage times 100)
  */
-uint16_t bme280_read_humidity(bmx280_t *dev);
+uint16_t bme280_read_humidity(const bmx280_t *dev);
 #endif
 
 #ifdef __cplusplus

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -116,7 +116,7 @@ int dht_init(dht_t *dev, const dht_params_t *params);
  * @return              -1 on checksum error
  * @return              -2 on parsing error
  */
-int dht_read(dht_t *dev, int16_t *temp, int16_t *hum);
+int dht_read(const dht_t *dev, int16_t *temp, int16_t *hum);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/dsp0401.h
+++ b/drivers/include/dsp0401.h
@@ -83,14 +83,14 @@ int dsp0401_init(dsp0401_t *dev, const dsp0401_params_t *params);
  * @param[in] dev           Device descriptor of the DSP0401 device
  * @param[in] text          The text to display
  */
-void dsp0401_display_text(dsp0401_t *dev, char *text);
+void dsp0401_display_text(const dsp0401_t *dev, char *text);
 
 /**
  * @brief Clear the text displayed on the DSP0401
  *
  * @param[in] dev           Device descriptor of the DSP0401 device
  */
-void dsp0401_clear_text(dsp0401_t *dev);
+void dsp0401_clear_text(const dsp0401_t *dev);
 
 /**
  * @brief Scroll the given text on the DSP0401
@@ -99,7 +99,7 @@ void dsp0401_clear_text(dsp0401_t *dev);
  * @param[in] text          The text to scroll on the display
  * @param[in] delay         Delay in ms between each horizontal move
  */
-void dsp0401_scroll_text(dsp0401_t *dev, char *text, uint16_t delay);
+void dsp0401_scroll_text(const dsp0401_t *dev, char *text, uint16_t delay);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/dynamixel.h
+++ b/drivers/include/dynamixel.h
@@ -89,7 +89,7 @@ void dynamixel_init(dynamixel_t *device, uart_half_duplex_t *stream, dynamixel_i
  * @return             DYNAMIXEL_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             DYNAMIXEL_INVALID_MESSAGE if an invalid message was received
  */
-int dynamixel_write8(dynamixel_t *device, dynamixel_addr_t reg, uint8_t value);
+int dynamixel_write8(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t value);
 
 /**
  * @brief Write to a device 16bits register
@@ -103,7 +103,7 @@ int dynamixel_write8(dynamixel_t *device, dynamixel_addr_t reg, uint8_t value);
  * @return             DYNAMIXEL_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             DYNAMIXEL_INVALID_MESSAGE if an invalid message was received
  */
-int dynamixel_write16(dynamixel_t *device, dynamixel_addr_t reg, uint16_t value);
+int dynamixel_write16(const dynamixel_t *device, dynamixel_addr_t reg, uint16_t value);
 
 /**
  * @brief Write to a device address
@@ -118,7 +118,7 @@ int dynamixel_write16(dynamixel_t *device, dynamixel_addr_t reg, uint16_t value)
  * @return             DYNAMIXEL_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             DYNAMIXEL_INVALID_MESSAGE if an invalid message was received
  */
-int dynamixel_write(dynamixel_t *device, dynamixel_addr_t reg, const uint8_t *data, size_t length);
+int dynamixel_write(const dynamixel_t *device, dynamixel_addr_t reg, const uint8_t *data, size_t length);
 
 /**
  * @brief Read from a device 8bits register
@@ -132,7 +132,7 @@ int dynamixel_write(dynamixel_t *device, dynamixel_addr_t reg, const uint8_t *da
  * @return             DYNAMIXEL_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             DYNAMIXEL_INVALID_MESSAGE if an invalid message was received
  */
-int dynamixel_read8(dynamixel_t *device, dynamixel_addr_t reg, uint8_t *value);
+int dynamixel_read8(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t *value);
 
 /**
  * @brief Read from a device 16bits register
@@ -146,7 +146,7 @@ int dynamixel_read8(dynamixel_t *device, dynamixel_addr_t reg, uint8_t *value);
  * @return             DYNAMIXEL_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             DYNAMIXEL_INVALID_MESSAGE if an invalid message was received
  */
-int dynamixel_read16(dynamixel_t *device, dynamixel_addr_t reg, uint16_t *value);
+int dynamixel_read16(const dynamixel_t *device, dynamixel_addr_t reg, uint16_t *value);
 
 /**
  * @brief Read from a device address
@@ -161,7 +161,7 @@ int dynamixel_read16(dynamixel_t *device, dynamixel_addr_t reg, uint16_t *value)
  * @return             DYNAMIXEL_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             DYNAMIXEL_INVALID_MESSAGE if an invalid message was received
  */
-int dynamixel_read(dynamixel_t *device, dynamixel_addr_t reg, uint8_t *data, size_t length);
+int dynamixel_read(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t *data, size_t length);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/feetech.h
+++ b/drivers/include/feetech.h
@@ -88,7 +88,7 @@ void feetech_init(feetech_t *device, uart_half_duplex_t *stream, feetech_id_t id
  * @return             FEETECH_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             FEETECH_INVALID_MESSAGE if an invalid message was received
  */
-int feetech_write8(feetech_t *device, feetech_addr_t addr, uint8_t value);
+int feetech_write8(const feetech_t *device, feetech_addr_t addr, uint8_t value);
 
 /**
  * @brief Write to a device 16bits address
@@ -102,7 +102,7 @@ int feetech_write8(feetech_t *device, feetech_addr_t addr, uint8_t value);
  * @return             FEETECH_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             FEETECH_INVALID_MESSAGE if an invalid message was received
  */
-int feetech_write16(feetech_t *device, feetech_addr_t addr, uint16_t value);
+int feetech_write16(const feetech_t *device, feetech_addr_t addr, uint16_t value);
 
 /**
  * @brief Write to a device address
@@ -117,7 +117,7 @@ int feetech_write16(feetech_t *device, feetech_addr_t addr, uint16_t value);
  * @return             FEETECH_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             FEETECH_INVALID_MESSAGE if an invalid message was received
  */
-int feetech_write(feetech_t *device, feetech_addr_t addr, const uint8_t *data, size_t length);
+int feetech_write(const feetech_t *device, feetech_addr_t addr, const uint8_t *data, size_t length);
 
 /**
  * @brief Read from a device 8bits address
@@ -131,7 +131,7 @@ int feetech_write(feetech_t *device, feetech_addr_t addr, const uint8_t *data, s
  * @return             FEETECH_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             FEETECH_INVALID_MESSAGE if an invalid message was received
  */
-int feetech_read8(feetech_t *device, feetech_addr_t addr, uint8_t *value);
+int feetech_read8(const feetech_t *device, feetech_addr_t addr, uint8_t *value);
 
 /**
  * @brief Read from a device 16bits address
@@ -145,7 +145,7 @@ int feetech_read8(feetech_t *device, feetech_addr_t addr, uint8_t *value);
  * @return             FEETECH_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             FEETECH_INVALID_MESSAGE if an invalid message was received
  */
-int feetech_read16(feetech_t *device, feetech_addr_t addr, uint16_t *value);
+int feetech_read16(const feetech_t *device, feetech_addr_t addr, uint16_t *value);
 
 /**
  * @brief Read from a device address
@@ -160,7 +160,7 @@ int feetech_read16(feetech_t *device, feetech_addr_t addr, uint16_t *value);
  * @return             FEETECH_BUFFER_TOO_SMALL if buffer is too small for the message
  * @return             FEETECH_INVALID_MESSAGE if an invalid message was received
  */
-int feetech_read(feetech_t *device, feetech_addr_t addr, uint8_t *data, size_t length);
+int feetech_read(const feetech_t *device, feetech_addr_t addr, uint8_t *data, size_t length);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/hd44780.h
+++ b/drivers/include/hd44780.h
@@ -105,14 +105,14 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params);
  *
  * @param[in]  dev          device descriptor of LCD
  */
-void hd44780_clear(hd44780_t *dev);
+void hd44780_clear(const hd44780_t *dev);
 
 /**
  * @brief Reset cursor to row 0 and column 0
  *
  * @param[in]  dev          device descriptor of LCD
  */
-void hd44780_home(hd44780_t *dev);
+void hd44780_home(const hd44780_t *dev);
 
 /**
  * @brief Set cursor to specific position in column and row
@@ -121,7 +121,7 @@ void hd44780_home(hd44780_t *dev);
  * @param[in]  col          column position
  * @param[in]  row          row position
  */
-void hd44780_set_cursor(hd44780_t *dev, uint8_t col, uint8_t row);
+void hd44780_set_cursor(const hd44780_t *dev, uint8_t col, uint8_t row);
 
 /**
  * @brief Turn display on or off
@@ -152,14 +152,14 @@ void hd44780_blink(hd44780_t *dev, hd44780_state_t state);
  *
  * @param[in]  dev          device descriptor of LCD
  */
-void hd44780_scroll_left(hd44780_t *dev);
+void hd44780_scroll_left(const hd44780_t *dev);
 
 /**
  * @brief Enable right scrolling
  *
  * @param[in]  dev          device descriptor of LCD
  */
-void hd44780_scroll_right(hd44780_t *dev);
+void hd44780_scroll_right(const hd44780_t *dev);
 
 /**
  * @brief set display direction left to right
@@ -192,7 +192,7 @@ void hd44780_autoscroll(hd44780_t *dev, hd44780_state_t state);
  *
  * @pre charmap has to be of size HD44780_CGRAM_SIZE, which is 8 by default
  */
-void hd44780_create_char(hd44780_t *dev, uint8_t location, uint8_t charmap[]);
+void hd44780_create_char(const hd44780_t *dev, uint8_t location, uint8_t charmap[]);
 
 /**
  * @brief Write a single character on the LCD
@@ -200,7 +200,7 @@ void hd44780_create_char(hd44780_t *dev, uint8_t location, uint8_t charmap[]);
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  value        the character to print, i.e., memory location
  */
-void hd44780_write(hd44780_t *dev, uint8_t value);
+void hd44780_write(const hd44780_t *dev, uint8_t value);
 
 /**
  * @brief Write a string on the LCD
@@ -208,7 +208,7 @@ void hd44780_write(hd44780_t *dev, uint8_t value);
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  data         the string to print
  */
-void hd44780_print(hd44780_t *dev, const char *data);
+void hd44780_print(const hd44780_t *dev, const char *data);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -124,7 +124,7 @@ int hdc1000_init(hdc1000_t *dev, const hdc1000_params_t *params);
  * @return                  HDC1000_OK on success
  * @return                  HDC1000_BUSERR on I2C communication failures
  */
-int hdc1000_trigger_conversion(hdc1000_t *dev);
+int hdc1000_trigger_conversion(const hdc1000_t *dev);
 
 /**
  * @brief   Read conversion results for temperature and humidity
@@ -136,7 +136,7 @@ int hdc1000_trigger_conversion(hdc1000_t *dev);
  * @return                  HDC1000_OK on success
  * @return                  HDC1000_BUSERR on I2C communication failures
  */
-int hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum);
+int hdc1000_get_results(const hdc1000_t *dev, int16_t *temp, int16_t *hum);
 
 /**
  * @brief   Convenience function for reading temperature and humidity
@@ -151,7 +151,7 @@ int hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum);
  * @return                  HDC1000_OK on success
  * @return                  HDC1000_BUSERR on I2C communication failures
  */
-int hdc1000_read(hdc1000_t *dev, int16_t *temp, int16_t *hum);
+int hdc1000_read(const hdc1000_t *dev, int16_t *temp, int16_t *hum);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/hih6130.h
+++ b/drivers/include/hih6130.h
@@ -59,7 +59,7 @@ void hih6130_init(hih6130_t *dev, i2c_t i2c, uint8_t address);
  * @return -1 on error
  * @return 1 if data is stale
  */
-int hih6130_get_humidity_temperature_float(hih6130_t *dev,
+int hih6130_get_humidity_temperature_float(const hih6130_t *dev,
     float *relative_humidity_percent, float *temperature_celsius);
 
 #ifdef __cplusplus

--- a/drivers/include/ina220.h
+++ b/drivers/include/ina220.h
@@ -157,7 +157,7 @@ int ina220_init(ina220_t *dev, i2c_t i2c, uint8_t address);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina220_set_calibration(ina220_t *dev, uint16_t calibration);
+int ina220_set_calibration(const ina220_t *dev, uint16_t calibration);
 
 /**
  * @brief Write to configuration register
@@ -168,7 +168,7 @@ int ina220_set_calibration(ina220_t *dev, uint16_t calibration);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina220_set_config(ina220_t *dev, uint16_t config);
+int ina220_set_config(const ina220_t *dev, uint16_t config);
 
 /**
  * @brief Read shunt voltage
@@ -179,7 +179,7 @@ int ina220_set_config(ina220_t *dev, uint16_t config);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina220_read_shunt(ina220_t *dev, int16_t *voltage);
+int ina220_read_shunt(const ina220_t *dev, int16_t *voltage);
 
 /**
  * @brief Read bus voltage register
@@ -195,7 +195,7 @@ int ina220_read_shunt(ina220_t *dev, int16_t *voltage);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina220_read_bus(ina220_t *dev, int16_t *voltage);
+int ina220_read_bus(const ina220_t *dev, int16_t *voltage);
 
 /**
  * @brief Read shunt current
@@ -206,7 +206,7 @@ int ina220_read_bus(ina220_t *dev, int16_t *voltage);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina220_read_current(ina220_t *dev, int16_t *current);
+int ina220_read_current(const ina220_t *dev, int16_t *current);
 
 /**
  * @brief Read power consumption
@@ -217,7 +217,7 @@ int ina220_read_current(ina220_t *dev, int16_t *current);
  * @return                  0 on success
  * @return                  <0 on error
  */
-int ina220_read_power(ina220_t *dev, int16_t *power);
+int ina220_read_power(const ina220_t *dev, int16_t *power);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/io1_xplained.h
+++ b/drivers/include/io1_xplained.h
@@ -79,7 +79,7 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params);
  * @return                  IO1_XPLAINED_READ_OK on success
  * @return                  -IO1_XPLAINED_READ_ERR if temperature sensor read failed
  */
-int io1_xplained_read_temperature(io1_xplained_t *dev, float *temperature);
+int io1_xplained_read_temperature(const io1_xplained_t *dev, float *temperature);
 
 /**
  * @brief Set the on-board led of the IO1 Xplained extension

--- a/drivers/include/isl29020.h
+++ b/drivers/include/isl29020.h
@@ -93,7 +93,7 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
  * @return              the measured brightness in lux
  * @return              -1 on error
  */
-int isl29020_read(isl29020_t *dev);
+int isl29020_read(const isl29020_t *dev);
 
 /**
  * @brief Enable the given sensor
@@ -103,7 +103,7 @@ int isl29020_read(isl29020_t *dev);
  * @return              0 on success
  * @return              -1 on error
  */
-int isl29020_enable(isl29020_t *dev);
+int isl29020_enable(const isl29020_t *dev);
 
 /**
  * @brief Disable the given sensor
@@ -113,7 +113,7 @@ int isl29020_enable(isl29020_t *dev);
  * @return              0 on success
  * @return              -1 on error
  */
-int isl29020_disable(isl29020_t *dev);
+int isl29020_disable(const isl29020_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/isl29125.h
+++ b/drivers/include/isl29125.h
@@ -181,7 +181,7 @@ int isl29125_init_int(isl29125_t *dev, isl29125_interrupt_status_t interrupt_sta
  * @param[in] dev       device descriptor of an ISL29125 device
  * @param[in] dest      pointer to lux RGB color object data is written to
  */
-void isl29125_read_rgb_lux(isl29125_t *dev, isl29125_rgb_t *dest);
+void isl29125_read_rgb_lux(const isl29125_t *dev, isl29125_rgb_t *dest);
 
  /**
  * @brief read color values from device
@@ -189,7 +189,7 @@ void isl29125_read_rgb_lux(isl29125_t *dev, isl29125_rgb_t *dest);
  * @param[in] dev       device descriptor of an ISL29125 device
  * @param[in] dest      pointer to RGB color object data is written to
  */
-void isl29125_read_rgb_color(isl29125_t *dev, color_rgb_t *dest);
+void isl29125_read_rgb_color(const isl29125_t *dev, color_rgb_t *dest);
 
 /**
  * @brief set the device's operation mode
@@ -197,7 +197,7 @@ void isl29125_read_rgb_color(isl29125_t *dev, color_rgb_t *dest);
  * @param[in] dev       device descriptor of an ISL29125 device
  * @param[in] mode      operation mode
  */
-void isl29125_set_mode(isl29125_t *dev, isl29125_mode_t mode);
+void isl29125_set_mode(const isl29125_t *dev, isl29125_mode_t mode);
 
 /**
  * @brief read isl29125 interrupt status
@@ -206,7 +206,7 @@ void isl29125_set_mode(isl29125_t *dev, isl29125_mode_t mode);
  *
  * @return              interrupt status
  */
-int isl29125_read_irq_status(isl29125_t *dev);
+int isl29125_read_irq_status(const isl29125_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/jc42.h
+++ b/drivers/include/jc42.h
@@ -92,7 +92,7 @@ int jc42_init(jc42_t* dev, jc42_params_t* params);
  * @return                   0 on success
  * @return                  -1 on error
  */
-int jc42_get_config(jc42_t* dev, uint16_t* data);
+int jc42_get_config(const jc42_t* dev, uint16_t* data);
 
 /**
  * @brief   Set content of configuration register
@@ -103,7 +103,7 @@ int jc42_get_config(jc42_t* dev, uint16_t* data);
  * @return                   0 on success
  * @return                  -1 on error
  */
-int jc42_set_config(jc42_t* dev, uint16_t data);
+int jc42_set_config(const jc42_t* dev, uint16_t data);
 
 
 /**
@@ -115,7 +115,7 @@ int jc42_set_config(jc42_t* dev, uint16_t data);
  * @return                   0 on success
  * @return                  -1 on error
  */
-int jc42_get_temperature(jc42_t* dev, int16_t* temperature);
+int jc42_get_temperature(const jc42_t* dev, int16_t* temperature);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/l3g4200d.h
+++ b/drivers/include/l3g4200d.h
@@ -125,7 +125,7 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
  * @return                  0 on success
  * @return                  -1 on error
  */
-int l3g4200d_read(l3g4200d_t *dev, l3g4200d_data_t *acc_data);
+int l3g4200d_read(const l3g4200d_t *dev, l3g4200d_data_t *acc_data);
 
 /**
  * @brief Power-up the given device
@@ -135,7 +135,7 @@ int l3g4200d_read(l3g4200d_t *dev, l3g4200d_data_t *acc_data);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int l3g4200d_enable(l3g4200d_t *dev);
+int l3g4200d_enable(const l3g4200d_t *dev);
 
 /**
  * @brief Power-down the given device
@@ -145,7 +145,7 @@ int l3g4200d_enable(l3g4200d_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int l3g4200d_disable(l3g4200d_t *dev);
+int l3g4200d_disable(const l3g4200d_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/lis3dh.h
+++ b/drivers/include/lis3dh.h
@@ -782,7 +782,7 @@ int lis3dh_read_aux_adc3(const lis3dh_t *dev, int16_t *out);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int lis3dh_set_aux_adc(lis3dh_t *dev, const uint8_t enable, const uint8_t temperature);
+int lis3dh_set_aux_adc(const lis3dh_t *dev, const uint8_t enable, const uint8_t temperature);
 
 /**
  * @brief Enable/disable accelerometer axes.
@@ -796,7 +796,7 @@ int lis3dh_set_aux_adc(lis3dh_t *dev, const uint8_t enable, const uint8_t temper
  * @return                  0 on success
  * @return                  -1 on error
  */
-int lis3dh_set_axes(lis3dh_t *dev, const uint8_t axes);
+int lis3dh_set_axes(const lis3dh_t *dev, const uint8_t axes);
 
 /**
  * @brief Enable/disable the FIFO.
@@ -808,7 +808,7 @@ int lis3dh_set_axes(lis3dh_t *dev, const uint8_t axes);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int lis3dh_set_fifo(lis3dh_t *dev, const uint8_t mode, const uint8_t watermark);
+int lis3dh_set_fifo(const lis3dh_t *dev, const uint8_t mode, const uint8_t watermark);
 
 /**
  * Set the output data rate of the sensor.
@@ -819,7 +819,7 @@ int lis3dh_set_fifo(lis3dh_t *dev, const uint8_t mode, const uint8_t watermark);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int lis3dh_set_odr(lis3dh_t *dev, const uint8_t odr);
+int lis3dh_set_odr(const lis3dh_t *dev, const uint8_t odr);
 
 /**
  * @brief Set the full scale range of the sensor.
@@ -846,7 +846,7 @@ int lis3dh_set_scale(lis3dh_t *dev, const uint8_t scale);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int lis3dh_set_int1(lis3dh_t *dev, const uint8_t mode);
+int lis3dh_set_int1(const lis3dh_t *dev, const uint8_t mode);
 
 /**
  * @brief Get the current number of elements in the FIFO
@@ -856,7 +856,7 @@ int lis3dh_set_int1(lis3dh_t *dev, const uint8_t mode);
  * @return                  number of elements in device FIFO on success
  * @return                  -1 on error
  */
-int lis3dh_get_fifo_level(lis3dh_t *dev);
+int lis3dh_get_fifo_level(const lis3dh_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/lis3mdl.h
+++ b/drivers/include/lis3mdl.h
@@ -124,7 +124,7 @@ int lis3mdl_init(lis3mdl_t *dev, i2c_t i2c, uint8_t address,
  * @param[in] dev          device descriptor of LIS3MDL
  * @param[in] data         measured magnetometer data
  */
-void lis3mdl_read_mag(lis3mdl_t *dev, lis3mdl_3d_data_t *data);
+void lis3mdl_read_mag(const lis3mdl_t *dev, lis3mdl_3d_data_t *data);
 
 /**
  * @brief Reads the temperature value of LIS3MDL.
@@ -132,21 +132,21 @@ void lis3mdl_read_mag(lis3mdl_t *dev, lis3mdl_3d_data_t *data);
  * @param[in] dev          device descriptor of LIS3MDL
  * @param[in] value        measured temperature in degree celsius
  */
-void lis3mdl_read_temp(lis3mdl_t *dev, int16_t *value);
+void lis3mdl_read_temp(const lis3mdl_t *dev, int16_t *value);
 
 /**
  * @brief Enable the LIS3MDL device.
  *
  * @param[in] dev          device descriptor of LIS3MDL
  */
-void lis3mdl_enable(lis3mdl_t *dev);
+void lis3mdl_enable(const lis3mdl_t *dev);
 
 /**
  * @brief Disable the LIS3MDL device.
  *
  * @param[in] dev          device descriptor of LIS3MDL
  */
-void lis3mdl_disable(lis3mdl_t *dev);
+void lis3mdl_disable(const lis3mdl_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/lpd8808.h
+++ b/drivers/include/lpd8808.h
@@ -73,7 +73,7 @@ int lpd8808_init(lpd8808_t *dev, const lpd8808_params_t *params);
  * @param[in] vals      array of color values, MUST be of same length as LEDs on
  *                      the strip
  */
-void lpd8808_load_rgb(lpd8808_t *dev, color_rgb_t vals[]);
+void lpd8808_load_rgb(const lpd8808_t *dev, color_rgb_t vals[]);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/lps331ap.h
+++ b/drivers/include/lps331ap.h
@@ -82,7 +82,7 @@ int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t r
  *
  * @return              temperature value in m°C
  */
-int lps331ap_read_temp(lps331ap_t *dev);
+int lps331ap_read_temp(const lps331ap_t *dev);
 
 /**
  * @brief Read a pressure value from the given sensor, returned in mbar
@@ -91,7 +91,7 @@ int lps331ap_read_temp(lps331ap_t *dev);
  *
  * @return              pressure value in mbar
  */
-int lps331ap_read_pres(lps331ap_t *dev);
+int lps331ap_read_pres(const lps331ap_t *dev);
 
 /**
  * @brief Enable the given sensor
@@ -101,7 +101,7 @@ int lps331ap_read_pres(lps331ap_t *dev);
  * @return              0 on success
  * @return              -1 on error
  */
-int lps331ap_enable(lps331ap_t *dev);
+int lps331ap_enable(const lps331ap_t *dev);
 
 /**
  * @brief Disable the given sensor
@@ -111,7 +111,7 @@ int lps331ap_enable(lps331ap_t *dev);
  * @return              0 on success
  * @return              -1 on error
  */
-int lps331ap_disable(lps331ap_t *dev);
+int lps331ap_disable(const lps331ap_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/lsm303dlhc.h
+++ b/drivers/include/lsm303dlhc.h
@@ -171,7 +171,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
  * @return              0 on success
  * @return              -1 on error
  */
-int lsm303dlhc_read_acc(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
+int lsm303dlhc_read_acc(const lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
 
 /**
  * @brief Read a magnetometer value from the sensor.
@@ -195,7 +195,7 @@ int lsm303dlhc_read_acc(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
  * @return              0 on success
  * @return              -1 on error
  */
-int lsm303dlhc_read_mag(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
+int lsm303dlhc_read_mag(const lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
 
 /**
  * @brief Read a temperature value from the sensor.
@@ -206,7 +206,7 @@ int lsm303dlhc_read_mag(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
  * @return              0 on success
  * @return              -1 on error
  */
-int lsm303dlhc_read_temp(lsm303dlhc_t *dev, int16_t *value);
+int lsm303dlhc_read_temp(const lsm303dlhc_t *dev, int16_t *value);
 
 /**
  * @brief Enable the given sensor
@@ -216,7 +216,7 @@ int lsm303dlhc_read_temp(lsm303dlhc_t *dev, int16_t *value);
  * @return              0 on success
  * @return              -1 on error
  */
-int lsm303dlhc_enable(lsm303dlhc_t *dev);
+int lsm303dlhc_enable(const lsm303dlhc_t *dev);
 
 /**
  * @brief Disable the given sensor
@@ -226,7 +226,7 @@ int lsm303dlhc_enable(lsm303dlhc_t *dev);
  * @return              0 on success
  * @return              -1 on error
  */
-int lsm303dlhc_disable(lsm303dlhc_t *dev);
+int lsm303dlhc_disable(const lsm303dlhc_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/lsm6dsl.h
+++ b/drivers/include/lsm6dsl.h
@@ -116,7 +116,7 @@ int lsm6dsl_init(lsm6dsl_t *dev, const lsm6dsl_params_t *params);
  * @return 0 on success
  * @return < 0 on error
  */
-int lsm6dsl_read_acc(lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
+int lsm6dsl_read_acc(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
 
 /**
  * @brief Read gyroscope data
@@ -127,7 +127,7 @@ int lsm6dsl_read_acc(lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
  * @return 0 on success
  * @return < 0 on error
  */
-int lsm6dsl_read_gyro(lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
+int lsm6dsl_read_gyro(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
 
 /**
  * @brief Read temperature data
@@ -138,7 +138,7 @@ int lsm6dsl_read_gyro(lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
  * @return 0 on success
  * @return < 0 on error
  */
-int lsm6dsl_read_temp(lsm6dsl_t *dev, int16_t *data);
+int lsm6dsl_read_temp(const lsm6dsl_t *dev, int16_t *data);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/mag3110.h
+++ b/drivers/include/mag3110.h
@@ -141,7 +141,7 @@ int mag3110_init(mag3110_t *dev, const mag3110_params_t *params);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mag3110_set_user_offset(mag3110_t *dev, int16_t x, int16_t y, int16_t z);
+int mag3110_set_user_offset(const mag3110_t *dev, int16_t x, int16_t y, int16_t z);
 
 /**
  * @brief Set active mode, this enables periodic measurements.
@@ -151,7 +151,7 @@ int mag3110_set_user_offset(mag3110_t *dev, int16_t x, int16_t y, int16_t z);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mag3110_set_active(mag3110_t *dev);
+int mag3110_set_active(const mag3110_t *dev);
 
 /**
  * @brief Set standby mode.
@@ -161,7 +161,7 @@ int mag3110_set_active(mag3110_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mag3110_set_standby(mag3110_t *dev);
+int mag3110_set_standby(const mag3110_t *dev);
 
 /**
  * @brief Check for new set of measurement data.
@@ -172,7 +172,7 @@ int mag3110_set_standby(mag3110_t *dev);
  * @return                  0 if measurement is in progress
  * @return                  -1 on error
  */
-int mag3110_is_ready(mag3110_t *dev);
+int mag3110_is_ready(const mag3110_t *dev);
 
 /**
  * @brief Read magnetometer's data.
@@ -185,7 +185,7 @@ int mag3110_is_ready(mag3110_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mag3110_read(mag3110_t *dev, mag3110_data_t *data);
+int mag3110_read(const mag3110_t *dev, mag3110_data_t *data);
 
 /**
  * @brief Read die temperature.
@@ -196,7 +196,7 @@ int mag3110_read(mag3110_t *dev, mag3110_data_t *data);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mag3110_read_dtemp(mag3110_t *dev, int8_t *dtemp);
+int mag3110_read_dtemp(const mag3110_t *dev, int8_t *dtemp);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/mma8x5x.h
+++ b/drivers/include/mma8x5x.h
@@ -136,21 +136,21 @@ int mma8x5x_init(mma8x5x_t *dev, const mma8x5x_params_t *params);
  * @param[in]  y            offset correction value for y-axis
  * @param[in]  z            offset correction value for z-axis
  */
-void mma8x5x_set_user_offset(mma8x5x_t *dev, int8_t x, int8_t y, int8_t z);
+void mma8x5x_set_user_offset(const mma8x5x_t *dev, int8_t x, int8_t y, int8_t z);
 
 /**
  * @brief   Set active mode, this enables periodic measurements
  *
  * @param[out] dev          device descriptor of accelerometer to reset
  */
-void mma8x5x_set_active(mma8x5x_t *dev);
+void mma8x5x_set_active(const mma8x5x_t *dev);
 
 /**
  * @brief   Set standby mode.
  *
  * @param[in]  dev          device descriptor of accelerometer
  */
-void mma8x5x_set_standby(mma8x5x_t *dev);
+void mma8x5x_set_standby(const mma8x5x_t *dev);
 
 /**
  * @brief   Check for new set of measurement data
@@ -160,7 +160,7 @@ void mma8x5x_set_standby(mma8x5x_t *dev);
  * @return                  MMA8X5X_DATA_READY if new sample is ready
  * @return                  MMA8X5X_NODATA if nothing is available
  */
-int mma8x5x_is_ready(mma8x5x_t *dev);
+int mma8x5x_is_ready(const mma8x5x_t *dev);
 
 /**
  * @brief   Read accelerometer's data
@@ -176,7 +176,7 @@ int mma8x5x_is_ready(mma8x5x_t *dev);
  * @param[in]  dev          device descriptor of accelerometer
  * @param[out] data         the current acceleration data [in mg]
  */
-void mma8x5x_read(mma8x5x_t *dev, mma8x5x_data_t *data);
+void mma8x5x_read(const mma8x5x_t *dev, mma8x5x_data_t *data);
 
 /**
  * @brief   Configure motion detection interrupt
@@ -189,7 +189,7 @@ void mma8x5x_read(mma8x5x_t *dev, mma8x5x_data_t *data);
  * @param[in]   int_pin     select mma8x5x int pin (1 or 2)
  * @param[in]   threshold   motion detection threshold (see datasheet)
  */
-void mma8x5x_set_motiondetect(mma8x5x_t *dev, uint8_t int_pin, uint8_t threshold);
+void mma8x5x_set_motiondetect(const mma8x5x_t *dev, uint8_t int_pin, uint8_t threshold);
 
 /**
  * @brief   Acknowledge motion detection interrupt
@@ -202,7 +202,7 @@ void mma8x5x_set_motiondetect(mma8x5x_t *dev, uint8_t int_pin, uint8_t threshold
  *
  * @param[in]   dev         device descriptor of accelerometer
  */
-void mma8x5x_ack_int(mma8x5x_t *dev);
+void mma8x5x_ack_int(const mma8x5x_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -75,7 +75,7 @@ typedef struct {
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mpl3115a2_test(mpl3115a2_t *dev);
+int mpl3115a2_test(const mpl3115a2_t *dev);
 
 /**
  * @brief Initialize the MPL3115A2 sensor driver.
@@ -111,7 +111,7 @@ int mpl3115a2_reset(mpl3115a2_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mpl3115a2_set_active(mpl3115a2_t *dev);
+int mpl3115a2_set_active(const mpl3115a2_t *dev);
 
 /**
  * @brief Set standby mode.
@@ -121,7 +121,7 @@ int mpl3115a2_set_active(mpl3115a2_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mpl3115a2_set_standby(mpl3115a2_t *dev);
+int mpl3115a2_set_standby(const mpl3115a2_t *dev);
 
 /**
  * @brief Check for new set of measurement data.
@@ -132,7 +132,7 @@ int mpl3115a2_set_standby(mpl3115a2_t *dev);
  * @return                  0 measurement in progress
  * @return                  -1 on error
  */
-int mpl3115a2_is_ready(mpl3115a2_t *dev);
+int mpl3115a2_is_ready(const mpl3115a2_t *dev);
 
 /**
  * @brief Read sensor's data in pressure mode.
@@ -144,7 +144,7 @@ int mpl3115a2_is_ready(mpl3115a2_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status);
+int mpl3115a2_read_pressure(const mpl3115a2_t *dev, uint32_t *pres, uint8_t *status);
 
 /**
  * @brief Read sensor's temperature.
@@ -155,7 +155,7 @@ int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int mpl3115a2_read_temp(mpl3115a2_t *dev, int16_t *temp);
+int mpl3115a2_read_temp(const mpl3115a2_t *dev, int16_t *temp);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/mpu9150.h
+++ b/drivers/include/mpu9150.h
@@ -229,7 +229,7 @@ int mpu9150_set_compass_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf);
  * @return                  -1 if device's I2C is not enabled in board config
  * @return                  -2 if gyro full-scale range is configured wrong
  */
-int mpu9150_read_gyro(mpu9150_t *dev, mpu9150_results_t *output);
+int mpu9150_read_gyro(const mpu9150_t *dev, mpu9150_results_t *output);
 
 /**
  * @brief Read acceleration values from the given MPU9150 device, returned in mG
@@ -244,7 +244,7 @@ int mpu9150_read_gyro(mpu9150_t *dev, mpu9150_results_t *output);
  * @return                  -1 if device's I2C is not enabled in board config
  * @return                  -2 if accel full-scale range is configured wrong
  */
-int mpu9150_read_accel(mpu9150_t *dev, mpu9150_results_t *output);
+int mpu9150_read_accel(const mpu9150_t *dev, mpu9150_results_t *output);
 
 /**
  * @brief Read magnetic field values from the given MPU9150 device, returned in mikroT
@@ -258,7 +258,7 @@ int mpu9150_read_accel(mpu9150_t *dev, mpu9150_results_t *output);
  * @return                  0 on success
  * @return                  -1 if device's I2C is not enabled in board config
  */
-int mpu9150_read_compass(mpu9150_t *dev, mpu9150_results_t *output);
+int mpu9150_read_compass(const mpu9150_t *dev, mpu9150_results_t *output);
 
 /**
  * @brief Read temperature value from the given MPU9150 device, returned in m°C
@@ -273,7 +273,7 @@ int mpu9150_read_compass(mpu9150_t *dev, mpu9150_results_t *output);
  * @return                  0 on success
  * @return                  -1 if device's I2C is not enabled in board config
  */
-int mpu9150_read_temperature(mpu9150_t *dev, int32_t *output);
+int mpu9150_read_temperature(const mpu9150_t *dev, int32_t *output);
 
 /**
  * @brief Set the full-scale range for raw gyroscope data

--- a/drivers/include/mq3.h
+++ b/drivers/include/mq3.h
@@ -62,7 +62,7 @@ int mq3_init(mq3_t *dev, adc_t adc_line);
  *
  * @return              the raw sensor value, between 0 and MQ3_MAX_RAW_VALUE
  */
-int mq3_read_raw(mq3_t *dev);
+int mq3_read_raw(const mq3_t *dev);
 
 /**
  * @brief Read the scaled sensor value of PPM of alcohol
@@ -71,7 +71,7 @@ int mq3_read_raw(mq3_t *dev);
  *
  * @return              the scaled sensor value in PPM of alcohol
  */
-int mq3_read(mq3_t *dev);
+int mq3_read(const mq3_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -133,7 +133,7 @@ typedef enum {
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer);
+int nrf24l01p_read_reg(const nrf24l01p_t *dev, char reg, char *answer);
 
 /**
 * @brief Write one register to the nrf24l01+ transceiver.
@@ -145,7 +145,7 @@ int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_write_reg(nrf24l01p_t *dev, char reg, char write);
+int nrf24l01p_write_reg(const nrf24l01p_t *dev, char reg, char write);
 
 /**
 * @brief Initialize the nrf24l01+ transceiver.
@@ -172,7 +172,7 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t csn, gpio_t ir
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_on(nrf24l01p_t *dev);
+int nrf24l01p_on(const nrf24l01p_t *dev);
 
 /**
 * @brief Power off the nrf24l01+ transceiver.
@@ -182,7 +182,7 @@ int nrf24l01p_on(nrf24l01p_t *dev);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_off(nrf24l01p_t *dev);
+int nrf24l01p_off(const nrf24l01p_t *dev);
 
 /**
 * @brief Transmit payload laying in TX FIFO of the nrf24l01+ transceiver.
@@ -190,7 +190,7 @@ int nrf24l01p_off(nrf24l01p_t *dev);
 * @param[in] dev    Transceiver device to use.
 *
 */
-void nrf24l01p_transmit(nrf24l01p_t *dev);
+void nrf24l01p_transmit(const nrf24l01p_t *dev);
 
 /**
 * @brief Read payload from RX FIFO of the nrf24l01+ transceiver.
@@ -202,7 +202,7 @@ void nrf24l01p_transmit(nrf24l01p_t *dev);
 * @return           Number of bytes that were transfered.
 * @return           -1 on error.
 */
-int nrf24l01p_read_payload(nrf24l01p_t *dev, char *answer, unsigned int size);
+int nrf24l01p_read_payload(const nrf24l01p_t *dev, char *answer, unsigned int size);
 
 /**
 * @brief Register a given ID to the nrf24l01+ transceiver.
@@ -222,7 +222,7 @@ void nrf24l01p_register(nrf24l01p_t *dev, unsigned int *pid);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_enable_dynamic_payload(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
+int nrf24l01p_enable_dynamic_payload(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 
 /**
 * @brief Enable dynamic ack for the nrf24l01+ transceiver.
@@ -232,7 +232,7 @@ int nrf24l01p_enable_dynamic_payload(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_enable_dynamic_ack(nrf24l01p_t *dev);
+int nrf24l01p_enable_dynamic_ack(const nrf24l01p_t *dev);
 
 /**
 * @brief Unregister the nrf24l01+ transceiver from his ID.
@@ -252,7 +252,7 @@ int nrf24l01p_unregister(nrf24l01p_t *dev, unsigned int pid);
 * @param[in] pid    Transceiver ID.
 *
 */
-void nrf24l01p_get_id(nrf24l01p_t *dev, unsigned int *pid);
+void nrf24l01p_get_id(const nrf24l01p_t *dev, unsigned int *pid);
 
 /**
 * @brief Start searching packets while in RX mode.
@@ -260,7 +260,7 @@ void nrf24l01p_get_id(nrf24l01p_t *dev, unsigned int *pid);
 * @param[in] dev    Transceiver device to use.
 *
 */
-void nrf24l01p_start(nrf24l01p_t *dev);
+void nrf24l01p_start(const nrf24l01p_t *dev);
 
 /**
 * @brief Stop searching packets while in RX mode.
@@ -268,7 +268,7 @@ void nrf24l01p_start(nrf24l01p_t *dev);
 * @param[in] dev    Transceiver device to use.
 *
 */
-void nrf24l01p_stop(nrf24l01p_t *dev);
+void nrf24l01p_stop(const nrf24l01p_t *dev);
 
 /**
 * @brief Preload TX FIFO with payload to transmit.
@@ -280,7 +280,7 @@ void nrf24l01p_stop(nrf24l01p_t *dev);
 * @return           Number of bytes that were transfered.
 * @return           -1 on error.
 */
-int nrf24l01p_preload(nrf24l01p_t *dev, char *data, unsigned int size);
+int nrf24l01p_preload(const nrf24l01p_t *dev, char *data, unsigned int size);
 
 /**
 * @brief Set the RF channel for the nrf24l01+ transceiver.
@@ -295,7 +295,7 @@ int nrf24l01p_preload(nrf24l01p_t *dev, char *data, unsigned int size);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_channel(nrf24l01p_t *dev, uint8_t chan);
+int nrf24l01p_set_channel(const nrf24l01p_t *dev, uint8_t chan);
 
 /**
 * @brief Set the address width for the nrf24l01+ transceiver.
@@ -306,7 +306,7 @@ int nrf24l01p_set_channel(nrf24l01p_t *dev, uint8_t chan);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_address_width(nrf24l01p_t *dev, nrf24l01p_aw_t aw);
+int nrf24l01p_set_address_width(const nrf24l01p_t *dev, nrf24l01p_aw_t aw);
 
 /**
 * @brief Set the RX payload width for the nrf24l01+ transceiver
@@ -322,7 +322,7 @@ int nrf24l01p_set_address_width(nrf24l01p_t *dev, nrf24l01p_aw_t aw);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char width);
+int nrf24l01p_set_payload_width(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char width);
 
 /**
 * @brief Set the TX address for the nrf24l01+ transceiver (byte array).
@@ -339,7 +339,7 @@ int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_tx_address(nrf24l01p_t *dev, char *saddr, unsigned int length);
+int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, char *saddr, unsigned int length);
 
 /**
 * @brief Set the TX address for the nrf24l01+ transceiver (long int).
@@ -351,7 +351,7 @@ int nrf24l01p_set_tx_address(nrf24l01p_t *dev, char *saddr, unsigned int length)
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_tx_address_long(nrf24l01p_t *dev, uint64_t saddr, unsigned int length);
+int nrf24l01p_set_tx_address_long(const nrf24l01p_t *dev, uint64_t saddr, unsigned int length);
 
 /**
 * @brief Set the RX address for the nrf24l01+ transceiver (byte array).
@@ -369,7 +369,7 @@ int nrf24l01p_set_tx_address_long(nrf24l01p_t *dev, uint64_t saddr, unsigned int
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *saddr, unsigned int length);
+int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *saddr, unsigned int length);
 
 /**
 * @brief Set the RX address for the nrf24l01+ transceiver (long int).
@@ -382,7 +382,7 @@ int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *s
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint64_t saddr, unsigned int length);
+int nrf24l01p_set_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint64_t saddr, unsigned int length);
 
 /**
 * @brief Get the TX address for the nrf24l01+ transceiver (long int).
@@ -392,7 +392,7 @@ int nrf24l01p_set_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, ui
 * @return           TX address of the nrf24l01+ transceiver.
 * @return           -1 on error.
 */
-uint64_t nrf24l01p_get_tx_address_long(nrf24l01p_t *dev);
+uint64_t nrf24l01p_get_tx_address_long(const nrf24l01p_t *dev);
 
 /**
 * @brief Get the RX address for the nrf24l01+ transceiver (long int).
@@ -403,7 +403,7 @@ uint64_t nrf24l01p_get_tx_address_long(nrf24l01p_t *dev);
 * @return           RX address of the nrf24l01+ transceiver.
 * @return           -1 on error.
 */
-uint64_t nrf24l01p_get_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
+uint64_t nrf24l01p_get_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 
 /**
 * @brief Get the TX address for the nrf24l01+ transceiver (long int).
@@ -417,7 +417,7 @@ uint64_t nrf24l01p_get_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pip
 * @return           1 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_datarate(nrf24l01p_t *dev, nrf24l01p_dr_t dr);
+int nrf24l01p_set_datarate(const nrf24l01p_t *dev, nrf24l01p_dr_t dr);
 
 /**
 * @brief Get the status (register) of the nrf24l01+ transceiver device.
@@ -426,7 +426,7 @@ int nrf24l01p_set_datarate(nrf24l01p_t *dev, nrf24l01p_dr_t dr);
 *
 * @return           Value of the status register.
 */
-int nrf24l01p_get_status(nrf24l01p_t *dev);
+int nrf24l01p_get_status(const nrf24l01p_t *dev);
 
 /**
 * @brief Set the transmit power for the nrf24l01+ transceiver device.
@@ -440,7 +440,7 @@ int nrf24l01p_get_status(nrf24l01p_t *dev);
 * @return           1 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_power(nrf24l01p_t *dev, int pwr);
+int nrf24l01p_set_power(const nrf24l01p_t *dev, int pwr);
 
 /**
 * @brief Get the transmit power for the nrf24l01+ transceiver device.
@@ -449,7 +449,7 @@ int nrf24l01p_set_power(nrf24l01p_t *dev, int pwr);
 *
 * @return           TX power value of the nrf24l01+ transceiver.
 */
-int nrf24l01p_get_power(nrf24l01p_t *dev);
+int nrf24l01p_get_power(const nrf24l01p_t *dev);
 
 /**
 * @brief Set the nrf24l01+ into TX mode.
@@ -459,7 +459,7 @@ int nrf24l01p_get_power(nrf24l01p_t *dev);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_txmode(nrf24l01p_t *dev);
+int nrf24l01p_set_txmode(const nrf24l01p_t *dev);
 
 /**
 * @brief Set the nrf24l01+ into RX mode.
@@ -469,7 +469,7 @@ int nrf24l01p_set_txmode(nrf24l01p_t *dev);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_rxmode(nrf24l01p_t *dev);
+int nrf24l01p_set_rxmode(const nrf24l01p_t *dev);
 
 /**
 * @brief Reset all interrupts on the nrf24l01+ transceiver.
@@ -479,7 +479,7 @@ int nrf24l01p_set_rxmode(nrf24l01p_t *dev);
 * @return           1 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_reset_all_interrupts(nrf24l01p_t *dev);
+int nrf24l01p_reset_all_interrupts(const nrf24l01p_t *dev);
 
 /**
 * @brief Reset interrupts on the nrf24l01+ transceiver.
@@ -490,7 +490,7 @@ int nrf24l01p_reset_all_interrupts(nrf24l01p_t *dev);
 * @return           1 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_reset_interrupts(nrf24l01p_t *dev, char intrs);
+int nrf24l01p_reset_interrupts(const nrf24l01p_t *dev, char intrs);
 
 /**
 * @brief Mask one interrupt on the nrf24l01+ transceiver.
@@ -506,7 +506,7 @@ int nrf24l01p_reset_interrupts(nrf24l01p_t *dev, char intrs);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, char intr);
+int nrf24l01p_mask_interrupt(const nrf24l01p_t *dev, char intr);
 
 /**
 * @brief Unmask one interrupt on the nrf24l01+ transceiver.
@@ -522,7 +522,7 @@ int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, char intr);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_unmask_interrupt(nrf24l01p_t *dev, char intr);
+int nrf24l01p_unmask_interrupt(const nrf24l01p_t *dev, char intr);
 
 /**
 * @brief Enable RX datapipe on the nrf24l01+ transceiver.
@@ -533,7 +533,7 @@ int nrf24l01p_unmask_interrupt(nrf24l01p_t *dev, char intr);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_enable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
+int nrf24l01p_enable_pipe(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 
 /**
 * @brief Disable RX datapipe on the nrf24l01+ transceiver.
@@ -544,7 +544,7 @@ int nrf24l01p_enable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_disable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
+int nrf24l01p_disable_pipe(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 
 /**
 * @brief Disable CRC error detection on the nrf24l01+ transceiver.
@@ -553,7 +553,7 @@ int nrf24l01p_disable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 *
 * @return           0.
 */
-int nrf24l01p_disable_crc(nrf24l01p_t *dev);
+int nrf24l01p_disable_crc(const nrf24l01p_t *dev);
 
 /**
 * @brief Enable CRC error detection on the nrf24l01+ transceiver.
@@ -564,7 +564,7 @@ int nrf24l01p_disable_crc(nrf24l01p_t *dev);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_enable_crc(nrf24l01p_t *dev, nrf24l01p_crc_t crc);
+int nrf24l01p_enable_crc(const nrf24l01p_t *dev, nrf24l01p_crc_t crc);
 
 /**
 * @brief Setup and enable automatic ACK and retransmission on the nrf24l01+ transceiver.
@@ -582,7 +582,7 @@ int nrf24l01p_enable_crc(nrf24l01p_t *dev, nrf24l01p_crc_t crc);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_setup_auto_ack(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l01p_retransmit_delay_t delay_retrans, char count_retrans);
+int nrf24l01p_setup_auto_ack(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l01p_retransmit_delay_t delay_retrans, char count_retrans);
 
 /**
 * @brief Disable automatic ACK on the nrf24l01+ transceiver.
@@ -592,7 +592,7 @@ int nrf24l01p_setup_auto_ack(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l0
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_disable_all_auto_ack(nrf24l01p_t *dev);
+int nrf24l01p_disable_all_auto_ack(const nrf24l01p_t *dev);
 
 /**
 * @brief Flush TX FIFO on the nrf24l01+ transceiver.
@@ -602,7 +602,7 @@ int nrf24l01p_disable_all_auto_ack(nrf24l01p_t *dev);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_flush_tx_fifo(nrf24l01p_t *dev);
+int nrf24l01p_flush_tx_fifo(const nrf24l01p_t *dev);
 
 /**
 * @brief Flush RX FIFO on the nrf24l01+ transceiver.
@@ -612,7 +612,7 @@ int nrf24l01p_flush_tx_fifo(nrf24l01p_t *dev);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_flush_rx_fifo(nrf24l01p_t *dev);
+int nrf24l01p_flush_rx_fifo(const nrf24l01p_t *dev);
 
 /**
 * @brief Callback that is called when interrupt occurs on interrupt

--- a/drivers/include/pcd8544.h
+++ b/drivers/include/pcd8544.h
@@ -84,7 +84,7 @@ int pcd8544_init(pcd8544_t *dev, spi_t spi, gpio_t cs,
  * @param[in] dev           display device descriptor
  * @param[in] contrast      targeted contrast value [0 - 127]
  */
-void pcd8544_set_contrast(pcd8544_t *dev, uint8_t contrast);
+void pcd8544_set_contrast(const pcd8544_t *dev, uint8_t contrast);
 
 /**
  * @brief   Set the temperature coefficient for the given display
@@ -94,7 +94,7 @@ void pcd8544_set_contrast(pcd8544_t *dev, uint8_t contrast);
  * @param[in] dev           device descriptor of display to use
  * @param[in] coef          temperature coefficient to use [0 - 3]
  */
-void pcd8544_set_tempcoef(pcd8544_t *dev, uint8_t coef);
+void pcd8544_set_tempcoef(const pcd8544_t *dev, uint8_t coef);
 
 /**
  * @brief   Set the internal BIAS for the given display
@@ -105,7 +105,7 @@ void pcd8544_set_tempcoef(pcd8544_t *dev, uint8_t coef);
  * @param[in] bias          the BIAS to use [0 - 7]
  *
  */
-void pcd8544_set_bias(pcd8544_t *dev, uint8_t bias);
+void pcd8544_set_bias(const pcd8544_t *dev, uint8_t bias);
 
 /**
  * @brief   Write an image to memory of the given display
@@ -120,7 +120,7 @@ void pcd8544_set_bias(pcd8544_t *dev, uint8_t bias);
  * @param[in] dev           device descriptor of display to use
  * @param[in] img           char array with image data (must be of size := 504)
  */
-void pcd8544_write_img(pcd8544_t *dev, const char img[]);
+void pcd8544_write_img(const pcd8544_t *dev, const char img[]);
 
 /**
  * @brief   Write a single ASCII character to the display
@@ -132,7 +132,7 @@ void pcd8544_write_img(pcd8544_t *dev, const char img[]);
  * @param[in] y             row to put the character [0 - 5]
  * @param[in] c             ASCII code for the character to write
  */
-void pcd8544_write_c(pcd8544_t *dev, uint8_t x, uint8_t y, const char c);
+void pcd8544_write_c(const pcd8544_t *dev, uint8_t x, uint8_t y, const char c);
 
 /**
  * @brief   Write a string to a given position on the display
@@ -147,14 +147,14 @@ void pcd8544_write_c(pcd8544_t *dev, uint8_t x, uint8_t y, const char c);
  * @param[in] y             row to write the string to [0 - 5]
  * @param[in] str           string to write to the display
  */
-void pcd8544_write_s(pcd8544_t *dev, uint8_t x, uint8_t y, const char* str);
+void pcd8544_write_s(const pcd8544_t *dev, uint8_t x, uint8_t y, const char* str);
 
 /**
  * @brief   Clear the current display (clear the display memory)
  *
  * @param[in] dev           device descriptor of display to use
  */
-void pcd8544_clear(pcd8544_t *dev);
+void pcd8544_clear(const pcd8544_t *dev);
 
 /**
  * @brief   Invert the display (toggles dark and bright pixels)
@@ -171,28 +171,28 @@ void pcd8544_invert(pcd8544_t *dev);
  * @return      0 -> display is not inverted
  * @return      1 -> display is inverted
  */
-int pcd8544_is_inverted(pcd8544_t *dev);
+int pcd8544_is_inverted(const pcd8544_t *dev);
 
 /**
  * @brief   Power on the display
  *
  * @param[in] dev           device descriptor of display to use
  */
-void pcd8544_poweron(pcd8544_t *dev);
+void pcd8544_poweron(const pcd8544_t *dev);
 
 /**
  * @brief   Poser off the display
  *
  * @param[in] dev           device descriptor of display to use
  */
-void pcd8544_poweroff(pcd8544_t *dev);
+void pcd8544_poweroff(const pcd8544_t *dev);
 
 /**
  * @brief   I wonder what this does -> find out!
  *
  * @param[in] dev           device descriptor of display to use
  */
-void pcd8544_riot(pcd8544_t *dev);
+void pcd8544_riot(const pcd8544_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/pir.h
+++ b/drivers/include/pir.h
@@ -76,7 +76,7 @@ int pir_init(pir_t *dev, gpio_t gpio);
  *
  * @return              1 if motion is detected, 0 otherwise
  */
-pir_event_t pir_get_status(pir_t *dev);
+pir_event_t pir_get_status(const pir_t *dev);
 
 /**
  * @brief   Register a thread for notification whan state changes on the

--- a/drivers/include/pn532.h
+++ b/drivers/include/pn532.h
@@ -160,7 +160,7 @@ typedef enum {
  * @param[in]  dev          target device
  *
  */
-void pn532_reset(pn532_t *dev);
+void pn532_reset(const pn532_t *dev);
 
 /**
  * @brief Initialize the module and peripherals

--- a/drivers/include/rgbled.h
+++ b/drivers/include/rgbled.h
@@ -56,7 +56,7 @@ void rgbled_init(rgbled_t *led, pwm_t pwm, int channel_r, int channel_g, int cha
  * @param[in] led           Struct identifying the LED to set
  * @param[in] color         Color to set the led to
  */
-void rgbled_set(rgbled_t *led, color_rgb_t *color);
+void rgbled_set(const rgbled_t *led, color_rgb_t *color);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/servo.h
+++ b/drivers/include/servo.h
@@ -86,7 +86,7 @@ int servo_init(servo_t *dev, pwm_t pwm, int pwm_channel, unsigned int min, unsig
  * @param[in] dev           the servo to set
  * @param[in] pos           the position to set the servo (in the resolution range)
  */
-void servo_set(servo_t *dev, unsigned int pos);
+void servo_set(const servo_t *dev, unsigned int pos);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/si70xx.h
+++ b/drivers/include/si70xx.h
@@ -94,7 +94,7 @@ typedef struct {
  * @return                  zero on succesful test
  * @return                  non-zero on unsuccesfull test.
  */
-int si70xx_test(si70xx_t *dev);
+int si70xx_test(const si70xx_t *dev);
 
 /**
  * @brief   Initialize and reset the sensor.
@@ -113,7 +113,7 @@ int si70xx_init(si70xx_t *dev, i2c_t i2c_dev, uint8_t address);
  * @param[in] dev           device descriptor
  * @return                  relative humidity in centi-percent (times 100)
  */
-uint16_t si70xx_get_relative_humidity(si70xx_t *dev);
+uint16_t si70xx_get_relative_humidity(const si70xx_t *dev);
 
 /**
  * @brief   Read the current temperature from the sensor. Uses clock streching.
@@ -122,7 +122,7 @@ uint16_t si70xx_get_relative_humidity(si70xx_t *dev);
  * @return                  current temperature in centi-degrees Celsius
  *                          (times 100)
  */
-int16_t si70xx_get_temperature(si70xx_t *dev);
+int16_t si70xx_get_temperature(const si70xx_t *dev);
 
 /**
  * @brief   Read the relative humidity and temperature from the sensor. Uses
@@ -132,7 +132,7 @@ int16_t si70xx_get_temperature(si70xx_t *dev);
  * @param[out] humidity     pointer to relative humidity (in centi-percent)
  * @param[out] temperature  pointer to temperature (in centi-degrees Celsius)
  */
-void si70xx_get_both(si70xx_t *dev, uint16_t *humidity, int16_t *temperature);
+void si70xx_get_both(const si70xx_t *dev, uint16_t *humidity, int16_t *temperature);
 
 /**
  * @brief   Read the sensor serial number.
@@ -140,7 +140,7 @@ void si70xx_get_both(si70xx_t *dev, uint16_t *humidity, int16_t *temperature);
  * @param[in] dev           device descriptor
  * @return                  sensor serial number
  */
-uint64_t si70xx_get_serial(si70xx_t *dev);
+uint64_t si70xx_get_serial(const si70xx_t *dev);
 
 /**
  * @brief   Read the sensor id, to identifier the sensor variant.
@@ -148,7 +148,7 @@ uint64_t si70xx_get_serial(si70xx_t *dev);
  * @param[in] dev           device descriptor
  * @return                  device id
  */
-uint8_t si70xx_get_id(si70xx_t *dev);
+uint8_t si70xx_get_id(const si70xx_t *dev);
 
 /**
  * @brief   Read the firmware revision of the sensor.
@@ -156,7 +156,7 @@ uint8_t si70xx_get_id(si70xx_t *dev);
  * @param[in] dev           device descriptor
  * @return                  sensor firmware revision number
  */
-uint8_t si70xx_get_revision(si70xx_t *dev);
+uint8_t si70xx_get_revision(const si70xx_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/srf02.h
+++ b/drivers/include/srf02.h
@@ -88,7 +88,7 @@ int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr);
  *                          Another set of three fake ranging modes do the same
  *                          but without transmitting the burst
  */
-void srf02_trigger(srf02_t *dev, srf02_mode_t mode);
+void srf02_trigger(const srf02_t *dev, srf02_mode_t mode);
 
 /**
  * @brief    Read the results of the last ranging operation
@@ -98,7 +98,7 @@ void srf02_trigger(srf02_t *dev, srf02_mode_t mode);
  * @return  result of the last ranging operation, meaning depends on the mode
  *          parameter given to the srf02_trigger function
  */
-uint16_t srf02_read(srf02_t *dev);
+uint16_t srf02_read(const srf02_t *dev);
 
 /**
  * @brief   Get the distance measured from the SRF02 ultrasonic sensor
@@ -115,7 +115,7 @@ uint16_t srf02_read(srf02_t *dev);
  * @return  the ranging result in inches, centimeters or microseconds
  *
  */
-uint16_t srf02_get_distance(srf02_t *dev, srf02_mode_t mode);
+uint16_t srf02_get_distance(const srf02_t *dev, srf02_mode_t mode);
 
 /**
  * @brief   Program the given device with a new bus address

--- a/drivers/include/srf08.h
+++ b/drivers/include/srf08.h
@@ -113,7 +113,7 @@ int srf08_init(srf08_t *dev, i2c_t i2c, uint8_t addr, i2c_speed_t speed);
  * @return                  -1 on undefined device given
  *
  */
-int srf08_set_max_range(srf08_t *dev, uint8_t max_range);
+int srf08_set_max_range(const srf08_t *dev, uint8_t max_range);
 
 /**
  * @brief       Set the maximum of the analog stages.
@@ -130,7 +130,7 @@ int srf08_set_max_range(srf08_t *dev, uint8_t max_range);
  * @return                  -1 on undefined device given
  *
  */
-int srf08_set_max_gain(srf08_t *dev, uint8_t max_gain);
+int srf08_set_max_gain(const srf08_t *dev, uint8_t max_gain);
 
 /**
  * @brief       Get all distances measured from the SRF08 ultrasonic sensor.
@@ -154,7 +154,10 @@ int srf08_set_max_gain(srf08_t *dev, uint8_t max_gain);
  * @return                  -4 if i2c read low byte failed
  *
  */
-int srf08_get_distances(srf08_t *dev, uint16_t *range_array, int num_echos, srf08_mode_t ranging_mode);
+int srf08_get_distances(const srf08_t *dev,
+                        uint16_t *range_array,
+                        int num_echos,
+                        srf08_mode_t ranging_mode);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/tcs37727.h
+++ b/drivers/include/tcs37727.h
@@ -112,7 +112,7 @@ int tcs37727_init(tcs37727_t *dev, const tcs37727_params_t *params);
  *
  * @param[out] dev          device descriptor of sensor
  */
-void tcs37727_set_rgbc_active(tcs37727_t *dev);
+void tcs37727_set_rgbc_active(const tcs37727_t *dev);
 
 /**
  * @brief Set RGBC disable, this deactivates periodic RGBC measurements
@@ -121,7 +121,7 @@ void tcs37727_set_rgbc_active(tcs37727_t *dev);
  *
  * @param[in]  dev          device descriptor of sensor
  */
-void tcs37727_set_rgbc_standby(tcs37727_t *dev);
+void tcs37727_set_rgbc_standby(const tcs37727_t *dev);
 
 /**
  * @brief Read sensor's data
@@ -133,7 +133,7 @@ void tcs37727_set_rgbc_standby(tcs37727_t *dev);
  * @param[in]  dev         device descriptor of sensor
  * @param[out] data        device sensor data, MUST not be NULL
  */
-void tcs37727_read(tcs37727_t *dev, tcs37727_data_t *data);
+void tcs37727_read(const tcs37727_t *dev, tcs37727_data_t *data);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/tmp006.h
+++ b/drivers/include/tmp006.h
@@ -177,7 +177,7 @@ int tmp006_init(tmp006_t *dev, const tmp006_params_t *params);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int tmp006_reset(tmp006_t *dev);
+int tmp006_reset(const tmp006_t *dev);
 
 /**
  * @brief   Set active mode, this enables periodic measurements.
@@ -187,7 +187,7 @@ int tmp006_reset(tmp006_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int tmp006_set_active(tmp006_t *dev);
+int tmp006_set_active(const tmp006_t *dev);
 
 /**
  * @brief   Set standby mode.
@@ -197,7 +197,7 @@ int tmp006_set_active(tmp006_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int tmp006_set_standby(tmp006_t *dev);
+int tmp006_set_standby(const tmp006_t *dev);
 
 /**
  * @brief   Read sensor's data.
@@ -210,7 +210,7 @@ int tmp006_set_standby(tmp006_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int tmp006_read(tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy);
+int tmp006_read(const tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy);
 
 /**
  * @brief   Convert raw sensor values to temperature.
@@ -231,7 +231,7 @@ void tmp006_convert(int16_t rawv, int16_t rawt,  float *tamb, float *tobj);
  * @param[out] ta           converted ambient temperature
  * @param[out] to           converted object temperature
  */
-int tmp006_read_temperature(tmp006_t *dev, int16_t *ta, int16_t *to);
+int tmp006_read_temperature(const tmp006_t *dev, int16_t *ta, int16_t *to);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/tsl2561.h
+++ b/drivers/include/tsl2561.h
@@ -103,7 +103,7 @@ int tsl2561_init(tsl2561_t *dev, i2c_t i2c, uint8_t addr,
  *
  * @return                  Illuminance in Lux (lx)
  */
-uint16_t tsl2561_read_illuminance(tsl2561_t *dev);
+uint16_t tsl2561_read_illuminance(const tsl2561_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/veml6070.h
+++ b/drivers/include/veml6070.h
@@ -79,7 +79,7 @@ int veml6070_init(veml6070_t *dev, const veml6070_params_t * params);
  *
  * @return                  UV index
  */
-uint16_t veml6070_read_uv(veml6070_t *dev);
+uint16_t veml6070_read_uv(const veml6070_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/io1_xplained/io1_xplained.c
+++ b/drivers/io1_xplained/io1_xplained.c
@@ -64,7 +64,7 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params)
     return IO1_XPLAINED_OK;
 }
 
-int io1_xplained_read_temperature(io1_xplained_t *dev, float *temperature)
+int io1_xplained_read_temperature(const io1_xplained_t *dev, float *temperature)
 {
     if (at30tse75x_get_temperature(&dev->temp, temperature) < 0) {
         LOG_ERROR("Cannot read temperature sensor.\n");

--- a/drivers/isl29020/isl29020.c
+++ b/drivers/isl29020/isl29020.c
@@ -53,7 +53,7 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
     return 0;
 }
 
-int isl29020_read(isl29020_t *dev)
+int isl29020_read(const isl29020_t *dev)
 {
     uint8_t low, high;
     uint16_t res;
@@ -73,7 +73,7 @@ int isl29020_read(isl29020_t *dev)
     return (int)(dev->lux_fac * res);
 }
 
-int isl29020_enable(isl29020_t *dev)
+int isl29020_enable(const isl29020_t *dev)
 {
     int res;
     uint8_t tmp;
@@ -94,7 +94,7 @@ int isl29020_enable(isl29020_t *dev)
     return 0;
 }
 
-int isl29020_disable(isl29020_t *dev)
+int isl29020_disable(const isl29020_t *dev)
 {
     int res;
     uint8_t tmp;

--- a/drivers/isl29125/isl29125.c
+++ b/drivers/isl29125/isl29125.c
@@ -148,7 +148,7 @@ int isl29125_init_int(isl29125_t *dev, isl29125_interrupt_status_t interrupt_sta
     return 0;
 }
 
-void isl29125_read_rgb_lux(isl29125_t *dev, isl29125_rgb_t *dest)
+void isl29125_read_rgb_lux(const isl29125_t *dev, isl29125_rgb_t *dest)
 {
     /* acquire exclusive access to the bus */
     (void) i2c_acquire(dev->i2c);
@@ -176,7 +176,7 @@ void isl29125_read_rgb_lux(isl29125_t *dev, isl29125_rgb_t *dest)
     dest->blue = blue * luxfactor;
 }
 
-void isl29125_read_rgb_color(isl29125_t *dev, color_rgb_t *dest)
+void isl29125_read_rgb_color(const isl29125_t *dev, color_rgb_t *dest)
 {
     /* acquire exclusive access to the bus */
     (void) i2c_acquire(dev->i2c);
@@ -196,7 +196,7 @@ void isl29125_read_rgb_color(isl29125_t *dev, color_rgb_t *dest)
     dest->b = (bytes[4] | (bytes[5] << 8)) >> normfactor;
 }
 
-void isl29125_set_mode(isl29125_t *dev, isl29125_mode_t mode)
+void isl29125_set_mode(const isl29125_t *dev, isl29125_mode_t mode)
 {
     uint8_t conf1;
 
@@ -210,7 +210,7 @@ void isl29125_set_mode(isl29125_t *dev, isl29125_mode_t mode)
     (void) i2c_release(dev->i2c);
 }
 
-int isl29125_read_irq_status(isl29125_t *dev)
+int isl29125_read_irq_status(const isl29125_t *dev)
 {
     /* acquire exclusive access to the bus */
     (void) i2c_acquire(dev->i2c);

--- a/drivers/jc42/jc42.c
+++ b/drivers/jc42/jc42.c
@@ -28,7 +28,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static int jc42_get_register(jc42_t* dev, uint8_t reg, uint16_t* data)
+static int jc42_get_register(const jc42_t* dev, uint8_t reg, uint16_t* data)
 {
     i2c_acquire(dev->i2c);
     if (i2c_read_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
@@ -40,7 +40,7 @@ static int jc42_get_register(jc42_t* dev, uint8_t reg, uint16_t* data)
     return JC42_OK;
 }
 
-static int jc42_set_register(jc42_t* dev, uint8_t reg, uint16_t* data)
+static int jc42_set_register(const jc42_t* dev, uint8_t reg, uint16_t* data)
 {
     i2c_acquire(dev->i2c);
     if (i2c_write_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
@@ -53,17 +53,17 @@ static int jc42_set_register(jc42_t* dev, uint8_t reg, uint16_t* data)
     return JC42_OK;
 }
 
-int jc42_get_config(jc42_t* dev, uint16_t* data)
+int jc42_get_config(const jc42_t* dev, uint16_t* data)
 {
     return jc42_get_register(dev, JC42_REG_CONFIG, data);
 }
 
-int jc42_set_config(jc42_t* dev, uint16_t data)
+int jc42_set_config(const jc42_t* dev, uint16_t data)
 {
     return jc42_set_register(dev, JC42_REG_CONFIG, &data);
 }
 
-int jc42_get_temperature(jc42_t* dev, int16_t* temperature)
+int jc42_get_temperature(const jc42_t* dev, int16_t* temperature)
 {
     struct { signed int x:12;} s;
     uint16_t tmp;

--- a/drivers/l3g4200d/l3g4200d.c
+++ b/drivers/l3g4200d/l3g4200d.c
@@ -84,7 +84,7 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
     return 0;
 }
 
-int l3g4200d_read(l3g4200d_t *dev, l3g4200d_data_t *data)
+int l3g4200d_read(const l3g4200d_t *dev, l3g4200d_data_t *data)
 {
     uint8_t tmp[6];
     int16_t res;
@@ -104,7 +104,7 @@ int l3g4200d_read(l3g4200d_t *dev, l3g4200d_data_t *data)
     return 0;
 }
 
-int l3g4200d_enable(l3g4200d_t *dev)
+int l3g4200d_enable(const l3g4200d_t *dev)
 {
     uint8_t tmp;
     int res;
@@ -124,7 +124,7 @@ int l3g4200d_enable(l3g4200d_t *dev)
     return 0;
 }
 
-int l3g4200d_disable(l3g4200d_t *dev)
+int l3g4200d_disable(const l3g4200d_t *dev)
 {
     uint8_t tmp;
     int res;

--- a/drivers/lis3dh/lis3dh.c
+++ b/drivers/lis3dh/lis3dh.c
@@ -125,7 +125,7 @@ int lis3dh_read_aux_adc3(const lis3dh_t *dev, int16_t *out)
                             LIS3DH_ADC_DATA_SIZE, (uint8_t *)out);
 }
 
-int lis3dh_set_aux_adc(lis3dh_t *dev, const uint8_t enable,
+int lis3dh_set_aux_adc(const lis3dh_t *dev, const uint8_t enable,
                        const uint8_t temperature)
 {
     return lis3dh_write_bits(dev, LIS3DH_REG_TEMP_CFG_REG,
@@ -134,13 +134,13 @@ int lis3dh_set_aux_adc(lis3dh_t *dev, const uint8_t enable,
                              (temperature ? LIS3DH_TEMP_CFG_REG_TEMP_EN_MASK : 0));
 }
 
-int lis3dh_set_axes(lis3dh_t *dev, const uint8_t axes)
+int lis3dh_set_axes(const lis3dh_t *dev, const uint8_t axes)
 {
     return lis3dh_write_bits(dev, LIS3DH_REG_CTRL_REG1,
                              LIS3DH_CTRL_REG1_XYZEN_MASK, axes);
 }
 
-int lis3dh_set_fifo(lis3dh_t *dev, const uint8_t mode, const uint8_t watermark)
+int lis3dh_set_fifo(const lis3dh_t *dev, const uint8_t mode, const uint8_t watermark)
 {
     int status;
     uint8_t reg;
@@ -162,7 +162,7 @@ int lis3dh_set_fifo(lis3dh_t *dev, const uint8_t mode, const uint8_t watermark)
     return status;
 }
 
-int lis3dh_set_odr(lis3dh_t *dev, const uint8_t odr)
+int lis3dh_set_odr(const lis3dh_t *dev, const uint8_t odr)
 {
     return lis3dh_write_bits(dev, LIS3DH_REG_CTRL_REG1,
         LIS3DH_CTRL_REG1_ODR_MASK, odr);
@@ -198,12 +198,12 @@ int lis3dh_set_scale(lis3dh_t *dev, const uint8_t scale)
                              LIS3DH_CTRL_REG4_FS_MASK, scale_reg);
 }
 
-int lis3dh_set_int1(lis3dh_t *dev, const uint8_t mode)
+int lis3dh_set_int1(const lis3dh_t *dev, const uint8_t mode)
 {
     return lis3dh_write_reg(dev, LIS3DH_REG_CTRL_REG3, mode);
 }
 
-int lis3dh_get_fifo_level(lis3dh_t *dev)
+int lis3dh_get_fifo_level(const lis3dh_t *dev)
 {
     uint8_t reg;
     int level;

--- a/drivers/lis3mdl/lis3mdl.c
+++ b/drivers/lis3mdl/lis3mdl.c
@@ -96,7 +96,7 @@ int lis3mdl_init(lis3mdl_t *dev,
     return 0;
 }
 
-void lis3mdl_read_mag(lis3mdl_t *dev, lis3mdl_3d_data_t *data)
+void lis3mdl_read_mag(const lis3mdl_t *dev, lis3mdl_3d_data_t *data)
 {
     uint8_t tmp[2] = {0, 0};
 
@@ -123,7 +123,7 @@ void lis3mdl_read_mag(lis3mdl_t *dev, lis3mdl_3d_data_t *data)
     i2c_release(dev->i2c);
 }
 
-void lis3mdl_read_temp(lis3mdl_t *dev, int16_t *value)
+void lis3mdl_read_temp(const lis3mdl_t *dev, int16_t *value)
 {
     i2c_acquire(dev->i2c);
     i2c_read_regs(dev->i2c, dev->addr, LIS3MDL_TEMP_OUT_L_REG, (uint8_t*)value, 2);
@@ -134,7 +134,7 @@ void lis3mdl_read_temp(lis3mdl_t *dev, int16_t *value)
     *value = (TEMP_OFFSET + (*value / TEMP_DIVIDER));
 }
 
-void lis3mdl_enable(lis3mdl_t *dev)
+void lis3mdl_enable(const lis3mdl_t *dev)
 {
     i2c_acquire(dev->i2c);
     /* Z-axis medium-power mode */
@@ -143,7 +143,7 @@ void lis3mdl_enable(lis3mdl_t *dev)
     i2c_release(dev->i2c);
 }
 
-void lis3mdl_disable(lis3mdl_t *dev)
+void lis3mdl_disable(const lis3mdl_t *dev)
 {
     uint8_t tmp = ( LIS3MDL_MASK_REG3_LOW_POWER_EN   /**< enable power-down mode */
                   | LIS3MDL_MASK_REG3_Z_LOW_POWER);  /**< Z-axis low-power mode */

--- a/drivers/lpd8808/lpd8808.c
+++ b/drivers/lpd8808/lpd8808.c
@@ -28,7 +28,7 @@
  * @param[in] dev   device to use
  * @param[in] d     byte to shift out
  */
-static void put_byte(lpd8808_t *dev, uint8_t d)
+static void put_byte(const lpd8808_t *dev, uint8_t d)
 {
     for (int i = 0; i < 8; i++) {
         gpio_write(dev->pin_dat, d & 0x80);
@@ -47,7 +47,7 @@ static void put_byte(lpd8808_t *dev, uint8_t d)
  *
  * @param[in] dev   device to flush
  */
-static void flush(lpd8808_t *dev)
+static void flush(const lpd8808_t *dev)
 {
     for (int i = 0; i < ((dev->led_cnt + 31) / 32); i++) {
         put_byte(dev, 0);
@@ -66,7 +66,7 @@ int lpd8808_init(lpd8808_t *dev, const lpd8808_params_t *params)
     return 0;
 }
 
-void lpd8808_load_rgb(lpd8808_t *dev, color_rgb_t vals[])
+void lpd8808_load_rgb(const lpd8808_t *dev, color_rgb_t vals[])
 {
     for (int i = 0; i < dev->led_cnt; i++) {
         put_byte(dev, ((vals[i].g >> 1) | 0x80));

--- a/drivers/lps331ap/lps331ap.c
+++ b/drivers/lps331ap/lps331ap.c
@@ -75,7 +75,7 @@ int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t r
     return 0;
 }
 
-int lps331ap_read_temp(lps331ap_t *dev)
+int lps331ap_read_temp(const lps331ap_t *dev)
 {
     uint8_t tmp;
     int16_t val = 0;
@@ -95,7 +95,7 @@ int lps331ap_read_temp(lps331ap_t *dev)
     return (int)(res * 1000);
 }
 
-int lps331ap_read_pres(lps331ap_t *dev)
+int lps331ap_read_pres(const lps331ap_t *dev)
 {
     uint8_t tmp;
     int32_t val = 0;
@@ -121,7 +121,7 @@ int lps331ap_read_pres(lps331ap_t *dev)
 }
 
 
-int lps331ap_enable(lps331ap_t *dev)
+int lps331ap_enable(const lps331ap_t *dev)
 {
     uint8_t tmp;
     int status;
@@ -138,7 +138,7 @@ int lps331ap_enable(lps331ap_t *dev)
     return status;
 }
 
-int lps331ap_disable(lps331ap_t *dev)
+int lps331ap_disable(const lps331ap_t *dev)
 {
     uint8_t tmp;
     int status;

--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -92,7 +92,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
     return (res < 7) ? -1 : 0;
 }
 
-int lsm303dlhc_read_acc(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
+int lsm303dlhc_read_acc(const lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
 {
     int res;
     uint8_t tmp;
@@ -136,7 +136,7 @@ int lsm303dlhc_read_acc(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
     return 0;
 }
 
-int lsm303dlhc_read_mag(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
+int lsm303dlhc_read_mag(const lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
 {
     int res;
 
@@ -169,7 +169,7 @@ int lsm303dlhc_read_mag(lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data)
     return 0;
 }
 
-int lsm303dlhc_read_temp(lsm303dlhc_t *dev, int16_t *value)
+int lsm303dlhc_read_temp(const lsm303dlhc_t *dev, int16_t *value)
 {
     int res;
 
@@ -188,7 +188,7 @@ int lsm303dlhc_read_temp(lsm303dlhc_t *dev, int16_t *value)
     return 0;
 }
 
-int lsm303dlhc_disable(lsm303dlhc_t *dev)
+int lsm303dlhc_disable(const lsm303dlhc_t *dev)
 {
     int res;
 
@@ -204,7 +204,7 @@ int lsm303dlhc_disable(lsm303dlhc_t *dev)
     return (res < 3) ? -1 : 0;
 }
 
-int lsm303dlhc_enable(lsm303dlhc_t *dev)
+int lsm303dlhc_enable(const lsm303dlhc_t *dev)
 {
     int res;
     uint8_t tmp = (LSM303DLHC_CTRL1_A_XEN

--- a/drivers/lsm6dsl/lsm6dsl.c
+++ b/drivers/lsm6dsl/lsm6dsl.c
@@ -76,7 +76,7 @@ int lsm6dsl_init(lsm6dsl_t *dev, const lsm6dsl_params_t *params)
     return 0;
 }
 
-int lsm6dsl_read_acc(lsm6dsl_t *dev, lsm6dsl_3d_data_t *data)
+int lsm6dsl_read_acc(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data)
 {
     int res;
     uint8_t tmp;
@@ -136,7 +136,7 @@ int lsm6dsl_read_acc(lsm6dsl_t *dev, lsm6dsl_3d_data_t *data)
     return 0;
 }
 
-int lsm6dsl_read_gyro(lsm6dsl_t *dev, lsm6dsl_3d_data_t *data)
+int lsm6dsl_read_gyro(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data)
 {
     int res;
     uint8_t tmp;
@@ -196,7 +196,7 @@ int lsm6dsl_read_gyro(lsm6dsl_t *dev, lsm6dsl_3d_data_t *data)
     return 0;
 }
 
-int lsm6dsl_read_temp(lsm6dsl_t *dev, int16_t *data)
+int lsm6dsl_read_temp(const lsm6dsl_t *dev, int16_t *data)
 {
     int res;
     uint8_t tmp;

--- a/drivers/mag3110/mag3110.c
+++ b/drivers/mag3110/mag3110.c
@@ -96,7 +96,7 @@ int mag3110_init(mag3110_t *dev, const mag3110_params_t *params)
                                    dev->params.offset[1], dev->params.offset[2]);
 }
 
-int mag3110_set_user_offset(mag3110_t *dev, int16_t x, int16_t y, int16_t z)
+int mag3110_set_user_offset(const mag3110_t *dev, int16_t x, int16_t y, int16_t z)
 {
     uint8_t buf[6];
 
@@ -123,7 +123,7 @@ int mag3110_set_user_offset(mag3110_t *dev, int16_t x, int16_t y, int16_t z)
     return MAG3110_OK;
 }
 
-int mag3110_set_active(mag3110_t *dev)
+int mag3110_set_active(const mag3110_t *dev)
 {
     uint8_t reg;
 
@@ -146,7 +146,7 @@ int mag3110_set_active(mag3110_t *dev)
     return MAG3110_OK;
 }
 
-int mag3110_set_standby(mag3110_t *dev)
+int mag3110_set_standby(const mag3110_t *dev)
 {
     uint8_t reg;
 
@@ -169,7 +169,7 @@ int mag3110_set_standby(mag3110_t *dev)
     return MAG3110_OK;
 }
 
-int mag3110_is_ready(mag3110_t *dev)
+int mag3110_is_ready(const mag3110_t *dev)
 {
     uint8_t reg;
 
@@ -185,7 +185,7 @@ int mag3110_is_ready(mag3110_t *dev)
     return (int)(reg & MAG3110_DR_STATUS_ZYXDR);
 }
 
-int mag3110_read(mag3110_t *dev, mag3110_data_t *data)
+int mag3110_read(const mag3110_t *dev, mag3110_data_t *data)
 {
     uint8_t buf[7];
 
@@ -207,7 +207,7 @@ int mag3110_read(mag3110_t *dev, mag3110_data_t *data)
     return MAG3110_OK;
 }
 
-int mag3110_read_dtemp(mag3110_t *dev, int8_t *dtemp)
+int mag3110_read_dtemp(const mag3110_t *dev, int8_t *dtemp)
 {
     assert(dev);
 

--- a/drivers/mma8x5x/mma8x5x.c
+++ b/drivers/mma8x5x/mma8x5x.c
@@ -87,7 +87,7 @@ int mma8x5x_init(mma8x5x_t *dev, const mma8x5x_params_t *params)
     return MMA8X5X_OK;
 }
 
-void mma8x5x_set_user_offset(mma8x5x_t *dev, int8_t x, int8_t y, int8_t z)
+void mma8x5x_set_user_offset(const mma8x5x_t *dev, int8_t x, int8_t y, int8_t z)
 {
     uint8_t buf[3];
 
@@ -105,7 +105,7 @@ void mma8x5x_set_user_offset(mma8x5x_t *dev, int8_t x, int8_t y, int8_t z)
     i2c_release(BUS);
 }
 
-static int _get_reg(mma8x5x_t *dev, uint8_t addr)
+static int _get_reg(const mma8x5x_t *dev, uint8_t addr)
 {
     uint8_t reg;
 
@@ -121,7 +121,7 @@ static int _get_reg(mma8x5x_t *dev, uint8_t addr)
     return reg;
 }
 
-static void _reg_setbits(mma8x5x_t *dev, uint8_t reg, uint8_t val)
+static void _reg_setbits(const mma8x5x_t *dev, uint8_t reg, uint8_t val)
 {
     uint8_t tmp;
 
@@ -136,7 +136,7 @@ static void _reg_setbits(mma8x5x_t *dev, uint8_t reg, uint8_t val)
     i2c_release(BUS);
 }
 
-static void _reg_clearbits(mma8x5x_t *dev, uint8_t reg, uint8_t val)
+static void _reg_clearbits(const mma8x5x_t *dev, uint8_t reg, uint8_t val)
 {
     uint8_t tmp;
 
@@ -151,19 +151,19 @@ static void _reg_clearbits(mma8x5x_t *dev, uint8_t reg, uint8_t val)
     i2c_release(BUS);
 }
 
-void mma8x5x_set_active(mma8x5x_t *dev)
+void mma8x5x_set_active(const mma8x5x_t *dev)
 {
     DEBUG("[mma8x5x] put device to active mode\n");
     _reg_setbits(dev, MMA8X5X_CTRL_REG1, MMA8X5X_CTRL_REG1_ACTIVE);
 }
 
-void mma8x5x_set_standby(mma8x5x_t *dev)
+void mma8x5x_set_standby(const mma8x5x_t *dev)
 {
     DEBUG("[mma8x5x] put device to standby mode\n");
     _reg_clearbits(dev, MMA8X5X_CTRL_REG1, MMA8X5X_CTRL_REG1_ACTIVE);
 }
 
-void mma8x5x_set_motiondetect(mma8x5x_t *dev, uint8_t int_pin, uint8_t threshold)
+void mma8x5x_set_motiondetect(const mma8x5x_t *dev, uint8_t int_pin, uint8_t threshold)
 {
     DEBUG("[mma8x5x] put device to motion detect mode (ELE=1, OAE=1)\n");
     assert(int_pin < 3);
@@ -195,12 +195,12 @@ out:
     mma8x5x_set_active(dev);
 }
 
-void mma8x5x_ack_int(mma8x5x_t *dev)
+void mma8x5x_ack_int(const mma8x5x_t *dev)
 {
     _get_reg(dev, MMA8X5X_FF_MT_SRC);
 }
 
-int mma8x5x_is_ready(mma8x5x_t *dev)
+int mma8x5x_is_ready(const mma8x5x_t *dev)
 {
     DEBUG("[mma8x5x] checking for new available data\n");
 
@@ -214,7 +214,7 @@ int mma8x5x_is_ready(mma8x5x_t *dev)
     }
 }
 
-void mma8x5x_read(mma8x5x_t *dev, mma8x5x_data_t *data)
+void mma8x5x_read(const mma8x5x_t *dev, mma8x5x_data_t *data)
 {
     uint8_t buf[7];
 

--- a/drivers/mpl3115a2/mpl3115a2.c
+++ b/drivers/mpl3115a2/mpl3115a2.c
@@ -31,7 +31,7 @@
 
 #define I2C_SPEED                  I2C_SPEED_FAST
 
-int mpl3115a2_test(mpl3115a2_t *dev)
+int mpl3115a2_test(const mpl3115a2_t *dev)
 {
     uint8_t reg;
 
@@ -118,7 +118,7 @@ int mpl3115a2_reset(mpl3115a2_t *dev)
     return 0;
 }
 
-int mpl3115a2_set_active(mpl3115a2_t *dev)
+int mpl3115a2_set_active(const mpl3115a2_t *dev)
 {
     uint8_t reg;
 
@@ -143,7 +143,7 @@ int mpl3115a2_set_active(mpl3115a2_t *dev)
     return 0;
 }
 
-int mpl3115a2_set_standby(mpl3115a2_t *dev)
+int mpl3115a2_set_standby(const mpl3115a2_t *dev)
 {
     uint8_t reg;
 
@@ -164,7 +164,7 @@ int mpl3115a2_set_standby(mpl3115a2_t *dev)
     return 0;
 }
 
-int mpl3115a2_is_ready(mpl3115a2_t *dev)
+int mpl3115a2_is_ready(const mpl3115a2_t *dev)
 {
     uint8_t reg;
 
@@ -182,7 +182,7 @@ int mpl3115a2_is_ready(mpl3115a2_t *dev)
     return reg & MPL3115A2_STATUS_PTDR;
 }
 
-int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status)
+int mpl3115a2_read_pressure(const mpl3115a2_t *dev, uint32_t *pres, uint8_t *status)
 {
     uint8_t buf[4];
 
@@ -205,7 +205,7 @@ int mpl3115a2_read_pressure(mpl3115a2_t *dev, uint32_t *pres, uint8_t *status)
     return 0;
 }
 
-int mpl3115a2_read_temp(mpl3115a2_t *dev, int16_t *temp)
+int mpl3115a2_read_temp(const mpl3115a2_t *dev, int16_t *temp)
 {
     uint8_t buf[2];
 

--- a/drivers/mpu9150/mpu9150.c
+++ b/drivers/mpu9150/mpu9150.c
@@ -45,8 +45,8 @@ static const mpu9150_status_t DEFAULT_STATUS = {
 
 /* Internal function prototypes */
 static int compass_init(mpu9150_t *dev);
-static void conf_bypass(mpu9150_t *dev, uint8_t bypass_enable);
-static void conf_lpf(mpu9150_t *dev, uint16_t rate);
+static void conf_bypass(const mpu9150_t *dev, uint8_t bypass_enable);
+static void conf_lpf(const mpu9150_t *dev, uint16_t rate);
 
 /*---------------------------------------------------------------------------*
  *                          MPU9150 Core API                                 *
@@ -242,7 +242,7 @@ int mpu9150_set_compass_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf)
     return 0;
 }
 
-int mpu9150_read_gyro(mpu9150_t *dev, mpu9150_results_t *output)
+int mpu9150_read_gyro(const mpu9150_t *dev, mpu9150_results_t *output)
 {
     uint8_t data[6];
     int16_t temp;
@@ -285,7 +285,7 @@ int mpu9150_read_gyro(mpu9150_t *dev, mpu9150_results_t *output)
     return 0;
 }
 
-int mpu9150_read_accel(mpu9150_t *dev, mpu9150_results_t *output)
+int mpu9150_read_accel(const mpu9150_t *dev, mpu9150_results_t *output)
 {
     uint8_t data[6];
     int16_t temp;
@@ -328,7 +328,7 @@ int mpu9150_read_accel(mpu9150_t *dev, mpu9150_results_t *output)
     return 0;
 }
 
-int mpu9150_read_compass(mpu9150_t *dev, mpu9150_results_t *output)
+int mpu9150_read_compass(const mpu9150_t *dev, mpu9150_results_t *output)
 {
     uint8_t data[6];
 
@@ -361,7 +361,7 @@ int mpu9150_read_compass(mpu9150_t *dev, mpu9150_results_t *output)
     return 0;
 }
 
-int mpu9150_read_temperature(mpu9150_t *dev, int32_t *output)
+int mpu9150_read_temperature(const mpu9150_t *dev, int32_t *output)
 {
     uint8_t data[2];
     int16_t temp;
@@ -567,7 +567,7 @@ static int compass_init(mpu9150_t *dev)
  * Caution: This internal function does not acquire exclusive access to the I2C bus.
  *          Acquisation and release is supposed to be handled by the calling function.
  */
-static void conf_bypass(mpu9150_t *dev, uint8_t bypass_enable)
+static void conf_bypass(const mpu9150_t *dev, uint8_t bypass_enable)
 {
    uint8_t data;
    i2c_read_reg(dev->i2c_dev, dev->hw_addr, MPU9150_USER_CTRL_REG, &data);
@@ -591,7 +591,7 @@ static void conf_bypass(mpu9150_t *dev, uint8_t bypass_enable)
  * Caution: This internal function does not acquire exclusive access to the I2C bus.
  *          Acquisation and release is supposed to be handled by the calling function.
  */
-static void conf_lpf(mpu9150_t *dev, uint16_t half_rate)
+static void conf_lpf(const mpu9150_t *dev, uint16_t half_rate)
 {
     mpu9150_lpf_t lpf_setting;
 

--- a/drivers/mq3/mq3.c
+++ b/drivers/mq3/mq3.c
@@ -30,12 +30,12 @@ int mq3_init(mq3_t *dev, adc_t adc_line)
     return adc_init(dev->adc_line);
 }
 
-int mq3_read_raw(mq3_t *dev)
+int mq3_read_raw(const mq3_t *dev)
 {
     return adc_sample(dev->adc_line, PRECISION);
 }
 
-int mq3_read(mq3_t *dev)
+int mq3_read(const mq3_t *dev)
 {
     float res = mq3_read_raw(dev);
     res = (res > MIN) ? res - MIN : 0;

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -34,7 +34,7 @@
 #define SPI_MODE            SPI_MODE_0
 #define SPI_CLK             SPI_CLK_400KHZ
 
-int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer)
+int nrf24l01p_read_reg(const nrf24l01p_t *dev, char reg, char *answer)
 {
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
@@ -48,7 +48,7 @@ int nrf24l01p_read_reg(nrf24l01p_t *dev, char reg, char *answer)
     return 0;
 }
 
-int nrf24l01p_write_reg(nrf24l01p_t *dev, char reg, char write)
+int nrf24l01p_write_reg(const nrf24l01p_t *dev, char reg, char write)
 {
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
@@ -186,7 +186,7 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq
     return nrf24l01p_on(dev);
 }
 
-int nrf24l01p_on(nrf24l01p_t *dev)
+int nrf24l01p_on(const nrf24l01p_t *dev)
 {
     char read;
     int status;
@@ -199,7 +199,7 @@ int nrf24l01p_on(nrf24l01p_t *dev)
     return status;
 }
 
-int nrf24l01p_off(nrf24l01p_t *dev)
+int nrf24l01p_off(const nrf24l01p_t *dev)
 {
     char read;
     int status;
@@ -212,7 +212,7 @@ int nrf24l01p_off(nrf24l01p_t *dev)
     return status;
 }
 
-void nrf24l01p_transmit(nrf24l01p_t *dev)
+void nrf24l01p_transmit(const nrf24l01p_t *dev)
 {
     gpio_set(dev->ce);
     xtimer_usleep(DELAY_CE_HIGH_US); /* at least 10 us high */
@@ -221,7 +221,7 @@ void nrf24l01p_transmit(nrf24l01p_t *dev)
     xtimer_spin(DELAY_CHANGE_TXRX_TICKS);
 }
 
-int nrf24l01p_read_payload(nrf24l01p_t *dev, char *answer, unsigned int size)
+int nrf24l01p_read_payload(const nrf24l01p_t *dev, char *answer, unsigned int size)
 {
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
@@ -249,24 +249,24 @@ int nrf24l01p_unregister(nrf24l01p_t *dev, unsigned int pid)
     }
 }
 
-void nrf24l01p_get_id(nrf24l01p_t *dev, unsigned int *pid)
+void nrf24l01p_get_id(const nrf24l01p_t *dev, unsigned int *pid)
 {
     *((int *)pid) = dev->listener;
 }
 
-void nrf24l01p_start(nrf24l01p_t *dev)
+void nrf24l01p_start(const nrf24l01p_t *dev)
 {
     gpio_set(dev->ce);
     xtimer_usleep(DELAY_CE_START_US);
 }
 
-void nrf24l01p_stop(nrf24l01p_t *dev)
+void nrf24l01p_stop(const nrf24l01p_t *dev)
 {
     xtimer_spin(DELAY_CS_TOGGLE_TICKS);
     gpio_clear(dev->ce);
 }
 
-int nrf24l01p_preload(nrf24l01p_t *dev, char *data, unsigned int size)
+int nrf24l01p_preload(const nrf24l01p_t *dev, char *data, unsigned int size)
 {
     size = (size <= 32) ? size : 32;
 
@@ -281,7 +281,7 @@ int nrf24l01p_preload(nrf24l01p_t *dev, char *data, unsigned int size)
 }
 
 
-int nrf24l01p_set_channel(nrf24l01p_t *dev, uint8_t chan)
+int nrf24l01p_set_channel(const nrf24l01p_t *dev, uint8_t chan)
 {
     if (chan > 125) {
         chan = 125;
@@ -290,7 +290,7 @@ int nrf24l01p_set_channel(nrf24l01p_t *dev, uint8_t chan)
     return nrf24l01p_write_reg(dev, REG_RF_CH, chan);
 }
 
-int nrf24l01p_set_address_width(nrf24l01p_t *dev, nrf24l01p_aw_t aw)
+int nrf24l01p_set_address_width(const nrf24l01p_t *dev, nrf24l01p_aw_t aw)
 {
     char aw_setup;
     nrf24l01p_read_reg(dev, REG_SETUP_AW, &aw_setup);
@@ -320,7 +320,7 @@ int nrf24l01p_set_address_width(nrf24l01p_t *dev, nrf24l01p_aw_t aw)
     return nrf24l01p_write_reg(dev, REG_SETUP_AW, aw_setup);
 }
 
-int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char width)
+int nrf24l01p_set_payload_width(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char width)
 {
     char pipe_pw_address;
 
@@ -366,7 +366,7 @@ int nrf24l01p_set_payload_width(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char
 
 
 
-int nrf24l01p_set_tx_address(nrf24l01p_t *dev, char *saddr, unsigned int length)
+int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, char *saddr, unsigned int length)
 {
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
@@ -381,7 +381,7 @@ int nrf24l01p_set_tx_address(nrf24l01p_t *dev, char *saddr, unsigned int length)
     return (int)length;
 }
 
-int nrf24l01p_set_tx_address_long(nrf24l01p_t *dev, uint64_t saddr, unsigned int length)
+int nrf24l01p_set_tx_address_long(const nrf24l01p_t *dev, uint64_t saddr, unsigned int length)
 {
     char buf[length];
 
@@ -407,7 +407,7 @@ int nrf24l01p_set_tx_address_long(nrf24l01p_t *dev, uint64_t saddr, unsigned int
     return (int)length;
 }
 
-uint64_t nrf24l01p_get_tx_address_long(nrf24l01p_t *dev)
+uint64_t nrf24l01p_get_tx_address_long(const nrf24l01p_t *dev)
 {
     uint64_t saddr_64 = 0;
     char addr_array[INITIAL_ADDRESS_WIDTH];
@@ -430,7 +430,7 @@ uint64_t nrf24l01p_get_tx_address_long(nrf24l01p_t *dev)
 }
 
 
-int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *saddr, unsigned int length)
+int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *saddr, unsigned int length)
 {
     char pipe_addr;
 
@@ -478,7 +478,7 @@ int nrf24l01p_set_rx_address(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *s
     return (int)length;
 }
 
-int nrf24l01p_set_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint64_t saddr, unsigned int length)
+int nrf24l01p_set_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint64_t saddr, unsigned int length)
 {
     char buf[length];
 
@@ -496,7 +496,7 @@ int nrf24l01p_set_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, ui
 }
 
 
-uint64_t nrf24l01p_get_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
+uint64_t nrf24l01p_get_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 {
     char pipe_addr;
     uint64_t saddr_64 = 0;
@@ -550,7 +550,7 @@ uint64_t nrf24l01p_get_rx_address_long(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pip
 }
 
 
-int nrf24l01p_set_datarate(nrf24l01p_t *dev, nrf24l01p_dr_t dr)
+int nrf24l01p_set_datarate(const nrf24l01p_t *dev, nrf24l01p_dr_t dr)
 {
     char rf_setup;
 
@@ -578,7 +578,7 @@ int nrf24l01p_set_datarate(nrf24l01p_t *dev, nrf24l01p_dr_t dr)
     return nrf24l01p_write_reg(dev, REG_RF_SETUP, rf_setup);
 }
 
-int nrf24l01p_get_status(nrf24l01p_t *dev)
+int nrf24l01p_get_status(const nrf24l01p_t *dev)
 {
     uint8_t status;
 
@@ -593,7 +593,7 @@ int nrf24l01p_get_status(nrf24l01p_t *dev)
     return (int)status;
 }
 
-int nrf24l01p_set_power(nrf24l01p_t *dev, int pwr)
+int nrf24l01p_set_power(const nrf24l01p_t *dev, int pwr)
 {
     char rf_setup;
 
@@ -621,7 +621,7 @@ int nrf24l01p_set_power(nrf24l01p_t *dev, int pwr)
     return nrf24l01p_write_reg(dev, REG_RF_SETUP, rf_setup);
 }
 
-int nrf24l01p_get_power(nrf24l01p_t *dev)
+int nrf24l01p_get_power(const nrf24l01p_t *dev)
 {
     char rf_setup;
     int pwr;
@@ -648,7 +648,7 @@ int nrf24l01p_get_power(nrf24l01p_t *dev)
 }
 
 
-int nrf24l01p_set_txmode(nrf24l01p_t *dev)
+int nrf24l01p_set_txmode(const nrf24l01p_t *dev)
 {
     char conf;
     int status;
@@ -668,7 +668,7 @@ int nrf24l01p_set_txmode(nrf24l01p_t *dev)
     return status;
 }
 
-int nrf24l01p_set_rxmode(nrf24l01p_t *dev)
+int nrf24l01p_set_rxmode(const nrf24l01p_t *dev)
 {
     char conf;
     int status;
@@ -690,17 +690,17 @@ int nrf24l01p_set_rxmode(nrf24l01p_t *dev)
 }
 
 
-int nrf24l01p_reset_interrupts(nrf24l01p_t *dev, char intrs)
+int nrf24l01p_reset_interrupts(const nrf24l01p_t *dev, char intrs)
 {
     return nrf24l01p_write_reg(dev, REG_STATUS, intrs);
 }
 
-int nrf24l01p_reset_all_interrupts(nrf24l01p_t *dev)
+int nrf24l01p_reset_all_interrupts(const nrf24l01p_t *dev)
 {
     return nrf24l01p_write_reg(dev, REG_STATUS, ALL_INT_MASK);
 }
 
-int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, char intr)
+int nrf24l01p_mask_interrupt(const nrf24l01p_t *dev, char intr)
 {
     char conf;
 
@@ -710,7 +710,7 @@ int nrf24l01p_mask_interrupt(nrf24l01p_t *dev, char intr)
     return nrf24l01p_write_reg(dev, REG_CONFIG, conf);
 }
 
-int nrf24l01p_unmask_interrupt(nrf24l01p_t *dev, char intr)
+int nrf24l01p_unmask_interrupt(const nrf24l01p_t *dev, char intr)
 {
     char conf;
 
@@ -720,7 +720,7 @@ int nrf24l01p_unmask_interrupt(nrf24l01p_t *dev, char intr)
     return nrf24l01p_write_reg(dev, REG_CONFIG, conf);
 }
 
-int nrf24l01p_enable_dynamic_payload(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
+int nrf24l01p_enable_dynamic_payload(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 {
     char feature_val;
     char en_aa_val;
@@ -795,7 +795,7 @@ int nrf24l01p_enable_dynamic_payload(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
     return 0;
 }
 
-int nrf24l01p_enable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
+int nrf24l01p_enable_pipe(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 {
     char pipe_conf;
 
@@ -805,7 +805,7 @@ int nrf24l01p_enable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
     return nrf24l01p_write_reg(dev, REG_EN_RXADDR, pipe_conf);
 }
 
-int nrf24l01p_disable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
+int nrf24l01p_disable_pipe(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
 {
     char pipe_conf;
 
@@ -815,7 +815,7 @@ int nrf24l01p_disable_pipe(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe)
     return nrf24l01p_write_reg(dev, REG_EN_RXADDR, pipe_conf);
 }
 
-int nrf24l01p_disable_crc(nrf24l01p_t *dev)
+int nrf24l01p_disable_crc(const nrf24l01p_t *dev)
 {
     char conf;
 
@@ -823,7 +823,7 @@ int nrf24l01p_disable_crc(nrf24l01p_t *dev)
     return nrf24l01p_write_reg(dev, REG_CONFIG, (conf & ~(EN_CRC)));
 }
 
-int nrf24l01p_enable_crc(nrf24l01p_t *dev, nrf24l01p_crc_t crc)
+int nrf24l01p_enable_crc(const nrf24l01p_t *dev, nrf24l01p_crc_t crc)
 {
     char conf;
 
@@ -845,7 +845,7 @@ int nrf24l01p_enable_crc(nrf24l01p_t *dev, nrf24l01p_crc_t crc)
     return nrf24l01p_write_reg(dev, REG_CONFIG, (conf | EN_CRC));
 }
 
-int nrf24l01p_setup_auto_ack(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l01p_retransmit_delay_t delay_retrans, char count_retrans)
+int nrf24l01p_setup_auto_ack(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l01p_retransmit_delay_t delay_retrans, char count_retrans)
 {
     char en_aa;
     int status;
@@ -893,7 +893,7 @@ int nrf24l01p_setup_auto_ack(nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l0
     return nrf24l01p_write_reg(dev, REG_SETUP_RETR, ((delay_retrans << 4) | count_retrans));
 }
 
-int nrf24l01p_enable_dynamic_ack(nrf24l01p_t *dev)
+int nrf24l01p_enable_dynamic_ack(const nrf24l01p_t *dev)
 {
     char feature;
 
@@ -911,13 +911,13 @@ int nrf24l01p_enable_dynamic_ack(nrf24l01p_t *dev)
     return 0;
 }
 
-int nrf24l01p_disable_all_auto_ack(nrf24l01p_t *dev)
+int nrf24l01p_disable_all_auto_ack(const nrf24l01p_t *dev)
 {
     return nrf24l01p_write_reg(dev, REG_EN_AA, 0x00);
 }
 
 
-int nrf24l01p_flush_tx_fifo(nrf24l01p_t *dev)
+int nrf24l01p_flush_tx_fifo(const nrf24l01p_t *dev)
 {
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
@@ -930,7 +930,7 @@ int nrf24l01p_flush_tx_fifo(nrf24l01p_t *dev)
     return 0;
 }
 
-int nrf24l01p_flush_rx_fifo(nrf24l01p_t *dev)
+int nrf24l01p_flush_rx_fifo(const nrf24l01p_t *dev)
 {
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);

--- a/drivers/pcd8544/pcd8544.c
+++ b/drivers/pcd8544/pcd8544.c
@@ -199,17 +199,17 @@ static const char _riot[] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static inline void lock(pcd8544_t *dev)
+static inline void lock(const pcd8544_t *dev)
 {
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
 }
 
-static inline void done(pcd8544_t *dev)
+static inline void done(const pcd8544_t *dev)
 {
     spi_release(dev->spi);
 }
 
-static void _write(pcd8544_t *dev, uint8_t is_data, char data)
+static void _write(const pcd8544_t *dev, uint8_t is_data, char data)
 {
     /* set command or data mode */
     gpio_write(dev->mode, is_data);
@@ -217,12 +217,12 @@ static void _write(pcd8544_t *dev, uint8_t is_data, char data)
     spi_transfer_bytes(dev->spi, dev->cs, false, (uint8_t *)&data, NULL, 1);
 }
 
-static inline void _set_x(pcd8544_t *dev, uint8_t x)
+static inline void _set_x(const pcd8544_t *dev, uint8_t x)
 {
     _write(dev, MODE_CMD, CMD_SET_X | x);
 }
 
-static inline void _set_y(pcd8544_t *dev, uint8_t y)
+static inline void _set_y(const pcd8544_t *dev, uint8_t y)
 {
     _write(dev, MODE_CMD, CMD_SET_Y | y);
 }
@@ -266,7 +266,7 @@ int pcd8544_init(pcd8544_t *dev, spi_t spi, gpio_t cs, gpio_t reset, gpio_t mode
     return 0;
 }
 
-void pcd8544_set_contrast(pcd8544_t *dev, uint8_t contrast)
+void pcd8544_set_contrast(const pcd8544_t *dev, uint8_t contrast)
 {
     if (contrast > CONTRAST_MAX) {
         contrast = CONTRAST_MAX;
@@ -278,7 +278,7 @@ void pcd8544_set_contrast(pcd8544_t *dev, uint8_t contrast)
     done(dev);
 }
 
-void pcd8544_set_tempcoef(pcd8544_t *dev, uint8_t coef)
+void pcd8544_set_tempcoef(const pcd8544_t *dev, uint8_t coef)
 {
     if (coef > TEMP_MAX) {
         coef = TEMP_MAX;
@@ -290,7 +290,7 @@ void pcd8544_set_tempcoef(pcd8544_t *dev, uint8_t coef)
     done(dev);
 }
 
-void pcd8544_set_bias(pcd8544_t *dev, uint8_t bias)
+void pcd8544_set_bias(const pcd8544_t *dev, uint8_t bias)
 {
     if (bias > BIAS_MAX) {
         bias = BIAS_MAX;
@@ -302,12 +302,12 @@ void pcd8544_set_bias(pcd8544_t *dev, uint8_t bias)
     done(dev);
 }
 
-void pcd8544_riot(pcd8544_t *dev)
+void pcd8544_riot(const pcd8544_t *dev)
 {
     pcd8544_write_img(dev, _riot);
 }
 
-void pcd8544_write_img(pcd8544_t *dev, const char img[])
+void pcd8544_write_img(const pcd8544_t *dev, const char img[])
 {
     /* set initial position */
     lock(dev);
@@ -320,7 +320,7 @@ void pcd8544_write_img(pcd8544_t *dev, const char img[])
     done(dev);
 }
 
-void pcd8544_write_c(pcd8544_t *dev, uint8_t x, uint8_t y, char c)
+void pcd8544_write_c(const pcd8544_t *dev, uint8_t x, uint8_t y, char c)
 {
     /* check position */
     if (x >= PCD8544_COLS || y >= PCD8544_ROWS) {
@@ -338,14 +338,14 @@ void pcd8544_write_c(pcd8544_t *dev, uint8_t x, uint8_t y, char c)
     done(dev);
 }
 
-void pcd8544_write_s(pcd8544_t *dev, uint8_t x, uint8_t y, const char *s)
+void pcd8544_write_s(const pcd8544_t *dev, uint8_t x, uint8_t y, const char *s)
 {
     for (; (*s != '\0') && x < PCD8544_COLS; x++, s++) {
         pcd8544_write_c(dev, x, y, *s);
     }
 }
 
-void pcd8544_clear(pcd8544_t *dev)
+void pcd8544_clear(const pcd8544_t *dev)
 {
     lock(dev);
     _set_x(dev, 0);
@@ -369,19 +369,19 @@ void pcd8544_invert(pcd8544_t *dev)
     done(dev);
 }
 
-int pcd8544_is_inverted(pcd8544_t *dev)
+int pcd8544_is_inverted(const pcd8544_t *dev)
 {
     return dev->inverted;
 }
 
-void pcd8544_poweron(pcd8544_t *dev)
+void pcd8544_poweron(const pcd8544_t *dev)
 {
     lock(dev);
     _write(dev, MODE_CMD, CMD_ENABLE_H);
     done(dev);
 }
 
-void pcd8544_poweroff(pcd8544_t *dev)
+void pcd8544_poweroff(const pcd8544_t *dev)
 {
     lock(dev);
     _write(dev, MODE_CMD, CMD_DISABLE);

--- a/drivers/pir/pir.c
+++ b/drivers/pir/pir.c
@@ -44,7 +44,7 @@ int pir_init(pir_t *dev, gpio_t gpio)
     return gpio_init(dev->gpio_dev, GPIO_IN);
 }
 
-pir_event_t pir_get_status(pir_t *dev)
+pir_event_t pir_get_status(const pir_t *dev)
 {
     return ((gpio_read(dev->gpio_dev) == 0) ? PIR_STATUS_LO : PIR_STATUS_HI);
 }

--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -97,7 +97,7 @@ static void _nfc_event(void *dev)
     mutex_unlock(&((pn532_t *)dev)->trap);
 }
 
-void pn532_reset(pn532_t *dev)
+void pn532_reset(const pn532_t *dev)
 {
     assert(dev != NULL);
 
@@ -165,7 +165,7 @@ static void reverse(char *buff, unsigned len)
 }
 #endif
 
-static int _write(pn532_t *dev, char *buff, unsigned len)
+static int _write(const pn532_t *dev, char *buff, unsigned len)
 {
     int ret = -1;
 
@@ -197,7 +197,7 @@ static int _write(pn532_t *dev, char *buff, unsigned len)
     return ret;
 }
 
-static int _read(pn532_t *dev, char *buff, unsigned len)
+static int _read(const pn532_t *dev, char *buff, unsigned len)
 {
     int ret = -1;
 
@@ -231,7 +231,7 @@ static int _read(pn532_t *dev, char *buff, unsigned len)
     return ret;
 }
 
-static int send_cmd(pn532_t *dev, char *buff, unsigned len)
+static int send_cmd(const pn532_t *dev, char *buff, unsigned len)
 {
     unsigned pos, checksum;
 
@@ -271,7 +271,7 @@ static void wait_ready(pn532_t *dev)
 }
 
 /* Returns >0 payload len (or <0 received len but not as expected) */
-static int read_command(pn532_t *dev, char *buff, unsigned len, int expected_cmd)
+static int read_command(const pn532_t *dev, char *buff, unsigned len, int expected_cmd)
 {
     int r;
     unsigned j, fi, lp, lc;

--- a/drivers/rgbled/rgbled.c
+++ b/drivers/rgbled/rgbled.c
@@ -41,7 +41,7 @@ void rgbled_init(rgbled_t *led, pwm_t pwm, int channel_r, int channel_g, int cha
     pwm_init(pwm, PWM_LEFT, PWM_FREQU, PWM_RES);
 }
 
-void rgbled_set(rgbled_t *led, color_rgb_t *color)
+void rgbled_set(const rgbled_t *led, color_rgb_t *color)
 {
     pwm_set(led->device, led->channel_r, (unsigned int)color->r);
     pwm_set(led->device, led->channel_g, (unsigned int)color->g);

--- a/drivers/servo/servo.c
+++ b/drivers/servo/servo.c
@@ -88,7 +88,7 @@ int servo_init(servo_t *dev, pwm_t pwm, int pwm_channel, unsigned int min, unsig
     return 0;
 }
 
-void servo_set(servo_t *dev, unsigned int pos)
+void servo_set(const servo_t *dev, unsigned int pos)
 {
     unsigned int raw_value;
     if (pos > dev->max) {

--- a/drivers/si70xx/si70xx.c
+++ b/drivers/si70xx/si70xx.c
@@ -26,7 +26,7 @@
 /**
  * @brief   Utility method to perform and reconstruct a measurement.
  */
-static uint32_t si70xx_measure(si70xx_t *dev, uint8_t command)
+static uint32_t si70xx_measure(const si70xx_t *dev, uint8_t command)
 {
     uint8_t result[2];
 
@@ -39,7 +39,7 @@ static uint32_t si70xx_measure(si70xx_t *dev, uint8_t command)
     return ((uint32_t)result[0] << 8) + (result[1] & 0xfc);
 }
 
-int si70xx_test(si70xx_t *dev)
+int si70xx_test(const si70xx_t *dev)
 {
     uint8_t revision = si70xx_get_revision(dev);
 
@@ -87,7 +87,7 @@ int si70xx_init(si70xx_t *dev, i2c_t i2c_dev, uint8_t address)
     return 0;
 }
 
-uint16_t si70xx_get_relative_humidity(si70xx_t *dev)
+uint16_t si70xx_get_relative_humidity(const si70xx_t *dev)
 {
     uint32_t raw;
     int32_t humidity;
@@ -109,7 +109,7 @@ uint16_t si70xx_get_relative_humidity(si70xx_t *dev)
     }
 }
 
-int16_t si70xx_get_temperature(si70xx_t *dev)
+int16_t si70xx_get_temperature(const si70xx_t *dev)
 {
     uint32_t raw;
 
@@ -119,7 +119,7 @@ int16_t si70xx_get_temperature(si70xx_t *dev)
     return ((17572 * raw) / 65536) - 4685;
 }
 
-void si70xx_get_both(si70xx_t *dev, uint16_t *humidity, int16_t *temperature)
+void si70xx_get_both(const si70xx_t *dev, uint16_t *humidity, int16_t *temperature)
 {
     uint32_t raw;
 
@@ -132,7 +132,7 @@ void si70xx_get_both(si70xx_t *dev, uint16_t *humidity, int16_t *temperature)
     *temperature = ((17572 * raw) / 65536) - 4685;
 }
 
-uint64_t si70xx_get_serial(si70xx_t *dev)
+uint64_t si70xx_get_serial(const si70xx_t *dev)
 {
     uint8_t out[2];
     uint8_t in_first[8] = { 0 };
@@ -163,12 +163,12 @@ uint64_t si70xx_get_serial(si70xx_t *dev)
     return (((uint64_t) id_first) << 32) + id_second;
 }
 
-uint8_t si70xx_get_id(si70xx_t *dev)
+uint8_t si70xx_get_id(const si70xx_t *dev)
 {
     return (si70xx_get_serial(dev) >> 24) & 0xff;
 }
 
-uint8_t si70xx_get_revision(si70xx_t *dev)
+uint8_t si70xx_get_revision(const si70xx_t *dev)
 {
     uint8_t out[2];
     uint8_t in = 0;

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -86,7 +86,7 @@ int srf02_init(srf02_t *dev, i2c_t i2c, uint8_t addr)
     return 0;
 }
 
-void srf02_trigger(srf02_t *dev, srf02_mode_t mode)
+void srf02_trigger(const srf02_t *dev, srf02_mode_t mode)
 {
     /* trigger a new measurement by writing the mode to the CMD register */
     DEBUG("[srf02] trigger new reading\n");
@@ -95,7 +95,7 @@ void srf02_trigger(srf02_t *dev, srf02_mode_t mode)
     i2c_release(dev->i2c);
 }
 
-uint16_t srf02_read(srf02_t *dev)
+uint16_t srf02_read(const srf02_t *dev)
 {
     uint8_t res[2];
 
@@ -109,7 +109,7 @@ uint16_t srf02_read(srf02_t *dev)
     return ((((uint16_t)res[0]) << 8) | (res[1] & 0xff));
 }
 
-uint16_t srf02_get_distance(srf02_t *dev, srf02_mode_t mode)
+uint16_t srf02_get_distance(const srf02_t *dev, srf02_mode_t mode)
 {
     /* trigger a new reading */
     srf02_trigger(dev, mode);

--- a/drivers/srf08/srf08.c
+++ b/drivers/srf08/srf08.c
@@ -63,7 +63,7 @@ int srf08_init(srf08_t *dev, i2c_t i2c, uint8_t addr, i2c_speed_t speed)
 }
 
 
-int srf08_set_max_range(srf08_t *dev, uint8_t max_range)
+int srf08_set_max_range(const srf08_t *dev, uint8_t max_range)
 {
     int status;
 
@@ -77,7 +77,7 @@ int srf08_set_max_range(srf08_t *dev, uint8_t max_range)
 }
 
 
-int srf08_set_max_gain(srf08_t *dev, uint8_t gain)
+int srf08_set_max_gain(const srf08_t *dev, uint8_t gain)
 {
     int status;
 
@@ -91,7 +91,7 @@ int srf08_set_max_gain(srf08_t *dev, uint8_t gain)
 }
 
 
-int srf08_get_distances(srf08_t *dev, uint16_t *range_array, int num_echos, srf08_mode_t ranging_mode)
+int srf08_get_distances(const srf08_t *dev, uint16_t *range_array, int num_echos, srf08_mode_t ranging_mode)
 {
     int status;
     int echo_number = 0;

--- a/drivers/tcs37727/tcs37727.c
+++ b/drivers/tcs37727/tcs37727.c
@@ -77,7 +77,7 @@ int tcs37727_init(tcs37727_t *dev, const tcs37727_params_t *params)
     return TCS37727_OK;
 }
 
-void tcs37727_set_rgbc_active(tcs37727_t *dev)
+void tcs37727_set_rgbc_active(const tcs37727_t *dev)
 {
     uint8_t reg;
 
@@ -90,7 +90,7 @@ void tcs37727_set_rgbc_active(tcs37727_t *dev)
     i2c_release(BUS);
 }
 
-void tcs37727_set_rgbc_standby(tcs37727_t *dev)
+void tcs37727_set_rgbc_standby(const tcs37727_t *dev)
 {
     uint8_t reg;
 
@@ -177,7 +177,7 @@ static uint8_t tcs37727_trim_gain(tcs37727_t *dev, int rawc)
     return 0;
 }
 
-void tcs37727_read(tcs37727_t *dev, tcs37727_data_t *data)
+void tcs37727_read(const tcs37727_t *dev, tcs37727_data_t *data)
 {
     uint8_t buf[8];
 
@@ -210,7 +210,7 @@ void tcs37727_read(tcs37727_t *dev, tcs37727_data_t *data)
     int32_t lux = gi / cpl;
 
     /* Autogain */
-    tcs37727_trim_gain(dev, tmpc);
+    tcs37727_trim_gain((tcs37727_t *)dev, tmpc);
 
     data->red = (tmpr < 0) ? 0 : (tmpr * 1000) / cpl;
     data->green = (tmpg < 0) ? 0 : (tmpg * 1000) / cpl;

--- a/drivers/tmp006/tmp006.c
+++ b/drivers/tmp006/tmp006.c
@@ -106,7 +106,7 @@ int tmp006_init(tmp006_t *dev, const tmp006_params_t *params)
     return TMP006_OK;
 }
 
-int tmp006_reset(tmp006_t *dev)
+int tmp006_reset(const tmp006_t *dev)
 {
     uint8_t reg[2];
     uint16_t tmp = TMP006_CONFIG_RST;
@@ -123,7 +123,7 @@ int tmp006_reset(tmp006_t *dev)
     return TMP006_OK;
 }
 
-int tmp006_set_active(tmp006_t *dev)
+int tmp006_set_active(const tmp006_t *dev)
 {
     uint8_t reg[2];
 
@@ -142,7 +142,7 @@ int tmp006_set_active(tmp006_t *dev)
     return TMP006_OK;
 }
 
-int tmp006_set_standby(tmp006_t *dev)
+int tmp006_set_standby(const tmp006_t *dev)
 {
     uint8_t reg[2];
 
@@ -161,7 +161,7 @@ int tmp006_set_standby(tmp006_t *dev)
     return TMP006_OK;
 }
 
-int tmp006_read(tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy)
+int tmp006_read(const tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy)
 {
     uint8_t reg[2];
 
@@ -224,7 +224,7 @@ void tmp006_convert(int16_t rawv, int16_t rawt,  float *tamb, float *tobj)
     *tobj = (t - 273.15);
 }
 
-int tmp006_read_temperature(tmp006_t *dev, int16_t *ta, int16_t *to)
+int tmp006_read_temperature(const tmp006_t *dev, int16_t *ta, int16_t *to)
 {
     int16_t rawtemp, rawvolt;
     float tamb, tobj;

--- a/drivers/tsl2561/tsl2561.c
+++ b/drivers/tsl2561/tsl2561.c
@@ -31,10 +31,10 @@
 #include "debug.h"
 
 /* internal helpers */
-static void _enable(tsl2561_t *dev);
-static void _disable(tsl2561_t *dev);
-static void _read_data(tsl2561_t *dev, uint16_t *full, uint16_t *ir);
-static void _print_init_info(tsl2561_t *dev);
+static void _enable(const tsl2561_t *dev);
+static void _disable(const tsl2561_t *dev);
+static void _read_data(const tsl2561_t *dev, uint16_t *full, uint16_t *ir);
+static void _print_init_info(const tsl2561_t *dev);
 
 /*---------------------------------------------------------------------------*
  *                          TSL2561 Core API                                 *
@@ -92,7 +92,7 @@ int tsl2561_init(tsl2561_t *dev,
     return TSL2561_OK;
 }
 
-uint16_t tsl2561_read_illuminance(tsl2561_t *dev)
+uint16_t tsl2561_read_illuminance(const tsl2561_t *dev)
 {
     /* Read IR and full spectrum values */
     uint16_t ir = 0;
@@ -184,7 +184,7 @@ uint16_t tsl2561_read_illuminance(tsl2561_t *dev)
 }
 
 
-static void _enable(tsl2561_t *dev)
+static void _enable(const tsl2561_t *dev)
 {
     /* enabling device */
     i2c_write_reg(dev->i2c_dev, dev->addr,
@@ -199,7 +199,7 @@ static void _enable(tsl2561_t *dev)
 }
 
 
-static void _disable(tsl2561_t *dev)
+static void _disable(const tsl2561_t *dev)
 {
     /* disabling device */
     i2c_write_reg(dev->i2c_dev, dev->addr,
@@ -214,7 +214,7 @@ static void _disable(tsl2561_t *dev)
 #endif
 }
 
-static void _read_data(tsl2561_t *dev, uint16_t *full, uint16_t *ir)
+static void _read_data(const tsl2561_t *dev, uint16_t *full, uint16_t *ir)
 {
     /* Enable the device */
     _enable(dev);
@@ -253,7 +253,7 @@ static void _read_data(tsl2561_t *dev, uint16_t *full, uint16_t *ir)
     _disable(dev);
 }
 
-static void _print_init_info(tsl2561_t *dev)
+static void _print_init_info(const tsl2561_t *dev)
 {
     DEBUG("[Info] I2C device: %d\n", dev->i2c_dev);
     DEBUG("[Info] Address: %d\n", dev->addr);

--- a/drivers/uart_half_duplex/include/uart_half_duplex.h
+++ b/drivers/uart_half_duplex/include/uart_half_duplex.h
@@ -124,7 +124,7 @@ static inline void uart_half_duplex_set_rx(uart_half_duplex_t *dev)
  *
  * @return               the number of characters actually sent
  */
-size_t uart_half_duplex_send(uart_half_duplex_t *dev, size_t size);
+size_t uart_half_duplex_send(const uart_half_duplex_t *dev, size_t size);
 
 /**
  * @brief Recv data an fill the driver's buffer
@@ -134,7 +134,7 @@ size_t uart_half_duplex_send(uart_half_duplex_t *dev, size_t size);
  *
  * @return               the number of characters actually received
  */
-size_t uart_half_duplex_recv(uart_half_duplex_t *dev, size_t size);
+size_t uart_half_duplex_recv(const uart_half_duplex_t *dev, size_t size);
 
 #ifdef __cplusplus
 }

--- a/drivers/uart_half_duplex/uart_half_duplex.c
+++ b/drivers/uart_half_duplex/uart_half_duplex.c
@@ -30,14 +30,14 @@
 #define IS_PIN(dir)    (dir >= UART_HALF_DUPLEX_DIR_PIN_SET(0))
 #define GET_PIN(dir)   ((dir >> 1) - 1)
 
-static inline void _enable_tx(uart_half_duplex_t *dev)
+static inline void _enable_tx(const uart_half_duplex_t *dev)
 {
     if (dev->params.dir.enable_tx) {
         dev->params.dir.enable_tx(dev->params.uart);
     }
 }
 
-static inline void _disable_tx(uart_half_duplex_t *dev)
+static inline void _disable_tx(const uart_half_duplex_t *dev)
 {
     if (dev->params.dir.disable_tx) {
         dev->params.dir.disable_tx(dev->params.uart);
@@ -75,7 +75,7 @@ int uart_half_duplex_init(uart_half_duplex_t *dev, uint8_t *buffer, size_t buffe
     return ret;
 }
 
-size_t uart_half_duplex_send(uart_half_duplex_t *dev, size_t size)
+size_t uart_half_duplex_send(const uart_half_duplex_t *dev, size_t size)
 {
     _enable_tx(dev);
     uart_write(dev->params.uart, dev->buffer, size);
@@ -83,7 +83,7 @@ size_t uart_half_duplex_send(uart_half_duplex_t *dev, size_t size)
     return size;
 }
 
-size_t uart_half_duplex_recv(uart_half_duplex_t *dev, size_t size)
+size_t uart_half_duplex_recv(const uart_half_duplex_t *dev, size_t size)
 {
     const uint32_t begin = xtimer_now_usec();
     while (xtimer_now_usec() - begin < dev->timeout_us) {

--- a/drivers/veml6070/veml6070.c
+++ b/drivers/veml6070/veml6070.c
@@ -58,7 +58,7 @@ int veml6070_init(veml6070_t *dev, const veml6070_params_t * params)
     return VEML6070_OK;
 }
 
-uint16_t veml6070_read_uv(veml6070_t *dev)
+uint16_t veml6070_read_uv(const veml6070_t *dev)
 {
     /* Acquire exclusive access */
     i2c_acquire(dev->params.i2c_dev);


### PR DESCRIPTION
This PR tries to make use of `const` with device descriptor pointer when possible.
Only basic drivers have been updated. Still remain:
* radio drivers
* sd card driver
* mtd driver

I split the PR in 'atomic' commits for each modified drivers to simplify review but I can squash in one if needed.