### PR TITLE
cbor: fix out of bound memory access

### DIFF
--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -400,7 +400,7 @@ static size_t decode_bytes(const cbor_stream_t *s, size_t offset, char *out, siz
         return 0;
     }
 
-    if (length + 1 < bytes_length) {
+    if (length < bytes_length + 1) {
         return 0;
     }
 

--- a/tests/unittests/tests-cbor/tests-cbor.c
+++ b/tests/unittests/tests-cbor/tests-cbor.c
@@ -272,6 +272,17 @@ static void test_byte_string(void)
         TEST_ASSERT(cbor_deserialize_byte_string(&stream, 0, buffer, sizeof(buffer)));
         CBOR_CHECK_DESERIALIZED(input, buffer, EQUAL_STRING);
     }
+
+    cbor_clear(&stream);
+
+    {
+        /* check out buffer too small */
+        const char *input = "a";
+        TEST_ASSERT(cbor_serialize_byte_string(&stream, input));
+        unsigned char data[] = {0x41, 0x61};
+        CBOR_CHECK_SERIALIZED(stream, data, sizeof(data));
+        TEST_ASSERT(cbor_deserialize_byte_string(&stream, 0, buffer, strlen(input)) == 0);
+    }
 }
 
 static void test_byte_string_no_copy(void)


### PR DESCRIPTION
I think the buffersize check in `decode_bytes` allows for an out of bound memory write. This pull request solves it