### PR TITLE
boards: improve documentation

### DIFF
--- a/boards/nrf52840dk/include/board.h
+++ b/boards/nrf52840dk/include/board.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    boards_nrf52840dk nRF52840 DK
  * @ingroup     boards
+ * @brief       Board specific configuration for the nRF52840 DK
  * @{
  *
  * @file

--- a/boards/nrf52dk/include/board.h
+++ b/boards/nrf52dk/include/board.h
@@ -9,10 +9,11 @@
 /**
  * @defgroup    boards_nrf52dk nRF52 DK
  * @ingroup     boards
+ * @brief       Board specific configuration for the nRF52 DK
  * @{
  *
  * @file
- * @brief       Board specific configuaration for the nRF52 DK
+ * @brief       Board specific configuration for the nRF52 DK
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Sebastian Meiling <s@mlng.net>

--- a/boards/nucleo-common/include/board_common.h
+++ b/boards/nucleo-common/include/board_common.h
@@ -7,9 +7,15 @@
  */
 
 /**
- * @defgroup    boards_nucleo_common STM Nucleo Common
+ * @defgroup    boards_nucleo STM Nucleo boards
  * @ingroup     boards
- * @brief       Common files for STM Nucleo boards
+ * @brief       STM Nucleo boards
+ */
+
+/**
+ * @defgroup    boards_nucleo64_common STM Nucleo 64 boards common
+ * @ingroup     boards_nucleo
+ * @brief       Common files for STM Nucleo 64 boards
  * @{
  *
  * @file

--- a/boards/nucleo-f030/include/board.h
+++ b/boards/nucleo-f030/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-f030 Nucleo-F030
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f030 board
  * @{
  *

--- a/boards/nucleo-f070/include/board.h
+++ b/boards/nucleo-f070/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo-f072 Nucleo-F072
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f072 board
  * @{
  *

--- a/boards/nucleo-f072/include/board.h
+++ b/boards/nucleo-f072/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-f072 Nucleo-F072
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f072 board
  * @{
  *

--- a/boards/nucleo-f091/include/board.h
+++ b/boards/nucleo-f091/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-f091 Nucleo-F091
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f091 board
  * @{
  *

--- a/boards/nucleo-f103/include/board.h
+++ b/boards/nucleo-f103/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-f103 Nucleo-F103
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f103 board
  * @{
  *

--- a/boards/nucleo-f302/include/board.h
+++ b/boards/nucleo-f302/include/board.h
@@ -10,7 +10,7 @@
 
 /**
  * @defgroup    boards_nucleo-f302 Nucleo-F302
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f302 board
  * @{
  *

--- a/boards/nucleo-f303/include/board.h
+++ b/boards/nucleo-f303/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo-f303 Nucleo-F303
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f303 board
  * @{
  *

--- a/boards/nucleo-f334/include/board.h
+++ b/boards/nucleo-f334/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-f334 Nucleo-F334
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f334 board
  * @{
  *

--- a/boards/nucleo-f401/include/board.h
+++ b/boards/nucleo-f401/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-f401 Nucleo-F401
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f401 board
  * @{
  *

--- a/boards/nucleo-f410/include/board.h
+++ b/boards/nucleo-f410/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-f410 Nucleo-F410
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f410 board
  * @{
  *

--- a/boards/nucleo-f411/include/board.h
+++ b/boards/nucleo-f411/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-f411 Nucleo-F411
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f411 board
  * @{
  *

--- a/boards/nucleo-f446/include/board.h
+++ b/boards/nucleo-f446/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-f446 Nucleo-F446
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-f446 board
  * @{
  *

--- a/boards/nucleo-l053/include/board.h
+++ b/boards/nucleo-l053/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo-l053 Nucleo-L053
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-l053 board
  * @{
  *

--- a/boards/nucleo-l073/include/board.h
+++ b/boards/nucleo-l073/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo-l073 Nucleo-L073
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-l073 board
  * @{
  *

--- a/boards/nucleo-l1/include/board.h
+++ b/boards/nucleo-l1/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo-l1 Nucleo-L1
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-l1 board.
  * @{
  *

--- a/boards/nucleo-l476/include/board.h
+++ b/boards/nucleo-l476/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo-l476 Nucleo-L476
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo-l476 board
  * @{
  *

--- a/boards/nucleo144-common/include/board_common.h
+++ b/boards/nucleo144-common/include/board_common.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo144-common STM Nucleo-144 Common
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Common files for STM Nucleo-144 boards
  * @{
  *

--- a/boards/nucleo144-f207/include/board.h
+++ b/boards/nucleo144-f207/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo144-f207 Nucleo144-F207
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo144-f207 board
  * @{
  *

--- a/boards/nucleo144-f303/include/board.h
+++ b/boards/nucleo144-f303/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo144-f303 Nucleo144-F303
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo144-f303 board
  * @{
  *

--- a/boards/nucleo144-f412/include/board.h
+++ b/boards/nucleo144-f412/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo144-f412 Nucleo-F412
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo144-f412 board
  * @{
  *

--- a/boards/nucleo144-f413/include/board.h
+++ b/boards/nucleo144-f413/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo144-f413 Nucleo-F413
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo144-f413 board
  * @{
  *

--- a/boards/nucleo144-f429/include/board.h
+++ b/boards/nucleo144-f429/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo144-f429 Nucleo144-F429
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo144-f429 board
  * @{
  *

--- a/boards/nucleo144-f446/include/board.h
+++ b/boards/nucleo144-f446/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo144-f446 Nucleo144-F446
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo144-f446 board
  * @{
  *

--- a/boards/nucleo144-f746/include/board.h
+++ b/boards/nucleo144-f746/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo144-f746 Nucleo144-F746
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo144-f746 board
  * @{
  *

--- a/boards/nucleo144-f767/include/board.h
+++ b/boards/nucleo144-f767/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo144-f767 Nucleo144-F767
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo144-f767 board
  * @{
  *

--- a/boards/nucleo32-common/include/board_common.h
+++ b/boards/nucleo32-common/include/board_common.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo32-common STM Nucleo-32 Common
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Common files for STM Nucleo-32 boards
  * @{
  *

--- a/boards/nucleo32-f031/include/board.h
+++ b/boards/nucleo32-f031/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo32-f031 Nucleo32-F031
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo32-f031 board
  * @{
  *

--- a/boards/nucleo32-f042/include/board.h
+++ b/boards/nucleo32-f042/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo32-f042 Nucleo-F042
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo32-f042 board
  * @{
  *

--- a/boards/nucleo32-f303/include/board.h
+++ b/boards/nucleo32-f303/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    boards_nucleo32-f303 Nucleo32-F303
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo32-f303 board
  * @{
  *

--- a/boards/nucleo32-l031/include/board.h
+++ b/boards/nucleo32-l031/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo32-l031 Nucleo32-L031
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo32-l031 board
  * @{
  *

--- a/boards/nucleo32-l432/include/board.h
+++ b/boards/nucleo32-l432/include/board.h
@@ -9,7 +9,7 @@
 
 /**
  * @defgroup    boards_nucleo32-l432 Nucleo32-L432
- * @ingroup     boards
+ * @ingroup     boards_nucleo
  * @brief       Board specific files for the nucleo32-l432 board
  * @{
  *


### PR DESCRIPTION
This is a first (very small) step toward a better doxygen documentation of the boards:
* add missing brief for 2 NRF boards
* group nucleo together in a subgroup of boards

We could apply the same for Arduino.

I'm also evaluating the possibility to move boards documentation from the wiki to doxygen