### PR TITLE
periph/rtc: add support for stm32l4

### DIFF
--- a/boards/nucleo-l476/Makefile.features
+++ b/boards/nucleo-l476/Makefile.features
@@ -3,9 +3,10 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo boards

--- a/boards/nucleo-l476/include/periph_conf.h
+++ b/boards/nucleo-l476/include/periph_conf.h
@@ -238,6 +238,13 @@ static const spi_conf_t spi_config[] = {
 #define RTT_MAX_VALUE       (0x0000ffff)        /* 16-bit timer */
 /** @} */
 
+/**
+ * @name   RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -29,7 +29,7 @@
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F2) || \
     defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32F4) || \
     defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
-    defined(CPU_FAM_STM32L1)
+    defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32L4)
 
 /* guard file in case no RTC device was specified */
 #if RTC_NUMOF
@@ -60,8 +60,12 @@ static uint8_t byte2bcd(uint8_t value);
 void rtc_init(void)
 {
     /* Enable write access to RTC registers */
+#if defined(CPU_FAM_STM32L4)
+    periph_clk_en(APB1, RCC_APB1ENR1_PWREN);
+#else
     periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-#if defined(CPU_FAM_STM32F7)
+#endif
+#if defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L4)
     PWR->CR1 |= PWR_CR1_DBP;
 #else
     PWR->CR |= PWR_CR_DBP;
@@ -103,8 +107,13 @@ void rtc_init(void)
 int rtc_set_time(struct tm *time)
 {
     /* Enable write access to RTC registers */
+#if defined(CPU_FAM_STM32L4)
+    periph_clk_en(APB1, RCC_APB1ENR1_PWREN);
+#else
     periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-#if defined(CPU_FAM_STM32F7)
+#endif
+
+#if defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L4)
     PWR->CR1 |= PWR_CR1_DBP;
 #else
     PWR->CR |= PWR_CR_DBP;
@@ -161,8 +170,13 @@ int rtc_get_time(struct tm *time)
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
     /* Enable write access to RTC registers */
+#if defined(CPU_FAM_STM32L4)
+    periph_clk_en(APB1, RCC_APB1ENR1_PWREN);
+#else
     periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-#if defined(CPU_FAM_STM32F7)
+#endif
+
+#if defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L4)
     PWR->CR1 |= PWR_CR1_DBP;
 #else
     PWR->CR |= PWR_CR_DBP;
@@ -196,11 +210,17 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 
 #if defined(CPU_FAM_STM32L0)
     EXTI->IMR  |= EXTI_IMR_IM17;
+#elif defined (CPU_FAM_STM32L4)
+    EXTI->IMR  |= EXTI_IMR1_IM18;
 #else
     EXTI->IMR  |= EXTI_IMR_MR17;
 #endif
 
-    EXTI->RTSR |= EXTI_RTSR_TR17;
+#if defined (CPU_FAM_STM32L4)
+    EXTI->RTSR |= EXTI_RTSR1_RT18;
+#else
+    EXTI->RTSR |= EXTI_RTSR1_TR17;
+#endif
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0)
     NVIC_SetPriority(RTC_IRQn, 10);
@@ -313,7 +333,13 @@ void isr_rtc_alarm(void)
         }
         RTC->ISR &= ~RTC_ISR_ALRAF;
     }
+
+#if defined(CPU_FAM_STM32L4)
+    EXTI->PR |= EXTI_PR1_PIF18;
+#else
     EXTI->PR |= EXTI_PR_PR17;
+#endif
+
     cortexm_isr_end();
 }
 
@@ -340,4 +366,4 @@ static uint8_t byte2bcd(uint8_t value)
 #endif /* defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F2) || \
           defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32F4) || \
           defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
-          defined(CPU_FAM_STM32L1) */
+          defined(CPU_FAM_STM32L1) || defined(CPU_FAM_STM32L4)*/

--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -219,7 +219,7 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 #if defined (CPU_FAM_STM32L4)
     EXTI->RTSR |= EXTI_RTSR1_RT18;
 #else
-    EXTI->RTSR |= EXTI_RTSR1_TR17;
+    EXTI->RTSR |= EXTI_RTSR_TR17;
 #endif
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0)


### PR DESCRIPTION
As the title says, this adds rtc support for stm32l4. Currently this was only tested on `nucleo-l476`.
Can someone test this on other stm32l4-based boards?