### PR TITLE
pkg/spiffs: implement statvfs and improve doc

### DIFF
--- a/sys/include/fs/spiffs_fs.h
+++ b/sys/include/fs/spiffs_fs.h
@@ -14,6 +14,25 @@
  * The RIOT integration of SPIFFS follows the SPIFFS wiki:
  * https://github.com/pellepl/spiffs/wiki/Integrate-spiffs#integrating-spiffs
  *
+ * The RIOT integration uses by default the @p SPIFFS_HAL_CALLBACK_EXTRA option
+ * and needs a @p mtd device, passed as spiffs_desc_t::dev.
+ *
+ * If one disable @p SPIFFS_HAL_CALLBACK_EXTRA, the mtd device is passed through
+ * the @p SPIFFS_MTD_DEV macro as a @p mtd_dev_t pointer.
+ *
+ * Note that only one filesystem can be used if @p SPIFFS_HAL_CALLBACK_EXTRA is
+ * disabled.
+ *
+ * @p SPIFFS_SINGLETON is disabled by default, the memory layout is retrieved from
+ * the @p mtd device used. If @p SPIFFS_SINGLETON is enabled, the proper SPIFFS
+ * variables must be set (see spiffs_config.h from SPIFFS).
+ *
+ * The default integration enable @p SPIFFS_CACHE and uses the macro
+ * @p SPIFFS_FS_CACHE_SIZE as cache size.
+ *
+ * @p SPIFFS_LOCK and @p SPIFFS_UNLOCK are also defined in the RIOT custom
+ * spiffs_config.h to use @p spiffs_lock() and @p spiffs_unlock()
+ *
  * @{
  *
  * @file
@@ -101,6 +120,26 @@ typedef struct spiffs_desc {
 
 /** The SPIFFS vfs driver, a pointer to a spiffs_desc_t must be provided as vfs_mountp::private_data */
 extern const vfs_file_system_t spiffs_file_system;
+
+/**
+ * @brief SPIFFS lock function
+ *
+ * This function must be used by @p SPIFFS_LOCK to lock the file system using
+ * the spiffs_desc_t::lock.
+ *
+ * @param fs   spiffs descriptor
+ */
+void spiffs_lock(struct spiffs_t *fs);
+
+/**
+ * @brief SPIFFS unlock function
+ *
+ * This function must be used by @p SPIFFS_UNLOCK to lock the file system using
+ * the spiffs_desc_t::lock.
+ *
+ * @param fs   spiffs descriptor
+ */
+void spiffs_unlock(struct spiffs_t *fs);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This implements the `statvfs` fs ops. The shell command `vfs df` can show file system usage.

Documentation is also improved.