### PR TITLE
doc: added LOSTANDFOUND.md

### DIFF
--- a/LOSTANDFOUND.md
+++ b/LOSTANDFOUND.md
@@ -1,0 +1,57 @@
+# Removed Features and Modules
+
+This document contains a listing of all features and modules that were removed
+from RIOT at some point in time, mostly due to missing maintenance. The purpose
+of this list is to have a reference point for reintegrating those features in
+the future, if new interest arises or a new maintainer is found.
+
+This list is **not** supposed to contain a change log of all the things that are
+being removed from RIOT, but it should contain only full modules that are
+removed without any alternative being merged at the same time. For example
+things like the first `netdev` should not be put in this list, as a successor
+(former `netdev2`) has been merged.
+
+
+## How to read this list
+
+For each high-level feature removed there should be one entry in this list. The
+entries should comply to the following template:
+
+~~~~~~~~~~~~~~~~~~~ {.md}
+### path/feature_name [HASH of removal commit]
+Author(s):
+- author 1 <foo.bar@abc.com>
+- author 2 <a.b@c.net>
+
+Reason for removal:
+- give a short and comprehensive argumentation why this feature was removed
+- typical reasons are:
+- feature is not maintained anymore
+- lack of hardware so feature can not be tested (anymore)
+- feature was never used and there is no reason for keeping it
+~~~~~~~~~~~~~~~~~~~
+
+By putting the name of the removed feature and the commit hash in the same line,
+one can very quickly find the commit using `get grep`.
+
+Listing the authors of the removed code is done for appreciation of their work.
+This way, there names are never removed from the RIOT repository.
+
+
+# Removed Features
+
+### boards/weio [cfa9580f319508f858c8fe30ecce8b2b59b6caa3]
+Author(s):
+- Paul Rathgeb <paul.rathgeb@skynet.be>
+
+Reason for removal:
+- hardware not available to the community for testing
+- original author and maintainer won't be able to maintain the code
+
+### cpu/lpc11u34 [7bc271807cecbffbb01a37c56a367b98fb823573]
+Author(s):
+- Paul Rathgeb <paul.rathgeb@skynet.be>
+
+Reason for removal:
+- hardware not available to the community for testing
+- original author and maintainer won't be able to maintain the code

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -765,7 +765,8 @@ INPUT                  = ../../doc.txt \
                          src/creating-modules.md \
                          src/creating-an-application.md \
                          src/getting-started.md \
-                         src/changelog.md
+                         src/changelog.md \
+                         ../../LOSTANDFOUND.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This PR completes #7511.

Once #7511 is merged, this PR is to be updated with the final merge commit hashes from #7511...

The `LOSTANDFOUND.md` file adds means to document (temporarily) removed features. The file contains a list of all modules/features that were removed for various reasons (typically: not maintained anymore), so that these can be reintegrated in a later point of time.