### PR TITLE
ipv6/rpl: add hop-by-hop extension handling

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -130,6 +130,11 @@ ifneq (,$(filter gnrc_rpl_p2p,$(USEMODULE)))
   USEMODULE += gnrc_rpl
 endif
 
+ifneq (,$(filter gnrc_rpl_hop,$(USEMODULE)))
+  USEMODULE += gnrc_rpl
+  USEMODULE += gnrc_ipv6_ext
+endif
+
 ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   USEMODULE += gnrc_icmpv6
   USEMODULE += gnrc_ipv6_nib

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -39,7 +39,7 @@ USEMODULE += ps
 USEMODULE += netstats_l2
 USEMODULE += netstats_ipv6
 USEMODULE += netstats_rpl
-
+USEMODULE += gnrc_rpl_hop
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -145,13 +145,14 @@ kernel_pid_t gnrc_ipv6_init(void);
  * This situation may happen when the packet has a source routing extension
  * header (RFC 6554), and the packet is forwarded from an interface to another.
  *
- * @param[in] netif     The receiving interface.
- * @param[in] current   A snip to process.
- * @param[in] pkt       A packet.
- * @param[in] nh        A protocol number (see @ref net_protnum) of the current snip.
+ * @param[in] netif      The receiving interface.
+ * @param[in] current    A snip to process.
+ * @param[in] pkt        A packet.
+ * @param[in] nh         A protocol number (see @ref net_protnum) of the current snip.
+ * @param[in] is_for_me  Indicates if we are the destination of the packet.
  */
 void gnrc_ipv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *current,
-                     gnrc_pktsnip_t *pkt, uint8_t nh);
+                     gnrc_pktsnip_t *pkt, uint8_t nh, bool is_for_me);
 
 /**
  * @brief   Get the IPv6 header from a given list of @ref gnrc_pktsnip_t

--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -58,11 +58,13 @@ extern "C" {
  * @param[in] current   A snip to process.
  * @param[in] pkt       A packet.
  * @param[in] nh        A protocol number (see @ref net_protnum) of the current snip.
+ * @param[in] is_for_me  Indicates if We are the destination of the packet.
  */
 void gnrc_ipv6_ext_demux(gnrc_netif_t *netif,
                          gnrc_pktsnip_t *current,
                          gnrc_pktsnip_t *pkt,
-                         uint8_t nh);
+                         uint8_t nh,
+                         bool is_for_me);
 
 /**
  * @brief   Builds an extension header for sending.

--- a/sys/include/net/gnrc/rpl/hop.h
+++ b/sys/include/net/gnrc/rpl/hop.h
@@ -20,8 +20,8 @@
  *
  * @author  Martin Landsmann <martin.landsmann@haw-hamburg.de>
  */
-#ifndef GNRC_RPL_HOP_H
-#define GNRC_RPL_HOP_H
+#ifndef NET_GNRC_RPL_HOP_H
+#define NET_GNRC_RPL_HOP_H
 
 #include "net/ipv6/hdr.h"
 #include "net/ipv6/addr.h"
