### PR TITLE
cpu/cc2538: remove CS pin init from spi_init_pins

### DIFF
--- a/cpu/cc2538/periph/spi.c
+++ b/cpu/cc2538/periph/spi.c
@@ -73,7 +73,6 @@ void spi_init_pins(spi_t bus)
         case (uintptr_t)SSI0:
             IOC_PXX_SEL[spi_config[bus].mosi_pin] = SSI0_TXD;
             IOC_PXX_SEL[spi_config[bus].sck_pin ] = SSI0_CLKOUT;
-            IOC_PXX_SEL[spi_config[bus].cs_pin  ] = SSI0_FSSOUT;
 
             IOC_SSIRXD_SSI0 = spi_config[bus].miso_pin;
             break;
@@ -81,7 +80,6 @@ void spi_init_pins(spi_t bus)
         case (uintptr_t)SSI1:
             IOC_PXX_SEL[spi_config[bus].mosi_pin] = SSI1_TXD;
             IOC_PXX_SEL[spi_config[bus].sck_pin ] = SSI1_CLKOUT;
-            IOC_PXX_SEL[spi_config[bus].cs_pin  ] = SSI1_FSSOUT;
 
             IOC_SSIRXD_SSI1 = spi_config[bus].miso_pin;
             break;
@@ -90,12 +88,10 @@ void spi_init_pins(spi_t bus)
     IOC_PXX_OVER[spi_config[bus].mosi_pin] = IOC_OVERRIDE_OE;
     IOC_PXX_OVER[spi_config[bus].miso_pin] = IOC_OVERRIDE_DIS;
     IOC_PXX_OVER[spi_config[bus].sck_pin ] = IOC_OVERRIDE_OE;
-    IOC_PXX_OVER[spi_config[bus].cs_pin  ] = IOC_OVERRIDE_OE;
 
     gpio_hardware_control(spi_config[bus].mosi_pin);
     gpio_hardware_control(spi_config[bus].miso_pin);
     gpio_hardware_control(spi_config[bus].sck_pin);
-    gpio_hardware_control(spi_config[bus].cs_pin);
 }
 
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)


### PR DESCRIPTION
The HW-CS pin should never be touched in that function, its (optional) initialization needs to be done in spi_init_cs().