### PR TITLE
boards: add Zolertia Firefly board

### DIFF
--- a/boards/firefly/Makefile
+++ b/boards/firefly/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS += $(RIOTBOARD)/common/remote
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/firefly/Makefile.dep
+++ b/boards/firefly/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/remote/Makefile.dep

--- a/boards/firefly/Makefile.features
+++ b/boards/firefly/Makefile.features
@@ -1,0 +1,12 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m3_2
+
+-include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/firefly/Makefile.include
+++ b/boards/firefly/Makefile.include
@@ -1,0 +1,7 @@
+USEMODULE += boards_common_remote
+
+# define the default port depending on the host OS
+PORT_LINUX  ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/firefly/board.c
+++ b/boards/firefly/board.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 DAI Labor Technische Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_firefly
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Firefly board
+ *
+ * @author      Anon Mall <anon.mall@gt-arc.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+#include "fancy_leds.h"
+
+static inline void leds_init(void);
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+    /* initialize the boards LEDs */
+    leds_init();
+}
+
+/**
+ * @brief Initialize the boards on-board LEDs
+ *
+ * The LED initialization is hard-coded in this function. As the LED (RGB) are
+ * soldered onto the board they are fixed to their CPU pins.
+ */
+static inline void leds_init(void)
+{
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
+
+    /* Shoot rainbows */
+    LED_RAINBOW();
+}

--- a/boards/firefly/doc.txt
+++ b/boards/firefly/doc.txt
@@ -1,0 +1,111 @@
+Zolertia Firefly platform
+============================================
+
+The Firefly platform (Revision A) is a IoT Hardware development platform based
+on TI's CC2538 system on chip (SoC), featuring an ARM Cortex-M3 with 512KB
+flash, 32Kb RAM, double RF interface (Sub-1GHz CC1200 RF transceiver), and the
+following goodies:
+
+* ISM 2.4-GHz IEEE 802.15.4 & Zigbee compliant.
+* ISM 868-, 915-, 920-, 950-MHz ISM/SRD Band.
+* AES-128/256, SHA2 Hardware Encryption Engine.
+* ECC-128/256, RSA Hardware Acceleration Engine for Secure Key Exchange.
+* Power consumption down to 150nA using our shutdown mode.
+* Flashing over BSL without requiring to press any button to enter bootloader mode.
+* Built-in battery charger (500mA), Energy Harvesting and Solar Panels to be connected to standards LiPo batteries.
+* Power input with 2.3-5.1VDC depending on battery or USB supply
+
+
+Port Features
+=============
+In terms of hardware support, the following drivers have been implemented:
+
+  * CC2538 System-on-Chip:
+    * UART
+    * Random number generator
+    * Low Power Modes
+    * General-Purpose Timers
+    * I2C/SPI library
+    * LEDs
+    * Buttons
+    * RF 2.4GHz built-in in CC2538
+
+And under work or pending at cc2538 base cpu:
+
+    * Built-in core temperature and battery sensor.
+    * CC1200 sub-1GHz radio interface.
+    * Micro-SD external storage.
+    * ADC
+    * USB (in CDC-ACM).
+    * uDMA Controller.
+
+Requirements
+============
+
+ * Toolchain to compile RIOT for the CC2538
+ * Drivers to enable your host to communicate with the platform
+ * Built-in BSL programming over USB using cc2538-bsl (included)
+
+
+Install a Toolchain
+-------------------
+The toolchain used to build is arm-gcc, to check if it is currently installed run:
+
+    $ arm-none-eabi-gcc -v
+    Using built-in specs.
+    Target: arm-none-eabi
+    Configured with: /scratch/julian/lite-respin/eabi/src/gcc-4.3/configure
+    ...
+    (skip)
+    ...
+    Thread model: single
+    gcc version 4.3.2 (Sourcery G++ Lite 2008q3-66)
+
+Else install from <https://launchpad.net/gcc-arm-embedded>
+
+
+Drivers
+-------
+The Firefly features a CP2104 serial-to-USB module, the driver is commonly found in most OS, but if required it can be downloaded
+from <https://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
+
+
+### For the CC2538EM (USB CDC-ACM)
+The Firefly has built-in support for USB 2.0 USB, Vendor and Product IDs are the following:
+
+  * VID 0x0451
+  * PID 0x16C8
+
+On Linux and OS X this is straightforward, on windows you need to install the following driver:
+
+<https://github.com/alignan/lufa/blob/remote-zongle/LUFA/CodeTemplates/WindowsINF/LUFA%20CDC-ACM.inf>
+
+And replace the IDs accordingly.
+
+### Device Enumerations
+For the UART, serial line settings are 115200 8N1, no flow control.
+
+Once all drivers have been installed correctly:
+
+On windows, devices will appear as a virtual `COM` port.
+
+On Linux, devices will appear under `/dev/`.
+
+On OS X, `/dev/tty.SLAB_USBtoUARTx`.
+
+On Linux:
+
+* Firefly over CP2104: `ttyUSB0`
+* Firefly over USB driver (in CDC-ACM): `ttyACMn` (n=0, 1, ....)
+
+More Reading
+============
+1. [Zolertia Firefly website][remote-site]
+2. [Zolertia Wiki page][zolertia-wiki]
+2. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
+3. [CC1200 sub-1GHz RF transceiver][cc1200]
+
+[remote-site]: http://www.zolertia.io/products "Zolertia Firefly"
+[zolertia-wiki]: https://github.com/Zolertia/Resources/wiki
+[cc1200]: http://www.ti.com/product/cc1200     "CC1200"
+[cc2538]: http://www.ti.com/product/cc2538     "CC2538"

