### PR TITLE
gnrc tcp: use push flag in send

### DIFF
--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -275,7 +275,7 @@ static int _fsm_call_send(gnrc_tcp_tcb_t *tcb, void *buf, size_t len)
         /* Calculate payload size for this segment */
         gnrc_pktsnip_t *out_pkt = NULL;
         uint16_t seq_con = 0;
-        _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt, tcb->rcv_nxt, buf, payload);
+        _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK | MSK_PSH, tcb->snd_nxt, tcb->rcv_nxt, buf, payload);
         _pkt_setup_retransmit(tcb, out_pkt, false);
         _pkt_send(tcb, out_pkt, seq_con, false);
         return payload;


### PR DESCRIPTION
This PR sets the PUSH flag in tcp send. ~~The~~ This fixes performance issues when sending from RIOT to a Linux (or macOS) based host system, because TCP on Linux is optimized for larger, continues flows it tries to use _delay ACKs_ which is counter productive for RIOTs TCP with windows size 1. Using PUSH flag it forces the Linux host to send out an ACK immediately for each received segment instead of delaying it.