### PR TITLE
boards/sparkfun-samd-mini : add complete gpio support, beta spi and i2c support

### DIFF
--- a/boards/sparkfun-samd21-mini/Makefile
+++ b/boards/sparkfun-samd21-mini/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/sparkfun-samd21-mini/Makefile.dep
+++ b/boards/sparkfun-samd21-mini/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/sparkfun-samd21-mini/Makefile.features
+++ b/boards/sparkfun-samd21-mini/Makefile.features
@@ -1,0 +1,17 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += arduino
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/sparkfun-samd21-mini/Makefile.include
+++ b/boards/sparkfun-samd21-mini/Makefile.include
@@ -1,0 +1,25 @@
+# define the cpu used by SparkFun SAMD21 Mini Breakout board
+export CPU = samd21
+export CPU_MODEL = samd21g18a
+
+# set default port depending on operating system
+export PORT_LINUX ?= /dev/ttyACM0
+export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# Add board selector (USB serial) to OpenOCD options if specified.
+# Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
+#   Usage: SERIAL="<SERIAL>" BOARD="arduino-zero" make flash
+ifneq (,$(SERIAL))
+    export OPENOCD_EXTRA_INIT += "-c cmsis_dap_serial $(SERIAL)"
+    SERIAL_TTY = $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL))
+    ifeq (,$(SERIAL_TTY))
+        $(error Did not find a device with serial $(SERIAL))
+    endif
+    PORT_LINUX := $(SERIAL_TTY)
+endif
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/sparkfun-samd21-mini/board.c
+++ b/boards/sparkfun-samd21-mini/board.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C)  2017 Tom Keddie
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sparkfun-samd-mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Sparkfun SAMD Mini board
+ *
+ * @author      Tom Keddie <github@bronwenandtom.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+    /* initialize the on-board LED on pin PA17 */
+    gpio_init(LED0_PIN, GPIO_OUT);
+}

--- a/boards/sparkfun-samd21-mini/dist/openocd.cfg
+++ b/boards/sparkfun-samd21-mini/dist/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/cmsis-dap.cfg]
+
+set CHIPNAME at91samd21g18
+set ENDIAN little
+set telnet_port 0
+
+source [find target/at91samdXX.cfg]

--- a/boards/sparkfun-samd21-mini/include/arduino_board.h
+++ b/boards/sparkfun-samd21-mini/include/arduino_board.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016 Inria
+ *                2017 Tom Keddie
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sparkfun-samd-mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Hauke Petersen  <hauke.petersen@fu-berlin.de>
+ * @author      Alexandre Abadie  <alexandre.abadie@inria.fr>
+ * @author      Tom Keddie <github@bronwenandtom.com>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 13 on this board
+ */
+#define ARDUINO_LED         (13)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/sparkfun-samd21-mini/include/arduino_board.h
+++ b/boards/sparkfun-samd21-mini/include/arduino_board.h
@@ -15,8 +15,6 @@
  * @file
  * @brief       Board specific configuration for the Arduino API
  *
- * @author      Hauke Petersen  <hauke.petersen@fu-berlin.de>
- * @author      Alexandre Abadie  <alexandre.abadie@inria.fr>
  * @author      Tom Keddie <github@bronwenandtom.com>
  */
 

