### PR TITLE
Board cc2650stk: add full xtimer config

### DIFF
--- a/boards/cc2650stk/include/board.h
+++ b/boards/cc2650stk/include/board.h
@@ -29,10 +29,16 @@ extern "C" {
 #endif
 
 /**
- * @name   Xtimer configuration
+ * @name    xtimer configuration
  * @{
  */
-#define XTIMER_WIDTH                (16)
+#define XTIMER_DEV          (0)
+#define XTIMER_CHAN         (0)
+#define XTIMER_WIDTH        (16)
+#define XTIMER_SHIFT        (0)
+#define XTIMER_HZ           (1000000UL)
+#define XTIMER_BACKOFF      (50)
+#define XTIMER_ISR_BACKOFF  (40)
 /** @} */
 
 /**


### PR DESCRIPTION
PR adds missing (explicit) xtimer configuration parameters to board configuration.

PR is based on #7335 ~~and #7342~~.

Nice to know: with all 3 PRs applied, xtimer tests start working.