@@ -72,7 +72,9 @@ extern "C" {
  *      </a>
  */
 typedef struct __attribute__((packed)) {
-    uint8_t nh;           /**< next header identifier (0x63) */
+    uint8_t nh;           /**< the option type of the next extension */
+    uint8_t hbh_len;      /**< the hbh length without the first octet */
+    uint8_t type;         /**< option identifier (0x63) */
     uint8_t len;          /**< length in 8 octets without first octet */
     uint8_t ORF_flags;    /**< O|R|F flags followed by 5 unused bits */
     uint8_t instance_id;  /**< id of the instance */
@@ -99,5 +101,5 @@ int gnrc_rpl_hop_opt_process(gnrc_rpl_hop_opt_t *hop);
 }
 #endif
 
-#endif /* GNRC_RPL_HOP_H */
+#endif /* NET_GNRC_RPL_HOP_H */
 /** @} */

--- a/sys/include/net/gnrc/rpl/hop.h
+++ b/sys/include/net/gnrc/rpl/hop.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2017 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_rpl_hop RPL Hop-by-Hop header extension
+ * @ingroup     net_gnrc_rpl
+ * @brief       Implementation of RPL Hop-by-Hop extension headers
+ * @see <a href="https://tools.ietf.org/html/rfc6553">
+ *          RFC 6553
+ *      </a>
+ * @{
+ *
+ * @file
+ * @brief       Definitions for Carrying RPL Information in Data-Plane Datagrams
+ *
+ * @author  Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ */
+#ifndef GNRC_RPL_HOP_H
+#define GNRC_RPL_HOP_H
+
+#include "net/ipv6/hdr.h"
+#include "net/ipv6/addr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Type of the Hop-by-Hop Option.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6553#section-6">
+ *         RFC6553, section 6
+ *      </a>
+ */
+#define GNRC_RPL_HOP_OPT_TYPE   (0x63)
+
+/**
+ * @name   Return types used in processing a hop-by-hop option
+ *
+ * @{
+ */
+#define HOP_OPT_SUCCESS                   (0)
+#define HOP_OPT_ERR_HEADER_LENGTH         (-1)
+#define HOP_OPT_ERR_INCONSISTENCY         (-2)
+#define HOP_OPT_ERR_FLAG_R_SET            (-3)
+#define HOP_OPT_ERR_FLAG_F_SET            (-4)
+#define HOP_OPT_ERR_NOT_FOR_ME            (-5)
+/** @} */
+
+/**
+ * @name Option flags
+ * @see <a href="https://tools.ietf.org/html/rfc6553#section-3">
+ *         RFC6553, section 3
+ *     </a>
+ * @{
+ */
+#define GNRC_RPL_HOP_OPT_FLAG_O  (1 << 0)
+#define GNRC_RPL_HOP_OPT_FLAG_R  (1 << 1)
+#define GNRC_RPL_HOP_OPT_FLAG_F  (1 << 2)
+/** @} */
+
+/**
+ * @brief   The RPL Hop-by-Hop header extension.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6553#section-3">
+ *          RFC 6553
+ *      </a>
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t nh;           /**< next header identifier (0x63) */
+    uint8_t len;          /**< length in 8 octets without first octet */
+    uint8_t ORF_flags;    /**< O|R|F flags followed by 5 unused bits */
+    uint8_t instance_id;  /**< id of the instance */
+    uint16_t sender_rank; /**< rank of the sender */
+} gnrc_rpl_hop_opt_t;
+
+
+/**
+ * @brief parse the given hop-by-hop option, check for inconsistencies,
+ *        adjust the option for further processing and return the result.
+ *
+ * @param[in,out] hop pointer to the hop-by-hop header option
+ *
+ * @returns HOP_OPT_SUCCESS on success
+ *          HOP_OPT_ERR_HEADER_LENGTH if there was a header length mismatch
+ *          HOP_OPT_ERR_INCONSISTENCY if the F flag was already set
+ *          HOP_OPT_ERR_FLAG_R_SET if we set the R flag
+ *          HOP_OPT_ERR_FLAG_F_SET if we set the F flag
+ *          HOP_OPT_ERR_NOT_FOR_ME if the content is not for us
+ */
+int gnrc_rpl_hop_opt_process(gnrc_rpl_hop_opt_t *hop);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_RPL_HOP_H */
+/** @} */

--- a/sys/include/net/ipv6/ext.h
+++ b/sys/include/net/ipv6/ext.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 
 #include "net/ipv6/ext/rh.h"
+#include "net/gnrc/pkt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,6 +31,19 @@ extern "C" {
 
 #define IPV6_EXT_LEN_UNIT   (8U)    /**< Unit in byte for the extension header's
                                      *   length field */
+
+/** @brief Message type to reply IPv6 that a next header has been processed */
+#define GNRC_IPV6_EXT_HANDLE_NEXT_HDR   (0x0399)
+
+/**
+ * @brief   Message content container to process extension headers sequentially.
+ */
+typedef struct {
+    kernel_pid_t    iface;      /**< The interface we received the packet */
+    gnrc_pktsnip_t  *current;   /**< The snip of the IP6 header */
+    gnrc_pktsnip_t  *next_hdr;  /**< The next header to be processed */
+    uint8_t         nh_type;    /**< The type of the next header */
+} gnrc_ipv6_ext_hdr_handle_t;
 
 /**
  * @brief   IPv6 extension headers.

--- a/sys/include/net/ipv6/ext.h
+++ b/sys/include/net/ipv6/ext.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 
 #include "net/ipv6/ext/rh.h"
+#include "net/gnrc/netif.h"
 #include "net/gnrc/pkt.h"
 
 #ifdef __cplusplus
@@ -39,7 +40,7 @@ extern "C" {
  * @brief   Message content container to process extension headers sequentially.
  */
 typedef struct {
-    kernel_pid_t    iface;      /**< The interface we received the packet */
+    gnrc_netif_t    *netif;     /**< The interface we received the packet */
     gnrc_pktsnip_t  *current;   /**< The snip of the IP6 header */
     gnrc_pktsnip_t  *next_hdr;  /**< The next header to be processed */
     uint8_t         nh_type;    /**< The type of the next header */

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -553,6 +553,18 @@ typedef enum {
      * incoming frames until unset.
      */
     NETOPT_PHY_BUSY,
+    /**
+     * @brief   Type for sequiential processing of IPv6 extension headers
+     *
+     * On GET it requests a thread to provide an extension header
+     *        and prepends it to the given payload of the given (IPv6) packet.
+     * On SET it always returns -ENOTSUP.
+     *
+     * When the header is done the thread replies to the call.
+     * The result is the pktsnip_t with the extension header
+     * The result is NULL if no extension header is passed.
+     */
+    NETOPT_IPV6_EXT_HDR,
 
     /* add more options if needed */
 

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -82,6 +82,9 @@ endif
 ifneq (,$(filter gnrc_rpl_p2p,$(USEMODULE)))
   DIRS += routing/rpl/p2p
 endif
+ifneq (,$(filter gnrc_rpl_hop,$(USEMODULE)))
+    DIRS += routing/rpl/hop
+endif
 ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
   DIRS += network_layer/sixlowpan
 endif

--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -168,7 +168,8 @@ static inline bool _has_valid_size(gnrc_pktsnip_t *pkt, uint8_t nh)
 void gnrc_ipv6_ext_demux(gnrc_netif_t *netif,
                          gnrc_pktsnip_t *current,
                          gnrc_pktsnip_t *pkt,
-                         uint8_t nh)
+                         uint8_t nh,
+                         bool is_for_me)
 {
     ipv6_ext_t *ext;
 
@@ -195,7 +196,7 @@ void gnrc_ipv6_ext_demux(gnrc_netif_t *netif,
                             return;
                         }
 
-                        gnrc_ipv6_demux(netif, current, pkt, nh); /* demultiplex next header */
+                        gnrc_ipv6_demux(netif, current, pkt, nh, is_for_me); /* demultiplex next header */
 
                         return;
 
@@ -261,7 +262,7 @@ void gnrc_ipv6_ext_demux(gnrc_netif_t *netif,
                 break;
 
             default:
-                gnrc_ipv6_demux(netif, current, pkt, nh); /* demultiplex next header */
+                gnrc_ipv6_demux(netif, current, pkt, nh, is_for_me); /* demultiplex next header */
                 return;
         }
     }

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -93,6 +93,49 @@ kernel_pid_t gnrc_ipv6_init(void)
     return gnrc_ipv6_pid;
 }
 
+static void _dispatch_insert_ext_headers(gnrc_pktsnip_t *pkt)
+{
+    DEBUG("ipv6: dispatch insertion of extension headers\n");
+    uint8_t ext_demux[] = { PROTNUM_IPV6_EXT_HOPOPT
+                          , PROTNUM_IPV6_EXT_RH
+                          , PROTNUM_IPV6_EXT_FRAG
+                          , PROTNUM_IPV6_EXT_ESP
+                          , PROTNUM_IPV6_EXT_AH
+                          , PROTNUM_IPV6_EXT_DST
+                          , PROTNUM_IPV6_EXT_MOB
+                          };
+    bool encapsulate = false;
+
+    for ( size_t i = 0; i < sizeof(ext_demux); ++i ) {
+        gnrc_netreg_entry_t *call = gnrc_netreg_lookup(GNRC_NETAPI_MSG_TYPE_SND, ext_demux[i]);
+        msg_t msg, rcv;
+        msg.type = ext_demux[i];
+
+        while (call) {
+            if (   ext_demux[i] == PROTNUM_IPV6_EXT_HOPOPT
+                || ext_demux[i] == PROTNUM_IPV6_EXT_RH ) {
+                encapsulate = true;
+            }
+            msg.content.ptr = pkt;
+            msg_send_receive(&msg, &rcv, call->target.pid);
+            call = gnrc_netreg_getnext(call);
+        }
+    }
+
+    if (encapsulate) {
+        ipv6_hdr_t* hdr = gnrc_ipv6_get_header(pkt);
+        if (hdr) {
+            gnrc_pktsnip_t* tmp = pkt;
+            pkt = gnrc_ipv6_hdr_build(pkt, &hdr->src, &hdr->dst);
+            if (pkt == NULL) {
+                /* revert but what do we now */
+                DEBUG("ipv6: dispatch insertion of extension headers, encapsulation Error!\n");
+                pkt = tmp;
+            }
+        }
+    }
+}
+
 static void _dispatch_next_header(gnrc_pktsnip_t *current, gnrc_pktsnip_t *pkt,
                                   uint8_t nh, bool interested);
 
@@ -278,6 +321,7 @@ static void *_event_loop(void *args)
 
             case GNRC_NETAPI_MSG_TYPE_SND:
                 DEBUG("ipv6: GNRC_NETAPI_MSG_TYPE_SND received\n");
+                _dispatch_insert_ext_headers(msg.content.ptr);
                 _send(msg.content.ptr, true);
                 break;
 
@@ -286,6 +330,19 @@ static void *_event_loop(void *args)
                 DEBUG("ipv6: reply to unsupported get/set\n");
                 reply.content.value = -ENOTSUP;
                 msg_reply(&msg, &reply);
+                break;
+
+            case GNRC_IPV6_EXT_HANDLE_NEXT_HDR:
+                DEBUG("ipv6: GNRC_IPV6_EXT_HANDLE_NEXT_HDR received\n");
+                gnrc_ipv6_ext_hdr_handle_t *handle = (gnrc_ipv6_ext_hdr_handle_t*)msg.content.ptr;
+                assert(handle->current);
+
+                if (handle->next_hdr) {
+                    gnrc_ipv6_demux(handle->iface, handle->current, handle->next_hdr, handle->nh_type);
+                } else {
+                    /* no more headers passed send the packet further */
+                    _send(handle->current, false);
+                }
                 break;
 
             case GNRC_IPV6_NIB_SND_UC_NS:
@@ -866,40 +923,12 @@ static void _receive(gnrc_pktsnip_t *pkt)
             gnrc_pktbuf_release(pkt);
             return;
         }
