### PR TITLE
net/gcoap: Create confirm request infrastructure and adapt existing messaging

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Ken Bannister. All rights reserved.
+ * Copyright (c) 2015-2017 Ken Bannister. All rights reserved.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Ken Bannister. All rights reserved.
+ * Copyright (c) 2015-2017 Ken Bannister. All rights reserved.
  *               2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -303,6 +303,11 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Value for send_limit in request memo when non-confirmable type
+ */
+#define GCOAP_SEND_LIMIT_NON    (-1)
+
+/**
  * @brief   Time in usec that the event loop waits for an incoming CoAP message
  */
 #ifndef GCOAP_RECV_TIMEOUT
@@ -425,12 +430,27 @@ typedef void (*gcoap_resp_handler_t)(unsigned req_state, coap_pkt_t* pdu,
                                      sock_udp_ep_t *remote);
 
 /**
+ * @brief  Extends request memo for resending a confirmable request.
+ */
+typedef struct {
+    sock_udp_ep_t remote_ep;            /**< Remote endpoint */
+    uint8_t *pdu_buf;                   /**< Buffer containing the PDU */
+    size_t pdu_len;                     /**< Length of pdu_buf */
+} gcoap_resend_t;
+
+/**
  * @brief   Memo to handle a response for a request
  */
 typedef struct {
     unsigned state;                     /**< State of this memo, a GCOAP_MEMO... */
-    uint8_t hdr_buf[GCOAP_HEADER_MAXLEN];
-                                        /**< Stores a copy of the request header */
+    int send_limit;                     /**< Remaining resends, 0 if none;
+                                             GCOAP_SEND_LIMIT_NON if non-confirmable */
+    union {
+        uint8_t hdr_buf[GCOAP_HEADER_MAXLEN];
+                                        /**< Copy of PDU header, if no resends */
+        gcoap_resend_t data;            /**< Endpoint and PDU buffer, for resend */
+    } msg;                              /**< Request message data; if confirmable,
+                                             supports resending message */
     gcoap_resp_handler_t resp_handler;  /**< Callback for the response */
     xtimer_t response_timer;            /**< Limits wait for response */
     msg_t timeout_msg;                  /**< For response timer */

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Ken Bannister. All rights reserved.
+ * Copyright (c) 2015-2017 Ken Bannister. All rights reserved.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -347,7 +347,7 @@ static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu,
 
         /* setup memo PDU from memo header */
         memo                 = &_coap_state.open_reqs[i];
-        coap_hdr_t *memo_hdr = (coap_hdr_t *) &memo->hdr_buf[0];
+        coap_hdr_t *memo_hdr = (coap_hdr_t *) &memo->msg.hdr_buf[0];
         memo_pdu.hdr         = memo_hdr;
         if (coap_get_token_len(&memo_pdu)) {
             memo_pdu.token = &memo_hdr->data[0];
@@ -379,7 +379,7 @@ static void _expire_request(gcoap_request_memo_t *memo)
         memo->state = GCOAP_MEMO_TIMEOUT;
         /* Pass response to handler */
         if (memo->resp_handler) {
-            req.hdr = (coap_hdr_t *)&memo->hdr_buf[0];   /* for reference */
+            req.hdr = (coap_hdr_t *)&memo->msg.hdr_buf[0];   /* for reference */
             memo->resp_handler(memo->state, &req, NULL);
         }
         memo->state = GCOAP_MEMO_UNUSED;
@@ -692,7 +692,8 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
     mutex_unlock(&_coap_state.lock);
 
     if (memo) {
-        memcpy(&memo->hdr_buf[0], buf, GCOAP_HEADER_MAXLEN);
+        memo->send_limit = GCOAP_SEND_LIMIT_NON;
+        memcpy(&memo->msg.hdr_buf[0], buf, GCOAP_HEADER_MAXLEN);
         memo->resp_handler = resp_handler;
 
         size_t res = sock_udp_send(&_sock, buf, len, remote);

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -35,8 +35,7 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                                          sock_udp_ep_t *remote);
 static ssize_t _finish_pdu(coap_pkt_t *pdu, uint8_t *buf, size_t len);
 static void _expire_request(gcoap_request_memo_t *memo);
-static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *pdu,
-                                                            uint8_t *buf, size_t len);
+static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *pdu);
 static void _find_resource(coap_pkt_t *pdu, coap_resource_t **resource_ptr,
                                             gcoap_listener_t **listener_ptr);
 static int _find_observer(sock_udp_ep_t **observer, sock_udp_ep_t *remote);
