### PR TITLE
doc: fix doxygen grouping of cpu periph drivers

### DIFF
--- a/cpu/arm7_common/periph/pm.c
+++ b/cpu/arm7_common/periph/pm.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_arm7_common
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_atmega_common
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/atmega_common/periph/pm.c
+++ b/cpu/atmega_common/periph/pm.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_atmega_common
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_atmega_common
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_atmega_common
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_atmega_common
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_cc2538
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/cc2538/periph/hwrng.c
+++ b/cpu/cc2538/periph/hwrng.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_cc2538
+ * @ingroup     drivers_periph_hwng
  * @{
  *
  * @file

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @ingroup     cpu_cc2538
+ * @ingroup     drivers_periph
  * @{
  *
  * @file

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -161,7 +161,7 @@ static void recover_i2c_bus(void) {
 }
 
 #ifdef MODULE_XTIMER
-static void callback(void *arg)
+static void _timer_cb(void *arg)
 {
     mutex_unlock(&i2c_wait_mutex);
 }
@@ -180,7 +180,7 @@ static uint_fast8_t i2c_ctrl_blocking(uint_fast8_t flags)
 
 #ifdef MODULE_XTIMER
     /* Set a timeout at double the expected time to transmit a byte: */
-    xtimer_t xtimer = {.callback = callback};
+    xtimer_t xtimer = { .callback = _timer_cb, .arg = NULL };
     xtimer_set(&xtimer, xtimer_timeout);
 #endif
 

--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @addtogroup  cpu_cc2538
+ * @ingroup     cpu_cc2538
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_cc2538
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_cc2538
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_cc26x0
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/cc26x0/periph/timer.c
+++ b/cpu/cc26x0/periph/timer.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_cc26x0
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/cc26x0/periph/uart.c
+++ b/cpu/cc26x0/periph/uart.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_cc26x0
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/cc430/periph/rtc.c
+++ b/cpu/cc430/periph/rtc.c
@@ -8,10 +8,15 @@
  */
 
 /**
- * @ingroup driver_periph_rtc
+ * @ingroup     cc430
+ * @ingroup     drivers_periph_rtc
+ * @{
+ *
  * @file
  * @brief       CC430 real time clock implementation
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @}
  */
 
 #include <string.h>

--- a/cpu/cc430/periph/timer.c
+++ b/cpu/cc430/periph/timer.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     cpu_cc430
+ * @ingroup     cc430
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/cortexm_common/periph/pm.c
+++ b/cpu/cortexm_common/periph/pm.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/ezr32wg/periph/gpio.c
+++ b/cpu/ezr32wg/periph/gpio.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_ezr32wg
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_ezr32wg
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/ezr32wg/periph/uart.c
+++ b/cpu/ezr32wg/periph/uart.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_ezr32wg
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/kinetis_common/periph/adc.c
+++ b/cpu/kinetis_common/periph/adc.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_adc
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/kinetis_common/periph/dac.c
+++ b/cpu/kinetis_common/periph/dac.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_dac
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_dac
  *
  * @{
  *

--- a/cpu/kinetis_common/periph/gpio.c
+++ b/cpu/kinetis_common/periph/gpio.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_gpio
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_gpio
  *
  * @{
  *

--- a/cpu/kinetis_common/periph/hwrng_rnga.c
+++ b/cpu/kinetis_common/periph/hwrng_rnga.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_rnga
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_hwng
  *
  * @{
  *

--- a/cpu/kinetis_common/periph/hwrng_rngb.c
+++ b/cpu/kinetis_common/periph/hwrng_rngb.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_rngb
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_hwng
  * @{
  *
  * @file

--- a/cpu/kinetis_common/periph/i2c.c
+++ b/cpu/kinetis_common/periph/i2c.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_i2c
+ * @ingroup     cpu_kinetis_commo
+ * @ingroup     drivers_periph_i2c
  *
  * @note        This driver only implements the 7-bit addressing master mode.
  *

--- a/cpu/kinetis_common/periph/mcg.c
+++ b/cpu/kinetis_common/periph/mcg.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_mcg
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_mcg
  * @{
  *
  * @file

--- a/cpu/kinetis_common/periph/pm.c
+++ b/cpu/kinetis_common/periph/pm.c
@@ -10,6 +10,7 @@
 
 /**
  * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/kinetis_common/periph/pwm.c
+++ b/cpu/kinetis_common/periph/pwm.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_pwm
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_pwm
  *
  * @{
  *

--- a/cpu/kinetis_common/periph/rtc.c
+++ b/cpu/kinetis_common/periph/rtc.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_rtt
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_rtc
  *
  * @{
  *

--- a/cpu/kinetis_common/periph/rtt.c
+++ b/cpu/kinetis_common/periph/rtt.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_rtt
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_rtt
  *
  * @{
  *

--- a/cpu/kinetis_common/periph/spi.c
+++ b/cpu/kinetis_common/periph/spi.c
@@ -10,7 +10,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_spi
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_spi
  *
  * @{
  *

--- a/cpu/kinetis_common/periph/timer.c
+++ b/cpu/kinetis_common/periph/timer.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_timer
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_timer
  *
  * @{
  *

--- a/cpu/kinetis_common/periph/uart.c
+++ b/cpu/kinetis_common/periph/uart.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_uart
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_uart
  *
  * @{
  *

--- a/cpu/kinetis_common/periph/wdog.c
+++ b/cpu/kinetis_common/periph/wdog.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     cpu_kinetis_common_wdog
+ * @ingroup     cpu_kinetis_common
+ * @ingroup     drivers_periph_watchdog
  *
  * @{
  *

--- a/cpu/lm4f120/periph/adc.c
+++ b/cpu/lm4f120/periph/adc.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lm4f120
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/lm4f120/periph/gpio.c
+++ b/cpu/lm4f120/periph/gpio.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lm4f120
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_lm4f120
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file        timer.c

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lm4f120
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file        uart.c

--- a/cpu/lpc11u34/periph/adc.c
+++ b/cpu/lpc11u34/periph/adc.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc11u34
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/lpc11u34/periph/cpuid.c
+++ b/cpu/lpc11u34/periph/cpuid.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc11u34
+ * @ingroup     drivers_periph_cpuid
  * @{
  *
  * @file

--- a/cpu/lpc11u34/periph/gpio.c
+++ b/cpu/lpc11u34/periph/gpio.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc11u34
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/lpc11u34/periph/pwm.c
+++ b/cpu/lpc11u34/periph/pwm.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     lpc11u34
+ * @ingroup     drivers_periph_pwm
  * @{
  *
  * @file

--- a/cpu/lpc11u34/periph/spi.c
+++ b/cpu/lpc11u34/periph/spi.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_lpc11u34
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/cpu/lpc11u34/periph/timer.c
+++ b/cpu/lpc11u34/periph/timer.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc11u34
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/lpc11u34/periph/uart.c
+++ b/cpu/lpc11u34/periph/uart.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc11u34
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/lpc1768/periph/cpuid.c
+++ b/cpu/lpc1768/periph/cpuid.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_lpc1768
+ * @ingroup     drivers_periph_cpuid
  * @{
  *
  * @file

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc1768
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/lpc1768/periph/uart.c
+++ b/cpu/lpc1768/periph/uart.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc1768
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     lpc2387
+ * @ingroup     cpu_lpc2387
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/lpc2387/periph/pwm.c
+++ b/cpu/lpc2387/periph/pwm.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc2387
+ * @ingroup     drivers_periph_pwm
  * @{
  *
  * @file

--- a/cpu/lpc2387/periph/rtc.c
+++ b/cpu/lpc2387/periph/rtc.c
@@ -7,6 +7,19 @@
  * directory for more details.
  */
 
+ /**
+  * @ingroup     cpu_lpc2387
+  * @ingroup     drivers_periph_rtc
+  * @{
+  *
+  * @file
+  * @brief       Peripheral UART driver implementation
+  *
+  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+  *
+  * @}
+  */
+
 #include <sys/time.h>
 #include <stdint.h>
 #include <string.h>

--- a/cpu/lpc2387/periph/spi.c
+++ b/cpu/lpc2387/periph/spi.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_lpc2387
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc2387
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/lpc2387/periph/uart.c
+++ b/cpu/lpc2387/periph/uart.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_lpc2387
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/mips32r2_common/periph/pm.c
+++ b/cpu/mips32r2_common/periph/pm.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup      cpu_mips32r2_common
+ * @ingroup     cpu_mips32r2_common
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/mips32r2_common/periph/timer.c
+++ b/cpu/mips32r2_common/periph/timer.c
@@ -6,6 +6,17 @@
  * directory for more details.
  */
 
+ /**
+  * @ingroup     cpu_mips32r2_common
+  * @ingroup     drivers_periph_timer
+  * @{
+  *
+  * @file
+  * @brief       Implementation of the low-level timer driver
+  *
+  * @}
+  */
+
 #include <mips/cpu.h>
 #include <mips/m32c0.h>
 #include <mips/regdef.h>

--- a/cpu/mips_pic32_common/periph/gpio.c
+++ b/cpu/mips_pic32_common/periph/gpio.c
@@ -8,6 +8,17 @@
  *
  */
 
+ /**
+  * @ingroup     cpu_mips_pic32_common
+  * @ingroup     drivers_periph_gpio
+  * @{
+  *
+  * @file
+  * @brief       Low-level GPIO driver implementation
+  *
+  * @}
+  */
+
 #include <assert.h>
 #include <stdint.h>
 #include "periph/gpio.h"

--- a/cpu/mips_pic32_common/periph/uart.c
+++ b/cpu/mips_pic32_common/periph/uart.c
@@ -7,6 +7,17 @@
  * directory for more details.
  *
  */
+
+ /**
+  * @ingroup     cpu_mips_pic32_common
+  * @ingroup     drivers_periph_uart
+  * @{
+  *
+  * @file
+  * @brief       Peripheral UART driver implementation
+  *
+  * @}
+  */
 #include <assert.h>
 #include "periph/uart.h"
 #include "board.h"

--- a/cpu/msp430_common/periph/pm.c
+++ b/cpu/msp430_common/periph/pm.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_msp430_common
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/msp430fxyz/periph/gpio.c
+++ b/cpu/msp430fxyz/periph/gpio.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_msp430fxyz
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/msp430fxyz/periph/spi.c
+++ b/cpu/msp430fxyz/periph/spi.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_msp430fxyz
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_msp430fxyz
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/msp430fxyz/periph/uart.c
+++ b/cpu/msp430fxyz/periph/uart.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_msp430fxyz
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/native/periph/cpuid.c
+++ b/cpu/native/periph/cpuid.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @addtogroup  cpu_native
+ * @ingroup     cpu_native
+ * @ingroup     drivers_periph_cpuid
  * @{
  *
  * @file

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     native_cpu
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/native/periph/hwrng.c
+++ b/cpu/native/periph/hwrng.c
@@ -9,7 +9,7 @@
 
 /**
  * @ingroup     native_cpu
- * @defgroup    native_rng
+ * @ingroup     drivers_periph_hwrng
  * @{
  *
  * @file

--- a/cpu/native/periph/pm.c
+++ b/cpu/native/periph/pm.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     native_cpu
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/native/periph/rtc.c
+++ b/cpu/native/periph/rtc.c
@@ -7,16 +7,19 @@
  */
 
 /**
- * Native CPU periph/rtc.h implementation
+ * @ingroup     cpu_native
+ * @ingroup     drivers_periph_rtc
+ * @{
+ *
+ * @file
+ * @brief Native CPU periph/rtc.h implementation
  *
  * The implementation uses POSIX system calls to emulate a real-time
  * clock based on the system clock.
  *
  * @author Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  *
- * @ingroup _native_cpu
- * @defgroup _native_rtc
- * @file
+ * @}
  */
 
 #include <time.h>

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -5,19 +5,23 @@
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * @ingroup timer
- * @ingroup native_cpu
+ */
+
+/**
+ * @ingroup     native_cpu
+ * @ingroup     drivers_periph_timer
  * @{
- * @author  Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ *
  * @file
- * @brief Native CPU periph/timer.h implementation
+ * @brief       Native CPU periph/timer.h implementation
  *
  * Uses POSIX realtime clock and POSIX itimer to mimic hardware.
  *
  * This is based on native's hwtimer implementation by Ludwig Knüpfer.
  * I removed the multiplexing, as xtimer does the same. (kaspar)
+ *
+ * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *
  * @}
  */

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -8,12 +8,15 @@
 
 /**
  * @ingroup     native_cpu
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file
  * @brief       UART implementation based on /dev/tty devices on host
  *
  * @author      Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+ *
+ * @}
  */
 
 #include <errno.h>
@@ -174,5 +177,3 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 
     _native_write(tty_fds[uart], data, len);
 }
-
-/** @} */

--- a/cpu/nrf51/periph/adc.c
+++ b/cpu/nrf51/periph/adc.c
@@ -8,14 +8,12 @@
  */
 
 /**
- * @ingroup     cpu_nrf51822
+ * @ingroup     cpu_nrf51
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file
  * @brief       Low-level ADC driver implementation
- *
- * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  *
  * @}
  */

--- a/cpu/nrf51/periph/i2c.c
+++ b/cpu/nrf51/periph/i2c.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_nrf51
+ * @ingroup     drivers_periph_i2c
  * @{
  *
  * @file
@@ -17,7 +18,16 @@
  *
  * @}
  */
-
+/**
+ * @ingroup     cpu_nrf51
+ * @ingroup     drivers_periph_i2c
+ * @{
+ *
+ * @file
+ * @brief       Low-level I2V driver implementation
+ *
+ * @}
+ */
 #include "cpu.h"
 #include "mutex.h"
 #include "assert.h"

--- a/cpu/nrf5x_common/periph/flashpage.c
+++ b/cpu/nrf5x_common/periph/flashpage.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_flashpage
  * @{
  *
  * @file

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/nrf5x_common/periph/hwrng.c
+++ b/cpu/nrf5x_common/periph/hwrng.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_hwrng
  * @{
  *
  * @file

--- a/cpu/nrf5x_common/periph/pm.c
+++ b/cpu/nrf5x_common/periph/pm.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/nrf5x_common/periph/rtt.c
+++ b/cpu/nrf5x_common/periph/rtt.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_rtt
  * @{
  *
  * @file

--- a/cpu/nrf5x_common/periph/spi.c
+++ b/cpu/nrf5x_common/periph/spi.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/nrf5x_common/periph/uart.c
+++ b/cpu/nrf5x_common/periph/uart.c
@@ -10,6 +10,7 @@
 
 /**
  * @ingroup     cpu_nrf5x_common
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -8,6 +8,16 @@
  * directory for more details.
  */
 
+/**
+ * @ingroup     cpu_sam0_common
+ * @ingroup     drivers_periph_adc
+ * @{
+ *
+ * @file
+ * @brief       Low-level ADC driver implementation
+ *
+ * @}
+ */
 #include <stdint.h>
 #include "cpu.h"
 #include "periph/gpio.h"

--- a/cpu/sam0_common/periph/cpuid.c
+++ b/cpu/sam0_common/periph/cpuid.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @addtogroup  cpu_sam0_common
+ * @ingroup     cpu_sam0_common
+ * @ingroup     drivers_periph_cpuid
  * @{
  *
  * @file

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_sam0_common
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -7,12 +7,16 @@
  */
 
 /**
- * @ingroup  cpu_samd21
+ * @ingroup     cpu_sam0_common
+ * @ingroup     drivers_periph_i2c
  * @{
+ *
  * @file
  * @brief       Low-level I2C driver implementation
+ *
  * @author      Baptiste Clenet <bapclenet@gmail.com>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ *
  * @}
  */
 

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_samd21
+ * @ingroup     cpu_sam0_common
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/cpu/sam3/periph/cpuid.c
+++ b/cpu/sam3/periph/cpuid.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @addtogroup  cpu_sam3
+ * @ingroup     cpu_sam3
+ * @ingroup     drivers_periph_cpuid
  * @{
  *
  * @file

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -10,6 +10,7 @@
 
 /**
  * @ingroup     cpu_sam3
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/sam3/periph/hwrng.c
+++ b/cpu/sam3/periph/hwrng.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_sam3
+ * @ingroup     drivers_periph_hwrng
  * @{
  *
  * @file

--- a/cpu/sam3/periph/pwm.c
+++ b/cpu/sam3/periph/pwm.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     cpu_sam3x8e
+ * @ingroup     cpu_sam3
+ * @ingroup     drivers_periph_pwm
  * @{
  *
  * @file

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_sam3
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_sam3
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/sam3/periph/uart.c
+++ b/cpu/sam3/periph/uart.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_sam3
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/samd21/periph/gpio.c
+++ b/cpu/samd21/periph/gpio.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_samd21
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/samd21/periph/pm.c
+++ b/cpu/samd21/periph/pm.c
@@ -10,6 +10,7 @@
 
 /**
  * @ingroup     cpu_samd21
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/samd21/periph/pwm.c
+++ b/cpu/samd21/periph/pwm.c
@@ -9,6 +9,7 @@
 
 /**
  * @ingroup     cpu_samd21
+ * @ingroup     drivers_periph_pwm
  * @{
  *
  * @file

--- a/cpu/samd21/periph/rtc.c
+++ b/cpu/samd21/periph/rtc.c
@@ -8,10 +8,14 @@
 
 /**
  * @ingroup     cpu_samd21
+ * @ingroup     drivers_periph_rtc
  * @{
+ *
  * @file
  * @brief       Low-level RTC driver implementation
+ *
  * @author      Baptiste Clenet <bapclenet@gmail.com>
+ *
  * @}
  */
 

--- a/cpu/samd21/periph/rtt.c
+++ b/cpu/samd21/periph/rtt.c
@@ -8,10 +8,14 @@
 
 /**
  * @ingroup     cpu_samd21
+ * @ingroup     drivers_periph_rtt
  * @{
+ *
  * @file
  * @brief       Low-level RTT driver implementation
+ *
  * @author      Daniel Krebs <github@daniel-krebs.net>
+ *
  * @}
  */
 

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_samd21
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_samd21
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/saml21/periph/gpio.c
+++ b/cpu/saml21/periph/gpio.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_saml21
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file        gpio.c

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_saml21
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/saml21/periph/rtc.c
+++ b/cpu/saml21/periph/rtc.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_saml21
+ * @ingroup     drivers_periph_rtc
  * @{
  * @file
  * @brief       Low-level RTC driver implementation

--- a/cpu/saml21/periph/rtt.c
+++ b/cpu/saml21/periph/rtt.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_saml21
+ * @ingroup     drivers_periph_rtt
  * @{
  *
  * @file        rtt.c

--- a/cpu/saml21/periph/timer.c
+++ b/cpu/saml21/periph/timer.c
@@ -10,7 +10,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_saml21
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file        timer.c

--- a/cpu/saml21/periph/uart.c
+++ b/cpu/saml21/periph/uart.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     driver_periph
+ * @ingroup     cpu_saml21
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file        uart.c

--- a/cpu/stm32_common/periph/dac.c
+++ b/cpu/stm32_common/periph/dac.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32_common
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_stm32_common
+ * @ingroup     drivers_periph_flashpage
  * @{
  *
  * @file

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -10,7 +10,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32_common
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/stm32_common/periph/hwrng.c
+++ b/cpu/stm32_common/periph/hwrng.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32_common
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_hwrng
  * @{
  *
  * @file

--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_pm
  * @{
  *
  * @file

--- a/cpu/stm32_common/periph/pwm.c
+++ b/cpu/stm32_common/periph/pwm.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32_common
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_pwm
  * @{
  *
  * @file

--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32_common
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_rtc
  * @{
  * @file
  * @brief       Low-level RTC driver implementation

--- a/cpu/stm32_common/periph/rtt_lptim.c
+++ b/cpu/stm32_common/periph/rtt_lptim.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32_common
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_rtt
  * @{
  *
  * @file

--- a/cpu/stm32_common/periph/spi.c
+++ b/cpu/stm32_common/periph/spi.c
@@ -9,7 +9,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32_common
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32_common
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -8,7 +8,8 @@
  */
 
 /**
- * @ingroup     cpu_stm32_common
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_uart
  * @{
  *
  * @file

--- a/cpu/stm32f0/periph/adc.c
+++ b/cpu/stm32f0/periph/adc.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_stm32f0
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/stm32f1/periph/adc.c
+++ b/cpu/stm32f1/periph/adc.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_stm32f1
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_stm32f1
+ * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file

--- a/cpu/stm32f1/periph/i2c.c
+++ b/cpu/stm32f1/periph/i2c.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @ingroup     cpu_stm32f1
+ * @ingroup     drivers_periph_i2c
  * @{
  *
  * @file

--- a/cpu/stm32f1/periph/rtt.c
+++ b/cpu/stm32f1/periph/rtt.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_stm32f1
+ * @ingroup     drivers_periph_rtt
  * @{
  *
  * @file

--- a/cpu/stm32f2/periph/adc.c
+++ b/cpu/stm32f2/periph/adc.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_stm32f2
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/stm32f2/periph/dac.c
+++ b/cpu/stm32f2/periph/dac.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_stm32f2
+ * @ingroup     drivers_periph_dac
  * @{
  *
  * @file

--- a/cpu/stm32f2/periph/i2c.c
+++ b/cpu/stm32f2/periph/i2c.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @ingroup     cpu_stm32f2
+ * @ingroup     drivers_periph_i2c
  * @{
  *
  * @file

--- a/cpu/stm32f3/periph/i2c.c
+++ b/cpu/stm32f3/periph/i2c.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @ingroup     cpu_stm32f3
+ * @ingroup     drivers_periph_i2c
  * @{
  *
  * @file

--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_stm32f4
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/stm32f4/periph/i2c.c
+++ b/cpu/stm32f4/periph/i2c.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @ingroup     cpu_stm32f4
+ * @ingroup     drivers_periph_i2c
  * @{
  *
  * @file

--- a/cpu/stm32l0/periph/i2c.c
+++ b/cpu/stm32l0/periph/i2c.c
@@ -7,14 +7,15 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @ingroup     cpu_stm32l0
+ * @ingroup     drivers_periph_i2c
  * @{
  *
  * @file
  * @brief       Low-level I2C driver implementation
  *
- * @note This implementation only implements the 7-bit addressing polling mode (for now
- * interrupt mode is not available)
+ * @note This implementation only implements the 7-bit addressing polling mode
+ * (for now interrupt mode is not available)
  *
  * @author      Aurélien Fillau <aurelien.fillau@we-sens.com>
  *

--- a/cpu/stm32l1/periph/adc.c
+++ b/cpu/stm32l1/periph/adc.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_stm32l1
+ * @ingroup     drivers_periph_adc
  * @{
  *
  * @file

--- a/cpu/stm32l1/periph/i2c.c
+++ b/cpu/stm32l1/periph/i2c.c
@@ -7,7 +7,8 @@
  */
 
 /**
- * @addtogroup  driver_periph
+ * @ingroup     cpu_stm32l1
+ * @ingroup     drivers_periph_i2c
  * @{
  *
  * @file


### PR DESCRIPTION
this PR consolidates the doxygen grouping of cpu specific low-level periph drivers.

Note: doxygen allows files to be in multiple groups, hence this feature is used here to put the driver into the cpu and the periph driver group