### PR TITLE
can: merge candev with netdev [WIP]

### DIFF
--- a/cpu/native/can/candev_linux.c
+++ b/cpu/native/can/candev_linux.c
@@ -32,7 +32,8 @@
 #include <linux/can/error.h>
 
 #include "native_internal.h"
-#include "can/device.h"
+//#include "can/device.h"
+#include "net/netdev.h"
 #include "candev_linux.h"
 #include "thread.h"
 #include "mutex.h"
@@ -42,31 +43,30 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static int _init(candev_t *candev);
-static int _send(candev_t *candev, const struct can_frame *frame);
-static void _isr(candev_t *candev);
-static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len);
-static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len);
-static int _abort(candev_t *candev, const struct can_frame *frame);
-static int _set_filter(candev_t *candev, const struct can_filter *filter);
-static int _remove_filter(candev_t *candev, const struct can_filter *filter);
-static int _power_up(candev_t *candev);
-static int _power_down(candev_t *candev);
+static int _init(netdev_t *candev);
+static int _send(netdev_t *candev, const struct iovec *vector, unsigned count);
+static void _isr(netdev_t *candev);
+static int _set(netdev_t *candev, netopt_t opt, void *value, size_t value_len);
+static int _get(netdev_t *candev, netopt_t opt, void *value, size_t max_len);
+static int _recv(netdev_t *candev, void *buf, size_t len, void *info);
+static int _abort(netdev_t *candev, const struct can_frame *frame);
+static int _set_filter(netdev_t *candev, const struct can_filter *filter);
+static int _remove_filter(netdev_t *candev, const struct can_filter *filter);
+static int _power_up(netdev_t *candev);
+static int _power_down(netdev_t *candev);
 
 static int _set_bittiming(candev_linux_t *dev, struct can_bittiming *bittiming);
 
-static const candev_driver_t candev_linux_driver = {
+static const netdev_driver_t candev_linux_driver = {
     .send = _send,
+    .recv = _recv,
     .init = _init,
     .isr = _isr,
     .get = _get,
     .set = _set,
-    .abort = _abort,
-    .set_filter = _set_filter,
-    .remove_filter = _remove_filter,
 };
 
-static candev_event_t _can_error_to_can_evt(struct can_frame can_frame_err);
+static int _can_error_to_can_evt(struct can_frame can_frame_err);
 static void _callback_can_sigio(int sock, void *arg);
 
 candev_linux_conf_t candev_linux_conf[CAN_DLL_NUMOF] = {
@@ -87,40 +87,40 @@ int candev_linux_init(candev_linux_t *dev, const candev_linux_conf_t *conf)
     memset(dev, 0, sizeof(candev_linux_t));
     dev->candev.driver = &candev_linux_driver;
     dev->conf = conf;
-    dev->candev.bittiming.bitrate = CANDEV_LINUX_DEFAULT_BITRATE;
-    dev->candev.bittiming.sample_point = CANDEV_LINUX_DEFAULT_SPT;
+    dev->bittiming.bitrate = CANDEV_LINUX_DEFAULT_BITRATE;
+    dev->bittiming.sample_point = CANDEV_LINUX_DEFAULT_SPT;
 
     return 0;
 }
 
-static candev_event_t _can_error_to_can_evt(struct can_frame can_frame_err)
+static int _can_error_to_can_evt(struct can_frame can_frame_err)
 {
-    candev_event_t can_evt = CANDEV_EVENT_NOEVENT;
+    int can_evt = -1;
     can_err_mask_t can_err_type = can_frame_err.can_id & CAN_ERR_MASK;
 
     if (can_err_type & CAN_ERR_TX_TIMEOUT) {
-        can_evt = CANDEV_EVENT_TX_ERROR;
+        can_evt = NETDEV_EVENT_TX_TIMEOUT;
     }
     else if (can_err_type & CAN_ERR_CRTL) {
         switch(can_frame_err.data[1]) {
-        case CAN_ERR_CRTL_RX_OVERFLOW:
+        /*case CAN_ERR_CRTL_RX_OVERFLOW:
             can_evt = CANDEV_EVENT_RX_ERROR;
-            break;
+            break;*/
         case CAN_ERR_CRTL_TX_OVERFLOW:
-            can_evt = CANDEV_EVENT_TX_ERROR;
+            can_evt = NETDEV_EVENT_TX_ERROR;
             break;
         case CAN_ERR_CRTL_RX_PASSIVE:
         case CAN_ERR_CRTL_TX_PASSIVE:
-            can_evt = CANDEV_EVENT_ERROR_PASSIVE;
+            can_evt = NETDEV_EVENT_ERROR_PASSIVE;
             break;
         case CAN_ERR_CRTL_RX_WARNING:
         case CAN_ERR_CRTL_TX_WARNING:
-            can_evt = CANDEV_EVENT_ERROR_WARNING;
+            can_evt = NETDEV_EVENT_ERROR_WARNING;
             break;
         }
     }
     else if (can_err_type & CAN_ERR_BUSOFF) {
-        can_evt = CANDEV_EVENT_BUS_OFF;
+        can_evt = NETDEV_EVENT_BUS_OFF;
     }
 
     return can_evt;
@@ -132,7 +132,7 @@ static void _callback_can_sigio(int sockfd, void *arg)
     candev_linux_t *dev = (candev_linux_t *) arg;
 
     if (dev->candev.event_callback) {
-        dev->candev.event_callback(&dev->candev, CANDEV_EVENT_ISR, NULL);
+        dev->candev.event_callback(&dev->candev, NETDEV_EVENT_ISR);
     }
 
     native_async_read_continue(sockfd);
@@ -142,7 +142,7 @@ static void _callback_can_sigio(int sockfd, void *arg)
     }
 }
 
