### PR TITLE
net/emcute: check value of length field before use

### DIFF
--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -106,6 +106,9 @@ extern "C" {
 /**
  * @brief   Buffer size used for emCute's transmit and receive buffers
  *
+ * @note    The buffer size MUST be less than 32768 on 16-bit and 8-bit
+ *          platforms to prevent buffer overflows.
+ *
  * The overall buffer size used by emCute is this value time two (Rx + Tx).
  */
 #define EMCUTE_BUFSIZE          (512U)

--- a/sys/include/net/emcute.h
+++ b/sys/include/net/emcute.h
@@ -210,7 +210,7 @@ typedef struct {
  * @brief   Signature for callbacks fired when publish messages are received
  *
  * @param[in] topic     topic the received data was published on
- * @param[in] data      published data
+ * @param[in] data      published data, can be NULL
  * @param[in] len       length of @p data in bytes
  */
 typedef void(*emcute_cb_t)(const emcute_topic_t *topic, void *data, size_t len);

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -79,7 +79,7 @@ static inline void set_u16(uint8_t *buf, uint16_t val)
 #endif
 }
 
-static int set_len(uint8_t *buf, size_t len)
+static size_t set_len(uint8_t *buf, size_t len)
 {
     if (len < (0xff - 7)) {
         buf[0] = len + 1;
@@ -92,7 +92,7 @@ static int set_len(uint8_t *buf, size_t len)
     }
 }
 
-static int get_len(uint8_t *buf, uint16_t *len)
+static size_t get_len(uint8_t *buf, uint16_t *len)
 {
     if (buf[0] != 0x01) {
         *len = (uint16_t)buf[0];
@@ -165,10 +165,10 @@ static void on_ack(uint8_t type, int id_pos, int ret_pos, int res_pos)
     }
 }
 
-static void on_publish(uint16_t len, int pos)
+static void on_publish(size_t len, size_t pos)
 {
     /* make sure packet length is valid - if not, drop packet silently */
-    if ((int)len < (pos + 6)) {
+    if (len < (pos + 6)) {
         return;
     }
 
@@ -274,7 +274,7 @@ int emcute_con(sock_udp_ep_t *remote, bool clean, const char *will_topic,
         }
 
         /* now send WILLTOPIC */
-        int pos = set_len(tbuf, (topic_len + 2));
+        size_t pos = set_len(tbuf, (topic_len + 2));
         len = (pos + topic_len + 2);
         tbuf[pos++] = WILLTOPIC;
         tbuf[pos++] = will_flags;
@@ -361,7 +361,7 @@ int emcute_pub(emcute_topic_t *topic, const void *data, size_t len,
 
     mutex_lock(&txlock);
 
-    int pos = set_len(tbuf, (len + 6));
+    size_t pos = set_len(tbuf, (len + 6));
     len += (pos + 6);
     tbuf[pos++] = PUBLISH;
     tbuf[pos++] = flags;
@@ -498,7 +498,7 @@ int emcute_willupd_msg(const void *data, size_t len)
 
     mutex_lock(&txlock);
 
-    int pos = set_len(tbuf, (len + 1));
+    size_t pos = set_len(tbuf, (len + 1));
     len += (pos + 1);
     tbuf[pos++] = WILLMSGUPD;
     memcpy(&tbuf[pos], data, len);
@@ -542,28 +542,28 @@ void emcute_run(uint16_t port, const char *id)
                 continue;
             }
             /* parse length field */
-            int pos = get_len(rbuf, &pkt_len);
+            size_t pos = get_len(rbuf, &pkt_len);
             /* verify length to prevent overflows */
-            if (((ssize_t)pkt_len > len) || ((ssize_t)pos >= len)) {
+            if (((size_t)pkt_len > (size_t)len) || (pos >= (size_t)len)) {
                 continue;
             }
             /* get packet type */
             uint8_t type = rbuf[pos];
 
             switch (type) {
-                case CONNACK:       on_ack(type, 0, 2, 0);  break;
-                case WILLTOPICREQ:  on_ack(type, 0, 0, 0);  break;
-                case WILLMSGREQ:    on_ack(type, 0, 0, 0);  break;
-                case REGACK:        on_ack(type, 4, 6, 2);  break;
-                case PUBLISH:       on_publish(len, pos);   break;
-                case PUBACK:        on_ack(type, 4, 6, 0);  break;
-                case SUBACK:        on_ack(type, 5, 7, 3);  break;
-                case UNSUBACK:      on_ack(type, 2, 0, 0);  break;
-                case PINGREQ:       on_pingreq(&remote);    break;
-                case PINGRESP:      on_pingresp();          break;
-                case DISCONNECT:    on_disconnect();        break;
-                case WILLTOPICRESP: on_ack(type, 0, 0, 0);  break;
-                case WILLMSGRESP:   on_ack(type, 0, 0, 0);  break;
+                case CONNACK:       on_ack(type, 0, 2, 0);              break;
+                case WILLTOPICREQ:  on_ack(type, 0, 0, 0);              break;
+                case WILLMSGREQ:    on_ack(type, 0, 0, 0);              break;
+                case REGACK:        on_ack(type, 4, 6, 2);              break;
+                case PUBLISH:       on_publish((size_t)pkt_len, pos);   break;
+                case PUBACK:        on_ack(type, 4, 6, 0);              break;
+                case SUBACK:        on_ack(type, 5, 7, 3);              break;
+                case UNSUBACK:      on_ack(type, 2, 0, 0);              break;
+                case PINGREQ:       on_pingreq(&remote);                break;
+                case PINGRESP:      on_pingresp();                      break;
+                case DISCONNECT:    on_disconnect();                    break;
+                case WILLTOPICRESP: on_ack(type, 0, 0, 0);              break;
+                case WILLMSGRESP:   on_ack(type, 0, 0, 0);              break;
                 default:
                     LOG_DEBUG("[emcute] received unexpected type [%s]\n",
                               emcute_type_str(type));


### PR DESCRIPTION
The value of the length field was not checked/verified, leading to potential security/stability vulnerabilities. I might not have fixed all problems, but this PR is at least fixing some obvious ones.

-> Thanks to Eric for pointing this out!