### PR TITLE
makefiles/tools/bossa: remove duplicate info option and add erase option

### DIFF
--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -1,5 +1,5 @@
 export FLASHER ?= $(RIOTBASE)/dist/tools/bossa/bossac
-export FFLAGS  ?= -p $(PORT) -i -i -w -v -b -R $(HEXFILE)
+export FFLAGS  ?= -p $(PORT) -e -i -w -v -b -R $(HEXFILE)
 
 export OFLAGS  = -O binary
 export HEXFILE = $(ELFFILE:.elf=.bin)


### PR DESCRIPTION
I notice the bossac command line uses twice the same option.

Also sometimes, I had to erase any previous firmware on flash to be able to correctly reflash a board. This PR does the 2 at the same time: removing the extra `-i` option and adding `-e` option. Maybe only the first change is required.