### PR TITLE
net/gcoap: collection of simple fixes

### DIFF
--- a/sys/net/application_layer/coap/gcoap.c
+++ b/sys/net/application_layer/coap/gcoap.c
@@ -159,6 +159,7 @@ static void _listen(sock_udp_t *sock)
         _find_req_memo(&memo, &pdu, buf, sizeof(buf));
         if (memo) {
             xtimer_remove(&memo->response_timer);
+            memo->state = GCOAP_MEMO_RESP;
             memo->resp_handler(memo->state, &pdu);
             memo->state = GCOAP_MEMO_UNUSED;
         }

--- a/sys/net/application_layer/coap/gcoap.c
+++ b/sys/net/application_layer/coap/gcoap.c
@@ -135,7 +135,7 @@ static void _listen(sock_udp_t *sock)
         return;
     }
 
-    if (coap_get_code(&pdu) == COAP_CODE_EMPTY) {
+    if (pdu.hdr->code == COAP_CODE_EMPTY) {
         DEBUG("gcoap: empty messages not handled yet\n");
         return;
 


### PR DESCRIPTION
This PR collects a number of small fixes to `gcoap`. It can be merged anytime, but until someone starts to review I will probably add a thing or two while working further with `gcoap`...

The PR contains (so far):
- Fixed request state on getting responses: The request state should be set to GCOAP_MEMO_RESP before calling the response handler in case we actually go a response...