### PR TITLE
stm32_common/periph/rtc: fix wrong read order of rtc regs

### DIFF
--- a/tests/periph_rtc/main.c
+++ b/tests/periph_rtc/main.c
@@ -74,8 +74,6 @@ int main(void)
                                                     time.tm_sec);
     rtc_set_time(&time);
 
-    xtimer_usleep(100);
-
     rtc_get_time(&time);
     printf("Clock set to %04d-%02d-%02d %02d:%02d:%02d\n",
                                                     time.tm_year + TM_YEAR_OFFSET,


### PR DESCRIPTION
This fixes a race condition/sync problem with the stm32_common RTC implementation.
According to all the reference manuals of [STM32L0x1](http://www.st.com/content/ccc/resource/technical/document/reference_manual/21/bd/0f/bd/1c/88/40/f0/DM00108282.pdf/files/DM00108282.pdf/jcr:content/translations/en.DM00108282.pdf) (22.4.8), [STM32L151xx](http://www.st.com/content/ccc/resource/technical/document/reference_manual/cc/f9/93/b2/f0/82/42/57/CD00240193.pdf/files/CD00240193.pdf/jcr:content/translations/en.CD00240193.pdf) (20.3.6), [STM32L4x6](http://www.st.com/content/ccc/resource/technical/document/reference_manual/02/35/09/0c/4f/f7/40/03/DM00083560.pdf/files/DM00083560.pdf/jcr:content/translations/en.DM00083560.pdf) (38.3.8 ) there is a strict order for reading the TR and DR registers when shadow register bypassing is disabled - which is default using this driver: "To ensure consistency between the 3 values, reading either RTC_SSR or RTC_TR locks the values in the higher-order calendar shadow registers until RTC_DR is read". 
In the current implementation the TR reg is read after DR -> this leads to the DR value being locked till you call rtc_get_time() again. Also composing the time struct value by reading the time dependent register multiple times seems a bit spooky to me.
The RTC test didn't show this problem because [this line](https://github.com/RIOT-OS/RIOT/blob/master/tests/periph_rtc/main.c#L77) masked the problem.

Without this fix the following code:

```c
...
rtc_init();

struct tm time;
time.tm_year = 2011 - TM_YEAR_OFFSET; // years are counted from 1900
time.tm_mon  = 11; // 0 = January, 11 = December
time.tm_mday = 13;
time.tm_hour = 23;
time.tm_min  = 59;
time.tm_sec  = 57;

printf("Setting clock to %04d-%02d-%02d %02d:%02d:%02d\n",
                                                time.tm_year + TM_YEAR_OFFSET,
                                                time.tm_mon + 1,
                                                time.tm_mday,
                                                time.tm_hour,
                                                time.tm_min,
                                                time.tm_sec);
rtc_set_time(&time);

//xtimer_usleep(100);

rtc_get_time(&time);
printf("Clock set to %04d-%02d-%02d %02d:%02d:%02d\n",
                                                time.tm_year + TM_YEAR_OFFSET,
                                                time.tm_mon + 1,
                                                time.tm_mday,
                                                time.tm_hour,
                                                time.tm_min,
                                                time.tm_sec);
xtimer_usleep(1000 * 1000 * 10);

rtc_get_time(&time);
printf("Clock after 10s sleep %04d-%02d-%02d %02d:%02d:%02d\n",
                                                time.tm_year + TM_YEAR_OFFSET,
                                                time.tm_mon + 1,
                                                time.tm_mday,
                                                time.tm_hour,
                                                time.tm_min,
                                                time.tm_sec);
...
```
leads to something like this:
Setting clock to 2011-12-13 23:59:57
Clock set to 2011-12-13 23:59:58
Clock after 10s sleep 2011-12-**13** 00:00:06

I tested this on nucleo-l073, nucleo-l152 and nucleo-l476 (the latter with #7420 applied), and all of them are broken without this fix.