### PR TITLE
drivers/sx127x, sys: configure auto_init and improve netif adaption

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.dep
+++ b/boards/b-l072z-lrwan1/Makefile.dep
@@ -1,3 +1,7 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += sx1276
+endif
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -231,6 +231,10 @@ ifneq (,$(filter sx127%,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
   USEMODULE += xtimer
   USEMODULE += sx127x
+  USEMODULE += netif
+  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+    USEMODULE += gnrc_netdev
+  endif
 endif
 
 ifneq (,$(filter tcs37727,$(USEMODULE)))

--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -660,7 +660,16 @@ void sx127x_set_rx_timeout(sx127x_t *dev, uint32_t timeout);
 void sx127x_set_tx_timeout(sx127x_t *dev, uint32_t timeout);
 
 /**
- * @brief   Sets the SX127X LoRa IQ inverted mode
+ * @brief   Checks if the SX127X LoRa inverted IQ mode is enabled/disabled
+ *
+ * @param[in] dev                      The sx127x device descriptor
+ *
+ * @return the LoRa IQ inverted mode
+ */
+bool sx127x_get_iq_invert(const sx127x_t *dev);
+
+/**
+ * @brief   Enable/disable the SX127X LoRa IQ inverted mode
  *
  * @param[in] dev                      The sx127x device descriptor
  * @param[in] iq_invert                The LoRa IQ inverted mode

--- a/drivers/sx127x/include/sx127x_netdev.h
+++ b/drivers/sx127x/include/sx127x_netdev.h
@@ -38,7 +38,6 @@ typedef struct netdev_radio_lora_packet_info {
     uint8_t rssi;           /**< RSSI of a received packet */
     uint8_t lqi;            /**< LQI of a received packet */
     int8_t snr;             /**< S/N ratio */
-    uint32_t time_on_air;   /**< Time on air of a received packet (ms) */
 } netdev_sx127x_lora_packet_info_t;
 
 #ifdef __cplusplus

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -848,6 +848,11 @@ void sx127x_set_symbol_timeout(sx127x_t *dev, uint16_t timeout)
     sx127x_reg_write(dev, SX127X_REG_LR_SYMBTIMEOUTLSB,timeout & 0xFF);
 }
 
+bool sx127x_get_iq_invert(const sx127x_t *dev)
+{
+    return dev->settings.lora.flags & SX127X_IQ_INVERTED_FLAG;
+}
+
 void sx127x_set_iq_invert(sx127x_t *dev, bool iq_invert)
 {
     DEBUG("[DEBUG] Set IQ invert: %d\n", iq_invert);

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -340,6 +340,16 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             *((netopt_enable_t*) val) = sx127x_get_rx_single(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
             break;
 
+        case NETOPT_TX_POWER:
+            assert(max_len >= sizeof(int8_t));
+            *((int8_t*) val) = sx127x_get_tx_power(dev);
+            return sizeof(int8_t);
+
+        case NETOPT_IQ_INVERT:
+            assert(max_len >= sizeof(uint8_t));
+            *((netopt_enable_t*) val) = sx127x_get_iq_invert(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
+            break;
+
         default:
             break;
     }
@@ -425,7 +435,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             return sizeof(uint8_t);
 
         case NETOPT_SINGLE_RECEIVE:
-            assert(len <= sizeof(uint8_t));
+            assert(len <= sizeof(netopt_enable_t));
             sx127x_set_rx_single(dev, *((const netopt_enable_t*) val) ? true : false);
             return sizeof(netopt_enable_t);
 

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -89,7 +89,7 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
             }
 
             /* Write payload buffer */
-            for (size_t i = 0;i < count ; i++) {
+            for (size_t i = 0; i < count; i++) {
                 sx127x_write_fifo(dev, vector[i].iov_base, vector[i].iov_len);
             }
             break;
@@ -194,7 +194,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
                     }
 #endif
                 }
-                packet_info->time_on_air = sx127x_get_time_on_air(dev, len);
             }
 
             size = sx127x_reg_read(dev, SX127X_REG_LR_RXNBBYTES);

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -34,10 +34,10 @@ USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 
-BOARD_PROVIDES_NETIF := airfy-beacon cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
-        microbit native nrf51dongle nrf52dk nrf6310 openmote-cc2538 pba-d-01-kw2x \
-        pca10000 pca10005 remote-pa remote-reva samr21-xpro \
-        spark-core telosb yunjia-nrf51822 z1
+BOARD_PROVIDES_NETIF := airfy-beacon b-l072z-lrwan1 cc2538dk fox iotlab-m3 \
+        iotlab-a8-m3 mulle microbit native nrf51dongle nrf52dk nrf6310 \
+        openmote-cc2538 pba-d-01-kw2x pca10000 pca10005 remote-pa remote-reva \
+        samr21-xpro spark-core telosb yunjia-nrf51822 z1
 
 ifneq (,$(filter $(BOARD),$(BOARD_PROVIDES_NETIF)))
   # Use modules for networking

