### PR TITLE
ds1307: initial import of a driver for the DS1307 RTC

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -84,6 +84,10 @@ ifneq (,$(filter dht,$(USEMODULE)))
     FEATURES_REQUIRED += periph_gpio
 endif
 
+ifneq (,$(filter ds1307,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter dsp0401,$(USEMODULE)))
     USEMODULE += xtimer
     FEATURES_REQUIRED += periph_gpio

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -10,6 +10,9 @@ endif
 ifneq (,$(filter cc110x,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cc110x/include
 endif
+ifneq (,$(filter ds1307,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ds1307/include
+endif
 ifneq (,$(filter kw2xrf,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/kw2xrf/include
 endif

--- a/drivers/ds1307/Makefile
+++ b/drivers/ds1307/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ds1307/ds1307.c
+++ b/drivers/ds1307/ds1307.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include <string.h>
+
+#include "bcd.h"
+
+#include "ds1307.h"
+#include "ds1307_internal.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+static int _nvram_read(struct nvram *dev, uint8_t *dst, uint32_t src,
+                       size_t size);
+static int _nvram_write(struct nvram *dev, const uint8_t *src, uint32_t dst,
+                        size_t size);
+
+static uint8_t _convert_12_to_24(uint8_t hour)
+{
+    if (hour & DS1307_REG_HOUR_12H) {
+        uint8_t tmp = bcd_to_byte(hour & DS1307_REG_HOUR_12H_MASK);
+        if (hour & DS1307_REG_HOUR_PM) {
+            if (tmp < 12) {
+                tmp += 12;
+            }
+        }
+        else {
+            if (tmp == 12) {
+                tmp = 0;
+            }
+        }
+        hour = (bcd_from_byte(tmp) & DS1307_REG_HOUR_24H_MASK);
+    }
+    return hour;
+}
+
+int ds1307_init(ds1307_t *dev, const ds1307_params_t *params)
+{
+    int res;
+    uint8_t hour;
+
+    dev->i2c = params->i2c;
+
+    i2c_acquire(dev->i2c);
+    res = i2c_init_master(dev->i2c, params->clk);
+    if (res < 0) {
+        i2c_release(dev->i2c);
+        DEBUG("ds1307: Error initializing I2C: %i\n", res);
+        return -1;
+    }
+    /* normalize hour format */
+    res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_HOUR, &hour);
+    if (res < 0) {
+        i2c_release(dev->i2c);
+        DEBUG("ds1307: Error reading HOUR register on init: %i\n", res);
+        return -1;
+    }
+    res = i2c_write_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_HOUR,
+                        _convert_12_to_24(hour));
+    i2c_release(dev->i2c);
+
+    if (res < 0) {
+        DEBUG("ds1307: Error writing HOUR register on init: %i\n", res);
+        return -1;
+    }
+    dev->nvram.read = _nvram_read;
+    dev->nvram.write = _nvram_write;
+    dev->nvram.size = (DS1307_REG_RAM_LAST - DS1307_REG_RAM_FIRST) + 1;
+    dev->nvram.extra = dev;
+    return 0;
+}
+
+int ds1307_set_time(const ds1307_t *dev, const struct tm *time)
+{
+    uint8_t regs[DS1307_REG_YEAR - DS1307_REG_SEC + 1];
+    int res;
+
+    regs[DS1307_REG_SEC] = (bcd_from_byte(time->tm_sec) & DS1307_REG_SEC_MASK);
+    regs[DS1307_REG_MIN] = (bcd_from_byte(time->tm_min) & DS1307_REG_MIN_MASK);
+    regs[DS1307_REG_HOUR] = (bcd_from_byte(time->tm_hour) &
+                             DS1307_REG_HOUR_24H_MASK);
+    regs[DS1307_REG_DOW] = (bcd_from_byte(time->tm_wday + DS1307_DOW_OFFSET) &
+                            DS1307_REG_DOW_MASK);
+    regs[DS1307_REG_DOM] = (bcd_from_byte(time->tm_mday) & DS1307_REG_DOM_MASK);
+    regs[DS1307_REG_MON] = (bcd_from_byte(time->tm_mon + DS1307_MON_OFFSET) &
+                            DS1307_REG_MON_MASK);
+    regs[DS1307_REG_YEAR] = bcd_from_byte(time->tm_year + DS1307_YEAR_OFFSET);
+    i2c_acquire(dev->i2c);
+    res = i2c_write_regs(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, regs,
+                         sizeof(regs));
+    DEBUG("ds1307: wrote bytes %02x %02x %02x %02x %02x %02x %02x to device (result: %i)\n",
+          regs[DS1307_REG_SEC], regs[DS1307_REG_MIN], regs[DS1307_REG_HOUR],
+          regs[DS1307_REG_DOW], regs[DS1307_REG_DOM], regs[DS1307_REG_MON],
+          regs[DS1307_REG_YEAR], res);
+    i2c_release(dev->i2c);
+    return (res < 0) ? -1 : 0;
+}
+
+int ds1307_get_time(const ds1307_t *dev, struct tm *time)
+{
+    uint8_t regs[DS1307_REG_YEAR - DS1307_REG_SEC + 1];
+    int res;
+
+    i2c_acquire(dev->i2c);
+    res = i2c_read_regs(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, regs,
+                         sizeof(regs));
+    DEBUG("ds1307: read bytes %02x %02x %02x %02x %02x %02x %02x from device (result: %i)\n",
+          regs[DS1307_REG_SEC], regs[DS1307_REG_MIN], regs[DS1307_REG_HOUR],
+          regs[DS1307_REG_DOW], regs[DS1307_REG_DOM], regs[DS1307_REG_MON],
+          regs[DS1307_REG_YEAR], res);
+    i2c_release(dev->i2c);
+    if (res < 0) {
+        return -1;
+    }
+    time->tm_sec = bcd_to_byte(regs[DS1307_REG_SEC] & DS1307_REG_SEC_MASK);
+    time->tm_min = bcd_to_byte(regs[DS1307_REG_MIN] & DS1307_REG_MIN_MASK);
+    time->tm_hour = bcd_to_byte(regs[DS1307_REG_HOUR] &
+                                DS1307_REG_HOUR_24H_MASK);
+    time->tm_wday = (bcd_to_byte(regs[DS1307_REG_DOW] & DS1307_REG_DOW_MASK) -
+                     DS1307_DOW_OFFSET);
+    time->tm_mday = bcd_to_byte(regs[DS1307_REG_DOM] & DS1307_REG_DOM_MASK);
+    time->tm_mon = bcd_to_byte(regs[DS1307_REG_MON] & DS1307_REG_MON_MASK) -
+                     DS1307_MON_OFFSET;
+    time->tm_year = (bcd_to_byte(regs[DS1307_REG_YEAR]) - DS1307_YEAR_OFFSET);
+    return 0;
+}
+
+int ds1307_halt(const ds1307_t *dev)
+{
+    int res;
+    uint8_t sec;
+
+    i2c_acquire(dev->i2c);
+    res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, &sec);
+    if (res < 0) {
+        i2c_release(dev->i2c);
+        DEBUG("ds1307: Error reading SEC register on halt: %i\n", res);
+        return -1;
+    }
+    sec |= DS1307_REG_SEC_CH;
+    res = i2c_write_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, sec);
+    i2c_release(dev->i2c);
+    return (res < 0) ? -1 : 0;
+}
+
+int ds1307_set_sqw_mode(const ds1307_t *dev, ds1307_sqw_mode_t mode)
+{
+    int res;
+
+    i2c_acquire(dev->i2c);
+    res = i2c_write_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SQW_CTL,
+                        (uint8_t)mode);
+    i2c_release(dev->i2c);
+    return res;
+}
+
+int ds1307_get_sqw_mode(const ds1307_t *dev)
+{
+    uint8_t mode;
+    int res;
+
+    i2c_acquire(dev->i2c);
+    res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SQW_CTL, &mode);
+    i2c_release(dev->i2c);
+    return (res < 0) ? res : (int)mode;
+}
+
+static int _nvram_read(struct nvram *nvram, uint8_t *dst, uint32_t src,
+                       size_t size)
+{
+    const ds1307_t *dev = nvram->extra;
+    int res;
+
+    if ((src + size) > nvram->size) {
+        return -3;
+    }
+    i2c_acquire(dev->i2c);
+    res = i2c_read_regs(dev->i2c, DS1307_I2C_ADDRESS,
+                        DS1307_REG_RAM_FIRST + src, dst, size);
+    i2c_release(dev->i2c);
+    return res;
+}
+
+static int _nvram_write(struct nvram *nvram, const uint8_t *src, uint32_t dst,
+                        size_t size)
+{
+    const ds1307_t *dev = nvram->extra;
+    int res;
+
+    if ((dst + size) > nvram->size) {
+        return -3;
+    }
+    i2c_acquire(dev->i2c);
+    res = i2c_write_regs(dev->i2c, DS1307_I2C_ADDRESS,
+                         DS1307_REG_RAM_FIRST + dst, src, size);
+    i2c_release(dev->i2c);
+    return res;
+}
+
+/** @} */

