### PR TITLE
tests: add test for priority inversion using overlapping mutexes

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,7 +1,8 @@
 # exclude submodule sources from *.c wildcard source selection
-SRC := $(filter-out mbox.c msg.c thread_flags.c,$(wildcard *.c))
+SRC := $(filter-out mbox.c msg.c thread_flags.c priority_inheritance.c,$(wildcard *.c))
 
 # enable submodules
 SUBMODULES := 1
+SUBMODULES_NOFORCE := 1
 
 include $(RIOTBASE)/Makefile.base

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2013, 2014 Freie Universität Berlin
+ *               2013 - 2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -17,6 +17,7 @@
  * @brief       RIOT synchronization API
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef MUTEX_H
@@ -25,6 +26,11 @@
 #include <stddef.h>
 
 #include "list.h"
+
+#ifdef MODULE_CORE_PRIORITY_INHERITANCE
+#include "thread.h"
+#include "kernel_types.h"
+#endif
 
 #ifdef __cplusplus
  extern "C" {
@@ -40,18 +46,30 @@ typedef struct {
      * @internal
      */
     list_node_t queue;
+#ifdef MODULE_CORE_PRIORITY_INHERITANCE
+    kernel_pid_t owner;
+    uint8_t prio_before;
+#endif
 } mutex_t;
 
 /**
  * @brief Static initializer for mutex_t.
  * @details This initializer is preferable to mutex_init().
  */
+#ifdef MODULE_CORE_PRIORITY_INHERITANCE
+#define MUTEX_INIT { { NULL }, KERNEL_PID_UNDEF, THREAD_PRIORITY_UNDEF }
+#else
 #define MUTEX_INIT { { NULL } }
+#endif
 
 /**
  * @brief Static initializer for mutex_t with a locked mutex
  */
+#ifdef MODULE_CORE_PRIORITY_INHERITANCE
+#define MUTEX_INIT_LOCKED { { MUTEX_LOCKED }, KERNEL_PID_UNDEF, THREAD_PRIORITY_UNDEF }
+#else
 #define MUTEX_INIT_LOCKED { { MUTEX_LOCKED } }
+#endif
 
 /**
  * @cond INTERNAL

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2013 - 2017 Freie Universität Berlin
+ *               2013-2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -75,6 +75,7 @@
  * @brief       Scheduler API definition
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef SCHED_H
@@ -173,6 +174,21 @@ extern clist_node_t sched_runqueues[SCHED_PRIO_LEVELS];
  * @brief  Removes thread from scheduler and set status to #STATUS_STOPPED
  */
 NORETURN void sched_task_exit(void);
+
+#ifdef MODULE_CORE_PRIORITY_INHERITANCE
+/**
+ * @brief   Change the priority of the given thread
+ *
+ * @note    This functions expects interrupts to be disabled when called!
+ *
+ * @pre     (thread != NULL)
+ * @pre     (priority < SCHED_PRIO_LEVELS)
+ *
+ * @param[in,out] thread    target thread
+ * @param[in]     priority  new priority to assign to @p thread
+ */
+void sched_change_priority(thread_t *thread, uint8_t priority);
+#endif
 
 #ifdef MODULE_SCHEDSTATISTICS
 /**

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -119,6 +119,8 @@
 #ifndef THREAD_H
 #define THREAD_H
 
+#include <stdint.h>
+
 #include "clist.h"
 #include "cib.h"
 #include "msg.h"
@@ -172,7 +174,6 @@ struct _thread {
     char *sp;                       /**< thread's stack pointer         */
     uint8_t status;                 /**< thread's status                */
     uint8_t priority;               /**< thread's priority              */
-
     kernel_pid_t pid;               /**< thread's process id            */
 
 #ifdef MODULE_CORE_THREAD_FLAGS
@@ -258,6 +259,12 @@ struct _thread {
 #ifndef THREAD_STACKSIZE_MINIMUM
 #define THREAD_STACKSIZE_MINIMUM  (sizeof(thread_t))
 #endif
+
+/**
+ * @def THREAD_PRIORITY_UNDEF
+ * @brief Value for explicitly marking a priority undefined
+ */
+#define THREAD_PRIORITY_UNDEF           (UINT8_MAX)
 
 /**
  * @def THREAD_PRIORITY_MIN

--- a/core/msg.c
+++ b/core/msg.c
@@ -208,16 +208,33 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
 int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
 {
     assert(sched_active_pid != target_pid);
+
     unsigned state = irq_disable();
     thread_t *me = (thread_t*) sched_threads[sched_active_pid];
     sched_set_status(me, STATUS_REPLY_BLOCKED);
     me->wait_data = (void*) reply;
 
+#ifdef MODULE_CORE_PRIORITY_INHERITANCE
+    thread_t *recv_thread = (thread_t*) sched_threads[target_pid];
+    uint8_t prio_backup = recv_thread->priority;
+    /* When priority inheritance is enabled, we lend the receiver thread our
+     * current priority if lower */
+    if (me->priority < recv_thread->priority) {
+        sched_change_priority(recv_thread, me->priority);
+    }
+#endif
+
     /* we re-use (abuse) reply for sending, because wait_data might be
      * overwritten if the target is not in RECEIVE_BLOCKED */
     *reply = *m;
     /* msg_send blocks until reply received */
+#ifdef MODULE_CORE_PRIORITY_INHERITANCE
+    int res = _msg_send(reply, target_pid, true, state);
+    sched_change_priority(recv_thread, prio_backup);
+    return res;
+#else
     return _msg_send(reply, target_pid, true, state);
+#endif
 }
 
 int msg_reply(msg_t *m, msg_t *reply)

--- a/core/sched.c
+++ b/core/sched.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014-2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +15,7 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      René Kijewski <rene.kijewski@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
@@ -78,6 +79,18 @@ uint8_t _tcb_name_offset = offsetof(thread_t, name);
 static void (*sched_cb) (uint32_t timestamp, uint32_t value) = NULL;
 schedstat sched_pidlist[KERNEL_PID_LAST + 1];
 #endif
+
+static inline void runqueue_push(thread_t *thread, uint8_t priority) {
+    clist_rpush(&sched_runqueues[priority], &(thread->rq_entry));
+    runqueue_bitcache |= 1 << priority;
+}
+
+static inline void runqueue_pop(thread_t *thread) {
+    clist_lpop(&sched_runqueues[thread->priority]);
+    if (!sched_runqueues[thread->priority].next) {
+        runqueue_bitcache &= ~(1 << thread->priority);
+    }
+}
 
 int __attribute__((used)) sched_run(void)
 {
@@ -164,19 +177,14 @@ void sched_set_status(thread_t *process, unsigned int status)
         if (!(process->status >= STATUS_ON_RUNQUEUE)) {
             DEBUG("sched_set_status: adding thread %" PRIkernel_pid " to runqueue %" PRIu16 ".\n",
                   process->pid, process->priority);
-            clist_rpush(&sched_runqueues[process->priority], &(process->rq_entry));
-            runqueue_bitcache |= 1 << process->priority;
+            runqueue_push(process, process->priority);
         }
     }
     else {
         if (process->status >= STATUS_ON_RUNQUEUE) {
             DEBUG("sched_set_status: removing thread %" PRIkernel_pid " to runqueue %" PRIu16 ".\n",
                   process->pid, process->priority);
-            clist_lpop(&sched_runqueues[process->priority]);
-
-            if (!sched_runqueues[process->priority].next) {
-                runqueue_bitcache &= ~(1 << process->priority);
-            }
+            runqueue_pop(process);
         }
     }
 
@@ -221,3 +229,21 @@ NORETURN void sched_task_exit(void)
     sched_active_thread = NULL;
     cpu_switch_context_exit();
 }
