### PR TITLE
auto_init: upgrade bootstrap of Ethernet devices for gnrc_netif2

### DIFF
--- a/sys/auto_init/netif/auto_init_enc28j60.c
+++ b/sys/auto_init/netif/auto_init_enc28j60.c
@@ -24,8 +24,12 @@
 #include "log.h"
 #include "enc28j60.h"
 #include "enc28j60_params.h"
+#ifdef MODULE_GNRC_NETIF2
+#include "net/gnrc/netif2/ethernet.h"
+#else
 #include "net/gnrc/netdev.h"
 #include "net/gnrc/netdev/eth.h"
+#endif
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
@@ -33,7 +37,11 @@
  */
 #define ENC28J60_MAC_STACKSIZE   (THREAD_STACKSIZE_DEFAULT)
 #ifndef ENC28J60_MAC_PRIO
+#ifdef MODULE_GNRC_NETIF2
+#define ENC28J60_MAC_PRIO        (GNRC_NETIF2_PRIO)
+#else
 #define ENC28J60_MAC_PRIO        (GNRC_NETDEV_MAC_PRIO)
+#endif
 #endif
 /*** @} */
 
@@ -47,7 +55,9 @@
  * @{
  */
 static enc28j60_t dev[ENC28J60_NUM];
+#ifndef MODULE_GNRC_NETIF2
 static gnrc_netdev_t gnrc_adpt[ENC28J60_NUM];
+#endif
 /** @} */
 
 /**
@@ -63,11 +73,17 @@ void auto_init_enc28j60(void)
 
         /* setup netdev device */
         enc28j60_setup(&dev[i], &enc28j60_params[i]);
+#ifdef MODULE_GNRC_NETIF2
+        gnrc_netif2_ethernet_create(stack[i], ENC28J60_MAC_STACKSIZE,
+                                    ENC28J60_MAC_PRIO, "enc28j60",
+                                    (netdev_t *)&dev[i]);
+#else
         /* initialize netdev <-> gnrc adapter state */
         gnrc_netdev_eth_init(&gnrc_adpt[i], (netdev_t *)&dev[i]);
         /* start gnrc netdev thread */
         gnrc_netdev_init(stack[i], ENC28J60_MAC_STACKSIZE, ENC28J60_MAC_PRIO,
                          "gnrc_enc28j60", &gnrc_adpt[i]);
+#endif
     }
 }
 

--- a/sys/auto_init/netif/auto_init_encx24j600.c
+++ b/sys/auto_init/netif/auto_init_encx24j600.c
@@ -22,8 +22,12 @@
 #include "log.h"
 #include "debug.h"
 #include "encx24j600.h"
+#ifdef MODULE_GNRC_NETIF2
+#include "net/gnrc/netif2/ethernet.h"
+#else
 #include "net/gnrc/netdev.h"
 #include "net/gnrc/netdev/eth.h"
+#endif
 
 static encx24j600_t encx24j600;
 
@@ -33,14 +37,20 @@ static encx24j600_t encx24j600;
  */
 #define ENCX24J600_MAC_STACKSIZE    (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
 #ifndef ENCX24J600_MAC_PRIO
+#ifdef MODULE_GNRC_NETIF2
+#define ENCX24J600_MAC_PRIO         (GNRC_NETIF2_PRIO)
+#else
 #define ENCX24J600_MAC_PRIO         (GNRC_NETDEV_MAC_PRIO)
+#endif
 #endif
 
 /**
  * @brief   Stacks for the MAC layer threads
  */
 static char _netdev_eth_stack[ENCX24J600_MAC_STACKSIZE];
+#ifndef MODULE_GNRC_NETIF2
 static gnrc_netdev_t _gnrc_encx24j600;
+#endif
 
 void auto_init_encx24j600(void)
 {
@@ -54,12 +64,18 @@ void auto_init_encx24j600(void)
     encx24j600_setup(&encx24j600, &p);
 
     /* initialize netdev<->gnrc adapter state */
+#ifdef MODULE_GNRC_NETIF2
+    gnrc_netif2_ethernet_create(_netdev_eth_stack, ENCX24J600_MAC_STACKSIZE,
+                                ENCX24J600_MAC_PRIO, "encx24j600",
+                                (netdev_t *)&encx24j600);
+#else
     gnrc_netdev_eth_init(&_gnrc_encx24j600, (netdev_t*)&encx24j600);
 
     /* start gnrc netdev thread */
     gnrc_netdev_init(_netdev_eth_stack, ENCX24J600_MAC_STACKSIZE,
                      ENCX24J600_MAC_PRIO, "gnrc_encx24j600",
                      &_gnrc_encx24j600);
+#endif
 }
 
 #else

--- a/sys/auto_init/netif/auto_init_ethos.c
+++ b/sys/auto_init/netif/auto_init_ethos.c
@@ -23,8 +23,12 @@
 #include "debug.h"
 #include "ethos.h"
 #include "periph/uart.h"
+#ifdef MODULE_GNRC_NETIF2
+#include "net/gnrc/netif2/ethernet.h"
+#else
 #include "net/gnrc/netdev.h"
 #include "net/gnrc/netdev/eth.h"
