### PR TITLE
cpu, cc2538: adapt periph i2c to GPIO API

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -92,7 +92,6 @@ static const timer_conf_t timer_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -100,15 +99,15 @@ static const timer_conf_t timer_config[] = {
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PA2 /* SPI_SCK on the SmartRF06 baseboard */
-#define I2C_0_SDA_PIN           GPIO_PA4 /* SPI_MOSI on the SmartRF06 baseboard */
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = GPIO_PA2, /* SPI_SCK on the SmartRF06 baseboard */
-        .sda_pin = GPIO_PA4, /* SPI_MOSI on the SmartRF06 baseboard */
+        .scl_pin = GPIO_PIN(0, 2),  /**< GPIO_PA2, SPI_SCK  on SmartRF06 */
+        .sda_pin = GPIO_PIN(0, 4)   /**< GPIO_PA4, SPI_MOSI on SmartRF06 */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -103,7 +103,6 @@ static const adc_conf_t adc_config[] = {
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -111,15 +110,15 @@ static const adc_conf_t adc_config[] = {
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PB3 /* OpenBattery */
-#define I2C_0_SDA_PIN           GPIO_PB4 /* OpenBattery */
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = GPIO_PB3, /* OpenBattery */
-        .sda_pin = GPIO_PB4, /* OpenBattery */
+        .scl_pin = GPIO_PIN(1, 3),  /**< GPIO_PB3, OpenBattery */
+        .sda_pin = GPIO_PIN(1, 4)   /**< GPIO_PB4, OpenBattery */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -49,7 +49,6 @@
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -57,15 +56,15 @@
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PB1
-#define I2C_0_SDA_PIN           GPIO_PB0
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = I2C_0_SCL_PIN,
-        .sda_pin = I2C_0_SDA_PIN,
+        .scl_pin = GPIO_PIN(1, 1),  /**< GPIO_PB1 */
+        .sda_pin = GPIO_PIN(1, 0)   /**< GPIO_PB0 */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -50,7 +50,6 @@
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -58,15 +57,15 @@
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PC3
-#define I2C_0_SDA_PIN           GPIO_PC2
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = I2C_0_SCL_PIN,
-        .sda_pin = I2C_0_SDA_PIN,
+        .scl_pin = GPIO_PIN(2, 3),  /**< GPIO_PC3 */
+        .sda_pin = GPIO_PIN(2, 2)   /**< GPIO_PC2 */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -53,7 +53,6 @@
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -61,15 +60,15 @@
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PC3
-#define I2C_0_SDA_PIN           GPIO_PC2
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = I2C_0_SCL_PIN,
-        .sda_pin = I2C_0_SDA_PIN,
+        .scl_pin = GPIO_PIN(2, 3),  /**< GPIO_PC3 */
+        .sda_pin = GPIO_PIN(2, 2)   /**< GPIO_PC2 */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -86,7 +86,6 @@
 static mutex_t mutex = MUTEX_INIT;
 static mutex_t i2c_wait_mutex = MUTEX_INIT;
 static uint32_t speed_hz;
-static uint32_t scl_delay;
 
 #define WARN_IF(cond) \
         if (cond) { \
@@ -223,11 +222,6 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     }
 
     cc2538_i2c_init_master(dev, speed_hz);
-
-    /* Pre-compute an SCL delay in microseconds */
-    scl_delay = US_PER_SEC;
-    scl_delay += speed_hz;
-    scl_delay /= 2 * speed_hz;
 
     return 0;
 }

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -167,8 +167,8 @@ void cc2538_i2c_init_master(i2c_t dev, uint32_t speed_hz)
     /* clear periph reset trigger */
     SYS_CTRL_SRI2C &= ~1;
 
-    gpio_init_af(SCL_PIN(dev), I2C_CMSSCL, GPIO_IN_PU);
-    gpio_init_af(SDA_PIN(dev), I2C_CMSSDA, GPIO_IN_PU);
+    gpio_init_af(SCL_PIN(dev), I2C_SCL_OUT, GPIO_IN_PU);
+    gpio_init_af(SDA_PIN(dev), I2C_SDA_OUT, GPIO_IN_PU);
 
     /* Initialize the I2C master by setting the Master Function Enable bit */
     I2CM_CR |= MFE;

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -170,8 +170,6 @@ void cc2538_i2c_init_master(i2c_t dev, uint32_t speed_hz)
 
     gpio_init_af(SCL_PIN(dev), I2C_CMSSCL, GPIO_IN_PU);
     gpio_init_af(SDA_PIN(dev), I2C_CMSSDA, GPIO_IN_PU);
-    IOC_I2CMSSCL = gpio_pp_num(SCL_PIN(dev));
-    IOC_I2CMSSDA = gpio_pp_num(SDA_PIN(dev));
 
     /* Initialize the I2C master by setting the Master Function Enable bit */
     I2CM_CR |= MFE;

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -95,13 +95,8 @@ static uint32_t scl_delay;
 
 static void cc2538_i2c_init_master(i2c_t dev, uint32_t speed_hz);
 
-static inline bool bus_quiet(i2c_t dev)
-{
-    return (gpio_read(SCL_PIN(dev)) && gpio_read(SDA_PIN(dev)));
-}
 
-static void i2cm_ctrl_write(uint_fast8_t value) {
-    WARN_IF(I2CM_STAT & BUSY);
+static inline void i2cm_ctrl_write(uint_fast8_t value) {
     I2CM_CTRL = value;
 }
 
@@ -173,8 +168,8 @@ void cc2538_i2c_init_master(i2c_t dev, uint32_t speed_hz)
     /* clear periph reset trigger */
     SYS_CTRL_SRI2C &= ~1;
 
-    gpio_init_af(SCL_PIN(dev), I2C_CMSSCL, IOC_OVERRIDE_PUE);
-    gpio_init_af(SDA_PIN(dev), I2C_CMSSDA, IOC_OVERRIDE_PUE);
+    gpio_init_af(SCL_PIN(dev), I2C_CMSSCL, GPIO_IN_PU);
+    gpio_init_af(SDA_PIN(dev), I2C_CMSSDA, GPIO_IN_PU);
     IOC_I2CMSSCL = gpio_pp_num(SCL_PIN(dev));
     IOC_I2CMSSDA = gpio_pp_num(SDA_PIN(dev));
 

--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Loci Controls Inc.
+ *               2017 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -8,14 +9,14 @@
 
 /**
  * @ingroup     cpu_cc2538
- * @ingroup     drivers_periph
+ * @ingroup     drivers_periph_i2c
  * @{
  *
  * @file
  * @brief       Low-level I2C driver implementation
  *
  * @author      Ian Martin <ian@locicontrols.com>
- *
+ * @author      Sebastian Meiling <s@mlng.net>
  * @}
  */
 
@@ -26,33 +27,33 @@
 
 #include "mutex.h"
 #include "cpu.h"
+#include "periph/gpio.h"
 #include "periph/i2c.h"
-#include "thread.h"
 #ifdef MODULE_XTIMER
 #include "xtimer.h"
-#endif
+#else
+#include "thread.h"
 #include "timex.h" /* for US_PER_SEC */
+#endif
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
 /* guard this file in case no I2C device is defined */
-#if I2C_NUMOF
+#ifdef I2C_NUMOF
 
-#ifndef I2C_0_SCL_PIN
-#define I2C_0_SCL_PIN i2c_config[I2C_0].scl_pin
-#endif
+/* pin short cuts */
+#define SCL_PIN(x) (i2c_config[x].scl_pin)
+#define SDA_PIN(x) (i2c_config[x].sda_pin)
 
-#ifndef I2C_0_SDA_PIN
-#define I2C_0_SDA_PIN i2c_config[I2C_0].sda_pin
-#endif
+#define SDA_TRY_LIMIT   (200U)
 
 #undef BIT
 #define BIT(n)     ( 1 << (n) )
 
 /* Standard I2C Parameters */
-#define DATA_BITS  8
-#define ACK_BITS   1
+#define DATA_BITS  (8U)
+#define ACK_BITS   (1U)
 
 /* I2CM_DR Bits */
 #define RS         BIT(0)
@@ -87,53 +88,38 @@ static mutex_t i2c_wait_mutex = MUTEX_INIT;
 static uint32_t speed_hz;
 static uint32_t scl_delay;
 
-#define bus_quiet()            ( cc2538_gpio_read(I2C_0_SCL_PIN) && cc2538_gpio_read(I2C_0_SDA_PIN) )
 #define WARN_IF(cond) \
         if (cond) { \
             DEBUG("%s at %s:%u\n", #cond, RIOT_FILE_NOPATH, __LINE__); \
         }
 
-void cc2538_i2c_init_master(uint32_t speed_hz);
+static void cc2538_i2c_init_master(i2c_t dev, uint32_t speed_hz);
+
+static inline bool bus_quiet(i2c_t dev)
+{
+    return (gpio_read(SCL_PIN(dev)) && gpio_read(SDA_PIN(dev)));
+}
 
 static void i2cm_ctrl_write(uint_fast8_t value) {
     WARN_IF(I2CM_STAT & BUSY);
     I2CM_CTRL = value;
 }
 
-static void assert_scl(void) {
-    cc2538_gpio_clear(I2C_0_SCL_PIN);
-    IOC_PXX_OVER[I2C_0_SCL_PIN] |= IOC_OVERRIDE_OE;
-    gpio_dir_output(I2C_0_SCL_PIN);
-    gpio_software_control(I2C_0_SCL_PIN);
-}
-
-static void release_scl(void) {
-    IOC_PXX_OVER[I2C_0_SCL_PIN] &= ~(IOC_OVERRIDE_OE | IOC_OVERRIDE_PDE);
-    gpio_dir_input(I2C_0_SCL_PIN);
-    gpio_software_control(I2C_0_SCL_PIN);
-}
-
-static void release_sda(void) {
-    IOC_PXX_OVER[I2C_0_SDA_PIN] &= ~(IOC_OVERRIDE_OE | IOC_OVERRIDE_PDE);
-    gpio_dir_input(I2C_0_SDA_PIN);
-    gpio_software_control(I2C_0_SDA_PIN);
-}
-
-static void recover_i2c_bus(void) {
+static void recover_i2c_bus(i2c_t dev) {
     /* Switch to software GPIO mode for bus recovery */
-    release_sda();
-    release_scl();
+    gpio_release(SDA_PIN(dev));
+    gpio_release(SCL_PIN(dev));
 
-    if (!bus_quiet()) {
-        const uint_fast8_t try_limit = 200;
+    if (!bus_quiet(dev)) {
+        const uint_fast8_t try_limit = SDA_TRY_LIMIT;
         uint_fast8_t n;
         for (n = 0; n < try_limit; n++) {
-            if (bus_quiet()) {
+            if (bus_quiet(dev)) {
                 DEBUG("%s(): SDA released after%4u SCL pulses.\n", __FUNCTION__, n);
                 break;
             }
 
-            assert_scl();
+            gpio_assert(SCL_PIN(dev));
 
 #ifdef MODULE_XTIMER
             xtimer_usleep(scl_delay);
@@ -141,7 +127,7 @@ static void recover_i2c_bus(void) {
             thread_yield();
 #endif
 
-            release_scl();
+            gpio_release(SCL_PIN(dev));
 
 #ifdef MODULE_XTIMER
             xtimer_usleep(scl_delay);
@@ -151,13 +137,14 @@ static void recover_i2c_bus(void) {
         }
 
         if (n >= try_limit) {
-            DEBUG("%s(): Failed to release SDA after%4u SCL pulses.\n", __FUNCTION__, n);
+            DEBUG("%s(): Failed to release SDA after%4u SCL pulses.\n",
+                  __FUNCTION__, n);
         }
     }
 
     /* Return to hardware mode for the I2C pins */
-    gpio_hardware_control(I2C_0_SCL_PIN);
-    gpio_hardware_control(I2C_0_SDA_PIN);
+    gpio_hw_ctrl(SCL_PIN(dev));
+    gpio_hw_ctrl(SDA_PIN(dev));
 }
 
 #ifdef MODULE_XTIMER
@@ -168,7 +155,7 @@ static void _timer_cb(void *arg)
 }
 #endif
 
-static uint_fast8_t i2c_ctrl_blocking(uint_fast8_t flags)
+static uint_fast8_t i2c_ctrl_blocking(i2c_t dev, uint_fast8_t flags)
 {
 #ifdef MODULE_XTIMER
     const unsigned int xtimer_timeout = 3 * (DATA_BITS + ACK_BITS) * US_PER_SEC / speed_hz;
@@ -196,7 +183,7 @@ static uint_fast8_t i2c_ctrl_blocking(uint_fast8_t flags)
 #ifdef MODULE_XTIMER
         DEBUG("Master is still BUSY after %u usec. Resetting.\n", xtimer_timeout);
 #endif
-        cc2538_i2c_init_master(speed_hz);
+        cc2538_i2c_init_master(dev, speed_hz);
     }
 
     WARN_IF(I2CM_STAT & BUSY);
@@ -215,7 +202,7 @@ void isr_i2c(void)
     cortexm_isr_end();
 }
 
-void cc2538_i2c_init_master(uint32_t speed_hz)
+void cc2538_i2c_init_master(i2c_t dev, uint32_t speed_hz)
 {
     SYS_CTRL_RCGCI2C |= 1; /**< Enable the I2C0 clock. */
     SYS_CTRL_SCGCI2C |= 1; /**< Enable the I2C0 clock. */
@@ -223,27 +210,13 @@ void cc2538_i2c_init_master(uint32_t speed_hz)
 
     /* Reset I2C peripheral */
     SYS_CTRL_SRI2C |= 1;
-
-#ifdef MODULE_XTIMER
-    xtimer_usleep(50);
-#else
-    thread_yield();
-#endif
-
+    /* wait shortly for reset */
+    for (unsigned delay = 0; delay < 32; ++delay) {};
+    /* clear periph reset trigger */
     SYS_CTRL_SRI2C &= ~1;
 
-    /* Clear all pin override flags except PUE (Pull-Up Enable) */
-    IOC_PXX_OVER[I2C_0_SCL_PIN] &= IOC_OVERRIDE_PUE;
-    IOC_PXX_OVER[I2C_0_SDA_PIN] &= IOC_OVERRIDE_PUE;
-
-    IOC_PXX_SEL[I2C_0_SCL_PIN] = I2C_SCL_OUT;
-    IOC_PXX_SEL[I2C_0_SDA_PIN] = I2C_SDA_OUT;
-
-    IOC_I2CMSSCL = I2C_0_SCL_PIN;
-    IOC_I2CMSSDA = I2C_0_SDA_PIN;
-
-    gpio_hardware_control(I2C_0_SCL_PIN);
-    gpio_hardware_control(I2C_0_SDA_PIN);
+    IOC_I2CMSSCL = gpio_init_af(SCL_PIN(dev), I2C_CMSSCL, IOC_OVERRIDE_PUE);
+    IOC_I2CMSSDA = gpio_init_af(SDA_PIN(dev), I2C_CMSSDA, IOC_OVERRIDE_PUE);
 
     /* Initialize the I2C master by setting the Master Function Enable bit */
     I2CM_CR |= MFE;
@@ -267,13 +240,8 @@ void cc2538_i2c_init_master(uint32_t speed_hz)
 
 int i2c_init_master(i2c_t dev, i2c_speed_t speed)
 {
-    switch (dev) {
-#if I2C_0_EN
-        case I2C_0:
-            break;
-#endif
-        default:
-            return -1;
+    if (dev >= I2C_NUMOF) {
+        return -1;
     }
 
     switch (speed) {
@@ -301,7 +269,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
             return -2;
     }
 
-    cc2538_i2c_init_master(speed_hz);
+    cc2538_i2c_init_master(dev, speed_hz);
 
     /* Pre-compute an SCL delay in microseconds */
     scl_delay = US_PER_SEC;
@@ -311,39 +279,27 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
     return 0;
 }
 
-int i2c_init_slave(i2c_t dev, uint8_t address)
-{
-    (void) dev;
-    (void) address;
-    /* Slave mode is not (yet) supported. */
-    return -1;
-}
-
 int i2c_acquire(i2c_t dev)
 {
-    if (dev == I2C_0) {
+    if (dev < I2C_NUMOF) {
         mutex_lock(&mutex);
         return 0;
     }
-    else {
-        return -1;
-    }
+    return -1;
 }
 
 int i2c_release(i2c_t dev)
 {
-    if (dev == I2C_0) {
+    if (dev < I2C_NUMOF) {
         mutex_unlock(&mutex);
         return 0;
     }
-    else {
-        return -1;
-    }
+    return -1;
 }
 
-static bool i2c_busy(void) {
+static bool i2c_busy(i2c_t dev) {
     if (I2CM_STAT & BUSY) {
-        cc2538_i2c_init_master(speed_hz);
+        cc2538_i2c_init_master(dev, speed_hz);
         return (I2CM_STAT & BUSY) != 0;
     }
 
@@ -355,7 +311,7 @@ int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
     return i2c_read_bytes(dev, address, data, 1);
 }
 
-static int i2c_read_bytes_dumb(uint8_t address, uint8_t *data, int length)
+static int i2c_read_bytes_dumb(i2c_t dev, uint8_t address, uint8_t *data, int length)
 {
     int n = 0;
     uint_fast8_t stat;
@@ -365,12 +321,12 @@ static int i2c_read_bytes_dumb(uint8_t address, uint8_t *data, int length)
             break;
 
         case 1:
-            if (i2c_busy()) {
+            if (i2c_busy(dev)) {
                 break;
             }
 
             I2CM_SA = (address << 1) | RS;
-            stat = i2c_ctrl_blocking(STOP | START | RUN);
+            stat = i2c_ctrl_blocking(dev, (STOP | START | RUN));
             if (stat & ANY_ERROR) {
                 break;
             }
@@ -379,12 +335,12 @@ static int i2c_read_bytes_dumb(uint8_t address, uint8_t *data, int length)
             break;
 
         default:
-            if (i2c_busy()) {
+            if (i2c_busy(dev)) {
                 break;
             }
 
             I2CM_SA = (address << 1) | RS;
-            stat = i2c_ctrl_blocking(ACK | START | RUN);
+            stat = i2c_ctrl_blocking(dev, (ACK | START | RUN));
 
             if (stat & ARBLST) {
                  break;
@@ -398,7 +354,7 @@ static int i2c_read_bytes_dumb(uint8_t address, uint8_t *data, int length)
             n++;
 
             while (n < length) {
-                stat = i2c_ctrl_blocking((n < length - 1) ? (ACK | RUN) : (STOP | RUN));
+                stat = i2c_ctrl_blocking(dev, (n < length - 1) ? (ACK | RUN) : (STOP | RUN));
 
                 if (stat & ARBLST) {
                      break;
@@ -420,33 +376,27 @@ static int i2c_read_bytes_dumb(uint8_t address, uint8_t *data, int length)
 
 int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
-    switch (dev) {
-#if I2C_0_EN
-        case I2C_0:
-            break;
-#endif
-
-        default:
-            return -1;
+    if (dev >= I2C_NUMOF) {
+        return -1;
     }
 
     WARN_IF(I2CM_STAT & BUSY);
 
-    if ( (length <= 0) || i2c_busy() ) {
+    if ( (length <= 0) || i2c_busy(dev) ) {
         return 0;
     }
 
     WARN_IF(I2CM_STAT & BUSBSY);
 
     if (I2CM_STAT & BUSBSY) {
-        recover_i2c_bus();
+        recover_i2c_bus(dev);
 
         if (I2CM_STAT & BUSBSY) {
             return 0;
         }
     }
 
-    return i2c_read_bytes_dumb(address, data, length);
+    return i2c_read_bytes_dumb(dev, address, data, length);
 }
 
 int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
@@ -458,19 +408,19 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
 {
     uint_fast8_t stat;
 
-    if (dev != I2C_0) {
+    if (dev >= I2C_NUMOF) {
         return -1;
     }
 
     /* Transmit reg byte to slave */
-    if (i2c_busy()) {
+    if (i2c_busy(dev)) {
         return 0;
     }
 
     WARN_IF(I2CM_STAT & BUSBSY);
 
     if (I2CM_STAT & BUSBSY) {
-        recover_i2c_bus();
+        recover_i2c_bus(dev);
 
         if (I2CM_STAT & BUSBSY) {
             return 0;
@@ -479,7 +429,7 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
 
     I2CM_SA = address << 1;
     I2CM_DR = reg;
-    stat = i2c_ctrl_blocking(START | RUN);
+    stat = i2c_ctrl_blocking(dev, (START | RUN));
 
     if (stat & ARBLST) {
         return 0;
@@ -490,7 +440,7 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int lengt
     }
     else {
         /* Receive data from slave */
-        return i2c_read_bytes_dumb(address, data, length);
+        return i2c_read_bytes_dumb(dev, address, data, length);
     }
 }
 
@@ -504,14 +454,14 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
     int n = 0;
     const uint8_t *my_data = data;
 
-    if (dev != I2C_0) {
+    if (dev >= I2C_NUMOF) {
         return -1;
     }
 
     WARN_IF(I2CM_STAT & BUSBSY);
 
     if (I2CM_STAT & BUSBSY) {
-        recover_i2c_bus();
+        recover_i2c_bus(dev);
 
         if (I2CM_STAT & BUSBSY) {
             return 0;
@@ -522,10 +472,12 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
     uint_fast8_t flags = START | RUN;
 
     for (n = 0; n < length; n++) {
-        if (n >= length - 1) flags |= STOP;
+        if (n >= length - 1) {
+            flags |= STOP;
+        }
         WARN_IF(I2CM_STAT & BUSY);
         I2CM_DR = my_data[n];
-        i2c_ctrl_blocking(flags);
+        i2c_ctrl_blocking(dev, flags);
 
         WARN_IF(I2CM_STAT & ARBLST);
         WARN_IF(I2CM_STAT & DATACK);
@@ -561,19 +513,19 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     uint_fast8_t stat;
     const uint8_t *my_data = data;
 
-    if (dev != I2C_0) {
+    if (dev >= I2C_NUMOF) {
         return -1;
     }
 
     /* Transmit reg byte to slave */
-    if (i2c_busy()) {
+    if (i2c_busy(dev)) {
         return 0;
     }
 
     WARN_IF(I2CM_STAT & BUSBSY);
 
     if (I2CM_STAT & BUSBSY) {
-        recover_i2c_bus();
+        recover_i2c_bus(dev);
 
         if (I2CM_STAT & BUSBSY) {
             return 0;
@@ -583,8 +535,8 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
     I2CM_SA = address << 1;
     I2CM_DR = reg;
 
-    uint_fast8_t flags = (length > 0)? (START | RUN) : (STOP | START | RUN);
-    stat = i2c_ctrl_blocking(flags);
+    uint_fast8_t flags = (length > 0) ? (START | RUN) : (STOP | START | RUN);
+    stat = i2c_ctrl_blocking(dev, flags);
 
     if (stat & ARBLST) {
         return 0;
@@ -600,11 +552,14 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
         flags &= ~START;
 
         for (n = 0; n < length; n++) {
-            if (n >= length - 1) flags |= STOP;
+            if (n >= length - 1) {
+                flags |= STOP;
+            }
+
             WARN_IF(I2CM_STAT & BUSY);
             I2CM_DR = my_data[n];
 
-            i2c_ctrl_blocking(flags);
+            i2c_ctrl_blocking(dev, flags);
 
             WARN_IF(I2CM_STAT & ARBLST);
             WARN_IF(I2CM_STAT & DATACK);
@@ -621,17 +576,8 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
         }
 
         if (n < length) {
-            DEBUG(
-                "%s(%u, %u, %u, %p, %u): %u/%u bytes delivered.\n",
-                __FUNCTION__,
-                dev,
-                address,
-                reg,
-                data,
-                length,
-                n,
-                length
-            );
+            DEBUG("%s(%u, %u, %u, %p, %u): %u/%u bytes delivered.\n",
+                  __FUNCTION__, dev, address, reg, data, length, n, length);
         }
 
         return n;
@@ -640,7 +586,7 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
 
 void i2c_poweron(i2c_t dev)
 {
-    if (dev == I2C_0) {
+    if (dev < I2C_NUMOF) {
         SYS_CTRL_RCGCI2C |= 1; /**< Enable the I2C0 clock. */
         SYS_CTRL_SCGCI2C |= 1; /**< Enable the I2C0 clock. */
         SYS_CTRL_DCGCI2C |= 1; /**< Enable the I2C0 clock. */
@@ -654,7 +600,7 @@ void i2c_poweron(i2c_t dev)
 
 void i2c_poweroff(i2c_t dev)
 {
-    if (dev == I2C_0) {
+    if (dev < I2C_NUMOF) {
         /* Disable I2C master interrupts */
         I2CM_IMR = 0;
         NVIC_DisableIRQ(I2C_IRQn);


### PR DESCRIPTION
This PR requires #7316 and 
- adapts low level I2C periph driver of cc2538 to use RIOTs GPIO API
- enhance coding style 
- adapt board periph_conf for cc2538 based boards