### PR TITLE
board/arduino-mkr1000: Fixed bad MUX config for SPI bus

### DIFF
--- a/boards/arduino-mkr1000/include/periph_conf.h
+++ b/boards/arduino-mkr1000/include/periph_conf.h
@@ -209,9 +209,9 @@ static const spi_conf_t spi_config[] = {
         .miso_pin = GPIO_PIN(PA, 15),
         .mosi_pin = GPIO_PIN(PA, 12),
         .clk_pin  = GPIO_PIN(PA, 13),
-        .miso_mux = GPIO_MUX_D,
-        .mosi_mux = GPIO_MUX_D,
-        .clk_mux  = GPIO_MUX_D,
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1
     }


### PR DESCRIPTION
The title says it all. This is needed for #7433 . I thought it was fixed in the initial PR for the board though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/riot-os/riot/7432)
<!-- Reviewable:end -->
