### PR TITLE
nrfmin: add missing return

### DIFF
--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -480,6 +480,7 @@ static int nrfmin_get(netdev_t *dev, netopt_t opt, void *val, size_t max_len)
         case NETOPT_MAX_PACKET_SIZE:
             assert(max_len >= sizeof(uint16_t));
             *((uint16_t *)val) = NRFMIN_PAYLOAD_MAX;
+            return sizeof(uint16_t);
         case NETOPT_ADDRESS_LONG:
             assert(max_len >= sizeof(uint64_t));
             nrfmin_get_pseudo_long_addr((uint16_t *)val);


### PR DESCRIPTION
@haukepetersen, I on't know why `objdump` told you the regression is in `gnrc_ipv6.c` this morning (but apparently the address output on a failed assertion is completely wrong, because we got wrong addresses as well), but after some heavy debugging @dnahm and I found this regression in `nrfmin.c`, introduced in a7e54e10c074ba0f2a97ee227b. Now the assertion in `gnrc_networking` doesn't fail anymore.