@@ -156,7 +155,7 @@ static void _listen(sock_udp_t *sock)
 
     /* incoming response */
     else {
-        _find_req_memo(&memo, &pdu, buf, sizeof(buf));
+        _find_req_memo(&memo, &pdu);
         if (memo) {
             xtimer_remove(&memo->response_timer);
             memo->state = GCOAP_MEMO_RESP;
@@ -331,39 +330,34 @@ static ssize_t _finish_pdu(coap_pkt_t *pdu, uint8_t *buf, size_t len)
  * Finds the memo for an outstanding request within the _coap_state.open_reqs
  * array. Matches on token.
  *
- * src_pdu Source for the match token
+ * memo_ptr[out] -- Registered request memo, or NULL if not found
+ * src_pdu[in] -- PDU for token to match
  */
-static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu,
-                                                            uint8_t *buf, size_t len)
+static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu)
 {
-    gcoap_request_memo_t *memo;
-    coap_pkt_t memo_pdu = { .token = NULL };
-    (void) buf;
-    (void) len;
+    *memo_ptr = NULL;
+    /* no need to initialize struct; we only care about buffer contents below */
+    coap_pkt_t memo_pdu_data;
+    coap_pkt_t *memo_pdu = &memo_pdu_data;
+    unsigned cmplen      = coap_get_token_len(src_pdu);
 
     for (int i = 0; i < GCOAP_REQ_WAITING_MAX; i++) {
         if (_coap_state.open_reqs[i].state == GCOAP_MEMO_UNUSED)
             continue;
 
-        /* setup memo PDU from memo header */
-        memo                 = &_coap_state.open_reqs[i];
-        coap_hdr_t *memo_hdr = (coap_hdr_t *) &memo->msg.hdr_buf[0];
-        memo_pdu.hdr         = memo_hdr;
-        if (coap_get_token_len(&memo_pdu)) {
-            memo_pdu.token = &memo_hdr->data[0];
+        gcoap_request_memo_t *memo = &_coap_state.open_reqs[i];
+        if (memo->send_limit == GCOAP_SEND_LIMIT_NON) {
+            memo_pdu->hdr = (coap_hdr_t *) &memo->msg.hdr_buf[0];
         }
-        /* match on token */
-        if (coap_get_token_len(src_pdu) == coap_get_token_len(&memo_pdu)) {
-            uint8_t *src_byte  = src_pdu->token;
-            uint8_t *memo_byte = memo_pdu.token;
-            size_t j;
-            for (j = 0; j < coap_get_token_len(src_pdu); j++) {
-                if (*src_byte++ != *memo_byte++) {
-                    break;      /* token mismatch */
-                }
-            }
-            if (j == coap_get_token_len(src_pdu)) {
+        else {
+            memo_pdu->hdr = (coap_hdr_t *) memo->msg.data.pdu_buf;
+        }
+
+        if (coap_get_token_len(memo_pdu) == cmplen) {
+            memo_pdu->token = &memo_pdu->hdr->data[0];
+            if (memcmp(src_pdu->token, memo_pdu->token, cmplen) == 0) {
                 *memo_ptr = memo;
+                break;
             }
         }
     }


### PR DESCRIPTION
This PR implements the second step in the confirmable messaging plan in #7192. It extends the request memo struct to support sending, and resending, a message of type CON. In addition, the existing message sending code has been adapted to use the changed struct.

This PR allows sending a request of CON type, but the message will not be resent if the response times out. The gcoap example also has been updated to specify use of the CON type, by addition of a `-c` option. Notice the call to `coap_hdr_set_type()` after initializing the PDU in `gcoap_cli_cmd()`.

The resend implementation and documentation on sending a confirmable request are the subjects of the next PR in the series. I have started to implement it as a WIP (#7337) to verify that the present PR provides what's required.