### PR TITLE
cpu/kinetis: optimization of DAC driver impl.

### DIFF
--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -121,14 +121,6 @@ static const adc_conf_t adc_config[] = {
 /** @} */
 
 /**
- * @name DAC configuration
- * @{
- */
-#define DAC_CONFIG {}
-#define DAC_NUMOF  0
-/** @} */
-
-/**
  * @name    PWM configuration
  * @{
  */

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -115,14 +115,6 @@ static const adc_conf_t adc_config[] = {
 /** @} */
 
 /**
- * @name DAC configuration
- * @{
- */
-#define DAC_CONFIG {}
-#define DAC_NUMOF  0
-/** @} */
-
-/**
  * @name    PWM configuration
  * @{
  */

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -172,15 +172,18 @@ static const adc_conf_t adc_config[] = {
 /** @} */
 
 /**
- * @name DAC configuration
+ * @name    DAC configuration
  * @{
  */
+static const dac_conf_t dac_config[] = {
+    {
+        .dev       = DAC0,
+        .scgc_addr = &SIM->SCGC2,
+        .scgc_bit  = SIM_SCGC2_DAC0_SHIFT
+    }
+};
 
-#define DAC_CONFIG { \
-    { DAC0, (uint32_t volatile *)BITBAND_REGADDR(SIM->SCGC2, SIM_SCGC2_DAC0_SHIFT) }, \
-  }
-#define DAC_NUMOF 1
-
+#define DAC_NUMOF           (sizeof(dac_config) / sizeof(dac_config[0]))
 /** @} */
 
 /**

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -130,14 +130,6 @@ static const adc_conf_t adc_config[] = {
 /** @} */
 
 /**
- * @name DAC configuration
- * @{
- */
-#define DAC_CONFIG {}
-#define DAC_NUMOF  0
-/** @} */
-
-/**
  * @name    PWM configuration
  * @{
  */

--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -239,10 +239,9 @@ typedef struct {
  * @brief   CPU specific DAC configuration
  */
 typedef struct {
-    /** DAC device base pointer */
-    DAC_Type *dev;
-    /** Pointer to module clock gate bit in bitband region, use BITBAND_REGADDR() */
-    uint32_t volatile *clk_gate;
+    DAC_Type *dev;                  /**< DAC device base pointer */
+    volatile uint32_t *scgc_addr;   /**< Clock enable register, in SIM module */
+    uint8_t scgc_bit;               /**< Clock enable bit, within the register */
 } dac_conf_t;
 
 /**


### PR DESCRIPTION
- use assert() for checking the line parameter
- use 'bit.h' for bitbanding
- simplified code a bit
- unified style of defifining the board configuration
- removed unused configurations form pba-d-01-kw2x and frdm-k64f

This PR saves 44 byte on the `mulle`...