### PR TITLE
board, nucleo32-l031: fix board_init

### DIFF
--- a/boards/nucleo32-l031/board.c
+++ b/boards/nucleo32-l031/board.c
@@ -26,8 +26,8 @@
 
 void board_init(void)
 {
-    /* initialize the boards LED */
-    gpio_init(LED0_PIN, GPIO_OUT);
+    /* initialize the CPU */
+    cpu_init();
 
 #ifdef AUTO_INIT_LED0
     /* The LED pin is also used for SPI, so we enable it


### PR DESCRIPTION
fixes board_init for nucleo32-l031, i.e., remove duplicate init of LED0 and add missing `cpu_init()`.

Looks like copy-pasta when this board was ported and adapted. 