### PR TITLE
cpu, cc2538: add gpio alternative functions

### DIFF
--- a/boards/remote-pa/board.c
+++ b/boards/remote-pa/board.c
@@ -60,7 +60,7 @@ static void rf_switch_init(void)
     RF_SWITCH_PORT->DIR |= (1 << RF_SWITCH_PIN);
 
     /* configure io-mux for used pins */
-    IOC->OVER[RF_SWITCH_PIN] = IOC_OVERRIDE_OE;
+    IOC_PXX_OVER[RF_SWITCH_PIN] = IOC_OVERRIDE_OE;
 
     /* Set to default */
     RF_SWITCH_INTERNAL;

--- a/boards/remote-pa/board.c
+++ b/boards/remote-pa/board.c
@@ -53,15 +53,7 @@ void board_init(void)
  */
 static void rf_switch_init(void)
 {
-    /* set pins to be controlled by software */
-    RF_SWITCH_PORT->AFSEL &= ~(1 << RF_SWITCH_PIN);
-
-    /* configure pins as output */
-    RF_SWITCH_PORT->DIR |= (1 << RF_SWITCH_PIN);
-
-    /* configure io-mux for used pins */
-    IOC_PXX_OVER[RF_SWITCH_PIN] = IOC_OVERRIDE_OE;
-
-    /* Set to default */
-    RF_SWITCH_INTERNAL;
+    /* Set RF 2.4GHz as default */
+    gpio_init(RF_SWITCH_GPIO, GPIO_OUT);
+    RF_SWITCH_2_4_GHZ;
 }

--- a/boards/remote-pa/include/board.h
+++ b/boards/remote-pa/include/board.h
@@ -70,11 +70,10 @@
  * 2.4GHz RF switch controlled by SW
  * @{
  */
-#define RF_SWITCH_PORT      GPIO_D
-#define RF_SWITCH_PIN       (4)
-#define RF_SWITCH_EXTERNAL  (RF_SWITCH_PORT->DATA |= (1 << RF_SWITCH_PIN))
-#define RF_SWITCH_INTERNAL  (RF_SWITCH_PORT->DATA &= ~(1 << RF_SWITCH_PIN))
-#define RF_SWITCH_TOGGLE    (RF_SWITCH_PORT->DATA ^= (1 << RF_SWITCH_PIN))
+ #define RF_SWITCH_GPIO      GPIO_PIN(3, 4)
+ #define RF_SWITCH_SUB_GHZ   gpio_set(RF_SWITCH_GPIO)
+ #define RF_SWITCH_2_4_GHZ   gpio_clear(RF_SWITCH_GPIO)
+ #define RF_SWITCH_TOGGLE    gpio_toggle(RF_SWITCH_GPIO)
 /** @} */
 
 /**

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -127,24 +127,13 @@ static inline uint8_t gpio_pp_num(gpio_t pin)
 }
 
 /**
- * @brief   Helper function to enable gpio hardware control
+ * @brief   Configure an alternate function for the given pin
  *
  * @param[in] pin   gpio pin
+ * @param[in] sel   Setting for IOC select register, (-1) to ignore
+ * @param[in] over  Setting for IOC override register, (-1) to ignore
  */
-static inline void gpio_hw_ctrl(gpio_t pin)
-{
-    gpio(pin)->AFSEL |= gpio_pin_mask(pin);
-}
-
-/**
- * @brief   Helper function to enable gpio software control
- *
- * @param[in] pin   gpio pin
- */
-static inline void gpio_sw_ctrl(gpio_t pin)
-{
-    gpio(pin)->AFSEL &= ~gpio_pin_mask(pin);
-}
+void gpio_init_af(gpio_t pin, int sel, int over);
 
 /**
  * @brief   Define a custom GPIO_UNDEF value

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -46,7 +46,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     gpio(pin)->IE &= ~gpio_pin_mask(pin);
     gpio(pin)->AFSEL &= ~gpio_pin_mask(pin);
     /* configure pull configuration */
-    IOC->OVER[gpio_pp_num(pin)] = mode;
+    IOC_PXX_OVER[gpio_pp_num(pin)] = mode;
 
     /* set pin direction */
     if (mode == IOC_OVERRIDE_OE) {
@@ -183,4 +183,20 @@ void isr_gpioc(void)
 void isr_gpiod(void)
 {
     handle_isr(GPIO_D, 3);
+}
+
+/* CC2538 specific add-on GPIO functions */
+
+void gpio_init_af(gpio_t pin, int sel, int over)
+{
+    assert(pin != GPIO_UNDEF);
+
+    if (over >= 0) {
+        IOC_PXX_OVER[gpio_pp_num(pin)] = over;
+    }
+    if(sel >= 0) {
+        IOC_PXX_SEL[gpio_pp_num(pin)] = sel;
+    }
+    /* enable alternative function mode */
+    gpio(pin)->AFSEL |= gpio_pin_mask(pin);
 }


### PR DESCRIPTION
based on discussion in #7316 this add alternative gpio functions to be used in periph drivers to hide internal gpio configuration.