### PR TITLE
boards: use EDBG flasher with arduino-zero and saml21-xpro

### DIFF
--- a/boards/arduino-zero/Makefile.include
+++ b/boards/arduino-zero/Makefile.include
@@ -2,4 +2,7 @@
 export CPU = samd21
 export CPU_MODEL = samd21g18a
 
+# set edbg device type
+EDBG_DEVICE_TYPE = atmel_cm0p
+
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/saml21-xpro/Makefile.include
+++ b/boards/saml21-xpro/Makefile.include
@@ -3,4 +3,7 @@ export CPU = saml21
 export CPU_MODEL = saml21j18a
 export CFLAGS += -D__SAML21J18A__
 
+# set edbg device type
+EDBG_DEVICE_TYPE = atmel_cm0p
+
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=edbg
 PKG_URL=https://github.com/ataradov/edbg
-PKG_VERSION=935bb4b1efd0e2f8434cf97443e0d95b9e02ec1d
+PKG_VERSION=76f85abdea212ba23760723cce15e00ca4ae4b76
 PKG_LICENSE=BSD-3-Clause
 PKG_BUILDDIR=$(CURDIR)/bin
 


### PR DESCRIPTION
While testing the RC2 on arduino-zero board, I noticed that openocd was still used although EDBG programmer can also be used with this one.

In the meantime, this PR configure EDBG as default programmer for saml21-xpro.