### PR TITLE
cpu, cc26x0: fixing periph timer

### DIFF
--- a/boards/cc2650stk/include/periph_conf.h
+++ b/boards/cc2650stk/include/periph_conf.h
@@ -39,17 +39,22 @@ extern "C" {
  */
 static const timer_conf_t timer_config[] = {
     {
-        .dev  = GPT0,
-        .num  = 0
+        .cfg = GPT_CFG_16T,
+        .chn = 2,
     },
     {
-        .dev  = GPT1,
-        .num  = 1
+        .cfg = GPT_CFG_32T,
+        .chn = 1,
+    },
+    {
+        .cfg = GPT_CFG_16T,
+        .chn = 2,
+    },
+    {
+        .cfg = GPT_CFG_32T,
+        .chn = 1,
     }
 };
-
-#define TIMER_0_ISR         isr_timer0_chan0
-#define TIMER_1_ISR         isr_timer1_chan0
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */

--- a/cpu/cc26x0/include/periph_cpu.h
+++ b/cpu/cc26x0/include/periph_cpu.h
@@ -60,12 +60,14 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 
 /**
- * @brief   Timer configuration options
+ * @brief   Configuration of low-level general purpose timers
+ *
+ * @note Timers *must* be configured consecutively and in order (without gaps)
+ *       starting from GPT0, specifically if multiple timers are enabled.
  */
 typedef struct {
-    gpt_reg_t *dev; /**< the GPT base address */
-    uint8_t num; /**< number of the timer */
-    uint8_t irqn; /**< interrupt number */
+    uint8_t     cfg;    /**< timer config [16,32 Bit] */
+    uint8_t     chn;    /**< number of channels [1,2] */
 } timer_conf_t;
 
 #ifdef __cplusplus

--- a/cpu/cc26x0/periph/timer.c
+++ b/cpu/cc26x0/periph/timer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Leon George
+ * Copyright (C) 2017 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,24 +16,74 @@
  * @brief       Low-level timer driver implementation for the CC26x0
  *
  * @author      Leon M. George <leon@georgemail.eu>
- *
+ * @author      Sebastian Meiling <s@mlng.net>
  * @}
  */
 
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "assert.h"
+#include "board.h"
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph/timer.h"
 
-/**
- * @brief   Allocate memory for the interrupt context
- */
-static timer_isr_ctx_t ctx[TIMER_NUMOF];
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define LOAD_VALUE              (0xffff)
+
+#define TIMER_A_IRQ_MASK        (0x000000ff)
+#define TIMER_B_IRQ_MASK        (0x0000ff00)
+
+#define TIMER_IRQ_PRIO          (1U)
+
+typedef struct {
+    uint16_t mask;
+    uint16_t flag;
+} _isr_cfg_t;
+
+static _isr_cfg_t chn_isr_cfg[] = {
+    { .mask = TIMER_A_IRQ_MASK, .flag = GPT_IMR_TAMIM },
+    { .mask = TIMER_B_IRQ_MASK, .flag = GPT_IMR_TBMIM }
+};
 
 /**
- * @brief           Get the GPT register base for a timer
+ * @name function prototypes
+ * @{
+ */
+static void irq_handler(tim_t tim, int channel);
+/** @} */
+
+/**
+ * @brief   Allocate memory for timer interrupt context(s)
+ */
+static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
+
+/**
+ * @brief   Enable global interrupts for timer channel(s)
+ *
+ * @param[in] tim   index of the timer
+ */
+static void _irq_enable(tim_t tim)
+{
+    assert(tim < TIMER_NUMOF);
+
+    /* enable global timer interrupt for channel A */
+    IRQn_Type irqn = GPTIMER_0A_IRQN + (2 * tim);
+    NVIC_SetPriority(irqn, TIMER_IRQ_PRIO);
+    NVIC_EnableIRQ(irqn);
+    /* and channel B, if enabled */
+    if(timer_config[tim].chn == 2) {
+        irqn++;
+        NVIC_SetPriority(irqn, TIMER_IRQ_PRIO);
+        NVIC_EnableIRQ(irqn);
+    }
+}
+
+/**
+ * @brief   Get the GPT register base for a timer
  *
  * @param[in] tim   index of the timer
  *
@@ -40,18 +91,21 @@ static timer_isr_ctx_t ctx[TIMER_NUMOF];
  */
 static inline gpt_reg_t *dev(tim_t tim)
 {
-    return timer_config[tim].dev;
+    assert(tim < TIMER_NUMOF);
+
+    return ((gpt_reg_t *)(GPT0_BASE | (((uint32_t)tim) << 12)));
 }
 
 int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 {
+    DEBUG("timer_init(%u, %lu)\n", tim, freq);
     /* make sure given timer is valid */
     if (tim >= TIMER_NUMOF) {
         return -1;
     }
 
-    /* enable the times clock */
-    PRCM->GPTCLKGR |= (1 << timer_config[tim].num);
+    /* enable the timer clock */
+    PRCM->GPTCLKGR |= (1 << tim);
     PRCM->CLKLOADCTL = CLKLOADCTL_LOAD;
     while (!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE)) {}
 
