### PR TITLE
WIP: Native GPIO 

### DIFF
--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -34,9 +34,7 @@ static async_read_t pollers[ASYNC_READ_NUMOF];
 static void _sigio_child(int fd);
 
 static void _async_io_isr(void) {
-    int max_fd = 0;
-
-    if (real_poll(_fds, max_fd + 1, 0) > 0) {
+    if (real_poll(_fds, _next_index, 0) > 0) {
         for (int i = 0; i < _next_index; i++) {
             /* handle if one of the events has happened */
             if (_fds[i].revents & _fds[i].events) { 
@@ -61,7 +59,6 @@ void native_async_read_cleanup(void) {
 }
 
 void native_async_read_continue(int fd) {
-    (void) fd;
     for (int i = 0; i < _next_index; i++) {
         if (_fds[i].fd == fd && pollers[i].child_pid) {
             kill(pollers[i].child_pid, SIGCONT);
@@ -100,7 +97,7 @@ void native_async_read_add_handler(int fd, void *arg, native_async_read_callback
     _next_index++;
 }
 
-void native_async_read_add_int_handdler(int fd, void *arg, native_async_read_callback_t handler) {
+void native_async_read_add_int_handler(int fd, void *arg, native_async_read_callback_t handler) {
     if (_next_index >= ASYNC_READ_NUMOF) {
         err(EXIT_FAILURE, "native_async_read_add_handler(): too many callbacks");
     }

--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -37,7 +37,7 @@ static void _async_io_isr(void) {
     if (real_poll(_fds, _next_index, 0) > 0) {
         for (int i = 0; i < _next_index; i++) {
             /* handle if one of the events has happened */
-            if (_fds[i].revents & _fds[i].events) { 
+            if (_fds[i].revents & _fds[i].events) {
                 pollers[i].cb(_fds[i].fd, pollers[i].arg);
             }
         }

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -77,6 +77,16 @@ void native_async_read_continue(int fd);
  */
 void native_async_read_add_handler(int fd, void *arg, native_async_read_callback_t handler);
 
+/**
+ * @brief   start monitoring of file descriptor as interrupt
+ *
+ * @param[in] fd       The file descriptor to monitor
+ * @param[in] arg      Pointer to be passed as arguments to the callback
+ * @param[in] handler  The callback function to be called when the file
+ *                     descriptor is ready to read.
+ */
+void native_async_read_add_int_handler(int fd, void *arg, native_async_read_callback_t handler);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -37,11 +37,14 @@ extern "C" {
  */
 typedef void (*native_async_read_callback_t)(int fd, void *arg);
 
+/**
+ * @brief    Interrupt callback information structure
+ */
 typedef struct {
-    pid_t child_pid;
-    native_async_read_callback_t cb;
-    void *arg;
-    struct pollfd *fd;
+    pid_t child_pid;                    /**< PID of the interrupt listener */
+    native_async_read_callback_t cb;    /**< Interrupt callback funtion */
+    void *arg;                          /**< Argument ptr for the callback */
+    struct pollfd *fd;                  /**< sysfs gpio fd */
 } async_read_t;
 
 /**

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -18,6 +18,9 @@
 #ifndef ASYNC_READ_H
 #define ASYNC_READ_H
 
+#include <stdlib.h>
+#include <poll.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,6 +36,13 @@ extern "C" {
  * @brief   asynchronus read callback type
  */
 typedef void (*native_async_read_callback_t)(int fd, void *arg);
+
+typedef struct {
+    pid_t child_pid;
+    native_async_read_callback_t cb;
+    void *arg;
+    struct pollfd *fd;
+} async_read_t;
 
 /**
  * @brief   initialize asynchronus read system

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -21,6 +21,7 @@
 
 #include <signal.h>
 #include <stdio.h>
+#include <poll.h>
 /* enable signal handler register access on different platforms
  * check here for more:
  * http://sourceforge.net/p/predef/wiki/OperatingSystems/
@@ -117,6 +118,7 @@ extern int (*real_pause)(void);
 extern int (*real_pipe)(int[2]);
 /* The ... is a hack to save includes: */
 extern int (*real_select)(int nfds, ...);
+extern int (*real_poll)(struct pollfd *nfds, ...);
 extern int (*real_setitimer)(int which, const struct itimerval
         *__restrict value, struct itimerval *__restrict ovalue);
 extern int (*real_setsid)(void);

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -42,6 +42,20 @@
 /** @} */
 
 /**
+ * @name GPIO sysfs dir
+ * @{
+ */
+#define GPIO_SYSFS_DIR      "/sys/class/gpio"
+/** @} */
+
+/**
+ * @name Maximum number of GPIO supported (also highest GPIO number supported)
+ * @{
+ */
+#define GPIO_NATIVE_NUMOF   42
+/** @} */
+
+/**
  * @name Timer peripheral configuration
  * @{
  */

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+ * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for
@@ -12,9 +12,8 @@
  * @{
  *
  * @file
- * @brief       empty GPIO implementation
+ * @brief       native GPIO implementation using sysfs
  *
- * @author      Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
@@ -39,7 +38,7 @@ typedef struct {
     int fd;
 } native_gpio_cb_t;
 
-static native_gpio_cb_t gpio_list[GPIO_NATIVE_NUMOF];
+static native_gpio_cb_t gpio_list[GPIO_NATIVE_NUMOF] = { 0 };
 static int gpio_num;
 
 static native_gpio_cb_t *get_new_gpio(void) {

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -116,7 +116,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     }
 
     native_async_read_setup();
-    native_async_interrupt_add_handler(fd, gpio, _gpio_isr);
+    native_async_add_int_handler(fd, gpio, _gpio_isr);
     return -1;
 }
 

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -129,6 +129,8 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
         return fd;
     }
     gpio->fd = fd;
+    lseek(fd, 0, SEEK_SET);  // Read from the start of the file
+    read(fd, buf, 128);
     native_async_read_setup();
     native_async_read_add_int_handler(fd, gpio, _gpio_isr);
     return -1;

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -15,26 +15,109 @@
  * @brief       empty GPIO implementation
  *
  * @author      Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+ * @author      Koen Zandberg <koen@bergzand.net>
  */
 
 #include "periph/gpio.h"
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "async_read.h"
+
+#define NATIVE_GPIO_NUMOF   42
+
+char buf[128];
+
+
+static void _gpio_isr(int fd, void* arg);
+
+typedef struct {
+    int active;
+    gpio_t pin;
+    gpio_cb_t cb;
+    void* arg;
+} native_gpio_cb_t;
+
+native_gpio_cb_t gpio_list[NATIVE_GPIO_NUMOF];
 
 int gpio_init(gpio_t pin, gpio_mode_t mode) {
-  (void) pin;
-  (void) mode;
+    int fd, len;
+    fd = open(GPIO_SYSFS_DIR "/export", O_WRONLY);
+    if (fd < 0) {
+        return fd;
+    }
+    len = snprintf(buf, sizeof(buf), "%d", pin);
+    write(fd, buf, len);
+    close(fd);
 
-  return -1;
+    len = snprintf(buf, sizeof(buf), GPIO_SYSFS_DIR "/gpio%d/direction", pin);
+    fd = open(buf, O_WRONLY);
+    if (fd < 0 ) {
+        return fd;
+    }
+    int ret = 0;
+    switch(mode) {
+        case GPIO_IN:
+        case GPIO_IN_PD:
+        case GPIO_IN_PU:
+            write(fd, "in", 3);
+            break;
+        case GPIO_OUT:
+            write(fd, "out", 4);
+            break;
+        default:
+            ret = -1;
+    }
+    close(fd);
+    return ret;
 }
 
 int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
                   gpio_cb_t cb, void *arg){
-  (void) pin;
-  (void) mode;
-  (void) flank;
-  (void) cb;
-  (void) arg;
 
-  return -1;
+    int fd;
+
+    native_gpio_cb_t *gpio = &(gpio_list[pin]);
+    gpio->active = 1;
+    gpio->pin = pin;
+    gpio->cb = cb;
+    gpio->arg = arg;
+
+    gpio_init(pin, mode);
+
+    snprintf(buf, sizeof(buf), GPIO_SYSFS_DIR "/gpio%d/edge", pin);
+    fd = open(buf, O_WRONLY);
+    if (fd < 0 ) {
+        return fd;
+    }
+    switch(flank) {
+        case GPIO_FALLING:
+            write(fd, "falling", 8);
+            break;
+        case GPIO_RISING:
+            write(fd, "rising", 7);
+            break;
+        case GPIO_BOTH:
+            write(fd, "both", 5);
+            break;
+        default:
+            break;
+    }
+    close(fd);
+
+    snprintf(buf, sizeof(buf), GPIO_SYSFS_DIR "/gpio%d/value", pin);
+
+    fd = open(buf, O_RDONLY);
+    if (fd < 0) {
+        return fd;
+    }
+
+    native_async_read_setup();
+    native_async_interrupt_add_handler(fd, gpio, _gpio_isr);
+    return -1;
 }
 
 void gpio_irq_enable(gpio_t pin) {
@@ -46,25 +129,67 @@ void gpio_irq_disable(gpio_t pin) {
 }
 
 int gpio_read(gpio_t pin) {
-  (void) pin;
+    int fd, val;
+    char c;
 
-  return 0;
+    snprintf(buf, sizeof(buf), GPIO_SYSFS_DIR "/gpio%d/value", pin);
+
+    fd = open(buf, O_RDONLY);
+    if (fd < 0) {
+        return fd;
+    }
+
+    read(fd, &c, 1);
+    if (c != '0') {
+        val = 1;
+    } else {
+        val = 0;
+    }
+    close(fd);
+
+    return val;
 }
 
 void gpio_set(gpio_t pin) {
-  (void) pin;
+    gpio_write(pin, 1);
 }
 
 void gpio_clear(gpio_t pin) {
-  (void) pin;
+    gpio_write(pin, 0);
 }
 
 void gpio_toggle(gpio_t pin) {
-  (void) pin;
+    if(gpio_read(pin) == 1) {
+        gpio_clear(pin);
+    } else {
+        gpio_set(pin);
+    }
 }
 
 void gpio_write(gpio_t pin, int value) {
-  (void) pin;
-  (void) value;
+    int fd;
+
+    snprintf(buf, sizeof(buf), GPIO_SYSFS_DIR "/gpio%d/value", pin);
+
+    fd = open(buf, O_WRONLY);
+    if (fd < 0) {
+        return;
+    }
+
+    if (value) {
+        write(fd, "1", 2);
+    } else {
+        write(fd, "0", 2);
+    }
+    close(fd);
+}
+
+static void _gpio_isr(int fd, void* arg)
+{
+    (void)arg;
+    lseek(fd, 0, SEEK_SET);  // Read from the start of the file
+    read(fd, buf, 128);
+    printf("\npoll() GPIO interrupt occurred\n");
+    native_async_read_continue(fd);
 }
 /** @} */

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -25,6 +25,7 @@
 
 #include <err.h>
 #include <errno.h>
+#include <poll.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -83,6 +84,7 @@ int (*real_open)(const char *path, int oflag, ...);
 int (*real_pause)(void);
 int (*real_pipe)(int[2]);
 int (*real_select)(int nfds, ...);
+int (*real_poll)(struct pollfd *fds, ...);
 int (*real_setitimer)(int which, const struct itimerval
         *restrict value, struct itimerval *restrict ovalue);
 int (*real_setsid)(void);
@@ -463,6 +465,7 @@ void _native_init_syscalls(void)
     *(void **)(&real_fork) = dlsym(RTLD_NEXT, "fork");
     *(void **)(&real_dup2) = dlsym(RTLD_NEXT, "dup2");
     *(void **)(&real_select) = dlsym(RTLD_NEXT, "select");
+    *(void **)(&real_poll) = dlsym(RTLD_NEXT, "poll");
     *(void **)(&real_setitimer) = dlsym(RTLD_NEXT, "setitimer");
     *(void **)(&real_setsid) = dlsym(RTLD_NEXT, "setsid");
     *(void **)(&real_setsockopt) = dlsym(RTLD_NEXT, "setsockopt");


### PR DESCRIPTION
Sysfs GPIO implementation for native. Except for pull-up and down, everything works. Pull-up and down configuration is not managed via sysfs, so I can't configure that.

I noticed #1737. If a split between sysfs GPIO and printf based dummy GPIO is required, I can build that the same way as done in #1737.

I rewrote a part of the async_read handling to use `poll` instead of `select`. Mostly because I thought that `select` was unable to trigger on something like `POLLPRI`. It might be possible with the list of exception fd's in `select` but I didn't test that. I know that the whole async_read conversion might warrant a separate PR, So I'll split them if needed.

Unfortunately, I don't have access to OS X to test issues that might arise from this.