-        /* TODO: check if receiving interface is router */
-        else if (--(hdr->hl) > 0) {  /* drop packets that *reach* Hop Limit 0 */
-            DEBUG("ipv6: forward packet to next hop\n");
-
-            /* pkt might not be writable yet, if header was given above */
-            ipv6 = gnrc_pktbuf_start_write(ipv6);
-            if (ipv6 == NULL) {
-                DEBUG("ipv6: unable to get write access to packet: dropping it\n");
-                gnrc_pktbuf_release(pkt);
-                return;
-            }
-
-            /* remove L2 headers around IPV6 */
-            netif_hdr = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
-            if (netif_hdr != NULL) {
-                gnrc_pktbuf_remove_snip(pkt, netif_hdr);
-            }
-            pkt = gnrc_pktbuf_reverse_snips(pkt);
-            if (pkt != NULL) {
-                _send(pkt, false);
-            }
-            else {
-                DEBUG("ipv6: unable to reverse pkt from receive order to send "
-                      "order; dropping it\n");
-            }
-            return;
-        }
-        else {
+        else if (--(hdr->hl) <= 0) {
             DEBUG("ipv6: hop limit reached 0: drop packet\n");
             gnrc_icmpv6_error_time_exc_send(ICMPV6_ERROR_TIME_EXC_HL, pkt);
             gnrc_pktbuf_release_error(pkt, ETIMEDOUT);
             return;
         }
-
 #else  /* MODULE_GNRC_IPV6_ROUTER */
         DEBUG("ipv6: dropping packet\n");
         /* non rounting hosts just drop the packet */

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -32,6 +32,10 @@
 #include "net/gnrc/rpl/p2p_dodag.h"
 #endif
 
+#include "net/gnrc/rpl/hop.h"
+#include "net/gnrc/pkt.h"
+#include "net/gnrc/pktbuf.h"
+#include "net/gnrc/nettype.h"
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
@@ -45,6 +49,7 @@ static msg_t _lt_msg = { .type = GNRC_RPL_MSG_TYPE_LIFETIME_UPDATE };
 #endif
 static msg_t _msg_q[GNRC_RPL_MSG_QUEUE_SIZE];
 static gnrc_netreg_entry_t _me_reg;
+static gnrc_netreg_entry_t _me_reg_dataplane_ext;
 static mutex_t _inst_id_mutex = MUTEX_INIT;
 static uint8_t _instance_id;
 
@@ -83,6 +88,11 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid)
         _me_reg.target.pid = gnrc_rpl_pid;
         /* register interest in all ICMPv6 packets */
         gnrc_netreg_register(GNRC_NETTYPE_ICMPV6, &_me_reg);