-static int _init(candev_t *candev)
+static int _init(netdev_t *candev)
 {
     struct sockaddr_can addr;
     struct ifreq ifr;
@@ -195,17 +195,19 @@ static int _init(candev_t *candev)
 
     real_bind(dev->sock, (struct sockaddr *)&addr, sizeof(addr));
 
-    _set_bittiming(dev, &candev->bittiming);
+    _set_bittiming(dev, &dev->bittiming);
 
     DEBUG("CAN linux device ready\n");
 
     return 0;
 }
 
-static int _send(candev_t *candev, const struct can_frame *frame)
+static int _send(netdev_t *candev, const struct iovec *vector, unsigned count)
 {
     int nbytes;
     candev_linux_t *dev = (candev_linux_t *)candev;
+    assert(count == 1);
+    struct can_frame *frame = vector->iov_base;
 
     nbytes = real_write(dev->sock, frame, sizeof(struct can_frame));
 
@@ -215,66 +217,78 @@ static int _send(candev_t *candev, const struct can_frame *frame)
     }
 
     if (dev->candev.event_callback) {
-        dev->candev.event_callback(&dev->candev, CANDEV_EVENT_TX_CONFIRMATION, (void *)frame);
+        dev->candev.event_callback(&dev->candev, NETDEV_EVENT_TX_COMPLETE);
     }
 
     return 0;
 }
 
-static void _isr(candev_t *candev)
+static void _isr(netdev_t *candev)
 {
-    int nbytes;
-    struct can_frame rcv_frame;
     candev_linux_t *dev = (candev_linux_t *)candev;
 
     if (dev == NULL) {
         return;
     }
 
-    DEBUG("candev_native _isr: CAN SIGIO interrupt received, sock = %i\n", dev->sock);
-    nbytes = real_read(dev->sock, &rcv_frame, sizeof(struct can_frame));
+    if (dev->candev.event_callback) {
+        DEBUG("candev_native _isr: calling event callback\n");
+        dev->candev.event_callback(&dev->candev, NETDEV_EVENT_RX_COMPLETE);
+    }
+}
+
+static int _recv(netdev_t *candev, void *buf, size_t len, void *info)
+{
+    candev_linux_t *dev = (candev_linux_t *)candev;
+    struct can_frame rcv_frame;
+    (void)info;
+
+    DEBUG("candev_native _recv: CAN SIGIO interrupt received, sock = %i\n", dev->sock);
+    ssize_t nbytes = real_read(dev->sock, &rcv_frame, sizeof(struct can_frame));
 
     if (nbytes < 0) {   /* SIGIO signal was probably due to an error with the socket */
         DEBUG("candev_native _isr: read: error during read\n");
-        return;
+        return -errno;
     }
 
     if (nbytes < (int)sizeof(struct can_frame)) {
         DEBUG("candev_native _isr: read: incomplete CAN frame\n");
-        return;
+        return -EOVERFLOW;
     }
 
     if (rcv_frame.can_id & CAN_ERR_FLAG) {
         DEBUG("candev_native _isr: error frame\n");
-        candev_event_t evt = _can_error_to_can_evt(rcv_frame);
-        if ((evt != CANDEV_EVENT_NOEVENT) && (dev->candev.event_callback)) {
-            dev->candev.event_callback(&dev->candev, evt, NULL);
+        int evt = _can_error_to_can_evt(rcv_frame);
+        if ((evt >= 0) && (dev->candev.event_callback)) {
+            dev->candev.event_callback(&dev->candev, evt);
         }
-        return;
+        return -EIO;
     }
 
     if (rcv_frame.can_id & CAN_RTR_FLAG) {
         DEBUG("candev_native _isr: rtr frame\n");
-        return;
+        return 0;
     }
 
-    if (dev->candev.event_callback) {
-        DEBUG("candev_native _isr: calling event callback\n");
-        dev->candev.event_callback(&dev->candev, CANDEV_EVENT_RX_INDICATION, &rcv_frame);
+    if (len < sizeof(struct can_frame)) {
+        return 0;
     }
 
+    memcpy(buf, &rcv_frame, sizeof(struct can_frame));
+
+    return sizeof(struct can_frame);
 }
 
 static int _set_bittiming(candev_linux_t *dev, struct can_bittiming *bittiming)
 {
     int res;
 
-    dev->candev.bittiming = *bittiming;
+    dev->bittiming = *bittiming;
 
     DEBUG("bitrate = %d, brp= %d, phase_seg1 = %d, phase_seg2 = %d, sjw = %d\n",
-          dev->candev.bittiming.bitrate, dev->candev.bittiming.brp,
-          dev->candev.bittiming.phase_seg1, dev->candev.bittiming.phase_seg2,
-          dev->candev.bittiming.sjw);
+          dev->bittiming.bitrate, dev->bittiming.brp,
+          dev->bittiming.phase_seg1, dev->bittiming.phase_seg2,
+          dev->bittiming.sjw);
 
     /* bitrate setting */
     DEBUG("_set: setting %s down\n", dev->conf->interface_name);
@@ -283,21 +297,21 @@ static int _set_bittiming(candev_linux_t *dev, struct can_bittiming *bittiming)
         return res;
     }
     DEBUG("_set: setting bittiming to %s\n", dev->conf->interface_name);
-    res = can_set_bitrate(dev->conf->interface_name, dev->candev.bittiming.bitrate);
-    can_get_bittiming(dev->conf->interface_name, &dev->candev.bittiming);
+    res = can_set_bitrate(dev->conf->interface_name, dev->bittiming.bitrate);
+    can_get_bittiming(dev->conf->interface_name, &dev->bittiming);
     DEBUG("_set: setting %s up\n", dev->conf->interface_name);
     can_do_start(dev->conf->interface_name);
 
     return res;
 }
 
