### PR TITLE
gnrc_netif2: add IEEE 802.15.4 support

### DIFF
--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -21,8 +21,12 @@
 
 #include "log.h"
 #include "board.h"
+#ifdef MODULE_GNRC_NETIF2
+#include "net/gnrc/netif2/ieee802154.h"
+#else
 #include "net/gnrc/netdev.h"
 #include "net/gnrc/netdev/ieee802154.h"
+#endif
 #include "net/gnrc/lwmac/lwmac.h"
 #include "net/gnrc.h"
 
@@ -35,25 +39,35 @@
  */
 #define AT86RF2XX_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
 #ifndef AT86RF2XX_MAC_PRIO
+#ifdef MODULE_GNRC_NETIF2
+#define AT86RF2XX_MAC_PRIO          (GNRC_NETIF2_PRIO)
+#else
 #define AT86RF2XX_MAC_PRIO          (GNRC_NETDEV_MAC_PRIO)
+#endif
 #endif
 
 #define AT86RF2XX_NUM (sizeof(at86rf2xx_params) / sizeof(at86rf2xx_params[0]))
 
 static at86rf2xx_t at86rf2xx_devs[AT86RF2XX_NUM];
+#ifndef MODULE_GNRC_NETIF2
 static gnrc_netdev_t gnrc_adpt[AT86RF2XX_NUM];
+#endif
 static char _at86rf2xx_stacks[AT86RF2XX_NUM][AT86RF2XX_MAC_STACKSIZE];
 
 void auto_init_at86rf2xx(void)
 {
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {
-        int res;
-
         LOG_DEBUG("[auto_init_netif] initializing at86rf2xx #%u\n", i);
 
         at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i]);
-        res = gnrc_netdev_ieee802154_init(&gnrc_adpt[i],
-                                          (netdev_ieee802154_t *)&at86rf2xx_devs[i]);
+#ifdef MODULE_GNRC_NETIF2
+        gnrc_netif2_ieee802154_create(_at86rf2xx_stacks[i],
+                                      AT86RF2XX_MAC_STACKSIZE,
+                                      AT86RF2XX_MAC_PRIO, "at86rf2xx",
+                                      (netdev_t *)&at86rf2xx_devs[i]);
+#else
+        int res = gnrc_netdev_ieee802154_init(&gnrc_adpt[i],
+                                              (netdev_ieee802154_t *)&at86rf2xx_devs[i]);
 
         if (res < 0) {
             LOG_ERROR("[auto_init_netif] error initializing at86rf2xx radio #%u\n", i);
@@ -73,6 +87,7 @@ void auto_init_at86rf2xx(void)
                              &gnrc_adpt[i]);
 #endif
         }
+#endif
     }
 }
 #else

--- a/sys/auto_init/netif/auto_init_cc2420.c
+++ b/sys/auto_init/netif/auto_init_cc2420.c
@@ -23,8 +23,12 @@
 
 #include "log.h"
 #include "board.h"
+#ifdef MODULE_GNRC_NETIF2
+#include "net/gnrc/netif2/ieee802154.h"
+#else
 #include "net/gnrc/netdev.h"
 #include "net/gnrc/netdev/ieee802154.h"
+#endif
 #include "net/gnrc.h"
 
 #include "cc2420.h"
@@ -36,7 +40,11 @@
  */
 #define CC2420_MAC_STACKSIZE           (THREAD_STACKSIZE_MAIN)
 #ifndef CC2420_MAC_PRIO
+#ifdef MODULE_GNRC_NETIF2
+#define CC2420_MAC_PRIO                (GNRC_NETIF2_PRIO)
+#else
 #define CC2420_MAC_PRIO                (GNRC_NETDEV_MAC_PRIO)
+#endif
 #endif
 /** @} */
 
@@ -50,7 +58,9 @@
  * @{
  */
 static cc2420_t cc2420_devs[CC2420_NUMOF];
+#ifndef MODULE_GNRC_NETIF2
 static gnrc_netdev_t gnrc_adpt[CC2420_NUMOF];
+#endif
 static char _cc2420_stacks[CC2420_NUMOF][CC2420_MAC_STACKSIZE];
 /** @} */
 
@@ -60,6 +70,11 @@ void auto_init_cc2420(void)
         LOG_DEBUG("[auto_init_netif] initializing cc2420 #%u\n", i);
 
         cc2420_setup(&cc2420_devs[i], &cc2420_params[i]);
+#ifdef MODULE_GNRC_NETIF2
+        gnrc_netif2_ieee802154_create(_cc2420_stacks[i], CC2420_MAC_STACKSIZE,
+                                      CC2420_MAC_PRIO, "cc2420",
+                                      (netdev_t *)&cc2420_devs[i]);
+#else
         int res = gnrc_netdev_ieee802154_init(&gnrc_adpt[i],
                                               (netdev_ieee802154_t *)&cc2420_devs[i]);
 
@@ -72,6 +87,7 @@ void auto_init_cc2420(void)
                              CC2420_MAC_PRIO,
                              "cc2420", &gnrc_adpt[i]);
         }
