### PR TITLE
cpu/stm32l0: power management updated

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -77,8 +77,8 @@ extern "C" {
 /**
  * @brief   Number of usable low power modes
  */
-#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) \
-    || defined(CPU_FAM_STM32F4) || defined(DOXYGEN)
+#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0) || defined(DOXYGEN)
 #define PM_NUM_MODES    (2U)
 
 /**

--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -25,7 +25,8 @@
 
 #include "irq.h"
 #include "periph/pm.h"
-#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
+#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0)
 #include "stmclk.h"
 #endif
 
@@ -47,21 +48,41 @@ void pm_set(unsigned mode)
 
 /* I just copied it from stm32f1/2/4, but I suppose it would work for the
  * others... /KS */
-#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
+#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0)
     switch (mode) {
         case STM32_PM_STANDBY:
             /* Set PDDS to enter standby mode on deepsleep and clear flags */
             PWR->CR |= (PWR_CR_PDDS | PWR_CR_CWUF | PWR_CR_CSBF);
             /* Enable WKUP pin to use for wakeup from standby mode */
+#if defined(CPU_FAM_STM32L0)
+            PWR->CSR |= (PWR_CSR_EWUP1 | PWR_CSR_EWUP2);
+#if !defined(CPU_MODEL_STM32L053R8)
+            /* STM32L053 only have 2 wake pins */
+            PWR->CSR |= PWR_CSR_EWUP3;
+#endif
+#else
             PWR->CSR |= PWR_CSR_EWUP;
+#endif
             /* Set SLEEPDEEP bit of system control block */
             deep = 1;
             break;
         case STM32_PM_STOP:
+#if defined(CPU_FAM_STM32L0)
+            /* Clear PDDS to enter stop mode on */
+            /*
+             * Regarding LPSDSR, it's up to the user to configure it :
+             * 0: Voltage regulator on during Deepsleep/Sleep/Low-power run mode
+             * 1: Voltage regulator in low-power mode during
+             *    Deepsleep/Sleep/Low-power run mode
+             */
+            PWR->CR &= ~(PWR_CR_PDDS);
+#else
             /* Clear PDDS and LPDS bits to enter stop mode on */
             /* deepsleep with voltage regulator on */
             PWR->CR &= ~(PWR_CR_PDDS | PWR_CR_LPDS);
             PWR->CR |= PM_STOP_CONFIG;
+#endif
             /* Set SLEEPDEEP bit of system control block */
             deep = 1;
             break;
@@ -72,7 +93,8 @@ void pm_set(unsigned mode)
 
     cortexm_sleep(deep);
 
-#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
+#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0)
     if (deep) {
         /* Re-init clock after STOP */
         stmclk_init_sysclk();
@@ -80,7 +102,8 @@ void pm_set(unsigned mode)
 #endif
 }
 
-#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4)
+#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
+    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32L0)
 void pm_off(void)
 {
     irq_disable();

--- a/cpu/stm32l0/Makefile.include
+++ b/cpu/stm32l0/Makefile.include
@@ -1,5 +1,7 @@
 export CPU_ARCH = cortex-m0
 export CPU_FAM  = stm32l0
 
+USEMODULE += pm_layered
+
 include $(RIOTCPU)/stm32_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32l0/include/periph_cpu.h
+++ b/cpu/stm32l0/include/periph_cpu.h
@@ -82,6 +82,12 @@ typedef struct {
     uint8_t ev_irqn;        /**< event IRQ */
 } i2c_conf_t;
 
+/**
+ * @brief   Override the default initial PM blocker
+ * @todo   we block all modes per default, until PM is cleanly implemented
+ */
+#define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Now, stm32l0 is able to go in sleep and stop mode. By default, low power modes are deactivated.