### PR TITLE
cpu/stm32: cleanup interrupt vectors

### DIFF
--- a/cpu/stm32f0/include/cpu_conf.h
+++ b/cpu/stm32f0/include/cpu_conf.h
@@ -55,7 +55,15 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
+#if defined(CPU_MODEL_STM32F030R8)
+#define CPU_IRQ_NUMOF                   (29U)
+#elif defined(CPU_MODEL_STM32F031K6)
+#define CPU_IRQ_NUMOF                   (28U)
+#elif defined(CPU_MODEL_STM32F051R8) || defined(CPU_MODEL_STM32F091RC)
 #define CPU_IRQ_NUMOF                   (31U)
+#else /* CPU_MODEL_STM32F042K6, CPU_MODEL_STM32F070RB, CPU_MODEL_STM32F072RB */
+#define CPU_IRQ_NUMOF                   (32U)
+#endif
 /** @} */
 
 /**

--- a/cpu/stm32f0/vectors.c
+++ b/cpu/stm32f0/vectors.c
@@ -64,60 +64,217 @@ WEAK_DEFAULT void isr_usart1(void);
 WEAK_DEFAULT void isr_usart2(void);
 WEAK_DEFAULT void isr_usart3_8(void);
 WEAK_DEFAULT void isr_cec(void);
+WEAK_DEFAULT void isr_usb(void);
 
 /* interrupt vector table */
 ISR_VECTORS const void *interrupt_vector[] = {
     /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
+    (void*) (&_estack),              /* pointer to the top of the stack */
     /* Cortex-M0 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    (void*) reset_handler_default,   /* entry point of the program */
+    (void*) nmi_default,             /* [-14] non maskable interrupt handler */
+    (void*) hard_fault_default,      /* [-13] hard fault exception */
+    (void*) (0UL),                   /* [-12] reserved */
+    (void*) (0UL),                   /* [-11] reserved */
+    (void*) (0UL),                   /* [-10] reserved */
+    (void*) (0UL),                   /* [-9] reserved */
+    (void*) (0UL),                   /* [-8] reserved */
+    (void*) (0UL),                   /* [-7] reserved */
+    (void*) (0UL),                   /* [-6] reserved */
+    (void*) isr_svc,                 /* [-5] system call interrupt, in RIOT used for
+                                            switching into thread context on boot */
+    (void*) (0UL),                   /* [-4] reserved */
+    (void*) (0UL),                   /* [-3] reserved */
+    (void*) isr_pendsv,              /* [-2] pendSV interrupt, in RIOT the actual
+                                            context switching is happening here */
+    (void*) isr_systick,             /* [-1] SysTick interrupt, not used in RIOT */
     /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* windowed watchdog */
-    (void*) isr_pvd,                /* power control */
-    (void*) isr_rtc,                /* real time clock */
-    (void*) isr_flash,              /* flash memory controller */
-    (void*) isr_rcc,                /* reset and clock control */
-    (void*) isr_exti,               /* external interrupt lines 0 and 1 */
-    (void*) isr_exti,               /* external interrupt lines 2 and 3 */
-    (void*) isr_exti,               /* external interrupt lines 4 to 15 */
-    (void*) isr_ts,                 /* touch sensing input*/
-    (void*) isr_dma1_ch1,           /* direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,         /* direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5,         /* direct memory access controller 1, channel 4 and 5*/
-    (void*) isr_adc1_comp,          /* analog digital converter */
-    (void*) isr_tim1_brk_up_trg_com, /* timer 1 break, update, trigger and communication */
-    (void*) isr_tim1_cc,            /* timer 1 capture compare */
-    (void*) isr_tim2,               /* timer 2 */
-    (void*) isr_tim3,               /* timer 3 */
-    (void*) isr_tim6_dac,           /* timer 6 and digital to analog converter */
-    (void*) isr_tim7,               /* timer 7 */
-    (void*) isr_tim14,              /* timer 14 */
-    (void*) isr_tim15,              /* timer 15 */
-    (void*) isr_tim16,              /* timer 16 */
-    (void*) isr_tim17,              /* timer 17 */
-    (void*) isr_i2c1,               /* I2C 1 */
-    (void*) isr_i2c2,               /* I2C 2 */
-    (void*) isr_spi1,               /* SPI 1 */
-    (void*) isr_spi2,               /* SPI 2 */
-    (void*) isr_usart1,             /* USART 1 */
-    (void*) isr_usart2,             /* USART 2 */
-    (void*) isr_usart3_8,           /* USART 3 to 8 */
-    (void*) isr_cec,                /* consumer electronics control */
-    (void*) (0UL)                   /* reserved */
+    (void*) isr_wwdg,                /* [0] windowed watchdog */
+#if defined(CPU_MODEL_STM32F030R8)
+    (void*) (0UL),                   /* [1] reserved */
+    (void*) isr_rtc,                 /* [2] real time clock */
+    (void*) isr_flash,               /* [3] flash memory controller */
+    (void*) isr_rcc,                 /* [4] reset and clock control */
+    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    (void*) (0UL),                   /* [8] reserved */
+    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    (void*) isr_adc1_comp,           /* [12] analog digital converter */
+    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
+    (void*) isr_tim2,                /* [15] timer 2 */
+    (void*) isr_tim3,                /* [16] timer 3 */
+    (void*) isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
+    (void*) (0UL),                   /* [18] reserved */
+    (void*) isr_tim14,               /* [19] timer 14 */
+    (void*) isr_tim15,               /* [20] timer 15 */
+    (void*) isr_tim16,               /* [21] timer 16 */
+    (void*) isr_tim17,               /* [22] timer 17 */
+    (void*) isr_i2c1,                /* [23] I2C 1 */
+    (void*) isr_i2c2,                /* [24] I2C 2 */
+    (void*) isr_spi1,                /* [25] SPI 1 */
+    (void*) isr_spi2,                /* [26] SPI 2 */
+    (void*) isr_usart1,              /* [27] USART 1 */
+    (void*) isr_usart2               /* [28] USART 2 */
+#elif defined(CPU_MODEL_STM32F031K6)
+    (void*) isr_pvd,                 /* [1] power control */
+    (void*) isr_rtc,                 /* [2] real time clock */
+    (void*) isr_flash,               /* [3] flash memory controller */
+    (void*) isr_rcc,                 /* [4] reset and clock control */
+    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    (void*) (0UL),                   /* [8] reserved */
+    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    (void*) isr_adc1_comp,           /* [12] analog digital converter */
+    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
+    (void*) isr_tim2,                /* [15] timer 2 */
+    (void*) isr_tim3,                /* [16] timer 3 */
+    (void*) (0UL),                   /* [17] reserved */
+    (void*) (0UL),                   /* [18] reserved */
+    (void*) isr_tim14,               /* [19] timer 14 */
+    (void*) (0UL),                   /* [20] reserved */
+    (void*) isr_tim16,               /* [21] timer 16 */
+    (void*) isr_tim17,               /* [22] timer 17 */
+    (void*) isr_i2c1,                /* [23] I2C 1 */
+    (void*) (0UL),                   /* [24] reserved */
+    (void*) isr_spi1,                /* [25] SPI 1 */
+    (void*) (0UL),                   /* [26] reserved */
+    (void*) isr_usart1               /* [27] USART 1 */
+#elif defined(CPU_MODEL_STM32F042K6)
+    (void*) isr_pvd,                 /* [1] power control */
+    (void*) isr_rtc,                 /* [2] real time clock */
+    (void*) isr_flash,               /* [3] flash memory controller */
+    (void*) isr_rcc,                 /* [4] reset and clock control */
+    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    (void*) isr_ts,                  /* [8] touch sensing input*/
+    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    (void*) isr_adc1_comp,           /* [12] analog digital converter */
+    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
+    (void*) isr_tim2,                /* [15] timer 2 */
+    (void*) isr_tim3,                /* [16] timer 3 */
+    (void*) (0UL),                   /* [17] reserved */
+    (void*) (0UL),                   /* [18] reserved */
+    (void*) isr_tim14,               /* [19] timer 14 */
+    (void*) (0UL),                   /* [20] reserved */
+    (void*) isr_tim16,               /* [21] timer 16 */
+    (void*) isr_tim17,               /* [22] timer 17 */
+    (void*) isr_i2c1,                /* [23] I2C 1 */
+    (void*) (0UL),                   /* [24] reserved */
+    (void*) isr_spi1,                /* [25] SPI 1 */
+    (void*) isr_spi2,                /* [26] SPI 2 */
+    (void*) isr_usart1,              /* [27] USART 1 */
+    (void*) isr_usart2,              /* [28] USART 2 */
+    (void*) (0UL),                   /* [29] reserved */
+    (void*) isr_cec,                 /* [30] consumer electronics control */
+    (void*) isr_usb                  /* [31] USB global Interrupts & EXTI Line18 Interrup */
+#elif defined(CPU_MODEL_STM32F051R8)
+    (void*) isr_pvd,                 /* [1] power control */
+    (void*) isr_rtc,                 /* [2] real time clock */
+    (void*) isr_flash,               /* [3] flash memory controller */
+    (void*) isr_rcc,                 /* [4] reset and clock control */
+    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    (void*) isr_ts,                  /* [8] touch sensing input*/
+    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    (void*) isr_adc1_comp,           /* [12] analog digital converter */
+    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
+    (void*) isr_tim2,                /* [15] timer 2 */
+    (void*) isr_tim3,                /* [16] timer 3 */
+    (void*) isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
+    (void*) (0UL),                   /* [18] reserved */
+    (void*) isr_tim14,               /* [19] timer 14 */
+    (void*) isr_tim15,               /* [20] timer 15 */
+    (void*) isr_tim16,               /* [21] timer 16 */
+    (void*) isr_tim17,               /* [22] timer 17 */
+    (void*) isr_i2c1,                /* [23] I2C 1 */
+    (void*) isr_i2c2,                /* [24] I2C 2 */
+    (void*) isr_spi1,                /* [25] SPI 1 */
+    (void*) isr_spi2,                /* [26] SPI 2 */
+    (void*) isr_usart1,              /* [27] USART 1 */
+    (void*) isr_usart2,              /* [28] USART 2 */
+    (void*) (0UL),                   /* [29] reserved */
+    (void*) isr_cec,                 /* [30] consumer electronics control */
+#elif defined(CPU_MODEL_STM32F070RB)
+    (void*) (0UL),                   /* [1] reserved */
+    (void*) isr_rtc,                 /* [2] real time clock */
+    (void*) isr_flash,               /* [3] flash memory controller */
+    (void*) isr_rcc,                 /* [4] reset and clock control */
+    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    (void*) isr_ts,                  /* [8] touch sensing input*/
+    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    (void*) isr_adc1_comp,           /* [12] analog digital converter */
+    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
+    (void*) (0UL),                   /* [15] reserved */
+    (void*) isr_tim3,                /* [16] timer 3 */
+    (void*) isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
+    (void*) isr_tim7,                /* [18] timer 7 */
+    (void*) isr_tim14,               /* [19] timer 14 */
+    (void*) isr_tim15,               /* [20] timer 15 */
+    (void*) isr_tim16,               /* [21] timer 16 */
+    (void*) isr_tim17,               /* [22] timer 17 */
+    (void*) isr_i2c1,                /* [23] I2C 1 */
+    (void*) isr_i2c2,                /* [24] I2C 2 */
+    (void*) isr_spi1,                /* [25] SPI 1 */
+    (void*) isr_spi2,                /* [26] SPI 2 */
+    (void*) isr_usart1,              /* [27] USART 1 */
+    (void*) isr_usart2,              /* [28] USART 2 */
+    (void*) isr_usart3_8,            /* [29] USART 3 to 8 */
+    (void*) (0UL),                   /* [30] reserved */
+    (void*) isr_usb                  /* [31] USB global Interrupts & EXTI Line18 Interrup */
+#else /* CPU_MODEL_STM32_F072RB, CPU_MODEL_STM32F091RC*/
+    (void*) isr_pvd,                 /* [1] power control */
+    (void*) isr_rtc,                 /* [2] real time clock */
+    (void*) isr_flash,               /* [3] flash memory controller */
+    (void*) isr_rcc,                 /* [4] reset and clock control */
+    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    (void*) isr_ts,                  /* [8] touch sensing input*/
+    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    (void*) isr_adc1_comp,           /* [12] analog digital converter */
+    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
+    (void*) isr_tim2,                /* [15] timer 2 */
+    (void*) isr_tim3,                /* [16] timer 3 */
+    (void*) isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
+    (void*) isr_tim7,                /* [18] timer 7 */
+    (void*) isr_tim14,               /* [19] timer 14 */
+    (void*) isr_tim15,               /* [20] timer 15 */
+    (void*) isr_tim16,               /* [21] timer 16 */
+    (void*) isr_tim17,               /* [22] timer 17 */
+    (void*) isr_i2c1,                /* [23] I2C 1 */
+    (void*) isr_i2c2,                /* [24] I2C 2 */
+    (void*) isr_spi1,                /* [25] SPI 1 */
+    (void*) isr_spi2,                /* [26] SPI 2 */
+    (void*) isr_usart1,              /* [27] USART 1 */
+    (void*) isr_usart2,              /* [28] USART 2 */
+    (void*) isr_usart3_8,            /* [29] USART 3 to 8 */
+    (void*) isr_cec,                 /* [30] consumer electronics control */
+#if defined(CPU_MODEL_STM32F072RB)
+    (void*) isr_usb                  /* [31] USB global Interrupts & EXTI Line18 Interrup */
+#endif
+#endif
 };

--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -40,7 +40,11 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
+#if defined(CPU_MODEL_STM32F103RE)
 #define CPU_IRQ_NUMOF                   (60U)
+#else
+#define CPU_IRQ_NUMOF                   (43U)
+#endif
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 

