### PR TITLE
Board, cc2650stk: fix button config

### DIFF
--- a/boards/cc2650stk/include/board.h
+++ b/boards/cc2650stk/include/board.h
@@ -40,9 +40,9 @@ extern "C" {
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(0, 4)
-#define BTN0_MODE           GPIO_IN
+#define BTN0_MODE           GPIO_IN_PU
 #define BTN1_PIN            GPIO_PIN(0, 0)
-#define BTN1_MODE           GPIO_IN
+#define BTN1_MODE           GPIO_IN_PU
 /** @} */
 
 /**


### PR DESCRIPTION
this PR fixes the button gpio configuration for board cc2650stk (aka SensorTag), the problem is that in `tests/button` on master the buttons will be trigger in a loop without actually pressing them. Adding a PULLUP on init fixes this.

PR requires #7335 to fix a more general platform issue.