### PR TITLE
nrfmin: add missing return [2017.07 backport]

### DIFF
--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -480,6 +480,7 @@ static int nrfmin_get(netdev_t *dev, netopt_t opt, void *val, size_t max_len)
         case NETOPT_MAX_PACKET_SIZE:
             assert(max_len >= sizeof(uint16_t));
             *((uint16_t *)val) = NRFMIN_PAYLOAD_MAX;
+            return sizeof(uint16_t);
         case NETOPT_ADDRESS_LONG:
             assert(max_len >= sizeof(uint64_t));
             nrfmin_get_pseudo_long_addr((uint16_t *)val);


### PR DESCRIPTION
Backport of #7412.