### PR TITLE
doc: restore syntax highlight in C snippet + increase padding of code fragments

### DIFF
--- a/doc/doxygen/src/creating-an-application.md
+++ b/doc/doxygen/src/creating-an-application.md
@@ -19,7 +19,7 @@ priorities - is the first thread that runs and calls the `main()` function.
 This function needs to be defined in the source code of the application
 (typically located in `main.c`).
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
 #include <stdio.h>
 
 int main(void)

--- a/doc/doxygen/src/css/riot.css
+++ b/doc/doxygen/src/css/riot.css
@@ -197,6 +197,7 @@ div.fragment {
   font-size: 14px;
   line-height: 1.42857143;
   margin: 0 0 10px;
+  padding: 10px;
   overflow: visible;
   page-break-inside: avoid;
   word-break: break-all;

--- a/doc/doxygen/src/css/riot.less
+++ b/doc/doxygen/src/css/riot.less
@@ -185,6 +185,7 @@ div.fragment {
   font-size: @font-size-base;
   line-height: @line-height-base;
   margin: 0 0 10px;
+  padding: 10px;
   overflow: visible;
   page-break-inside: avoid;
   word-break: break-all;


### PR DESCRIPTION
Minor fix in doxygen documentation.

I looked at how to improve syntax highlighting (using highlight.js) but it doesn't seem very easy with the doxygen + bootstrap that is in place now.