--- a/cpu/stm32f1/vectors.c
+++ b/cpu/stm32f1/vectors.c
@@ -97,81 +97,83 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) (&_estack),             /* pointer to the top of the stack */
     /* Cortex-M3 handlers */
     (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
+    (void*) hard_fault_default,     /* [-13] hard fault exception */
+    (void*) mem_manage_default,     /* [-12] memory manage exception */
+    (void*) bus_fault_default,      /* [-11] bus fault exception */
+    (void*) usage_fault_default,    /* [-10] usage fault exception */
+    (void*) (0UL),                  /* [-9] Reserved */
+    (void*) (0UL),                  /* [-8] Reserved */
+    (void*) (0UL),                  /* [-7] Reserved */
+    (void*) (0UL),                  /* [-6] Reserved */
+    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
+                                             switching into thread context on boot */
+    (void*) debug_mon_default,      /* [-4] debug monitor exception */
+    (void*) (0UL),                  /* [-3] Reserved */
+    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
+                                             context switching is happening here */
+    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
     /* STM specific peripheral handlers */
-    (void*) isr_wwdg,
-    (void*) isr_pvd,
-    (void*) isr_tamper,
-    (void*) isr_rtc,
-    (void*) isr_flash,
-    (void*) isr_rcc,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_dma1_ch1,
-    (void*) isr_dma1_ch2,
-    (void*) isr_dma1_ch3,
-    (void*) isr_dma1_ch4,
-    (void*) isr_dma1_ch5,
-    (void*) isr_dma1_ch6,
-    (void*) isr_dma1_ch7,
-    (void*) isr_adc1_2,
-    (void*) isr_usb_hp_can1_tx,
-    (void*) isr_usb_lp_can1_rx0,
-    (void*) isr_can1_rx1,
-    (void*) isr_can1_sce,
-    (void*) isr_exti,
-    (void*) isr_tim1_brk,
-    (void*) isr_tim1_up,
-    (void*) isr_tim1_trg_com,
-    (void*) isr_tim1_cc,
-    (void*) isr_tim2,
-    (void*) isr_tim3,
-    (void*) isr_tim4,
-    (void*) isr_i2c1_ev,
-    (void*) isr_i2c1_er,
-    (void*) isr_i2c2_ev,
-    (void*) isr_i2c2_er,
-    (void*) isr_spi1,
-    (void*) isr_spi2,
-    (void*) isr_usart1,
-    (void*) isr_usart2,
-    (void*) isr_usart3,
-    (void*) isr_exti,
-    (void*) isr_rtc_alarm,
-    (void*) isr_usb_wakeup,
-    (void*) isr_tim8_brk,
-    (void*) isr_tim8_up,
-    (void*) isr_tim8_trg_com,
-    (void*) isr_tim8_cc,
-    (void*) isr_adc3,
-    (void*) isr_fsmc,
-    (void*) isr_sdio,
-    (void*) isr_tim5,
-    (void*) isr_spi3,
-    (void*) isr_uart4,
-    (void*) isr_uart5,
-    (void*) isr_tim6,
-    (void*) isr_tim7,
-    (void*) isr_dma2_ch1,
-    (void*) isr_dma2_ch2,
-    (void*) isr_dma2_ch3,
-    (void*) isr_dma2_ch4_5,
+    (void*) isr_wwdg,               /* [0] Window WatchDog Interrupt */
+    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
+    (void*) isr_tamper,             /* [2] Tamper Interrupt */
+    (void*) isr_rtc,                /* [3] RTC global Interrupt */
+    (void*) isr_flash,              /* [4] FLASH global Interrupt */
+    (void*) isr_rcc,                /* [5] RCC global Interrupt */
+    (void*) isr_exti,               /* [6] EXTI Line0 Interrupt */
+    (void*) isr_exti,               /* [7] EXTI Line1 Interrupt */
+    (void*) isr_exti,               /* [8] EXTI Line2 Interrupt */
+    (void*) isr_exti,               /* [9] EXTI Line3 Interrupt */
+    (void*) isr_exti,               /* [10] EXTI Line4 Interrupt */
+    (void*) isr_dma1_ch1,           /* [11] DMA1 Channel 1 global Interrupt */
+    (void*) isr_dma1_ch2,           /* [12] DMA1 Channel 2 global Interrupt */
+    (void*) isr_dma1_ch3,           /* [13] DMA1 Channel 3 global Interrupt */
+    (void*) isr_dma1_ch4,           /* [14] DMA1 Channel 4 global Interrupt */
+    (void*) isr_dma1_ch5,           /* [15] DMA1 Channel 5 global Interrupt */
+    (void*) isr_dma1_ch6,           /* [16] DMA1 Channel 6 global Interrupt */
+    (void*) isr_dma1_ch7,           /* [17] DMA1 Channel 7 global Interrupt */
+    (void*) isr_adc1_2,             /* [18] ADC1 and ADC2 global Interrupt */
+    (void*) isr_usb_hp_can1_tx,     /* [19] USB Device High Priority or CAN1 TX Interrupts */
+    (void*) isr_usb_lp_can1_rx0,    /* [20] USB Device Low Priority or CAN1 RX0 Interrupts */
+    (void*) isr_can1_rx1,           /* [21] CAN1 RX1 Interrupt */
+    (void*) isr_can1_sce,           /* [22] CAN1 SCE Interrupt */
+    (void*) isr_exti,               /* [23] External Line[9:5] Interrupts */
+    (void*) isr_tim1_brk,           /* [24] TIM1 Break Interrupt */
+    (void*) isr_tim1_up,            /* [25] TIM1 Update Interrupt */
+    (void*) isr_tim1_trg_com,       /* [26] TIM1 Trigger and Commutation Interrupt */
+    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
+    (void*) isr_tim2,               /* [28] TIM2 global Interrupt */
+    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
+    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
+    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
+    (void*) isr_usart1,             /* [37] USART1 global Interrupt */
+    (void*) isr_usart2,             /* [38] USART2 global Interrupt */
+    (void*) isr_usart3,             /* [39] USART3 global Interrupt */
+    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm through EXTI Line Interrupt */
+    (void*) isr_usb_wakeup,         /* [42] USB Device WakeUp from suspend through EXTI Line Interrupt */
+#if defined(CPU_MODEL_STM32F103RE)
+    (void*) isr_tim8_brk,           /* [43] TIM8 Break Interrupt */
+    (void*) isr_tim8_up,            /* [44] TIM8 Update Interrupt */
+    (void*) isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
+    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
+    (void*) isr_adc3,               /* [47] ADC3 global Interrupt */
+    (void*) isr_fsmc,               /* [48] FSMC global Interrupt */
+    (void*) isr_sdio,               /* [49] SDIO global Interrupt */
+    (void*) isr_tim5,               /* [50] TIM5 global Interrupt */
+    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
+    (void*) isr_uart4,              /* [52] UART4 global Interrupt */
+    (void*) isr_uart5,              /* [53] UART5 global Interrupt */
+    (void*) isr_tim6,               /* [54] TIM6 global Interrupt */
+    (void*) isr_tim7,               /* [55] TIM7 global Interrupt */
+    (void*) isr_dma2_ch1,           /* [56] DMA2 Channel 1 global Interrupt */
+    (void*) isr_dma2_ch2,           /* [57] DMA2 Channel 2 global Interrupt */
+    (void*) isr_dma2_ch3,           /* [58] DMA2 Channel 3 global Interrupt */
+    (void*) isr_dma2_ch4_5,         /* [59] DMA2 Channel 4 and Channel 5 global Interrupt */
+#endif
 };

--- a/cpu/stm32f2/vectors.c
+++ b/cpu/stm32f2/vectors.c
@@ -118,102 +118,167 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) (&_estack),             /* pointer to the top of the stack */
     /* Cortex-M3 handlers */
     (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
+    (void*) hard_fault_default,     /* [-13] hard fault exception */
+    (void*) mem_manage_default,     /* [-12] memory manage exception */
+    (void*) bus_fault_default,      /* [-11] bus fault exception */
+    (void*) usage_fault_default,    /* [-10] usage fault exception */
+    (void*) (0UL),                  /* [-9] Reserved */
+    (void*) (0UL),                  /* [-8] Reserved */
+    (void*) (0UL),                  /* [-7] Reserved */
+    (void*) (0UL),                  /* [-6] Reserved */
+    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
+                                            switching into thread context on boot */
+    (void*) debug_mon_default,      /* [-4] debug monitor exception */
+    (void*) (0UL),                  /* [-3] Reserved */
+    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
+                                            context switching is happening here */
+    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
     /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* Window WatchDog */
-    (void*) isr_pvd,                /* PVD through EXTI Line detection */
-    (void*) isr_tamp_stamp,         /* Tamper and TimeStamps through the EXTI line */
-    (void*) isr_rtc_wkup,           /* RTC Wakeup through the EXTI line */
-    (void*) isr_flash,              /* FLASH */
-    (void*) isr_rcc,                /* RCC */
-    (void*) isr_exti,               /* EXTI Line0 */
-    (void*) isr_exti,               /* EXTI Line1 */
-    (void*) isr_exti,               /* EXTI Line2 */
-    (void*) isr_exti,               /* EXTI Line3 */
-    (void*) isr_exti,               /* EXTI Line4 */
-    (void*) isr_dma1_stream0,       /* DMA1 Stream 0 */
-    (void*) isr_dma1_stream1,       /* DMA1 Stream 1 */
-    (void*) isr_dma1_stream2,       /* DMA1 Stream 2 */
-    (void*) isr_dma1_stream3,       /* DMA1 Stream 3 */
-    (void*) isr_dma1_stream4,       /* DMA1 Stream 4 */
-    (void*) isr_dma1_stream5,       /* DMA1 Stream 5 */
-    (void*) isr_dma1_stream6,       /* DMA1 Stream 6 */
-    (void*) isr_adc,                /* ADC1, ADC2 and ADC3s */
-    (void*) isr_can1_tx,            /* CAN1 TX */
-    (void*) isr_can1_rx0,           /* CAN1 RX0 */
-    (void*) isr_can1_rx1,           /* CAN1 RX1 */
-    (void*) isr_can1_sce,           /* CAN1 SCE */
-    (void*) isr_exti,               /* External Line[9:5]s */
-    (void*) isr_tim1_brk_tim9,      /* TIM1 Break and TIM9 */
-    (void*) isr_tim1_up_tim10,      /* TIM1 Update and TIM10 */
-    (void*) isr_tim1_trg_com_tim11, /* TIM1 Trigger and Commutation and TIM11 */
-    (void*) isr_tim1_cc,            /* TIM1 Capture Compare */
-    (void*) isr_tim2,               /* TIM2 */
-    (void*) isr_tim3,               /* TIM3 */
-    (void*) isr_tim4,               /* TIM4 */
-    (void*) isr_i2c1_ev,            /* I2C1 Event */
-    (void*) isr_i2c1_er,            /* I2C1 Error */
-    (void*) isr_i2c2_ev,            /* I2C2 Event */
-    (void*) isr_i2c2_er,            /* I2C2 Error */
-    (void*) isr_spi1,               /* SPI1 */
-    (void*) isr_spi2,               /* SPI2 */
-    (void*) isr_usart1,             /* USART1 */
-    (void*) isr_usart2,             /* USART2 */
-    (void*) isr_usart3,             /* USART3 */
-    (void*) isr_exti,               /* External Line[15:10]s */
-    (void*) isr_rtc_alarm,          /* RTC Alarm (A and B) through EXTI Line */
-    (void*) isr_otg_fs_wkup,        /* USB OTG FS Wakeup through EXTI line */
-    (void*) isr_tim8_brk_tim12,     /* TIM8 Break and TIM12 */
-    (void*) isr_tim8_up_tim13,      /* TIM8 Update and TIM13 */
-    (void*) isr_tim8_trg_com_tim14, /* TIM8 Trigger and Commutation and TIM14 */
-    (void*) isr_tim8_cc,            /* TIM8 Capture Compare */
-    (void*) isr_dma1_stream7,       /* DMA1 Stream7 */
-    (void*) isr_fsmc,               /* FSMC */
-    (void*) isr_sdio,               /* SDIO */
-    (void*) isr_tim5,               /* TIM5 */
-    (void*) isr_spi3,               /* SPI3 */
-    (void*) isr_uart4,              /* UART4 */
-    (void*) isr_uart5,              /* UART5 */
-    (void*) isr_tim6_dac,           /* TIM6 and DAC1&2 underrun errors */
-    (void*) isr_tim7,               /* TIM7 */
-    (void*) isr_dma2_stream0,       /* DMA2 Stream 0 */
-    (void*) isr_dma2_stream1,       /* DMA2 Stream 1 */
-    (void*) isr_dma2_stream2,       /* DMA2 Stream 2 */
-    (void*) isr_dma2_stream3,       /* DMA2 Stream 3 */
-    (void*) isr_dma2_stream4,       /* DMA2 Stream 4 */
-    (void*) isr_eth,                /* Ethernet */
-    (void*) isr_eth_wkup,           /* Ethernet Wakeup through EXTI line */
-    (void*) isr_can2_tx,            /* CAN2 TX */
-    (void*) isr_can2_rx0,           /* CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* CAN2 RX1 */
-    (void*) isr_can2_sce,           /* CAN2 SCE */
-    (void*) isr_otg_fs,             /* USB OTG FS */
-    (void*) isr_dma2_stream5,       /* DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* DMA2 Stream 7 */
-    (void*) isr_usart6,             /* USART6 */
-    (void*) isr_i2c3_ev,            /* I2C3 event */
-    (void*) isr_i2c3_er,            /* I2C3 error */
-    (void*) isr_otg_hs_ep1_out,     /* USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* USB OTG HS */
-    (void*) isr_dcmi,               /* DCMI */
-    (void*) isr_cryp,               /* CRYP crypto */
-    (void*) isr_hash_rng,           /* Hash and Rng */
+    (void*) isr_wwdg,               /* [0] Window WatchDog */
+    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection */
+    (void*) isr_tamp_stamp,         /* [2] Tamper and TimeStamps through the EXTI line */
+    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup through the EXTI line */
+    (void*) isr_flash,              /* [4] FLASH */
+    (void*) isr_rcc,                /* [5] RCC */
+    (void*) isr_exti,               /* [6] EXTI Line0 */
+    (void*) isr_exti,               /* [7] EXTI Line1 */
+    (void*) isr_exti,               /* [8] EXTI Line2 */
+    (void*) isr_exti,               /* [9] EXTI Line3 */
+    (void*) isr_exti,               /* [10] EXTI Line4 */
+    (void*) isr_dma1_stream0,       /* [11] DMA1 Stream 0 */
+    (void*) isr_dma1_stream1,       /* [12] DMA1 Stream 1 */
+    (void*) isr_dma1_stream2,       /* [13] DMA1 Stream 2 */
+    (void*) isr_dma1_stream3,       /* [14] DMA1 Stream 3 */
+    (void*) isr_dma1_stream4,       /* [15] DMA1 Stream 4 */
+    (void*) isr_dma1_stream5,       /* [16] DMA1 Stream 5 */
+    (void*) isr_dma1_stream6,       /* [17] DMA1 Stream 6 */
+    (void*) isr_adc,                /* [18] ADC1, ADC2 and ADC3s */
+    (void*) isr_can1_tx,            /* [19] CAN1 TX */
+    (void*) isr_can1_rx0,           /* [20] CAN1 RX0 */
+    (void*) isr_can1_rx1,           /* [21] CAN1 RX1 */
+    (void*) isr_can1_sce,           /* [22] CAN1 SCE */
+    (void*) isr_exti,               /* [23] External Line[9:5]s */
+    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    (void*) isr_tim2,               /* [28] TIM2 */
+    (void*) isr_tim3,               /* [29] TIM3 */
+    (void*) isr_tim4,               /* [30] TIM4 */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
+    (void*) isr_spi1,               /* [35] SPI1 */
+    (void*) isr_spi2,               /* [36] SPI2 */
+    (void*) isr_usart1,             /* [37] USART1 */
+    (void*) isr_usart2,             /* [38] USART2 */
+    (void*) isr_usart3,             /* [39] USART3 */
+    (void*) isr_exti,               /* [40] External Line[15:10]s */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    (void*) isr_otg_fs_wkup,        /* [42] USB OTG FS Wakeup through EXTI line */
+    (void*) isr_tim8_brk_tim12,     /* [43] TIM8 Break and TIM12 */
+    (void*) isr_tim8_up_tim13,      /* [44] TIM8 Update and TIM13 */
+    (void*) isr_tim8_trg_com_tim14, /* [45] TIM8 Trigger and Commutation and TIM14 */
+    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare */
+    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    (void*) isr_fsmc,               /* [48] FSMC */
+    (void*) isr_sdio,               /* [49] SDIO */
+    (void*) isr_tim5,               /* [50] TIM5 */
+    (void*) isr_spi3,               /* [51] SPI3 */
+    (void*) isr_uart4,              /* [52] UART4 */
+    (void*) isr_uart5,              /* [53] UART5 */
+    (void*) isr_tim6_dac,           /* [54] TIM6 and DAC1&2 underrun errors */
+    (void*) isr_tim7,               /* [55] TIM7 */
+    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+#if defined(CPU_MODEL_STM32F205RG)
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    (void*) isr_otg_hs,             /* [77] USB OTG HS */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+#elif defined(CPU_MODEL_STM32F207ZG)
+    (void*) isr_eth,                /* [61] Ethernet */
+    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    (void*) isr_otg_hs,             /* [77] USB OTG HS */
+    (void*) isr_dcmi,               /* [78] DCMI */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+#elif defined(CPU_MODEL_STM32F215RG) || defined (CPU_MODEL_STM32F215VG)
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    (void*) isr_otg_hs,             /* [77] USB OTG HS */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) isr_cryp,               /* [79] CRYP crypto */
+    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+#else /* CPU_MODEL_STM32F217ZG */
+    (void*) isr_eth,                /* [61] Ethernet */
+    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    (void*) isr_otg_hs,             /* [77] USB OTG HS */
+    (void*) isr_dcmi,               /* [78] DCMI */
+    (void*) isr_cryp,               /* [79] CRYP crypto */
+    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+#endif
 };

