### PR TITLE
sys, ssp: fix doxygen grouping

### DIFF
--- a/sys/ssp/ssp.c
+++ b/sys/ssp/ssp.c
@@ -7,9 +7,9 @@
  */
 
 /**
+ * @ingroup     sys_ssp
  * @{
  *
- * @ingroup     sys
  * @file
  * @brief       Stack Smashing Protector (SSP) helper functions
  *


### PR DESCRIPTION
fixes doxygen grouping of `sys/ssp/ssp.c`, just for completeness and consistency.