@@ -59,18 +113,54 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     dev(tim)->CTL = 0;
 
     /* save context */
-    ctx[tim].cb = cb;
-    ctx[tim].arg = arg;
+    isr_ctx[tim].cb = cb;
+    isr_ctx[tim].arg = arg;
 
-    /* configure timer to 16-bit, periodic, up-counting */
-    dev(tim)->CFG  = GPT_CFG_16T;
-    dev(tim)->TAMR = (GPT_TXMR_TXMR_PERIODIC | GPT_TXMR_TXCDIR_UP | GPT_TXMR_TXMIE);
-
-    /* set the timer speed */
-    dev(tim)->TAPR = (RCOSC48M_FREQ / freq) - 1;
-    /* enable global timer interrupt and start the timer */
-    NVIC_EnableIRQ(GPTIMER_0A_IRQN + (2 * timer_config[tim].num));
+    uint32_t chan_mode = (GPT_TXMR_TXMR_PERIODIC | GPT_TXMR_TXMIE);
+    uint32_t prescaler = 0;
+    if (timer_config[tim].cfg == GPT_CFG_32T) {
+        if (timer_config[tim].chn > 1) {
+            DEBUG("timer_init: in 32Bit mode single channel only!\n");
+            return -1;
+        }
+        if (freq != RCOSC48M_FREQ) {
+            DEBUG("timer_init: in 32Bit mode freq must equal system clock!\n");
+            return -1;
+        }
+        chan_mode |= GPT_TXMR_TXCDIR_UP;
+    }
+    else if (timer_config[tim].cfg == GPT_CFG_16T) {
+        /* prescaler only available in 16Bit mode */
+        prescaler = RCOSC48M_FREQ;
+        prescaler += freq / 2;
+        prescaler /= freq;
+        if (prescaler > 0) {
+            prescaler--;
+        }
+        if (prescaler > 255) {
+            prescaler = 255;
+        }
+        dev(tim)->TAILR = LOAD_VALUE;
+        dev(tim)->TAPR = prescaler;
+    }
+    else {
+        DEBUG("timer_init: invalid timer config must be 16 or 32Bit mode!\n");
+        return -1;
+    }
+    /* configure channels and start timer */
+    dev(tim)->CFG  = timer_config[tim].cfg;
     dev(tim)->CTL = GPT_CTL_TAEN;
+    dev(tim)->TAMR = chan_mode;
+
+    if (timer_config[tim].chn == 2) {
+        /* set the timer speed */
+        dev(tim)->TBPR = prescaler;
+        dev(tim)->TBMR = chan_mode;
+        dev(tim)->TBILR = LOAD_VALUE;
+        dev(tim)->CTL = GPT_CTL_TAEN | GPT_CTL_TBEN;
+    }
+    /* enable timer IRQs */
+    _irq_enable(tim);
 
     return 0;
 }
