### PR TITLE
netopt: Add option for retrieving number of retransmissions

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -340,6 +340,15 @@ typedef enum {
      */
     NETOPT_IQ_INVERT,
 
+    /**
+     * @brief   Get retry amount from missing ACKs of the last transmission
+     *
+     * This retrieves the number of retries needed for the last transmissions.
+     * Only retransmissions due to missing ACK packets are considered.
+     * Retries due to CCA failures are not counted.
+     */
+    NETOPT_TX_RETRIES_NEEDED,
+
     /* add more options if needed */
 
     /**

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -74,6 +74,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_CHANNEL_HOP_PERIOD]    = "NETOPT_CHANNEL_HOP_PERIOD",
     [NETOPT_FIXED_HEADER]          = "NETOPT_FIXED_HEADER",
     [NETOPT_IQ_INVERT]             = "NETOPT_IQ_INVERT",
+    [NETOPT_TX_RETRIES_NEEDED]     = "NETOPT_TX_RETRIES_NEEDED",
     [NETOPT_NUMOF]                 = "NETOPT_NUMOF",
 };
 


### PR DESCRIPTION
To request the number of retransmissions needed for the last transmission. Useful for ETX calculation. Can only be supported by radio's that report this information such as the at86rf233 and the mrf24j40.