### PR TITLE
.gitignore: Add scan-build to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Makefile.local
 
 # Ignore download cache
 .dlcache
+
+# scan-build artifacts
+scan-build/


### PR DESCRIPTION
A directory named scan-build is generated when running `make scan-build` in any RIOT application directory.