### PR TITLE
stm32: unified and renamed stmclk_dbp functions

### DIFF
--- a/cpu/stm32_common/include/stmclk.h
+++ b/cpu/stm32_common/include/stmclk.h
@@ -77,12 +77,12 @@ void stmclk_disable_lfclk(void);
 /**
  * @brief   Unlock write access to the backup domain control
  */
-void stmclk_bdp_unlock(void);
+void stmclk_dbp_unlock(void);
 
 /**
  * @brief   Lock write access to backup control domain
  */
-void stmclk_bdp_lock(void);
+void stmclk_dbp_lock(void);
 
 #ifdef __cplusplus
 }

--- a/cpu/stm32_common/stmclk_common.c
+++ b/cpu/stm32_common/stmclk_common.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *               2017 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32_common
+ * @{
+ *
+ * @file
+ * @brief       Implementation of common STM32 clock configuration functions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ * @}
+ */
+
+#include "periph_cpu.h"
+
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)
+#define REG_PWR_CR          CR1
+#define BIT_CR_DBP          PWR_CR1_DBP
+#else
+#define REG_PWR_CR          CR
+#define BIT_CR_DBP          PWR_CR_DBP
+#endif
+
+#if defined (CPU_FAM_STM32L4)
+#define BIT_APB_PWREN       RCC_APB1ENR1_PWREN
+#else
+#define BIT_APB_PWREN       RCC_APB1ENR_PWREN
+#endif
+
+void stmclk_dbp_unlock(void)
+{
+    periph_clk_en(APB1, BIT_APB_PWREN);
+    PWR->REG_PWR_CR |= BIT_CR_DBP;
+}
+
+void stmclk_dbp_lock(void)
+{
+    PWR->REG_PWR_CR &= ~(BIT_CR_DBP);
+    periph_clk_dis(APB1, BIT_APB_PWREN);
+}

--- a/cpu/stm32_common/stmclk_common.c
+++ b/cpu/stm32_common/stmclk_common.c
@@ -46,3 +46,27 @@ void stmclk_dbp_lock(void)
     PWR->REG_PWR_CR &= ~(BIT_CR_DBP);
     periph_clk_dis(APB1, BIT_APB_PWREN);
 }
+
+void stmclk_enable_lfclk(void)
+{
+#if CLOCK_LSE
+    stmclk_dbp_unlock();
+    RCC->BDCR |= RCC_BDCR_LSEON;
+    while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
+    stmclk_dbp_lock();
+#else
+    RCC->CSR |= RCC_CSR_LSION;
+    while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
+#endif
+}
+
+void stmclk_disable_lfclk(void)
+{
+#if CLOCK_LSE
+    stmclk_dbp_unlock();
+    RCC->BDCR &= ~(RCC_BDCR_LSEON);
+    stmclk_dbp_lock();
+#else
+    RCC->CSR &= ~(RCC_CSR_LSION);
+#endif
+}

--- a/cpu/stm32f1/stmclk.c
+++ b/cpu/stm32f1/stmclk.c
@@ -175,10 +175,10 @@ void stmclk_disable_hsi(void)
 void stmclk_enable_lfclk(void)
 {
 #if CLOCK_LSE
-    stmclk_bdp_unlock();
+    stmclk_dbp_unlock();
     RCC->BDCR |= RCC_BDCR_LSEON;
     while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
-    stmclk_bdp_lock();
+    stmclk_dbp_lock();
 #else
     RCC->CSR |= RCC_CSR_LSION;
     while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
@@ -188,22 +188,10 @@ void stmclk_enable_lfclk(void)
 void stmclk_disable_lfclk(void)
 {
 #if CLOCK_LSE
-    stmclk_bdp_unlock();
+    stmclk_dbp_unlock();
     RCC->BDCR &= ~(RCC_BDCR_LSEON);
-    stmclk_bdp_lock();
+    stmclk_dbp_lock();
 #else
     RCC->CSR &= ~(RCC_CSR_LSION);
 #endif
-}
-
-void stmclk_bdp_unlock(void)
-{
-    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-    PWR->CR |= PWR_CR_DBP;
-}
-
-void stmclk_bdp_lock(void)
-{
-    PWR->CR &= ~(PWR_CR_DBP);
-    periph_clk_dis(APB1, RCC_APB1ENR_PWREN);
 }

--- a/cpu/stm32f1/stmclk.c
+++ b/cpu/stm32f1/stmclk.c
@@ -171,27 +171,3 @@ void stmclk_disable_hsi(void)
     }
 #endif
 }
