### PR TITLE
tests: added benchmark for periph_gpio driver

### DIFF
--- a/tests/bench_periph_gpio/Makefile
+++ b/tests/bench_periph_gpio/Makefile
@@ -1,0 +1,8 @@
+APPLICATION = bench_periph_gpio
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_gpio
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/bench_periph_gpio/README.md
+++ b/tests/bench_periph_gpio/README.md
@@ -1,0 +1,19 @@
+## About
+This application implements a benchmark for measuring the run-time of GPIO
+driver functions. It is meant to be used when optimizing specific GPIO driver
+implementations.
+
+The output will look similar to this:
+```
+2017-08-16 13:07:18,728 - INFO # main(): This is RIOT! (Version: xxx)
+2017-08-16 13:07:18,728 - INFO #
+2017-08-16 13:07:18,733 - INFO # GPIO driver run-time performance benchmark
+2017-08-16 13:07:18,733 - INFO #
+2017-08-16 13:07:20,112 - INFO #    gpio_set:   1375004us  ---   1.375us per call
+2017-08-16 13:07:21,493 - INFO #  gpio_clear:   1375004us  ---   1.375us per call
+2017-08-16 13:07:23,435 - INFO # gpio_toggle:   1937504us  ---   1.937us per call
+2017-08-16 13:07:25,127 - INFO #  gpio_write:   1687503us  ---   1.687us per call
+2017-08-16 13:07:27,196 - INFO #   gpio_read:   2062504us  ---   2.062us per call
+2017-08-16 13:07:27,196 - INFO #
+2017-08-16 13:07:27,197 - INFO #  --- DONE ---
+```

--- a/tests/bench_periph_gpio/main.c
+++ b/tests/bench_periph_gpio/main.c
@@ -1,0 +1,93 @@
+    /*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Benchmark measuring the GPIO driver's run-time performance
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+#include "periph/gpio.h"
+
+#define RUNS            (1000 * 1000UL)
+
+static void print_time(uint32_t time, const char *name)
+{
+    uint32_t full = (time / RUNS);
+    uint32_t div  = (time - (full * RUNS)) / (RUNS / 1000);
+
+    printf("%11s: %9luus  ---  %2u.%03uus per call\n", name,
+           (unsigned long) time, (unsigned)full, (unsigned)div);
+}
+
+static void bench_pin(gpio_t pin)
+{
+    uint32_t time;
+
+    /* gpio_set */
+    time = xtimer_now_usec();
+    for (unsigned long i = 0; i < RUNS; i++) {
+        gpio_set(pin);
+    }
+    time = (xtimer_now_usec() - time);
+    print_time(time, "gpio_set");
+
+    /* gpio_clear */
+    time = xtimer_now_usec();
+    for (unsigned long i = 0; i < RUNS; i++) {
+        gpio_clear(pin);
+    }
+    time = (xtimer_now_usec() - time);
+    print_time(time, "gpio_clear");
+
+    /* gpio_clear */
+    time = xtimer_now_usec();
+    for (unsigned long i = 0; i < RUNS; i++) {
+        gpio_toggle(pin);
+    }
+    time = (xtimer_now_usec() - time);
+    print_time(time, "gpio_toggle");
+
+    /* gpio_clear */
+    time = xtimer_now_usec();
+    for (unsigned long i = 0; i < RUNS; i++) {
+        gpio_write(pin, 1);
+    }
+    time = (xtimer_now_usec() - time);
+    print_time(time, "gpio_write");
+
+    /* gpio_read */
+    time = xtimer_now_usec();
+    for (unsigned long i = 0; i < RUNS; i++) {
+        int tmp = gpio_read(pin);
+        (void)tmp;
+    }
+    time = (xtimer_now_usec() - time);
+    print_time(time, "gpio_read");
+
+}
+
+int main(void)
+{
+    puts("\nGPIO driver run-time performance benchmark\n");
+
+    bench_pin(GPIO_PIN(0, 0));
+
+    puts("\n --- DONE ---");
+
+    return 0;
+}


### PR DESCRIPTION
I had some ideas this morning on how to optimize some of our GPIO driver implementations. So for testing my ideas, I created this simple benchmark application that would allow me to see the impact of my changes. This seems to be something useful so I share this one stand-alone.

I would think this kind of application would make sense for many parts of RIOT, probably not only periph drivers but also for other modules. So maybe we can develop some kind of unified output format, which would allow us to read the output from many different benchmark application into some kind of generic tool for e.g. regression testing and performance tracking.

I am however not sure, if this kind of application should reside in the `tests/` folder. I tend to think that a dedicated `bench/` folder would make sense here. Any opinions on this?