### PR TITLE
sys/fmt: extended fmt_s16_dfp to handle scales

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -263,48 +263,56 @@ size_t fmt_s16_dec(char *out, int16_t val)
     return fmt_s32_dec(out, val);
 }
 
-size_t fmt_s16_dfp(char *out, int16_t val, unsigned fp_digits)
+size_t fmt_s16_dfp(char *out, int16_t val, int fp_digits)
 {
     return fmt_s32_dfp(out, val, fp_digits);
 }
 
-size_t fmt_s32_dfp(char *out, int32_t val, unsigned fp_digits)
+size_t fmt_s32_dfp(char *out, int32_t val, int fp_digits)
 {
-    assert(fp_digits < TENMAP_SIZE);
+    assert(fp_digits > -(int)TENMAP_SIZE);
 
-    int32_t absolute, divider;
-    unsigned div_len, len, pos = 0;
-    char tmp[9];
+    unsigned  pos = 0;
 
     if (fp_digits == 0) {
-        return fmt_s32_dec(out, val);
+        pos = fmt_s32_dec(out, val);
     }
-    if (val < 0) {
+    else if (fp_digits > 0) {
+        pos = fmt_s32_dec(out, val);
         if (out) {
-            out[pos++] = '-';
+            memset(&out[pos], '0', fp_digits);
         }
-        val = -val;
+        pos += fp_digits;
     }
+    else {
+        fp_digits *= -1;
+        uint32_t e = _tenmap[fp_digits];
+        int32_t abs = (val / (int32_t)e);
+        int32_t div = val - (abs * e);
 
-    uint32_t e = _tenmap[fp_digits];
-    absolute = (val / e);
-    divider = val - (absolute * e);
+        /* the divisor should never be negative */
+        if (div < 0) {
+            div *= -1;
+        }
+        /* handle special case for negative number with zero as absolute value */
+        if ((abs == 0) && (val < 0)) {
+            if (out) {
+                out[pos] = '-';
+            }
+            pos++;
+        }
 
-    pos += fmt_s32_dec(&out[pos], absolute);
-
-    if (!out) {
-        return pos + 1 + fp_digits;     /* abs len + decimal point + divider */
-    }
-
-    out[pos++] = '.';
-    len = pos + fp_digits;
-    div_len = fmt_s32_dec(tmp, divider);
-
-    while (pos < (len - div_len)) {
-        out[pos++] = '0';
-    }
-    for (size_t i = 0; i < div_len; i++) {
-        out[pos++] = tmp[i];
+        if (!out) {
+            /* compensate for the decimal point character... */
+            pos += fmt_s32_dec(NULL, abs) + 1;
+        }
+        else {
+            pos += fmt_s32_dec(&out[pos], abs);
+            out[pos++] = '.';
+            unsigned div_len = fmt_s32_dec(&out[pos], div);
+            fmt_lpad(&out[pos], div_len, (size_t)fp_digits, '0');
+        }
+        pos += fp_digits;
     }
 
     return pos;

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -225,60 +225,43 @@ size_t fmt_s16_dec(char *out, int16_t val);
 /**
  * @brief Convert 16-bit fixed point number to a decimal string
  *
- * The input for this function is a signed 16-bit integer holding the fixed
- * point value as well as an unsigned integer defining the position of the
- * decimal point, so this value defines the number of decimal digits after the
- * decimal point.
- *
- * The resulting string will always be patted with zeros after the decimal point.
- *
- * For example: if @p val is -3548 and @p fp_digits is 2, the resulting string
- * will be "-35.48". For @p val := 12010 and @p fp_digits := 3 the result will
- * be "12.010".
- *
- * Will add a leading "-" if @p val is negative.
- *
- * If @p out is NULL, will only return the number of bytes that would have
- * been written.
- *
- * @pre fp_digits < 8 (TENMAP_SIZE)
+ * See fmt_s32_dfp() for more details
  *
  * @param[out] out          Pointer to the output buffer, or NULL
  * @param[in]  val          Fixed point value
- * @param[in]  fp_digits    Number of digits after the decimal point
+ * @param[in]  fp_digits    Number of digits after the decimal point, MUST be
+ *                          >= -7
  *
  * @return      Length of the resulting string
  */
-size_t fmt_s16_dfp(char *out, int16_t val, unsigned fp_digits);
+size_t fmt_s16_dfp(char *out, int16_t val, int fp_digits);
 
 /**
  * @brief Convert 32-bit fixed point number to a decimal string
  *
  * The input for this function is a signed 32-bit integer holding the fixed
- * point value as well as an unsigned integer defining the position of the
- * decimal point, so this value defines the number of decimal digits after the
- * decimal point.
+ * point value as well as an integer defining the position of the decimal point.
+ * This value is used to shift the decimal point to the right (positive value
+ * of @p fp_digits) or to the left (negative value of @p fp_digits).
  *
  * Will add a leading "-" if @p val is negative.
  *
  * The resulting string will always be patted with zeros after the decimal point.
  *
- * For example: if @p val is -314159 and @p fp_digits is 5, the resulting string
- * will be "-3.14159". For @p val := 16777215 and @p fp_digits := 6 the result
- * will be "16.777215".
+ * For example: if @p val is -3548 and @p fp_digits is -2, the resulting string
+ * will be "-35.48". The same value for @p val with @p fp_digits of 2 will
+ * result in "-354800".
  *
- * If @p out is NULL, will only return the number of bytes that would have
- * been written.
- *
- * @pre fp_digits < 8 (TENMAP_SIZE)
+ * @pre fp_digits > -8 (TENMAP_SIZE)
  *
  * @param[out] out          Pointer to the output buffer, or NULL
  * @param[in]  val          Fixed point value
- * @param[in]  fp_digits    Number of digits after the decimal point
+ * @param[in]  fp_digits    Number of digits after the decimal point, MUST be
+ *                          >= -7
  *
  * @return      Length of the resulting string
  */
-size_t fmt_s32_dfp(char *out, int32_t val, unsigned fp_digits);
+size_t fmt_s32_dfp(char *out, int32_t val, int fp_digits);
 
 /**
  * @brief Format float to string

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -64,7 +64,7 @@ void phydat_dump(phydat_t *data, uint8_t dim)
         }
         else if ((data->scale > -5) && (data->scale < 0)) {
             char num[8];
-            size_t len = fmt_s16_dfp(num, data->val[i], data->scale * -1);
+            size_t len = fmt_s16_dfp(num, data->val[i], data->scale);
             num[len] = '\0';
             printf("%s", num);
         }

--- a/tests/driver_dht/main.c
+++ b/tests/driver_dht/main.c
@@ -57,9 +57,9 @@ int main(void)
             continue;
         }
 
-        size_t n = fmt_s16_dfp(temp_s, temp, 1);
+        size_t n = fmt_s16_dfp(temp_s, temp, -1);
         temp_s[n] = '\0';
-        n = fmt_s16_dfp(hum_s, hum, 1);
+        n = fmt_s16_dfp(hum_s, hum, -1);
         hum_s[n] = '\0';
 
         printf("DHT values - temp: %s°C - relative humidity: %s%%\n",

--- a/tests/driver_hdc1000/main.c
+++ b/tests/driver_hdc1000/main.c
@@ -51,9 +51,9 @@ int main(void)
         size_t len;
         hdc1000_read(&dev, &temp, &hum);
 
-        len = fmt_s16_dfp(tstr, temp, 2);
+        len = fmt_s16_dfp(tstr, temp, -2);
         tstr[len] = '\0';
-        len = fmt_s16_dfp(hstr, hum, 2);
+        len = fmt_s16_dfp(hstr, hum, -2);
         hstr[len] = '\0';
         printf("Reading: T: %s °C  RH: %s %%\n", tstr, hstr);
 

--- a/tests/driver_lis2dh12/main.c
+++ b/tests/driver_lis2dh12/main.c
@@ -59,7 +59,7 @@ int main(void)
 
         /* format data */
         for (int i = 0; i < 3; i++) {
-            size_t len = fmt_s16_dfp(str_out[i], data[i], 3);
+            size_t len = fmt_s16_dfp(str_out[i], data[i], -3);
             str_out[i][len] = '\0';
         }
 

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -418,129 +418,279 @@ static void test_fmt_s16_dec(void)
 
 static void test_fmt_s16_dfp(void)
 {
-    char out[12] = "zzzzzzzzzzz";
+    char out[14] = "zzzzzzzzzzzzz";
     int16_t val;
-    unsigned fpp;
-    size_t len;
+    int fpp;
+    size_t len, act_len;
 
     val = 0;
-    fpp = 3;
-    len = fmt_s16_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -3;
+    len = fmt_s16_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(5, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(5, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("0.000", (char *)out);
 
     val = 12345;
-    fpp = 4;
-    len = fmt_s16_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -4;
+    len = fmt_s16_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(6, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(6, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("1.2345", (char *)out);
 
     val = 12030;
-    fpp = 3;
-    len = fmt_s16_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -3;
+    len = fmt_s16_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(6, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(6, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("12.030", (char *)out);
 
     val = -3548;
-    fpp = 2;
-    len = fmt_s16_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -2;
+    len = fmt_s16_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(6, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(6, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("-35.48", (char *)out);
 
     val = -23;
-    fpp = 4;
-    len = fmt_s16_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -4;
+    len = fmt_s16_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(7, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(7, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("-0.0023", (char *)out);
 
     val = 50;
-    fpp = 3;
-    len = fmt_s16_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -3;
+    len = fmt_s16_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(5, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(5, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("0.050", (char *)out);
 
     val = -12345;
-    fpp = 0;
-    len = fmt_s16_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -0;
+    len = fmt_s16_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(6, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(6, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("-12345", (char *)out);
 
     val = 31987;
-    fpp = 6;
-    len = fmt_s16_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -5;
+    len = fmt_s16_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(7, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(7, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("0.31987", (char *)out);
+
+
+    val = -32768;
+    fpp = -2;
+    len = fmt_s16_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(7, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(7, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-327.68", (char *)out);
+
+    /* test also for positive fp digits */
+    val = 32767;
+    fpp = 0;
+    len = fmt_s16_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(5, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(5, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("32767", (char *)out);
+
+    val = 31987;
+    fpp = 3;
+    len = fmt_s16_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(8, len);
-    TEST_ASSERT_EQUAL_STRING("0.031987", (char *)out);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(8, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("31987000", (char *)out);
+
+    val = -23;
+    fpp = 4;
+    len = fmt_s16_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(7, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(7, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-230000", (char *)out);
+
+    val = -1023;
+    fpp = 6;
+    len = fmt_s16_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(11, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(11, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-1023000000", (char *)out);
+
+    val = -32768;
+    fpp = -7;
+    len = fmt_s16_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(10, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(10, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-0.0032768", (char *)out);
+
+    val = 17;
+    fpp = 9;
+    len = fmt_s16_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(11, len);
+    act_len = fmt_s16_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(11, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("17000000000", (char *)out);
 
     /* check that the buffer was not overflowed */
-    TEST_ASSERT_EQUAL_STRING("zz", &out[9]);
+    TEST_ASSERT_EQUAL_STRING("z", &out[12]);
 }
 
 static void test_fmt_s32_dfp(void)
 {
-    char out[16] = "zzzzzzzzzzzzzzz";
+    char out[30] = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
     int32_t val;
     unsigned fpp;
     size_t len;
+    size_t act_len;
 
     val = 0;
-    fpp = 7;
-    len = fmt_s32_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -7;
+    len = fmt_s32_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(9, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(9, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("0.0000000", (char *)out);
 
     val = 123456789;
-    fpp = 7;
-    len = fmt_s32_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -7;
+    len = fmt_s32_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(10, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(10, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("12.3456789", (char *)out);
 
     val = 120030;
-    fpp = 3;
-    len = fmt_s32_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -3;
+    len = fmt_s32_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(7, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(7, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("120.030", (char *)out);
 
     val = -314159;
-    fpp = 5;
-    len = fmt_s32_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -5;
+    len = fmt_s32_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(8, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(8, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("-3.14159", (char *)out);
 
     val = -23;
-    fpp = 7;
-    len = fmt_s32_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -7;
+    len = fmt_s32_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(10, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(10, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("-0.0000023", (char *)out);
 
     val = 50;
-    fpp = 6;
-    len = fmt_s32_dfp(out, val, fpp);
-    out[len] = '\0';
+    fpp = -6;
+    len = fmt_s32_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(8, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(8, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("0.000050", (char *)out);
 
     val = -123456789;
     fpp = 0;
-    len = fmt_s32_dfp(out, val, fpp);
-    out[len] = '\0';
+    len = fmt_s32_dfp(NULL, val, fpp);
     TEST_ASSERT_EQUAL_INT(10, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(10, act_len);
+    out[act_len] = '\0';
     TEST_ASSERT_EQUAL_STRING("-123456789", (char *)out);
 
+    val = 2147483647; /* INT32_MAX */
+    fpp = 2;
+    len = fmt_s32_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(12, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(12, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("214748364700", (char *)out);
+
+    val = 2147483647; /* INT32_MAX */
+    fpp = -5;
+    len = fmt_s32_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(11, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(11, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("21474.83647", (char *)out);
+
+    val = -2147483648; /* INT32_MIN */
+    fpp = 2;
+    len = fmt_s32_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(13, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(13, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-214748364800", (char *)out);
+
+    val = -2147483648; /* INT32_MIN */
+    fpp = -5;
+    len = fmt_s32_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(12, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(12, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-21474.83648", (char *)out);
+
+    val = -1;
+    fpp = 25;
+    len = fmt_s32_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(27, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(27, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-10000000000000000000000000", (char *)out);
+
+    val = -1;
+    fpp = -7;
+    len = fmt_s32_dfp(NULL, val, fpp);
+    TEST_ASSERT_EQUAL_INT(10, len);
+    act_len = fmt_s32_dfp(out, val, fpp);
+    TEST_ASSERT_EQUAL_INT(10, act_len);
+    out[act_len] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-0.0000001", (char *)out);
+
     /* check that the buffer was not overflowed */
-    TEST_ASSERT_EQUAL_STRING("zzzz", &out[11]);
+    TEST_ASSERT_EQUAL_STRING("z", &out[28]);
 }
 
 static void test_fmt_strlen(void)


### PR DESCRIPTION
- it is not possible to format FP numbers with a positive scaling
  factor, e.g. 23*10^2 := "2300" (-> fp_s16_dfp(buf, 23, 2))
- the semantic of the @p fp_digits parameter changed: @p fp_digits
  can now be negative and positive
- adapted existing usages of this function
- fixed bugs when calling the function with @p out := NULL
- adapted unittests
- added unittests for case @ fp_digits > 0

In the current form, the PR increases the code size (~90byte, `default` @ `iotlab-m3`). Reasons are:
- added functionality for positive fp_digit values -> ~30byte
- removal of `pwr()` and use of the exiting `_tenmapm[]` array -> ~50byte. This does however yield runtime advantages and saves size in the case `fmt_flaot` and `fmt_s16_dfp` are used concurrently (though that scenario is not very likely?)