### PR TITLE
mrf24j40: Minor cleanup

### DIFF
--- a/drivers/mrf24j40/include/mrf24j40_internal.h
+++ b/drivers/mrf24j40/include/mrf24j40_internal.h
@@ -104,16 +104,6 @@ void mrf24j40_tx_normal_fifo_write(mrf24j40_t *dev, const uint16_t offset, const
 void mrf24j40_rx_fifo_read(mrf24j40_t *dev, const uint16_t offset, uint8_t *data, const size_t len);
 
 /**
- * @brief   Write a chunk of data into the RX_FIFO area of the given device
- *
- * @param[in] dev       device to write to
- * @param[in] offset    address in the RX FIFO to write to [valid 0x00-0x1ff]
- * @param[in] data      data to copy into FIFO
- * @param[in] len       number of bytes to write to FIFO
- */
-void mrf24j40_rx_fifo_write(mrf24j40_t *dev, const uint16_t offset, const uint8_t *data, const size_t len);
-
-/**
  * @brief   Reset the pending task list of a device
  *
  * @param[in] dev       device to reset tasks of

--- a/drivers/mrf24j40/include/mrf24j40_internal.h
+++ b/drivers/mrf24j40/include/mrf24j40_internal.h
@@ -74,16 +74,6 @@ uint8_t mrf24j40_reg_read_long(mrf24j40_t *dev, const uint16_t addr);
 void mrf24j40_reg_write_long(mrf24j40_t *dev, const uint16_t addr, const uint8_t value);
 
 /**
- * @brief   Read a chunk of data from the TX Normal FIFO area of the given device
- *
- * @param[in]  dev      device to read from
- * @param[in]  offset   starting address to read from [valid 0x00-0x1ff]
- * @param[out] data     buffer to read data into
- * @param[in]  len      number of bytes to read from FIFO
- */
-void mrf24j40_tx_normal_fifo_read(mrf24j40_t *dev, const uint16_t offset, uint8_t *data, const size_t len);
-
-/**
  * @brief   Write a chunk of data into the TX Normal FIFO area of the given device
  *
  * @param[in] dev       device to write to

--- a/drivers/mrf24j40/mrf24j40_internal.c
+++ b/drivers/mrf24j40/mrf24j40_internal.c
@@ -203,15 +203,6 @@ void mrf24j40_rx_fifo_read(mrf24j40_t *dev, const uint16_t offset, uint8_t *data
     spi_release(SPIDEV);
 }
 
-void mrf24j40_rx_fifo_write(mrf24j40_t *dev, const uint16_t offset, const uint8_t *data, const size_t len)
-{
-    uint16_t i;
-
-    for (i = 0; i < len; i++) {
-        mrf24j40_reg_write_long(dev, i, data[i]);
-    }
-}
-
 void mrf24j40_reset_tasks(mrf24j40_t *dev)
 {
     dev->pending = MRF24J40_TASK_TX_DONE;

--- a/drivers/mrf24j40/mrf24j40_internal.c
+++ b/drivers/mrf24j40/mrf24j40_internal.c
@@ -153,19 +153,6 @@ void mrf24j40_reg_write_long(mrf24j40_t *dev, const uint16_t addr, const uint8_t
     spi_release(SPIDEV);
 }
 
-void mrf24j40_tx_normal_fifo_read(mrf24j40_t *dev, const uint16_t offset, uint8_t *data, const size_t len)
-{
-    uint8_t reg1, reg2;
-
-    reg1 = MRF24J40_LONG_ADDR_TRANS | (offset >> 3);
-    reg2 = (offset << 5) | MRF24J40_ACCESS_READ;
-    getbus(dev);
-    spi_transfer_byte(SPIDEV, CSPIN, true, reg1);
-    spi_transfer_byte(SPIDEV, CSPIN, true, reg2);
-    spi_transfer_bytes(SPIDEV, CSPIN, false, NULL, (char *)data, len);
-    spi_release(SPIDEV);
-}
-
 void mrf24j40_tx_normal_fifo_write(mrf24j40_t *dev,
                                    const uint16_t offset,
                                    const uint8_t *data,

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -92,7 +92,7 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
     mrf24j40_tx_prepare(dev);
 
     /* load packet data into FIFO */
-    for (int i = 0; i < count; i++, ptr++) {
+    for (unsigned i = 0; i < count; i++, ptr++) {
         /* current packet data + FCS too long */
         if ((len + ptr->iov_len + 2) > IEEE802154_FRAME_LEN_MAX) {
             DEBUG("[mrf24j40] error: packet too large (%u byte) to be send\n",


### PR DESCRIPTION
- Removes the `rx_fifo_write` function since it is not used (and doesn't really make sense).
- changes an iterator to unsigned because it is compared to an unsigned variable.