### PR TITLE
netdev: Make set() value parameter const void *

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -34,7 +34,7 @@
 #define _MAX_MHR_OVERHEAD   (25)
 
 static int  _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
-static int  _set(netdev_t *dev, netopt_t opt, void *value, size_t value_len);
+static int  _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len);
 static int  _send(netdev_t *netdev, const struct iovec *vector, unsigned count);
 static int  _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static void _isr(netdev_t *netdev);
@@ -148,7 +148,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     return -ENOTSUP;
 }
 
-static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
+static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_len)
 {
     cc2538_rf_t *dev = (cc2538_rf_t *)netdev;
     int res = -ENOTSUP;
@@ -163,7 +163,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
                 res = -EOVERFLOW;
             }
             else {
-                cc2538_set_addr_short(*((uint16_t*)value));
+                cc2538_set_addr_short(*((const uint16_t*)value));
             }
             break;
 
@@ -172,12 +172,12 @@ static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
                 res = -EOVERFLOW;
             }
             else {
-                cc2538_set_addr_long(*((uint64_t*)value));
+                cc2538_set_addr_long(*((const uint64_t*)value));
             }
             break;
 
         case NETOPT_AUTOACK:
-            RFCORE->XREG_FRMCTRL0bits.AUTOACK = ((bool *)value)[0];
+            RFCORE->XREG_FRMCTRL0bits.AUTOACK = ((const bool *)value)[0];
             res = sizeof(netopt_enable_t);
             break;
 
@@ -186,7 +186,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
                 res = -EINVAL;
             }
             else {
-                uint8_t chan = ((uint8_t *)value)[0];
+                uint8_t chan = ((const uint8_t *)value)[0];
                 if (chan < IEEE802154_CHANNEL_MIN ||
                     chan > IEEE802154_CHANNEL_MAX) {
                     res = -EINVAL;
@@ -200,7 +200,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
         case NETOPT_CHANNEL_PAGE:
             /* This tranceiver only supports page 0 */
             if (value_len != sizeof(uint16_t) ||
-                *((uint16_t *)value) != 0 ) {
+                *((const uint16_t *)value) != 0 ) {
                 res = -EINVAL;
             }
             else {
@@ -216,12 +216,12 @@ static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
                 res = -EOVERFLOW;
             }
             else {
-                cc2538_set_pan(*((uint16_t *)value));
+                cc2538_set_pan(*((const uint16_t *)value));
             }
             break;
 
         case NETOPT_PROMISCUOUSMODE:
-            cc2538_set_monitor(((bool *)value)[0]);
+            cc2538_set_monitor(((const bool *)value)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
@@ -229,7 +229,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
             if (value_len > sizeof(netopt_state_t)) {
                 return -EOVERFLOW;
             }
-            cc2538_set_state(dev, *((netopt_state_t *)value));
+            cc2538_set_state(dev, *((const netopt_state_t *)value));
             res = sizeof(netopt_state_t);
             break;
 
@@ -237,7 +237,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
             if (value_len > sizeof(int16_t)) {
                 return -EOVERFLOW;
             }
-            cc2538_set_tx_power(*((int16_t *)value));
+            cc2538_set_tx_power(*((const int16_t *)value));
             res = sizeof(uint16_t);
             break;
 

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -73,7 +73,7 @@ static inline void _get_mac_addr(netdev_t *netdev, uint8_t *dst)
     memcpy(dst, dev->addr, ETHERNET_ADDR_LEN);
 }
 
-static inline void _set_mac_addr(netdev_t *netdev, uint8_t *src)
+static inline void _set_mac_addr(netdev_t *netdev, const uint8_t *src)
 {
     netdev_tap_t *dev = (netdev_tap_t*)netdev;
     memcpy(dev->addr, src, ETHERNET_ADDR_LEN);
@@ -130,7 +130,7 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
     return res;
 }
 
-static int _set(netdev_t *dev, netopt_t opt, void *value, size_t value_len)
+static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len)
 {
     (void)value_len;
     int res = 0;
@@ -138,10 +138,10 @@ static int _set(netdev_t *dev, netopt_t opt, void *value, size_t value_len)
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(value_len >= ETHERNET_ADDR_LEN);
-            _set_mac_addr(dev, (uint8_t*)value);
+            _set_mac_addr(dev, (const uint8_t*)value);
             break;
         case NETOPT_PROMISCUOUSMODE:
-            _set_promiscous(dev, ((bool *)value)[0]);
+            _set_promiscous(dev, ((const bool *)value)[0]);
             break;
         default:
             res = netdev_eth_set(dev, opt, value, value_len);

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -509,31 +509,31 @@ static int nrfmin_get(netdev_t *dev, netopt_t opt, void *val, size_t max_len)
     }
 }
 