@@ -82,84 +172,104 @@ int timer_set(tim_t tim, int channel, unsigned int timeout)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel != 0) {
+    DEBUG("timer_set_absolute(%u, %u, %u)\n", tim, channel, value);
+
+    if ((tim >= TIMER_NUMOF) || (channel >= timer_config[tim].chn)) {
         return -1;
     }
 
-    dev(tim)->TAMATCHR = value;
-    dev(tim)->IMR |= GPT_IMR_TAMIM;
+    dev(tim)->ICLR = chn_isr_cfg[channel].flag;
+    if (channel == 0) {
+        dev(tim)->TAMATCHR = (timer_config[tim].cfg == GPT_CFG_32T) ?
+                             value : (LOAD_VALUE - value);
+    }
+    else {
+        dev(tim)->TBMATCHR = (timer_config[tim].cfg == GPT_CFG_32T) ?
+                             value : (LOAD_VALUE - value);
+    }
+    dev(tim)->IMR |= chn_isr_cfg[channel].flag;
 
-    return 0;
+    return 1;
 }
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel != 0) {
+    DEBUG("timer_clear(%u, %d)\n", tim, channel);
+    if ((tim >= TIMER_NUMOF) || (channel >= timer_config[tim].chn)) {
         return -1;
     }
-
-    dev(tim)->IMR &= ~(GPT_IMR_TAMIM);
+    /* clear interupt flags */
+    dev(tim)->IMR &= ~(chn_isr_cfg[channel].flag);
 
     return 0;
 }
 
 unsigned int timer_read(tim_t tim)
 {
-    return dev(tim)->TAV & 0xFFFF;
+    DEBUG("timer_read(%u)\n", tim);
+    if (tim >= TIMER_NUMOF) {
+        return 0;
+    }
+    if (timer_config[tim].cfg == GPT_CFG_32T) {
+        return dev(tim)->TAV;
+    }
+    return LOAD_VALUE - (dev(tim)->TAV & 0xFFFF);
 }
 
 void timer_stop(tim_t tim)
 {
-    dev(tim)->CTL = 0;
+    DEBUG("timer_stop(%u)\n", tim);
+    if (tim < TIMER_NUMOF) {
+        dev(tim)->CTL = 0;
+    }
 }
 
 void timer_start(tim_t tim)
 {
-    dev(tim)->CTL = GPT_CTL_TAEN;
+    DEBUG("timer_start(%u)\n", tim);
+
+    if (tim < TIMER_NUMOF) {
+        if (timer_config[tim].chn == 1) {
+            dev(tim)->CTL = GPT_CTL_TAEN;
+        }
+        else if (timer_config[tim].chn == 2) {
+            dev(tim)->CTL = GPT_CTL_TAEN | GPT_CTL_TBEN;
+        }
+    }
 }
 
 /**
- * @brief           handle interrupt for a timer
+ * @brief   Timer interrupt handler
  *
  * @param[in] tim   index of the timer
+ * @param[in] chn   channel number (0=A, 1=B)
  */
