### PR TITLE
boards/nucleo-l476: fixed AF for SPI pin config

### DIFF
--- a/boards/nucleo-l476/include/periph_conf.h
+++ b/boards/nucleo-l476/include/periph_conf.h
@@ -211,7 +211,7 @@ static const spi_conf_t spi_config[] = {
         .miso_pin = GPIO_PIN(PORT_A, 6),
         .sclk_pin = GPIO_PIN(PORT_A, 5),
         .cs_pin   = GPIO_UNDEF,
-        .af       = GPIO_AF0,
+        .af       = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
         .apbbus   = APB2
     }


### PR DESCRIPTION
`SPI1` is mapped to `AF5`, not `AF0`...