--- a/cpu/stm32f3/include/cpu_conf.h
+++ b/cpu/stm32f3/include/cpu_conf.h
@@ -32,8 +32,7 @@
 #include "vendor/stm32f303xe.h"
 #elif defined(CPU_MODEL_STM32F303K8)
 #include "vendor/stm32f303x8.h"
-#endif
-#ifdef CPU_MODEL_STM32F302R8
+#elif defined(CPU_MODEL_STM32F302R8)
 #include "vendor/stm32f302x8.h"
 #endif
 #ifdef __cplusplus
@@ -45,7 +44,11 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
+#if defined(CPU_MODEL_STM32F303RE) || defined (CPU_MODEL_STM32F303ZE)
+#define CPU_IRQ_NUMOF                   (85U)
+#else
 #define CPU_IRQ_NUMOF                   (82U)
+#endif
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 

--- a/cpu/stm32f3/vectors.c
+++ b/cpu/stm32f3/vectors.c
@@ -65,6 +65,8 @@ WEAK_DEFAULT void isr_i2c1_ev(void);
 WEAK_DEFAULT void isr_i2c1_er(void);
 WEAK_DEFAULT void isr_i2c2_ev(void);
 WEAK_DEFAULT void isr_i2c2_er(void);
+WEAK_DEFAULT void isr_i2c3_ev(void);
+WEAK_DEFAULT void isr_i2c3_er(void);
 WEAK_DEFAULT void isr_spi1(void);
 WEAK_DEFAULT void isr_spi2(void);
 WEAK_DEFAULT void isr_usart1(void);
@@ -77,11 +79,13 @@ WEAK_DEFAULT void isr_tim8_up(void);
 WEAK_DEFAULT void isr_tim8_trg_com(void);
 WEAK_DEFAULT void isr_tim8_cc(void);
 WEAK_DEFAULT void isr_adc3(void);
+WEAK_DEFAULT void isr_fmc(void);
 WEAK_DEFAULT void isr_spi3(void);
 WEAK_DEFAULT void isr_uart4(void);
 WEAK_DEFAULT void isr_uart5(void);
 WEAK_DEFAULT void isr_tim6_dac(void);
 WEAK_DEFAULT void isr_tim7(void);
+WEAK_DEFAULT void isr_tim7_dac(void);
 WEAK_DEFAULT void isr_dma2_channel1(void);
 WEAK_DEFAULT void isr_dma2_channel2(void);
 WEAK_DEFAULT void isr_dma2_channel3(void);
@@ -91,10 +95,22 @@ WEAK_DEFAULT void isr_adc4(void);
 WEAK_DEFAULT void isr_comp1_2_3(void);
 WEAK_DEFAULT void isr_comp4_5_6(void);
 WEAK_DEFAULT void isr_comp7(void);
+WEAK_DEFAULT void isr_hrtim(void);
+WEAK_DEFAULT void isr_hrtim_tim_a(void);
+WEAK_DEFAULT void isr_hrtim_tim_b(void);
+WEAK_DEFAULT void isr_hrtim_tim_c(void);
+WEAK_DEFAULT void isr_hrtim_tim_d(void);
+WEAK_DEFAULT void isr_hrtim_tim_e(void);
+WEAK_DEFAULT void isr_hrtim_flt(void);
 WEAK_DEFAULT void isr_usb_hp(void);
 WEAK_DEFAULT void isr_usb_lp(void);
 WEAK_DEFAULT void isr_usbwakeup_rmp(void);
+WEAK_DEFAULT void isr_tim20_brk(void);
+WEAK_DEFAULT void isr_tim20_up(void);
+WEAK_DEFAULT void isr_tim20_trg_com(void);
+WEAK_DEFAULT void isr_tim20_cc(void);
 WEAK_DEFAULT void isr_fpu(void);
+WEAK_DEFAULT void isr_spi4(void);
 
 /* interrupt vector table */
 ISR_VECTORS const void *interrupt_vector[] = {
@@ -102,103 +118,287 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) (&_estack),             /* pointer to the top of the stack */
     /* Cortex-M4 handlers */
     (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
+    (void*) hard_fault_default,     /* [-13] hard fault exception */
+    (void*) mem_manage_default,     /* [-12] memory manage exception */
+    (void*) bus_fault_default,      /* [-11] bus fault exception */
+    (void*) usage_fault_default,    /* [-10] usage fault exception */
+    (void*) (0UL),                  /* [-9] Reserved */
+    (void*) (0UL),                  /* [-8] Reserved */
+    (void*) (0UL),                  /* [-7] Reserved */
+    (void*) (0UL),                  /* [-6] Reserved */
+    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
+                                            switching into thread context on boot */
+    (void*) debug_mon_default,      /* [-4] debug monitor exception */
+    (void*) (0UL),                  /* [-3] Reserved */
+    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
+                                            context switching is happening here */
+    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
     /* STMF3 specific peripheral handlers */
-    (void*) isr_wwdg,               /*  */
-    (void*) isr_pvd,                /*  */
-    (void*) isr_tamp_stamp,         /*  */
-    (void*) isr_rtc_wkup,           /*  */
-    (void*) isr_flash,              /*  */
-    (void*) isr_rcc,                /*  */
-    (void*) isr_exti,               /*  */
-    (void*) isr_exti,               /*  */
-    (void*) isr_exti,               /*  */
-    (void*) isr_exti,               /*  */
-    (void*) isr_exti,               /*  */
-    (void*) isr_dma1_channel1,      /*  */
-    (void*) isr_dma1_channel2,      /*  */
-    (void*) isr_dma1_channel3,      /*  */
-    (void*) isr_dma1_channel4,      /*  */
-    (void*) isr_dma1_channel5,      /*  */
-    (void*) isr_dma1_channel6,      /*  */
-    (void*) isr_dma1_channel7,      /*  */
-    (void*) isr_adc1_2,             /*  */
-    (void*) isr_usb_hp_can_tx,      /*  */
-    (void*) isr_usb_lp_can_rx0,     /*  */
-    (void*) isr_can_rx1,            /*  */
-    (void*) isr_can_sce,            /*  */
-    (void*) isr_exti,               /*  */
-    (void*) isr_tim1_brk_tim15,     /*  */
-    (void*) isr_tim1_up_tim16,      /*  */
-    (void*) isr_tim1_trg_com_tim17, /*  */
-    (void*) isr_tim1_cc,            /*  */
-    (void*) isr_tim2,               /*  */
-    (void*) isr_tim3,               /*  */
-    (void*) isr_tim4,               /*  */
-    (void*) isr_i2c1_ev,            /*  */
-    (void*) isr_i2c1_er,            /*  */
-    (void*) isr_i2c2_ev,            /*  */
-    (void*) isr_i2c2_er,            /*  */
-    (void*) isr_spi1,               /*  */
-    (void*) isr_spi2,               /*  */
-    (void*) isr_usart1,             /*  */
-    (void*) isr_usart2,             /*  */
-    (void*) isr_usart3,             /*  */
-    (void*) isr_exti,               /*  */
-    (void*) isr_rtc_alarm,          /*  */
-    (void*) isr_usbwakeup,          /*  */
-    (void*) isr_tim8_brk,           /*  */
-    (void*) isr_tim8_up,            /*  */
-    (void*) isr_tim8_trg_com,       /*  */
-    (void*) isr_tim8_cc,            /*  */
-    (void*) isr_adc3,               /*  */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_spi3,               /*  */
-    (void*) isr_uart4,              /*  */
-    (void*) isr_uart5,              /*  */
-    (void*) isr_tim6_dac,           /*  */
-    (void*) isr_tim7,               /*  */
-    (void*) isr_dma2_channel1,      /*  */
-    (void*) isr_dma2_channel2,      /*  */
-    (void*) isr_dma2_channel3,      /*  */
-    (void*) isr_dma2_channel4,      /*  */
-    (void*) isr_dma2_channel5,      /*  */
-    (void*) isr_adc4,               /*  */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_comp1_2_3,          /*  */
-    (void*) isr_comp4_5_6,          /*  */
-    (void*) isr_comp7,              /*  */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_usb_hp,             /*  */
-    (void*) isr_usb_lp,             /*  */
-    (void*) isr_usbwakeup_rmp,      /*  */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_fpu,                /*  */
+    (void*) isr_wwdg,               /* [0] Window WatchDog Interrupt */
+    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
+    (void*) isr_tamp_stamp,         /* [2] Tamper and TimeStamp interrupts through the EXTI line 19 */
+    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup interrupt through the EXTI line 20 */
+    (void*) isr_flash,              /* [4] FLASH global Interrupt */
+    (void*) isr_rcc,                /* [5] RCC global Interrupt */
+    (void*) isr_exti,               /* [6] EXTI Line0 Interrupt */
+    (void*) isr_exti,               /* [7] EXTI Line1 Interrupt */
+    (void*) isr_exti,               /* [8] EXTI Line2 Interrupt and Touch Sense Controller Interrupt */
+    (void*) isr_exti,               /* [9] EXTI Line3 Interrupt */
+    (void*) isr_exti,               /* [10] EXTI Line4 Interrupt */
+    (void*) isr_dma1_channel1,      /* [11] DMA1 Channel 1 Interrupt */
+    (void*) isr_dma1_channel2,      /* [12] DMA1 Channel 2 Interrupt */
+    (void*) isr_dma1_channel3,      /* [13] DMA1 Channel 3 Interrupt */
+    (void*) isr_dma1_channel4,      /* [14] DMA1 Channel 4 Interrupt */
+    (void*) isr_dma1_channel5,      /* [15] DMA1 Channel 5 Interrupt */
+    (void*) isr_dma1_channel6,      /* [16] DMA1 Channel 6 Interrupt */
+    (void*) isr_dma1_channel7,      /* [17] DMA1 Channel 7 Interrupt */
+    (void*) isr_adc1_2,             /* [18] ADC1 & ADC2 Interrupts */
+    (void*) isr_usb_hp_can_tx,      /* [19] USB Device High Priority or CAN TX Interrupts */
+    (void*) isr_usb_lp_can_rx0,     /* [20] USB Device Low Priority or CAN RX0 Interrupts */
+    (void*) isr_can_rx1,            /* [21] CAN RX1 Interrupt */
+    (void*) isr_can_sce,            /* [22] CAN SCE Interrupt */
+    (void*) isr_exti,               /* [23] External Line[9:5] Interrupts */
+    (void*) isr_tim1_brk_tim15,     /* [24] TIM1 Break and TIM15 Interrupts */
+    (void*) isr_tim1_up_tim16,      /* [25] TIM1 Update and TIM16 Interrupts */
+    (void*) isr_tim1_trg_com_tim17, /* [26] TIM1 Trigger and Commutation and TIM17 Interrupt */
+    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
+    (void*) isr_tim2,               /* [28] TIM2 global Interrupt */
+#if defined(CPU_MODEL_STM32F302R8)
+    (void*) (0UL),                  /* [29] Reserved */
+    (void*) (0UL),                  /* [30] Reserved */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt & EXTI Line24 Interrupt (I2C2 wakeup) */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    (void*) (0UL),                  /* [35] Reserved */
+    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
+    (void*) isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
+    (void*) isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
+    (void*) isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
+    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
+    (void*) isr_usbwakeup,          /* [42] USB Wakeup Interrupt */
+    (void*) (0UL),                  /* [43] Reserved */
+    (void*) (0UL),                  /* [44] Reserved */
+    (void*) (0UL),                  /* [45] Reserved */
+    (void*) (0UL),                  /* [46] Reserved */
+    (void*) (0UL),                  /* [47] Reserved */
+    (void*) (0UL),                  /* [48] Reserved */
+    (void*) (0UL),                  /* [49] Reserved */
+    (void*) (0UL),                  /* [50] Reserved */
+    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
+    (void*) (0UL),                  /* [52] Reserved */
+    (void*) (0UL),                  /* [53] Reserved */
+    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error  interrupts */
+    (void*) (0UL),                  /* [55] Reserved */
+    (void*) (0UL),                  /* [56] Reserved */
+    (void*) (0UL),                  /* [57] Reserved */
+    (void*) (0UL),                  /* [58] Reserved */
+    (void*) (0UL),                  /* [59] Reserved */
+    (void*) (0UL),                  /* [60] Reserved */
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) (0UL),                  /* [63] Reserved */
+    (void*) isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
+    (void*) isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
+    (void*) (0UL),                  /* [66] Reserved */
+    (void*) (0UL),                  /* [67] Reserved */
+    (void*) (0UL),                  /* [68] Reserved */
+    (void*) (0UL),                  /* [69] Reserved */
+    (void*) (0UL),                  /* [70] Reserved */
+    (void*) (0UL),                  /* [71] Reserved */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event interrupt */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error interrupt */
+    (void*) isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
+    (void*) isr_usb_lp,             /* [75] USB Low Priority global Interrupt  remap */
+    (void*) isr_usbwakeup_rmp,      /* [76] USB Wakeup Interrupt remap */
+    (void*) (0UL),                  /* [77] Reserved */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [80] Reserved */
+    (void*) isr_fpu                 /* [81] Floating point Interrupt */
+#elif defined(CPU_MODEL_STM32F303K8)
+    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
+    (void*) (0UL),                  /* [30] Reserved */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (void*) (0UL),                  /* [33] Reserved */
+    (void*) (0UL),                  /* [34] Reserved */
+    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
+    (void*) (0UL),                  /* [36] Reserved */
+    (void*) isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
+    (void*) isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
+    (void*) isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
+    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
+    (void*) (0UL),                  /* [42] Reserved */
+    (void*) (0UL),                  /* [43] Reserved */
+    (void*) (0UL),                  /* [44] Reserved */
+    (void*) (0UL),                  /* [45] Reserved */
+    (void*) (0UL),                  /* [46] Reserved */
+    (void*) (0UL),                  /* [47] Reserved */
+    (void*) (0UL),                  /* [48] Reserved */
+    (void*) (0UL),                  /* [49] Reserved */
+    (void*) (0UL),                  /* [50] Reserved */
+    (void*) (0UL),                  /* [51] Reserved */
+    (void*) (0UL),                  /* [52] Reserved */
+    (void*) (0UL),                  /* [53] Reserved */
+    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error interrupts */
+    (void*) isr_tim7_dac,           /* [55] TIM7 global and DAC2 channel1 underrun error Interrupt */
+    (void*) (0UL),                  /* [56] Reserved */
+    (void*) (0UL),                  /* [57] Reserved */
+    (void*) (0UL),                  /* [58] Reserved */
+    (void*) (0UL),                  /* [59] Reserved */
+    (void*) (0UL),                  /* [60] Reserved */
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) (0UL),                  /* [63] Reserved */
+    (void*) isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
+    (void*) isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
+    (void*) (0UL),                  /* [66] Reserved */
+    (void*) (0UL),                  /* [67] Reserved */
+    (void*) (0UL),                  /* [68] Reserved */
+    (void*) (0UL),                  /* [69] Reserved */
+    (void*) (0UL),                  /* [70] Reserved */
+    (void*) (0UL),                  /* [71] Reserved */
+    (void*) (0UL),                  /* [72] Reserved */
+    (void*) (0UL),                  /* [73] Reserved */
+    (void*) (0UL),                  /* [74] Reserved */
+    (void*) (0UL),                  /* [75] Reserved */
+    (void*) (0UL),                  /* [76] Reserved */
+    (void*) (0UL),                  /* [77] Reserved */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [80] Reserved */
+    (void*) isr_fpu                 /* [81] Floating point Interrupt */
+#elif (CPU_MODEL_STM32F334R8)
+    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
+    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (void*) (0UL),                  /* [33] Reserved */
+    (void*) (0UL),                  /* [34] Reserved */
+    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
+    (void*) (0UL),                  /* [36] Reserved */
+    (void*) isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
+    (void*) isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
+    (void*) isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
+    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
+    (void*) (0UL),                  /* [42] Reserved */
+    (void*) (0UL),                  /* [43] Reserved */
+    (void*) (0UL),                  /* [44] Reserved */
+    (void*) (0UL),                  /* [45] Reserved */
+    (void*) (0UL),                  /* [46] Reserved */
+    (void*) (0UL),                  /* [47] Reserved */
+    (void*) (0UL),                  /* [48] Reserved */
+    (void*) (0UL),                  /* [49] Reserved */
+    (void*) (0UL),                  /* [50] Reserved */
+    (void*) (0UL),                  /* [51] Reserved */
+    (void*) (0UL),                  /* [52] Reserved */
+    (void*) (0UL),                  /* [53] Reserved */
+    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error  interrupts */
+    (void*) isr_tim7_dac,           /* [55] TIM7 global and DAC2 channel1 underrun error Interrupt */
+    (void*) (0UL),                  /* [56] Reserved */
+    (void*) (0UL),                  /* [57] Reserved */
+    (void*) (0UL),                  /* [58] Reserved */
+    (void*) (0UL),                  /* [59] Reserved */
+    (void*) (0UL),                  /* [60] Reserved */
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) (0UL),                  /* [63] Reserved */
+    (void*) isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
+    (void*) isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
+    (void*) (0UL),                  /* [66] Reserved */
+    (void*) isr_hrtim,              /* [67] HRTIM Master Timer global Interrupts */
+    (void*) isr_hrtim_tim_a,        /* [68] HRTIM Timer A global Interrupt */
+    (void*) isr_hrtim_tim_b,        /* [69] HRTIM Timer B global Interrupt */
+    (void*) isr_hrtim_tim_c,        /* [70] HRTIM Timer C global Interrupt */
+    (void*) isr_hrtim_tim_d,        /* [71] HRTIM Timer D global Interrupt */
+    (void*) isr_hrtim_tim_e,        /* [72] HRTIM Timer E global Interrupt */
+    (void*) isr_hrtim_flt,          /* [73] HRTIM Fault global Interrupt */
+    (void*) (0UL),                  /* [74] Reserved */
+    (void*) (0UL),                  /* [75] Reserved */
+    (void*) (0UL),                  /* [76] Reserved */
+    (void*) (0UL),                  /* [77] Reserved */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [80] Reserved */
+    (void*) isr_fpu                 /* [81] Floating point Interrupt */
+#else /* CPU_MODEL_STM32F303VC, CPU_MODEL_STM32F303RE, CPU_MODEL_STM32F303ZE */
+    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
+    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt & EXTI Line24 Interrupt (I2C2 wakeup) */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
+    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
+    (void*) isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
+    (void*) isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
+    (void*) isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
+    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
+    (void*) isr_usbwakeup,          /* [42] USB Wakeup Interrupt */
+    (void*) isr_tim8_brk,           /* [43] TIM8 Break Interrupt */
+    (void*) isr_tim8_up,            /* [44] TIM8 Update Interrupt */
+    (void*) isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
+    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
+    (void*) isr_adc3,               /* [47] ADC3 global Interrupt */
+#if defined(CPU_MODEL_STM32F303VC)
+    (void*) (0UL),                  /* [48] Reserved */
+#else
+    (void*) isr_fmc,                /* [48] FMC global Interrupt */
+#endif
+    (void*) (0UL),                  /* [49] Reserved */
+    (void*) (0UL),                  /* [50] Reserved */
+    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
+    (void*) isr_uart4,              /* [52] UART4 global Interrupt & EXTI Line34 Interrupt (UART4 wakeup) */
+    (void*) isr_uart5,              /* [53] UART5 global Interrupt & EXTI Line35 Interrupt (UART5 wakeup) */
+    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error  interrupts */
+    (void*) isr_tim7,               /* [55] TIM7 global Interrupt */
+    (void*) isr_dma2_channel1,      /* [56] DMA2 Channel 1 global Interrupt */
+    (void*) isr_dma2_channel2,      /* [57] DMA2 Channel 2 global Interrupt */
+    (void*) isr_dma2_channel3,      /* [58] DMA2 Channel 3 global Interrupt */
+    (void*) isr_dma2_channel4,      /* [59] DMA2 Channel 4 global Interrupt */
+    (void*) isr_dma2_channel5,      /* [60] DMA2 Channel 5 global Interrupt */
+    (void*) isr_adc4,               /* [61] ADC4  global Interrupt */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) (0UL),                  /* [63] Reserved */
+    (void*) isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
+    (void*) isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
+    (void*) isr_comp7,              /* [66] COMP7 global Interrupt via EXTI Line33 */
+    (void*) (0UL),                  /* [67] Reserved */
+    (void*) (0UL),                  /* [68] Reserved */
+    (void*) (0UL),                  /* [69] Reserved */
+    (void*) (0UL),                  /* [70] Reserved */
+    (void*) (0UL),                  /* [71] Reserved */
+#if defined(CPU_MODEL_STM32F303VC)
+    (void*) (0UL),                  /* [72] Reserved */
+    (void*) (0UL),                  /* [73] Reserved */
+    (void*) isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
+    (void*) isr_usb_lp,             /* [75] USB Low Priority global Interrupt  remap */
+    (void*) isr_usbwakeup_rmp,      /* [76] USB Wakeup Interrupt remap */
+    (void*) (0UL),                  /* [77] Reserved */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [80] Reserved */
+    (void*) isr_fpu                 /* [81] Floating point Interrupt */
+#else /* CPU_MODEL_STM32F303RE, CPU_MODEL_STM32F303ZE */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event interrupt */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error interrupt */
+    (void*) isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
+    (void*) isr_usb_lp,             /* [75] USB Low Priority global Interrupt  remap */
+    (void*) isr_usbwakeup_rmp,      /* [76] USB Wakeup Interrupt remap */
+    (void*) isr_tim20_brk,          /* [77] TIM20 Break Interrupt */
+    (void*) isr_tim20_up,           /* [78] TIM20 Update Interrupt */
+    (void*) isr_tim20_trg_com,      /* [79] TIM20 Trigger and Commutation Interrupt */
+    (void*) isr_tim8_cc,            /* [80] TIM20 Capture Compare Interrupt */
+    (void*) isr_fpu,                /* [81] Floating point Interrupt */
+    (void*) (0UL),                  /* [82] Reserved */
+    (void*) (0UL),                  /* [83] Reserved */
+    (void*) isr_spi4,               /* [84] SPI4 global Interrupt */
+#endif
+#endif
 };