+
+        _me_reg_dataplane_ext.demux_ctx = PROTNUM_IPV6_EXT_HOPOPT;
+        _me_reg_dataplane_ext.target.pid = gnrc_rpl_pid;
+        /* register interest for IPv6 Hop-by-Hop extension headers */
+        gnrc_netreg_register(GNRC_NETTYPE_IPV6, &_me_reg_dataplane_ext);
 
         gnrc_rpl_of_manager_init();
         evtimer_init_msg(&gnrc_rpl_evtimer);
@@ -141,6 +151,159 @@ gnrc_rpl_instance_t *gnrc_rpl_root_init(uint8_t instance_id, ipv6_addr_t *dodag_
                   dodag->dio_redun);
 
     return inst;
+}
+
+static void _handle_ext_hdr_insert(gnrc_pktsnip_t *pkt)
+{
+    ipv6_hdr_t* hdr = gnrc_ipv6_get_header(pkt);
+    /* get the ipv6 header to append the extensions */
+    if (hdr == NULL) {
+        return;
+    }
+
+    for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
+        /* check if the destination is in one of our DODAGs */
+        gnrc_ipv6_netif_addr_t* prefix = gnrc_rpl_instances[i].dodag.netif_addr;
+
+        if (ipv6_addr_match_prefix(&(prefix->addr), &(hdr->dst)) == prefix->prefix_len) {
+            /* determine the forwarding direction towards the destination */
+            kernel_pid_t fib_iface;
+            ipv6_addr_t next_hop;
+            size_t next_hop_size = sizeof(ipv6_addr_t);
+            uint32_t next_hop_flags;
+
+            int ret = fib_get_next_hop(&gnrc_ipv6_fib_table, &fib_iface,
+                                       next_hop.u8, &next_hop_size,
+                                       &next_hop_flags, hdr->dst.u8, next_hop_size,
+                                       0);
+            if ( (ret == 0) && (next_hop_flags & FIB_FLAG_RPL_ROUTE) ) {
+                /* we know a next hop and it has been set by RPL */
+                gnrc_rpl_hop_opt_t ext_hdr;
+
+                ext_hdr.nh = 0x63;
+                ext_hdr.len = (sizeof(gnrc_rpl_hop_opt_t) - 2);
+                /* set default propagation direction to upward */
+                ext_hdr.ORF_flags = GNRC_RPL_HOP_OPT_FLAG_O;
+
+                ext_hdr.instance_id = gnrc_rpl_instances[i].id;
+                ext_hdr.sender_rank = gnrc_rpl_instances[i].dodag.my_rank;
+
+                if ( !ipv6_addr_is_unspecified(&next_hop) ) {
+                    /* its a downward route entry so we clear the bit */
+                    ext_hdr.ORF_flags &= ~GNRC_RPL_HOP_OPT_FLAG_O;
+                }
+                /* append the extension below the IPv6 Header */
+                gnrc_pktsnip_t* ext = gnrc_pktbuf_add(pkt->next, &ext_hdr,
+                                                      sizeof(gnrc_ipv6_ext_hdr_handle_t),
+                                                      GNRC_NETTYPE_UNDEF);
+                if (ext) {
+                    /* bend the pointers */
+                    pkt->next = ext;
+                }
+            }
+        }
+    }
+}
+
+static void _handle_ext_hdr_process(gnrc_pktsnip_t *ext, msg_t *msg)
+{
+        ipv6_ext_t *ext_header = ext->data;
+        gnrc_ipv6_ext_hdr_handle_t* content = (gnrc_ipv6_ext_hdr_handle_t*)msg->content.ptr;
+        content->next_hdr = NULL;
+        content->nh_type = 0;
+        content->iface = KERNEL_PID_UNDEF;
+
+        if (ext_header->nh == GNRC_RPL_HOP_OPT_TYPE) {
+            gnrc_rpl_hop_opt_t *hop = (gnrc_rpl_hop_opt_t *)ext_header;
+            int ret = gnrc_rpl_hop_opt_process(hop);
+            switch (ret) {
+                case HOP_OPT_SUCCESS:
+                /* fallthrough intentionally */
+                case HOP_OPT_ERR_FLAG_R_SET:
+                    /* we determined the first forwarding error and have set the R Flag */
+                    /* we check for more headers and let IPv6 demux them */
+                    if ((ext->next) && ext->next->type == GNRC_NETTYPE_IPV6_EXT) {
+
+                        content->next_hdr = ext->next;
+                        content->nh_type = ((ipv6_ext_t*)ext->next->data)->nh;
+
+                        gnrc_pktsnip_t *netif = gnrc_pktsnip_search_type(content->current, GNRC_NETTYPE_NETIF);
+                        content->iface = ((gnrc_netif_hdr_t *)netif->data)->if_pid;
+                    }
+                    else {
+                        /* done. no more headers to handle so we just forward the packet */
+                        gnrc_pktsnip_t *reversed_pkt = NULL, *ptr = content->current, *ipv6 = NULL;
+
+                        for (ipv6 = content->current; ipv6 != NULL; ipv6 = ipv6->next) { /* find IPv6 header if already marked */
+                                if ((ipv6->type == GNRC_NETTYPE_IPV6) && (ipv6->size == sizeof(ipv6_hdr_t)) &&
+                                    (ipv6_hdr_is(ipv6->data))) {
+                                    break;
+                                }
+                        }
+                        DEBUG("RPL: prepare to forward extended packet to next hop\n");
+
+                        /* pkt might not be writable yet, if header was given above */
+                        ipv6 = gnrc_pktbuf_start_write(ipv6);
+                        if (ipv6 == NULL) {
+                            DEBUG("RPL: unable to get write access to packet: dropping it\n");
+                            gnrc_pktbuf_release(content->current);
+                            return;
+                        }
+
+                        /* remove L2 headers around IPV6 */
+                        gnrc_pktsnip_t *netif = gnrc_pktsnip_search_type(content->current, GNRC_NETTYPE_NETIF);
+                        if (netif != NULL) {
+                            gnrc_pktbuf_remove_snip(content->current, netif);
+                        }
+
+                        /* reverse packet snip list order */
+                        while (ptr != NULL) {
+                            gnrc_pktsnip_t *next;
+                            ptr = gnrc_pktbuf_start_write(ptr);     /* duplicate if not already done */
+                            if (ptr == NULL) {
+                                DEBUG("RPL: unable to get write access to packet: dropping it\n");
+                                gnrc_pktbuf_release(reversed_pkt);
+                                gnrc_pktbuf_release(content->current);
+                                reversed_pkt = NULL;
+                                break;
+                            }
+                            next = ptr->next;
+                            ptr->next = reversed_pkt;
+                            reversed_pkt = ptr;
+                            ptr = next;
+                        }
+                        content->current = reversed_pkt;
+                    }
+                    msg_send(msg, msg->sender_pid);
+
+                    break;
+                case HOP_OPT_ERR_INCONSISTENCY:
+                    // we received a F Flag, process dependant on MOP
+                    // drop on non-storing
+                    // TODO: keep track of original sender and count F errors
+                    break;
+                case HOP_OPT_ERR_FLAG_F_SET:
+                    // we determined the second forwarding error and set the F Flag
+                    // drop on non-storing
+                    // TODO: keep track of original sender and count F errors
+                    break;
+                case HOP_OPT_ERR_NOT_FOR_ME:
+                    /* we found the header is just not for us */
+                case HOP_OPT_ERR_HEADER_LENGTH:
+                    /* something is broken with the extension -> ignore header, probably just not for us */
+                    if ((ext->next) && ext->next->type == GNRC_NETTYPE_IPV6_EXT) {
+                        content->next_hdr = ext->next;
+                        content->nh_type = ((ipv6_ext_t*)ext->next->data)->nh;
+
+                        gnrc_pktsnip_t *netif = gnrc_pktsnip_search_type(content->current, GNRC_NETTYPE_NETIF);
+                        content->iface = ((gnrc_netif_hdr_t *)netif->data)->if_pid;
+                        msg_send(msg, msg->sender_pid);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
 }
 
 static void _receive(gnrc_pktsnip_t *icmpv6)
@@ -242,10 +405,15 @@ static void _parent_timeout(gnrc_rpl_parent_t *parent)
 
 static void *_event_loop(void *args)
 {
-    msg_t msg, reply;
+    msg_t msg, reply, ext_handle;
+    gnrc_ipv6_ext_hdr_handle_t ext_msg_content;
 
     (void)args;
     msg_init_queue(_msg_q, GNRC_RPL_MSG_QUEUE_SIZE);
+
+    /* preinitialize next header call */
+    ext_handle.type = GNRC_IPV6_EXT_HANDLE_NEXT_HDR;
+    ext_handle.content.ptr = (void*)&ext_msg_content;
 
     /* preinitialize ACK */
     reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
@@ -260,12 +428,20 @@ static void *_event_loop(void *args)
         msg_receive(&msg);
 
         switch (msg.type) {
-#ifdef MODULE_GNRC_RPL_P2P
+            case PROTNUM_IPV6_EXT_HOPOPT:
+                DEBUG("RPL: call to add extension header received\n");
+                /* add our Hop-by-Hop extension header */
+                if (gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_ICMPV6) == NULL) {
+                    /* but only if we send a dataplane packet */
+                    _handle_ext_hdr_insert(msg.content.ptr);
+                }
+                /* reply to allow others adding their extension headers */
+                msg_reply(&msg, &reply);
+                break;
             case GNRC_RPL_MSG_TYPE_LIFETIME_UPDATE:
                 DEBUG("RPL: GNRC_RPL_MSG_TYPE_LIFETIME_UPDATE received\n");
                 _update_lifetime();
                 break;
-#endif
             case GNRC_RPL_MSG_TYPE_PARENT_TIMEOUT:
                 DEBUG("RPL: GNRC_RPL_MSG_TYPE_PARENT_TIMEOUT received\n");
                 parent = msg.content.ptr;
@@ -292,7 +468,17 @@ static void *_event_loop(void *args)
                 break;
             case GNRC_NETAPI_MSG_TYPE_RCV:
                 DEBUG("RPL: GNRC_NETAPI_MSG_TYPE_RCV received\n");
-                _receive(msg.content.ptr);
+                /* check for header extensions */
+                gnrc_pktsnip_t *ext = gnrc_pktsnip_search_type(msg.content.ptr,
+                                                               GNRC_NETTYPE_IPV6_EXT);
+                if (ext) {
+                    ext_msg_content.current = msg.content.ptr;
+                    _handle_ext_hdr_process(ext, &ext_handle);
+                }
+                else {
+                /* handle control msg */
+                    _receive(msg.content.ptr);
+                }
                 break;
             case GNRC_NETAPI_MSG_TYPE_SND:
                 break;

--- a/sys/net/gnrc/routing/rpl/hop/Makefile
+++ b/sys/net/gnrc/routing/rpl/hop/Makefile
@@ -1,0 +1,3 @@
+MODULE = gnrc_rpl_hop
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/routing/rpl/hop/gnrc_rpl_hop_opt.c
+++ b/sys/net/gnrc/routing/rpl/hop/gnrc_rpl_hop_opt.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Martin Landsmann  <martin.landsmann@haw-hamburg.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <string.h>
+#include "net/gnrc/ipv6/netif.h"
+#include "net/gnrc/rpl/dodag.h"
+#include "net/gnrc/rpl/hop.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#if ENABLE_DEBUG
+static char addr_str[IPV6_ADDR_MAX_STR_LEN];
+#endif
+
+int gnrc_rpl_hop_opt_process(gnrc_rpl_hop_opt_t *hop)
+{
+    /* excluding the Option Type and Opt Data Len fields */
+    if (hop->len >= (sizeof(gnrc_rpl_hop_opt_t) - 2)) {
+        return HOP_OPT_ERR_HEADER_LENGTH;
+    }
+
+    if (hop->ORF_flags & GNRC_RPL_HOP_OPT_FLAG_F) {
+        /* we received a forwarding incosistency */
+        return HOP_OPT_ERR_INCONSISTENCY;
+    }
+
+    for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
+        /* check if the option is for us */
+        if (gnrc_rpl_instances[i].id == hop->instance_id) {
+            /* check if the packet traversed in the expected direction */
+            if ((gnrc_rpl_instances[i].dodag.my_rank < hop->sender_rank)
+                && (hop->ORF_flags & GNRC_RPL_HOP_OPT_FLAG_O)) {
+                /* everything worked out as expectes so we store our rank */
+                hop->sender_rank = gnrc_rpl_instances[i].dodag.my_rank;
+                /* and push the paket further towards its destination */
+                return HOP_OPT_SUCCESS;
+            }
+            else {
+                /* it didn't */
+                if (hop->ORF_flags & GNRC_RPL_HOP_OPT_FLAG_R) {
+                    /* its not the first time so we set error flag F */
+                    hop->ORF_flags |= GNRC_RPL_HOP_OPT_FLAG_F;
+                    /* start local repair and return */
+                    gnrc_rpl_local_repair(&gnrc_rpl_instances[i].dodag);
+
+                    return HOP_OPT_ERR_FLAG_F_SET;
+                }
+                /* set error flag R and return */
+                hop->ORF_flags |= GNRC_RPL_HOP_OPT_FLAG_R;
+                return HOP_OPT_ERR_FLAG_R_SET;
+            }
+        }
+    }
+    /* the option is not related to us, we just forward the packet further */
+    return HOP_OPT_ERR_NOT_FOR_ME;
+}
+
+/** @} */

--- a/sys/net/gnrc/routing/rpl/hop/gnrc_rpl_hop_opt.c
+++ b/sys/net/gnrc/routing/rpl/hop/gnrc_rpl_hop_opt.c
@@ -13,7 +13,6 @@
  */
 
 #include <string.h>
-#include "net/gnrc/ipv6/netif.h"
 #include "net/gnrc/rpl/dodag.h"
 #include "net/gnrc/rpl/hop.h"
 


### PR DESCRIPTION
This PR introduces hop-by-hop header handling for RPL, 
which includes an adjustment to extension header processing in `gnrc_ipv6`.

For receiving packets the adjustment introduces a sequential procedure which enables all interested threads to evaluate an extension and react before the packet is forwarded further.
When sending a packet all interested threads will be called to insert their extension before the packet is sent.