### PR TITLE
cpu, cc2538: gpio cleanup

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -76,10 +76,10 @@ static const timer_conf_t timer_config[] = {
 #define UART_0_IRQ          UART0_IRQn
 #define UART_0_ISR          isr_uart0
 /* UART 0 pin configuration */
-#define UART_0_TX_PIN       GPIO_PA1
-#define UART_0_RX_PIN       GPIO_PA0
-#define UART_0_RTS_PIN      GPIO_PD3
-#define UART_0_CTS_PIN      GPIO_PB0
+#define UART_0_TX_PIN       GPIO_PIN(0, 1)  /**< GPIO_PA1 */
+#define UART_0_RX_PIN       GPIO_PIN(0, 0)  /**< GPIO_PA0 */
+#define UART_0_RTS_PIN      GPIO_PIN(3, 3)  /**< GPIO_PD3 */
+#define UART_0_CTS_PIN      GPIO_PIN(1, 0)  /**< GPIO_PB0 */
 
 /* UART 1 device configuration */
 #define UART_1_DEV          UART1

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -92,7 +92,6 @@ static const timer_conf_t timer_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -100,15 +99,15 @@ static const timer_conf_t timer_config[] = {
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PA2 /* SPI_SCK on the SmartRF06 baseboard */
-#define I2C_0_SDA_PIN           GPIO_PA4 /* SPI_MOSI on the SmartRF06 baseboard */
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = GPIO_PA2, /* SPI_SCK on the SmartRF06 baseboard */
-        .sda_pin = GPIO_PA4, /* SPI_MOSI on the SmartRF06 baseboard */
+        .scl_pin = GPIO_PIN(0, 2),  /**< GPIO_PA2, SPI_SCK  on SmartRF06 */
+        .sda_pin = GPIO_PIN(0, 4)   /**< GPIO_PA4, SPI_MOSI on SmartRF06 */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -132,10 +132,10 @@ static const spi_clk_conf_t spi_clk_config[] = {
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SSI0,
-        .mosi_pin = GPIO_PA4,
-        .miso_pin = GPIO_PA5,
-        .sck_pin  = GPIO_PA2,
-        .cs_pin   = GPIO_PD0
+        .mosi_pin = GPIO_PIN(0, 4),     /**< GPIO_PA4 */
+        .miso_pin = GPIO_PIN(0, 5),     /**< GPIO_PA5 */
+        .sck_pin  = GPIO_PIN(0, 2),     /**< GPIO_PA2 */
+        .cs_pin   = GPIO_PIN(3, 0)      /**< GPIO_PD0 */
     }
 };
 

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -85,7 +85,6 @@ static const timer_conf_t timer_config[] = {
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -93,15 +92,15 @@ static const timer_conf_t timer_config[] = {
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PB3 /* OpenBattery */
-#define I2C_0_SDA_PIN           GPIO_PB4 /* OpenBattery */
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = GPIO_PB3, /* OpenBattery */
-        .sda_pin = GPIO_PB4, /* OpenBattery */
+        .scl_pin = GPIO_PIN(1, 3),  /**< GPIO_PB3, OpenBattery */
+        .sda_pin = GPIO_PIN(1, 4)   /**< GPIO_PB4, OpenBattery */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -77,8 +77,8 @@ static const timer_conf_t timer_config[] = {
 #define UART_0_IRQ          UART0_IRQn
 #define UART_0_ISR          isr_uart0
 /* UART 0 pin configuration */
-#define UART_0_TX_PIN       GPIO_PA1
-#define UART_0_RX_PIN       GPIO_PA0
+#define UART_0_TX_PIN       GPIO_PIN(0, 1)  /**< GPIO_PA1 */
+#define UART_0_RX_PIN       GPIO_PIN(0, 0)  /**< GPIO_PA0 */
 /** @} */
 
 /**

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -125,10 +125,10 @@ static const spi_clk_conf_t spi_clk_config[] = {
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SSI0,
-        .mosi_pin = GPIO_PA5,
-        .miso_pin = GPIO_PA4,
-        .sck_pin  = GPIO_PA2,
-        .cs_pin   = GPIO_PA3,
+        .mosi_pin = GPIO_PIN(0, 5),     /**< GPIO_PA5 */
+        .miso_pin = GPIO_PIN(0, 4),     /**< GPIO_PA4 */
+        .sck_pin  = GPIO_PIN(0, 2),     /**< GPIO_PA2 */
+        .cs_pin   = GPIO_PIN(0, 3)      /**< GPIO_PA3 */
     },
 };
 

--- a/boards/remote-common/include/periph_common.h
+++ b/boards/remote-common/include/periph_common.h
@@ -73,6 +73,24 @@ static const timer_conf_t timer_config[] = {
 #define RADIO_IRQ_PRIO      1
 /** @} */
 
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_0_EN           1
+#define UART_IRQ_PRIO       1
+
+/* UART 0 device configuration */
+#define UART_0_DEV          UART0
+#define UART_0_IRQ          UART0_IRQn
+#define UART_0_ISR          isr_uart0
+/* UART 0 pin configuration */
+#define UART_0_TX_PIN       GPIO_PIN(0, 1)  /**< GPIO_PA1 */
+#define UART_0_RX_PIN       GPIO_PIN(0, 0)  /**< GPIO_PA0 */
+/** @} */
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/remote-pa/include/board.h
+++ b/boards/remote-pa/include/board.h
@@ -72,9 +72,10 @@
  */
 #define RF_SWITCH_PORT      GPIO_D
 #define RF_SWITCH_PIN       (4)
-#define RF_SWITCH_EXTERNAL  (RF_SWITCH_PORT->DATA |= (1 << RF_SWITCH_PIN))
-#define RF_SWITCH_INTERNAL  (RF_SWITCH_PORT->DATA &= ~(1 << RF_SWITCH_PIN))
-#define RF_SWITCH_TOGGLE    (RF_SWITCH_PORT->DATA ^= (1 << RF_SWITCH_PIN))
+#define RF_SWITCH_GPIO      GPIO_PIN(3, 4)                  /**< GPIO_PD4 */
+#define RF_SWITCH_EXTERNAL  gpio_set(RF_SWITCH_GPIO)
+#define RF_SWITCH_INTERNAL  gpio_clear(RF_SWITCH_GPIO)
+#define RF_SWITCH_TOGGLE    gpio_toggle(RF_SWITCH_GPIO)
 /** @} */
 
 /**

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -28,23 +28,6 @@
 #endif
 
 /**
- * @name    UART configuration
- * @{
- */
-#define UART_NUMOF          (1U)
-#define UART_0_EN           1
-#define UART_IRQ_PRIO       1
-
-/* UART 0 device configuration */
-#define UART_0_DEV          UART0
-#define UART_0_IRQ          UART0_IRQn
-#define UART_0_ISR          isr_uart0
-/* UART 0 pin configuration */
-#define UART_0_TX_PIN       GPIO_PA1
-#define UART_0_RX_PIN       GPIO_PA0
-/** @} */
-
-/**
  * @name    I2C configuration
  * @{
  */

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -48,7 +48,6 @@
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -56,15 +55,15 @@
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PB1
-#define I2C_0_SDA_PIN           GPIO_PB0
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = I2C_0_SCL_PIN,
-        .sda_pin = I2C_0_SDA_PIN,
+        .scl_pin = GPIO_PIN(1, 1),  /**< GPIO_PB1 */
+        .sda_pin = GPIO_PIN(1, 0)   /**< GPIO_PB0 */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -88,16 +88,16 @@ static const spi_clk_conf_t spi_clk_config[] = {
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SSI0,
-        .mosi_pin = GPIO_PD0,
-        .miso_pin = GPIO_PC4,
-        .sck_pin  = GPIO_PD1,
-        .cs_pin   = GPIO_PD3
+        .mosi_pin = GPIO_PIN(3, 0),     /**< GPIO_PD0 */
+        .miso_pin = GPIO_PIN(2, 4),     /**< GPIO_PC4 */
+        .sck_pin  = GPIO_PIN(3, 1),     /**< GPIO_PD1 */
+        .cs_pin   = GPIO_PIN(3, 3)      /**< GPIO_PD3 */
     },
     {
         .dev      = SSI1,
-        .mosi_pin = GPIO_PC7,
-        .miso_pin = GPIO_PA4,
-        .sck_pin  = GPIO_PB5,
+        .mosi_pin = GPIO_PIN(2, 7),     /**< GPIO_PC7 */
+        .miso_pin = GPIO_PIN(0, 4),     /**< GPIO_PA4 */
+        .sck_pin  = GPIO_PIN(1, 5),     /**< GPIO_PB5 */
         .cs_pin   = GPIO_UNDEF
     }
 };

--- a/boards/remote-reva/include/board.h
+++ b/boards/remote-reva/include/board.h
@@ -84,7 +84,7 @@
  *
  * @{
  */
-#define RF_SWITCH_GPIO      GPIO_PD2
+#define RF_SWITCH_GPIO      GPIO_PIN(3, 2)                  /**< GPIO_PD2 */
 #define RF_SWITCH_SUB_GHZ   gpio_set(RF_SWITCH_GPIO)
 #define RF_SWITCH_2_4_GHZ   gpio_clear(RF_SWITCH_GPIO)
 #define RF_SWITCH_TOGGLE    gpio_toggle(RF_SWITCH_GPIO)
@@ -94,8 +94,8 @@
  * @name Shutdown enable/done pins
  * @{
  */
-#define SHUTDOWN_DONE_GPIO  GPIO_PD0
-#define SHUTDOWN_EN_GPIO    GPIO_PD1
+#define SHUTDOWN_DONE_GPIO  GPIO_PIN(3, 0)                  /**< GPIO_PD0 */
+#define SHUTDOWN_EN_GPIO    GPIO_PIN(3, 1)                  /**< GPIO_PD1 */
 /** @} */
 
 /**
@@ -103,13 +103,13 @@
  * @{
  */
 #define CC1200_SPI_DEV      SSI0
-#define CC1200_MOSI_GPIO    GPIO_PB1
-#define CC1200_MISO_GPIO    GPIO_PB3
-#define CC1200_SCLK_GPIO    GPIO_PB2
-#define CC1200_CSN_GPIO     GPIO_PB5
-#define CC1200_RESET_GPIO   GPIO_PC7
-#define CC1200_GPD0_GPIO    GPIO_PB4
-#define CC1200_GPD2_GPIO    GPIO_PB0
+#define CC1200_MOSI_GPIO    GPIO_PIN(1, 1)                  /**< GPIO_PB1 */
+#define CC1200_MISO_GPIO    GPIO_PIN(1, 3)                  /**< GPIO_PB3 */
+#define CC1200_SCLK_GPIO    GPIO_PIN(1, 2)                  /**< GPIO_PB2 */
+#define CC1200_CSN_GPIO     GPIO_PIN(1, 5)                  /**< GPIO_PB5 */
+#define CC1200_RESET_GPIO   GPIO_PIN(2, 7)                  /**< GPIO_PC7 */
+#define CC1200_GPD0_GPIO    GPIO_PIN(1, 4)                  /**< GPIO_PB4 */
+#define CC1200_GPD2_GPIO    GPIO_PIN(1, 0)                  /**< GPIO_PB0 */
 /** @} */
 
 /**

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -28,24 +28,6 @@
 #endif
 
 /**
- * @name UART configuration
- * @{
- */
-#define UART_NUMOF          (1U)
-#define UART_0_EN           1
-#define UART_IRQ_PRIO       1
-
-/* UART 0 device configuration */
-#define UART_0_DEV          UART0
-#define UART_0_IRQ          UART0_IRQn
-#define UART_0_ISR          isr_uart0
-/* UART 0 pin configuration */
-#define UART_0_TX_PIN       GPIO_PA1
-#define UART_0_RX_PIN       GPIO_PA0
-
-/** @} */
-
-/**
  * @name I2C configuration
  * @{
  */

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -49,7 +49,6 @@
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -57,15 +56,15 @@
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PC3
-#define I2C_0_SDA_PIN           GPIO_PC2
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = I2C_0_SCL_PIN,
-        .sda_pin = I2C_0_SDA_PIN,
+        .scl_pin = GPIO_PIN(2, 3),  /**< GPIO_PC3 */
+        .sda_pin = GPIO_PIN(2, 2)   /**< GPIO_PC2 */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -89,17 +89,17 @@ static const spi_clk_conf_t spi_clk_config[] = {
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SSI0,
-        .mosi_pin = GPIO_PB1,
-        .miso_pin = GPIO_PB3,
-        .sck_pin  = GPIO_PB2,
-        .cs_pin   = GPIO_PB5
+        .mosi_pin = GPIO_PIN(1, 1),     /**< GPIO_PB1 */
+        .miso_pin = GPIO_PIN(1, 3),     /**< GPIO_PB3 */
+        .sck_pin  = GPIO_PIN(1, 2),     /**< GPIO_PB2 */
+        .cs_pin   = GPIO_PIN(1, 5)      /**< GPIO_PB5 */
     },
     {
         .dev      = SSI1,
-        .mosi_pin = GPIO_PC5,
-        .miso_pin = GPIO_PC6,
-        .sck_pin  = GPIO_PC4,
-        .cs_pin   = GPIO_PA7
+        .mosi_pin = GPIO_PIN(2, 5),     /**< GPIO_PC5 */
+        .miso_pin = GPIO_PIN(2, 6),     /**< GPIO_PC6 */
+        .sck_pin  = GPIO_PIN(2, 4),     /**< GPIO_PC4 */
+        .cs_pin   = GPIO_PIN(0, 7)      /**< GPIO_PA7 */
     }
 };
 

--- a/boards/remote-revb/include/board.h
+++ b/boards/remote-revb/include/board.h
@@ -84,7 +84,7 @@
  *
  * @{
  */
-#define RF_SWITCH_GPIO      GPIO_PD2
+#define RF_SWITCH_GPIO      GPIO_PIN(3, 2)              /**< GPIO_PD2 */
 #define RF_SWITCH_SUB_GHZ   gpio_set(RF_SWITCH_GPIO)
 #define RF_SWITCH_2_4_GHZ   gpio_clear(RF_SWITCH_GPIO)
 #define RF_SWITCH_TOGGLE    gpio_toggle(RF_SWITCH_GPIO)
@@ -94,7 +94,7 @@
  * @name Power management enable pin
  * @{
  */
-#define SHUTDOWN_EN_GPIO    GPIO_PD1
+#define SHUTDOWN_EN_GPIO    GPIO_PIN(3, 1)              /**< GPIO_PD1 */
 /** @} */
 
 /**
@@ -102,13 +102,13 @@
  * @{
  */
 #define CC1200_SPI_DEV      SSI0
-#define CC1200_MOSI_GPIO    GPIO_PB1
-#define CC1200_MISO_GPIO    GPIO_PB3
-#define CC1200_SCLK_GPIO    GPIO_PB2
-#define CC1200_CSN_GPIO     GPIO_PB5
-#define CC1200_RESET_GPIO   GPIO_PC7
-#define CC1200_GPD0_GPIO    GPIO_PB4
-#define CC1200_GPD2_GPIO    GPIO_PB0
+#define CC1200_MOSI_GPIO    GPIO_PIN(1, 1)              /**< GPIO_PB1 */
+#define CC1200_MISO_GPIO    GPIO_PIN(1, 3)              /**< GPIO_PB3 */
+#define CC1200_SCLK_GPIO    GPIO_PIN(1, 2)              /**< GPIO_PB2 */
+#define CC1200_CSN_GPIO     GPIO_PIN(1, 5)              /**< GPIO_PB5 */
+#define CC1200_RESET_GPIO   GPIO_PIN(2, 7)              /**< GPIO_PC7 */
+#define CC1200_GPD0_GPIO    GPIO_PIN(1, 4)              /**< GPIO_PB4 */
+#define CC1200_GPD2_GPIO    GPIO_PIN(1, 0)              /**< GPIO_PB0 */
 /** @} */
 
 /**

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -24,28 +24,11 @@
 #include "cc2538_gpio.h"
 #include "periph_cpu.h"
 #include "periph_common.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-/**
- * @name UART configuration
- * @{
- */
-#define UART_NUMOF          (1U)
-#define UART_0_EN           1
-#define UART_IRQ_PRIO       1
-
-/* UART 0 device configuration */
-#define UART_0_DEV          UART0
-#define UART_0_IRQ          UART0_IRQn
-#define UART_0_ISR          isr_uart0
-/* UART 0 pin configuration */
-#define UART_0_TX_PIN       GPIO_PA1
-#define UART_0_RX_PIN       GPIO_PA0
-
-/** @} */
 
 /**
  * @name I2C configuration

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -51,7 +51,6 @@
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF               1
 #define I2C_0_EN                1
 #define I2C_IRQ_PRIO            1
 
@@ -59,15 +58,15 @@
 #define I2C_0_DEV               0
 #define I2C_0_IRQ               I2C_IRQn
 #define I2C_0_IRQ_HANDLER       isr_i2c
-#define I2C_0_SCL_PIN           GPIO_PC3
-#define I2C_0_SDA_PIN           GPIO_PC2
 
-static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+static const i2c_conf_t i2c_config[] = {
     {
-        .scl_pin = I2C_0_SCL_PIN,
-        .sda_pin = I2C_0_SDA_PIN,
+        .scl_pin = GPIO_PIN(2, 3),  /**< GPIO_PC3 */
+        .sda_pin = GPIO_PIN(2, 2)   /**< GPIO_PC2 */
     },
 };
+
+#define I2C_NUMOF               (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -91,17 +91,17 @@ static const spi_clk_conf_t spi_clk_config[] = {
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SSI0,
-        .mosi_pin = GPIO_PB1,
-        .miso_pin = GPIO_PB3,
-        .sck_pin  = GPIO_PB2,
-        .cs_pin   = GPIO_PB5
+        .mosi_pin = GPIO_PIN(1, 1),     /**< GPIO_PB1 */
+        .miso_pin = GPIO_PIN(1, 3),     /**< GPIO_PB3 */
+        .sck_pin  = GPIO_PIN(1, 2),     /**< GPIO_PB2 */
+        .cs_pin   = GPIO_PIN(1, 5)      /**< GPIO_PB5 */
     },
     {
         .dev      = SSI1,
-        .mosi_pin = GPIO_PC5,
-        .miso_pin = GPIO_PC6,
-        .sck_pin  = GPIO_PC4,
-        .cs_pin   = GPIO_PA7
+        .mosi_pin = GPIO_PIN(2, 5),     /**< GPIO_PC5 */
+        .miso_pin = GPIO_PIN(2, 6),     /**< GPIO_PC6 */
+        .sck_pin  = GPIO_PIN(2, 4),     /**< GPIO_PC4 */
+        .cs_pin   = GPIO_PIN(0, 7)      /**< GPIO_PA7 */
     }
 };
 

--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -21,6 +21,7 @@
 
 #include "cpu.h"
 #include "periph/init.h"
+#include "periph/gpio.h"
 
 #define BIT(n)          ( 1UL << (n) )
 
@@ -68,24 +69,27 @@ static void cpu_clock_init(void)
 
 #if SYS_CTRL_OSC32K_USE_XTAL
     /* Set the XOSC32K_Q pads to analog for the external crystal: */
-    gpio_software_control(GPIO_PD6);
-    gpio_dir_input(GPIO_PD6);
-    IOC_PXX_OVER[GPIO_PD6] = IOC_OVERRIDE_ANA;
+    gpio_t pd6 = GPIO_PIN(3, 6);
+    gpio_sw_ctrl(pd6);
+    gpio_init(pd6, GPIO_IN);
+    IOC_PXX_OVER[gpio_pp_num(pd6)] = IOC_OVERRIDE_ANA;
 
-    gpio_software_control(GPIO_PD7);
-    gpio_dir_input(GPIO_PD7);
-    IOC_PXX_OVER[GPIO_PD7] = IOC_OVERRIDE_ANA;
+    gpio_t pd7 = GPIO_PIN(3, 7);
+    gpio_sw_ctrl(pd7);
+    gpio_init(pd7, GPIO_IN);
+    IOC_PXX_OVER[gpio_pp_num(pd7)] = IOC_OVERRIDE_ANA;
 #endif
 
     /* Configure the clock settings: */
     SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRL = CLOCK_CTRL_VALUE;
 
     /* Wait for the new clock settings to take effect: */
-    while ((SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STA ^ CLOCK_CTRL_VALUE) & CLOCK_STA_MASK);
+    while ((SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STA ^ CLOCK_CTRL_VALUE) &
+           CLOCK_STA_MASK) {}
 
 #if SYS_CTRL_OSC32K_USE_XTAL
     /* Wait for the 32-kHz crystal oscillator to stabilize: */
-    while ( SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K);
-    while (!SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K);
+    while ( SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K) {}
+    while (!SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K) {}
 #endif
 }

