### PR TITLE
gnrc_ipv6_nib: port to gnrc_netif2

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -136,29 +136,30 @@ endif
 
 ifneq (,$(filter gnrc_sixlowpan_default,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_default
+  USEMODULE += gnrc_ipv6_nib_6ln
   USEMODULE += gnrc_sixlowpan
-  USEMODULE += gnrc_sixlowpan_nd
   USEMODULE += gnrc_sixlowpan_frag
   USEMODULE += gnrc_sixlowpan_iphc
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_router_default,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_router_default
+  USEMODULE += gnrc_ipv6_nib_6lr
   USEMODULE += gnrc_sixlowpan_router
   USEMODULE += gnrc_sixlowpan_frag
   USEMODULE += gnrc_sixlowpan_iphc
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_border_router_default,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6_nib_6lbr
   USEMODULE += gnrc_ipv6_router_default
-  USEMODULE += gnrc_sixlowpan_nd_border_router
   USEMODULE += gnrc_sixlowpan_router
   USEMODULE += gnrc_sixlowpan_frag
   USEMODULE += gnrc_sixlowpan_iphc
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_router,$(USEMODULE)))
-  USEMODULE += gnrc_sixlowpan_nd_router
+  USEMODULE += gnrc_ipv6_router
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_frag,$(USEMODULE)))
@@ -182,50 +183,14 @@ ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter gnrc_sixlowpan_nd_border_router,$(USEMODULE)))
-  USEMODULE += gnrc_sixlowpan_nd_router
-endif
-
-ifneq (,$(filter gnrc_sixlowpan_nd_router,$(USEMODULE)))
-  USEMODULE += gnrc_sixlowpan_nd
-endif
-
-ifneq (,$(filter gnrc_sixlowpan_nd,$(USEMODULE)))
-  USEMODULE += gnrc_ndp
-  USEMODULE += gnrc_ndp_internal
-  USEMODULE += gnrc_sixlowpan_ctx
-  USEMODULE += random
-  USEMODULE += xtimer
-endif
-
 ifneq (,$(filter gnrc_ipv6_default,$(USEMODULE)))
   USEMODULE += gnrc_ipv6
   USEMODULE += gnrc_icmpv6
-  ifeq (1,$(GNRC_NETIF_NUMOF))
-    ifeq (,$(filter gnrc_sixlowpan_nd,$(USEMODULE)))
-      USEMODULE += gnrc_ndp_host
-    endif
-  else
-    USEMODULE += gnrc_ndp_host
-  endif
 endif
 
 ifneq (,$(filter gnrc_ipv6_router_default,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_router
   USEMODULE += gnrc_icmpv6
-  ifeq (1,$(GNRC_NETIF_NUMOF))
-    ifeq (,$(filter gnrc_sixlowpan_nd_router,$(USEMODULE)))
-      USEMODULE += gnrc_ndp_router
-    endif
-  else
-    USEMODULE += gnrc_ndp_router
-  endif
-endif
-
-ifneq (,$(filter gnrc_ndp_host,$(USEMODULE)))
-  USEMODULE += gnrc_ndp_node
-  USEMODULE += random
-  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter gnrc_ndp_router,$(USEMODULE)))
@@ -240,18 +205,6 @@ endif
 
 ifneq (,$(filter gnrc_ndp_%,$(USEMODULE)))
   USEMODULE += gnrc_ndp
-endif
-
-ifneq (,$(filter gnrc_ndp,$(USEMODULE)))
-  ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
-    USEMODULE += gnrc_sixlowpan_nd
-  else
-    USEMODULE += gnrc_ndp_node
-  endif
-  USEMODULE += gnrc_ndp_internal
-  USEMODULE += gnrc_icmpv6
-  USEMODULE += random
-  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter gnrc_ndp2,$(USEMODULE)))
@@ -302,7 +255,7 @@ ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
   USEMODULE += inet_csum
   USEMODULE += ipv6_addr
   USEMODULE += gnrc_ipv6_hdr
-  USEMODULE += gnrc_ipv6_nc
+  USEMODULE += gnrc_ipv6_nib
   USEMODULE += gnrc_netif2
 endif
 

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -256,6 +256,7 @@ endif
 
 ifneq (,$(filter gnrc_ndp2,$(USEMODULE)))
   USEMODULE += gnrc_icmpv6
+  USEMODULE += gnrc_netif2
 endif
 
 ifneq (,$(filter gnrc_icmpv6_echo,$(USEMODULE)))

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -36,9 +36,7 @@
 #include "net/ipv6.h"
 #include "net/gnrc/ipv6/ext.h"
 #include "net/gnrc/ipv6/hdr.h"
