### PR TITLE
sys/shell add neighbor stats output for ifconfig

### DIFF
--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -142,6 +142,7 @@ typedef struct {
     uint8_t header_len;
     uint8_t pending;                        /**< Flags for pending tasks */
     uint8_t irq_flag;
+    uint8_t tx_retries;                     /**< Number of retries needed for last transmission */
 } mrf24j40_t;
 
 /**

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -271,14 +271,20 @@ typedef void (*netdev_event_cb_t)(netdev_t *dev, netdev_event_t event);
  * be used by upper layers to store reference information.
  */
 struct netdev {
-    const struct netdev_driver *driver;     /**< ptr to that driver's interface. */
-    netdev_event_cb_t event_callback;       /**< callback for device events */
-    void* context;                          /**< ptr to network stack context */
+    const struct netdev_driver *driver;                     /**< ptr to that driver's interface. */
+    netdev_event_cb_t event_callback;                       /**< callback for device events */
+    void* context;                                          /**< ptr to network stack context */
 #ifdef MODULE_NETSTATS_L2
-    netstats_t stats;                       /**< transceiver's statistics */
+    netstats_t stats;                                       /**< transceiver's statistics */
 #endif
 #ifdef MODULE_L2FILTER
     l2filter_t filter[L2FILTER_LISTSIZE];   /**< link layer address filters */
+#endif
+#ifdef MODULE_NETSTATS_NEIGHBOR
+    uint8_t send_index;                                     /**< send index */
+    uint8_t cb_index;                                       /**< callback index */
+    netstats_nb_t *stats_queue[NETSTATS_NB_QUEUE_SIZE]; /**< send/callback mac association array */
+    netstats_nb_t pstats[NETSTATS_NB_SIZE];
 #endif
 };
 

--- a/drivers/mrf24j40/include/mrf24j40_registers.h
+++ b/drivers/mrf24j40/include/mrf24j40_registers.h
@@ -268,6 +268,14 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Shift offsets for TXSTAT register (0x24)
+ * @{
+ */
+#define MRF24J40_TXSTAT_MAX_FRAME_RETRIES_SHIFT 6
+#define MRF24J40_TXSTAT_CCAFAIL_SHIFT           5
+/** @} */
+
+/**
  * @brief   Bitfield definitions for the SOFTRST register (0x2A)
  * @{
  */

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -319,6 +319,15 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
                 res = sizeof(int8_t);
             }
             break;
+        case NETOPT_TX_RETRIES_NEEDED:
+            if (max_len < sizeof(uint8_t)) {
+                res = -EOVERFLOW;
+            }
+            else {
+                *((uint8_t *)val) = dev->tx_retries;
+                res = sizeof(int8_t);
+            }
+            break;
 
         default:
             /* try netdev settings */
