### PR TITLE
drivers/diskio: cleanup documentation

### DIFF
--- a/drivers/include/diskio.h
+++ b/drivers/include/diskio.h
@@ -12,8 +12,6 @@
  * @ingroup     drivers_storage
  * @brief       Low level disk interface
  *
- * The connection between the MCU and the SRF08 is based on the i2c-interface.
- *
  * @{
  *
  * @file


### PR DESCRIPTION
Found this one while reviewing drivers documentation. SF08 (Ultrasound distance sensor) has obviously nothing to do in diskio header file.