### PR TITLE
cpu, cc2538: add low-level adc periph driver

### DIFF
--- a/boards/cc2538dk/Makefile.features
+++ b/boards/cc2538dk/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -144,6 +144,19 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
+ * @name ADC configuration
+ * @{
+ */
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+
+static const adc_conf_t adc_config[] = {
+    GPIO_PIN(0, 6), /**< GPIO_PA6 = ADC_ALS_PIN */
+};
+
+#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+/** @} */
+
+/**
  * @name Radio peripheral configuration
  * @{
  */

--- a/boards/openmote-cc2538/Makefile.features
+++ b/boards/openmote-cc2538/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -14,6 +14,7 @@
  * @brief       Peripheral MCU configuration for the OpenMote-cc2538 board
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Sebastian Meiling <s@mlng.net>
  */
 
 #ifndef PERIPH_CONF_H
@@ -62,6 +63,23 @@ static const timer_conf_t timer_config[] = {
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 #define TIMER_IRQ_PRIO      1
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+
+static const adc_conf_t adc_config[] = {
+    GPIO_PIN(0, 2), /**< GPIO_PA2 = AD4_PIN */
+    GPIO_PIN(0, 3), /**< GPIO_PA3 = CTS_DI07_PIN */
+    GPIO_PIN(0, 4), /**< GPIO_PA4 = AD5_PIN */
+    GPIO_PIN(0, 5), /**< GPIO_PA5 = AD6_PIN */
+    GPIO_PIN(0, 6), /**< GPIO_PA6 = ON_SLEEP_PIN */
+};
+
+#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
 /** @} */
 
 /**

--- a/boards/remote-common/Makefile.dep
+++ b/boards/remote-common/Makefile.dep
@@ -4,6 +4,8 @@ ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += gnrc_netdev
     USEMODULE += netdev_ieee802154
 endif
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_adc
 endif

--- a/boards/remote-pa/Makefile.features
+++ b/boards/remote-pa/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/remote-pa/include/adc_params.h
+++ b/boards/remote-pa/include/adc_params.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_remote
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Antonio Lignan <alinan@zolertia.com>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "ADC2",
+        .line = ADC_LINE(0),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC3",
+        .line = ADC_LINE(1),
+        .res  = ADC_RES_12BIT,
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -16,6 +16,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Antonio Lignan <alinan@zolertia.com>
+ * @author      Sebastian Meiling <s@mlng.net>
  */
 
 #ifndef PERIPH_CONF_H
@@ -104,6 +105,20 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+
+static const adc_conf_t adc_config[] = {
+    GPIO_PIN(0, 6), /**< GPIO_PA6 = ADC2_PIN */
+    GPIO_PIN(0, 7), /**< GPIO_PA7 = ADC3_PIN */
+};
+
+#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/remote-reva/Makefile.features
+++ b/boards/remote-reva/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/remote-reva/README.md
+++ b/boards/remote-reva/README.md
@@ -27,6 +27,7 @@ In terms of hardware support, the following drivers have been implemented:
     * I2C/SPI library
     * LEDs
     * Buttons
+    * ADC
     * RF switch to programatically drive either 2.4GHz or sub-1GHz to a single RP-SMA
     * RF 2.4GHz built-in in CC2538
 
@@ -35,7 +36,6 @@ And under work or pending at cc2538 base cpu:
     * Built-in core temperature and battery sensor.
     * CC1200 sub-1GHz radio interface.
     * Micro-SD external storage.
-    * ADC
     * USB (in CDC-ACM).
     * uDMA Controller.
 

--- a/boards/remote-reva/include/adc_params.h
+++ b/boards/remote-reva/include/adc_params.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_remote
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Antonio Lignan <alinan@zolertia.com>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "ADC1",
+        .line = ADC_LINE(0),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC2",
+        .line = ADC_LINE(1),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC3",
+        .line = ADC_LINE(2),
+        .res  = ADC_RES_12BIT,
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -16,6 +16,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Antonio Lignan <alinan@zolertia.com>
+ * @author      Sebastian Meiling <s@mlng.net>
  */
 
 #ifndef PERIPH_CONF_H
@@ -106,6 +107,24 @@ static const spi_conf_t spi_config[] = {
 
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+
+static const adc_conf_t adc_config[] = {
+    GPIO_PIN(0, 5), /**< GPIO_PA5 = ADC1_PIN */
+    GPIO_PIN(0, 4), /**< GPIO_PA4 = ADC2_PIN */
+    /* voltage divider with 5/3 relationship to allow 5V sensors */
+    GPIO_PIN(0, 2), /**< GPIO_PA2 = ADC3_PIN */
+};
+
+#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+/** @} */
+
+
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/boards/remote-revb/Makefile.features
+++ b/boards/remote-revb/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 
 # Various other features (if any)
 FEATURES_PROVIDED += cpp

--- a/boards/remote-revb/include/adc_params.h
+++ b/boards/remote-revb/include/adc_params.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_remote
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC in Revision B
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Antonio Lignan <alinan@zolertia.com>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "ADC1",
+        .line = ADC_LINE(0),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC2",
+        .line = ADC_LINE(1),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC3",
+        .line = ADC_LINE(2),
+        .res  = ADC_RES_12BIT,
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
  * Copyright (C) 2015 Zolertia SL
+ *               2017 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -15,7 +16,8 @@
  * @brief       Peripheral MCU configuration for the RE-Mote board revision B
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
- *              Antonio Lignan <alinan@zolertia.com>
+ * @author      Antonio Lignan <alinan@zolertia.com>
+ * @author      Sebastian Meiling <s@mlng.net>
  */
 
 #ifndef PERIPH_CONF_H
@@ -105,8 +107,23 @@ static const spi_conf_t spi_config[] = {
         .cs_pin   = GPIO_PA7
     }
 };
-
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+
+static const adc_conf_t adc_config[] = {
+    GPIO_PIN(0, 5), /**< GPIO_PA5 = ADC1_PIN */
+    GPIO_PIN(0, 4), /**< GPIO_PA4 = ADC2_PIN */
+    /* voltage divider with 5/3 relationship to allow 5V sensors */
+    GPIO_PIN(0, 2), /**< GPIO_PA2 = ADC3_PIN */
+};
+
+#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/cc2538/include/cpu_conf.h
+++ b/cpu/cc2538/include/cpu_conf.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @addtogroup      cpu_cc2538
+ * @ingroup      cpu_cc2538
  * @{
  *
  * @file
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   ARM Cortex-M specific CPU configuration
+ * @name   ARM Cortex-M specific CPU configuration
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -160,7 +160,7 @@ typedef struct {
 } i2c_conf_t;
 
 /**
- * @brief declare needed generic SPI functions
+ * @name declare needed generic SPI functions
  * @{
  */
 #define PERIPH_SPI_NEEDS_INIT_CS
@@ -170,7 +170,7 @@ typedef struct {
 /** @} */
 
 /**
- * @brief   Override the default GPIO mode settings
+ * @name   Override the default GPIO mode settings
  * @{
  */
 #define HAVE_GPIO_MODE_T
@@ -185,7 +185,7 @@ typedef enum {
 /** @} */
 
 /**
- * @brief   Override SPI mode settings
+ * @name   Override SPI mode settings
  * @{
  */
 #define HAVE_SPI_MODE_T
@@ -198,7 +198,7 @@ typedef enum {
 /** @ */
 
 /**
- * @brief   Override SPI clock settings
+ * @name   Override SPI clock settings
  * @{
  */
 #define HAVE_SPI_CLK_T
@@ -220,7 +220,7 @@ typedef struct {
 } spi_clk_conf_t;
 
 /**
- * @brief   SPI configuration data structure
+ * @name    SPI configuration data structure
  * @{
  */
 typedef struct {
@@ -240,6 +240,71 @@ typedef struct {
     uint_fast8_t channels;  /**< number of channels */
     uint_fast8_t cfg;       /**< timer config word */
 } timer_conf_t;
+
+/**
+ * @name   Override resolution options
+ * @{
+ */
+#define HAVE_ADC_RES_T
+typedef enum {
+    ADC_RES_6BIT  =             (0xa00),    /**< not supported by hardware */
+    ADC_RES_7BIT  =             (0 << 4),   /**< ADC resolution: 7 bit */
+    ADC_RES_8BIT  =             (0xb00),    /**< not supported by hardware */
+    ADC_RES_9BIT  =             (1 << 4),   /**< ADC resolution: 9 bit */
+    ADC_RES_10BIT =             (2 << 4),   /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT =             (3 << 4),   /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT =             (0xc00),    /**< not supported by hardware */
+    ADC_RES_16BIT =             (0xd00),    /**< not supported by hardware */
+} adc_res_t;
+/** @} */
+
+/**
+ * @brief ADC configuration wrapper
+ */
+typedef gpio_t adc_conf_t;
+
+/**
+ * @name SOC_ADC_ADCCON3 register bit masks
+ * @{
+ */
+#define SOC_ADC_ADCCON3_EREF    (0x000000C0) /**< Reference voltage for extra */
+#define SOC_ADC_ADCCON3_EDIV    (0x00000030) /**< Decimation rate for extra */
+#define SOC_ADC_ADCCON3_ECH     (0x0000000F) /**< Single channel select */
+/** @} */
+
+/**
+ * @name SOC_ADC_ADCCONx registers field values
+ * @{
+ */
+#define SOC_ADC_ADCCON_REF_INT      (0 << 6)    /**< Internal reference */
+#define SOC_ADC_ADCCON_REF_EXT      (1 << 6)    /**< External reference on AIN7 pin */
+#define SOC_ADC_ADCCON_REF_AVDD5    (2 << 6)    /**< AVDD5 pin */
+#define SOC_ADC_ADCCON_REF_DIFF     (3 << 6)    /**< External reference on AIN6-AIN7 differential input */
+#define SOC_ADC_ADCCON_CH_GND       (0xC)       /**< GND */
+/** @} */
+
+/**
+ * @brief Mask to check end-of-conversion (EOC) bit
+ */
+#define SOC_ADC_ADCCON1_EOC_MASK    (0x80)
+
+/**
+ * @name Masks for ADC raw data
+ * @{
+ */
+#define SOC_ADC_ADCL_MASK       (0x000000FC)
+#define SOC_ADC_ADCH_MASK       (0x000000FF)
+/** @} */
+
+/**
+ * @name Bit shift for data per ADC resolution
+ * @{
+ */
+#define SOCADC_7_BIT_RSHIFT     (9U) /**< Mask for getting data( 7 bits ENOB) */
+#define SOCADC_9_BIT_RSHIFT     (7U) /**< Mask for getting data( 9 bits ENOB) */
+#define SOCADC_10_BIT_RSHIFT    (6U) /**< Mask for getting data(10 bits ENOB) */
+#define SOCADC_12_BIT_RSHIFT    (4U) /**< Mask for getting data(12 bits ENOB) */
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+ /**
+ * @ingroup     cpu_cc2538
+ * @ingroup     drivers_periph_adc
+ * @{
+ *
+ * @file
+ * @brief       Low-level ADC driver implementation
+ *
+ * @notice      based on TI peripheral drivers library
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ * @}
+  */
+
+#include "board.h"
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph_cpu.h"
+#include "periph/adc.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+int adc_init(adc_t line)
+{
+    if (line >= ADC_NUMOF) {
+        DEBUG("adc_init: invalid ADC line (%d)!\n", line);
+        return -1;
+    }
+
+    cc2538_soc_adc_t *adca = SOC_ADC;
+    /* stop random number generator, and set STSEL = 1 */
+    adca->cc2538_adc_adccon1.ADCCON1 = 0x3c;
+    /* disable any DMA, continous ADC settings */
+    adca->ADCCON2 = 0x0;
+    /* configure ADC GPIO as analog input */
+    gpio_init(adc_config[line], IOC_OVERRIDE_ANA);
+
+    return 0;
+}
+
+int adc_sample(adc_t line, adc_res_t res)
+{
+    /* check if adc line valid */
+    if (line >= ADC_NUMOF) {
+        DEBUG("adc_sample: invalid ADC line!\n");
+        return -1;
+    }
+
+    uint8_t rshift;
+    /* check if given resolution valid, and set right shift */
+    switch(res) {
+        case ADC_RES_7BIT:
+            rshift = SOCADC_7_BIT_RSHIFT;
+            break;
+        case ADC_RES_9BIT:
+            rshift = SOCADC_9_BIT_RSHIFT;
+            break;
+        case ADC_RES_10BIT:
+            rshift = SOCADC_10_BIT_RSHIFT;
+            break;
+        case ADC_RES_12BIT:
+            rshift = SOCADC_12_BIT_RSHIFT;
+            break;
+        default:
+            DEBUG("adc_sample: invalid resultion!\n");
+            return -1;
+    }
+    /**
+     * @attention CC2538 ADC supports differential comparision of two analog
+     * GPIO inputs, hence negative values are possible. RIOT currently allows
+     * positive ADC output only. Thus, reduce shift by one to compensate and
+     * get full value range according to ADC resolution. E.g. 10 Bit resultion
+     * with diff ADC would have [-512,511] range but RIOT expects [0,1023].
+     */
+    rshift--;
+
+    cc2538_soc_adc_t *adca = SOC_ADC;
+    /* configure adc line with parameters and trigger a single conversion*/
+    uint32_t reg = (adca->ADCCON3) & ~(SOC_ADC_ADCCON3_EREF |
+                                       SOC_ADC_ADCCON3_EDIV |
+                                       SOC_ADC_ADCCON3_ECH);
+    adca->ADCCON3 = reg | res | SOC_ADC_ADCCON_REF |
+                    gpio_pp_num(adc_config[line]);
+
+    DEBUG("ADCCON1: %"PRIu32" ADCCON2: %"PRIu32" ADCCON3: %"PRIu32"\n",
+          adca->cc2538_adc_adccon1.ADCCON1, adca->ADCCON2, adca->ADCCON3);
+
+    /* Poll/wait until end of conversion */
+    while ((adca->cc2538_adc_adccon1.ADCCON1 &
+            SOC_ADC_ADCCON1_EOC_MASK) == 0) {}
+
+    /* Read result after conversion completed,
+     * reading SOC_ADC_ADCH last will clear SOC_ADC_ADCCON1.EOC */
+    int16_t sample = adca->ADCL & SOC_ADC_ADCL_MASK;
+    sample |= (adca->ADCH & SOC_ADC_ADCH_MASK) << 8;
+    /* sample right shifted depending on resolution */
+    sample = sample >> rshift;
+    DEBUG("adc_sample: raw value %"PRIi16"\n", sample);
+    /* FIXME: currently RIOT ADC allows values >0 only */
+    if (sample < 0) {
+        sample = 0;
+    }
+
+    return (int)sample;
+}


### PR DESCRIPTION
started from #5823 (and makes that obsolete), but rewrote ADC based on TI periphal driver library. Adds also board periph confs for all CC2538 based boards, including SAUL adaption for Zolertia Remotes.

~~Requires #7320 (and all sub PRs dependencies of that one).~~