+#endif
     }
 }
 

--- a/sys/auto_init/netif/auto_init_cc2538_rf.c
+++ b/sys/auto_init/netif/auto_init_cc2538_rf.c
@@ -20,8 +20,12 @@
 #ifdef MODULE_CC2538_RF
 
 #include "log.h"
+#ifdef MODULE_GNRC_NETIF2
+#include "net/gnrc/netif2/ieee802154.h"
+#else
 #include "net/gnrc/netdev.h"
 #include "net/gnrc/netdev/ieee802154.h"
+#endif
 
 #include "cc2538_rf.h"
 
@@ -31,22 +35,34 @@
  */
 #define CC2538_MAC_STACKSIZE       (THREAD_STACKSIZE_DEFAULT)
 #ifndef CC2538_MAC_PRIO
+#ifdef MODULE_GNRC_NETIF2
+#define CC2538_MAC_PRIO            (GNRC_NETIF2_PRIO)
+#else
 #define CC2538_MAC_PRIO            (GNRC_NETDEV_MAC_PRIO)
+#endif
 #endif
 
 static cc2538_rf_t cc2538_rf_dev;
+#ifndef MODULE_GNRC_NETIF2
 static gnrc_netdev_t gnrc_adpt;
+#endif
 static char _cc2538_rf_stack[CC2538_MAC_STACKSIZE];
 
 void auto_init_cc2538_rf(void)
 {
-    int res;
-
     LOG_DEBUG("[auto_init_netif] initializing cc2538 radio\n");
 
     cc2538_setup(&cc2538_rf_dev);
-    res = gnrc_netdev_ieee802154_init(&gnrc_adpt,
-                                      (netdev_ieee802154_t *)&cc2538_rf_dev);
+#ifdef MODULE_GNRC_NETIF2
+    if (!gnrc_netif2_ieee802154_create(_cc2538_rf_stack,
+                                       CC2538_MAC_STACKSIZE,
+                                       CC2538_MAC_PRIO, "cc2538_rf",
+                                       (netdev_t *)&cc2538_rf_dev)) {
+        LOG_ERROR("[auto_init_netif] error initializing cc2538 radio\n");
+    }
+#else
+    int res = gnrc_netdev_ieee802154_init(&gnrc_adpt,
+                                          (netdev_ieee802154_t *)&cc2538_rf_dev);
 
     if (res < 0) {
         LOG_ERROR("[auto_init_netif] error initializing cc2538 radio\n");
@@ -58,6 +74,7 @@ void auto_init_cc2538_rf(void)
                          "cc2538_rf",
                          &gnrc_adpt);
     }
+#endif
 }
 
 #else

--- a/sys/auto_init/netif/auto_init_kw2xrf.c
+++ b/sys/auto_init/netif/auto_init_kw2xrf.c
@@ -24,8 +24,12 @@
 
 #include "log.h"
 #include "board.h"
+#ifdef MODULE_GNRC_NETIF2
+#include "net/gnrc/netif2/ieee802154.h"
+#else
 #include "net/gnrc/netdev.h"
 #include "net/gnrc/netdev/ieee802154.h"
+#endif
 #include "net/gnrc.h"
 
 #include "kw2xrf.h"
@@ -37,13 +41,19 @@
  */
 #define KW2XRF_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
 #ifndef KW2XRF_MAC_PRIO
+#ifdef MODULE_GNRC_NETIF2
+#define KW2XRF_MAC_PRIO          (GNRC_NETIF2_PRIO)
+#else
 #define KW2XRF_MAC_PRIO          (GNRC_NETDEV_MAC_PRIO)
+#endif
 #endif
 
 #define KW2XRF_NUM (sizeof(kw2xrf_params)/sizeof(kw2xrf_params[0]))
 
 static kw2xrf_t kw2xrf_devs[KW2XRF_NUM];