@@ -538,6 +547,7 @@ static void _isr(netdev_t *netdev)
 #ifdef MODULE_NETSTATS_L2
         if (netdev->event_callback && (dev->netdev.flags & MRF24J40_OPT_TELL_TX_END)) {
             uint8_t txstat = mrf24j40_reg_read_short(dev, MRF24J40_REG_TXSTAT);
+            dev->tx_retries = (txstat >> MRF24J40_TXSTAT_MAX_FRAME_RETRIES_SHIFT);
             /* transmision failed */
             if (txstat & MRF24J40_TXSTAT_TXNSTAT) {
                 /* TX_NOACK - CCAFAIL */

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -133,6 +133,13 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
             res = sizeof(l2filter_t **);
             break;
 #endif
+#ifdef MODULE_NETSTATS_NEIGHBOR
+        case NETOPT_STATS_NEIGHBOR:
+            assert(max_len == sizeof(uintptr_t));
+            *((netstats_nb_t **)value) = dev->netdev.pstats;
+            res = sizeof(uintptr_t);
+            break;
+#endif
         default:
             break;
     }

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -32,6 +32,7 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 USEMODULE += netstats_l2
+USEMODULE += netstats_neighbor
 USEMODULE += netstats_ipv6
 USEMODULE += netstats_rpl
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -45,6 +45,7 @@ PSEUDOMODULES += netdev_default
 PSEUDOMODULES += netif
 PSEUDOMODULES += netstats
 PSEUDOMODULES += netstats_l2
+PSEUDOMODULES += netstats_neighbor_ext
 PSEUDOMODULES += netstats_ipv6
 PSEUDOMODULES += netstats_rpl
 PSEUDOMODULES += newlib

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -97,6 +97,9 @@ endif
 ifneq (,$(filter netopt,$(USEMODULE)))
     DIRS += net/crosslayer/netopt
 endif
+ifneq (,$(filter netstats_neighbor,$(USEMODULE)))
+    DIRS += net/netstats
+endif
 ifneq (,$(filter sema,$(USEMODULE)))
     DIRS += sema
 endif

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -340,6 +340,11 @@ typedef enum {
      */
     NETOPT_IQ_INVERT,
 
+    /**
+     * @brief   Get the retries needed for the last transmission
+     */
+    NETOPT_TX_RETRIES_NEEDED,
+
     /* add more options if needed */
 
     /**

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -219,6 +219,15 @@ typedef enum {
     NETOPT_STATS,
 
     /**
+     * @brief get statistics about sent and received packets of the device split out by peer
+     *
+     * Expects a pointer to a @ref netstats_nb_t struct that will be pointed to
+     * the corresponding @ref netstats_nb_t array of the module. Can be iterated
+     * over with the corresponding iteration function of the neighbor stats module.
+     */
+    NETOPT_STATS_NEIGHBOR,
+
+    /**
      * @brief en/disable encryption.
      */
     NETOPT_ENCRYPTION,        /**< en/disable encryption */

--- a/sys/include/net/netstats.h
+++ b/sys/include/net/netstats.h
@@ -37,6 +37,18 @@ extern "C" {
 #define NETSTATS_ALL        (0xFF)
 /** @} */
 
+#ifndef NETSTATS_NB_SIZE
+/**
+ * @brief   The max number of entries in the peer stats table
+ */
+#define NETSTATS_NB_SIZE           (8)
+#endif
+
+/**
+ * @brief   The queue size for tx correlation
+ */
+#define NETSTATS_NB_QUEUE_SIZE     (4)
+
 /**
  * @brief       Global statistics struct
  */
@@ -52,6 +64,27 @@ typedef struct {
     uint32_t rx_count;          /**< received (data) packets */
     uint32_t rx_bytes;          /**< received bytes */
 } netstats_t;
+
+/**
+ * @brief       Stats per peer struct
+ */
+typedef struct netstats_nb {
+    uint8_t l2_addr[8];     /**< Link layer address of the neighbor */
+    uint8_t l2_addr_len;    /**< Length of netstats_nb::l2_addr */
+    uint16_t etx;           /**< ETX of this peer */
+#ifdef MODULE_NETSTATS_NEIGHBOR_EXT
+    uint8_t rssi;           /**< Average RSSI of received frames in abs([dBm]) */
+    uint8_t lqi;            /**< Average LQI of received frames */
+    uint32_t tx_count;      /**< Number of sent frames to this peer */
+    uint32_t tx_failed;     /**< Number of failed transmission tries to this peer */
+    uint32_t rx_count;      /**< Number of received frames */
+    uint32_t tx_bytes;      /**< Bytes sent */
+    uint32_t rx_bytes;      /**< Bytes received */
+#endif
+    uint8_t  freshness;     /**< Freshness counter */
+    uint32_t last_updated;  /**< seconds timestamp of last update */
+    uint32_t last_halved;   /**< seconds timestamp of last halving */
+} netstats_nb_t;
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/netstats/neighbor.h
+++ b/sys/include/net/netstats/neighbor.h
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_netdev_stats  Netdev stats group
+ * @ingroup     net_gnrc_netdev
+ * @brief       Records statistics about link layer neighbors
+ * @{
+ *
+ * @file
+ * @brief       Neighbor stats definitions
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+#ifndef NET_NETSTATS_NEIGHBOR_H
+#define NET_NETSTATS_NEIGHBOR_H
+
+#include <string.h>
+#include "net/netdev.h"
+#include "xtimer.h"
+#include "timex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Result of the transmission
+ * @{
+ */
+typedef enum {
+    NETSTATS_NB_BUSY,       /**< Failed due to medium busy */
+    NETSTATS_NB_NOACK,      /**< Failed due to no ack received */
+    NETSTATS_NB_SUCCESS,    /**< Succesful transmission */
+} netstats_nb_result_t;
+/** @} */
+
+/**
+ * @brief Max length of a L2 address
+ */
+#define NETSTATS_NB_L2_ADDR_MAX_SIZE      (8)
+
+/**
+ * @name @ref EWMA parameters
+ * @{
+ */
+#define NETSTATS_NB_EWMA_SCALE            100   /**< Multiplication factor of the EWMA */
+#define NETSTATS_NB_EWMA_ALPHA             15   /**< Alpha factor of the EWMA */
+#define NETSTATS_NB_EWMA_ALPHA_RAMP        30   /**< Alpha factor of the EWMA when stats are not fresh */
+/** @} */
+
+/**
+ * @name @ref ETX parameters
+ * @{
+ */
+#define NETSTATS_NB_ETX_NOACK_PENALTY       6   /**< ETX penalty for not receiving any ACK */
+#define NETSTATS_NB_ETX_DIVISOR           128   /**< ETX fixed point divisor (rfc 6551) */
+#define NETSTATS_NB_ETX_INIT                2   /**< Initial ETX, assume a mediocre link */
+/** @} */
+
+/**
+ * @name @ref Freshness parameters
+ * @{
+ */
+#define NETSTATS_NB_FRESHNESS_HALF        600   /**< seconds after the freshness counter is halved */
+#define NETSTATS_NB_FRESHNESS_TARGET        4   /**< freshness count needed before considering the statistics fresh */
+#define NETSTATS_NB_FRESHNESS_MAX          16   /**< Maximum freshness */
+#define NETSTATS_NB_FRESHNESS_EXPIRATION 1200   /**< seconds after statistics have expired */
+/** @} */
+
+/**
+ * @brief Initialize the neighbor stats
+ *
+ * @param[in] dev  ptr to netdev device
+ *
+ */
+void netstats_nb_init(netdev_t *dev);
+
+/**
+ * @brief Find or create a neighbor stat by the mac address.
+ *
+ * Find the entry by the mac address. if there is no statistics entry of the
+ * mac address, an entry is created, potentially replacing the oldest nonfresh
+ * statistics entry. NULL is only returned if all entries are fresh and no
+ * matching entry is found.
+ *
+ * @param[in] dev       ptr to netdev device
+ * @param[in] l2_addr   ptr to the L2 address
+ * @param[in] len       length of the L2 address
+ *
+ * @return ptr to the statistics record
+ */
+netstats_nb_t *netstats_nb_get_or_create(netdev_t *dev, const uint8_t *l2_addr, uint8_t len);
+
+/**
+ * @brief Iterator over the recorded neighbors, returns the next non-zero record. NULL if none remaining
+ *
+ * @param[in] first     ptr to the first record
+ * @param[in] prev      ptr to the previous record
+ *
+ * @return ptr to the record
+ * @return NULL if no records remain
+ */
+netstats_nb_t *netstats_nb_get_next(netstats_nb_t *first, netstats_nb_t *prev);
+
+/**
+ * @brief Store this neighbor as next in the transmission queue.
+ *
+ * Set len to zero if a nop record is needed, for example if the
+ * transmission has a multicast address as a destination.
+ *
+ * @param[in] dev       ptr to netdev device
+ * @param[in] l2_addr   ptr to the L2 address
+ * @param[in] len       length of the L2 address
+ *
+ */
+void netstats_nb_record(netdev_t *dev, const uint8_t *l2_addr, uint8_t len);
+
+/**
+ * @brief Get the first available neighbor in the transmission queue and increment pointer.
+ *
+ * @param[in] dev       ptr to netdev device
+ *
+ * @return ptr to the record
+ */
+netstats_nb_t *netstats_nb_get_recorded(netdev_t *dev);
+
+/**
+ * @brief Update the next recorded neighbor with the provided numbers
+ *
+ * This only increments the statistics if the length of the l2-address of the retrieved record
+ * is non-zero. see also @ref netstats_nb_record. The numbers indicate the number of transmissions
+ * the radio had to perform before a successful transmission was performed. For example: in the case
+ * of a single send operation needing 3 tries before an ACK was received, there are 2 failed
+ * transmissions and 1 successful transmission.
+ *
+ * @param[in] dev      ptr to netdev device
+ * @param[in] result   Result of the transmission
+ * @param[in] retries  Number of retries necessary for the transmission
+ *
+ * @return ptr to the record
+ */
+netstats_nb_t *netstats_nb_update_tx(netdev_t *dev, netstats_nb_result_t result, uint8_t retries);
+
+/**
+ * @brief Update the ETX value of the statistic.
+ *
+ * @param[in] stats    ptr to the statistic
+ * @param[in] result   Result of the transmission
+ * @param[in] retries  Number of retries necessary for the transmission
+ */
+void netstats_nb_update_etx(netstats_nb_t *stats, netstats_nb_result_t result, uint8_t retries);
+
+/**
+ * @brief Record rx stats for the l2_addr
+ *
+ * @param[in] dev          ptr to netdev device
+ * @param[in] l2_addr ptr  to the L2 address
+ * @param[in] l2_addr_len  length of the L2 address
+ * @param[in] rssi         RSSI of the received transmission in abs([dBm])
+ * @param[in] lqi          Link Quality Indication provided by the radio
+ *
+ * @return ptr to the updated record
+ */
+netstats_nb_t *netstats_nb_update_rx(netdev_t *dev, const uint8_t *l2_addr, uint8_t l2_addr_len, uint8_t rssi, uint8_t lqi);
+
+/**
+ * @brief Increase the freshness of the record
+ *
+ * Freshness half time is checked before incrementing the freshness.
+ *
+ * @param[in] stats  ptr to the statistic
+ */
+void netstats_nb_incr_freshness(netstats_nb_t *stats);
+
+/**
+ * @brief Check if a record is fresh
+ *
+ * Freshness half time is checked and updated before verifying freshness.
+ *
+ * @param[in] stats  ptr to the statistic
+ */
+bool netstats_nb_isfresh(netstats_nb_t *stats);
+
+/**
+ * @brief Reduce freshness by the amount of half time periods passed
+ *
+ * @param[in] stats  ptr to the statistic
+ * @param[in] cur    ptr to the current time
+ */
+void netstats_nb_half_freshness(netstats_nb_t *stats, timex_t *cur);
+
+
+/**
+ * @brief Compare the freshness of two records
+ *
+ * @param[in] a  ptr to the first record
+ * @param[in] b  ptr to the second record
+ *
+ * @return       ptr to the least fresh record
+ */
+static inline netstats_nb_t *netstats_nb_comp(const netstats_nb_t *a,
+                                              const netstats_nb_t *b)
+{
+    return (netstats_nb_t *)((a->last_updated < b->last_updated) ? a : b);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_NETSTATS_NEIGHBOR_H */
+/**
+ * @}
+ */

--- a/sys/net/gnrc/link_layer/netdev/gnrc_netdev_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev/gnrc_netdev_ieee802154.c
@@ -22,6 +22,10 @@
 
 #include "net/gnrc/netdev/ieee802154.h"
 
+#ifdef MODULE_NETSTATS_NEIGHBOR
+#include "net/netstats/neighbor.h"
+#endif
+
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
@@ -216,9 +220,17 @@ static int _send(gnrc_netdev_t *gnrc_netdev, gnrc_pktsnip_t *pkt)
     if (netif_hdr->flags &
         (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
             gnrc_netdev->dev->stats.tx_mcast_count++;
+#ifdef MODULE_NETSTATS_NEIGHBOR
+            DEBUG("l2 stats: Destination is multicast or unicast, NULL recorded");
+            netstats_nb_record(netdev, NULL, 0);
+#endif
         }
         else {
             gnrc_netdev->dev->stats.tx_unicast_count++;
+#ifdef MODULE_NETSTATS_NEIGHBOR
+            DEBUG("l2 stats: recording transmission\n");
+            netstats_nb_record(netdev, dst, dst_len);
+#endif
         }
 #endif
 #ifdef MODULE_GNRC_MAC

--- a/sys/net/netstats/Makefile
+++ b/sys/net/netstats/Makefile
@@ -1,0 +1,3 @@
+MODULE = netstats_neighbor
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/netstats/netstats_neighbor.c
+++ b/sys/net/netstats/netstats_neighbor.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net
+ * @file
+ * @brief       Neighbor level stats for netdev
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ * @}
+ */
+
+#include <errno.h>
+
+#include "net/netdev.h"
+#include "net/netstats/neighbor.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+//static char addr_str[30];
+
+static bool l2_addr_equal(const uint8_t *a, uint8_t a_len, const uint8_t *b, uint8_t b_len);
+
+void netstats_nb_init(netdev_t *dev)
+{
+    memset(dev->pstats, 0, sizeof(netstats_nb_t) * NETSTATS_NB_SIZE);
+    dev->send_index = 0;
+    dev->cb_index = 0;
+}
+
+void netstats_nb_create(netstats_nb_t *entry, const uint8_t *l2_addr, uint8_t l2_len)
+{
+    memset(entry, 0, sizeof(netstats_nb_t));
+    memcpy(entry->l2_addr, l2_addr, l2_len);
+    entry->l2_addr_len = l2_len;
+    entry->etx = NETSTATS_NB_ETX_INIT * NETSTATS_NB_ETX_DIVISOR;
+}
+
+/* find the oldest inactive entry to replace. Empty entries are infinity old */
+netstats_nb_t *netstats_nb_get_or_create(netdev_t *dev, const uint8_t *l2_addr, uint8_t len)
+{
+    netstats_nb_t *old_entry = NULL;
+    netstats_nb_t *matching_entry = NULL;
+    netstats_nb_t *stats = dev->pstats;
+
+    for (int i = 0; i < NETSTATS_NB_SIZE; i++) {
+        /* Check if this is the matching entry */
+        if (l2_addr_equal(stats[i].l2_addr, stats[i].l2_addr_len,
+                          l2_addr, len)) {
+            matching_entry = &stats[i];
+            break;
+        }
+        /* Entry is oldest if it is empty */
+        else if (stats[i].l2_addr_len == 0) {
+            old_entry = &stats[i];
+        }
+        /* Check if the entry is expired */
+        else if (!(netstats_nb_isfresh(&stats[i]))) {
+            if (old_entry == NULL) {
+                old_entry = &stats[i];
+            }
+            /* Check if current entry is older than current oldest entry */
+            else {
+                old_entry = netstats_nb_comp(old_entry, &stats[i]);
+            }
+        }
+    }
+    if (matching_entry) {
+        return matching_entry;
+    }
+    /* if there is no matching entry,
+     * create a new entry if we have an expired one */
+    netstats_nb_create(old_entry, l2_addr, len);
+    return old_entry;
+}
+
+netstats_nb_t *netstats_nb_get_next(netstats_nb_t *first, netstats_nb_t *prev)
+{
+    prev++;                                         /* get next entry */
+    while (prev < (first + NETSTATS_NB_SIZE)) {     /* while not reached end */
+        if (prev->l2_addr_len) {
+            return prev;
+        }
+        prev++;
+    }
+    return NULL;
+}
+
+void netstats_nb_record(netdev_t *dev, const uint8_t *l2_addr, uint8_t len)
+{
+    if (!(len)) {
+        /* Fill queue with a NOP */
+        dev->stats_queue[dev->send_index] = NULL;
+    }
+    else {
+        dev->stats_queue[dev->send_index] = netstats_nb_get_or_create(dev, l2_addr, len);
+    }
+    dev->send_index++;
+    if (dev->send_index == 4) {
+        dev->send_index = 0;
+    }
+}
+
+netstats_nb_t *netstats_nb_get_recorded(netdev_t *dev)
+{
+    netstats_nb_t *stats = dev->stats_queue[dev->cb_index];
+
+    dev->cb_index++;
+    if (dev->cb_index == 4) {
+        dev->cb_index = 0;
+    }
+    return stats;
+}
+
+netstats_nb_t *netstats_nb_update_tx(netdev_t *dev, netstats_nb_result_t result, uint8_t retries)
+{
+    netstats_nb_t *stats = netstats_nb_get_recorded(dev);
+
+    if (result == NETSTATS_NB_BUSY) {
+        return stats;
+    }
+    if (stats) {
+#ifdef MODULE_NETSTATS_NEIGHBOR_EXT
+        stats->tx_count += retries + 1;
+        stats->tx_failed += retries;
+#endif
+        netstats_nb_update_etx(stats, result, retries);
+        netstats_nb_incr_freshness(stats);
+    }
+    return stats;
+}
+
+#ifdef MODULE_NETSTATS_NEIGHBOR_EXT
+netstats_nb_t *netstats_nb_update_rx(netdev_t *dev, const uint8_t *l2_addr, uint8_t l2_addr_len, uint8_t rssi, uint8_t lqi)
+{
+    netstats_nb_t *stats = netstats_nb_get_or_create(
+        dev, l2_addr, l2_addr_len
+        );
+
+    if (stats) {
+        if (stats->rx_count == 0) {
+            stats->rssi = rssi;
+            stats->lqi = lqi;
+        }
+        else {
+            /* Exponential weighted moving average */
+            stats->rssi = ((uint32_t)stats->rssi *
+                           (NETSTATS_NB_EWMA_SCALE - NETSTATS_NB_EWMA_ALPHA) +
+                           (uint32_t)rssi * NETSTATS_NB_EWMA_ALPHA
+                           ) / NETSTATS_NB_EWMA_SCALE;
+            stats->lqi = ((uint32_t)stats->lqi *
+                          (NETSTATS_NB_EWMA_SCALE - NETSTATS_NB_EWMA_ALPHA) +
+                          (uint32_t)lqi * NETSTATS_NB_EWMA_ALPHA
+                          ) / NETSTATS_NB_EWMA_SCALE;
+        }
+        stats->rx_count++;
+    }
+    return stats;
+}
+#endif
+
+void netstats_nb_update_etx(netstats_nb_t *stats, netstats_nb_result_t success, uint8_t retries)
+{
+    uint16_t packet_etx = 0;
+    uint8_t ewma_alpha;
+
+    /* If the stats are not fresh, use a larger alpha to average aggressive */
+    if (netstats_nb_isfresh(stats)) {
+        ewma_alpha = NETSTATS_NB_EWMA_ALPHA;
+    }
+    else {
+        ewma_alpha = NETSTATS_NB_EWMA_ALPHA_RAMP;
+    }
+
+    if (success == NETSTATS_NB_SUCCESS) {
+        /* Number of tries is retries + original atempt */
+        packet_etx = (retries + 1) * NETSTATS_NB_ETX_DIVISOR;
+    }
+    else {
+        packet_etx = NETSTATS_NB_ETX_NOACK_PENALTY * NETSTATS_NB_ETX_DIVISOR;
+    }
+
+    DEBUG("L2 neighbor: Calculated ETX of %u\n", packet_etx);
+    /* Exponential weighted moving average */
+    stats->etx = ((uint32_t)stats->etx *
+                  (NETSTATS_NB_EWMA_SCALE - ewma_alpha) +
+                  (uint32_t)packet_etx * ewma_alpha
+                  ) / NETSTATS_NB_EWMA_SCALE;
+}
+
+void netstats_nb_incr_freshness(netstats_nb_t *stats)
+{
+    timex_t cur;
+
+    xtimer_now_timex(&cur);
+    /* First halve the freshness if applicable */
+    netstats_nb_half_freshness(stats, &cur);
+    /* Increment the freshness capped at FRESHNESS_MAX */
+    stats->freshness = (stats->freshness >= NETSTATS_NB_FRESHNESS_MAX) ? \
+                       NETSTATS_NB_FRESHNESS_MAX : stats->freshness + 1;
+    stats->last_updated = cur.seconds;
+}
+
+bool netstats_nb_isfresh(netstats_nb_t *stats)
+{
+    timex_t cur;
+
+    xtimer_now_timex(&cur);
+    /* Half freshness if applicable to update to current freshness */
+    netstats_nb_half_freshness(stats, &cur);
+    return (stats->freshness >= NETSTATS_NB_FRESHNESS_TARGET && \
+            cur.seconds - stats->last_updated < NETSTATS_NB_FRESHNESS_EXPIRATION);
+}
+
+void netstats_nb_half_freshness(netstats_nb_t *stats, timex_t *cur)
+{
+    uint8_t diff;
+
+    diff = (cur->seconds - stats->last_halved) / NETSTATS_NB_FRESHNESS_HALF;
+    stats->freshness >>= diff;
+    if (diff) {
+        /* Set to the last time point where this should have been halved */
+        stats->last_halved = cur->seconds - diff;
+    }
+}
+
+static bool l2_addr_equal(const uint8_t *a, uint8_t a_len, const uint8_t *b, uint8_t b_len)
+{
+    if (a_len != b_len) {
+        return false;
+    }
+    if (memcmp(a, b, a_len) == 0) {
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
Pretty output for the netstats_neighbor module from #6873.

Based on #7447, #7448 and #6873.