### PR TITLE
Wi-Fire: Add hardware RNG peripheral support

### DIFF
--- a/boards/pic32-wifire/Makefile.features
+++ b/boards/pic32-wifire/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/pic32-wifire/wifire.c
+++ b/boards/pic32-wifire/wifire.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include "periph/gpio.h"
+#include "periph/hwrng.h"
 #include "periph/uart.h"
 #include "bitarithm.h"
 #include "board.h"
@@ -30,6 +31,8 @@ void board_init(void)
 #ifdef DEBUG_VIA_UART
     uart_init(DEBUG_VIA_UART, DEBUG_UART_BAUD, NULL, 0);
 #endif
+
+    hwrng_init();
 
     /* Turn off all LED's */
     gpio_init(LED1_PIN, GPIO_OUT);

--- a/cpu/mips_pic32_common/periph/hwrng.c
+++ b/cpu/mips_pic32_common/periph/hwrng.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright(C) 2017 Francois Berder <fberder@outlook.fr>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+#include <string.h>
+#include "board.h"
+#include "periph/hwrng.h"
+
+#ifdef _RNG
+
+static void wait_plen_cycles(void)
+{
+    unsigned int i;
+    for (i = 0; i < (RNGCON & _RNGCON_PLEN_MASK); ++i)
+        __asm volatile ("nop");
+}
+
+void hwrng_init(void)
+{
+    RNGCON = _RNGCON_TRNGEN_MASK;
+
+    /*
+    * Wait to have at least 64 bits before setting the 64-bit seed
+    * of the pseudo random generator.
+    */
+    while (RNGCNT < 64) {}
+
+    /* Load seed from the TRNG */
+    RNGCON |= _RNGCON_LOAD_MASK;
+    while (RNGCON & _RNGCON_LOAD_MASK) {}
+
+    RNGCON &= ~_RNGCON_TRNGEN_MASK;
+
+    RNGPOLY1 = 0x00C00003;
+    RNGPOLY2 = 0x00000000;
+
+    RNGCON |= 42;   /* Set PLEN to 42 */
+    RNGCON |= _RNGCON_CONT_MASK;
+}
+
+void hwrng_read(void *buf, unsigned int num)
+{
+    unsigned int i = 0;
+
+    RNGCON |= _RNGCON_PRNGEN_MASK;
+
+    for (i = 0; i < (num >> 3); ++i) {
+        uint32_t rng1, rng2;
+
+        wait_plen_cycles();
+        rng1 = RNGNUMGEN1;
+        rng2 = RNGNUMGEN2;
+        memcpy(buf, &rng1, sizeof(rng1));
+        memcpy(buf + 4, &rng2, sizeof(rng2));
+        buf += 8;
+    }
+
+    num &= 0x7;
+    if (num) {
+        uint32_t rng1, n = num & 0x3;
+
+        wait_plen_cycles();
+        rng1 = RNGNUMGEN1;
+        memcpy(buf, &rng1, n);
+        num -= n;
+        buf += n;
+
+        if (num) {
+            uint32_t rng2 = RNGNUMGEN2;
+            memcpy(buf, &rng2, num);
+        }
+    }
+
+    RNGCON &= ~_RNGCON_PRNGEN_MASK;
+}
+
+#endif /* _RNG */

--- a/cpu/mips_pic32_common/periph/hwrng.c
+++ b/cpu/mips_pic32_common/periph/hwrng.c
@@ -46,6 +46,7 @@ void hwrng_init(void)
 void hwrng_read(void *buf, unsigned int num)
 {
     unsigned int i = 0;
+    uint8_t *buffer = (uint8_t *)buf;
 
     RNGCON |= _RNGCON_PRNGEN_MASK;
 
@@ -55,9 +56,9 @@ void hwrng_read(void *buf, unsigned int num)
         wait_plen_cycles();
         rng1 = RNGNUMGEN1;
         rng2 = RNGNUMGEN2;
-        memcpy(buf, &rng1, sizeof(rng1));
-        memcpy(buf + 4, &rng2, sizeof(rng2));
-        buf += 8;
+        memcpy(buffer, &rng1, sizeof(rng1));
+        memcpy(buffer + 4, &rng2, sizeof(rng2));
+        buffer += 8;
     }
 
     num &= 0x7;
@@ -66,13 +67,13 @@ void hwrng_read(void *buf, unsigned int num)
 
         wait_plen_cycles();
         rng1 = RNGNUMGEN1;
-        memcpy(buf, &rng1, n);
+        memcpy(buffer, &rng1, n);
         num -= n;
-        buf += n;
+        buffer += n;
 
         if (num) {
             uint32_t rng2 = RNGNUMGEN2;
-            memcpy(buf, &rng2, num);
+            memcpy(buffer, &rng2, num);
         }
     }
 


### PR DESCRIPTION
Note: the hardware RNG peripheral does **not** work on rev A and B of the Wi-Fire board due to a hardware bug in PIC32MZ2048ECG100.