+#ifndef MODULE_GNRC_NETIF2
 static gnrc_netdev_t gnrc_adpt[KW2XRF_NUM];
+#endif
 static char _kw2xrf_stacks[KW2XRF_NUM][KW2XRF_MAC_STACKSIZE];
 
 void auto_init_kw2xrf(void)
@@ -53,6 +63,11 @@ void auto_init_kw2xrf(void)
 
         LOG_DEBUG("[auto_init_netif] initializing kw2xrf #%u\n", i);
         kw2xrf_setup(&kw2xrf_devs[i], (kw2xrf_params_t*) p);
+#ifdef MODULE_GNRC_NETIF2
+        gnrc_netif2_ieee802154_create(_kw2xrf_stacks[i], KW2XRF_MAC_STACKSIZE,
+                                      KW2XRF_MAC_PRIO, "kw2xrf",
+                                      (netdev_t *)&kw2xrf_devs[i]);
+#else
         if (gnrc_netdev_ieee802154_init(&gnrc_adpt[i], (netdev_ieee802154_t *)&kw2xrf_devs[i]) < 0) {
             LOG_ERROR("[auto_init_netif] error, initializing kw2xrf #%u\n", i);
         }
@@ -60,6 +75,7 @@ void auto_init_kw2xrf(void)
             gnrc_netdev_init(_kw2xrf_stacks[i], KW2XRF_MAC_STACKSIZE,
                              KW2XRF_MAC_PRIO, "kw2xrf", &gnrc_adpt[i]);
         }
+#endif
     }
 }
 #else

--- a/sys/auto_init/netif/auto_init_mrf24j40.c
+++ b/sys/auto_init/netif/auto_init_mrf24j40.c
@@ -21,8 +21,12 @@
 
 #include "log.h"
 #include "board.h"
+#ifdef MODULE_GNRC_NETIF2
+#include "net/gnrc/netif2/ieee802154.h"
+#else
 #include "net/gnrc/netdev.h"
 #include "net/gnrc/netdev/ieee802154.h"
+#endif
 #include "net/gnrc.h"
 
 #include "mrf24j40.h"
@@ -34,25 +38,35 @@
  */
 #define MRF24J40_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
 #ifndef MRF24J40_MAC_PRIO
+#ifdef MODULE_GNRC_NETIF2
+#define MRF24J40_MAC_PRIO          (GNRC_NETIF2_PRIO)
+#else
 #define MRF24J40_MAC_PRIO          (GNRC_NETDEV_MAC_PRIO)
+#endif
 #endif
 
 #define MRF24J40_NUM (sizeof(mrf24j40_params) / sizeof(mrf24j40_params[0]))
 
 static mrf24j40_t mrf24j40_devs[MRF24J40_NUM];
+#ifndef MODULE_GNRC_NETIF2
 static gnrc_netdev_t gnrc_adpt[MRF24J40_NUM];
+#endif
 static char _mrf24j40_stacks[MRF24J40_NUM][MRF24J40_MAC_STACKSIZE];
 
 void auto_init_mrf24j40(void)
 {
     for (unsigned i = 0; i < MRF24J40_NUM; i++) {
-        int res;
-
         LOG_DEBUG("[auto_init_netif] initializing mrf24j40 #%u\n", i);
 
         mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i]);
-        res = gnrc_netdev_ieee802154_init(&gnrc_adpt[i],
-                                          (netdev_ieee802154_t *)&mrf24j40_devs[i]);
+#ifdef MODULE_GNRC_NETIF2
+        gnrc_netif2_ieee802154_create(_mrf24j40_stacks[i],
+                                      MRF24J40_MAC_STACKSIZE, MRF24J40_MAC_PRIO,
+                                      "mrf24j40",
+                                      (netdev_t *)&mrf24j40_devs[i]);
+#else
+        int res = gnrc_netdev_ieee802154_init(&gnrc_adpt[i],
+                                              (netdev_ieee802154_t *)&mrf24j40_devs[i]);
 
         if (res < 0) {
             LOG_ERROR("[auto_init_netif] error initializing mrf24j40 #%u\n", i);
@@ -64,6 +78,7 @@ void auto_init_mrf24j40(void)
                              "mrf24j40",
                              &gnrc_adpt[i]);
         }
+#endif
     }
 }
 #else