+
+#ifdef MODULE_CORE_PRIORITY_INHERITANCE
+void sched_change_priority(thread_t *thread, uint8_t priority)
+{
+    assert(thread && (priority < SCHED_PRIO_LEVELS));
+
+    if (thread->priority == priority) {
+        return;
+    }
+
+    if (thread->status >= STATUS_ON_RUNQUEUE) {
+        runqueue_pop(thread);
+        runqueue_push(thread, priority);
+    }
+
+    thread->priority = priority;
+}
+#endif

--- a/tests/msg_priority_inversion/Makefile
+++ b/tests/msg_priority_inversion/Makefile
@@ -1,0 +1,10 @@
+APPLICATION = msg_priority_inversion
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f030 \
+                             nucleo-l053 stm32f0discovery weio
+
+USEMODULE += core_priority_inheritance
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/msg_priority_inversion/README.md
+++ b/tests/msg_priority_inversion/README.md
@@ -1,0 +1,44 @@
+NOTE
+====
+THIS TEST WILL FAIL WHEN RUNNING RIOT USING THE DEFAULT CORE/KERNEL CONFIGURATION!
+
+You need to select the `core_priority_inheritance` module (using
+`USEMODULE += core_priority_inheritance`) to see this test succeeding.
+
+Expected result
+===============
+When successful, you will see the 3 configured threads printing 6 different
+events in a defined order. If the test passes, the output should look like this:
+
+```
+main(): This is RIOT! (Version: xxx)
+Test for showing priority inversion when using msg_send_receive
+
+If this tests succeeds, you should see 6 events appearing in order.
+The expected output should look like this:
+Event  1:      t3 - waiting for incoming message
+Event  2:      t2 - starting infinite loop, potentially starving others
+Event  3:      t1 - sending msg to t3 (msg_send_receive)
+Event  4:      t3 - received message
+Event  5:      t3 - sending reply
+Event  6:      t1 - received reply
+
+TEST OUTPUT:
+Event  1:      t3 - waiting for incoming message
+Event  2:      t2 - starting infinite loop, potentially starving others
+Event  3:      t1 - sending msg to t3 (msg_send_receive)
+Event  4:      t3 - received message
+Event  5:      t3 - sending reply
+Event  6:      t1 - received reply
+
+   *** result: SUCCESS ***
+```
+
+Background
+==========
+Priority inversion is a known problem in real-time systems, leading in certain
+constellations to lower priority threads indirectly blocking higher priority
+threads. This test constructs a simple scenario, where a high priority thread
+(`t1`) is trying to `send_receive` a message to a low priority thread (`t3`),
+but never gets a reply as a medium priority thread (`t2`) is never letting `t3`
+to be scheduled.