--- a/cpu/cc2538/include/cc2538_gpio.h
+++ b/cpu/cc2538/include/cc2538_gpio.h
@@ -32,6 +32,7 @@
 extern "C" {
 #endif
 
+#if 0 /* USE RIOT GPIO API */
 /**
  * @name Numeric representation of the four GPIO ports
  * @{
@@ -189,6 +190,7 @@ enum {
 };
 /** @} */
 
+#endif /* USE RIOT GPIO API */
 /**
  * @brief GPIO port component registers
  */

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2016 Freie Universität Berlin
+ *               2017 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief           CPU specific definitions for internal peripheral handling
  *
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Sebastian Meiling <s@mlng.net>
  */
 
 #ifndef PERIPH_CPU_H
@@ -45,12 +47,102 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @name Internal GPIO shift and masking
+ * @{
+ */
+#define PORTNUM_MASK        (0x00007000)    /**< bit mask for GPIO port [0-3] */
+#define PORTNUM_SHIFT       (12U)           /**< bit shift for GPIO port      */
+#define PIN_MASK            (0x00000007)    /**< bit mask for GPIO pin [0-7]  */
+#define GPIO_MASK           (0xfffff000)    /**< bit mask for GPIO port addr  */
+/** @} */
+
+/**
  * @brief   Define a custom GPIO_PIN macro
  *
  * For the CC2538, we use OR the gpio ports base register address with the
  * actual pin number.
  */
-#define GPIO_PIN(port, pin) (gpio_t)(((uint32_t)GPIO_A + (port << 12)) | pin)
+#define GPIO_PIN(port, pin) (gpio_t)(((uint32_t)GPIO_A + \
+                                      (port << PORTNUM_SHIFT)) | pin)
+
+/**
+ * @brief Access GPIO low-level device
+ *
+ * @param[in] pin   gpio pin
+ *
+ * @return          pointer to gpio low level device address
+ */
+static inline cc2538_gpio_t *gpio(gpio_t pin)
+{
+    return (cc2538_gpio_t *)(pin & GPIO_MASK);
+}
+
+/**
+ * @brief   Helper function to get port number for gpio pin
+ *
+ * @param[in] pin   gpio pin
+ *
+ * @return          port number of gpio pin, [0=A - 3=D]
+ */
+static inline int gpio_port_num(gpio_t pin)
+{
+    return (int)((pin & PORTNUM_MASK) >> PORTNUM_SHIFT) - 1;
+}
+
+/**
+ * @brief   Helper function to get pin number for gpio pin
+ *
+ * @param[in] pin   gpio pin
+ *
+ * @return          pin number of gpio pin, [0 - 7]
+ */
+static inline int gpio_pin_num(gpio_t pin)
+{
+    return (int)(pin & PIN_MASK);
+}
+/**
+ * @brief   Helper function to get bit mask for gpio pin number
+ *
+ * @param[in] pin   gpio pin
+ *
+ * @return          bit mask for gpio pin number, 2^[0 - 7]
+ */
+static inline uint32_t gpio_pin_mask(gpio_t pin)
+{
+    return (1 << (pin & PIN_MASK));
+}
+
+/**
+ * @brief   Helper function to get CC2538 gpio number from port and pin
+ *
+ * @param[in] pin   gpio pin
+ *
+ * @return          number of gpio pin, [0 - 31]
+ */
+static inline int gpio_pp_num(gpio_t pin)
+{
+    return (gpio_port_num(pin) * 8) + gpio_pin_num(pin);
+}
+
+/**
+ * @brief   Helper function to enable gpio hardware control
+ *
+ * @param[in] pin   gpio pin
+ */
+static inline void gpio_hw_ctrl(gpio_t pin)
+{
+    gpio(pin)->AFSEL |= gpio_pin_mask(pin);
+}
+
+/**
+ * @brief   Helper function to enable gpio software control
+ *
+ * @param[in] pin   gpio pin
+ */
+static inline void gpio_sw_ctrl(gpio_t pin)
+{
+    gpio(pin)->AFSEL &= ~gpio_pin_mask(pin);
+}
 
 /**
  * @brief   Define a custom GPIO_UNDEF value

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -54,6 +54,7 @@ typedef uint32_t gpio_t;
 #define PORTNUM_SHIFT       (12U)           /**< bit shift for GPIO port      */
 #define PIN_MASK            (0x00000007)    /**< bit mask for GPIO pin [0-7]  */
 #define GPIO_MASK           (0xfffff000)    /**< bit mask for GPIO port addr  */