--- a/sys/include/net/gnrc/netif2/ieee802154.h
+++ b/sys/include/net/gnrc/netif2/ieee802154.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup net_gnrc_netif2
+ * @{
+ *
+ * @file
+ * @brief   IEEE 802.15.4 adaption for @ref net_gnrc_netif2
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NET_GNRC_NETIF2_IEEE802154_H
+#define NET_GNRC_NETIF2_IEEE802154_H
+
+#include "net/gnrc/netif2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Creates an IEEE 802.15.4 network interface
+ *
+ * @param[in] stack     The stack for the network interface's thread.
+ * @param[in] stacksize Size of @p stack.
+ * @param[in] priority  Priority for the network interface's thread.
+ * @param[in] name      Name for the network interface. May be NULL.
+ * @param[in] dev       Device for the interface
+ *
+ * @see @ref gnrc_netif2_create()
+ *
+ * @return  The network interface on success.
+ * @return  NULL, on error.
+ */
+gnrc_netif2_t *gnrc_netif2_ieee802154_create(char *stack, int stacksize,
+                                             char priority, char *name,
+                                             netdev_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_GNRC_NETIF2_IEEE802154_H */
+/** @} */

--- a/sys/net/gnrc/netif2/gnrc_netif2_ieee802154.c
+++ b/sys/net/gnrc/netif2/gnrc_netif2_ieee802154.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "net/gnrc.h"
+#include "net/gnrc/netif2/ieee802154.h"
+#include "net/netdev/ieee802154.h"
+
+#ifdef MODULE_GNRC_IPV6
+#include "net/ipv6/hdr.h"
+#endif
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifdef MODULE_NETDEV_IEEE802154
+static int _send(gnrc_netif2_t *netif, gnrc_pktsnip_t *pkt);
+static gnrc_pktsnip_t *_recv(gnrc_netif2_t *netif);
+
+static const gnrc_netif2_ops_t ieee802154_ops = {
+    .send = _send,
+    .recv = _recv,
+    .get = gnrc_netif2_get_from_netdev,
+    .set = gnrc_netif2_set_from_netdev,
+};
+
+gnrc_netif2_t *gnrc_netif2_ieee802154_create(char *stack, int stacksize,
+                                             char priority, char *name,
+                                             netdev_t *dev)
+{
+    return gnrc_netif2_create(stack, stacksize, priority, name, dev,
+                              &ieee802154_ops);
+}
+
+static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)
+{
+    gnrc_pktsnip_t *snip;
+    uint8_t src[IEEE802154_LONG_ADDRESS_LEN], dst[IEEE802154_LONG_ADDRESS_LEN];
+    int src_len, dst_len;
+    le_uint16_t _pan_tmp;   /* TODO: hand-up PAN IDs to GNRC? */
+
+    dst_len = ieee802154_get_dst(mhr, dst, &_pan_tmp);
+    src_len = ieee802154_get_src(mhr, src, &_pan_tmp);
+    if ((dst_len < 0) || (src_len < 0)) {
+        DEBUG("_make_netif_hdr: unable to get addresses\n");
+        return NULL;
+    }
+    /* allocate space for header */
+    snip = gnrc_netif_hdr_build(src, (size_t)src_len, dst, (size_t)dst_len);
+    if (snip == NULL) {
+        DEBUG("_make_netif_hdr: no space left in packet buffer\n");
+        return NULL;
+    }
+    /* set broadcast flag for broadcast destination */
+    if ((dst_len == 2) && (dst[0] == 0xff) && (dst[1] == 0xff)) {
+        gnrc_netif_hdr_t *hdr = snip->data;
+        hdr->flags |= GNRC_NETIF_HDR_FLAGS_BROADCAST;
+    }
+    return snip;
+}
+
+static gnrc_pktsnip_t *_recv(gnrc_netif2_t *netif)
+{
+    netdev_t *dev = netif->dev;
+    netdev_ieee802154_rx_info_t rx_info;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    gnrc_pktsnip_t *pkt = NULL;
+    int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
+
+    if (bytes_expected > 0) {
+        int nread;
+
+        pkt = gnrc_pktbuf_add(NULL, NULL, bytes_expected, GNRC_NETTYPE_UNDEF);
+        if (pkt == NULL) {
+            DEBUG("_recv_ieee802154: cannot allocate pktsnip.\n");
+            return NULL;
+        }
+        nread = dev->driver->recv(dev, pkt->data, bytes_expected, &rx_info);
+        if (nread <= 0) {
+            gnrc_pktbuf_release(pkt);
+            return NULL;
+        }
+        if (!(state->flags & NETDEV_IEEE802154_RAW)) {
+            gnrc_pktsnip_t *ieee802154_hdr, *netif_hdr;
+            gnrc_netif_hdr_t *hdr;
+#if ENABLE_DEBUG
+            char src_str[GNRC_NETIF_HDR_L2ADDR_PRINT_LEN];
+#endif
+            size_t mhr_len = ieee802154_get_frame_hdr_len(pkt->data);
+
+            if (mhr_len == 0) {
+                DEBUG("_recv_ieee802154: illegally formatted frame received\n");
+                gnrc_pktbuf_release(pkt);
+                return NULL;
+            }
+            nread -= mhr_len;
+            /* mark IEEE 802.15.4 header */
+            ieee802154_hdr = gnrc_pktbuf_mark(pkt, mhr_len, GNRC_NETTYPE_UNDEF);
+            if (ieee802154_hdr == NULL) {
+                DEBUG("_recv_ieee802154: no space left in packet buffer\n");
+                gnrc_pktbuf_release(pkt);
+                return NULL;
+            }
+            netif_hdr = _make_netif_hdr(ieee802154_hdr->data);
+            if (netif_hdr == NULL) {
+                DEBUG("_recv_ieee802154: no space left in packet buffer\n");
+                gnrc_pktbuf_release(pkt);
+                return NULL;
+            }
+
+            hdr = netif_hdr->data;
+
+#ifdef MODULE_L2FILTER
+            if (!l2filter_pass(dev->filter, gnrc_netif_hdr_get_src_addr(hdr),
+                               hdr->src_l2addr_len)) {
+                gnrc_pktbuf_release(pkt);
+                gnrc_pktbuf_release(netif_hdr);
+                DEBUG("_recv_ieee802154: packet dropped by l2filter\n");
+                return NULL;
+            }
+#endif
+
+            hdr->lqi = rx_info.lqi;
+            hdr->rssi = rx_info.rssi;
+            hdr->if_pid = thread_getpid();
+            pkt->type = state->proto;
+#if ENABLE_DEBUG
+            DEBUG("_recv_ieee802154: received packet from %s of length %u\n",
+                  gnrc_netif_addr_to_str(src_str, sizeof(src_str),
+                                         gnrc_netif_hdr_get_src_addr(hdr),
+                                         hdr->src_l2addr_len),
+                  nread);
+#if defined(MODULE_OD)
+            od_hex_dump(pkt->data, nread, OD_WIDTH_DEFAULT);
+#endif
+#endif
+            gnrc_pktbuf_remove_snip(pkt, ieee802154_hdr);
+            LL_APPEND(pkt, netif_hdr);
+        }
+
+        DEBUG("_recv_ieee802154: reallocating.\n");
+        gnrc_pktbuf_realloc_data(pkt, nread);
+    }
+
+    return pkt;
+}
+
+static int _send(gnrc_netif2_t *netif, gnrc_pktsnip_t *pkt)
+{
+    netdev_t *dev = netif->dev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    gnrc_netif_hdr_t *netif_hdr;
+    gnrc_pktsnip_t *vec_snip;
+    const uint8_t *src, *dst = NULL;
+    int res = 0;
+    size_t n, src_len, dst_len;
+    uint8_t mhr[IEEE802154_MAX_HDR_LEN];
+    uint8_t flags = (uint8_t)(state->flags & NETDEV_IEEE802154_SEND_MASK);
+    le_uint16_t dev_pan = byteorder_btols(byteorder_htons(state->pan));
+
+    flags |= IEEE802154_FCF_TYPE_DATA;
+    if (pkt == NULL) {
+        DEBUG("_send_ieee802154: pkt was NULL\n");
+        return -EINVAL;
+    }
+    if (pkt->type != GNRC_NETTYPE_NETIF) {
+        DEBUG("_send_ieee802154: first header is not generic netif header\n");
+        return -EBADMSG;
+    }
+    netif_hdr = pkt->data;
+    /* prepare destination address */
+    if (netif_hdr->flags & /* If any of these flags is set assume broadcast */
+        (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
+        dst = ieee802154_addr_bcast;
+        dst_len = IEEE802154_ADDR_BCAST_LEN;
+    }
+    else {
+        dst = gnrc_netif_hdr_get_dst_addr(netif_hdr);
+        dst_len = netif_hdr->dst_l2addr_len;
+    }
+    src_len = netif_hdr->src_l2addr_len;
+    if (src_len > 0) {
+        src = gnrc_netif_hdr_get_src_addr(netif_hdr);
+    }
+    else {
+        src_len = netif->l2addr_len;
+        src = netif->l2addr;
+    }
+    /* fill MAC header, seq should be set by device */
+    if ((res = ieee802154_set_frame_hdr(mhr, src, src_len,
+                                        dst, dst_len, dev_pan,
+                                        dev_pan, flags, state->seq++)) == 0) {
+        DEBUG("_send_ieee802154: Error preperaring frame\n");
+        return -EINVAL;
+    }
+    /* prepare packet for sending */
+    vec_snip = gnrc_pktbuf_get_iovec(pkt, &n);
+    if (vec_snip != NULL) {
+        struct iovec *vector;
+
+        pkt = vec_snip;     /* reassign for later release; vec_snip is prepended to pkt */
+        vector = (struct iovec *)pkt->data;
+        vector[0].iov_base = mhr;
+        vector[0].iov_len = (size_t)res;
+#ifdef MODULE_NETSTATS_L2
+    if (netif_hdr->flags &
+        (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
+            netif->dev->stats.tx_mcast_count++;
+        }
+        else {
+            netif->dev->stats.tx_unicast_count++;
+        }
+#endif
+#ifdef MODULE_GNRC_MAC
+        if (netif->mac_info & GNRC_NETDEV_MAC_INFO_CSMA_ENABLED) {
+            res = csma_sender_csma_ca_send(dev, vector, n, &netif->csma_conf);
+        }
+        else {
+            res = dev->driver->send(dev, vector, n);
+        }
+#else
+        res = dev->driver->send(dev, vector, n);
+#endif
+    }
+    else {
+        return -ENOBUFS;
+    }
+    /* release old data */
+    gnrc_pktbuf_release(pkt);
+    return res;
+}
+#else   /* MODULE_NETDEV_IEEE802154 */
+typedef int dont_be_pedantic;
+#endif  /* MODULE_NETDEV_IEEE802154 */
+/** @} */

--- a/tests/gnrc_netif2/Makefile
+++ b/tests/gnrc_netif2/Makefile
@@ -19,6 +19,7 @@ USEMODULE += gnrc_sixlowpan
 USEMODULE += gnrc_sixlowpan_iphc
 USEMODULE += gnrc_ipv6
 USEMODULE += netdev_eth
+USEMODULE += netdev_ieee802154
 USEMODULE += netdev_test
 USEMODULE += od
 

--- a/tests/gnrc_netif2/common.h
+++ b/tests/gnrc_netif2/common.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-#define SPECIAL_DEVS        (1)
+#define SPECIAL_DEVS        (2)
 #define DEFAULT_DEVS_NUMOF  (GNRC_NETIF_NUMOF - SPECIAL_DEVS)
 
 #define GP1 (0x20U)
@@ -56,11 +56,19 @@ extern "C" {
 #define LA7 (0xfdU)
 #define LA8 (0x0aU)
 
+#define TEST_IEEE802154_MAX_FRAG_SIZE   (102)
+
 #define ETHERNET_SRC        { LA1, LA2, LA3, LA6, LA7, LA8 }
 #define ETHERNET_IPV6_LL    { LP1, LP2, LP3, LP4, LP5, LP6, LP7, LP8, \
                               LA1 ^ 0x2, LA2, LA3, 0xff, 0xfe, LA6, LA7, LA8 }
 #define ETHERNET_IPV6_G     { GP1, GP2, GP3, GP4, GP5, GP6, GP7, GP8, \
                               LA1 ^ 0x2, LA2, LA3, 0xff, 0xfe, LA6, LA7, LA8 }
+#define IEEE802154_LONG_SRC     { LA1, LA2, LA3, LA4, LA5, LA6, LA7, LA8 }
+#define IEEE802154_SHORT_SRC    { LA7, LA8 }
+#define IEEE802154_IPV6_LL  { LP1, LP2, LP3, LP4, LP5, LP6, LP7, LP8, \
+                              LA1 ^ 0x2, LA2, LA3, LA4, LA5, LA6, LA7, LA8 }
+#define IEEE802154_IPV6_G   { GP1, GP2, GP3, GP4, GP5, GP6, GP7, GP8, \
+                              LA1 ^ 0x2, LA2, LA3, LA4, LA5, LA6, LA7, LA8 }
 #define NETIF0_SRC          { LA1, LA2 + 1, LA3, LA4, LA5, LA6, LA7, LA8 }
 #define NETIF0_IPV6_LL      { LP1, LP2, LP3, LP4, LP5, LP6, LP7, LP8, \
                               LA1 ^ 0x2, LA2 + 1, LA3, LA4, LA5, LA6, LA7, LA8 }
