### PR TITLE
LWMAC: avoid receiving duplicate broadcast packet.

### DIFF
--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -74,9 +74,11 @@ typedef struct {
 #endif /* (GNRC_MAC_DISPATCH_BUFFER_SIZE != 0) || defined(DOXYGEN) */
 
 #ifdef MODULE_GNRC_LWMAC
-    gnrc_lwmac_l2_addr_t l2_addr; /**< Records the sender's address */
-    gnrc_lwmac_rx_state_t state;  /**< LWMAC specific internal reception state */
-    uint8_t rx_bad_exten_count;   /**< Count how many unnecessary RX extensions have been executed */
+    gnrc_lwmac_l2_addr_t l2_addr;        /**< Records the sender's address */
+    gnrc_lwmac_rx_state_t state;         /**< LWMAC specific internal reception state */
+    uint8_t rx_bad_exten_count;          /**< Count how many unnecessary RX extensions have been executed */
+    gnrc_lwmac_l2_addr_t rx_bcast_id;    /**< Records bcast node's ID in last cycle */
+    uint8_t rx_bcast_seq;                /**< Records bcast node's bcast sequence in last cycle */
 #endif
 
 #ifdef MODULE_GNRC_GOMACH

--- a/sys/net/gnrc/link_layer/lwmac/include/lwmac_internal.h
+++ b/sys/net/gnrc/link_layer/lwmac/include/lwmac_internal.h
@@ -81,6 +81,11 @@ extern "C" {
 #define GNRC_LWMAC_QUIT_RX              (0x0040U)
 
 /**
+ * @brief   Flag to track if the device has received broadcast packet in last cycle.
+ */
+#define GNRC_NETDEV_LWMAC_GOT_BCAST            (0x0080U)
+
+/**
  * @brief Type to pass information about parsing.
  */
 typedef struct {

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -702,6 +702,7 @@ void rtt_handler(uint32_t event, gnrc_netif_t *netif)
             alarm = _next_inphase_event(netif->mac.prot.lwmac.last_wakeup,
                                         RTT_US_TO_TICKS(GNRC_LWMAC_WAKEUP_DURATION_US));
             rtt_set_alarm(alarm, rtt_cb, (void *) GNRC_LWMAC_EVENT_RTT_SLEEP_PENDING);
+
             gnrc_lwmac_set_quit_tx(netif, false);
             gnrc_lwmac_set_quit_rx(netif, false);
             gnrc_lwmac_set_phase_backoff(netif, false);

--- a/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/rx_state_machine.c
@@ -76,16 +76,16 @@ static uint8_t _packet_process_in_wait_for_wr(gnrc_netif_t *netif)
             bcast_hdr = (gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_LWMAC))->data;
             uint8_t bcast_seq = bcast_hdr->seq_nr;
 
-            if ((gnrc_netdev->rx.rx_bcast_seq == bcast_seq) &&
-                (gnrc_netdev->rx.rx_bcast_id.len > 0) &&
-                (memcmp(&info.src_addr.addr, &gnrc_netdev->rx.rx_bcast_id.addr,
-                        gnrc_netdev->rx.rx_bcast_id.len) == 0)) {
+            if ((netif->mac.rx.rx_bcast_seq == bcast_seq) &&
+                (netif->mac.rx.rx_bcast_id.len > 0) &&
+                (memcmp(&info.src_addr.addr, &netif->mac.rx.rx_bcast_id.addr,
+                		netif->mac.rx.rx_bcast_id.len) == 0)) {
         	    LOG_INFO("[LWMAC-rx] received duplicate broadcast packet!\n");
         	    gnrc_pktbuf_release(pkt);
             }
             else {
-                _gnrc_lwmac_dispatch_defer(gnrc_netdev->rx.dispatch_buffer, pkt);
-                gnrc_mac_dispatch(&gnrc_netdev->rx);
+                _gnrc_lwmac_dispatch_defer(netif->mac.rx.dispatch_buffer, pkt);
+                gnrc_mac_dispatch(&netif->mac.rx);
             }
 
             rx_info |= GNRC_LWMAC_RX_FOUND_BROADCAST;
@@ -94,13 +94,11 @@ static uint8_t _packet_process_in_wait_for_wr(gnrc_netif_t *netif)
             /* quit TX in this cycle to avoid collisions with broadcast packets */
             gnrc_lwmac_set_quit_tx(netif, true);
 
-            gnrc_netdev_lwmac_set_quit_tx(gnrc_netdev, true);
-
             /* record broadcast node's ID and broadcast sequence for avoiding receiving
              * duplicate broadcast packet */
-            gnrc_netdev->rx.rx_bcast_seq = bcast_seq;
-            gnrc_netdev->rx.rx_bcast_id = info.src_addr;
-            gnrc_netdev->mac_info |= GNRC_NETDEV_LWMAC_GOT_BCAST;
+            netif->mac.rx.rx_bcast_seq = bcast_seq;
+            netif->mac.rx.rx_bcast_id = info.src_addr;
+            netif->mac.mac_info |= GNRC_NETDEV_LWMAC_GOT_BCAST;
             break;
         }
 

--- a/tests/lwmac/Makefile
+++ b/tests/lwmac/Makefile
@@ -12,6 +12,11 @@ BOARD ?= samr21-xpro
 # be then accordingly extended.
 BOARD_WHITELIST := samr21-xpro
 
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
 # Modules to include:
 USEMODULE += shell
 USEMODULE += shell_commands


### PR DESCRIPTION
This PR solves the problem of LWMAC that nodes will sometimes receive duplicate broadcast packet.

When broadcasting a packet in LWMAC, the sender keep transmitting the same frame for fully a `GNRC_LWMAC_BROADCAST_DURATION_US` duration which is slightly longer than a LWMAC cycle duration, to guarantee that all neighbour node will at least receive a copy. However, in case the start of the broadcast duration is right with the start of a neighbour receiver's wake-up period, this neighbour receiver may receive duplicate broadcasting frames in their adjacent two cycles' wake-up periods. Namely:
```
|-Wakeup-|----------sleep-------------|-Wakeup-|----------sleep-------------|
|********* broadcasting period **********|
```

This PR solves this problem by introducing some parameters to record recent broadcasting information, e.g., **the ID and bcast sequence of the broadcasting sender**. Once the receiver indicates receiving duplicate broadcast frames (i.e., `bcast-node-ID` and `bcast-sequence` are the same as in the last cycle), it ignores the duplicate copy.