--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -52,10 +52,21 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
-#define CPU_IRQ_NUMOF                   (102U)
-#else
+#if defined(CPU_MODEL_STM32F401RE)
+#define CPU_IRQ_NUMOF                   (85U)
+#elif defined(CPU_MODEL_STM32F407VG) || defined(CPU_MODEL_STM32F415RG)
 #define CPU_IRQ_NUMOF                   (82U)
+#elif defined(CPU_MODEL_STM32F410RB)
+#define CPU_IRQ_NUMOF                   (98U)
+#elif defined(CPU_MODEL_STM32F411RE)
+#define CPU_IRQ_NUMOF                   (86U)
+#elif defined(CPU_MODEL_STM32F412ZG) || defined(CPU_MODEL_STM32F446RE) \
+    || defined(CPU_MODEL_STM32F446ZE)
+#define CPU_IRQ_NUMOF                   (97U)
+#elif defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
+#define CPU_IRQ_NUMOF                   (102U)
+#elif defined(CPU_MODEL_STM32F429ZI)
+#define CPU_IRQ_NUMOF                   (91U)
 #endif
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */

--- a/cpu/stm32f4/include/vendor/stm32f410rx.h
+++ b/cpu/stm32f4/include/vendor/stm32f410rx.h
@@ -114,7 +114,7 @@ typedef enum
   ADC_IRQn                    = 18,     /*!< ADC1 global Interrupts                                            */
   EXTI9_5_IRQn                = 23,     /*!< External Line[9:5] Interrupts                                     */
   TIM1_BRK_TIM9_IRQn          = 24,     /*!< TIM1 Break interrupt and TIM9 global interrupt                    */
-   TIM1_UP_IRQn                = 25,     /*!< TIM1 Update Interrupt                                            */
+  TIM1_UP_IRQn                = 25,     /*!< TIM1 Update Interrupt                                            */
   TIM1_TRG_COM_TIM11_IRQn     = 26,     /*!< TIM1 Trigger and Commutation Interrupt and TIM11 global interrupt */
   TIM1_CC_IRQn                = 27,     /*!< TIM1 Capture Compare Interrupt                                    */
   I2C1_EV_IRQn                = 31,     /*!< I2C1 Event Interrupt                                              */

--- a/cpu/stm32f4/vectors.c
+++ b/cpu/stm32f4/vectors.c
@@ -105,38 +105,41 @@ WEAK_DEFAULT void isr_dma2_stream7(void);
 WEAK_DEFAULT void isr_usart6(void);
 WEAK_DEFAULT void isr_i2c3_ev(void);
 WEAK_DEFAULT void isr_i2c3_er(void);
-#if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
-/* STM32F413 specific interrupt vectors
- * See RM0430, part 10.2 */
 WEAK_DEFAULT void isr_can3_tx(void);
 WEAK_DEFAULT void isr_can3_rx0(void);
 WEAK_DEFAULT void isr_can3_rx1(void);
 WEAK_DEFAULT void isr_can3_sce(void);
 WEAK_DEFAULT void isr_usart7(void);
 WEAK_DEFAULT void isr_usart8(void);
-WEAK_DEFAULT void isr_spi4(void);
-WEAK_DEFAULT void isr_spi5(void);
-WEAK_DEFAULT void isr_sai1(void);
 WEAK_DEFAULT void isr_uart9(void);
 WEAK_DEFAULT void isr_uart10(void);
-WEAK_DEFAULT void isr_quadspi(void);
-WEAK_DEFAULT void isr_fmpi2c1_ev(void);
-WEAK_DEFAULT void isr_fmpi2c1_er(void);
-WEAK_DEFAULT void isr_lptim1(void);
 WEAK_DEFAULT void isr_dfsdm2_flt0(void);
 WEAK_DEFAULT void isr_dfsdm2_flt1(void);
 WEAK_DEFAULT void isr_dfsdm2_flt2(void);
 WEAK_DEFAULT void isr_dfsdm2_flt3(void);
-#else
 WEAK_DEFAULT void isr_otg_hs_ep1_out(void);
 WEAK_DEFAULT void isr_otg_hs_ep1_in(void);
 WEAK_DEFAULT void isr_otg_hs_wkup(void);
 WEAK_DEFAULT void isr_otg_hs(void);
 WEAK_DEFAULT void isr_dcmi(void);
-#endif
 WEAK_DEFAULT void isr_cryp(void);
 WEAK_DEFAULT void isr_hash_rng(void);
+WEAK_DEFAULT void isr_rng(void);
 WEAK_DEFAULT void isr_fpu(void);