+#endif
 
 /**
  * @brief global ethos object, used by uart_stdio
@@ -37,14 +41,20 @@ ethos_t ethos;
  */
 #define ETHOS_MAC_STACKSIZE (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
 #ifndef ETHOS_MAC_PRIO
+#ifdef MODULE_GNRC_NETIF2
+#define ETHOS_MAC_PRIO      (GNRC_NETIF2_PRIO)
+#else
 #define ETHOS_MAC_PRIO      (GNRC_NETDEV_MAC_PRIO)
+#endif
 #endif
 
 /**
  * @brief   Stacks for the MAC layer threads
  */
 static char _netdev_eth_stack[ETHOS_MAC_STACKSIZE];
+#ifndef MODULE_GNRC_NETIF2
 static gnrc_netdev_t _gnrc_ethos;
+#endif
 
 static uint8_t _inbuf[2048];
 
@@ -61,11 +71,16 @@ void auto_init_ethos(void)
     ethos_setup(&ethos, &p);
 
     /* initialize netdev<->gnrc adapter state */
+#ifdef MODULE_GNRC_NETIF2
+    gnrc_netif2_ethernet_create(_netdev_eth_stack, ETHOS_MAC_STACKSIZE,
+                                ETHOS_MAC_PRIO, "ethos", (netdev_t *)&ethos);
+#else
     gnrc_netdev_eth_init(&_gnrc_ethos, (netdev_t*)&ethos);
 
     /* start gnrc netdev thread */
     gnrc_netdev_init(_netdev_eth_stack, ETHOS_MAC_STACKSIZE, ETHOS_MAC_PRIO,
                      "gnrc_ethos", &_gnrc_ethos);
+#endif
 }
 
 #else

--- a/sys/auto_init/netif/auto_init_netdev_tap.c
+++ b/sys/auto_init/netif/auto_init_netdev_tap.c
@@ -51,13 +51,9 @@ void auto_init_netdev_tap(void)
 
         netdev_tap_setup(&netdev_tap[i], p);
 #ifdef MODULE_GNRC_NETIF2
-        if (!gnrc_netif2_ethernet_create(_netdev_eth_stack[i],
-                                         TAP_MAC_STACKSIZE,
-                                         TAP_MAC_PRIO, "gnrc_netdev_tap",
-                                         &netdev_tap[i].netdev)) {
-            LOG_ERROR("[auto_init_netif] error initializing TAP %s\n",
-                      *(p->tap_name));
-        }
+        gnrc_netif2_ethernet_create(_netdev_eth_stack[i], TAP_MAC_STACKSIZE,
+                                    TAP_MAC_PRIO, "gnrc_netdev_tap",
+                                    &netdev_tap[i].netdev);
 #else
         gnrc_netdev_eth_init(&_gnrc_netdev_tap[i], (netdev_t*)&netdev_tap[i]);
 

--- a/sys/auto_init/netif/auto_init_w5100.c
+++ b/sys/auto_init/netif/auto_init_w5100.c
@@ -22,15 +22,23 @@
 #include "log.h"
 #include "w5100.h"
 #include "w5100_params.h"
+#ifdef MODULE_GNRC_NETIF2
+#include "net/gnrc/netif2/ethernet.h"
+#else
 #include "net/gnrc/netdev.h"
 #include "net/gnrc/netdev/eth.h"
+#endif
 
 /**
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
 #define MAC_STACKSIZE   (THREAD_STACKSIZE_DEFAULT)
+#ifdef MODULE_GNRC_NETIF2
+#define MAC_PRIO        (GNRC_NETIF2_PRIO)
+#else
 #define MAC_PRIO        (THREAD_PRIORITY_MAIN - 4)
+#endif
 /*** @} */
 
 /**
@@ -43,7 +51,9 @@
  * @{
  */
 static w5100_t dev[W5100_NUM];
+#ifndef MODULE_GNRC_NETIF2
 static gnrc_netdev_t gnrc_adpt[W5100_NUM];
+#endif
 /** @} */
 
 /**
@@ -60,10 +70,15 @@ void auto_init_w5100(void)
         /* setup netdev device */
         w5100_setup(&dev[i], &w5100_params[i]);
         /* initialize netdev <-> gnrc adapter state */
+#ifdef MODULE_GNRC_NETIF2
+    gnrc_netif2_ethernet_create(stack[i], MAC_STACKSIZE, MAC_PRIO, "w5100",
+                                (netdev_t *)&dev[i]);
+#else
         gnrc_netdev_eth_init(&gnrc_adpt[i], (netdev_t *)&dev[i]);
         /* start gnrc netdev thread */
         gnrc_netdev_init(stack[i], MAC_STACKSIZE, MAC_PRIO,
                          "gnrc_w5100", &gnrc_adpt[i]);
+#endif
     }
 }
 


### PR DESCRIPTION
Bootstraps all ethernet devices for `gnrc_netif2` (non-intrusively)

~~Depends on #7370.~~

This PR is part of the network layer remodelling effort:
![PR dependencies](https://miri64.github.io/riot-ndp-model/PR%20overview.svg)