-static int nrfmin_set(netdev_t *dev, netopt_t opt, void *val, size_t len)
+static int nrfmin_set(netdev_t *dev, netopt_t opt, const void *val, size_t len)
 {
     (void)dev;
 
     switch (opt) {
         case NETOPT_CHANNEL:
             assert(len == sizeof(uint16_t));
-            return nrfmin_set_channel(*((uint16_t *)val));
+            return nrfmin_set_channel(*((const uint16_t *)val));
         case NETOPT_ADDRESS:
             assert(len == sizeof(uint16_t));
-            nrfmin_set_addr(*((uint16_t *)val));
+            nrfmin_set_addr(*((const uint16_t *)val));
             return sizeof(uint16_t);
         case NETOPT_ADDR_LEN:
         case NETOPT_SRC_LEN:
             assert(len == sizeof(uint16_t));
-            if (*((uint16_t *)val) != 2) {
+            if (*((const uint16_t *)val) != 2) {
                 return -EAFNOSUPPORT;
             }
             return sizeof(uint16_t);
         case NETOPT_STATE:
             assert(len == sizeof(netopt_state_t));
-            return nrfmin_set_state(*((netopt_state_t *)val));
+            return nrfmin_set_state(*((const netopt_state_t *)val));
         case NETOPT_TX_POWER:
             assert(len == sizeof(int16_t));
-            nrfmin_set_txpower(*((int16_t *)val));
+            nrfmin_set_txpower(*((const int16_t *)val));
             return sizeof(int16_t);
         default:
             return -ENOTSUP;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -45,7 +45,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len);
-static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len);
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len);
 
 const netdev_driver_t at86rf2xx_driver = {
     .send = _send,
@@ -347,7 +347,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
     return res;
 }
 
-static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
     at86rf2xx_t *dev = (at86rf2xx_t *) netdev;
     uint8_t old_state = at86rf2xx_get_status(dev);
@@ -368,22 +368,22 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(len <= sizeof(uint16_t));
-            at86rf2xx_set_addr_short(dev, *((uint16_t *)val));
+            at86rf2xx_set_addr_short(dev, *((const uint16_t *)val));
             /* don't set res to set netdev_ieee802154_t::short_addr */
             break;
         case NETOPT_ADDRESS_LONG:
             assert(len <= sizeof(uint64_t));
-            at86rf2xx_set_addr_long(dev, *((uint64_t *)val));
+            at86rf2xx_set_addr_long(dev, *((const uint64_t *)val));
             /* don't set res to set netdev_ieee802154_t::long_addr */
             break;
         case NETOPT_NID:
             assert(len <= sizeof(uint16_t));
-            at86rf2xx_set_pan(dev, *((uint16_t *)val));
+            at86rf2xx_set_pan(dev, *((const uint16_t *)val));
             /* don't set res to set netdev_ieee802154_t::pan */
             break;
         case NETOPT_CHANNEL:
             assert(len != sizeof(uint8_t));
-            uint8_t chan = ((uint8_t *)val)[0];
+            uint8_t chan = ((const uint8_t *)val)[0];
             if (chan < AT86RF2XX_MIN_CHANNEL ||
                 chan > AT86RF2XX_MAX_CHANNEL) {
                 res = -EINVAL;
@@ -395,7 +395,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
 
         case NETOPT_CHANNEL_PAGE:
             assert(len != sizeof(uint8_t));
-            uint8_t page = ((uint8_t *)val)[0];
+            uint8_t page = ((const uint8_t *)val)[0];
 #ifdef MODULE_AT86RF212B
             if ((page != 0) && (page != 2)) {
                 res = -EINVAL;
@@ -417,66 +417,66 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
 
         case NETOPT_TX_POWER:
             assert(len <= sizeof(int16_t));
-            at86rf2xx_set_txpower(dev, *((int16_t *)val));
+            at86rf2xx_set_txpower(dev, *((const int16_t *)val));
             res = sizeof(uint16_t);
             break;
 
         case NETOPT_STATE:
             assert(len <= sizeof(netopt_state_t));
-            res = _set_state(dev, *((netopt_state_t *)val));
+            res = _set_state(dev, *((const netopt_state_t *)val));
             break;
 
         case NETOPT_AUTOACK:
             at86rf2xx_set_option(dev, AT86RF2XX_OPT_AUTOACK,
-                                 ((bool *)val)[0]);
+                                 ((const bool *)val)[0]);
             /* don't set res to set netdev_ieee802154_t::flags */
             break;
 
         case NETOPT_RETRANS:
             assert(len <= sizeof(uint8_t));
-            at86rf2xx_set_max_retries(dev, *((uint8_t *)val));
+            at86rf2xx_set_max_retries(dev, *((const uint8_t *)val));
             res = sizeof(uint8_t);
             break;
 
         case NETOPT_PRELOADING:
             at86rf2xx_set_option(dev, AT86RF2XX_OPT_PRELOADING,
-                                 ((bool *)val)[0]);
+                                 ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_PROMISCUOUSMODE:
             at86rf2xx_set_option(dev, AT86RF2XX_OPT_PROMISCUOUS,
-                                 ((bool *)val)[0]);
+                                 ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_RX_START_IRQ:
             at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_START,
-                                 ((bool *)val)[0]);
+                                 ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_RX_END_IRQ:
             at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_END,
