### PR TITLE
doxygen: fix typo on word 'successfully'

### DIFF
--- a/cpu/atmega1281/include/cpu_conf.h
+++ b/cpu/atmega1281/include/cpu_conf.h
@@ -29,7 +29,7 @@ extern "C" {
  * @name Kernel configuration
  *
  * Since printf seems to get memory allocated by the linker/avr-libc the stack
- * size tested sucessfully even with pretty small stacks.
+ * size tested successfully even with pretty small stacks.
  * @{
  */
 #define THREAD_EXTRA_STACKSIZE_PRINTF    (128)

--- a/cpu/atmega2560/include/cpu_conf.h
+++ b/cpu/atmega2560/include/cpu_conf.h
@@ -30,7 +30,7 @@ extern "C" {
  * @name Kernel configuration
  *
  * Since printf seems to get memory allocated by the linker/avr-libc the stack
- * size tested sucessfully even with pretty small stacks.k
+ * size tested successfully even with pretty small stacks.k
  * @{
  */
 #define THREAD_EXTRA_STACKSIZE_PRINTF    (128)

--- a/cpu/atmega328p/include/cpu_conf.h
+++ b/cpu/atmega328p/include/cpu_conf.h
@@ -30,7 +30,7 @@ extern "C" {
  * @name Kernel configuration
  *
  * Since printf seems to get memory allocated by the linker/avr-libc the stack
- * size tested sucessfully even with pretty small stacks.k
+ * size tested successfully even with pretty small stacks.k
  * @{
  */
 #define THREAD_EXTRA_STACKSIZE_PRINTF    (128)

--- a/drivers/include/sdcard_spi.h
+++ b/drivers/include/sdcard_spi.h
@@ -188,7 +188,7 @@ struct {
     sdcard_spi_params_t params;     /**< parameters for pin and spi config */
     spi_clk_t spi_clk;              /**< active SPI clock speed */
     bool use_block_addr;            /**< true if block adressing (vs. byte adressing) is used */
-    bool init_done;                 /**< set to true once the init procedure completed sucessfully */
+    bool init_done;                 /**< set to true once the init procedure completed successfully */
     sd_version_t card_type;         /**< version of SD-card */
     int csd_structure;              /**< version of the CSD register structure */
     cid_t cid;                      /**< CID register */
@@ -228,7 +228,7 @@ int sdcard_spi_init(sdcard_spi_t *card, const sdcard_spi_params_t *params);
  * @param[out] state      Contains information about the error state if something went wrong
  *                        (if return value is lower than nblocks).
  *
- * @return                number of sucessfully read blocks (0 if no block was read).
+ * @return                number of successfully read blocks (0 if no block was read).
  */
 int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, char *data, int blocksize,
                            int nblocks, sd_rw_response_t *state);
@@ -250,7 +250,7 @@ int sdcard_spi_read_blocks(sdcard_spi_t *card, int blockaddr, char *data, int bl
  * @param[out] state      Contains information about the error state if something went wrong
  *                         (if return value is lower than nblocks).
  *
- * @return                number of sucessfully written blocks (0 if no block was written).
+ * @return                number of successfully written blocks (0 if no block was written).
  */
 int sdcard_spi_write_blocks(sdcard_spi_t *card, int blockaddr, const char *data, int blocksize,
                             int nblocks, sd_rw_response_t *state);

--- a/pkg/fatfs/fatfs_diskio/native/native_diskio.c
+++ b/pkg/fatfs/fatfs_diskio/native/native_diskio.c
@@ -86,7 +86,7 @@ DSTATUS disk_status(BYTE pdrv)
  * @param[in] pdrv  drive number to identify the drive
  *
  * @return          STA_NODISK if no disk exists with the given id
- * @return          0 if disk was initialized sucessfully
+ * @return          0 if disk was initialized successfully
  * @return          STA_NOINIT if disk id exists, but couldn't be initialized
  */
 DSTATUS disk_initialize(BYTE pdrv)

--- a/pkg/fatfs/fatfs_diskio/sdcard_spi/sdcard_spi_diskio.c
+++ b/pkg/fatfs/fatfs_diskio/sdcard_spi/sdcard_spi_diskio.c
@@ -74,7 +74,7 @@ DSTATUS disk_status(BYTE pdrv)
  * @param[in] pdrv  drive number to identify the drive
  *
  * @return          STA_NODISK if no disk exists with the given id
- * @return          0 if disk was initialized sucessfully
+ * @return          0 if disk was initialized successfully
  * @return          STA_NOINIT if disk id exists, but couldn't be initialized
  */
 DSTATUS disk_initialize(BYTE pdrv)


### PR DESCRIPTION
Found this typo while looking at some documentation. The same typo seems to happen in several places.

Should now be all fixed.