+#define GPIO_BITS_PER_PORT  (8U)            /**< number of GPIO pins per port */
 /** @} */
 
 /**

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -17,7 +17,7 @@
  *
  * @author      Ian Martin <ian@locicontrols.com>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- *
+ * @author      Sebastian Meiling <s@mlng.net>
  * @}
  */
 
@@ -26,36 +26,7 @@
 #include "cpu.h"
 #include "periph/gpio.h"
 
-#define GPIO_MASK           (0xfffff000)
-#define PORTNUM_MASK        (0x00007000)
-#define PORTNUM_SHIFT       (12U)
-#define PIN_MASK            (0x00000007)
 #define MODE_NOTSUP         (0xff)
-
-static inline cc2538_gpio_t *gpio(gpio_t pin)
-{
-    return (cc2538_gpio_t *)(pin & GPIO_MASK);
-}
-
-static inline int port_num(gpio_t pin)
-{
-    return (int)((pin & PORTNUM_MASK) >> PORTNUM_SHIFT) - 1;
-}
-
-static inline int pin_num(gpio_t pin)
-{
-    return (int)(pin & PIN_MASK);
-}
-
-static inline uint32_t pin_mask(gpio_t pin)
-{
-    return (1 << (pin & PIN_MASK));
-}
-
-static inline int pp_num(gpio_t pin)
-{
-    return (port_num(pin) * 8) + pin_num(pin);
-}
 
 static gpio_isr_ctx_t isr_ctx[4][8];
 
