### PR TITLE
doc: introduce memtitle CSS class

### DIFF
--- a/doc/doxygen/src/css/riot.css
+++ b/doc/doxygen/src/css/riot.css
@@ -279,6 +279,9 @@ table.directory {
 .navpath li.navelem a {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
+.memtitle {
+  display: none;
+}
 .memitem {
   margin-bottom: 20px;
   background-color: #ffffff;

--- a/doc/doxygen/src/css/riot.less
+++ b/doc/doxygen/src/css/riot.less
@@ -266,6 +266,9 @@ table.directory {
 .navpath li.navelem a {
   font-family: @font-family-base;
 }
+.memtitle {
+  display: none;
+}
 .memitem {
   margin-bottom: 20px;
   background-color: @panel-bg;


### PR DESCRIPTION
Our doc builder at doc.riot-os.org was updated and now the documentation looks weird (see http://doc.riot-os.org/group__core__msg.html#gad1353dec9af776d4caf5f4e00cec112e e.g.). This fixes that.