-                                 ((bool *)val)[0]);
+                                 ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_TX_START_IRQ:
             at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_TX_START,
-                                 ((bool *)val)[0]);
+                                 ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_TX_END_IRQ:
             at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_TX_END,
-                                 ((bool *)val)[0]);
+                                 ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_CSMA:
             at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA,
-                                 ((bool *)val)[0]);
+                                 ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
@@ -488,14 +488,14 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
                 res = -EINVAL;
             }
             else {
-                at86rf2xx_set_csma_max_retries(dev, *((uint8_t *)val));
+                at86rf2xx_set_csma_max_retries(dev, *((const uint8_t *)val));
                 res = sizeof(uint8_t);
             }
             break;
 
         case NETOPT_CCA_THRESHOLD:
             assert(len <= sizeof(int8_t));
-            at86rf2xx_set_cca_threshold(dev, *((int8_t *)val));
+            at86rf2xx_set_cca_threshold(dev, *((const int8_t *)val));
             res = sizeof(int8_t);
             break;
 

--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -121,14 +121,14 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t value_len)
     return -ENOTSUP;
 }
 
-static int _set(netdev_t *dev, netopt_t opt, void *value, size_t value_len)
+static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len)
 {
     cc110x_t *cc110x = &((netdev_cc110x_t*) dev)->cc110x;
 
     switch (opt) {
         case NETOPT_CHANNEL:
             {
-                uint8_t *arg = (uint8_t*)value;
+                const uint8_t *arg = value;
                 uint8_t channel = arg[value_len-1];
                 if ((channel < CC110X_MIN_CHANNR) || (channel > CC110X_MAX_CHANNR)) {
                     return -EINVAL;
@@ -142,7 +142,7 @@ static int _set(netdev_t *dev, netopt_t opt, void *value, size_t value_len)
             if (value_len < 1) {
                 return -EINVAL;
             }
-            if (!cc110x_set_address(cc110x, *(uint8_t*)value)) {
+            if (!cc110x_set_address(cc110x, *(const uint8_t*)value)) {
                 return -EINVAL;
             }
             return 1;

--- a/drivers/cc2420/cc2420_getset.c
+++ b/drivers/cc2420/cc2420_getset.c
@@ -64,7 +64,7 @@ void cc2420_get_addr_short(cc2420_t *dev, uint8_t *addr)
     addr[1] = tmp[0];
 }
 
-void cc2420_set_addr_short(cc2420_t *dev, uint8_t *addr)
+void cc2420_set_addr_short(cc2420_t *dev, const uint8_t *addr)
 {
     uint8_t tmp[2];
     tmp[0] = addr[1];
@@ -91,7 +91,7 @@ void cc2420_get_addr_long(cc2420_t *dev, uint8_t *addr)
     }
 }
 
-void cc2420_set_addr_long(cc2420_t *dev, uint8_t *addr)
+void cc2420_set_addr_long(cc2420_t *dev, const uint8_t *addr)
 {
     int i, j;
     uint8_t tmp[8];

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -44,7 +44,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len);
-static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len);
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len);
 
 const netdev_driver_t cc2420_driver = {
     .send = _send,
@@ -64,19 +64,19 @@ static void _irq_handler(void *arg)
     }
 }
 
-static inline uint16_t to_u16(void *buf)
+static inline uint16_t to_u16(const void *buf)
 {
-    return *((uint16_t *)buf);
+    return *((const uint16_t *)buf);
 }
 
-static inline int16_t to_i16(void *buf)
+static inline int16_t to_i16(const void *buf)
 {
-    return *((int16_t *)buf);
+    return *((const int16_t *)buf);
 }
 
