### PR TITLE
boards/nucleo-f4xx: add ADC configuration

### DIFF
--- a/boards/nucleo-f410/Makefile.features
+++ b/boards/nucleo-f410/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio

--- a/boards/nucleo-f410/include/periph_conf.h
+++ b/boards/nucleo-f410/include/periph_conf.h
@@ -181,9 +181,23 @@ static const spi_conf_t spi_config[] = {
 
 /**
  * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F410 order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
  * @{
  */
-#define ADC_NUMOF          (0)
+#define ADC_NUMOF          (6U)
+#define ADC_CONFIG {             \
+    {GPIO_PIN(PORT_A, 0), 0, 0}, \
+    {GPIO_PIN(PORT_A, 1), 0, 1}, \
+    {GPIO_PIN(PORT_A, 4), 0, 4}, \
+    {GPIO_PIN(PORT_B, 0), 0, 8}, \
+    {GPIO_PIN(PORT_C, 1), 0, 11}, \
+    {GPIO_PIN(PORT_C, 0), 0, 10}, \
+}
 /** @} */
 
 /**

--- a/boards/nucleo-f446/Makefile.features
+++ b/boards/nucleo-f446/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio

--- a/boards/nucleo-f446/include/periph_conf.h
+++ b/boards/nucleo-f446/include/periph_conf.h
@@ -256,9 +256,23 @@ static const spi_conf_t spi_config[] = {
 
 /**
  * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F446 order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
  * @{
  */
-#define ADC_NUMOF          (0)
+#define ADC_NUMOF          (6U)
+#define ADC_CONFIG {             \
+    {GPIO_PIN(PORT_A, 0), 0, 0}, \
+    {GPIO_PIN(PORT_A, 1), 0, 1}, \
+    {GPIO_PIN(PORT_A, 4), 0, 4}, \
+    {GPIO_PIN(PORT_B, 0), 0, 8}, \
+    {GPIO_PIN(PORT_C, 1), 0, 11}, \
+    {GPIO_PIN(PORT_C, 0), 0, 10}, \
+}
 /** @} */
 
 /**

--- a/boards/nucleo144-f412/Makefile.features
+++ b/boards/nucleo144-f412/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c

--- a/boards/nucleo144-f412/include/periph_conf.h
+++ b/boards/nucleo144-f412/include/periph_conf.h
@@ -226,10 +226,24 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
+ * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F412zg order. Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
  * @{
  */
-#define ADC_NUMOF          (0)
+#define ADC_NUMOF          (6U)
+#define ADC_CONFIG {              \
+    {GPIO_PIN(PORT_A, 3), 0, 3},  \
+    {GPIO_PIN(PORT_C, 0), 0, 10}, \
+    {GPIO_PIN(PORT_C, 3), 0, 13}, \
+    {GPIO_PIN(PORT_C, 1), 0, 11}, \
+    {GPIO_PIN(PORT_C, 4), 0, 14}, \
+    {GPIO_PIN(PORT_C, 5), 0, 15}, \
+}
 /** @} */
 
 /**

--- a/boards/nucleo144-f413/Makefile.features
+++ b/boards/nucleo144-f413/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng

--- a/boards/nucleo144-f413/include/periph_conf.h
+++ b/boards/nucleo144-f413/include/periph_conf.h
@@ -226,11 +226,26 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
+ * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F413zh order. Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
  * @{
  */
-#define ADC_NUMOF          (0)
+#define ADC_NUMOF          (6U)
+#define ADC_CONFIG {              \
+    {GPIO_PIN(PORT_A, 3), 0, 3},  \
+    {GPIO_PIN(PORT_C, 0), 0, 10}, \
+    {GPIO_PIN(PORT_C, 3), 0, 13}, \
+    {GPIO_PIN(PORT_C, 1), 0, 11}, \
+    {GPIO_PIN(PORT_C, 4), 0, 14}, \
+    {GPIO_PIN(PORT_C, 5), 0, 15}, \
+}
 /** @} */
+
 
 /**
  * @name    DAC configuration

--- a/boards/nucleo144-f429/Makefile.features
+++ b/boards/nucleo144-f429/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng

--- a/boards/nucleo144-f429/include/periph_conf.h
+++ b/boards/nucleo144-f429/include/periph_conf.h
@@ -224,10 +224,24 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
+ * @name   ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F429zi order. Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
  * @{
  */
-#define ADC_NUMOF          (0)
+#define ADC_NUMOF          (6U)
+#define ADC_CONFIG {              \
+    {GPIO_PIN(PORT_A, 3), 2, 3},  \
+    {GPIO_PIN(PORT_C, 0), 2, 10}, \
+    {GPIO_PIN(PORT_C, 3), 2, 13}, \
+    {GPIO_PIN(PORT_F, 3), 2, 9},  \
+    {GPIO_PIN(PORT_F, 5), 2, 15}, \
+    {GPIO_PIN(PORT_F, 10), 2, 8}, \
+}
 /** @} */
 
 /**


### PR DESCRIPTION
Tested on all modified boards (except nucleo144-f413) and works.

It application `tests/periph_adc` doesn't work on nucleo144-f446: no output is provided. I removed it from the changeset for fast review.