### PR TITLE
tests: xtimer_msg_receive_timeout: always wait for not received message

### DIFF
--- a/tests/xtimer_msg_receive_timeout/main.c
+++ b/tests/xtimer_msg_receive_timeout/main.c
@@ -40,6 +40,7 @@ int main(void)
         xtimer_set_msg(&t, TEST_PERIOD + offset, &tmsg, sched_active_pid);
         if (xtimer_msg_receive_timeout(&m, TEST_PERIOD) < 0) {
             puts("Timeout!");
+            msg_receive(&m);
         }
         else {
             printf("Message: %" PRIu16 "\n", m.type);


### PR DESCRIPTION
After the last iteration of the test, the xtimer structure went out of scope *before* it triggered.
This PR simply waits for every message in the timeout case.
Fixes a hard fault on at least samr21-xpro.