### PR TITLE
board, cc2650stk add support for uniflash 4.1

### DIFF
--- a/boards/cc2650stk/Makefile.include
+++ b/boards/cc2650stk/Makefile.include
@@ -11,9 +11,14 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # configure the flash tool
 export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
-export FLASHER = $(UNIFLASH_PATH)/uniflash.sh
-export FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(ELFFILE)
-
+# check which uniflash version is available, either 4.x or 3.x
+ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
+  export FLASHER ?= $(UNIFLASH_PATH)/dslite.sh
+  export FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(ELFFILE)
+else
+  export FLASHER = $(UNIFLASH_PATH)/uniflash.sh
+  export FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(ELFFILE)
+endif
 # configure the debug server
 export DEBUGSERVER = $(UNIFLASH_PATH)/ccs_base/common/uscif/gdb_agent_console
 export DEBUGSERVER_FLAGS = -p 3333 $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).dat


### PR DESCRIPTION
this PR adds support for the new TI Uniflash Tool version 4.x, needed to flash the SensorTag, i.e. cc2650stk. 

Tested on macOS, and required cause uniflash 3.4 wasn't working anymore on macOS Sierra, at least for me.