@@ -74,6 +82,7 @@ extern "C" {
                               LA1 ^ 0x82, LA2, LA3, LA4, LA5, LA6, LA7, LA8 }
 
 extern netdev_t *ethernet_dev;
+extern netdev_t *ieee802154_dev;
 extern netdev_t *devs[DEFAULT_DEVS_NUMOF];
 
 void _tests_init(void);

--- a/tests/gnrc_netif2/tests/01-run.py
+++ b/tests/gnrc_netif2/tests/01-run.py
@@ -27,6 +27,42 @@ def testfunc(child):
     child.expect("00000000  FF  FF  FF  FF  FF  FF  3E  E6  B5  22  FD  0A  " +
                            "FF  FF  41  42")
     child.expect("00000010  43  44  45  46  47  00")
+    # test_netapi_send__raw_unicast_ieee802154_long_long_packet
+    child.expect(r"Sending data from IEEE 802\.15\.4 device:")
+    child.expect("00000000  41  DC  00  00  00  0B  FD  22  19  0F  B5  E6  " +
+                           "3E  0A  FD  22")
+    child.expect("00000010  19  0F  B5  E6  3E  31  32  33  41  42  43  44  " +
+                           "45  46  47  00")
+    # test_netapi_send__raw_unicast_ieee802154_long_short_packet
+    child.expect(r"Sending data from IEEE 802\.15\.4 device:")
+    child.expect("00000000  41  D8  01  00  00  0B  FD  0A  FD  22  19  0F  " +
+                           "B5  E6  3E  31")
+    child.expect("00000010  32  33  41  42  43  44  45  46  47  00")
+    # test_netapi_send__raw_unicast_ieee802154_short_long_packet1
+    child.expect(r"Sending data from IEEE 802\.15\.4 device:")
+    child.expect("00000000  41  9C  02  00  00  0B  FD  22  19  0F  B5  E6  " +
+                           "3E  0A  FD  31")
+    child.expect("00000010  32  33  41  42  43  44  45  46  47  00")
+    # test_netapi_send__raw_unicast_ieee802154_short_long_packet2
+    child.expect(r"Sending data from IEEE 802\.15\.4 device:")
+    child.expect("00000000  41  9C  03  00  00  0B  FD  22  19  0F  B5  E6  " +
+                           "3E  0A  FD  31")
+    child.expect("00000010  32  33  41  42  43  44  45  46  47  00")
+    # test_netapi_send__raw_unicast_ieee802154_short_short_packet
+    child.expect(r"Sending data from IEEE 802\.15\.4 device:")
+    child.expect("00000000  41  98  04  00  00  0B  FD  0A  FD  31  32  33  " +
+                           "41  42  43  44")
+    child.expect("00000010  45  46  47  00")
+    # test_netapi_send__raw_broadcast_ieee802154_long_packet
+    child.expect(r"Sending data from IEEE 802\.15\.4 device:")
+    child.expect("00000000  41  D8  05  00  00  FF  FF  0A  FD  22  19  0F  " +
+                              "B5  E6  3E  31")
+    child.expect("00000010  32  33  41  42  43  44  45  46  47  00")
+    # test_netapi_send__raw_broadcast_ieee802154_short_packet
+    child.expect(r"Sending data from IEEE 802\.15\.4 device:")
+    child.expect("00000000  41  98  06  00  00  FF  FF  0A  FD  31  32  33  " +
+                           "41  42  43  44")
+    child.expect("00000010  45  46  47  00")
     # test_netapi_send__ipv6_unicast_ethernet_packet
     child.expect("Sending data from Ethernet device:")
     child.expect("00000000  3E  E6  B5  0F  19  23  3E  E6  B5  22  FD  0A  86  DD  60  00")
