### PR TITLE
net/gcoap: Provide piggybacked ACK response to confirmable request

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -184,7 +184,8 @@
  * gcoap includes server and client capability. Available features include:
  *
  * - Message Type: Supports non-confirmable (NON) messaging. Additionally
- *   provides a callback on timeout.
+ *   provides a callback on timeout. Provides piggybacked ACK response to a
+ *   confirmable (CON) request.
  * - Observe extension: Provides server-side registration and notifications.
  * - Server and Client provide helper functions for writing the
  *   response/request. See the CoAP topic in the source documentation for

--- a/sys/net/application_layer/coap/gcoap.c
+++ b/sys/net/application_layer/coap/gcoap.c
@@ -135,8 +135,12 @@ static void _listen(sock_udp_t *sock)
         return;
     }
 
+    if (coap_get_code(&pdu) == COAP_CODE_EMPTY) {
+        DEBUG("gcoap: empty messages not handled yet\n");
+        return;
+
     /* incoming request */
-    if (coap_get_code_class(&pdu) == COAP_CLASS_REQ) {
+    } else if (coap_get_code_class(&pdu) == COAP_CLASS_REQ) {
         if (coap_get_type(&pdu) == COAP_TYPE_NON
                 || coap_get_type(&pdu) == COAP_TYPE_CON) {
             size_t pdu_len = _handle_req(&pdu, buf, sizeof(buf), &remote);
@@ -149,6 +153,7 @@ static void _listen(sock_udp_t *sock)
             return;
         }
     }
+
     /* incoming response */
     else {
         _find_req_memo(&memo, &pdu, buf, sizeof(buf));

--- a/sys/net/application_layer/coap/gcoap.c
+++ b/sys/net/application_layer/coap/gcoap.c
@@ -137,9 +137,16 @@ static void _listen(sock_udp_t *sock)
 
     /* incoming request */
     if (coap_get_code_class(&pdu) == COAP_CLASS_REQ) {
-        size_t pdu_len = _handle_req(&pdu, buf, sizeof(buf), &remote);
-        if (pdu_len > 0) {
-            sock_udp_send(sock, buf, pdu_len, &remote);
+        if (coap_get_type(&pdu) == COAP_TYPE_NON
+                || coap_get_type(&pdu) == COAP_TYPE_CON) {
+            size_t pdu_len = _handle_req(&pdu, buf, sizeof(buf), &remote);
+            if (pdu_len > 0) {
+                sock_udp_send(sock, buf, pdu_len, &remote);
+            }
+        }
+        else {
+            DEBUG("gcoap: illegal request type: %u\n", coap_get_type(&pdu));
+            return;
         }
     }
     /* incoming response */
@@ -730,9 +737,10 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
 
 int gcoap_resp_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code)
 {
-    /* Assume NON type request, so response type is the same. */
+    if (coap_get_type(pdu) == COAP_TYPE_CON) {
+        coap_hdr_set_type(pdu->hdr, COAP_TYPE_ACK);
+    }
     coap_hdr_set_code(pdu->hdr, code);
-    /* Create message ID since NON? */
 
     /* Reserve some space between the header and payload to write options later */
     pdu->payload      = buf + coap_get_total_hdr_len(pdu) + GCOAP_RESP_OPTIONS_BUF;

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -169,6 +169,63 @@ static void test_gcoap__server_get_resp(void)
     }
 }
 
+/*
+ * Helper for server_con_* tests below.
+ * Confirmable request from libcoap example for gcoap_cli /cli/stats resource.
+ * Include 2-byte token.
+ */
+static int _read_cli_stats_req_con(coap_pkt_t *pdu, uint8_t *buf)
+{
+    uint8_t pdu_data[] = {
+        0x42, 0x01, 0x8e, 0x03, 0x35, 0x61, 0xb3, 0x63,
+        0x6c, 0x69, 0x05, 0x73, 0x74, 0x61, 0x74, 0x73
+    };
+    memcpy(buf, pdu_data, sizeof(pdu_data));
+
+    return coap_parse(pdu, buf, sizeof(pdu_data));
+}
+
+/* Server CON GET request success case. Validate request is confirmable. */
+static void test_gcoap__server_con_req(void)
+{
+    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    coap_pkt_t pdu;
+
+    int res = _read_cli_stats_req_con(&pdu, &buf[0]);
+
+    TEST_ASSERT_EQUAL_INT(0, res);
+    TEST_ASSERT_EQUAL_INT(COAP_METHOD_GET, coap_get_code(&pdu));
+    TEST_ASSERT_EQUAL_INT(COAP_TYPE_CON, coap_get_type(&pdu));
+}
+
+/*
+ * Server CON GET response success case. Test response is ACK.
+ * Response for libcoap example for gcoap_cli /cli/stats resource
+ */
+static void test_gcoap__server_con_resp(void)
+{
+    uint8_t buf[GCOAP_PDU_BUF_SIZE];
+    coap_pkt_t pdu;
+
+    /* read request */
+    _read_cli_stats_req_con(&pdu, &buf[0]);
+
+    /* generate response */
+    gcoap_resp_init(&pdu, &buf[0], sizeof(buf), COAP_CODE_CONTENT);
+    char resp_payload[]  = "2";
+    memcpy(&pdu.payload[0], &resp_payload[0], strlen(resp_payload));
+    ssize_t res = gcoap_finish(&pdu, strlen(resp_payload), COAP_FORMAT_TEXT);
+
+    uint8_t resp_data[] = {
+        0x62, 0x45, 0x8e, 0x03, 0x35, 0x61, 0xc0, 0xff,
+        0x30
+    };
+
+    TEST_ASSERT_EQUAL_INT(COAP_CLASS_SUCCESS, coap_get_code_class(&pdu));
+    TEST_ASSERT_EQUAL_INT(COAP_TYPE_ACK, coap_get_type(&pdu));
+    TEST_ASSERT_EQUAL_INT(sizeof(resp_data), res);
+}
+
 Test *tests_gcoap_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -176,6 +233,8 @@ Test *tests_gcoap_tests(void)
         new_TestFixture(test_gcoap__client_get_resp),
         new_TestFixture(test_gcoap__server_get_req),
         new_TestFixture(test_gcoap__server_get_resp),
+        new_TestFixture(test_gcoap__server_con_req),
+        new_TestFixture(test_gcoap__server_con_resp),
     };
 
     EMB_UNIT_TESTCALLER(gcoap_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
Implements the first task of #7192 for confirmable messaging. Also updated documentation and added a couple of unit tests.