### PR TITLE
at86rf2xx: remove redundant radio wake-up

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -360,7 +360,8 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
     }
 
     /* temporarily wake up if sleeping */
-    if (old_state == AT86RF2XX_STATE_SLEEP && opt != NETOPT_STATE) {
+    if ((old_state == AT86RF2XX_STATE_SLEEP) &&
+        (opt != NETOPT_STATE)) {
         at86rf2xx_assert_awake(dev);
     }
 

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -360,7 +360,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
     }
 
     /* temporarily wake up if sleeping */
-    if (old_state == AT86RF2XX_STATE_SLEEP) {
+    if (old_state == AT86RF2XX_STATE_SLEEP && opt != NETOPT_STATE) {
         at86rf2xx_assert_awake(dev);
     }
 

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -359,7 +359,10 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
         return -ENODEV;
     }
 
-    /* temporarily wake up if sleeping */
+    /* temporarily wake up if sleeping and opt != NETOPT_STATE.
+     * opt != NETOPT_STATE check prevents redundant wake-up. 
+     * when opt == NETOPT_STATE, at86rf2xx_set_state() will wake up the radio if needed.
+    */
     if ((old_state == AT86RF2XX_STATE_SLEEP) &&
         (opt != NETOPT_STATE)) {
         at86rf2xx_assert_awake(dev);


### PR DESCRIPTION
When you want at86rf2xx to fall asleep, it is possible that it is already in the sleep state.
The current implementation lets the radio wake up again and fall asleep, which consumes additional energy redundantly. This PR removes that redundant wake-up.