### PR TITLE
cpu/msp430: call periph_init during CPU init

### DIFF
--- a/cpu/msp430_common/msp430-main.c
+++ b/cpu/msp430_common/msp430-main.c
@@ -44,6 +44,7 @@
 
 #include "cpu.h"
 #include "irq.h"
+#include "periph/init.h"
 
 /*---------------------------------------------------------------------------*/
 static void
@@ -113,6 +114,8 @@ void msp430_cpu_init(void)
     irq_disable();
     init_ports();
     irq_enable();
+
+    periph_init();
 
     if ((uintptr_t)cur_break & 1) { /* Workaround for msp430-ld bug!*/
         cur_break++;


### PR DESCRIPTION
the MSP430 never called the shared `periph_init`, leading to peripherals that build on this (currently only SPI) not being initialized on system startup. This lead to broken SPI drivers (e.g. the default example on the `z1`)....