### PR TITLE
boards: re-work LED handling

### DIFF
--- a/boards/samr21-xpro/Makefile.include
+++ b/boards/samr21-xpro/Makefile.include
@@ -5,4 +5,7 @@ export CPU_MODEL = samr21g18a
 # set edbg device type
 EDBG_DEVICE_TYPE = atmel_cm0p
 
+# use shared on-board LED module
+USEMODULE += onboard_led
+
 include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -20,13 +20,12 @@
  * @}
  */
 
-#include "board.h"
-#include "periph/gpio.h"
+#include "onboard_led.h"
 
 void board_init(void)
 {
     /* initialize the on-board LED */
-    gpio_init(LED0_PIN, GPIO_OUT);
+    onboard_led_init();
 
     /* initialize the CPU */
     cpu_init();

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -52,18 +52,21 @@ extern "C" {
                                      .reset_pin = GPIO_PIN(PB, 15)}
 
 /**
- * @name    LED pin definitions and handlers
+ * @name    On-board LED mapping
  * @{
  */
-#define LED0_PIN            GPIO_PIN(0, 19)
-
-#define LED_PORT            PORT->Group[0]
-#define LED0_MASK           (1 << 19)
-
-#define LED0_ON             (LED_PORT.OUTCLR.reg = LED0_MASK)
-#define LED0_OFF            (LED_PORT.OUTSET.reg = LED0_MASK)
-#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+#define ONBOARD_LED_ACTIVE_LOW
+static const gpio_t led_config[] = {
+    GPIO_PIN(PA, 19)        /* LED0 */
+};
 /** @} */
+
+/**
+ * @brief   Give on-board LEDs some user friendly names [optional]
+ */
+enum {
+    LED0
+};
 
 /**
  * @name    SW0 (Button) pin definitions

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = stm32f3
 export CPU_MODEL = stm32f303vc
 
+# use on-board LEDs
+USEMODULE += onboard_led
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/stm32f3discovery/board.c
+++ b/boards/stm32f3discovery/board.c
@@ -18,20 +18,12 @@
  * @}
  */
 
-#include "board.h"
-#include "periph/gpio.h"
+#include "onboard_led.h"
 
 void board_init(void)
 {
     /* initialize the boards LEDs */
-    gpio_init(LED0_PIN, GPIO_OUT);
-    gpio_init(LED1_PIN, GPIO_OUT);
-    gpio_init(LED2_PIN, GPIO_OUT);
-    gpio_init(LED3_PIN, GPIO_OUT);
-    gpio_init(LED4_PIN, GPIO_OUT);
-    gpio_init(LED5_PIN, GPIO_OUT);
-    gpio_init(LED6_PIN, GPIO_OUT);
-    gpio_init(LED7_PIN, GPIO_OUT);
+    onboard_led_init();
 
     /* initialize the CPU */
     cpu_init();

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -23,66 +23,39 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name Macros for controlling the on-board LEDs.
- * @{
+ * @brief    On-board LED configuration
  */
-#define LED0_PIN            GPIO_PIN(PORT_E, 9)
-#define LED1_PIN            GPIO_PIN(PORT_E, 8)
-#define LED2_PIN            GPIO_PIN(PORT_E, 10)
-#define LED3_PIN            GPIO_PIN(PORT_E, 15)
-#define LED4_PIN            GPIO_PIN(PORT_E, 11)
-#define LED5_PIN            GPIO_PIN(PORT_E, 14)
-#define LED6_PIN            GPIO_PIN(PORT_E, 12)
-#define LED7_PIN            GPIO_PIN(PORT_E, 13)
+static const gpio_t led_config[] = {
+    GPIO_PIN(PORT_E, 9),
+    GPIO_PIN(PORT_E, 8),
+    GPIO_PIN(PORT_E, 10),
+    GPIO_PIN(PORT_E, 15),
+    GPIO_PIN(PORT_E, 11),
+    GPIO_PIN(PORT_E, 14),
+    GPIO_PIN(PORT_E, 12),
+    GPIO_PIN(PORT_E, 13)
+};
 
-#define LED_PORT            GPIOE
-#define LED0_MASK           (1 << 9)
-#define LED1_MASK           (1 << 8)
-#define LED2_MASK           (1 << 10)
-#define LED3_MASK           (1 << 15)
-#define LED4_MASK           (1 << 11)
-#define LED5_MASK           (1 << 14)
-#define LED6_MASK           (1 << 12)
-#define LED7_MASK           (1 << 13)
-
-#define LED0_ON             (LED_PORT->BSRR = LED0_MASK)
-#define LED0_OFF            (LED_PORT->BSRR = (LED0_MASK << 16))
-#define LED0_TOGGLE         (LED_PORT->ODR  ^= LED0_MASK)
-
-#define LED1_ON             (LED_PORT->BSRR = LED1_MASK)
-#define LED1_OFF            (LED_PORT->BSRR = (LED1_MASK << 16))
-#define LED1_TOGGLE         (LED_PORT->ODR  ^= LED1_MASK)
-
-#define LED2_ON             (LED_PORT->BSRR = LED2_MASK)
-#define LED2_OFF            (LED_PORT->BSRR = (LED2_MASK << 16))
-#define LED2_TOGGLE         (LED_PORT->ODR  ^= LED2_MASK)
-
-#define LED3_ON             (LED_PORT->BSRR = LED3_MASK)
-#define LED3_OFF            (LED_PORT->BSRR = (LED3_MASK << 16))
-#define LED3_TOGGLE         (LED_PORT->ODR  ^= LED3_MASK)
-
-#define LED4_ON             (LED_PORT->BSRR = LED4_MASK)
-#define LED4_OFF            (LED_PORT->BSRR = (LED4_MASK << 16))
-#define LED4_TOGGLE         (LED_PORT->ODR  ^= LED4_MASK)
-
-#define LED5_ON             (LED_PORT->BSRR = LED5_MASK)
-#define LED5_OFF            (LED_PORT->BSRR = (LED5_MASK << 16))
-#define LED5_TOGGLE         (LED_PORT->ODR  ^= LED5_MASK)
-
-#define LED6_ON             (LED_PORT->BSRR = LED6_MASK)
-#define LED6_OFF            (LED_PORT->BSRR = (LED6_MASK << 16))
-#define LED6_TOGGLE         (LED_PORT->ODR  ^= LED6_MASK)
-
-#define LED7_ON             (LED_PORT->BSRR = LED7_MASK)
-#define LED7_OFF            (LED_PORT->BSRR = (LED7_MASK << 16))
-#define LED7_TOGGLE         (LED_PORT->ODR  ^= LED7_MASK)
-/** @} */
+/**
+ * @brief   Give on-board LEDs some user friendly names [optional]
+ */
+enum {
+    LD3,
+    LD4,
+    LD5,
+    LD6,
+    LD7,
+    LD8,
+    LD9,
+    LD10
+};
 
 /**
  * @brief User button

--- a/drivers/include/onboard_led.h
+++ b/drivers/include/onboard_led.h
@@ -44,18 +44,33 @@ extern "C" {
  */
 void onboard_led_init(void);
 
+/**
+ * @brief   Turn on the given on-board LED
+ *
+ * @param[in] num       LED to turn on
+ */
 static inline void onboard_led_on(unsigned num)
 {
     assert(num < LED_NUMOF);
     TURN_ON(led_config[num]);
 }
 
+/**
+ * @brief   Turn off the given on-board LED
+ *
+ * @param[in] num       LED to turn off
+ */
 static inline void onboard_led_off(unsigned num)
 {
     assert(num < LED_NUMOF);
     TURN_OFF(led_config[num]);
 }
 
+/**
+ * @brief   Toggle the given on-board LED
+ *
+ * @param[in] num       LED to toggle
+ */
 static inline void onboard_led_toggle(unsigned num)
 {
     assert(num < LED_NUMOF);

--- a/drivers/include/onboard_led.h
+++ b/drivers/include/onboard_led.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_onboard_led
+ * @ingroup     drivers
+ * @brief       Abstraction for handling on-board LEDs
+ * @{
+ *
+ * @file
+ * @brief       On-board LED handling abstraction
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef ONBOARD_LED_H
+#define ONBOARD_LED_H
+
+#include "board.h"
+#include "assert.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LED_NUMOF       (sizeof(led_config) / sizeof(led_config[0]))
+
+#ifndef ONBOARD_LED_ACTIVE_LOW
+#define TURN_ON         gpio_set
+#define TURN_OFF        gpio_clear
+#else
+#define TURN_ON         gpio_clear
+#define TURN_OFF        gpio_set
+#endif
+
+/**
+ * @brief   Initialize all available on-board LEDs
+ */
+void onboard_led_init(void);
+
+static inline void onboard_led_on(unsigned num)
+{
+    assert(num < LED_NUMOF);
+    TURN_ON(led_config[num]);
+}
+
+static inline void onboard_led_off(unsigned num)
+{
+    assert(num < LED_NUMOF);
+    TURN_OFF(led_config[num]);
+}
+
+static inline void onboard_led_toggle(unsigned num)
+{
+    assert(num < LED_NUMOF);
+    gpio_toggle(led_config[num]);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ONBOARD_LED_H */
+/** @} */

--- a/drivers/onboard_led/Makefile
+++ b/drivers/onboard_led/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/onboard_led/onboard_led.c
+++ b/drivers/onboard_led/onboard_led.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_onboard_led
+ * @{
+ *
+ * @file
+ * @brief       On-board LED abstraction implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "onboard_led.h"
+
+void onboard_led_init(void)
+{
+    for (unsigned i = 0; i < LED_NUMOF; i++) {
+        gpio_init(led_config[i], GPIO_OUT);
+        onboard_led_off(i);
+    }
+}

--- a/tests/leds/main.c
+++ b/tests/leds/main.c
@@ -21,8 +21,9 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#include "board.h"
-#include "periph_conf.h"
+#ifdef MODULE_ONBOARD_LED
+#include "onboard_led.h"
+#endif
 
 #ifdef CLOCK_CORECLOCK
 #define DELAY_SHORT         (CLOCK_CORECLOCK / 50)
@@ -40,168 +41,33 @@ void dumb_delay(uint32_t delay)
 
 int main(void)
 {
-    int numof = 0;
-
-    /* get the number of available LED's and turn them all off*/
-#ifdef LED0_ON
-    ++numof;
-    LED0_OFF;
-#endif
-#ifdef LED1_ON
-    ++numof;
-    LED1_OFF;
-#endif
-#ifdef LED2_ON
-    ++numof;
-    LED2_OFF;
-#endif
-#ifdef LED3_ON
-    ++numof;
-    LED3_OFF;
-#endif
-#ifdef LED4_ON
-    ++numof;
-    LED4_OFF;
-#endif
-#ifdef LED5_ON
-    ++numof;
-    LED5_OFF;
-#endif
-#ifdef LED6_ON
-    ++numof;
-    LED6_OFF;
-#endif
-#ifdef LED7_ON
-    ++numof;
-    LED7_OFF;
-#endif
-
     puts("On-board LED test\n");
-    /* cppcheck-suppress knownConditionTrueFalse
-     * rationale: board-dependent ifdefs */
-    if (numof == 0) {
-        puts("NO LEDs AVAILABLE");
-    }
-    else {
-        printf("Available LEDs: %i\n\n", numof);
-        puts("Will now light up each LED once short and twice long in a loop");
+
+#ifndef MODULE_ONBOARD_LED
+
+    puts("No on-board LED(s) available");
+
+#else
+
+    printf("Available LEDs: %u\n\n", LED_NUMOF);
+    puts("Will now light up each LED once short and twice long in a loop");
+
+    for (unsigned i = 0; i < LED_NUMOF; i++) {
+        onboard_led_on(i);
+        dumb_delay(DELAY_LONG);
+        onboard_led_off(i);
+        dumb_delay(DELAY_LONG);
+        onboard_led_toggle(i);
+        dumb_delay(DELAY_SHORT);
+        onboard_led_toggle(i);
+        dumb_delay(DELAY_SHORT);
+        onboard_led_toggle(i);
+        dumb_delay(DELAY_SHORT);
+        onboard_led_toggle(i);
+        dumb_delay(DELAY_LONG);
     }
 
-
-    while (1) {
-#ifdef LED0_ON
-        LED0_ON;
-        dumb_delay(DELAY_LONG);
-        LED0_OFF;
-        dumb_delay(DELAY_LONG);
-        LED0_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED0_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED0_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED0_TOGGLE;
-        dumb_delay(DELAY_LONG);
 #endif
-#ifdef LED1_ON
-        LED1_ON;
-        dumb_delay(DELAY_LONG);
-        LED1_OFF;
-        dumb_delay(DELAY_LONG);
-        LED1_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED1_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED1_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED1_TOGGLE;
-        dumb_delay(DELAY_LONG);
-#endif
-#ifdef LED2_ON
-        LED2_ON;
-        dumb_delay(DELAY_LONG);
-        LED2_OFF;
-        dumb_delay(DELAY_LONG);
-        LED2_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED2_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED2_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED2_TOGGLE;
-        dumb_delay(DELAY_LONG);
-#endif
-#ifdef LED3_ON
-        LED3_ON;
-        dumb_delay(DELAY_LONG);
-        LED3_OFF;
-        dumb_delay(DELAY_LONG);
-        LED3_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED3_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED3_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED3_TOGGLE;
-        dumb_delay(DELAY_LONG);
-#endif
-#ifdef LED4_ON
-        LED4_ON;
-        dumb_delay(DELAY_LONG);
-        LED4_OFF;
-        dumb_delay(DELAY_LONG);
-        LED4_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED4_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED4_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED4_TOGGLE;
-        dumb_delay(DELAY_LONG);
-#endif
-#ifdef LED5_ON
-        LED5_ON;
-        dumb_delay(DELAY_LONG);
-        LED5_OFF;
-        dumb_delay(DELAY_LONG);
-        LED5_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED5_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED5_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED5_TOGGLE;
-        dumb_delay(DELAY_LONG);
-#endif
-#ifdef LED6_ON
-        LED6_ON;
-        dumb_delay(DELAY_LONG);
-        LED6_OFF;
-        dumb_delay(DELAY_LONG);
-        LED6_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED6_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED6_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED6_TOGGLE;
-        dumb_delay(DELAY_LONG);
-#endif
-#ifdef LED7_ON
-        LED7_ON;
-        dumb_delay(DELAY_LONG);
-        LED7_OFF;
-        dumb_delay(DELAY_LONG);
-        LED7_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED7_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED7_TOGGLE;
-        dumb_delay(DELAY_SHORT);
-        LED7_TOGGLE;
-        dumb_delay(DELAY_LONG);
-#endif
-    }
 
     return 0;
 }


### PR DESCRIPTION
WIP/RFC

I quickly played around a bit when thinking about #7321... Comments welcome!

So far only adapted `samr21-xpro` and `stm32f3discovery`. 

Code size for `tests/leds`:
`stm32f3discovery` (8 LEDs) - before 8692, after: 8200 -> saves 492 byte
'samr21-xpro` (1 LED) - before 7860, after: 7960 -> adds 100 byte

Code size for `hello-world`:
`stm32f3discovery` (8 LEDs) - before 9036, after: 9040 -> adds 4 byte
'samr21-xpro` (1 LED) - before 8620, after: 8672 -> adds 52 byte

I am not sure, but it seems to me, that the sam is not inlining correctly, need to investigate...

