### PR TITLE
gnrc_ipv6: fix packet snip switch-up

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -795,7 +795,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
     /* if available, remove any padding that was added by lower layers
      * to fulfill their minimum size requirements (e.g. ethernet) */
-    if (byteorder_ntohs(hdr->len) < pkt->size) {
+    if ((ipv6 != pkt) && (byteorder_ntohs(hdr->len) < pkt->size)) {
         gnrc_pktbuf_realloc_data(pkt, byteorder_ntohs(hdr->len));
     }
     else if (byteorder_ntohs(hdr->len) >


### PR DESCRIPTION
Minimal bug I noticed in GNRC's IPv6 port: if an IPv6 packet doesn't contain a payload, the header is removed by the demux functionality (minimal, because payload-less IPv6 packets do not happen that often). This fixes that.