-static inline bool to_bool(void *buf)
+static inline bool to_bool(const void *buf)
 {
-    return *((bool *)buf);
+    return *((const bool *)buf);
 }
 
 static inline int w_u16(void *buf, uint16_t val)
@@ -236,7 +236,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
     }
 }
 
-static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t val_len)
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t val_len)
 {
     if (netdev == NULL) {
         return -ENODEV;
@@ -249,12 +249,12 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t val_len)
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(val_len == 2);
-            cc2420_set_addr_short(dev, (uint8_t *)val);
+            cc2420_set_addr_short(dev, val);
             return 2;
 
         case NETOPT_ADDRESS_LONG:
             assert(val_len == 8);
-            cc2420_set_addr_long(dev, (uint8_t *)val);
+            cc2420_set_addr_long(dev, val);
             return 8;
 
         case NETOPT_NID:

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -458,7 +458,7 @@ static int nd_get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     }
 }
 
-static int nd_set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
+static int nd_set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_len)
 {
     enc28j60_t *dev = (enc28j60_t *)netdev;
 

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -154,7 +154,7 @@ void cc2420_get_addr_short(cc2420_t *dev, uint8_t *addr);
  * @param[in] dev           device to write to
  * @param[in] addr          (2-byte) short address to set
  */
-void cc2420_set_addr_short(cc2420_t *dev, uint8_t *addr);
+void cc2420_set_addr_short(cc2420_t *dev, const uint8_t *addr);
 
 /**
  * @brief   Get the configured long address of the given device
@@ -172,7 +172,7 @@ void cc2420_get_addr_long(cc2420_t *dev, uint8_t *addr_long);
  * @param[in] dev           device to write to
  * @param[in] addr_long     (8-byte) long address to set
  */
-void cc2420_set_addr_long(cc2420_t *dev, uint8_t *addr_long);
+void cc2420_set_addr_long(cc2420_t *dev, const uint8_t *addr_long);
 
 /**
  * @brief   Get the configured PAN ID of the given device

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -386,7 +386,7 @@ typedef struct netdev_driver {
      * @return              `< 0` on error, 0 on success
      */
     int (*set)(netdev_t *dev, netopt_t opt,
-               void *value, size_t value_len);
+               const void *value, size_t value_len);
 } netdev_driver_t;
 
 #ifdef __cplusplus

--- a/drivers/include/net/netdev/eth.h
+++ b/drivers/include/net/netdev/eth.h
@@ -56,7 +56,7 @@ int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
  * @return              number of bytes used from @p value
  * @return              <0 on error
  */
-int netdev_eth_set(netdev_t *dev, netopt_t opt, void *value, size_t value_len);
+int netdev_eth_set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -157,7 +157,7 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
  * @return              number of bytes used from @p value
  * @return              <0 on error
  */
-int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, void *value,
+int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *value,
                           size_t value_len);
 
 #ifdef __cplusplus

--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -339,7 +339,7 @@ int nrf24l01p_set_payload_width(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, char *saddr, unsigned int length);
+int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, const char *saddr, unsigned int length);
 
 /**
 * @brief Set the TX address for the nrf24l01+ transceiver (long int).
@@ -369,7 +369,7 @@ int nrf24l01p_set_tx_address_long(const nrf24l01p_t *dev, uint64_t saddr, unsign
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *saddr, unsigned int length);
+int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, const char *saddr, unsigned int length);
 
 /**
 * @brief Set the RX address for the nrf24l01+ transceiver (long int).

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -326,7 +326,7 @@ int _get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
     return netdev_ieee802154_get((netdev_ieee802154_t *)netdev, opt, value, len);
 }
 
-static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t len)
+static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t len)
 {
     kw2xrf_t *dev = (kw2xrf_t *)netdev;
     int res = -ENOTSUP;

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -44,7 +44,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len);
-static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len);
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len);
 
 const netdev_driver_t mrf24j40_driver = {
     .send = _send,
@@ -351,7 +351,7 @@ static int _set_state(mrf24j40_t *dev, netopt_state_t state)
     return sizeof(netopt_state_t);
 }
 
-static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
     mrf24j40_t *dev = (mrf24j40_t *) netdev;
     int res = -ENOTSUP;
@@ -366,7 +366,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
                 res = -EOVERFLOW;
             }
             else {
-                mrf24j40_set_addr_short(dev, *((uint16_t *)val));
+                mrf24j40_set_addr_short(dev, *((const uint16_t *)val));
                 /* don't set res to set netdev_ieee802154_t::short_addr */
             }
             break;