@@ -66,22 +37,21 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
         return -1;
     }
 
-
     /* disable any alternate function and any eventual interrupts */
-    gpio(pin)->IE &= ~pin_mask(pin);
-    gpio(pin)->AFSEL &= ~pin_mask(pin);
+    gpio(pin)->IE &= ~gpio_pin_mask(pin);
+    gpio(pin)->AFSEL &= ~gpio_pin_mask(pin);
     /* configure pull configuration */
-    IOC->OVER[pp_num(pin)] = mode;
+    IOC->OVER[gpio_pp_num(pin)] = mode;
 
     /* set pin direction */
     if (mode == IOC_OVERRIDE_OE) {
-        gpio(pin)->DIR |= pin_mask(pin);
+        gpio(pin)->DIR |= gpio_pin_mask(pin);
     }
     else {
-        gpio(pin)->DIR &= ~pin_mask(pin);
+        gpio(pin)->DIR &= ~gpio_pin_mask(pin);
     }
     /* clear pin */
-    gpio(pin)->DATA &= ~pin_mask(pin);
+    gpio(pin)->DATA &= ~gpio_pin_mask(pin);
 
     return 0;
 }
@@ -94,80 +64,80 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     }
 
     /* store the callback information for later: */
-    isr_ctx[port_num(pin)][pin_num(pin)].cb  = cb;
-    isr_ctx[port_num(pin)][pin_num(pin)].arg = arg;
+    isr_ctx[gpio_port_num(pin)][gpio_pin_num(pin)].cb  = cb;
+    isr_ctx[gpio_port_num(pin)][gpio_pin_num(pin)].arg = arg;
 
     /* enable power-up interrupts for this GPIO port: */
