### PR TITLE
at86rf2xx: add NETOPT_TX_RETRIES_NEEDED support

### DIFF
--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -24,6 +24,8 @@
 #ifndef AT86RF2XX_REGISTERS_H
 #define AT86RF2XX_REGISTERS_H
 
+#include "at86rf2xx.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -93,6 +95,9 @@ extern "C" {
 #endif
 #define AT86RF2XX_REG__XAH_CTRL_1                               (0x17)
 #define AT86RF2XX_REG__FTN_CTRL                                 (0x18)
+#if AT86RF2XX_HAVE_RETRIES
+#define AT86RF2XX_REG__XAH_CTRL_2                               (0x19)
+#endif
 #define AT86RF2XX_REG__PLL_CF                                   (0x1A)
 #define AT86RF2XX_REG__PLL_DCU                                  (0x1B)
 #define AT86RF2XX_REG__PART_NUM                                 (0x1C)
@@ -327,6 +332,23 @@ extern "C" {
 #define AT86RF2XX_XAH_CTRL_1__AACK_UPLD_RES_FT                  (0x10)
 #define AT86RF2XX_XAH_CTRL_1__AACK_ACK_TIME                     (0x04)
 #define AT86RF2XX_XAH_CTRL_1__AACK_PROM_MODE                    (0x02)
+/** @} */
+
+/**
+ * @name    Bitfield definitions for the XAH_CTRL_2 register
+ *
+ * This register contains both the CSMA-CA retry counter and the frame retry
+ * counter. At this moment only the at86rf232 and the at86rf233 support this
+ * register.
+ *
+ * @{
+ */
+#if AT86RF2XX_HAVE_RETRIES
+#define AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_MASK           (0xF0)
+#define AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_OFFSET         (4)
+#define AT86RF2XX_XAH_CTRL_2__ARET_CSMA_RETRIES_MASK            (0x0E)
+#define AT86RF2XX_XAH_CTRL_2__ARET_CSMA_RETRIES_OFFSET          (1)
+#endif
 /** @} */
 
 /**

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -91,6 +91,20 @@ extern "C" {
 #   define RSSI_BASE_VAL                   (-91)
 #endif
 
+#if defined(DOXYGEN) || defined(MODULE_AT86RF232) || defined(MODULE_AT86RF233)
+/**
+ * @brief   Frame retry counter reporting
+ *
+ * The AT86RF2XX_HAVE_RETRIES flag enables support for NETOPT_TX_RETRIES NEEDED
+ * operation. Required for this functionality is the XAH_CTRL_2 register which
+ * contains the frame retry counter. Only the at86rf232 and the at86rf233
+ * support this register.
+ */
+#define AT86RF2XX_HAVE_RETRIES             (1)
+#else
+#define AT86RF2XX_HAVE_RETRIES             (0)
+#endif
+
 /**
  * @name    Flags for device internal states (see datasheet)
  * @{
@@ -167,6 +181,11 @@ typedef struct {
     uint8_t pending_tx;                 /**< keep track of pending TX calls
                                              this is required to know when to
                                              return to @ref at86rf2xx_t::idle_state */
+#if AT86RF2XX_HAVE_RETRIES
+    /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
+    uint8_t tx_retries;                 /**< Number of NOACK retransmissions */
+#endif
+    /** @} */
 } at86rf2xx_t;
 
 /**


### PR DESCRIPTION
Support for `NETOPT_TX_RETRIES_NEEDED` for the at86rf233. As far as I've found, only the at86rf233 supports reporting no ack retransmissions. This is based on #7448.

The code compiles, but as I don't have access to an at86rf233, I have no way to check if the code is functionally correct.