### PR TITLE
[RFC] introduce common periph led driver

### DIFF
--- a/boards/pba-d-01-kw2x/board.c
+++ b/boards/pba-d-01-kw2x/board.c
@@ -26,12 +26,7 @@
 void board_init(void)
 {
     /* initialize the on-board LEDs */
-    gpio_init(LED0_PIN, GPIO_OUT);
-    gpio_set(LED0_PIN);
-    gpio_init(LED1_PIN, GPIO_OUT);
-    gpio_set(LED1_PIN);
-    gpio_init(LED2_PIN, GPIO_OUT);
-    gpio_set(LED2_PIN);
+    led_init();
 
     /* initialize the CPU core */
     cpu_init();

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -32,28 +32,14 @@ extern "C"
 #endif
 
 /**
- * @name    LED pin definitions and handlers
+ * @name    LED pin definitions
  * @{
  */
 #define LED0_PIN            GPIO_PIN(PORT_D, 6)
 #define LED1_PIN            GPIO_PIN(PORT_D, 4)
 #define LED2_PIN            GPIO_PIN(PORT_A, 4)
 
-#define LED0_MASK           (1 << 6)
-#define LED1_MASK           (1 << 4)
-#define LED2_MASK           (1 << 4)
-
-#define LED0_ON            (GPIOD->PCOR = LED0_MASK)
-#define LED0_OFF           (GPIOD->PSOR = LED0_MASK)
-#define LED0_TOGGLE        (GPIOD->PTOR = LED0_MASK)
-
-#define LED1_ON            (GPIOD->PCOR = LED1_MASK)
-#define LED1_OFF           (GPIOD->PSOR = LED1_MASK)
-#define LED1_TOGGLE        (GPIOD->PTOR = LED1_MASK)
-
-#define LED2_ON            (GPIOA->PCOR = LED2_MASK)
-#define LED2_OFF           (GPIOA->PSOR = LED2_MASK)
-#define LED2_TOGGLE        (GPIOA->PTOR = LED2_MASK)
+#include "periph/led.h"
 /** @} */
 
 /**

--- a/boards/remote-revb/board.c
+++ b/boards/remote-revb/board.c
@@ -23,6 +23,7 @@
 
 #include "board.h"
 #include "cpu.h"
+#include "periph/led.h"
 #include "fancy_leds.h"
 
 static inline void leds_init(void);
@@ -46,9 +47,7 @@ void board_init(void)
  */
 static inline void leds_init(void)
 {
-    gpio_init(LED0_PIN, GPIO_OUT);
-    gpio_init(LED1_PIN, GPIO_OUT);
-    gpio_init(LED2_PIN, GPIO_OUT);
+    led_init();
 
     /* Shoot rainbows */
     LED_RAINBOW();

--- a/boards/remote-revb/include/board.h
+++ b/boards/remote-revb/include/board.h
@@ -25,7 +25,6 @@
 #define BOARD_H
 
 #include "cpu.h"
-#include "board_common.h"
 
 #ifdef __cplusplus
  extern "C" {
@@ -38,23 +37,10 @@
 #define LED0_PIN        GPIO_PIN(3, 4)
 #define LED1_PIN        GPIO_PIN(1, 7)
 #define LED2_PIN        GPIO_PIN(1, 6)
-
-#define LED0_MASK       (1 << 4)
-#define LED1_MASK       (1 << 7)
-#define LED2_MASK       (1 << 6)
-
-#define LED0_ON         (GPIO_D->DATA |=  LED0_MASK)
-#define LED0_OFF        (GPIO_D->DATA &= ~LED0_MASK)
-#define LED0_TOGGLE     (GPIO_D->DATA ^=  LED0_MASK)
-
-#define LED1_ON         (GPIO_B->DATA |=  LED1_MASK)
-#define LED1_OFF        (GPIO_B->DATA &= ~LED1_MASK)
-#define LED1_TOGGLE     (GPIO_B->DATA ^=  LED1_MASK)
-
-#define LED2_ON         (GPIO_B->DATA |=  LED2_MASK)
-#define LED2_OFF        (GPIO_B->DATA &= ~LED2_MASK)
-#define LED2_TOGGLE     (GPIO_B->DATA ^=  LED2_MASK)
 /** @} */
+
+#include "periph/led.h"
+#include "board_common.h"
 
 /**
  * @name User button pin definition

--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -21,13 +21,12 @@
  */
 
 #include "board.h"
-#include "periph/gpio.h"
+#include "periph/led.h"
 
 void board_init(void)
 {
-    /* initialize the on-board LED */
-    gpio_init(LED0_PIN, GPIO_OUT);
-
     /* initialize the CPU */
     cpu_init();
+
+    led_init();
 }

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -56,13 +56,7 @@ extern "C" {
  * @{
  */
 #define LED0_PIN            GPIO_PIN(0, 19)
-
-#define LED_PORT            PORT->Group[0]
-#define LED0_MASK           (1 << 19)
-
-#define LED0_ON             (LED_PORT.OUTCLR.reg = LED0_MASK)
-#define LED0_OFF            (LED_PORT.OUTSET.reg = LED0_MASK)
-#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+#include "periph/led.h"
 /** @} */
 
 /**

--- a/drivers/include/periph/led.h
+++ b/drivers/include/periph/led.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_led LED
+ * @ingroup     drivers_periph
+ * @brief       Low-level LED peripheral driver
+ *
+ *
+ * @{
+ * @file
+ * @brief       Low-level LED peripheral driver interface definitions
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef PERIPH_LED_H
+#define PERIPH_LED_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Util macros to turn on and off, or toggle on-board LEDs
+ *
+ * @ {
+ */
+#ifdef LED0_PIN
+#ifndef LED0_ON
+/* assuming LED0_OFF and LED0_TOGGLE are undefined too */
+#define LED0_ON                 gpio_set(LED0_PIN)
+#define LED0_OFF                gpio_clear(LED0_PIN)
+#define LED0_TOGGLE             gpio_toggle(LED0_PIN)
+#endif /* LED0_ON */
+#ifndef LED0_INIT
+#define LED0_INIT               do { gpio_init(LED0_PIN, GPIO_OUT); LED0_OFF; } while(0)
+#endif /* LED0_INIT */
+#endif /* LED0_PIN */
+
+#ifdef LED1_PIN
+#ifndef LED1_ON
+/* assuming LED1_OFF and LED1_TOGGLE are undefined too */
+#define LED1_ON                 gpio_set(LED1_PIN)
+#define LED1_OFF                gpio_clear(LED1_PIN)
+#define LED1_TOGGLE             gpio_toggle(LED1_PIN)
+#endif /* LED1_ON */
+#ifndef LED1_INIT
+#define LED1_INIT               do { gpio_init(LED1_PIN, GPIO_OUT); LED1_OFF; } while(0)
+#endif /* LED1_INIT */
+#endif /* LED1_PIN */
+
+#ifdef LED2_PIN
+#ifndef LED2_ON
+/* assuming LED2_OFF and LED2_TOGGLE are undefined too */
+#define LED2_ON                 gpio_set(LED2_PIN)
+#define LED2_OFF                gpio_clear(LED2_PIN)
+#define LED2_TOGGLE             gpio_toggle(LED2_PIN)
+#endif /* LED2_ON */
+#ifndef LED2_INIT
+#define LED2_INIT               do { gpio_init(LED2_PIN, GPIO_OUT); LED2_OFF; } while(0)
+#endif /* LED2_INIT */
+#endif /* LED2_PIN */
+
+#ifdef LED3_PIN
+#ifndef LED3_ON
+/* assuming LED3_OFF and LED3_TOGGLE are undefined too */
+#define LED3_ON                 gpio_set(LED3_PIN)
+#define LED3_OFF                gpio_clear(LED3_PIN)
+#define LED3_TOGGLE             gpio_toggle(LED3_PIN)
+#endif /* LED3_ON */
+#ifndef LED3_INIT
+#define LED3_INIT               do { gpio_init(LED3_PIN, GPIO_OUT); LED3_OFF; } while(0)
+#endif /* LED3_INIT */
+#endif /* LED3_PIN */
+
+#ifdef LED4_PIN
+#ifndef LED4_ON
+/* assuming LED4_OFF and LED4_TOGGLE are undefined too */
+#define LED4_ON                 gpio_set(LED4_PIN)
+#define LED4_OFF                gpio_clear(LED4_PIN)
+#define LED4_TOGGLE             gpio_toggle(LED4_PIN)
+#endif /* LED4_ON */
+#ifndef LED4_INIT
+#define LED4_INIT               do { gpio_init(LED4_PIN, GPIO_OUT); LED4_OFF; } while(0)
+#endif /* LED4_INIT */
+#endif /* LED4_PIN */
+
+#ifdef LED5_PIN
+#ifndef LED5_ON
+/* assuming LED5_OFF and LED5_TOGGLE are undefined too */
+#define LED5_ON                 gpio_set(LED5_PIN)
+#define LED5_OFF                gpio_clear(LED5_PIN)
+#define LED5_TOGGLE             gpio_toggle(LED5_PIN)
+#endif /* LED5_ON */
+#ifndef LED5_INIT
+#define LED5_INIT               do { gpio_init(LED5_PIN, GPIO_OUT); LED5_OFF; } while(0)
+#endif /* LED5_INIT */
+#endif /* LED5_PIN */
+
+#ifdef LED6_PIN
+#ifndef LED6_ON
+/* assuming LED6_OFF and LED6_TOGGLE are undefined too */
+#define LED6_ON                 gpio_set(LED6_PIN)
+#define LED6_OFF                gpio_clear(LED6_PIN)
+#define LED6_TOGGLE             gpio_toggle(LED6_PIN)
+#endif /* LED6_ON */
+#ifndef LED6_INIT
+#define LED6_INIT               do { gpio_init(LED6_PIN, GPIO_OUT); LED6_OFF; } while(0)
+#endif /* LED6_INIT */
+#endif /* LED6_PIN */
+
+#ifdef LED7_PIN
+#ifndef LED7_ON
+/* assuming LED7_OFF and LED7_TOGGLE are undefined too */
+#define LED7_ON                 gpio_set(LED7_PIN)
+#define LED7_OFF                gpio_clear(LED7_PIN)
+#define LED7_TOGGLE             gpio_toggle(LED7_PIN)
+#endif /* LED7_ON */
+#ifndef LED7_INIT
+#define LED7_INIT               do { gpio_init(LED7_PIN, GPIO_OUT); LED7_OFF; } while(0)
+#endif /* LED7_INIT */
+#endif /* LED7_PIN */
+/** @} */
+
+/**
+ * @brief Init available on-board LEDs and set to off
+ */
+void led_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_LED_H */
+/** @} */

--- a/drivers/periph_common/led.c
+++ b/drivers/periph_common/led.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup drivers_periph_led
+ * @{
+ *
+ * @file
+ * @brief       common LED macros and init function
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/led.h"
+
+void led_init(void)
+{
+#ifdef LED0_PIN
+    LED0_INIT;
+#endif /* LED0_PIN */
+
+#ifdef LED1_PIN
+    LED1_INIT;
+#endif /* LED1_PIN */
+
+#ifdef LED2_PIN
+    LED2_INIT;
+#endif /* LED2_PIN */
+
+#ifdef LED3_PIN
+    LED3_INIT;
+#endif /* LED3_PIN */
+
+#ifdef LED4_PIN
+    LED4_INIT;
+#endif /* LED4_PIN */
+
+#ifdef LED5_PIN
+    LED5_INIT;
+#endif /* LED5_PIN */
+
+#ifdef LED6_PIN
+    LED6_INIT;
+#endif /* LED6_PIN */
+
+#ifdef LED7_PIN
+    LED7_INIT;
+#endif /* LED7_PIN */
+}


### PR DESCRIPTION
this PR introduces a simplified handling of on-board LEDs by fully utilizing RIOTs hardware independent gpio driver. That way per board redefinition of led macros such as `LEDX_ON`, `LEDX_OFF`, and `LEDX_TOGGLE` will be obsolete, it simple requires to define the respective gpio pin for each LED as it is already done. 

As an example this PR shows this feature on board `remote-revb`. However, this is foremost a Request-For-Comments and hence Work-In-Progress.