### PR TITLE
net/gcoap: expose creation of resource list to API

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -634,6 +634,26 @@ size_t gcoap_obs_send(const uint8_t *buf, size_t len,
  */
 uint8_t gcoap_op_state(void);
 
+/**
+ * @brief   Get the resource list, currently only `CoRE Link Format`
+ *          (COAP_FORMAT_LINK) supported
+ *
+ * If @p buf := NULL, nothing will be written but the size of the resulting
+ * resource list is computed and returned.
+ *
+ * @param[out] buf      output buffer to write resource list into, my be NULL
+ * @param[in]  maxlen   length of @p buf, ignored if @p buf is NULL
+ * @param[in]  cf       content format to use for the resource list, currently
+ *                      only COAP_FORMAT_LINK supported
+ *
+ * @todo    add support for `JSON CoRE Link Format`
+ * @todo    add support for 'CBOR CoRE Link Format`
+ *
+ * @return  the number of bytes written to @p buf
+ * @return  -1 on error
+ */
+int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -23,6 +23,23 @@
 #include "tests-gcoap.h"
 
 /*
+ * A test set of dummy resources. The resource handlers are set to NULL.
+ */
+static const coap_resource_t ressources[] = {
+    { "/test/info/all", (COAP_GET), NULL },
+    { "/sensor/temp", (COAP_GET), NULL },
+    { "/act/switch", (COAP_GET | COAP_POST), NULL }
+};
+
+static gcoap_listener_t listener = {
+    .resources     = (coap_resource_t *)&ressources[0],
+    .resources_len = (sizeof(ressources) / sizeof(ressources[0])),
+    .next          = NULL
+};
+
+static const char *resource_list_str = "</test/info/all>,</sensor/temp>,</act/switch>";
+
+/*
  * Client GET request success case. Test request generation.
  * Request /time resource from libcoap example
  * Includes token of length GCOAP_TOKENLEN.
@@ -226,6 +243,30 @@ static void test_gcoap__server_con_resp(void)
     TEST_ASSERT_EQUAL_INT(sizeof(resp_data), res);
 }
 
+/*
+ * Test the export of configured resources as CoRE link format string
+ */
+static void test_gcoap__server_get_resource_list(void)
+{
+    char res[128];
+    int size = 0;
+
+    gcoap_register_listener(&listener);
+
+    size = gcoap_get_resource_list(NULL, 0, COAP_CT_LINK_FORMAT);
+    TEST_ASSERT_EQUAL_INT(strlen(resource_list_str), size);
+
+    res[0] = 'A';
+    size = gcoap_get_resource_list(res, 0, COAP_CT_LINK_FORMAT);
+    TEST_ASSERT_EQUAL_INT(0, size);
+    TEST_ASSERT_EQUAL_INT((int)'A', (int)res[0]);
+
+    size = gcoap_get_resource_list(res, 127, COAP_CT_LINK_FORMAT);
+    res[size] = '\0';
+    TEST_ASSERT_EQUAL_INT(strlen(resource_list_str), size);
+    TEST_ASSERT_EQUAL_STRING(resource_list_str, (char *)res);
+}
+
 Test *tests_gcoap_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -235,6 +276,7 @@ Test *tests_gcoap_tests(void)
         new_TestFixture(test_gcoap__server_get_resp),
         new_TestFixture(test_gcoap__server_con_req),
         new_TestFixture(test_gcoap__server_con_resp),
+        new_TestFixture(test_gcoap__server_get_resource_list)
     };
 
     EMB_UNIT_TESTCALLER(gcoap_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
Creating the resource list is useful outside the /.well-known/core
handler, e.g. for the registration to resource directories.