@@ -376,7 +376,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
                 res = -EOVERFLOW;
             }
             else {
-                mrf24j40_set_addr_long(dev, *((uint64_t *)val));
+                mrf24j40_set_addr_long(dev, *((const uint64_t *)val));
                 /* don't set res to set netdev_ieee802154_t::long_addr */
             }
             break;
@@ -386,7 +386,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
                 res = -EOVERFLOW;
             }
             else {
-                mrf24j40_set_pan(dev, *((uint16_t *)val));
+                mrf24j40_set_pan(dev, *((const uint16_t *)val));
                 /* don't set res to set netdev_ieee802154_t::pan */
             }
             break;
@@ -396,7 +396,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
                 res = -EINVAL;
             }
             else {
-                uint8_t chan = ((uint8_t *)val)[0];
+                uint8_t chan = ((const uint8_t *)val)[0];
                 if (chan < IEEE802154_CHANNEL_MIN ||
                     chan > IEEE802154_CHANNEL_MAX ||
                     dev->netdev.chan == chan) {
@@ -413,7 +413,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
                 res = -EINVAL;
             }
             else {
-                uint8_t page = ((uint8_t *)val)[0];
+                uint8_t page = ((const uint8_t *)val)[0];
 
                 /* mrf24j40 only supports page 0, no need to configure anything in the driver. */
                 if (page != 0) {
@@ -430,7 +430,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
                 res = -EOVERFLOW;
             }
             else {
-                mrf24j40_set_txpower(dev, *((int16_t *)val));
+                mrf24j40_set_txpower(dev, *((const int16_t *)val));
                 res = sizeof(uint16_t);
             }
             break;
@@ -440,66 +440,66 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
                 res = -EOVERFLOW;
             }
             else {
-                res = _set_state(dev, *((netopt_state_t *)val));
+                res = _set_state(dev, *((const netopt_state_t *)val));
             }
             break;
 
         case NETOPT_AUTOACK:
             mrf24j40_set_option(dev, NETDEV_IEEE802154_ACK_REQ,
-                                ((bool *)val)[0]);
+                                ((const bool *)val)[0]);
             /* don't set res to set netdev_ieee802154_t::flags */
             break;
 
         case NETOPT_PRELOADING:
             mrf24j40_set_option(dev, MRF24J40_OPT_PRELOADING,
-                                ((bool *)val)[0]);
+                                ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_PROMISCUOUSMODE:
             mrf24j40_set_option(dev, MRF24J40_OPT_PROMISCUOUS,
-                                ((bool *)val)[0]);
+                                ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_RX_START_IRQ:
             mrf24j40_set_option(dev, MRF24J40_OPT_TELL_RX_START,
-                                ((bool *)val)[0]);
+                                ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_RX_END_IRQ:
             mrf24j40_set_option(dev, MRF24J40_OPT_TELL_RX_END,
-                                ((bool *)val)[0]);
+                                ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_TX_START_IRQ:
             mrf24j40_set_option(dev, MRF24J40_OPT_TELL_TX_START,
-                                ((bool *)val)[0]);
+                                ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_TX_END_IRQ:
             mrf24j40_set_option(dev, MRF24J40_OPT_TELL_TX_END,
-                                ((bool *)val)[0]);
+                                ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_CSMA:
             mrf24j40_set_option(dev, MRF24J40_OPT_CSMA,
-                                ((bool *)val)[0]);
+                                ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_CSMA_RETRIES:
             if ((len > sizeof(uint8_t)) ||
-                (*((uint8_t *)val) > 5)) {
+                (*((const uint8_t *)val) > 5)) {
                 res = -EOVERFLOW;
             }
             else if (dev->netdev.flags & MRF24J40_OPT_CSMA) {
                 /* only set if CSMA is enabled */
-                mrf24j40_set_csma_max_retries(dev, *((uint8_t *)val));
+                mrf24j40_set_csma_max_retries(dev, *((const uint8_t *)val));
                 res = sizeof(uint8_t);
             }
             break;
@@ -509,7 +509,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
                 res = -EOVERFLOW;
             }
             else {
-                mrf24j40_set_cca_threshold(dev, *((int8_t *)val));
+                mrf24j40_set_cca_threshold(dev, *((const int8_t *)val));
                 res = sizeof(int8_t);
             }
             break;

--- a/drivers/netdev_eth/netdev_eth.c
+++ b/drivers/netdev_eth/netdev_eth.c
@@ -107,7 +107,7 @@ int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
     return res;
 }
 
-int netdev_eth_set(netdev_t *dev, netopt_t opt, void *value, size_t value_len)
+int netdev_eth_set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len)
 {
 #ifndef MODULE_L2FILTER
     (void)dev;

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -139,7 +139,7 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
     return res;
 }
 
