### PR TITLE
drivers, at86rf2xx: cleanup

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -142,19 +142,10 @@ void at86rf2xx_tx_prepare(at86rf2xx_t *dev)
     uint8_t state;
 
     dev->pending_tx++;
-
-    /* make sure ongoing transmissions are finished */
-    do {
-        state = at86rf2xx_get_status(dev);
-    } while (state == AT86RF2XX_STATE_BUSY_RX_AACK ||
-             state == AT86RF2XX_STATE_BUSY_TX_ARET);
-
+    state = at86rf2xx_set_state(dev, AT86RF2XX_STATE_TX_ARET_ON);
     if (state != AT86RF2XX_STATE_TX_ARET_ON) {
         dev->idle_state = state;
     }
-
-    at86rf2xx_set_state(dev, AT86RF2XX_STATE_TX_ARET_ON);
-
     dev->tx_frame_len = IEEE802154_FCS_LEN;
 }
 

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
  * Copyright (C) 2015 Freie Universität Berlin
+ *               2017 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -19,7 +20,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
- *
+ * @author      Sebastian Meiling <s@mlng.net>
  * @}
  */
 
@@ -124,7 +125,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     DEBUG("at86rf2xx_reset(): reset complete.\n");
 }
 
-size_t at86rf2xx_send(at86rf2xx_t *dev, uint8_t *data, size_t len)
+size_t at86rf2xx_send(at86rf2xx_t *dev, const uint8_t *data, size_t len)
 {
     /* check data length */
     if (len > AT86RF2XX_MAX_PKT_LENGTH) {
@@ -149,7 +150,7 @@ void at86rf2xx_tx_prepare(at86rf2xx_t *dev)
     dev->tx_frame_len = IEEE802154_FCS_LEN;
 }
 
-size_t at86rf2xx_tx_load(at86rf2xx_t *dev, uint8_t *data,
+size_t at86rf2xx_tx_load(at86rf2xx_t *dev, const uint8_t *data,
                          size_t len, size_t offset)
 {
     dev->tx_frame_len += (uint8_t)len;
@@ -157,7 +158,7 @@ size_t at86rf2xx_tx_load(at86rf2xx_t *dev, uint8_t *data,
     return offset + len;
 }
 
-void at86rf2xx_tx_exec(at86rf2xx_t *dev)
+void at86rf2xx_tx_exec(const at86rf2xx_t *dev)
 {
     netdev_t *netdev = (netdev_t *)dev;
 

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -18,7 +18,6 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- *
  * @}
  */
 
@@ -36,9 +35,7 @@ static inline void getbus(const at86rf2xx_t *dev)
     spi_acquire(SPIDEV, CSPIN, SPI_MODE_0, dev->params.spi_clk);
 }
 
-void at86rf2xx_reg_write(const at86rf2xx_t *dev,
-                         const uint8_t addr,
-                         const uint8_t value)
+void at86rf2xx_reg_write(const at86rf2xx_t *dev, uint8_t addr, uint8_t value)
 {
     uint8_t reg = (AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_WRITE | addr);
 
@@ -47,7 +44,7 @@ void at86rf2xx_reg_write(const at86rf2xx_t *dev,
     spi_release(SPIDEV);
 }
 
-uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, const uint8_t addr)
+uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, uint8_t addr)
 {
     uint8_t reg = (AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_READ | addr);
     uint8_t value;
@@ -59,10 +56,8 @@ uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, const uint8_t addr)
     return value;
 }
 
