### PR TITLE
shell/ccnl: remove use of ccnl_wait_for chunk()

### DIFF
--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -27,6 +27,8 @@ USEMODULE += shell_commands
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
+# This application dumps received packets to STDIO using the pktdump module
+USEMODULE += gnrc_pktdump
 USEMODULE += timex
 USEMODULE += xtimer
 USEMODULE += random

--- a/examples/ccn-lite-relay/main.c
+++ b/examples/ccn-lite-relay/main.c
@@ -25,6 +25,7 @@
 #include "shell.h"
 #include "ccn-lite-riot.h"
 #include "net/gnrc/netif.h"
+#include "net/gnrc/pktdump.h"
 
 /* main thread's message queue */
 #define MAIN_QUEUE_SIZE     (8)
@@ -53,6 +54,12 @@ int main(void)
         puts("Error registering at network interface!");
         return -1;
     }
+
+#ifdef MODULE_NETIF
+    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                          gnrc_pktdump_pid);
+    gnrc_netreg_register(GNRC_NETTYPE_CCN_CHUNK, &dump);
+#endif
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -88,6 +88,12 @@ static void _dump_snip(gnrc_pktsnip_t *pkt)
             udp_hdr_print(pkt->data);
             break;
 #endif
+#ifdef MODULE_CCN_LITE_UTILS
+        case GNRC_NETTYPE_CCN_CHUNK:
+            printf("GNRC_NETTYPE_CCN_CHUNK (%i)\n", pkt->type);
+            printf("Content is: %.*s\n", pkt->size, (char*)pkt->data);
+            break;
+#endif
 #ifdef TEST_SUITES
         case GNRC_NETTYPE_TEST:
             printf("NETTYPE_TEST (%i)\n", pkt->type);

--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -29,7 +29,6 @@
 #define MAX_ADDR_LEN            (8U)
 
 static unsigned char _int_buf[BUF_SIZE];
-static unsigned char _cont_buf[BUF_SIZE];
 
 static const char *_default_content = "Start the RIOT!";
 static unsigned char _out[CCNL_MAX_PACKET_SIZE];
@@ -206,26 +205,10 @@ int _ccnl_interest(int argc, char **argv)
     }
 
     memset(_int_buf, '\0', BUF_SIZE);
-    memset(_cont_buf, '\0', BUF_SIZE);
-
-    gnrc_netreg_entry_t _ne =
-        GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                   sched_active_pid);
-    /* register for content chunks */
-    gnrc_netreg_register(GNRC_NETTYPE_CCN_CHUNK, &_ne);
 
     struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(argv[1], CCNL_SUITE_NDNTLV, NULL, 0);
-    ccnl_send_interest(prefix, _int_buf, BUF_SIZE);
-    int res = 0;
-    if (ccnl_wait_for_chunk(_cont_buf, BUF_SIZE, 0) > 0) {
-        printf("Content received: %s\n", _cont_buf);
-    }
-    else {
-        printf("Timeout! No content received in response to the Interest for %s.\n", argv[1]);
-        res = -1;
-    }
+    int res = ccnl_send_interest(prefix, _int_buf, BUF_SIZE);
     free_prefix(prefix);
-    gnrc_netreg_unregister(GNRC_NETTYPE_CCN_CHUNK, &_ne);
 
     return res;
 }


### PR DESCRIPTION
This PR removes use of the [`ccnl_wait_for_chunk`](https://github.com/cn-uofbasel/ccn-lite/blob/master/src/ccn-lite-riot.c#L525) function within the ccnl shell and prints received contents through `pktdump`. IMO data packet forwarding to the application should be up to the interest timeout parameters and PIT entries.