--- a/tests/msg_priority_inversion/main.c
+++ b/tests/msg_priority_inversion/main.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017 Technische Universität Berlin
+ *               2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for testing priority inheritance for nested
+ *              mutexes
+ *
+ * @author      Thomas Geithner <thomas.geithner@dai-labor.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "thread.h"
+#include "msg.h"
+#include "xtimer.h"
+
+#define TICK_LEN            (50 * US_PER_MS)
+#define EXSPECTED_RESULT    (-3)
+
+#define T_NUMOF             (3U)
+#define MSG_TYPE            (0xabcd)
+
+static char stacks[T_NUMOF][THREAD_STACKSIZE_MAIN];
+static kernel_pid_t pids[T_NUMOF];
+static const char *names[] = { "t1", "t2", "t3" };
+
+static int result = 0;
+static int res_addsub = 1;
+
+static inline void delay(unsigned ticks)
+{
+    xtimer_usleep(ticks * TICK_LEN);
+}
+
+static inline void event(int num, const char *t_name, const char *msg)
+{
+    /* record event */
+    result += (res_addsub * num);
+    res_addsub *= -1;
+
+    printf("Event %2i: %7s - %s\n", num, t_name, msg);
+}
+
+static void *t1(void *arg)
+{
+    (void)arg;
+    msg_t m;
+    msg_t rply;
+
+    m.type = MSG_TYPE;
+    m.content.value = (uint32_t)'M';
+
+    delay(2);
+
+    event(3, "t1", "sending msg to t3 (msg_send_receive)");
+    msg_send_receive(&m, &rply, pids[2]);
+    event(6, "t1", "received reply");
+
+    return NULL;
+}
+
+static void *t2(void *arg)
+{
+    (void)arg;
+
+    delay(1);
+
+    event(2, "t2", "starting infinite loop, potentially starving others");
+    while (1) {
+        thread_yield_higher();
+    }
+
+    return NULL;
+}
+
+static void *t3(void *arg)
+{
+    (void)arg;
+    msg_t m;
+    msg_t rply;
+
+    rply.type = MSG_TYPE;
+    rply.content.value = (uint32_t)'m';
+
+    event(1, "t3", "waiting for incoming message");
+    msg_receive(&m);
+    event(4, "t3", "received message");
+
+    event(5, "t3", "sending reply");
+    msg_reply(&m, &rply);
+
+    return NULL;
+}
+
+static thread_task_func_t handlers[] = { t1, t2, t3 };
+
+int main(void)
+{
+    puts("Test for showing priority inversion when using msg_send_receive\n");
+    puts("If this tests succeeds, you should see 6 events appearing in order.\n"
+         "The expected output should look like this:\n"
+         "Event  1:      t3 - waiting for incoming message\n"
+         "Event  2:      t2 - starting infinite loop, potentially starving others\n"
+         "Event  3:      t1 - sending msg to t3 (msg_send_receive)\n"
+         "Event  4:      t3 - received message\n"
+         "Event  5:      t3 - sending reply\n"
+         "Event  6:      t1 - received reply\n");
+    puts("TEST OUTPUT:");
+
+    /* create threads */
+    for (unsigned i = 0; i < T_NUMOF; i++) {
+        pids[i] = thread_create(stacks[i], sizeof(stacks[i]),
+                                (THREAD_PRIORITY_MAIN + 1 + i),
+                                THREAD_CREATE_WOUT_YIELD,
+                                handlers[i], NULL,
+                                names[i]);
+    }
+
+    delay(3);
+
+    if (result == EXSPECTED_RESULT) {
+        puts("\n   *** result: SUCCESS ***");
+    }
+    else {
+        puts("\n   *** result: FAILED ***");
+    }
+
+    return 0;
+}