-    SYS_CTRL->IWE |= (1 << port_num(pin));
+    SYS_CTRL->IWE |= (1 << gpio_port_num(pin));
 
     /* configure the active flank(s) */
-    gpio(pin)->IS &= ~pin_mask(pin);
+    gpio(pin)->IS &= ~gpio_pin_mask(pin);
     switch(flank) {
         case GPIO_FALLING:
-            gpio(pin)->IBE &= ~pin_mask(pin);
-            gpio(pin)->IEV &= ~pin_mask(pin);
-            gpio(pin)->P_EDGE_CTRL |= (1 << pp_num(pin));
+            gpio(pin)->IBE &= ~gpio_pin_mask(pin);
+            gpio(pin)->IEV &= ~gpio_pin_mask(pin);
+            gpio(pin)->P_EDGE_CTRL |= (1 << gpio_pp_num(pin));
             break;
         case GPIO_RISING:
-            gpio(pin)->IBE &= ~pin_mask(pin);
-            gpio(pin)->IEV |=  pin_mask(pin);
-            gpio(pin)->P_EDGE_CTRL &= ~(1 << pp_num(pin));
+            gpio(pin)->IBE &= ~gpio_pin_mask(pin);
+            gpio(pin)->IEV |=  gpio_pin_mask(pin);
+            gpio(pin)->P_EDGE_CTRL &= ~(1 << gpio_pp_num(pin));
             break;
         case GPIO_BOTH:
-            gpio(pin)->IBE |= pin_mask(pin);
+            gpio(pin)->IBE |= gpio_pin_mask(pin);
             break;
         default:
             return -1;
     }
 
     /* reset interrupt status */
