### PR TITLE
drivers, adxl345: fix constness in adxl345_init

### DIFF
--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -34,7 +34,7 @@
 #define BUS                 (dev->i2c)
 #define ADDR                (dev->addr)
 
-int adxl345_init(adxl345_t *dev, adxl345_params_t* params)
+int adxl345_init(adxl345_t *dev, const adxl345_params_t* params)
 {
     uint8_t reg;
 

--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -168,7 +168,7 @@ typedef struct {
  * @return                  ADXL345_NOI2C if initialization of I2C bus failed
  * @return                  ADXL345_NODEV if accelerometer test failed
  */
-int adxl345_init(adxl345_t *dev, adxl345_params_t* params);
+int adxl345_init(adxl345_t *dev, const adxl345_params_t* params);
 /**
  * @brief   Read accelerometer's data
  *


### PR DESCRIPTION
fixes:

```
/RIOT/sys/auto_init/saul/auto_init_adxl345.c:56:44: error: passing argument 2 of 'adxl345_init' discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
         if (adxl345_init(&adxl345_devs[i], &adxl345_params[i]) != ADXL345_OK) {
                                            ^
In file included from /RIOT/sys/auto_init/saul/auto_init_adxl345.c:26:0:
/RIOT/drivers/include/adxl345.h:171:5: note: expected 'adxl345_params_t * {aka struct <anonymous> *}' but argument is of type 'const adxl345_params_t * {aka const struct <anonymous> *}'
 int adxl345_init(adxl345_t *dev, adxl345_params_t* params);
     ^~~~~~~~~~~~
cc1: all warnings being treated as errors
```