@@ -39,6 +75,19 @@ def testfunc(child):
     child.expect("00000010  00  00  00  08  3B  40  FE  80  00  00  00  00  00  00  3C  E6")
     child.expect("00000020  B5  FF  FE  22  FD  0A  FF  02  00  00  00  00  00  00  00  00")
     child.expect("00000030  00  00  00  00  00  01  41  42  43  44  45  46  47  00")
+    # test_netapi_send__ipv6_unicast_ieee802154_packet
+    child.expect("Sending data from IEEE 802.15.4 device:")
+    child.expect("00000000  41  DC  07  00  00  0B  FD  22  19  0F  B5  E6  3E  0A  FD  22")
+    child.expect("00000010  19  0F  B5  E6  3E  60  00  00  00  00  08  3B  40  FE  80  00")
+    child.expect("00000020  00  00  00  00  00  3C  E6  B5  0F  19  22  FD  0A  FE  80  00")
+    child.expect("00000030  00  00  00  00  00  3C  E6  B5  FF  FE  0F  19  23  41  42  43")
+    child.expect("00000040  44  45  46  47  00")
+    # test_netapi_send__ipv6_multicast_ieee802154_packet
+    child.expect("Sending data from IEEE 802.15.4 device:")
+    child.expect("00000000  41  D8  08  00  00  FF  FF  0A  FD  22  19  0F  B5  E6  3E  60")
+    child.expect("00000010  00  00  00  00  08  3B  40  FE  80  00  00  00  00  00  00  3C")
+    child.expect("00000020  E6  B5  0F  19  22  FD  0A  FF  02  00  00  00  00  00  00  00")
+    child.expect("00000030  00  00  00  00  00  00  01  41  42  43  44  45  46  47  00")
     # test_netapi_recv__empty_ethernet_payload
     child.expect("pktdump dumping Ethernet packet with empty payload")
     child.expect("PKTDUMP: data received:")
