### PR TITLE
net/gcoap: Make references to coap_resource_t all const in gcoap

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -41,7 +41,7 @@ static const coap_resource_t _resources[] = {
 };
 
 static gcoap_listener_t _listener = {
-    (coap_resource_t *)&_resources[0],
+    &_resources[0],
     sizeof(_resources) / sizeof(_resources[0]),
     NULL
 };

--- a/examples/rdcli_simple/main.c
+++ b/examples/rdcli_simple/main.c
@@ -57,7 +57,7 @@ static const coap_resource_t resources[] = {
 };
 
 static gcoap_listener_t listener = {
-    .resources     = (coap_resource_t *)&resources[0],
+    .resources     = &resources[0],
     .resources_len = sizeof(resources) / sizeof(resources[0]),
     .next          = NULL
 };

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -433,10 +433,10 @@ extern "C" {
  * @brief   A modular collection of resources for a server
  */
 typedef struct gcoap_listener {
-    coap_resource_t *resources;     /**< First element in the array of
-                                     *   resources; must order alphabetically */
-    size_t resources_len;           /**< Length of array */
-    struct gcoap_listener *next;    /**< Next listener in list */
+    const coap_resource_t *resources;   /**< First element in the array of
+                                         *   resources; must order alphabetically */
+    size_t resources_len;               /**< Length of array */
+    struct gcoap_listener *next;        /**< Next listener in list */
 } gcoap_listener_t;
 
 /**
@@ -480,7 +480,7 @@ typedef struct {
  */
 typedef struct {
     sock_udp_ep_t *observer;            /**< Client endpoint; unused if null */
-    coap_resource_t *resource;          /**< Entity being observed */
+    const coap_resource_t *resource;    /**< Entity being observed */
     uint8_t token[GCOAP_TOKENLEN_MAX];  /**< Client token for notifications */
     unsigned token_len;                 /**< Actual length of token attribute */
 } gcoap_observe_memo_t;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -48,7 +48,7 @@ static void _expire_request(gcoap_request_memo_t *memo);
 static bool _endpoints_equal(const sock_udp_ep_t *ep1, const sock_udp_ep_t *ep2);
 static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *pdu,
                            const sock_udp_ep_t *remote);
-static int _find_resource(coap_pkt_t *pdu, coap_resource_t **resource_ptr,
+static int _find_resource(coap_pkt_t *pdu, const coap_resource_t **resource_ptr,
                                             gcoap_listener_t **listener_ptr);
 static int _find_observer(sock_udp_ep_t **observer, sock_udp_ep_t *remote);
 static int _find_obs_memo(gcoap_observe_memo_t **memo, sock_udp_ep_t *remote,
@@ -62,7 +62,7 @@ const coap_resource_t _default_resources[] = {
 };
 
 static gcoap_listener_t _default_listener = {
-    (coap_resource_t *)&_default_resources[0],
+    &_default_resources[0],
     sizeof(_default_resources) / sizeof(_default_resources[0]),
     NULL
 };
@@ -267,10 +267,10 @@ static void _listen(sock_udp_t *sock)
 static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                                          sock_udp_ep_t *remote)
 {
-    coap_resource_t *resource  = NULL;
-    gcoap_listener_t *listener = NULL;
-    sock_udp_ep_t *observer    = NULL;
-    gcoap_observe_memo_t *memo = NULL;
+    const coap_resource_t *resource     = NULL;
+    gcoap_listener_t *listener          = NULL;
+    sock_udp_ep_t *observer             = NULL;
+    gcoap_observe_memo_t *memo          = NULL;
     gcoap_observe_memo_t *resource_memo = NULL;
 
     switch (_find_resource(pdu, &resource, &listener)) {
@@ -382,7 +382,7 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
  *        code didn't match and `GCOAP_RESOURCE_NO_PATH` if no matching
  *        resource was found.
  */
-static int _find_resource(coap_pkt_t *pdu, coap_resource_t **resource_ptr,
+static int _find_resource(coap_pkt_t *pdu, const coap_resource_t **resource_ptr,
                                             gcoap_listener_t **listener_ptr)
 {
     int ret = GCOAP_RESOURCE_NO_PATH;
@@ -391,7 +391,7 @@ static int _find_resource(coap_pkt_t *pdu, coap_resource_t **resource_ptr,
     /* Find path for CoAP msg among listener resources and execute callback. */
     gcoap_listener_t *listener = _coap_state.listeners;
     while (listener) {
-        coap_resource_t *resource = listener->resources;
+        const coap_resource_t *resource = listener->resources;
         for (size_t i = 0; i < listener->resources_len; i++) {
             if (i) {
                 resource++;
@@ -1008,7 +1008,7 @@ int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf)
 
     /* write payload */
     while (listener) {
-        coap_resource_t *resource = listener->resources;
+        const coap_resource_t *resource = listener->resources;
 
         for (unsigned i = 0; i < listener->resources_len; i++) {
             size_t path_len = strlen(resource->path);

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -36,13 +36,13 @@ static const coap_resource_t resources_second[] = {
 };
 
 static gcoap_listener_t listener = {
-    .resources     = (coap_resource_t *)&resources[0],
+    .resources     = &resources[0],
     .resources_len = (sizeof(resources) / sizeof(resources[0])),
     .next          = NULL
 };
 
 static gcoap_listener_t listener_second = {
-    .resources     = (coap_resource_t *)&resources_second[0],
+    .resources     = &resources_second[0],
     .resources_len = (sizeof(resources_second) / sizeof(resources_second[0])),
     .next          = NULL
 };


### PR DESCRIPTION
The `coap_resource_t` data structures are a major interface between the application using CoAP and the CoAP library.  The application defines the resources, and the library uses arrays of resources to find the right resource and call its handler.  (At this point that takes place only for handling requests, but in the future we will try to extend this also to CoAP observe notifications.)  However, it is useful if the application can extend the `coap_resource_t` data structure with extra, application specific information.

Prior to 95543a3, extending the `coap_resource_t` data structures would have required to create a separate data structure for each resource.  Commit 95543a3 adds an layer of indirection, where the application constructs arrays of *pointers* to `coap_resource_t` data structures instead of having mere arrays of `coap_resource_t`.  This allows each of the `coap_resource_t` structs to be of any size, allowing the application to add more information into the structs.

Commit f126bd9 is a separate but related.  It simply changes all `coap_resource_t` pointers within the library to point to `const` structs.  That allows the application to store the resources either in flash or SRAM, as it desires, without needing to use type casts.  