-static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
+static int _set(netdev_t *candev, netopt_t opt, void *value, size_t value_len)
 {
     candev_linux_t *dev = (candev_linux_t *) candev;
     int res = 0;
 
     switch (opt) {
-    case CANOPT_BITTIMING:
+    case NETOPT_BITTIMING:
         DEBUG("candev_linux: CANOPT_BITTIMING\n");
 
         if (strncmp(dev->conf->interface_name, "can", strlen("can"))) {
@@ -318,16 +332,33 @@ static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
         res = _set_bittiming(dev, value);
 
         break;
-    case CANOPT_STATE:
-        switch (*((canopt_state_t *)value)) {
-            case CANOPT_STATE_SLEEP:
-            case CANOPT_STATE_OFF:
-                _power_down(candev);
+    case NETOPT_STATE:
+        switch (*((netopt_state_t *)value)) {
+            case NETOPT_STATE_SLEEP:
+            case NETOPT_STATE_OFF:
+                res = _power_down(candev);
                 break;
             default:
-                _power_up(candev);
+                res = _power_up(candev);
                 break;
         }
+        break;
+    case NETOPT_FILTER:
+        if (value_len < sizeof(netopt_set_filter_t)) {
+            res = -EOVERFLOW;
+        }
+        else {
+            switch (((netopt_set_filter_t *)value)->op) {
+            case NETOPT_FILTER_SET:
+                res = _set_filter(candev, ((netopt_set_filter_t *)value)->filter);
+                break;
+            case NETOPT_FILTER_RM:
+                res = _remove_filter(candev, ((netopt_set_filter_t *)value)->filter);
+                break;
+            }
+        }
+    case NETOPT_ABORT:
+        res = _abort(candev, value);
         break;
     default:
         DEBUG("CAN set, not supported opt\n");
@@ -338,13 +369,13 @@ static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
     return res;
 }
 
-static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
+static int _get(netdev_t *candev, netopt_t opt, void *value, size_t max_len)
 {
     candev_linux_t *dev = (candev_linux_t *) candev;
     int res = 0;
 
     switch (opt) {
-    case CANOPT_BITTIMING:
+    case NETOPT_BITTIMING:
         if (max_len < sizeof(struct can_bittiming)) {
             res = -EOVERFLOW;
             break;
@@ -360,7 +391,7 @@ static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
             res = -ENOTSUP;
         }
         break;
-    case CANOPT_BITTIMING_CONST:
+    case NETOPT_BITTIMING_CONST:
         if (max_len < sizeof(struct can_bittiming_const)) {
             res = -EOVERFLOW;
             break;
@@ -376,7 +407,7 @@ static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
             res = -ENOTSUP;
         }
         break;
-    case CANOPT_CLOCK:
+    case NETOPT_CLOCK:
         if (max_len < sizeof(uint32_t)) {
             res = -EOVERFLOW;
             break;
@@ -396,7 +427,7 @@ static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
         }
         }
         break;
-    case CANOPT_TEC:
+    /*case CANOPT_TEC:
     case CANOPT_REC:
         if (max_len < sizeof(uint16_t)) {
             res = -EOVERFLOW;
@@ -421,8 +452,8 @@ static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
             res = -ENOTSUP;
         }
         }
-        break;
-    case CANOPT_RX_FILTERS: {
+        break;*/
+    case NETOPT_FILTER: {
         if (max_len % sizeof(struct can_filter) != 0) {
             res = -EOVERFLOW;
             break;
@@ -445,7 +476,7 @@ static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
     return res;
 }
 
-static int _set_filter(candev_t *candev, const struct can_filter *filter)
+static int _set_filter(netdev_t *candev, const struct can_filter *filter)
 {
     candev_linux_t *dev = (candev_linux_t *)candev;
 
@@ -489,7 +520,7 @@ static int _set_filter(candev_t *candev, const struct can_filter *filter)
     return i;
 }
 
-static int _remove_filter(candev_t *candev, const struct can_filter *filter)
+static int _remove_filter(netdev_t *candev, const struct can_filter *filter)
 {
     candev_linux_t *dev = (candev_linux_t *)candev;
 
@@ -534,7 +565,7 @@ static int _remove_filter(candev_t *candev, const struct can_filter *filter)
     return 0;
 }
 
-static int _abort(candev_t *candev, const struct can_frame *frame)
+static int _abort(netdev_t *candev, const struct can_frame *frame)
 {
     (void)frame;
     (void)candev;
@@ -542,14 +573,14 @@ static int _abort(candev_t *candev, const struct can_frame *frame)
     return 0;
 }
 
-static int _power_down(candev_t *candev)
+static int _power_down(netdev_t *candev)
 {
     (void)candev;
 
     return 0;
 }
 
-static int _power_up(candev_t *candev)
+static int _power_up(netdev_t *candev)
 {
     (void)candev;
 

--- a/cpu/native/include/candev_linux.h
+++ b/cpu/native/include/candev_linux.h
@@ -31,7 +31,9 @@ extern "C" {
 
 #include <stdbool.h>
 
-#include "can/candev.h"
+//#include "can/candev.h"
+#include "net/netdev.h"
+#include "can/can.h"
 #include "mutex.h"
 
 /**
@@ -72,11 +74,12 @@ typedef struct candev_linux_conf {
  * @brief The candev_linux struct
  */
 typedef struct candev_linux {
-    candev_t candev;                  /**< candev base structure */
+    netdev_t candev;                  /**< candev base structure */
     int sock;                         /**< local socket id */
     const candev_linux_conf_t *conf;  /**< device configuration */
     /** filter list */
     struct can_filter filters[CANDEV_LINUX_MAX_FILTERS_RX];
+    struct can_bittiming bittiming;
 } candev_linux_t;
 
 /**

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -236,6 +236,12 @@ typedef enum {
     NETDEV_EVENT_CRC_ERROR,                 /**< wrong CRC */
     NETDEV_EVENT_FHSS_CHANGE_CHANNEL,       /**< channel changed */
     NETDEV_EVENT_CAD_DONE,                  /**< channel activity detection done */
+    /* CAN events */
+    NETDEV_EVENT_TX_ERROR,
+    NETDEV_EVENT_ERROR_PASSIVE,
+    NETDEV_EVENT_ERROR_WARNING,
+    NETDEV_EVENT_BUS_OFF,
+    NETDEV_EVENT_WAKE_UP,
     /* expand this list if needed */
 } netdev_event_t;
 

--- a/sys/auto_init/can/auto_init_can_native.c
+++ b/sys/auto_init/can/auto_init_can_native.c
@@ -17,6 +17,7 @@
  */
 
 #ifdef MODULE_CAN_LINUX
+#include "thread.h"
 #include "can/device.h"
 #include "candev_linux_params.h"
 
@@ -38,7 +39,7 @@ void auto_init_can_native(void) {
 
     for (size_t i = 0; i < CANDEV_LINUX_NUMOF; i++) {
         candev_linux_init(&candev_linux[i], &candev_linux_conf[i]);
-        candev_dev_linux[i].dev = (candev_t *)&candev_linux[i];
+        candev_dev_linux[i].dev = (netdev_t *)&candev_linux[i];
         candev_dev_linux[i].name = candev_linux_params[i].name;
 #ifdef MODULE_CAN_TRX
         candev_dev_linux[i].trx = candev_linux_params[i].trx;

--- a/sys/can/conn/raw.c
+++ b/sys/can/conn/raw.c
@@ -53,8 +53,8 @@ int conn_can_raw_create(conn_can_raw_t *conn, struct can_filter *filter, size_t 
 
     if (flags & CONN_CAN_RECVONLY) {
         can_opt_t opt;
-        opt.opt = CANOPT_STATE;
-        canopt_state_t state = CANOPT_STATE_LISTEN_ONLY;
+        opt.opt = NETOPT_STATE;
+        netopt_state_t state = NETOPT_STATE_LISTEN_ONLY;
         opt.data = &state;
         opt.data_len = sizeof(state);
         int ret = raw_can_set_can_opt(ifnum, &opt);

--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -49,82 +49,76 @@ static void pm_cb(void *arg);
 static void pm_reset(candev_dev_t *candev_dev, uint32_t value);
 #endif
 
-static inline enum can_msg _can_event_error_to_msg(candev_event_t error)
+static inline enum can_msg _can_event_error_to_msg(netdev_event_t error)
 {
     switch (error) {
-    case CANDEV_EVENT_TX_ERROR:
+    case NETDEV_EVENT_TX_ERROR:
         return CAN_MSG_TX_ERROR;
-    case CANDEV_EVENT_RX_ERROR:
-        return CAN_MSG_RX_ERROR;
-    case CANDEV_EVENT_BUS_OFF:
+    case NETDEV_EVENT_BUS_OFF:
         return CAN_MSG_BUS_OFF;
-    case CANDEV_EVENT_ERROR_PASSIVE:
+    case NETDEV_EVENT_ERROR_PASSIVE:
         return CAN_MSG_ERROR_PASSIVE;
-    case CANDEV_EVENT_ERROR_WARNING:
+    case NETDEV_EVENT_ERROR_WARNING:
         return CAN_MSG_ERROR_WARNING;
     default:
         return 0;
     }
 }
 
-static void _can_event(candev_t *dev, candev_event_t event, void *arg)
+static void _can_event(netdev_t *dev, netdev_event_t event)
 {
     msg_t msg;
-    struct can_frame *frame;
-    can_pkt_t *pkt;
-    candev_dev_t *candev_dev = dev->isr_arg;
+    candev_dev_t *candev_dev = dev->context;
 
     DEBUG("_can_event: dev=%p, params=%p\n", (void*)dev, (void*)candev_dev);
     DEBUG("_can_event: params->ifnum=%d, params->pid=%" PRIkernel_pid ", params->dev=%p\n",
           candev_dev->ifnum, candev_dev->pid, (void*)candev_dev->dev);
 
     switch (event) {
-    case CANDEV_EVENT_ISR:
+    case NETDEV_EVENT_ISR:
         DEBUG("_can_event: CANDEV_EVENT_ISR\n");
         msg.type = CAN_MSG_EVENT;
         if (msg_send(&msg, candev_dev->pid) <= 0) {
             DEBUG("can device: isr lost\n");
         }
         break;
-    case CANDEV_EVENT_WAKE_UP:
+    case NETDEV_EVENT_WAKE_UP:
         DEBUG("_can_event: CANDEV_EVENT_WAKE_UP\n");
         power_up(candev_dev);
 #ifdef MODULE_CAN_PM
         pm_reset(candev_dev, candev_dev->rx_inactivity_timeout);
 #endif
         break;
-    case CANDEV_EVENT_TX_CONFIRMATION:
+    case NETDEV_EVENT_TX_COMPLETE:
         DEBUG("_can_event: CANDEV_EVENT_TX_CONFIRMATION\n");
         /* frame pointer in arg */
-        pkt = container_of((struct can_frame *)arg, can_pkt_t, frame);
-        can_dll_dispatch_tx_conf(pkt);
+        /*pkt = container_of((struct can_frame *)arg, can_pkt_t, frame);
+        can_dll_dispatch_tx_conf(pkt);*/
         break;
-    case CANDEV_EVENT_TX_ERROR:
+    case NETDEV_EVENT_TX_ERROR:
         DEBUG("_can_event: CANDEV_EVENT_TX_ERROR\n");
         /* frame pointer in arg */
-        pkt = container_of((struct can_frame *)arg, can_pkt_t, frame);
-        can_dll_dispatch_tx_error(pkt);
+        /*pkt = container_of((struct can_frame *)arg, can_pkt_t, frame);
+        can_dll_dispatch_tx_error(pkt);*/
         break;
-    case CANDEV_EVENT_RX_INDICATION:
+    case NETDEV_EVENT_RX_COMPLETE:
         DEBUG("_can_event: CANDEV_EVENT_RX_INDICATION\n");
 #ifdef MODULE_CAN_PM
         pm_reset(candev_dev, candev_dev->rx_inactivity_timeout);
 #endif
-        /* received frame in arg */
-        frame = (struct can_frame *) arg;
-        can_dll_dispatch_rx_frame(frame, candev_dev->pid);
+        msg.type = CAN_MSG_RX_INDICATION;
+        if (msg_send(&msg, candev_dev->pid) <= 0) {
+            DEBUG("can device: isr lost\n");
+        }
         break;
-    case CANDEV_EVENT_RX_ERROR:
-        DEBUG("_can_event: CANDEV_EVENT_RX_ERROR\n");
+    case NETDEV_EVENT_BUS_OFF:
+        candev_dev->state = CAN_STATE_BUS_OFF;
         break;
-    case CANDEV_EVENT_BUS_OFF:
-        dev->state = CAN_STATE_BUS_OFF;
+    case NETDEV_EVENT_ERROR_PASSIVE:
+        candev_dev->state = CAN_STATE_ERROR_PASSIVE;
         break;
-    case CANDEV_EVENT_ERROR_PASSIVE:
-        dev->state = CAN_STATE_ERROR_PASSIVE;
-        break;
-    case CANDEV_EVENT_ERROR_WARNING:
-        dev->state = CAN_STATE_ERROR_WARNING;
+    case NETDEV_EVENT_ERROR_WARNING:
+        candev_dev->state = CAN_STATE_ERROR_WARNING;
         break;
     default:
         DEBUG("_can_event: unknown event\n");
@@ -134,7 +128,7 @@ static void _can_event(candev_t *dev, candev_event_t event, void *arg)
 
 static int power_up(candev_dev_t *candev_dev)
 {
-    candev_t *dev = candev_dev->dev;
+    netdev_t *dev = candev_dev->dev;
 
     DEBUG("candev: power up\n");
 
@@ -143,14 +137,14 @@ static int power_up(candev_dev_t *candev_dev)
 #endif
     canopt_state_t state = CANOPT_STATE_ON;
     int res = dev->driver->set(dev, CANOPT_STATE, &state, sizeof(state));
-    dev->state = CAN_STATE_ERROR_ACTIVE;
+    candev_dev->state = CAN_STATE_ERROR_ACTIVE;
 
     return res;
 }
 
 static int power_down(candev_dev_t *candev_dev)
 {
-    candev_t *dev = candev_dev->dev;
+    netdev_t *dev = candev_dev->dev;
 
     DEBUG("candev: power down\n");
 
@@ -159,7 +153,7 @@ static int power_down(candev_dev_t *candev_dev)
 #endif
     canopt_state_t state = CANOPT_STATE_SLEEP;
     int res = dev->driver->set(dev, CANOPT_STATE, &state, sizeof(state));
-    dev->state = CAN_STATE_SLEEPING;
+    candev_dev->state = CAN_STATE_SLEEPING;
 
 #ifdef MODULE_CAN_PM
     xtimer_remove(&candev_dev->pm_timer);
@@ -203,7 +197,7 @@ static void pm_reset(candev_dev_t *candev_dev, uint32_t value)
 static void *_can_device_thread(void *args)
 {
     candev_dev_t *candev_dev = (candev_dev_t *) args;
-    candev_t *dev = candev_dev->dev;
+    netdev_t *dev = candev_dev->dev;
 
     DEBUG("_can_device_thread: starting thread for ifnum=%d, pid=%" PRIkernel_pid "\n",
           candev_dev->ifnum, thread_getpid());
@@ -227,20 +221,23 @@ static void *_can_device_thread(void *args)
 #endif
 
     int res;
+    struct can_frame frame;
+    struct iovec iovec;
     can_pkt_t *pkt;
     can_opt_t *opt;
+    netopt_set_filter_t opt_filter;
     msg_t msg, reply, msg_queue[CAN_DEVICE_MSG_QUEUE_SIZE];
 
     /* setup the device layers message queue */
     msg_init_queue(msg_queue, CAN_DEVICE_MSG_QUEUE_SIZE);
 
     dev->event_callback = _can_event;
-    dev->isr_arg = candev_dev;
+    dev->context = candev_dev;
 
     candev_dev->ifnum = can_dll_register_candev(candev_dev);
 
     dev->driver->init(dev);
-    dev->state = CAN_STATE_ERROR_ACTIVE;
+    candev_dev->state = CAN_STATE_ERROR_ACTIVE;
 
     while (1) {
         msg_receive(&msg);
@@ -249,30 +246,38 @@ static void *_can_device_thread(void *args)
             DEBUG("can device: CAN_MSG_EVENT received\n");
             dev->driver->isr(dev);
             break;
-        case CAN_MSG_ABORT_FRAME:
+        /*case CAN_MSG_ABORT_FRAME:
             DEBUG("can device: CAN_MSG_ABORT_FRAME received\n");
             pkt = (can_pkt_t *) msg.content.ptr;
             dev->driver->abort(dev, &pkt->frame);
             reply.type = CAN_MSG_ACK;
             reply.content.value = 0;
             msg_reply(&msg, &reply);
-            break;
+            break;*/
         case CAN_MSG_SEND_FRAME:
             DEBUG("can device: CAN_MSG_SEND_FRAME received\n");
             pkt = (can_pkt_t *) msg.content.ptr;
-            if (dev->state == CAN_STATE_BUS_OFF || dev->state == CAN_STATE_SLEEPING) {
+            if (candev_dev->state == CAN_STATE_BUS_OFF || candev_dev->state == CAN_STATE_SLEEPING) {
                 DEBUG("can device: waking up driver\n");
                 power_up(candev_dev);
             }
 #ifdef MODULE_CAN_PM
             pm_reset(candev_dev, candev_dev->tx_wakeup_timeout);
 #endif
-            dev->driver->send(dev, &pkt->frame);
+            iovec.iov_base = &pkt->frame;
+            iovec.iov_len = sizeof(struct can_frame);
+            dev->driver->send(dev, &iovec, 1);
+            can_dll_dispatch_tx_conf(pkt);
+            break;
+        case CAN_MSG_RX_INDICATION:
+            DEBUG("can device: CAN_MSG_RX_INDICATION received\n");
+            dev->driver->recv(dev, &frame, sizeof(frame), NULL);
+            can_dll_dispatch_rx_frame(&frame, candev_dev->pid);
             break;
         case CAN_MSG_SET:
             DEBUG("can device: CAN_MSG_SET received\n");
             /* read incoming options */
-            opt = (can_opt_t *)msg.content.ptr;
+            opt = msg.content.ptr;
             /* set option for device driver */
             res = dev->driver->set(dev, opt->opt, opt->data, opt->data_len);
             /* send reply to calling thread */
@@ -283,7 +288,7 @@ static void *_can_device_thread(void *args)
         case CAN_MSG_GET:
             DEBUG("can device: CAN_MSG_GET received\n");
             /* read incoming options */
-            opt = (can_opt_t *)msg.content.ptr;
+            opt = msg.content.ptr;
             /* get option for device driver */
             res = dev->driver->get(dev, opt->opt, opt->data, opt->data_len);
             /* send reply to calling thread */
@@ -293,8 +298,10 @@ static void *_can_device_thread(void *args)
             break;
         case CAN_MSG_SET_FILTER:
             DEBUG("can device: CAN_MSG_SET_FILTER received\n");
+            opt_filter.op = NETOPT_FILTER_SET;
+            opt_filter.filter = msg.content.ptr;
             /* set filter for device driver */
-            res = dev->driver->set_filter(dev, msg.content.ptr);
+            res = dev->driver->set(dev, NETOPT_FILTER, &opt_filter, sizeof(opt_filter));
             /* send reply to calling thread */
             reply.type = CAN_MSG_ACK;
             reply.content.value = (uint32_t)res;
@@ -302,8 +309,10 @@ static void *_can_device_thread(void *args)
             break;
         case CAN_MSG_REMOVE_FILTER:
             DEBUG("can device: CAN_MSG_REMOVE_FILTER received\n");
+            opt_filter.op = NETOPT_FILTER_RM;
+            opt_filter.filter = msg.content.ptr;
             /* set filter for device driver */
-            res = dev->driver->remove_filter(dev, msg.content.ptr);
+            res = dev->driver->set(dev, NETOPT_FILTER, &opt_filter, sizeof(opt_filter));
             /* send reply to calling thread */
             reply.type = CAN_MSG_ACK;
             reply.content.value = (uint32_t)res;
@@ -332,7 +341,7 @@ static void *_can_device_thread(void *args)
         case CAN_MSG_SET_TRX:
             DEBUG("can device: CAN_MSG_SET_TRX received\n");
             reply.type = CAN_MSG_ACK;
-            if (dev->state != CAN_STATE_SLEEPING) {
+            if (candev_dev->state != CAN_STATE_SLEEPING) {
                 reply.content.value = -EBUSY;
             }
             else {

--- a/sys/can/dll.c
+++ b/sys/can/dll.c
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "thread.h"
+#include "mutex.h"
 #include "can/dll.h"
 #include "can/raw.h"
 #include "can/device.h"
@@ -431,7 +432,7 @@ int raw_can_set_bitrate(int ifnum, uint32_t bitrate, uint32_t sample_point)
     bittiming.sample_point = sample_point;
 
     can_opt_t opt;
-    opt.opt = CANOPT_CLOCK;
+    opt.opt = NETOPT_CLOCK;
     opt.data = &clock;
     opt.data_len = sizeof(clock);
     ret = raw_can_get_can_opt(ifnum, &opt);
@@ -441,7 +442,7 @@ int raw_can_set_bitrate(int ifnum, uint32_t bitrate, uint32_t sample_point)
     }
     DEBUG("raw_can_set_bitrate: clock=%" PRIu32 " Hz\n", clock);
 
-    opt.opt = CANOPT_BITTIMING_CONST;
+    opt.opt = NETOPT_BITTIMING_CONST;
     opt.data = &btc;
     opt.data_len = sizeof(btc);
     ret = raw_can_get_can_opt(ifnum, &opt);
@@ -458,7 +459,7 @@ int raw_can_set_bitrate(int ifnum, uint32_t bitrate, uint32_t sample_point)
 
     opt.data = &bittiming;
     opt.data_len = sizeof(bittiming);
-    opt.opt = CANOPT_BITTIMING;
+    opt.opt = NETOPT_BITTIMING;
 
     ret = raw_can_set_can_opt(ifnum, &opt);
     if (ret < 0) {

--- a/sys/include/can/common.h
+++ b/sys/include/can/common.h
@@ -41,43 +41,6 @@ extern "C" {
 #include "net/gnrc/pktbuf.h"
 
 /**
- * @brief CAN options
- */
-typedef enum {
-    CANOPT_BITTIMING,       /**< bit timing parameter */
-    CANOPT_RX_FILTERS,      /**< rx filters */
-    CANOPT_TEC,             /**< Transmit Error Counter */
-    CANOPT_REC,             /**< Receive Error Counter*/
-    CANOPT_LEC,             /**< Last Error Code */
-    CANOPT_CLOCK,           /**< controller main clock */
-    CANOPT_BITTIMING_CONST, /**< controller bittiming parameters */
-    CANOPT_STATE,           /**< set controller state @ref canopt_state_t */
-} canopt_t;
-
-/**
- * @brief CAN state options
- *
- * CAN state options to be used with @p CANOPT_STATE
- */
-typedef enum {
-    CANOPT_STATE_OFF,             /**< powered off */
-    CANOPT_STATE_SLEEP,           /**< sleep mode */
-    CANOPT_STATE_LISTEN_ONLY,     /**< listen only mode */
-    CANOPT_STATE_ON,              /**< power on, rx / tx mode */
-} canopt_state_t;
-
-
-/**
- * @brief Structure to pass a CAN option
- */
-typedef struct {
-    canopt_t opt;               /**< the option to get/set */
-    uint16_t context;           /**< (optional) context for that option */
-    void *data;                 /**< data to set or buffer to read into */
-    uint16_t data_len;          /**< size of the data / the buffer */
-} can_opt_t;
-
-/**
  * @brief Messages which can be sent through the CAN stack
  */
 enum can_msg {

--- a/sys/include/can/device.h
+++ b/sys/include/can/device.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-#include "can/candev.h"
+#include "net/netdev.h"
 #include "kernel_types.h"
 
 #ifdef MODULE_CAN_PM
@@ -67,10 +67,11 @@ typedef struct candev_params {
  * @brief candev descriptor to pass to the device thread
  */
 typedef struct candev_dev {
-    candev_t *dev;    /**< the device */
+    netdev_t *dev;    /**< the device */
     int ifnum;        /**< interface number */
     kernel_pid_t pid; /**< pid */
     const char *name; /**< device name */
+    enum can_state state; /**< CAN state */
 #if defined(MODULE_CAN_TRX) || defined(DOXYGEN)
     can_trx_t *trx;   /**< transceiver attached to the device */
 #endif

--- a/sys/include/can/device.h
+++ b/sys/include/can/device.h
@@ -50,6 +50,16 @@ extern "C" {
 #endif
 
 /**
+ * @brief Structure to pass a CAN option
+ */
+typedef struct {
+    netopt_t opt;               /**< the option to get/set */
+    uint16_t context;           /**< (optional) context for that option */
+    void *data;                 /**< data to set or buffer to read into */
+    uint16_t data_len;          /**< size of the data / the buffer */
+} can_opt_t;
+
+/**
  * @brief Parameters to initialize a candev
  */
 typedef struct candev_params {

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -340,6 +340,12 @@ typedef enum {
      */
     NETOPT_IQ_INVERT,
 
+    NETOPT_BITTIMING,
+    NETOPT_BITTIMING_CONST,
+    NETOPT_CLOCK,
+    NETOPT_FILTER,
+    NETOPT_ABORT,
+
     /* add more options if needed */
 
     /**
@@ -379,6 +385,7 @@ typedef enum {
                                  *   state of the network device is @ref NETOPT_STATE_IDLE */
     NETOPT_STATE_STANDBY,       /**< standby mode. The devices is awake but
                                  *   not listening to packets. */
+    NETOPT_STATE_LISTEN_ONLY,
     /* add other states if needed */
 } netopt_state_t;
 
@@ -391,6 +398,18 @@ typedef enum {
     NETOPT_RF_TESTMODE_CTX_CW,      /**< carrier wave continuous tx mode */
     NETOPT_RF_TESTMODE_CTX_PRBS9,   /**< PRBS9 continuous tx mode */
 } netopt_rf_testmode_t;
+
+typedef enum {
+    NETOPT_FILTER_SET,
+    NETOPT_FILTER_RM,
+} netopt_filter_t;
+
+#include "can/can.h"
+
+typedef struct {
+    netopt_filter_t op;
+    struct can_filter *filter;
+} netopt_set_filter_t;
 
 /**
  * @brief   Get a string ptr corresponding to opt, for debugging

--- a/tests/conn_can/main.c
+++ b/tests/conn_can/main.c
@@ -319,7 +319,7 @@ static int _get_filter(int argc, char **argv)
     can_opt_t opt;
     opt.data = (void *)filters;
     opt.data_len = sizeof(filters);
-    opt.opt = CANOPT_RX_FILTERS;
+    opt.opt = NETOPT_FILTER;
     res = raw_can_get_can_opt(ifnum, &opt);
     if (res < 0) {
         puts("Error when reading filters");
@@ -383,7 +383,7 @@ static int _get_bitrate(int argc, char **argv)
     can_opt_t opt;
     opt.data = &bittiming;
     opt.data_len = sizeof(bittiming);
-    opt.opt = CANOPT_BITTIMING;
+    opt.opt = NETOPT_BITTIMING;
 
     int ret = raw_can_get_can_opt(ifnum, &opt);
     if (ret < 0) {
@@ -399,6 +399,7 @@ static int _get_bitrate(int argc, char **argv)
     return 0;
 }
 
+#if 0
 static int _get_counter(int argc, char **argv)
 {
     if (argc < 3) {
@@ -417,7 +418,7 @@ static int _get_counter(int argc, char **argv)
     can_opt_t opt;
     opt.data = &cnt;
     opt.data_len = sizeof(cnt);
-    opt.opt = CANOPT_TEC;
+    opt.opt = NETOPT_TEC;
 
     int ret = raw_can_get_can_opt(ifnum, &opt);
     if (ret < 0) {
@@ -428,7 +429,7 @@ static int _get_counter(int argc, char **argv)
         printf("TEC=%" PRIu16, cnt);
     }
 
-    opt.opt = CANOPT_REC;
+    opt.opt = NETOPT_REC;
 
     ret = raw_can_get_can_opt(ifnum, &opt);
     if (ret < 0) {
@@ -441,6 +442,7 @@ static int _get_counter(int argc, char **argv)
 
     return res;
 }
+#endif
 
 static int _power_up(int argc, char **argv)
 {
@@ -529,9 +531,9 @@ static int _can_handler(int argc, char **argv)
     else if (strncmp(argv[1], "get_bitrate", 11) == 0) {
         return _get_bitrate(argc, argv);
     }
-    else if (strncmp(argv[1], "get_counter", 11) == 0) {
+    /*else if (strncmp(argv[1], "get_counter", 11) == 0) {
         return _get_counter(argc, argv);
-    }
+    }*/
     else if (strncmp(argv[1], "power_up", 9) == 0) {
         return _power_up(argc, argv);
     }


### PR DESCRIPTION
This is an attempt to fix #7294.

This still need some work to clean up and try with other drivers (I gave a try with stm32, though).

My only concern is about tx confirmation, which are not routed to the upper layer anymore. I didn't find a way which suits the netdev API.