-    gpio(pin)->IC = pin_mask(pin);
-    gpio(pin)->PI_IEN |= (1 << pp_num(pin));
+    gpio(pin)->IC = gpio_pin_mask(pin);
+    gpio(pin)->PI_IEN |= (1 << gpio_pp_num(pin));
     /* enable global interrupt for the selected GPIO port */
-    NVIC_EnableIRQ(GPIO_PORT_A_IRQn + port_num(pin));
+    NVIC_EnableIRQ(GPIO_PORT_A_IRQn + gpio_port_num(pin));
     /* unmask pin interrupt */
-    gpio(pin)->IE |= pin_mask(pin);
+    gpio(pin)->IE |= gpio_pin_mask(pin);
 
     return 0;
 }
 
 void gpio_irq_enable(gpio_t pin)
 {
-    gpio(pin)->IE |= pin_mask(pin);
+    gpio(pin)->IE |= gpio_pin_mask(pin);
 }
 
 void gpio_irq_disable(gpio_t pin)
 {
-    gpio(pin)->IE &= ~pin_mask(pin);
+    gpio(pin)->IE &= ~gpio_pin_mask(pin);
 }
 
 int gpio_read(gpio_t pin)
 {
-    return (int)(gpio(pin)->DATA & pin_mask(pin));
+    return (int)(gpio(pin)->DATA & gpio_pin_mask(pin));
 }
 
 void gpio_set(gpio_t pin)
 {
-    gpio(pin)->DATA |= pin_mask(pin);
+    gpio(pin)->DATA |= gpio_pin_mask(pin);
 }
 
 void gpio_clear(gpio_t pin)
 {
-    gpio(pin)->DATA &= ~pin_mask(pin);
+    gpio(pin)->DATA &= ~gpio_pin_mask(pin);
 }
 
 void gpio_toggle(gpio_t pin)
 {
-    gpio(pin)->DATA ^= pin_mask(pin);
+    gpio(pin)->DATA ^= gpio_pin_mask(pin);
 }
 
 void gpio_write(gpio_t pin, int value)
 {
     if (value) {
-        gpio(pin)->DATA |= pin_mask(pin);
+        gpio(pin)->DATA |= gpio_pin_mask(pin);
     }
     else {
-        gpio(pin)->DATA &= ~pin_mask(pin);
+        gpio(pin)->DATA &= ~gpio_pin_mask(pin);
     }
 }
 

