### PR TITLE
[WIP] cpu/stm32_common: add LPTIM driver

### DIFF
--- a/boards/nucleo144-f413/include/board.h
+++ b/boards/nucleo144-f413/include/board.h
@@ -33,10 +33,19 @@ extern "C" {
  * @name    xtimer configuration
  * @{
  */
+#if 0
 #define XTIMER_DEV          TIMER_DEV(0)
 #define XTIMER_CHAN         (0)
 #define XTIMER_OVERHEAD     (6)
 #define XTIMER_BACKOFF      (5)
+#else
+#define XTIMER_DEV          TIMER_DEV(1)
+#define XTIMER_HZ           (32768ul)
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      (11)
+#define XTIMER_ISR_BACKOFF  (11)
+#define XTIMER_OVERHEAD     (10)
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo144-f413/include/periph_conf.h
+++ b/boards/nucleo144-f413/include/periph_conf.h
@@ -60,10 +60,18 @@ static const timer_conf_t timer_config[] = {
         .rcc_mask = RCC_APB1ENR_TIM5EN,
         .bus      = APB1,
         .irqn     = TIM5_IRQn
+    },
+    {
+        .max      = 0xffff,
+        .rcc_mask = RCC_APB1ENR_LPTIM1EN,
+        .bus      = APB1,
+        .irqn     = LPTIM1_IRQn,
+        .type     = TIMER_TYPE_LPTIM,
     }
 };
 
 #define TIMER_0_ISR         isr_tim5
+#define TIMER_1_ISR         isr_lptim1
 
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -198,15 +198,25 @@ typedef struct {
     uint8_t chan;           /**< DAC device used for this line */
 } dac_conf_t;
 
+
+/**
+ * @brief   Timer type
+ */
+typedef enum {
+    TIMER_TYPE_GPTIM, /**< General-purpose timer */
+    TIMER_TYPE_LPTIM, /**< Low-power timer */
+} timer_type_t;
+
 /**
  * @brief   Timer configuration
  */
 typedef struct {
-    TIM_TypeDef *dev;       /**< timer device */
+    TIM_TypeDef *dev;       /**< timer device, not set for LPTIM */
     uint32_t max;           /**< maximum value to count to (16/32 bit) */
     uint32_t rcc_mask;      /**< corresponding bit in the RCC register */
     uint8_t bus;            /**< APBx bus the timer is clock from */
     uint8_t irqn;           /**< global IRQ channel */
+    uint8_t type;
 } timer_conf_t;
 
 /**


### PR DESCRIPTION
This is rough and WIP, but it adds an implementation of timer API for the stm32f4 LPTIM.

`tests/xtimer_msg` works, but `tests/xtimer_longterm` does not, and I don't know why!

Not related to that PR, but pm / pm_layered do not work on stm32...