### PR TITLE
doc: Enable REPEAT_BRIEF in Doxygen

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -107,7 +107,7 @@ BRIEF_MEMBER_DESC      = YES
 # brief descriptions will be completely suppressed.
 # The default value is: YES.
 
-REPEAT_BRIEF           = NO
+REPEAT_BRIEF           = YES
 
 # This tag implements a quasi-intelligent brief description abbreviator that is
 # used to form the text in various listings. Each string in this list, if found


### PR DESCRIPTION
The detailed documentation of some functions need the brief description included to make sense without having to jump back and forth between the brief list and the detailed descriptions when scrolling through the API docs.

This will make all API documentation HTML pages longer, but I think it helps readability of the manual.