### PR TITLE
[SAMR21] fix samr21 uart driver

### DIFF
--- a/cpu/samd21/periph/uart.c
+++ b/cpu/samd21/periph/uart.c
@@ -26,6 +26,7 @@
 #include "periph/uart.h"
 #include "periph/gpio.h"
 
+#ifdef UART_NUMOF
 /**
  * @brief   Allocate memory to store the callback functions
  */
@@ -184,4 +185,5 @@ void UART_5_ISR(void)
 {
     irq_handler(5);
 }
+#endif
 #endif


### PR DESCRIPTION
UART driver should be included only if UART_NUMOF is larger than 0.