-void at86rf2xx_sram_read(const at86rf2xx_t *dev,
-                         const uint8_t offset,
-                         uint8_t *data,
-                         const size_t len)
+void at86rf2xx_sram_read(const at86rf2xx_t *dev, uint8_t offset,
+                         uint8_t *data, size_t len)
 {
     uint8_t reg = (AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_READ);
 
@@ -73,10 +68,8 @@ void at86rf2xx_sram_read(const at86rf2xx_t *dev,
     spi_release(SPIDEV);
 }
 
-void at86rf2xx_sram_write(const at86rf2xx_t *dev,
-                          const uint8_t offset,
-                          const uint8_t *data,
-                          const size_t len)
+void at86rf2xx_sram_write(const at86rf2xx_t *dev, uint8_t offset,
+                          const uint8_t *data, size_t len)
 {
     uint8_t reg = (AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_WRITE);
 
@@ -96,8 +89,7 @@ void at86rf2xx_fb_start(const at86rf2xx_t *dev)
 }
 
 void at86rf2xx_fb_read(const at86rf2xx_t *dev,
-                       uint8_t *data,
-                       const size_t len)
+                       uint8_t *data, size_t len)
 {
     spi_transfer_bytes(SPIDEV, CSPIN, true, NULL, data, len);
 }
@@ -112,17 +104,17 @@ void at86rf2xx_fb_stop(const at86rf2xx_t *dev)
 uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev)
 {
     /* if sleeping immediately return state */
-    if(dev->state == AT86RF2XX_STATE_SLEEP)
+    if (dev->state == AT86RF2XX_STATE_SLEEP) {
         return dev->state;
+    }
 
-    return at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
-                & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
+    return (at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
+            & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS);
 }
 
 void at86rf2xx_assert_awake(at86rf2xx_t *dev)
 {
-    if(at86rf2xx_get_status(dev) == AT86RF2XX_STATE_SLEEP) {
-
+    if (at86rf2xx_get_status(dev) == AT86RF2XX_STATE_SLEEP) {
         /* wake up and wait for transition to TRX_OFF */
         gpio_clear(dev->params.sleep_pin);
         xtimer_usleep(AT86RF2XX_WAKEUP_DELAY);
@@ -133,9 +125,9 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev)
          * Spin until we are actually awake
          */
         do {
-            dev->state = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS) &
-                         AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
-        } while(dev->state != AT86RF2XX_TRX_STATUS__TRX_OFF);
+            dev->state = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
+                         & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
+        } while (dev->state != AT86RF2XX_TRX_STATUS__TRX_OFF);
     }
 }
 
@@ -151,10 +143,10 @@ void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
      * it remains P_ON. Otherwise, it should go to TRX_OFF
      */
     do {
-        dev->state = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS) &
-                     AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
-    } while((dev->state != AT86RF2XX_STATE_TRX_OFF) &&
-            (dev->state != AT86RF2XX_STATE_P_ON));
+        dev->state = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
+                     & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
+    } while ((dev->state != AT86RF2XX_STATE_TRX_OFF)
+             && (dev->state != AT86RF2XX_STATE_P_ON));
 }
 
 void at86rf2xx_configure_phy(at86rf2xx_t *dev)
@@ -214,7 +206,7 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev)
 }
 
 #if defined(MODULE_AT86RF233) || defined(MODULE_AT86RF231)
-void at86rf2xx_get_random(at86rf2xx_t *dev, uint8_t *data, const size_t len)
+void at86rf2xx_get_random(const at86rf2xx_t *dev, uint8_t *data, size_t len)
 {
     for (size_t byteCount = 0; byteCount < len; ++byteCount) {
         uint8_t rnd = 0;
@@ -231,10 +223,3 @@ void at86rf2xx_get_random(at86rf2xx_t *dev, uint8_t *data, const size_t len)
     }
 }
 #endif
-
-void at86rf2xx_force_trx_off(const at86rf2xx_t *dev)
-{
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_STATE,
-                        AT86RF2XX_TRX_STATE__FORCE_TRX_OFF);
-    while (at86rf2xx_get_status(dev) != AT86RF2XX_STATE_TRX_OFF) {}
-}

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -81,8 +81,7 @@ static int _init(netdev_t *netdev)
     at86rf2xx_reset(dev);
 
     /* test if the SPI is set up correctly and the device is responding */
