### PR TITLE
make: allow for disabling colored compiler output

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -25,9 +25,13 @@ ifeq ($(shell $(CC) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null 
   endif
 endif
 
-# Use colored gcc output if the compiler supports this
-ifeq ($(shell $(CC) -fdiagnostics-color -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-  CFLAGS += -fdiagnostics-color
+# Use colored compiler output if the compiler supports this and if this is not
+# disabled by the user
+CC_NOCOLOR ?= 0
+ifeq ($(CC_NOCOLOR),0)
+  ifeq ($(shell $(CC) -fdiagnostics-color -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+    CFLAGS += -fdiagnostics-color
+  endif
 endif
 
 # Fast-out on old style function definitions.


### PR DESCRIPTION
As pointed out by @keestux on the devel list: for some use cases the colored compiler output breaks things, so this PR allows to disable this on demand, simply compile with `CC_NOCOLOR=1 make ...`