--- a/boards/sparkfun-samd21-mini/include/arduino_pinmap.h
+++ b/boards/sparkfun-samd21-mini/include/arduino_pinmap.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C)  2016 Inria
+ *                2017 Tom Keddie
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sparkfun-samd-mini
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Tom Keddie <github@bronwenandtom.com>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PA, 11)
+#define ARDUINO_PIN_1           GPIO_PIN(PA, 10)
+#define ARDUINO_PIN_2           GPIO_PIN(PA, 14)
+#define ARDUINO_PIN_3           GPIO_PIN(PA, 9)
+#define ARDUINO_PIN_4           GPIO_PIN(PA, 8)
+#define ARDUINO_PIN_5           GPIO_PIN(PA, 15)
+#define ARDUINO_PIN_6           GPIO_PIN(PA, 20)
+#define ARDUINO_PIN_7           GPIO_PIN(PA, 21)
+
+#define ARDUINO_PIN_8           GPIO_PIN(PA, 6)
+#define ARDUINO_PIN_9           GPIO_PIN(PA, 7)
+#define ARDUINO_PIN_10          GPIO_PIN(PA, 18)
+#define ARDUINO_PIN_11          GPIO_PIN(PA, 16)
+#define ARDUINO_PIN_12          GPIO_PIN(PA, 19)
+#define ARDUINO_PIN_13          GPIO_PIN(PA, 17) /* on-board LED */
+
+#define ARDUINO_PIN_A0          GPIO_PIN(PA, 2)
+#define ARDUINO_PIN_A1          GPIO_PIN(PB, 8)
+#define ARDUINO_PIN_A2          GPIO_PIN(PB, 9)
+/** @ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/sparkfun-samd21-mini/include/arduino_pinmap.h
+++ b/boards/sparkfun-samd21-mini/include/arduino_pinmap.h
@@ -53,6 +53,7 @@ extern "C" {
 #define ARDUINO_PIN_A0          GPIO_PIN(PA, 2)
 #define ARDUINO_PIN_A1          GPIO_PIN(PB, 8)
 #define ARDUINO_PIN_A2          GPIO_PIN(PB, 9)
+#define ARDUINO_PIN_A3          GPIO_PIN(PA, 4)
 /** @ */
 
 #ifdef __cplusplus

--- a/boards/sparkfun-samd21-mini/include/arduino_pinmap.h
+++ b/boards/sparkfun-samd21-mini/include/arduino_pinmap.h
@@ -17,7 +17,6 @@
  * You can use the defines in this file for simplified interaction with the
  * Arduino specific pin numbers.
  *
- * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  * @author      Tom Keddie <github@bronwenandtom.com>
  */
 

--- a/boards/sparkfun-samd21-mini/include/board.h
+++ b/boards/sparkfun-samd21-mini/include/board.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016 Inria
+ *               2017 Tom Keddie
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_sparkfun-samd-mini
+ * @ingroup     boards
+ * @brief       Support for the SparkFun SAMD21 Mini Breakout board.
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the SparkFun SAMD21 Mini
+ *              Breakout board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Tom Keddie <github@bronwenandtom.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph_cpu.h"
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER              TIMER_0
+#define XTIMER_CHAN         (0)
+/** @} */
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 17)
+
+#define LED_PORT            PORT->Group[PA]
+#define LED0_MASK           (1 << 17)
+
+#define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/sparkfun-samd21-mini/include/board.h
+++ b/boards/sparkfun-samd21-mini/include/board.h
@@ -17,7 +17,6 @@
  * @brief       Board specific definitions for the SparkFun SAMD21 Mini
  *              Breakout board
  *
- * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  * @author      Tom Keddie <github@bronwenandtom.com>
  */
 

--- a/boards/sparkfun-samd21-mini/include/gpio_params.h
+++ b/boards/sparkfun-samd21-mini/include/gpio_params.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016 Inria
+ *                2017 Tom Keddie
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup    boards_sparkfun-samd-mini
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author    Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Tom Keddie <github@bronwenandtom.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(orange)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/sparkfun-samd21-mini/include/gpio_params.h
+++ b/boards/sparkfun-samd21-mini/include/gpio_params.h
@@ -15,9 +15,7 @@
  * @file
  * @brief     Board specific configuration of direct mapped GPIOs
  *
- * @author    Hauke Petersen <hauke.petersen@fu-berlin.de>
- * @author    Alexandre Abadie <alexandre.abadie@inria.fr>
- * @author      Tom Keddie <github@bronwenandtom.com>
+ * @author    Tom Keddie <github@bronwenandtom.com>
  */
 
 #ifndef GPIO_PARAMS_H

