### PR TITLE
bcd: initial import of binary coded decimal en-/decoder

### DIFF
--- a/sys/include/bcd.h
+++ b/sys/include/bcd.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_bcd Binary coded decimal
+ * @ingroup     sys
+ * @brief       Library to de- and encode binary coded decimals
+ * @{
+ *
+ * @file
+ * @brief       BCD definitions
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef BCD_H
+#define BCD_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Converts a byte to a binary coded decimal
+ *
+ * @param[in] byte  A byte
+ *
+ * @return  A binary coded decimal (4 MSB = 10s, 4 LSB = 1s)
+ */
+static inline uint8_t bcd_from_byte(uint8_t byte)
+{
+    /* ((byte / 10) << 4) | (byte % 10) */
+    return byte + (6 * (byte / 10));
+}
+
+/**
+ * @brief   Converts a binary coded decimal to a byte
+ *
+ * @param[in] bcd   A binary coded decimal (4 MSB = 10, 4 LSB = 1s)
+ *
+ * @return  A byte
+ */
+static inline uint8_t bcd_to_byte(uint8_t bcd)
+{
+    /* == (10 * (bcd >> 4)) + (bcd & 0xf) */
+    return bcd - (6 * (bcd >> 4));
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BCD_H */
+/** @} */

--- a/tests/unittests/tests-bcd/Makefile
+++ b/tests/unittests/tests-bcd/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-bcd/tests-bcd.c
+++ b/tests/unittests/tests-bcd/tests-bcd.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "embUnit.h"
+
+#include "bcd.h"
+
+static void test_bcd_from_byte__zero(void)
+{
+    TEST_ASSERT_EQUAL_INT(0x00, bcd_from_byte(0));
+}
+
+static void test_bcd_from_byte__greater_99(void)
+{
+    /* output is garbled intentionally */
+    TEST_ASSERT_EQUAL_INT(0xa0, bcd_from_byte(100));
+    TEST_ASSERT_EQUAL_INT(0x95, bcd_from_byte(255));
+}
+
+static void test_bcd_from_byte(void)
+{
+    TEST_ASSERT_EQUAL_INT(0x01, bcd_from_byte(1));
+    TEST_ASSERT_EQUAL_INT(0x09, bcd_from_byte(9));
+    TEST_ASSERT_EQUAL_INT(0x10, bcd_from_byte(10));
+    TEST_ASSERT_EQUAL_INT(0x11, bcd_from_byte(11));
+    TEST_ASSERT_EQUAL_INT(0x99, bcd_from_byte(99));
+}
+
+static void test_bcd_to_byte__zero(void)
+{
+    TEST_ASSERT_EQUAL_INT(0, bcd_to_byte(0x00));
+}
+
+static void test_bcd_to_byte__greater_0x99(void)
+{
+    TEST_ASSERT_EQUAL_INT(100, bcd_to_byte(0xa0));
+    TEST_ASSERT_EQUAL_INT(110, bcd_to_byte(0xaa));
+    TEST_ASSERT_EQUAL_INT(165, bcd_to_byte(0xff));
+}
+
+static void test_bcd_to_byte(void)
+{
+    TEST_ASSERT_EQUAL_INT( 1, bcd_to_byte(0x01));
+    TEST_ASSERT_EQUAL_INT( 9, bcd_to_byte(0x09));
+    TEST_ASSERT_EQUAL_INT(10, bcd_to_byte(0x10));
+    TEST_ASSERT_EQUAL_INT(11, bcd_to_byte(0x11));
+    TEST_ASSERT_EQUAL_INT(99, bcd_to_byte(0x99));
+}
+
+Test *tests_bcd_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_bcd_from_byte__zero),
+        new_TestFixture(test_bcd_from_byte__greater_99),
+        new_TestFixture(test_bcd_from_byte),
+        new_TestFixture(test_bcd_to_byte__zero),
+        new_TestFixture(test_bcd_to_byte__greater_0x99),
+        new_TestFixture(test_bcd_to_byte),
+    };
+
+    EMB_UNIT_TESTCALLER(bcd_tests, NULL, NULL, fixtures);
+
+    return (Test *)&bcd_tests;
+}
+
+void tests_bcd(void)
+{
+    TESTS_RUN(tests_bcd_tests());
+}

--- a/tests/unittests/tests-bcd/tests-bcd.h
+++ b/tests/unittests/tests-bcd/tests-bcd.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief   Unittests for the `bcd` header
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef TESTS_BCD_H
+#define TESTS_BCD_H
+
+#include "embUnit/embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+*  @brief   The entry point of this test suite.
+*/
+void tests_bcd(void);
+
+/**
+ * @brief   Generates tests for bcd
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_bcd_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_BCD_H */
+/** @} */


### PR DESCRIPTION
This imports a simple BCD en-/decoder. I require that for a driver I'm currently porting.