### PR TITLE
net/gcoap: add Uri-Query strings for requests

### DIFF
--- a/pkg/nanocoap/Makefile
+++ b/pkg/nanocoap/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=nanocoap
 PKG_URL=https://github.com/kaspar030/sock
-PKG_VERSION=1bba8bb16463914266dd5a04fe2a3eac4ee129ae
+PKG_VERSION=fc0a9470536bc760998827a6dc05d7dedf7b93ad
 PKG_LICENSE=LGPL-2.1
 
 .PHONY: all

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -242,9 +242,9 @@ extern "C" {
  * @brief   Size of the buffer used to write options, other than Uri-Path, in a
  *          request
  *
- * Accommodates Content-Format.
+ * Accommodates Content-Format and Uri-Queries
  */
-#define GCOAP_REQ_OPTIONS_BUF   (8)
+#define GCOAP_REQ_OPTIONS_BUF   (40)
 
 /**
  * @brief   Size of the buffer used to write options in a response
@@ -653,6 +653,23 @@ uint8_t gcoap_op_state(void);
  * @return  -1 on error
  */
 int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf);
+
+/**
+ * @brief   Adds a single Uri-Query option to a CoAP request
+ *
+ * To add multiple Uri-Query options, simply call this function multiple times.
+ * The Uri-Query options will be added in the order those calls.
+ *
+ * @param[out] pdu      The package that is being build
+ * @param[in]  key      Key to add to the query string
+ * @param[in]  val      Value to assign to @p key (may be NULL)
+ *
+ * @pre     ((pdu != NULL) && (key != NULL))
+ *
+ * @return  overall length of new query string
+ * @return  -1 on error
+ */
+int gcoap_add_qstring(coap_pkt_t *pdu, const char *key, const char *val);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
~~Needs https://github.com/kaspar030/sock/pull/16 merged to work...~~

This PR adds means to `gcoap` for adding query strings (Uri-Query options) to any given CoAP request. The functionality is split and partly placed in `nanocoap`.

The usage is very simple, e.g.:
```c
gcoap_req_init(&pkt, buf, sizeof(buf), COAP_METHOD_POST, "/some/url");
gcoap_add_qstring(&pkt, "key1", "some_value");
gcoap_add_qstring(&pkt, "bier", NULL);
gcoap_add_qstring(&pkt, "foo", "bar");
gcoap_finish(&pkt, 0, COAP_FORMAT_TEXT);
```
will result in:
```
POST: HOST.../some/url?key1=some_value&bier&foo=bar
```

