### PR TITLE
drivers, jc42: fix constness in jc42_init

### DIFF
--- a/drivers/include/jc42.h
+++ b/drivers/include/jc42.h
@@ -81,7 +81,7 @@ extern const saul_driver_t jc42_temperature_saul_driver;
  * @return                   0 on success
  * @return                  -1 on error
  */
-int jc42_init(jc42_t* dev, jc42_params_t* params);
+int jc42_init(jc42_t* dev, const jc42_params_t* params);
 
 /**
  * @brief   Get content of configuration register

--- a/drivers/jc42/jc42.c
+++ b/drivers/jc42/jc42.c
@@ -78,7 +78,7 @@ int jc42_get_temperature(const jc42_t* dev, int16_t* temperature)
     return JC42_OK;
 }
 
-int jc42_init(jc42_t* dev, jc42_params_t* params)
+int jc42_init(jc42_t* dev, const jc42_params_t* params)
 {
     uint16_t config;
     dev->i2c = params->i2c;

--- a/sys/auto_init/saul/auto_init_jc42.c
+++ b/sys/auto_init/saul/auto_init_jc42.c
@@ -50,11 +50,9 @@ extern const saul_driver_t jc42_temperature_saul_driver;
 void auto_init_jc42(void)
 {
     for (unsigned i = 0; i < JC42_NUMOF; i++) {
-        const jc42_params_t *p = &jc42_params[i];
-
         LOG_DEBUG("[auto_init_saul] initializing jc42 #%u\n", i);
 
-        if (jc42_init(&jc42_devs[i], (jc42_params_t*) p) < 0) {
+        if (jc42_init(&jc42_devs[i], &jc42_params[i]) < 0) {
             LOG_ERROR("[auto_init_saul] error initializing jc42 #%u\n", i);
             continue;
         }


### PR DESCRIPTION
fixes:

```
/RIOT/sys/auto_init/saul/auto_init_jc42.c: In function 'auto_init_jc42':
/RIOT/sys/auto_init/saul/auto_init_jc42.c:55:38: error: passing argument 2 of 'jc42_init' discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
         if (jc42_init(&jc42_devs[i], &jc42_params[i]) < 0) {
                                      ^
In file included from /RIOT/sys/auto_init/saul/auto_init_jc42.c:25:0:
/RIOT/drivers/include/jc42.h:84:5: note: expected 'jc42_params_t * {aka struct <anonymous> *}' but argument is of type 'const jc42_params_t * {aka const struct <anonymous> *}'
 int jc42_init(jc42_t* dev, jc42_params_t* params);
```

follow up on #7213 and similar to #7243