### PR TITLE
gitignore: ignore python compiled file in git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,5 @@ Makefile.local
 # Python compiled files
 *.pyc
 
+# Ignore download cache
 .dlcache

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ Makefile.local
 .clang_complete
 # YouCompleteMe (https://github.com/Valloric/YouCompleteMe)
 .ycm_extra_conf.py
-.ycm_extra_conf.pyc
-__pycache__
+
+# Python compiled files
+*.pyc
+
 .dlcache


### PR DESCRIPTION
Reviewing #7367 gave me the idea of this PR: I tried the testrunner script for the release and have the pyc file returned with git status. This PR fixes this.