### PR TITLE
drivers/adcxx1c: small doxygen fixes

### DIFF
--- a/drivers/include/adcxx1c.h
+++ b/drivers/include/adcxx1c.h
@@ -9,12 +9,15 @@
 /**
  * @defgroup   drivers_adcxx1x ADCXX1C ADC device driver
  * @ingroup    drivers_sensors
+ * @brief      I2C Analog-to-Digital Converter device driver
  * @{
  *
  * @file
- * @brief       ADCXX1C ADC device driver
+ * @brief      ADCXX1C ADC device driver
  *
- * @author      Vincent Dupont <vincent@otakeys.com>
+ *             This driver works with adc081c, adc101c and adc121c versions.
+ *
+ * @author     Vincent Dupont <vincent@otakeys.com>
  */
 
 #ifndef ADCXX1C_H


### PR DESCRIPTION
Another documentation cleanup: add a brief description of this driver in the drivers modules page.