+WEAK_DEFAULT void isr_spi4(void);
+WEAK_DEFAULT void isr_spi5(void);
+WEAK_DEFAULT void isr_spi6(void);
+WEAK_DEFAULT void isr_fmpi2c1_ev(void);
+WEAK_DEFAULT void isr_fmpi2c1_er(void);
+WEAK_DEFAULT void isr_lptim1(void);
+WEAK_DEFAULT void isr_sai1(void);
+WEAK_DEFAULT void isr_sai2(void);
+WEAK_DEFAULT void isr_quadspi(void);
+WEAK_DEFAULT void isr_cec(void);
+WEAK_DEFAULT void isr_spdif_rx(void);
+WEAK_DEFAULT void isr_ltdc(void);
+WEAK_DEFAULT void isr_ltdc_er(void);
+WEAK_DEFAULT void isr_dma2d(void);
 
 /* interrupt vector table */
 ISR_VECTORS const void *interrupt_vector[] = {
@@ -144,134 +147,493 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) (&_estack),             /* pointer to the top of the stack */
     /* Cortex-M4 handlers */
     (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
+    (void*) hard_fault_default,     /* [-13] hard fault exception */
+    (void*) mem_manage_default,     /* [-12] memory manage exception */
+    (void*) bus_fault_default,      /* [-11] bus fault exception */
+    (void*) usage_fault_default,    /* [-10] usage fault exception */
+    (void*) (0UL),                  /* [-9] Reserved */
+    (void*) (0UL),                  /* [-8] Reserved */
+    (void*) (0UL),                  /* [-7] Reserved */
+    (void*) (0UL),                  /* [-6] Reserved */
+    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
+                                            switching into thread context on boot */
+    (void*) debug_mon_default,      /* [-4] debug monitor exception */
+    (void*) (0UL),                  /* [-3] Reserved */
+    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
+                                            context switching is happening here */
+    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
     /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* Window WatchDog */
-    (void*) isr_pvd,                /* PVD through EXTI Line detection */
-    (void*) isr_tamp_stamp,         /* Tamper and TimeStamps through the EXTI line */
-    (void*) isr_rtc_wkup,           /* RTC Wakeup through the EXTI line */
-    (void*) isr_flash,              /* FLASH */
-    (void*) isr_rcc,                /* RCC */
-    (void*) isr_exti,               /* EXTI Line0 */
-    (void*) isr_exti,               /* EXTI Line1 */
-    (void*) isr_exti,               /* EXTI Line2 */
-    (void*) isr_exti,               /* EXTI Line3 */
-    (void*) isr_exti,               /* EXTI Line4 */
-    (void*) isr_dma1_stream0,       /* DMA1 Stream 0 */
-    (void*) isr_dma1_stream1,       /* DMA1 Stream 1 */
-    (void*) isr_dma1_stream2,       /* DMA1 Stream 2 */
-    (void*) isr_dma1_stream3,       /* DMA1 Stream 3 */
-    (void*) isr_dma1_stream4,       /* DMA1 Stream 4 */
-    (void*) isr_dma1_stream5,       /* DMA1 Stream 5 */
-    (void*) isr_dma1_stream6,       /* DMA1 Stream 6 */
-    (void*) isr_adc,                /* ADC1, ADC2 and ADC3s */
-    (void*) isr_can1_tx,            /* CAN1 TX */
-    (void*) isr_can1_rx0,           /* CAN1 RX0 */
-    (void*) isr_can1_rx1,           /* CAN1 RX1 */
-    (void*) isr_can1_sce,           /* CAN1 SCE */
-    (void*) isr_exti,               /* External Line[9:5]s */
-    (void*) isr_tim1_brk_tim9,      /* TIM1 Break and TIM9 */
-    (void*) isr_tim1_up_tim10,      /* TIM1 Update and TIM10 */
-    (void*) isr_tim1_trg_com_tim11, /* TIM1 Trigger and Commutation and TIM11 */
-    (void*) isr_tim1_cc,            /* TIM1 Capture Compare */
-    (void*) isr_tim2,               /* TIM2 */
-    (void*) isr_tim3,               /* TIM3 */
-    (void*) isr_tim4,               /* TIM4 */
-    (void*) isr_i2c1_ev,            /* I2C1 Event */
-    (void*) isr_i2c1_er,            /* I2C1 Error */
-    (void*) isr_i2c2_ev,            /* I2C2 Event */
-    (void*) isr_i2c2_er,            /* I2C2 Error */
-    (void*) isr_spi1,               /* SPI1 */
-    (void*) isr_spi2,               /* SPI2 */
-    (void*) isr_usart1,             /* USART1 */
-    (void*) isr_usart2,             /* USART2 */
-    (void*) isr_usart3,             /* USART3 */
-    (void*) isr_exti,               /* External Line[15:10]s */
-    (void*) isr_rtc_alarm,          /* RTC Alarm (A and B) through EXTI Line */
-    (void*) isr_otg_fs_wkup,        /* USB OTG FS Wakeup through EXTI line */
-    (void*) isr_tim8_brk_tim12,     /* TIM8 Break and TIM12 */
-    (void*) isr_tim8_up_tim13,      /* TIM8 Update and TIM13 */
-    (void*) isr_tim8_trg_com_tim14, /* TIM8 Trigger and Commutation and TIM14 */
-    (void*) isr_tim8_cc,            /* TIM8 Capture Compare */
-    (void*) isr_dma1_stream7,       /* DMA1 Stream7 */
-    (void*) isr_fsmc,               /* FSMC */
-    (void*) isr_sdio,               /* SDIO */
-    (void*) isr_tim5,               /* TIM5 */
-    (void*) isr_spi3,               /* SPI3 */
-    (void*) isr_uart4,              /* UART4 */
-    (void*) isr_uart5,              /* UART5 */
-    (void*) isr_tim6_dac,           /* TIM6 and DAC1&2 underrun errors */
-    (void*) isr_tim7,               /* TIM7 */
-    (void*) isr_dma2_stream0,       /* DMA2 Stream 0 */
-    (void*) isr_dma2_stream1,       /* DMA2 Stream 1 */
-    (void*) isr_dma2_stream2,       /* DMA2 Stream 2 */
-    (void*) isr_dma2_stream3,       /* DMA2 Stream 3 */
-    (void*) isr_dma2_stream4,       /* DMA2 Stream 4 */
-    (void*) isr_eth,                /* Ethernet */
-    (void*) isr_eth_wkup,           /* Ethernet Wakeup through EXTI line */
-    (void*) isr_can2_tx,            /* CAN2 TX */
-    (void*) isr_can2_rx0,           /* CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* CAN2 RX1 */
-    (void*) isr_can2_sce,           /* CAN2 SCE */
-    (void*) isr_otg_fs,             /* USB OTG FS */
-    (void*) isr_dma2_stream5,       /* DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* DMA2 Stream 7 */
-    (void*) isr_usart6,             /* USART6 */
-    (void*) isr_i2c3_ev,            /* I2C3 event */
-    (void*) isr_i2c3_er,            /* I2C3 error */
-#if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
-    (void*) isr_can3_tx,            /* CAN3 TX */
-    (void*) isr_can3_rx0,           /* CAN3 RX0 */
-    (void*) isr_can3_rx1,           /* CAN3 RX1 */
-    (void*) isr_can3_sce,           /* CAN3 SCE */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-#else
-    (void*) isr_otg_hs_ep1_out,     /* USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* USB OTG HS */
-    (void*) isr_dcmi,               /* DCMI */
-    (void*) isr_cryp,               /* CRYP crypto */
+    (void*) isr_wwdg,               /* [0] Window WatchDog */
+    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection */
+    (void*) isr_tamp_stamp,         /* [2] Tamper and TimeStamps through the EXTI line */
+    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup through the EXTI line */
+    (void*) isr_flash,              /* [4] FLASH */
+    (void*) isr_rcc,                /* [5] RCC */
+    (void*) isr_exti,               /* [6] EXTI Line0 */
+    (void*) isr_exti,               /* [7] EXTI Line1 */
+    (void*) isr_exti,               /* [8] EXTI Line2 */
+    (void*) isr_exti,               /* [9] EXTI Line3 */
+    (void*) isr_exti,               /* [10] EXTI Line4 */
+    (void*) isr_dma1_stream0,       /* [11] DMA1 Stream 0 */
+    (void*) isr_dma1_stream1,       /* [12] DMA1 Stream 1 */
+    (void*) isr_dma1_stream2,       /* [13] DMA1 Stream 2 */
+    (void*) isr_dma1_stream3,       /* [14] DMA1 Stream 3 */
+    (void*) isr_dma1_stream4,       /* [15] DMA1 Stream 4 */
+    (void*) isr_dma1_stream5,       /* [16] DMA1 Stream 5 */
+    (void*) isr_dma1_stream6,       /* [17] DMA1 Stream 6 */
+    (void*) isr_adc,                /* [18] ADC1, ADC2 and ADC3s */
+#if defined(CPU_MODEL_STM32F401RE)
+    (void*) (0UL),                  /* [19] Reserved */
+    (void*) (0UL),                  /* [20] Reserved */
+    (void*) (0UL),                  /* [21] Reserved */
+    (void*) (0UL),                  /* [22] Reserved */
+    (void*) isr_exti,               /* [23] External Line[9:5]s */
+    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    (void*) isr_tim2,               /* [28] TIM2 */
+    (void*) isr_tim3,               /* [29] TIM3 */
+    (void*) isr_tim4,               /* [30] TIM4 */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
+    (void*) isr_spi1,               /* [35] SPI1 */
+    (void*) isr_spi2,               /* [36] SPI2 */
+    (void*) isr_usart1,             /* [37] USART1 */
+    (void*) isr_usart2,             /* [38] USART2 */
+    (void*) (0UL),                  /* [39] Reserved */
+    (void*) isr_exti,               /* [40] External Line[15:10]s */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    (void*) (0UL),                  /* [42] Reserved */
+    (void*) (0UL),                  /* [43] Reserved */
+    (void*) (0UL),                  /* [44] Reserved */
+    (void*) (0UL),                  /* [45] Reserved */
+    (void*) (0UL),                  /* [46] Reserved */
+    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    (void*) (0UL),                  /* [48] Reserved */
+    (void*) isr_sdio,               /* [49] SDIO */
+    (void*) isr_tim5,               /* [50] TIM5 */
+    (void*) (0UL),                  /* [51] Reserved */
+    (void*) (0UL),                  /* [52] Reserved */
+    (void*) (0UL),                  /* [53] Reserved */
+    (void*) (0UL),                  /* [54] Reserved */
+    (void*) (0UL),                  /* [55] Reserved */
+    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) (0UL),                  /* [63] Reserved */
+    (void*) (0UL),                  /* [64] Reserved */
+    (void*) (0UL),                  /* [65] Reserved */
+    (void*) (0UL),                  /* [66] Reserved */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) (0UL),                  /* [74] Reserved */
+    (void*) (0UL),                  /* [75] Reserved */
+    (void*) (0UL),                  /* [76] Reserved */
+    (void*) (0UL),                  /* [77] Reserved */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [80] Reserved */
+    (void*) isr_fpu,                /* [81] FPU */
+    (void*) (0UL),                  /* [82] Reserved */
+    (void*) (0UL),                  /* [83] Reserved */
+    (void*) isr_spi4                /* [84] SPI4 */
+#elif defined(CPU_MODEL_STM32F410RB)
+    (void*) (0UL),                  /* [19] Reserved */
+    (void*) (0UL),                  /* [20] Reserved */
+    (void*) (0UL),                  /* [21] Reserved */
+    (void*) (0UL),                  /* [22] Reserved */
+    (void*) isr_exti,               /* [23] External Line[9:5]s */
+    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    (void*) (0UL),                  /* [28] Reserved */
+    (void*) (0UL),                  /* [29] Reserved */
+    (void*) (0UL),                  /* [30] Reserved */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
+    (void*) isr_spi1,               /* [35] SPI1 */
+    (void*) isr_spi2,               /* [36] SPI2 */
+    (void*) isr_usart1,             /* [37] USART1 */
+    (void*) isr_usart2,             /* [38] USART2 */
+    (void*) (0UL),                  /* [39] Reserved */
+    (void*) isr_exti,               /* [40] External Line[15:10]s */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    (void*) (0UL),                  /* [42] Reserved */
+    (void*) (0UL),                  /* [43] Reserved */
+    (void*) (0UL),                  /* [44] Reserved */
+    (void*) (0UL),                  /* [45] Reserved */
+    (void*) (0UL),                  /* [46] Reserved */
+    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    (void*) (0UL),                  /* [48] Reserved */
+    (void*) (0UL),                  /* [49] Reserved */
+    (void*) isr_tim5,               /* [50] TIM5 */
+    (void*) (0UL),                  /* [51] Reserved */
+    (void*) (0UL),                  /* [52] Reserved */
+    (void*) (0UL),                  /* [53] Reserved */
+    (void*) isr_tim6_dac,           /* [54] TIM6 and DAC1&2 underrun errors */
+    (void*) (0UL),                  /* [55] Reserved */
+    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) (0UL),                  /* [63] Reserved */
+    (void*) (0UL),                  /* [64] Reserved */
+    (void*) (0UL),                  /* [65] Reserved */
+    (void*) (0UL),                  /* [66] Reserved */
+    (void*) (0UL),                  /* [67] Reserved */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) (0UL),                  /* [72] Reserved */
+    (void*) (0UL),                  /* [73] Reserved */
+    (void*) (0UL),                  /* [74] Reserved */
+    (void*) (0UL),                  /* [75] Reserved */
+    (void*) (0UL),                  /* [76] Reserved */
+    (void*) (0UL),                  /* [77] Reserved */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+    (void*) isr_fpu,                /* [81] FPU */
+    (void*) (0UL),                  /* [82] Reserved */
+    (void*) (0UL),                  /* [83] Reserved */
+    (void*) (0UL),                  /* [84] Reserved */
+    (void*) isr_spi5,               /* [85] SPI5 */
+    (void*) (0UL),                  /* [86] Reserved */
+    (void*) (0UL),                  /* [87] Reserved */
+    (void*) (0UL),                  /* [88] Reserved */
+    (void*) (0UL),                  /* [89] Reserved */
+    (void*) (0UL),                  /* [90] Reserved */
+    (void*) (0UL),                  /* [91] Reserved */
+    (void*) (0UL),                  /* [92] Reserved */
+    (void*) (0UL),                  /* [93] Reserved */
+    (void*) (0UL),                  /* [94] Reserved */
+    (void*) isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
+    (void*) isr_fmpi2c1_er,         /* [96] FMPI2C1 Error */
+    (void*) isr_lptim1              /* [97] LP TIM1 */
+#elif defined(CPU_MODEL_STM32F411RE)
+    (void*) (0UL),                  /* [19] Reserved */
+    (void*) (0UL),                  /* [20] Reserved */
+    (void*) (0UL),                  /* [21] Reserved */
+    (void*) (0UL),                  /* [22] Reserved */
+    (void*) isr_exti,               /* [23] External Line[9:5]s */
+    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    (void*) isr_tim2,               /* [28] TIM2 */
+    (void*) isr_tim3,               /* [29] TIM3 */
+    (void*) isr_tim4,               /* [30] TIM4 */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
+    (void*) isr_spi1,               /* [35] SPI1 */
+    (void*) isr_spi2,               /* [36] SPI2 */
+    (void*) isr_usart1,             /* [37] USART1 */
+    (void*) isr_usart2,             /* [38] USART2 */
+    (void*) isr_usart3,             /* [39] USART3 */
+    (void*) isr_exti,               /* [40] External Line[15:10]s */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    (void*) isr_otg_fs_wkup,        /* [42] USB OTG FS Wakeup through EXTI line */
+    (void*) (0UL),                  /* [43] Reserved */
+    (void*) (0UL),                  /* [44] Reserved */
+    (void*) (0UL),                  /* [45] Reserved */
+    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare */
+    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    (void*) (0UL),                  /* [22] Reserved */
+    (void*) isr_sdio,               /* [49] SDIO */
+    (void*) isr_tim5,               /* [50] TIM5 */
+    (void*) isr_spi3,               /* [51] SPI3 */
+    (void*) (0UL),                  /* [52] Reserved */
+    (void*) (0UL),                  /* [53] Reserved */
+    (void*) (0UL),                  /* [54] Reserved */
+    (void*) (0UL),                  /* [55] Reserved */
+    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) (0UL),                  /* [63] Reserved */
+    (void*) (0UL),                  /* [64] Reserved */
+    (void*) (0UL),                  /* [65] Reserved */
+    (void*) (0UL),                  /* [66] Reserved */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) (0UL),                  /* [74] Reserved */
+    (void*) (0UL),                  /* [75] Reserved */
+    (void*) (0UL),                  /* [76] Reserved */
+    (void*) (0UL),                  /* [77] Reserved */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [80] Reserved */
+    (void*) isr_fpu,                /* [81] FPU */
+    (void*) (0UL),                  /* [82] Reserved */
+    (void*) (0UL),                  /* [83] Reserved */
+    (void*) isr_spi4,               /* [84] SPI4 */
+    (void*) isr_spi5                /* [85] SPI5 */
+#else /* CPU_MODEL_STM32F413ZH, CPU_MODEL_STM32F413VG, CPU_MODEL_STM32F407VG
+         CPU_MODEL_STM32F415RG, CPU_MODEL_STM32F412ZG, CPU_MODEL_STM32F446RE,
+         CPU_MODEL_STM32F4446ZE */
+    (void*) isr_can1_tx,            /* [19] CAN1 TX */
+    (void*) isr_can1_rx0,           /* [20] CAN1 RX0 */
+    (void*) isr_can1_rx1,           /* [21] CAN1 RX1 */
+    (void*) isr_can1_sce,           /* [22] CAN1 SCE */
+    (void*) isr_exti,               /* [23] External Line[9:5]s */
+    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    (void*) isr_tim2,               /* [28] TIM2 */
+    (void*) isr_tim3,               /* [29] TIM3 */
+    (void*) isr_tim4,               /* [30] TIM4 */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
+    (void*) isr_spi1,               /* [35] SPI1 */
+    (void*) isr_spi2,               /* [36] SPI2 */
+    (void*) isr_usart1,             /* [37] USART1 */
+    (void*) isr_usart2,             /* [38] USART2 */
+    (void*) isr_usart3,             /* [39] USART3 */
+    (void*) isr_exti,               /* [40] External Line[15:10]s */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    (void*) isr_otg_fs_wkup,        /* [42] USB OTG FS Wakeup through EXTI line */
+    (void*) isr_tim8_brk_tim12,     /* [43] TIM8 Break and TIM12 */
+    (void*) isr_tim8_up_tim13,      /* [44] TIM8 Update and TIM13 */
+    (void*) isr_tim8_trg_com_tim14, /* [45] TIM8 Trigger and Commutation and TIM14 */
+    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare */
+    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    (void*) isr_fsmc,               /* [48] FSMC */
+    (void*) isr_sdio,               /* [49] SDIO */
+    (void*) isr_tim5,               /* [50] TIM5 */
+    (void*) isr_spi3,               /* [51] SPI3 */
+    (void*) isr_uart4,              /* [52] UART4 */
+    (void*) isr_uart5,              /* [53] UART5 */
+    (void*) isr_tim6_dac,           /* [54] TIM6 and DAC1&2 underrun errors */
+    (void*) isr_tim7,               /* [55] TIM7 */
+    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+#if defined(CPU_MODEL_STM32F407VG)
+    (void*) isr_eth,                /* [61] Ethernet */
+    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    (void*) isr_otg_hs,             /* [77] USB OTG HS */
+    (void*) isr_dcmi,               /* [78] DCMI */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [80] Reserved */
+    (void*) isr_fpu                 /* [81] FPU */
+#elif defined(CPU_MODEL_STM32F415RG)
+    (void*) isr_eth,                /* [61] Ethernet */
+    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    (void*) isr_otg_hs,             /* [77] USB OTG HS */
+    (void*) isr_dcmi,               /* [78] DCMI */
+    (void*) isr_cryp,               /* [79] CRYP crypto */
+    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+    (void*) isr_fpu                 /* [81] FPU */
+#elif defined(CPU_MODEL_STM32F412ZG)
+    (void*) isr_eth,                /* [61] Ethernet */
+    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) (0UL),                  /* [74] Reserved */
+    (void*) (0UL),                  /* [75] Reserved */
+    (void*) (0UL),                  /* [76] Reserved */
+    (void*) (0UL),                  /* [77] Reserved */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) isr_rng,                /* [80] Rng */
+    (void*) isr_fpu,                /* [81] FPU */
+    (void*) (0UL),                  /* [82] Reserved */
+    (void*) (0UL),                  /* [83] Reserved */
+    (void*) isr_spi4,               /* [84] SPI4 */
+    (void*) isr_spi5,               /* [85] SPI5 */
+    (void*) (0UL),                  /* [86] Reserved */
+    (void*) (0UL),                  /* [87] Reserved */
+    (void*) (0UL),                  /* [88] Reserved */
+    (void*) (0UL),                  /* [89] Reserved */
+    (void*) (0UL),                  /* [90] Reserved */
+    (void*) (0UL),                  /* [91] Reserved */
+    (void*) isr_quadspi,            /* [92] QuadSPI */
+    (void*) (0UL),                  /* [93] Reserved */
+    (void*) (0UL),                  /* [94] Reserved */
+    (void*) isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
+    (void*) isr_fmpi2c1_er          /* [96] FMPI2C1 Error */
+#elif defined(CPU_MODEL_STM32F446RE) || defined(CPU_MODEL_STM32F446ZE)
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    (void*) isr_otg_hs,             /* [77] USB OTG HS */
+    (void*) isr_dcmi,               /* [78] DCMI */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) isr_fpu,                /* [81] FPU */
+    (void*) (0UL),                  /* [82] Reserved */
+    (void*) (0UL),                  /* [83] Reserved */
+    (void*) isr_spi4,               /* [84] SPI4 */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [86] Reserved */
+    (void*) isr_sai1,               /* [87] SAI1 */
+    (void*) (0UL),                  /* [88] Reserved */
+    (void*) (0UL),                  /* [89] Reserved */
+    (void*) (0UL),                  /* [90] Reserved */
+    (void*) isr_sai2,               /* [91] SAI2 */
+    (void*) isr_quadspi,            /* [92] QuadSPI */
+    (void*) isr_cec,                /* [93] CEC */
+    (void*) isr_spdif_rx,           /* [94] SPDIF-RX */
+    (void*) isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
+    (void*) isr_fmpi2c1_er          /* [96] FMPI2C1 Error */
+#elif defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
+    (void*) isr_eth,                /* [61] Ethernet */
+    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) isr_can3_tx,            /* [74] CAN3 TX */
+    (void*) isr_can3_rx0,           /* [75] CAN3 RX0 */
+    (void*) isr_can3_rx1,           /* [76] CAN3 RX1 */
+    (void*) isr_can3_sce,           /* [77] CAN3 SCE */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+    (void*) isr_fpu,                /* [81] FPU */
+    (void*) isr_usart7,             /* [82] USART7 */
+    (void*) isr_usart8,             /* [83] USART8 */
+    (void*) isr_spi4,               /* [84] SPI4 */
+    (void*) isr_spi5,               /* [85] SPI5 */
+    (void*) (0UL),                  /* [86] Reserved */
+    (void*) isr_sai1,               /* [87] SAI1 */
+    (void*) isr_uart9,              /* [88] UART9 */
+    (void*) isr_uart10,             /* [89] UART10 */
+    (void*) (0UL),                  /* [90] Reserved */
+    (void*) (0UL),                  /* [91] Reserved */
+    (void*) isr_quadspi,            /* [92] QuadSPI */
+    (void*) (0UL),                  /* [93] Reserved */
+    (void*) (0UL),                  /* [94] Reserved */
+    (void*) isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
+    (void*) isr_fmpi2c1_er,         /* [96] FMPI2C1 Error */
+    (void*) isr_lptim1,             /* [97] LP TIM1 */
+    (void*) isr_dfsdm2_flt0,        /* [98] DFSDM2 Filter 0 */
+    (void*) isr_dfsdm2_flt1,        /* [99] DFSDM2 Filter 1 */
+    (void*) isr_dfsdm2_flt2,        /* [100] DFSDM2 Filter 2 */
+    (void*) isr_dfsdm2_flt3         /* [101] DFSDM2 Filter 3 */
+#else /* CPU_MODEL_STM32F429ZI */
+    (void*) isr_eth,                /* [61] Ethernet */
+    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    (void*) isr_can2_tx,            /* [63] CAN2 TX */
+    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
+    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
+    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS */
+    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    (void*) isr_usart6,             /* [71] USART6 */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error */
+    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    (void*) isr_otg_hs,             /* [77] USB OTG HS */
+    (void*) isr_dcmi,               /* [78] DCMI */
+    (void*) (0UL),                  /* [79] Reserved */
+    (void*) (0UL),                  /* [80] Reserved */
+    (void*) isr_fpu,                /* [81] FPU */
+    (void*) isr_usart7,             /* [82] USART7 */
+    (void*) isr_usart8,             /* [83] USART8 */
+    (void*) isr_spi4,               /* [84] SPI4 */
+    (void*) isr_spi5,               /* [85] SPI5 */
+    (void*) isr_spi6,               /* [86] SPI6 */
+    (void*) isr_sai1,               /* [87] SAI1 */
+    (void*) isr_ltdc,               /* [88] LDTC */
+    (void*) isr_ltdc_er,            /* [89] LTDC Error */
+    (void*) isr_dma2d               /* [90] Reserved */
 #endif
