### PR TITLE
cpu/stm32: fix RTC init and disable outputs

### DIFF
--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -86,14 +86,14 @@ void rtc_init(void)
         RTC->ISR |= RTC_ISR_INIT;
         while ((RTC->ISR & RTC_ISR_INITF) == 0) {}
 
+        /* Configure the RTC PRER */
+        RTC->PRER = RTC_SYNC_PRESCALER;
+        RTC->PRER |= (RTC_ASYNC_PRESCALER << 16);
+
         /* Set 24-h clock */
         RTC->CR &= ~RTC_CR_FMT;
         /* Timestamps enabled */
         RTC->CR |= RTC_CR_TSE;
-
-        /* Configure the RTC PRER */
-        RTC->PRER = RTC_SYNC_PRESCALER;
-        RTC->PRER |= (RTC_ASYNC_PRESCALER << 16);
 
         /* Exit RTC init mode */
         RTC->ISR &= (uint32_t) ~RTC_ISR_INIT;


### PR DESCRIPTION
This PR fixes a delay each time the mcu boots.

If the RTC is powered with a V_bckp, there was ~800ms lost in the RTC counter at each power on.

The RTC alternate function outputs are also disabled, to make PC13 usable as gpio.