### PR TITLE
random: add random_bytes() function

### DIFF
--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -27,6 +27,7 @@
 #define RANDOM_H
 
 #include <inttypes.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +67,11 @@ void random_init_by_array(uint32_t init_key[], int key_length);
  * @return a random number on [0,0xffffffff]-interval
  */
 uint32_t random_uint32(void);
+
+/**
+ * @brief writes random bytes in the [0,0xff]-interval to memory
+ */
+void random_bytes(uint8_t *buf, size_t size);
 
 /**
  * @brief   generates a random number r with a <= r < b.


### PR DESCRIPTION
Adds a `random_bytes()` function allowing to read a specified amount of bytes to a buffer. This might be useful, as currently it is only possible to read 32-bit integers from the random module.
Possible use cases include #7393. 