### PR TITLE
samd21:add prescaler option for rtt.c

### DIFF
--- a/cpu/samd21/periph/rtt.c
+++ b/cpu/samd21/periph/rtt.c
@@ -27,6 +27,10 @@
 /* guard file in case no RTT device was specified */
 #if RTT_NUMOF
 
+/* if RTT_PRESCALER is not set, then set it to DIV1 */
+#ifndef RTT_PRESCALER
+#define RTT_PRESCALER       RTC_MODE0_CTRL_PRESCALER_DIV1
+#endif
 
 typedef struct {
     rtt_cb_t    overflow_cb;    /**< called from RTT interrupt on overflow */
@@ -100,7 +104,8 @@ void rtt_init(void)
     while (rtcMode0->STATUS.bit.SYNCBUSY || rtcMode0->CTRL.bit.SWRST) {}
 
     /* Configure as 32bit counter with no prescaler and no clear on match compare */
-    rtcMode0->CTRL.reg = RTC_MODE0_CTRL_MODE_COUNT32 | RTC_MODE0_CTRL_PRESCALER_DIV1;
+    rtcMode0->CTRL.reg = RTC_MODE0_CTRL_MODE_COUNT32 |
+                         RTT_PRESCALER;
     while (rtcMode0->STATUS.bit.SYNCBUSY) {}
 
     /* Setup interrupt */


### PR DESCRIPTION
Allows for the modification of the rtt prescaler.  No change is necessary to periph_conf.h unless the user wants to modify the prescaler: (RTT_PRESCALER).  For example to do a divide by 32:

```
#define RTT_PRESCALER RTC_MODE0_CTRL_PRESCALER_DIV32
```