### PR TITLE
cpu, cc26x0: add missing Makefile.features, with pm

### DIFF
--- a/cpu/cc26x0/Makefile.features
+++ b/cpu/cc26x0/Makefile.features
@@ -1,0 +1,1 @@
+FEATURES_PROVIDED += periph_pm


### PR DESCRIPTION
this PR adds a missing `Makefile.features` for `cpu/cc26x0` to enable freature `pm`. Similar to #6692 this is required, as otherwise RIOT (seems to) stop because a switch to idle-thread (e.g., after xtimer_usleep) will put the device into deep-sleep, from which it will never wake up.