--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -17,7 +17,7 @@
  *
  * @author      Ian Martin <ian@locicontrols.com>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- *
+ * @author      Sebastian Meiling <s@mlng.net>
  * @}
  */
 
@@ -25,6 +25,7 @@
 #include "mutex.h"
 #include "assert.h"
 #include "periph/spi.h"
+#include "periph/gpio.h"
 
 /**
  * @brief   Array holding one pre-initialized mutex for each SPI device
@@ -71,31 +72,31 @@ void spi_init_pins(spi_t bus)
 {
     switch ((uintptr_t)spi_config[bus].dev) {
         case (uintptr_t)SSI0:
-            IOC_PXX_SEL[spi_config[bus].mosi_pin] = SSI0_TXD;
-            IOC_PXX_SEL[spi_config[bus].sck_pin ] = SSI0_CLKOUT;
-            IOC_PXX_SEL[spi_config[bus].cs_pin  ] = SSI0_FSSOUT;
+            IOC_PXX_SEL[gpio_pp_num(spi_config[bus].mosi_pin)] = SSI0_TXD;
+            IOC_PXX_SEL[gpio_pp_num(spi_config[bus].sck_pin)]  = SSI0_CLKOUT;
+            IOC_PXX_SEL[gpio_pp_num(spi_config[bus].cs_pin)]   = SSI0_FSSOUT;
 
-            IOC_SSIRXD_SSI0 = spi_config[bus].miso_pin;
+            IOC_SSIRXD_SSI0 = gpio_pp_num(spi_config[bus].miso_pin);
             break;
 
         case (uintptr_t)SSI1:
-            IOC_PXX_SEL[spi_config[bus].mosi_pin] = SSI1_TXD;
-            IOC_PXX_SEL[spi_config[bus].sck_pin ] = SSI1_CLKOUT;
-            IOC_PXX_SEL[spi_config[bus].cs_pin  ] = SSI1_FSSOUT;
+            IOC_PXX_SEL[gpio_pp_num(spi_config[bus].mosi_pin)] = SSI1_TXD;
+            IOC_PXX_SEL[gpio_pp_num(spi_config[bus].sck_pin)]  = SSI1_CLKOUT;
+            IOC_PXX_SEL[gpio_pp_num(spi_config[bus].cs_pin)]   = SSI1_FSSOUT;
 
-            IOC_SSIRXD_SSI1 = spi_config[bus].miso_pin;
+            IOC_SSIRXD_SSI1 = gpio_pp_num(spi_config[bus].miso_pin);
             break;
     }
 
-    IOC_PXX_OVER[spi_config[bus].mosi_pin] = IOC_OVERRIDE_OE;
-    IOC_PXX_OVER[spi_config[bus].miso_pin] = IOC_OVERRIDE_DIS;
-    IOC_PXX_OVER[spi_config[bus].sck_pin ] = IOC_OVERRIDE_OE;
-    IOC_PXX_OVER[spi_config[bus].cs_pin  ] = IOC_OVERRIDE_OE;
+    IOC_PXX_OVER[gpio_pp_num(spi_config[bus].mosi_pin)] = IOC_OVERRIDE_OE;
+    IOC_PXX_OVER[gpio_pp_num(spi_config[bus].miso_pin)] = IOC_OVERRIDE_DIS;
+    IOC_PXX_OVER[gpio_pp_num(spi_config[bus].sck_pin)]  = IOC_OVERRIDE_OE;
+    IOC_PXX_OVER[gpio_pp_num(spi_config[bus].cs_pin)]   = IOC_OVERRIDE_OE;
 
-    gpio_hardware_control(spi_config[bus].mosi_pin);
-    gpio_hardware_control(spi_config[bus].miso_pin);
-    gpio_hardware_control(spi_config[bus].sck_pin);
-    gpio_hardware_control(spi_config[bus].cs_pin);
+    gpio_hw_ctrl(spi_config[bus].mosi_pin);
+    gpio_hw_ctrl(spi_config[bus].miso_pin);
+    gpio_hw_ctrl(spi_config[bus].sck_pin);
+    gpio_hw_ctrl(spi_config[bus].cs_pin);
 }
 
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)

--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Loci Controls Inc.
+ *               2017 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,7 +16,7 @@
  * @brief       Low-level UART driver implementation
  *
  * @author      Ian Martin <ian@locicontrols.com>
- *
+ * @author      Sebastian Meiling <s@mlng.net>
  * @}
  */
 
