### PR TITLE
tests/xtimer: add small values test for xtimer_usleep

### DIFF
--- a/tests/xtimer_usleep_short/Makefile
+++ b/tests/xtimer_usleep_short/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	./tests/01-run.py

--- a/tests/xtimer_usleep_short/main.c
+++ b/tests/xtimer_usleep_short/main.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 HAW-Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       xtimer_usleep_short test application
+ *
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ * @}
+ */
+#include <stdio.h>
+#include "xtimer.h"
+
+#define TEST_USLEEP_MIN (0)
+#define TEST_USLEEP_MAX (500)
+
+int main(void)
+{
+    xtimer_sleep(3);
+    printf("This test will call xtimer_usleep for values from %d down to %d\n",
+            TEST_USLEEP_MAX, TEST_USLEEP_MIN);
+
+    for (int i = TEST_USLEEP_MAX; i >= TEST_USLEEP_MIN; i--) {
+        printf("going to sleep %d usecs...\n", i);
+        xtimer_usleep(i);
+    }
+
+    puts("Test end.");
+
+    return 0;
+}

--- a/tests/xtimer_usleep_short/main.c
+++ b/tests/xtimer_usleep_short/main.c
@@ -33,7 +33,7 @@ int main(void)
         xtimer_usleep(i);
     }
 
-    puts("Test end.");
+    puts("[SUCCESS]");
 
     return 0;
 }

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -26,9 +26,9 @@ def testfunc(child):
             print("xtimer stuck when trying to sleep %d usecs" % (i+1));
             print("[FAILED]")
             break;
-        i = i -1
+        i = i - 1
 
-    child.expect(u"Test end.", timeout=3)
+    child.expect(u"[SUCCESS]", timeout=3)
 
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2017 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+import pexpect
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+
+    child.expect(u"This test will call xtimer_usleep for values from \\d+ down to \\d+\r\n")
+
+    i = 500
+
+    while (i >= 0):
+        try:
+            child.expect(u"going to sleep \\d+ usecs...\r\n", timeout=3)
+        except pexpect.TIMEOUT:
+            print("xtimer stuck when trying to sleep %d usecs" % (i+1));
+            print("[FAILED]")
+            break;
+        i = i -1
+
+    child.expect(u"Test end.", timeout=3)
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
On some boards xtimer_usleep never returns when called with rather small values. 
This adds a small test that shows if the problem exists on the used platform. 
On boards where this test fails (e.g `nucleo-l1`) the xtimer config ([`XTIMER_BACKOFF `](https://github.com/RIOT-OS/RIOT/blob/master/boards/nucleo-l1/include/board.h#L37)?)  probably needs to be adjusted. See #7347 for more details. 