### PR TITLE
devfs: add /dev/urandom and /dev/hwrng

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -856,6 +856,15 @@ endif
 ifneq (,$(filter periph_gpio_irq,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
 endif
+
+ifneq (,$(filter devfs_hwrng,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_hwrng
+endif
+
+ifneq (,$(filter devfs_random,$(USEMODULE)))
+  USEMODULE += random
+endif
+
 # always select gpio (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -9,6 +9,7 @@ PSEUDOMODULES += cord_ep_standalone
 PSEUDOMODULES += core_%
 PSEUDOMODULES += cortexm_fpu
 PSEUDOMODULES += cpu_check_address
+PSEUDOMODULES += devfs_%
 PSEUDOMODULES += ecc_%
 PSEUDOMODULES += emb6_router
 PSEUDOMODULES += event_%

--- a/sys/fs/devfs/auto_init_devfs.c
+++ b/sys/fs/devfs/auto_init_devfs.c
@@ -21,6 +21,7 @@
 
 #include "vfs.h"
 #include "fs/devfs.h"
+#include "random-vfs.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -30,8 +31,30 @@ static vfs_mount_t _devfs_auto_init_mount = {
     .mount_point = "/dev",
 };
 
+#ifdef MODULE_DEVFS_HWRNG
+static devfs_t hwrng_devfs = {
+    .path = "/hwrng",
+    .f_op = &hwrng_vfs_ops,
+};
+#endif
+
+#ifdef MODULE_DEVFS_RANDOM
+static devfs_t random_devfs = {
+    .path = "/urandom",
+    .f_op = &random_vfs_ops,
+};
+#endif
+
 void auto_init_devfs(void)
 {
     DEBUG("auto_init_devfs: mounting /dev\n");
     vfs_mount(&_devfs_auto_init_mount);
+
+#ifdef MODULE_DEVFS_HWRNG
+    devfs_register(&hwrng_devfs);
+#endif
+
+#ifdef MODULE_DEVFS_RANDOM
+    devfs_register(&random_devfs);
+#endif
 }

--- a/sys/fs/devfs/random-vfs.c
+++ b/sys/fs/devfs/random-vfs.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     sys_fs_devfs
+ * @{
+ *
+ * @file
+ * @brief       Random backends for devfs implementation
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include "vfs.h"
+
+#ifdef MODULE_DEVFS_HWRNG
+
+#include "periph/hwrng.h"
+
+static ssize_t hwrng_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes);
+
+const vfs_file_ops_t hwrng_vfs_ops = {
+    .read  = hwrng_vfs_read,
+};
+
+static ssize_t hwrng_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
+{
+    (void)filp;
+
+    hwrng_read(dest, nbytes);
+
+    return nbytes;
+}
+#endif /* MODULE_PERIPH_HWRNG */
+
+#ifdef MODULE_DEVFS_RANDOM
+
+#include "random.h"
+
+static ssize_t random_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes);
+
+const vfs_file_ops_t random_vfs_ops = {
+    .read = random_vfs_read,
+};
+
+static ssize_t random_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
+{
+    (void)filp;
+    random_bytes(dest, nbytes);
+
+    return nbytes;
+}
+#endif /* MODULE_RANDOM */

--- a/sys/fs/devfs/random-vfs.h
+++ b/sys/fs/devfs/random-vfs.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     sys_fs_devfs
+ * @{
+ *
+ * @file
+ * @brief       Random backends for devfs
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ */
+
+#ifndef RANDOM_VFS_H
+#define RANDOM_VFS_H
+
+#include "vfs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(MODULE_PERIPH_HWRNG) || defined(DOXYGEN)
+/**
+ * @brief hwrng driver for vfs
+ */
+extern const vfs_file_ops_t hwrng_vfs_ops;
+#endif
+
+#if defined(MODULE_RANDOM) || defined(DOXYGEN)
+/**
+ * @brief urandom driver for vfs
+ */
+extern const vfs_file_ops_t random_vfs_ops;
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RANDOM_VFS_H */
+/** @} */

--- a/tests/unittests/tests-devfs/Makefile.include
+++ b/tests/unittests/tests-devfs/Makefile.include
@@ -1,2 +1,4 @@
 USEMODULE += vfs
 USEMODULE += devfs
+USEMODULE += devfs_random
+USEMODULE += devfs_hwrng


### PR DESCRIPTION
This PR adds a `/dev/urandom` file to the devfs registry when `periph_hwrng` is available.