### PR TITLE
tests: add saul_drivers application

### DIFF
--- a/tests/saul_drivers/Makefile
+++ b/tests/saul_drivers/Makefile
@@ -1,0 +1,33 @@
+APPLICATION = saul_drivers
+include ../Makefile.tests_common
+
+SAUL_DRIVERS = adc081c \
+               adc101c \
+               adc121c \
+               adxl345 \
+               bmp180 \
+               bmp280 \
+               bme280 \
+               dht \
+               hdc1000 \
+               io1_xplained \
+               isl29020 \
+               jc42 \
+               l3g4200d \
+               lis3dh \
+               lps331ap \
+               lsm6dsl \
+               lsm303dlhc \
+               mag3110 \
+               mma8x5x \
+               si70xx \
+               tcs37727 \
+               tmp006 \
+               tsl2561 \
+               veml6070
+
+USEMODULE += saul_default
+USEMODULE += auto_init_saul
+USEMODULE += $(SAUL_DRIVERS)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/saul_drivers/README.md
+++ b/tests/saul_drivers/README.md
@@ -1,0 +1,6 @@
+Expected result
+===============
+This application is just a smoke test to verify the saul adaptions of drivers
+can be built without errors.
+
+**Don't flash it on hardware**

--- a/tests/saul_drivers/main.c
+++ b/tests/saul_drivers/main.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ *
+ * @file
+ * @brief       This application is not meant to be run: it's just a 
+ *              smoke test to verify the saul adaption of drivers can be built
+ *              without errors.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
As discussed in #6405.

This PR is meant to provide an application that will build all saul drivers adaption.
For the moment, the list of drivers is hard coded making this difficult to maintain in the long term.

~~The PR also contains some cleanup of the DHT driver. But I can remove it if needed.~~

I'm still looking for a good programmatic way to get this list from the Makefile. Suggestions welcomed.