--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -7,11 +7,12 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon calliope-mini chronos microbit msb-430 \
-                             msb-430h nrf51dongle nrf6310 nucleo32-f031 \
-                             nucleo32-f042 nucleo32-f303 nucleo32-l031 nucleo-f030 \
-                             nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f302 nucleo-f334 \
-                             nucleo-l053 pca10000 pca10005 spark-core stm32f0discovery \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini chronos \
+                             microbit msb-430 msb-430h nrf51dongle nrf6310 \
+                             nucleo32-f031 nucleo32-f042 nucleo32-f303 \
+                             nucleo32-l031 nucleo-f030 nucleo-f070 nucleo-f072 \
+                             nucleo-f103 nucleo-f302 nucleo-f334 nucleo-l053 \
+                             pca10000 pca10005 spark-core stm32f0discovery \
                              telosb wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -245,6 +245,11 @@ void auto_init(void)
     auto_init_w5100();
 #endif
 
+#ifdef MODULE_SX127X
+    extern void auto_init_sx127x(void);
+    auto_init_sx127x();
+#endif
+
 #endif /* MODULE_AUTO_INIT_GNRC_NETIF */
 
 #ifdef MODULE_GNRC_IPV6_NETIF

--- a/sys/auto_init/netif/auto_init_sx127x.c
+++ b/sys/auto_init/netif/auto_init_sx127x.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     auto_init_gnrc_netif
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for SX1272/SX1276 LoRa interfaces
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifdef MODULE_SX127X
+
+#include "log.h"
+#include "board.h"
+#include "net/gnrc/netdev/lora.h"
+#include "sx127x_params.h"
+
+/**
+ * @brief   Calculate the number of configured SX127x devices
+ */
+#define SX127X_NUMOF        (sizeof(sx127x_params) / sizeof(sx127x_params_t))
+
+/**
+ * @brief   Define stack parameters for the MAC layer thread
+ */
+#define SX127X_STACKSIZE           (THREAD_STACKSIZE_DEFAULT)
+#ifndef SX127X_PRIO
+#define SX127X_PRIO                (GNRC_NETDEV_MAC_PRIO)
+#endif
+
+/**
+ * @brief   Allocate memory for device descriptors, stacks, and GNRC adaption
+ */
+static sx127x_t sx127x_devs[SX127X_NUMOF];
+static gnrc_netdev_t gnrc_adpt[SX127X_NUMOF];
+static char stacks[SX127X_NUMOF][SX127X_STACKSIZE];
+
+void auto_init_sx127x(void)
+{
+    for (unsigned i = 0; i < SX127X_NUMOF; ++i) {
+#if defined(MODULE_SX1272)
+        LOG_DEBUG("[auto_init_netif] initializing sx1272 #%u\n", i);
+#else /* MODULE_SX1276 */
+        LOG_DEBUG("[auto_init_netif] initializing sx1276 #%u\n", i);
+#endif
+
+        sx127x_setup(&sx127x_devs[i], &sx127x_params[i]);
+        gnrc_netdev_lora_init(&gnrc_adpt[i], (netdev_t *)&sx127x_devs[i]);
+        gnrc_netdev_init(stacks[i], SX127X_STACKSIZE, SX127X_PRIO, "sx127x",
+                         &gnrc_adpt[i]);
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_SX127X */
+/** @} */

--- a/sys/include/net/gnrc/netdev/lora.h
+++ b/sys/include/net/gnrc/netdev/lora.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup net_gnrc_netdev
+ * @{
+ *
+ * @file
+ * @brief       GNRC to LoRa netdev glue code interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef NET_GNRC_NETDEV_LORA_H
+#define NET_GNRC_NETDEV_LORA_H
+
+#include "net/gnrc/netdev.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Initialize GNRC handler for netdev LoRa devices
+ *
+ * @param[out] gnrc_netdev     gnrc_netdev struct to initialize
+ * @param[in]  dev             netdev device to handle
+ */
+void gnrc_netdev_lora_init(gnrc_netdev_t *gnrc_netdev, netdev_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_GNRC_NETDEV_LORA_H */
+/** @} */

--- a/sys/net/gnrc/link_layer/netdev/gnrc_netdev_lora.c
+++ b/sys/net/gnrc/link_layer/netdev/gnrc_netdev_lora.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_gnrc
+ * @{
+ *
+ * @file
+ * @brief       GNRC to netdev adapter for LoRa devices
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "assert.h"
+#include "net/gnrc.h"
+#include "net/gnrc/netdev/lora.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+static gnrc_pktsnip_t *lora_adpt_recv(gnrc_netdev_t *gnrc_netdev)
+{
+    netdev_t *dev = gnrc_netdev->dev;
+    int pktlen;
+    gnrc_pktsnip_t *payload;
+
+    assert(dev);
+
+    /* see how much data there is to process */
+    pktlen = dev->driver->recv(dev, NULL, 0, NULL);
+    if (pktlen <= 0) {
+        DEBUG("[lora-gnrc] recv: no data available to process\n");
+        return NULL;
+    }
+
+    /* allocate space for the packet in the pktbuf */
+    payload = gnrc_pktbuf_add(NULL, NULL, pktlen, GNRC_NETTYPE_UNDEF);
+    if (payload == NULL) {
+        DEBUG("[lora-gnrc] recv: unable to allocate space in the pktbuf\n");
+        /* tell the driver to drop the packet */
+        dev->driver->recv(dev, NULL, 1, NULL);
+        return NULL;
+    }
+
+    /* copy the complete payload into the packet buffer */
+    dev->driver->recv(dev, payload->data, pktlen, NULL);
+
+    return payload;
+}
+
+static int lora_adpt_send(gnrc_netdev_t *dev, gnrc_pktsnip_t *pkt)
+{
+    int res = 0;
+    size_t size;
+    size_t count;
+    gnrc_pktsnip_t *vec;
+
+    /* check device descriptor and packet */
+    assert(dev && pkt);
+
+    /* get the payload size */
+    size = gnrc_pkt_len(pkt);
+    DEBUG("[lora-gnrc] send: payload of packet is %i\n", (int)size);
+
+    /* now let's extract the iovector and send out the stuff */
+    vec = gnrc_pktbuf_get_iovec(pkt, &count);
+    if (vec != NULL) {
+        pkt = vec;
+        struct iovec *vector = (struct iovec *)pkt->data;
+        vector[0].iov_base = pkt->next->data;
+        vector[0].iov_len = size;
+        DEBUG("[lora-gnrc] send: triggering the drivers send function\n");
+        res = dev->dev->driver->send(dev->dev, vector, count);
+        if (res == -ENOTSUP) {
+            DEBUG("[lora-gnrc] send: cannot send, radio is still transmitting");
+        }
+    }
+    else {
+        DEBUG("[lora-gnrc] send: unable to create iovec\n");
+    }
+
+    gnrc_pktbuf_release(pkt);
+
+    return res;
+}
+
+void gnrc_netdev_lora_init(gnrc_netdev_t *gnrc_netdev, netdev_t *dev)
+{
+    assert(gnrc_netdev && dev);
+
+    gnrc_netdev->send = lora_adpt_send;
+    gnrc_netdev->recv = lora_adpt_recv;
+    gnrc_netdev->dev = dev;
+}

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -240,7 +240,10 @@ int listen_cmd(int argc, char **argv)
 
     /* Switch to continuous listen mode */
     netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, false, sizeof(uint8_t));
-    sx127x_set_rx(&sx127x);
+
+    /* Switch to RX state */
+    uint8_t state = NETOPT_STATE_RX;
+    netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(uint8_t));
 
     printf("Listen mode set\n");
 
@@ -307,10 +310,10 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
             case NETDEV_EVENT_RX_COMPLETE:
                 len = dev->driver->recv(dev, NULL, 0, 0);
                 dev->driver->recv(dev, message, len, &packet_info);
-                printf("{Payload: \"%s\" (%d bytes), RSSI: %i, SNR: %i, TOA: %i}\n",
+                printf("{Payload: \"%s\" (%d bytes), RSSI: %i, SNR: %i, TOA: %lu}\n",
                        message, (int)len,
                        packet_info.rssi, (int)packet_info.snr,
-                       (int)packet_info.time_on_air);
+                       sx127x_get_time_on_air((const sx127x_t*)dev, len));
                 break;
             case NETDEV_EVENT_TX_COMPLETE:
                 sx127x_set_sleep(&sx127x);


### PR DESCRIPTION
Another step toward better integration of LoRa into RIOT.

This PR provides adaption of Semtech SX1272/76 devices to `gnrc_netdev`, and gives the possibility to auto-initialize them and use shell commands (e.g ifconfig).
With this PR, the code should be ready to be used with LoRaWAN stacks (I guess).

There are obviously things that I made wrong because of my poor knowledge of the way gnrc and netapi works, so comments are welcome (especially the way packet snips are handled).

There are 2 shell commands provided when `netdev_default` and `sx127x` modules are loaded:
* *ifconfig*: allows to configure the essential LoRa radio parameter (channel, bandwidth, SF, CR, etc).
* *lora*: for setting the radio to RX mode or send raw packets.

Examples:
```
> ifconfig
Iface  4   Channel: 868299987Hz  TX-Power: 14dBm  State: 
           Bandwidth: 125kHz
           Spreading factor: 12 
           Coding rate: 4/8 
           Inverted IQ: off
> lora 4 listen
> lora 4 send test
```

 The `ifconfig` command here is a pale adaption of the initial `ifconfig` command. I think there's room for improvement (and factorization), but since the `_sc_netif.c` is already huge, I didn't want to put more mess on it.

I applied the auto configuration for the b-l072z-lrwan1 board: this way, the `examples/default` can be used to interact with the radio on it without having to tweak anything.