### PR TITLE
net/gcoap: added remote sock ep to resp handler cb

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -29,7 +29,8 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static void _resp_handler(unsigned req_state, coap_pkt_t* pdu);
+static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
+                          sock_udp_ep_t *remote);
 static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len);
 
 /* CoAP resources */
@@ -48,8 +49,11 @@ static uint16_t req_count = 0;
 /*
  * Response callback.
  */
-static void _resp_handler(unsigned req_state, coap_pkt_t* pdu)
+static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
+                          sock_udp_ep_t *remote)
 {
+    (void)remote;       /* not interested in the source currently */
+
     if (req_state == GCOAP_MEMO_TIMEOUT) {
         printf("gcoap: timeout for msg ID %02u\n", coap_get_id(pdu));
         return;

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -413,7 +413,8 @@ typedef struct gcoap_listener {
  *
  * If request timed out, the packet header is for the request.
  */
-typedef void (*gcoap_resp_handler_t)(unsigned req_state, coap_pkt_t* pdu);
+typedef void (*gcoap_resp_handler_t)(unsigned req_state, coap_pkt_t* pdu,
+                                     sock_udp_ep_t *remote);
 
 /**
  * @brief   Memo to handle a response for a request

--- a/sys/net/application_layer/coap/gcoap.c
+++ b/sys/net/application_layer/coap/gcoap.c
@@ -160,7 +160,7 @@ static void _listen(sock_udp_t *sock)
         if (memo) {
             xtimer_remove(&memo->response_timer);
             memo->state = GCOAP_MEMO_RESP;
-            memo->resp_handler(memo->state, &pdu);
+            memo->resp_handler(memo->state, &pdu, &remote);
             memo->state = GCOAP_MEMO_UNUSED;
         }
     }
@@ -380,7 +380,7 @@ static void _expire_request(gcoap_request_memo_t *memo)
         /* Pass response to handler */
         if (memo->resp_handler) {
             req.hdr = (coap_hdr_t *)&memo->hdr_buf[0];   /* for reference */
-            memo->resp_handler(memo->state, &req);
+            memo->resp_handler(memo->state, &req, NULL);
         }
         memo->state = GCOAP_MEMO_UNUSED;
     }


### PR DESCRIPTION
When receiving a response to a request send our earlier, it is in some cases essential, to know something about who send the reponse. This is needed for example when sending requests to multicast addresses to be able to identify the responding node.