-#ifndef MODULE_GNRC_IPV6_NIB
-#include "net/gnrc/ipv6/nc.h"
-#endif
+#include "net/gnrc/ipv6/nib.h"
 
 #ifdef MODULE_FIB
 #include "net/fib.h"

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -199,10 +199,8 @@ extern "C" {
 /**
  * @brief   Maximum link-layer address length (aligned)
  */
-#if (GNRC_NETIF_HDR_L2ADDR_MAX_LEN % 8)
-#define GNRC_IPV6_NIB_L2ADDR_MAX_LEN        (((GNRC_NETIF_HDR_L2ADDR_MAX_LEN >> 3) + 1) << 3)
-#else
-#define GNRC_IPV6_NIB_L2ADDR_MAX_LEN        (GNRC_NETIF_HDR_L2ADDR_MAX_LEN)
+#ifndef GNRC_IPV6_NIB_L2ADDR_MAX_LEN
+#define GNRC_IPV6_NIB_L2ADDR_MAX_LEN        (8U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/ndp2.h
+++ b/sys/include/net/gnrc/ndp2.h
@@ -24,8 +24,9 @@
 
 #include "kernel_types.h"
 #include "net/gnrc/pkt.h"
-#include "net/gnrc/ipv6/netif.h"
+#include "net/gnrc/netif2.h"
 #include "net/ipv6/addr.h"
+#include "net/ipv6/hdr.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -269,7 +270,7 @@ gnrc_pktsnip_t *gnrc_ndp2_opt_mtu_build(uint32_t mtu, gnrc_pktsnip_t *next);
  *                      for a neighbor solicitation so be sure to check that.
  *                      **Will be released** in an error case.
  */
-void gnrc_ndp2_nbr_sol_send(const ipv6_addr_t *tgt, gnrc_ipv6_netif_t *netif,
+void gnrc_ndp2_nbr_sol_send(const ipv6_addr_t *tgt, gnrc_netif2_t *netif,
                             const ipv6_addr_t *src, const ipv6_addr_t *dst,
                             gnrc_pktsnip_t *ext_opts);
 
@@ -315,7 +316,7 @@ void gnrc_ndp2_nbr_sol_send(const ipv6_addr_t *tgt, gnrc_ipv6_netif_t *netif,
  *                          check that.
  *                          **Will be released** in an error case.
  */
-void gnrc_ndp2_nbr_adv_send(const ipv6_addr_t *tgt, gnrc_ipv6_netif_t *netif,
+void gnrc_ndp2_nbr_adv_send(const ipv6_addr_t *tgt, gnrc_netif2_t *netif,
                             const ipv6_addr_t *dst, bool supply_tl2a,
                             gnrc_pktsnip_t *ext_opts);
 
@@ -328,7 +329,7 @@ void gnrc_ndp2_nbr_adv_send(const ipv6_addr_t *tgt, gnrc_ipv6_netif_t *netif,
  * @param[in] netif Interface to send over. May not be NULL.
  * @param[in] dst   Destination for the router solicitation. ff02::2 if NULL.
  */
-void gnrc_ndp2_rtr_sol_send(gnrc_ipv6_netif_t *netif, const ipv6_addr_t *dst);
+void gnrc_ndp2_rtr_sol_send(gnrc_netif2_t *netif, const ipv6_addr_t *dst);
 
 /**
  * @brief   Send pre-compiled router advertisement depending on a given network
@@ -355,7 +356,7 @@ void gnrc_ndp2_rtr_sol_send(gnrc_ipv6_netif_t *netif, const ipv6_addr_t *dst);
  *                      for a neighbor advertisement so be sure to check that.
  *                      **Will be released** in an error case.
  */
-void gnrc_ndp2_rtr_adv_send(gnrc_ipv6_netif_t *netif, const ipv6_addr_t *src,
+void gnrc_ndp2_rtr_adv_send(gnrc_netif2_t *netif, const ipv6_addr_t *src,
                             const ipv6_addr_t *dst, bool fin,
                             gnrc_pktsnip_t *ext_opts);
 

--- a/sys/include/net/gnrc/netif2/conf.h
+++ b/sys/include/net/gnrc/netif2/conf.h
@@ -20,6 +20,7 @@
 
 #include "net/ieee802154.h"
 #include "net/ethernet/hdr.h"
+#include "net/gnrc/ipv6/nib/conf.h"
 #include "thread.h"
 
 #ifdef __cplusplus
@@ -60,7 +61,7 @@ extern "C" {
  *
  * @note    Used for calculation of @ref GNRC_NETIF2_IPV6_GROUPS_NUMOF
  */
-#ifdef MODULE_GNRC_IPV6_ROUTER
+#if GNRC_IPV6_NIB_CONF_ROUTER
 #define GNRC_NETIF2_IPV6_RTR_ADDR   (1)
 #else
 #define GNRC_NETIF2_IPV6_RTR_ADDR   (0)
@@ -109,7 +110,7 @@ extern "C" {
 #elif   MODULE_CC110X
 #define GNRC_NETIF2_L2ADDR_MAXLEN   (1U)
 #else
-#define GNRC_NETIF2_L2ADDR_MAXLEN   (8U)
+#define GNRC_NETIF2_L2ADDR_MAXLEN   (GNRC_IPV6_NIB_L2ADDR_MAX_LEN)
 #endif
 #endif
 

--- a/sys/include/net/gnrc/netif2/ipv6.h
+++ b/sys/include/net/gnrc/netif2/ipv6.h
@@ -115,9 +115,8 @@ typedef struct {
      * The callback may be `NULL` if no such behavior is required by the routing
      * protocol (or no routing protocol is present).
      *
-     * @todo    Define types (RRQ, RRN, NSC) in NIB
-     *
-     * @param[in] type      Type of the route info.
+     * @param[in] type      [Type](@ref net_gnrc_ipv6_nib_route_info_type) of
+     *                      the route info.
      * @param[in] ctx_addr  Context address of the route info.
      * @param[in] ctx       Further context of the route info.
      */

--- a/sys/net/gnrc/netif2/gnrc_netif2.c
+++ b/sys/net/gnrc/netif2/gnrc_netif2.c
@@ -19,6 +19,9 @@
 #include "net/ethernet.h"
 #include "net/ipv6.h"
 #include "net/gnrc.h"
+#ifdef MODULE_GNRC_IPV6_NIB
+#include "net/gnrc/ipv6/nib.h"
+#endif /* MODULE_GNRC_IPV6_NIB */
 #ifdef MODULE_NETSTATS_IPV6
 #include "net/netstats.h"
 #endif
@@ -278,7 +281,7 @@ int gnrc_netif2_set_from_netdev(gnrc_netif2_t *netif,
             }
             else {
                 if (gnrc_netif2_is_rtr_adv(netif)) {
-                    gnrc_ipv6_nib_iface_cease_rtr_adv(netif);
+                    gnrc_ipv6_nib_change_rtr_adv_iface(netif, false);
                 }
                 netif->flags &= ~GNRC_NETIF2_FLAGS_IPV6_FORWARDING;
             }
@@ -286,12 +289,8 @@ int gnrc_netif2_set_from_netdev(gnrc_netif2_t *netif,
             break;
         case NETOPT_IPV6_SND_RTR_ADV:
             assert(opt->data_len == sizeof(netopt_enable_t));
-            if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
-                gnrc_ipv6_nib_iface_start_rtr_adv(netif);
-            }
-            else {
-                gnrc_ipv6_nib_iface_cease_rtr_adv(netif);
-            }
+            gnrc_ipv6_nib_change_rtr_adv_iface(netif,
+                    (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE));
             res = sizeof(netopt_enable_t);
             break;
 #endif  /* GNRC_IPV6_NIB_CONF_ROUTER */

--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -23,11 +23,7 @@
 #include "kernel_types.h"
 #include "net/ipv6/hdr.h"
 #include "net/gnrc.h"
-#ifndef MODULE_GNRC_IPV6_NIB
-#include "net/gnrc/ndp.h"
-#else
 #include "net/gnrc/ipv6/nib.h"
-#endif
 #include "net/protnum.h"
 #include "od.h"
 #include "utlist.h"
@@ -98,40 +94,6 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
             break;
 #endif
 
-#ifndef MODULE_GNRC_IPV6_NIB
-#if (defined(MODULE_GNRC_NDP_ROUTER) || defined(MODULE_GNRC_SIXLOWPAN_ND_ROUTER))
-        case ICMPV6_RTR_SOL:
-            DEBUG("icmpv6: router solicitation received\n");
-            gnrc_ndp_rtr_sol_handle(iface, pkt, ipv6->data, (ndp_rtr_sol_t *)hdr,
-                                    icmpv6->size);
-            break;
-#endif
-
-#ifdef MODULE_GNRC_NDP
-        case ICMPV6_RTR_ADV:
-            DEBUG("icmpv6: router advertisement received\n");
-            gnrc_ndp_rtr_adv_handle(iface, pkt, ipv6->data, (ndp_rtr_adv_t *)hdr,
-                                    icmpv6->size);
-            break;
-
-        case ICMPV6_NBR_SOL:
-            DEBUG("icmpv6: neighbor solicitation received\n");
-            gnrc_ndp_nbr_sol_handle(iface, pkt, ipv6->data, (ndp_nbr_sol_t *)hdr,
-                                    icmpv6->size);
-            break;
-
-        case ICMPV6_NBR_ADV:
-            DEBUG("icmpv6: neighbor advertisement received\n");
-            gnrc_ndp_nbr_adv_handle(iface, pkt, ipv6->data, (ndp_nbr_adv_t *)hdr,
-                                    icmpv6->size);
-            break;
-#endif
-
-        case ICMPV6_REDIRECT:
-            DEBUG("icmpv6: redirect message received\n");
-            /* TODO */
-            break;
-#else   /* MODULE_GNRC_IPV6_NIB */
         case ICMPV6_RTR_SOL:
         case ICMPV6_RTR_ADV:
         case ICMPV6_NBR_SOL:
@@ -140,9 +102,9 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
         case ICMPV6_DAR:
         case ICMPV6_DAC:
             DEBUG("icmpv6: NDP message received. Handle with gnrc_ipv6_nib\n");
-            gnrc_ipv6_nib_handle_pkt(iface, ipv6->data, hdr, icmpv6->size);
+            gnrc_ipv6_nib_handle_pkt(gnrc_netif2_get_by_pid(iface),
+                                     ipv6->data, hdr, icmpv6->size);
             break;
-#endif  /* MODULE_GNRC_IPV6_NIB */
 
         default:
             DEBUG("icmpv6: unknown type field %u\n", hdr->type);

--- a/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
+++ b/sys/net/gnrc/network_layer/ipv6/netif/gnrc_ipv6_netif.c
@@ -25,9 +25,6 @@
 
 #include "net/eui64.h"
 #include "net/ipv6/addr.h"
-#ifdef MODULE_GNRC_IPV6_NIB
-#include "net/gnrc/ipv6/nib.h"
-#endif
 #include "net/gnrc/ndp.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/netif.h"
@@ -176,11 +173,9 @@ static void _ipv6_netif_remove(gnrc_ipv6_netif_t *entry)
         return;
     }
 
-#ifndef MODULE_GNRC_IPV6_NIB
 #ifdef MODULE_GNRC_NDP
     gnrc_ndp_netif_remove(entry);
 #endif
-#endif  /* MODULE_GNRC_IPV6_NIB */
 
     mutex_lock(&entry->mutex);
     xtimer_remove(&entry->rtr_sol_timer);
@@ -240,13 +235,9 @@ void gnrc_ipv6_netif_add(kernel_pid_t pid)
 
     mutex_unlock(&free_entry->mutex);
 
-#ifndef MODULE_GNRC_IPV6_NIB
 #ifdef MODULE_GNRC_NDP
     gnrc_ndp_netif_add(free_entry);
 #endif
-#else   /* MODULE_GNRC_IPV6_NIB */
-    gnrc_ipv6_nib_init_iface(pid);
-#endif  /* MODULE_GNRC_IPV6_NIB */
 
     DEBUG(" * pid = %" PRIkernel_pid "  ", free_entry->pid);
     DEBUG("cur_hl = %d  ", free_entry->cur_hl);

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -13,6 +13,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include "net/gnrc/netif2/internal.h"
 #include "net/gnrc/ipv6/nib.h"
 
 #include "_nib-6ln.h"
@@ -26,49 +27,88 @@
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #endif
 
-static bool _is_iface_eui64(kernel_pid_t iface, const eui64_t *eui64)
+static inline bool _is_iface_eui64(gnrc_netif2_t *netif, const eui64_t *eui64)
 {
-    eui64_t iface_eui64;
-
-    /* XXX: this *should* return successful so don't test it ;-) */
-    gnrc_netapi_get(iface, NETOPT_ADDRESS_LONG, 0,
-                    &iface_eui64, sizeof(iface_eui64));
-    return (memcmp(&iface_eui64, eui64, sizeof(iface_eui64)) != 0);
+    /* TODO: adapt for short addresses */
+    return (netif->l2addr_len == sizeof(eui64_t)) &&
+            (memcmp(&netif->l2addr, eui64, netif->l2addr_len) == 0);
 }
 
-bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, kernel_pid_t iface,
+static inline uint8_t _reverse_iid(const ipv6_addr_t *dst,
+                                   const gnrc_netif2_t *netif, uint8_t *l2addr)
+{
+    switch (netif->device_type) {
+#ifdef MODULE_NETDEV_ETH
+        case NETDEV_TYPE_ETHERNET:
+            l2addr[0] = dst->u8[8] ^ 0x02;
+            l2addr[1] = dst->u8[9];
+            l2addr[2] = dst->u8[10];
+            l2addr[3] = dst->u8[13];
+            l2addr[4] = dst->u8[14];
+            l2addr[5] = dst->u8[15];
+            return ETHERNET_ADDR_LEN;
+#endif
+#ifdef MODULE_NETDEV_IEEE802154
+        case NETDEV_TYPE_IEEE802154:
+            /* assume address was based on EUI-64
+             * (see https://tools.ietf.org/html/rfc6775#section-5.2) */
+            memcpy(l2addr, &dst->u64[1], sizeof(dst->u64[1]));
+            l2addr[0] ^= 0x02;
+            return sizeof(dst->u64[1]);
+#endif
+#ifdef MODULE_CC110X
+        case NETDEV_TYPE_CC110X:
+            l2addr[0] = dst->u8[15];
+            return sizeof(uint8_t);
+#endif
+        default:
+            (void)dst;
+            (void)l2addr;
+            return 0;
+    }
+}
+
+bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, gnrc_netif2_t *netif,
                              gnrc_ipv6_nib_nc_t *nce)
 {
-    gnrc_ipv6_netif_t *netif = gnrc_ipv6_netif_get(iface);
-    bool res = (netif != NULL) && _is_6ln(netif) &&
+    bool res = (netif != NULL) && gnrc_netif2_is_6ln(netif) &&
                ipv6_addr_is_link_local(dst);
 
     if (res) {
-        memcpy(&nce->ipv6, dst, sizeof(nce->ipv6));
-        memcpy(&nce->l2addr, &dst->u64[1], sizeof(dst->u64[1]));
-        nce->l2addr[0] ^= 0x02;
-        nce->info = 0;
-        nce->info |= (iface << GNRC_IPV6_NIB_NC_INFO_IFACE_POS) &
-                     GNRC_IPV6_NIB_NC_INFO_IFACE_MASK;
-        nce->info |= GNRC_IPV6_NIB_NC_INFO_NUD_STATE_REACHABLE;
-        nce->info |= GNRC_IPV6_NIB_NC_INFO_AR_STATE_REGISTERED;
-        nce->l2addr_len = sizeof(dst->u64[1]);
+        uint8_t l2addr_len;
+
+        if ((l2addr_len = _reverse_iid(dst, netif, nce->l2addr)) > 0) {
+            DEBUG("nib: resolve address %s%%%u by reverse translating to ",
+                  ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)),
+                  (unsigned)netif->pid);
+            nce->l2addr_len = l2addr_len;
+            DEBUG("%s\n",
+                  gnrc_netif2_addr_to_str(nce->l2addr, nce->l2addr_len,
+                                          addr_str));
+            memcpy(&nce->ipv6, dst, sizeof(nce->ipv6));
+            nce->info = 0;
+            nce->info |= (netif->pid << GNRC_IPV6_NIB_NC_INFO_IFACE_POS) &
+                         GNRC_IPV6_NIB_NC_INFO_IFACE_MASK;
+            nce->info |= GNRC_IPV6_NIB_NC_INFO_NUD_STATE_REACHABLE;
+            nce->info |= GNRC_IPV6_NIB_NC_INFO_AR_STATE_REGISTERED;
+        }
+        else {
+            res = false;
+        }
     }
     return res;
 }
 
-uint8_t _handle_aro(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
+uint8_t _handle_aro(gnrc_netif2_t *netif, const ipv6_hdr_t *ipv6,
                     const icmpv6_hdr_t *icmpv6,
                     const sixlowpan_nd_opt_ar_t *aro, const ndp_opt_t *sl2ao,
                     _nib_onl_entry_t *nce)
 {
-    gnrc_ipv6_netif_t *netif = gnrc_ipv6_netif_get(iface);
-
 #if !GNRC_IPV6_NIB_CONF_6LR
     (void)sl2ao;
 #endif
     assert(netif != NULL);
-    if (_is_6ln(netif) && (aro->len == SIXLOWPAN_ND_OPT_AR_LEN)) {
+    if (gnrc_netif2_is_6ln(netif) && (aro->len == SIXLOWPAN_ND_OPT_AR_LEN)) {
         DEBUG("nib: valid ARO received\n");
         DEBUG(" - length: %u\n", aro->len);
         DEBUG(" - status: %u\n", aro->status);
@@ -78,7 +118,7 @@ uint8_t _handle_aro(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
               aro->eui64.uint8[3], aro->eui64.uint8[4], aro->eui64.uint8[5],
               aro->eui64.uint8[6], aro->eui64.uint8[7]);
         if (icmpv6->type == ICMPV6_NBR_ADV) {
-            if (!_is_iface_eui64(iface, &aro->eui64)) {
+            if (!_is_iface_eui64(netif, &aro->eui64)) {
                 DEBUG("nib: ARO EUI-64 is not mine, ignoring ARO\n");
                 return _ADDR_REG_STATUS_IGNORE;
             }
@@ -92,7 +132,7 @@ uint8_t _handle_aro(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
                                 (byteorder_ntohs(aro->ltime) - 1U) *
                                 SEC_PER_MIN * MS_PER_SEC;
                     DEBUG("nib: Address registration successful. "
-                               "Scheduling re-registration in %ums\n",
+                               "Scheduling re-registration in %" PRIu32 "ms\n",
                           next_ns);
                     assert(nce != NULL);
                     _evtimer_add(nce, GNRC_IPV6_NIB_SND_UC_NS, &nce->nud_timeout,
@@ -103,22 +143,19 @@ uint8_t _handle_aro(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
                     DEBUG("nib: Address registration reports duplicate. "
                                "Removing address %s%%%u\n",
                           ipv6_addr_to_str(addr_str,
-                                           &((ndp_nbr_adv_t *)icmpv6)->tgt,
-                                           sizeof(addr_str)),
-                          iface);
-                    gnrc_ipv6_netif_remove_addr(iface,
-                                                &((ndp_nbr_adv_t *)icmpv6)->tgt);
+                                           &ipv6->dst,
+                                           sizeof(addr_str)), netif->pid);
+                    gnrc_netif2_ipv6_addr_remove(netif, &ipv6->dst);
                     /* TODO: generate new address */
                     break;
                 case SIXLOWPAN_ND_STATUS_NC_FULL: {
                         DEBUG("nib: Router's neighbor cache is full. "
                                    "Searching new router for DAD\n");
-                        _nib_dr_entry_t *dr = _nib_drl_get(&ipv6->src, iface);
+                        _nib_dr_entry_t *dr = _nib_drl_get(&ipv6->src, netif->pid);
                         assert(dr != NULL); /* otherwise we wouldn't be here */
                         _nib_drl_remove(dr);
                         if (_nib_drl_iter(NULL) == NULL) { /* no DRL left */
-                            _nib_iface_t *nib_iface = _nib_iface_get(iface);
-                            nib_iface->rs_sent = 0;
+                            netif->ipv6.rs_sent = 0;
                             /* TODO: search new router */
                         }
                         else {
@@ -131,8 +168,9 @@ uint8_t _handle_aro(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
             return aro->status;
         }
 #if GNRC_IPV6_NIB_CONF_6LR
-        else if (_is_6lr(netif) && (icmpv6->type == ICMPV6_NBR_SOL)) {
-            return _reg_addr_upstream(iface, ipv6, icmpv6, aro, sl2ao);
+        else if (gnrc_netif2_is_6lr(netif) &&
+                 (icmpv6->type == ICMPV6_NBR_SOL)) {
+            return _reg_addr_upstream(netif, ipv6, icmpv6, aro, sl2ao);
         }
 #endif
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.h
@@ -45,37 +45,22 @@ extern "C" {
 #define _ADDR_REG_STATUS_IGNORE         (4)
 
 /**
- * @brief   Checks if interface represents a 6LN
- *
- * @todo    Use corresponding function in `gnrc_netif2` instead.
- *
- * @param[in] netif A network interface.
- *
- * @return  true, when the @p netif represents a 6LN.
- * @return  false, when the @p netif does not represent a 6LN.
- */
-static inline bool _is_6ln(const gnrc_ipv6_netif_t *netif)
-{
-    return (netif->flags & GNRC_IPV6_NETIF_FLAGS_SIXLOWPAN);
-}
-
-/**
  * @brief   Resolves address statically from destination address using reverse
  *          translation of the IID
  *
  * @param[in] dst   A destination address.
- * @param[in] iface The interface to @p dst.
+ * @param[in] netif The interface to @p dst.
  * @param[out] nce  Neighbor cache entry to resolve into
  *
  * @return  true when @p nce was set, false when not.
  */
-bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, kernel_pid_t iface,
+bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, gnrc_netif2_t *netif,
                              gnrc_ipv6_nib_nc_t *nce);
 
 /**
  * @brief   Handles ARO
  *
- * @param[in] iface     The interface the ARO-carrying message came over.
+ * @param[in] netif     The interface the ARO-carrying message came over.
  * @param[in] ipv6      The IPv6 header of the message carrying the ARO.
  * @param[in] icmpv6    The message carrying the ARO.
  * @param[in] aro       ARO that carries the address registration information.
@@ -85,13 +70,12 @@ bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, kernel_pid_t iface,
  * @return  registration status of the address (including
  *          @ref _ADDR_REG_STATUS_TENTATIVE and @ref _ADDR_REG_STATUS_IGNORE).
  */
-uint8_t _handle_aro(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
+uint8_t _handle_aro(gnrc_netif2_t *netif, const ipv6_hdr_t *ipv6,
                     const icmpv6_hdr_t *icmpv6,
                     const sixlowpan_nd_opt_ar_t *aro, const ndp_opt_t *sl2ao,
                     _nib_onl_entry_t *nce);
 #else   /* GNRC_IPV6_NIB_CONF_6LN || defined(DOXYGEN) */
-#define _is_6ln(netif)                              (false)
-#define _resolve_addr_from_ipv6(dst, iface, nce)    (false)
+#define _resolve_addr_from_ipv6(dst, netif, nce)    (false)
 /* _handle_aro() doesn't make sense without 6LR so don't even use it
  * => throw error in case it is compiled in => don't define it here as NOP macro
  */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.h
@@ -34,21 +34,6 @@ extern "C" {
 
 #if GNRC_IPV6_NIB_CONF_6LR || defined(DOXYGEN)
 /**
- * @brief   Checks if interface represents a 6LR
- *
- * @todo    Use corresponding function in `gnrc_netif2` instead.
- *
- * @param[in] netif A network interface.
- *
- * @return  true, when the @p netif represents a 6LR.
- * @return  false, when the @p netif does not represent a 6LR.
- */
-static inline bool _is_6lr(const gnrc_ipv6_netif_t *netif)
-{
-    return _is_6ln(netif) && (netif->flags & GNRC_IPV6_NETIF_FLAGS_ROUTER);
-}
-
-/**
  * @brief   Gets address registration state of a neighbor
  *
  * @param[in] entry Neighbor cache entry representing the neighbor.
@@ -81,17 +66,17 @@ static inline void _set_ar_state(_nib_onl_entry_t *entry, uint16_t state)
  * @param[in] netif     A network interface.
  * @param[in] icmpv6    An ICMPv6 message.
  */
-static inline bool _rtr_sol_on_6lr(const gnrc_ipv6_netif_t *netif,
+static inline bool _rtr_sol_on_6lr(const gnrc_netif2_t *netif,
                                    const icmpv6_hdr_t *icmpv6)
 {
-    return _is_6lr(netif) && (icmpv6->type == ICMPV6_RTR_SOL);
+    return gnrc_netif2_is_6lr(netif) && (icmpv6->type == ICMPV6_RTR_SOL);
 }
 
 /**
  * @brief   Registers an address to the (upstream; in case of multihop DAD)
  *          router
  *
- * @param[in] iface     The interface the ARO-carrying NS came over.
+ * @param[in] netif     The interface the ARO-carrying NS came over.
  * @param[in] ipv6      The IPv6 header of the message carrying the ARO.
  * @param[in] icmpv6    The neighbor solicitation carrying the ARO
  *                      (handed over as @ref icmpv6_hdr_t, since it is just
@@ -102,7 +87,7 @@ static inline bool _rtr_sol_on_6lr(const gnrc_ipv6_netif_t *netif,
  * @return  registration status of the address (including
  *          @ref _ADDR_REG_STATUS_TENTATIVE and @ref _ADDR_REG_STATUS_IGNORE).
  */
-uint8_t _reg_addr_upstream(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
+uint8_t _reg_addr_upstream(gnrc_netif2_t *netif, const ipv6_hdr_t *ipv6,
                            const icmpv6_hdr_t *icmpv6,
                            const sixlowpan_nd_opt_ar_t *aro,
                            const ndp_opt_t *sl2ao);
@@ -111,7 +96,7 @@ uint8_t _reg_addr_upstream(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
 /**
  * @brief   Handles and copies ARO from NS to NA
  *
- * @param[in] iface     The interface the ARO-carrying NS came over.
+ * @param[in] netif     The interface the ARO-carrying NS came over.
  * @param[in] ipv6      The IPv6 header of the message carrying the original
  *                      ARO.
  * @param[in] nbr_sol   The neighbor solicitation carrying the original ARO
@@ -123,16 +108,15 @@ uint8_t _reg_addr_upstream(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
  * @return  registration status of the address (including
  *          @ref _ADDR_REG_STATUS_TENTATIVE and @ref _ADDR_REG_STATUS_IGNORE).
  */
-gnrc_pktsnip_t *_copy_and_handle_aro(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
+gnrc_pktsnip_t *_copy_and_handle_aro(gnrc_netif2_t *netif, const ipv6_hdr_t *ipv6,
                                      const ndp_nbr_sol_t *nbr_sol,
                                      const sixlowpan_nd_opt_ar_t *aro,
                                      const ndp_opt_t *sl2ao);
 #else   /* GNRC_IPV6_NIB_CONF_6LR || defined(DOXYGEN) */
-#define _is_6lr(netif)                  (false)
 #define _rtr_sol_on_6lr(netif, icmpv6)  (false)
 #define _get_ar_state(nbr)              (_ADDR_REG_STATUS_IGNORE)
 #define _set_ar_state(nbr, state)       (void)nbr; (void)state
-#define _copy_and_handle_aro(iface, ipv6, icmpv6, aro, sl2ao) \
+#define _copy_and_handle_aro(netif, ipv6, icmpv6, aro, sl2ao) \
                                         (NULL)
 /* _reg_addr_upstream() doesn't make sense without 6LR so don't even use it
  * => throw error in case it is compiled in => don't define it here as NOP macro

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include "net/gnrc/ipv6/nib/conf.h"
+#include "net/gnrc/netif2.h"
 #include "net/ndp.h"
 #include "net/icmpv6.h"
 
@@ -47,7 +48,7 @@ extern "C" {
  * @param[in] dst       Destination address for neighbor solicitation. May not
  *                      be NULL.
  */
-void _snd_ns(const ipv6_addr_t *tgt, gnrc_ipv6_netif_t *netif,
+void _snd_ns(const ipv6_addr_t *tgt, gnrc_netif2_t *netif,
              const ipv6_addr_t *src, const ipv6_addr_t *dst);
 
 /**
@@ -72,12 +73,12 @@ void _snd_uc_ns(_nib_onl_entry_t *nbr, bool reset);
  *          to the ARSM, but ARSM isn't the only mechanism using it (e.g. the
  *          6Lo address registration uses it).
  *
- * @param[in] iface     Interface the SL2AO was sent over.
+ * @param[in] netif     Interface the SL2AO was sent over.
  * @param[in] ipv6      IPv6 header of the message carrying the SL2AO.
  * @param[in] icmpv6    ICMPv6 header of the message carrying the SL2AO.
  * @param[in] sl2ao     The SL2AO
  */
-void _handle_sl2ao(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
+void _handle_sl2ao(gnrc_netif2_t *netif, const ipv6_hdr_t *ipv6,
                    const icmpv6_hdr_t *icmpv6, const ndp_opt_t *sl2ao);
 
 #if GNRC_IPV6_NIB_CONF_ARSM || defined(DOXYGEN)
@@ -111,7 +112,7 @@ void _probe_nbr(_nib_onl_entry_t *nbr, bool reset);
  * This can either be an TL2AO or for a link-layer without addresses just a
  * neighbor advertisement.
  *
- * @param[in] iface     Interface the link-layer information was advertised
+ * @param[in] netif     Interface the link-layer information was advertised
  *                      over.
  * @param[in] nce       Neighbor cache entry that is updated by the advertised
  *                      link-layer information.
@@ -120,53 +121,62 @@ void _probe_nbr(_nib_onl_entry_t *nbr, bool reset);
  * @param[in] tl2ao     The TL2AO carrying the link-layer information. May be
  *                      NULL for link-layers without addresses.
  */
-void _handle_adv_l2(kernel_pid_t iface, _nib_onl_entry_t *nce,
+void _handle_adv_l2(gnrc_netif2_t *netif, _nib_onl_entry_t *nce,
                     const icmpv6_hdr_t *icmpv6, const ndp_opt_t *tl2ao);
+
+
+/**
+ * @brief   Recalculates the (randomized) reachable time of on a network
+ *          interface.
+ *
+ * @see [RFC 4861, section 6.3.4](https://tools.ietf.org/html/rfc4861#section-6.3.4)
+ *
+ * @param[in] netif Interface to set reachable time for.
+ */
+void _recalc_reach_time(gnrc_netif2_ipv6_t *netif);
 
 /**
  * @brief   Sets a neighbor cache entry reachable and starts the required
  *          event timers
  *
- * @param[in] iface Interface to the NCE
+ * @param[in] netif Interface to the NCE
  * @param[in] nce   The neighbor cache entry to set reachable
  */
-void _set_reachable(unsigned iface, _nib_onl_entry_t *nce);
+void _set_reachable(gnrc_netif2_t *netif, _nib_onl_entry_t *nce);
 
 /**
  * @brief   Initializes interface for address registration state machine
  *
- * @param[in] nib_iface An interface
+ * @param[in] netif An interface
  */
-static inline void _init_iface_arsm(_nib_iface_t *nib_iface)
+static inline void _init_iface_arsm(gnrc_netif2_t *netif)
 {
-    nib_iface->reach_time_base = NDP_REACH_MS;
-    nib_iface->retrans_time = NDP_RETRANS_TIMER_MS;
-    _nib_iface_recalc_reach_time(nib_iface);
+    netif->ipv6.reach_time_base = NDP_REACH_MS;
+    _recalc_reach_time(&netif->ipv6);
 }
 
 /**
  * @brief   Gets neighbor unreachability state of a neighbor
  *
- * @param[in] entry Neighbor cache entry representing the neighbor.
+ * @param[in] nbr   Neighbor cache entry representing the neighbor.
  *
- * @return  Neighbor unreachability state of the @p entry.
+ * @return  Neighbor unreachability state of the @p nbr.
  */
-static inline uint16_t _get_nud_state(_nib_onl_entry_t *entry)
+static inline uint16_t _get_nud_state(_nib_onl_entry_t *nbr)
 {
-    return (entry->info & GNRC_IPV6_NIB_NC_INFO_NUD_STATE_MASK);
+    return (nbr->info & GNRC_IPV6_NIB_NC_INFO_NUD_STATE_MASK);
 }
 
 /**
  * @brief   Sets neighbor unreachablility state of a neighbor
  *
- * @param[in] entry Neighbor cache entry representing the neighbor.
+ * @param[in] netif The network interface (to signal routing protocol using
+ *                  gnrc_netif_t::ipv6::route_info_cb())
+ * @param[in] nbr   Neighbor cache entry representing the neighbor.
  * @param[in] state Neighbor unreachability state for the neighbor.
  */
-static inline void _set_nud_state(_nib_onl_entry_t *entry, uint16_t state)
-{
-    entry->info &= ~GNRC_IPV6_NIB_NC_INFO_NUD_STATE_MASK;
-    entry->info |= state;
-}
+void _set_nud_state(gnrc_netif2_t *netif, _nib_onl_entry_t *nbr,
+                    uint16_t state);
 
 #else   /* GNRC_IPV6_NIB_CONF_ARSM || defined(DOXYGEN) */
 #define _handle_snd_ns(ctx)                         (void)ctx
@@ -175,11 +185,12 @@ static inline void _set_nud_state(_nib_onl_entry_t *entry, uint16_t state)
 #define _init_iface_arsm(netif)                     (void)netif
 #define _handle_adv_l2(netif, nce, icmpv6, tl2ao)   (void)netif; (void)nce; \
                                                     (void)icmpv6; (void)tl2ao
+#define _recalc_reach_time(netif)                   (void)netif;
 #define _set_reachable(netif, nce)                  (void)netif; (void)nce
 #define _init_iface_arsm(netif)                     (void)netif
 
-#define _get_nud_state(entry)         (GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNMANAGED)
-#define _set_nud_state(entry, state)  (void)entry; (void)state
+#define _get_nud_state(nbr)                 (GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNMANAGED)
+#define _set_nud_state(netif, nce, state)   (void)netif; (void)nbr; (void)state
 #endif  /* GNRC_IPV6_NIB_CONF_ARSM || defined(DOXYGEN) */
 
 #ifdef __cplusplus

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -194,56 +194,6 @@ typedef struct {
 } _nib_offl_entry_t;
 
 /**
- * @brief   Interface specific information for Neighbor Discovery
- */
-typedef struct {
-#if GNRC_IPV6_NIB_CONF_ARSM
-    /**
-     * @brief   base for random reachable time calculation
-     */
-    uint32_t reach_time_base;
-    uint32_t reach_time;                /**< reachable time (in ms) */
-#endif
-    uint32_t retrans_time;              /**< retransmission time (in ms) */
-#if GNRC_IPV6_NIB_CONF_ROUTER || defined(DOXYGEN)
-    /**
-     * @brief   timestamp in milliseconds of last unsolicited router
-     *          advertisement
-     *
-     * @note    Only available if @ref GNRC_IPV6_NIB_CONF_ROUTER.
-     */
-    uint32_t last_ra;
-#endif
-#if GNRC_IPV6_NIB_CONF_ARSM || defined(DOXYGEN)
-    /**
-     * @brief   Event for @ref GNRC_IPV6_NIB_RECALC_REACH_TIME
-     */
-    evtimer_msg_event_t recalc_reach_time;
-#endif
-    kernel_pid_t pid;                   /**< identifier of the interface */
-#if GNRC_IPV6_NIB_CONF_ROUTER || defined(DOXYGEN)
-    /**
-     * @brief   number of unsolicited router advertisements sent
-     *
-     * This only counts up to the first @ref NDP_MAX_INIT_RA_NUMOF on interface
-     * initialization. The last @ref NDP_MAX_FIN_RA_NUMOF of an advertising
-     * interface are counted from UINT8_MAX - @ref NDP_MAX_FIN_RA_NUMOF + 1.
-     *
-     * @note    Only available if @ref GNRC_IPV6_NIB_CONF_ROUTER.
-     */
-    uint8_t ra_sent;
-#endif
-    /**
-     * @brief   number of unsolicited router solicitations scheduled
-     */
-    uint8_t rs_sent;
-    /**
-     * @brief   number of unsolicited neighbor advertisements scheduled
-     */
-    uint8_t na_sent;
-} _nib_iface_t;
-
-/**
  * @brief   Internal NIB-representation of the authoritative border router
  *          for multihop prefix and 6LoWPAN context dissemination
  */
@@ -794,30 +744,6 @@ void _nib_ft_get(const _nib_offl_entry_t *dst, gnrc_ipv6_nib_ft_t *fte);
  */
 int _nib_get_route(const ipv6_addr_t *dst, gnrc_pktsnip_t *ctx,
                    gnrc_ipv6_nib_ft_t *entry);
-
-/**
- * @brief   Gets (or creates if it not exists) interface information for
- *          neighbor discovery
- *
- * @pre `(iface <= _NIB_IF_MAX)`
- *
- * @param[in] iface Interface identifier to get information for.
- *
- * @return  Interface information on @p iface.
- * @return  NULL, if no space left for interface.
- */
-_nib_iface_t *_nib_iface_get(unsigned iface);
-
-/**
- * @brief   Recalculates randomized reachable time of an interface.
- *
- * @param[in] iface An interface.
- */
-#if GNRC_IPV6_NIB_CONF_ARSM
-void _nib_iface_recalc_reach_time(_nib_iface_t *iface);
-#else
-#define _nib_iface_recalc_reach_time(iface) (void)iface
-#endif
 
 /**
  * @brief   Looks up if an event is queued in the event timer

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 
 #include "net/gnrc/ipv6.h"
-#include "net/gnrc/netif.h"
+#include "net/gnrc/netif2.h"
 
 #include "net/gnrc/ipv6/nib/nc.h"
 
@@ -127,15 +127,16 @@ static const char *_ar_str[] = {
 
 void gnrc_ipv6_nib_nc_print(gnrc_ipv6_nib_nc_t *entry)
 {
-    char addr_str[IPV6_ADDR_MAX_STR_LEN];
+    char addr_str[(IPV6_ADDR_MAX_STR_LEN > GNRC_IPV6_NIB_L2ADDR_MAX_LEN) ?
+                   IPV6_ADDR_MAX_STR_LEN : GNRC_IPV6_NIB_L2ADDR_MAX_LEN];
 
     printf("%s ", ipv6_addr_to_str(addr_str, &entry->ipv6, sizeof(addr_str)));
     if (gnrc_ipv6_nib_nc_get_iface(entry) != KERNEL_PID_UNDEF) {
         printf("dev #%u ", gnrc_ipv6_nib_nc_get_iface(entry));
     }
-    printf("lladdr %s ", gnrc_netif_addr_to_str(addr_str, sizeof(addr_str),
-                                                entry->l2addr,
-                                                entry->l2addr_len));
+    printf("lladdr %s ", gnrc_netif2_addr_to_str(entry->l2addr,
+                                                 entry->l2addr_len,
+                                                 addr_str));
     if (gnrc_ipv6_nib_nc_is_router(entry)) {
         printf("router");
     }

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -106,8 +106,7 @@ static int _nib_neigh(int argc, char **argv)
             return 1;
         }
         if ((argc > 5) && /* TODO also check if interface supports link-layers or not */
-            (l2addr_len = gnrc_netif_addr_from_str(l2addr, sizeof(l2addr),
-                                                   argv[5])) == 0) {
+            (l2addr_len = gnrc_netif2_addr_from_str(argv[5], l2addr)) == 0) {
             _usage_nib_neigh(argv);
             return 1;
         }
@@ -150,7 +149,7 @@ static int _nib_prefix(int argc, char **argv)
         ipv6_addr_t pfx;
         unsigned iface = atoi(argv[3]);
         unsigned pfx_len = ipv6_addr_split_prefix(argv[4]);
-        unsigned valid_ltime = UINT32_MAX, pref_ltime = UINT32_MAX;
+        uint32_t valid_ltime = UINT32_MAX, pref_ltime = UINT32_MAX;
 
         if (ipv6_addr_from_str(&pfx, argv[4]) == NULL) {
             _usage_nib_prefix(argv);

--- a/tests/driver_kw2xrf/main.c
+++ b/tests/driver_kw2xrf/main.c
@@ -44,27 +44,13 @@ static bool _is_number(char *str)
     return true;
 }
 
-static bool _is_iface(kernel_pid_t dev)
-{
-    kernel_pid_t ifs[GNRC_NETIF_NUMOF];
-    size_t numof = gnrc_netif_get(ifs);
-
-    for (size_t i = 0; i < numof && i < GNRC_NETIF_NUMOF; i++) {
-        if (ifs[i] == dev) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 static void _set_test_mode(int argc, char **argv, uint8_t mode)
 {
     (void) argc;
     if (_is_number(argv[1])) {
         kernel_pid_t dev = atoi(argv[1]);
 
-        if (_is_iface(dev)) {
+        if (gnrc_netif2_get_by_pid(dev)) {
             gnrc_netapi_set(dev, NETOPT_RF_TESTMODE, 0, (void *)&mode, sizeof(mode));
             return;
         }

--- a/tests/gnrc_ipv6_nib/Makefile
+++ b/tests/gnrc_ipv6_nib/Makefile
@@ -6,7 +6,10 @@ BOARD_INSUFFICIENT_MEMORY := chronos nucleo32-f031 nucleo32-f042
 
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_ipv6_nib
+USEMODULE += gnrc_netif2
 USEMODULE += embunit
+USEMODULE += netdev_eth
+USEMODULE += netdev_test
 
 CFLAGS += -DDEVELHELP
 CFLAGS += -DGNRC_NETTYPE_NDP2=GNRC_NETTYPE_TEST

--- a/tests/gnrc_ipv6_nib/common.h
+++ b/tests/gnrc_ipv6_nib/common.h
@@ -22,14 +22,20 @@
 #include <stdio.h>
 
 #include "net/gnrc.h"
+#include "net/gnrc/netif2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define _CALL(fn)   _common_set_up(); _set_up(); puts("Calling " # fn); fn()
+#define _LL0            (0xce)
+#define _LL1            (0xab)
+#define _LL2            (0xfe)
+#define _LL3            (0xad)
+#define _LL4            (0xf7)
+#define _LL5            (0x26)
 
-extern kernel_pid_t _mock_netif_pid;
+extern gnrc_netif2_t *_mock_netif;
 
 void _tests_init(void);
 int _mock_netif_get(gnrc_netapi_opt_t *opt);

--- a/tests/gnrc_ipv6_nib/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib/mockup_netif.c
@@ -16,63 +16,73 @@
 #include "common.h"
 #include "msg.h"
 #include "net/gnrc.h"
+#include "net/ethernet.h"
 #include "net/gnrc/ipv6/nib.h"
-#include "net/gnrc/ipv6/netif.h"
-#include "net/gnrc/netdev.h"
+#include "net/gnrc/netif2/ethernet.h"
+#include "net/gnrc/netif2/internal.h"
+#include "net/netdev_test.h"
 #include "sched.h"
 #include "thread.h"
 
 #define _MSG_QUEUE_SIZE  (2)
 
-kernel_pid_t _mock_netif_pid = KERNEL_PID_UNDEF;
+gnrc_netif2_t *_mock_netif = NULL;
 
+static netdev_test_t _mock_netdev;
 static char _mock_netif_stack[THREAD_STACKSIZE_DEFAULT];
 static gnrc_netreg_entry_t dumper;
 static msg_t _main_msg_queue[_MSG_QUEUE_SIZE];
-static msg_t _mock_netif_msg_queue[_MSG_QUEUE_SIZE];
-
-static void *_mock_netif_thread(void *args)
-{
-    msg_t msg, reply = { .type = GNRC_NETAPI_MSG_TYPE_ACK };
-
-    (void)args;
-    msg_init_queue(_mock_netif_msg_queue, _MSG_QUEUE_SIZE);
-    while (1) {
-        msg_receive(&msg);
-        switch (msg.type) {
-            case GNRC_NETAPI_MSG_TYPE_GET:
-                reply.content.value = (uint32_t)_mock_netif_get(msg.content.ptr);
-                break;
-            case GNRC_NETAPI_MSG_TYPE_SET:
-                reply.content.value = (uint32_t)(-ENOTSUP);
-                break;
-            case GNRC_NETAPI_MSG_TYPE_SND:
-            case GNRC_NETAPI_MSG_TYPE_RCV:
-                gnrc_pktbuf_release(msg.content.ptr);
-        }
-        msg_reply(&msg, &reply);
-    }
-    return NULL;
-}
 
 void _common_set_up(void)
 {
+    assert(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
-    gnrc_ipv6_nib_init_iface(_mock_netif_pid);
+    gnrc_netif2_acquire(_mock_netif);
+    gnrc_ipv6_nib_init_iface(_mock_netif);
+    gnrc_netif2_release(_mock_netif);
+}
+
+int _get_device_type(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    assert(max_len == sizeof(uint16_t));
+    *((uint16_t *)value) = NETDEV_TYPE_ETHERNET;
+    return sizeof(uint16_t);
+}
+
+int _get_max_packet_size(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    assert(max_len == sizeof(uint16_t));
+    *((uint16_t *)value) = ETHERNET_DATA_LEN;
+    return sizeof(uint16_t);
+}
+
+int _get_address(netdev_t *dev, void *value, size_t max_len)
+{
+    static const uint8_t addr[] = { _LL0, _LL1, _LL2, _LL3, _LL4, _LL5 };
+
+    (void)dev;
+    assert(max_len >= sizeof(addr));
+    memcpy(value, addr, sizeof(addr));
+    return sizeof(addr);
 }
 
 void _tests_init(void)
 {
     msg_init_queue(_main_msg_queue, _MSG_QUEUE_SIZE);
-    _mock_netif_pid = thread_create(_mock_netif_stack,
-                                    sizeof(_mock_netif_stack),
-                                    GNRC_NETDEV_MAC_PRIO,
-                                    THREAD_CREATE_STACKTEST,
-                                    _mock_netif_thread, NULL, "mock_netif");
-    assert(_mock_netif_pid > KERNEL_PID_UNDEF);
-    gnrc_netif_add(_mock_netif_pid);
-    gnrc_ipv6_netif_init_by_dev();
-    thread_yield();
+    netdev_test_setup(&_mock_netdev, 0);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_DEVICE_TYPE,
+                           _get_device_type);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_MAX_PACKET_SIZE,
+                           _get_max_packet_size);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_ADDRESS,
+                           _get_address);
+    _mock_netif = gnrc_netif2_ethernet_create(
+           _mock_netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF2_PRIO,
+            "mockup_eth", &_mock_netdev.netdev
+        );
+    assert(_mock_netif != NULL);
     gnrc_netreg_entry_init_pid(&dumper, GNRC_NETREG_DEMUX_CTX_ALL,
                                sched_active_pid);
     gnrc_netreg_register(GNRC_NETTYPE_NDP2, &dumper);

--- a/tests/gnrc_ipv6_nib_6ln/Makefile
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile
@@ -8,8 +8,10 @@ BOARD_INSUFFICIENT_MEMORY := chronos nucleo-f030 nucleo-l053 nucleo32-f031 \
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_sixlowpan
 USEMODULE += gnrc_ipv6_nib_6ln
+USEMODULE += gnrc_netif2
 USEMODULE += embunit
-USEMODULE += netopt
+USEMODULE += netdev_ieee802154
+USEMODULE += netdev_test
 
 CFLAGS += -DDEVELHELP
 CFLAGS += -DGNRC_NETTYPE_NDP2=GNRC_NETTYPE_TEST

--- a/tests/gnrc_ipv6_nib_6ln/common.h
+++ b/tests/gnrc_ipv6_nib_6ln/common.h
@@ -22,14 +22,22 @@
 #include <stdio.h>
 
 #include "net/gnrc.h"
+#include "net/gnrc/netif2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define _CALL(fn)   _common_set_up(); _set_up(); puts("Calling " # fn); fn()
+#define _LL0            (0xce)
+#define _LL1            (0xab)
+#define _LL2            (0xfe)
+#define _LL3            (0xad)
+#define _LL4            (0xf7)
+#define _LL5            (0x26)
+#define _LL6            (0xef)
+#define _LL7            (0xa4)
 
-extern kernel_pid_t _mock_netif_pid;
+extern gnrc_netif2_t *_mock_netif;
 
 void _tests_init(void);
 int _mock_netif_get(gnrc_netapi_opt_t *opt);

--- a/tests/gnrc_ipv6_nib_6ln/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib_6ln/mockup_netif.c
@@ -16,63 +16,84 @@
 #include "common.h"
 #include "msg.h"
 #include "net/gnrc.h"
+#include "net/ethernet.h"
 #include "net/gnrc/ipv6/nib.h"
-#include "net/gnrc/ipv6/netif.h"
-#include "net/gnrc/netdev.h"
+#include "net/gnrc/netif2/ieee802154.h"
+#include "net/gnrc/netif2/internal.h"
+#include "net/netdev_test.h"
 #include "sched.h"
 #include "thread.h"
 
 #define _MSG_QUEUE_SIZE  (2)
 
-kernel_pid_t _mock_netif_pid = KERNEL_PID_UNDEF;
+gnrc_netif2_t *_mock_netif = NULL;
 
+static netdev_test_t _mock_netdev;
 static char _mock_netif_stack[THREAD_STACKSIZE_DEFAULT];
 static gnrc_netreg_entry_t dumper;
 static msg_t _main_msg_queue[_MSG_QUEUE_SIZE];
-static msg_t _mock_netif_msg_queue[_MSG_QUEUE_SIZE];
-
-static void *_mock_netif_thread(void *args)
-{
-    msg_t msg, reply = { .type = GNRC_NETAPI_MSG_TYPE_ACK };
-
-    (void)args;
-    msg_init_queue(_mock_netif_msg_queue, _MSG_QUEUE_SIZE);
-    while (1) {
-        msg_receive(&msg);
-        switch (msg.type) {
-            case GNRC_NETAPI_MSG_TYPE_GET:
-                reply.content.value = (uint32_t)_mock_netif_get(msg.content.ptr);
-                break;
-            case GNRC_NETAPI_MSG_TYPE_SET:
-                reply.content.value = (uint32_t)(-ENOTSUP);
-                break;
-            case GNRC_NETAPI_MSG_TYPE_SND:
-            case GNRC_NETAPI_MSG_TYPE_RCV:
-                gnrc_pktbuf_release(msg.content.ptr);
-        }
-        msg_reply(&msg, &reply);
-    }
-    return NULL;
-}
 
 void _common_set_up(void)
 {
+    assert(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
-    gnrc_ipv6_nib_init_iface(_mock_netif_pid);
+    gnrc_netif2_acquire(_mock_netif);
+    gnrc_ipv6_nib_init_iface(_mock_netif);
+    gnrc_netif2_release(_mock_netif);
+}
+
+int _get_device_type(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    assert(max_len == sizeof(uint16_t));
+    *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
+    return sizeof(uint16_t);
+}
+
+int _get_max_packet_size(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    assert(max_len == sizeof(uint16_t));
+    *((uint16_t *)value) = 102U;
+    return sizeof(uint16_t);
+}
+
+int _get_src_len(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    assert(max_len == sizeof(uint16_t));
+    *((uint16_t *)value) = IEEE802154_LONG_ADDRESS_LEN;
+    return sizeof(uint16_t);
+}
+
+int _get_address_long(netdev_t *dev, void *value, size_t max_len)
+{
+    static const uint8_t addr[] = { _LL0, _LL1, _LL2, _LL3,
+                                    _LL4, _LL5, _LL6, _LL7 };
+
+    (void)dev;
+    assert(max_len >= sizeof(addr));
+    memcpy(value, addr, sizeof(addr));
+    return sizeof(addr);
 }
 
 void _tests_init(void)
 {
     msg_init_queue(_main_msg_queue, _MSG_QUEUE_SIZE);
-    _mock_netif_pid = thread_create(_mock_netif_stack,
-                                    sizeof(_mock_netif_stack),
-                                    GNRC_NETDEV_MAC_PRIO,
-                                    THREAD_CREATE_STACKTEST,
-                                    _mock_netif_thread, NULL, "mock_netif");
-    assert(_mock_netif_pid > KERNEL_PID_UNDEF);
-    gnrc_netif_add(_mock_netif_pid);
-    gnrc_ipv6_netif_init_by_dev();
-    thread_yield();
+    netdev_test_setup(&_mock_netdev, 0);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_DEVICE_TYPE,
+                           _get_device_type);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_MAX_PACKET_SIZE,
+                           _get_max_packet_size);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_SRC_LEN,
+                           _get_src_len);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_ADDRESS_LONG,
+                           _get_address_long);
+    _mock_netif = gnrc_netif2_ieee802154_create(
+           _mock_netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF2_PRIO,
+            "mockup_wpan", &_mock_netdev.netdev.netdev
+        );
+    assert(_mock_netif != NULL);
     gnrc_netreg_entry_init_pid(&dumper, GNRC_NETREG_DEMUX_CTX_ALL,
                                sched_active_pid);
     gnrc_netreg_register(GNRC_NETTYPE_NDP2, &dumper);

--- a/tests/gnrc_ndp2/Makefile
+++ b/tests/gnrc_ndp2/Makefile
@@ -4,8 +4,11 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
 
+USEMODULE += gnrc_ipv6_nib
 USEMODULE += gnrc_ndp2
+USEMODULE += gnrc_netif2
 USEMODULE += embunit
+USEMODULE += netdev_test
 
 CFLAGS += -DGNRC_NETTYPE_NDP2=GNRC_NETTYPE_TEST
 CFLAGS += -DGNRC_PKTBUF_SIZE=512

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
@@ -1910,33 +1910,6 @@ static void test_nib_abr_iter__three_elem_middle_removed(void)
 }
 #endif
 
-/*
- * Creates GNRC_NETIF_NUMOF interfaces and then tries to add another.
- * Expected result: should return NULL
- */
-static void test_nib_iface_get__no_space_left(void)
-{
-    unsigned iface = 1;
-
-    for (int i = 0; i < GNRC_NETIF_NUMOF; i++) {
-        TEST_ASSERT_NOT_NULL(_nib_iface_get(iface++));
-    }
-    TEST_ASSERT_NULL(_nib_iface_get(iface));
-}
-
-/*
- * Creates an interface and then gets the same interface.
- * Expected result: interface pointers should equal
- */
-static void test_nib_iface_get__success(void)
-{
-    _nib_iface_t *ni1, *ni2;
-
-    TEST_ASSERT_NOT_NULL((ni1 = _nib_iface_get(IFACE)));
-    TEST_ASSERT_NOT_NULL((ni2 = _nib_iface_get(IFACE)));
-    TEST_ASSERT(ni1 == ni2);
-}
-
 Test *tests_gnrc_ipv6_nib_internal_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -2035,8 +2008,6 @@ Test *tests_gnrc_ipv6_nib_internal_tests(void)
         new_TestFixture(test_nib_abr_iter__three_elem),
         new_TestFixture(test_nib_abr_iter__three_elem_middle_removed),
 #endif
-        new_TestFixture(test_nib_iface_get__no_space_left),
-        new_TestFixture(test_nib_iface_get__success),
     };
 
     EMB_UNIT_TESTCALLER(tests, set_up, NULL,

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-nc.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-nc.c
@@ -276,20 +276,12 @@ static void test_nib_nc_mark_reachable__unmanaged(void)
 static void test_nib_nc_mark_reachable__success(void)
 {
     void *iter_state = NULL;
-    _nib_onl_entry_t *node;
-#if GNRC_IPV6_NIB_CONF_ARSM
-    evtimer_msg_event_t *event;
-#endif
-    _nib_iface_t *iface;
     static const ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
                                              { .u64 = TEST_UINT64 } } };
     gnrc_ipv6_nib_nc_t nce;
 
-    TEST_ASSERT_NOT_NULL((node = _nib_nc_add(&addr, IFACE,
-                                             GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE)));
-    /* set an "infinite" reachability time */
-    iface = _nib_iface_get(_nib_onl_get_if(node));
-    iface->reach_time = UINT32_MAX;
+    TEST_ASSERT_NOT_NULL(_nib_nc_add(&addr, IFACE,
+                                     GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE));
 
     /* check pre-state */
     TEST_ASSERT(gnrc_ipv6_nib_nc_iter(0, &iter_state, &nce));
@@ -306,11 +298,6 @@ static void test_nib_nc_mark_reachable__success(void)
     /* check if entry is reachable */
     TEST_ASSERT_EQUAL_INT(GNRC_IPV6_NIB_NC_INFO_NUD_STATE_REACHABLE,
                           gnrc_ipv6_nib_nc_get_nud_state(&nce));
-    /* check if there now is an event for reachability timeout of node */
-    TEST_ASSERT_NOT_NULL((event = (evtimer_msg_event_t *)_nib_evtimer.events));
-    TEST_ASSERT_EQUAL_INT(GNRC_IPV6_NIB_REACH_TIMEOUT, event->msg.type);
-    TEST_ASSERT_MESSAGE(node == event->msg.content.ptr,
-                        "event's context is not node");
 #endif
     /* check if still the only entry */
     TEST_ASSERT(!gnrc_ipv6_nib_nc_iter(0, &iter_state, &nce));


### PR DESCRIPTION
This ports the NIB to the new network interface API (since I don't want to make the unnecessary effort to port the old neighbor discovery to `gnrc_netif2` I did it this way around).

Depends on ~~#7014~~ (merged) and ~~#7424~~ (merged). 

This PR is part of the network layer remodelling effort:
![PR dependencies](https://miri64.github.io/riot-ndp-model/PR%20overview.svg)