### PR TITLE
drivers: doxygen cleanup

### DIFF
--- a/drivers/adcxx1c/adcxx1c_saul.c
+++ b/drivers/adcxx1c/adcxx1c_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_adcxx1c
+ * @ingroup     drivers_adcxx1c
  * @{
  *
  * @file

--- a/drivers/adcxx1c/include/adcxx1c_params.h
+++ b/drivers/adcxx1c/include/adcxx1c_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the ADCXX1C driver
+ * @name    Set default configuration parameters for the ADCXX1C driver
  * @{
  */
 #ifndef ADCXX1C_PARAM_I2C

--- a/drivers/adcxx1c/include/adcxx1c_regs.h
+++ b/drivers/adcxx1c/include/adcxx1c_regs.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 /**
- * @name ADCxx1C register addesses
+ * @name    ADCxx1C register addesses
  * @{
  */
 #define ADCXX1C_CONV_RES_ADDR      (0)
@@ -38,7 +38,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name ADCxx1C Config flags
+ * @name    ADCxx1C Config flags
  * @{
  */
 #define ADCXX1C_CONF_ALERT_PIN_EN   (1 << 2)

--- a/drivers/adxl345/include/adxl345_params.h
+++ b/drivers/adxl345/include/adxl345_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the ADXL345 driver
+ * @name    Set default configuration parameters for the ADXL345 driver
  * @{
  */
 #ifndef ADXL345_PARAM_I2C

--- a/drivers/adxl345/include/adxl345_regs.h
+++ b/drivers/adxl345/include/adxl345_regs.h
@@ -23,8 +23,9 @@
  extern "C" {
 #endif
 
-/** \name Register addresses
- *  @{
+/**
+ * @name    Register addresses
+ * @{
  */
 #define ACCEL_ADXL345_CHIP_ID_REG    (0x00) /**< Device ID */
 #define ACCEL_ADXL345_THRESH_TAP     (0x1D) /**< Tap threshold */
@@ -59,14 +60,14 @@
 /** @} */
 
 /**
- * @name Device ID for ADXL345
+ * @name    Device ID for ADXL345
  * @{
  */
 #define ACCEL_ADXL345_CHIP_ID        (0xE5)
 /** @} */
 
 /**
- * @name Resolution masks for output data
+ * @name    Resolution masks for output data
  * @{
  */
 #define RES_10_BITS       (0x03FF)
@@ -76,7 +77,7 @@
 /** @} */
 
 /**
- * @name bits definitions for ACT_INACT_CTL register
+ * @name    bits definitions for ACT_INACT_CTL register
  * @{
  */
 #define INACT_Z_ENABLE    (1 << 0)
@@ -90,7 +91,7 @@
 /** @} */
 
 /**
- * @name bits definitions for TAP_AXES register
+ * @name    bits definitions for TAP_AXES register
  * @{
  */
 #define TAP_Z_ENABLE      (1 << 0)
@@ -101,7 +102,7 @@
 /** @} */
 
 /**
- * @name bits definitions for ACT_TAP_STATUS register
+ * @name    bits definitions for ACT_TAP_STATUS register
  * @{
  */
 #define TAP_Z_SRC         (1 << 0)
@@ -114,7 +115,7 @@
 /** @} */
 
 /**
- * @name bits definitions for BW_RATE register
+ * @name    bits definitions for BW_RATE register
  * @{
  */
 #define RATE_MASK         (0x0F)
@@ -122,7 +123,7 @@
 /** @} */
 
 /**
- * @name bits definitions for PWR_CTL register
+ * @name    bits definitions for PWR_CTL register
  * @{
  */
 #define WAKEUP_8HZ        (0x00)
@@ -136,7 +137,7 @@
 /** @} */
 
 /**
- * @name interrupts pins definitions for INT_ENABLE, INT_MAP and INT_SOURCE
+ * @name    interrupts pins definitions for INT_ENABLE, INT_MAP and INT_SOURCE
  * registers
  * @{
  */
@@ -151,7 +152,7 @@
 /** @} */
 
 /**
- * @name bits definitions for DATA_FORMAT register
+ * @name    bits definitions for DATA_FORMAT register
  * @{
  */
 #define RANGE_MASK        (0x03)
@@ -163,7 +164,7 @@
 /** @} */
 
 /**
- * @name bits definitions for FIFO_CTL register
+ * @name    bits definitions for FIFO_CTL register
  * @{
  */
 #define SAMPLES_MASK      (0x0F)
@@ -174,7 +175,7 @@
 /** @} */
 
 /**
- * @name bits definitions for FIFO_STATUS register
+ * @name    bits definitions for FIFO_STATUS register
  * @{
  */
 #define FIFO_ENTRIES_MASK (0x3F)

--- a/drivers/at30tse75x/at30tse75x.c
+++ b/drivers/at30tse75x/at30tse75x.c
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @ingroup     drivers_at30tse75x
  * @file
  * @brief       Driver for the AT30TSE75x temperature sensor with serial EEPROM
  *

--- a/drivers/at86rf2xx/include/at86rf2xx_params.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the AT86RF2xx driver
+ * @name    Set default configuration parameters for the AT86RF2xx driver
  * @{
  */
 #ifndef AT86RF2XX_PARAM_SPI

--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Constant part numbers of the AT86RF2xx device family
+ * @name    Constant part numbers of the AT86RF2xx device family
  * @{
  */
 #define AT86RF212B_PARTNUM       (0x07)
@@ -39,7 +39,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Assign the part number for the device we are building the driver for
+ * @name    Assign the part number for the device we are building the driver for
  * @{
  */
 #ifdef MODULE_AT86RF212B
@@ -54,7 +54,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   SPI access specifiers
+ * @name    SPI access specifiers
  * @{
  */
 #define AT86RF2XX_ACCESS_REG                                    (0x80)
@@ -65,7 +65,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Register addresses
+ * @name    Register addresses
  * @{
  */
 #define AT86RF2XX_REG__TRX_STATUS                               (0x01)
@@ -119,7 +119,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the TRX_CTRL_0 register
+ * @name    Bitfield definitions for the TRX_CTRL_0 register
  * @{
  */
 #define AT86RF2XX_TRX_CTRL_0_MASK__PAD_IO                       (0xC0)
@@ -143,7 +143,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the TRX_CTRL_1 register
+ * @name    Bitfield definitions for the TRX_CTRL_1 register
  * @{
  */
 #define AT86RF2XX_TRX_CTRL_1_MASK__PA_EXT_EN                    (0x80)
@@ -156,7 +156,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the TRX_CTRL_2 register
+ * @name    Bitfield definitions for the TRX_CTRL_2 register
  * @{
  */
 #define AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE                 (0x80)
@@ -170,7 +170,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the IRQ_STATUS register
+ * @name    Bitfield definitions for the IRQ_STATUS register
  * @{
  */
 #define AT86RF2XX_IRQ_STATUS_MASK__BAT_LOW                      (0x80)
@@ -184,7 +184,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the TRX_STATUS register
+ * @name    Bitfield definitions for the TRX_STATUS register
  * @{
  */
 #define AT86RF2XX_TRX_STATUS_MASK__CCA_DONE                     (0x80)
@@ -209,7 +209,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the TRX_STATE register
+ * @name    Bitfield definitions for the TRX_STATE register
  * @{
  */
 #define AT86RF2XX_TRX_STATE_MASK__TRAC                          (0xe0)
@@ -232,7 +232,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the PHY_CCA register
+ * @name    Bitfield definitions for the PHY_CCA register
  * @{
  */
 #define AT86RF2XX_PHY_CC_CCA_MASK__CCA_REQUEST                  (0x80)
@@ -243,7 +243,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the CCA_THRES register
+ * @name    Bitfield definitions for the CCA_THRES register
  * @{
  */
 #define AT86RF2XX_CCA_THRES_MASK__CCA_ED_THRES                  (0x0F)
@@ -252,7 +252,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the PHY_TX_PWR register
+ * @name    Bitfield definitions for the PHY_TX_PWR register
  * @{
  */
 #ifdef MODULE_AT86RF212B
@@ -272,7 +272,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the PHY_RSSI register
+ * @name    Bitfield definitions for the PHY_RSSI register
  * @{
  */
 #define AT86RF2XX_PHY_RSSI_MASK__RX_CRC_VALID                   (0x80)
@@ -281,7 +281,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the XOSC_CTRL register
+ * @name    Bitfield definitions for the XOSC_CTRL register
  * @{
  */
 #define AT86RF2XX_XOSC_CTRL__XTAL_MODE_CRYSTAL                  (0xF0)
@@ -289,7 +289,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Timing values
+ * @name    Timing values
  * @{
  */
 #define AT86RF2XX_TIMING__VCC_TO_P_ON                           (330)
@@ -302,7 +302,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the XAH_CTRL_0 register
+ * @name    Bitfield definitions for the XAH_CTRL_0 register
  * @{
  */
 #define AT86RF2XX_XAH_CTRL_0__MAX_FRAME_RETRIES                 (0xF0)
@@ -311,7 +311,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the XAH_CTRL_1 register
+ * @name    Bitfield definitions for the XAH_CTRL_1 register
  * @{
  */
 #define AT86RF2XX_XAH_CTRL_1__AACK_FLTR_RES_FT                  (0x20)
@@ -321,7 +321,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the CSMA_SEED_1 register
+ * @name    Bitfield definitions for the CSMA_SEED_1 register
  * @{
  */
 #define AT86RF2XX_CSMA_SEED_1__AACK_SET_PD                      (0x20)
@@ -331,7 +331,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RF_CTRL_0 register
+ * @name    Bitfield definitions for the RF_CTRL_0 register
  * @{
  */
 #ifdef MODULE_AT86RF212B

--- a/drivers/bh1750fvi/include/bh1750fvi_internal.h
+++ b/drivers/bh1750fvi/include/bh1750fvi_internal.h
@@ -34,7 +34,7 @@ extern "C" {
 #define RES_DIV                 (78642)
 
 /**
- * @brief   Opcodes
+ * @name    Opcodes
  * @{
  */
 #define OP_POWER_DOWN           (0x00)
@@ -51,7 +51,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Measurement delays (in us)
+ * @name    Measurement delays (in us)
  * @{
  */
 #define DELAY_HMODE             (120000)    /**< typ. 120ms in H-mode */

--- a/drivers/bh1750fvi/include/bh1750fvi_params.h
+++ b/drivers/bh1750fvi/include/bh1750fvi_params.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for BH1750FVI devices
+ * @name    Set default configuration parameters for BH1750FVI devices
  * @{
  */
 #ifndef BH1750FVI_PARAM_I2C

--- a/drivers/bmp180/include/bmp180_internals.h
+++ b/drivers/bmp180/include/bmp180_internals.h
@@ -25,14 +25,14 @@ extern "C" {
 #endif
 
 /**
- * @name BMP180 I2C address
+ * @name    BMP180 I2C address
  * @{
  */
 #define BMP180_ADDR                   (0x77) /* 7 bit address */
 /** @} */
 
 /**
- * @name BMP180 registers
+ * @name    BMP180 registers
  * @{
  */
 #define BMP180_REGISTER_ID            (0xD0)
@@ -44,7 +44,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name Oversampling modes delays (micros)
+ * @name    Oversampling modes delays (micros)
  * @{
  */
 #define BMP180_ULTRALOWPOWER_DELAY    (5000UL)

--- a/drivers/bmp180/include/bmp180_params.h
+++ b/drivers/bmp180/include/bmp180_params.h
@@ -31,7 +31,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the BMP180
+ * @name    Set default configuration parameters for the BMP180
  * @{
  */
 #ifndef BMP180_PARAM_I2C_DEV

--- a/drivers/bmx280/bmx280_saul.c
+++ b/drivers/bmx280/bmx280_saul.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     driver_bmx280
+ * @ingroup     drivers_bmx280
  * @{
  *
  * @file

--- a/drivers/bmx280/include/bmx280_internals.h
+++ b/drivers/bmx280/include/bmx280_internals.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * @name BME280 registers
+ * @name    BME280 registers
  * @{
  */
 #define BME280_CHIP_ID                          0x60    /* The identifier of the BME280 */

--- a/drivers/bmx280/include/bmx280_params.h
+++ b/drivers/bmx280/include/bmx280_params.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the BMX280
+ * @name    Set default configuration parameters for the BMX280
  * @{
  */
 #ifndef BMX280_PARAM_I2C_DEV

--- a/drivers/cc110x/include/cc110x-defaultsettings.h
+++ b/drivers/cc110x/include/cc110x-defaultsettings.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup   driver_cc110x
+ * @ingroup   drivers_cc110x
  * @{
  *
  * @file

--- a/drivers/cc110x/include/cc110x-defines.h
+++ b/drivers/cc110x/include/cc110x-defines.h
@@ -203,5 +203,5 @@ extern "C" {
 }
 #endif
 
-/** @} */
 #endif /* CC110X_DEFINES_H */
+/** @} */

--- a/drivers/cc110x/include/cc110x-interface.h
+++ b/drivers/cc110x/include/cc110x-interface.h
@@ -62,5 +62,5 @@ void cc110x_hook_off(void);
 }
 #endif
 
-/** @} */
 #endif /* CC110X_INTERFACE_H */
+/** @} */

--- a/drivers/cc110x/include/cc110x-internal.h
+++ b/drivers/cc110x/include/cc110x-internal.h
@@ -206,5 +206,5 @@ typedef struct cc110x_statistic {
 }
 #endif
 
-/** @} */
 #endif /* CC110X_INTERNAL_H */
+/** @} */

--- a/drivers/cc110x/include/cc110x-netdev.h
+++ b/drivers/cc110x/include/cc110x-netdev.h
@@ -64,3 +64,4 @@ int netdev_cc110x_setup(netdev_cc110x_t *netdev_cc110x, const cc110x_params_t *p
 #endif
 
 #endif /* CC110X_NETDEV_H */
+/** @} */

--- a/drivers/cc110x/include/cc110x-spi.h
+++ b/drivers/cc110x/include/cc110x-spi.h
@@ -112,5 +112,5 @@ void cc110x_cs(cc110x_t *dev);
 }
 #endif
 
-/** @} */
 #endif /* CC110X_SPI_H */
+/** @} */

--- a/drivers/cc2420/include/cc2420_params.h
+++ b/drivers/cc2420/include/cc2420_params.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the CC2420 driver
+ * @name    Set default configuration parameters for the CC2420 driver
  * @{
  */
 #ifndef CC2420_PARAM_SPI

--- a/drivers/cc2420/include/cc2420_registers.h
+++ b/drivers/cc2420/include/cc2420_registers.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Internal device option flags
+ * @name    Internal device option flags
  * @{
  */
 #define CC2420_OPT_AUTOACK          (0x0001)    /**< auto ACKs active */
@@ -45,7 +45,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Possible device state change commands
+ * @name    Possible device state change commands
  * @{
  */
 enum {
@@ -57,7 +57,7 @@ enum {
 };
 
 /**
- * @brief   (Selected) device states
+ * @name    (Selected) device states
  */
 enum {
     CC2420_STATE_PD          = 0,   /**< power down */
@@ -68,7 +68,7 @@ enum {
 };
 
 /**
- * @brief   CC2420 SPI commands
+ * @name    CC2420 SPI commands
  * @{
  */
 #define CC2420_REG_WRITE            (0x00)  /**< read register value */
@@ -82,7 +82,7 @@ enum {
 
 
 /**
- * @brief   CC2420 strobe commands
+ * @name    CC2420 strobe commands
  * @see     Datasheet section 37, pages 61--62
  * @{
  */
@@ -104,7 +104,7 @@ enum {
 /** @} */
 
 /**
- * @brief   CC2420 configuration registers
+ * @name    CC2420 configuration registers
  * @see     Datasheet section 37, pages 61 to 80
  * @{
  */
@@ -145,7 +145,7 @@ enum {
 /** @} */
 
 /**
- * @brief   CC2420 section address in RAM
+ * @name    CC2420 section address in RAM
  * @see     Datasheet section 13.5 page 31.
  * @{
  */
@@ -165,7 +165,7 @@ enum {
 /** @} */
 
 /**
- * @brief   Status byte bit fields
+ * @name    Status byte bit fields
  * @see     Datasheet section 13.3, page 29
  * @{
  */
@@ -178,7 +178,7 @@ enum {
 /** @} */
 
 /**
- * @brief   Modem control 0 register bitfields
+ * @name    Modem control 0 register bitfields
  * @{
  */
 #define CC2420_MDMCTRL0_RES_FRM     (0x2000
@@ -191,21 +191,21 @@ enum {
 /** @} */
 
 /**
- * @brief   Transmit control register bitfields
+ * @name    Transmit control register bitfields
  * @{
  */
 #define CC2420_TXCTRL_PA_MASK       (0x001f)
 /** @} */
 
 /**
- * @brief   Receive control register 1 bitfields
+ * @name    Receive control register 1 bitfields
  * @{
  */
 #define CC2420_RXCTRL1_RXBPF_LOCUR  (0x2000)
 /** @} */
 
 /**
- * @brief   Frequency synthesizer control and status register bitfields
+ * @name    Frequency synthesizer control and status register bitfields
  * @{
  */
 #define CC2420_FSCTRL_LOCK_THR_MASK (0xc000)
@@ -217,21 +217,25 @@ enum {
 /** @} */
 
 /**
- * @brief   Security control register 0 bitfields
+ * @name    Security control register 0 bitfields
  * @{
  */
 #define CC2420_SECCTRL0_RXFIFO_PROT (0x0200)
 /** @} */
 
 /**
- * @brief   Manufacturer ID low register value
+ * @name    Manufacturer ID low register value
+ * @{
  */
 #define CC2420_MANFIDL_VAL          (0x233d)
+/** @} */
 
 /**
- * @brief  Manufacturer ID high register value
+ * @name   Manufacturer ID high register value
+ * @{
  */
 #define CC2420_MANFIDH_VAL          (0x3000)
+/** @} */
 
 
 #ifdef __cplusplus
@@ -239,3 +243,4 @@ enum {
 #endif
 
 #endif /* CC2420_REGISTERS_H */
+/** @} */

--- a/drivers/dht/include/dht_params.h
+++ b/drivers/dht/include/dht_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the DHT devices
+ * @name    Set default configuration parameters for the DHT devices
  * @{
  */
 #ifndef DHT_PARAM_PIN

--- a/drivers/ds1307/ds1307.c
+++ b/drivers/ds1307/ds1307.c
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @ingroup drivers_ds1307
  * @{
  *
  * @file

--- a/drivers/dsp0401/include/dsp0401_params.h
+++ b/drivers/dsp0401/include/dsp0401_params.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the DSP0401 (for Nucleo-F411)
+ * @name    Set default configuration parameters for the DSP0401 (for Nucleo-F411)
  * @{
  */
 #ifndef DSP0401_PARAM_SDI_PIN

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_enc28j60
+ * @ingroup     drivers_enc28j60
  * @{
  *
  * @file

--- a/drivers/enc28j60/include/enc28j60_params.h
+++ b/drivers/enc28j60/include/enc28j60_params.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_enc28j60
+ * @ingroup     drivers_enc28j60
  * @{
  *
  * @file
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the ENC28J60 driver
+ * @name    Set default configuration parameters for the ENC28J60 driver
  * @{
  */
 #ifndef ENC28J60_PARAM_SPI

--- a/drivers/enc28j60/include/enc28j60_regs.h
+++ b/drivers/enc28j60/include/enc28j60_regs.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_enc28j60
+ * @ingroup     drivers_enc28j60
  * @{
  *
  * @file
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   SPI instruction set
+ * @name    SPI instruction set
  * @{
  */
 #define CMD_RCR             0x00            /* read control register */
@@ -37,7 +37,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Available address pointers
+ * @name    Available address pointers
  * @{
  */
 #define ADDR_READ_PTR       0x00    /**< Read pointer */
@@ -51,7 +51,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Shared registers (accessible on each bank)
+ * @name  Shared registers (accessible on each bank)
  * @{
  */
 #define REG_EIE             0x1b    /**< interrupt enable */
@@ -62,7 +62,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Register in bank 0 - Ethernet registers
+ * @name    Register in bank 0 - Ethernet registers
  * @{
  */
 #define REG_B0_ERDPTL       0x00    /* read data pointer - low byte */
@@ -92,7 +92,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Registers in bank 1 - Ethernet registers
+ * @name    Registers in bank 1 - Ethernet registers
  * @{
  */
 #define REG_B1_EHT0         0x00    /* hash table - byte 0 */
@@ -120,7 +120,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Registers in bank 2 - MAC registers
+ * @name    Registers in bank 2 - MAC registers
  * @{
  */
 #define REG_B2_MACON1       0x00    /* MAC control register 1 */
@@ -142,7 +142,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Registers in bank 3 - MIXED registers
+ * @name    Registers in bank 3 - MIXED registers
  * @{
  */
 #define REG_B3_MAADR5       0x00    /* MAC address - byte 5 */
@@ -164,7 +164,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   PHY Registers
+ * @name    PHY Registers
  * @{
  */
 #define REG_PHY_PHCON1      0x00
@@ -179,7 +179,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   EIE bitfields
+ * @name    EIE bitfields
  * @{
  */
 #define EIE_INTIE           0x80
@@ -192,7 +192,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   EIR bitfields
+ * @name    EIR bitfields
  * @{
  */
 #define EIR_PKTIF           0x40
@@ -204,7 +204,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   ESTAT bitfields
+ * @name    ESTAT bitfields
  * @{
  */
 #define ESTAT_INT           0x80
@@ -216,7 +216,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   ECON1 bitfields
+ * @name    ECON1 bitfields
  * @{
  */
 #define ECON1_TXRST         0x80
@@ -231,7 +231,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   ECON2 bitfields
+ * @name    ECON2 bitfields
  * @{
  */
 #define ECON2_AUTOINC       0x80
@@ -241,7 +241,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   ERXFCON bitfields
+ * @name    ERXFCON bitfields
  * @{
  */
 #define ERXFCON_UCEN        0x80
@@ -255,7 +255,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   MACON1 bitfields
+ * @name    MACON1 bitfields
  * @{
  */
 #define MACON1_TXPAUS       0x08
@@ -265,7 +265,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   MACON3 bitfields
+ * @name    MACON3 bitfields
  * @{
  */
 #define MACON3_PADCFG2      0x80
@@ -279,7 +279,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   MACON4 bitfields
+ * @name    MACON4 bitfields
  * @{
  */
 #define MACON4_DEFER        0x40
@@ -288,7 +288,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   MABBIPG bitfields
+ * @name    MABBIPG bitfields
  * @{
  */
 #define MABBIPG_FD          0x15
@@ -296,14 +296,14 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   MAIPGL bitfields
+ * @name    MAIPGL bitfields
  * @{
  */
 #define MAIPGL_FD           0x12
 /** @} */
 
 /**
- * @brief   MICMD bitfields
+ * @name    MICMD bitfields
  * @{
  */
 #define MICMD_MIISCAN       0x02
@@ -311,7 +311,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   MISTAT bitfields
+ * @name    MISTAT bitfields
  * @{
  */
 #define MISTAT_NVALID       0x04
@@ -320,7 +320,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   EFLOCON bitfields
+ * @name    EFLOCON bitfields
  * @{
  */
 #define EFLOCON_FULDPXS     0x04
@@ -331,7 +331,7 @@ extern "C" {
 
 
 /**
- * @brief   PHCON1 bitfields
+ * @name    PHCON1 bitfields
  * @{
  */
 #define PHCON1_PRST         0x8000
@@ -341,7 +341,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   PHSTAT1 bitfields
+ * @name    PHSTAT1 bitfields
  * @{
  */
 #define PHSTAT1_PFDPX       0x1000
@@ -351,7 +351,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   PHCON2 bitfields
+ * @name    PHCON2 bitfields
  * @{
  */
 #define PHCON2_FRCLNK       0x4000
@@ -361,7 +361,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   PHSTAT2 bitfields
+ * @name    PHSTAT2 bitfields
  * @{
  */
 #define PHSTAT2_TXSTAT      0x2000
@@ -373,7 +373,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   PHIE bitfields
+ * @name    PHIE bitfields
  * @{
  */
 #define PHIE_PLNKIE         0x0010
@@ -381,7 +381,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   PHIR bitfields
+ * @name    PHIR bitfields
  * @{
  */
 #define PHIR_PLNKIF         0x0010
@@ -389,7 +389,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   PHLCON bitfields
+ * @name    PHLCON bitfields
  * @{
  */
 #define PHLCON_LACFG(x)     ((x & 0xf) << 8)
@@ -399,7 +399,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Frame status bitfields
+ * @name    Frame status bitfields
  * @{
  */
 #define FRAME_4_RECV_OK     0x80
@@ -419,7 +419,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   TX control byte bitfields
+ * @name    TX control byte bitfields
  * @{
  */
 #define TX_PHUGEEN          0x08

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     driver_encx24j600
+ * @ingroup     drivers_encx24j600
  * @{
  *
  * @file

--- a/drivers/encx24j600/include/encx24j600_defines.h
+++ b/drivers/encx24j600/include/encx24j600_defines.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     driver_encx24j600
+ * @ingroup     drivers_encx24j600
  * @{
  *
  * @file
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 /**
- * @name SPI instruction set
+ * @name    SPI instruction set
  * @{
  */
 #define ENC_RCR         0x00  /* read control register */
@@ -66,7 +66,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name 16bit Registers
+ * @name    16bit Registers
  * @{
  */
 #define ENC_ETXST       0x00
@@ -105,7 +105,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name PHY Registers
+ * @name    PHY Registers
  *
  * (access with phy_reg_* functions)
  *
@@ -122,7 +122,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name ESTAT bits
+ * @name    ESTAT bits
  * @{
  */
 #define ENC_PHYLNK  (1<<8)
@@ -130,7 +130,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name ECON1 bits
+ * @name    ECON1 bits
  * @{
  */
 #define ENC_RXEN    (1<<0)
@@ -152,7 +152,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name ECON2 bits
+ * @name    ECON2 bits
  * @{
  */
 #define ENC_ETHRST    (1<<4)
@@ -160,7 +160,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name EIR bits
+ * @name    EIR bits
  * @{
  */
 #define ENC_PCFULIE     (1<<0)
@@ -177,7 +177,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name EIR bits
+ * @name    EIR bits
  * @{
  */
 #define ENC_PCFULIF     (1<<0)
@@ -194,7 +194,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name ERXFCON bits
+ * @name    ERXFCON bits
  */
 #define ENC_MCEN        (1<<1)
 /** @} */

--- a/drivers/encx24j600/include/encx24j600_internal.h
+++ b/drivers/encx24j600/include/encx24j600_internal.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     driver_encx24j600
+ * @ingroup     drivers_encx24j600
  * @{
  *
  * @file

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_ethos
+ * @ingroup     drivers_ethos
  * @{
  *
  * @file

--- a/drivers/hd44780/include/hd44780_internal.h
+++ b/drivers/hd44780/include/hd44780_internal.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   HD44780 LCD commands
+ * @name    HD44780 LCD commands
  * @{
  */
 #define HD44780_CLEARDISPLAY            (0x01)
@@ -38,7 +38,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   HD44780 LCD entry modes flags
+ * @name    HD44780 LCD entry modes flags
  * @{
  */
 #define HD44780_ENTRYRIGHT              (0x00)
@@ -48,7 +48,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   HD44780 LCD control flags
+ * @name    HD44780 LCD control flags
  * @{
  */
 #define HD44780_DISPLAYON               (0x04)
@@ -60,7 +60,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   HD44780 display and cursor shift flags
+ * @name    HD44780 display and cursor shift flags
  * @{
  */
 #define HD44780_DISPLAYMOVE             (0x08)
@@ -70,7 +70,7 @@ extern "C" {
 /**@}*/
 
 /**
- * @brief   HD44780 LCD functional flags
+ * @name    HD44780 LCD functional flags
  * @{
  */
 #define HD44780_8BITMODE                (0x10)
@@ -82,7 +82,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   HD44780 LCD timings
+ * @name    HD44780 LCD timings
  * @{
  */
 #define HD44780_CMD_WAIT                (2000U)

--- a/drivers/hdc1000/hdc1000_saul.c
+++ b/drivers/hdc1000/hdc1000_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_hdc1000
+ * @ingroup     drivers_hdc1000
  * @{
  *
  * @file

--- a/drivers/hdc1000/include/hdc1000_params.h
+++ b/drivers/hdc1000/include/hdc1000_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the HDC1000 driver
+ * @name    Set default configuration parameters for the HDC1000 driver
  * @{
  */
 #ifndef HDC1000_PARAM_I2C

--- a/drivers/hdc1000/include/hdc1000_regs.h
+++ b/drivers/hdc1000/include/hdc1000_regs.h
@@ -27,7 +27,7 @@ extern "C"
 #endif
 
 /**
- * @brief   Manufacturer and Device IDs
+ * @name    Manufacturer and Device IDs
  * @{
  */
 #define HDC1000_MID_VALUE          0x5449
@@ -35,7 +35,7 @@ extern "C"
 /** @} */
 
 /**
- * @brief   Register Map
+ * @name    Register Map
  * @{
  */
 #define HDC1000_TEMPERATURE         (0x00)
@@ -49,7 +49,7 @@ extern "C"
 /** @} */
 
 /**
- * @brief   Configuration register bitmap
+ * @name    Configuration register bitmap
  * @{
  */
 #define HDC1000_RST                 (1 << 15)

--- a/drivers/hih6130/hih6130.c
+++ b/drivers/hih6130/hih6130.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_hih6130
+ * @ingroup     drivers_hih6130
  * @{
  *
  * @file

--- a/drivers/ina220/ina220.c
+++ b/drivers/ina220/ina220.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_ina220
+ * @ingroup     drivers_ina220
  * @{
  *
  * @file

--- a/drivers/ina220/include/ina220-regs.h
+++ b/drivers/ina220/include/ina220-regs.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_ina220
+ * @ingroup     drivers_ina220
  * @{
  *
  * @file

--- a/drivers/include/adcxx1c.h
+++ b/drivers/include/adcxx1c.h
@@ -30,8 +30,10 @@ extern "C" {
 #include "periph/i2c.h"
 #include "periph/gpio.h"
 
+/**
+ * @brief  ADCxx1C default address (ADCxx1C021 address)
+ */
 #ifndef ADCXX1C_I2C_ADDRESS
-/** ADCxx1C default address (ADCxx1C021 address) */
 #define ADCXX1C_I2C_ADDRESS  (0x54)
 #endif
 
@@ -111,7 +113,7 @@ typedef struct adcxx1c {
 } adcxx1c_t;
 
 /**
- * @brief Initialize an ADCxx1C ADC device
+ * @brief   Initialize an ADCxx1C ADC device
  *
  * @param[in,out] dev  device descriptor
  * @param[in] params   device configuration
@@ -121,7 +123,7 @@ typedef struct adcxx1c {
 int adcxx1c_init(adcxx1c_t *dev, const adcxx1c_params_t *params);
 
 /**
- * @brief Read a raw ADC value
+ * @brief   Read a raw ADC value
  *
  * @param[in] dev   device descriptor
  * @param[out] raw  read value
@@ -131,7 +133,7 @@ int adcxx1c_init(adcxx1c_t *dev, const adcxx1c_params_t *params);
 int adcxx1c_read_raw(const adcxx1c_t *dev, int16_t *raw);
 
 /**
- * @brief Enable alert interrupt
+ * @brief   Enable alert interrupt
  *
  * @param[in] dev   device descriptor
  * @param[in] cb    callback called when the alert fires
@@ -142,7 +144,7 @@ int adcxx1c_read_raw(const adcxx1c_t *dev, int16_t *raw);
 int adcxx1c_enable_alert(adcxx1c_t *dev, adcxx1c_cb_t cb, void *arg);
 
 /**
- * @brief Set the alert parameters
+ * @brief   Set the alert parameters
  *
  * @param[in,out] dev      device descriptor
  * @param[in] low_limit    alert low limit

--- a/drivers/include/adt7310.h
+++ b/drivers/include/adt7310.h
@@ -61,7 +61,7 @@ extern "C"
 #endif
 
 /**
- * @brief Device descriptor for ADT7310 sensors.
+ * @brief   Device descriptor for ADT7310 sensors.
  */
 typedef struct {
     spi_t spi;              /**< SPI bus the sensor is connected to */
@@ -71,8 +71,10 @@ typedef struct {
     bool high_res;          /**< Sensor resolution, true if configured to 16 bit resolution */
 } adt7310_t;
 
-/** @name ADT7310 configuration bits */
-/** @{ */
+/**
+ * @name    ADT7310 configuration bits
+ * @{
+ */
 #define ADT7310_CONF_FAULT_QUEUE_MASK  (0x03)
 #define ADT7310_CONF_FAULT_QUEUE_SHIFT (0)
 #define ADT7310_CONF_FAULT_QUEUE(x) (((x) << ADT7310_CONF_FAULT_QUEUE_SHIFT) & ADT7310_CONF_FAULT_QUEUE_MASK)
@@ -92,18 +94,26 @@ typedef struct {
 #define ADT7310_CONF_RESOLUTION_SHIFT (7)
 #define ADT7310_CONF_RESOLUTION(x) (((x) << ADT7310_CONF_RESOLUTION_SHIFT) & ADT7310_CONF_RESOLUTION_MASK)
 
-/** @brief Continuous operation mode */
+/**
+ * @brief   Continuous operation mode
+ */
 #define ADT7310_MODE_CONTINUOUS (ADT7310_CONF_OPERATION_MODE(0))
-/** @brief One shot */
+/**
+ * @brief   One shot
+ */
 #define ADT7310_MODE_ONE_SHOT   (ADT7310_CONF_OPERATION_MODE(1))
-/** @brief 1 sample per second */
+/**
+ * @brief   1 sample per second
+ */
 #define ADT7310_MODE_1SPS       (ADT7310_CONF_OPERATION_MODE(2))
-/** @brief Shut down (powersave) */
+/**
+ * @brief   Shut down (powersave)
+ */
 #define ADT7310_MODE_SHUTDOWN   (ADT7310_CONF_OPERATION_MODE(3))
 /** @} */
 
 /**
- * @brief Set configuration register of an ADT7310 sensor
+ * @brief   Set configuration register of an ADT7310 sensor
  *
  * @param[in]  dev          pointer to sensor device descriptor
  * @param[in]  config       configuration byte, see macros in adt7310.h
@@ -114,7 +124,7 @@ typedef struct {
 int adt7310_set_config(adt7310_t *dev, uint8_t config);
 
 /**
- * @brief Initialize the ADT7310 sensor driver.
+ * @brief   Initialize the ADT7310 sensor driver.
  *
  * @note The SPI bus is expected to have been initialized when adt7310_init is called.
  *
@@ -129,7 +139,7 @@ int adt7310_set_config(adt7310_t *dev, uint8_t config);
 int adt7310_init(adt7310_t *dev, spi_t spi, spi_clk_t clk, gpio_t cs);
 
 /**
- * @brief Read raw temperature register value
+ * @brief   Read raw temperature register value
  *
  * @note The three least-significant bits of the value register are used for
  *       flags if the sensor is configured for 13 bit mode.
@@ -142,7 +152,7 @@ int adt7310_init(adt7310_t *dev, spi_t spi, spi_clk_t clk, gpio_t cs);
 int16_t adt7310_read_raw(const adt7310_t *dev);
 
 /**
- * @brief Read temperature value from sensor and convert to milli-degrees Celsius.
+ * @brief   Read temperature value from sensor and convert to milli-degrees Celsius.
  *
  * Divide the returned value by 1000 to get integer degrees.
  *
@@ -154,7 +164,7 @@ int16_t adt7310_read_raw(const adt7310_t *dev);
 int32_t adt7310_read(const adt7310_t *dev);
 
 /**
- * @brief Read temperature value from sensor and convert to degrees Celsius.
+ * @brief   Read temperature value from sensor and convert to degrees Celsius.
  *
  * @param[in]  dev          pointer to sensor device descriptor
  *

--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -29,7 +29,7 @@ extern "C" {
 #include "periph/gpio.h"
 
 /**
- * @brief Possible ADXL345 hardware addresses (wiring specific)
+ * @brief   Possible ADXL345 hardware addresses (wiring specific)
  */
 enum {
     ADXL345_ADDR_1D = 0x1D, /**< I2C device address if Alt addr pin is high */
@@ -37,7 +37,7 @@ enum {
 };
 
 /**
- * @brief List ADXL345 power mode
+ * @brief   List ADXL345 power mode
  */
 enum {
     ADXL345_MEASURE_MODE,
@@ -47,7 +47,7 @@ enum {
 };
 
 /**
- * @brief Define ADXL345 sensitivity
+ * @brief   Define ADXL345 sensitivity
  */
 enum {
     ADXL345_RANGE_2G    = 1,     /**< +/- 2 g Full Scale Rang */
@@ -57,7 +57,7 @@ enum {
 };
 
 /**
- * @brief List bandwidth rate
+ * @brief   List bandwidth rate
  */
 enum {
     ADXL345_RATE_0HZ1   = 0,   /**< 0.1 Hz Output Data Rate */
@@ -79,7 +79,7 @@ enum {
 };
 
 /**
- * @brief List fifo mode
+ * @brief   List fifo mode
  */
 enum {
     BYPASS  = 0,          /**< FIFO bypass mode */
@@ -87,8 +87,9 @@ enum {
     STREAM  = 2,          /**< FIFO stream mode */
     TRIGGER = 3           /**< FIFO trigger mode */
 };
+
 /**
- * @brief Output Interrupt selection
+ * @brief   Output Interrupt selection
  */
 enum {
     INT1,  /**< Output interrupt on INT1 pin */
@@ -107,7 +108,7 @@ enum {
 };
 
 /**
- * @brief ADXL345 result vector struct
+ * @brief   ADXL345 result vector struct
  */
 typedef struct {
     int16_t x;             /**< X-Axis measurement result */
@@ -116,7 +117,7 @@ typedef struct {
 } adxl345_data_t;
 
 /**
- * @brief Interrupt configuration struct for the ADXL345 sensor
+ * @brief   Interrupt configuration struct for the ADXL345 sensor
  */
 typedef struct {
     uint8_t source;       /**< Source of interrupts */
@@ -136,7 +137,7 @@ typedef struct {
 } adxl345_interrupt_t;
 
 /**
- * @brief Configuration struct for the ADXL345 sensor
+ * @brief   Configuration struct for the ADXL345 sensor
  */
 typedef struct {
     gpio_t int1;              /**< accelerometer int1 pin */
@@ -148,7 +149,7 @@ typedef struct {
 } adxl345_params_t;
 
 /**
- * @brief Device descriptor for the ADXL345 sensor
+ * @brief   Device descriptor for the ADXL345 sensor
  */
 typedef struct {
     i2c_t i2c;                      /**< I2C device which is used */

--- a/drivers/include/at30tse75x.h
+++ b/drivers/include/at30tse75x.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 /**
- * @name AT30TSE75x I2C addresses
+ * @name    AT30TSE75x I2C addresses
  * @{
  */
 #define AT30TSE75X_TEMP_ADDR            (0x48)
@@ -41,7 +41,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name AT30TSE75x register addresses
+ * @name    AT30TSE75x register addresses
  * @{
  */
 #define AT30TSE75X_REG__TEMPERATURE     (0x00)
@@ -54,7 +54,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name AT30TSE75x number formatting
+ * @name    AT30TSE75x number formatting
  * @{
  */
 #define AT30TSE75X_INTEGER_MASK         (0x00ff)
@@ -66,7 +66,7 @@ extern "C" {
 
 
 /**
- * @name AT30TSE75x configuration register
+ * @name    AT30TSE75x configuration register
  *
  * Only upper byte can be read/written, so treat as 8-bit register.
  * @{
@@ -82,7 +82,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name AT30TSE75x commands
+ * @name    AT30TSE75x commands
  *
  * @{
  */
@@ -93,7 +93,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name AT30TSE75x constants
+ * @name    AT30TSE75x constants
  *
  * @{
  */
@@ -102,10 +102,11 @@ extern "C" {
 
 /**
   * @name AT30TSE75x configuration types
-  *
-  * @brief   Temperature resolution
-  *
   * @{
+  */
+
+/**
+  * @brief   Temperature resolution
   */
 typedef enum {
     AT30TSE75X_RESOLUTION_9BIT = 0,
@@ -113,7 +114,6 @@ typedef enum {
     AT30TSE75X_RESOLUTION_11BIT = 2,
     AT30TSE75X_RESOLUTION_12BIT = 3
 } at30tse75x_resolution_t;
-/** @} */
 
 /**
   * @brief   Operation mode
@@ -122,18 +122,15 @@ typedef enum {
   * is effectively shutdown and only wakes up to perform a single measurement.
   * When in comparator or interrupt mode, the device samples contiously the
   * temperature and sets the ALERT pin according to the chosen mode.
-  * @{
   */
 typedef enum {
     AT30TSE75X_MODE_COMPARATOR,
     AT30TSE75X_MODE_INTERRUPT,
     AT30TSE75X_MODE_ONE_SHOT
 } at30tse75x_mode_t;
-/** @} */
 
 /**
   * @brief   After how many limit exceeding measurements the ALERT pin is set
-  * @{
   */
 typedef enum {
     AT30TSE75X_ALARM_AFTER_1 = 0,
@@ -141,27 +138,24 @@ typedef enum {
     AT30TSE75X_ALARM_AFTER_4 = 2,
     AT30TSE75X_ALARM_AFTER_6 = 3
 } at30tse75x_fault_tolerance_t;
-/** @} */
 
 /**
   * @brief   Polarity of the ALERT pin
-  * @{
   */
 typedef enum {
     AT30TSE75X_ALARM_ACTIVE_LOW,
     AT30TSE75X_ALARM_ACTIVE_HIGH
 } at30tse75x_alarm_polatity_t;
-/** @} */
+
+/** @} */ /* AT30TSE75x configuration types */
 
 /**
   * @brief   Device descriptor for a AT30TSE75x device
-  * @{
   */
 typedef struct {
     i2c_t i2c;          /**< I2C device that sensor is connected to */
     uint8_t addr;       /**< I2C address of this particular sensor */
 } at30tse75x_t;
-/** @} */
 
 /**
  * @brief   Initialize a AT30TSE75x device
@@ -308,5 +302,5 @@ int at30tse75x_get_temperature(const at30tse75x_t* dev, float* temperature);
 }
 #endif
 
-/** @} */
 #endif /* AT30TSE75X_H */
+/** @} */

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -49,7 +49,7 @@ extern "C" {
 #define AT86RF2XX_MAX_PKT_LENGTH        (IEEE802154_FRAME_LEN_MAX)
 
 /**
- * @brief   Channel configuration
+ * @name    Channel configuration
  * @{
  */
 #ifdef MODULE_AT86RF212B
@@ -92,7 +92,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Flags for device internal states (see datasheet)
+ * @name    Flags for device internal states (see datasheet)
  * @{
  */
 #define AT86RF2XX_STATE_P_ON           (0x00)     /**< initial power on */
@@ -108,7 +108,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Internal device option flags
+ * @name    Internal device option flags
  *
  * `0x00ff` is reserved for general IEEE 802.15.4 flags
  * (see @ref netdev_ieee802154_t)
@@ -134,7 +134,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief struct holding all params needed for device initialization
+ * @brief   struct holding all params needed for device initialization
  */
 typedef struct at86rf2xx_params {
     spi_t spi;              /**< SPI bus the device is connected to */
@@ -152,10 +152,7 @@ typedef struct at86rf2xx_params {
  */
 typedef struct {
     netdev_ieee802154_t netdev;             /**< netdev parent struct */
-    /**
-     * @brief   device specific fields
-     * @{
-     */
+    /* device specific fields */
     at86rf2xx_params_t params;              /**< parameters for initialization */
     uint8_t state;                          /**< current state of the radio */
     uint8_t tx_frame_len;                   /**< length of the current TX frame */
@@ -167,7 +164,6 @@ typedef struct {
     uint8_t pending_tx;                 /**< keep track of pending TX calls
                                              this is required to know when to
                                              return to @ref at86rf2xx_t::idle_state */
-    /** @} */
 } at86rf2xx_t;
 
 /**

--- a/drivers/include/bh1750fvi.h
+++ b/drivers/include/bh1750fvi.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Possible I2C bus addresses of the device
+ * @name    Possible I2C bus addresses of the device
  *
  * The actual address of the device depends on the state of the ADDR pin.
  * @{
@@ -36,7 +36,6 @@ extern "C" {
 #define BH1750FVI_ADDR_PIN_LOW          (0x5c)      /**< ADDR pin := 0 */
 #define BH1750FVI_ADDR_PIN_HIGH         (0x23)      /**< ADDR pin := 1 */
 /** @} */
-
 
 /**
  * @brief   Default address of BH1750FVI sensors

--- a/drivers/include/bmp180.h
+++ b/drivers/include/bmp180.h
@@ -29,8 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @name Oversampling modes
- * @{
+ * @brief   Oversampling modes
  */
 typedef enum {
     BMP180_ULTRALOWPOWER = 0,
@@ -38,10 +37,9 @@ typedef enum {
     BMP180_HIGHRES,
     BMP180_ULTRAHIGHRES
 } bmp180_oversampling_mode_t;
-/** @} */
 
 /**
- * @brief Calibration struct for the BMP180 sensor
+ * @brief   Calibration struct for the BMP180 sensor
  */
 typedef struct {
     int16_t ac1;                                /**< ac1 coefficient */
@@ -58,7 +56,7 @@ typedef struct {
 } bmp180_calibration_t;
 
 /**
- * @brief Device initialization parameters
+ * @brief   Device initialization parameters
  */
 typedef struct {
     i2c_t i2c_dev;                              /**< I2C device which is used */
@@ -67,7 +65,7 @@ typedef struct {
 } bmp180_params_t;
 
 /**
- * @brief Device descriptor for the BMP180 sensor
+ * @brief   Device descriptor for the BMP180 sensor
  */
 typedef struct {
     bmp180_params_t      params;                /**< Device initialization parameters */
@@ -85,7 +83,7 @@ enum {
 };
 
 /**
- * @brief Initialize the given BMP180 device
+ * @brief   Initialize the given BMP180 device
  *
  * @param[out] dev          Initialized device descriptor of BMP180 device
  * @param[in]  params       Initialization parameters
@@ -98,7 +96,7 @@ enum {
 int bmp180_init(bmp180_t *dev, const bmp180_params_t *params);
 
 /**
- * @brief Read temperature value from the given BMP180 device, returned in d°C
+ * @brief   Read temperature value from the given BMP180 device, returned in d°C
  *
  * @param[in] dev           Device descriptor of BMP180 device to read from
  *
@@ -107,7 +105,7 @@ int bmp180_init(bmp180_t *dev, const bmp180_params_t *params);
 int16_t bmp180_read_temperature(const bmp180_t *dev);
 
 /**
- * @brief Read pressure value from the given BMP180 device, returned in Pa
+ * @brief   Read pressure value from the given BMP180 device, returned in Pa
  *
  * @param[in]  dev          Device descriptor of BMP180 device to read from
  *
@@ -116,7 +114,7 @@ int16_t bmp180_read_temperature(const bmp180_t *dev);
 uint32_t bmp180_read_pressure(const bmp180_t *dev);
 
 /**
- * @brief Compute altitude, returned in m.
+ * @brief   Compute altitude, returned in m.
  *
  * @param[in]  dev          Device descriptor of BMP180 device to read from
  * @param[in]  pressure_0   The pressure at sea level in Pa
@@ -126,7 +124,7 @@ uint32_t bmp180_read_pressure(const bmp180_t *dev);
 int16_t bmp180_altitude(const bmp180_t *dev, uint32_t pressure_0);
 
 /**
- * @brief Compute pressure at sea level, returned in Pa.
+ * @brief   Compute pressure at sea level, returned in Pa.
  *
  * @param[in]  dev          Device descriptor of BMP180 device to read from
  * @param[in]  altitude     Altitude in m

--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -48,7 +48,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Calibration struct for the BMX280 sensor
+ * @brief   Calibration struct for the BMX280 sensor
  *
  * This must be read from the device at startup.
  */
@@ -76,7 +76,7 @@ typedef struct {
 } bmx280_calibration_t;
 
 /**
- * @brief Values for t_sb field of the BMX280 config register
+ * @brief   Values for t_sb field of the BMX280 config register
  */
 typedef enum {
     BMX280_SB_0_5 = 0,
@@ -90,7 +90,7 @@ typedef enum {
 } bmx280_t_sb_t;
 
 /**
- * @brief Values for filter field of the BMX280 config register
+ * @brief   Values for filter field of the BMX280 config register
  */
 typedef enum {
     BMX280_FILTER_OFF = 0,
@@ -101,7 +101,7 @@ typedef enum {
 } bmx280_filter_t;
 
 /**
- * @brief Values for mode field of the BMX280 ctrl_meas register
+ * @brief   Values for mode field of the BMX280 ctrl_meas register
  */
 typedef enum {
     BMX280_MODE_SLEEP = 0,
@@ -111,7 +111,7 @@ typedef enum {
 } bmx280_mode_t;
 
 /**
- * @brief Values for oversampling settings
+ * @brief   Values for oversampling settings
  *
  * These values are used for:
  *  - osrs_h field of the BME280 ctrl_hum register
@@ -128,7 +128,7 @@ typedef enum {
 } bmx280_osrs_t;
 
 /**
- * @brief Parameters for the BMX280 sensor
+ * @brief   Parameters for the BMX280 sensor
  *
  * These parameters are needed to configure the device at startup.
  */
@@ -152,7 +152,7 @@ typedef struct {
 } bmx280_params_t;
 
 /**
- * @brief Device descriptor for the BMX280 sensor
+ * @brief   Device descriptor for the BMX280 sensor
  */
 typedef struct {
     bmx280_params_t params;             /**< Device Parameters */
@@ -170,7 +170,7 @@ enum {
 };
 
 /**
- * @brief Initialize the given BMX280 device
+ * @brief   Initialize the given BMX280 device
  *
  * @param[out] dev          Initialized device descriptor of BMX280 device
  * @param[in]  params       The parameters for the BMX280 device (sampling rate, etc)
@@ -183,7 +183,7 @@ enum {
 int bmx280_init(bmx280_t* dev, const bmx280_params_t* params);
 
 /**
- * @brief Read temperature value from the given BMX280 device, returned in centi °C
+ * @brief   Read temperature value from the given BMX280 device, returned in centi °C
  *
  * @param[in] dev           Device descriptor of BMX280 device to read from
  *
@@ -193,7 +193,7 @@ int bmx280_init(bmx280_t* dev, const bmx280_params_t* params);
 int16_t bmx280_read_temperature(const bmx280_t* dev);
 
 /**
- * @brief Read air pressure value from the given BMX280 device, returned in PA
+ * @brief   Read air pressure value from the given BMX280 device, returned in PA
  *
  * @details This function should only be called after doing bmx280_read_temperature
  *          first.
@@ -206,7 +206,7 @@ uint32_t bmx280_read_pressure(const bmx280_t *dev);
 
 #if defined(MODULE_BME280)
 /**
- * @brief Read humidity value from the given BME280 device, returned in centi %RH
+ * @brief   Read humidity value from the given BME280 device, returned in centi %RH
  *
  * @details This function should only be called after doing bmx280_read_temperature
  *          first. It's only available with BME280 sensor.

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -30,7 +30,7 @@ extern "C" {
 #include "net/gnrc/nettype.h"
 
 /**
- * @brief Struct for holding cc110x IO parameters
+ * @brief   Struct for holding cc110x IO parameters
  */
 typedef struct cc110x_params {
     spi_t spi;          /**< what */
@@ -41,12 +41,12 @@ typedef struct cc110x_params {
 } cc110x_params_t;
 
 /**
- * @brief forward declaration
+ * @brief   Forward declaration
  */
 typedef struct cc110x cc110x_t;
 
 /**
- * @brief Struct for holding cc110x device state
+ * @brief   Struct for holding cc110x device state
  */
 struct cc110x {
     cc110x_params_t params;                     /**< cc110x IO configuration */
@@ -67,7 +67,7 @@ struct cc110x {
 };
 
 /**
- * @brief Setup cc110x device parameters
+ * @brief   Setup cc110x device parameters
  *
  * @param[in] dev       device struct to set up
  * @param[in] params    struct holding parameters
@@ -77,7 +77,7 @@ struct cc110x {
 int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params);
 
 /**
- * @brief Set cc110x channel number
+ * @brief   Set cc110x channel number
  *
  * @param[in] dev       device to work on
  * @param[in] channr    guess what
@@ -89,7 +89,7 @@ int16_t cc110x_set_channel(cc110x_t *dev, uint8_t channr);
 
 
 /**
- * @brief Send raw cc110x packet
+ * @brief   Send raw cc110x packet
  *
  * @param[in] dev       Device to send on
  * @param[in] packet    ptr to packet to be sent
@@ -100,7 +100,7 @@ int16_t cc110x_set_channel(cc110x_t *dev, uint8_t channr);
 int cc110x_send(cc110x_t *dev, cc110x_pkt_t *packet);
 
 /**
- * @brief Set cc110x radio address
+ * @brief   Set cc110x radio address
  *
  * @param[in] dev   device to query
  *
@@ -109,7 +109,7 @@ int cc110x_send(cc110x_t *dev, cc110x_pkt_t *packet);
 uint8_t cc110x_get_address(cc110x_t *dev);
 
 /**
- * @brief Set cc110x radio address
+ * @brief   Set cc110x radio address
  *
  * @param[in] dev       device to work on
  * @param[in] address   new address
@@ -121,7 +121,7 @@ uint8_t cc110x_set_address(cc110x_t *dev, uint8_t address);
 
 
 /**
- * @brief Set cc110x monitor mode setting
+ * @brief   Set cc110x monitor mode setting
  *
  * @param[in] dev   device to work on
  * @param[in] mode  mode to set (0 or 1)

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -44,7 +44,7 @@ extern "C" {
 #define CC2420_PANID_DEFAULT    (IEEE802154_DEFAULT_PANID)
 
 /**
-  * @brief   Channel configuration
+  * @name    Channel configuration
   * @{
   */
 #define CC2420_CHAN_MIN         (IEEE802154_CHANNEL_MIN)
@@ -53,7 +53,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Default TX power configuration [in dBm]
+ * @name    Default TX power configuration [in dBm]
  * @{
  */
 #define CC2420_TXPOWER_MIN      (-25)
@@ -70,7 +70,6 @@ enum {
 
 /**
  * @brief   Struct holding all parameters needed for device initialization
- * @{
  */
 typedef struct cc2420_params {
     spi_t spi;              /**< SPI bus the device is connected to */
@@ -83,11 +82,9 @@ typedef struct cc2420_params {
     gpio_t pin_vrefen;      /**< pin connected to the Vref enable pin */
     gpio_t pin_reset;       /**< pin connected to the reset pin */
 } cc2420_params_t;
-/** @} */
 
 /**
  * @brief   Device descriptor for CC2420 radio devices
- * @{
  */
 typedef struct {
     /* netdev fields */
@@ -98,7 +95,6 @@ typedef struct {
     uint8_t state;                /**< current state of the radio */
     uint16_t options;             /**< state of used options */
 } cc2420_t;
-/** @} */
 
 /**
  * @brief   Setup the device descriptor for the given device

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 /**
- * @brief possible return codes
+ * @brief   Possible return codes
  */
 enum {
     DHT_OK      =  0,       /**< all good */
@@ -46,7 +46,7 @@ enum {
 };
 
 /**
- * @brief data type for storing DHT sensor readings
+ * @brief   Data type for storing DHT sensor readings
  */
 typedef struct {
     uint16_t humidity;      /**< relative deca-humidity */
@@ -54,7 +54,7 @@ typedef struct {
 } dht_data_t;
 
 /**
- * @brief device type of the DHT device
+ * @brief   Device type of the DHT device
  */
 typedef enum {
     DHT11,                  /**< DHT11 device identifier */
@@ -63,7 +63,7 @@ typedef enum {
 } dht_type_t;
 
 /**
- * @brief device descriptor for DHT sensor devices
+ * @brief   Device descriptor for DHT sensor devices
  */
 typedef struct {
     gpio_t pin;             /**< GPIO pin of the device's data pin */
@@ -73,12 +73,12 @@ typedef struct {
 } dht_t;
 
 /**
- * @brief configuration parameters for DHT devices
+ * @brief   Configuration parameters for DHT devices
  */
 typedef dht_t dht_params_t;
 
 /**
- * @brief initialize a new DHT device
+ * @brief   Initialize a new DHT device
  *
  * @param[out] dev      device descriptor of a DHT device
  * @param[in]  params   configuration parameters

--- a/drivers/include/diskio.h
+++ b/drivers/include/diskio.h
@@ -31,7 +31,7 @@ extern "C" {
 /* These functions are defined in asmfunc.S */
 
 /**
- * @brief Copy aligned to unaligned
+ * @brief   Copy aligned to unaligned
  *
  * @param[out] dst   Pointer to unaligned destination address
  * @param[in]  src   Pointer to aligned source address
@@ -40,7 +40,7 @@ extern "C" {
 void copy_al2un(unsigned char *dst, const unsigned long *src, int count);
 
 /**
- * @brief Copy unaligned to aligned
+ * @brief   Copy unaligned to aligned
  *
  * @param[out] dst   Pointer to unaligned destination address
  * @param[in]  src   Pointer to aligned source address
@@ -59,18 +59,16 @@ typedef enum {
 } diskio_result_t;
 
 /**
- * @name Disk Status Bits
- * @{
+ * @brief   Disk Status Bits
  */
 typedef enum {
     DISKIO_STA_NOINIT  = 0x01, /**< Drive not initialized */
     DISKIO_STA_NODISK  = 0x02, /**< No medium in the drive */
     DISKIO_STA_PROTECT = 0x04  /**< Write protected */
 } diskio_sta_t;
-/** @} */
 
 /**
- * @name Command code for disk_ioctrl fucntion
+ * @name    Command code for disk_ioctrl fucntion
  * @{
  */
 
@@ -86,7 +84,7 @@ typedef enum {
 /** @} */
 
 /**
- * @name Generic ioctl command
+ * @name    Generic ioctl command
  * @{
  */
 #define CTRL_POWER          5   /**< Get/Set power status */
@@ -95,7 +93,7 @@ typedef enum {
 /** @} */
 
 /**
- * @name MMC/SDC specific ioctl command
+ * @name    MMC/SDC specific ioctl command
  * @{
  */
 #define MMC_GET_TYPE        10  /**< Get card type */
@@ -109,7 +107,7 @@ typedef enum {
 
 
 /**
- * @brief Initialize media control interface (MCI)
+ * @brief   Initialize media control interface (MCI)
  *
  * @returns 0 on success
  * @returns a @ref diskio_sta_t value on error
@@ -117,7 +115,7 @@ typedef enum {
 diskio_sta_t mci_initialize(void);
 
 /**
- * @brief Get the status of the media control interface (MCI)
+ * @brief   Get the status of the media control interface (MCI)
  *
  * @returns 0 on success
  * @returns a @ref diskio_sta_t value on error
@@ -125,7 +123,7 @@ diskio_sta_t mci_initialize(void);
 diskio_sta_t mci_status(void);
 
 /**
- * @brief Read sectors over the media control interface (MCI)
+ * @brief   Read sectors over the media control interface (MCI)
  *
  * @param[out] buff      Pointer to the data buffer to store read data
  * @param[in]  sector    Start sector number (LBA)
@@ -137,7 +135,7 @@ diskio_sta_t mci_status(void);
 diskio_result_t mci_read(unsigned char *buff, unsigned long sector, unsigned char count);
 
 /**
- * @brief Write sectors over the media control interface (MCI)
+ * @brief   Write sectors over the media control interface (MCI)
  * @param[in] buff     Pointer to the data to be written
  * @param[in] sector   Start sector number (LBA)
  * @param[in] count    Sector count (1..127)
@@ -148,7 +146,7 @@ diskio_result_t mci_read(unsigned char *buff, unsigned long sector, unsigned cha
 diskio_result_t mci_write(const unsigned char *buff, unsigned long sector, unsigned char count);
 
 /**
- * @brief IOCTL functions for the media control interface (MCI)
+ * @brief   IOCTL functions for the media control interface (MCI)
  *
  * @param[in]       ctrl  Control code
  * @param[in,out]   buff  Buffer to send/receive data block
@@ -162,5 +160,5 @@ diskio_result_t mci_ioctl(unsigned char ctrl, void *buff);
 }
 #endif
 
-/** @} */
 #endif /* DISKIO_H */
+/** @} */

--- a/drivers/include/dsp0401.h
+++ b/drivers/include/dsp0401.h
@@ -31,8 +31,7 @@ extern "C" {
 #endif
 
 /**
- * @name Return codes
- * @{
+ * @brief   Return codes
  */
 enum {
     DSP0401_OK = 0,       /**< All ok */
@@ -41,10 +40,9 @@ enum {
     DSP0401_ERR_LAT_GPIO, /**< Something went wrong with LAT GPIO */
     DSP0401_ERR_PWM,      /**< Something went wrong with PWM */
 };
-/** @} */
 
 /**
- * @brief Device initialization parameters
+ * @brief   Device initialization parameters
  */
 typedef struct {
     gpio_t sdi;              /**< Data input pin */
@@ -57,14 +55,14 @@ typedef struct {
 } dsp0401_params_t;
 
 /**
- * @brief Device descriptor for the DSP0401
+ * @brief   Device descriptor for the DSP0401
  */
 typedef struct {
     dsp0401_params_t params; /**< Device parameters */
 } dsp0401_t;
 
 /**
- * @brief Initialize the given DSP0401
+ * @brief   Initialize the given DSP0401
  *
  * @param[out] dev          Initialized device descriptor of DSP0401 device
  * @param[in]  params       Device parameters to use
@@ -78,7 +76,7 @@ typedef struct {
 int dsp0401_init(dsp0401_t *dev, const dsp0401_params_t *params);
 
 /**
- * @brief Display the given text on the DSP0401
+ * @brief   Display the given text on the DSP0401
  *
  * @param[in] dev           Device descriptor of the DSP0401 device
  * @param[in] text          The text to display
@@ -86,14 +84,14 @@ int dsp0401_init(dsp0401_t *dev, const dsp0401_params_t *params);
 void dsp0401_display_text(const dsp0401_t *dev, char *text);
 
 /**
- * @brief Clear the text displayed on the DSP0401
+ * @brief   Clear the text displayed on the DSP0401
  *
  * @param[in] dev           Device descriptor of the DSP0401 device
  */
 void dsp0401_clear_text(const dsp0401_t *dev);
 
 /**
- * @brief Scroll the given text on the DSP0401
+ * @brief   Scroll the given text on the DSP0401
  *
  * @param[in] dev           Device descriptor of the DSP0401 device
  * @param[in] text          The text to scroll on the display

--- a/drivers/include/dynamixel.h
+++ b/drivers/include/dynamixel.h
@@ -9,8 +9,8 @@
 /**
  * @defgroup    drivers_dynamixel Dynamixel driver
  * @ingroup     drivers_actuators
+ * @brief       Drivers for any device using dynamixel's servomotors communication bus
  *
- * This module contains drivers for any device using dynamixel's servomotors communication bus.
  * The bus is mainly used for servomotors, but a device can be anything : sensors, other actuators.
  *
  * @{
@@ -34,11 +34,11 @@
 extern "C" {
 #endif
 
-typedef uint8_t dynamixel_id_t; /**< device id type */
+typedef uint8_t dynamixel_id_t;    /**< device id type */
 typedef uint16_t dynamixel_addr_t; /**< register address type */
 
 /**
- * @brief Descriptor struct for a dynamixel device
+ * @brief   Descriptor struct for a dynamixel device
  */
 typedef struct {
     uart_half_duplex_t *stream; /**< the stream used */
@@ -56,7 +56,7 @@ enum {
 };
 
 /**
- * @brief Send a PING message to a device
+ * @brief   Send a PING message to a device
  *
  * @param[in] stream   the stream
  * @param[in] id       the device address
@@ -69,7 +69,7 @@ enum {
 int dynamixel_ping(uart_half_duplex_t *stream, dynamixel_id_t id);
 
 /**
- * @brief Initialize a Dynamixel device
+ * @brief   Initialize a Dynamixel device
  *
  * @param[out] device  the Dynamixel device
  * @param[in] stream   the stream
@@ -78,7 +78,7 @@ int dynamixel_ping(uart_half_duplex_t *stream, dynamixel_id_t id);
 void dynamixel_init(dynamixel_t *device, uart_half_duplex_t *stream, dynamixel_id_t id);
 
 /**
- * @brief Write to a device 8bits register
+ * @brief   Write to a device 8bits register
  *
  * @param[in] device   the Dynamixel device
  * @param[in] reg      the register to write
@@ -92,7 +92,7 @@ void dynamixel_init(dynamixel_t *device, uart_half_duplex_t *stream, dynamixel_i
 int dynamixel_write8(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t value);
 
 /**
- * @brief Write to a device 16bits register
+ * @brief   Write to a device 16bits register
  *
  * @param[in] device   the Dynamixel device
  * @param[in] reg      the register to write
@@ -106,7 +106,7 @@ int dynamixel_write8(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t va
 int dynamixel_write16(const dynamixel_t *device, dynamixel_addr_t reg, uint16_t value);
 
 /**
- * @brief Write to a device address
+ * @brief   Write to a device address
  *
  * @param[in] device   the Dynamixel device
  * @param[in] reg      the address to start write
@@ -121,7 +121,7 @@ int dynamixel_write16(const dynamixel_t *device, dynamixel_addr_t reg, uint16_t 
 int dynamixel_write(const dynamixel_t *device, dynamixel_addr_t reg, const uint8_t *data, size_t length);
 
 /**
- * @brief Read from a device 8bits register
+ * @brief   Read from a device 8bits register
  *
  * @param[in] device   the Dynamixel device
  * @param[in] reg      the register to read
@@ -135,7 +135,7 @@ int dynamixel_write(const dynamixel_t *device, dynamixel_addr_t reg, const uint8
 int dynamixel_read8(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t *value);
 
 /**
- * @brief Read from a device 16bits register
+ * @brief   Read from a device 16bits register
  *
  * @param[in] device   the Dynamixel device
  * @param[in] reg      the register to read
@@ -149,7 +149,7 @@ int dynamixel_read8(const dynamixel_t *device, dynamixel_addr_t reg, uint8_t *va
 int dynamixel_read16(const dynamixel_t *device, dynamixel_addr_t reg, uint16_t *value);
 
 /**
- * @brief Read from a device address
+ * @brief   Read from a device address
  *
  * @param[in] device   the Dynamixel device
  * @param[in] reg      the address to start read

--- a/drivers/include/encx24j600.h
+++ b/drivers/include/encx24j600.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 
 /**
- * @brief encx24j600 netdev device
+ * @brief   encx24j600 netdev device
  * @extends netdev_t
  */
 typedef struct {
@@ -53,7 +53,7 @@ typedef struct {
 } encx24j600_params_t;
 
 /**
- * @brief Setup an encx24j600 based device state.
+ * @brief   Setup an encx24j600 based device state.
  *
  * This function sets SPI pins, initializes the device state structure.
  * It does not initialize the device itself.

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -43,7 +43,7 @@ extern "C" {
 #endif
 
 /**
- * @name Escape char definitions
+ * @name    Escape char definitions
  * @{
  */
 #define ETHOS_FRAME_DELIMITER           (0x7E)
@@ -55,7 +55,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   enum describing line state
+ * @brief   Enum describing line state
  */
 typedef enum {
     WAIT_FRAMESTART,
@@ -64,7 +64,7 @@ typedef enum {
 } line_state_t;
 
 /**
- * @brief ethos netdev device
+ * @brief   ethos netdev device
  * @extends netdev_t
  */
 typedef struct {
@@ -91,7 +91,7 @@ typedef struct {
 } ethos_params_t;
 
 /**
- * @brief Setup an ethos based device state.
+ * @brief   Setup an ethos based device state.
  *
  * The supplied buffer *must* have a power-of-two size, and it *must* be large
  * enough for the largest expected packet + enough buffer space to buffer
@@ -105,7 +105,7 @@ typedef struct {
 void ethos_setup(ethos_t *dev, const ethos_params_t *params);
 
 /**
- * @brief send frame over serial port using ethos' framing
+ * @brief   Send frame over serial port using ethos' framing
  *
  * This is used by e.g., stdio over ethos to send text frames.
  *

--- a/drivers/include/feetech.h
+++ b/drivers/include/feetech.h
@@ -9,8 +9,8 @@
 /**
  * @defgroup    drivers_feetech Feetech driver
  * @ingroup     drivers_actuators
+ * @brief       Drivers for any device using feetech's servomotors communication bus.
  *
- * This module contains drivers for any device using feetech's servomotors communication bus.
  * The bus is mainly used for servomotors, but a device can be anything : sensors, other actuators.
  *
  * @{
@@ -37,7 +37,7 @@ typedef uint8_t feetech_id_t;    /**< device id type */
 typedef uint8_t feetech_addr_t;  /**< address type */
 
 /**
- * @brief Descriptor struct for a feetech device
+ * @brief   Descriptor struct for a feetech device
  */
 typedef struct {
     uart_half_duplex_t *stream; /**< the stream used */
@@ -55,7 +55,7 @@ enum {
 };
 
 /**
- * @brief Send a PING message to a device
+ * @brief   Send a PING message to a device
  *
  * @param[in] stream   the stream
  * @param[in] id       the device address
@@ -68,7 +68,7 @@ enum {
 int feetech_ping(uart_half_duplex_t *stream, feetech_id_t id);
 
 /**
- * @brief Initialize a Feetech device
+ * @brief   Initialize a Feetech device
  *
  * @param[out] device  the Feetech device
  * @param[in] stream   the stream
@@ -77,7 +77,7 @@ int feetech_ping(uart_half_duplex_t *stream, feetech_id_t id);
 void feetech_init(feetech_t *device, uart_half_duplex_t *stream, feetech_id_t id);
 
 /**
- * @brief Write to a device 8bits address
+ * @brief   Write to a device 8bits address
  *
  * @param[in] device   the Feetech device
  * @param[in] addr     the address to write
@@ -91,7 +91,7 @@ void feetech_init(feetech_t *device, uart_half_duplex_t *stream, feetech_id_t id
 int feetech_write8(const feetech_t *device, feetech_addr_t addr, uint8_t value);
 
 /**
- * @brief Write to a device 16bits address
+ * @brief   Write to a device 16bits address
  *
  * @param[in] device   the Feetech device
  * @param[in] addr     the address to write
@@ -105,7 +105,7 @@ int feetech_write8(const feetech_t *device, feetech_addr_t addr, uint8_t value);
 int feetech_write16(const feetech_t *device, feetech_addr_t addr, uint16_t value);
 
 /**
- * @brief Write to a device address
+ * @brief   Write to a device address
  *
  * @param[in] device   the Feetech device
  * @param[in] addr     the address to start write
@@ -120,7 +120,7 @@ int feetech_write16(const feetech_t *device, feetech_addr_t addr, uint16_t value
 int feetech_write(const feetech_t *device, feetech_addr_t addr, const uint8_t *data, size_t length);
 
 /**
- * @brief Read from a device 8bits address
+ * @brief   Read from a device 8bits address
  *
  * @param[in] device   the Feetech device
  * @param[in] addr     the address to read
@@ -134,7 +134,7 @@ int feetech_write(const feetech_t *device, feetech_addr_t addr, const uint8_t *d
 int feetech_read8(const feetech_t *device, feetech_addr_t addr, uint8_t *value);
 
 /**
- * @brief Read from a device 16bits address
+ * @brief   Read from a device 16bits address
  *
  * @param[in] device   the Feetech device
  * @param[in] addr     the address to read
@@ -148,7 +148,7 @@ int feetech_read8(const feetech_t *device, feetech_addr_t addr, uint8_t *value);
 int feetech_read16(const feetech_t *device, feetech_addr_t addr, uint16_t *value);
 
 /**
- * @brief Read from a device address
+ * @brief   Read from a device address
  *
  * @param[in] device   the Feetech device
  * @param[in] addr      the address to start read

--- a/drivers/include/flashrom.h
+++ b/drivers/include/flashrom.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Erase sector
+ * @brief   Erase sector
  *
  * @param[out] addr Address within a flash sector to erase
  *
@@ -43,7 +43,7 @@ extern "C" {
 uint8_t             flashrom_erase(uint8_t *addr);
 
 /**
- * @brief Write buffer from ram to flash
+ * @brief   Write buffer from ram to flash
  *
  * @param[out] dst  Address within a flash sector to write, must be a 256 byte boundary
  * @param[in] src   Address within ram, must be a word boundary

--- a/drivers/include/hd44780.h
+++ b/drivers/include/hd44780.h
@@ -32,17 +32,17 @@ extern "C" {
 #endif
 
 /**
- * @brief Maximal number of columns supported by the driver
+ * @brief   Maximal number of columns supported by the driver
  */
 #define HD44780_MAX_COLS        (40U)
 
 /**
- * @brief Maximal number of rows supported by the driver
+ * @brief   Maximal number of rows supported by the driver
  */
 #define HD44780_MAX_ROWS        (4U)
 
 /**
- * @brief Number of data pins for communication 4 or 8.
+ * @brief   Number of data pins for communication 4 or 8.
  */
 #define HD44780_MAX_PINS        (8U)
 
@@ -52,7 +52,7 @@ extern "C" {
 #define HD44780_RW_OFF          (255U)
 
 /**
- * @brief Size of RAM for custom chars
+ * @brief   Size of RAM for custom chars
  *
  * Generally the driver could support 8 chars of size 5x8 or 4 of size 5x10.
  * However, most displays only use the former, which is (hard wired) default.
@@ -83,7 +83,7 @@ typedef struct {
 } hd44780_t;
 
 /**
- * @brief Simple state values
+ * @brief   Simple state values
  */
 typedef enum {
     HD44780_OFF,                    /**< disable feature */
@@ -91,7 +91,7 @@ typedef enum {
 } hd44780_state_t;
 
 /**
- * @brief Initialize the given driver
+ * @brief   Initialize the given driver
  *
  * @param[out] dev          device descriptor of display to initialize
  * @param[in]  params       configuration parameters
@@ -101,21 +101,21 @@ typedef enum {
 int hd44780_init(hd44780_t *dev, const hd44780_params_t *params);
 
 /**
- * @brief Clear display, delete all chars
+ * @brief   Clear display, delete all chars
  *
  * @param[in]  dev          device descriptor of LCD
  */
 void hd44780_clear(const hd44780_t *dev);
 
 /**
- * @brief Reset cursor to row 0 and column 0
+ * @brief   Reset cursor to row 0 and column 0
  *
  * @param[in]  dev          device descriptor of LCD
  */
 void hd44780_home(const hd44780_t *dev);
 
 /**
- * @brief Set cursor to specific position in column and row
+ * @brief   Set cursor to specific position in column and row
  *
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  col          column position
@@ -124,7 +124,7 @@ void hd44780_home(const hd44780_t *dev);
 void hd44780_set_cursor(const hd44780_t *dev, uint8_t col, uint8_t row);
 
 /**
- * @brief Turn display on or off
+ * @brief   Turn display on or off
  *
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  state        display on or off
@@ -132,7 +132,7 @@ void hd44780_set_cursor(const hd44780_t *dev, uint8_t col, uint8_t row);
 void hd44780_display(hd44780_t *dev, hd44780_state_t state);
 
 /**
- * @brief Show cursor, on or off
+ * @brief   Show cursor, on or off
  *
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  state        cursor on or off
@@ -140,7 +140,7 @@ void hd44780_display(hd44780_t *dev, hd44780_state_t state);
 void hd44780_cursor(hd44780_t *dev, hd44780_state_t state);
 
 /**
- * @brief Blink cursor, on or off
+ * @brief   Blink cursor, on or off
  *
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  state        blink on or off
@@ -148,35 +148,35 @@ void hd44780_cursor(hd44780_t *dev, hd44780_state_t state);
 void hd44780_blink(hd44780_t *dev, hd44780_state_t state);
 
 /**
- * @brief Enable left scrolling
+ * @brief   Enable left scrolling
  *
  * @param[in]  dev          device descriptor of LCD
  */
 void hd44780_scroll_left(const hd44780_t *dev);
 
 /**
- * @brief Enable right scrolling
+ * @brief   Enable right scrolling
  *
  * @param[in]  dev          device descriptor of LCD
  */
 void hd44780_scroll_right(const hd44780_t *dev);
 
 /**
- * @brief set display direction left to right
+ * @brief   Set display direction left to right
  *
  * @param[in]  dev          device descriptor of LCD
  */
 void hd44780_left2right(hd44780_t *dev);
 
 /**
- * @brief set   display direction right to left
+ * @brief   Set display direction right to left
  *
  * @param[in]  dev          device descriptor of LCD
  */
 void hd44780_right2left(hd44780_t *dev);
 
 /**
- * @brief display autoscroll on or off
+ * @brief   Display autoscroll on or off
  *
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  state        scroll on or off
@@ -184,7 +184,7 @@ void hd44780_right2left(hd44780_t *dev);
 void hd44780_autoscroll(hd44780_t *dev, hd44780_state_t state);
 
 /**
- * @brief Create and store a custom character on display memory
+ * @brief   Create and store a custom character on display memory
  *
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  location     memory location
@@ -195,7 +195,7 @@ void hd44780_autoscroll(hd44780_t *dev, hd44780_state_t state);
 void hd44780_create_char(const hd44780_t *dev, uint8_t location, uint8_t charmap[]);
 
 /**
- * @brief Write a single character on the LCD
+ * @brief   Write a single character on the LCD
  *
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  value        the character to print, i.e., memory location
@@ -203,7 +203,7 @@ void hd44780_create_char(const hd44780_t *dev, uint8_t location, uint8_t charmap
 void hd44780_write(const hd44780_t *dev, uint8_t value);
 
 /**
- * @brief Write a string on the LCD
+ * @brief   Write a string on the LCD
  *
  * @param[in]  dev          device descriptor of LCD
  * @param[in]  data         the string to print

--- a/drivers/include/hih6130.h
+++ b/drivers/include/hih6130.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Device descriptor for HIH6130/HIH6131 sensors
+ * @brief   Device descriptor for HIH6130/HIH6131 sensors
  */
 typedef struct {
     i2c_t i2c;              /**< I2C device the sensor is connected to */
@@ -40,7 +40,7 @@ typedef struct {
 } hih6130_t;
 
 /**
- * @brief Initialize a sensor
+ * @brief   Initialize a sensor
  *
  * @param[out] dev          device descriptor of sensor to initialize
  * @param[in]  i2c          I2C bus the sensor is connected to
@@ -49,7 +49,7 @@ typedef struct {
 void hih6130_init(hih6130_t *dev, i2c_t i2c, uint8_t address);
 
 /**
- * @brief Read humidity and temperature from sensor and convert to floating-point
+ * @brief   Read humidity and temperature from sensor and convert to floating-point
  *
  * @param[in]  dev                       Sensor device descriptor
  * @param[out] relative_humidity_percent Measured relative humidity in percent

--- a/drivers/include/ina220.h
+++ b/drivers/include/ina220.h
@@ -33,14 +33,16 @@ extern "C" {
 #endif
 
 /**
- * @brief Device descriptor for INA220 sensors
+ * @brief   Device descriptor for INA220 sensors
  */
 typedef struct {
     i2c_t i2c;              /**< I2C device the sensor is connected to */
     uint8_t addr;           /**< the slave address of the sensor on the I2C bus */
 } ina220_t;
 
-/** @brief INA220 possible mode settings */
+/**
+ * @brief   INA220 possible mode settings
+ */
 typedef enum ina220_mode {
     INA220_MODE_POWERDOWN             = 0x0000, /**< Power down */
     INA220_MODE_TRIGGER_SHUNT_ONLY    = 0x0001, /**< Shunt Voltage, Triggered */
@@ -52,7 +54,9 @@ typedef enum ina220_mode {
     INA220_MODE_CONTINUOUS_SHUNT_BUS  = 0x0007, /**< Shunt and Bus, Continuous, default */
 } ina220_mode_t;
 
-/** @brief Shunt voltage measurement range (PGA settings) */
+/**
+ * @brief   Shunt voltage measurement range (PGA settings)
+ */
 typedef enum ina220_range {
     INA220_RANGE_40MV  = 0x0000, /**< +/- 40 mV range */
     INA220_RANGE_80MV  = 0x0800, /**< +/- 80 mV range */
@@ -60,14 +64,16 @@ typedef enum ina220_range {
     INA220_RANGE_320MV = 0x1800, /**< +/- 320 mV range, default */
 } ina220_range_t;
 
-/** @brief Bus voltage measurement range */
+/**
+ * @brief   Bus voltage measurement range
+ */
 typedef enum ina220_brng {
     INA220_BRNG_16V_FSR = 0x0000, /**< 16 V bus voltage full scale range */
     INA220_BRNG_32V_FSR = 0x0200, /**< 32 V bus voltage full scale range, default. */
 } ina220_brng_t;
 
 /**
- * @brief Shunt ADC settings
+ * @brief   Shunt ADC settings
  *
  * @see Table 5 in INA220 data sheet
  */
@@ -99,7 +105,7 @@ typedef enum ina220_sadc {
 } ina220_sadc_t;
 
 /**
- * @brief Bus ADC settings
+ * @brief   Bus ADC settings
  *
  * @see Table 5 in INA220 data sheet
  */
@@ -137,7 +143,7 @@ typedef enum ina220_badc {
 #define INA220_BUS_VOLTAGE_SHIFT (3)
 
 /**
- * @brief Initialize a current sensor
+ * @brief   Initialize a current sensor
  *
  * @param[out] dev          device descriptor of sensor to initialize
  * @param[in]  i2c          I2C bus the sensor is connected to
@@ -149,7 +155,7 @@ typedef enum ina220_badc {
 int ina220_init(ina220_t *dev, i2c_t i2c, uint8_t address);
 
 /**
- * @brief Write to calibration register
+ * @brief   Write to calibration register
  *
  * @param[in]  dev          device descriptor of sensor to configure
  * @param[in]  calibration  calibration register settings, see data sheet
@@ -160,7 +166,7 @@ int ina220_init(ina220_t *dev, i2c_t i2c, uint8_t address);
 int ina220_set_calibration(const ina220_t *dev, uint16_t calibration);
 
 /**
- * @brief Write to configuration register
+ * @brief   Write to configuration register
  *
  * @param[in]  dev          device descriptor of sensor to configure
  * @param[in]  config       configuration register settings, see data sheet
@@ -171,7 +177,7 @@ int ina220_set_calibration(const ina220_t *dev, uint16_t calibration);
 int ina220_set_config(const ina220_t *dev, uint16_t config);
 
 /**
- * @brief Read shunt voltage
+ * @brief   Read shunt voltage
  *
  * @param[in]  dev          device descriptor of sensor
  * @param[out] voltage      measured voltage across shunt resistor
@@ -182,7 +188,7 @@ int ina220_set_config(const ina220_t *dev, uint16_t config);
 int ina220_read_shunt(const ina220_t *dev, int16_t *voltage);
 
 /**
- * @brief Read bus voltage register
+ * @brief   Read bus voltage register
  *
  * The bus voltage can be found in the most significant bits of the bus voltage
  * register, the lower three bits are flags/reserved.
@@ -198,7 +204,7 @@ int ina220_read_shunt(const ina220_t *dev, int16_t *voltage);
 int ina220_read_bus(const ina220_t *dev, int16_t *voltage);
 
 /**
- * @brief Read shunt current
+ * @brief   Read shunt current
  *
  * @param[in]  dev          device descriptor of sensor
  * @param[out] current      measured current through shunt resistor
@@ -209,7 +215,7 @@ int ina220_read_bus(const ina220_t *dev, int16_t *voltage);
 int ina220_read_current(const ina220_t *dev, int16_t *current);
 
 /**
- * @brief Read power consumption
+ * @brief   Read power consumption
  *
  * @param[in]  dev          device descriptor of sensor
  * @param[out] power        measured power consumption

--- a/drivers/include/io1_xplained.h
+++ b/drivers/include/io1_xplained.h
@@ -46,7 +46,7 @@ extern "C" {
 #endif
 
 /**
- * @brief IO1 Xplained driver return codes
+ * @brief   IO1 Xplained driver return codes
  */
 enum {
     IO1_XPLAINED_OK = 0,           /**< Initialization successful */
@@ -59,14 +59,14 @@ enum {
 };
 
 /**
- * @brief Device initialization parameters
+ * @brief   Device initialization parameters
  */
 typedef struct {
     uint8_t addr;                  /**< extension custom address */
 } io1_xplained_params_t;
 
 /**
- * @brief Device descriptor for the IO1 Xplained extension.
+ * @brief   Device descriptor for the IO1 Xplained extension.
  */
 typedef struct {
     io1_xplained_params_t params;  /**< Initialization parameters */
@@ -74,7 +74,7 @@ typedef struct {
 } io1_xplained_t;
 
 /**
- * @brief Initialize the given IO1 Xplained extension
+ * @brief   Initialize the given IO1 Xplained extension
  *
  * @param[out] dev          Initialized device descriptor of IO1 Xplained extension
  * @param[in]  params       Device initialization parameters
@@ -88,7 +88,7 @@ typedef struct {
 int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params);
 
 /**
- * @brief Read temperature value from the given IO1 Xplained extension, returned in °C
+ * @brief   Read temperature value from the given IO1 Xplained extension, returned in °C
  *
  * @param[in] dev           Device descriptor of IO1 Xplained to read from
  * @param[out] temperature  Temperature in °C
@@ -99,17 +99,17 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params);
 int io1_xplained_read_temperature(const io1_xplained_t *dev, float *temperature);
 
 /**
- * @brief Set the on-board led of the IO1 Xplained extension
+ * @brief   Set the on-board led of the IO1 Xplained extension
  */
 void io1_xplained_set_led(void);
 
 /**
- * @brief Clear the on-board led of the IO1 Xplained extension
+ * @brief   Clear the on-board led of the IO1 Xplained extension
  */
 void io1_xplained_clear_led(void);
 
 /**
- * @brief Toggle the on-board led of the IO1 Xplained extension
+ * @brief   Toggle the on-board led of the IO1 Xplained extension
  */
 void io1_xplained_toggle_led(void);
 

--- a/drivers/include/isl29020.h
+++ b/drivers/include/isl29020.h
@@ -29,12 +29,12 @@ extern "C" {
 #endif
 
  /**
-  * @brief The sensors default I2C address
+  * @brief   The sensors default I2C address
   */
 #define ISL29020_DEFAULT_ADDRESS        0x44
 
 /**
- * @brief Device descriptor for ISL29020 sensors
+ * @brief   Device descriptor for ISL29020 sensors
  */
 typedef struct {
     i2c_t i2c;                  /**< I2C device the sensor is connected to */
@@ -43,7 +43,7 @@ typedef struct {
 } isl29020_t;
 
 /**
- * @brief Possible modes for the ISL29020 sensor
+ * @brief   Possible modes for the ISL29020 sensor
  */
 typedef enum {
     ISL29020_MODE_AMBIENT = 0,  /**< set sensor to detect ambient light */
@@ -51,7 +51,7 @@ typedef enum {
 } isl29020_mode_t;
 
 /**
- * @brief Possible range values for the ISL29020 sensor
+ * @brief   Possible range values for the ISL29020 sensor
  */
 typedef enum {
     ISL29020_RANGE_1K = 0,      /**< set range to 0-1000 lux */
@@ -61,7 +61,7 @@ typedef enum {
 } isl29020_range_t;
 
 /**
- * @brief Data structure holding the full set of configuration parameters
+ * @brief   Data structure holding the full set of configuration parameters
  */
 typedef struct {
     i2c_t i2c;                  /**< I2C bus the device is connected to */
@@ -71,7 +71,7 @@ typedef struct {
 } isl29020_params_t;
 
 /**
- * @brief Initialize a new ISL29020 device
+ * @brief   Initialize a new ISL29020 device
  *
  * @param[in] dev       device descriptor of an ISL29020 device
  * @param[in] i2c       I2C device the sensor is connected to
@@ -86,7 +86,7 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
                   isl29020_range_t range, isl29020_mode_t mode);
 
 /**
- * @brief Read a lighting value from the sensor, the result is given in lux
+ * @brief   Read a lighting value from the sensor, the result is given in lux
  *
  * @param[in] dev       device descriptor of an ISL29020 device
  *
@@ -96,7 +96,7 @@ int isl29020_init(isl29020_t *dev, i2c_t i2c, uint8_t address,
 int isl29020_read(const isl29020_t *dev);
 
 /**
- * @brief Enable the given sensor
+ * @brief   Enable the given sensor
  *
  * @param[in] dev       device descriptor of an ISL29020 device
  *
@@ -106,7 +106,7 @@ int isl29020_read(const isl29020_t *dev);
 int isl29020_enable(const isl29020_t *dev);
 
 /**
- * @brief Disable the given sensor
+ * @brief   Disable the given sensor
  *
  * @param[in] dev       device descriptor of an ISL29020 device
  *

--- a/drivers/include/isl29125.h
+++ b/drivers/include/isl29125.h
@@ -59,7 +59,7 @@ extern "C" {
 #endif
 
 /**
- * @brief data type for storing lux RGB sensor readings
+ * @brief   Data type for storing lux RGB sensor readings
  */
 typedef struct {
     float red;              /**< red lux value */
@@ -68,7 +68,7 @@ typedef struct {
 } isl29125_rgb_t;
 
 /**
- * @brief supported operation modes of the ISL29125 sensor's AD
+ * @brief   Supported operation modes of the ISL29125 sensor's AD
  * conversion
  */
 typedef enum {
@@ -83,7 +83,7 @@ typedef enum {
 } isl29125_mode_t;
 
 /**
- * @brief supported RGB sensing range values of the ISL29125 sensor
+ * @brief   Supported RGB sensing range values of the ISL29125 sensor
  */
 typedef enum {
     ISL29125_RANGE_375 = 0x00,      /**< range: 5.7m - 375 lux */
@@ -91,7 +91,7 @@ typedef enum {
 } isl29125_range_t;
 
 /**
- * @brief supported color resolutions of the ISL29125 sensor's AD
+ * @brief   Supported color resolutions of the ISL29125 sensor's AD
  * conversion
  */
 typedef enum {
@@ -100,7 +100,7 @@ typedef enum {
 } isl29125_resolution_t;
 
 /**
- * @brief Device descriptor for ISL29125 sensors
+ * @brief   Device descriptor for ISL29125 sensors
  */
 typedef struct {
     i2c_t i2c;                      /**< I2C device the sensor is connected to */
@@ -110,7 +110,7 @@ typedef struct {
 } isl29125_t;
 
 /**
- * @brief Configuration-3 Register 0x03 B1:0
+ * @brief   Configuration-3 Register 0x03 B1:0
  */
 typedef enum {
     ISL29125_INTERRUPT_STATUS_NONE = 0x00,      /**< No interrupt */
@@ -120,7 +120,7 @@ typedef enum {
 } isl29125_interrupt_status_t;
 
 /**
- * @brief Configuration-3 Register 0x03 B3:2
+ * @brief   Configuration-3 Register 0x03 B3:2
  */
 typedef enum {
     ISL29125_INTERRUPT_PERSIST_1 = (0x00 << 2), /**< Int. Persist: Number of integration cycle 1 */
@@ -130,7 +130,7 @@ typedef enum {
 } isl29125_interrupt_persist_t;
 
 /**
- * @brief Configuration-3 Register 0x03 B4
+ * @brief   Configuration-3 Register 0x03 B4
  */
 typedef enum {
     ISL29125_INTERRUPT_CONV_DIS = (0x0 << 4),   /**< RGB Conversion done to ~INT Control disable */
@@ -138,7 +138,7 @@ typedef enum {
 } isl29125_interrupt_conven_t;
 
 /**
- * @brief initialize a new ISL29125 device
+ * @brief   Initialize a new ISL29125 device
  *
  * @param[in] dev           device descriptor of an ISL29125 device
  * @param[in] i2c           I2C device the sensor is connected to
@@ -155,7 +155,7 @@ int isl29125_init(isl29125_t *dev, i2c_t i2c, gpio_t gpio,
                   isl29125_resolution_t resolution);
 
 /**
- * @brief initialize interrupts
+ * @brief   Initialize interrupts
  *
  * @param[in] dev                   device descriptor of an ISL29125 device
  * @param[in] interrupt_status      Interrupt status
@@ -176,7 +176,7 @@ int isl29125_init_int(isl29125_t *dev, isl29125_interrupt_status_t interrupt_sta
                       gpio_cb_t cb, void *arg);
 
 /**
- * @brief read RGB values from device
+ * @brief   Read RGB values from device
  *
  * @param[in] dev       device descriptor of an ISL29125 device
  * @param[in] dest      pointer to lux RGB color object data is written to
@@ -184,7 +184,7 @@ int isl29125_init_int(isl29125_t *dev, isl29125_interrupt_status_t interrupt_sta
 void isl29125_read_rgb_lux(const isl29125_t *dev, isl29125_rgb_t *dest);
 
  /**
- * @brief read color values from device
+ * @brief   Read color values from device
  *
  * @param[in] dev       device descriptor of an ISL29125 device
  * @param[in] dest      pointer to RGB color object data is written to
@@ -192,7 +192,7 @@ void isl29125_read_rgb_lux(const isl29125_t *dev, isl29125_rgb_t *dest);
 void isl29125_read_rgb_color(const isl29125_t *dev, color_rgb_t *dest);
 
 /**
- * @brief set the device's operation mode
+ * @brief   Set the device's operation mode
  *
  * @param[in] dev       device descriptor of an ISL29125 device
  * @param[in] mode      operation mode
@@ -200,7 +200,7 @@ void isl29125_read_rgb_color(const isl29125_t *dev, color_rgb_t *dest);
 void isl29125_set_mode(const isl29125_t *dev, isl29125_mode_t mode);
 
 /**
- * @brief read isl29125 interrupt status
+ * @brief   Read isl29125 interrupt status
  *
  * @param[in] dev       device descriptor of an ISL29125 device
  *

--- a/drivers/include/jc42.h
+++ b/drivers/include/jc42.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 /**
- * @name jc42 status return codes
+ * @name    jc42 status return codes
  * @{
  */
 #define JC42_OK                       (0)
@@ -58,7 +58,7 @@ typedef struct {
 } jc42_t;
 
 /**
- * @brief Device initialization parameters
+ * @brief   Device initialization parameters
  */
 typedef struct {
     i2c_t i2c;	        /**< I2C device that sensor is connected to */
@@ -67,7 +67,7 @@ typedef struct {
 } jc42_params_t;
 
 /**
- * @brief export SAUL endpoint
+ * @brief   Export SAUL endpoint
  */
 extern const saul_driver_t jc42_temperature_saul_driver;
 
@@ -121,5 +121,5 @@ int jc42_get_temperature(const jc42_t* dev, int16_t* temperature);
 }
 #endif
 
-/** @} */
 #endif /* JC42_H */
+/** @} */

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -47,7 +47,7 @@ extern "C" {
 #define KW2XRF_DEFAULT_PANID            (IEEE802154_DEFAULT_PANID)
 
 /**
- * @brief   Default channel used after initialization
+ * @name    Default channel used after initialization
  *
  * @{
  */
@@ -57,7 +57,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Allowed range of channels
+ * @name    Allowed range of channels
  *
  * @{
  */
@@ -109,7 +109,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief struct holding all params needed for device initialization
+ * @brief   Struct holding all params needed for device initialization
  */
 typedef struct kw2xrf_params {
     spi_t spi;                          /**< SPI bus the device is connected to */

--- a/drivers/include/l3g4200d.h
+++ b/drivers/include/l3g4200d.h
@@ -33,12 +33,12 @@
 #endif
 
 /**
- * @brief The sensors default I2C address
+ * @brief   The sensors default I2C address
  */
 #define L3G4200D_DEFAULT_ADDRESS        0x68
 
 /**
- * @brief Result vector for gyro measurement
+ * @brief   Result vector for gyro measurement
  */
 typedef struct {
     int16_t acc_x;          /**< roll rate in dgs (degree per second) */
@@ -47,7 +47,7 @@ typedef struct {
 } l3g4200d_data_t;
 
 /**
- * @brief Measurement scale for the gyro
+ * @brief   Measurement scale for the gyro
  */
 typedef enum {
     L3G4200D_SCALE_250DPS  = 0x0,       /**< scale: 250 degree per second */
@@ -56,7 +56,7 @@ typedef enum {
 } l3g4200d_scale_t;
 
 /**
- * @brief Sampling frequency and bandwidth settings for the gyro
+ * @brief   Sampling frequency and bandwidth settings for the gyro
  */
 typedef enum {
     L3G4200D_MODE_100_12  = 0x0,        /**< data rate: 100Hz, cut-off: 12.5Hz */
@@ -76,7 +76,7 @@ typedef enum {
 } l3g4200d_mode_t;
 
 /**
- * @brief Device descriptor for L3G4200D sensors
+ * @brief   Device descriptor for L3G4200D sensors
  */
 typedef struct {
     i2c_t i2c;              /**< I2C device the sensor is connected to */
@@ -87,7 +87,7 @@ typedef struct {
 } l3g4200d_t;
 
 /**
- * @brief Data structure holding the device parameters needed for initialization
+ * @brief   Data structure holding the device parameters needed for initialization
  */
 typedef struct {
     i2c_t i2c;              /**< I2C bus the device is connected to */
@@ -99,7 +99,7 @@ typedef struct {
 } l3g4200d_params_t;
 
 /**
- * @brief Initialize a gyro
+ * @brief   Initialize a gyro
  *
  * @param[out] dev          device descriptor of sensor to initialize
  * @param[in]  i2c          I2C bus the gyro is connected to
@@ -117,7 +117,7 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
                   l3g4200d_mode_t mode, l3g4200d_scale_t scale);
 
 /**
- * @brief Read angular speed value in degree per second from gyro
+ * @brief   Read angular speed value in degree per second from gyro
  *
  * @param[in]  dev          device descriptor of gyro
  * @param[out] acc_data     result vector in dps per axis
@@ -128,7 +128,7 @@ int l3g4200d_init(l3g4200d_t *dev, i2c_t i2c, uint8_t address,
 int l3g4200d_read(const l3g4200d_t *dev, l3g4200d_data_t *acc_data);
 
 /**
- * @brief Power-up the given device
+ * @brief   Power-up the given device
  *
  * @param[in]  dev          device to enable
  *
@@ -138,7 +138,7 @@ int l3g4200d_read(const l3g4200d_t *dev, l3g4200d_data_t *acc_data);
 int l3g4200d_enable(const l3g4200d_t *dev);
 
 /**
- * @brief Power-down the given device
+ * @brief   Power-down the given device
  *
  * @param[in]  dev          device to power-down
  *

--- a/drivers/include/led.h
+++ b/drivers/include/led.h
@@ -39,65 +39,65 @@ extern "C" {
 #endif
 
 /**
- * @brief   LED fallback macros
+ * @name    LED fallback macros
  * @{
  */
 #ifndef LED0_ON
-#define LED0_ON             /* defined empty */
-#define LED0_OFF            /* defined empty */
-#define LED0_TOGGLE         /* defined empty */
+#define LED0_ON             /**< defined empty */
+#define LED0_OFF            /**< defined empty */
+#define LED0_TOGGLE         /**< defined empty */
 #endif
 
 #ifndef LED1_ON
-#define LED1_ON             /* defined empty */
-#define LED1_OFF            /* defined empty */
-#define LED1_TOGGLE         /* defined empty */
+#define LED1_ON             /**< defined empty */
+#define LED1_OFF            /**< defined empty */
+#define LED1_TOGGLE         /**< defined empty */
 #endif
 
 #ifndef LED2_ON
-#define LED2_ON             /* defined empty */
-#define LED2_OFF            /* defined empty */
-#define LED2_TOGGLE         /* defined empty */
+#define LED2_ON             /**< defined empty */
+#define LED2_OFF            /**< defined empty */
+#define LED2_TOGGLE         /**< defined empty */
 #endif
 
 #ifndef LED3_ON
-#define LED3_ON             /* defined empty */
-#define LED3_OFF            /* defined empty */
-#define LED3_TOGGLE         /* defined empty */
+#define LED3_ON             /**< defined empty */
+#define LED3_OFF            /**< defined empty */
+#define LED3_TOGGLE         /**< defined empty */
 #endif
 
 #ifndef LED4_ON
-#define LED4_ON             /* defined empty */
-#define LED4_OFF            /* defined empty */
-#define LED4_TOGGLE         /* defined empty */
+#define LED4_ON             /**< defined empty */
+#define LED4_OFF            /**< defined empty */
+#define LED4_TOGGLE         /**< defined empty */
 #endif
 
 #ifndef LED5_ON
-#define LED5_ON             /* defined empty */
-#define LED5_OFF            /* defined empty */
-#define LED5_TOGGLE         /* defined empty */
+#define LED5_ON             /**< defined empty */
+#define LED5_OFF            /**< defined empty */
+#define LED5_TOGGLE         /**< defined empty */
 #endif
 
 #ifndef LED6_ON
-#define LED6_ON             /* defined empty */
-#define LED6_OFF            /* defined empty */
-#define LED6_TOGGLE         /* defined empty */
+#define LED6_ON             /**< defined empty */
+#define LED6_OFF            /**< defined empty */
+#define LED6_TOGGLE         /**< defined empty */
 #endif
 
 #ifndef LED7_ON
-#define LED7_ON             /* defined empty */
-#define LED7_OFF            /* defined empty */
-#define LED7_TOGGLE         /* defined empty */
+#define LED7_ON             /**< defined empty */
+#define LED7_OFF            /**< defined empty */
+#define LED7_TOGGLE         /**< defined empty */
 #endif
 /** @} */
 
 /**
- * @brief   Convenience LED control macros
+ * @name    Convenience LED control macros
  * @{
  */
-#define LED_ON(x)           LED ## x ##_ON
-#define LED_OFF(x)          LED ## x ## _OFF
-#define LED_TOGGLE(x)       LED ## x ##_TOGGLE
+#define LED_ON(x)           LED ## x ##_ON      /**< Turn on led x */
+#define LED_OFF(x)          LED ## x ## _OFF    /**< Turn off led x */
+#define LED_TOGGLE(x)       LED ## x ##_TOGGLE  /**< Toggle led x */
 /** @} */
 
 #ifdef __cplusplus

--- a/drivers/include/lis3dh.h
+++ b/drivers/include/lis3dh.h
@@ -32,52 +32,54 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Identifier register value
+ *
  * The WHO_AM_I register should contain this value in order to correctly
  * identify the chip.
  */
-#define LIS3DH_WHO_AM_I_RESPONSE (0b00110011)
+#define LIS3DH_WHO_AM_I_RESPONSE                 (0x33)
 
 /**
- * @brief LIS3DH hardware register addresses
+ * @name    LIS3DH hardware register addresses
+ * @{
  */
-typedef enum {
-    LIS3DH_REG_STATUS_AUX = 0x07,
-    LIS3DH_REG_OUT_AUX_ADC1_L = 0x08,
-    LIS3DH_REG_OUT_AUX_ADC1_H = 0x09,
-    LIS3DH_REG_OUT_AUX_ADC2_L = 0x0A,
-    LIS3DH_REG_OUT_AUX_ADC2_H = 0x0B,
-    LIS3DH_REG_OUT_AUX_ADC3_L = 0x0C,
-    LIS3DH_REG_OUT_AUX_ADC3_H = 0x0D,
-    LIS3DH_REG_INT_COUNTER_REG = 0x0E,
-    LIS3DH_REG_WHO_AM_I = 0x0F,
-    LIS3DH_REG_TEMP_CFG_REG = 0x1F,
-    LIS3DH_REG_CTRL_REG1 = 0x20,
-    LIS3DH_REG_CTRL_REG2 = 0x21,
-    LIS3DH_REG_CTRL_REG3 = 0x22,
-    LIS3DH_REG_CTRL_REG4 = 0x23,
-    LIS3DH_REG_CTRL_REG5 = 0x24,
-    LIS3DH_REG_CTRL_REG6 = 0x25,
-    LIS3DH_REG_REFERENCE = 0x26,
-    LIS3DH_REG_STATUS_REG = 0x27,
-    LIS3DH_REG_OUT_X_L = 0x28,
-    LIS3DH_REG_OUT_X_H = 0x29,
-    LIS3DH_REG_OUT_Y_L = 0x2A,
-    LIS3DH_REG_OUT_Y_H = 0x2B,
-    LIS3DH_REG_OUT_Z_L = 0x2C,
-    LIS3DH_REG_OUT_Z_H = 0x2D,
-    LIS3DH_REG_FIFO_CTRL_REG = 0x2E,
-    LIS3DH_REG_FIFO_SRC_REG = 0x2F,
-    LIS3DH_REG_INT1_CFG = 0x30,
-    LIS3DH_REG_INT1_SOURCE = 0x31,
-    LIS3DH_REG_INT1_THS = 0x32,
-    LIS3DH_REG_INT1_DURATION = 0x33,
-    LIS3DH_REG_CLICK_CFG = 0x38,
-    LIS3DH_REG_CLICK_SRC = 0x39,
-    LIS3DH_REG_CLICK_THS = 0x3A,
-    LIS3DH_REG_TIME_LIMIT = 0x3B,
-    LIS3DH_REG_TIME_LATENCY = 0x3C,
-    LIS3DH_REG_TIME_WINDOW = 0x3D,
-} lis3dh_reg_t;
+#define LIS3DH_REG_STATUS_AUX                    (0x07)
+#define LIS3DH_REG_OUT_AUX_ADC1_L                (0x08)
+#define LIS3DH_REG_OUT_AUX_ADC1_H                (0x09)
+#define LIS3DH_REG_OUT_AUX_ADC2_L                (0x0A)
+#define LIS3DH_REG_OUT_AUX_ADC2_H                (0x0B)
+#define LIS3DH_REG_OUT_AUX_ADC3_L                (0x0C)
+#define LIS3DH_REG_OUT_AUX_ADC3_H                (0x0D)
+#define LIS3DH_REG_INT_COUNTER_REG               (0x0E)
+#define LIS3DH_REG_WHO_AM_I                      (0x0F)
+#define LIS3DH_REG_TEMP_CFG_REG                  (0x1F)
+#define LIS3DH_REG_CTRL_REG1                     (0x20)
+#define LIS3DH_REG_CTRL_REG2                     (0x21)
+#define LIS3DH_REG_CTRL_REG3                     (0x22)
+#define LIS3DH_REG_CTRL_REG4                     (0x23)
+#define LIS3DH_REG_CTRL_REG5                     (0x24)
+#define LIS3DH_REG_CTRL_REG6                     (0x25)
+#define LIS3DH_REG_REFERENCE                     (0x26)
+#define LIS3DH_REG_STATUS_REG                    (0x27)
+#define LIS3DH_REG_OUT_X_L                       (0x28)
+#define LIS3DH_REG_OUT_X_H                       (0x29)
+#define LIS3DH_REG_OUT_Y_L                       (0x2A)
+#define LIS3DH_REG_OUT_Y_H                       (0x2B)
+#define LIS3DH_REG_OUT_Z_L                       (0x2C)
+#define LIS3DH_REG_OUT_Z_H                       (0x2D)
+#define LIS3DH_REG_FIFO_CTRL_REG                 (0x2E)
+#define LIS3DH_REG_FIFO_SRC_REG                  (0x2F)
+#define LIS3DH_REG_INT1_CFG                      (0x30)
+#define LIS3DH_REG_INT1_SOURCE                   (0x31)
+#define LIS3DH_REG_INT1_THS                      (0x32)
+#define LIS3DH_REG_INT1_DURATION                 (0x33)
+#define LIS3DH_REG_CLICK_CFG                     (0x38)
+#define LIS3DH_REG_CLICK_SRC                     (0x39)
+#define LIS3DH_REG_CLICK_THS                     (0x3A)
+#define LIS3DH_REG_TIME_LIMIT                    (0x3B)
+#define LIS3DH_REG_TIME_LATENCY                  (0x3C)
+#define LIS3DH_REG_TIME_WINDOW                   (0x3D)
+/** @} */
 
 /*
  * Bit offsets within the individual registers
@@ -85,38 +87,53 @@ typedef enum {
  */
 
 /**
- * @name TEMP_CFG_REG bitfield macros
+ * @name    TEMP_CFG_REG bitfield macros
+ * @{
  */
-/** @{ */
-
-
 /**
- * @brief ADC enable
+ * @brief   ADC enable
  *
  * Default value: 0
  *
  * 0: ADC disabled; 1: ADC enabled
  */
-#define LIS3DH_TEMP_CFG_REG_ADC_PD_MASK (1 << 7)
-
+#define LIS3DH_TEMP_CFG_REG_ADC_PD_MASK          (1 << 7)
 /**
- * @brief Temperature sensor (T) enable.
+ * @brief   Temperature sensor (T) enable.
  *
  * Default value: 0
  *
  * 0: T disabled; 1: T enabled
  */
-#define LIS3DH_TEMP_CFG_REG_TEMP_EN_MASK (1 << 6)
-
-/** @} */
+#define LIS3DH_TEMP_CFG_REG_TEMP_EN_MASK         (1 << 6)
+/** @} */ /* TEMP_CFG_REG bitfield macros */
 
 /**
- * @name CTRL_REG1 bitfield macros
+ * @name    CTRL_REG1 bitfield macros
+ * @{
  */
-/** @{ */
-
 /**
- * @name Output data rate selection bitfield macros
+ * @brief    ODR global shift
+ */
+#define LIS3DH_CTRL_REG1_ODR_SHIFT               (4)
+/**
+ * @brief    ODR fourth bit mask
+ */
+#define LIS3DH_CTRL_REG1_ODR3_MASK               (1 << (LIS3DH_CTRL_REG1_ODR_SHIFT + 3))
+/**
+ * @brief    ODR third bit mask
+ */
+#define LIS3DH_CTRL_REG1_ODR2_MASK               (1 << (LIS3DH_CTRL_REG1_ODR_SHIFT + 2))
+/**
+ * @brief    ODR second bit mask
+ */
+#define LIS3DH_CTRL_REG1_ODR1_MASK               (1 << (LIS3DH_CTRL_REG1_ODR_SHIFT + 1))
+/**
+ * @brief   ODR first bit mask
+ */
+#define LIS3DH_CTRL_REG1_ODR0_MASK               (1 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   Output data rate (ODR) selection bitfield
  *
  * Default value: 0000
  *
@@ -124,336 +141,336 @@ typedef enum {
  *
  * @see LIS3DH data sheet Table 25, “Data rate configuration”
  */
-/** @{ */
-#define LIS3DH_CTRL_REG1_ODR_SHIFT (4)
-#define LIS3DH_CTRL_REG1_ODR3_MASK (1 << (LIS3DH_CTRL_REG1_ODR_SHIFT + 3))
-#define LIS3DH_CTRL_REG1_ODR2_MASK (1 << (LIS3DH_CTRL_REG1_ODR_SHIFT + 2))
-#define LIS3DH_CTRL_REG1_ODR1_MASK (1 << (LIS3DH_CTRL_REG1_ODR_SHIFT + 1))
-#define LIS3DH_CTRL_REG1_ODR0_MASK (1 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-
-#define LIS3DH_CTRL_REG1_ODR_MASK  (LIS3DH_CTRL_REG1_ODR3_MASK | \
-                                    LIS3DH_CTRL_REG1_ODR2_MASK | \
-                                    LIS3DH_CTRL_REG1_ODR1_MASK | \
-                                    LIS3DH_CTRL_REG1_ODR0_MASK)
-
-/** @} */
-
+#define LIS3DH_CTRL_REG1_ODR_MASK                (LIS3DH_CTRL_REG1_ODR3_MASK | \
+                                                  LIS3DH_CTRL_REG1_ODR2_MASK | \
+                                                  LIS3DH_CTRL_REG1_ODR1_MASK | \
+                                                  LIS3DH_CTRL_REG1_ODR0_MASK)
 /**
- * @brief Low power mode enable.
+ * @brief   Low power mode enable.
  *
  * Default value: 0
  *
  *  0. normal mode
  *  1. low power mode
  */
-#define LIS3DH_CTRL_REG1_LPEN_MASK (1 << 3)
-
-/** @brief Z enable bit offset */
-#define LIS3DH_CTRL_REG1_ZEN_SHIFT (2)
+#define LIS3DH_CTRL_REG1_LPEN_MASK               (1 << 3)
 /**
- * @brief Z axis enable.
+ * @brief   Z enable bit offset
+ */
+#define LIS3DH_CTRL_REG1_ZEN_SHIFT               (2)
+/**
+ * @brief   Z axis enable.
  *
  * Default value: 1
  *
  *  0. Z axis disabled
  *  1. Z axis enabled
  */
-#define LIS3DH_CTRL_REG1_ZEN_MASK (1 << LIS3DH_CTRL_REG1_ZEN_SHIFT)
-
-/** @brief Y enable bit offset */
-#define LIS3DH_CTRL_REG1_YEN_SHIFT (1)
+#define LIS3DH_CTRL_REG1_ZEN_MASK                (1 << LIS3DH_CTRL_REG1_ZEN_SHIFT)
 /**
- * @brief Y axis enable.
+ * @brief   Y enable bit offset
+ */
+#define LIS3DH_CTRL_REG1_YEN_SHIFT               (1)
+/**
+ * @brief   Y axis enable.
  *
  * Default value: 1
  *
  *  0. Y axis disabled
  *  1. Y axis enabled
  */
-#define LIS3DH_CTRL_REG1_YEN_MASK (1 << LIS3DH_CTRL_REG1_YEN_SHIFT)
-
-/** @brief X enable bit offset */
-#define LIS3DH_CTRL_REG1_XEN_SHIFT (0)
+#define LIS3DH_CTRL_REG1_YEN_MASK                (1 << LIS3DH_CTRL_REG1_YEN_SHIFT)
 /**
- * @brief X axis enable.
+ * @brief   X enable bit offset
+ */
+#define LIS3DH_CTRL_REG1_XEN_SHIFT               (0)
+/**
+ * @brief   X axis enable.
  *
  * Default value: 1
  *
  *  0. X axis disabled
  *  1. X axis enabled
  */
-#define LIS3DH_CTRL_REG1_XEN_MASK (1 << LIS3DH_CTRL_REG1_XEN_SHIFT)
-
-/** @brief XYZ enable bitfield offset */
-#define LIS3DH_CTRL_REG1_XYZEN_SHIFT (0)
-/** @brief X, Y, Z enable bitfield mask */
-#define LIS3DH_CTRL_REG1_XYZEN_MASK (LIS3DH_CTRL_REG1_XEN_MASK | \
-                                     LIS3DH_CTRL_REG1_YEN_MASK | LIS3DH_CTRL_REG1_ZEN_MASK)
-/** @} */
+#define LIS3DH_CTRL_REG1_XEN_MASK                (1 << LIS3DH_CTRL_REG1_XEN_SHIFT)
 /**
- * @name Axis selection macros
- *
- * Use these when calling lis3dh_set_axes()
+ * @brief   XYZ enable bitfield offset
  */
-/** @{ */
-#define LIS3DH_AXES_X (LIS3DH_CTRL_REG1_XEN_MASK) /**< enable X axis */
-#define LIS3DH_AXES_Y (LIS3DH_CTRL_REG1_YEN_MASK) /**< enable Y axis */
-#define LIS3DH_AXES_Z (LIS3DH_CTRL_REG1_ZEN_MASK) /**< enable Z axis */
+#define LIS3DH_CTRL_REG1_XYZEN_SHIFT             (0)
 /**
- * @brief Convenience macro for enabling all axes.
+ * @brief   X, Y, Z enable bitfield mask
+ */
+#define LIS3DH_CTRL_REG1_XYZEN_MASK              (LIS3DH_CTRL_REG1_XEN_MASK | \
+                                                  LIS3DH_CTRL_REG1_YEN_MASK | LIS3DH_CTRL_REG1_ZEN_MASK)
+
+/**
+ * @brief    enable X axis (Use when calling lis3dh_set_axes())
+ */
+#define LIS3DH_AXES_X                            (LIS3DH_CTRL_REG1_XEN_MASK)
+/**
+ * @brief   enable Y axis (Use when calling lis3dh_set_axes())
+ */
+#define LIS3DH_AXES_Y                            (LIS3DH_CTRL_REG1_YEN_MASK)
+/**
+ * @brief   enable Z axis (Use when calling lis3dh_set_axes())
+ */
+#define LIS3DH_AXES_Z                            (LIS3DH_CTRL_REG1_ZEN_MASK)
+/** @} */  /* CTRL_REG1 bitfield macros */
+
+/**
+ * @brief   Convenience macro for enabling all axes.
  */
 #define LIS3DH_AXES_XYZ (LIS3DH_CTRL_REG1_XYZEN_MASK)
-/** @} */
 
 /**
- * @name CTRL_REG2 bitfield macros
+ * @name    CTRL_REG2 bitfield macros
+ * @{
  */
-/** @{ */
 /**
- * @name High pass filter mode selection
+ * @brief   High pass filter mode selection second bit
  *
- * Default value: 00
+ * Default value: 0
  *
  * @see Refer to Table 29, "High pass filter mode configuration"
  */
-/** @{ */
-#define LIS3DH_CTRL_REG2_HPM1_MASK (1 << 7)
-#define LIS3DH_CTRL_REG2_HPM0_MASK (1 << 6)
-/** @} */
-
+#define LIS3DH_CTRL_REG2_HPM1_MASK               (1 << 7)
 /**
- * @name High pass filter cut off frequency selection
+ * @brief   High pass filter mode selection first bit
+ *
+ * Default value: 0
+ *
+ * @see Refer to Table 29, "High pass filter mode configuration"
  */
-/** @{ */
-#define LIS3DH_CTRL_REG2_HPCF2_MASK (1 << 5)
-#define LIS3DH_CTRL_REG2_HPCF1_MASK (1 << 4)
-/** @} */
-
+#define LIS3DH_CTRL_REG2_HPM0_MASK               (1 << 6)
 /**
- * @brief Filtered data selection
+ * @brief   High pass filter cut off frequency selection second bit
+ */
+#define LIS3DH_CTRL_REG2_HPCF2_MASK              (1 << 5)
+/**
+ * @brief   High pass filter cut off frequency selection second bit
+ */
+#define LIS3DH_CTRL_REG2_HPCF1_MASK              (1 << 4)
+/**
+ * @brief   Filtered data selection
  *
  * Default value: 0
  *
  *  0. internal filter bypassed
  *  1. data from internal filter sent to output register and FIFO
  */
-#define LIS3DH_CTRL_REG2_FDS_MASK  (1 << 3)
-
+#define LIS3DH_CTRL_REG2_FDS_MASK                (1 << 3)
 /**
- * @brief High pass filter enabled for CLICK function.
+ * @brief   High pass filter enabled for CLICK function.
  *
  *  0. filter bypassed
  *  1. filter enabled
  */
-#define LIS3DH_CTRL_REG2_HPCLICK_MASK  (1 << 2)
-
+#define LIS3DH_CTRL_REG2_HPCLICK_MASK            (1 << 2)
 /**
- * @name High pass filter enabled for AOI function on interrupt 2
+ * @brief   High pass filter enabled for AOI function on interrupt 2, second bit
  *
  *  0. filter bypassed
  *  1. filter enabled
  */
-/** @{ */
-#define LIS3DH_CTRL_REG2_HPIS2_MASK  (1 << 1)
-#define LIS3DH_CTRL_REG2_HPIS1_MASK  (1 << 0)
-/** @} */
-/** @} */
+#define LIS3DH_CTRL_REG2_HPIS2_MASK              (1 << 1)
+/**
+ * @brief   High pass filter enabled for AOI function on interrupt 2, first bit
+ *
+ *  0. filter bypassed
+ *  1. filter enabled
+ */
+#define LIS3DH_CTRL_REG2_HPIS1_MASK              (1 << 0)
+/** @} */ /* CTRL_REG2 bitfield macros */
 
 /**
- * @name CTRL_REG3 bitfield macros
+ * @name    CTRL_REG3 bitfield macros
+ * @{
  */
-/** @{ */
 /**
- * @brief CLICK interrupt on INT1
+ * @brief   CLICK interrupt on INT1
  *
  * Default value 0.
  *
  *  0. Disable
  *  1. Enable
  */
-#define LIS3DH_CTRL_REG3_I1_CLICK_MASK  (1 << 7)
-
+#define LIS3DH_CTRL_REG3_I1_CLICK_MASK           (1 << 7)
 /**
- * @brief AOI1 interrupt on INT1
+ * @brief   AOI1 interrupt on INT1
  *
  * Default value 0.
  *
  *  0. Disable
  *  1. Enable
  */
-#define LIS3DH_CTRL_REG3_I1_AOI1_MASK    (1 << 6)
+#define LIS3DH_CTRL_REG3_I1_AOI1_MASK            (1 << 6)
 /**
- * @brief AOI2 interrupt on INT1.
+ * @brief   AOI2 interrupt on INT1.
  *
  * Default value 0.
  *
  *  0. Disable
  *  1. Enable
  */
-#define LIS3DH_CTRL_REG3_I1_AOI2_MASK    (1 << 5)
+#define LIS3DH_CTRL_REG3_I1_AOI2_MASK            (1 << 5)
 /**
- * @brief DRDY1 interrupt on INT1
+ * @brief   DRDY1 interrupt on INT1
  *
  * Default value 0.
  *
  *  0. Disable
  *  1. Enable
  */
-#define LIS3DH_CTRL_REG3_I1_DRDY1_MASK   (1 << 4)
+#define LIS3DH_CTRL_REG3_I1_DRDY1_MASK           (1 << 4)
 /**
- * @brief DRDY2 interrupt on INT1
+ * @brief   DRDY2 interrupt on INT1
  *
  * Default value 0.
  *
  *  0. Disable
  *  1. Enable
  */
-#define LIS3DH_CTRL_REG3_I1_DRDY2_MASK   (1 << 3)
+#define LIS3DH_CTRL_REG3_I1_DRDY2_MASK           (1 << 3)
 /**
- * @brief FIFO Watermark interrupt on INT1
+ * @brief   FIFO Watermark interrupt on INT1
  *
  * Default value 0.
  *
  *  0. Disable
  *  1. Enable
  */
-#define LIS3DH_CTRL_REG3_I1_WTM_MASK     (1 << 2)
+#define LIS3DH_CTRL_REG3_I1_WTM_MASK             (1 << 2)
 /**
- * @brief FIFO Overrun interrupt on INT1
+ * @brief   FIFO Overrun interrupt on INT1
  *
  * Default value 0.
  *
  *  0. Disable
  *  1. Enable
  */
-#define LIS3DH_CTRL_REG3_I1_OVERRUN_MASK (1 << 1)
-
-/** @} */
+#define LIS3DH_CTRL_REG3_I1_OVERRUN_MASK         (1 << 1)
+/** @} */ /* CTRL_REG3 bitfield macros */
 
 /**
  * @name CTRL_REG4 bitfield macros
+ * @{
  */
-/** @{ */
-
 /**
- * @name Block data update.
+ * @brief   Block data update (BDU) bit mask
  *
- * Default value: 0
+ * Default value of BDU: 0
  *
  *  0. continuous update
  *  1. output registers not updated until MSB and LSB reading
  */
-/** @{ */
-/** @brief BDU bit mask */
-#define LIS3DH_CTRL_REG4_BDU_MASK (1 << 7)
-/** @brief BDU enable */
-#define LIS3DH_CTRL_REG4_BDU_ENABLE (LIS3DH_CTRL_REG4_BDU_MASK)
-/** @brief BDU disable */
-#define LIS3DH_CTRL_REG4_BDU_DISABLE (0)
-/** @} */
-
+#define LIS3DH_CTRL_REG4_BDU_MASK                (1 << 7)
 /**
- * @name Big/little endian data selection
+ * @brief   Block data update (BDU) enable
+ */
+#define LIS3DH_CTRL_REG4_BDU_ENABLE              (LIS3DH_CTRL_REG4_BDU_MASK)
+/**
+ * @brief    Block data update (BDU) disable
+ */
+#define LIS3DH_CTRL_REG4_BDU_DISABLE             (0)
+/**
+ * @brief   Big/little endian bit mask
  *
- * Default value 0.
+ * Default value of BLE: 0.
  *
  *  0. Data LSB @ lower address
  *  1. Data MSB @ lower address
  */
-/** @{ */
-/** @brief BLE bit mask */
-#define LIS3DH_CTRL_REG4_BLE_MASK (1 << 6)
-
-/** @brief BLE little endian mode */
-#define LIS3DH_CTRL_REG4_BLE_LITTLE_ENDIAN (0)
-/** @brief BLE big endian mode */
-#define LIS3DH_CTRL_REG4_BLE_BIG_ENDIAN (LIS3DH_CTRL_REG4_BLE_MASK)
-/** @} */
-
+#define LIS3DH_CTRL_REG4_BLE_MASK                (1 << 6)
 /**
- * @name Full scale selection.
- *
- * Default value: 00
- *
- *  - 00: +/- 2G
- *  - 01: +/- 4G
- *  - 10: +/- 8G
- *  - 11: +/- 16G
+ * @brief   Big/little endian little endian mode
  */
-/** @{ */
-#define LIS3DH_CTRL_REG4_FS1_MASK (1 << 5)
-#define LIS3DH_CTRL_REG4_FS0_MASK (1 << 4)
-#define LIS3DH_CTRL_REG4_FS_MASK (LIS3DH_CTRL_REG4_FS1_MASK | LIS3DH_CTRL_REG4_FS0_MASK)
-/** @} */
-
+#define LIS3DH_CTRL_REG4_BLE_LITTLE_ENDIAN       (0)
 /**
- * @name Scale register values symbolic names
+ * @brief   Big/little endian big endian mode
  */
-/** @{ */
-#define LIS3DH_CTRL_REG4_SCALE_2G  (0) /**< Scale: +/- 2G */
-#define LIS3DH_CTRL_REG4_SCALE_4G  (LIS3DH_CTRL_REG4_FS0_MASK) /**< Scale: +/- 4G */
-#define LIS3DH_CTRL_REG4_SCALE_8G  (LIS3DH_CTRL_REG4_FS1_MASK) /**< Scale: +/- 8G */
-/** Scale: +/- 16G */
-#define LIS3DH_CTRL_REG4_SCALE_16G (LIS3DH_CTRL_REG4_FS1_MASK | LIS3DH_CTRL_REG4_FS0_MASK)
-/** @} */
-
+#define LIS3DH_CTRL_REG4_BLE_BIG_ENDIAN          (LIS3DH_CTRL_REG4_BLE_MASK)
 /**
- * @brief High resolution output mode
+ * @brief   Full scale selection mask second bit
+ */
+#define LIS3DH_CTRL_REG4_FS1_MASK                (1 << 5)
+/**
+ * @brief   Full scale selection mask first bit
+ */
+#define LIS3DH_CTRL_REG4_FS0_MASK                (1 << 4)
+/**
+ * @brief   Full scale selection mask
+ */
+#define LIS3DH_CTRL_REG4_FS_MASK                 (LIS3DH_CTRL_REG4_FS1_MASK | \
+                                                  LIS3DH_CTRL_REG4_FS0_MASK)
+/**
+ * @brief   Scale register value: +/- 2G
+ */
+#define LIS3DH_CTRL_REG4_SCALE_2G                (0)
+/**
+ * @brief   Scale register value: +/- 4G
+ */
+#define LIS3DH_CTRL_REG4_SCALE_4G                (LIS3DH_CTRL_REG4_FS0_MASK)
+/**
+ * @brief   Scale register value: +/- 8G
+ */
+#define LIS3DH_CTRL_REG4_SCALE_8G                (LIS3DH_CTRL_REG4_FS1_MASK)
+/**
+ * @brief   Scale: +/- 16G
+ */
+#define LIS3DH_CTRL_REG4_SCALE_16G               (LIS3DH_CTRL_REG4_FS1_MASK | LIS3DH_CTRL_REG4_FS0_MASK)
+/**
+ * @brief   High resolution output mode
  *
  * Default value: 0
  *
  *  0. High resolution disable
  *  1. High resolution enable
  */
-#define LIS3DH_CTRL_REG4_HR_MASK  (1 << 3)
-
+#define LIS3DH_CTRL_REG4_HR_MASK                 (1 << 3)
 /**
- * @name Self test enable
+ * @brief   Self test enable second bit mask
  *
- * Default value: 00
+ * Default value of self test: 00
  *
  *  - 00: Self test disabled
  *  - Other: See Table 34
  *
  * @see Table 34
  */
-/** @{ */
-#define LIS3DH_CTRL_REG4_ST1_MASK (1 << 2)
-#define LIS3DH_CTRL_REG4_ST0_MASK (1 << 1)
-/** @} */
-
+#define LIS3DH_CTRL_REG4_ST1_MASK                (1 << 2)
 /**
- * @brief SPI serial interface mode selection
+ * @brief   Self test enable first bit mask
+ */
+#define LIS3DH_CTRL_REG4_ST0_MASK                (1 << 1)
+/**
+ * @brief   SPI serial interface mode selection
  *
  * Default value: 0
  *
  *  0. 4-wire interface
  *  1. 3-wire interface
  */
-#define LIS3DH_CTRL_REG4_SIM_MASK (1 << 0)
-
+#define LIS3DH_CTRL_REG4_SIM_MASK                (1 << 0)
 /**
- * @brief Reboot memory content
+ * @brief   Reboot memory content
  *
  * Default value: 0
  *
  *  0. normal mode
  *  1. reboot memory content
  */
-#define LIS3DH_CTRL_REG5_REBOOT_MASK (1 << 7)
-
+#define LIS3DH_CTRL_REG5_REBOOT_MASK             (1 << 7)
 /**
- * @brief FIFO enable
+ * @brief   FIFO enable
  *
  * Default value: 0
  *
  *  0. FIFO disable
  *  1. FIFO enable
  */
-#define LIS3DH_CTRL_REG5_FIFO_EN_MASK (1 << 6)
-
+#define LIS3DH_CTRL_REG5_FIFO_EN_MASK            (1 << 6)
 /**
- * @brief Latch interrupt request on INT1
+ * @brief   Latch interrupt request on INT1
  *
  * Latch interrupt request on INT1_SRC register, with INT1_SRC register
  * cleared by reading INT1_SRC itself.
@@ -463,221 +480,247 @@ typedef enum {
  *  0. interrupt request not latched
  *  1. interrupt request latched
  */
-#define LIS3DH_CTRL_REG5_LIR_I1_MASK  (1 << 3)
-
+#define LIS3DH_CTRL_REG5_LIR_I1_MASK             (1 << 3)
 /**
- * @brief 4D enable
+ * @brief   4D enable
  *
  * 4D detection is enabled on INT1 when 6D bit on INT1_CFG is set to 1.
  */
-#define LIS3DH_CTRL_REG5_D4D_I1_MASK  (1 << 2)
-
-/** @} */
+#define LIS3DH_CTRL_REG5_D4D_I1_MASK             (1 << 2)
+/** @} */ /* CTRL_REG4 bitfield macros */
 
 /**
- * @name STATUS_REG bitfield macros
+ * @name    STATUS_REG bitfield macros
+ * @{
  */
-/** @{ */
 /**
- * @brief X, Y or Z axis data overrun
+ * @brief   X, Y or Z axis data overrun
  *
  * Default value: 0
  *
  *  0. no overrun has occurred
  *  1. a new set of data has overwritten the previous ones
  */
-#define LIS3DH_STATUS_REG_ZYXOR_MASK  (1 << 7)
-
+#define LIS3DH_STATUS_REG_ZYXOR_MASK             (1 << 7)
 /**
- * @brief Z axis data overrun
+ * @brief   Z axis data overrun
  *
  * Default value: 0
  *
  *  0. no overrun has occurred
  *  1. a new data for the Z-axis has overwritten the previous one
  */
-#define LIS3DH_STATUS_REG_ZOR_MASK  (1 << 6)
-
+#define LIS3DH_STATUS_REG_ZOR_MASK               (1 << 6)
 /**
- * @brief Y axis data overrun
+ * @brief   Y axis data overrun
  *
  * Default value: 0
  *
  *  0. no overrun has occurred
  *  1. a new data for the Y-axis has overwritten the previous one
  */
-#define LIS3DH_STATUS_REG_YOR_MASK  (1 << 5)
-
+#define LIS3DH_STATUS_REG_YOR_MASK               (1 << 5)
 /**
- * @brief X axis data overrun
+ * @brief   X axis data overrun
  *
  * Default value: 0
  *
  *  0. no overrun has occurred
  *  1. a new data for the X-axis has overwritten the previous one
  */
-#define LIS3DH_STATUS_REG_XOR_MASK  (1 << 4)
-
+#define LIS3DH_STATUS_REG_XOR_MASK               (1 << 4)
 /**
- * @brief X, Y or Z axis new data available
+ * @brief   X, Y or Z axis new data available
  *
  * Default value: 0
  *
  *  0. a new set of data is not yet available
  *  1. a new set of data is available
  */
-#define LIS3DH_STATUS_REG_ZYXDA_MASK (1 << 3)
-
+#define LIS3DH_STATUS_REG_ZYXDA_MASK             (1 << 3)
 /**
- * @brief Z axis new data available
+ * @brief   Z axis new data available
  *
  * Default value: 0
  *
  *  0. a new data for the Z-axis is not yet available
  *  1. a new data for the Z-axis is available
  */
-#define LIS3DH_STATUS_REG_ZDA_MASK  (1 << 2)
-
+#define LIS3DH_STATUS_REG_ZDA_MASK               (1 << 2)
 /**
- * @brief Y axis new data available
+ * @brief   Y axis new data available
  *
  * Default value: 0
  *
  *  0. a new data for the Y-axis is not yet available
  *  1. a new data for the Y-axis is available
  */
-#define LIS3DH_STATUS_REG_YDA_MASK  (1 << 1)
-
+#define LIS3DH_STATUS_REG_YDA_MASK               (1 << 1)
 /**
- * @brief X axis new data available
+ * @brief   X axis new data available
  *
  * Default value: 0
  *
  *  0. a new data for the X-axis is not yet available
  *  1. a new data for the X-axis is available
  */
-#define LIS3DH_STATUS_REG_XDA_MASK  (1 << 0)
-
-/** @} */
+#define LIS3DH_STATUS_REG_XDA_MASK               (1 << 0)
+/** @} */ /* STATUS_REG bitfield macros */
 
 /**
- * @name FIFO_CTRL_REG bitfield macros
+ * @name    FIFO_CTRL_REG bitfield macros
+ * @{
  */
-/** @{ */
-#define LIS3DH_FIFO_CTRL_REG_FM_SHIFT  (6)
-#define LIS3DH_FIFO_CTRL_REG_FM1_MASK  (1 << 7)
-#define LIS3DH_FIFO_CTRL_REG_FM0_MASK  (1 << 6)
-#define LIS3DH_FIFO_CTRL_REG_FM_MASK   (LIS3DH_FIFO_CTRL_REG_FM1_MASK | \
-                                        LIS3DH_FIFO_CTRL_REG_FM0_MASK)
-
-#define LIS3DH_FIFO_CTRL_REG_TR_MASK   (1 << 5)
-#define LIS3DH_FIFO_CTRL_REG_FTH4_MASK (1 << 4)
-#define LIS3DH_FIFO_CTRL_REG_FTH3_MASK (1 << 3)
-#define LIS3DH_FIFO_CTRL_REG_FTH2_MASK (1 << 2)
-#define LIS3DH_FIFO_CTRL_REG_FTH1_MASK (1 << 1)
-#define LIS3DH_FIFO_CTRL_REG_FTH0_MASK (1 << 0)
-#define LIS3DH_FIFO_CTRL_REG_FTH_SHIFT  (0)
-#define LIS3DH_FIFO_CTRL_REG_FTH_MASK \
-  (LIS3DH_FIFO_CTRL_REG_FTH0_MASK | \
-   LIS3DH_FIFO_CTRL_REG_FTH1_MASK | \
-   LIS3DH_FIFO_CTRL_REG_FTH2_MASK | \
-   LIS3DH_FIFO_CTRL_REG_FTH3_MASK | \
-   LIS3DH_FIFO_CTRL_REG_FTH4_MASK)
-/** @} */
+#define LIS3DH_FIFO_CTRL_REG_FM_SHIFT            (6)
+#define LIS3DH_FIFO_CTRL_REG_FM1_MASK            (1 << 7)
+#define LIS3DH_FIFO_CTRL_REG_FM0_MASK            (1 << 6)
+#define LIS3DH_FIFO_CTRL_REG_FM_MASK             (LIS3DH_FIFO_CTRL_REG_FM1_MASK | \
+                                                  LIS3DH_FIFO_CTRL_REG_FM0_MASK)
+#define LIS3DH_FIFO_CTRL_REG_TR_MASK             (1 << 5)
+#define LIS3DH_FIFO_CTRL_REG_FTH4_MASK           (1 << 4)
+#define LIS3DH_FIFO_CTRL_REG_FTH3_MASK           (1 << 3)
+#define LIS3DH_FIFO_CTRL_REG_FTH2_MASK           (1 << 2)
+#define LIS3DH_FIFO_CTRL_REG_FTH1_MASK           (1 << 1)
+#define LIS3DH_FIFO_CTRL_REG_FTH0_MASK           (1 << 0)
+#define LIS3DH_FIFO_CTRL_REG_FTH_SHIFT           (0)
+#define LIS3DH_FIFO_CTRL_REG_FTH_MASK            (LIS3DH_FIFO_CTRL_REG_FTH0_MASK | \
+                                                  LIS3DH_FIFO_CTRL_REG_FTH1_MASK | \
+                                                  LIS3DH_FIFO_CTRL_REG_FTH2_MASK | \
+                                                  LIS3DH_FIFO_CTRL_REG_FTH3_MASK | \
+                                                  LIS3DH_FIFO_CTRL_REG_FTH4_MASK)
+/** @} */ /* FIFO_CTRL_REG bitfield macros */
 
 /**
- * @name FIFO_SRC_REG bitfield macros
+ * @name    FIFO_SRC_REG bitfield macros
+ * @{
  */
-/** @{ */
-#define LIS3DH_FIFO_SRC_REG_WTM_MASK (1 << 7)
-#define LIS3DH_FIFO_SRC_REG_OVRN_FIFO_MASK (1 << 6)
-#define LIS3DH_FIFO_SRC_REG_EMPTY_MASK (1 << 5)
-#define LIS3DH_FIFO_SRC_REG_FSS4_MASK (1 << 4)
-#define LIS3DH_FIFO_SRC_REG_FSS3_MASK (1 << 3)
-#define LIS3DH_FIFO_SRC_REG_FSS2_MASK (1 << 2)
-#define LIS3DH_FIFO_SRC_REG_FSS1_MASK (1 << 1)
-#define LIS3DH_FIFO_SRC_REG_FSS0_MASK (1 << 0)
-#define LIS3DH_FIFO_SRC_REG_FSS_SHIFT  (0)
-#define LIS3DH_FIFO_SRC_REG_FSS_MASK \
-  (LIS3DH_FIFO_SRC_REG_FSS0_MASK | \
-   LIS3DH_FIFO_SRC_REG_FSS1_MASK | \
-   LIS3DH_FIFO_SRC_REG_FSS2_MASK | \
-   LIS3DH_FIFO_SRC_REG_FSS3_MASK | \
-   LIS3DH_FIFO_SRC_REG_FSS4_MASK)
-/** @} */
+#define LIS3DH_FIFO_SRC_REG_WTM_MASK             (1 << 7)
+#define LIS3DH_FIFO_SRC_REG_OVRN_FIFO_MASK       (1 << 6)
+#define LIS3DH_FIFO_SRC_REG_EMPTY_MASK           (1 << 5)
+#define LIS3DH_FIFO_SRC_REG_FSS4_MASK            (1 << 4)
+#define LIS3DH_FIFO_SRC_REG_FSS3_MASK            (1 << 3)
+#define LIS3DH_FIFO_SRC_REG_FSS2_MASK            (1 << 2)
+#define LIS3DH_FIFO_SRC_REG_FSS1_MASK            (1 << 1)
+#define LIS3DH_FIFO_SRC_REG_FSS0_MASK            (1 << 0)
+#define LIS3DH_FIFO_SRC_REG_FSS_SHIFT            (0)
+#define LIS3DH_FIFO_SRC_REG_FSS_MASK             (LIS3DH_FIFO_SRC_REG_FSS0_MASK | \
+                                                  LIS3DH_FIFO_SRC_REG_FSS1_MASK | \
+                                                  LIS3DH_FIFO_SRC_REG_FSS2_MASK | \
+                                                  LIS3DH_FIFO_SRC_REG_FSS3_MASK | \
+                                                  LIS3DH_FIFO_SRC_REG_FSS4_MASK)
+/** @} */ /* FIFO_CTRL_REG bitfield macros */
 
 /**
- * @name Register address bitfield macros
+ * @name    Register address bitfield macros
+ * @{
  */
-/** @{ */
+/**
+ * @brief   Write to register
+ */
+#define LIS3DH_SPI_WRITE_MASK                    (0 << 7)
+/**
+ * @brief   The READ bit must be set when reading
+ */
+#define LIS3DH_SPI_READ_MASK                     (1 << 7)
+/**
+ * @brief   Multi byte transfers must assert this bit when writing the address.
+ */
+#define LIS3DH_SPI_MULTI_MASK                    (1 << 6)
+/**
+ * @brief   Opposite of LIS3DH_SPI_MULTI_MASK.
+ */
+#define LIS3DH_SPI_SINGLE_MASK                   (0 << 6)
+/**
+ * @brief   Mask of the address bits in the address byte during transfers.
+ */
+#define LIS3DH_SPI_ADDRESS_MASK                  (0x3F)
+/** @} */ /* Register address bitfield macros */
 
 /**
- * Write to register
+ * @brief   Length of scalar measurement data in bytes.
  */
-#define LIS3DH_SPI_WRITE_MASK (0 << 7)
-/**
- * The READ bit must be set when reading
- */
-#define LIS3DH_SPI_READ_MASK (1 << 7)
-/**
- * Multi byte transfers must assert this bit when writing the address.
- */
-#define LIS3DH_SPI_MULTI_MASK (1 << 6)
-/**
- * Opposite of LIS3DH_SPI_MULTI_MASK.
- */
-#define LIS3DH_SPI_SINGLE_MASK (0 << 6)
-/**
- * Mask of the address bits in the address byte during transfers.
- */
-#define LIS3DH_SPI_ADDRESS_MASK (0x3F)
-
-/** @} */
+#define LIS3DH_ADC_DATA_SIZE                     (2U)
 
 /**
- * Length of scalar measurement data in bytes.
- */
-#define LIS3DH_ADC_DATA_SIZE (2)
-
-
-/**
- * @name Output Data Rates (ODR)
- *
- * Use these when calling lis3dh_set_odr(odr).
- */
-/** @{ */
-#define LIS3DH_ODR_POWERDOWN (0x00 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-#define LIS3DH_ODR_1Hz       (0x01 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-#define LIS3DH_ODR_10Hz      (0x02 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-#define LIS3DH_ODR_25Hz      (0x03 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-#define LIS3DH_ODR_50Hz      (0x04 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-#define LIS3DH_ODR_100Hz     (0x05 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-#define LIS3DH_ODR_200Hz     (0x06 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-#define LIS3DH_ODR_400Hz     (0x07 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-#define LIS3DH_ODR_LP1600Hz  (0x08 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-/* Normal mode 1250 Hz and Low power mode 5000 Hz share the same setting */
-#define LIS3DH_ODR_NP1250Hz  (0x09 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-#define LIS3DH_ODR_LP5000HZ  (0x09 << LIS3DH_CTRL_REG1_ODR_SHIFT)
-/** @} */
-
-/**
- * @name FIFO modes.
+ * @name    FIFO modes.
  *
  * Used when calling lis3dh_set_fifo()
+ * @{
  */
-/** @{ */
-/** FIFO mode: Bypass */
-#define LIS3DH_FIFO_MODE_BYPASS (0x00 << LIS3DH_FIFO_CTRL_REG_FM_SHIFT)
-/** FIFO mode: FIFO */
-#define LIS3DH_FIFO_MODE_FIFO (0x01 << LIS3DH_FIFO_CTRL_REG_FM_SHIFT)
-/** FIFO mode: Stream */
-#define LIS3DH_FIFO_MODE_STREAM (0x02 << LIS3DH_FIFO_CTRL_REG_FM_SHIFT)
-/** FIFO mode: Stream to FIFO */
-#define LIS3DH_FIFO_MODE_STREAM_TO_FIFO (0x03 << LIS3DH_FIFO_CTRL_REG_FM_SHIFT)
+/**
+ * @brief   FIFO mode: Bypass
+ */
+#define LIS3DH_FIFO_MODE_BYPASS                  (0x00 << LIS3DH_FIFO_CTRL_REG_FM_SHIFT)
+/**
+ * @brief   FIFO mode: FIFO
+ */
+#define LIS3DH_FIFO_MODE_FIFO                    (0x01 << LIS3DH_FIFO_CTRL_REG_FM_SHIFT)
+/**
+ * @brief   FIFO mode: Stream
+ */
+#define LIS3DH_FIFO_MODE_STREAM                  (0x02 << LIS3DH_FIFO_CTRL_REG_FM_SHIFT)
+/**
+ * @brief   FIFO mode: Stream to FIFO
+ */
+#define LIS3DH_FIFO_MODE_STREAM_TO_FIFO          (0x03 << LIS3DH_FIFO_CTRL_REG_FM_SHIFT)
 /** @} */
 
 /**
- * @brief Configuration parameters for LIS3DH devices
+ * @name    Output Data Rates (ODR) macros
+ *
+ * Use these when calling lis3dh_set_odr(odr).
+ * @{
+ */
+/**
+ * @brief    Powerdown mode
+ */
+#define LIS3DH_ODR_POWERDOWN                     (0x00 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   1Hz mode
+ */
+#define LIS3DH_ODR_1Hz                           (0x01 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   10Hz mode
+ */
+#define LIS3DH_ODR_10Hz                          (0x02 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   25Hz mode
+ */
+#define LIS3DH_ODR_25Hz                          (0x03 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   50Hz mode
+ */
+#define LIS3DH_ODR_50Hz                          (0x04 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   100Hz mode
+ */
+#define LIS3DH_ODR_100Hz                         (0x05 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   200Hz mode
+ */
+#define LIS3DH_ODR_200Hz                         (0x06 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   400Hz mode
+ */
+#define LIS3DH_ODR_400Hz                         (0x07 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   Low power 1600Hz mode
+ */
+#define LIS3DH_ODR_LP1600Hz                      (0x08 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   Normal mode 1250 Hz
+ * @note    Normal mode 1250 Hz and Low power mode 5000 Hz share the same setting
+ */
+#define LIS3DH_ODR_NP1250Hz                      (0x09 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/**
+ * @brief   Low power mode 5000 Hz
+ * @note    Normal mode 1250 Hz and Low power mode 5000 Hz share the same setting
+ */
+#define LIS3DH_ODR_LP5000HZ                      (0x09 << LIS3DH_CTRL_REG1_ODR_SHIFT)
+/** @} */
+
+/**
+ * @brief   Configuration parameters for LIS3DH devices
  */
 typedef struct {
     spi_t spi;              /**< SPI device the sensor is connected to */
@@ -690,7 +733,7 @@ typedef struct {
 } lis3dh_params_t;
 
 /**
- * @brief Device descriptor for LIS3DH sensors
+ * @brief   Device descriptor for LIS3DH sensors
  */
 typedef struct {
     spi_t spi;              /**< SPI device the sensor is connected to */
@@ -700,7 +743,7 @@ typedef struct {
 } lis3dh_t;
 
 /**
- * @brief Result vector for accelerometer measurement
+ * @brief   Result vector for accelerometer measurement
  */
 typedef struct __attribute__((packed))
 {
@@ -709,9 +752,8 @@ typedef struct __attribute__((packed))
     int16_t acc_z;          /**< Acceleration in the Z direction in milli-G */
 } lis3dh_data_t;
 
-
 /**
- * @brief Initialize a LIS3DH sensor instance
+ * @brief   Initialize a LIS3DH sensor instance
  *
  * @param[in]  dev          Device descriptor of sensor to initialize
  * @param[in]  params       Configuration parameters
@@ -722,7 +764,7 @@ typedef struct __attribute__((packed))
 int lis3dh_init(lis3dh_t *dev, const lis3dh_params_t *params);
 
 /**
- * @brief Read 3D acceleration data from the accelerometer
+ * @brief   Read 3D acceleration data from the accelerometer
  *
  * @param[in]  dev          Device descriptor of sensor
  * @param[out] acc_data     Accelerometer data output buffer
@@ -733,7 +775,7 @@ int lis3dh_init(lis3dh_t *dev, const lis3dh_params_t *params);
 int lis3dh_read_xyz(const lis3dh_t *dev, lis3dh_data_t *acc_data);
 
 /**
- * @brief Read auxiliary ADC channel 1 data from the accelerometer
+ * @brief   Read auxiliary ADC channel 1 data from the accelerometer
  *
  * @param[in]  dev          Device descriptor of sensor
  * @param[out] out          The value of ADC1 (OUT_1_{L,H}) will be written to this buffer
@@ -744,7 +786,7 @@ int lis3dh_read_xyz(const lis3dh_t *dev, lis3dh_data_t *acc_data);
 int lis3dh_read_aux_adc1(const lis3dh_t *dev, int16_t *out);
 
 /**
- * @brief Read auxiliary ADC channel 2 data from the accelerometer
+ * @brief   Read auxiliary ADC channel 2 data from the accelerometer
  *
  * @param[in]  dev          Device descriptor of sensor
  * @param[out] out          The value of ADC2 (OUT_2_{L,H}) will be written to this buffer
@@ -755,7 +797,7 @@ int lis3dh_read_aux_adc1(const lis3dh_t *dev, int16_t *out);
 int lis3dh_read_aux_adc2(const lis3dh_t *dev, int16_t *out);
 
 /**
- * @brief Read auxiliary ADC channel 3 data from the accelerometer
+ * @brief   Read auxiliary ADC channel 3 data from the accelerometer
  *
  * @param[in]  dev          Device descriptor of sensor
  * @param[out] out          The value of ADC3 (OUT_3_{L,H}) will be written to this buffer
@@ -769,7 +811,7 @@ int lis3dh_read_aux_adc2(const lis3dh_t *dev, int16_t *out);
 int lis3dh_read_aux_adc3(const lis3dh_t *dev, int16_t *out);
 
 /**
- * @brief Turn on/off power to the auxiliary ADC in LIS3DH.
+ * @brief   Turn on/off power to the auxiliary ADC in LIS3DH.
  *
  * @param[in]  dev          Device descriptor of sensor
  * @param[in]  enable       Power state of the auxiliary ADC
@@ -785,7 +827,7 @@ int lis3dh_read_aux_adc3(const lis3dh_t *dev, int16_t *out);
 int lis3dh_set_aux_adc(const lis3dh_t *dev, const uint8_t enable, const uint8_t temperature);
 
 /**
- * @brief Enable/disable accelerometer axes.
+ * @brief   Enable/disable accelerometer axes.
  *
  * @param[in]  dev          Device descriptor of sensor
  * @param[in]  axes         An OR-ed combination of LIS3DH_AXES_X,
@@ -799,7 +841,7 @@ int lis3dh_set_aux_adc(const lis3dh_t *dev, const uint8_t enable, const uint8_t 
 int lis3dh_set_axes(const lis3dh_t *dev, const uint8_t axes);
 
 /**
- * @brief Enable/disable the FIFO.
+ * @brief   Enable/disable the FIFO.
  *
  * @param[in]  dev          Device descriptor of sensor
  * @param[in]  mode         FIFO mode, see data sheet for details.
@@ -811,7 +853,7 @@ int lis3dh_set_axes(const lis3dh_t *dev, const uint8_t axes);
 int lis3dh_set_fifo(const lis3dh_t *dev, const uint8_t mode, const uint8_t watermark);
 
 /**
- * Set the output data rate of the sensor.
+ * @brief   Set the output data rate of the sensor.
  *
  * @param[in]  dev          Device descriptor of sensor
  * @param[in]  odr          Chosen output data rate.
@@ -822,7 +864,7 @@ int lis3dh_set_fifo(const lis3dh_t *dev, const uint8_t mode, const uint8_t water
 int lis3dh_set_odr(const lis3dh_t *dev, const uint8_t odr);
 
 /**
- * @brief Set the full scale range of the sensor.
+ * @brief   Set the full scale range of the sensor.
  *
  * Valid values for scale are 2, 4, 8, 16 and represents the full range of the
  * sensor.
@@ -836,7 +878,7 @@ int lis3dh_set_odr(const lis3dh_t *dev, const uint8_t odr);
 int lis3dh_set_scale(lis3dh_t *dev, const uint8_t scale);
 
 /**
- * @brief Set INT1 pin function
+ * @brief   Set INT1 pin function
  *
  * Set the bits of CTRL_REG3 for choosing sources for the INT1 pin.
  *
@@ -849,7 +891,7 @@ int lis3dh_set_scale(lis3dh_t *dev, const uint8_t scale);
 int lis3dh_set_int1(const lis3dh_t *dev, const uint8_t mode);
 
 /**
- * @brief Get the current number of elements in the FIFO
+ * @brief   Get the current number of elements in the FIFO
  *
  * @param[in]  dev          Device descriptor of sensor
  *

--- a/drivers/include/lis3mdl.h
+++ b/drivers/include/lis3mdl.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_LIS3MDL LIS3MDL 3-axis magnetometer
+ * @defgroup    drivers_lis3mdl LIS3MDL 3-axis magnetometer
  * @ingroup     drivers_sensors
  * @brief       Device driver for the LIS3MDL 3-axis magnetometer
  * @{
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /**
- * @brief 3d data container of the LIS3MDL sensor
+ * @brief   3d data container of the LIS3MDL sensor
  */
 typedef struct {
     int16_t x_axis;                  /**< Magnometer data from x-axis */
@@ -39,7 +39,7 @@ typedef struct {
 } lis3mdl_3d_data_t;
 
 /**
- * @brief Device descriptor for LIS3MDL sensor
+ * @brief   Device descriptor for LIS3MDL sensor
  */
 typedef struct {
     i2c_t i2c;                       /**< I2C device */
@@ -47,7 +47,7 @@ typedef struct {
 } lis3mdl_t;
 
 /**
- * @brief Operating mode of x- and y-axis for LIS3MDL
+ * @brief   Operating mode of x- and y-axis for LIS3MDL
  */
 typedef enum {
     LIS3MDL_XY_MODE_LOW    = 0x00,   /**< Low-power mode */
@@ -57,7 +57,7 @@ typedef enum {
 } lis3mdl_xy_mode_t;
 
 /**
- * @brief Operating mode of z-axis for LIS3MDL
+ * @brief   Operating mode of z-axis for LIS3MDL
  */
 typedef enum {
     LIS3MDL_Z_MODE_LOW    = 0x00,    /**< Low-power mode */
@@ -67,7 +67,7 @@ typedef enum {
 } lis3mdl_z_mode_t;
 
 /**
- * @brief Output data rate [Hz] for LIS3MDL
+ * @brief   Output data rate [Hz] for LIS3MDL
  */
 typedef enum {
     LIS3MDL_ODR_0_625Hz = 0x00,      /**<  0.625Hz */
@@ -80,7 +80,7 @@ typedef enum {
 } lis3mdl_odr_t;
 
 /**
- * @brief Scale [gauss] for LIS3MDL
+ * @brief   Scale [gauss] for LIS3MDL
  */
 typedef enum {
     LIS3MDL_SCALE_4G  = 0x00,        /**< +-  4 gauss */
@@ -90,7 +90,7 @@ typedef enum {
 } lis3mdl_scale_t;
 
 /**
- * @brief Operating modes
+ * @brief   Operating modes
  */
 typedef enum {
     LIS3MDL_OP_CONT_CONV = 0x00,     /**< Continous-conversion mode */
@@ -99,7 +99,7 @@ typedef enum {
 } lis3mdl_op_t;
 
 /**
- * @brief Initialize a new LIS3DML device.
+ * @brief   Initialize a new LIS3DML device.
  *
  * @param[in] dev          device descriptor of LIS3MDL
  * @param[in] i2c          I2C device connected to
@@ -119,7 +119,7 @@ int lis3mdl_init(lis3mdl_t *dev, i2c_t i2c, uint8_t address,
                  lis3mdl_op_t op_mode);
 
 /**
- * @brief Reads the magnometer value of LIS3MDL.
+ * @brief   Reads the magnometer value of LIS3MDL.
  *
  * @param[in] dev          device descriptor of LIS3MDL
  * @param[in] data         measured magnetometer data
@@ -127,7 +127,7 @@ int lis3mdl_init(lis3mdl_t *dev, i2c_t i2c, uint8_t address,
 void lis3mdl_read_mag(const lis3mdl_t *dev, lis3mdl_3d_data_t *data);
 
 /**
- * @brief Reads the temperature value of LIS3MDL.
+ * @brief   Reads the temperature value of LIS3MDL.
  *
  * @param[in] dev          device descriptor of LIS3MDL
  * @param[in] value        measured temperature in degree celsius
@@ -135,14 +135,14 @@ void lis3mdl_read_mag(const lis3mdl_t *dev, lis3mdl_3d_data_t *data);
 void lis3mdl_read_temp(const lis3mdl_t *dev, int16_t *value);
 
 /**
- * @brief Enable the LIS3MDL device.
+ * @brief   Enable the LIS3MDL device.
  *
  * @param[in] dev          device descriptor of LIS3MDL
  */
 void lis3mdl_enable(const lis3mdl_t *dev);
 
 /**
- * @brief Disable the LIS3MDL device.
+ * @brief   Disable the LIS3MDL device.
  *
  * @param[in] dev          device descriptor of LIS3MDL
  */

--- a/drivers/include/lps331ap.h
+++ b/drivers/include/lps331ap.h
@@ -31,12 +31,12 @@ extern "C" {
 #include "periph/i2c.h"
 
  /**
-  * @brief The sensors default I2C address
+  * @brief   The sensors default I2C address
   */
-#define LPS331AP_DEFAULT_ADDRESS        0x5c
+#define LPS331AP_DEFAULT_ADDRESS        (0x5c)
 
 /**
- * @brief Device descriptor for LPS331AP sensors
+ * @brief   Device descriptor for LPS331AP sensors
  */
 typedef struct {
     i2c_t i2c;                  /**< I2C device the sensor is connected to */
@@ -44,7 +44,7 @@ typedef struct {
 } lps331ap_t;
 
 /**
- * @brief Possible sampling rates for LPS331AP sensors
+ * @brief   Possible sampling rates for LPS331AP sensors
  */
 typedef enum {
     LPS331AP_RATE_1HZ = 1,      /**< sample with 1Hz */
@@ -63,7 +63,7 @@ typedef struct {
 } lps331ap_params_t;
 
 /**
- * @brief Initialize a given LPS331AP pressure sensor
+ * @brief   Initialize a given LPS331AP pressure sensor
  *
  * @param[out] dev      device descriptor of the sensor
  * @param[in]  i2c      I2C bus the sensor is connected to
@@ -76,7 +76,7 @@ typedef struct {
 int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t rate);
 
 /**
- * @brief Read a temperature value from the given sensor, returned in m°C
+ * @brief   Read a temperature value from the given sensor, returned in m°C
  *
  * @param[in] dev       device descriptor of sensor to read from
  *
@@ -85,7 +85,7 @@ int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t r
 int lps331ap_read_temp(const lps331ap_t *dev);
 
 /**
- * @brief Read a pressure value from the given sensor, returned in mbar
+ * @brief   Read a pressure value from the given sensor, returned in mbar
  *
  * @param[in] dev       device descriptor of sensor to read from
  *
@@ -94,7 +94,7 @@ int lps331ap_read_temp(const lps331ap_t *dev);
 int lps331ap_read_pres(const lps331ap_t *dev);
 
 /**
- * @brief Enable the given sensor
+ * @brief   Enable the given sensor
  *
  * @param[in] dev       device descriptor of sensor to enable
  *
@@ -104,7 +104,7 @@ int lps331ap_read_pres(const lps331ap_t *dev);
 int lps331ap_enable(const lps331ap_t *dev);
 
 /**
- * @brief Disable the given sensor
+ * @brief   Disable the given sensor
  *
  * @param[in] dev       device descriptor of sensor to disable
  *

--- a/drivers/include/lsm303dlhc.h
+++ b/drivers/include/lsm303dlhc.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /**
- * @brief The sensors default I2C address
+ * @name    The sensors default I2C address
  * @{
  */
 #define LSM303DLHC_ACC_DEFAULT_ADDRESS        (0x19)
@@ -38,7 +38,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Possible accelerometer sample rates
+ * @brief   Possible accelerometer sample rates
  */
 typedef enum {
     LSM303DLHC_ACC_SAMPLE_RATE_1HZ              = 0x10, /**< 1Hz sample rate       */
@@ -54,7 +54,7 @@ typedef enum {
 } lsm303dlhc_acc_sample_rate_t;
 
 /**
- * @brief Possible accelerometer scales
+ * @brief   Possible accelerometer scales
  */
 typedef enum {
     LSM303DLHC_ACC_SCALE_2G     = 0x00, /**< +- 2g range */
@@ -64,7 +64,7 @@ typedef enum {
 } lsm303dlhc_acc_scale_t;
 
 /**
- * @brief Possible magnetometer sample rates
+ * @brief   Possible magnetometer sample rates
  */
 typedef enum {
     LSM303DLHC_MAG_SAMPLE_RATE_0_75HZ   = 0x00, /**< 0.75Hz sample rate */
@@ -78,7 +78,7 @@ typedef enum {
 } lsm303dlhc_mag_sample_rate_t;
 
 /**
- * @brief Possible magnetometer gain values
+ * @brief   Possible magnetometer gain values
  */
  typedef enum {
     LSM303DLHC_MAG_GAIN_1100_980_GAUSS = 0x20, /**< 1100Gauss XYZ 980Gauss Z */
@@ -91,7 +91,7 @@ typedef enum {
  } lsm303dlhc_mag_gain_t;
 
 /**
- * @brief 3d data container
+ * @brief   3d data container
  */
 typedef struct {
     int16_t x_axis;     /**< holds the x axis value. WOW! */
@@ -100,7 +100,7 @@ typedef struct {
 } lsm303dlhc_3d_data_t;
 
 /**
- * @brief Device descriptor for LSM303DLHC sensors
+ * @brief   Device descriptor for LSM303DLHC sensors
  */
 typedef struct {
     i2c_t i2c;                          /**< I2C device                  */
@@ -113,7 +113,7 @@ typedef struct {
 } lsm303dlhc_t;
 
 /**
- * @brief Data structure holding all the information needed for initialization
+ * @brief   Data structure holding all the information needed for initialization
  */
 typedef struct {
     i2c_t i2c;                              /**< I2C bus used */
@@ -128,7 +128,7 @@ typedef struct {
 } lsm303dlhc_params_t;
 
 /**
- * @brief Initialize a new LSM303DLHC device
+ * @brief   Initialize a new LSM303DLHC device
  *
  * @param[in] dev               device descriptor of an LSM303DLHC device
  * @param[in] i2c               I2C device the sensor is connected to
@@ -153,7 +153,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
                     lsm303dlhc_mag_gain_t mag_gain);
 
 /**
- * @brief Read a accelerometer value from the sensor.
+ * @brief   Read a accelerometer value from the sensor.
  *
  * @details This function provides raw acceleration data. To get the
  *          corresponding values in g please refer to the following
@@ -174,7 +174,7 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, i2c_t i2c, gpio_t acc_pin, gpio_t mag_pin
 int lsm303dlhc_read_acc(const lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
 
 /**
- * @brief Read a magnetometer value from the sensor.
+ * @brief   Read a magnetometer value from the sensor.
  *
  * @details This function returns raw magnetic data. To get the
  *          corresponding values in gauss please refer to the following
@@ -198,7 +198,7 @@ int lsm303dlhc_read_acc(const lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
 int lsm303dlhc_read_mag(const lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
 
 /**
- * @brief Read a temperature value from the sensor.
+ * @brief   Read a temperature value from the sensor.
  *
  * @param[in]  dev      device descriptor of an LSM303DLHC device
  * @param[out] value    the measured temperature
@@ -209,7 +209,7 @@ int lsm303dlhc_read_mag(const lsm303dlhc_t *dev, lsm303dlhc_3d_data_t *data);
 int lsm303dlhc_read_temp(const lsm303dlhc_t *dev, int16_t *value);
 
 /**
- * @brief Enable the given sensor
+ * @brief   Enable the given sensor
  *
  * @param[in] dev       device descriptor of an LSM303DLHC device
  *
@@ -219,7 +219,7 @@ int lsm303dlhc_read_temp(const lsm303dlhc_t *dev, int16_t *value);
 int lsm303dlhc_enable(const lsm303dlhc_t *dev);
 
 /**
- * @brief Disable the given sensor
+ * @brief   Disable the given sensor
  *
  * @param[in] dev       device descriptor of an LSM303DLHC device
  *

--- a/drivers/include/lsm6dsl.h
+++ b/drivers/include/lsm6dsl.h
@@ -32,7 +32,7 @@ extern "C" {
 #include "periph/i2c.h"
 
 /**
- * @brief Data rate settings
+ * @brief   Data rate settings
  */
 enum {
     LSM6DSL_DATA_RATE_POWER_DOWN = 0x0,
@@ -50,7 +50,7 @@ enum {
 };
 
 /**
- * @brief Decimation settings
+ * @brief   Decimation settings
  */
 enum {
     LSM6DSL_DECIMATION_NOT_IN_FIFO = 0,
@@ -64,7 +64,7 @@ enum {
 };
 
 /**
- * @brief Accelerometer full scale
+ * @brief   Accelerometer full scale
  */
 enum {
     LSM6DSL_ACC_FS_2G  = 0,
@@ -75,7 +75,7 @@ enum {
 };
 
 /**
- * @brief Gyroscope full scale
+ * @brief   Gyroscope full scale
  */
 enum {
     LSM6DSL_GYRO_FS_245DPS    = 0,
@@ -86,7 +86,7 @@ enum {
 };
 
 /**
- * @brief LSM6DSL driver parameters
+ * @brief   LSM6DSL driver parameters
  */
 typedef struct {
     i2c_t i2c;                  /**< i2c bus */
@@ -100,14 +100,14 @@ typedef struct {
 } lsm6dsl_params_t;
 
 /**
- * @brief LSM6DSL device descriptor
+ * @brief   LSM6DSL device descriptor
  */
 typedef struct {
     lsm6dsl_params_t params; /**< driver parameters */
 } lsm6dsl_t;
 
 /**
- * @brief 3D output data
+ * @brief   3D output data
  */
 typedef struct {
     int16_t x;  /**< X axis */
@@ -116,7 +116,7 @@ typedef struct {
 } lsm6dsl_3d_data_t;
 
 /**
- * @brief Named return values
+ * @brief   Named return values
  */
 enum {
     LSM6DSL_OK = 0,             /**< all good */
@@ -126,7 +126,7 @@ enum {
 };
 
 /**
- * @brief Initialize a LSM6DSL device
+ * @brief   Initialize a LSM6DSL device
  *
  * @param[out] dev     device to initialize
  * @param[in] params  driver parameters
@@ -137,7 +137,7 @@ enum {
 int lsm6dsl_init(lsm6dsl_t *dev, const lsm6dsl_params_t *params);
 
 /**
- * @brief Read accelerometer data
+ * @brief   Read accelerometer data
  *
  * @param[in] dev    device to read
  * @param[out] data  accelerometer values
@@ -148,7 +148,7 @@ int lsm6dsl_init(lsm6dsl_t *dev, const lsm6dsl_params_t *params);
 int lsm6dsl_read_acc(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
 
 /**
- * @brief Read gyroscope data
+ * @brief   Read gyroscope data
  *
  * @param[in] dev    device to read
  * @param[out] data  gyroscope values
@@ -159,7 +159,7 @@ int lsm6dsl_read_acc(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
 int lsm6dsl_read_gyro(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
 
 /**
- * @brief Read temperature data
+ * @brief   Read temperature data
  *
  * @note To avoid floating point data types but still provide high resolution
  *       for temperature readings, resulting values are scale by factor 100.
@@ -174,7 +174,7 @@ int lsm6dsl_read_gyro(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data);
 int lsm6dsl_read_temp(const lsm6dsl_t *dev, int16_t *data);
 
 /**
- * @brief Power down accelerometer
+ * @brief   Power down accelerometer
  *
  * @param[in] dev    device to power down
  *
@@ -184,7 +184,7 @@ int lsm6dsl_read_temp(const lsm6dsl_t *dev, int16_t *data);
 int lsm6dsl_acc_power_down(const lsm6dsl_t *dev);
 
 /**
- * @brief Power down gyroscope
+ * @brief   Power down gyroscope
  *
  * @param[in] dev    device to power down
  *
@@ -194,7 +194,7 @@ int lsm6dsl_acc_power_down(const lsm6dsl_t *dev);
 int lsm6dsl_gyro_power_down(const lsm6dsl_t *dev);
 
 /**
- * @brief Power up accelerometer
+ * @brief   Power up accelerometer
  *
  * @param[in] dev    device to power up
  *
@@ -204,7 +204,7 @@ int lsm6dsl_gyro_power_down(const lsm6dsl_t *dev);
 int lsm6dsl_acc_power_up(const lsm6dsl_t *dev);
 
 /**
- * @brief Power up gyroscope
+ * @brief   Power up gyroscope
  *
  * @param[in] dev    device to power up
  *

--- a/drivers/include/mag3110.h
+++ b/drivers/include/mag3110.h
@@ -55,6 +55,10 @@ enum {
 #define MAG3110_I2C_ADDRESS             0x0E /**< Magnetometer Default Address */
 #endif
 
+/**
+ * @name    Output data rate macros
+ * @{
+ */
 #define MAG3110_DROS_8000_16    0 /**< Output Rate 80 Hz, Over Sample Ratio 16 */
 #define MAG3110_DROS_4000_32    1 /**< Output Rate 40 Hz, Over Sample Ratio 32 */
 #define MAG3110_DROS_2000_64    2 /**< Output Rate 20 Hz, Over Sample Ratio 64 */
@@ -88,6 +92,7 @@ enum {
 #define MAG3110_DROS_0016_64    30 /**< Output Rate 0.16 Hz, Over Sample Ratio 64 */
 #define MAG3110_DROS_0008_128   31 /**< Output Rate 0.08 Hz, Over Sample Ratio 128 */
 #define MAG3110_DROS_DEFAULT    MAG3110_DROS_0125_128 /**< Default Setting for testing */
+/** @} */
 
 /**
  * @brief   Configuration parameters
@@ -101,7 +106,7 @@ typedef struct {
 } mag3110_params_t;
 
 /**
- * @brief Device descriptor for MAG3110 magnetometer.
+ * @brief   Device descriptor for MAG3110 magnetometer.
  */
 typedef struct {
     mag3110_params_t params;    /**< device configuration parameters */
@@ -117,7 +122,7 @@ typedef struct {
 } mag3110_data_t;
 
 /**
- * @brief Initialise the MAG3110 magnetometer driver.
+ * @brief   Initialise the MAG3110 magnetometer driver.
  *
  * @param[out] dev          device descriptor of magnetometer to initialize
  * @param[in]  params       configuration parameters
@@ -130,7 +135,8 @@ typedef struct {
 int mag3110_init(mag3110_t *dev, const mag3110_params_t *params);
 
 /**
- * @brief Set user offset correction.
+ * @brief   Set user offset correction.
+ *
  * Offset correction register will be erased after accelerometer reset.
  *
  * @param[out] dev          device descriptor of magnetometer
@@ -144,7 +150,7 @@ int mag3110_init(mag3110_t *dev, const mag3110_params_t *params);
 int mag3110_set_user_offset(const mag3110_t *dev, int16_t x, int16_t y, int16_t z);
 
 /**
- * @brief Set active mode, this enables periodic measurements.
+ * @brief   Set active mode, this enables periodic measurements.
  *
  * @param[out] dev          device descriptor of magnetometer
  *
@@ -154,7 +160,7 @@ int mag3110_set_user_offset(const mag3110_t *dev, int16_t x, int16_t y, int16_t 
 int mag3110_set_active(const mag3110_t *dev);
 
 /**
- * @brief Set standby mode.
+ * @brief   Set standby mode.
  *
  * @param[in]  dev          device descriptor of magnetometer
  *
@@ -164,7 +170,7 @@ int mag3110_set_active(const mag3110_t *dev);
 int mag3110_set_standby(const mag3110_t *dev);
 
 /**
- * @brief Check for new set of measurement data.
+ * @brief   Check for new set of measurement data.
  *
  * @param[in]  dev          device descriptor of magnetometer
  *
@@ -175,7 +181,8 @@ int mag3110_set_standby(const mag3110_t *dev);
 int mag3110_is_ready(const mag3110_t *dev);
 
 /**
- * @brief Read magnetometer's data.
+ * @brief   Read magnetometer's data.
+ *
  * To get the actual values for the magnetic field in \f$\mu T\f$,
  * one have to divide the returned values from the magnetometer by 10.
  *
@@ -188,7 +195,7 @@ int mag3110_is_ready(const mag3110_t *dev);
 int mag3110_read(const mag3110_t *dev, mag3110_data_t *data);
 
 /**
- * @brief Read die temperature.
+ * @brief   Read die temperature.
  *
  * @param[in]  dev          device descriptor of magnetometer
  * @param[out] dtemp        die temperature

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -74,9 +74,9 @@ enum {
 
 #ifndef MPL3115A2_CONVERSION_TIME
 /**
- * @brief Maximum Conversion Time in microseconds [us]
+ * @brief   Maximum Conversion Time in microseconds [us]
  *
- * @note Conversion time is: ((oversampling ratio * 4) + 2) * 1000 us
+ * @note    Conversion time is: ((oversampling ratio * 4) + 2) * 1000 us
  */
 #define MPL3115A2_CONVERSION_TIME   (514000UL)
 #endif
@@ -91,14 +91,14 @@ typedef struct {
 } mpl3115a2_params_t;
 
 /**
- * @brief Device descriptor for MPL3115A2 sensors.
+ * @brief   Device descriptor for MPL3115A2 sensors.
  */
 typedef struct {
     mpl3115a2_params_t params;  /**< device configuration parameters */
 } mpl3115a2_t;
 
 /**
- * @brief Initialize the MPL3115A2 sensor driver.
+ * @brief   Initialize the MPL3115A2 sensor driver.
  *
  * @param[out] dev          device descriptor of sensor to initialize
  * @param[in]  params       configuration parameters
@@ -111,7 +111,7 @@ typedef struct {
 int mpl3115a2_init(mpl3115a2_t *dev, const mpl3115a2_params_t *params);
 
 /**
- * @brief Reset the MPL3115A2 sensor. After that, the sensor should be reinitialized.
+ * @brief   Reset the MPL3115A2 sensor. After that, the sensor should be reinitialized.
  *
  * @param[in] dev           device descriptor of sensor
  *
@@ -121,7 +121,7 @@ int mpl3115a2_init(mpl3115a2_t *dev, const mpl3115a2_params_t *params);
 int mpl3115a2_reset(const mpl3115a2_t *dev);
 
 /**
- * @brief Set active mode, this enables periodic measurements.
+ * @brief   Set active mode, this enables periodic measurements.
  *
  * @param[in] dev           device descriptor of sensor
  *
@@ -131,7 +131,7 @@ int mpl3115a2_reset(const mpl3115a2_t *dev);
 int mpl3115a2_set_active(const mpl3115a2_t *dev);
 
 /**
- * @brief Set standby mode.
+ * @brief   Set standby mode.
  *
  * @param[in]  dev          device descriptor of sensor
  *
@@ -141,7 +141,7 @@ int mpl3115a2_set_active(const mpl3115a2_t *dev);
 int mpl3115a2_set_standby(const mpl3115a2_t *dev);
 
 /**
- * @brief Check for new set of measurement data.
+ * @brief   Check for new set of measurement data.
  *
  * @param[in]  dev          device descriptor of sensor
  *
@@ -152,7 +152,7 @@ int mpl3115a2_set_standby(const mpl3115a2_t *dev);
 int mpl3115a2_is_ready(const mpl3115a2_t *dev);
 
 /**
- * @brief Read sensor's data in pressure mode.
+ * @brief   Read sensor's data in pressure mode.
  *
  * @param[in]  dev          device descriptor of sensor
  * @param[out] pres         pressure in Pascals
@@ -164,7 +164,7 @@ int mpl3115a2_is_ready(const mpl3115a2_t *dev);
 int mpl3115a2_read_pressure(const mpl3115a2_t *dev, uint32_t *pres, uint8_t *status);
 
 /**
- * @brief Read sensor's temperature.
+ * @brief   Read sensor's temperature.
  *
  * @param[in]  dev          device descriptor of sensor
  * @param[out] temp         temperature in \f$^\circ C \cdot 10\f$

--- a/drivers/include/mpu9150.h
+++ b/drivers/include/mpu9150.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @name Sample rate macro definitions
+ * @name    Sample rate macro definitions
  * @{
  */
 #define MPU9150_MIN_SAMPLE_RATE     (4)
@@ -39,7 +39,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name Power Management 1 register macros
+ * @name    Power Management 1 register macros
  * @{
  */
 #define MPU9150_PWR_WAKEUP          (0x00)
@@ -48,7 +48,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name Power Management 2 register macros
+ * @name    Power Management 2 register macros
  * @{
  */
 #define MPU9150_PWR_GYRO            (0x07)
@@ -56,7 +56,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name Sleep times in microseconds
+ * @name    Sleep times in microseconds
  * @{
  */
 #define MPU9150_COMP_MODE_SLEEP_US  (1000)
@@ -66,7 +66,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name MPU-9150 compass operating modes and reg values
+ * @name    MPU-9150 compass operating modes and reg values
  * @{
  */
 #define MPU9150_COMP_POWER_DOWN     (0x00)
@@ -77,7 +77,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Power enum values
+ * @brief   Power enum values
  */
 typedef enum {
     MPU9150_SENSOR_PWR_OFF = 0x00,
@@ -85,7 +85,7 @@ typedef enum {
 } mpu9150_pwr_t;
 
 /**
- * @brief Possible MPU-9150 hardware addresses (wiring specific)
+ * @brief   Possible MPU-9150 hardware addresses (wiring specific)
  */
 typedef enum {
     MPU9150_HW_ADDR_HEX_68 = 0x68,
@@ -93,7 +93,7 @@ typedef enum {
 } mpu9150_hw_addr_t;
 
 /**
- * @brief Possible compass addresses (wiring specific)
+ * @brief   Possible compass addresses (wiring specific)
  */
 typedef enum {
     MPU9150_COMP_ADDR_HEX_0C = 0x0C,
@@ -103,7 +103,7 @@ typedef enum {
 } mpu9150_comp_addr_t;
 
 /**
- * @brief Possible full scale ranges for the gyroscope
+ * @brief   Possible full scale ranges for the gyroscope
  */
 typedef enum {
     MPU9150_GYRO_FSR_250DPS = 0x00,
@@ -113,7 +113,7 @@ typedef enum {
 } mpu9150_gyro_ranges_t;
 
 /**
- * @brief Possible full scale ranges for the accelerometer
+ * @brief   Possible full scale ranges for the accelerometer
  */
 typedef enum {
     MPU9150_ACCEL_FSR_2G = 0x00,
@@ -123,7 +123,7 @@ typedef enum {
 } mpu9150_accel_ranges_t;
 
 /**
- * @brief Possible low pass filter values
+ * @brief   Possible low pass filter values
  */
 typedef enum {
     MPU9150_FILTER_188HZ = 0x01,
@@ -135,7 +135,7 @@ typedef enum {
 } mpu9150_lpf_t;
 
 /**
- * @brief MPU-9150 result vector struct
+ * @brief   MPU-9150 result vector struct
  */
 typedef struct {
     int16_t x_axis;             /**< X-Axis measurement result */
@@ -144,7 +144,7 @@ typedef struct {
 } mpu9150_results_t;
 
 /**
- * @brief Configuration struct for the MPU-9150 sensor
+ * @brief   Configuration struct for the MPU-9150 sensor
  */
 typedef struct {
     mpu9150_pwr_t accel_pwr;            /**< Accel power status (on/off) */
@@ -160,7 +160,7 @@ typedef struct {
 } mpu9150_status_t;
 
 /**
- * @brief Device descriptor for the MPU-9150 sensor
+ * @brief   Device descriptor for the MPU-9150 sensor
  */
 typedef struct {
     i2c_t i2c_dev;              /**< I2C device which is used */
@@ -170,7 +170,7 @@ typedef struct {
 } mpu9150_t;
 
 /**
- * @brief Initialize the given MPU9150 device
+ * @brief   Initialize the given MPU9150 device
  *
  * @param[out] dev          Initialized device descriptor of MPU9150 device
  * @param[in]  i2c          I2C bus the sensor is connected to
@@ -184,7 +184,7 @@ int mpu9150_init(mpu9150_t *dev, i2c_t i2c, mpu9150_hw_addr_t hw_addr,
         mpu9150_comp_addr_t comp_addr);
 
 /**
- * @brief Enable or disable accelerometer power
+ * @brief   Enable or disable accelerometer power
  *
  * @param[in] dev           Device descriptor of MPU9150 device
  * @param[in] pwr_conf      Target power setting: PWR_ON or PWR_OFF
@@ -195,7 +195,7 @@ int mpu9150_init(mpu9150_t *dev, i2c_t i2c, mpu9150_hw_addr_t hw_addr,
 int mpu9150_set_accel_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf);
 
 /**
- * @brief Enable or disable gyroscope power
+ * @brief   Enable or disable gyroscope power
  *
  * @param[in] dev           Device descriptor of MPU9150 device
  * @param[in] pwr_conf      Target power setting: PWR_ON or PWR_OFF
@@ -206,7 +206,7 @@ int mpu9150_set_accel_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf);
 int mpu9150_set_gyro_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf);
 
 /**
- * @brief Enable or disable compass power
+ * @brief   Enable or disable compass power
  *
  * @param[in] dev           Device descriptor of MPU9150 device
  * @param[in] pwr_conf      Target power setting: PWR_ON or PWR_OFF
@@ -217,7 +217,7 @@ int mpu9150_set_gyro_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf);
 int mpu9150_set_compass_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf);
 
 /**
- * @brief Read angular speed values from the given MPU9150 device, returned in dps
+ * @brief   Read angular speed values from the given MPU9150 device, returned in dps
  *
  * The raw gyroscope data is read from the sensor and normalized with respect to
  * the configured gyroscope full-scale range.
@@ -232,7 +232,7 @@ int mpu9150_set_compass_power(mpu9150_t *dev, mpu9150_pwr_t pwr_conf);
 int mpu9150_read_gyro(const mpu9150_t *dev, mpu9150_results_t *output);
 
 /**
- * @brief Read acceleration values from the given MPU9150 device, returned in mG
+ * @brief   Read acceleration values from the given MPU9150 device, returned in mG
  *
  * The raw acceleration data is read from the sensor and normalized with respect to
  * the configured accelerometer full-scale range.
@@ -247,7 +247,7 @@ int mpu9150_read_gyro(const mpu9150_t *dev, mpu9150_results_t *output);
 int mpu9150_read_accel(const mpu9150_t *dev, mpu9150_results_t *output);
 
 /**
- * @brief Read magnetic field values from the given MPU9150 device, returned in mikroT
+ * @brief   Read magnetic field values from the given MPU9150 device, returned in mikroT
  *
  * The raw compass data is read from the sensor and normalized with respect to
  * the compass full-scale range (which can not be configured).
@@ -261,7 +261,7 @@ int mpu9150_read_accel(const mpu9150_t *dev, mpu9150_results_t *output);
 int mpu9150_read_compass(const mpu9150_t *dev, mpu9150_results_t *output);
 
 /**
- * @brief Read temperature value from the given MPU9150 device, returned in m°C
+ * @brief   Read temperature value from the given MPU9150 device, returned in m°C
  *
  * @note
  * The measured temperature is slightly higher than the real room temperature.
@@ -276,7 +276,7 @@ int mpu9150_read_compass(const mpu9150_t *dev, mpu9150_results_t *output);
 int mpu9150_read_temperature(const mpu9150_t *dev, int32_t *output);
 
 /**
- * @brief Set the full-scale range for raw gyroscope data
+ * @brief   Set the full-scale range for raw gyroscope data
  *
  * @param[in] dev           Device descriptor of MPU9150 device
  * @param[in] fsr           Target full-scale range
@@ -288,7 +288,7 @@ int mpu9150_read_temperature(const mpu9150_t *dev, int32_t *output);
 int mpu9150_set_gyro_fsr(mpu9150_t *dev, mpu9150_gyro_ranges_t fsr);
 
 /**
- * @brief Set the full-scale range for raw accelerometer data
+ * @brief   Set the full-scale range for raw accelerometer data
  *
  * @param[in] dev           Device descriptor of MPU9150 device
  * @param[in] fsr           Target full-scale range
@@ -300,7 +300,7 @@ int mpu9150_set_gyro_fsr(mpu9150_t *dev, mpu9150_gyro_ranges_t fsr);
 int mpu9150_set_accel_fsr(mpu9150_t *dev, mpu9150_accel_ranges_t fsr);
 
 /**
- * @brief Set the rate at which the gyroscope and accelerometer data is sampled
+ * @brief   Set the rate at which the gyroscope and accelerometer data is sampled
  *
  * Sample rate can be chosen between 4 Hz and 1kHz. The actual set value might
  * slightly differ. If necessary, check the actual set value in the device's
@@ -316,7 +316,7 @@ int mpu9150_set_accel_fsr(mpu9150_t *dev, mpu9150_accel_ranges_t fsr);
 int mpu9150_set_sample_rate(mpu9150_t *dev, uint16_t rate);
 
 /**
- * @brief Set the rate at which the compass data is sampled
+ * @brief   Set the rate at which the compass data is sampled
  *
  * Sample rate can be chosen between 1 Hz and 100 Hz but has to be a fraction
  * of the configured accel/gyro sample rate. The actual set value might

--- a/drivers/include/mq3.h
+++ b/drivers/include/mq3.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_mq3 MQ-3 Alcohol Tester
+ * @defgroup    drivers_mq3 MQ-3 Alcohol Tester
  * @ingroup     drivers_sensors
  * @brief       Device driver for the MQ-3 alcohol sensor
  * @{
@@ -28,19 +28,19 @@ extern "C" {
 #endif
 
 /**
- * @brief maximum unprocessed value fetched form the sensor
+ * @brief   maximum unprocessed value fetched form the sensor
  */
 #define MQ3_MAX_RAW_VALUE           (1023U)
 
 /**
- * @brief device descriptor for a MQ-3 sensor
+ * @brief   device descriptor for a MQ-3 sensor
  */
 typedef struct {
     adc_t adc_line;         /**< the used ADC line */
 } mq3_t;
 
 /**
- * @brief Initialize a MQ-3 alcohol sensor
+ * @brief   Initialize a MQ-3 alcohol sensor
  *
  * The MQ-3 sensor is interfaced by a single ADC pin, specified by `adc` and `channel`.
  *
@@ -56,7 +56,7 @@ typedef struct {
 int mq3_init(mq3_t *dev, adc_t adc_line);
 
 /**
- * @brief Read the RAW sensor value, can be between 0 and MQ3_MAX_RAW_VALUE
+ * @brief   Read the RAW sensor value, can be between 0 and MQ3_MAX_RAW_VALUE
  *
  * @param[in] dev       device descriptor of the MQ-3 sensor to read from
  *
@@ -65,7 +65,7 @@ int mq3_init(mq3_t *dev, adc_t adc_line);
 int mq3_read_raw(const mq3_t *dev);
 
 /**
- * @brief Read the scaled sensor value of PPM of alcohol
+ * @brief   Read the scaled sensor value of PPM of alcohol
  *
  * @param[in] dev       device descriptor of the MQ-3 sensor to read from
  *

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -14,6 +14,42 @@
  * This module contains drivers for radio devices in Microchip MRF24J40 series.
  * The driver is aimed to work with all devices of this series.
  *
+ * Default TX power is 0dBm.
+ *
+ * TX power mapping:
+ * * 0 -> -36dB
+ * * 1 -> -35dB
+ * * 2 -> -34dB
+ * * 3 -> -33dB
+ * * 4 -> -32dB
+ * * 5 -> -31dB
+ * * 6 -> -30dB
+ * * 7 -> -30dB
+ * * 8 -> -26dB
+ * * 9 -> -25dB
+ * * 10 -> -24dB
+ * * 11 -> -23dB
+ * * 12 -> -22dB
+ * * 13 -> -21dB
+ * * 14 -> -20dB
+ * * 15 -> -20dB
+ * * 16 -> -16dB
+ * * 17 -> -15dB
+ * * 18 -> -14dB
+ * * 19 -> -13dB
+ * * 20 -> -12dB
+ * * 21 -> -11dB
+ * * 22 -> -10dB
+ * * 23 -> -10dB
+ * * 24 -> -6dB
+ * * 25 -> -5dB
+ * * 26 -> -4dB
+ * * 27 -> -3dB
+ * * 28 -> -2dB
+ * * 29 -> -1dB
+ * * 30 -> -0dB
+ * * 31 -> -0dB
+ *
  * @{
  *
  * @file
@@ -40,43 +76,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default TX power (0dBm)
- *  0 -> -36dB
- *  1 -> -35dB
- *  2 -> -34dB
- *  3 -> -33dB
- *  4 -> -32dB
- *  5 -> -31dB
- *  6 -> -30dB
- *  7 -> -30dB
- *  8 -> -26dB
- *  9 -> -25dB
- *  10 -> -24dB
- *  11 -> -23dB
- *  12 -> -22dB
- *  13 -> -21dB
- *  14 -> -20dB
- *  15 -> -20dB
- *  16 -> -16dB
- *  17 -> -15dB
- *  18 -> -14dB
- *  19 -> -13dB
- *  20 -> -12dB
- *  21 -> -11dB
- *  22 -> -10dB
- *  23 -> -10dB
- *  24 -> -6dB
- *  25 -> -5dB
- *  26 -> -4dB
- *  27 -> -3dB
- *  28 -> -2dB
- *  29 -> -1dB
- *  30 -> -0dB
- *  31 -> -0dB
- */
-
-/**
- * @brief   Flags for PSEUDO DEVICE INTERNAL STATES
+ * @name    Flags for pseudo device internal states
  * @{
  */
 #define MRF24J40_PSEUDO_STATE_IDLE      (0x01)      /**< Idle, ready to transmit or receive */
@@ -85,7 +85,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Internal device option flags
+ * @name    Internal device option flags
  *
  * `0x00ff` is reserved for general IEEE 802.15.4 flags
  * (see @ref netdev_ieee802154_t)
@@ -116,12 +116,12 @@ extern "C" {
 #define MRF24J40_MAX_FRAME_RETRIES      (3U)        /**< Number of frame retries (fixed) */
 
 /**
- * @brief struct holding all params needed for device initialization
+ * @brief   struct holding all params needed for device initialization
  */
 typedef struct mrf24j40_params {
     spi_t spi;              /**< SPI bus the device is connected to */
-    spi_clk_t spi_clk;  /**< SPI speed to use */
-    spi_cs_t cs_pin;          /**< GPIO pin connected to chip select */
+    spi_clk_t spi_clk;      /**< SPI speed to use */
+    spi_cs_t cs_pin;        /**< GPIO pin connected to chip select */
     gpio_t int_pin;         /**< GPIO pin connected to the interrupt pin */
     gpio_t reset_pin;       /**< GPIO pin connected to the reset pin */
 } mrf24j40_params_t;
@@ -131,17 +131,14 @@ typedef struct mrf24j40_params {
  */
 typedef struct {
     netdev_ieee802154_t netdev;             /**< netdev parent struct */
-    /**
-     * @brief   device specific fields
-     * @{
-     */
+    /*  device specific fields  */
     mrf24j40_params_t params;               /**< parameters for initialization */
     uint8_t state;                          /**< current state of the radio */
     uint8_t idle_state;                     /**< state to return to after sending */
     uint8_t tx_frame_len;                   /**< length of the current TX frame */
-    uint8_t header_len;
+    uint8_t header_len;                     /**< length of the header */
     uint8_t pending;                        /**< Flags for pending tasks */
-    uint8_t irq_flag;
+    uint8_t irq_flag;                       /**< Flags for IRQs */
 } mrf24j40_t;
 
 /**

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 /**
- * @brief MTD power states
+ * @brief   MTD power states
  */
 enum mtd_power_state {
     MTD_POWER_UP,    /**< Power up */
@@ -41,7 +41,7 @@ enum mtd_power_state {
 };
 
 /**
- * @brief MTD driver interface
+ * @brief   MTD driver interface
  *
  * This define the functions to access a MTD.
  *
@@ -53,7 +53,7 @@ enum mtd_power_state {
 typedef struct mtd_desc mtd_desc_t;
 
 /**
- * @brief MTD device descriptor
+ * @brief   MTD device descriptor
  */
 typedef struct {
     const mtd_desc_t *driver;  /**< MTD driver */
@@ -63,7 +63,7 @@ typedef struct {
 } mtd_dev_t;
 
 /**
- * @brief MTD driver interface
+ * @brief   MTD driver interface
  *
  * This define the functions to access a MTD.
  *
@@ -74,7 +74,7 @@ typedef struct {
  */
 struct mtd_desc {
     /**
-     * @brief Initialize Memory Technology Device (MTD)
+     * @brief   Initialize Memory Technology Device (MTD)
      *
      * @param[in] dev  Pointer to the selected driver
      *
@@ -84,7 +84,7 @@ struct mtd_desc {
     int (*init)(mtd_dev_t *dev);
 
     /**
-     * @brief Read from the Memory Technology Device (MTD)
+     * @brief   Read from the Memory Technology Device (MTD)
      *
      * No alignment is required on @p addr and @p size.
      *
@@ -102,7 +102,7 @@ struct mtd_desc {
                 uint32_t size);
 
     /**
-     * @brief Write to the Memory Technology Device (MTD)
+     * @brief   Write to the Memory Technology Device (MTD)
      *
      * @p addr + @p size must be inside a page boundary. @p addr can be anywhere
      * but the buffer cannot overlap two pages.
@@ -121,7 +121,7 @@ struct mtd_desc {
                  uint32_t size);
 
     /**
-     * @brief Erase sector(s) over the Memory Technology Device (MTD)
+     * @brief   Erase sector(s) over the Memory Technology Device (MTD)
      *
      * @p addr must be aligned on a sector boundary. @p size must be a multiple of a sector size.
      *
@@ -137,7 +137,7 @@ struct mtd_desc {
                  uint32_t size);
 
     /**
-     * @brief Control power of Memory Technology Device (MTD)
+     * @brief   Control power of Memory Technology Device (MTD)
      *
      * @param[in] dev       Pointer to the selected driver
      * @param[in] power     Power state to apply (from @ref mtd_power_state)
@@ -149,7 +149,7 @@ struct mtd_desc {
 };
 
 /**
- * @brief mtd_init Initialize a MTD device
+ * @brief   mtd_init Initialize a MTD device
  *
  * @param mtd the device to initialize
  *
@@ -158,7 +158,7 @@ struct mtd_desc {
 int mtd_init(mtd_dev_t *mtd);
 
 /**
- * @brief mtd_read Read data from a MTD device
+ * @brief   mtd_read Read data from a MTD device
  *
  * No alignment is required on @p addr and @p count.
  *
@@ -177,7 +177,7 @@ int mtd_init(mtd_dev_t *mtd);
 int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count);
 
 /**
- * @brief mtd_read write data to a MTD device
+ * @brief   mtd_read write data to a MTD device
  *
  * @p addr + @p count must be inside a page boundary. @p addr can be anywhere
  * but the buffer cannot overlap two pages.
@@ -198,7 +198,7 @@ int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count);
 int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
 
 /**
- * @brief mtd_erase Erase sectors of a MTD device
+ * @brief   mtd_erase Erase sectors of a MTD device
  *
  * @p addr must be aligned on a sector boundary. @p count must be a multiple of a sector size.
  *
@@ -216,7 +216,7 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
 int mtd_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count);
 
 /**
- * @brief mtd_power Set power mode on a MTD device
+ * @brief   mtd_power Set power mode on a MTD device
  *
  * @param      mtd   the device to access
  * @param[in]  power the power mode to set
@@ -231,7 +231,7 @@ int mtd_power(mtd_dev_t *mtd, enum mtd_power_state power);
 
 #if defined(MODULE_VFS) || defined(DOXYGEN)
 /**
- * @brief MTD driver for VFS
+ * @brief   MTD driver for VFS
  */
 extern const vfs_file_ops_t mtd_vfs_ops;
 #endif
@@ -240,5 +240,5 @@ extern const vfs_file_ops_t mtd_vfs_ops;
 }
 #endif
 
-/** @} */
 #endif /* MTD_H */
+/** @} */

--- a/drivers/include/mtd_sdcard.h
+++ b/drivers/include/mtd_sdcard.h
@@ -33,7 +33,7 @@ extern "C"
 #endif
 
 /**
- * @brief Device descriptor for mtd_sdcard device
+ * @brief   Device descriptor for mtd_sdcard device
  *
  * This is an extension of the @c mtd_dev_t struct
  */
@@ -45,17 +45,17 @@ typedef struct {
 
 
 /**
- * @brief sdcards handle sector erase internally so it's possible to directly
- *        write to the card without erasing the sector first.
- *        Attention: an erase call will therefore NOT touch the content,
- *                   so disable this feature to ensure overriding the data.
+ * @brief   sdcards handle sector erase internally so it's possible to directly
+ *          write to the card without erasing the sector first.
+ *          Attention: an erase call will therefore NOT touch the content,
+ *                     so disable this feature to ensure overriding the data.
  */
 #ifndef MTD_SDCARD_SKIP_ERASE
 #define MTD_SDCARD_SKIP_ERASE (1)
 #endif
 
 /**
- * @brief sdcard device operations table for mtd
+ * @brief   sdcard device operations table for mtd
  */
 extern const mtd_desc_t mtd_sdcard_driver;
 

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -37,7 +37,7 @@ extern "C"
 #endif
 
 /**
- * @brief SPI NOR flash opcode table
+ * @brief   SPI NOR flash opcode table
  */
 typedef struct {
     uint8_t rdid;            /**< Read identification (JEDEC ID) */
@@ -57,7 +57,7 @@ typedef struct {
 } mtd_spi_nor_opcode_t;
 
 /**
- * @brief Internal representation of JEDEC memory ID codes.
+ * @brief   Internal representation of JEDEC memory ID codes.
  *
  * @see http://www.jedec.org/standards-documents/results/jep106
  */
@@ -68,23 +68,23 @@ typedef struct __attribute__((packed)) {
 } mtd_jedec_id_t;
 
 /**
- * @brief Byte to signal increment bank number when reading manufacturer ID
+ * @brief   Byte to signal increment bank number when reading manufacturer ID
  *
  * @see http://www.jedec.org/standards-documents/results/jep106
  */
 #define JEDEC_NEXT_BANK (0x7f)
 
 /**
- * @brief Flag to set when the device support 4KiB sector erase (sector_erase opcode)
+ * @brief   Flag to set when the device support 4KiB sector erase (sector_erase opcode)
  */
 #define SPI_NOR_F_SECT_4K   (1)
 /**
- * @brief Flag to set when the device support 32KiB block erase (block_erase_32k opcode)
+ * @brief   Flag to set when the device support 32KiB block erase (block_erase_32k opcode)
  */
 #define SPI_NOR_F_SECT_32K  (2)
 
 /**
- * @brief Device descriptor for serial flash memory devices
+ * @brief   Device descriptor for serial flash memory devices
  *
  * This is an extension of the @c mtd_dev_t struct
  */
@@ -98,26 +98,26 @@ typedef struct {
     uint16_t flag;           /**< Config flags */
     mtd_jedec_id_t jedec_id; /**< JEDEC ID of the chip */
     /**
-     * @brief bitmask to corresponding to the page address
+     * @brief   bitmask to corresponding to the page address
      *
      * Computed by mtd_spi_nor_init, no need to touch outside the driver.
      */
     uint32_t page_addr_mask;
     /**
-     * @brief bitmask to corresponding to the sector address
+     * @brief   bitmask to corresponding to the sector address
      *
      * Computed by mtd_spi_nor_init, no need to touch outside the driver.
      */
     uint32_t sec_addr_mask;
     uint8_t addr_width;      /**< Number of bytes in addresses, usually 3 for small devices */
     /**
-     * @brief number of right shifts to get the address to the start of the page
+     * @brief   number of right shifts to get the address to the start of the page
      *
      * Computed by mtd_spi_nor_init, no need to touch outside the driver.
      */
     uint8_t page_addr_shift;
     /**
-     * @brief number of right shifts to get the address to the start of the sector
+     * @brief   number of right shifts to get the address to the start of the sector
      *
      * Computed by mtd_spi_nor_init, no need to touch outside the driver.
      */
@@ -125,14 +125,14 @@ typedef struct {
 } mtd_spi_nor_t;
 
 /**
- * @brief NOR flash SPI MTD device operations table
+ * @brief   NOR flash SPI MTD device operations table
  */
 extern const mtd_desc_t mtd_spi_nor_driver;
 
 /* Available opcode tables for known devices */
 /* Defined in mtd_spi_nor_configs.c */
 /**
- * @brief Default command opcodes
+ * @brief   Default command opcodes
  *
  * The numbers were taken from Micron M25P16, but the same opcodes can
  * be found in Macronix MX25L25735E, and multiple other data sheets for

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -392,5 +392,6 @@ typedef struct netdev_driver {
 #ifdef __cplusplus
 }
 #endif
-/** @} */
+
 #endif /* NET_NETDEV_H */
+/** @} */

--- a/drivers/include/net/netdev/eth.h
+++ b/drivers/include/net/netdev/eth.h
@@ -61,5 +61,6 @@ int netdev_eth_set(netdev_t *dev, netopt_t opt, const void *value, size_t value_
 #ifdef __cplusplus
 }
 #endif
-/** @} */
+
 #endif /* NET_NETDEV_ETH_H */
+/** @} */

--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -33,7 +33,7 @@ extern "C" {
 #include "periph/spi.h"
 
 /**
- * @brief Structure that represents the hardware setup of the nrf24l01+ transceiver.
+ * @brief   Structure that represents the hardware setup of the nrf24l01+ transceiver.
  */
 typedef struct {
     spi_t spi;      /**< SPI device to initialize */
@@ -44,7 +44,7 @@ typedef struct {
 } nrf24l01p_t;
 
 /**
- * @brief Defines the address width of the nrf24l01+ transceiver.
+ * @brief   Defines the address width of the nrf24l01+ transceiver.
  */
 typedef enum {
     NRF24L01P_AW_3BYTE, /**< address width is 3 Byte */
@@ -54,7 +54,7 @@ typedef enum {
 
 
 /**
- * @brief Defines the RF datarate.
+ * @brief   Defines the RF datarate.
  */
 typedef enum {
     NRF24L01P_DR_250KBS,/**< datarate is 250 kbps */
@@ -63,7 +63,7 @@ typedef enum {
 } nrf24l01p_dr_t;
 
 /**
- * @brief Defines the RF power level.
+ * @brief   Defines the RF power level.
  */
 typedef enum {
     NRF24L01P_PWR_N18DBM = 0,   /**< power is -18dBm */
@@ -73,7 +73,7 @@ typedef enum {
 } nrf24l01p_pwr_t;
 
 /**
- * @brief Defines the datapipe on which the receiver searches for packets.
+ * @brief   Defines the datapipe on which the receiver searches for packets.
  */
 typedef enum {
     NRF24L01P_PIPE0 = 0,/**< RX pipe 0 */
@@ -85,7 +85,7 @@ typedef enum {
 } nrf24l01p_rx_pipe_t;
 
 /**
- * @brief Defines the error detection encoding scheme for the nrf24l01p transceiver.
+ * @brief   Defines the error detection encoding scheme for the nrf24l01p transceiver.
  */
 typedef enum {
     NRF24L01P_CRC_1BYTE = 0,    /**< encoding scheme generates 1 Byte redundancy */
@@ -93,7 +93,7 @@ typedef enum {
 } nrf24l01p_crc_t;
 
 /**
- * @brief Defines the automatic retransmission delay defined from end of transmission
+ * @brief   Defines the automatic retransmission delay defined from end of transmission
  * to start of next treansmission.
  */
 typedef enum {
@@ -116,7 +116,7 @@ typedef enum {
 } nrf24l01p_retransmit_delay_t;
 
 /**
- * @brief Defines states for the nrf24l01+ transceiver
+ * @brief   Defines states for the nrf24l01+ transceiver
  */
 typedef enum {
     RCV_PKT_NRF24L01P = 0,  /**< transceiver received data */
@@ -124,7 +124,7 @@ typedef enum {
 
 
 /**
-* @brief Read one register of the nrf24l01+ transceiver.
+* @brief   Read one register of the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] reg    Register address to read from.
@@ -136,7 +136,7 @@ typedef enum {
 int nrf24l01p_read_reg(const nrf24l01p_t *dev, char reg, char *answer);
 
 /**
-* @brief Write one register to the nrf24l01+ transceiver.
+* @brief   Write one register to the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] reg    Register address to write to.
@@ -148,7 +148,7 @@ int nrf24l01p_read_reg(const nrf24l01p_t *dev, char reg, char *answer);
 int nrf24l01p_write_reg(const nrf24l01p_t *dev, char reg, char write);
 
 /**
-* @brief Initialize the nrf24l01+ transceiver.
+* @brief   Initialize the nrf24l01+ transceiver.
 *
 * @ note
 * This function initializes the transceiver so that it is ready to use.
@@ -165,7 +165,7 @@ int nrf24l01p_write_reg(const nrf24l01p_t *dev, char reg, char write);
 int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t csn, gpio_t irq);
 
 /**
-* @brief Power on the nrf24l01+ transceiver.
+* @brief   Power on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -175,7 +175,7 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t csn, gpio_t ir
 int nrf24l01p_on(const nrf24l01p_t *dev);
 
 /**
-* @brief Power off the nrf24l01+ transceiver.
+* @brief   Power off the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -185,7 +185,7 @@ int nrf24l01p_on(const nrf24l01p_t *dev);
 int nrf24l01p_off(const nrf24l01p_t *dev);
 
 /**
-* @brief Transmit payload laying in TX FIFO of the nrf24l01+ transceiver.
+* @brief   Transmit payload laying in TX FIFO of the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -193,7 +193,7 @@ int nrf24l01p_off(const nrf24l01p_t *dev);
 void nrf24l01p_transmit(const nrf24l01p_t *dev);
 
 /**
-* @brief Read payload from RX FIFO of the nrf24l01+ transceiver.
+* @brief   Read payload from RX FIFO of the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] answer Buffer to receive bytes to.
@@ -205,7 +205,7 @@ void nrf24l01p_transmit(const nrf24l01p_t *dev);
 int nrf24l01p_read_payload(const nrf24l01p_t *dev, char *answer, unsigned int size);
 
 /**
-* @brief Register a given ID to the nrf24l01+ transceiver.
+* @brief   Register a given ID to the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] pid    ID to register.
@@ -214,7 +214,7 @@ int nrf24l01p_read_payload(const nrf24l01p_t *dev, char *answer, unsigned int si
 void nrf24l01p_register(nrf24l01p_t *dev, unsigned int *pid);
 
 /**
-* @brief Enable dynamic payload for the pipe on give nrf24l01+ transceiver.
+* @brief   Enable dynamic payload for the pipe on give nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] pipe   RX pipe for which dynamic payload is enabled
@@ -225,7 +225,7 @@ void nrf24l01p_register(nrf24l01p_t *dev, unsigned int *pid);
 int nrf24l01p_enable_dynamic_payload(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 
 /**
-* @brief Enable dynamic ack for the nrf24l01+ transceiver.
+* @brief   Enable dynamic ack for the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -235,7 +235,7 @@ int nrf24l01p_enable_dynamic_payload(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t
 int nrf24l01p_enable_dynamic_ack(const nrf24l01p_t *dev);
 
 /**
-* @brief Unregister the nrf24l01+ transceiver from his ID.
+* @brief   Unregister the nrf24l01+ transceiver from his ID.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] pid    Actual ID to unregister.
@@ -246,7 +246,7 @@ int nrf24l01p_enable_dynamic_ack(const nrf24l01p_t *dev);
 int nrf24l01p_unregister(nrf24l01p_t *dev, unsigned int pid);
 
 /**
-* @brief Get ID from the nrf24l01p transceiver.
+* @brief   Get ID from the nrf24l01p transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] pid    Transceiver ID.
@@ -255,7 +255,7 @@ int nrf24l01p_unregister(nrf24l01p_t *dev, unsigned int pid);
 void nrf24l01p_get_id(const nrf24l01p_t *dev, unsigned int *pid);
 
 /**
-* @brief Start searching packets while in RX mode.
+* @brief   Start searching packets while in RX mode.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -263,7 +263,7 @@ void nrf24l01p_get_id(const nrf24l01p_t *dev, unsigned int *pid);
 void nrf24l01p_start(const nrf24l01p_t *dev);
 
 /**
-* @brief Stop searching packets while in RX mode.
+* @brief   Stop searching packets while in RX mode.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -271,7 +271,7 @@ void nrf24l01p_start(const nrf24l01p_t *dev);
 void nrf24l01p_stop(const nrf24l01p_t *dev);
 
 /**
-* @brief Preload TX FIFO with payload to transmit.
+* @brief   Preload TX FIFO with payload to transmit.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] data   Buffer to preload.
@@ -283,7 +283,7 @@ void nrf24l01p_stop(const nrf24l01p_t *dev);
 int nrf24l01p_preload(const nrf24l01p_t *dev, char *data, unsigned int size);
 
 /**
-* @brief Set the RF channel for the nrf24l01+ transceiver.
+* @brief   Set the RF channel for the nrf24l01+ transceiver.
 *
 * @note
 * To ensure non-overlapping channels in 2Mbps mode, don't use directly
@@ -298,7 +298,7 @@ int nrf24l01p_preload(const nrf24l01p_t *dev, char *data, unsigned int size);
 int nrf24l01p_set_channel(const nrf24l01p_t *dev, uint8_t chan);
 
 /**
-* @brief Set the address width for the nrf24l01+ transceiver.
+* @brief   Set the address width for the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] aw     Address width (type nrf24l01p_aw_t).
@@ -309,7 +309,7 @@ int nrf24l01p_set_channel(const nrf24l01p_t *dev, uint8_t chan);
 int nrf24l01p_set_address_width(const nrf24l01p_t *dev, nrf24l01p_aw_t aw);
 
 /**
-* @brief Set the RX payload width for the nrf24l01+ transceiver
+* @brief   Set the RX payload width for the nrf24l01+ transceiver
 *
 * @ note
 * This function sets the payload width for one packet. If the maximum of 32 bytes is
@@ -325,7 +325,7 @@ int nrf24l01p_set_address_width(const nrf24l01p_t *dev, nrf24l01p_aw_t aw);
 int nrf24l01p_set_payload_width(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char width);
 
 /**
-* @brief Set the TX address for the nrf24l01+ transceiver (byte array).
+* @brief   Set the TX address for the nrf24l01+ transceiver (byte array).
 *
 * @note
 * You can either use this function and give it a pointer to a byte array which
@@ -342,7 +342,7 @@ int nrf24l01p_set_payload_width(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe
 int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, const char *saddr, unsigned int length);
 
 /**
-* @brief Set the TX address for the nrf24l01+ transceiver (long int).
+* @brief   Set the TX address for the nrf24l01+ transceiver (long int).
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] saddr  Long integer which holds the TX address in LSBs.
@@ -354,7 +354,7 @@ int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, const char *saddr, unsigned
 int nrf24l01p_set_tx_address_long(const nrf24l01p_t *dev, uint64_t saddr, unsigned int length);
 
 /**
-* @brief Set the RX address for the nrf24l01+ transceiver (byte array).
+* @brief   Set the RX address for the nrf24l01+ transceiver (byte array).
 *
 * @note
 * You can either use this function and give it a pointer to a byte array which
@@ -372,7 +372,7 @@ int nrf24l01p_set_tx_address_long(const nrf24l01p_t *dev, uint64_t saddr, unsign
 int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, const char *saddr, unsigned int length);
 
 /**
-* @brief Set the RX address for the nrf24l01+ transceiver (long int).
+* @brief   Set the RX address for the nrf24l01+ transceiver (long int).
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] pipe   RX pipe to set the address.
@@ -385,7 +385,7 @@ int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, c
 int nrf24l01p_set_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint64_t saddr, unsigned int length);
 
 /**
-* @brief Get the TX address for the nrf24l01+ transceiver (long int).
+* @brief   Get the TX address for the nrf24l01+ transceiver (long int).
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -395,7 +395,7 @@ int nrf24l01p_set_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pi
 uint64_t nrf24l01p_get_tx_address_long(const nrf24l01p_t *dev);
 
 /**
-* @brief Get the RX address for the nrf24l01+ transceiver (long int).
+* @brief   Get the RX address for the nrf24l01+ transceiver (long int).
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] pipe   RX pipe to get the address from.
@@ -406,7 +406,7 @@ uint64_t nrf24l01p_get_tx_address_long(const nrf24l01p_t *dev);
 uint64_t nrf24l01p_get_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 
 /**
-* @brief Get the TX address for the nrf24l01+ transceiver (long int).
+* @brief   Get the TX address for the nrf24l01+ transceiver (long int).
 *
 * @note
 * If you chose 2Mbps you should not allocate directly neighboring RF channels.
@@ -420,7 +420,7 @@ uint64_t nrf24l01p_get_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe
 int nrf24l01p_set_datarate(const nrf24l01p_t *dev, nrf24l01p_dr_t dr);
 
 /**
-* @brief Get the status (register) of the nrf24l01+ transceiver device.
+* @brief   Get the status (register) of the nrf24l01+ transceiver device.
 *
 * @param[in] dev    Transceiver device to use.s of the.
 *
@@ -429,7 +429,7 @@ int nrf24l01p_set_datarate(const nrf24l01p_t *dev, nrf24l01p_dr_t dr);
 int nrf24l01p_get_status(const nrf24l01p_t *dev);
 
 /**
-* @brief Set the transmit power for the nrf24l01+ transceiver device.
+* @brief   Set the transmit power for the nrf24l01+ transceiver device.
 *
 * @note
 * This function rounds the input values to the nearest possible setting.
@@ -443,7 +443,7 @@ int nrf24l01p_get_status(const nrf24l01p_t *dev);
 int nrf24l01p_set_power(const nrf24l01p_t *dev, int pwr);
 
 /**
-* @brief Get the transmit power for the nrf24l01+ transceiver device.
+* @brief   Get the transmit power for the nrf24l01+ transceiver device.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -452,7 +452,7 @@ int nrf24l01p_set_power(const nrf24l01p_t *dev, int pwr);
 int nrf24l01p_get_power(const nrf24l01p_t *dev);
 
 /**
-* @brief Set the nrf24l01+ into TX mode.
+* @brief   Set the nrf24l01+ into TX mode.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -462,7 +462,7 @@ int nrf24l01p_get_power(const nrf24l01p_t *dev);
 int nrf24l01p_set_txmode(const nrf24l01p_t *dev);
 
 /**
-* @brief Set the nrf24l01+ into RX mode.
+* @brief   Set the nrf24l01+ into RX mode.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -472,7 +472,7 @@ int nrf24l01p_set_txmode(const nrf24l01p_t *dev);
 int nrf24l01p_set_rxmode(const nrf24l01p_t *dev);
 
 /**
-* @brief Reset all interrupts on the nrf24l01+ transceiver.
+* @brief   Reset all interrupts on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -482,7 +482,7 @@ int nrf24l01p_set_rxmode(const nrf24l01p_t *dev);
 int nrf24l01p_reset_all_interrupts(const nrf24l01p_t *dev);
 
 /**
-* @brief Reset interrupts on the nrf24l01+ transceiver.
+* @brief   Reset interrupts on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] intrs  Interrupt mask to reset
@@ -493,7 +493,7 @@ int nrf24l01p_reset_all_interrupts(const nrf24l01p_t *dev);
 int nrf24l01p_reset_interrupts(const nrf24l01p_t *dev, char intrs);
 
 /**
-* @brief Mask one interrupt on the nrf24l01+ transceiver.
+* @brief   Mask one interrupt on the nrf24l01+ transceiver.
 *
 * @note
 * There are three interrupts on the nrf24l01+ which can be masked:
@@ -509,7 +509,7 @@ int nrf24l01p_reset_interrupts(const nrf24l01p_t *dev, char intrs);
 int nrf24l01p_mask_interrupt(const nrf24l01p_t *dev, char intr);
 
 /**
-* @brief Unmask one interrupt on the nrf24l01+ transceiver.
+* @brief   Unmask one interrupt on the nrf24l01+ transceiver.
 *
 * @note
 * There are three interrupts on the nrf24l01+ which can be unmasked:
@@ -525,7 +525,7 @@ int nrf24l01p_mask_interrupt(const nrf24l01p_t *dev, char intr);
 int nrf24l01p_unmask_interrupt(const nrf24l01p_t *dev, char intr);
 
 /**
-* @brief Enable RX datapipe on the nrf24l01+ transceiver.
+* @brief   Enable RX datapipe on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] pipe   RX pipe to enable.
@@ -536,7 +536,7 @@ int nrf24l01p_unmask_interrupt(const nrf24l01p_t *dev, char intr);
 int nrf24l01p_enable_pipe(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 
 /**
-* @brief Disable RX datapipe on the nrf24l01+ transceiver.
+* @brief   Disable RX datapipe on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] pipe   RX pipe to disable.
@@ -547,7 +547,7 @@ int nrf24l01p_enable_pipe(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 int nrf24l01p_disable_pipe(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 
 /**
-* @brief Disable CRC error detection on the nrf24l01+ transceiver.
+* @brief   Disable CRC error detection on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -556,7 +556,7 @@ int nrf24l01p_disable_pipe(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe);
 int nrf24l01p_disable_crc(const nrf24l01p_t *dev);
 
 /**
-* @brief Enable CRC error detection on the nrf24l01+ transceiver.
+* @brief   Enable CRC error detection on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 * @param[in] crc    Length of cyclic redundancy check (type nrf24l01p_crc_t).
@@ -567,7 +567,7 @@ int nrf24l01p_disable_crc(const nrf24l01p_t *dev);
 int nrf24l01p_enable_crc(const nrf24l01p_t *dev, nrf24l01p_crc_t crc);
 
 /**
-* @brief Setup and enable automatic ACK and retransmission on the nrf24l01+ transceiver.
+* @brief   Setup and enable automatic ACK and retransmission on the nrf24l01+ transceiver.
 *
 * @note
 * This function enables automatic acknowledgement for a given RX data pipe and also sets up the
@@ -585,7 +585,7 @@ int nrf24l01p_enable_crc(const nrf24l01p_t *dev, nrf24l01p_crc_t crc);
 int nrf24l01p_setup_auto_ack(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, nrf24l01p_retransmit_delay_t delay_retrans, char count_retrans);
 
 /**
-* @brief Disable automatic ACK on the nrf24l01+ transceiver.
+* @brief   Disable automatic ACK on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -595,7 +595,7 @@ int nrf24l01p_setup_auto_ack(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, n
 int nrf24l01p_disable_all_auto_ack(const nrf24l01p_t *dev);
 
 /**
-* @brief Flush TX FIFO on the nrf24l01+ transceiver.
+* @brief   Flush TX FIFO on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -605,7 +605,7 @@ int nrf24l01p_disable_all_auto_ack(const nrf24l01p_t *dev);
 int nrf24l01p_flush_tx_fifo(const nrf24l01p_t *dev);
 
 /**
-* @brief Flush RX FIFO on the nrf24l01+ transceiver.
+* @brief   Flush RX FIFO on the nrf24l01+ transceiver.
 *
 * @param[in] dev    Transceiver device to use.
 *
@@ -615,7 +615,7 @@ int nrf24l01p_flush_tx_fifo(const nrf24l01p_t *dev);
 int nrf24l01p_flush_rx_fifo(const nrf24l01p_t *dev);
 
 /**
-* @brief Callback that is called when interrupt occurs on interrupt
+* @brief   Callback that is called when interrupt occurs on interrupt
 * pin from the nrf24l01+ transceiver.
 *
 * @param[in] arg    Used to pass transceiver device "dev".

--- a/drivers/include/nvram-spi.h
+++ b/drivers/include/nvram-spi.h
@@ -33,21 +33,21 @@ extern "C" {
 #endif
 
 /**
- * @brief Bus parameters for SPI NVRAM.
+ * @brief   Bus parameters for SPI NVRAM.
  */
 typedef struct nvram_spi_params {
-    /** @brief RIOT SPI device */
+    /** @brief   RIOT SPI device */
     spi_t spi;
-    /** @brief SPI clock speed */
+    /** @brief   SPI clock speed */
     spi_clk_t clk;
-    /** @brief Chip select pin */
+    /** @brief   Chip select pin */
     gpio_t cs;
-    /** @brief Number of address bytes following each read/write command. */
+    /** @brief   Number of address bytes following each read/write command. */
     uint8_t address_count;
 } nvram_spi_params_t;
 
 /**
- * @brief Initialize an nvram_t structure with SPI settings.
+ * @brief   Initialize an nvram_t structure with SPI settings.
  *
  * This will also initialize the CS pin as a GPIO output, without pull resistors.
  *

--- a/drivers/include/nvram.h
+++ b/drivers/include/nvram.h
@@ -43,11 +43,11 @@ extern "C" {
 struct nvram;
 
 /**
- * @brief Device descriptor for generic NVRAM devices.
+ * @brief   Device descriptor for generic NVRAM devices.
  */
 typedef struct nvram {
     /**
-     * @brief Pointer to device-specific read function
+     * @brief   Pointer to device-specific read function
      *
      * Copy data from system memory to NVRAM.
      *
@@ -62,7 +62,7 @@ typedef struct nvram {
     int (*read)(struct nvram *dev, uint8_t *dst, uint32_t src, size_t size);
 
     /**
-     * @brief Pointer to device-specific write function
+     * @brief   Pointer to device-specific write function
      *
      * Copy data from NVRAM to system memory.
      *
@@ -76,10 +76,10 @@ typedef struct nvram {
      */
     int (*write)(struct nvram *dev, const uint8_t *src, uint32_t dst, size_t size);
 
-    /** @brief Device capacity */
+    /** @brief   Device capacity */
     size_t size;
 
-    /** @brief Device-specific parameters, if any. */
+    /** @brief   Device-specific parameters, if any. */
     void *extra;
 } nvram_t;
 

--- a/drivers/include/pcd8544.h
+++ b/drivers/include/pcd8544.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_pcd8544 PCD8544 LCD driver
+ * @defgroup    drivers_pcd8544 PCD8544 LCD driver
  * @ingroup     drivers_actuators
  * @brief       Driver for PCD8544 LCD displays
  *
@@ -32,7 +32,7 @@
 #endif
 
 /**
- * @brief   Definition of display dimensions
+ * @name    Definition of display dimensions
  * @{
  */
 #define PCD8544_RES_X                   (84U)   /**< pixels per row */
@@ -42,7 +42,7 @@
 /** @} */
 
 /**
- * @brief   Default values for temperature compensation and contrast
+ * @name    Default values for temperature compensation and contrast
  * @{
  */
 #define PCD8544_DEFAULT_CONTRAST        (45U)

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -54,34 +54,27 @@ extern "C" {
 
 /**
  * @brief   Define default ADC type identifier
- * @{
  */
 #ifndef HAVE_ADC_T
 typedef unsigned int adc_t;
 #endif
-/** @} */
 
 /**
  * @brief   Default ADC undefined value
- * @{
  */
 #ifndef ADC_UNDEF
 #define ADC_UNDEF           (UINT_MAX)
 #endif
-/** @} */
 
 /**
  * @brief   Default ADC line access macro
- * @{
  */
 #ifndef ADC_LINE
 #define ADC_LINE(x)          (x)
 #endif
-/** @} */
 
 /**
  * @brief   Possible ADC resolution settings
- * @{
  */
 #ifndef HAVE_ADC_RES_T
 typedef enum {
@@ -93,7 +86,6 @@ typedef enum {
     ADC_RES_16BIT,          /**< ADC resolution: 16 bit */
 } adc_res_t;
 #endif
-/** @} */
 
 /**
  * @brief   Initialize the given ADC line

--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -52,6 +52,4 @@ void cpuid_get(void *id);
 #endif
 
 #endif /* PERIPH_CPUID_H */
-/**
- * @}
- */
+/** @} */

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -50,12 +50,10 @@ extern "C" {
 
 /**
  * @brief   Define default DAC type identifier
- * @{
  */
 #ifndef HAVE_DAC_T
 typedef unsigned int dac_t;
 #endif
-/** @} */
 
 /**
  * @brief   Return codes used by the DAC driver interface
@@ -67,21 +65,17 @@ enum {
 
 /**
  * @brief   Default DAC undefined value
- * @{
  */
 #ifndef DAC_UNDEF
 #define DAC_UNDEF           (UINT_MAX)
 #endif
-/** @} */
 
 /**
  * @brief   Default DAC access macro
- * @{
  */
 #ifndef DAC_LINE
 #define DAC_LINE(x)         (x)
 #endif
-/** @} */
 
 /**
  * @brief   Initialize the given DAC line

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -125,7 +125,6 @@ typedef void (*gpio_cb_t)(void *arg);
 
 /**
  * @brief   Default interrupt context for GPIO pins
- * @{
  */
 #ifndef HAVE_GPIO_ISR_CTX_T
 typedef struct {
@@ -133,7 +132,6 @@ typedef struct {
     void *arg;              /**< optional argument */
 } gpio_isr_ctx_t;
 #endif
-/** @} */
 
 /**
  * @brief   Initialize the given pin as general purpose input or output

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -89,34 +89,27 @@ extern "C" {
 
 /**
  * @brief   Default I2C device access macro
- * @{
  */
 #ifndef I2C_DEV
 #define I2C_DEV(x)          (x)
 #endif
-/** @} */
 
 /**
  * @brief   Default I2C undefined value
- * @{
  */
 #ifndef I2C_UNDEF
 #define I2C_UNDEF           (UINT_MAX)
 #endif
-/** @} */
 
 /**
  * @brief   Default i2c_t type definition
- * @{
  */
 #ifndef HAVE_I2C_T
 typedef unsigned int i2c_t;
 #endif
-/**  @} */
 
 /**
  * @brief   Default mapping of I2C bus speed values
- * @{
  */
 #ifndef HAVE_I2C_SPEED_T
 typedef enum {
@@ -127,7 +120,6 @@ typedef enum {
     I2C_SPEED_HIGH,         /**< high speed mode:   ~3.4Mbit/s */
 } i2c_speed_t;
 #endif
-/** @} */
 
 /**
  * @brief   Initialize an I2C device to run as bus master

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -73,34 +73,27 @@ extern "C" {
 
 /**
  * @brief   Default PWM access macro
- * @{
  */
 #ifndef PWM_DEV
 #define PWM_DEV(x)          (x)
 #endif
-/** @} */
 
 /**
  * @brief  Default PWM undefined value
- * @{
  */
 #ifndef PWM_UNDEF
 #define PWM_UNDEF           (UINT_MAX)
 #endif
-/** @} */
 
 /**
  * @brief   Default PWM type definition
- * @{
  */
 #ifndef HAVE_PWM_T
 typedef unsigned int pwm_t;
 #endif
-/** @} */
 
 /**
  * @brief   Default PWM mode definition
- * @{
  */
 #ifndef HAVE_PWM_MODE_T
 typedef enum {
@@ -109,7 +102,6 @@ typedef enum {
     PWM_CENTER          /*< use center aligned PWM */
 } pwm_mode_t;
 #endif
-/** @} */
 
 /**
  * @brief   Initialize a PWM device

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -67,7 +67,6 @@ typedef void (*timer_cb_t)(void *arg, int channel);
 
 /**
  * @brief   Default interrupt context entry holding callback and argument
- * @{
  */
 #ifndef HAVE_TIMER_ISR_CTX_T
 typedef struct {
@@ -75,7 +74,6 @@ typedef struct {
     void *arg;              /**< optional argument given to that callback */
 } timer_isr_ctx_t;
 #endif
-/** @} */
 
 /**
  * @brief Initialize the given timer

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -60,30 +60,24 @@ extern "C" {
 
 /**
  * @brief   Define default UART type identifier
- * @{
  */
 #ifndef HAVE_UART_T
 typedef unsigned int uart_t;
 #endif
-/** @} */
 
 /**
  * @brief   Default UART undefined value
- * @{
  */
 #ifndef UART_UNDEF
 #define UART_UNDEF          (UINT_MAX)
 #endif
-/** @} */
 
 /**
  * @brief   Default UART device access macro
- * @{
  */
 #ifndef UART_DEV
 #define UART_DEV(x)         (x)
 #endif
-/** @} */
 
 /**
  * @brief   Signature for receive interrupt callback
@@ -95,7 +89,6 @@ typedef void(*uart_rx_cb_t)(void *arg, uint8_t data);
 
 /**
  * @brief   Interrupt context for a UART device
- * @{
  */
 #ifndef HAVE_UART_ISR_CTX_T
 typedef struct {
@@ -103,7 +96,6 @@ typedef struct {
     void *arg;              /**< argument to both callback routines */
 } uart_isr_ctx_t;
 #endif
-/** @} */
 
 /**
  * @brief   Possible UART return values

--- a/drivers/include/pir.h
+++ b/drivers/include/pir.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_pir PIR Motion Sensor
+ * @defgroup    drivers_pir PIR Motion Sensor
  * @ingroup     drivers_sensors
  * @brief       Device driver interface for the PIR motion sensor
  * @{
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief device descriptor for a PIR sensor
+ * @brief   device descriptor for a PIR sensor
  */
 typedef struct {
     gpio_t          gpio_dev;       /**< GPIO device which is used */
@@ -37,14 +37,14 @@ typedef struct {
 } pir_t;
 
 /**
- * @brief value to configure sensitivity of sensore
+ * @brief   value to configure sensitivity of sensore
  */
 #ifndef PIR_MSG_T_STATUS_START
 #define PIR_MSG_T_STATUS_START 150
 #endif
 
 /**
- * @brief event type for a PIR sensor
+ * @brief   event type for a PIR sensor
  */
 typedef enum {
     PIR_STATUS_HI = PIR_MSG_T_STATUS_START,     /**< motion was detected */
@@ -52,7 +52,7 @@ typedef enum {
 } pir_event_t;
 
 /**
- * @brief               Initialize a PIR motion sensor
+ * @brief   Initialize a PIR motion sensor
  *
  * The PIR motion sensor is interfaced by a single GPIO pin, specified by
  * `gpio`.
@@ -70,7 +70,7 @@ typedef enum {
 int pir_init(pir_t *dev, gpio_t gpio);
 
 /**
- * @brief               Read the current status of the motion sensor
+ * @brief   Read the current status of the motion sensor
  *
  * @param[in] dev       device descriptor of the PIR motion sensor to read from
  *

--- a/drivers/include/pn532.h
+++ b/drivers/include/pn532.h
@@ -37,7 +37,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Data structure with the configuration parameters
+ * @brief   Data structure with the configuration parameters
  */
 typedef struct {
     union {
@@ -56,7 +56,7 @@ typedef struct {
 } pn532_params_t;
 
 /**
- * @brief Working mode of the PN532
+ * @brief   Working mode of the PN532
  */
 typedef enum {
     PN532_I2C,
@@ -64,7 +64,7 @@ typedef enum {
 } pn532_mode_t;
 
 /**
- * @brief Device descriptor for the PN532
+ * @brief   Device descriptor for the PN532
  */
 typedef struct {
     const pn532_params_t *conf;     /**< Configuration struct */
@@ -73,7 +73,7 @@ typedef struct {
 } pn532_t;
 
 /**
- * @brief Internal buffer size
+ * @brief   Internal buffer size
  *
  * A small buffer size is enough for most applications, however if large NDEF
  * files are to be written this size shall be increased. Otherwise the files
@@ -84,7 +84,7 @@ typedef struct {
 #endif
 
 /**
- * @brief Helpers to extract firmware information from word
+ * @name    Helpers to extract firmware information from word
  * @{
  */
 #define PN532_IC_VERSION(fwver)  ((fwver >> 24) & 0xff)
@@ -94,7 +94,7 @@ typedef struct {
 /** @} */
 
 /**
- * @brief Possible SAM configurations
+ * @brief   Possible SAM configurations
  */
 typedef enum {
     PN532_SAM_NORMAL = 1,
@@ -104,7 +104,7 @@ typedef enum {
 } pn532_sam_conf_mode_t;
 
 /**
- * @brief PN532 supported targets
+ * @brief   PN532 supported targets
  */
 typedef enum {
     PN532_BR_106_ISO_14443_A = 0,
@@ -115,7 +115,7 @@ typedef enum {
 } pn532_target_t;
 
 /**
- * @brief ISO14443A Card types
+ * @brief   ISO14443A Card types
  */
 typedef enum {
     ISO14443A_UNKNOWN,
@@ -124,7 +124,7 @@ typedef enum {
 } nfc_iso14443a_type_t;
 
 /**
- * @brief ISO14443A tag description
+ * @brief   ISO14443A tag description
  */
 typedef struct {
     char target;                /**< Target */
@@ -137,7 +137,7 @@ typedef struct {
 } nfc_iso14443a_t;
 
 /**
- * @brief Mifare keys
+ * @brief   Mifare keys
  */
 typedef enum {
     PN532_MIFARE_KEY_A = 0x60,
@@ -145,7 +145,7 @@ typedef enum {
 } pn532_mifare_key_t;
 
 /**
- * @brief Obtain Tag 4 data length from buffer
+ * @brief   Obtain Tag 4 data length from buffer
  *
  * This is useful in case the length has been read and one intents to read the
  * data.
@@ -153,7 +153,7 @@ typedef enum {
 #define PN532_ISO14443A_4_LEN_FROM_BUFFER(b) ((b[0] << 8) | b[1])
 
 /**
- * @brief Hard reset the chipset
+ * @brief   Hard reset the chipset
  *
  * The chipset is reset by toggling the reset pins
  *
@@ -163,7 +163,7 @@ typedef enum {
 void pn532_reset(const pn532_t *dev);
 
 /**
- * @brief Initialize the module and peripherals
+ * @brief   Initialize the module and peripherals
  *
  * This is the first method to be called in order to interact with the pn532.
  * It configures the GPIOs and the i2c/spi interface (depending on @p mode).
@@ -181,7 +181,7 @@ int pn532_init(pn532_t *dev, const pn532_params_t *params, pn532_mode_t mode);
 
 #if defined(PN532_SUPPORT_I2C) || DOXYGEN
 /**
- * @brief Initialization of PN532 using i2c
+ * @brief   Initialization of PN532 using i2c
  *
  * @see pn532_init for parameter and return value details
  */
@@ -193,7 +193,7 @@ static inline int pn532_init_i2c(pn532_t *dev, const pn532_params_t *params)
 
 #if defined(PN532_SUPPORT_SPI) || DOXYGEN
 /**
- * @brief Initialization of PN532 using spi
+ * @brief   Initialization of PN532 using spi
  *
  * @see pn532_init for parameter and return value details
  */
@@ -204,7 +204,7 @@ static inline int pn532_init_spi(pn532_t *dev, const pn532_params_t *params)
 #endif
 
 /**
- * @brief Get the firmware version of the pn532
+ * @brief   Get the firmware version of the pn532
  *
  * The firmware version returned is a 4 byte long value:
  *  - ic version,
@@ -220,7 +220,7 @@ static inline int pn532_init_spi(pn532_t *dev, const pn532_params_t *params)
 int pn532_fw_version(pn532_t *dev, uint32_t *fw_ver);
 
 /**
- * @brief Read register of the pn532
+ * @brief   Read register of the pn532
  *
  * Refer to the datasheet for a comprehensive list of registers and meanings.
  * For SFR registers the high byte must be set to 0xff.
@@ -236,7 +236,7 @@ int pn532_fw_version(pn532_t *dev, uint32_t *fw_ver);
 int pn532_read_reg(pn532_t *dev, char *out, unsigned addr);
 
 /**
- * @brief Write register of the pn532
+ * @brief   Write register of the pn532
  *
  * Refer to the datasheet for a comprehensive list of registers and meanings.
  *
@@ -251,7 +251,7 @@ int pn532_read_reg(pn532_t *dev, char *out, unsigned addr);
 int pn532_write_reg(pn532_t *dev, unsigned addr, char val);
 
 /**
- * @brief Set new settings for the Security Access Module
+ * @brief   Set new settings for the Security Access Module
  *
  * @param[in]  dev          target device
  * @param[in]  mode         new mode for the SAM
@@ -263,7 +263,7 @@ int pn532_write_reg(pn532_t *dev, unsigned addr, char val);
 int pn532_sam_configuration(pn532_t *dev, pn532_sam_conf_mode_t mode, unsigned timeout);
 
 /**
- * @brief Get one ISO14443-A passive target
+ * @brief   Get one ISO14443-A passive target
  *
  * This method blocks until a target is detected.
  *
@@ -278,7 +278,7 @@ int pn532_sam_configuration(pn532_t *dev, pn532_sam_conf_mode_t mode, unsigned t
 int pn532_get_passive_iso14443a(pn532_t *dev, nfc_iso14443a_t *out, unsigned max_retries);
 
 /**
- * @brief Authenticate a Mifare classic card
+ * @brief   Authenticate a Mifare classic card
  *
  * This operation must be done before reading or writing the segment.
  *
@@ -294,7 +294,7 @@ int pn532_mifareclassic_authenticate(pn532_t *dev, nfc_iso14443a_t *card,
                                      pn532_mifare_key_t keyid, char *key, unsigned block);
 
 /**
- * @brief Read a block of a Mifare classic card
+ * @brief   Read a block of a Mifare classic card
  *
  * The block size is 16 bytes and it must be authenticated before read.
  *
@@ -308,7 +308,7 @@ int pn532_mifareclassic_authenticate(pn532_t *dev, nfc_iso14443a_t *card,
 int pn532_mifareclassic_read(pn532_t *dev, char *odata, nfc_iso14443a_t *card, unsigned block);
 
 /**
- * @brief Write a block of a Mifare classic card
+ * @brief   Write a block of a Mifare classic card
  *
  * The block size is 16 bytes and it must be authenticated before written.
  *
@@ -322,7 +322,7 @@ int pn532_mifareclassic_read(pn532_t *dev, char *odata, nfc_iso14443a_t *card, u
 int pn532_mifareclassic_write(pn532_t *dev, char *idata, nfc_iso14443a_t *card, unsigned block);
 
 /**
- * @brief Read a block of a Mifare Ultralight card
+ * @brief   Read a block of a Mifare Ultralight card
  *
  * The block size is 32 bytes and it must be authenticated before read.
  *
@@ -336,7 +336,7 @@ int pn532_mifareclassic_write(pn532_t *dev, char *idata, nfc_iso14443a_t *card, 
 int pn532_mifareulight_read(pn532_t *dev, char *odata, nfc_iso14443a_t *card, unsigned page);
 
 /**
- * @brief Activate the NDEF file of a ISO14443-A Type 4 tag
+ * @brief   Activate the NDEF file of a ISO14443-A Type 4 tag
  *
  * @param[in]  dev          target device
  * @param[in]  card         card to activate
@@ -346,7 +346,7 @@ int pn532_mifareulight_read(pn532_t *dev, char *odata, nfc_iso14443a_t *card, un
 int pn532_iso14443a_4_activate(pn532_t *dev, nfc_iso14443a_t *card);
 
 /**
- * @brief Read data from the NDEF file of a ISO14443-A Type 4 tag
+ * @brief   Read data from the NDEF file of a ISO14443-A Type 4 tag
  *
  * The first two bytes of an NDEF file are the length of the data. Afterwards,
  * at offset 0x02 starts the data itself. If one tries to read further than the
@@ -364,7 +364,7 @@ int pn532_iso14443a_4_read(pn532_t *dev, char *odata, nfc_iso14443a_t *card, uns
                            char len);
 
 /**
- * @brief Deselect a previously selected passive card
+ * @brief   Deselect a previously selected passive card
  *
  * @param[in]  dev          target device
  * @param[in] target_id     id of the target to deselect (0x00 for all)
@@ -372,7 +372,7 @@ int pn532_iso14443a_4_read(pn532_t *dev, char *odata, nfc_iso14443a_t *card, uns
 void pn532_deselect_passive(pn532_t *dev, unsigned target_id);
 
 /**
- * @brief Release an active passive card
+ * @brief   Release an active passive card
  *
  * @param[in]  dev          target device
  * @param[in] target_id     id of the target to release (0x00 for all)

--- a/drivers/include/rgbled.h
+++ b/drivers/include/rgbled.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_rgbled RGB-LED driver
+ * @defgroup    drivers_rgbled RGB-LED driver
  * @ingroup     drivers_actuators
  * @brief       High-level driver for RGB-LEDs
  * @{
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Descriptor struct for rgbleds
+ * @brief   Descriptor struct for rgbleds
  */
 typedef struct {
     pwm_t device;       /**< PWM device to use to control rgbleds */
@@ -40,7 +40,7 @@ typedef struct {
 
 
 /**
- * @brief Initialize the RGB LED by assigning PWM channels to colors
+ * @brief   Initialize the RGB LED by assigning PWM channels to colors
  *
  * @param[in] led           Struct identifying the LED
  * @param[in] pwm           PWM device to drive the LED
@@ -51,7 +51,7 @@ typedef struct {
 void rgbled_init(rgbled_t *led, pwm_t pwm, int channel_r, int channel_g, int channel_b);
 
 /**
- * @brief Set the RGB-LED to the given color value
+ * @brief   Set the RGB-LED to the given color value
  *
  * @param[in] led           Struct identifying the LED to set
  * @param[in] color         Color to set the led to

--- a/drivers/include/servo.h
+++ b/drivers/include/servo.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @defgroup    driver_servo Servo Motor Driver
+ * @defgroup    drivers_servo Servo Motor Driver
  * @ingroup     drivers_actuators
  * @brief       High-level driver for servo motors
  * @{
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Descriptor struct for a servo
+ * @brief   Descriptor struct for a servo
  */
 typedef struct {
     pwm_t device;           /**< the PWM device driving the servo */
@@ -42,7 +42,7 @@ typedef struct {
 } servo_t;
 
 /**
- * @brief Initialize a servo motor by assigning it a PWM device and channel
+ * @brief   Initialize a servo motor by assigning it a PWM device and channel
  *
  * Digital servos are controlled by regular pulses sent to them. The width
  * of a pulse determines the position of the servo. A pulse width of 1.5ms
@@ -73,7 +73,7 @@ typedef struct {
 int servo_init(servo_t *dev, pwm_t pwm, int pwm_channel, unsigned int min, unsigned int max);
 
 /**
- * @brief Set the servo motor to a specified position
+ * @brief   Set the servo motor to a specified position
  *
  * The position of the servo is specified in the pulse width that
  * controls the servo. With default configurations, a value of 1500

--- a/drivers/include/sht11.h
+++ b/drivers/include/sht11.h
@@ -6,9 +6,6 @@
  * directory for more details.
  */
 
-#ifndef SHT11_H
-#define SHT11_H
-
 /**
  * @defgroup    drivers_sht11 SHT11 Humidity and Temperature Sensor
  * @ingroup     drivers_sensors
@@ -20,6 +17,9 @@
  *
  * @author      Freie Universität Berlin, Computer Systems & Telematics
  */
+
+#ifndef SHT11_H
+#define SHT11_H
 
 #include <stdint.h>
 
@@ -104,5 +104,5 @@ uint8_t sht11_read_status(uint8_t *p_value, uint8_t *p_checksum);
 }
 #endif
 
-/** @} */
 #endif /* SHT11_H */
+/** @} */

--- a/drivers/include/si70xx.h
+++ b/drivers/include/si70xx.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_si70xx Si7006/13/20/21 temperature and humidity sensors
+ * @defgroup    drivers_si70xx Si7006/13/20/21 temperature and humidity sensors
  * @ingroup     drivers_sensors
  * @brief       Driver for the Si7006/13/20/21 temperature and humidity sensor.
  * @{
@@ -28,16 +28,18 @@ extern "C" {
 #endif
 
 /**
- * @name Si70xx chip addresses.
+ * @name    Si70xx chip addresses.
+ * @{
  */
 #define SI70XX_ADDRESS_SI7006       (0x80)
 #define SI70XX_ADDRESS_SI7013       (0x80)
 #define SI70XX_ADDRESS_SI7013_ALT   (0x81)
 #define SI70XX_ADDRESS_SI7020       (0x80)
 #define SI70XX_ADDRESS_SI7021       (0x80)
+/** @} */
 
 /**
- * @name Si70xx device commands.
+ * @name    Si70xx device commands.
  * @{
  */
 #define SI70XX_MEASURE_RH_HOLD      (0xE5)
@@ -59,7 +61,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name Si70xx register values.
+ * @name    Si70xx register values.
  * @{
  */
 #define SI70XX_ID_SI7006            (0x06)
@@ -72,7 +74,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Si70xx device descriptor.
+ * @brief   Si70xx device descriptor.
  */
 typedef struct {
     i2c_t i2c_dev;              /**< I2C bus the sensors is connected to */
@@ -80,7 +82,7 @@ typedef struct {
 } si70xx_t;
 
 /**
- * @brief Device initialization parameters.
+ * @brief   Device initialization parameters.
  */
 typedef struct {
     i2c_t i2c_dev;              /**< I2C bus the sensor is connected to */

--- a/drivers/include/srf02.h
+++ b/drivers/include/srf02.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @defgroup    driver_srf02 SRF02 ultrasonic range sensor
+ * @defgroup    drivers_srf02 SRF02 ultrasonic range sensor
  * @ingroup     drivers_sensors
  * @brief       Driver for the SRF02 ultrasonic range sensor
  * @{

--- a/drivers/include/srf08.h
+++ b/drivers/include/srf08.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_srf08 SRF08 ultrasonic range sensor
+ * @defgroup    drivers_srf08 SRF08 ultrasonic range sensor
  * @ingroup     drivers_sensors
  * @brief       Driver for the SRF08 ultrasonic range sensor
  *
@@ -34,38 +34,38 @@
 extern "C" {
 #endif
 
-/** @brief The sensors default I2C address */
+/** @brief   The sensors default I2C address */
 #define SRF08_DEFAULT_ADDR              112
 
-/** @brief The sensors command register (write) */
+/** @brief   The sensors command register (write) */
 #define SRF08_COMMAND_REG               0x0
 
-/** @brief Max. gain register (write) */
+/** @brief   Max. gain register (write) */
 #define SRF08_GAIN_REG                  0x1
 
-/** @brief The sensors range register (write) */
+/** @brief   The sensors range register (write) */
 #define SRF08_RANGE_REG                 0x2
 
-/** @brief The upper measurement byte (read) */
+/** @brief   The upper measurement byte (read) */
 #define SRF08_RANGE_HIGH_BYTE           0x2
 
-/** @brief The lower measurement byte (read)*/
+/** @brief   The lower measurement byte (read)*/
 #define SRF08_RANGE_LOW_BYTE            0x3
 
-/** @brief Number of highest register */
+/** @brief   Number of highest register */
 #define SRF08_MAX_REGISTER_NUMBER       35
 
-/** @brief Maximum number of echos from more distant objects */
+/** @brief   Maximum number of echos from more distant objects */
 #define SRF08_MAX_ECHO_NUMBER           17
 
-/** @brief Maximum range the sensor can measure (6m) */
+/** @brief   Maximum range the sensor can measure (6m) */
 #define SRF08_MAX_RANGE_6M              0x8C
 
-/** @brief Maximum gain of the sensor (1025)*/
+/** @brief   Maximum gain of the sensor (1025)*/
 #define SRF08_MAX_GAIN                  0x25
 
 /**
- * @brief Device descriptor for SRF08 sensors
+ * @brief   Device descriptor for SRF08 sensors
  */
 typedef struct {
     i2c_t i2c;               /**< I2C device the sensor is connected to */
@@ -73,7 +73,7 @@ typedef struct {
 } srf08_t;
 
 /**
- * @brief Possible measurement modes for the SRF08 sensor
+ * @brief   Possible measurement modes for the SRF08 sensor
  */
 typedef enum {
     SRF08_MODE_INCH =          0x50,      /**< result in inches */
@@ -85,7 +85,7 @@ typedef enum {
 }srf08_mode_t;
 
 /**
- * @brief       Initialize the SRF08 ultrasonic sensor
+ * @brief   Initialize the SRF08 ultrasonic sensor
  *
  * @param[in] dev           device descriptor of an SRF08 sensor
  * @param[in] i2c           I2C device the sensor is connected to
@@ -102,7 +102,7 @@ typedef enum {
 int srf08_init(srf08_t *dev, i2c_t i2c, uint8_t addr, i2c_speed_t speed);
 
 /**
- * @brief       Set the maximum range of the SRF08.
+ * @brief   Set the maximum range of the SRF08.
  *
  * @param[in] dev           device descriptor of an SRF08 sensor
  * @param[in] max_range     the adjusted maximal range is:
@@ -116,7 +116,7 @@ int srf08_init(srf08_t *dev, i2c_t i2c, uint8_t addr, i2c_speed_t speed);
 int srf08_set_max_range(const srf08_t *dev, uint8_t max_range);
 
 /**
- * @brief       Set the maximum of the analog stages.
+ * @brief   Set the maximum of the analog stages.
  *
  * @ note
  * This value is just a limitation of the maximum amplification and not the actual.
@@ -133,9 +133,9 @@ int srf08_set_max_range(const srf08_t *dev, uint8_t max_range);
 int srf08_set_max_gain(const srf08_t *dev, uint8_t max_gain);
 
 /**
- * @brief       Get all distances measured from the SRF08 ultrasonic sensor.
- *              The results of a ranging can be returned in inches, centimeters
- *              or microseconds. The SRF08 can detect up to 17 targets.
+ * @brief   Get all distances measured from the SRF08 ultrasonic sensor.
+ *          The results of a ranging can be returned in inches, centimeters
+ *          or microseconds. The SRF08 can detect up to 17 targets.
  *
  *
  * @param[in] dev           device descriptor of an SRF08 sensor

--- a/drivers/include/tcs37727.h
+++ b/drivers/include/tcs37727.h
@@ -108,14 +108,14 @@ extern const saul_driver_t tcs37727_saul_driver;
 int tcs37727_init(tcs37727_t *dev, const tcs37727_params_t *params);
 
 /**
- * @brief Set RGBC enable, this activates periodic RGBC measurements.
+ * @brief   Set RGBC enable, this activates periodic RGBC measurements.
  *
  * @param[out] dev          device descriptor of sensor
  */
 void tcs37727_set_rgbc_active(const tcs37727_t *dev);
 
 /**
- * @brief Set RGBC disable, this deactivates periodic RGBC measurements
+ * @brief   Set RGBC disable, this deactivates periodic RGBC measurements
  *
  * Also turns off the sensor when proximity measurement is disabled.
  *
@@ -124,7 +124,7 @@ void tcs37727_set_rgbc_active(const tcs37727_t *dev);
 void tcs37727_set_rgbc_standby(const tcs37727_t *dev);
 
 /**
- * @brief Read sensor's data
+ * @brief   Read sensor's data
  *
  * Besides an Autogain routine is called. If a maximum or minimum threshold
  * value of the channel clear is reached, then the gain will be changed

--- a/drivers/include/tmp006.h
+++ b/drivers/include/tmp006.h
@@ -223,9 +223,9 @@ int tmp006_read(const tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy
 void tmp006_convert(int16_t rawv, int16_t rawt,  float *tamb, float *tobj);
 
 /**
- * @brief Convenience function to get ambient and object temperatures in [°C]
+ * @brief   Convenience function to get ambient and object temperatures in [°C]
  *
- * @note Temperature scaled by x100 for accuracy and avoid floats
+ * @note    Temperature scaled by x100 for accuracy and avoid floats
  *
  * @param[in]  dev          device descriptor of sensor
  * @param[out] ta           converted ambient temperature

--- a/drivers/include/tsl2561.h
+++ b/drivers/include/tsl2561.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @name TSL2561 I2C addresses
+ * @name    TSL2561 I2C addresses
  * @{
  */
 #define TSL2561_ADDR_LOW                  (0x29)
@@ -38,7 +38,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name TSL2561 integration times
+ * @name    TSL2561 integration times
  * @{
  */
 #define TSL2561_INTEGRATIONTIME_13MS      (0x00)    /* 13.7ms */
@@ -48,7 +48,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name TSL2561 gains
+ * @name    TSL2561 gains
  * @{
  */
 #define TSL2561_GAIN_1X                   (0x00)
@@ -56,7 +56,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name tsl2561 driver initialization return codes
+ * @name    TSL2561 driver initialization return codes
  * @{
  */
 #define TSL2561_OK                        (0)
@@ -65,7 +65,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Device descriptor for the TSL2561 sensor
+ * @brief   Device descriptor for the TSL2561 sensor
  */
 typedef struct {
     i2c_t i2c_dev;                     /**< I2C device which is used */
@@ -74,14 +74,13 @@ typedef struct {
     uint8_t integration;               /**< integration time */
 } tsl2561_t;
 
-
 /**
- * @brief Device initialization parameters
+ * @brief   Device initialization parameters
  */
 typedef tsl2561_t tsl2561_params_t;
 
 /**
- * @brief Initialize the given TSL2561 device
+ * @brief   Initialize the given TSL2561 device
  *
  * @param[out] dev          Initialized device descriptor of BMP180 device
  * @param[in]  i2c          I2C bus the sensor is connected to
@@ -97,7 +96,7 @@ int tsl2561_init(tsl2561_t *dev, i2c_t i2c, uint8_t addr,
                  uint8_t gain, uint8_t integration);
 
 /**
- * @brief Read illuminance value from the given TSL2561 device, returned in lx.
+ * @brief   Read illuminance value from the given TSL2561 device, returned in lx.
  *
  * @param[in]  dev          Device descriptor of TSL2561 device to read from
  *

--- a/drivers/include/veml6070.h
+++ b/drivers/include/veml6070.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Integration times
+ * @brief   Integration times
  */
 typedef enum veml6070_integrationtime {
   VEML6070_HALF_T = 0,              /**< 1/2 T integration time */
@@ -47,7 +47,7 @@ enum {
 };
 
 /**
- * @brief Device initialization parameters
+ * @brief   Device initialization parameters
  */
 typedef struct {
      i2c_t i2c_dev;                 /**< I2C device which is used */
@@ -55,14 +55,14 @@ typedef struct {
 } veml6070_params_t;
 
 /**
- * @brief Device descriptor for the VEML6070 sensor
+ * @brief   Device descriptor for the VEML6070 sensor
  */
 typedef struct {
     veml6070_params_t params;       /**< Device parameters */
 } veml6070_t;
 
 /**
- * @brief Initialize the given VEML6070 device
+ * @brief   Initialize the given VEML6070 device
  *
  * @param[out] dev          Initialized device descriptor of VEML6070 device
  * @param[in]  params       The parameters for the VEML6070 device (integration time)
@@ -73,7 +73,7 @@ typedef struct {
 int veml6070_init(veml6070_t *dev, const veml6070_params_t * params);
 
 /**
- * @brief Read UV index from the given VEML6070 device
+ * @brief   Read UV index from the given VEML6070 device
  *
  * @param[in] dev           Device descriptor of VEML6070 device to read from
  *

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -89,9 +89,7 @@ extern "C" {
  *          addresses when unset.
  */
 #define XBEE_ADDR_FLAGS_LONG              (0x80)
-/**
- * @}
- */
+/** @} */
 
 /**
  * @brief   States of the internal FSM for handling incoming UART frames

--- a/drivers/io1_xplained/include/io1_xplained_internals.h
+++ b/drivers/io1_xplained/include/io1_xplained_internals.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @name IO1 Xplained I2C addresses
+ * @name    IO1 Xplained I2C addresses
  * @{
  */
 #define TEMPERATURE_BASE_ADDR          (0x48)
@@ -37,14 +37,14 @@ extern "C" {
 /** @} */
 
 /**
- * @name IO1 Xplained LED pin
+ * @name    IO1 Xplained LED pin
  * @{
  */
 #define IO1_LED_PIN                    GPIO_PIN(0,18)
 /** @} */
 
 /**
- * @name IO1 Xplained gpio pins
+ * @name    IO1 Xplained gpio pins
  * @{
  */
 #define IO1_GPIO1_PIN                  GPIO_PIN(0,13)

--- a/drivers/io1_xplained/include/io1_xplained_params.h
+++ b/drivers/io1_xplained/include/io1_xplained_params.h
@@ -31,7 +31,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the IO1 Xplained extension
+ * @name    Set default configuration parameters for the IO1 Xplained extension
  * @{
  */
 #ifndef IO1_XPLAINED_PARAM_ADDR

--- a/drivers/isl29020/isl29020.c
+++ b/drivers/isl29020/isl29020.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_isl29020
+ * @ingroup     drivers_isl29020
  * @{
  *
  * @file

--- a/drivers/isl29020/isl29020_saul.c
+++ b/drivers/isl29020/isl29020_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_isl29020
+ * @ingroup     drivers_isl29020
  * @{
  *
  * @file

--- a/drivers/isl29125/include/isl29125-internal.h
+++ b/drivers/isl29125/include/isl29125-internal.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_isl29125
+ * @ingroup     drivers_isl29125
  * @{
  *
  * @file
@@ -24,19 +24,19 @@ extern "C" {
 #endif
 
 /**
- * @brief The sensors hard coded I2C address
+ * @brief   The sensors hard coded I2C address
  */
 #define ISL29125_I2C_ADDRESS 0x44
 
 /**
- * @name ISL29125 constants
+ * @name    ISL29125 constants
  * @{
  */
 #define ISL29125_ID             0x7D
 /** @} */
 
 /**
- * @name ISL29125 register map
+ * @name    ISL29125 register map
  * @{
  */
 /* main register */
@@ -63,14 +63,14 @@ extern "C" {
 /** @} */
 
 /**
- * @name ISL29125 commands
+ * @name    ISL29125 commands
  * @{
  */
 #define ISL29125_CMD_RESET      0x46
 /** @} */
 
 /**
- * @name ISL29125 configuration masks and bits
+ * @name    ISL29125 configuration masks and bits
  * @{
  */
 /* ISL29125_REG_CONF1 B2:B0 */

--- a/drivers/isl29125/isl29125.c
+++ b/drivers/isl29125/isl29125.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     driver_isl29125
+ * @ingroup     drivers_isl29125
  * @{
  *
  * @file

--- a/drivers/jc42/include/jc42_internal.h
+++ b/drivers/jc42/include/jc42_internal.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 /**
- * @name JC42 register addresses
+ * @name    JC42 register addresses
  * @{
  */
 #define JC42_REG_CAP                    (0x00)
@@ -38,18 +38,15 @@ extern "C" {
 /** @} */
 
 /**
- * @name JC42 constants
+ * @name    JC42 constants
  * @{
  */
 #define JC42_BUS_FREE_TIME_US           (1U)
 /** @} */
 
-
 #ifdef __cplusplus
 }
 #endif
 
-/** @} */
-
-
 #endif /* JC42_INTERNAL_H */
+/** @} */

--- a/drivers/jc42/include/jc42_params.h
+++ b/drivers/jc42/include/jc42_params.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the JC42
+ * @name    Set default configuration parameters for the JC42
  * @{
  */
 #ifndef JC42_PARAM_I2C_DEV

--- a/drivers/kw2xrf/include/kw2xrf_params.h
+++ b/drivers/kw2xrf/include/kw2xrf_params.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the KW2XRF driver
+ * @name    Set default configuration parameters for the KW2XRF driver
  * @{
  */
 #ifndef KW2XRF_PARAM_SPI

--- a/drivers/l3g4200d/include/l3g4200d-regs.h
+++ b/drivers/l3g4200d/include/l3g4200d-regs.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_l3g4200d
+ * @ingroup     drivers_l3g4200d
  * @{
  *
  * @file
@@ -25,12 +25,12 @@
 #endif
 
 /**
- * @brief Flag for reading multiple bytes
+ * @brief   Flag for reading multiple bytes
  */
 #define L3G4200D_AUTOINC                0x80
 
 /**
- * @name L3G4200D register definitions
+ * @name    L3G4200D register definitions
  * @{
  */
 #define L3G4200D_REG_WHO_AM_I           0x0f
@@ -62,7 +62,7 @@
 /** @} */
 
 /**
- * @name CTRL1 bitfields
+ * @name    CTRL1 bitfields
  * @{
  */
 #define L3G4200D_CTRL1_PD               0x08
@@ -74,7 +74,7 @@
 /** @} */
 
 /**
- * @name CTRL4 bitfields
+ * @name    CTRL4 bitfields
  */
 #define L3G4200D_CTRL4_BDU              0x80
 #define L3G4200D_CTRL4_BLE              0x40

--- a/drivers/l3g4200d/include/l3g4200d_params.h
+++ b/drivers/l3g4200d/include/l3g4200d_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters
+ * @name    Set default configuration parameters
  * @{
  */
 #ifndef L3G4200D_PARAM_I2C

--- a/drivers/l3g4200d/l3g4200d.c
+++ b/drivers/l3g4200d/l3g4200d.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_l3g4200d
+ * @ingroup     drivers_l3g4200d
  * @{
  *
  * @file

--- a/drivers/l3g4200d/l3g4200d_saul.c
+++ b/drivers/l3g4200d/l3g4200d_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_l3g4200d
+ * @ingroup     drivers_l3g4200d
  * @{
  *
  * @file

--- a/drivers/lis3dh/include/lis3dh_params.h
+++ b/drivers/lis3dh/include/lis3dh_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters
+ * @name    Set default configuration parameters
  * @{
  */
 #ifndef LIS3DH_PARAM_SPI

--- a/drivers/lis3dh/lis3dh.c
+++ b/drivers/lis3dh/lis3dh.c
@@ -29,11 +29,11 @@
 
 #define SPI_MODE            SPI_MODE_3
 
-static inline int lis3dh_write_bits(const lis3dh_t *dev, const lis3dh_reg_t reg,
+static inline int lis3dh_write_bits(const lis3dh_t *dev, const uint8_t reg,
                                     const uint8_t mask,  const uint8_t values);
-static int lis3dh_write_reg(const lis3dh_t *dev, const lis3dh_reg_t reg,
+static int lis3dh_write_reg(const lis3dh_t *dev, const uint8_t reg,
                             const uint8_t value);
-static int lis3dh_read_regs(const lis3dh_t *dev, const lis3dh_reg_t reg,
+static int lis3dh_read_regs(const lis3dh_t *dev, const uint8_t reg,
                             const uint8_t len, uint8_t *buf);
 
 int lis3dh_init(lis3dh_t *dev, const lis3dh_params_t *params)
@@ -228,7 +228,7 @@ int lis3dh_get_fifo_level(const lis3dh_t *dev)
  * @return                  0 on success
  * @return                  -1 on error
  */
-static int lis3dh_read_regs(const lis3dh_t *dev, const lis3dh_reg_t reg,
+static int lis3dh_read_regs(const lis3dh_t *dev, const uint8_t reg,
                             const uint8_t len, uint8_t *buf)
 {
     /* Set READ MULTIPLE mode */
@@ -254,7 +254,7 @@ static int lis3dh_read_regs(const lis3dh_t *dev, const lis3dh_reg_t reg,
  * @return                  0 on success
  * @return                  -1 on error
  */
-static int lis3dh_write_reg(const lis3dh_t *dev, const lis3dh_reg_t reg,
+static int lis3dh_write_reg(const lis3dh_t *dev, const uint8_t reg,
                             const uint8_t value)
 {
     /* Set WRITE SINGLE mode */
@@ -281,7 +281,7 @@ static int lis3dh_write_reg(const lis3dh_t *dev, const lis3dh_reg_t reg,
  * @return                  0 on success
  * @return                  -1 on error
  */
-static inline int lis3dh_write_bits(const lis3dh_t *dev, const lis3dh_reg_t reg,
+static inline int lis3dh_write_bits(const lis3dh_t *dev, const uint8_t reg,
                                     const uint8_t mask, const uint8_t values)
 {
     uint8_t tmp;

--- a/drivers/lis3dh/lis3dh_saul.c
+++ b/drivers/lis3dh/lis3dh_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup   driver_lis3dh
+ * @ingroup   drivers_lis3dh
  * @{
  *
  * @file

--- a/drivers/lis3mdl/include/lis3mdl-internal.h
+++ b/drivers/lis3mdl/include/lis3mdl-internal.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_lis3mdl
+ * @ingroup     drivers_lis3mdl
  *
  * @{
  *
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 /**
- * @brief LIS3DML chip identification
+ * @name    LIS3DML chip identification
  * @{
  */
 #define LIS3MDL_CHIP_ID                   (0x3D)
@@ -33,14 +33,14 @@ extern "C" {
 /** @} */
 
 /**
- * @name LIS3DML device identification register
+ * @name    LIS3DML device identification register
  * @{
  */
 #define LIS3DML_WHO_AM_I_REG              (0x0F)
 /**  @} */
 
 /**
- * @name LIS3DML controll register
+ * @name    LIS3DML controll register
  * @{
  */
 #define LIS3MDL_CTRL_REG1                 (0x20)
@@ -51,14 +51,14 @@ extern "C" {
 /**  @} */
 
 /**
- * @name LIS3DML masks for CTRL_REG1
+ * @name    LIS3DML masks for CTRL_REG1
  * @{
  */
 #define LIS3MDL_MASK_REG1_TEMP_EN         (0x80)
 /**  @} */
 
 /**
- * @name LIS3DML masks for CTRL_REG2
+ * @name    LIS3DML masks for CTRL_REG2
  * @{
  */
 #define LIS3MDL_MASK_REG2_REBOOT          (0x06)
@@ -66,7 +66,7 @@ extern "C" {
 /**  @} */
 
 /**
- * @name LIS3DML masks for CTRL_REG3
+ * @name    LIS3DML masks for CTRL_REG3
  * @{
  */
 #define LIS3MDL_MASK_REG3_LOW_POWER_EN    (0x02)
@@ -76,7 +76,7 @@ extern "C" {
 /**  @} */
 
 /**
- * @name LIS3DML masks for CTRL_REG5
+ * @name    LIS3DML masks for CTRL_REG5
  * @{
  */
 #define LIS3MDL_MASK_REG5_BDU             (0x40)
@@ -84,14 +84,14 @@ extern "C" {
 /**  @} */
 
 /**
- * @name LIS3DML status register
+ * @name    LIS3DML status register
  * @{
  */
 #define LIS3MDL_STATUS_REG                (0x27)
 /**  @} */
 
 /**
- * @name LIS3DML magnometer output register
+ * @name    LIS3DML magnometer output register
  * @{
  */
 #define LIS3MDL_OUT_X_L_REG               (0x28)
@@ -103,7 +103,7 @@ extern "C" {
 /**  @} */
 
 /**
- * @name LIS3DML temperature output register
+ * @name    LIS3DML temperature output register
  * @{
  */
 #define LIS3MDL_TEMP_OUT_L_REG            (0x2E)
@@ -111,7 +111,7 @@ extern "C" {
 /**  @} */
 
 /**
- * @name LIS3DML interrupt register
+ * @name    LIS3DML interrupt register
  * @{
  */
 #define LIS3MDL_INT_CFG_REG               (0x30)
@@ -121,7 +121,7 @@ extern "C" {
 /**  @} */
 
 /**
- * @name LIS3MDL masks for interrupt cfg register
+ * @name    LIS3MDL masks for interrupt cfg register
  * @{
  */
 #define LIS3MDL_MASK_INT_CFG_XIEN         (0x80)
@@ -133,7 +133,7 @@ extern "C" {
 /** }@ */
 
 /**
- * @name LIS3MDL masks for interrupt src register
+ * @name    LIS3MDL masks for interrupt src register
  * @{
  */
 #define LIS3MDL_MASK_INT_SRC_PTH_X        (0x80)

--- a/drivers/lis3mdl/lis3mdl.c
+++ b/drivers/lis3mdl/lis3mdl.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_lis3mdl
+ * @ingroup     drivers_lis3mdl
  * @{
  *
  * @file

--- a/drivers/lpd8808/include/lpd8808_params.h
+++ b/drivers/lpd8808/include/lpd8808_params.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the LPD8808 driver
+ * @name    Set default configuration parameters for the LPD8808 driver
  * @{
  */
 #ifndef LPD8808_PARAM_LED_CNT

--- a/drivers/lpd8808/lpd8808.c
+++ b/drivers/lpd8808/lpd8808.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     lpd8808
+ * @ingroup     drivers_lpd8808
  * @{
  *
  * @file

--- a/drivers/lps331ap/include/lps331ap-internal.h
+++ b/drivers/lps331ap/include/lps331ap-internal.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_lps331ap
+ * @ingroup     drivers_lps331ap
  * @{
  *
  * @file
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 /**
- * @name LPS331AP registers
+ * @name    LPS331AP registers
  * @{
  */
 #define LPS331AP_AUTO_INC               0x80
@@ -50,7 +50,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name LPS331AP CTRL_REG1 bitfields
+ * @name    LPS331AP CTRL_REG1 bitfields
  * @{
  */
 #define LPS331AP_CTRL_REG1_PD           0x80

--- a/drivers/lps331ap/include/lps331ap_params.h
+++ b/drivers/lps331ap/include/lps331ap_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters
+ * @name    Set default configuration parameters
  * @{
  */
 #ifndef LPS331AP_PARAM_I2C

--- a/drivers/lps331ap/lps331ap.c
+++ b/drivers/lps331ap/lps331ap.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_lps331ap
+ * @ingroup     drivers_lps331ap
  * @{
  *
  * @file

--- a/drivers/lps331ap/lps331ap_saul.c
+++ b/drivers/lps331ap/lps331ap_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_lps331ap
+ * @ingroup     drivers_lps331ap
  * @{
  *
  * @file

--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_lsm303dlhc
+ * @ingroup     drivers_lsm303dlhc
  * @{
  *
  * @file

--- a/drivers/lsm303dlhc/lsm303dlhc_saul.c
+++ b/drivers/lsm303dlhc/lsm303dlhc_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_lsm303dlhc
+ * @ingroup     drivers_lsm303dlhc
  * @{
  *
  * @file

--- a/drivers/lsm6dsl/include/lsm6dsl_internal.h
+++ b/drivers/lsm6dsl/include/lsm6dsl_internal.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @name LSM6DSL registers
+ * @name    LSM6DSL registers
  * @{
  */
 #define LSM6DSL_REG_FUNC_CFG_ACCESS         (0x01)
@@ -132,7 +132,7 @@ extern "C" {
 #define LSM6DSL_WHO_AM_I                    (0b01101010)
 
 /**
- * @name CTRL_x registers
+ * @name    CTRL_x registers
  * @{
  */
 #define LSM6DSL_CTRL_ODR_SHIFT              (4)
@@ -144,7 +144,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name FIFO_CTRL_x registers
+ * @name    FIFO_CTRL_x registers
  * @{
  */
 #define LSM6DSL_FIFO_CTRL5_CONTINUOUS_MODE  (0x6)

--- a/drivers/lsm6dsl/include/lsm6dsl_params.h
+++ b/drivers/lsm6dsl/include/lsm6dsl_params.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters
+ * @name    Set default configuration parameters
  * @{
  */
 #ifndef LSM6DSL_PARAM_I2C

--- a/drivers/mag3110/mag3110_saul.c
+++ b/drivers/mag3110/mag3110_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_mag3110
+ * @ingroup     drivers_mag3110
  * @{
  *
  * @file

--- a/drivers/mma8x5x/include/mma8x5x_params.h
+++ b/drivers/mma8x5x/include/mma8x5x_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the MMA8x5x driver
+ * @name    Set default configuration parameters for the MMA8x5x driver
  * @{
  */
 #ifndef MMA8X5X_PARAM_I2C

--- a/drivers/mma8x5x/include/mma8x5x_regs.h
+++ b/drivers/mma8x5x/include/mma8x5x_regs.h
@@ -29,7 +29,7 @@ extern "C"
 #endif
 
 /**
- * @brief   Register addresses
+ * @name    Register addresses
  * @{
  */
 #define MMA8X5X_STATUS              0x00 /**< Data or FIFO Status */

--- a/drivers/mpu9150/include/mpu9150-regs.h
+++ b/drivers/mpu9150/include/mpu9150-regs.h
@@ -25,7 +25,7 @@
 #endif
 
 /**
- * @name MPU-9150 register definitions
+ * @name    MPU-9150 register definitions
  * @{
  */
 #define MPU9150_YG_OFFS_TC_REG          (0x01)
@@ -65,7 +65,7 @@
 /** @} */
 
  /**
-  * @name Compass register definitions
+  * @name    Compass register definitions
   * @{
   */
 #define COMPASS_WHOAMI_REG              (0x00)
@@ -80,7 +80,7 @@
 /** @} */
 
 /**
- * @name MPU9150 bitfield definitions
+ * @name    MPU9150 bitfield definitions
  * @{
  */
 #define BIT_SLV0_DELAY_EN               (0x01)

--- a/drivers/mq3/mq3.c
+++ b/drivers/mq3/mq3.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_mq3
+ * @ingroup     drivers_mq3
  * @{
  *
  * @file

--- a/drivers/mrf24j40/include/mrf24j40_params.h
+++ b/drivers/mrf24j40/include/mrf24j40_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the MRF24J40 driver
+ * @name    Set default configuration parameters for the MRF24J40 driver
  * @{
  */
 #ifndef MRF24J40_PARAM_SPI

--- a/drivers/mrf24j40/include/mrf24j40_registers.h
+++ b/drivers/mrf24j40/include/mrf24j40_registers.h
@@ -27,7 +27,7 @@ extern "C" {
 
 
 /**
- * @brief SPI access specifiers
+ * @name    SPI access specifiers
  * @{
  */
 #define MRF24J40_SHORT_ADDR_TRANS       (0x00)
@@ -39,7 +39,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief FIFO-Address-Map
+ * @name    FIFO-Address-Map
  * @{
  */
 #define MRF24J40_TX_NORMAL_FIFO         (0x000)
@@ -50,7 +50,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Short-Register addresses
+ * @name    Short-Register addresses
  * @{
  */
 #define MRF24J40_REG_RXMCR              (0x00)
@@ -114,7 +114,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Long-Register addresses
+ * @name    Long-Register addresses
  * @{
  */
 #define MRF24J40_REG_RFCON0             (0x200)
@@ -167,7 +167,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Timing definition for the mrf24j40.
+ * @name    Timing definition for the mrf24j40.
  * @{
  */
 #define MRF24J40_RESET_DELAY                    (2000U)     /* Datasheet MRF24J40 ~2ms */
@@ -180,7 +180,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RXMCR register (0x00)
+ * @name    Bitfield definitions for the RXMCR register (0x00)
  * @{
  */
 #define MRF24J40_RXMCR_NOACKRSP                 (0x20)
@@ -191,7 +191,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RXFLUSH register (0x0D)
+ * @name    Bitfield definitions for the RXFLUSH register (0x0D)
  * @{
  */
 #define MRF24J40_RXFLUSH_WAKEPOL                (0x40)
@@ -221,7 +221,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the PACON2 register (0x18)
+ * @name    Bitfield definitions for the PACON2 register (0x18)
  * @{
  */
 #define MRF24J40_PACON2_FIFOEN                  (0x80)
@@ -234,7 +234,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the TXNCON register (0x1B)
+ * @name    Bitfield definitions for the TXNCON register (0x1B)
  * @{
  */
 #define MRF24J40_TXNCON_FPSTAT            (0x10)
@@ -245,7 +245,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the WAKECON register (0x22)
+ * @name    Bitfield definitions for the WAKECON register (0x22)
  * @{
  */
 #define MRF24J40_WAKECON_IMMWAKE                (0x80)
@@ -253,7 +253,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the TXSTAT register (0x24)
+ * @name    Bitfield definitions for the TXSTAT register (0x24)
  * @{
  */
 #define MRF24J40_TXSTAT_MAX_FRAME_RETRIES       (0xC0)
@@ -268,7 +268,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the SOFTRST register (0x2A)
+ * @name    Bitfield definitions for the SOFTRST register (0x2A)
  * @{
  */
 #define MRF24J40_SOFTRST_RSTPWR                 (0x04)
@@ -277,7 +277,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the TXSTBL register (0x2E)
+ * @name    Bitfield definitions for the TXSTBL register (0x2E)
  * @{
  */
 #define MRF24J40_TXSTBL_RFSTBL3        (0x80)
@@ -291,7 +291,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the INTSTAT register (0x31)
+ * @name    Bitfield definitions for the INTSTAT register (0x31)
  * @{
  */
 #define MRF24J40_INTSTAT_SLPIF          (0x80)
@@ -305,7 +305,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the INTCON register (0x32)
+ * @name    Bitfield definitions for the INTCON register (0x32)
  * @{
  */
 #define MRF24J40_INTCON_SLPIE           (0x80)
@@ -319,14 +319,14 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the SLPACK register (0x35)
+ * @name    Bitfield definitions for the SLPACK register (0x35)
  * @{
  */
 #define MRF24J40_SLPACK_SLPACK                  (0x80)
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RFCTL register (0x36)
+ * @name    Bitfield definitions for the RFCTL register (0x36)
  * @{
  */
 #define MRF24J40_RFCTL_WAKECNT8         (0x10)
@@ -337,14 +337,14 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the BBREG1 register (0x39)
+ * @name    Bitfield definitions for the BBREG1 register (0x39)
  * @{
  */
 #define MRF24J40_BBREG1_RXDECINV                (0x04)
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the BBREG2 register (0x3A)
+ * @name    Bitfield definitions for the BBREG2 register (0x3A)
  * @{
  */
 #define MRF24J40_BBREG2_CCAMODE3                (0xC0)
@@ -355,7 +355,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the BBREG6 register (0x3E)
+ * @name    Bitfield definitions for the BBREG6 register (0x3E)
  * @{
  */
 #define MRF24J40_BBREG6_RSSIMODE1               (0x80)
@@ -366,7 +366,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RFCON1 register (0x201)
+ * @name    Bitfield definitions for the RFCON1 register (0x201)
  * @{
  */
 #define MRF24J40_RFCON1_VCOOPT7         (0x80)
@@ -380,14 +380,14 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RFCON2 register (0x202)
+ * @name    Bitfield definitions for the RFCON2 register (0x202)
  * @{
  */
 #define MRF24J40_RFCON2_PLLEN           (0x80)
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RFCON6 register (0x206)
+ * @name    Bitfield definitions for the RFCON6 register (0x206)
  * @{
  */
 #define MRF24J40_RFCON6_TXFIL           (0x80)
@@ -396,7 +396,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RFCON7 register (0x207)
+ * @name    Bitfield definitions for the RFCON7 register (0x207)
  * @{
  */
 #define MRF24J40_RFCON7_SLPCLKSEL1      (0x80)
@@ -404,14 +404,14 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RFCON8 register (0x208)
+ * @name    Bitfield definitions for the RFCON8 register (0x208)
  * @{
  */
 #define MRF24J40_RFCON8_RFVCO           (0x10)
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the RFSTATE register (0x20F)
+ * @name    Bitfield definitions for the RFSTATE register (0x20F)
  * @{
  */
 #define MRF24J40_RFSTATE_MASK           (0xA0)
@@ -426,7 +426,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the SLPCON1 register (0x211)
+ * @name    Bitfield definitions for the SLPCON1 register (0x211)
  * @{
  */
 #define MRF24J40_SLPCON0_INTEDGE        (0x02)
@@ -434,7 +434,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Bitfield definitions for the SLPCON1 register (0x212)
+ * @name    Bitfield definitions for the SLPCON1 register (0x212)
  * @{
  */
 #define MRF24J40_SLPCON1_CLKOUTEN       (0x20)

--- a/drivers/mtd/mtd-vfs.c
+++ b/drivers/mtd/mtd-vfs.c
@@ -16,7 +16,7 @@
 #include "vfs.h"
 
 /**
- * @ingroup     mtd
+ * @ingroup     drivers_mtd
  * @{
  *
  * @file

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     mtd
+ * @ingroup     drivers_mtd
  * @{
  * @brief       Low level Memory Technology Device interface
  *

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -7,6 +7,7 @@
  */
 
 /**
+ * @ingroup     driver_netdev_ieee802154
  * @{
  *
  * @file

--- a/drivers/nrf24l01p/include/nrf24l01p_settings.h
+++ b/drivers/nrf24l01p/include/nrf24l01p_settings.h
@@ -16,7 +16,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
- * @}
  */
 
 #ifndef NRF24L01P_SETTINGS_H
@@ -185,3 +184,4 @@ extern "C" {
 #endif
 
 #endif /* NRF24L01P_SETTINGS_H */
+/** @} */

--- a/drivers/pcd8544/include/pcd8544_internal.h
+++ b/drivers/pcd8544/include/pcd8544_internal.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_pcd8544
+ * @ingroup     drivers_pcd8544
  *
  * @{
  *
@@ -30,7 +30,7 @@
 #define RESET_DELAY         (5000)  /* keep reset low for 5ms */
 
 /**
- * @brief   Communication modes: command or data
+ * @name    Communication modes: command or data
  * @{
  */
 #define MODE_CMD            (0)     /**< we are sending a command */
@@ -38,7 +38,7 @@
 /** @} */
 
 /**
- * @brief   Maximum parameter values
+ * @name    Maximum parameter values
  * @{
  */
 #define CONTRAST_MAX        (127U)  /**< maximum possible contrast value */
@@ -47,7 +47,7 @@
 /** @} */
 
 /**
- * @brief   Display commands
+ * @name    Display commands
  * @{
  */
 #define CMD_DISABLE         (0x24)  /**< set LCD into power down mode */

--- a/drivers/periph_common/spi.c
+++ b/drivers/periph_common/spi.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup drivers
+ * @ingroup     drivers
  * @{
  *
  * @file

--- a/drivers/pir/pir.c
+++ b/drivers/pir/pir.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_pir
+ * @ingroup     drivers_pir
  * @{
  *
  * @file

--- a/drivers/rgbled/rgbled.c
+++ b/drivers/rgbled/rgbled.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_rgbled
+ * @ingroup     drivers_rgbled
  * @{
  *
  * @file

--- a/drivers/sdcard_spi/include/sdcard_spi_params.h
+++ b/drivers/sdcard_spi/include/sdcard_spi_params.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the sdcard_spi driver
+ * @name    Set default configuration parameters for the sdcard_spi driver
  * @{
  */
 #ifndef SDCARD_SPI_PARAM_SPI
@@ -67,7 +67,6 @@ static const  sdcard_spi_params_t sdcard_spi_params[] = {
         .power_act_high = SDCARD_SPI_PARAM_POWER_AH
     },
 };
-/** @} */
 
 #ifdef __cplusplus
 }

--- a/drivers/servo/servo.c
+++ b/drivers/servo/servo.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     driver_servo
+ * @ingroup     drivers_servo
  * @{
  *
  * @file

--- a/drivers/sht11/sht11.c
+++ b/drivers/sht11/sht11.c
@@ -7,19 +7,17 @@
  */
 
 /**
- * @defgroup    sht11 SHT11
- * @ingroup     drivers
+ * @ingroup     drivers_sht11
  * @brief       Driver for the Sensirion SHT11 humidity and temperature sensor
  * @{
- */
-
-/**
+ *
  * @file
  * @brief       SHT11 Device Driver
  *
  * @version     $Revision: 2396 $
  *
  * @note        $Id: sht11.c 2396 2010-07-06 15:12:35Z ziegert $
+ * @}
  */
 
 #include <stdio.h>
@@ -350,5 +348,3 @@ uint8_t sht11_read_sensor(sht11_val_t *value, sht11_mode_t mode)
     mutex_unlock(&sht11_mutex);
     return 1;
 }
-
-/** @} */

--- a/drivers/si70xx/include/si70xx_params.h
+++ b/drivers/si70xx/include/si70xx_params.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the Si7006/13/20/21 sensor
+ * @name    Set default configuration parameters for the Si7006/13/20/21 sensor
  * @{
  */
 #ifndef SI70XX_PARAM_I2C_DEV

--- a/drivers/si70xx/si70xx.c
+++ b/drivers/si70xx/si70xx.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_si70xx
+ * @ingroup     drivers_si70xx
  * @{
  *
  * @file

--- a/drivers/si70xx/si70xx_saul.c
+++ b/drivers/si70xx/si70xx_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_si70xx
+ * @ingroup     drivers_si70xx
  * @{
  *
  * @file

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     driver_srf02
+ * @ingroup     drivers_srf02
  * @{
  *
  * @file

--- a/drivers/srf08/srf08.c
+++ b/drivers/srf08/srf08.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_srf08
+ * @ingroup     drivers_srf08
  * @{
  *
  * @file

--- a/drivers/sx127x/include/sx127x_internal.h
+++ b/drivers/sx127x/include/sx127x_internal.h
@@ -132,3 +132,4 @@ int16_t sx127x_read_rssi(const sx127x_t *dev);
 #endif
 
 #endif /* SX127X_INTERNAL_H */
+/** @} */

--- a/drivers/sx127x/include/sx127x_netdev.h
+++ b/drivers/sx127x/include/sx127x_netdev.h
@@ -46,3 +46,4 @@ typedef struct netdev_radio_lora_packet_info {
 #endif
 
 #endif /* SX127X_NETDEV_H */
+/** @} */

--- a/drivers/sx127x/include/sx127x_registers.h
+++ b/drivers/sx127x/include/sx127x_registers.h
@@ -1424,3 +1424,4 @@ extern "C" {
 #endif
 
 #endif /* SX127X_REGISTERS_H */
+/** @} */

--- a/drivers/tcs37727/include/tcs37727-internal.h
+++ b/drivers/tcs37727/include/tcs37727-internal.h
@@ -35,90 +35,103 @@ extern "C"
 #endif
 
 /**
- * @brief Register Map
+ * @name    Register Map
  *
- * All setting register are defined for repeated byte protocol transaction.
+ * @note    All setting register are defined for repeated byte protocol transaction.
+ * @{
  */
-#define TCS37727_ENABLE             0x80 /* Enables states and interrupts */
-#define TCS37727_ATIME              0x81 /* RGBC time */
-#define TCS37727_PTIME              0x82 /* Proximity time */
-#define TCS37727_WTIME              0x83 /* Wait time */
-#define TCS37727_AILTL              0x04 /* Clear interrupt low threshold low byte */
-#define TCS37727_AILTH              0x05 /* Clear interrupt low threshold high byte */
-#define TCS37727_AIHTL              0x06 /* Clear interrupt high threshold low byte */
-#define TCS37727_AIHTH              0x07 /* Clear interrupt high threshold high byte */
-#define TCS37727_PILTL              0x08 /* Proximity interrupt low threshold low byte */
-#define TCS37727_PILTH              0x09 /* Proximity interrupt low threshold high byte */
-#define TCS37727_PIHTL              0x0A /* Proximity interrupt high threshold low byte */
-#define TCS37727_PIHTH              0x0B /* Proximity interrupt high threshold high byte */
-#define TCS37727_PERS               0x8C /* Interrupt persistence filters */
-#define TCS37727_CONFIG             0x8D /* Configuration */
-#define TCS37727_PPULSE             0x8E /* Proximity pulse count */
-#define TCS37727_CONTROL            0x8F /* Gain control register */
-#define TCS37727_ID                 0x92 /* Device IDID */
-#define TCS37727_STATUS             0x93 /* Device status */
-#define TCS37727_CDATA              0x14 /* Clear ADC data low byte */
-#define TCS37727_CDATAH             0x15 /* Clear ADC data high byte */
-#define TCS37727_RDATA              0x16 /* Red ADC data low byte */
-#define TCS37727_RDATAH             0x17 /* Red ADC data high byte */
-#define TCS37727_GDATA              0x18 /* Green ADC data low byte */
-#define TCS37727_GDATAH             0x19 /* Green ADC data high byte */
-#define TCS37727_BDATA              0x1A /* Blue ADC data low byte */
-#define TCS37727_BDATAH             0x1B /* Blue ADC data high byte */
-#define TCS37727_PDATA              0x1C /* Proximity ADC data low byte */
-#define TCS37727_PDATAH             0x1D /* Proximity ADC data high byte */
+#define TCS37727_ENABLE             0x80 /**< Enables states and interrupts */
+#define TCS37727_ATIME              0x81 /**< RGBC time */
+#define TCS37727_PTIME              0x82 /**< Proximity time */
+#define TCS37727_WTIME              0x83 /**< Wait time */
+#define TCS37727_AILTL              0x04 /**< Clear interrupt low threshold low byte */
+#define TCS37727_AILTH              0x05 /**< Clear interrupt low threshold high byte */
+#define TCS37727_AIHTL              0x06 /**< Clear interrupt high threshold low byte */
+#define TCS37727_AIHTH              0x07 /**< Clear interrupt high threshold high byte */
+#define TCS37727_PILTL              0x08 /**< Proximity interrupt low threshold low byte */
+#define TCS37727_PILTH              0x09 /**< Proximity interrupt low threshold high byte */
+#define TCS37727_PIHTL              0x0A /**< Proximity interrupt high threshold low byte */
+#define TCS37727_PIHTH              0x0B /**< Proximity interrupt high threshold high byte */
+#define TCS37727_PERS               0x8C /**< Interrupt persistence filters */
+#define TCS37727_CONFIG             0x8D /**< Configuration */
+#define TCS37727_PPULSE             0x8E /**< Proximity pulse count */
+#define TCS37727_CONTROL            0x8F /**< Gain control register */
+#define TCS37727_ID                 0x92 /**< Device IDID */
+#define TCS37727_STATUS             0x93 /**< Device status */
+#define TCS37727_CDATA              0x14 /**< Clear ADC data low byte */
+#define TCS37727_CDATAH             0x15 /**< Clear ADC data high byte */
+#define TCS37727_RDATA              0x16 /**< Red ADC data low byte */
+#define TCS37727_RDATAH             0x17 /**< Red ADC data high byte */
+#define TCS37727_GDATA              0x18 /**< Green ADC data low byte */
+#define TCS37727_GDATAH             0x19 /**< Green ADC data high byte */
+#define TCS37727_BDATA              0x1A /**< Blue ADC data low byte */
+#define TCS37727_BDATAH             0x1B /**< Blue ADC data high byte */
+#define TCS37727_PDATA              0x1C /**< Proximity ADC data low byte */
+#define TCS37727_PDATAH             0x1D /**< Proximity ADC data high byte */
+/** @} */
 
 /**
- * @brief Command Register
+ * @name    Command Register
+ * @{
  */
-#define TCS37727_BYTE_TRANS         0x80 /* Repeated byte protocol transaction */
-#define TCS37727_INC_TRANS          0xA0 /* Auto-increment protocol transaction */
-#define TCS37727_SF_PICLR           0xE5 /* Proximity interrupt clear */
-#define TCS37727_SF_CICLR           0xE6 /* Clear channel interrupt clear */
-#define TCS37727_SF_PCICLR          0xE7 /* Proximity and Clear channel interrupt clear */
+#define TCS37727_BYTE_TRANS         0x80 /**< Repeated byte protocol transaction */
+#define TCS37727_INC_TRANS          0xA0 /**< Auto-increment protocol transaction */
+#define TCS37727_SF_PICLR           0xE5 /**< Proximity interrupt clear */
+#define TCS37727_SF_CICLR           0xE6 /**< Clear channel interrupt clear */
+#define TCS37727_SF_PCICLR          0xE7 /**< Proximity and Clear channel interrupt clear */
+/** @} */
 
 /**
- * @brief Enable Register
+ * @name    Enable Register
+ * @{
  */
-#define TCS37727_ENABLE_PIEN        (1 << 5) /* Proximity interrupt enable */
-#define TCS37727_ENABLE_AIEN        (1 << 4) /* Clear channel interrupt enable */
-#define TCS37727_ENABLE_WEN         (1 << 3) /* Wait enable, activates the wait feature */
-#define TCS37727_ENABLE_PEN         (1 << 2) /* Proximity enable, activates the proximity function */
-#define TCS37727_ENABLE_AEN         (1 << 1) /* RGBC enable, actives the two-channel ADC */
-#define TCS37727_ENABLE_PON         (1 << 0) /* Power ON */
+#define TCS37727_ENABLE_PIEN        (1 << 5) /**< Proximity interrupt enable */
+#define TCS37727_ENABLE_AIEN        (1 << 4) /**< Clear channel interrupt enable */
+#define TCS37727_ENABLE_WEN         (1 << 3) /**< Wait enable, activates the wait feature */
+#define TCS37727_ENABLE_PEN         (1 << 2) /**< Proximity enable, activates the proximity function */
+#define TCS37727_ENABLE_AEN         (1 << 1) /**< RGBC enable, actives the two-channel ADC */
+#define TCS37727_ENABLE_PON         (1 << 0) /**< Power ON */
+/** @} */
 
 /**
- * @brief Control Register
+ * @name    Control Register
+ * @{
  */
-#define TCS37727_CONTROL_PDRIVE_100     0x00 /* 100 mA LED Drive Strength */
-#define TCS37727_CONTROL_PDRIVE_50      0x04 /* 50 mA LED Drive Strength */
-#define TCS37727_CONTROL_PDRIVE_25      0x08 /* 25 mA LED Drive Strength */
-#define TCS37727_CONTROL_PDRIVE_12      0x0C /* 12.5 mA LED Drive Strength */
-#define TCS37727_CONTROL_PDRIVE_MASK    0x0C /* PDRIVE Mask */
-#define TCS37727_CONTROL_AGAIN_1        0x00 /* 1 × gain RGBC Gain Value */
-#define TCS37727_CONTROL_AGAIN_4        0x01 /* 4 × gain RGBC Gain Value */
-#define TCS37727_CONTROL_AGAIN_16       0x02 /* 16 × gain RGBC Gain Value */
-#define TCS37727_CONTROL_AGAIN_60       0x03 /* 60 × gain RGBC Gain Value */
-#define TCS37727_CONTROL_AGAIN_MASK     0x03 /* AGAIN Mask */
+#define TCS37727_CONTROL_PDRIVE_100     0x00 /**< 100 mA LED Drive Strength */
+#define TCS37727_CONTROL_PDRIVE_50      0x04 /**< 50 mA LED Drive Strength */
+#define TCS37727_CONTROL_PDRIVE_25      0x08 /**< 25 mA LED Drive Strength */
+#define TCS37727_CONTROL_PDRIVE_12      0x0C /**< 12.5 mA LED Drive Strength */
+#define TCS37727_CONTROL_PDRIVE_MASK    0x0C /**< PDRIVE Mask */
+#define TCS37727_CONTROL_AGAIN_1        0x00 /**< 1 × gain RGBC Gain Value */
+#define TCS37727_CONTROL_AGAIN_4        0x01 /**< 4 × gain RGBC Gain Value */
+#define TCS37727_CONTROL_AGAIN_16       0x02 /**< 16 × gain RGBC Gain Value */
+#define TCS37727_CONTROL_AGAIN_60       0x03 /**< 60 × gain RGBC Gain Value */
+#define TCS37727_CONTROL_AGAIN_MASK     0x03 /**< AGAIN Mask */
+/** @} */
 
 /**
- * @brief Device ID
+ * @name    Device ID
+ * @{
  */
 #define TCS37727_ID_VALUE           0x49
+/** @} */
 
 /**
- * @brief Predefined ATIME register values.
+ * @name    Predefined ATIME register values.
+ * @{
  */
 #define TCS37727_ATIME_MIN          2400    /* 2.4ms integration time, max count 1024 */
 #define TCS37727_ATIME_MAX          614000  /* 614ms integration time, max count 0xffff */
 
 #define TCS37727_ATIME_TO_REG(val)  (256 - (uint8_t)((val) / 2400))
 #define TCS37727_ATIME_TO_US(reg)   ((256 - (uint8_t)(reg)) * 2400)
+/** @} */
 
 /**
- * @brief Coefficients for Lux and CT Equations (DN40)
+ * @name    Coefficients for Lux and CT Equations (DN40)
  *
- * Coefficients in integer format, multiplied by 1000.
+ * @note    Coefficients in integer format, multiplied by 1000.
+ * @{
  */
 #define DGF_IF                      310
 #define R_COEF_IF                   136
@@ -126,6 +139,7 @@ extern "C"
 #define B_COEF_IF                   -444
 #define CT_COEF_IF                  3810
 #define CT_OFFSET_IF                1391
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/drivers/tcs37727/tcs37727_saul.c
+++ b/drivers/tcs37727/tcs37727_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_tcs37727
+ * @ingroup     drivers_tcs37727
  * @{
  *
  * @file

--- a/drivers/tmp006/tmp006_saul.c
+++ b/drivers/tmp006/tmp006_saul.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_tmp006
+ * @ingroup     drivers_tmp006
  * @{
  *
  * @file

--- a/drivers/tsl2561/include/tsl2561_params.h
+++ b/drivers/tsl2561/include/tsl2561_params.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the TSL2561
+ * @name    Set default configuration parameters for the TSL2561
  * @{
  */
 #ifndef TSL2561_PARAM_I2C_DEV

--- a/drivers/veml6070/include/veml6070_params.h
+++ b/drivers/veml6070/include/veml6070_params.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the VEML6070
+ * @name    Set default configuration parameters for the VEML6070
  * @{
  */
 #ifndef VEML6070_PARAM_I2C_DEV

--- a/drivers/w5100/include/w5100_params.h
+++ b/drivers/w5100/include/w5100_params.h
@@ -24,20 +24,20 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the W5100 driver
+ * @name    Default configuration parameters for the W5100 driver
  * @{
  */
 #ifndef W5100_PARAM_SPI
-#define W5100_PARAM_SPI         (SPI_DEV(0))
+#define W5100_PARAM_SPI         (SPI_DEV(0))       /**< Default SPI device */
 #endif
 #ifndef W5100_PARAM_SPI_CLK
-#define W5100_PARAM_SPI_CLK     (SPI_CLK_5MHZ)
+#define W5100_PARAM_SPI_CLK     (SPI_CLK_5MHZ)     /**< Default SPI speed */
 #endif
 #ifndef W5100_PARAM_CS
-#define W5100_PARAM_CS          (GPIO_PIN(0, 0))
+#define W5100_PARAM_CS          (GPIO_PIN(0, 0))   /**< Default SPI chip select pin */
 #endif
 #ifndef W5100_PARAM_EVT
-#define W5100_PARAM_EVT         (GPIO_PIN(0, 1))
+#define W5100_PARAM_EVT         (GPIO_PIN(0, 1))   /**< Default event pin */
 #endif
 /** @} */
 

--- a/drivers/w5100/include/w5100_regs.h
+++ b/drivers/w5100/include/w5100_regs.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   SPI commands
+ * @name    SPI commands
  * @{
  */
 #define CMD_READ            (0x0f)
@@ -32,7 +32,8 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Common registers
+ * @name    Common registers
+ * @{
  */
 #define REG_MODE            (0x0000)    /**< mode */
 #define REG_GAR0            (0x0001)    /**< gateway address 0 */
@@ -73,9 +74,10 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Socket 0 registers
+ * @name    Socket 0 registers
  *
  * As we are using the device in MACRAW mode, we only need socket 0.
+ * @{
  */
 #define S0_MR               (0x0400)    /**< mode */
 #define S0_CR               (0x0401)    /**< control */
@@ -111,7 +113,8 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Some selected bitfield definitions
+ * @name    Some selected bitfield definitions
+ * @{
  */
 #define MODE_RESET          (0x80)      /**< device mode: reset */
 

--- a/drivers/xbee/include/xbee_params.h
+++ b/drivers/xbee/include/xbee_params.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Set default configuration parameters for the XBee driver
+ * @name    Set default configuration parameters for the XBee driver
  * @{
  */
 #ifndef XBEE_PARAM_UART

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     driver_xbee
+ * @ingroup     drivers_xbee
  * @{
  *
  * @file


### PR DESCRIPTION
I went through the drivers documentation and fixed a few things:
* ensure all doxygen groups are called `drivers_<name>`
* fixed `@fixed` where `@name` should be used
* other things that I don't remember