### PR TITLE
sys/fmt: Fix unintentional pointer advancement for negative numbers in fmt_float

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -274,12 +274,11 @@ size_t fmt_float(char *out, float f, unsigned precision)
 
     uint32_t fraction = f * _tenmap[precision];
 
-    size_t res = negative;
     if (negative && out) {
         *out++ = '-';
     }
 
-    res += fmt_u32_dec(out, integer);
+    size_t res = fmt_u32_dec(out, integer);
     if (precision && fraction) {
         if (out) {
             out += res;
@@ -289,6 +288,7 @@ size_t fmt_float(char *out, float f, unsigned precision)
         }
         res += (1 + precision);
     }
+    res += negative;
 
     return res;
 }


### PR DESCRIPTION
Fixes the bug mentioned in #7220 

If the number is negative then the 1 from `negative` is added twice to the output pointer.