@@ -49,6 +98,16 @@ def testfunc(child):
     child.expect("src_l2addr: 3e:e6:b5:22:fd:0b")
     child.expect("dst_l2addr: 3e:e6:b5:22:fd:0a")
     child.expect("~~ PKT    -  2 snips, total size:  20 byte")
+    # test_netapi_recv__empty_ieee802154_payload
+    child.expect(r"pktdump dumping IEEE 802\.15\.4 packet with empty payload")
+    child.expect("PKTDUMP: data received:")
+    child.expect(r"~~ SNIP  0 - size:   0 byte, type: NETTYPE_UNDEF \(0\)")
+    child.expect(r"00000000~~ SNIP  1 - size:  24 byte, type: NETTYPE_NETIF \(-1\)")
+    child.expect("if_pid: 7  rssi: 0  lqi: 0")
+    child.expect("flags: 0x0")
+    child.expect("src_l2addr: 3e:e6:b5:0f:19:22:fd:0b")
+    child.expect("dst_l2addr: 3e:e6:b5:0f:19:22:fd:0a")
+    child.expect("~~ PKT    -  2 snips, total size:  24 byte")
     # test_netapi_recv__raw_ethernet_payload
     child.expect("pktdump dumping Ethernet packet with payload 12 34 45 56")
     child.expect("PKTDUMP: data received:")
