### PR TITLE
RPL: API update suggestions

### DIFF
--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -237,12 +237,34 @@ struct gnrc_rpl_parent {
  */
 typedef struct {
     uint16_t ocp;   /**< objective code point */
-    uint16_t (*calc_rank)(gnrc_rpl_parent_t *parent, uint16_t base_rank); /**< calculate the rank */
+
+    /**
+     * @brief Calculate the rank of this node.
+     *
+     * @param[in]   dodag       RPL DODAG to calculate rank from.
+     * @param[in]   base_rank   BASE_RANK parameter as in rfc6550
+     *
+     * @return      RPL Rank of this node.
+     * @return      GNRC_RPL_INFINITE_RANK, if no rank calculation is possible.
+     */
+    uint16_t (*calc_rank)(gnrc_rpl_dodag_t *dodag, uint16_t base_rank);
     gnrc_rpl_parent_t *(*which_parent)(gnrc_rpl_parent_t *, gnrc_rpl_parent_t *); /**< compare for parents */
     gnrc_rpl_dodag_t *(*which_dodag)(gnrc_rpl_dodag_t *, gnrc_rpl_dodag_t *); /**< compare for dodags */
-    void (*reset)(gnrc_rpl_dodag_t *);    /**< resets the OF */
+
+    /**
+     * @brief Reset the state of the objective function.
+     *
+     * @param[in]   dodag   RPL dodag object.
+     */
+    void (*reset)(gnrc_rpl_dodag_t *dodag);
     void (*parent_state_callback)(gnrc_rpl_parent_t *, int, int); /**< retrieves the state of a parent*/
-    void (*init)(void);  /**< OF specific init function */
+
+    /**
+     * @brief Initialize the objective function.
+     *
+     * @param[in]   dodag   RPL dodag object.
+     */
+    void (*init)(gnrc_rpl_dodag_t *dodag);  /**< OF specific init function */
     void (*process_dio)(void);  /**< DIO processing callback (acc. to OF0 spec, chpt 5) */
 } gnrc_rpl_of_t;
 


### PR DESCRIPTION
While implementing #7450 I've noticed some issues with the objective functions API. This pull request has some suggestions while documenting those suggestions. For now I've only updated the header file, since I first want to focus on these changes and then implement them with the RLP and the of0 code.

I would suggest changing the `calc_rank` to have a pointer to the dodag as a parameter. This because the dodag is often needed here, mainly when the rank doesn't depend only on the preferred parent, but for example on a larger parent set.

I've added a pointer to the dodag in the `init` function. This way actual dodag-specific parameters could be initialized. For example, with MRHOF, a pointer to the neighbor statistics struct could be initialized. Without DODAG information, the network information is unknown making it impossible to get the correct pointer.

I would suggest removing the `which_parent` function as soon as #7468 is merged since it is obsolete then.

I don't know whether the `which_dodag`, the `parent_state_callback` and the `process_dio` are still useful, so I did not touch them.