-static inline void isr_handler(tim_t tim)
+static void irq_handler(tim_t tim, int channel)
 {
-    uint32_t mis = dev(tim)->MIS;
+    assert(tim < TIMER_NUMOF);
+    assert(channel < timer_config[tim].chn);
+
+    uint32_t mis;
+    /* Latch the active interrupt flags */
+    mis = dev(tim)->MIS & chn_isr_cfg[channel].mask;
+    /* Clear the latched interrupt flags */
     dev(tim)->ICLR = mis;
 
-    if (mis & GPT_IMR_TAMIM) {
-        dev(tim)->IMR &= ~GPT_IMR_TAMIM;
-        ctx[tim].cb(ctx[tim].arg, 0);
+    if (mis & chn_isr_cfg[channel].flag) {
+        /* Disable further match interrupts for this timer/channel */
+        dev(tim)->IMR &= ~chn_isr_cfg[channel].flag;
+        /* Invoke the callback function */
+        isr_ctx[tim].cb(isr_ctx[tim].arg, channel);
     }
 
     cortexm_isr_end();
 }
 
-#ifdef TIMER_0_ISR
-void TIMER_0_ISR(void)
-{
-    isr_handler(0);
-}
-#endif
-
-#ifdef TIMER_1_ISR
-void TIMER_1_ISR(void)
-{
-    isr_handler(1);
-}
-#endif
-
-#ifdef TIMER_2_ISR
-void TIMER_2_ISR(void)
-{
-    isr_handler(2);
-}
-#endif
-
-#ifdef TIMER_3_ISR
-void TIMER_3_ISR(void)
-{
-    isr_handler(3);
-}
-#endif
+void isr_timer0_chan0(void) {irq_handler(0, 0);}
+void isr_timer0_chan1(void) {irq_handler(0, 1);}
+void isr_timer1_chan0(void) {irq_handler(1, 0);}
+void isr_timer1_chan1(void) {irq_handler(1, 1);}
+void isr_timer2_chan0(void) {irq_handler(2, 0);}
+void isr_timer2_chan1(void) {irq_handler(2, 1);}
+void isr_timer3_chan0(void) {irq_handler(3, 0);}
+void isr_timer3_chan1(void) {irq_handler(3, 1);}


### PR DESCRIPTION
This PR does:
- complete rework of periph/timer.c, based on TI CC2538
- adapt timer config of board cc2650stk (aka TI SensorTag)

With current master `tests/periph_timer` does not work correctly, see output:

```
2017-07-08 21:24:47,864 - INFO # Test for peripheral TIMERs
2017-07-08 21:24:47,864 - INFO # 
2017-07-08 21:24:47,869 - INFO # This test will test all configured peripheral timers of the
2017-07-08 21:24:47,875 - INFO # targeted platform. For each timer, it will set each channel with
2017-07-08 21:24:47,881 - INFO # an incrementing timeout. CH0 set to 5ms, CH1 to 10ms, CH2 to 15ms
2017-07-08 21:24:47,881 - INFO # and so on.
2017-07-08 21:24:47,887 - INFO # In the output you should see that every channel fired, after an
2017-07-08 21:24:47,892 - INFO # evenly distributed amount of time -> the shown diff values should
2017-07-08 21:24:47,896 - INFO # be pretty much equal (to some jitter...)
2017-07-08 21:24:47,901 - INFO # This test does however NOT show, if the timeouts were correct in
2017-07-08 21:24:47,907 - INFO # relation to the expected real-time ~ use e.g. tests/xtimer_msg for
2017-07-08 21:24:47,908 - INFO # this.
2017-07-08 21:24:47,908 - INFO # 
2017-07-08 21:24:47,908 - INFO # 
2017-07-08 21:24:47,910 - INFO # Available timers: 2
2017-07-08 21:24:47,910 - INFO # 
2017-07-08 21:24:47,912 - INFO # Testing TIMER_0:
2017-07-08 21:24:47,914 - INFO # TIMER_0: initialization successful
2017-07-08 21:24:47,916 - INFO # TIMER_0: stopped
2017-07-08 21:24:47,918 - INFO # TIMER_0: set channel 0 to 5000
2017-07-08 21:24:47,920 - INFO # TIMER_0: starting
2017-07-08 21:24:47,925 - INFO # TIMER_0: channel 0 fired at SW count        0 - init:        0
2017-07-08 21:24:47,926 - INFO # 
2017-07-08 21:24:47,927 - INFO # Testing TIMER_1:
2017-07-08 21:24:47,930 - INFO # TIMER_1: initialization successful
2017-07-08 21:24:47,932 - INFO # TIMER_1: stopped
2017-07-08 21:24:47,934 - INFO # TIMER_1: set channel 0 to 5000
2017-07-08 21:24:47,936 - INFO # TIMER_1: starting
2017-07-08 21:24:47,941 - INFO # TIMER_1: channel 0 fired at SW count        0 - init:        0
2017-07-08 21:24:47,941 - INFO # 
```

Though the tests compiles and runs on the board, please note that both timers fire at sw count 0.

With the fix of this PR the output looks like this: [edit] update output
```
2017-07-08 21:34:41,736 - INFO # Test for peripheral TIMERs
2017-07-08 21:34:41,736 - INFO # 
2017-07-08 21:34:41,741 - INFO # This test will test all configured peripheral timers of the
2017-07-08 21:34:41,746 - INFO # targeted platform. For each timer, it will set each channel with
2017-07-08 21:34:41,752 - INFO # an incrementing timeout. CH0 set to 5ms, CH1 to 10ms, CH2 to 15ms
2017-07-08 21:34:41,753 - INFO # and so on.
2017-07-08 21:34:41,759 - INFO # In the output you should see that every channel fired, after an
2017-07-08 21:34:41,764 - INFO # evenly distributed amount of time -> the shown diff values should
2017-07-08 21:34:41,768 - INFO # be pretty much equal (to some jitter...)
2017-07-08 21:34:41,773 - INFO # This test does however NOT show, if the timeouts were correct in
2017-07-08 21:34:41,779 - INFO # relation to the expected real-time ~ use e.g. tests/xtimer_msg for
2017-07-08 21:34:41,780 - INFO # this.
2017-07-08 21:34:41,780 - INFO # 
2017-07-08 21:34:41,780 - INFO # 
2017-07-08 21:34:41,781 - INFO # Available timers: 4
2017-07-08 21:34:41,782 - INFO # 
2017-07-08 21:34:41,783 - INFO # Testing TIMER_0:
2017-07-08 21:34:41,786 - INFO # TIMER_0: initialization successful
2017-07-08 21:34:41,787 - INFO # TIMER_0: stopped
2017-07-08 21:34:41,790 - INFO # TIMER_0: set channel 0 to 5000
2017-07-08 21:34:41,793 - INFO # TIMER_0: set channel 1 to 10000
2017-07-08 21:34:41,795 - INFO # TIMER_0: starting
2017-07-08 21:34:41,810 - INFO # TIMER_0: channel 0 fired at SW count    18463 - init:    18463
2017-07-08 21:34:41,815 - INFO # TIMER_0: channel 1 fired at SW count    36918 - diff:    18455
2017-07-08 21:34:41,815 - INFO # 
2017-07-08 21:34:41,816 - INFO # Testing TIMER_1:
2017-07-08 21:34:41,820 - INFO # TIMER_1: ERROR on initialization - skipping
2017-07-08 21:34:41,821 - INFO # 
2017-07-08 21:34:41,821 - INFO # 
2017-07-08 21:34:41,822 - INFO # Testing TIMER_2:
2017-07-08 21:34:41,825 - INFO # TIMER_2: initialization successful
2017-07-08 21:34:41,827 - INFO # TIMER_2: stopped
2017-07-08 21:34:41,829 - INFO # TIMER_2: set channel 0 to 5000
2017-07-08 21:34:41,833 - INFO # TIMER_2: set channel 1 to 10000
2017-07-08 21:34:41,834 - INFO # TIMER_2: starting
2017-07-08 21:34:41,849 - INFO # TIMER_2: channel 0 fired at SW count    18465 - init:    18465
2017-07-08 21:34:41,854 - INFO # TIMER_2: channel 1 fired at SW count    36920 - diff:    18455
2017-07-08 21:34:41,854 - INFO # 
2017-07-08 21:34:41,856 - INFO # Testing TIMER_3:
2017-07-08 21:34:41,860 - INFO # TIMER_3: ERROR on initialization - skipping
2017-07-08 21:34:41,860 - INFO # 
2017-07-08 21:34:41,860 - INFO # 
```

Please note, I changed the board config of cc2650stk to enable all 4 available timers, timer 0 and 2 are in 16Bit mode with 2 channels and timers 1 and 3 are in 32Bit mode with 1 channel. Further note, in 32Bit there is no prescaler and the timer has to run with cpu clock frequency (48MHz) which is why init with 1MHz fails here. 