-
-void stmclk_enable_lfclk(void)
-{
-#if CLOCK_LSE
-    stmclk_dbp_unlock();
-    RCC->BDCR |= RCC_BDCR_LSEON;
-    while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
-    stmclk_dbp_lock();
-#else
-    RCC->CSR |= RCC_CSR_LSION;
-    while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
-#endif
-}
-
-void stmclk_disable_lfclk(void)
-{
-#if CLOCK_LSE
-    stmclk_dbp_unlock();
-    RCC->BDCR &= ~(RCC_BDCR_LSEON);
-    stmclk_dbp_lock();
-#else
-    RCC->CSR &= ~(RCC_CSR_LSION);
-#endif
-}

--- a/cpu/stm32f2/stmclk.c
+++ b/cpu/stm32f2/stmclk.c
@@ -164,12 +164,12 @@ void stmclk_enable_lfclk(void)
     /* configure the low speed clock domain (LSE vs LSI) */
 #if CLOCK_LSE
     /* allow write access to backup domain */
-    stmclk_bdp_unlock();
+    stmclk_dbp_unlock();
     /* enable LSE */
     RCC->BDCR |= RCC_BDCR_LSEON;
     while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
     /* disable write access to back domain when done */
-    stmclk_bdp_lock();
+    stmclk_dbp_lock();
 #else
     RCC->CSR |= RCC_CSR_LSION;
     while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
@@ -179,22 +179,10 @@ void stmclk_enable_lfclk(void)
 void stmclk_disable_lfclk(void)
 {
 #if CLOCK_LSE
-    stmclk_bdp_unlock();
+    stmclk_dbp_unlock();
     RCC->BDCR &= ~(RCC_BDCR_LSEON);
-    stmclk_bdp_lock();
+    stmclk_dbp_lock();
 #else
     RCC->CSR &= ~(RCC_CSR_LSION);
 #endif
-}
-
-void stmclk_bdp_unlock(void)
-{
-    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-    PWR->CR |= PWR_CR_DBP;
-}
-
-void stmclk_bdp_lock(void)
-{
-    PWR->CR &= ~(PWR_CR_DBP);
-    periph_clk_dis(APB1, RCC_APB1ENR_PWREN);
 }

--- a/cpu/stm32f2/stmclk.c
+++ b/cpu/stm32f2/stmclk.c
@@ -158,31 +158,3 @@ void stmclk_disable_hsi(void)
         RCC->CR &= ~(RCC_CR_HSION);
     }
 }
-
-void stmclk_enable_lfclk(void)
-{
-    /* configure the low speed clock domain (LSE vs LSI) */
-#if CLOCK_LSE
-    /* allow write access to backup domain */
-    stmclk_dbp_unlock();
-    /* enable LSE */
-    RCC->BDCR |= RCC_BDCR_LSEON;
-    while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
-    /* disable write access to back domain when done */
-    stmclk_dbp_lock();
-#else
-    RCC->CSR |= RCC_CSR_LSION;
-    while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
-#endif
-}
-
-void stmclk_disable_lfclk(void)
-{
-#if CLOCK_LSE
-    stmclk_dbp_unlock();
-    RCC->BDCR &= ~(RCC_BDCR_LSEON);
-    stmclk_dbp_lock();
-#else
-    RCC->CSR &= ~(RCC_CSR_LSION);
-#endif
-}

--- a/cpu/stm32f4/stmclk.c
+++ b/cpu/stm32f4/stmclk.c
@@ -141,12 +141,12 @@ void stmclk_enable_lfclk(void)
     /* configure the low speed clock domain (LSE vs LSI) */
 #if CLOCK_LSE
     /* allow write access to backup domain */
-    stmclk_bdp_unlock();
+    stmclk_dbp_unlock();
     /* enable LSE */
     RCC->BDCR |= RCC_BDCR_LSEON;
     while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
     /* disable write access to back domain when done */
-    stmclk_bdp_lock();
+    stmclk_dbp_lock();
 #else
     RCC->CSR |= RCC_CSR_LSION;
     while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
@@ -156,22 +156,10 @@ void stmclk_enable_lfclk(void)
 void stmclk_disable_lfclk(void)
 {
 #if CLOCK_LSE
-    stmclk_bdp_unlock();
+    stmclk_dbp_unlock();
     RCC->BDCR &= ~(RCC_BDCR_LSEON);
-    stmclk_bdp_lock();
+    stmclk_dbp_lock();
 #else
     RCC->CSR &= ~(RCC_CSR_LSION);
 #endif
-}
-
-void stmclk_bdp_unlock(void)
-{
-    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-    PWR->CR |= PWR_CR_DBP;
-}
-
-void stmclk_bdp_lock(void)
-{
-    PWR->CR &= ~(PWR_CR_DBP);
-    periph_clk_dis(APB1, RCC_APB1ENR_PWREN);
 }

