### PR TITLE
pm: fix pm configuration

### DIFF
--- a/drivers/periph_common/pm.c
+++ b/drivers/periph_common/pm.c
@@ -24,6 +24,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#ifndef FEATURE_PERIPH_PM
 void __attribute__((weak)) pm_set_lowest(void) {}
 
 void __attribute__((weak)) pm_off(void)
@@ -31,3 +32,4 @@ void __attribute__((weak)) pm_off(void)
     irq_disable();
     while(1) {};
 }
+#endif


### PR DESCRIPTION
This PR fixes PM configuration.

PM functions in periph_common should not be executed if FEATURE_PERIPH_PM is used. PM_LAYERED will be used instead. 