--- a/boards/sparkfun-samd21-mini/include/periph_conf.h
+++ b/boards/sparkfun-samd21-mini/include/periph_conf.h
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016 Inria
+ *                2017 Tom Keddie
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sparkfun-samd-mini
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for SparkFun SAMD21 Mini Breakout board
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Tom Keddie <github@bronwenandtom.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   External oscillator and clock configuration
+ *
+ * For selection of the used CORECLOCK, we have implemented two choices:
+ *
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why we use this option as default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL       (1)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+/* generate the actual used core clock frequency */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+#define TIMER_NUMOF         (2U)
+#define TIMER_0_EN          1
+#define TIMER_1_EN          1
+
+/* Timer 0 configuration */
+#define TIMER_0_DEV         TC3->COUNT16
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_MAX_VALUE   (0xffff)
+#define TIMER_0_ISR         isr_tc3
+
+/* Timer 1 configuration */
+#define TIMER_1_DEV         TC4->COUNT32
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_MAX_VALUE   (0xffffffff)
+#define TIMER_1_ISR         isr_tc4
+
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev    = &SERCOM0->USART,
+        .rx_pin = GPIO_PIN(PA,11),
+        .tx_pin = GPIO_PIN(PA,10),
+        .mux    = GPIO_MUX_C,
+        .rx_pad = UART_PAD_RX_3,
+        .tx_pad = UART_PAD_TX_2
+    }
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom0
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_0_EN            1
+#define PWM_1_EN            1
+#define PWM_MAX_CHANNELS    2
+/* for compatibility with test application */
+#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
+#define PWM_1_CHANNELS      PWM_MAX_CHANNELS
+
+/* PWM device configuration */
+static const pwm_conf_t pwm_config[] = {
+#if PWM_0_EN
+    {TCC0, {
+        /* GPIO pin, MUX value, TCC channel */
+        { GPIO_PIN(PA, 8), GPIO_MUX_E,  0 },
+        { GPIO_PIN(PA, 9), GPIO_MUX_E,  1 },
+    }},
+#endif
+#if PWM_1_EN
+    {TCC1, {
+        /* GPIO pin, MUX value, TCC channel */
+        { GPIO_PIN(PA, 6), GPIO_MUX_E, 0 },
+        { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 },
+    }},
+#endif
+};
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           (2U)
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (0)
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {   /* EXT2 */
+        .dev      = &SERCOM1->SPI,
+        .miso_pin = GPIO_PIN(PA, 16),
+        .mosi_pin = GPIO_PIN(PA, 18),
+        .clk_pin  = GPIO_PIN(PA, 19),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+    },
+#if 0
+    {
+        .dev      = &SERCOM1->SPI,
+        .miso_pin = GPIO_PIN(PA, 19),
+        .mosi_pin = GPIO_PIN(PA, 16),
+        .clk_pin  = GPIO_PIN(PA, 17),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_3,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1
+    }
+#endif
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF          (1U)
+#define I2C_0_EN            1
+#define I2C_1_EN            0
+#define I2C_2_EN            0
+#define I2C_3_EN            0
+#define I2C_IRQ_PRIO        1
+
+#define I2C_0_DEV           SERCOM3->I2CM
+#define I2C_0_IRQ           SERCOM3_IRQn
+#define I2C_0_ISR           isr_sercom3
+/* I2C 0 GCLK */
+#define I2C_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
+#define I2C_0_GCLK_ID_SLOW  SERCOM3_GCLK_ID_SLOW
+/* I2C 0 pin configuration */
+#define I2C_0_SDA           GPIO_PIN(PA, 22)
+#define I2C_0_SCL           GPIO_PIN(PA, 23)
+#define I2C_0_MUX           GPIO_MUX_C
+
+/**
+ * @name RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1U)
+#define RTC_DEV             RTC->MODE2
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             RTC->MODE0
+#define RTT_IRQ             RTC_IRQn
+#define RTT_IRQ_PRIO        10
+#define RTT_ISR             isr_rtc
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
+#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/sparkfun-samd21-mini/include/periph_conf.h
+++ b/boards/sparkfun-samd21-mini/include/periph_conf.h
@@ -15,10 +15,6 @@
  * @file
  * @brief       Configuration of CPU peripherals for SparkFun SAMD21 Mini Breakout board
  *
- * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
- * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
- * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  * @author      Tom Keddie <github@bronwenandtom.com>
  */
 

--- a/boards/sparkfun-samd21-mini/include/periph_conf.h
+++ b/boards/sparkfun-samd21-mini/include/periph_conf.h
@@ -150,7 +150,7 @@ static const pwm_conf_t pwm_config[] = {
 };
 
 /* number of devices that are actually defined */
-#define PWM_NUMOF           (2U)
+#define PWM_NUMOF           (sizeof(pwm_config)/sizeof(pwm_config[0]))
 /** @} */
 
 /**


### PR DESCRIPTION
Native GPIO are tested on hardware
Arduino digital GPIO are tested on hardware

Contributes to resolution of https://github.com/RIOT-OS/RIOT/issues/7197