### PR TITLE
cpu/stm32_common: fix stm32f1/2/4 pm

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -96,10 +96,10 @@ static inline void cortexm_sleep(int deep)
     }
 
     /* ensure that all memory accesses have completed and trigger sleeping */
-    __disable_irq();
+    unsigned state = irq_disable();
     __DSB();
     __WFI();
-    __enable_irq();
+    irq_restore(state);
 }
 
 /**

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -62,6 +62,11 @@ extern "C" {
  */
 #define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
 
+/**
+ * @brief  Define the config flag for stop mode
+ */
+#define PM_STOP_CONFIG  (PWR_CR_LPDS)
+
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO mode options


### PR DESCRIPTION
The goal of this PR was to fix stm32 `pm_set` implementation. The clock needs to be reinitialized after leaving stop mode.

~I also added a simple test app for `pm_layered`, then I had to fix kinetis build issues.~ moved to #7666 