### PR TITLE
boards/nrf51-based: share CLOCK_CORECLOCK define

### DIFF
--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -33,7 +33,6 @@
  *
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all nRF51822 */
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */

--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -32,7 +32,6 @@ extern "C" {
  *
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all nRF51822 */
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */

--- a/boards/microbit/include/periph_conf.h
+++ b/boards/microbit/include/periph_conf.h
@@ -32,7 +32,6 @@ extern "C" {
  *
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all nRF51822 */
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */

--- a/boards/nrf51dongle/include/periph_conf.h
+++ b/boards/nrf51dongle/include/periph_conf.h
@@ -32,7 +32,6 @@ extern "C" {
  *
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all nRF51822 */
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -35,7 +35,6 @@ extern "C" {
  *
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all nRF51822 */
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */

--- a/boards/pca10000/include/periph_conf.h
+++ b/boards/pca10000/include/periph_conf.h
@@ -34,7 +34,6 @@ extern "C" {
  *
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all nRF51822 */
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */

--- a/boards/pca10005/include/periph_conf.h
+++ b/boards/pca10005/include/periph_conf.h
@@ -34,7 +34,6 @@ extern "C" {
  *
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all nRF51822 */
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */

--- a/boards/yunjia-nrf51822/include/periph_conf.h
+++ b/boards/yunjia-nrf51822/include/periph_conf.h
@@ -32,7 +32,6 @@ extern "C" {
  *
  * @{
  */
-#define CLOCK_CORECLOCK     (16000000U)     /* fixed for all nRF51822 */
 #define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
                                                       16: 16MHz crystal
                                                       32: 32MHz crystal */

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -26,6 +26,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   System core clock speed, fixed to 16MHz for all NRF51x CPUs
+ */
+#define CLOCK_CORECLOCK     (16000000U)
+
+/**
  * @brief   Redefine some peripheral names to unify them between nRF51 and 52
  * @{
  */


### PR DESCRIPTION
All nRF51 CPUs have their core clock fixed to 16MHz, so no need to redefine this for each board...