### PR TITLE
tests/thread_flood: improve test output

### DIFF
--- a/tests/thread_flood/Makefile
+++ b/tests/thread_flood/Makefile
@@ -6,4 +6,4 @@ DISABLE_MODULE += auto_init
 include $(RIOTBASE)/Makefile.include
 
 test:
-	tests/test_thread.py
+	tests/01-run.py

--- a/tests/thread_flood/main.c
+++ b/tests/thread_flood/main.c
@@ -36,7 +36,7 @@ int main(void)
 {
     kernel_pid_t thr_id = KERNEL_PID_UNDEF;
 
-    puts("Start spawning\n");
+    puts("[START] Spawning threads");
     do {
         thr_id = thread_create(
             dummy_stack, sizeof(dummy_stack),
@@ -46,7 +46,7 @@ int main(void)
     } while (-EOVERFLOW != thr_id);
 
     if (-EOVERFLOW == thr_id) {
-        puts("Thread creation successful aborted\n");
+        puts("[SUCCESS] Thread creation successfully aborted");
     }
 
     return 0;

--- a/tests/thread_flood/tests/01-run.py
+++ b/tests/thread_flood/tests/01-run.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact(u'[START] Spawning threads')
+    child.expect_exact(u'[SUCCESS] Thread creation')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/thread_flood/tests/test_thread.py
+++ b/tests/thread_flood/tests/test_thread.py
@@ -1,8 +1,0 @@
-#!/usr/bin/python
-
-import pexpect
-
-term = pexpect.spawn("make term")
-
-term.expect('Start spawning\r\n')
-term.expect('Thread creation successful aborted\r\n')


### PR DESCRIPTION
While performing 'manual' testing for the release, I realized that some testing script were missing or were outdated.
This PR is a try to cleanup one of them. Comments welcome.