--- a/cpu/stm32f4/stmclk.c
+++ b/cpu/stm32f4/stmclk.c
@@ -135,31 +135,3 @@ void stmclk_disable_hsi(void)
         RCC->CR &= ~(RCC_CR_HSION);
     }
 }
-
-void stmclk_enable_lfclk(void)
-{
-    /* configure the low speed clock domain (LSE vs LSI) */
-#if CLOCK_LSE
-    /* allow write access to backup domain */
-    stmclk_dbp_unlock();
-    /* enable LSE */
-    RCC->BDCR |= RCC_BDCR_LSEON;
-    while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
-    /* disable write access to back domain when done */
-    stmclk_dbp_lock();
-#else
-    RCC->CSR |= RCC_CSR_LSION;
-    while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
-#endif
-}
-
-void stmclk_disable_lfclk(void)
-{
-#if CLOCK_LSE
-    stmclk_dbp_unlock();
-    RCC->BDCR &= ~(RCC_BDCR_LSEON);
-    stmclk_dbp_lock();
-#else
-    RCC->CSR &= ~(RCC_CSR_LSION);
-#endif
-}

--- a/cpu/stm32f7/stmclk.c
+++ b/cpu/stm32f7/stmclk.c
@@ -134,12 +134,12 @@ void stmclk_enable_lfclk(void)
     /* configure the low speed clock domain (LSE vs LSI) */
 #if CLOCK_LSE
     /* allow write access to backup domain */
-    stmclk_bdp_unlock();
+    stmclk_dbp_unlock();
     /* enable LSE */
     RCC->BDCR |= RCC_BDCR_LSEON;
     while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
     /* disable write access to back domain when done */
-    stmclk_bdp_lock();
+    stmclk_dbp_lock();
 #else
     RCC->CSR |= RCC_CSR_LSION;
     while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
@@ -149,22 +149,10 @@ void stmclk_enable_lfclk(void)
 void stmclk_disable_lfclk(void)
 {
 #if CLOCK_LSE
-    stmclk_bdp_unlock();
+    stmclk_dbp_unlock();
     RCC->BDCR &= ~(RCC_BDCR_LSEON);
-    stmclk_bdp_lock();
+    stmclk_dbp_lock();
 #else
     RCC->CSR &= ~(RCC_CSR_LSION);
 #endif
-}
-
-void stmclk_bdp_unlock(void)
-{
-    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
-    PWR->CR1 |= PWR_CR1_DBP;
-}
-
-void stmclk_bdp_lock(void)
-{
-    PWR->CR1 &= ~(PWR_CR1_DBP);
-    periph_clk_dis(APB1, RCC_APB1ENR_PWREN);
 }

--- a/cpu/stm32f7/stmclk.c
+++ b/cpu/stm32f7/stmclk.c
@@ -128,31 +128,3 @@ void stmclk_disable_hsi(void)
         RCC->CR &= ~(RCC_CR_HSION);
     }
 }
-
-void stmclk_enable_lfclk(void)
-{
-    /* configure the low speed clock domain (LSE vs LSI) */
-#if CLOCK_LSE
-    /* allow write access to backup domain */
-    stmclk_dbp_unlock();
-    /* enable LSE */
-    RCC->BDCR |= RCC_BDCR_LSEON;
-    while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
-    /* disable write access to back domain when done */
-    stmclk_dbp_lock();
-#else
-    RCC->CSR |= RCC_CSR_LSION;
-    while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
-#endif
-}
-
-void stmclk_disable_lfclk(void)
-{
-#if CLOCK_LSE
-    stmclk_dbp_unlock();
-    RCC->BDCR &= ~(RCC_BDCR_LSEON);
-    stmclk_dbp_lock();
-#else
-    RCC->CSR &= ~(RCC_CSR_LSION);
-#endif
-}


### PR DESCRIPTION
This PR is a small step towards closing #7123. It is also taking a small part out of #7477.

I figured it easier to take this in small and simple steps, so that we can use #7477 to focus on the 'hard' part of implementing `stmclk_init_sysclk()` function.

In this PR:
- stmclk_dbp_x() functions now work for all STM32s
- renamed from bdp to dbp as this is the expression used in the reference manuals (old naming was a typo...)