-    (void*) isr_hash_rng,           /* Hash and Rng */
-    (void*) isr_fpu,                /* FPU */
-#if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
-    (void*) isr_usart7,             /* USART7 */
-    (void*) isr_usart8,             /* USART8 */
-    (void*) isr_spi4,               /* SPI4 */
-    (void*) isr_spi5,               /* SPI5 */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_sai1,               /* SAI1 */
-    (void*) isr_uart9,              /* UART9 */
-    (void*) isr_uart10,             /* UART10 */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_quadspi,            /* QuadSPI */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_fmpi2c1_ev,         /* FMPI2C1 Event */
-    (void*) isr_fmpi2c1_er,         /* FMPI2C1 Error */
-    (void*) isr_lptim1,             /* LP TIM1 */
-    (void*) isr_dfsdm2_flt0,        /* DFSDM2 Filter 0 */
-    (void*) isr_dfsdm2_flt1,        /* DFSDM2 Filter 1 */
-    (void*) isr_dfsdm2_flt2,        /* DFSDM2 Filter 2 */
-    (void*) isr_dfsdm2_flt3,        /* DFSDM2 Filter 3 */
 #endif
 };

--- a/cpu/stm32l0/include/cpu_conf.h
+++ b/cpu/stm32l0/include/cpu_conf.h
@@ -47,7 +47,11 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#define CPU_IRQ_NUMOF                   (31U)
+#if defined(CPU_MODEL_STM32L031K6)
+#define CPU_IRQ_NUMOF                   (30U)
+#else
+#define CPU_IRQ_NUMOF                   (32U)
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/stm32l0/vectors.c
+++ b/cpu/stm32l0/vectors.c
@@ -64,6 +64,7 @@ WEAK_DEFAULT void isr_spi2(void);
 WEAK_DEFAULT void isr_usart1(void);
 WEAK_DEFAULT void isr_usart2(void);
 WEAK_DEFAULT void isr_rng_lpuart1(void);
+WEAK_DEFAULT void isr_lpuart1(void);
 WEAK_DEFAULT void isr_lcd(void);
 WEAK_DEFAULT void isr_usb(void);
 
@@ -73,53 +74,103 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) (&_estack),             /* pointer to the top of the stack */
     /* Cortex-M0 handlers */
     (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
+    (void*) hard_fault_default,     /* [-13] hard fault exception */
+    (void*) (0UL),                  /* [-12] reserved */
+    (void*) (0UL),                  /* [-11] reserved */
+    (void*) (0UL),                  /* [-10] reserved */
+    (void*) (0UL),                  /* [-9] reserved */
+    (void*) (0UL),                  /* [-8] reserved */
+    (void*) (0UL),                  /* [-7] reserved */
+    (void*) (0UL),                  /* [-6] reserved */
+    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
+                                            switching into thread context on boot */
+    (void*) (0UL),                  /* [-4] reserved */
+    (void*) (0UL),                  /* [-3] reserved */
+    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
+                                            context switching is happening here */
+    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
     /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* windowed watchdog */
-    (void*) isr_pvd,                /* power control */
-    (void*) isr_rtc,                /* real time clock */
-    (void*) isr_flash,              /* flash memory controller */
-    (void*) isr_rcc,                /* reset and clock control */
-    (void*) isr_exti,               /* external interrupt lines 0 and 1 */
-    (void*) isr_exti,               /* external interrupt lines 2 and 3 */
-    (void*) isr_exti,               /* external interrupt lines 4 to 15 */
-    (void*) isr_ts,                 /* touch sensing input*/
-    (void*) isr_dma1_ch1,           /* direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,         /* direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5_6_7,     /* direct memory access controller 1, channel 4, 5, 6 and 7*/
-    (void*) isr_adc1_comp,          /* analog digital converter */
-    (void*) isr_lptim1,             /* low power timer 1 */
-    (void*) isr_usart4_5,           /* usart 4 to 5 */
-    (void*) isr_tim2,               /* timer 2 */
-    (void*) isr_tim3,               /* timer 3 */
-    (void*) isr_tim6_dac,           /* timer 6 and digital to analog converter */
-    (void*) isr_tim7,               /* timer 7 */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_tim21,              /* timer 21 */
-    (void*) isr_i2c3,               /* I2C 3 */
-    (void*) isr_tim22,              /* timer 22 */
-    (void*) isr_i2c1,               /* I2C 1 */
-    (void*) isr_i2c2,               /* I2C 2 */
-    (void*) isr_spi1,               /* SPI 1 */
-    (void*) isr_spi2,               /* SPI 2 */
-    (void*) isr_usart1,             /* USART 1 */
-    (void*) isr_usart2,             /* USART 2 */
-    (void*) isr_rng_lpuart1,        /* Low power UART 1 */
-    (void*) isr_lcd,                /* LCD */
-    (void*) isr_usb                 /* USB */
+    (void*) isr_wwdg,               /* [0] windowed watchdog */
+    (void*) isr_pvd,                /* [1] power control */
+    (void*) isr_rtc,                /* [2] real time clock */
+    (void*) isr_flash,              /* [3] flash memory controller */
+    (void*) isr_rcc,                /* [4] reset and clock control */
+    (void*) isr_exti,               /* [5] external interrupt lines 0 and 1 */
+    (void*) isr_exti,               /* [6] external interrupt lines 2 and 3 */
+    (void*) isr_exti,               /* [7] external interrupt lines 4 to 15 */
+#if defined(CPU_MODEL_STM32L031K6)
+    (void*) (0UL),                  /* [8] reserved */
+    (void*) isr_dma1_ch1,           /* [9] direct memory access controller 1, channel 1*/
+    (void*) isr_dma1_ch2_3,         /* [10] direct memory access controller 1, channel 2 and 3*/
+    (void*) isr_dma1_ch4_5_6_7,     /* [11] direct memory access controller 1, channel 4, 5, 6 and 7*/
+    (void*) isr_adc1_comp,          /* [12] analog digital converter */
+    (void*) isr_lptim1,             /* [13] low power timer 1 */
+    (void*) (0UL),                  /* [14] reserved */
+    (void*) isr_tim2,               /* [15] timer 2 */
+    (void*) (0UL),                  /* [16] reserved */
+    (void*) (0UL),                  /* [17] reserved */
+    (void*) (0UL),                  /* [18] reserved */
+    (void*) (0UL),                  /* [19] reserved */
+    (void*) isr_tim21,              /* [20] timer 21 */
+    (void*) (0UL),                  /* [21] reserved */
+    (void*) isr_tim22,              /* [22] timer 22 */
+    (void*) isr_i2c1,               /* [23] I2C 1 */
+    (void*) (0UL),                  /* [24] reserved */
+    (void*) isr_spi1,               /* [25] SPI 1 */
+    (void*) (0UL),                  /* [26] reserved */
+    (void*) (0UL),                  /* [27] reserved */
+    (void*) isr_usart2,             /* [28] USART 2 */
+    (void*) isr_lpuart1             /* [29] Low power UART 1 */
+#elif defined(CPU_MODEL_STM32L053R8)
+    (void*) isr_ts,                 /* [8] touch sensing input*/
+    (void*) isr_dma1_ch1,           /* [9] direct memory access controller 1, channel 1*/
+    (void*) isr_dma1_ch2_3,         /* [10] direct memory access controller 1, channel 2 and 3*/
+    (void*) isr_dma1_ch4_5_6_7,     /* [11] direct memory access controller 1, channel 4, 5, 6 and 7*/
+    (void*) isr_adc1_comp,          /* [12] analog digital converter */
+    (void*) isr_lptim1,             /* [13] low power timer 1 */
+    (void*) (0UL),                  /* [14] reserved */
+    (void*) isr_tim2,               /* [15] timer 2 */
+    (void*) (0UL),                  /* [16] reserved */
+    (void*) isr_tim6_dac,           /* [17] timer 6 and digital to analog converter */
+    (void*) (0UL),                  /* [18] reserved */
+    (void*) (0UL),                  /* [19] reserved */
+    (void*) isr_tim21,              /* [20] timer 21 */
+    (void*) (0UL),                  /* [21] reserved */
+    (void*) isr_tim22,              /* [22] timer 22 */
+    (void*) isr_i2c1,               /* [23] I2C 1 */
+    (void*) isr_i2c2,               /* [24] I2C 2 */
+    (void*) isr_spi1,               /* [25] SPI 1 */
+    (void*) isr_spi2,               /* [26] SPI 2 */
+    (void*) isr_usart1,             /* [27] USART 1 */
+    (void*) isr_usart2,             /* [28] USART 2 */
+    (void*) isr_rng_lpuart1,        /* [29] RNG and Low power UART 1 */
+    (void*) isr_lcd,                /* [30] LCD */
+    (void*) isr_usb                 /* [31] USB */
+#else /* CPU_MODEL_STM32L073RZ, CPU_MODEL_STM32L072CZ */
+    (void*) isr_ts,                 /* [8] touch sensing input*/
+    (void*) isr_dma1_ch1,           /* [9] direct memory access controller 1, channel 1*/
+    (void*) isr_dma1_ch2_3,         /* [10] direct memory access controller 1, channel 2 and 3*/
+    (void*) isr_dma1_ch4_5_6_7,     /* [11] direct memory access controller 1, channel 4, 5, 6 and 7*/
+    (void*) isr_adc1_comp,          /* [12] analog digital converter */
+    (void*) isr_lptim1,             /* [13] low power timer 1 */
+    (void*) isr_usart4_5,           /* [14] usart 4 to 5 */
+    (void*) isr_tim2,               /* [15] timer 2 */
+    (void*) isr_tim3,               /* [16] timer 3 */
+    (void*) isr_tim6_dac,           /* [17] timer 6 and digital to analog converter */
+    (void*) isr_tim7,               /* [18] timer 7 */
+    (void*) (0UL),                  /* [19] reserved */
+    (void*) isr_tim21,              /* [20] timer 21 */
+    (void*) isr_i2c3,               /* [21] I2C 3 */
+    (void*) isr_tim22,              /* [22] timer 22 */
+    (void*) isr_i2c1,               /* [23] I2C 1 */
+    (void*) isr_i2c2,               /* [24] I2C 2 */
+    (void*) isr_spi1,               /* [25] SPI 1 */
+    (void*) isr_spi2,               /* [26] SPI 2 */
+    (void*) isr_usart1,             /* [27] USART 1 */
+    (void*) isr_usart2,             /* [28] USART 2 */
+    (void*) isr_rng_lpuart1,        /* [29] RNG and Low power UART 1 */
+    (void*) isr_lcd,                /* [30] LCD */
+    (void*) isr_usb                 /* [31] USB */
+#endif
 };

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -23,6 +23,36 @@
 
 #include "cpu_conf_common.h"
 
