### PR TITLE
boards/samd21-based: fix xtimer configuration

### DIFF
--- a/boards/arduino-zero/include/board.h
+++ b/boards/arduino-zero/include/board.h
@@ -35,7 +35,7 @@ extern "C" {
  * @name    xtimer configuration
  * @{
  */
-#define XTIMER              TIMER_0
+#define XTIMER              TIMER_DEV(1)
 #define XTIMER_CHAN         (0)
 /** @} */
 

--- a/boards/samd21-xpro/include/board.h
+++ b/boards/samd21-xpro/include/board.h
@@ -37,7 +37,7 @@ extern "C" {
  * @name   xtimer configuration
  * @{
  */
-#define XTIMER_DEV          TIMER_1
+#define XTIMER_DEV          TIMER_DEV(1)
 #define XTIMER_CHAN         (0)
 /** @} */
 

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -35,7 +35,7 @@ extern "C" {
  * @name    xtimer configuration
  * @{
  */
-#define XTIMER_DEV          TIMER_1
+#define XTIMER_DEV          TIMER_DEV(1)
 #define XTIMER_CHAN         (0)
 /** @} */
 


### PR DESCRIPTION
The board's based on the `samd21` cpu use some `TIMER_0|1` define in their xtimer configuration. Actually I can't even tell, where this define comes from. Naturally, timer 1 should be defined using the`TIMER_DEV(x)` macro, so fixed in this PR.

Additionally, the configuration for the `arduino-zero` was broken: if `TIMER_DEV(0)` is used, the timer width would have to be redefined, so I take it that `TIMER_DEV(1)` was meant here...

Verified working on the `samr21-xpro`.