### PR TITLE
tools, edbg: fix compiler issue on macos

### DIFF
--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -4,6 +4,12 @@ PKG_VERSION=935bb4b1efd0e2f8434cf97443e0d95b9e02ec1d
 PKG_LICENSE=BSD-3-Clause
 PKG_BUILDDIR=$(CURDIR)/bin
 
+# CC and CXX variables are set by RIOT's build process to cross compiling for
+# a specific target platfrom. Thus, we have to unset them to build edgb using
+# the system C/C++ compilers - i.e, to avoid conflicts on macOS systems
+CC=
+CXX=
+
 .PHONY: all
 
 all: git-download


### PR DESCRIPTION
fixes #7200 

simply unsetting the compiler vars (CC, CXX) helps, at least for me.