### PR TITLE
board, cc2650stk: fix make reset with uniflash4.x

### DIFF
--- a/boards/cc2650stk/Makefile.include
+++ b/boards/cc2650stk/Makefile.include
@@ -15,9 +15,15 @@ export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
 ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
   export FLASHER ?= $(UNIFLASH_PATH)/dslite.sh
   export FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(ELFFILE)
+  # configure uniflash for resetting target
+  export RESET = $(UNIFLASH_PATH)/simplelink/gen2/bin/xds110reset
+  export RESET_FLAGS
 else
   export FLASHER = $(UNIFLASH_PATH)/uniflash.sh
   export FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(ELFFILE)
+  # configure uniflash for resetting target
+  export RESET = $(UNIFLASH_PATH)/uniflash.sh
+  export RESET_FLAGS = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset
 endif
 # configure the debug server
 export DEBUGSERVER = $(UNIFLASH_PATH)/ccs_base/common/uscif/gdb_agent_console
@@ -26,7 +32,3 @@ export DEBUGSERVER_FLAGS = -p 3333 $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDE
 # configure the debugging tool
 export DEBUGGER = $(PREFIX)gdb
 export DEBUGGER_FLAGS = -x $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_gdb.conf $(ELFFILE)
-
-# configure uniflash for resetting target
-export RESET = $(UNIFLASH_PATH)/uniflash.sh
-export RESET_FLAGS = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset


### PR DESCRIPTION
follow up on #7333, add support for `make reset` for board cc2650stk (aka TI SensorTag) with latest TI uniflash 4.x toolchain.