--- a/tests/mutex_priority_inversion_nested/Makefile
+++ b/tests/mutex_priority_inversion_nested/Makefile
@@ -1,0 +1,10 @@
+APPLICATION = mutex_priority_inversion_nested
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f030 \
+                             nucleo-l053 stm32f0discovery weio
+
+USEMODULE += core_priority_inheritance
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/mutex_priority_inversion_nested/README.md
+++ b/tests/mutex_priority_inversion_nested/README.md
@@ -1,0 +1,65 @@
+NOTE
+====
+THIS TEST WILL FAIL WHEN RUNNING RIOT USING THE DEFAULT CORE/KERNEL CONFIGURATION!
+
+You need to select the `core_priority_inheritance` module (using
+`USEMODULE += core_priority_inheritance`) to see this test succeeding.
+
+Expected result
+===============
+When successful, you will see the three configured threads printing 15 different
+events in a defined order. If the test passes, the output should look like this:
+
+```
+main(): This is RIOT! (Version: xxx)
+Simple test for showing the effect of priority inversion
+
+If this tests succeeds, you should see 15 events appearing in order.
+The expected output should look like this:
+Event  1:      t5 - locking mutex A
+Event  2:      t5 - holding mutex A
+Event  3:      t5 - locking mutex B
+Event  4:      t5 - holding mutex B
+Event  5:      t3 - locking mutex A
+Event  6:      t1 - locking mutex B
+Event  7:      t2 - starting extensive loop, potentially starving others
+Event  8:      t5 - unlocking mutex B
+Event  9:      t1 - holding mutex B
+Event 10:      t1 - unlocking mutex B
+Event 11:      t2 - finished extensive loop
+Event 12:      t4 - starting infinite loop, potentially starving others
+Event 13:      t5 - unlocking mutex A
+Event 14:      t3 - holding mutex A
+Event 15:      t3 - unlocking mutex A
+
+TEST OUTPUT:
+Event  1:      t5 - locking mutex A
+Event  2:      t5 - holding mutex A
+Event  3:      t5 - locking mutex B
+Event  4:      t5 - holding mutex B
+Event  5:      t3 - locking mutex A
+Event  6:      t1 - locking mutex B
+Event  7:      t2 - starting extensive loop, potentially starving others
+Event  8:      t5 - unlocking mutex B
+Event  9:      t1 - holding mutex B
+Event 10:      t1 - unlocking mutex B
+Event 11:      t2 - finished extensive loop
+Event 12:      t4 - starting infinite loop, potentially starving others
+Event 13:      t5 - unlocking mutex A
+Event 14:      t3 - holding mutex A
+Event 15:      t3 - unlocking mutex A
+
+   *** result: SUCCESS ***
+```
+
+Background
+==========
+Priority inversion is a known problem in real-time systems, leading in certain
+constellations to lower priority threads indirectly blocking higher priority
+threads. This test constructs a scenario with two, nested mutexes being shared
+among three different threads, while having two 'bogus' threads trying to starve
+the others out.
+
+The interesting part to observe here is the priority, that is assigned to the
+lowest prio thread `t5`. `t5`s priority will change from `PRIO_MAIN + 5` ->
+`PRIO_MAIN + 3` -> `PRIO_MAIN + 1` -> `PRIO_MAIN + 3` -> PRIO_MAIN + 5`.

--- a/tests/mutex_priority_inversion_nested/README.md
+++ b/tests/mutex_priority_inversion_nested/README.md
@@ -7,7 +7,7 @@ You need to select the `core_priority_inheritance` module (using
 
 Expected result
 ===============
-When successful, you will see the three configured threads printing 15 different
+When successful, you will see the 5 configured threads printing 15 different
 events in a defined order. If the test passes, the output should look like this:
 
 ```