-    if (at86rf2xx_reg_read(dev, AT86RF2XX_REG__PART_NUM) !=
-        AT86RF2XX_PARTNUM) {
+    if (at86rf2xx_reg_read(dev, AT86RF2XX_REG__PART_NUM) != AT86RF2XX_PARTNUM) {
         DEBUG("[at86rf2xx] error: unable to read correct part number\n");
         return -1;
     }
@@ -103,7 +102,7 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
     at86rf2xx_tx_prepare(dev);
 
     /* load packet data into FIFO */
-    for (unsigned i = 0; i < count; i++, ptr++) {
+    for (unsigned i = 0; i < count; ++i, ++ptr) {
         /* current packet data + FCS too long */
         if ((len + ptr->iov_len + 2) > AT86RF2XX_MAX_PKT_LENGTH) {
             DEBUG("[at86rf2xx] error: packet too large (%u byte) to be send\n",
@@ -427,8 +426,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         case NETOPT_CHANNEL:
             assert(len != sizeof(uint8_t));
             uint8_t chan = ((const uint8_t *)val)[0];
-            if (chan < AT86RF2XX_MIN_CHANNEL ||
-                chan > AT86RF2XX_MAX_CHANNEL) {
+            if ((chan < AT86RF2XX_MIN_CHANNEL)
+                || (chan > AT86RF2XX_MAX_CHANNEL)) {
                 res = -EINVAL;
                 break;
             }
@@ -547,14 +546,13 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     }
 
     /* go back to sleep if were sleeping and state hasn't been changed */
-    if ((old_state == AT86RF2XX_STATE_SLEEP) &&
-        (opt != NETOPT_STATE)) {
+    if ((old_state == AT86RF2XX_STATE_SLEEP)
+        && (opt != NETOPT_STATE)) {
         at86rf2xx_set_state(dev, AT86RF2XX_STATE_SLEEP);
     }
 
     if (res == -ENOTSUP) {
-        res = netdev_ieee802154_set((netdev_ieee802154_t *)netdev, opt,
-                                     val, len);
+        res = netdev_ieee802154_set((netdev_ieee802154_t *)netdev, opt, val, len);
     }
 
     return res;
@@ -578,8 +576,8 @@ static void _isr(netdev_t *netdev)
     /* read (consume) device status */
     irq_mask = at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_STATUS);
 
-    trac_status = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATE) &
-                  AT86RF2XX_TRX_STATE_MASK__TRAC;
+    trac_status = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATE)
+                  & AT86RF2XX_TRX_STATE_MASK__TRAC;
 
     if (irq_mask & AT86RF2XX_IRQ_STATUS_MASK__RX_START) {
         netdev->event_callback(netdev, NETDEV_EVENT_RX_STARTED);
@@ -587,16 +585,16 @@ static void _isr(netdev_t *netdev)
     }
 
     if (irq_mask & AT86RF2XX_IRQ_STATUS_MASK__TRX_END) {
-        if (state == AT86RF2XX_STATE_RX_AACK_ON ||
-            state == AT86RF2XX_STATE_BUSY_RX_AACK) {
+        if ((state == AT86RF2XX_STATE_RX_AACK_ON)
+            || (state == AT86RF2XX_STATE_BUSY_RX_AACK)) {
             DEBUG("[at86rf2xx] EVT - RX_END\n");
             if (!(dev->netdev.flags & AT86RF2XX_OPT_TELL_RX_END)) {
                 return;
             }
             netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
         }
-        else if (state == AT86RF2XX_STATE_TX_ARET_ON ||
-                 state == AT86RF2XX_STATE_BUSY_TX_ARET) {
+        else if ((state == AT86RF2XX_STATE_TX_ARET_ON)
+                 || (state == AT86RF2XX_STATE_BUSY_TX_ARET)) {
             /* check for more pending TX calls and return to idle state if
              * there are none */
             assert(dev->pending_tx != 0);
@@ -606,8 +604,8 @@ static void _isr(netdev_t *netdev)
             }
 /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
 #if AT86RF2XX_HAVE_RETRIES
-            dev->tx_retries = ( at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_2) &
-                                AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_MASK ) >>
+            dev->tx_retries = (at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_2)
+                               & AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_MASK) >>
                               AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_OFFSET;
 #endif
 

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
  * Copyright (C) 2015 Freie Universität Berlin
+ *               2017 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -17,6 +18,7 @@
  * @author      Alaeddine Weslati <alaeddine.weslati@inria.fr>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Sebastian Meiling <s@mlng.net>
  */
 
 #ifndef AT86RF2XX_INTERNAL_H
@@ -29,6 +31,26 @@
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/**
+ * @brief Max. allowed transmit power for the transceiver
+ */
+#ifdef MODULE_AT86RF212B
+#define AT86RF2XX_TXPOWER_MAX           (36)
+#elif MODULE_AT86RF233
+#define AT86RF2XX_TXPOWER_MAX           (21)
+#else
+#define AT86RF2XX_TXPOWER_MAX           (20)
+#endif
+
+/**
+ * @brief Transmit power offset
+ */
+#ifdef MODULE_AT86RF212B
+#define AT86RF2XX_TXPOWER_OFF           (25)
+#else
+#define AT86RF2XX_TXPOWER_OFF           (17)
 #endif
 
 /**
@@ -59,7 +81,7 @@ extern "C" {
  *
  * @return              the value of the specified register
  */
-uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, const uint8_t addr);
+uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, uint8_t addr);
 
 /**
  * @brief   Write to a register at address `addr` from device `dev`.
@@ -68,8 +90,7 @@ uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, const uint8_t addr);
  * @param[in] addr      address of the register to write
  * @param[in] value     value to write to the given register
  */
-void at86rf2xx_reg_write(const at86rf2xx_t *dev, const uint8_t addr,
-                         const uint8_t value);
+void at86rf2xx_reg_write(const at86rf2xx_t *dev, uint8_t addr, uint8_t value);
 
 /**
  * @brief   Read a chunk of data from the SRAM of the given device
@@ -79,10 +100,8 @@ void at86rf2xx_reg_write(const at86rf2xx_t *dev, const uint8_t addr,
  * @param[out] data     buffer to read data into
  * @param[in]  len      number of bytes to read from SRAM
  */
-void at86rf2xx_sram_read(const at86rf2xx_t *dev,
-                         const uint8_t offset,
-                         uint8_t *data,
-                         const size_t len);
+void at86rf2xx_sram_read(const at86rf2xx_t *dev, uint8_t offset,
+                         uint8_t *data, size_t len);
 
 /**
  * @brief   Write a chunk of data into the SRAM of the given device
@@ -92,10 +111,8 @@ void at86rf2xx_sram_read(const at86rf2xx_t *dev,
  * @param[in] data      data to copy into SRAM
  * @param[in] len       number of bytes to write to SRAM
  */
-void at86rf2xx_sram_write(const at86rf2xx_t *dev,
-                          const uint8_t offset,
-                          const uint8_t *data,
-                          const size_t len);
+void at86rf2xx_sram_write(const at86rf2xx_t *dev, uint8_t offset,
+                          const uint8_t *data, size_t len);
 
 /**
  * @brief   Start a read transcation internal frame buffer of the given device
@@ -116,8 +133,7 @@ void at86rf2xx_fb_start(const at86rf2xx_t *dev);
  * @param[out] data     buffer to copy the data to
  * @param[in]  len      number of bytes to read from the frame buffer
  */
-void at86rf2xx_fb_read(const at86rf2xx_t *dev,
-                       uint8_t *data, const size_t len);
+void at86rf2xx_fb_read(const at86rf2xx_t *dev, uint8_t *data, size_t len);
 
 /**
  * @brief   Stop a read transcation internal frame buffer of the given device
@@ -140,14 +156,14 @@ uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev);
 /**
  * @brief   Make sure that device is not sleeping
  *
- * @param[in] dev       device to eventually wake up
+ * @param[in,out] dev   device to eventually wake up
  */
 void at86rf2xx_assert_awake(at86rf2xx_t *dev);
 
 /**
  * @brief   Trigger a hardware reset
  *
- * @param[in] dev       device to reset
+ * @param[in,out] dev   device to reset
  */
 void at86rf2xx_hardware_reset(at86rf2xx_t *dev);
 
@@ -155,7 +171,7 @@ void at86rf2xx_hardware_reset(at86rf2xx_t *dev);
 /**
  * @brief   Set PHY parameters based on channel and page number
  *
- * @param[in] dev       device to configure
+ * @param[in,out] dev   device to configure
  */
 void at86rf2xx_configure_phy(at86rf2xx_t *dev);
 
@@ -175,7 +191,7 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev);
  * @param[out] data     buffer to copy the random data to
  * @param[in]  len      number of random bytes to store in data
  */
-void at86rf2xx_get_random(at86rf2xx_t *dev, uint8_t *data, const size_t len);
+void at86rf2xx_get_random(const at86rf2xx_t *dev, uint8_t *data, size_t len);
 #endif
 
 #ifdef __cplusplus

--- a/drivers/at86rf2xx/include/at86rf2xx_params.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_params.h
@@ -9,7 +9,6 @@
 
 /**
  * @ingroup     drivers_at86rf2xx
- *
  * @{
  * @file
  * @brief       Default configuration for the AT86RF2xx driver

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -199,7 +199,7 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params);
 /**
  * @brief   Trigger a hardware reset and configure radio with default values
  *
- * @param[in] dev           device to reset
+ * @param[in,out] dev       device to reset
  */
 void at86rf2xx_reset(at86rf2xx_t *dev);
 
@@ -210,12 +210,12 @@ void at86rf2xx_reset(at86rf2xx_t *dev);
  *
  * @return                  the currently set (2-byte) short address
  */
-uint16_t at86rf2xx_get_addr_short(at86rf2xx_t *dev);
+uint16_t at86rf2xx_get_addr_short(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the short address of the given device
  *
- * @param[in] dev           device to write to
+ * @param[in,out] dev       device to write to
  * @param[in] addr          (2-byte) short address to set
  */
 void at86rf2xx_set_addr_short(at86rf2xx_t *dev, uint16_t addr);
@@ -227,12 +227,12 @@ void at86rf2xx_set_addr_short(at86rf2xx_t *dev, uint16_t addr);
  *
  * @return                  the currently set (8-byte) long address
  */
-uint64_t at86rf2xx_get_addr_long(at86rf2xx_t *dev);
+uint64_t at86rf2xx_get_addr_long(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the long address of the given device
  *
- * @param[in] dev           device to write to
+ * @param[in,out] dev       device to write to
  * @param[in] addr          (8-byte) long address to set
  */
 void at86rf2xx_set_addr_long(at86rf2xx_t *dev, uint64_t addr);
@@ -244,12 +244,12 @@ void at86rf2xx_set_addr_long(at86rf2xx_t *dev, uint64_t addr);
  *
  * @return                  the currently set channel number
  */
-uint8_t at86rf2xx_get_chan(at86rf2xx_t *dev);
+uint8_t at86rf2xx_get_chan(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the channel number of the given device
  *
- * @param[in] dev           device to write to
+ * @param[in,out] dev       device to write to
  * @param[in] chan          channel number to set
  */
 void at86rf2xx_set_chan(at86rf2xx_t *dev, uint8_t chan);
@@ -261,12 +261,12 @@ void at86rf2xx_set_chan(at86rf2xx_t *dev, uint8_t chan);
  *
  * @return                  the currently set channel page
  */
-uint8_t at86rf2xx_get_page(at86rf2xx_t *dev);
+uint8_t at86rf2xx_get_page(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the channel page of the given device
  *
- * @param[in] dev           device to write to
+ * @param[in,out] dev       device to write to
  * @param[in] page          channel page to set
  */
 void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page);
@@ -278,12 +278,12 @@ void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page);
  *
  * @return                  the currently set PAN ID
  */
-uint16_t at86rf2xx_get_pan(at86rf2xx_t *dev);
+uint16_t at86rf2xx_get_pan(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the PAN ID of the given device
  *
- * @param[in] dev           device to write to
+ * @param[in,out] dev       device to write to
  * @param[in] pan           PAN ID to set
  */
 void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan);
@@ -295,7 +295,7 @@ void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan);
  *
  * @return                  configured transmission power in dBm
  */
-int16_t at86rf2xx_get_txpower(at86rf2xx_t *dev);
+int16_t at86rf2xx_get_txpower(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the transmission power of the given device [in dBm]
@@ -308,7 +308,7 @@ int16_t at86rf2xx_get_txpower(at86rf2xx_t *dev);
  * @param[in] dev           device to write to
  * @param[in] txpower       transmission power in dBm
  */
-void at86rf2xx_set_txpower(at86rf2xx_t *dev, int16_t txpower);
+void at86rf2xx_set_txpower(const at86rf2xx_t *dev, int16_t txpower);
 
 /**
  * @brief   Get the maximum number of retransmissions
@@ -317,7 +317,7 @@ void at86rf2xx_set_txpower(at86rf2xx_t *dev, int16_t txpower);
  *
  * @return                  configured number of retransmissions
  */
-uint8_t at86rf2xx_get_max_retries(at86rf2xx_t *dev);
+uint8_t at86rf2xx_get_max_retries(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the maximum number of retransmissions
@@ -329,7 +329,7 @@ uint8_t at86rf2xx_get_max_retries(at86rf2xx_t *dev);
  * @param[in] dev           device to write to
  * @param[in] max           the maximum number of retransmissions
  */
-void at86rf2xx_set_max_retries(at86rf2xx_t *dev, uint8_t max);
+void at86rf2xx_set_max_retries(const at86rf2xx_t *dev, uint8_t max);
 
 /**
  * @brief   Get the maximum number of channel access attempts per frame (CSMA)
@@ -338,7 +338,7 @@ void at86rf2xx_set_max_retries(at86rf2xx_t *dev, uint8_t max);
  *
  * @return                  configured number of retries
  */
-uint8_t at86rf2xx_get_csma_max_retries(at86rf2xx_t *dev);
+uint8_t at86rf2xx_get_csma_max_retries(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the maximum number of channel access attempts per frame (CSMA)
@@ -351,7 +351,7 @@ uint8_t at86rf2xx_get_csma_max_retries(at86rf2xx_t *dev);
  * @param[in] dev           device to write to
  * @param[in] retries       the maximum number of retries
  */
-void at86rf2xx_set_csma_max_retries(at86rf2xx_t *dev, int8_t retries);
+void at86rf2xx_set_csma_max_retries(const at86rf2xx_t *dev, int8_t retries);
 
 /**
  * @brief   Set the min and max backoff exponent for CSMA/CA
@@ -363,7 +363,8 @@ void at86rf2xx_set_csma_max_retries(at86rf2xx_t *dev, int8_t retries);
  * @param[in] min           the minimum BE
  * @param[in] max           the maximum BE
  */
-void at86rf2xx_set_csma_backoff_exp(at86rf2xx_t *dev, uint8_t min, uint8_t max);
+void at86rf2xx_set_csma_backoff_exp(const at86rf2xx_t *dev,
+                                    uint8_t min, uint8_t max);
 
 /**
  * @brief   Set seed for CSMA random backoff
@@ -371,7 +372,7 @@ void at86rf2xx_set_csma_backoff_exp(at86rf2xx_t *dev, uint8_t min, uint8_t max);
  * @param[in] dev           device to write to
  * @param[in] entropy       11 bit of entropy as seed for random backoff
  */
-void at86rf2xx_set_csma_seed(at86rf2xx_t *dev, uint8_t entropy[2]);
+void at86rf2xx_set_csma_seed(const at86rf2xx_t *dev, const uint8_t entropy[2]);
 
 /**
  * @brief   Get the CCA threshold value
@@ -380,7 +381,7 @@ void at86rf2xx_set_csma_seed(at86rf2xx_t *dev, uint8_t entropy[2]);
  *
  * @return                  the current CCA threshold value
  */
-int8_t at86rf2xx_get_cca_threshold(at86rf2xx_t *dev);
+int8_t at86rf2xx_get_cca_threshold(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the CCA threshold value
@@ -388,7 +389,7 @@ int8_t at86rf2xx_get_cca_threshold(at86rf2xx_t *dev);
  * @param[in] dev           device to write to
  * @param[in] value         the new CCA threshold value
  */
-void at86rf2xx_set_cca_threshold(at86rf2xx_t *dev, int8_t value);
+void at86rf2xx_set_cca_threshold(const at86rf2xx_t *dev, int8_t value);
 
 /**
  * @brief   Get the latest ED level measurement
@@ -402,7 +403,7 @@ int8_t at86rf2xx_get_ed_level(at86rf2xx_t *dev);
 /**
  * @brief   Enable or disable driver specific options
  *
- * @param[in] dev           device to set/clear option flag for
+ * @param[in,out] dev       device to set/clear option flag for
  * @param[in] option        option to enable/disable
  * @param[in] state         true for enable, false for disable
  */
@@ -411,7 +412,7 @@ void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state);
 /**
  * @brief   Set the state of the given device (trigger a state change)
  *
- * @param[in] dev           device to change state of
+ * @param[in,out] dev       device to change state of
  * @param[in] state         the targeted new state
  *
  * @return                  the previous state before the new state was set
@@ -423,14 +424,14 @@ uint8_t at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state);
  *
  * @note This function ignores the PRELOADING option
  *
- * @param[in] dev           device to use for sending
+ * @param[in,out] dev       device to use for sending
  * @param[in] data          data to send (must include IEEE802.15.4 header)
  * @param[in] len           length of @p data
  *
  * @return                  number of bytes that were actually send
  * @return                  0 on error
  */
-size_t at86rf2xx_send(at86rf2xx_t *dev, uint8_t *data, size_t len);
+size_t at86rf2xx_send(at86rf2xx_t *dev, const uint8_t *data, size_t len);
 
 /**
  * @brief   Prepare for sending of data
@@ -438,29 +439,29 @@ size_t at86rf2xx_send(at86rf2xx_t *dev, uint8_t *data, size_t len);
  * This function puts the given device into the TX state, so no receiving of
  * data is possible after it was called.
  *
- * @param[in] dev            device to prepare for sending
+ * @param[in,out] dev        device to prepare for sending
  */
 void at86rf2xx_tx_prepare(at86rf2xx_t *dev);
 
 /**
  * @brief   Load chunks of data into the transmit buffer of the given device
  *
- * @param[in] dev           device to write data to
+ * @param[in,out] dev       device to write data to
  * @param[in] data          buffer containing the data to load
  * @param[in] len           number of bytes in @p buffer
  * @param[in] offset        offset used when writing data to internal buffer
  *
  * @return                  offset + number of bytes written
  */
-size_t at86rf2xx_tx_load(at86rf2xx_t *dev, uint8_t *data, size_t len,
-                         size_t offset);
+size_t at86rf2xx_tx_load(at86rf2xx_t *dev, const uint8_t *data,
+                         size_t len, size_t offset);
 
 /**
  * @brief   Trigger sending of data previously loaded into transmit buffer
  *
  * @param[in] dev           device to trigger
  */
-void at86rf2xx_tx_exec(at86rf2xx_t *dev);
+void at86rf2xx_tx_exec(const at86rf2xx_t *dev);
 
 /**
  * @brief   Perform one manual channel clear assessment (CCA)


### PR DESCRIPTION
[originally - but now not anymore -] much simpler fix than #7275 , while still using the redefined `at86rf2xx_set_state(...)` function of #7115. 

[edit] plus avoiding the redundant `do {}  while` ...