--- a/boards/firefly/include/adc_params.h
+++ b/boards/firefly/include/adc_params.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_firefly
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC
+ *
+ * @author      Anon Mall <anon.mall@gt-arc.com>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "ADC1",
+        .line = ADC_LINE(0),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC2",
+        .line = ADC_LINE(1),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC3",
+        .line = ADC_LINE(2),
+        .res  = ADC_RES_12BIT,
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/firefly/include/board.h
+++ b/boards/firefly/include/board.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2017 DAI Labor Technische Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    boards_firefly Firefly Board
+ * @ingroup     boards
+ * @brief       Support for the Firefly board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Firefly board
+ *
+ * @author      Anon Mall <anon.mall@gt-arc.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name LED pin definitions
+ * @{
+ */
+#define LED0_PIN        GPIO_PIN(PORT_D, 5)
+#define LED0_MASK       (1 << 5)
+#define LED0_ON         (GPIO_D->DATA |=  LED0_MASK)
+#define LED0_OFF        (GPIO_D->DATA &= ~LED0_MASK)
+#define LED0_TOGGLE     (GPIO_D->DATA ^=  LED0_MASK)
+
+#define LED1_PIN        GPIO_PIN(PORT_D, 4)
+#define LED1_MASK       (1 << 4)
+#define LED1_ON         (GPIO_D->DATA |=  LED1_MASK)
+#define LED1_OFF        (GPIO_D->DATA &= ~LED1_MASK)
+#define LED1_TOGGLE     (GPIO_D->DATA ^=  LED1_MASK)
+
+#define LED2_PIN        GPIO_PIN(PORT_D, 3)
+#define LED2_MASK       (1 << 3)
+#define LED2_ON         (GPIO_D->DATA |=  LED2_MASK)
+#define LED2_OFF        (GPIO_D->DATA &= ~LED2_MASK)
+#define LED2_TOGGLE     (GPIO_D->DATA ^=  LED2_MASK)
+/** @} */
+
+/**
+ * @name User button pin definition
+ * @{
+ */
+#define BTN0_PIN        GPIO_PIN(PORT_A, 3)
+#define BTN0_MODE       GPIO_IN_PU
+/** @} */
+
+/**
+ * @name CC1200 SPI and pins definitions
+ * @{
+ */
+#define CC1200_SPI_DEV      SSI0
+#define CC1200_MOSI_GPIO    GPIO_PIN(PORT_B, 1)
+#define CC1200_MISO_GPIO    GPIO_PIN(PORT_B, 3)
+#define CC1200_SCLK_GPIO    GPIO_PIN(PORT_B, 2)
+#define CC1200_CSN_GPIO     GPIO_PIN(PORT_B, 5)
+#define CC1200_RESET_GPIO   GPIO_PIN(PORT_C, 7)
+#define CC1200_GPD0_GPIO    GPIO_PIN(PORT_B, 4)
+#define CC1200_GPD2_GPIO    GPIO_PIN(PORT_B, 0)
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/firefly/include/gpio_params.h
+++ b/boards/firefly/include/gpio_params.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 DAI Labor Technische Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_firefly
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Anon Mall <anon.mall@gt-arc.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(blue)",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Button(User)",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/firefly/include/periph_conf.h
+++ b/boards/firefly/include/periph_conf.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2017 DAI Labor Technische Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_firefly
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the Firefly  board revision A
+ *
+ * @author      Anon Mall <anon.mall@gt-arc.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF               1
+#define I2C_0_EN                1
+#define I2C_IRQ_PRIO            1
+
+/* I2C 0 device configuration */
+#define I2C_0_DEV               0
+#define I2C_0_IRQ               I2C_IRQn
+#define I2C_0_IRQ_HANDLER       isr_i2c
+#define I2C_0_SCL_PIN           GPIO_PIN(PORT_C, 3)
+#define I2C_0_SDA_PIN           GPIO_PIN(PORT_C, 2)
+
+static const i2c_conf_t i2c_config[I2C_NUMOF] = {
+    {
+        .speed = I2C_SPEED_FAST,    /**< bus speed */
+        .scl_pin = I2C_0_SCL_PIN,
+        .sda_pin = I2C_0_SDA_PIN,
+    },
+};
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .num      = 0,
+        .mosi_pin = GPIO_PIN(PORT_B, 1),
+        .miso_pin = GPIO_PIN(PORT_B, 3),
+        .sck_pin  = GPIO_PIN(PORT_B, 2),
+        .cs_pin   = GPIO_UNDEF
+    },
+    {
+        .num      = 1,
+        .mosi_pin = GPIO_PIN(PORT_C, 5),
+        .miso_pin = GPIO_PIN(PORT_C, 6),
+        .sck_pin  = GPIO_PIN(PORT_C, 4),
+        .cs_pin   = GPIO_PIN(PORT_A, 7)
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define SOC_ADC_ADCCON3_EREF  SOC_ADC_ADCCON3_EREF_AVDD5
+
+static const adc_conf_t adc_config[] = {
+    GPIO_PIN(PORT_A, 5),    /**< GPIO_PA5 = ADC1_PIN */
+    GPIO_PIN(PORT_A, 4),    /**< GPIO_PA4 = ADC2_PIN */
+    /* voltage divider with 5/3 relationship to allow 5V sensors */
+    GPIO_PIN(PORT_A, 2),    /**< GPIO_PA2 = ADC3_PIN */
+};
+
+#define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+/** @} */
+
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -24,7 +24,8 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
                              seeeduino_arch-pro sensebox_samd21 slstk3401a \
                              sltb001a slwstk6220a sodaq-autonomo sodaq-explorer \
                              sodaq-one stk3600 stm32f3discovery yunjia-nrf51822 \
-                             esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing
+                             esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
+                             firefly
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
                    chronos hifive1 jiminy-mega256rfr2 mega-xplained mips-malta \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -20,6 +20,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              chronos \
                              ek-lm4f120xl \
                              feather-m0 \
+                             firefly \
                              ikea-tradfri \
                              limifrog-v1 maple-mini \
                              lobaro-lorabox \
@@ -109,6 +110,7 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        ek-lm4f120xl \
                        f4vi1 \
                        feather-m0 \
+                       firefly \
                        fox \
                        frdm-k22f \
                        frdm-k64f \


### PR DESCRIPTION
I added the firefly board, with the remote-revb board as a template. I am still using remote-common, as the Firefly also has the Zoul core module installed. The gpio defines are adjusted according to #7320, which has to be merged first, because the spi and uart pins are depending on the changes, otherwise the board will not boot.