--- a/tests/mutex_priority_inversion_nested/main.c
+++ b/tests/mutex_priority_inversion_nested/main.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2017 Technische Universität Berlin
+ *               2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for testing priority inheritance for nested
+ *              mutexes
+ *
+ * @author      Thomas Geithner <thomas.geithner@dai-labor.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "thread.h"
+#include "mutex.h"
+#include "xtimer.h"
+
+#define TICK_LEN            (50 * US_PER_MS)
+#define EXSPECTED_RESULT    (8)
+
+#define T_NUMOF             (5U)
+
+static mutex_t a = MUTEX_INIT;
+static mutex_t b = MUTEX_INIT;
+
+static char stacks[T_NUMOF][THREAD_STACKSIZE_MAIN];
+static kernel_pid_t pids[T_NUMOF];
+static const char *names[] = { "t1", "t2", "t3", "t4", "t4" };
+
+static int result = 0;
+static int res_addsub = 1;
+
+static inline void delay(unsigned ticks)
+{
+    xtimer_usleep(ticks * TICK_LEN);
+}
+
+static inline void event(int num, const char *t_name, const char *msg)
+{
+    /* record event */
+    result += (res_addsub * num);
+    res_addsub *= -1;
+
+    printf("Event %2i: %7s - %s\n", num, t_name, msg);
+}
+
+static void *t1(void *arg)
+{
+    (void)arg;
+
+    delay(2);
+    event(6, "t1", "locking mutex B");
+    mutex_lock(&b);
+    event(9, "t1", "holding mutex B");
+
+    delay(1);
+    event(10, "t1", "unlocking mutex B");
+    mutex_unlock(&b);
+
+    return NULL;
+}
+
+static void *t2(void *arg)
+{
+    (void)arg;
+
+    delay(3);
+    event(7, "t2", "starting extensive loop, potentially starving others");
+
+    uint32_t time = xtimer_now_usec();
+    while((xtimer_now_usec() - time) < (4 * TICK_LEN)) {
+        thread_yield_higher();
+    }
+
+    event(11, "t2", "finished extensive loop");
+
+    return NULL;
+}
+
+static void *t3(void *arg)
+{
+    (void)arg;
+
+    delay(1);
+    event(5, "t3", "locking mutex A");
+    mutex_lock(&a);
+    event(14, "t3", "holding mutex A");
+
+    delay(1);
+    event(15, "t3", "unlocking mutex A");
+    mutex_unlock(&a);
+
+    return NULL;
+}
+
+static void *t4(void *arg)
+{
+    (void)arg;
+
+    delay(6);
+    event(12, "t4", "starting infinite loop, potentially starving others");
+    while (1) {
+        thread_yield_higher();
+    }
+
+    return NULL;
+}
+
+static void *t5(void *arg)
+{
+    (void)arg;
+
+    event(1, "t5", "locking mutex A");
+    mutex_lock(&a);
+    event(2, "t5", "holding mutex A");
+    event(3, "t5", "locking mutex B");
+    mutex_lock(&b);
+    event(4, "t5", "holding mutex B");
+
+    delay(4);
+    event(8, "t5", "unlocking mutex B");
+    mutex_unlock(&b);
+
+    delay(3);
+    event(13, "t5", "unlocking mutex A");
+    mutex_unlock(&a);
+
+    return NULL;
+}
+
+static thread_task_func_t handlers[] = { t1, t2, t3, t4, t5 };
+
+int main(void)
+{
+    puts("Test for showing the effect of priority inversion when nesting mutexes\n");
+    puts("If this tests succeeds, you should see 15 events appearing in order.\n"
+         "The expected output should look like this:\n"
+         "Event  1:      t5 - locking mutex A\n"
+         "Event  2:      t5 - holding mutex A\n"
+         "Event  3:      t5 - locking mutex B\n"
+         "Event  4:      t5 - holding mutex B\n"
+         "Event  5:      t3 - locking mutex A\n"
+         "Event  6:      t1 - locking mutex B\n"
+         "Event  7:      t2 - starting extensive loop, potentially starving others\n"
+         "Event  8:      t5 - unlocking mutex B\n"
+         "Event  9:      t1 - holding mutex B\n"
+         "Event 10:      t1 - unlocking mutex B\n"
+         "Event 11:      t2 - finished extensive loop\n"
+         "Event 12:      t4 - starting infinite loop, potentially starving others\n"
+         "Event 13:      t5 - unlocking mutex A\n"
+         "Event 14:      t3 - holding mutex A\n"
+         "Event 15:      t3 - unlocking mutex A\n");
+    puts("TEST OUTPUT:");
+
+    /* create threads */
+    for (unsigned i = 0; i < T_NUMOF; i++) {
+        pids[i] = thread_create(stacks[i], sizeof(stacks[i]),
+                                (THREAD_PRIORITY_MAIN + 1 + i),
+                                THREAD_CREATE_WOUT_YIELD,
+                                handlers[i], NULL,
+                                names[i]);
+    }
+
+    delay(13);
+
+    if (result == EXSPECTED_RESULT) {
+        puts("\n   *** result: SUCCESS ***");
+    }
+    else {
+        puts("\n   *** result: FAILED ***");
+    }
+
+    return 0;
+}