@@ -60,6 +119,17 @@ def testfunc(child):
     child.expect("src_l2addr: 3e:e6:b5:22:fd:0b")
     child.expect("dst_l2addr: 3e:e6:b5:22:fd:0a")
     child.expect("~~ PKT    -  2 snips, total size:  24 byte")
+    # test_netapi_recv__raw_ieee802154_payload
+    child.expect(r"pktdump dumping IEEE 802\.15\.4 packet with payload 12 34 45 56")
+    child.expect("PKTDUMP: data received:")
+    child.expect(r"~~ SNIP  0 - size:   4 byte, type: NETTYPE_UNDEF \(0\)")
+    child.expect("00000000  12  34  45  56")
+    child.expect(r"~~ SNIP  1 - size:  24 byte, type: NETTYPE_NETIF \(-1\)")
+    child.expect("if_pid: 7  rssi: 0  lqi: 0")
+    child.expect("flags: 0x0")
+    child.expect("src_l2addr: 3e:e6:b5:0f:19:22:fd:0b")
+    child.expect("dst_l2addr: 3e:e6:b5:0f:19:22:fd:0a")
+    child.expect("~~ PKT    -  2 snips, total size:  28 byte")
     # test_netapi_recv__ipv6_ethernet_payload
     child.expect("pktdump dumping IPv6 over Ethernet packet with payload 01")
     child.expect("PKTDUMP: data received:")


### PR DESCRIPTION
IEEE 802.15.4 support for `gnrc_netif2`.

~~Requires #7370.~~

This PR is part of the network layer remodelling effort:
![PR dependencies](https://miri64.github.io/riot-ndp-model/PR%20overview.svg)