### PR TITLE
drivers/lps331ap: add saul support for temperature sensor

### DIFF
--- a/drivers/lps331ap/lps331ap_saul.c
+++ b/drivers/lps331ap/lps331ap_saul.c
@@ -23,17 +23,31 @@
 #include "saul.h"
 #include "lps331ap.h"
 
-static int read(const void *dev, phydat_t *res)
+static int read_pres(const void *dev, phydat_t *res)
 {
     res->val[0] = (int16_t)lps331ap_read_pres((const lps331ap_t *)dev);
-    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_BAR;
     res->scale = -3;
     return 1;
 }
 
-const saul_driver_t lps331ap_saul_driver = {
-    .read = read,
+static int read_temp(const void *dev, phydat_t *res)
+{
+    res->val[0] = (int16_t)(lps331ap_read_temp((const lps331ap_t *)dev) / 10);
+    res->unit = UNIT_TEMP_C;
+    /* above division by ten leads to °C * 10^-2*/
+    res->scale = -2;
+    return 1;
+}
+
+const saul_driver_t lps331ap_saul_pres_driver = {
+    .read = read_pres,
     .write = saul_notsup,
     .type = SAUL_SENSE_PRESS,
+};
+
+const saul_driver_t lps331ap_saul_temp_driver = {
+    .read = read_temp,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TEMP,
 };

--- a/sys/auto_init/saul/auto_init_lps331ap.c
+++ b/sys/auto_init/saul/auto_init_lps331ap.c
@@ -39,12 +39,13 @@ static lps331ap_t lps331ap_devs[LPS331AP_NUM];
 /**
  * @brief   Memory for the SAUL registry entries
  */
-static saul_reg_t saul_entries[LPS331AP_NUM];
+static saul_reg_t saul_entries[LPS331AP_NUM * 2];
 
 /**
  * @brief   Reference the driver struct
  */
-extern saul_driver_t lps331ap_saul_driver;
+extern saul_driver_t lps331ap_saul_pres_driver;
+extern saul_driver_t lps331ap_saul_temp_driver;
 
 
 void auto_init_lps331ap(void)
@@ -62,8 +63,12 @@ void auto_init_lps331ap(void)
 
         saul_entries[i].dev = &(lps331ap_devs[i]);
         saul_entries[i].name = lps331ap_saul_info[i].name;
-        saul_entries[i].driver = &lps331ap_saul_driver;
+        saul_entries[i].driver = &lps331ap_saul_pres_driver;
         saul_reg_add(&(saul_entries[i]));
+        saul_entries[(i * 2) + 1].dev = &(lps331ap_devs[i]);
+        saul_entries[(i * 2) + 1].name = lps331ap_saul_info[i].name;
+        saul_entries[(i * 2) + 1].driver = &lps331ap_saul_temp_driver;
+        saul_reg_add(&(saul_entries[(i * 2) + 1]));
     }
 }
 


### PR DESCRIPTION
This PR adds SAUL support for the temperature sensor on the lps331ap. I'm a bit confused as it shows about 36°C (it doesn't feel so warm in here and neither I think it is so worm in the grenoble site of the IoTLab testbed). However that fact is independent from this PR as the actual driver implementation generates this value.