### PR TITLE
samd21:DFLL bug

### DIFF
--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -160,7 +160,7 @@ static void clk_init(void)
         /* Wait for DFLL sync */
     }
 
-    SYSCTRL->DFLLCTRL.reg = SYSCTRL_DFLLCTRL_ENABLE;
+    SYSCTRL->DFLLCTRL.bit.ENABLE = 1;
     while ((SYSCTRL->PCLKSR.reg & (SYSCTRL_PCLKSR_DFLLRDY |
                                    SYSCTRL_PCLKSR_DFLLLCKF |
                                    SYSCTRL_PCLKSR_DFLLLCKC)) == 0) {


### PR DESCRIPTION
Enabling DFLLCTRL without the |= negates the closed loop mode setting that takes advantage of the external clock to calibrate the DFLL.  See Issue #7334.