--- a/tests/mutex_priority_inversion_overlap/Makefile
+++ b/tests/mutex_priority_inversion_overlap/Makefile
@@ -1,0 +1,10 @@
+APPLICATION = mutex_priority_inversion_overlap
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f030 \
+                             nucleo-l053 stm32f0discovery weio
+
+USEMODULE += core_priority_inheritance
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/mutex_priority_inversion_overlap/README.md
+++ b/tests/mutex_priority_inversion_overlap/README.md
@@ -1,0 +1,67 @@
+NOTE
+====
+THIS TEST WILL FAIL WHEN RUNNING RIOT USING THE DEFAULT CORE/KERNEL CONFIGURATION!
+
+Using priority inheritance (`USEMODULE += core_priority_inheritance`) will also
+not help this test succeeding, as the module can not cope with nested mutexes,
+yet.
+
+Expected result
+===============
+When successful, you will see the 5 configured threads printing 15 different
+events in a defined order. If the test passes, the output should look like this:
+
+```
+main(): This is RIOT! (Version: xxx)
+Simple test for showing the effect of priority inversion
+
+If this tests succeeds, you should see 15 events appearing in order.
+The expected output should look like this:
+Event  1:      t5 - locking mutex A
+Event  2:      t5 - holding mutex A
+Event  3:      t5 - locking mutex B
+Event  4:      t5 - holding mutex B
+Event  5:      t1 - locking mutex B
+Event  6:      t3 - locking mutex A
+Event  7:      t2 - starting extensive loop, potentially starving others
+Event  8:      t5 - unlocking mutex B
+Event  9:      t1 - holding mutex B
+Event 10:      t1 - unlocking mutex B
+Event 11:      t2 - finished extensive loop
+Event 12:      t4 - starting infinite loop, potentially starving others
+Event 13:      t5 - unlocking mutex A
+Event 14:      t3 - holding mutex A
+Event 15:      t3 - unlocking mutex A
+
+TEST OUTPUT:
+Event  1:      t5 - locking mutex A
+Event  2:      t5 - holding mutex A
+Event  3:      t5 - locking mutex B
+Event  4:      t5 - holding mutex B
+Event  5:      t1 - locking mutex B
+Event  6:      t3 - locking mutex A
+Event  7:      t2 - starting extensive loop, potentially starving others
+Event  8:      t5 - unlocking mutex B
+Event  9:      t1 - holding mutex B
+Event 10:      t1 - unlocking mutex B
+Event 11:      t2 - finished extensive loop
+Event 12:      t4 - starting infinite loop, potentially starving others
+Event 13:      t5 - unlocking mutex A
+Event 14:      t3 - holding mutex A
+Event 15:      t3 - unlocking mutex A
+
+
+   *** result: SUCCESS ***
+```
+
+Background
+==========
+Priority inversion is a known problem in real-time systems, leading in certain
+constellations to lower priority threads indirectly blocking higher priority
+threads. This test constructs a scenario with two, overlapping mutexes being
+shared among three different threads, while having two 'bogus' threads trying to
+starve the others out.
+
+The interesting part to observe here is the priority, that is assigned to the
+lowest prio thread `t5`. `t5`s priority will change from `PRIO_MAIN + 5` ->
+`PRIO_MAIN + 1` -> `PRIO_MAIN + 3` -> PRIO_MAIN + 5`.

--- a/tests/mutex_priority_inversion_overlap/main.c
+++ b/tests/mutex_priority_inversion_overlap/main.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2017 Technische Universität Berlin
+ *               2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for testing priority inheritance for nested
+ *              mutexes
+ *
+ * @author      Thomas Geithner <thomas.geithner@dai-labor.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "thread.h"
+#include "mutex.h"
+#include "xtimer.h"
+
+#define TICK_LEN            (50 * US_PER_MS)
+#define EXSPECTED_RESULT    (8)
+
+#define T_NUMOF             (5U)
+
+static mutex_t a = MUTEX_INIT;
+static mutex_t b = MUTEX_INIT;
+
+static char stacks[T_NUMOF][THREAD_STACKSIZE_MAIN];
+static kernel_pid_t pids[T_NUMOF];
+static const char *names[] = { "t1", "t2", "t3", "t4", "t4" };
+
+static int result = 0;
+static int res_addsub = 1;
+
+static void printstat(kernel_pid_t pid, const char *name)
+{
+    thread_t *t = (thread_t *)thread_get(pid);
+
+    printf("%s: PID(%i) has prio %i\n", name, (int)t->pid, (int)t->priority);
+}
+
+static inline void delay(unsigned ticks)
+{
+    xtimer_usleep(ticks * TICK_LEN);
+}
+
+static inline void event(int num, const char *t_name, const char *msg)
+{
+    /* record event */
+    result += (res_addsub * num);
+    res_addsub *= -1;
+
+    printf("Event %2i: %7s - %s\n", num, t_name, msg);
+}
+
+static void *t1(void *arg)
+{
+    (void)arg;
+
+    delay(1);
+    event(6, "t1", "locking mutex B");
+    mutex_lock(&b);
+    event(9, "t1", "holding mutex B");
+
+    delay(1);
+    event(10, "t1", "unlocking mutex B");
+    mutex_unlock(&b);
+
+    printstat(thread_getpid(), "t1");
+
+    return NULL;
+}
+
+static void *t2(void *arg)
+{
+    (void)arg;
+
+    delay(3);
+    event(7, "t2", "starting extensive loop, potentially starving others");
+
+    uint32_t time = xtimer_now_usec();
+    while((xtimer_now_usec() - time) < (4 * TICK_LEN)) {
+        thread_yield_higher();
+    }
+
+    event(11, "t2", "finished extensive loop");
+
+    printstat(thread_getpid(), "t2");
+
+    return NULL;
+}
+
+static void *t3(void *arg)
+{
+    (void)arg;
+
+    delay(2);
+    event(5, "t3", "locking mutex A");
+    mutex_lock(&a);
+    event(14, "t3", "holding mutex A");
+
+    delay(1);
+    event(15, "t3", "unlocking mutex A");
+    mutex_unlock(&a);
+
+    printstat(thread_getpid(), "t3");
+
+    return NULL;
+}
+
+static void *t4(void *arg)
+{
+    (void)arg;
+
+    delay(6);
+    event(12, "t4", "starting infinite loop, potentially starving others");
+    while (1) {
+        thread_yield_higher();
+    }
+
+    return NULL;
+}
+
+static void *t5(void *arg)
+{
+    (void)arg;
+
+    event(1, "t5", "locking mutex A");
+    mutex_lock(&a);
+    event(2, "t5", "holding mutex A");
+    event(3, "t5", "locking mutex B");
+    mutex_lock(&b);
+    event(4, "t5", "holding mutex B");
+
+    delay(4);
+    event(8, "t5", "unlocking mutex B");
+    mutex_unlock(&b);
+
+    delay(3);
+    event(13, "t5", "unlocking mutex A");
+    mutex_unlock(&a);
+
+    printstat(thread_getpid(), "t5");
+
+    return NULL;
+}
+
+static thread_task_func_t handlers[] = { t1, t2, t3, t4, t5 };
+
+int main(void)
+{
+    puts("Test for showing the effect of priority inversion for overlapping mutexes\n");
+    puts("If this tests succeeds, you should see 15 events appearing in order.\n"
+         "The expected output should look like this:\n"
+         "Event  1:      t5 - locking mutex A\n"
+         "Event  2:      t5 - holding mutex A\n"
+         "Event  3:      t5 - locking mutex B\n"
+         "Event  4:      t5 - holding mutex B\n"
+         "Event  5:      t1 - locking mutex B\n"
+         "Event  6:      t3 - locking mutex A\n"
+         "Event  7:      t2 - starting extensive loop, potentially starving others\n"
+         "Event  8:      t5 - unlocking mutex B\n"
+         "Event  9:      t1 - holding mutex B\n"
+         "Event 10:      t1 - unlocking mutex B\n"
+         "Event 11:      t2 - finished extensive loop\n"
+         "Event 12:      t4 - starting infinite loop, potentially starving others\n"
+         "Event 13:      t5 - unlocking mutex A\n"
+         "Event 14:      t3 - holding mutex A\n"
+         "Event 15:      t3 - unlocking mutex A\n");
+    puts("TEST OUTPUT:");
+
+    /* create threads */
+    for (unsigned i = 0; i < T_NUMOF; i++) {
+        pids[i] = thread_create(stacks[i], sizeof(stacks[i]),
+                                (THREAD_PRIORITY_MAIN + 1 + i),
+                                THREAD_CREATE_WOUT_YIELD,
+                                handlers[i], NULL,
+                                names[i]);
+    }
+
+    delay(13);
+
+    if (result == EXSPECTED_RESULT) {
+        puts("\n   *** result: SUCCESS ***");
+    }
+    else {
+        puts("\n   *** result: FAILED ***");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
rebased on  #7445

This PR adds an additional test case for demonstrating priority inversion when using overlapping mutexes. As I am not sure (yet), how theoretical such a use case is in practice, I decided to put it in its own PR.

As pointed out in the comments for #7445, the solution for priority inheritance as proposed there does not work for this test case. So either I/we need to re-think #7445, or we decide that this overlapping case is not of our concern?!