### PR TITLE
make: introduce pkg-prepare target

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -328,7 +328,7 @@ include $(RIOTBASE)/drivers/Makefile.include
 
 # The `clean` needs to be serialized before everything else.
 ifneq (, $(filter clean, $(MAKECMDGOALS)))
-    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(RIOTBUILD_CONFIG_HEADER_C): clean
+    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(RIOTBUILD_CONFIG_HEADER_C) pkg-prepare: clean
 endif
 
 # include Makefile.includes for packages in $(USEPKG)
@@ -342,8 +342,11 @@ USEMODULE_INCLUDES_ = $(shell echo $(USEMODULE_INCLUDES) | tr ' ' '\n' | awk '!a
 
 INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
 
-.PHONY: $(USEPKG:%=${BINDIR}/%.a)
-$(USEPKG:%=${BINDIR}/%.a): $(RIOTBUILD_CONFIG_HEADER_C)
+.PHONY: pkg-prepare $(USEPKG:%=${BINDIR}/%.a)
+pkg-prepare:
+	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i prepare ; done
+
+$(USEPKG:%=${BINDIR}/%.a): $(RIOTBUILD_CONFIG_HEADER_C) pkg-prepare
 	@mkdir -p ${BINDIR}
 	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$(patsubst ${BINDIR}/%.a,%,$@)
 

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -10,8 +10,7 @@ RIOTBASE ?= $(CURDIR)/../..
 # TinyDTLS only has support for 32-bit architectures ATM
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 \
-                   z1 \
-                   nrf52dk # see #6022
+                   z1
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 \
                              calliope-mini cc2650stk maple-mini \

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -13,11 +13,6 @@ BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f04
                              nucleo32-l031 nucleo-f030 nucleo-f334 nucleo-l053 \
                              stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 z1
 
-# Must read nordic_softdevice_ble package before nanocoap package. However,
-# can't read it explicitly here because it is read later, as a dependency for
-# the nrf52dk board.
-BOARD_BLACKLIST := nrf52dk
-
 ## Uncomment to redefine port, for example use 61616 for RFC 6282 UDP compression.
 #GCOAP_PORT = 5683
 #CFLAGS += -DGCOAP_PORT=$(GCOAP_PORT)

--- a/examples/gcoap/Makefile.slip
+++ b/examples/gcoap/Makefile.slip
@@ -14,11 +14,6 @@ BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo-f334 \
                              stm32f0discovery telosb weio wsn430-v1_3b wsn430-v1_4 \
                              z1
 
-# Must read nordic_softdevice_ble package before nanocoap package. However,
-# can't read it explicitly here because it is read later, as a dependency for
-# the nrf52dk board.
-BOARD_BLACKLIST := nrf52dk
-
 # Redefine port, for example use 61616 for RFC 6282 UDP compression.
 #GCOAP_PORT = 5683
 #CFLAGS += -DGCOAP_PORT=$(GCOAP_PORT)

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -11,9 +11,6 @@ BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f04
                              nucleo32-l031 nucleo-f030 nucleo-l053 stm32f0discovery \
                              telosb weio
 
-# blacklist this until #6022 is sorted out
-BOARD_BLACKLIST := nrf52dk
-
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default

--- a/pkg/nordic_softdevice_ble/Makefile
+++ b/pkg/nordic_softdevice_ble/Makefile
@@ -12,9 +12,11 @@ SOFTDEVICE := components/softdevice/s1xx_iot/s1xx-iot-prototype3_nrf52_softdevic
 BLE_6LOWPAN_LIB := components/iot/ble_6lowpan/lib/ble_6lowpan.a
 MODULE_MAKEFILE := $(PKG_DIR)/Makefile.module
 
-.PHONY: all clean distclean
+.PHONY: all prepare clean distclean
 
 all: $(BINDIR)/ble_6lowpan.a $(BINDIR)/softdevice.hex
+
+prepare: $(PKG_SRCDIR)/.extracted
 
 $(BINDIR)/ble_6lowpan.a: $(PKG_SRCDIR)/.extracted
 	cp $(PKG_SRCDIR)/$(BLE_6LOWPAN_LIB) $@

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -4,7 +4,9 @@
 PKG_DIR?=$(CURDIR)
 PKG_BUILDDIR?=$(PKGDIRBASE)/$(PKG_NAME)
 
-.PHONY: git-download clean
+.PHONY: prepare git-download clean
+
+prepare: git-download
 
 ifneq (,$(wildcard $(PKG_DIR)/patches))
 git-download: $(PKG_BUILDDIR)/.git-patched

--- a/pkg/tlsf/Makefile
+++ b/pkg/tlsf/Makefile
@@ -8,9 +8,11 @@ PKG_DIR=$(CURDIR)
 PKG_BUILDDIR=$(PKGDIRBASE)/$(PKG_NAME)
 PKG_SRCDIR=$(PKG_BUILDDIR)/src
 
-.PHONY: all clean distclean
+.PHONY: all prepare clean distclean
 
 all: $(PKG_SRCDIR)/$(PKG_NAME).a
+
+prepare: $(PKG_SRCDIR)/Makefile
 
 $(PKG_SRCDIR)/$(PKG_NAME).a: $(PKG_SRCDIR)/Makefile
 	$(Q)make -C $(<D)


### PR DESCRIPTION
Previously, packages were downloaded/patched/compiled each in one go, in alphabetical order. This broke at least nrf52dk (see #6022).

This PR adds a "pkg-prepare" target, which all package ```*.a``` depend on, which in turn ```all``` depends on. The result is that before compiling anything, all packages get downloaded, extracted and patched.

Fixes #6022.