@@ -196,19 +197,19 @@ static int init_base(uart_t uart, uint32_t baudrate)
             /*
              * Select the UARTx RX pin by writing to the IOC_UARTRXD_UARTn register
              */
-            IOC_UARTRXD_UART0 = UART_0_RX_PIN;
+            IOC_UARTRXD_UART0 = gpio_pp_num(UART_0_RX_PIN);
 
             /*
              * Pad Control for the TX pin:
              * - Set function to UARTn TX
              * - Output Enable
              */
-            IOC_PXX_SEL[UART_0_TX_PIN] = UART0_TXD;
-            IOC_PXX_OVER[UART_0_TX_PIN] = IOC_OVERRIDE_OE;
+            IOC_PXX_SEL[gpio_pp_num(UART_0_TX_PIN)] = UART0_TXD;
+            IOC_PXX_OVER[gpio_pp_num(UART_0_TX_PIN)] = IOC_OVERRIDE_OE;
 
             /* Set RX and TX pins to peripheral mode */
-            gpio_hardware_control(UART_0_TX_PIN);
-            gpio_hardware_control(UART_0_RX_PIN);
+            gpio_hw_ctrl(UART_0_TX_PIN);
+            gpio_hw_ctrl(UART_0_RX_PIN);
             break;
 #endif
 #if UART_1_EN
@@ -218,19 +219,19 @@ static int init_base(uart_t uart, uint32_t baudrate)
             /*
              * Select the UARTx RX pin by writing to the IOC_UARTRXD_UARTn register
              */
-            IOC_UARTRXD_UART1 = UART_1_RX_PIN;
+            IOC_UARTRXD_UART1 = gpio_pp_num(UART_1_RX_PIN);
 
             /*
              * Pad Control for the TX pin:
              * - Set function to UARTn TX
              * - Output Enable
              */
-            IOC_PXX_SEL[UART_1_TX_PIN] = UART1_TXD;
-            IOC_PXX_OVER[UART_1_TX_PIN] = IOC_OVERRIDE_OE;
+            IOC_PXX_SEL[gpio_pp_num(UART_1_TX_PIN)] = UART1_TXD;
+            IOC_PXX_OVER[gpio_pp_num(UART_1_TX_PIN)] = IOC_OVERRIDE_OE;
 
             /* Set RX and TX pins to peripheral mode */
-            gpio_hardware_control(UART_1_TX_PIN);
-            gpio_hardware_control(UART_1_RX_PIN);
+            gpio_hw_ctrl(UART_1_TX_PIN);
+            gpio_hw_ctrl(UART_1_RX_PIN);
             break;
 #endif
 
@@ -255,16 +256,16 @@ static int init_base(uart_t uart, uint32_t baudrate)
     /* On the CC2538, hardware flow control is supported only on UART1 */
     if (u == UART1) {
 #ifdef UART_1_RTS_PIN
-        IOC_PXX_SEL[UART_1_RTS_PIN] = UART1_RTS;
-        gpio_hardware_control(UART_1_RTS_PIN);
-        IOC_PXX_OVER[UART_1_RTS_PIN] = IOC_OVERRIDE_OE;
+        IOC_PXX_SEL[gpio_pp_num(UART_1_RTS_PIN)] = UART1_RTS;
+        gpio_hw_ctrl(UART_1_RTS_PIN);
+        IOC_PXX_OVER[gpio_pp_num(UART_1_RTS_PIN)] = IOC_OVERRIDE_OE;
         u->cc2538_uart_ctl.CTLbits.RTSEN = 1;
 #endif
 
 #ifdef UART_1_CTS_PIN
-        IOC_UARTCTS_UART1 = UART_1_CTS_PIN;
-        gpio_hardware_control(UART_1_CTS_PIN);
-        IOC_PXX_OVER[UART_1_CTS_PIN] = IOC_OVERRIDE_DIS;
+        IOC_UARTCTS_UART1 = gpio_pp_num(UART_1_CTS_PIN);
+        gpio_hw_ctrl(UART_1_CTS_PIN);
+        IOC_PXX_OVER[gpio_pp_num(UART_1_CTS_PIN)] = IOC_OVERRIDE_DIS;
         u->cc2538_uart_ctl.CTLbits.CTSEN = 1;
 #endif
     }
@@ -334,7 +335,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 
     /* Block if the TX FIFO is full */
     for (size_t i = 0; i < len; i++) {
-        while (u->cc2538_uart_fr.FRbits.TXFF);
+        while (u->cc2538_uart_fr.FRbits.TXFF) {}
         u->DR = data[i];
     }
 }


### PR DESCRIPTION
remove any (okay: most) dependencies on the vendor specific (TI) gpio api, to fully embrace RIOTs own hardware independent periph gpio API.

Depends on #7310, #7313, #7316, and #7318 will resolve #6650 and makes workaround in #6773 obsolete as soon as all PRs merged.