-int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, void *value,
+int netdev_ieee802154_set(netdev_ieee802154_t *dev, netopt_t opt, const void *value,
                            size_t len)
 {
     int res = -ENOTSUP;

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -65,8 +65,8 @@ int nrf24l01p_write_reg(const nrf24l01p_t *dev, char reg, char write)
 int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq)
 {
     int status;
-    char INITIAL_TX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
-    char INITIAL_RX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
+    static const char INITIAL_TX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
+    static const char INITIAL_RX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
 
     dev->spi = spi;
     dev->ce = ce;
@@ -366,7 +366,7 @@ int nrf24l01p_set_payload_width(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe
 
 
 
-int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, char *saddr, unsigned int length)
+int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, const char *saddr, unsigned int length)
 {
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
@@ -430,7 +430,7 @@ uint64_t nrf24l01p_get_tx_address_long(const nrf24l01p_t *dev)
 }
 
 
-int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char *saddr, unsigned int length)
+int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, const char *saddr, unsigned int length)
 {
     char pipe_addr;
 

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -42,7 +42,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len);
-static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len);
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len);
 
 const netdev_driver_t sx127x_driver = {
     .send = _send,
@@ -344,7 +344,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
     return 0;
 }
 
-static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
     sx127x_t *dev = (sx127x_t*) netdev;
     int res = -ENOTSUP;
