### PR TITLE
cc110x: port to gnrc_netif2

### DIFF
--- a/drivers/cc110x/include/gnrc_netif2_cc110x.h
+++ b/drivers/cc110x/include/gnrc_netif2_cc110x.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup net_gnrc_netif2
+ * @{
+ *
+ * @file
+ * @brief   CC110x adaption for @ref net_gnrc_netif2
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef GNRC_NETIF2_CC110X_H
+#define GNRC_NETIF2_CC110X_H
+
+#include "net/gnrc/netif2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+gnrc_netif2_t *gnrc_netif2_cc110x_create(char *stack, int stacksize, char priority,
+                                         char *name, netdev_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GNRC_NETIF2_CC110X_H */
+/** @} */

--- a/sys/auto_init/netif/auto_init_cc110x.c
+++ b/sys/auto_init/netif/auto_init_cc110x.c
@@ -22,8 +22,8 @@
 #include "log.h"
 #include "debug.h"
 #include "board.h"
-#include "net/gnrc/netdev.h"
-#include "gnrc_netdev_cc110x.h"
+#include "gnrc_netif2_cc110x.h"
+#include "cc110x-netdev.h"
 #include "net/gnrc.h"
 
 #include "cc110x.h"
@@ -35,15 +35,13 @@
  */
 #define CC110X_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
 #ifndef CC110X_MAC_PRIO
-#define CC110X_MAC_PRIO          (GNRC_NETDEV_MAC_PRIO)
+#define CC110X_MAC_PRIO          (GNRC_NETIF2_PRIO)
 #endif
 
 #define CC110X_NUM (sizeof(cc110x_params)/sizeof(cc110x_params[0]))
 
 static netdev_cc110x_t cc110x_devs[CC110X_NUM];
 static char _stacks[CC110X_NUM][CC110X_MAC_STACKSIZE];
-
-static gnrc_netdev_t _gnrc_netdev_devs[CC110X_NUM];
 
 void auto_init_cc110x(void)
 {
@@ -57,12 +55,9 @@ void auto_init_cc110x(void)
             LOG_ERROR("[auto_init_netif] error initializing cc110x #%u\n", i);
         }
         else {
-            gnrc_netdev_cc110x_init(&_gnrc_netdev_devs[i], &cc110x_devs[i]);
-            res = gnrc_netdev_init(_stacks[i], CC110X_MAC_STACKSIZE,
-                    CC110X_MAC_PRIO, "cc110x", &_gnrc_netdev_devs[i]);
-            if (res < 0) {
-                LOG_ERROR("[auto_init_netif] error starting gnrc_cc110x thread\n");
-            }
+            gnrc_netif2_cc110x_create(_stacks[i], CC110X_MAC_STACKSIZE,
+                                      CC110X_MAC_PRIO, "cc110x",
+                                      (netdev_t *)&cc110x_devs[i]);
         }
     }
 }


### PR DESCRIPTION
(unintrusive) port of cc110x to `gnrc_netif2`

~~Depends on #7370.~~

This PR is part of the network layer remodelling effort:
![PR dependencies](https://miri64.github.io/riot-ndp-model/PR%20overview.svg)