### PR TITLE
drivers/sx127X: move SPI mode and speed definition to global driver configuration

### DIFF
--- a/drivers/sx127x/include/sx127x_params.h
+++ b/drivers/sx127x/include/sx127x_params.h
@@ -36,14 +36,6 @@ extern "C" {
 #define SX127X_PARAM_SPI                    (SPI_DEV(0))
 #endif
 
-#ifndef SX127X_PARAM_SPI_SPEED
-#define SX127X_PARAM_SPI_SPEED              (SPI_CLK_1MHZ)
-#endif
-
-#ifndef SX127X_PARAM_SPI_MODE
-#define SX127X_PARAM_SPI_MODE               (SPI_MODE_0)
-#endif
-
 #ifndef SX127X_PARAM_SPI_NSS
 #define SX127X_PARAM_SPI_NSS                GPIO_PIN(1, 6)       /* D10 */
 #endif

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -36,6 +36,10 @@
 #include "debug.h"
 
 
+#define SX127X_SPI_SPEED    (SPI_CLK_1MHZ)
+#define SX127X_SPI_MODE     (SPI_MODE_0)
+
+
 bool sx127x_test(const sx127x_t *dev)
 {
     /* Read version number and compare with sx127x assigned revision */
@@ -79,7 +83,7 @@ void sx127x_reg_write_burst(const sx127x_t *dev, uint8_t addr, uint8_t *buffer,
 {
     unsigned int cpsr;
 
-    spi_acquire(dev->params.spi, SPI_CS_UNDEF, SX127X_PARAM_SPI_MODE, SX127X_PARAM_SPI_SPEED);
+    spi_acquire(dev->params.spi, SPI_CS_UNDEF, SX127X_SPI_MODE, SX127X_SPI_SPEED);
     cpsr = irq_disable();
 
     gpio_clear(dev->params.nss_pin);
@@ -97,7 +101,7 @@ void sx127x_reg_read_burst(const sx127x_t *dev, uint8_t addr, uint8_t *buffer,
 
     cpsr = irq_disable();
 
-    spi_acquire(dev->params.spi, SPI_CS_UNDEF, SX127X_PARAM_SPI_MODE, SX127X_PARAM_SPI_SPEED);
+    spi_acquire(dev->params.spi, SPI_CS_UNDEF, SX127X_SPI_MODE, SX127X_SPI_SPEED);
 
     gpio_clear(dev->params.nss_pin);
     spi_transfer_regs(dev->params.spi, SPI_CS_UNDEF, addr & 0x7F, NULL, (char *) buffer, size);


### PR DESCRIPTION
Should address this [comment](https://github.com/RIOT-OS/RIOT/pull/7340#issuecomment-315703686) in #7340.

We could also add extra attributes to the params struc in order to have this defined independantly for each device.