--- a/drivers/ds1307/include/ds1307_internal.h
+++ b/drivers/ds1307/include/ds1307_internal.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup drivers_ds1307
+ * @brief
+ * @{
+ *
+ * @file
+ * @brief   Register definitions for DS1307 RTC
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef DS1307_INTERNAL_H
+#define DS1307_INTERNAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Registers
+ * @{
+ */
+#define DS1307_REG_SEC              (0x00)  /**< seconds */
+#define DS1307_REG_MIN              (0x01)  /**< minutes */
+#define DS1307_REG_HOUR             (0x02)  /**< hours */
+#define DS1307_REG_DOW              (0x03)  /**< day of week (1-7, 1 == sunday) */
+#define DS1307_REG_DOM              (0x04)  /**< day of month */
+#define DS1307_REG_MON              (0x05)  /**< month */
+#define DS1307_REG_YEAR             (0x06)  /**< year */
+#define DS1307_REG_SQW_CTL          (0x07)  /**< SQW control */
+#define DS1307_REG_RAM_FIRST        (0x08)  /**< NVRAM start */
+#define DS1307_REG_RAM_LAST         (0x3F)  /**< NVRAM end */
+/** @} */
+
+/**
+ * @name    Register bits
+ * @{
+ */
+#define DS1307_REG_SEC_CH           (0x80)  /**< clock halt bit */
+#define DS1307_REG_SEC_MASK         (0x7f)  /**< seconds mask */
+#define DS1307_REG_MIN_MASK         (0x7f)  /**< minutes mask */
+#define DS1307_REG_HOUR_12H         (0x40)  /**< 12-hour (0) / 24-hour (1) mode */
+#define DS1307_REG_HOUR_PM          (0x20)  /**< AM (0) / PM (1) in 12-hour mode */
+#define DS1307_REG_HOUR_12H_MASK    (0x2f)  /**< hour (12-hour mode) */
+#define DS1307_REG_HOUR_24H_MASK    (0x3f)  /**< hour (24-hour mode) */
+#define DS1307_REG_DOW_MASK         (0x07)  /**< day of week mask */
+#define DS1307_REG_DOM_MASK         (0x3f)  /**< day of month mask */
+#define DS1307_REG_MON_MASK         (0x1f)  /**< month mask */
+/** @} */
+
+/**
+ * @name    Custom offsets (to DS1307 registers to struct tm)
+ * @{
+ */
+#define DS1307_DOW_OFFSET           (1)     /**< offset in days from sunday */
+#define DS1307_MON_OFFSET           (1)     /**< offset in month from January */
+#define DS1307_YEAR_OFFSET          (-100)  /**< offset in years from 1900 */
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DS1307_INTERNAL_H */
+/** @} */

--- a/drivers/ds1307/include/ds1307_params.h
+++ b/drivers/ds1307/include/ds1307_params.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup drivers_ds1307
+ * @{
+ *
+ * @file
+ * @brief   Default configuration for DS1307 devices
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef DS1307_PARAMS_H
+#define DS1307_PARAMS_H
+
+#include "board.h"
+#include "ds1307.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Default configuration parameters for the DS1307 driver
+ * @{
+ */
+#ifndef DS1307_PARAM_I2C
+#define DS1307_PARAM_I2C        (I2C_DEV(0))
+#endif
+#ifndef DS1307_PARAM_I2C_CLK
+#define DS1307_PARAM_I2C_CLK    (DS1307_I2C_MAX_CLK)
+
+#define DS1307_PARAMS_DEFAULT   {   .i2c = DS1307_PARAM_I2C, \
+                                    .clk = DS1307_PARAM_I2C_CLK }
+
+#endif
+/** @} */
+
+/**
+ * @brief   DS1307 configuration
+ */
+static const ds1307_params_t ds1307_params[] =
+{
+#ifdef DS1307_PARAMS_BOARD
+    DS1307_PARAMS_BOARD,
+#else
+    DS1307_PARAMS_DEFAULT,
+#endif
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DS1307_PARAMS_H */
+/** @} */

--- a/drivers/include/ds1307.h
+++ b/drivers/include/ds1307.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_ds1307  DS1307 RTC
+ * @ingroup     drivers_sensors
+ * @brief       Device drive interface for the DS1307 real-time clock
+ * @{
+ *
+ * @file
+ * @brief       DS1307 definitions
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef DS1307_H
+#define DS1307_H
+
+#include <stdbool.h>
+#include <time.h>
+
+#include "nvram.h"
+#include "periph/i2c.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   I2C address of DS1307 RTC
+ */
+#ifndef DS1307_I2C_ADDRESS
+#define DS1307_I2C_ADDRESS      (0x68)
+#endif
+
+/**
+ * @brief   Maximum I2C bus speed to use with the device
+ */
+#ifndef DS1307_I2C_MAX_CLK
+#define DS1307_I2C_MAX_CLK      (I2C_SPEED_FAST)
+#endif
+
+/**
+ * @brief   Maximum size in byte of on-chip NVRAM
+ */
+#define DS1307_NVRAM_MAX_SIZE   (56U)
+
+/**
+ * @brief   Device descriptor for DS1307 devices
+ */
+typedef struct {
+    i2c_t i2c;                  /**< I2C bus the device is connected to */
+    nvram_t nvram;              /**< on-chip NVRAM (see nvram.h) */
+} ds1307_t;
+
+/**
+ * @brief   Set of configuration parameters for DS1307 devices
+ */
+typedef struct {
+    i2c_t i2c;                  /**< I2C bus the device is connected to */
+    i2c_speed_t clk;            /**< clock speed to use on the I2C bus */
+} ds1307_params_t;
+
+/**
+ * @brief   Modes for the DS1307 square wave / output driver
+ */
+typedef enum {
+    DS1307_SQW_MODE_0 = 0x00,       /**< OUT: 0 */
+    DS1307_SQW_MODE_1000HZ = 0x10,  /**< SQW: 1kHz */
+    DS1307_SQW_MODE_4096HZ = 0x11,  /**< SQW: 4.096 kHz */
+    DS1307_SQW_MODE_8192HZ = 0x12,  /**< SQW: 8.192 kHz */
+    DS1307_SQW_MODE_32768HZ = 0x13, /**< SQW: 32.768 kHz */
+    DS1307_SQW_MODE_1 = 0x80,       /**< OUT: 1 */
+} ds1307_sqw_mode_t;
+
+/**
+ * @brief   Initialize the given DS1307 device
+ *
+ * @param[out] dev      device descriptor of the targeted device
+ * @param[in] params    device configuration (i2c bus, address and bus clock)
+ *
+ * @return      0 on success
+ * @return      < 0 if unable to speak to the device
+ */
+int ds1307_init(ds1307_t *dev, const ds1307_params_t *params);
+
+/**
+ * @brief   Set RTC to a given time.
+ *
+ * @param[in] dev       device descriptor of the targeted device
+ * @param[in] time      pointer to the struct holding the time to set.
+ *
+ * @return      0 on success
+ * @return      < 0 if unable to speak to the device
+ */
+int ds1307_set_time(const ds1307_t *dev, const struct tm *time);
+
+/**
+ * @brief   Get current RTC time.
+ *
+ * @param[in] dev       device descriptor of the targeted device
+ * @param[out] time     pointer to the struct to write the time to.
+ *
+ * @return      0 on success
+ * @return      < 0 if unable to speak to the device
+ */
+int ds1307_get_time(const ds1307_t *dev, struct tm *time);
+
+/**
+ * @brief   Halt clock
+ *
+ * @note    Can be reversed using @ref ds1307_set_time()
+ *
+ * @param[in] dev       device descriptor of the targeted device
+ *
+ * @return      0 on success
+ * @return      < 0 if unable to speak to the device
+ */
+int ds1307_halt(const ds1307_t *dev);
+
+/**
+ * @brief   Set mode of square wave / output driver
+ *
+ * @note    To get the actual output of the driver, attach the pin via GPIO
+ *
+ * @param[in] dev       device descriptor of the targeted device
+ * @param[in] mode      mode for the square wave / output driver
+ *
+ * @return      0 on success
+ * @return      < 0 if unable to speak to the device
+ */
+int ds1307_set_sqw_mode(const ds1307_t *dev, ds1307_sqw_mode_t mode);
+
+/**
+ * @brief   Get current mode of square wave / output driver
+ *
+ * @note    To get the actual output of the driver, attach the pin via GPIO
+ *
+ * @param[in] dev       device descriptor of the targeted device
+ *
+ * @return  current mode of the square wave / output driver
+ *          (see ds1307_sqw_mode_t)
+ * @return  < 0 if unable to speak to the device
+ */
+int ds1307_get_sqw_mode(const ds1307_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DS1307_H */
+/** @} */

--- a/tests/driver_ds1307/Makefile
+++ b/tests/driver_ds1307/Makefile
@@ -1,0 +1,11 @@
+APPLICATION = driver_ds1307
+include ../Makefile.tests_common
+
+USEMODULE += ds1307
+USEMODULE += embunit
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/driver_ds1307/README.md
+++ b/tests/driver_ds1307/README.md
@@ -1,0 +1,15 @@
+# About
+This test application is created for testing DS1307 driver.
+It uses the default device parameters as specified in
+`drivers/ds1307/include/ds1307_params.h`. To override these setting, you
+can simply do this by defining these parameters as compiler flags while building,
+e.g.:
+```
+$ CFLAGS="-DDS1307_PARAM_I2C=I2C_DEV(1)"" make all
+```
+
+# Usage
+Simply flash this example to your board and after a while you will see a number
+of points and then `OK (x tests)` where `x` corresponds to the number of tests.
+
+The output might take a while.

--- a/tests/driver_ds1307/main.c
+++ b/tests/driver_ds1307/main.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the DS1307 RTC driver
+ *
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "ds1307.h"
+#include "ds1307_params.h"
+#include "embUnit.h"
+#include "embUnit/embUnit.h"
+#include "timex.h"
+#include "xtimer.h"
+
+#define TEST_STRING "This is a test"
+
+static ds1307_t dev;
+
+static struct tm init = {  /* Wed Sep 22 15:10:42 2010 is the author date of
+                            * RIOT's initial commit ;-) */
+    .tm_sec = 42,
+    .tm_min = 10,
+    .tm_hour = 15,
+    .tm_wday = 3,
+    .tm_mday = 22,
+    .tm_mon = 8,
+    .tm_year = 110
+};
+
+static int _tm_cmp(struct tm *a, struct tm *b)
+{
+    if (a->tm_year == b->tm_year) {
+        if (a->tm_mon == b->tm_mon) {
+            if (a->tm_mday == b->tm_mday) {
+                /* ignoring week day */
+                if (a->tm_hour == b->tm_hour) {
+                    if (a->tm_min == b->tm_min) {
+                        return a->tm_sec - b->tm_sec;
+                    }
+                    return a->tm_min - b->tm_min;
+                }
+                return a->tm_hour - b->tm_hour;
+            }
+            return a->tm_mday - b->tm_mday;
+        }
+        return a->tm_mon - b->tm_mon;
+    }
+    return a->tm_year - b->tm_year;
+}
+
+static void set_up(void)
+{
+    ds1307_set_time(&dev, &init);
+}
+
+static void test_nvram(void)
+{
+    struct tm time;
+    uint8_t buf[DS1307_NVRAM_MAX_SIZE] = { 0 };
+
+    ds1307_halt(&dev);
+    TEST_ASSERT_NOT_NULL(dev.nvram.read);
+    TEST_ASSERT_NOT_NULL(dev.nvram.write);
+    TEST_ASSERT(dev.nvram.read(&dev.nvram, buf, 0, DS1307_NVRAM_MAX_SIZE + 1) < 0);
+    TEST_ASSERT(dev.nvram.write(&dev.nvram, buf, 0, DS1307_NVRAM_MAX_SIZE + 1) < 0);
+    TEST_ASSERT(dev.nvram.read(&dev.nvram, buf, 1, DS1307_NVRAM_MAX_SIZE) < 0);
+    TEST_ASSERT(dev.nvram.write(&dev.nvram, buf, 1, DS1307_NVRAM_MAX_SIZE) < 0);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING),
+                          dev.nvram.write(&dev.nvram, (uint8_t *)TEST_STRING, 0,
+                                          sizeof(TEST_STRING)));
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING),
+                          dev.nvram.read(&dev.nvram, buf, 0,
+                                          sizeof(TEST_STRING)));
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING, (char *)buf);
+    TEST_ASSERT_EQUAL_INT(sizeof(TEST_STRING) - 1,
+                          dev.nvram.read(&dev.nvram, buf, 5,
+                                          sizeof(TEST_STRING) - 1));
+    TEST_ASSERT_EQUAL_STRING("is a test", (char *)buf);
+    ds1307_get_time(&dev, &time);
+    TEST_ASSERT_EQUAL_INT(0, _tm_cmp(&init, &time));
+}
+
+static void test_get_time(void)
+{
+    for (int i = 0; i < 5; i++) {
+        struct tm time;
+
+        xtimer_sleep(1);
+        ds1307_get_time(&dev, &time);
+        TEST_ASSERT(_tm_cmp(&init, &time) <= 0);
+    }
+}
+
+static void test_halt(void)
+{
+    ds1307_halt(&dev);
+    for (int i = 0; i < 3; i++) {
+        struct tm time;
+
+        xtimer_sleep(1);
+        ds1307_get_time(&dev, &time);
+        TEST_ASSERT_EQUAL_INT(0, _tm_cmp(&init, &time));
+    }
+}
+
+static Test *tests_ds1307(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_nvram),
+        new_TestFixture(test_get_time),
+        /* set tested in set_up */
+        new_TestFixture(test_halt),
+    };
+
+    EMB_UNIT_TESTCALLER(tests, set_up, NULL, fixtures);
+    return (Test *)&tests;
+}
+
+int main(void)
+{
+    int res;
+
+    puts("DS1307 RTC test\n");
+
+    /* initialize the device */
+    res = ds1307_init(&dev, (&ds1307_params[0]));
+    if (res != 0) {
+        puts("error: unable to initialize RTC [I2C initialization error]");
+        return 1;
+    }
+
+    TESTS_START();
+    TESTS_RUN(tests_ds1307());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/driver_ds1307/tests/01-run.py
+++ b/tests/driver_ds1307/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+    child.expect(u"OK \\([0-9]+ tests\\)")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
While searching my Arduino Leonardo to test #7306 I found this [breakout board](https://www.adafruit.com/product/264), and while the board itself is discontinued (there is an [updated version](https://www.adafruit.com/product/3296)) the chip itself is still a popular RTC in the arduino community, as far as I know. So I decided to build some skills and develop my first own driver :-).

Depends on ~~#7311~~ (merged).