### PR TITLE
cpu: fix missing doxygen group definitions + cleanup

### DIFF
--- a/cpu/mips_pic32mx/include/cpu.h
+++ b/cpu/mips_pic32mx/include/cpu.h
@@ -11,11 +11,11 @@
 /**
  * @defgroup    cpu_mips_pic32mx MIPS PIC32MX
  * @ingroup     cpu
- * @brief       main CPU definitions for pic32mx devices.
+ * @brief       CPU definitions for pic32mx devices.
  * @{
  *
  * @file
- * @brief       main CPU definitions for pic32mx devices.
+ * @brief       CPU definitions for pic32mx devices.
  *
  * @author      Neil Jones <neil.jones@imgtec.com>
  */

--- a/cpu/mips_pic32mz/include/cpu.h
+++ b/cpu/mips_pic32mz/include/cpu.h
@@ -11,10 +11,11 @@
 /**
  * @defgroup    cpu_mips_pic32mz MIPS PIC32MZ
  * @ingroup     cpu
+ * @brief       CPU definitions for pic32mz devices.
  * @{
  *
  * @file
- * @brief       main CPU definitions for pic32mz devices.
+ * @brief       CPU definitions for pic32mz devices.
  *
  * @author      Neil Jones <neil.jones@imgtec.com>
  */

--- a/cpu/sam0_common/doc.txt
+++ b/cpu/sam0_common/doc.txt
@@ -1,0 +1,8 @@
+/**
+ * @defgroup        cpu_sam0_common Atmel SAM0 common
+ * @ingroup         cpu
+ * @brief           Atmel SAM0 common
+ *
+ * This module contains all common code and definition to all Atmel SAM0 cpu
+ * families supported by RIOT: @ref cpu_samd21, @ref cpu_saml21.
+ */

--- a/cpu/sam0_common/include/cpu_conf.h
+++ b/cpu/sam0_common/include/cpu_conf.h
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup         cpu_sam0_common
+ * @brief           Implementation specific CPU configuration options
  * @{
  *
  * @file

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup         cpu_sam0_common
+ * @brief           Common CPU specific definitions for all SAMx21 based CPUs
  * @{
  *
  * @file

--- a/cpu/samd21/doc.txt
+++ b/cpu/samd21/doc.txt
@@ -1,0 +1,9 @@
+/**
+ * @defgroup        cpu_samd21 Atmel SAMD21
+ * @ingroup         cpu
+ * @brief           Atmel SAMD21 Cortex-M0 MCU specific implementation.
+ *
+ * This module contains Atmel SAMD21 specific code and definition.
+ *
+ * @see cpu_sam0_common
+ */

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup         cpu_samd21
+ * @brief           CPU specific definitions for internal peripheral handling
  * @{
  *
  * @file

--- a/cpu/saml21/doc.txt
+++ b/cpu/saml21/doc.txt
@@ -1,0 +1,9 @@
+/**
+ * @defgroup        cpu_saml21 Atmel SAML21
+ * @ingroup         cpu
+ * @brief           Atmel SAML21 Cortex-M0 MCU specific implementation.
+ *
+ * This module contains Atmel SAML21 specific code and definition.
+ *
+ * @see cpu_sam0_common
+ */

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup         cpu_saml21
+ * @brief           CPU specific definitions for internal peripheral handling
  * @{
  *
  * @file

--- a/cpu/stm32_common/doc.txt
+++ b/cpu/stm32_common/doc.txt
@@ -1,0 +1,10 @@
+/**
+ * @defgroup        cpu_stm32_common STM32 common
+ * @ingroup         cpu
+ * @brief           STM32 common code and definitions
+ *
+ * This module contains all common code and definition to all STM32 cpu
+ * families supported by RIOT: @ref cpu_stm32f0, @ref cpu_stm32l0,
+ * @ref cpu_stm32f1, @ref cpu_stm32f2, @ref cpu_stm32f3, @ref cpu_stm32f4,
+ * @ref cpu_stm32l4, @ref cpu_stm32f7.
+ */


### PR DESCRIPTION
This PR fixes a few issues in the doxygen documentation:
* STM32 common, SAM0 common, SAMD21 and SAML21 groups were not defined so not appearing in the list of CPU
* MIPS MX and MZ were missing a brief description