### PR TITLE
kinetis: Adjust RTT alarm trigger time

### DIFF
--- a/cpu/kinetis_common/periph/rtt.c
+++ b/cpu/kinetis_common/periph/rtt.c
@@ -126,12 +126,15 @@ void rtt_set_counter(uint32_t counter)
 
 void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
 {
+    /* The alarm is triggered when TSR matches TAR, and TSR increments. This
+     * seem counterintuitive as most users expect the alarm to trigger
+     * immediately when the counter becomes equal to the alarm time. */
     RTC_Type *rtt = RTT_DEV;
 
     /* Disable Timer Alarm Interrupt */
     rtt->IER &= ~(RTC_IER_TAIE_MASK);
 
-    rtt->TAR = alarm;
+    rtt->TAR = alarm - 1;
 
     rtt_callback.alarm_cb = cb;
     rtt_callback.alarm_arg = arg;
@@ -147,7 +150,7 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
 uint32_t rtt_get_alarm(void)
 {
     RTC_Type *rtt = RTT_DEV;
-    return rtt->TAR;
+    return rtt->TAR + 1;
 }
 
 void rtt_clear_alarm(void)


### PR DESCRIPTION
The RTT alarm will trigger when the RTT seconds register is equal to the set alarm target, instead of triggering at the following second. This makes the API behave more like what users seem to expect.

Fixes #6331 for Kinetis