+/**
+ * @brief  STM32 L1 cpu type
+ *
+ * From CMSIS header file, allowed values for L1 cpu types are:
+ * * STM32L1XX_MD:
+ *   * Ultra Low Power Medium-density devices: STM32L151x6xx, STM32L151x8xx,
+ *     STM32L151xBxx, STM32L152x6xx, STM32L152x8xx, STM32L152xBxx,
+ *     STM32L151x6xxA, STM32L151x8xxA, STM32L151xBxxA, STM32L152x6xxA,
+ *     SM32L152x8xxA and STM32L152xBxxA.
+ *   * Ultra Low Power Medium-density Value Line devices: STM32L100x6xx,
+ *     STM32L100x8xx and STM32L100xBxx.
+ *
+ * * STM32L1XX_MDP:
+ *   * Ultra Low Power Medium-density Plus devices: STM32L151xCxx,
+ *     STM32L152xCxx and STM32L162xCxx
+ *   * Ultra Low Power Medium-density Plus Value Line devices: STM32L100xCxx
+ *
+ * * STM32L1XX_HD: Ultra Low Power High-density devices: STM32L151xDxx,
+ *    STM32L152xDxx and STM32L162xDxx
+ *
+ * * STM32L1XX_XL: Ultra Low Power XL-density devices: STM32L151xExx,
+ *   STM32L152xExx and STM32L162xExx
+ */
+#if defined(CPU_MODEL_STM32L151RBA)
+#define STM32L1XX_MD (1U)
+#elif defined(CPU_MODEL_STM32L151RC)
+#define STM32L1XX_MDP (1U)
+#else
+#define STM32L1XX_XL (1U)
+#endif
 #include "vendor/stm32l1xx.h"
 
 #ifdef __cplusplus
@@ -34,7 +64,11 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
+#if defined(CPU_MODEL_STM32L151RBA)
+#define CPU_IRQ_NUMOF                   (45U)
+#else
 #define CPU_IRQ_NUMOF                   (57U)
+#endif
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 

--- a/cpu/stm32l1/include/vendor/stm32l1xx.h
+++ b/cpu/stm32l1/include/vendor/stm32l1xx.h
@@ -85,9 +85,8 @@
 /*  Tip: To avoid modifying this file each time you need to switch between these
         devices, you can define the device in your toolchain compiler preprocessor.
   */
-#define STM32L1XX_XL (1U)
 #if !defined (STM32L1XX_MD) && !defined (STM32L1XX_MDP) && !defined (STM32L1XX_HD) && !defined (STM32L1XX_XL)
- #error "Please select first the target STM32L1xx device used in your application (in stm32l1xx.h file)"
+#error "Please select first the target STM32L1xx device used in your application (in stm32l1xx.h file)"
 #endif
 
 #if !defined  USE_STDPERIPH_DRIVER

--- a/cpu/stm32l1/vectors.c
+++ b/cpu/stm32l1/vectors.c
@@ -94,78 +94,93 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) (&_estack),             /* pointer to the top of the stack */
     /* Cortex-M3 handlers */
     (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
+    (void*) hard_fault_default,     /* [-13] hard fault exception */
+    (void*) mem_manage_default,     /* [-12] memory manage exception */
+    (void*) bus_fault_default,      /* [-11] bus fault exception */
+    (void*) usage_fault_default,    /* [-10] usage fault exception */
+    (void*) (0UL),                  /* [-9] Reserved */
+    (void*) (0UL),                  /* [-8] Reserved */
+    (void*) (0UL),                  /* [-7] Reserved */
+    (void*) (0UL),                  /* [-6] Reserved */
+    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
+                                            switching into thread context on boot */
+    (void*) debug_mon_default,      /* [-4] debug monitor exception */
+    (void*) (0UL),                  /* [-3] Reserved */
+    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
+                                            context switching is happening here */
+    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
     /* STM specific peripheral handlers */
-    (void*) isr_wwdg,
-    (void*) isr_pvd,
-    (void*) isr_tamper_stamp,
-    (void*) isr_rtc_wkup,
-    (void*) isr_flash,
-    (void*) isr_rcc,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_dma1_ch1,
-    (void*) isr_dma1_ch2,
-    (void*) isr_dma1_ch3,
-    (void*) isr_dma1_ch4,
-    (void*) isr_dma1_ch5,
-    (void*) isr_dma1_ch6,
-    (void*) isr_dma1_ch7,
-    (void*) isr_adc1,
-    (void*) isr_usb_hp,
-    (void*) isr_usb_lp,
-    (void*) isr_dac,
-    (void*) isr_comp,
-    (void*) isr_exti,
-    (void*) isr_lcd,
-    (void*) isr_tim9,
-    (void*) isr_tim10,
-    (void*) isr_tim11,
-    (void*) isr_tim2,
-    (void*) isr_tim3,
-    (void*) isr_tim4,
-    (void*) isr_i2c1_ev,
-    (void*) isr_i2c1_er,
-    (void*) isr_i2c2_ev,
-    (void*) isr_i2c2_er,
-    (void*) isr_spi1,
-    (void*) isr_spi2,
-    (void*) isr_usart1,
-    (void*) isr_usart2,
-    (void*) isr_usart3,
-    (void*) isr_exti,
-    (void*) isr_rtc_alarm,
-    (void*) isr_usb_fs_wkup,
-    (void*) isr_tim6,
-    (void*) isr_tim7,
-    (void*) isr_sdio,
-    (void*) isr_tim5,
-    (void*) isr_spi3,
-    (void*) isr_uart4,
-    (void*) isr_uart5,
-    (void*) isr_dma2_ch1,
-    (void*) isr_dma2_ch2,
-    (void*) isr_dma2_ch3,
-    (void*) isr_dma2_ch4,
-    (void*) isr_dma2_ch5,
-    (void*) isr_aes,
-    (void*) isr_comp_acq,
+    (void*) isr_wwdg,               /* [0] Window WatchDog Interrupt */
+    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
+    (void*) isr_tamper_stamp,       /* [2] Tamper and Time Stamp through EXTI Line Interrupts */
+    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup Timer through EXTI Line Interrupt */
+    (void*) isr_flash,              /* [4] FLASH global Interrupt */
+    (void*) isr_rcc,                /* [5] RCC global Interrupt */
+    (void*) isr_exti,               /* [6] EXTI Line0 Interrupt */
+    (void*) isr_exti,               /* [7] EXTI Line1 Interrupt */
+    (void*) isr_exti,               /* [8] EXTI Line2 Interrupt */
+    (void*) isr_exti,               /* [9] EXTI Line3 Interrupt */
+    (void*) isr_exti,               /* [10] EXTI Line4 Interrupt */
+    (void*) isr_dma1_ch1,           /* [11] DMA1 Channel 1 global Interrupt */
+    (void*) isr_dma1_ch2,           /* [12] DMA1 Channel 2 global Interrupt */
+    (void*) isr_dma1_ch3,           /* [13] DMA1 Channel 3 global Interrupt */
+    (void*) isr_dma1_ch4,           /* [14] DMA1 Channel 4 global Interrupt */
+    (void*) isr_dma1_ch5,           /* [15] DMA1 Channel 5 global Interrupt */
+    (void*) isr_dma1_ch6,           /* [16] DMA1 Channel 6 global Interrupt */
+    (void*) isr_dma1_ch7,           /* [17] DMA1 Channel 7 global Interrupt */
+    (void*) isr_adc1,               /* [18] ADC1 global Interrupt */
+    (void*) isr_usb_hp,             /* [19] USB High Priority Interrupt */
+    (void*) isr_usb_lp,             /* [20] USB Low Priority Interrupt */
+    (void*) isr_dac,                /* [21] DAC Interrupt */
+    (void*) isr_comp,               /* [22] Comparator through EXTI Line Interrupt */
+    (void*) isr_exti,               /* [23] External Line[9:5] Interrupts */
+    (void*) isr_lcd,                /* [24] LCD Interrupt */
+    (void*) isr_tim9,               /* [25] TIM9 global Interrupt */
+    (void*) isr_tim10,              /* [26] TIM10 global Interrupt */
+    (void*) isr_tim11,              /* [27] TIM11 global Interrupt */
+    (void*) isr_tim2,               /* [28] TIM2 global Interrupt */
+    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
+    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
+    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
+    (void*) isr_usart1,             /* [37] USART1 global Interrupt */
+    (void*) isr_usart2,             /* [38] USART2 global Interrupt */
+    (void*) isr_usart3,             /* [39] USART3 global Interrupt */
+    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm through EXTI Line Interrupt */
+    (void*) isr_usb_fs_wkup,        /* [42] USB FS WakeUp from suspend through EXTI Line Interrupt */
+    (void*) isr_tim6,               /* [43] TIM6 global Interrupt */
+    (void*) isr_tim7,               /* [44] TIM7 global Interrupt */
+#if defined(CPU_MODEL_STM32L151RC)
+    (void*) (0UL),                  /* [45] Reserved */
+    (void*) isr_tim5,               /* [46] TIM5 global Interrupt */
+    (void*) isr_spi3,               /* [47] SPI3 global Interrupt */
+    (void*) (0UL),                  /* [48] Reserved */
+    (void*) (0UL),                  /* [49] Reserved */
+    (void*) isr_dma2_ch1,           /* [50] DMA2 Channel 1 global Interrupt */
+    (void*) isr_dma2_ch2,           /* [51] DMA2 Channel 2 global Interrupt */
+    (void*) isr_dma2_ch3,           /* [52] DMA2 Channel 3 global Interrupt */
+    (void*) isr_dma2_ch4,           /* [53] DMA2 Channel 4 global Interrupt */
+    (void*) isr_dma2_ch5,           /* [54] DMA2 Channel 5 global Interrupt */
+    (void*) isr_aes,                /* [55] AES global Interrupt */
+    (void*) isr_comp_acq            /* [56] Comparator Channel Acquisition global Interrupt */
+#elif defined(CPU_MODEL_STM32L152RET6)
+    (void*) (0UL),                  /* [45] Reserved */
+    (void*) isr_tim5,               /* [46] TIM5 global Interrupt */
+    (void*) isr_spi3,               /* [47] SPI3 global Interrupt */
+    (void*) isr_uart4,              /* [48] UART4 global Interrupt */
+    (void*) isr_uart5,              /* [49] UART5 global Interrupt */
+    (void*) isr_dma2_ch1,           /* [50] DMA2 Channel 1 global Interrupt */
+    (void*) isr_dma2_ch2,           /* [51] DMA2 Channel 2 global Interrupt */
+    (void*) isr_dma2_ch3,           /* [52] DMA2 Channel 3 global Interrupt */
+    (void*) isr_dma2_ch4,           /* [53] DMA2 Channel 4 global Interrupt */
+    (void*) isr_dma2_ch5,           /* [54] DMA2 Channel 5 global Interrupt */
+    (void*) isr_aes,                /* [55] AES global Interrupt */
+    (void*) isr_comp_acq            /* [56] Comparator Channel Acquisition global Interrupt */
+#endif
 };

--- a/cpu/stm32l4/include/cpu_conf.h
+++ b/cpu/stm32l4/include/cpu_conf.h
@@ -40,10 +40,10 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(STM32L432KC)
-#define CPU_IRQ_NUMOF                   (82U)
+#if defined(CPU_MODEL_STM32L432KC)
+#define CPU_IRQ_NUMOF                   (83U)
 #else
-#define CPU_IRQ_NUMOF                   (81U)
+#define CPU_IRQ_NUMOF                   (82U)
 #endif
 /** @} */
 