@@ -356,21 +356,21 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
     switch(opt) {
         case NETOPT_STATE:
             assert(len <= sizeof(netopt_state_t));
-            return _set_state(dev, *((netopt_state_t*) val));
+            return _set_state(dev, *((const netopt_state_t*) val));
 
         case NETOPT_DEVICE_MODE:
             assert(len <= sizeof(uint8_t));
-            sx127x_set_modem(dev, *((uint8_t*) val));
+            sx127x_set_modem(dev, *((const uint8_t*) val));
             return sizeof(netopt_enable_t);
 
         case NETOPT_CHANNEL:
             assert(len <= sizeof(uint32_t));
-            sx127x_set_channel(dev, *((uint32_t*) val));
+            sx127x_set_channel(dev, *((const uint32_t*) val));
             return sizeof(uint32_t);
 
         case NETOPT_BANDWIDTH:
             assert(len <= sizeof(uint8_t));
-            uint8_t bw = *((uint8_t *)val);
+            uint8_t bw = *((const uint8_t *)val);
             if (bw < SX127X_BW_125_KHZ ||
                 bw > SX127X_BW_500_KHZ) {
                 res = -EINVAL;
@@ -381,7 +381,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
 
         case NETOPT_SPREADING_FACTOR:
             assert(len <= sizeof(uint8_t));
-            uint8_t sf = *((uint8_t *)val);
+            uint8_t sf = *((const uint8_t *)val);
             if (sf < SX127X_SF6 ||
                 sf > SX127X_SF12) {
                 res = -EINVAL;
@@ -392,7 +392,7 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
 
         case NETOPT_CODING_RATE:
             assert(len <= sizeof(uint8_t));
-            uint8_t cr = *((uint8_t *)val);
+            uint8_t cr = *((const uint8_t *)val);
             if (cr < SX127X_CR_4_5 ||
                 cr > SX127X_CR_4_8) {
                 res = -EINVAL;
@@ -403,57 +403,57 @@ static int _set(netdev_t *netdev, netopt_t opt, void *val, size_t len)
 
         case NETOPT_MAX_PACKET_SIZE:
             assert(len <= sizeof(uint8_t));
-            sx127x_set_max_payload_len(dev, *((uint8_t*) val));
+            sx127x_set_max_payload_len(dev, *((const uint8_t*) val));
             return sizeof(uint8_t);
 
         case NETOPT_INTEGRITY_CHECK:
             assert(len <= sizeof(netopt_enable_t));
-            sx127x_set_crc(dev, *((netopt_enable_t*) val) ? true : false);
+            sx127x_set_crc(dev, *((const netopt_enable_t*) val) ? true : false);
             return sizeof(netopt_enable_t);
 
         case NETOPT_CHANNEL_HOP:
             assert(len <= sizeof(netopt_enable_t));
-            sx127x_set_freq_hop(dev, *((netopt_enable_t*) val) ? true : false);
+            sx127x_set_freq_hop(dev, *((const netopt_enable_t*) val) ? true : false);
             return sizeof(netopt_enable_t);
 
         case NETOPT_CHANNEL_HOP_PERIOD:
             assert(len <= sizeof(uint8_t));
-            sx127x_set_hop_period(dev, *((uint8_t*) val));
+            sx127x_set_hop_period(dev, *((const uint8_t*) val));
             return sizeof(uint8_t);
 
         case NETOPT_SINGLE_RECEIVE:
             assert(len <= sizeof(uint8_t));
-            sx127x_set_rx_single(dev, *((netopt_enable_t*) val) ? true : false);
+            sx127x_set_rx_single(dev, *((const netopt_enable_t*) val) ? true : false);
             return sizeof(netopt_enable_t);
 
         case NETOPT_RX_TIMEOUT:
             assert(len <= sizeof(uint32_t));
-            sx127x_set_rx_timeout(dev, *((uint32_t*) val));
+            sx127x_set_rx_timeout(dev, *((const uint32_t*) val));
             return sizeof(uint32_t);
 
         case NETOPT_TX_TIMEOUT:
             assert(len <= sizeof(uint32_t));
-            sx127x_set_tx_timeout(dev, *((uint32_t*) val));
+            sx127x_set_tx_timeout(dev, *((const uint32_t*) val));
             return sizeof(uint32_t);
 
         case NETOPT_TX_POWER:
             assert(len <= sizeof(uint8_t));
-            sx127x_set_tx_power(dev, *((uint8_t*) val));
+            sx127x_set_tx_power(dev, *((const uint8_t*) val));
             return sizeof(uint16_t);
 
         case NETOPT_FIXED_HEADER:
             assert(len <= sizeof(netopt_enable_t));
-            sx127x_set_fixed_header_len_mode(dev, *((netopt_enable_t*) val) ? true : false);
+            sx127x_set_fixed_header_len_mode(dev, *((const netopt_enable_t*) val) ? true : false);
             return sizeof(netopt_enable_t);
 
         case NETOPT_PREAMBLE_LENGTH:
             assert(len <= sizeof(uint16_t));
-            sx127x_set_preamble_length(dev, *((uint16_t*) val));
+            sx127x_set_preamble_length(dev, *((const uint16_t*) val));
             return sizeof(uint16_t);
 
         case NETOPT_IQ_INVERT:
             assert(len <= sizeof(netopt_enable_t));
-            sx127x_set_iq_invert(dev, *((netopt_enable_t*) val) ? true : false);
+            sx127x_set_iq_invert(dev, *((const netopt_enable_t*) val) ? true : false);
             return sizeof(bool);
 
         default:

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -277,7 +277,7 @@ static int _get_addr_long(xbee_t *dev, uint8_t *val, size_t len)
     return -ECANCELED;
 }
 
-static int _set_short_addr(xbee_t *dev, uint8_t *address)
+static int _set_short_addr(xbee_t *dev, const uint8_t *address)
 {
     uint8_t cmd[4];
     resp_t resp;
@@ -291,7 +291,7 @@ static int _set_short_addr(xbee_t *dev, uint8_t *address)
     return resp.status;
 }
 
-static int _set_addr(xbee_t *dev, uint8_t *val, size_t len)
+static int _set_addr(xbee_t *dev, const uint8_t *val, size_t len)
 {
     uint8_t addr[2];
 
@@ -320,7 +320,7 @@ static int _set_addr(xbee_t *dev, uint8_t *val, size_t len)
     return -ECANCELED;
 }
 
-static int _set_addr_len(xbee_t *dev, uint16_t *val, size_t len)
+static int _set_addr_len(xbee_t *dev, const uint16_t *val, size_t len)
 {
     if (len != sizeof(uint16_t)) {
         return -EOVERFLOW;
@@ -369,7 +369,7 @@ static int _get_channel(xbee_t *dev, uint8_t *val, size_t max)
     return -ECANCELED;
 }
 
-static int _set_channel(xbee_t *dev, uint8_t *val, size_t len)
+static int _set_channel(xbee_t *dev, const uint8_t *val, size_t len)
 {
     uint8_t cmd[3];
     resp_t resp;
@@ -406,7 +406,7 @@ static int _get_panid(xbee_t *dev, uint8_t *val, size_t max)
     return -ECANCELED;
 }
 
-static int _set_panid(xbee_t *dev, uint8_t *val, size_t len)
+static int _set_panid(xbee_t *dev, const uint8_t *val, size_t len)
 {
     uint8_t cmd[4];
     resp_t resp;
@@ -426,7 +426,7 @@ static int _set_panid(xbee_t *dev, uint8_t *val, size_t len)
 }
 
 #ifdef MODULE_XBEE_ENCRYPTION
-static int _set_encryption(xbee_t *dev, uint8_t *val)
+static int _set_encryption(xbee_t *dev, const uint8_t *val)
 {
     uint8_t cmd[3];
     resp_t resp;
@@ -448,7 +448,7 @@ static int _set_encryption(xbee_t *dev, uint8_t *val)
     return -ECANCELED;
 }
 
-static int _set_encryption_key(xbee_t *dev, uint8_t *val, size_t len)
+static int _set_encryption_key(xbee_t *dev, const uint8_t *val, size_t len)
 {
         uint8_t cmd[18];
         resp_t resp;
@@ -785,26 +785,26 @@ static int xbee_get(netdev_t *ndev, netopt_t opt, void *value, size_t max_len)
     }
 }
 
-static int xbee_set(netdev_t *ndev, netopt_t opt, void *value, size_t len)
+static int xbee_set(netdev_t *ndev, netopt_t opt, const void *value, size_t len)
 {
     xbee_t *dev = (xbee_t *)ndev;
     assert(dev);
 
     switch (opt) {
         case NETOPT_ADDRESS:
-            return _set_addr(dev, (uint8_t *)value, len);
+            return _set_addr(dev, value, len);
         case NETOPT_ADDR_LEN:
         case NETOPT_SRC_LEN:
             return _set_addr_len(dev, value, len);
         case NETOPT_CHANNEL:
-            return _set_channel(dev, (uint8_t *)value, len);
+            return _set_channel(dev, value, len);
         case NETOPT_NID:
-            return _set_panid(dev, (uint8_t *)value, len);
+            return _set_panid(dev, value, len);
 #ifdef MODULE_XBEE_ENCRYPTION
         case NETOPT_ENCRYPTION:
-            return _set_encryption(dev, (uint8_t *)value);
+            return _set_encryption(dev, value);
         case NETOPT_ENCRYPTION_KEY:
-            return _set_encryption_key(dev, (uint8_t *)value, len);
+            return _set_encryption_key(dev, value, len);
 #endif
         default:
             return -ENOTSUP;

--- a/sys/include/net/netdev_test.h
+++ b/sys/include/net/netdev_test.h
@@ -156,13 +156,13 @@ typedef int (*netdev_test_get_cb_t)(netdev_t *dev, void *value,
  * @brief   Callback type to handle set commands
  *
  * @param[in] dev       network device descriptor
- * @param[out] value    value to set
+ * @param[in] value     value to set
  * @param[in] value_len the length of @p value
  *
  * @return  number of bytes used from @p value
  * @return  <0 on error
  */
-typedef int (*netdev_test_set_cb_t)(netdev_t *dev, void *value,
+typedef int (*netdev_test_set_cb_t)(netdev_t *dev, const void *value,
                                     size_t value_len);
 
 /**

--- a/sys/net/netdev_test/netdev_test.c
+++ b/sys/net/netdev_test/netdev_test.c
@@ -24,7 +24,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *dev);
 static void _isr(netdev_t *dev);
 static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
-static int _set(netdev_t *dev, netopt_t opt, void *value, size_t value_len);
+static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len);
 
 static const netdev_driver_t _driver = {
     .send   = _send,
@@ -127,7 +127,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     return res;
 }
 
-static int _set(netdev_t *netdev, netopt_t opt, void *value, size_t value_len)
+static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_len)
 {
     netdev_test_t *dev = (netdev_test_t *)netdev;
     int res = -ENOTSUP;     /* option assumed to be not supported */

--- a/tests/netdev_test/main.c
+++ b/tests/netdev_test/main.c
@@ -64,7 +64,7 @@ static void _dev_isr(netdev_t *dev);
 static int _dev_recv(netdev_t *dev, char *buf, int len, void *info);
 static int _dev_send(netdev_t *dev, const struct iovec *vector, int count);
 static int _dev_get_addr(netdev_t *dev, void *value, size_t max_len);
-static int _dev_set_addr(netdev_t *dev, void *value, size_t max_len);
+static int _dev_set_addr(netdev_t *dev, const void *value, size_t max_len);
 
 /* tests getter */
 static int test_get_addr(void)
@@ -347,7 +347,7 @@ static int _dev_get_addr(netdev_t *dev, void *value, size_t max_len)
     return sizeof(_dev_addr);
 }
 
-static int _dev_set_addr(netdev_t *dev, void *value, size_t value_len)
+static int _dev_set_addr(netdev_t *dev, const void *value, size_t value_len)
 {
     (void)dev;
     if (value_len != sizeof(_dev_addr)) {


### PR DESCRIPTION
The value parameter for the set method on netdev drivers should not be writable.