### PR TITLE
cpu/atmega_common: adjust spi for at328p and at1281

### DIFF
--- a/boards/arduino-atmega-common/include/periph_conf.h
+++ b/boards/arduino-atmega-common/include/periph_conf.h
@@ -111,20 +111,24 @@ extern "C" {
 /**
  * @name    SPI configuration
  *
- * The atmega2560 has only one hardware SPI with fixed pin configuration, so all
- * we can do here, is to enable or disable it...
+ * The atmega2560/atmega1281/atmega328p has only one hardware SPI with fixed pin
+ * configuration, so all we can do here, is to enable or disable it...
  *
- * The fixed pins for arduino uno and duemilanove are:
+ * The fixed pins for arduino uno and duemilanove (atmega328p) are:
  * MOSI - PB3 (Arduino pin 11)
  * MISO - PB4 (Arduino pin 12)
  * SCK  - PB5 (Arduino pin 13)
  * SS   - PB2 (Arduino pin 10) -> this pin is configured as output, but not used
  *
- * The fixed pins for arduino mega2560 are:
+ * The fixed pins for arduino-mega2560 and atmega1281 are:
  * MOSI - PB2 (Arduino pin 51)
  * MISO - PB3 (Arduino pin 50)
  * SCK  - PB1 (Arduino pin 52)
  * SS   - PB0 (Arduino pin 53) -> this pin is configured as output, but not used
+ *
+ * The SS pin must be configured as output for the SPI device to work as
+ * master correctly, though we do not use it for now (as we handle the chip
+ * select externally for now)
  *
  * @{
  */

--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Daniel Amkaer Sorensen
  *               2016 Freie Universität Berlin
+ *               2017 Hamburg University of Applied Sciences
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,6 +17,7 @@
  *
  * @author      Daniel Amkaer Sorensen <daniel.amkaer@gmail.com>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
  *
  * @}
  */
@@ -46,18 +48,13 @@ void spi_init(spi_t bus)
 
 void spi_init_pins(spi_t bus)
 {
-
-    /* the pin configuration for this CPU is fixed:
-     * - PB3: MISO (configure as input - done automatically)
-     * - PB2: MOSI (configure as output)
-     * - PB1: SCK  (configure as output)
-     * - PB0: SS   (configure as output, but unused)
-     *
-     * The SS pin must be configured as output for the SPI device to work as
-     * master correctly, though we do not use it for now (as we handle the chip
-     * select externally for now)
-     */
+    /* set SPI pins as output */
+#if defined (CPU_ATMEGA2560) || defined (CPU_ATMEGA1281)
     DDRB |= ((1 << DDB2) | (1 << DDB1) | (1 << DDB0));
+#endif
+#ifdef CPU_ATMEGA328P
+    DDRB |= ((1 << DDB2) | (1 << DDB3) | (1 << DDB5));
+#endif
 }
 
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)


### PR DESCRIPTION
This PR fixes the SPI pin configuration for ATMEGA328P and adds a SPI pin configuration for ATMEGA1281.

Because the existing test program "tests/periph_spi" needs more than 2KB RAM, it cannot be used on the ATMEGA328P (Arduino UNO). Therefore, a thin version of the test program was created. It can be found [here](https://github.com/dnahm/RIOT/tree/test_spi_write_read_function)

