### PR TITLE
doc: fix rendering of multi-breadcrumbed groups

### DIFF
--- a/doc/doxygen/src/css/riot.css
+++ b/doc/doxygen/src/css/riot.css
@@ -144,6 +144,9 @@ div.toc-sm li {
 div.ingroups {
   font-size: 10pt;
 }
+div.ingroups .el::before {
+  content: " ";
+}
 div.header {
   background: none;
   border-bottom: 1px solid #eeeeee;

--- a/doc/doxygen/src/css/riot.less
+++ b/doc/doxygen/src/css/riot.less
@@ -139,6 +139,9 @@ div.toc li, div.toc-sm li {
 div.ingroups {
   font-size: 10pt;
 }
+div.ingroups .el::before {
+  content: " "
+}
 div.header {
   background: none;
   border-bottom: 1px solid @page-header-border-color;


### PR DESCRIPTION
Fixes the output of multi-breadcrumbed groups (groups that are in multiple groups) from something like e.g.

```
CPU » | NativeNetwork Device Drivers
```

to 


```
CPU » | Native Network Device Drivers
```