### PR TITLE
sys: enhance documentation

### DIFF
--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -9,9 +9,11 @@
 /**
  * @defgroup unittests Unittests
  * @ingroup  sys
+ * @brief RIOT Unittests based on the EmbUnit Framework
  *
- * @note
- * Please refer to https://github.com/RIOT-OS/RIOT/wiki/Testing-RIOT
+ * @see http://embunit.sourceforge.net/embunit/
+ *
+ * @note Please refer to https://github.com/RIOT-OS/RIOT/wiki/Testing-RIOT
  *
  * @author Martine Lenders <mlenders@inf.fu-berlin.de>
  */

--- a/sys/include/trickle.h
+++ b/sys/include/trickle.h
@@ -12,9 +12,14 @@
 /**
  * @defgroup sys_trickle Trickle Timer
  * @ingroup sys
- * @{
- * @file
  * @brief   Implementation of a generic Trickle Algorithm (RFC 6206)
+ *
+ * @see https://tools.ietf.org/html/rfc6206
+ *
+ * @{
+ *
+ * @file
+ * @brief   Trickle timer interface definition
  *
  * @author  Eric Engel <eric.engel@fu-berlin.de>
  * @author  Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
@@ -31,29 +36,31 @@
 #include "thread.h"
 
 /**
- * @brief a generic callback function with arguments that is called by
- *        trickle periodically
+ * @brief Trickle callback function with arguments
  */
 typedef struct {
     void (*func)(void *);       /**< callback function pointer */
     void *args;                 /**< callback function arguments */
 } trickle_callback_t;
 
-/** @brief all state variables for a trickle timer */
+/**
+ * @brief all state variables of a trickle timer
+ */
 typedef struct {
     uint8_t k;                      /**< redundancy constant */
-    uint8_t Imax;                   /**< maximum interval size, described as doublings */
+    uint8_t Imax;                   /**< maximum interval size,
+                                         described as of Imin doublings */
     uint16_t c;                     /**< counter */
     uint32_t Imin;                  /**< minimum interval size */
     uint32_t I;                     /**< current interval size */
     uint32_t t;                     /**< time within the current interval */
     kernel_pid_t pid;               /**< pid of trickles target thread */
-    trickle_callback_t callback;    /**< the callback function and parameter that trickle is calling
-                                         after each interval */
+    trickle_callback_t callback;    /**< callback function and parameter that
+                                         trickle calls after each interval */
     msg_t msg;                      /**< the msg_t to use for intervals */
     uint64_t msg_time;              /**< interval in ms */
-    xtimer_t msg_timer;             /**< xtimer to send a msg_t to the target thread
-                                         for a new interval */
+    xtimer_t msg_timer;             /**< xtimer to send a msg_t to the target
+                                         thread for a new interval */
 } trickle_t;
 
 /**
@@ -106,7 +113,7 @@ void trickle_increment_counter(trickle_t *trickle);
 void trickle_interval(trickle_t *trickle);
 
 /**
- * @brief is called after the callback interval is over and calls the callback function
+ * @brief is called after the interval is over and executes callback function
  *
  * @param[in] trickle   trickle timer
  */

--- a/sys/include/tsrb.h
+++ b/sys/include/tsrb.h
@@ -9,17 +9,16 @@
 /**
  * @defgroup    sys_tsrb Thread safe ringbuffer
  * @ingroup     sys
- * @{
- */
-
-/**
- * @file
  * @brief       Thread-safe ringbuffer implementation
+ * @{
  *
- * This ringbuffer implementation can be used without locking if
- * there's only one producer and one consumer.
+ * @file
+ * @brief       Thread-safe ringbuffer interface definition
  *
- * @note Buffer size must be a power of two!
+ * @note        This ringbuffer implementation can be used without locking if
+ *              there's only one producer and one consumer.
+ *
+ * @attention   Buffer size must be a power of two!
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
@@ -150,5 +149,5 @@ int tsrb_add(tsrb_t *rb, const char *src, size_t n);
 }
 #endif
 
-/** @} */
 #endif /* TSRB_H */
+/** @} */


### PR DESCRIPTION
currently 3 submodules of `sys` are missing brief doxygen descriptions, see [here](http://doc.riot-os.org/group__sys.html), this PR 

- fixes group description of _Trickle_, _Unittests_, and _TSRB_
- plus some general enhancements for trickle docu