### PR TITLE
gnrc/sock: fix fallthrough warning

### DIFF
--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -87,6 +87,7 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
                 return -ETIMEDOUT;
             }
 #endif
+            /*Falls Through.*/
         default:
             return -EINTR;
     }

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -87,7 +87,7 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
                 return -ETIMEDOUT;
             }
 #endif
-            /*Falls Through.*/
+            /* Falls Through. */
         default:
             return -EINTR;
     }


### PR DESCRIPTION
Fix fallthrough warning:
```
RIOT/sys/net/gnrc/sock/gnrc_sock.c:87:16: error: this statement may fall through [-Werror=implicit-fallthrough=]
             if (msg.content.value == _TIMEOUT_MAGIC) {
```