--- a/cpu/stm32l4/vectors.c
+++ b/cpu/stm32l4/vectors.c
@@ -119,106 +119,160 @@ ISR_VECTORS const void *interrupt_vector[] = {
     (void*) (&_estack),             /* pointer to the top of the stack */
     /* Cortex-M4 handlers */
     (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
+    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
+    (void*) hard_fault_default,     /* [-13] hard fault exception */
+    (void*) mem_manage_default,     /* [-12] memory manage exception */
+    (void*) bus_fault_default,      /* [-11] bus fault exception */
+    (void*) usage_fault_default,    /* [-10] usage fault exception */
+    (void*) (0UL),                  /* [-9] Reserved */
+    (void*) (0UL),                  /* [-8] Reserved */
+    (void*) (0UL),                  /* [-7] Reserved */
+    (void*) (0UL),                  /* [-6] Reserved */
+    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
+                                            switching into thread context on boot */
+    (void*) debug_mon_default,      /* [-4] debug monitor exception */
+    (void*) (0UL),                  /* [-3] Reserved */
+    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
+                                            context switching is happening here */
+    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
     /* STM specific peripheral handlers */
-    (void*) isr_wwdg,
-    (void*) isr_pvd_pvm,
-    (void*) isr_tamp_stamp,
-    (void*) isr_rtc_wkup,
-    (void*) isr_flash,
-    (void*) isr_rcc,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_exti,
-    (void*) isr_dma1_channel1,
-    (void*) isr_dma1_channel2,
-    (void*) isr_dma1_channel3,
-    (void*) isr_dma1_channel4,
-    (void*) isr_dma1_channel5,
-    (void*) isr_dma1_channel6,
-    (void*) isr_dma1_channel7,
-    (void*) isr_adc1_2,
-    (void*) isr_can1_tx,
-    (void*) isr_can1_rx0,
-    (void*) isr_can1_rx1,
-    (void*) isr_can1_sce,
-    (void*) isr_exti,
-    (void*) isr_tim1_brk_tim15,
-    (void*) isr_tim1_up_tim16,
-    (void*) isr_tim1_trg_com_tim17,
-    (void*) isr_tim1_cc,
-    (void*) isr_tim2,
-    (void*) isr_tim3,
-    (void*) isr_tim4,
-    (void*) isr_i2c1_ev,
-    (void*) isr_i2c1_er,
-    (void*) isr_i2c2_ev,
-    (void*) isr_i2c2_er,
-    (void*) isr_spi1,
-    (void*) isr_spi2,
-    (void*) isr_usart1,
-    (void*) isr_usart2,
-    (void*) isr_usart3,
-    (void*) isr_exti,
-    (void*) isr_rtc_alarm,
-    (void*) isr_dfsdm1_flt3,
-    (void*) isr_tim8_brk,
-    (void*) isr_tim8_up,
-    (void*) isr_tim8_trg_com,
-    (void*) isr_tim8_cc,
-    (void*) isr_adc3,
-    (void*) isr_fmc,
-    (void*) isr_sdmmc1,
-    (void*) isr_tim5,
-    (void*) isr_spi3,
-    (void*) isr_uart4,
-    (void*) isr_uart5,
-    (void*) isr_tim6_dac,
-    (void*) isr_tim7,
-    (void*) isr_dma2_channel1,
-    (void*) isr_dma2_channel2,
-    (void*) isr_dma2_channel3,
-    (void*) isr_dma2_channel4,
-    (void*) isr_dma2_channel5,
-    (void*) isr_dfsdm1_flt0,
-    (void*) isr_dfsdm1_flt1,
-    (void*) isr_dfsdm1_flt2,
-    (void*) isr_comp,
-    (void*) isr_lptim1,
-    (void*) isr_lptim2,
-    (void*) isr_otg_fs,
-    (void*) isr_dma2_channel6,
-    (void*) isr_dma2_channel7,
-    (void*) isr_lpuart1,
-    (void*) isr_quadspi,
-    (void*) isr_i2c3_ev,
-    (void*) isr_i2c3_er,
-    (void*) isr_sai1,
-    (void*) isr_sai2,
-    (void*) isr_swpmi1,
-    (void*) isr_tsc,
-    (void*) isr_lcd,
-    (void*) (0UL),
-    (void*) isr_rng,
-    (void*) isr_fpu,
-#if defined(STM32L432KC)
-    (void*) isr_crs
+    (void*) isr_wwdg,               /* [0] Window WatchDog Interrupt */
+    (void*) isr_pvd_pvm,            /* [1] PVD/PVM1/PVM2/PVM3/PVM4 through EXTI Line detection Interrupts */
+    (void*) isr_tamp_stamp,         /* [2] Tamper and TimeStamp interrupts through the EXTI line */
+    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup interrupt through the EXTI line */
+    (void*) isr_flash,              /* [4] FLASH global Interrupt */
+    (void*) isr_rcc,                /* [5] RCC global Interrupt */
+    (void*) isr_exti,               /* [6] EXTI Line0 Interrupt */
+    (void*) isr_exti,               /* [7] EXTI Line1 Interrupt */
+    (void*) isr_exti,               /* [8] EXTI Line2 Interrupt */
+    (void*) isr_exti,               /* [9] EXTI Line3 Interrupt */
+    (void*) isr_exti,               /* [10] EXTI Line4 Interrupt */
+    (void*) isr_dma1_channel1,      /* [11] DMA1 Channel 1 global Interrupt */
+    (void*) isr_dma1_channel2,      /* [12] DMA1 Channel 2 global Interrupt */
+    (void*) isr_dma1_channel3,      /* [13] DMA1 Channel 3 global Interrupt */
+    (void*) isr_dma1_channel4,      /* [14] DMA1 Channel 4 global Interrupt */
+    (void*) isr_dma1_channel5,      /* [15] DMA1 Channel 5 global Interrupt */
+    (void*) isr_dma1_channel6,      /* [16] DMA1 Channel 6 global Interrupt */
+    (void*) isr_dma1_channel7,      /* [17] DMA1 Channel 7 global Interrupt */
+    (void*) isr_adc1_2,             /* [18] ADC1 global Interrupt */
+    (void*) isr_can1_tx,            /* [19] CAN1 TX Interrupt */
+    (void*) isr_can1_rx0,           /* [20] CAN1 RX0 Interrupt */
+    (void*) isr_can1_rx1,           /* [21] CAN1 RX1 Interrupt */
+    (void*) isr_can1_sce,           /* [22] CAN1 SCE Interrupt */
+    (void*) isr_exti,               /* [23] External Line[9:5] Interrupts */
+    (void*) isr_tim1_brk_tim15,     /* [24] TIM1 Break interrupt and TIM15 global interrupt */
+    (void*) isr_tim1_up_tim16,      /* [25] TIM1 Update Interrupt and TIM16 global interrupt */
+    (void*) isr_tim1_trg_com_tim17, /* [26] TIM1 Trigger and Commutation Interrupt */
+    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
+    (void*) isr_tim2,               /* [28] TIM2 global Interrupt */
+#if defined(CPU_MODEL_STM32L432KC)
+    (void*) (0UL),                  /* [29] Reserved */
+    (void*) (0UL),                  /* [30] Reserved */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (void*) (0UL),                  /* [33] Reserved */
+    (void*) (0UL),                  /* [34] Reserved */
+    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
+    (void*) (0UL),                  /* [36] Reserved */
+    (void*) isr_usart1,             /* [37] USART1 global Interrupt */
+    (void*) isr_usart2,             /* [38] USART2 global Interrupt */
+    (void*) (0UL),                  /* [39] Reserved */
+    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line Interrupt */
+    (void*) (0UL),                  /* [42] Reserved */
+    (void*) (0UL),                  /* [43] Reserved */
+    (void*) (0UL),                  /* [44] Reserved */
+    (void*) (0UL),                  /* [45] Reserved */
+    (void*) (0UL),                  /* [46] Reserved */
+    (void*) (0UL),                  /* [47] Reserved */
+    (void*) (0UL),                  /* [48] Reserved */
+    (void*) (0UL),                  /* [49] Reserved */
+    (void*) (0UL),                  /* [50] Reserved */
+    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
+    (void*) (0UL),                  /* [52] Reserved */
+    (void*) (0UL),                  /* [53] Reserved */
+    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC1&2 underrun error interrupts */
+    (void*) isr_tim7,               /* [55] TIM7 global interrupt */
+    (void*) isr_dma2_channel1,      /* [56] DMA2 Channel 1 global Interrupt */
+    (void*) isr_dma2_channel2,      /* [57] DMA2 Channel 2 global Interrupt */
+    (void*) isr_dma2_channel3,      /* [58] DMA2 Channel 3 global Interrupt */
+    (void*) isr_dma2_channel4,      /* [59] DMA2 Channel 4 global Interrupt */
+    (void*) isr_dma2_channel5,      /* [60] DMA2 Channel 5 global Interrupt */
+    (void*) (0UL),                  /* [61] Reserved */
+    (void*) (0UL),                  /* [62] Reserved */
+    (void*) (0UL),                  /* [63] Reserved */
+    (void*) isr_comp,               /* [64] COMP1 and COMP2 Interrupts */
+    (void*) isr_lptim1,             /* [65] LP TIM1 interrupt */
+    (void*) isr_lptim2,             /* [66] LP TIM2 interrupt */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS global Interrupt */
+    (void*) isr_dma2_channel6,      /* [68] DMA2 Channel 6 global interrupt */
+    (void*) isr_dma2_channel7,      /* [69] DMA2 Channel 7 global interrupt */
+    (void*) isr_lpuart1,            /* [70] LP UART1 interrupt */
+    (void*) isr_quadspi,            /* [71] Quad SPI global interrupt */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event interrupt */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error interrupt */
+    (void*) isr_sai1,               /* [74] Serial Audio Interface 1 global interrupt */
+    (void*) (0UL),                  /* [75] Reserved */
+    (void*) isr_swpmi1,             /* [76] Serial Wire Interface 1 global interrupt */
+    (void*) isr_tsc,                /* [77] Touch Sense Controller global interrupt */
+    (void*) (0UL),                  /* [78] Reserved */
+    (void*) (0UL),                  /* [79] Reserved*/
+    (void*) isr_rng,                /* [80] RNG global interrupt */
+    (void*) isr_fpu,                /* [81] FPU global interrupt */
+    (void*) isr_crs                 /* [82] CRS global interrupt */
+#else /* CPU_MODEL_STM32L476RG */
+    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
+    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
+    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
+    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt */
+    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
+    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
+    (void*) isr_usart1,             /* [37] USART1 global Interrupt */
+    (void*) isr_usart2,             /* [38] USART2 global Interrupt */
+    (void*) isr_usart3,             /* [39] USART3 global Interrupt */
+    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
+    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line Interrupt */
+    (void*) isr_dfsdm1_flt3,        /* [42] DFSDM1 Filter 3 global Interrupt */
+    (void*) isr_tim8_brk,           /* [43] TIM8 Break Interrupt */
+    (void*) isr_tim8_up,            /* [44] TIM8 Update Interrupt */
+    (void*) isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
+    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
+    (void*) isr_adc3,               /* [47] ADC3 global  Interrupt */
+    (void*) isr_fmc,                /* [48] FMC global Interrupt */
+    (void*) isr_sdmmc1,             /* [49] SDMMC1 global Interrupt */
+    (void*) isr_tim5,               /* [50] TIM5 global Interrupt */
+    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
+    (void*) isr_uart4,              /* [52] UART4 global Interrupt */
+    (void*) isr_uart5,              /* [53] UART5 global Interrupt */
+    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC1&2 underrun error interrupts */
+    (void*) isr_tim7,               /* [55] TIM7 global interrupt */
+    (void*) isr_dma2_channel1,      /* [56] DMA2 Channel 1 global Interrupt */
+    (void*) isr_dma2_channel2,      /* [57] DMA2 Channel 2 global Interrupt */
+    (void*) isr_dma2_channel3,      /* [58] DMA2 Channel 3 global Interrupt */
+    (void*) isr_dma2_channel4,      /* [59] DMA2 Channel 4 global Interrupt */
+    (void*) isr_dma2_channel5,      /* [60] DMA2 Channel 5 global Interrupt */
+    (void*) isr_dfsdm1_flt0,        /* [61] DFSDM1 Filter 0 global Interrupt */
+    (void*) isr_dfsdm1_flt1,        /* [62] DFSDM1 Filter 1 global Interrupt */
+    (void*) isr_dfsdm1_flt2,        /* [63] DFSDM1 Filter 2 global Interrupt */
+    (void*) isr_comp,               /* [64] COMP1 and COMP2 Interrupts */
+    (void*) isr_lptim1,             /* [65] LP TIM1 interrupt */
+    (void*) isr_lptim2,             /* [66] LP TIM2 interrupt */
+    (void*) isr_otg_fs,             /* [67] USB OTG FS global Interrupt */
+    (void*) isr_dma2_channel6,      /* [68] DMA2 Channel 6 global interrupt */
+    (void*) isr_dma2_channel7,      /* [69] DMA2 Channel 7 global interrupt */
+    (void*) isr_lpuart1,            /* [70] LP UART1 interrupt */
+    (void*) isr_quadspi,            /* [71] Quad SPI global interrupt */
+    (void*) isr_i2c3_ev,            /* [72] I2C3 event interrupt */
+    (void*) isr_i2c3_er,            /* [73] I2C3 error interrupt */
+    (void*) isr_sai1,               /* [74] Serial Audio Interface 1 global interrupt */
+    (void*) isr_sai2,               /* [75] Serial Audio Interface 2 global interrupt */
+    (void*) isr_swpmi1,             /* [76] Serial Wire Interface 1 global interrupt */
+    (void*) isr_tsc,                /* [77] Touch Sense Controller global interrupt */
+    (void*) isr_lcd,                /* [78] LCD global interrupt */
+    (void*) (0UL),                  /* [79] Reserved*/
+    (void*) isr_rng,                /* [80] RNG global interrupt */
+    (void*) isr_fpu                 /* [81] FPU global interrupt */
 #endif
 };


### PR DESCRIPTION
After doing this for stm32f7 family in #6991, I though it would be nice to do it for the others family.

The strategy is the same:
* I split isr definitions for each cpu type, trying to keep the `vectors.c` as readable as possible.
```c
#if defined(CPU_MODEL_STM32FXXX)
...
(void*) isr_xxx,  /* [i] interrupt comment*/
...
#eilf defined(CPU_MODEL_STM32FYYY)
...
(void*) isr_jjj,  /* [j] interrupt comment*/
...
```
* Added comments for each line with the interrupt number: this simplify readability, I think and hence maintainability

While working on this, some issues were fixed:
* wrong number of IRQ for some cpus
* isr not defined, or defined whereas not available (I don't have the full list but there quite a few in this case)

Boards/CPU to test (feel free to add any missing ones):
- F0:
 - [x] Nucleo 32 F031 (@aabadie)
 - [x] Nucleo 32 F042 (@aabadie)
 - [ ] Nucleo 64 F030 (@aabadie)
 - [x] Nucleo 64 F070 (@aabadie)
 - [x] Nucleo 64 F072 (@aabadie)
 - [x] Nucleo 64 F091 (@aabadie)
 - [x] stm32f0discovery (@haukepetersen)
- F1:
 - [x] Nucleo 64 F103 (@aabadie)
 - [x] iotlab-m3
- F2:
 - [x] Nucleo 144 F207 (@aabadie)
- F3:
 - [x] Nucleo 32 F303 (@aabadie)
 - [x] Nucleo 64 F302 (@aabadie)
 - [x] Nucleo 64 F303 (@aabadie)
 - [x] Nucleo 64 F334 (@aabadie)
 - [x] Nucleo 144 F303 (@aabadie)
 - [x] stm32f3discovery (@haukepetersen)
- F4:
 - [x] Nucleo 64 F401 (@vincent-d)
 - [x] Nucleo 64 F410 (@aabadie)
 - [x] Nucleo 64 F411 (@aabadie)
 - [x] Nucleo 64 F446 (@aabadie)
 - [x] Nucleo 144 F412 (@aabadie)
 - [x] Nucleo 144 F413 (@vincent-d)
 - [x] Nucleo 144 F429 (@aabadie)
 - [x] Nucleo 144 F446 (@aabadie)
 - [x] stm32f4discovery (@haukepetersen)
- L0:
 - [ ] Nucleo 32 L031 (@aabadie) (seems broken on master)
 - [x] Nucleo 64 L053 (@aabadie) ~~shell broken~~ fixed
 - [x] Nucleo 64 L073 (@aabadie)
 - [x] b-l072z-lrwan1 (@aabadie)
- L1:
 - [x] Nucleo 64 L152 (@aabadie)
 - [ ] nz32-sc151 (@aabadie)
- L4:
 - [x] Nucleo 32 L432 (@aabadie)
 - [x] Nucleo 64 L476 (@aabadie)
- F7:
 - [ ] Nucleo 144 F722 (@aabadie)
 - [x] Nucleo 144 F746
 - [x] Nucleo 144 F767 (@aabadie)