### PR TITLE
crypto/cbc: constify input buffers

### DIFF
--- a/sys/crypto/modes/cbc.c
+++ b/sys/crypto/modes/cbc.c
@@ -23,7 +23,7 @@
 #include "crypto/modes/cbc.h"
 
 int cipher_encrypt_cbc(cipher_t* cipher, uint8_t iv[16],
-                       uint8_t* input, size_t length, uint8_t* output)
+                       const uint8_t* input, size_t length, uint8_t* output)
 {
     size_t offset = 0;
     uint8_t block_size, input_block[CIPHER_MAX_BLOCK_SIZE] = {0},
@@ -55,10 +55,11 @@ int cipher_encrypt_cbc(cipher_t* cipher, uint8_t iv[16],
 
 
 int cipher_decrypt_cbc(cipher_t* cipher, uint8_t iv[16],
-                       uint8_t* input, size_t length, uint8_t* output)
+                       const uint8_t* input, size_t length, uint8_t* output)
 {
     size_t offset = 0;
-    uint8_t* input_block, *input_block_last, block_size;
+    const uint8_t *input_block, *input_block_last;
+    uint8_t block_size;
 
 
     block_size = cipher_get_block_size(cipher);

--- a/sys/include/crypto/modes/cbc.h
+++ b/sys/include/crypto/modes/cbc.h
@@ -37,7 +37,7 @@ extern "C" {
  * @param output     pointer to allocated memory for encrypted data. It has to
  *                   be of size data_len + BLOCK_SIZE - data_len % BLOCK_SIZE.
  */
-int cipher_encrypt_cbc(cipher_t* cipher, uint8_t iv[16], uint8_t* input,
+int cipher_encrypt_cbc(cipher_t* cipher, uint8_t iv[16], const uint8_t* input,
                        size_t input_len, uint8_t* output);
 
 
@@ -51,7 +51,7 @@ int cipher_encrypt_cbc(cipher_t* cipher, uint8_t iv[16], uint8_t* input,
  * @param output     pointer to allocated memory for plaintext data. It has to
  *                   be of size input_len.
  */
-int cipher_decrypt_cbc(cipher_t* cipher, uint8_t iv[16], uint8_t* input,
+int cipher_decrypt_cbc(cipher_t* cipher, uint8_t iv[16], const uint8_t* input,
                        size_t input_len, uint8_t* output);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Use const pointer for input buffers with `cipher_encrypt_cbc` and `cipher_decrypt_cbc`.