### PR TITLE
gcc: add -fdiagnostics-color for native and arm

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -25,6 +25,11 @@ ifeq ($(shell $(CC) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null 
   endif
 endif
 
+# Use colored gcc output if the compiler supports this
+ifeq ($(shell $(CC) -fdiagnostics-color -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+  CFLAGS += -fdiagnostics-color
+endif
+
 # Fast-out on old style function definitions.
 # They cause unreadable error compiler errors on missing semicolons.
 # Worse yet they hide errors by accepting wildcard argument types.


### PR DESCRIPTION
Recently, using `ccache` broke my `colorgcc` configuration. When looking into this, I found out, that since version `4.9` gcc is supporting colored output by default (though not quite as nice as `colorgcc`...).

This PR enables that option for `native` and `arm` builds. I expect it to be safe to enable it, since we are expecting the compiler to support c11 which was also introduced with `gcc 4.9`. What do you think?