### PR TITLE
fmt: add signed 32 bit fixed point formatting

### DIFF
--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -204,6 +204,34 @@ size_t fmt_s16_dec(char *out, int16_t val);
 size_t fmt_s16_dfp(char *out, int16_t val, unsigned fp_digits);
 
 /**
+ * @brief Convert 32-bit fixed point number to a decimal string
+ *
+ * The input for this function is a signed 32-bit integer holding the fixed
+ * point value as well as an unsigned integer defining the position of the
+ * decimal point, so this value defines the number of decimal digits after the
+ * decimal point.
+ *
+ * Will add a leading "-" if @p val is negative.
+ *
+ * The resulting string will always be patted with zeros after the decimal point.
+ *
+ * For example: if @p val is -314159 and @p fp_digits is 5, the resulting string
+ * will be "-3.14159". For @p val := 16777215 and @p fp_digits := 6 the result
+ * will be "16.777215".
+ *
+ * If @p out is NULL, will only return the number of bytes that would have
+ * been written.
+ *
+ * @param[out] out          Pointer to the output buffer, or NULL
+ * @param[in]  val          Fixed point value
+ * @param[in]  fp_digits    Number of digits after the decimal point, MUST be <= 9
+ *
+ * @return      Length of the resulting string
+ * @return      0 if @p fp_digits is > 9
+ */
+size_t fmt_s32_dfp(char *out, int32_t val, unsigned fp_digits);
+
+/**
  * @brief Format float to string
  *
  * Converts float value @p f to string

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -157,7 +157,7 @@ static void test_fmt_u64_dec_c(void)
     TEST_ASSERT_EQUAL_STRING("1234567890123456789", (char *) out);
 }
 
-static void test_rmt_s16_dec(void)
+static void test_fmt_s16_dec(void)
 {
     char out[7] = "-------";
     int16_t val;
@@ -182,7 +182,7 @@ static void test_rmt_s16_dec(void)
     TEST_ASSERT_EQUAL_STRING("12345", (char *)out);
 }
 
-static void test_rmt_s16_dfp(void)
+static void test_fmt_s16_dfp(void)
 {
     char out[8] = "--------";
     int16_t val;
@@ -241,6 +241,70 @@ static void test_rmt_s16_dfp(void)
     val = 31987;
     fpp = 5;
     len = fmt_s16_dfp(out, val, fpp);
+    out[len] = '\0';
+    TEST_ASSERT_EQUAL_INT(0, len);
+    TEST_ASSERT_EQUAL_STRING("", (char *)out);
+}
+
+static void test_fmt_s32_dfp(void)
+{
+    char out[13] = "-------------";
+    int32_t val;
+    unsigned fpp;
+    size_t len;
+
+    val = 0;
+    fpp = 8;
+    len = fmt_s32_dfp(out, val, fpp);
+    out[len] = '\0';
+    TEST_ASSERT_EQUAL_INT(10, len);
+    TEST_ASSERT_EQUAL_STRING("0.00000000", (char *)out);
+
+    val = 123456789;
+    fpp = 7;
+    len = fmt_s32_dfp(out, val, fpp);
+    out[len] = '\0';
+    TEST_ASSERT_EQUAL_INT(10, len);
+    TEST_ASSERT_EQUAL_STRING("12.3456789", (char *)out);
+
+    val = 120030;
+    fpp = 3;
+    len = fmt_s32_dfp(out, val, fpp);
+    out[len] = '\0';
+    TEST_ASSERT_EQUAL_INT(7, len);
+    TEST_ASSERT_EQUAL_STRING("120.030", (char *)out);
+
+    val = -314159;
+    fpp = 5;
+    len = fmt_s32_dfp(out, val, fpp);
+    out[len] = '\0';
+    TEST_ASSERT_EQUAL_INT(8, len);
+    TEST_ASSERT_EQUAL_STRING("-3.14159", (char *)out);
+
+    val = -23;
+    fpp = 9;
+    len = fmt_s32_dfp(out, val, fpp);
+    out[len] = '\0';
+    TEST_ASSERT_EQUAL_INT(12, len);
+    TEST_ASSERT_EQUAL_STRING("-0.000000023", (char *)out);
+
+    val = 50;
+    fpp = 6;
+    len = fmt_s32_dfp(out, val, fpp);
+    out[len] = '\0';
+    TEST_ASSERT_EQUAL_INT(8, len);
+    TEST_ASSERT_EQUAL_STRING("0.000050", (char *)out);
+
+    val = -123456789;
+    fpp = 0;
+    len = fmt_s32_dfp(out, val, fpp);
+    out[len] = '\0';
+    TEST_ASSERT_EQUAL_INT(10, len);
+    TEST_ASSERT_EQUAL_STRING("-123456789", (char *)out);
+
+    val = 31987;
+    fpp = 10;
+    len = fmt_s32_dfp(out, val, fpp);
     out[len] = '\0';
     TEST_ASSERT_EQUAL_INT(0, len);
     TEST_ASSERT_EQUAL_STRING("", (char *)out);
@@ -321,8 +385,9 @@ Test *tests_fmt_tests(void)
         new_TestFixture(test_fmt_u64_dec_c),
         new_TestFixture(test_fmt_u16_dec),
         new_TestFixture(test_fmt_s32_dec),
-        new_TestFixture(test_rmt_s16_dec),
-        new_TestFixture(test_rmt_s16_dfp),
+        new_TestFixture(test_fmt_s16_dec),
+        new_TestFixture(test_fmt_s16_dfp),
+        new_TestFixture(test_fmt_s32_dfp),
         new_TestFixture(test_fmt_strlen),
         new_TestFixture(test_fmt_str),
         new_TestFixture(test_scn_u32_dec),


### PR DESCRIPTION
adds floating point formatting of `int32_t` similar to existing `fmt_s16_dfp` function.

I needed it (16Bit wasn't enough) and haven't found another suitable solution (if there is one?).