### PR TITLE
cpu: use shared Cortex-M base vector table

### DIFF
--- a/cpu/cc2538/vectors.c
+++ b/cpu/cc2538/vectors.c
@@ -65,7 +65,7 @@ WEAK_DEFAULT void isr_dma(void);
 WEAK_DEFAULT void isr_dmaerr(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_gpioa,              /* 16 GPIO Port A */
     isr_gpiob,              /* 17 GPIO Port B */
     isr_gpioc,              /* 18 GPIO Port C */

--- a/cpu/cc2538/vectors.c
+++ b/cpu/cc2538/vectors.c
@@ -31,10 +31,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* CC2538 specific interrupt vectors */
 WEAK_DEFAULT void isr_gpioa(void);
 WEAK_DEFAULT void isr_gpiob(void);
@@ -68,80 +64,60 @@ WEAK_DEFAULT void isr_usb(void);
 WEAK_DEFAULT void isr_dma(void);
 WEAK_DEFAULT void isr_dmaerr(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M3 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* CC2538 specific peripheral handlers */
-    (void*) isr_gpioa,              /* 16 GPIO Port A */
-    (void*) isr_gpiob,              /* 17 GPIO Port B */
-    (void*) isr_gpioc,              /* 18 GPIO Port C */
-    (void*) isr_gpiod,              /* 19 GPIO Port D */
-    (void*) (0UL),                  /* 20 none */
-    (void*) isr_uart0,              /* 21 UART0 Rx and Tx */
-    (void*) isr_uart1,              /* 22 UART1 Rx and Tx */
-    (void*) isr_ssi0,               /* 23 SSI0 Rx and Tx */
-    (void*) isr_i2c,                /* 24 I2C Master and Slave */
-    (void*) (0UL),                  /* 25 Reserved */
-    (void*) (0UL),                  /* 26 Reserved */
-    (void*) (0UL),                  /* 27 Reserved */
-    (void*) (0UL),                  /* 28 Reserved */
-    (void*) (0UL),                  /* 29 Reserved */
-    (void*) isr_adc,                /* 30 ADC Sequence 0 */
-    (void*) (0UL),                  /* 31 Reserved */
-    (void*) (0UL),                  /* 32 Reserved */
-    (void*) (0UL),                  /* 33 Reserved */
-    (void*) isr_watchdog,           /* 34 Watchdog timer, timer 0 */
-    (void*) isr_timer0_chan0,       /* 35 Timer 0 subtimer A */
-    (void*) isr_timer0_chan1,       /* 36 Timer 0 subtimer B */
-    (void*) isr_timer1_chan0,       /* 37 Timer 1 subtimer A */
-    (void*) isr_timer1_chan1,       /* 38 Timer 1 subtimer B */
-    (void*) isr_timer2_chan0,       /* 39 Timer 2 subtimer A */
-    (void*) isr_timer2_chan1,       /* 40 Timer 2 subtimer B */
-    (void*) isr_comp,               /* 41 Analog Comparator 0 */
-    (void*) isr_rfcorerxtx,         /* 42 RFCore Rx/Tx */
-    (void*) isr_rfcoreerr,          /* 43 RFCore Error */
-    (void*) isr_icepick,            /* 44 IcePick */
-    (void*) isr_flash,              /* 45 FLASH Control */
-    (void*) isr_aes,                /* 46 AES */
-    (void*) isr_pka,                /* 47 PKA */
-    (void*) isr_sleepmode,          /* 48 Sleep Timer */
-    (void*) isr_mactimer,           /* 49 MacTimer */
-    (void*) isr_ssi1,               /* 50 SSI1 Rx and Tx */
-    (void*) isr_timer3_chan0,       /* 51 Timer 3 subtimer A */
-    (void*) isr_timer3_chan1,       /* 52 Timer 3 subtimer B */
-    (void*) (0UL),                  /* 53 Reserved */
-    (void*) (0UL),                  /* 54 Reserved */
-    (void*) (0UL),                  /* 55 Reserved */
-    (void*) (0UL),                  /* 56 Reserved */
-    (void*) (0UL),                  /* 57 Reserved */
-    (void*) (0UL),                  /* 58 Reserved */
-    (void*) (0UL),                  /* 59 Reserved */
-    (void*) isr_usb,                /* 60 USB 2538 */
-    (void*) (0UL),                  /* 61 Reserved */
-    (void*) isr_dma,                /* 62 uDMA */
-    (void*) isr_dmaerr,             /* 63 uDMA Error */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_gpioa,              /* 16 GPIO Port A */
+    isr_gpiob,              /* 17 GPIO Port B */
+    isr_gpioc,              /* 18 GPIO Port C */
+    isr_gpiod,              /* 19 GPIO Port D */
+    (0UL),                  /* 20 none */
+    isr_uart0,              /* 21 UART0 Rx and Tx */
+    isr_uart1,              /* 22 UART1 Rx and Tx */
+    isr_ssi0,               /* 23 SSI0 Rx and Tx */
+    isr_i2c,                /* 24 I2C Master and Slave */
+    (0UL),                  /* 25 Reserved */
+    (0UL),                  /* 26 Reserved */
+    (0UL),                  /* 27 Reserved */
+    (0UL),                  /* 28 Reserved */
+    (0UL),                  /* 29 Reserved */
+    isr_adc,                /* 30 ADC Sequence 0 */
+    (0UL),                  /* 31 Reserved */
+    (0UL),                  /* 32 Reserved */
+    (0UL),                  /* 33 Reserved */
+    isr_watchdog,           /* 34 Watchdog timer, timer 0 */
+    isr_timer0_chan0,       /* 35 Timer 0 subtimer A */
+    isr_timer0_chan1,       /* 36 Timer 0 subtimer B */
+    isr_timer1_chan0,       /* 37 Timer 1 subtimer A */
+    isr_timer1_chan1,       /* 38 Timer 1 subtimer B */
+    isr_timer2_chan0,       /* 39 Timer 2 subtimer A */
+    isr_timer2_chan1,       /* 40 Timer 2 subtimer B */
+    isr_comp,               /* 41 Analog Comparator 0 */
+    isr_rfcorerxtx,         /* 42 RFCore Rx/Tx */
+    isr_rfcoreerr,          /* 43 RFCore Error */
+    isr_icepick,            /* 44 IcePick */
+    isr_flash,              /* 45 FLASH Control */
+    isr_aes,                /* 46 AES */
+    isr_pka,                /* 47 PKA */
+    isr_sleepmode,          /* 48 Sleep Timer */
+    isr_mactimer,           /* 49 MacTimer */
+    isr_ssi1,               /* 50 SSI1 Rx and Tx */
+    isr_timer3_chan0,       /* 51 Timer 3 subtimer A */
+    isr_timer3_chan1,       /* 52 Timer 3 subtimer B */
+    (0UL),                  /* 53 Reserved */
+    (0UL),                  /* 54 Reserved */
+    (0UL),                  /* 55 Reserved */
+    (0UL),                  /* 56 Reserved */
+    (0UL),                  /* 57 Reserved */
+    (0UL),                  /* 58 Reserved */
+    (0UL),                  /* 59 Reserved */
+    isr_usb,                /* 60 USB 2538 */
+    (0UL),                  /* 61 Reserved */
+    isr_dma,                /* 62 uDMA */
+    isr_dmaerr,             /* 63 uDMA Error */
 };
 
 #if UPDATE_CCA
+extern cortexm_base_t cortex_vector_base;
 /**
  * @brief Flash Customer Configuration Area (CCA)
  *
@@ -151,8 +127,8 @@ __attribute__((section(".flashcca"), used))
 const uint32_t cca[] = {
     /* Bootloader Backdoor Configuration: */
     0xe0ffffff | (CCA_BACKDOOR_ENABLE << 28) | (CCA_BACKDOOR_ACTIVE_LEVEL << 27) | (CCA_BACKDOOR_PORT_A_PIN << 24),
-    0x00000000,                  /**< Image Valid */
-    (uintptr_t)interrupt_vector, /**< Application Entry Point */
+    0x00000000,                     /**< Image Valid */
+    (uint32_t)&cortex_vector_base,  /**< Application Entry Point */
 
     /* Unlock all pages and debug: */
     0xffffffff,

--- a/cpu/cc26x0/vectors.c
+++ b/cpu/cc26x0/vectors.c
@@ -30,10 +30,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* CC26x0 specific interrupt vectors */
 WEAK_DEFAULT void isr_edge(void);
 WEAK_DEFAULT void isr_i2c(void);
@@ -70,63 +66,42 @@ WEAK_DEFAULT void isr_comp(void);
 WEAK_DEFAULT void isr_adc(void);
 WEAK_DEFAULT void isr_trng(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void *) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M3 handlers */
-    (void *) reset_handler_default,  /* entry point of the program */
-    (void *) nmi_default,            /* non maskable interrupt handler */
-    (void *) hard_fault_default,     /* hard fault exception */
-    (void *) mem_manage_default,     /* memory manage exception */
-    (void *) bus_fault_default,      /* bus fault exception */
-    (void *) usage_fault_default,    /* usage fault exception */
-    NULL,                           /* reserved */
-    NULL,                           /* reserved */
-    NULL,                           /* reserved */
-    NULL,                           /* reserved */
-    (void *) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void *) debug_mon_default,      /* debug monitor exception */
-    NULL,                           /* reserved */
-    (void *) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void *) isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* CC26x0 specific peripheral handlers */
-    (void *) isr_edge,              /* 16 AON edge detect                        */
-    (void *) isr_i2c,               /* 17 I2C                                    */
-    (void *) isr_rfc_cpe1,          /* 18 RF Command and Packet Engine 1         */
-    (void *) isr_aon_rx_tx_cs,      /* 19 AON SpiSplave Rx, Tx and CS            */
-    (void *) isr_aon_rtc,           /* 20 AON RTC                                */
-    (void *) isr_uart,              /* 21 UART0 Rx and Tx                        */
-    (void *) isr_scse0_aon,         /* 22 Sensor Controller software event 0, through AON domain */
-    (void *) isr_ssi0,              /* 23 SSI0 Rx and Tx                         */
-    (void *) isr_ssi1,              /* 24 SSI1 Rx and Tx                         */
-    (void *) isr_rfc_cpe0,          /* 25 RF Command and Packet Engine 0         */
-    (void *) isr_rfc_hw,            /* 26 RF Core Hardware                       */
-    (void *) isr_rfc_cmd_ack,       /* 27 RF Core Command Acknowledge            */
-    (void *) isr_i2s,               /* 28 I2S                                    */
-    (void *) isr_scse1_aon,         /* 29 Sensor Controller software event 1, through AON domain */
-    (void *) isr_watchdog,          /* 30 Watchdog timer                         */
-    (void *) isr_timer0_chan0,      /* 31 Timer 0 subtimer A                     */
-    (void *) isr_timer0_chan1,      /* 32 Timer 0 subtimer B                     */
-    (void *) isr_timer1_chan0,      /* 33 Timer 1 subtimer A                     */
-    (void *) isr_timer1_chan1,      /* 34 Timer 1 subtimer B                     */
-    (void *) isr_timer2_chan0,      /* 35 Timer 2 subtimer A                     */
-    (void *) isr_timer2_chan1,      /* 36 Timer 2 subtimer B                     */
-    (void *) isr_timer3_chan0,      /* 37 Timer 3 subtimer A                     */
-    (void *) isr_timer3_chan1,      /* 38 Timer 3 subtimer B                     */
-    (void *) isr_crypto_res,        /* 39 Crypto Core Result available           */
-    (void *) isr_dma,               /* 40 uDMA Software                          */
-    (void *) isr_dmaerr,            /* 41 uDMA Error                             */
-    (void *) isr_flash,             /* 42 Flash controller                       */
-    (void *) isr_se0,               /* 43 Software Event 0                       */
-    (void *) isr_aux_ce,            /* 44 AUX combined event, directly to MCU domain */
-    (void *) isr_aon_prog,          /* 45 AON programmable 0                     */
-    (void *) isr_dyn_prog,          /* 46 Dynamic Programmable interrupt (default source: PRCM) */
-    (void *) isr_comp,              /* 47 AUX Comparator A                       */
-    (void *) isr_adc,               /* 48 AUX ADC IRQ                            */
-    (void *) isr_trng,              /* 49 TRNG event                             */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_edge,              /* 16 AON edge detect                        */
+    isr_i2c,               /* 17 I2C                                    */
+    isr_rfc_cpe1,          /* 18 RF Command and Packet Engine 1         */
+    isr_aon_rx_tx_cs,      /* 19 AON SpiSplave Rx, Tx and CS            */
+    isr_aon_rtc,           /* 20 AON RTC                                */
+    isr_uart,              /* 21 UART0 Rx and Tx                        */
+    isr_scse0_aon,         /* 22 Sensor Controller software event 0, through AON domain */
+    isr_ssi0,              /* 23 SSI0 Rx and Tx                         */
+    isr_ssi1,              /* 24 SSI1 Rx and Tx                         */
+    isr_rfc_cpe0,          /* 25 RF Command and Packet Engine 0         */
+    isr_rfc_hw,            /* 26 RF Core Hardware                       */
+    isr_rfc_cmd_ack,       /* 27 RF Core Command Acknowledge            */
+    isr_i2s,               /* 28 I2S                                    */
+    isr_scse1_aon,         /* 29 Sensor Controller software event 1, through AON domain */
+    isr_watchdog,          /* 30 Watchdog timer                         */
+    isr_timer0_chan0,      /* 31 Timer 0 subtimer A                     */
+    isr_timer0_chan1,      /* 32 Timer 0 subtimer B                     */
+    isr_timer1_chan0,      /* 33 Timer 1 subtimer A                     */
+    isr_timer1_chan1,      /* 34 Timer 1 subtimer B                     */
+    isr_timer2_chan0,      /* 35 Timer 2 subtimer A                     */
+    isr_timer2_chan1,      /* 36 Timer 2 subtimer B                     */
+    isr_timer3_chan0,      /* 37 Timer 3 subtimer A                     */
+    isr_timer3_chan1,      /* 38 Timer 3 subtimer B                     */
+    isr_crypto_res,        /* 39 Crypto Core Result available           */
+    isr_dma,               /* 40 uDMA Software                          */
+    isr_dmaerr,            /* 41 uDMA Error                             */
+    isr_flash,             /* 42 Flash controller                       */
+    isr_se0,               /* 43 Software Event 0                       */
+    isr_aux_ce,            /* 44 AUX combined event, directly to MCU domain */
+    isr_aon_prog,          /* 45 AON programmable 0                     */
+    isr_dyn_prog,          /* 46 Dynamic Programmable interrupt (default source: PRCM) */
+    isr_comp,              /* 47 AUX Comparator A                       */
+    isr_adc,               /* 48 AUX ADC IRQ                            */
+    isr_trng,              /* 49 TRNG event                             */
 };
 
 /** @} */

--- a/cpu/cc26x0/vectors.c
+++ b/cpu/cc26x0/vectors.c
@@ -67,7 +67,7 @@ WEAK_DEFAULT void isr_adc(void);
 WEAK_DEFAULT void isr_trng(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_edge,              /* 16 AON edge detect                        */
     isr_i2c,               /* 17 I2C                                    */
     isr_rfc_cpe1,          /* 18 RF Command and Packet Engine 1         */

--- a/cpu/cortexm_common/include/vectors_cortexm.h
+++ b/cpu/cortexm_common/include/vectors_cortexm.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif
 
+#include "cpu_conf.h"
+
 /**
  * @brief   Use this macro to make interrupt functions overridable with the
  *          dummy_handler as fallback in case they are not implemented

--- a/cpu/cortexm_common/include/vectors_cortexm.h
+++ b/cpu/cortexm_common/include/vectors_cortexm.h
@@ -30,9 +30,13 @@ extern "C" {
 #define WEAK_DEFAULT    __attribute__((weak,alias("dummy_handler")))
 
 /**
- * @brief   Put this macro in front of the array holding the interrupt vectors
+ * @brief   Use this macro to define the parts of the vector table
+ *
+ * The entries in the vector table are sorted in ascending order defined by the
+ * (numeric) value given for `x`. The Cortex-M base vectors are always defined
+ * with `ISR_VECTOR(0)`, so the CPU specific vector(s) **must** start from 1.
  */
-#define ISR_VECTORS     __attribute__((used,section(".vectors")))
+#define ISR_VECTOR(x)   __attribute__((used,section(".vectors." # x )))
 
 /**
  * @brief   Number of Cortex-M non-ISR exceptions
@@ -42,6 +46,21 @@ extern "C" {
  */
 #define CPU_NONISR_EXCEPTIONS   (15)
 
+/**
+ * @brief   All ISR functions have this type
+ */
+typedef void (*isr_t)(void);
+
+/**
+ * @brief   Structure of Cortex-M basic vector table
+ */
+typedef struct {
+    void* _estack;                          /**< exception stack pointer */
+    isr_t vectors[CPU_NONISR_EXCEPTIONS];   /**< shared Cortex-M vectors */
+} cortexm_base_t;
+
+/* get the start of the ISR stack as defined in the linkerscript */
+extern uint32_t _estack;
 /**
  * @brief   This function is the default entry point after a system reset
  *

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -42,7 +42,7 @@ SECTIONS
         . = ALIGN(4);
         _sfixed = .;
         _isr_vectors = DEFINED(_isr_vectors) ? _isr_vectors : . ;
-        KEEP(*(.vectors .vectors.*))
+        KEEP(*(SORT(.vectors*)))
         *(.text .text.* .gnu.linkonce.t.*)
         *(.glue_7t) *(.glue_7)
         *(.rodata .rodata* .gnu.linkonce.r.*)

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -368,3 +368,40 @@ void dummy_handler_default(void)
 {
     core_panic(PANIC_DUMMY_HANDLER, "DUMMY HANDLER");
 }
+
+/* Cortex-M common interrupt vectors */
+__attribute__((weak,alias("dummy_handler_default"))) void isr_svc(void);
+__attribute__((weak,alias("dummy_handler_default"))) void isr_pendsv(void);
+__attribute__((weak,alias("dummy_handler_default"))) void isr_systick(void);
+
+/* define Cortex-M base interrupt vectors */
+ISR_VECTOR(0) cortexm_base_t cortex_vector_base = {
+    &_estack,
+    {
+        /* entry point of the program */
+        [ 0]         = reset_handler_default,
+        /* [-14] non maskable interrupt handler */
+        [ 1] = nmi_default,
+        /* [-13] hard fault exception */
+        [ 2] = hard_fault_default,
+        /* [-5] SW interrupt, in RIOT used for triggering context switches */
+        [10] = isr_svc,
+        /* [-2] pendSV interrupt, in RIOT use to do the actual context switch */
+        [13] = isr_pendsv,
+        /* [-1] SysTick interrupt, not used in RIOT */
+        [14] = isr_systick,
+
+        /* additional vectors used by M3, M4(F), and M7 */
+#if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
+    defined(CPU_ARCH_CORTEX_M4F) || defined(CPU_ARCH_CORTEX_M7)
+        /* [-12] memory manage exception */
+        [ 3] = mem_manage_default,
+        /* [-11] bus fault exception */
+        [ 4] = bus_fault_default,
+        /* [-10] usage fault exception */
+        [ 5] = usage_fault_default,
+        /* [-4] debug monitor exception */
+        [11] = debug_mon_default,
+#endif
+    }
+};

--- a/cpu/ezr32wg/vectors.c
+++ b/cpu/ezr32wg/vectors.c
@@ -72,7 +72,7 @@ WEAK_DEFAULT void isr_emu(void);
 WEAK_DEFAULT void isr_fpueh(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_dma,                /* 0 - DMA       */
     isr_gpio_even,          /* 1 - GPIO_EVEN       */
     isr_timer0,             /* 2 - TIMER0       */

--- a/cpu/ezr32wg/vectors.c
+++ b/cpu/ezr32wg/vectors.c
@@ -30,10 +30,6 @@ void dummy_handler(void) {
     __asm__("b     dummy_handler_default");
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* Silicon Labs specific interrupt vector */
 WEAK_DEFAULT void isr_dma(void);
 WEAK_DEFAULT void isr_gpio_even(void);
@@ -75,67 +71,46 @@ WEAK_DEFAULT void isr_aes(void);
 WEAK_DEFAULT void isr_emu(void);
 WEAK_DEFAULT void isr_fpueh(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M4 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* Silicon Labs specific peripheral handlers */
-    (void*) isr_dma,                /* 0 - DMA       */
-    (void*) isr_gpio_even,          /* 1 - GPIO_EVEN       */
-    (void*) isr_timer0,             /* 2 - TIMER0       */
-    (void*) isr_usart0_rx,          /* 3 - USART0_RX       */
-    (void*) isr_usart0_tx,          /* 4 - USART0_TX       */
-    (void*) isr_usb,                /* 5 - USB       */
-    (void*) isr_acmp0,              /* 6 - ACMP0       */
-    (void*) isr_adc0,               /* 7 - ADC0       */
-    (void*) isr_dac0,               /* 8 - DAC0       */
-    (void*) isr_i2c0,               /* 9 - I2C0       */
-    (void*) isr_i2c1,               /* 10 - I2C1       */
-    (void*) isr_gpio_odd,           /* 11 - GPIO_ODD       */
-    (void*) isr_timer1,             /* 12 - TIMER1       */
-    (void*) isr_timer2,             /* 13 - TIMER2       */
-    (void*) isr_timer3,             /* 14 - TIMER3       */
-    (void*) isr_usart1_rx,          /* 15 - USART1_RX       */
-    (void*) isr_usart1_tx,          /* 16 - USART1_TX       */
-    (void*) isr_lesense,            /* 17 - LESENSE       */
-    (void*) isr_usart2_rx,          /* 18 - USART2_RX       */
-    (void*) isr_usart2_tx,          /* 19 - USART2_TX       */
-    (void*) isr_uart0_rx,           /* 20 - UART0_RX       */
-    (void*) isr_uart0_tx,           /* 21 - UART0_TX       */
-    (void*) isr_uart1_rx,           /* 22 - UART1_RX       */
-    (void*) isr_uart1_tx,           /* 23 - UART1_TX       */
-    (void*) isr_leuart0,            /* 24 - LEUART0       */
-    (void*) isr_leuart1,            /* 25 - LEUART1       */
-    (void*) isr_letimer0,           /* 26 - LETIMER0       */
-    (void*) isr_pcnt0,              /* 27 - PCNT0       */
-    (void*) isr_pcnt1,              /* 28 - PCNT1       */
-    (void*) isr_pcnt2,              /* 29 - PCNT2       */
-    (void*) isr_rtc,                /* 30 - RTC       */
-    (void*) isr_burtc,              /* 31 - BURTC       */
-    (void*) isr_cmu,                /* 32 - CMU       */
-    (void*) isr_vcmp,               /* 33 - VCMP       */
-    (void*) isr_lcd,                /* 34 - LCD       */
-    (void*) isr_msc,                /* 35 - MSC       */
-    (void*) isr_aes,                /* 36 - AES       */
-    (void*) (0UL),                  /* 37 - Reserved */
-    (void*) isr_emu,                /* 38 - EMU       */
-    (void*) isr_fpueh,              /* 39 - FPUEH       */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_dma,                /* 0 - DMA       */
+    isr_gpio_even,          /* 1 - GPIO_EVEN       */
+    isr_timer0,             /* 2 - TIMER0       */
+    isr_usart0_rx,          /* 3 - USART0_RX       */
+    isr_usart0_tx,          /* 4 - USART0_TX       */
+    isr_usb,                /* 5 - USB       */
+    isr_acmp0,              /* 6 - ACMP0       */
+    isr_adc0,               /* 7 - ADC0       */
+    isr_dac0,               /* 8 - DAC0       */
+    isr_i2c0,               /* 9 - I2C0       */
+    isr_i2c1,               /* 10 - I2C1       */
+    isr_gpio_odd,           /* 11 - GPIO_ODD       */
+    isr_timer1,             /* 12 - TIMER1       */
+    isr_timer2,             /* 13 - TIMER2       */
+    isr_timer3,             /* 14 - TIMER3       */
+    isr_usart1_rx,          /* 15 - USART1_RX       */
+    isr_usart1_tx,          /* 16 - USART1_TX       */
+    isr_lesense,            /* 17 - LESENSE       */
+    isr_usart2_rx,          /* 18 - USART2_RX       */
+    isr_usart2_tx,          /* 19 - USART2_TX       */
+    isr_uart0_rx,           /* 20 - UART0_RX       */
+    isr_uart0_tx,           /* 21 - UART0_TX       */
+    isr_uart1_rx,           /* 22 - UART1_RX       */
+    isr_uart1_tx,           /* 23 - UART1_TX       */
+    isr_leuart0,            /* 24 - LEUART0       */
+    isr_leuart1,            /* 25 - LEUART1       */
+    isr_letimer0,           /* 26 - LETIMER0       */
+    isr_pcnt0,              /* 27 - PCNT0       */
+    isr_pcnt1,              /* 28 - PCNT1       */
+    isr_pcnt2,              /* 29 - PCNT2       */
+    isr_rtc,                /* 30 - RTC       */
+    isr_burtc,              /* 31 - BURTC       */
+    isr_cmu,                /* 32 - CMU       */
+    isr_vcmp,               /* 33 - VCMP       */
+    isr_lcd,                /* 34 - LCD       */
+    isr_msc,                /* 35 - MSC       */
+    isr_aes,                /* 36 - AES       */
+    (0UL),                  /* 37 - Reserved */
+    isr_emu,                /* 38 - EMU       */
+    isr_fpueh,              /* 39 - FPUEH       */
 };

--- a/cpu/k22f/vectors.c
+++ b/cpu/k22f/vectors.c
@@ -20,29 +20,8 @@
 
 #include "vectors_kinetis.h"
 
-/* interrupt vector table */
-ISR_VECTORS const isr_func_t interrupt_vector[] = {
-    /* Stack pointer */
-    (isr_func_t)(&_estack), /* pointer to the top of the empty stack */
-    /* Cortex-M4 handlers */
-    reset_handler_default,  /* entry point of the program */
-    nmi_default,            /* non maskable interrupt handler */
-    hard_fault_default,     /* hard fault exception */
-    mem_manage_default,     /* memory manage exception */
-    bus_fault_default,      /* bus fault exception */
-    usage_fault_default,    /* usage fault exception */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    isr_svc,                /* system call interrupt, in RIOT used for
-                             * switching into thread context on boot */
-    debug_mon_default,      /* debug monitor exception */
-    dummy_handler,          /* Reserved */
-    isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                             * context switching is happening here */
-    isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* K22F specific peripheral handlers */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
     isr_dma0,              /* DMA channel 0 transfer complete */
     isr_dma1,              /* DMA channel 1 transfer complete */
     isr_dma2,              /* DMA channel 2 transfer complete */

--- a/cpu/k22f/vectors.c
+++ b/cpu/k22f/vectors.c
@@ -21,7 +21,7 @@
 #include "vectors_kinetis.h"
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_dma0,              /* DMA channel 0 transfer complete */
     isr_dma1,              /* DMA channel 1 transfer complete */
     isr_dma2,              /* DMA channel 2 transfer complete */

--- a/cpu/k60/vectors.c
+++ b/cpu/k60/vectors.c
@@ -29,31 +29,8 @@
 
 #include "vectors_kinetis.h"
 
-/**
- * @brief Interrupt vector definition
- */
-ISR_VECTORS const isr_func_t interrupt_vector[] = {
-    /* Stack pointer */
-    (isr_func_t)(&_estack),     /* pointer to the top of the empty stack */
-    /* Cortex-M4 handlers */
-    reset_handler_default,  /* entry point of the program */
-    nmi_default,            /* non maskable interrupt handler */
-    hard_fault_default,     /* hard fault exception */
-    mem_manage_default,     /* memory manage exception */
-    bus_fault_default,      /* bus fault exception */
-    usage_fault_default,    /* usage fault exception */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    isr_svc,                /* system call interrupt, in RIOT used for
-                             * switching into thread context on boot */
-    debug_mon_default,      /* debug monitor exception */
-    dummy_handler,          /* Reserved */
-    isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                             * context switching is happening here */
-    isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* K60 specific peripheral handlers */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
     isr_dma0,
     isr_dma1,
     isr_dma2,

--- a/cpu/k60/vectors.c
+++ b/cpu/k60/vectors.c
@@ -30,7 +30,7 @@
 #include "vectors_kinetis.h"
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_dma0,
     isr_dma1,
     isr_dma2,

--- a/cpu/k64f/vectors.c
+++ b/cpu/k64f/vectors.c
@@ -22,29 +22,8 @@
 
 #include "vectors_kinetis.h"
 
-/* interrupt vector table */
-ISR_VECTORS const isr_func_t interrupt_vector[] = {
-    /* Stack pointer */
-    (isr_func_t)(&_estack),     /* pointer to the top of the empty stack */
-    /* Cortex-M4 handlers */
-    reset_handler_default,  /* entry point of the program */
-    nmi_default,            /* non maskable interrupt handler */
-    hard_fault_default,     /* hard fault exception */
-    mem_manage_default,     /* memory manage exception */
-    bus_fault_default,      /* bus fault exception */
-    usage_fault_default,    /* usage fault exception */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    isr_svc,                /* system call interrupt, in RIOT used for
-                             * switching into thread context on boot */
-    debug_mon_default,      /* debug monitor exception */
-    dummy_handler,          /* Reserved */
-    isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                             * context switching is happening here */
-    isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* K64F specific peripheral handlers */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
     isr_dma0,              /* DMA channel 0 transfer complete */
     isr_dma1,              /* DMA channel 1 transfer complete */
     isr_dma2,              /* DMA channel 2 transfer complete */

--- a/cpu/k64f/vectors.c
+++ b/cpu/k64f/vectors.c
@@ -23,7 +23,7 @@
 #include "vectors_kinetis.h"
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_dma0,              /* DMA channel 0 transfer complete */
     isr_dma1,              /* DMA channel 1 transfer complete */
     isr_dma2,              /* DMA channel 2 transfer complete */

--- a/cpu/kinetis_common/include/vectors_kinetis.h
+++ b/cpu/kinetis_common/include/vectors_kinetis.h
@@ -137,11 +137,6 @@ void isr_usb0(void);         /**< USB OTG interrupt handler */
 void isr_usbdcd(void);       /**< USB charger detection interrupt handler */
 void isr_wdog_ewm(void);     /**< WDOG and EWM interrupt handler */
 
-/**
- * @brief Interrupt vector pointer type
- */
-typedef void (*isr_func_t)(void);
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/cpu/kinetis_common/ldscripts/kinetis.ld
+++ b/cpu/kinetis_common/ldscripts/kinetis.ld
@@ -23,14 +23,14 @@
 SECTIONS
 {
     /* Interrupt vectors 0x00-0x3ff. */
-    .vectors :
+    .vector :
     {
         _isr_vectors = .;
-        KEEP(*(.vectors .vectors.*))
+        KEEP(*(SORT(.vector*)))
     } > vectors
-    ASSERT (SIZEOF(.vectors) == 0x400, "Interrupt vector table of invalid size.")
-    ASSERT (ADDR(.vectors) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
-    ASSERT (LOADADDR(.vectors) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
+    ASSERT (SIZEOF(.vector) == 0x400, "Interrupt vector table of invalid size.")
+    ASSERT (ADDR(.vector) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
+    ASSERT (LOADADDR(.vector) == 0x00000000, "Interrupt vector table at invalid location (linker-script error?)")
 
     /* Flash configuration field, very important in order to not accidentally lock the device */
     /* Flash configuration field 0x400-0x40f. */

--- a/cpu/kw2xd/vectors.c
+++ b/cpu/kw2xd/vectors.c
@@ -22,29 +22,8 @@
 
 #include "vectors_kinetis.h"
 
-/* interrupt vector table */
-ISR_VECTORS const isr_func_t interrupt_vector[] = {
-    /* Stack pointer */
-    (isr_func_t)(&_estack),     /* pointer to the top of the empty stack */
-    /* Cortex-M4 handlers */
-    reset_handler_default,  /* entry point of the program */
-    nmi_default,            /* non maskable interrupt handler */
-    hard_fault_default,     /* hard fault exception */
-    mem_manage_default,     /* memory manage exception */
-    bus_fault_default,      /* bus fault exception */
-    usage_fault_default,    /* usage fault exception */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    dummy_handler,          /* Reserved */
-    isr_svc,                /* system call interrupt, in RIOT used for
-                             * switching into thread context on boot */
-    debug_mon_default,      /* debug monitor exception */
-    dummy_handler,          /* Reserved */
-    isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                             * context switching is happening here */
-    isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* MKW22D512 specific peripheral handlers */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
     isr_dma0,              /* DMA channel 0 transfer complete */
     isr_dma1,              /* DMA channel 1 transfer complete */
     isr_dma2,              /* DMA channel 2 transfer complete */

--- a/cpu/kw2xd/vectors.c
+++ b/cpu/kw2xd/vectors.c
@@ -23,7 +23,7 @@
 #include "vectors_kinetis.h"
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_dma0,              /* DMA channel 0 transfer complete */
     isr_dma1,              /* DMA channel 1 transfer complete */
     isr_dma2,              /* DMA channel 2 transfer complete */

--- a/cpu/lm4f120/include/cpu_conf.h
+++ b/cpu/lm4f120/include/cpu_conf.h
@@ -56,7 +56,7 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#define CPU_IRQ_NUMOF                   (48U)
+#define CPU_IRQ_NUMOF                   (139U)
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 

--- a/cpu/lm4f120/vectors.c
+++ b/cpu/lm4f120/vectors.c
@@ -100,7 +100,7 @@ WEAK_DEFAULT void isr_wtimer5b(void);
 WEAK_DEFAULT void isr_sysex(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_gpio_porta,        /* GPIO Port A                      16 */
     isr_gpio_portb,        /* GPIO Port B                      17 */
     isr_gpio_portc,        /* GPIO Port C                      18 */

--- a/cpu/lm4f120/vectors.c
+++ b/cpu/lm4f120/vectors.c
@@ -99,167 +99,146 @@ WEAK_DEFAULT void isr_wtimer5a(void);
 WEAK_DEFAULT void isr_wtimer5b(void);
 WEAK_DEFAULT void isr_sysex(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M4 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* Peripherial interrupts start here.*/
-    (void *) isr_gpio_porta,        /* GPIO Port A                      16 */
-    (void *) isr_gpio_portb,        /* GPIO Port B                      17 */
-    (void *) isr_gpio_portc,        /* GPIO Port C                      18 */
-    (void *) isr_gpio_portd,        /* GPIO Port D                      19 */
-    (void *) isr_gpio_porte,        /* GPIO Port E                      20 */
-    (void *) isr_uart0,             /* UART 0                           21 */
-    (void *) isr_uart1,             /* UART 1                           22 */
-    (void *) isr_ssi0,              /* SSI 0                            23 */
-    (void *) isr_i2c0,              /* I2C 0                            24 */
-    (void *) (0UL),                 /* Reserved                         25 */
-    (void *) (0UL),                 /* Reserved                         26 */
-    (void *) (0UL),                 /* Reserved                         27 */
-    (void *) (0UL),                 /* Reserved                         28 */
-    (void *) (0UL),                 /* Reserved                         29 */
-    (void *) isr_adc0_seq0,         /* ADC 0 Seq 0                      30 */
-    (void *) isr_adc0_seq1,         /* ADC 0 Seq 1                      31 */
-    (void *) isr_adc0_seq2,         /* ADC 0 Seq 2                      32 */
-    (void *) isr_adc0_seq3,         /* ADC 0 Seq 3                      33 */
-    (void *) isr_wdt,               /* WDT 0 and 1                      34 */
-    (void *) isr_timer0a,           /* 16/32 bit timer 0 A              35 */
-    (void *) isr_timer0b,           /* 16/32 bit timer 0 B              36 */
-    (void *) isr_timer1a,           /* 16/32 bit timer 1 A              37 */
-    (void *) isr_timer1b,           /* 16/32 bit timer 1 B              38 */
-    (void *) isr_timer2a,           /* 16/32 bit timer 2 A              39 */
-    (void *) isr_timer2b,           /* 16/32 bit timer 2 B              40 */
-    (void *) isr_comp0,             /* Analog comparator 0              41 */
-    (void *) isr_comp1,             /* Analog comparator 1              42 */
-    (void *) (0UL),                 /* Reserved                         43 */
-    (void *) isr_sysctl,            /* System control                   44 */
-    (void *) isr_flashctl,          /* Flash + EEPROM control           45 */
-    (void *) isr_gpio_portf,        /* GPIO Port F                      46 */
-    (void *) (0UL),                 /* Reserved                         47 */
-    (void *) (0UL),                 /* Reserved                         48 */
-    (void *) isr_uart2,             /* UART 2                           49 */
-    (void *) isr_ssi1,              /* SSI 1                            50 */
-    (void *) isr_timer3a,           /* 16/32 bit timer 3 A              51 */
-    (void *) isr_timer3b,           /* 16/32 bit timer 3 B              52 */
-    (void *) isr_i2c1,              /* I2C 1                            53 */
-    (void *) (0UL),                 /* Reserved                         54 */
-    (void *) isr_can0,              /* CAN 0                            55 */
-    (void *) (0UL),                 /* Reserved                         56 */
-    (void *) (0UL),                 /* Reserved                         57 */
-    (void *) (0UL),                 /* Reserved                         58 */
-    (void *) isr_hibernate,         /* Hibernation module               59 */
-    (void *) isr_usb,               /* USB                              60 */
-    (void *) (0UL),                 /* Reserved                         61 */
-    (void *) isr_udma_sw,           /* UDMA SW                          62 */
-    (void *) isr_udma_error,        /* UDMA Error                       63 */
-    (void *) isr_adc1_seq0,         /* ADC 1 Seq 0                      64 */
-    (void *) isr_adc1_seq1,         /* ADC 1 Seq 1                      65 */
-    (void *) isr_adc1_seq2,         /* ADC 1 Seq 2                      66 */
-    (void *) isr_adc1_seq3,         /* ADC 1 Seq 3                      67 */
-    (void *) (0UL),                 /* Reserved                         68 */
-    (void *) (0UL),                 /* Reserved                         69 */
-    (void *) (0UL),                 /* Reserved                         70 */
-    (void *) (0UL),                 /* Reserved                         71 */
-    (void *) (0UL),                 /* Reserved                         72 */
-    (void *) isr_ssi2,              /* SSI 2                            73 */
-    (void *) isr_ssi3,              /* SSI 3                            74 */
-    (void *) isr_uart3,             /* UART 3                           75 */
-    (void *) isr_uart4,             /* UART 4                           76 */
-    (void *) isr_uart5,             /* UART 5                           77 */
-    (void *) isr_uart6,             /* UART 6                           78 */
-    (void *) isr_uart7,             /* UART 7                           79 */
-    (void *) (0UL),                 /* Reserved                         80 */
-    (void *) (0UL),                 /* Reserved                         81 */
-    (void *) (0UL),                 /* Reserved                         82 */
-    (void *) (0UL),                 /* Reserved                         83 */
-    (void *) isr_i2c2,              /* I2C 2                            84 */
-    (void *) isr_i2c4,              /* I2C 4                            85 */
-    (void *) isr_timer4a,           /* 16/32 bit timer 4 A              86 */
-    (void *) isr_timer4b,           /* 16/32 bit timer 4 B              87 */
-    (void *) (0UL),                 /* Reserved                         88 */
-    (void *) (0UL),                 /* Reserved                         89 */
-    (void *) (0UL),                 /* Reserved                         90 */
-    (void *) (0UL),                 /* Reserved                         91 */
-    (void *) (0UL),                 /* Reserved                         92 */
-    (void *) (0UL),                 /* Reserved                         93 */
-    (void *) (0UL),                 /* Reserved                         94 */
-    (void *) (0UL),                 /* Reserved                         95 */
-    (void *) (0UL),                 /* Reserved                         96 */
-    (void *) (0UL),                 /* Reserved                         97 */
-    (void *) (0UL),                 /* Reserved                         98 */
-    (void *) (0UL),                 /* Reserved                         99 */
-    (void *) (0UL),                 /* Reserved                         100 */
-    (void *) (0UL),                 /* Reserved                         101 */
-    (void *) (0UL),                 /* Reserved                         102 */
-    (void *) (0UL),                 /* Reserved                         103 */
-    (void *) (0UL),                 /* Reserved                         104 */
-    (void *) (0UL),                 /* Reserved                         105 */
-    (void *) (0UL),                 /* Reserved                         106 */
-    (void *) (0UL),                 /* Reserved                         107 */
-    (void *) isr_timer5a,           /* 16/32 bit timer 5 A              108 */
-    (void *) isr_timer5b,           /* 16/32 bit timer 5 B              109 */
-    (void *) isr_wtimer0a,          /* 32/64 bit timer 0 A              110 */
-    (void *) isr_wtimer0b,          /* 32/64 bit timer 0 B              111 */
-    (void *) isr_wtimer1a,          /* 32/64 bit timer 1 A              112 */
-    (void *) isr_wtimer1b,          /* 32/64 bit timer 1 B              113 */
-    (void *) isr_wtimer2a,          /* 32/64 bit timer 2 A              114 */
-    (void *) isr_wtimer2b,          /* 32/64 bit timer 2 B              115 */
-    (void *) isr_wtimer3a,          /* 32/64 bit timer 3 A              116 */
-    (void *) isr_wtimer3b,          /* 32/64 bit timer 3 B              117 */
-    (void *) isr_wtimer4a,          /* 32/64 bit timer 4 A              118 */
-    (void *) isr_wtimer4b,          /* 32/64 bit timer 4 B              119 */
-    (void *) isr_wtimer5a,          /* 32/64 bit timer 5 A              120 */
-    (void *) isr_wtimer5b,          /* 32/64 bit timer 5 B              121 */
-    (void *) isr_sysex,             /* System Exception                 122 */
-    (void *) (0UL),                 /* Reserved                         123 */
-    (void *) (0UL),                 /* Reserved                         124 */
-    (void *) (0UL),                 /* Reserved                         125 */
-    (void *) (0UL),                 /* Reserved                         126 */
-    (void *) (0UL),                 /* Reserved                         127 */
-    (void *) (0UL),                 /* Reserved                         128 */
-    (void *) (0UL),                 /* Reserved                         129 */
-    (void *) (0UL),                 /* Reserved                         130 */
-    (void *) (0UL),                 /* Reserved                         131 */
-    (void *) (0UL),                 /* Reserved                         132 */
-    (void *) (0UL),                 /* Reserved                         133 */
-    (void *) (0UL),                 /* Reserved                         134 */
-    (void *) (0UL),                 /* Reserved                         135 */
-    (void *) (0UL),                 /* Reserved                         136 */
-    (void *) (0UL),                 /* Reserved                         137 */
-    (void *) (0UL),                 /* Reserved                         138 */
-    (void *) (0UL),                 /* Reserved                         139 */
-    (void *) (0UL),                 /* Reserved                         140 */
-    (void *) (0UL),                 /* Reserved                         141 */
-    (void *) (0UL),                 /* Reserved                         142 */
-    (void *) (0UL),                 /* Reserved                         143 */
-    (void *) (0UL),                 /* Reserved                         144 */
-    (void *) (0UL),                 /* Reserved                         145 */
-    (void *) (0UL),                 /* Reserved                         146 */
-    (void *) (0UL),                 /* Reserved                         147 */
-    (void *) (0UL),                 /* Reserved                         148 */
-    (void *) (0UL),                 /* Reserved                         149 */
-    (void *) (0UL),                 /* Reserved                         150 */
-    (void *) (0UL),                 /* Reserved                         151 */
-    (void *) (0UL),                 /* Reserved                         152 */
-    (void *) (0UL),                 /* Reserved                         153 */
-    (void *) (0UL)                  /* Reserved                         154 */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_gpio_porta,        /* GPIO Port A                      16 */
+    isr_gpio_portb,        /* GPIO Port B                      17 */
+    isr_gpio_portc,        /* GPIO Port C                      18 */
+    isr_gpio_portd,        /* GPIO Port D                      19 */
+    isr_gpio_porte,        /* GPIO Port E                      20 */
+    isr_uart0,             /* UART 0                           21 */
+    isr_uart1,             /* UART 1                           22 */
+    isr_ssi0,              /* SSI 0                            23 */
+    isr_i2c0,              /* I2C 0                            24 */
+    (0UL),                 /* Reserved                         25 */
+    (0UL),                 /* Reserved                         26 */
+    (0UL),                 /* Reserved                         27 */
+    (0UL),                 /* Reserved                         28 */
+    (0UL),                 /* Reserved                         29 */
+    isr_adc0_seq0,         /* ADC 0 Seq 0                      30 */
+    isr_adc0_seq1,         /* ADC 0 Seq 1                      31 */
+    isr_adc0_seq2,         /* ADC 0 Seq 2                      32 */
+    isr_adc0_seq3,         /* ADC 0 Seq 3                      33 */
+    isr_wdt,               /* WDT 0 and 1                      34 */
+    isr_timer0a,           /* 16/32 bit timer 0 A              35 */
+    isr_timer0b,           /* 16/32 bit timer 0 B              36 */
+    isr_timer1a,           /* 16/32 bit timer 1 A              37 */
+    isr_timer1b,           /* 16/32 bit timer 1 B              38 */
+    isr_timer2a,           /* 16/32 bit timer 2 A              39 */
+    isr_timer2b,           /* 16/32 bit timer 2 B              40 */
+    isr_comp0,             /* Analog comparator 0              41 */
+    isr_comp1,             /* Analog comparator 1              42 */
+    (0UL),                 /* Reserved                         43 */
+    isr_sysctl,            /* System control                   44 */
+    isr_flashctl,          /* Flash + EEPROM control           45 */
+    isr_gpio_portf,        /* GPIO Port F                      46 */
+    (0UL),                 /* Reserved                         47 */
+    (0UL),                 /* Reserved                         48 */
+    isr_uart2,             /* UART 2                           49 */
+    isr_ssi1,              /* SSI 1                            50 */
+    isr_timer3a,           /* 16/32 bit timer 3 A              51 */
+    isr_timer3b,           /* 16/32 bit timer 3 B              52 */
+    isr_i2c1,              /* I2C 1                            53 */
+    (0UL),                 /* Reserved                         54 */
+    isr_can0,              /* CAN 0                            55 */
+    (0UL),                 /* Reserved                         56 */
+    (0UL),                 /* Reserved                         57 */
+    (0UL),                 /* Reserved                         58 */
+    isr_hibernate,         /* Hibernation module               59 */
+    isr_usb,               /* USB                              60 */
+    (0UL),                 /* Reserved                         61 */
+    isr_udma_sw,           /* UDMA SW                          62 */
+    isr_udma_error,        /* UDMA Error                       63 */
+    isr_adc1_seq0,         /* ADC 1 Seq 0                      64 */
+    isr_adc1_seq1,         /* ADC 1 Seq 1                      65 */
+    isr_adc1_seq2,         /* ADC 1 Seq 2                      66 */
+    isr_adc1_seq3,         /* ADC 1 Seq 3                      67 */
+    (0UL),                 /* Reserved                         68 */
+    (0UL),                 /* Reserved                         69 */
+    (0UL),                 /* Reserved                         70 */
+    (0UL),                 /* Reserved                         71 */
+    (0UL),                 /* Reserved                         72 */
+    isr_ssi2,              /* SSI 2                            73 */
+    isr_ssi3,              /* SSI 3                            74 */
+    isr_uart3,             /* UART 3                           75 */
+    isr_uart4,             /* UART 4                           76 */
+    isr_uart5,             /* UART 5                           77 */
+    isr_uart6,             /* UART 6                           78 */
+    isr_uart7,             /* UART 7                           79 */
+    (0UL),                 /* Reserved                         80 */
+    (0UL),                 /* Reserved                         81 */
+    (0UL),                 /* Reserved                         82 */
+    (0UL),                 /* Reserved                         83 */
+    isr_i2c2,              /* I2C 2                            84 */
+    isr_i2c4,              /* I2C 4                            85 */
+    isr_timer4a,           /* 16/32 bit timer 4 A              86 */
+    isr_timer4b,           /* 16/32 bit timer 4 B              87 */
+    (0UL),                 /* Reserved                         88 */
+    (0UL),                 /* Reserved                         89 */
+    (0UL),                 /* Reserved                         90 */
+    (0UL),                 /* Reserved                         91 */
+    (0UL),                 /* Reserved                         92 */
+    (0UL),                 /* Reserved                         93 */
+    (0UL),                 /* Reserved                         94 */
+    (0UL),                 /* Reserved                         95 */
+    (0UL),                 /* Reserved                         96 */
+    (0UL),                 /* Reserved                         97 */
+    (0UL),                 /* Reserved                         98 */
+    (0UL),                 /* Reserved                         99 */
+    (0UL),                 /* Reserved                         100 */
+    (0UL),                 /* Reserved                         101 */
+    (0UL),                 /* Reserved                         102 */
+    (0UL),                 /* Reserved                         103 */
+    (0UL),                 /* Reserved                         104 */
+    (0UL),                 /* Reserved                         105 */
+    (0UL),                 /* Reserved                         106 */
+    (0UL),                 /* Reserved                         107 */
+    isr_timer5a,           /* 16/32 bit timer 5 A              108 */
+    isr_timer5b,           /* 16/32 bit timer 5 B              109 */
+    isr_wtimer0a,          /* 32/64 bit timer 0 A              110 */
+    isr_wtimer0b,          /* 32/64 bit timer 0 B              111 */
+    isr_wtimer1a,          /* 32/64 bit timer 1 A              112 */
+    isr_wtimer1b,          /* 32/64 bit timer 1 B              113 */
+    isr_wtimer2a,          /* 32/64 bit timer 2 A              114 */
+    isr_wtimer2b,          /* 32/64 bit timer 2 B              115 */
+    isr_wtimer3a,          /* 32/64 bit timer 3 A              116 */
+    isr_wtimer3b,          /* 32/64 bit timer 3 B              117 */
+    isr_wtimer4a,          /* 32/64 bit timer 4 A              118 */
+    isr_wtimer4b,          /* 32/64 bit timer 4 B              119 */
+    isr_wtimer5a,          /* 32/64 bit timer 5 A              120 */
+    isr_wtimer5b,          /* 32/64 bit timer 5 B              121 */
+    isr_sysex,             /* System Exception                 122 */
+    (0UL),                 /* Reserved                         123 */
+    (0UL),                 /* Reserved                         124 */
+    (0UL),                 /* Reserved                         125 */
+    (0UL),                 /* Reserved                         126 */
+    (0UL),                 /* Reserved                         127 */
+    (0UL),                 /* Reserved                         128 */
+    (0UL),                 /* Reserved                         129 */
+    (0UL),                 /* Reserved                         130 */
+    (0UL),                 /* Reserved                         131 */
+    (0UL),                 /* Reserved                         132 */
+    (0UL),                 /* Reserved                         133 */
+    (0UL),                 /* Reserved                         134 */
+    (0UL),                 /* Reserved                         135 */
+    (0UL),                 /* Reserved                         136 */
+    (0UL),                 /* Reserved                         137 */
+    (0UL),                 /* Reserved                         138 */
+    (0UL),                 /* Reserved                         139 */
+    (0UL),                 /* Reserved                         140 */
+    (0UL),                 /* Reserved                         141 */
+    (0UL),                 /* Reserved                         142 */
+    (0UL),                 /* Reserved                         143 */
+    (0UL),                 /* Reserved                         144 */
+    (0UL),                 /* Reserved                         145 */
+    (0UL),                 /* Reserved                         146 */
+    (0UL),                 /* Reserved                         147 */
+    (0UL),                 /* Reserved                         148 */
+    (0UL),                 /* Reserved                         149 */
+    (0UL),                 /* Reserved                         150 */
+    (0UL),                 /* Reserved                         151 */
+    (0UL),                 /* Reserved                         152 */
+    (0UL),                 /* Reserved                         153 */
+    (0UL)                  /* Reserved                         154 */
 };
 /** @} */

--- a/cpu/lpc1768/vectors.c
+++ b/cpu/lpc1768/vectors.c
@@ -66,7 +66,7 @@ WEAK_DEFAULT void isr_qei(void);
 WEAK_DEFAULT void isr_pll1(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_wdt,                /* watchdog timer */
     isr_timer0,             /* timer0 */
     isr_timer1,             /* timer1 */

--- a/cpu/lpc1768/vectors.c
+++ b/cpu/lpc1768/vectors.c
@@ -30,10 +30,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* LPC1768 specific interrupt vector */
 WEAK_DEFAULT void isr_wdt(void);
 WEAK_DEFAULT void isr_timer0(void);
@@ -69,61 +65,39 @@ WEAK_DEFAULT void isr_mcpwm(void);
 WEAK_DEFAULT void isr_qei(void);
 WEAK_DEFAULT void isr_pll1(void);
 
-/* interrupt vector table */
-__attribute__ ((used,section(".vectors")))
-const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M3 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* LPC specific peripheral handlers */
-    (void*) isr_wdt,                /* watchdog timer */
-    (void*) isr_timer0,             /* timer0 */
-    (void*) isr_timer1,             /* timer1 */
-    (void*) isr_timer2,             /* timer2 */
-    (void*) isr_timer3,             /* timer3 */
-    (void*) isr_uart0,              /* uart0 */
-    (void*) isr_uart1,              /* uart1 */
-    (void*) isr_uart2,              /* uart2 */
-    (void*) isr_uart3,              /* uart3 */
-    (void*) isr_pwm1,               /* pwm1 */
-    (void*) isr_i2c0,               /* i2c0 */
-    (void*) isr_i2c1,               /* i2c1 */
-    (void*) isr_i2c2,               /* i2c2 */
-    (void*) isr_spi,                /* spi */
-    (void*) isr_ssp0,               /* ssp0 */
-    (void*) isr_ssp1,               /* ssp1 */
-    (void*) isr_pll0,               /* pll0 (main pll) */
-    (void*) isr_rtc,                /* real time clock */
-    (void*) isr_eint0,              /* external interrupt 0 */
-    (void*) isr_eint1,              /* external interrupt 1 */
-    (void*) isr_eint2,              /* external interrupt 2 */
-    (void*) isr_eint3,              /* external interrupt 3 */
-    (void*) isr_adc,                /* a/d converter */
-    (void*) isr_bod,                /* brown out detect */
-    (void*) isr_usb,                /* usb */
-    (void*) isr_can,                /* can */
-    (void*) isr_dma,                /* gp dma */
-    (void*) isr_i2s,                /* i2s */
-    (void*) isr_enet,               /* ethernet */
-    (void*) isr_rit,                /* repetitive interrupt timer */
-    (void*) isr_mcpwm,              /* motor control pwm */
-    (void*) isr_qei,                /* quadrature encoder interface */
-    (void*) isr_pll1,               /* pll1 (usb pll) */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wdt,                /* watchdog timer */
+    isr_timer0,             /* timer0 */
+    isr_timer1,             /* timer1 */
+    isr_timer2,             /* timer2 */
+    isr_timer3,             /* timer3 */
+    isr_uart0,              /* uart0 */
+    isr_uart1,              /* uart1 */
+    isr_uart2,              /* uart2 */
+    isr_uart3,              /* uart3 */
+    isr_pwm1,               /* pwm1 */
+    isr_i2c0,               /* i2c0 */
+    isr_i2c1,               /* i2c1 */
+    isr_i2c2,               /* i2c2 */
+    isr_spi,                /* spi */
+    isr_ssp0,               /* ssp0 */
+    isr_ssp1,               /* ssp1 */
+    isr_pll0,               /* pll0 (main pll) */
+    isr_rtc,                /* real time clock */
+    isr_eint0,              /* external interrupt 0 */
+    isr_eint1,              /* external interrupt 1 */
+    isr_eint2,              /* external interrupt 2 */
+    isr_eint3,              /* external interrupt 3 */
+    isr_adc,                /* a/d converter */
+    isr_bod,                /* brown out detect */
+    isr_usb,                /* usb */
+    isr_can,                /* can */
+    isr_dma,                /* gp dma */
+    isr_i2s,                /* i2s */
+    isr_enet,               /* ethernet */
+    isr_rit,                /* repetitive interrupt timer */
+    isr_mcpwm,              /* motor control pwm */
+    isr_qei,                /* quadrature encoder interface */
+    isr_pll1,               /* pll1 (usb pll) */
 };

--- a/cpu/nrf51/vectors.c
+++ b/cpu/nrf51/vectors.c
@@ -70,37 +70,30 @@ WEAK_DEFAULT void isr_swi4(void);
 WEAK_DEFAULT void isr_swi5(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
-    isr_power_clock,        /* power_clock */
-    isr_radio,              /* radio */
-    isr_uart0,              /* uart0 */
-    isr_spi0_twi0,          /* spi0_twi0 */
-    isr_spi1_twi1,          /* spi1_twi1 */
-    (0UL),                  /* reserved */
-    isr_gpiote,             /* gpiote */
-    isr_adc,                /* adc */
-    isr_timer0,             /* timer0 */
-    isr_timer1,             /* timer1 */
-    isr_timer2,             /* timer2 */
-    isr_rtc0,               /* rtc0 */
-    isr_temp,               /* temp */
-    isr_rng,                /* rng */
-    isr_ecb,                /* ecb */
-    isr_ccm_aar,            /* ccm_aar */
-    isr_wdt,                /* wdt */
-    isr_rtc1,               /* rtc1 */
-    isr_qdec,               /* qdec */
-    isr_lpcomp,             /* lpcomp */
-    isr_swi0,               /* swi0 */
-    isr_swi1,               /* swi1 */
-    isr_swi2,               /* swi2 */
-    isr_swi3,               /* swi3 */
-    isr_swi4,               /* swi4 */
-    isr_swi5,               /* swi5 */
-    (0UL),                  /* reserved */
-    (0UL),                  /* reserved */
-    (0UL),                  /* reserved */
-    (0UL),                  /* reserved */
-    (0UL),                  /* reserved */
-    (0UL),                  /* reserved */
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
+    [ 0] = isr_power_clock,        /* power_clock */
+    [ 1] = isr_radio,              /* radio */
+    [ 2] = isr_uart0,              /* uart0 */
+    [ 3] = isr_spi0_twi0,          /* spi0_twi0 */
+    [ 4] = isr_spi1_twi1,          /* spi1_twi1 */
+    [ 6] = isr_gpiote,             /* gpiote */
+    [ 7] = isr_adc,                /* adc */
+    [ 8] = isr_timer0,             /* timer0 */
+    [ 9] = isr_timer1,             /* timer1 */
+    [10] = isr_timer2,             /* timer2 */
+    [11] = isr_rtc0,               /* rtc0 */
+    [12] = isr_temp,               /* temp */
+    [13] = isr_rng,                /* rng */
+    [14] = isr_ecb,                /* ecb */
+    [15] = isr_ccm_aar,            /* ccm_aar */
+    [16] = isr_wdt,                /* wdt */
+    [17] = isr_rtc1,               /* rtc1 */
+    [18] = isr_qdec,               /* qdec */
+    [19] = isr_lpcomp,             /* lpcomp */
+    [20] = isr_swi0,               /* swi0 */
+    [21] = isr_swi1,               /* swi1 */
+    [22] = isr_swi2,               /* swi2 */
+    [23] = isr_swi3,               /* swi3 */
+    [24] = isr_swi4,               /* swi4 */
+    [25] = isr_swi5,               /* swi5 */
 };

--- a/cpu/nrf51/vectors.c
+++ b/cpu/nrf51/vectors.c
@@ -69,59 +69,38 @@ WEAK_DEFAULT void isr_swi3(void);
 WEAK_DEFAULT void isr_swi4(void);
 WEAK_DEFAULT void isr_swi5(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M0 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* nRF51 specific peripheral handlers */
-    (void*) isr_power_clock,        /* power_clock */
-    (void*) isr_radio,              /* radio */
-    (void*) isr_uart0,              /* uart0 */
-    (void*) isr_spi0_twi0,          /* spi0_twi0 */
-    (void*) isr_spi1_twi1,          /* spi1_twi1 */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_gpiote,             /* gpiote */
-    (void*) isr_adc,                /* adc */
-    (void*) isr_timer0,             /* timer0 */
-    (void*) isr_timer1,             /* timer1 */
-    (void*) isr_timer2,             /* timer2 */
-    (void*) isr_rtc0,               /* rtc0 */
-    (void*) isr_temp,               /* temp */
-    (void*) isr_rng,                /* rng */
-    (void*) isr_ecb,                /* ecb */
-    (void*) isr_ccm_aar,            /* ccm_aar */
-    (void*) isr_wdt,                /* wdt */
-    (void*) isr_rtc1,               /* rtc1 */
-    (void*) isr_qdec,               /* qdec */
-    (void*) isr_lpcomp,             /* lpcomp */
-    (void*) isr_swi0,               /* swi0 */
-    (void*) isr_swi1,               /* swi1 */
-    (void*) isr_swi2,               /* swi2 */
-    (void*) isr_swi3,               /* swi3 */
-    (void*) isr_swi4,               /* swi4 */
-    (void*) isr_swi5,               /* swi5 */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_power_clock,        /* power_clock */
+    isr_radio,              /* radio */
+    isr_uart0,              /* uart0 */
+    isr_spi0_twi0,          /* spi0_twi0 */
+    isr_spi1_twi1,          /* spi1_twi1 */
+    (0UL),                  /* reserved */
+    isr_gpiote,             /* gpiote */
+    isr_adc,                /* adc */
+    isr_timer0,             /* timer0 */
+    isr_timer1,             /* timer1 */
+    isr_timer2,             /* timer2 */
+    isr_rtc0,               /* rtc0 */
+    isr_temp,               /* temp */
+    isr_rng,                /* rng */
+    isr_ecb,                /* ecb */
+    isr_ccm_aar,            /* ccm_aar */
+    isr_wdt,                /* wdt */
+    isr_rtc1,               /* rtc1 */
+    isr_qdec,               /* qdec */
+    isr_lpcomp,             /* lpcomp */
+    isr_swi0,               /* swi0 */
+    isr_swi1,               /* swi1 */
+    isr_swi2,               /* swi2 */
+    isr_swi3,               /* swi3 */
+    isr_swi4,               /* swi4 */
+    isr_swi5,               /* swi5 */
+    (0UL),                  /* reserved */
+    (0UL),                  /* reserved */
+    (0UL),                  /* reserved */
+    (0UL),                  /* reserved */
+    (0UL),                  /* reserved */
+    (0UL),                  /* reserved */
 };

--- a/cpu/nrf52/vectors.c
+++ b/cpu/nrf52/vectors.c
@@ -33,10 +33,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* nRF52 specific interrupt vectors */
 WEAK_DEFAULT void isr_power_clock(void);
 WEAK_DEFAULT void isr_radio(void);
@@ -103,79 +99,58 @@ WEAK_DEFAULT void isr_pwm3(void);
 extern void SWI2_EGU2_IRQHandler(void);
 #endif
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M4 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* nRF52 specific peripheral handlers */
-    (void *) isr_power_clock,       /* power_clock */
-    (void *) isr_radio,             /* radio */
-    (void *) isr_uart0,             /* uart0 */
-    (void *) isr_spi0_twi0,         /* spi0_twi0 */
-    (void *) isr_spi1_twi1,         /* spi1_twi1 */
-    (void *) isr_nfct,              /* nfct */
-    (void *) isr_gpiote,            /* gpiote */
-    (void *) isr_saadc,             /* adc */
-    (void *) isr_timer0,            /* timer0 */
-    (void *) isr_timer1,            /* timer1 */
-    (void *) isr_timer2,            /* timer2 */
-    (void *) isr_rtc0,              /* rtc0 */
-    (void *) isr_temp,              /* temp */
-    (void *) isr_rng,               /* rng */
-    (void *) isr_ecb,               /* ecb */
-    (void *) isr_ccm_aar,           /* ccm_aar */
-    (void *) isr_wdt,               /* wdt */
-    (void *) isr_rtc1,              /* rtc1 */
-    (void *) isr_qdec,              /* qdec */
-    (void *) isr_lpcomp,            /* lpcomp */
-    (void *) isr_swi0,              /* swi0 */
-    (void *) isr_swi1,              /* swi1 */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_power_clock,       /* power_clock */
+    isr_radio,             /* radio */
+    isr_uart0,             /* uart0 */
+    isr_spi0_twi0,         /* spi0_twi0 */
+    isr_spi1_twi1,         /* spi1_twi1 */
+    isr_nfct,              /* nfct */
+    isr_gpiote,            /* gpiote */
+    isr_saadc,             /* adc */
+    isr_timer0,            /* timer0 */
+    isr_timer1,            /* timer1 */
+    isr_timer2,            /* timer2 */
+    isr_rtc0,              /* rtc0 */
+    isr_temp,              /* temp */
+    isr_rng,               /* rng */
+    isr_ecb,               /* ecb */
+    isr_ccm_aar,           /* ccm_aar */
+    isr_wdt,               /* wdt */
+    isr_rtc1,              /* rtc1 */
+    isr_qdec,              /* qdec */
+    isr_lpcomp,            /* lpcomp */
+    isr_swi0,              /* swi0 */
+    isr_swi1,              /* swi1 */
 #ifdef SOFTDEVICE_PRESENT
-    (void *) SWI2_EGU2_IRQHandler,  /* softdevice swi handler */
+    SWI2_EGU2_IRQHandler,  /* softdevice swi handler */
 #else
-    (void *) isr_swi2,              /* swi2 */
+    isr_swi2,              /* swi2 */
 #endif
-    (void *) isr_swi3,              /* swi3 */
-    (void *) isr_swi4,              /* swi4 */
-    (void *) isr_swi5,              /* swi5 */
-    (void *) isr_timer3,            /* timer 3 */
-    (void *) isr_timer4,            /* timer 4 */
-    (void *) isr_pwm0,              /* pwm 0 */
-    (void *) isr_pdm,               /* pdm */
-    (void *)(0UL),                  /* reserved */
-    (void *)(0UL),                  /* reserved */
-    (void *) isr_mwu,               /* mwu */
-    (void *) isr_pwm1,              /* pwm 1 */
-    (void *) isr_pwm2,              /* pwm 2 */
-    (void *) isr_spi2,              /* spi 2 */
-    (void *) isr_rtc2,              /* rtc 2 */
-    (void *) isr_i2s,               /* i2s */
+    isr_swi3,              /* swi3 */
+    isr_swi4,              /* swi4 */
+    isr_swi5,              /* swi5 */
+    isr_timer3,            /* timer 3 */
+    isr_timer4,            /* timer 4 */
+    isr_pwm0,              /* pwm 0 */
+    isr_pdm,               /* pdm */
+    (0UL),                  /* reserved */
+    (0UL),                  /* reserved */
+    isr_mwu,               /* mwu */
+    isr_pwm1,              /* pwm 1 */
+    isr_pwm2,              /* pwm 2 */
+    isr_spi2,              /* spi 2 */
+    isr_rtc2,              /* rtc 2 */
+    isr_i2s,               /* i2s */
 #ifdef CPU_MODEL_NRF52840XXAA
-    (void *) isr_fpu,               /* fpu */
-    (void *) isr_usbd,              /* usbc */
-    (void *) isr_uarte1,            /* uarte1 */
-    (void *) isr_qspi,              /* qspi */
-    (void *) isr_cryptocell,        /* cryptocell */
-    (void *) isr_spi3,              /* spi3 */
-    (void *) (0UL),                 /* reserved */
-    (void *) isr_pwm3,              /* pwm3 */
+    isr_fpu,               /* fpu */
+    isr_usbd,              /* usbc */
+    isr_uarte1,            /* uarte1 */
+    isr_qspi,              /* qspi */
+    isr_cryptocell,        /* cryptocell */
+    isr_spi3,              /* spi3 */
+    (0UL),                 /* reserved */
+    isr_pwm3,              /* pwm3 */
 #endif
 };

--- a/cpu/nrf52/vectors.c
+++ b/cpu/nrf52/vectors.c
@@ -100,7 +100,7 @@ extern void SWI2_EGU2_IRQHandler(void);
 #endif
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_power_clock,       /* power_clock */
     isr_radio,             /* radio */
     isr_uart0,             /* uart0 */

--- a/cpu/sam3/vectors.c
+++ b/cpu/sam3/vectors.c
@@ -78,7 +78,7 @@ WEAK_DEFAULT void isr_can0(void);
 WEAK_DEFAULT void isr_can1(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_supc,               /*  0 supply controller */
     isr_rstc,               /*  1 reset controller */
     isr_rtc,                /*  2 real time clock */

--- a/cpu/sam3/vectors.c
+++ b/cpu/sam3/vectors.c
@@ -77,72 +77,51 @@ WEAK_DEFAULT void isr_emac(void);
 WEAK_DEFAULT void isr_can0(void);
 WEAK_DEFAULT void isr_can1(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M3 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) mem_manage_default,     /* memory manage exception */
-    (void*) bus_fault_default,      /* bus fault exception */
-    (void*) usage_fault_default,    /* usage fault exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) debug_mon_default,      /* debug monitor exception */
-    (void*) (0UL),                  /* Reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* SAM3X8E specific peripheral handlers */
-    (void*) isr_supc,               /*  0 supply controller */
-    (void*) isr_rstc,               /*  1 reset controller */
-    (void*) isr_rtc,                /*  2 real time clock */
-    (void*) isr_rtt,                /*  3 real timer timer */
-    (void*) isr_wdt,                /*  4 watchdog timer */
-    (void*) isr_pmc,                /*  5 power management controller */
-    (void*) isr_efc0,               /*  6 enhanced flash controller 0 */
-    (void*) isr_efc1,               /*  7 enhanced flash controller 1 */
-    (void*) isr_uart,               /*  8 universal asynchronous receiver transceiver */
-    (void*) isr_smc,                /*  9 static memory controller */
-    (void*) (0UL),
-    (void*) isr_pioa,               /* 11 GPIO port A */
-    (void*) isr_piob,               /* 12 GPIO port B */
-    (void*) isr_pioc,               /* 13 GPIO port C */
-    (void*) isr_piod,               /* 14 GPIO port D */
-    (void*) (0UL),
-    (void*) (0UL),
-    (void*) isr_usart0,             /* 17 USART0 */
-    (void*) isr_usart1,             /* 18 USART1 */
-    (void*) isr_usart2,             /* 19 USART2 */
-    (void*) isr_usart3,             /* 20 USART3 */
-    (void*) isr_hsmci,              /* 21 multimedia card interface */
-    (void*) isr_twi0,               /* 22 two-wire interface 0 */
-    (void*) isr_twi1,               /* 23 two-wire interface 1 */
-    (void*) isr_spi0,               /* 24 serial peripheral interface */
-    (void*) (0UL),
-    (void*) isr_ssc,                /* 26 synchronous serial controller */
-    (void*) isr_tc0,                /* 27 timer counter 0 */
-    (void*) isr_tc1,                /* 28 timer counter 1 */
-    (void*) isr_tc2,                /* 29 timer counter 2 */
-    (void*) isr_tc3,                /* 30 timer counter 3 */
-    (void*) isr_tc4,                /* 31 timer counter 4 */
-    (void*) isr_tc5,                /* 32 timer counter 5 */
-    (void*) isr_tc6,                /* 33 timer counter 6 */
-    (void*) isr_tc7,                /* 34 timer counter 7 */
-    (void*) isr_tc8,                /* 35 timer counter 8 */
-    (void*) isr_pwm,                /* 36 pulse width modulation controller */
-    (void*) isr_adc,                /* 37 ADC controller */
-    (void*) isr_dacc,               /* 38 DAC controller */
-    (void*) isr_dmac,               /* 39 DMA controller */
-    (void*) isr_uotghs,             /* 40 USB OTG high speed */
-    (void*) isr_trng,               /* 41 true random number generator */
-    (void*) isr_emac,               /* 42 Ethernet MAC*/
-    (void*) isr_can0,               /* 43 CAN controller 0*/
-    (void*) isr_can1,               /* 44 CAN controller 1*/
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_supc,               /*  0 supply controller */
+    isr_rstc,               /*  1 reset controller */
+    isr_rtc,                /*  2 real time clock */
+    isr_rtt,                /*  3 real timer timer */
+    isr_wdt,                /*  4 watchdog timer */
+    isr_pmc,                /*  5 power management controller */
+    isr_efc0,               /*  6 enhanced flash controller 0 */
+    isr_efc1,               /*  7 enhanced flash controller 1 */
+    isr_uart,               /*  8 universal asynchronous receiver transceiver */
+    isr_smc,                /*  9 static memory controller */
+    (0UL),
+    isr_pioa,               /* 11 GPIO port A */
+    isr_piob,               /* 12 GPIO port B */
+    isr_pioc,               /* 13 GPIO port C */
+    isr_piod,               /* 14 GPIO port D */
+    (0UL),
+    (0UL),
+    isr_usart0,             /* 17 USART0 */
+    isr_usart1,             /* 18 USART1 */
+    isr_usart2,             /* 19 USART2 */
+    isr_usart3,             /* 20 USART3 */
+    isr_hsmci,              /* 21 multimedia card interface */
+    isr_twi0,               /* 22 two-wire interface 0 */
+    isr_twi1,               /* 23 two-wire interface 1 */
+    isr_spi0,               /* 24 serial peripheral interface */
+    (0UL),
+    isr_ssc,                /* 26 synchronous serial controller */
+    isr_tc0,                /* 27 timer counter 0 */
+    isr_tc1,                /* 28 timer counter 1 */
+    isr_tc2,                /* 29 timer counter 2 */
+    isr_tc3,                /* 30 timer counter 3 */
+    isr_tc4,                /* 31 timer counter 4 */
+    isr_tc5,                /* 32 timer counter 5 */
+    isr_tc6,                /* 33 timer counter 6 */
+    isr_tc7,                /* 34 timer counter 7 */
+    isr_tc8,                /* 35 timer counter 8 */
+    isr_pwm,                /* 36 pulse width modulation controller */
+    isr_adc,                /* 37 ADC controller */
+    isr_dacc,               /* 38 DAC controller */
+    isr_dmac,               /* 39 DMA controller */
+    isr_uotghs,             /* 40 USB OTG high speed */
+    isr_trng,               /* 41 true random number generator */
+    isr_emac,               /* 42 Ethernet MAC*/
+    isr_can0,               /* 43 CAN controller 0*/
+    isr_can1,               /* 44 CAN controller 1*/
 };

--- a/cpu/samd21/vectors.c
+++ b/cpu/samd21/vectors.c
@@ -33,10 +33,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* SAMR21 specific interrupt vector */
 WEAK_DEFAULT void isr_pm(void);
 WEAK_DEFAULT void isr_sysctrl(void);
@@ -67,60 +63,34 @@ WEAK_DEFAULT void isr_dac(void);
 WEAK_DEFAULT void isr_ptc(void);
 WEAK_DEFAULT void isr_i2c(void);
 
-/* interrupt vector table */
-ISR_VECTORS struct {
-    void* _estack;
-    void(*vectors[CPU_IRQ_NUMOF + CPU_NONISR_EXCEPTIONS])(void);
-} interrupt_vector = {
-    /* Exception stack pointer */
-    &_estack,                       /* pointer to the top of the stack */
-    {
-        /* Cortex-M0+ handlers */
-        reset_handler_default,  /* entry point of the program */
-        nmi_default,            /* non maskable interrupt handler */
-        hard_fault_default,     /* hard fault exception */
-        (0UL),                  /* reserved */
-        (0UL),                  /* reserved */
-        (0UL),                  /* reserved */
-        (0UL),                  /* reserved */
-        (0UL),                  /* reserved */
-        (0UL),                  /* reserved */
-        (0UL),                  /* reserved */
-        isr_svc,                /* system call interrupt, in RIOT used for
-                                 * switching into thread context on boot */
-        (0UL),                  /* reserved */
-        (0UL),                  /* reserved */
-        isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                 * context switching is happening here */
-        isr_systick,            /* SysTick interrupt, not used in RIOT */
-        /* Atmel specific peripheral handlers */
-        isr_pm,                 /*  0 Power Manager */
-        isr_sysctrl,            /*  1 System Control */
-        isr_wdt,                /*  2 Watchdog Timer */
-        isr_rtc,                /*  3 Real-Time Counter */
-        isr_eic,                /*  4 External Interrupt Controller */
-        isr_nvmctrl,            /*  5 Non-Volatile Memory Controller */
-        isr_dmac,               /*  6 Direct Memory Access Controller */
-        isr_usb,                /*  7 Universal Serial Bus */
-        isr_evsys,              /*  8 Event System Interface */
-        isr_sercom0,            /*  9 Serial Communication Interface 0 */
-        isr_sercom1,            /* 10 Serial Communication Interface 1 */
-        isr_sercom2,            /* 11 Serial Communication Interface 2 */
-        isr_sercom3,            /* 12 Serial Communication Interface 3 */
-        isr_sercom4,            /* 13 Serial Communication Interface 4 */
-        isr_sercom5,            /* 14 Serial Communication Interface 5 */
-        isr_tcc0,               /* 15 Timer Counter Control 0 */
-        isr_tcc1,               /* 16 Timer Counter Control 1 */
-        isr_tcc2,               /* 17 Timer Counter Control 2 */
-        isr_tc3,                /* 18 Basic Timer Counter 0 */
-        isr_tc4,                /* 19 Basic Timer Counter 1 */
-        isr_tc5,                /* 20 Basic Timer Counter 2 */
-        isr_tc6,                /* 21 Basic Timer Counter 3 */
-        isr_tc7,                /* 22 Basic Timer Counter 4 */
-        isr_adc,                /* 23 Analog Digital Converter */
-        isr_ac,                 /* 24 Analog Comparators */
-        isr_dac,                /* 25 Digital Analog Converter */
-        isr_ptc,                /* 26 Peripheral Touch Controller */
-        isr_i2c                 /* 27 Inter-IC Sound Interface */
-    }
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_pm,                 /*  0 Power Manager */
+    isr_sysctrl,            /*  1 System Control */
+    isr_wdt,                /*  2 Watchdog Timer */
+    isr_rtc,                /*  3 Real-Time Counter */
+    isr_eic,                /*  4 External Interrupt Controller */
+    isr_nvmctrl,            /*  5 Non-Volatile Memory Controller */
+    isr_dmac,               /*  6 Direct Memory Access Controller */
+    isr_usb,                /*  7 Universal Serial Bus */
+    isr_evsys,              /*  8 Event System Interface */
+    isr_sercom0,            /*  9 Serial Communication Interface 0 */
+    isr_sercom1,            /* 10 Serial Communication Interface 1 */
+    isr_sercom2,            /* 11 Serial Communication Interface 2 */
+    isr_sercom3,            /* 12 Serial Communication Interface 3 */
+    isr_sercom4,            /* 13 Serial Communication Interface 4 */
+    isr_sercom5,            /* 14 Serial Communication Interface 5 */
+    isr_tcc0,               /* 15 Timer Counter Control 0 */
+    isr_tcc1,               /* 16 Timer Counter Control 1 */
+    isr_tcc2,               /* 17 Timer Counter Control 2 */
+    isr_tc3,                /* 18 Basic Timer Counter 0 */
+    isr_tc4,                /* 19 Basic Timer Counter 1 */
+    isr_tc5,                /* 20 Basic Timer Counter 2 */
+    isr_tc6,                /* 21 Basic Timer Counter 3 */
+    isr_tc7,                /* 22 Basic Timer Counter 4 */
+    isr_adc,                /* 23 Analog Digital Converter */
+    isr_ac,                 /* 24 Analog Comparators */
+    isr_dac,                /* 25 Digital Analog Converter */
+    isr_ptc,                /* 26 Peripheral Touch Controller */
+    isr_i2c                 /* 27 Inter-IC Sound Interface */
 };

--- a/cpu/samd21/vectors.c
+++ b/cpu/samd21/vectors.c
@@ -20,8 +20,6 @@
  */
 
 #include <stdint.h>
-
-#include "cpu_conf.h"
 #include "vectors_cortexm.h"
 
 /* get the start of the ISR stack as defined in the linkerscript */
@@ -64,7 +62,7 @@ WEAK_DEFAULT void isr_ptc(void);
 WEAK_DEFAULT void isr_i2c(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_pm,                 /*  0 Power Manager */
     isr_sysctrl,            /*  1 System Control */
     isr_wdt,                /*  2 Watchdog Timer */

--- a/cpu/saml21/vectors.c
+++ b/cpu/saml21/vectors.c
@@ -65,7 +65,7 @@ WEAK_DEFAULT void isr_aes(void);
 WEAK_DEFAULT void isr_trng(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     (void*) isr_pm,                 /*  0 Power Manager */
     (void*) isr_wdt,                /*  1 Watchdog Timer */
     (void*) isr_rtc,                /*  2 Real-Time Counter */

--- a/cpu/saml21/vectors.c
+++ b/cpu/saml21/vectors.c
@@ -34,10 +34,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* SAML21 specific interrupt vector */
 WEAK_DEFAULT void isr_pm(void);
 WEAK_DEFAULT void isr_wdt(void);
@@ -68,29 +64,8 @@ WEAK_DEFAULT void isr_ptc(void);
 WEAK_DEFAULT void isr_aes(void);
 WEAK_DEFAULT void isr_trng(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M0+ handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* non maskable interrupt handler */
-    (void*) hard_fault_default,     /* hard fault exception */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_svc,                /* system call interrupt, in RIOT used for
-                                     * switching into thread context on boot */
-    (void*) (0UL),                  /* reserved */
-    (void*) (0UL),                  /* reserved */
-    (void*) isr_pendsv,             /* pendSV interrupt, in RIOT the actual
-                                     * context switching is happening here */
-    (void*) isr_systick,            /* SysTick interrupt, not used in RIOT */
-    /* Atmel SAML21 specific peripheral handlers */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
     (void*) isr_pm,                 /*  0 Power Manager */
     (void*) isr_wdt,                /*  1 Watchdog Timer */
     (void*) isr_rtc,                /*  2 Real-Time Counter */

--- a/cpu/stm32f0/vectors.c
+++ b/cpu/stm32f0/vectors.c
@@ -30,10 +30,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* STM32F0 specific interrupt vectors */
 WEAK_DEFAULT void isr_wwdg(void);
 WEAK_DEFAULT void isr_pvd(void);
@@ -66,215 +62,194 @@ WEAK_DEFAULT void isr_usart3_8(void);
 WEAK_DEFAULT void isr_cec(void);
 WEAK_DEFAULT void isr_usb(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),              /* pointer to the top of the stack */
-    /* Cortex-M0 handlers */
-    (void*) reset_handler_default,   /* entry point of the program */
-    (void*) nmi_default,             /* [-14] non maskable interrupt handler */
-    (void*) hard_fault_default,      /* [-13] hard fault exception */
-    (void*) (0UL),                   /* [-12] reserved */
-    (void*) (0UL),                   /* [-11] reserved */
-    (void*) (0UL),                   /* [-10] reserved */
-    (void*) (0UL),                   /* [-9] reserved */
-    (void*) (0UL),                   /* [-8] reserved */
-    (void*) (0UL),                   /* [-7] reserved */
-    (void*) (0UL),                   /* [-6] reserved */
-    (void*) isr_svc,                 /* [-5] system call interrupt, in RIOT used for
-                                            switching into thread context on boot */
-    (void*) (0UL),                   /* [-4] reserved */
-    (void*) (0UL),                   /* [-3] reserved */
-    (void*) isr_pendsv,              /* [-2] pendSV interrupt, in RIOT the actual
-                                            context switching is happening here */
-    (void*) isr_systick,             /* [-1] SysTick interrupt, not used in RIOT */
-    /* STM specific peripheral handlers */
-    (void*) isr_wwdg,                /* [0] windowed watchdog */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wwdg,                /* [0] windowed watchdog */
 #if defined(CPU_MODEL_STM32F030R8)
-    (void*) (0UL),                   /* [1] reserved */
-    (void*) isr_rtc,                 /* [2] real time clock */
-    (void*) isr_flash,               /* [3] flash memory controller */
-    (void*) isr_rcc,                 /* [4] reset and clock control */
-    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
-    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
-    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
-    (void*) (0UL),                   /* [8] reserved */
-    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
-    (void*) isr_adc1_comp,           /* [12] analog digital converter */
-    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
-    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
-    (void*) isr_tim2,                /* [15] timer 2 */
-    (void*) isr_tim3,                /* [16] timer 3 */
-    (void*) isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
-    (void*) (0UL),                   /* [18] reserved */
-    (void*) isr_tim14,               /* [19] timer 14 */
-    (void*) isr_tim15,               /* [20] timer 15 */
-    (void*) isr_tim16,               /* [21] timer 16 */
-    (void*) isr_tim17,               /* [22] timer 17 */
-    (void*) isr_i2c1,                /* [23] I2C 1 */
-    (void*) isr_i2c2,                /* [24] I2C 2 */
-    (void*) isr_spi1,                /* [25] SPI 1 */
-    (void*) isr_spi2,                /* [26] SPI 2 */
-    (void*) isr_usart1,              /* [27] USART 1 */
-    (void*) isr_usart2               /* [28] USART 2 */
+    (0UL),                   /* [1] reserved */
+    isr_rtc,                 /* [2] real time clock */
+    isr_flash,               /* [3] flash memory controller */
+    isr_rcc,                 /* [4] reset and clock control */
+    isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    (0UL),                   /* [8] reserved */
+    isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    isr_adc1_comp,           /* [12] analog digital converter */
+    isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    isr_tim1_cc,             /* [14] timer 1 capture compare */
+    isr_tim2,                /* [15] timer 2 */
+    isr_tim3,                /* [16] timer 3 */
+    isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
+    (0UL),                   /* [18] reserved */
+    isr_tim14,               /* [19] timer 14 */
+    isr_tim15,               /* [20] timer 15 */
+    isr_tim16,               /* [21] timer 16 */
+    isr_tim17,               /* [22] timer 17 */
+    isr_i2c1,                /* [23] I2C 1 */
+    isr_i2c2,                /* [24] I2C 2 */
+    isr_spi1,                /* [25] SPI 1 */
+    isr_spi2,                /* [26] SPI 2 */
+    isr_usart1,              /* [27] USART 1 */
+    isr_usart2               /* [28] USART 2 */
 #elif defined(CPU_MODEL_STM32F031K6)
-    (void*) isr_pvd,                 /* [1] power control */
-    (void*) isr_rtc,                 /* [2] real time clock */
-    (void*) isr_flash,               /* [3] flash memory controller */
-    (void*) isr_rcc,                 /* [4] reset and clock control */
-    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
-    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
-    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
-    (void*) (0UL),                   /* [8] reserved */
-    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
-    (void*) isr_adc1_comp,           /* [12] analog digital converter */
-    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
-    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
-    (void*) isr_tim2,                /* [15] timer 2 */
-    (void*) isr_tim3,                /* [16] timer 3 */
-    (void*) (0UL),                   /* [17] reserved */
-    (void*) (0UL),                   /* [18] reserved */
-    (void*) isr_tim14,               /* [19] timer 14 */
-    (void*) (0UL),                   /* [20] reserved */
-    (void*) isr_tim16,               /* [21] timer 16 */
-    (void*) isr_tim17,               /* [22] timer 17 */
-    (void*) isr_i2c1,                /* [23] I2C 1 */
-    (void*) (0UL),                   /* [24] reserved */
-    (void*) isr_spi1,                /* [25] SPI 1 */
-    (void*) (0UL),                   /* [26] reserved */
-    (void*) isr_usart1               /* [27] USART 1 */
+    isr_pvd,                 /* [1] power control */
+    isr_rtc,                 /* [2] real time clock */
+    isr_flash,               /* [3] flash memory controller */
+    isr_rcc,                 /* [4] reset and clock control */
+    isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    (0UL),                   /* [8] reserved */
+    isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    isr_adc1_comp,           /* [12] analog digital converter */
+    isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    isr_tim1_cc,             /* [14] timer 1 capture compare */
+    isr_tim2,                /* [15] timer 2 */
+    isr_tim3,                /* [16] timer 3 */
+    (0UL),                   /* [17] reserved */
+    (0UL),                   /* [18] reserved */
+    isr_tim14,               /* [19] timer 14 */
+    (0UL),                   /* [20] reserved */
+    isr_tim16,               /* [21] timer 16 */
+    isr_tim17,               /* [22] timer 17 */
+    isr_i2c1,                /* [23] I2C 1 */
+    (0UL),                   /* [24] reserved */
+    isr_spi1,                /* [25] SPI 1 */
+    (0UL),                   /* [26] reserved */
+    isr_usart1               /* [27] USART 1 */
 #elif defined(CPU_MODEL_STM32F042K6)
-    (void*) isr_pvd,                 /* [1] power control */
-    (void*) isr_rtc,                 /* [2] real time clock */
-    (void*) isr_flash,               /* [3] flash memory controller */
-    (void*) isr_rcc,                 /* [4] reset and clock control */
-    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
-    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
-    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
-    (void*) isr_ts,                  /* [8] touch sensing input*/
-    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
-    (void*) isr_adc1_comp,           /* [12] analog digital converter */
-    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
-    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
-    (void*) isr_tim2,                /* [15] timer 2 */
-    (void*) isr_tim3,                /* [16] timer 3 */
-    (void*) (0UL),                   /* [17] reserved */
-    (void*) (0UL),                   /* [18] reserved */
-    (void*) isr_tim14,               /* [19] timer 14 */
-    (void*) (0UL),                   /* [20] reserved */
-    (void*) isr_tim16,               /* [21] timer 16 */
-    (void*) isr_tim17,               /* [22] timer 17 */
-    (void*) isr_i2c1,                /* [23] I2C 1 */
-    (void*) (0UL),                   /* [24] reserved */
-    (void*) isr_spi1,                /* [25] SPI 1 */
-    (void*) isr_spi2,                /* [26] SPI 2 */
-    (void*) isr_usart1,              /* [27] USART 1 */
-    (void*) isr_usart2,              /* [28] USART 2 */
-    (void*) (0UL),                   /* [29] reserved */
-    (void*) isr_cec,                 /* [30] consumer electronics control */
-    (void*) isr_usb                  /* [31] USB global Interrupts & EXTI Line18 Interrup */
+    isr_pvd,                 /* [1] power control */
+    isr_rtc,                 /* [2] real time clock */
+    isr_flash,               /* [3] flash memory controller */
+    isr_rcc,                 /* [4] reset and clock control */
+    isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    isr_ts,                  /* [8] touch sensing input*/
+    isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    isr_adc1_comp,           /* [12] analog digital converter */
+    isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    isr_tim1_cc,             /* [14] timer 1 capture compare */
+    isr_tim2,                /* [15] timer 2 */
+    isr_tim3,                /* [16] timer 3 */
+    (0UL),                   /* [17] reserved */
+    (0UL),                   /* [18] reserved */
+    isr_tim14,               /* [19] timer 14 */
+    (0UL),                   /* [20] reserved */
+    isr_tim16,               /* [21] timer 16 */
+    isr_tim17,               /* [22] timer 17 */
+    isr_i2c1,                /* [23] I2C 1 */
+    (0UL),                   /* [24] reserved */
+    isr_spi1,                /* [25] SPI 1 */
+    isr_spi2,                /* [26] SPI 2 */
+    isr_usart1,              /* [27] USART 1 */
+    isr_usart2,              /* [28] USART 2 */
+    (0UL),                   /* [29] reserved */
+    isr_cec,                 /* [30] consumer electronics control */
+    isr_usb                  /* [31] USB global Interrupts & EXTI Line18 Interrup */
 #elif defined(CPU_MODEL_STM32F051R8)
-    (void*) isr_pvd,                 /* [1] power control */
-    (void*) isr_rtc,                 /* [2] real time clock */
-    (void*) isr_flash,               /* [3] flash memory controller */
-    (void*) isr_rcc,                 /* [4] reset and clock control */
-    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
-    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
-    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
-    (void*) isr_ts,                  /* [8] touch sensing input*/
-    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
-    (void*) isr_adc1_comp,           /* [12] analog digital converter */
-    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
-    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
-    (void*) isr_tim2,                /* [15] timer 2 */
-    (void*) isr_tim3,                /* [16] timer 3 */
-    (void*) isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
-    (void*) (0UL),                   /* [18] reserved */
-    (void*) isr_tim14,               /* [19] timer 14 */
-    (void*) isr_tim15,               /* [20] timer 15 */
-    (void*) isr_tim16,               /* [21] timer 16 */
-    (void*) isr_tim17,               /* [22] timer 17 */
-    (void*) isr_i2c1,                /* [23] I2C 1 */
-    (void*) isr_i2c2,                /* [24] I2C 2 */
-    (void*) isr_spi1,                /* [25] SPI 1 */
-    (void*) isr_spi2,                /* [26] SPI 2 */
-    (void*) isr_usart1,              /* [27] USART 1 */
-    (void*) isr_usart2,              /* [28] USART 2 */
-    (void*) (0UL),                   /* [29] reserved */
-    (void*) isr_cec,                 /* [30] consumer electronics control */
+    isr_pvd,                 /* [1] power control */
+    isr_rtc,                 /* [2] real time clock */
+    isr_flash,               /* [3] flash memory controller */
+    isr_rcc,                 /* [4] reset and clock control */
+    isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    isr_ts,                  /* [8] touch sensing input*/
+    isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    isr_adc1_comp,           /* [12] analog digital converter */
+    isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    isr_tim1_cc,             /* [14] timer 1 capture compare */
+    isr_tim2,                /* [15] timer 2 */
+    isr_tim3,                /* [16] timer 3 */
+    isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
+    (0UL),                   /* [18] reserved */
+    isr_tim14,               /* [19] timer 14 */
+    isr_tim15,               /* [20] timer 15 */
+    isr_tim16,               /* [21] timer 16 */
+    isr_tim17,               /* [22] timer 17 */
+    isr_i2c1,                /* [23] I2C 1 */
+    isr_i2c2,                /* [24] I2C 2 */
+    isr_spi1,                /* [25] SPI 1 */
+    isr_spi2,                /* [26] SPI 2 */
+    isr_usart1,              /* [27] USART 1 */
+    isr_usart2,              /* [28] USART 2 */
+    (0UL),                   /* [29] reserved */
+    isr_cec,                 /* [30] consumer electronics control */
 #elif defined(CPU_MODEL_STM32F070RB)
-    (void*) (0UL),                   /* [1] reserved */
-    (void*) isr_rtc,                 /* [2] real time clock */
-    (void*) isr_flash,               /* [3] flash memory controller */
-    (void*) isr_rcc,                 /* [4] reset and clock control */
-    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
-    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
-    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
-    (void*) isr_ts,                  /* [8] touch sensing input*/
-    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
-    (void*) isr_adc1_comp,           /* [12] analog digital converter */
-    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
-    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
-    (void*) (0UL),                   /* [15] reserved */
-    (void*) isr_tim3,                /* [16] timer 3 */
-    (void*) isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
-    (void*) isr_tim7,                /* [18] timer 7 */
-    (void*) isr_tim14,               /* [19] timer 14 */
-    (void*) isr_tim15,               /* [20] timer 15 */
-    (void*) isr_tim16,               /* [21] timer 16 */
-    (void*) isr_tim17,               /* [22] timer 17 */
-    (void*) isr_i2c1,                /* [23] I2C 1 */
-    (void*) isr_i2c2,                /* [24] I2C 2 */
-    (void*) isr_spi1,                /* [25] SPI 1 */
-    (void*) isr_spi2,                /* [26] SPI 2 */
-    (void*) isr_usart1,              /* [27] USART 1 */
-    (void*) isr_usart2,              /* [28] USART 2 */
-    (void*) isr_usart3_8,            /* [29] USART 3 to 8 */
-    (void*) (0UL),                   /* [30] reserved */
-    (void*) isr_usb                  /* [31] USB global Interrupts & EXTI Line18 Interrup */
+    (0UL),                   /* [1] reserved */
+    isr_rtc,                 /* [2] real time clock */
+    isr_flash,               /* [3] flash memory controller */
+    isr_rcc,                 /* [4] reset and clock control */
+    isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    isr_ts,                  /* [8] touch sensing input*/
+    isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    isr_adc1_comp,           /* [12] analog digital converter */
+    isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    isr_tim1_cc,             /* [14] timer 1 capture compare */
+    (0UL),                   /* [15] reserved */
+    isr_tim3,                /* [16] timer 3 */
+    isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
+    isr_tim7,                /* [18] timer 7 */
+    isr_tim14,               /* [19] timer 14 */
+    isr_tim15,               /* [20] timer 15 */
+    isr_tim16,               /* [21] timer 16 */
+    isr_tim17,               /* [22] timer 17 */
+    isr_i2c1,                /* [23] I2C 1 */
+    isr_i2c2,                /* [24] I2C 2 */
+    isr_spi1,                /* [25] SPI 1 */
+    isr_spi2,                /* [26] SPI 2 */
+    isr_usart1,              /* [27] USART 1 */
+    isr_usart2,              /* [28] USART 2 */
+    isr_usart3_8,            /* [29] USART 3 to 8 */
+    (0UL),                   /* [30] reserved */
+    isr_usb                  /* [31] USB global Interrupts & EXTI Line18 Interrup */
 #else /* CPU_MODEL_STM32_F072RB, CPU_MODEL_STM32F091RC*/
-    (void*) isr_pvd,                 /* [1] power control */
-    (void*) isr_rtc,                 /* [2] real time clock */
-    (void*) isr_flash,               /* [3] flash memory controller */
-    (void*) isr_rcc,                 /* [4] reset and clock control */
-    (void*) isr_exti,                /* [5] external interrupt lines 0 and 1 */
-    (void*) isr_exti,                /* [6] external interrupt lines 2 and 3 */
-    (void*) isr_exti,                /* [7] external interrupt lines 4 to 15 */
-    (void*) isr_ts,                  /* [8] touch sensing input*/
-    (void*) isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
-    (void*) isr_adc1_comp,           /* [12] analog digital converter */
-    (void*) isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
-    (void*) isr_tim1_cc,             /* [14] timer 1 capture compare */
-    (void*) isr_tim2,                /* [15] timer 2 */
-    (void*) isr_tim3,                /* [16] timer 3 */
-    (void*) isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
-    (void*) isr_tim7,                /* [18] timer 7 */
-    (void*) isr_tim14,               /* [19] timer 14 */
-    (void*) isr_tim15,               /* [20] timer 15 */
-    (void*) isr_tim16,               /* [21] timer 16 */
-    (void*) isr_tim17,               /* [22] timer 17 */
-    (void*) isr_i2c1,                /* [23] I2C 1 */
-    (void*) isr_i2c2,                /* [24] I2C 2 */
-    (void*) isr_spi1,                /* [25] SPI 1 */
-    (void*) isr_spi2,                /* [26] SPI 2 */
-    (void*) isr_usart1,              /* [27] USART 1 */
-    (void*) isr_usart2,              /* [28] USART 2 */
-    (void*) isr_usart3_8,            /* [29] USART 3 to 8 */
-    (void*) isr_cec,                 /* [30] consumer electronics control */
+    isr_pvd,                 /* [1] power control */
+    isr_rtc,                 /* [2] real time clock */
+    isr_flash,               /* [3] flash memory controller */
+    isr_rcc,                 /* [4] reset and clock control */
+    isr_exti,                /* [5] external interrupt lines 0 and 1 */
+    isr_exti,                /* [6] external interrupt lines 2 and 3 */
+    isr_exti,                /* [7] external interrupt lines 4 to 15 */
+    isr_ts,                  /* [8] touch sensing input*/
+    isr_dma1_ch1,            /* [9] direct memory access controller 1, channel 1*/
+    isr_dma1_ch2_3,          /* [10] direct memory access controller 1, channel 2 and 3*/
+    isr_dma1_ch4_5,          /* [11] direct memory access controller 1, channel 4 and 5*/
+    isr_adc1_comp,           /* [12] analog digital converter */
+    isr_tim1_brk_up_trg_com, /* [13] timer 1 break, update, trigger and communication */
+    isr_tim1_cc,             /* [14] timer 1 capture compare */
+    isr_tim2,                /* [15] timer 2 */
+    isr_tim3,                /* [16] timer 3 */
+    isr_tim6_dac,            /* [17] timer 6 and digital to analog converter */
+    isr_tim7,                /* [18] timer 7 */
+    isr_tim14,               /* [19] timer 14 */
+    isr_tim15,               /* [20] timer 15 */
+    isr_tim16,               /* [21] timer 16 */
+    isr_tim17,               /* [22] timer 17 */
+    isr_i2c1,                /* [23] I2C 1 */
+    isr_i2c2,                /* [24] I2C 2 */
+    isr_spi1,                /* [25] SPI 1 */
+    isr_spi2,                /* [26] SPI 2 */
+    isr_usart1,              /* [27] USART 1 */
+    isr_usart2,              /* [28] USART 2 */
+    isr_usart3_8,            /* [29] USART 3 to 8 */
+    isr_cec,                 /* [30] consumer electronics control */
 #if defined(CPU_MODEL_STM32F072RB)
-    (void*) isr_usb                  /* [31] USB global Interrupts & EXTI Line18 Interrup */
+    isr_usb                  /* [31] USB global Interrupts & EXTI Line18 Interrup */
 #endif
 #endif
 };

--- a/cpu/stm32f0/vectors.c
+++ b/cpu/stm32f0/vectors.c
@@ -63,7 +63,7 @@ WEAK_DEFAULT void isr_cec(void);
 WEAK_DEFAULT void isr_usb(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_wwdg,                /* [0] windowed watchdog */
 #if defined(CPU_MODEL_STM32F030R8)
     (0UL),                   /* [1] reserved */

--- a/cpu/stm32f1/vectors.c
+++ b/cpu/stm32f1/vectors.c
@@ -88,7 +88,7 @@ WEAK_DEFAULT void isr_dma2_ch3(void);
 WEAK_DEFAULT void isr_dma2_ch4_5(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_wwdg,               /* [0] Window WatchDog Interrupt */
     isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
     isr_tamper,             /* [2] Tamper Interrupt */

--- a/cpu/stm32f1/vectors.c
+++ b/cpu/stm32f1/vectors.c
@@ -31,10 +31,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* STM32F1 specific interrupt vectors */
 WEAK_DEFAULT void isr_wwdg(void);
 WEAK_DEFAULT void isr_pvd(void);
@@ -91,89 +87,68 @@ WEAK_DEFAULT void isr_dma2_ch2(void);
 WEAK_DEFAULT void isr_dma2_ch3(void);
 WEAK_DEFAULT void isr_dma2_ch4_5(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M3 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
-    (void*) hard_fault_default,     /* [-13] hard fault exception */
-    (void*) mem_manage_default,     /* [-12] memory manage exception */
-    (void*) bus_fault_default,      /* [-11] bus fault exception */
-    (void*) usage_fault_default,    /* [-10] usage fault exception */
-    (void*) (0UL),                  /* [-9] Reserved */
-    (void*) (0UL),                  /* [-8] Reserved */
-    (void*) (0UL),                  /* [-7] Reserved */
-    (void*) (0UL),                  /* [-6] Reserved */
-    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
-                                             switching into thread context on boot */
-    (void*) debug_mon_default,      /* [-4] debug monitor exception */
-    (void*) (0UL),                  /* [-3] Reserved */
-    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
-                                             context switching is happening here */
-    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
-    /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* [0] Window WatchDog Interrupt */
-    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
-    (void*) isr_tamper,             /* [2] Tamper Interrupt */
-    (void*) isr_rtc,                /* [3] RTC global Interrupt */
-    (void*) isr_flash,              /* [4] FLASH global Interrupt */
-    (void*) isr_rcc,                /* [5] RCC global Interrupt */
-    (void*) isr_exti,               /* [6] EXTI Line0 Interrupt */
-    (void*) isr_exti,               /* [7] EXTI Line1 Interrupt */
-    (void*) isr_exti,               /* [8] EXTI Line2 Interrupt */
-    (void*) isr_exti,               /* [9] EXTI Line3 Interrupt */
-    (void*) isr_exti,               /* [10] EXTI Line4 Interrupt */
-    (void*) isr_dma1_ch1,           /* [11] DMA1 Channel 1 global Interrupt */
-    (void*) isr_dma1_ch2,           /* [12] DMA1 Channel 2 global Interrupt */
-    (void*) isr_dma1_ch3,           /* [13] DMA1 Channel 3 global Interrupt */
-    (void*) isr_dma1_ch4,           /* [14] DMA1 Channel 4 global Interrupt */
-    (void*) isr_dma1_ch5,           /* [15] DMA1 Channel 5 global Interrupt */
-    (void*) isr_dma1_ch6,           /* [16] DMA1 Channel 6 global Interrupt */
-    (void*) isr_dma1_ch7,           /* [17] DMA1 Channel 7 global Interrupt */
-    (void*) isr_adc1_2,             /* [18] ADC1 and ADC2 global Interrupt */
-    (void*) isr_usb_hp_can1_tx,     /* [19] USB Device High Priority or CAN1 TX Interrupts */
-    (void*) isr_usb_lp_can1_rx0,    /* [20] USB Device Low Priority or CAN1 RX0 Interrupts */
-    (void*) isr_can1_rx1,           /* [21] CAN1 RX1 Interrupt */
-    (void*) isr_can1_sce,           /* [22] CAN1 SCE Interrupt */
-    (void*) isr_exti,               /* [23] External Line[9:5] Interrupts */
-    (void*) isr_tim1_brk,           /* [24] TIM1 Break Interrupt */
-    (void*) isr_tim1_up,            /* [25] TIM1 Update Interrupt */
-    (void*) isr_tim1_trg_com,       /* [26] TIM1 Trigger and Commutation Interrupt */
-    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
-    (void*) isr_tim2,               /* [28] TIM2 global Interrupt */
-    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
-    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
-    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
-    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
-    (void*) isr_usart1,             /* [37] USART1 global Interrupt */
-    (void*) isr_usart2,             /* [38] USART2 global Interrupt */
-    (void*) isr_usart3,             /* [39] USART3 global Interrupt */
-    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm through EXTI Line Interrupt */
-    (void*) isr_usb_wakeup,         /* [42] USB Device WakeUp from suspend through EXTI Line Interrupt */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wwdg,               /* [0] Window WatchDog Interrupt */
+    isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
+    isr_tamper,             /* [2] Tamper Interrupt */
+    isr_rtc,                /* [3] RTC global Interrupt */
+    isr_flash,              /* [4] FLASH global Interrupt */
+    isr_rcc,                /* [5] RCC global Interrupt */
+    isr_exti,               /* [6] EXTI Line0 Interrupt */
+    isr_exti,               /* [7] EXTI Line1 Interrupt */
+    isr_exti,               /* [8] EXTI Line2 Interrupt */
+    isr_exti,               /* [9] EXTI Line3 Interrupt */
+    isr_exti,               /* [10] EXTI Line4 Interrupt */
+    isr_dma1_ch1,           /* [11] DMA1 Channel 1 global Interrupt */
+    isr_dma1_ch2,           /* [12] DMA1 Channel 2 global Interrupt */
+    isr_dma1_ch3,           /* [13] DMA1 Channel 3 global Interrupt */
+    isr_dma1_ch4,           /* [14] DMA1 Channel 4 global Interrupt */
+    isr_dma1_ch5,           /* [15] DMA1 Channel 5 global Interrupt */
+    isr_dma1_ch6,           /* [16] DMA1 Channel 6 global Interrupt */
+    isr_dma1_ch7,           /* [17] DMA1 Channel 7 global Interrupt */
+    isr_adc1_2,             /* [18] ADC1 and ADC2 global Interrupt */
+    isr_usb_hp_can1_tx,     /* [19] USB Device High Priority or CAN1 TX Interrupts */
+    isr_usb_lp_can1_rx0,    /* [20] USB Device Low Priority or CAN1 RX0 Interrupts */
+    isr_can1_rx1,           /* [21] CAN1 RX1 Interrupt */
+    isr_can1_sce,           /* [22] CAN1 SCE Interrupt */
+    isr_exti,               /* [23] External Line[9:5] Interrupts */
+    isr_tim1_brk,           /* [24] TIM1 Break Interrupt */
+    isr_tim1_up,            /* [25] TIM1 Update Interrupt */
+    isr_tim1_trg_com,       /* [26] TIM1 Trigger and Commutation Interrupt */
+    isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
+    isr_tim2,               /* [28] TIM2 global Interrupt */
+    isr_tim3,               /* [29] TIM3 global Interrupt */
+    isr_tim4,               /* [30] TIM4 global Interrupt */
+    isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
+    isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    isr_i2c2_ev,            /* [33] I2C2 Event Interrupt */
+    isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    isr_spi1,               /* [35] SPI1 global Interrupt */
+    isr_spi2,               /* [36] SPI2 global Interrupt */
+    isr_usart1,             /* [37] USART1 global Interrupt */
+    isr_usart2,             /* [38] USART2 global Interrupt */
+    isr_usart3,             /* [39] USART3 global Interrupt */
+    isr_exti,               /* [40] External Line[15:10] Interrupts */
+    isr_rtc_alarm,          /* [41] RTC Alarm through EXTI Line Interrupt */
+    isr_usb_wakeup,         /* [42] USB Device WakeUp from suspend through EXTI Line Interrupt */
 #if defined(CPU_MODEL_STM32F103RE)
-    (void*) isr_tim8_brk,           /* [43] TIM8 Break Interrupt */
-    (void*) isr_tim8_up,            /* [44] TIM8 Update Interrupt */
-    (void*) isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
-    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
-    (void*) isr_adc3,               /* [47] ADC3 global Interrupt */
-    (void*) isr_fsmc,               /* [48] FSMC global Interrupt */
-    (void*) isr_sdio,               /* [49] SDIO global Interrupt */
-    (void*) isr_tim5,               /* [50] TIM5 global Interrupt */
-    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
-    (void*) isr_uart4,              /* [52] UART4 global Interrupt */
-    (void*) isr_uart5,              /* [53] UART5 global Interrupt */
-    (void*) isr_tim6,               /* [54] TIM6 global Interrupt */
-    (void*) isr_tim7,               /* [55] TIM7 global Interrupt */
-    (void*) isr_dma2_ch1,           /* [56] DMA2 Channel 1 global Interrupt */
-    (void*) isr_dma2_ch2,           /* [57] DMA2 Channel 2 global Interrupt */
-    (void*) isr_dma2_ch3,           /* [58] DMA2 Channel 3 global Interrupt */
-    (void*) isr_dma2_ch4_5,         /* [59] DMA2 Channel 4 and Channel 5 global Interrupt */
+    isr_tim8_brk,           /* [43] TIM8 Break Interrupt */
+    isr_tim8_up,            /* [44] TIM8 Update Interrupt */
+    isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
+    isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
+    isr_adc3,               /* [47] ADC3 global Interrupt */
+    isr_fsmc,               /* [48] FSMC global Interrupt */
+    isr_sdio,               /* [49] SDIO global Interrupt */
+    isr_tim5,               /* [50] TIM5 global Interrupt */
+    isr_spi3,               /* [51] SPI3 global Interrupt */
+    isr_uart4,              /* [52] UART4 global Interrupt */
+    isr_uart5,              /* [53] UART5 global Interrupt */
+    isr_tim6,               /* [54] TIM6 global Interrupt */
+    isr_tim7,               /* [55] TIM7 global Interrupt */
+    isr_dma2_ch1,           /* [56] DMA2 Channel 1 global Interrupt */
+    isr_dma2_ch2,           /* [57] DMA2 Channel 2 global Interrupt */
+    isr_dma2_ch3,           /* [58] DMA2 Channel 3 global Interrupt */
+    isr_dma2_ch4_5,         /* [59] DMA2 Channel 4 and Channel 5 global Interrupt */
 #endif
 };

--- a/cpu/stm32f2/vectors.c
+++ b/cpu/stm32f2/vectors.c
@@ -112,173 +112,152 @@ WEAK_DEFAULT void isr_dcmi(void);
 WEAK_DEFAULT void isr_cryp(void);
 WEAK_DEFAULT void isr_hash_rng(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M3 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
-    (void*) hard_fault_default,     /* [-13] hard fault exception */
-    (void*) mem_manage_default,     /* [-12] memory manage exception */
-    (void*) bus_fault_default,      /* [-11] bus fault exception */
-    (void*) usage_fault_default,    /* [-10] usage fault exception */
-    (void*) (0UL),                  /* [-9] Reserved */
-    (void*) (0UL),                  /* [-8] Reserved */
-    (void*) (0UL),                  /* [-7] Reserved */
-    (void*) (0UL),                  /* [-6] Reserved */
-    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
-                                            switching into thread context on boot */
-    (void*) debug_mon_default,      /* [-4] debug monitor exception */
-    (void*) (0UL),                  /* [-3] Reserved */
-    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
-                                            context switching is happening here */
-    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
-    /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* [0] Window WatchDog */
-    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection */
-    (void*) isr_tamp_stamp,         /* [2] Tamper and TimeStamps through the EXTI line */
-    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup through the EXTI line */
-    (void*) isr_flash,              /* [4] FLASH */
-    (void*) isr_rcc,                /* [5] RCC */
-    (void*) isr_exti,               /* [6] EXTI Line0 */
-    (void*) isr_exti,               /* [7] EXTI Line1 */
-    (void*) isr_exti,               /* [8] EXTI Line2 */
-    (void*) isr_exti,               /* [9] EXTI Line3 */
-    (void*) isr_exti,               /* [10] EXTI Line4 */
-    (void*) isr_dma1_stream0,       /* [11] DMA1 Stream 0 */
-    (void*) isr_dma1_stream1,       /* [12] DMA1 Stream 1 */
-    (void*) isr_dma1_stream2,       /* [13] DMA1 Stream 2 */
-    (void*) isr_dma1_stream3,       /* [14] DMA1 Stream 3 */
-    (void*) isr_dma1_stream4,       /* [15] DMA1 Stream 4 */
-    (void*) isr_dma1_stream5,       /* [16] DMA1 Stream 5 */
-    (void*) isr_dma1_stream6,       /* [17] DMA1 Stream 6 */
-    (void*) isr_adc,                /* [18] ADC1, ADC2 and ADC3s */
-    (void*) isr_can1_tx,            /* [19] CAN1 TX */
-    (void*) isr_can1_rx0,           /* [20] CAN1 RX0 */
-    (void*) isr_can1_rx1,           /* [21] CAN1 RX1 */
-    (void*) isr_can1_sce,           /* [22] CAN1 SCE */
-    (void*) isr_exti,               /* [23] External Line[9:5]s */
-    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
-    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
-    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
-    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
-    (void*) isr_tim2,               /* [28] TIM2 */
-    (void*) isr_tim3,               /* [29] TIM3 */
-    (void*) isr_tim4,               /* [30] TIM4 */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
-    (void*) isr_spi1,               /* [35] SPI1 */
-    (void*) isr_spi2,               /* [36] SPI2 */
-    (void*) isr_usart1,             /* [37] USART1 */
-    (void*) isr_usart2,             /* [38] USART2 */
-    (void*) isr_usart3,             /* [39] USART3 */
-    (void*) isr_exti,               /* [40] External Line[15:10]s */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
-    (void*) isr_otg_fs_wkup,        /* [42] USB OTG FS Wakeup through EXTI line */
-    (void*) isr_tim8_brk_tim12,     /* [43] TIM8 Break and TIM12 */
-    (void*) isr_tim8_up_tim13,      /* [44] TIM8 Update and TIM13 */
-    (void*) isr_tim8_trg_com_tim14, /* [45] TIM8 Trigger and Commutation and TIM14 */
-    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare */
-    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
-    (void*) isr_fsmc,               /* [48] FSMC */
-    (void*) isr_sdio,               /* [49] SDIO */
-    (void*) isr_tim5,               /* [50] TIM5 */
-    (void*) isr_spi3,               /* [51] SPI3 */
-    (void*) isr_uart4,              /* [52] UART4 */
-    (void*) isr_uart5,              /* [53] UART5 */
-    (void*) isr_tim6_dac,           /* [54] TIM6 and DAC1&2 underrun errors */
-    (void*) isr_tim7,               /* [55] TIM7 */
-    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
-    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
-    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
-    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
-    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wwdg,               /* [0] Window WatchDog */
+    isr_pvd,                /* [1] PVD through EXTI Line detection */
+    isr_tamp_stamp,         /* [2] Tamper and TimeStamps through the EXTI line */
+    isr_rtc_wkup,           /* [3] RTC Wakeup through the EXTI line */
+    isr_flash,              /* [4] FLASH */
+    isr_rcc,                /* [5] RCC */
+    isr_exti,               /* [6] EXTI Line0 */
+    isr_exti,               /* [7] EXTI Line1 */
+    isr_exti,               /* [8] EXTI Line2 */
+    isr_exti,               /* [9] EXTI Line3 */
+    isr_exti,               /* [10] EXTI Line4 */
+    isr_dma1_stream0,       /* [11] DMA1 Stream 0 */
+    isr_dma1_stream1,       /* [12] DMA1 Stream 1 */
+    isr_dma1_stream2,       /* [13] DMA1 Stream 2 */
+    isr_dma1_stream3,       /* [14] DMA1 Stream 3 */
+    isr_dma1_stream4,       /* [15] DMA1 Stream 4 */
+    isr_dma1_stream5,       /* [16] DMA1 Stream 5 */
+    isr_dma1_stream6,       /* [17] DMA1 Stream 6 */
+    isr_adc,                /* [18] ADC1, ADC2 and ADC3s */
+    isr_can1_tx,            /* [19] CAN1 TX */
+    isr_can1_rx0,           /* [20] CAN1 RX0 */
+    isr_can1_rx1,           /* [21] CAN1 RX1 */
+    isr_can1_sce,           /* [22] CAN1 SCE */
+    isr_exti,               /* [23] External Line[9:5]s */
+    isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    isr_tim2,               /* [28] TIM2 */
+    isr_tim3,               /* [29] TIM3 */
+    isr_tim4,               /* [30] TIM4 */
+    isr_i2c1_ev,            /* [31] I2C1 Event */
+    isr_i2c1_er,            /* [32] I2C1 Error */
+    isr_i2c2_ev,            /* [33] I2C2 Event */
+    isr_i2c2_er,            /* [34] I2C2 Error */
+    isr_spi1,               /* [35] SPI1 */
+    isr_spi2,               /* [36] SPI2 */
+    isr_usart1,             /* [37] USART1 */
+    isr_usart2,             /* [38] USART2 */
+    isr_usart3,             /* [39] USART3 */
+    isr_exti,               /* [40] External Line[15:10]s */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    isr_otg_fs_wkup,        /* [42] USB OTG FS Wakeup through EXTI line */
+    isr_tim8_brk_tim12,     /* [43] TIM8 Break and TIM12 */
+    isr_tim8_up_tim13,      /* [44] TIM8 Update and TIM13 */
+    isr_tim8_trg_com_tim14, /* [45] TIM8 Trigger and Commutation and TIM14 */
+    isr_tim8_cc,            /* [46] TIM8 Capture Compare */
+    isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    isr_fsmc,               /* [48] FSMC */
+    isr_sdio,               /* [49] SDIO */
+    isr_tim5,               /* [50] TIM5 */
+    isr_spi3,               /* [51] SPI3 */
+    isr_uart4,              /* [52] UART4 */
+    isr_uart5,              /* [53] UART5 */
+    isr_tim6_dac,           /* [54] TIM6 and DAC1&2 underrun errors */
+    isr_tim7,               /* [55] TIM7 */
+    isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
 #if defined(CPU_MODEL_STM32F205RG)
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* [77] USB OTG HS */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    isr_otg_hs,             /* [77] USB OTG HS */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    isr_hash_rng,           /* [80] Hash and Rng */
 #elif defined(CPU_MODEL_STM32F207ZG)
-    (void*) isr_eth,                /* [61] Ethernet */
-    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* [77] USB OTG HS */
-    (void*) isr_dcmi,               /* [78] DCMI */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+    isr_eth,                /* [61] Ethernet */
+    isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    isr_otg_hs,             /* [77] USB OTG HS */
+    isr_dcmi,               /* [78] DCMI */
+    (0UL),                  /* [79] Reserved */
+    isr_hash_rng,           /* [80] Hash and Rng */
 #elif defined(CPU_MODEL_STM32F215RG) || defined (CPU_MODEL_STM32F215VG)
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* [77] USB OTG HS */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) isr_cryp,               /* [79] CRYP crypto */
-    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    isr_otg_hs,             /* [77] USB OTG HS */
+    (0UL),                  /* [78] Reserved */
+    isr_cryp,               /* [79] CRYP crypto */
+    isr_hash_rng,           /* [80] Hash and Rng */
 #else /* CPU_MODEL_STM32F217ZG */
-    (void*) isr_eth,                /* [61] Ethernet */
-    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* [77] USB OTG HS */
-    (void*) isr_dcmi,               /* [78] DCMI */
-    (void*) isr_cryp,               /* [79] CRYP crypto */
-    (void*) isr_hash_rng,           /* [80] Hash and Rng */
+    isr_eth,                /* [61] Ethernet */
+    isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    isr_otg_hs,             /* [77] USB OTG HS */
+    isr_dcmi,               /* [78] DCMI */
+    isr_cryp,               /* [79] CRYP crypto */
+    isr_hash_rng,           /* [80] Hash and Rng */
 #endif
 };

--- a/cpu/stm32f2/vectors.c
+++ b/cpu/stm32f2/vectors.c
@@ -113,7 +113,7 @@ WEAK_DEFAULT void isr_cryp(void);
 WEAK_DEFAULT void isr_hash_rng(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_wwdg,               /* [0] Window WatchDog */
     isr_pvd,                /* [1] PVD through EXTI Line detection */
     isr_tamp_stamp,         /* [2] Tamper and TimeStamps through the EXTI line */

--- a/cpu/stm32f3/vectors.c
+++ b/cpu/stm32f3/vectors.c
@@ -30,10 +30,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* STM32F3 specific interrupt vectors */
 WEAK_DEFAULT void isr_wwdg(void);
 WEAK_DEFAULT void isr_pvd(void);
@@ -112,293 +108,272 @@ WEAK_DEFAULT void isr_tim20_cc(void);
 WEAK_DEFAULT void isr_fpu(void);
 WEAK_DEFAULT void isr_spi4(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M4 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
-    (void*) hard_fault_default,     /* [-13] hard fault exception */
-    (void*) mem_manage_default,     /* [-12] memory manage exception */
-    (void*) bus_fault_default,      /* [-11] bus fault exception */
-    (void*) usage_fault_default,    /* [-10] usage fault exception */
-    (void*) (0UL),                  /* [-9] Reserved */
-    (void*) (0UL),                  /* [-8] Reserved */
-    (void*) (0UL),                  /* [-7] Reserved */
-    (void*) (0UL),                  /* [-6] Reserved */
-    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
-                                            switching into thread context on boot */
-    (void*) debug_mon_default,      /* [-4] debug monitor exception */
-    (void*) (0UL),                  /* [-3] Reserved */
-    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
-                                            context switching is happening here */
-    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
-    /* STMF3 specific peripheral handlers */
-    (void*) isr_wwdg,               /* [0] Window WatchDog Interrupt */
-    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
-    (void*) isr_tamp_stamp,         /* [2] Tamper and TimeStamp interrupts through the EXTI line 19 */
-    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup interrupt through the EXTI line 20 */
-    (void*) isr_flash,              /* [4] FLASH global Interrupt */
-    (void*) isr_rcc,                /* [5] RCC global Interrupt */
-    (void*) isr_exti,               /* [6] EXTI Line0 Interrupt */
-    (void*) isr_exti,               /* [7] EXTI Line1 Interrupt */
-    (void*) isr_exti,               /* [8] EXTI Line2 Interrupt and Touch Sense Controller Interrupt */
-    (void*) isr_exti,               /* [9] EXTI Line3 Interrupt */
-    (void*) isr_exti,               /* [10] EXTI Line4 Interrupt */
-    (void*) isr_dma1_channel1,      /* [11] DMA1 Channel 1 Interrupt */
-    (void*) isr_dma1_channel2,      /* [12] DMA1 Channel 2 Interrupt */
-    (void*) isr_dma1_channel3,      /* [13] DMA1 Channel 3 Interrupt */
-    (void*) isr_dma1_channel4,      /* [14] DMA1 Channel 4 Interrupt */
-    (void*) isr_dma1_channel5,      /* [15] DMA1 Channel 5 Interrupt */
-    (void*) isr_dma1_channel6,      /* [16] DMA1 Channel 6 Interrupt */
-    (void*) isr_dma1_channel7,      /* [17] DMA1 Channel 7 Interrupt */
-    (void*) isr_adc1_2,             /* [18] ADC1 & ADC2 Interrupts */
-    (void*) isr_usb_hp_can_tx,      /* [19] USB Device High Priority or CAN TX Interrupts */
-    (void*) isr_usb_lp_can_rx0,     /* [20] USB Device Low Priority or CAN RX0 Interrupts */
-    (void*) isr_can_rx1,            /* [21] CAN RX1 Interrupt */
-    (void*) isr_can_sce,            /* [22] CAN SCE Interrupt */
-    (void*) isr_exti,               /* [23] External Line[9:5] Interrupts */
-    (void*) isr_tim1_brk_tim15,     /* [24] TIM1 Break and TIM15 Interrupts */
-    (void*) isr_tim1_up_tim16,      /* [25] TIM1 Update and TIM16 Interrupts */
-    (void*) isr_tim1_trg_com_tim17, /* [26] TIM1 Trigger and Commutation and TIM17 Interrupt */
-    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
-    (void*) isr_tim2,               /* [28] TIM2 global Interrupt */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wwdg,               /* [0] Window WatchDog Interrupt */
+    isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
+    isr_tamp_stamp,         /* [2] Tamper and TimeStamp interrupts through the EXTI line 19 */
+    isr_rtc_wkup,           /* [3] RTC Wakeup interrupt through the EXTI line 20 */
+    isr_flash,              /* [4] FLASH global Interrupt */
+    isr_rcc,                /* [5] RCC global Interrupt */
+    isr_exti,               /* [6] EXTI Line0 Interrupt */
+    isr_exti,               /* [7] EXTI Line1 Interrupt */
+    isr_exti,               /* [8] EXTI Line2 Interrupt and Touch Sense Controller Interrupt */
+    isr_exti,               /* [9] EXTI Line3 Interrupt */
+    isr_exti,               /* [10] EXTI Line4 Interrupt */
+    isr_dma1_channel1,      /* [11] DMA1 Channel 1 Interrupt */
+    isr_dma1_channel2,      /* [12] DMA1 Channel 2 Interrupt */
+    isr_dma1_channel3,      /* [13] DMA1 Channel 3 Interrupt */
+    isr_dma1_channel4,      /* [14] DMA1 Channel 4 Interrupt */
+    isr_dma1_channel5,      /* [15] DMA1 Channel 5 Interrupt */
+    isr_dma1_channel6,      /* [16] DMA1 Channel 6 Interrupt */
+    isr_dma1_channel7,      /* [17] DMA1 Channel 7 Interrupt */
+    isr_adc1_2,             /* [18] ADC1 & ADC2 Interrupts */
+    isr_usb_hp_can_tx,      /* [19] USB Device High Priority or CAN TX Interrupts */
+    isr_usb_lp_can_rx0,     /* [20] USB Device Low Priority or CAN RX0 Interrupts */
+    isr_can_rx1,            /* [21] CAN RX1 Interrupt */
+    isr_can_sce,            /* [22] CAN SCE Interrupt */
+    isr_exti,               /* [23] External Line[9:5] Interrupts */
+    isr_tim1_brk_tim15,     /* [24] TIM1 Break and TIM15 Interrupts */
+    isr_tim1_up_tim16,      /* [25] TIM1 Update and TIM16 Interrupts */
+    isr_tim1_trg_com_tim17, /* [26] TIM1 Trigger and Commutation and TIM17 Interrupt */
+    isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
+    isr_tim2,               /* [28] TIM2 global Interrupt */
 #if defined(CPU_MODEL_STM32F302R8)
-    (void*) (0UL),                  /* [29] Reserved */
-    (void*) (0UL),                  /* [30] Reserved */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt & EXTI Line24 Interrupt (I2C2 wakeup) */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
-    (void*) (0UL),                  /* [35] Reserved */
-    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
-    (void*) isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
-    (void*) isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
-    (void*) isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
-    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
-    (void*) isr_usbwakeup,          /* [42] USB Wakeup Interrupt */
-    (void*) (0UL),                  /* [43] Reserved */
-    (void*) (0UL),                  /* [44] Reserved */
-    (void*) (0UL),                  /* [45] Reserved */
-    (void*) (0UL),                  /* [46] Reserved */
-    (void*) (0UL),                  /* [47] Reserved */
-    (void*) (0UL),                  /* [48] Reserved */
-    (void*) (0UL),                  /* [49] Reserved */
-    (void*) (0UL),                  /* [50] Reserved */
-    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
-    (void*) (0UL),                  /* [52] Reserved */
-    (void*) (0UL),                  /* [53] Reserved */
-    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error  interrupts */
-    (void*) (0UL),                  /* [55] Reserved */
-    (void*) (0UL),                  /* [56] Reserved */
-    (void*) (0UL),                  /* [57] Reserved */
-    (void*) (0UL),                  /* [58] Reserved */
-    (void*) (0UL),                  /* [59] Reserved */
-    (void*) (0UL),                  /* [60] Reserved */
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) (0UL),                  /* [63] Reserved */
-    (void*) isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
-    (void*) isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
-    (void*) (0UL),                  /* [66] Reserved */
-    (void*) (0UL),                  /* [67] Reserved */
-    (void*) (0UL),                  /* [68] Reserved */
-    (void*) (0UL),                  /* [69] Reserved */
-    (void*) (0UL),                  /* [70] Reserved */
-    (void*) (0UL),                  /* [71] Reserved */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event interrupt */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error interrupt */
-    (void*) isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
-    (void*) isr_usb_lp,             /* [75] USB Low Priority global Interrupt  remap */
-    (void*) isr_usbwakeup_rmp,      /* [76] USB Wakeup Interrupt remap */
-    (void*) (0UL),                  /* [77] Reserved */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [80] Reserved */
-    (void*) isr_fpu                 /* [81] Floating point Interrupt */
+    (0UL),                  /* [29] Reserved */
+    (0UL),                  /* [30] Reserved */
+    isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
+    isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    isr_i2c2_ev,            /* [33] I2C2 Event Interrupt & EXTI Line24 Interrupt (I2C2 wakeup) */
+    isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    (0UL),                  /* [35] Reserved */
+    isr_spi2,               /* [36] SPI2 global Interrupt */
+    isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
+    isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
+    isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
+    isr_exti,               /* [40] External Line[15:10] Interrupts */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
+    isr_usbwakeup,          /* [42] USB Wakeup Interrupt */
+    (0UL),                  /* [43] Reserved */
+    (0UL),                  /* [44] Reserved */
+    (0UL),                  /* [45] Reserved */
+    (0UL),                  /* [46] Reserved */
+    (0UL),                  /* [47] Reserved */
+    (0UL),                  /* [48] Reserved */
+    (0UL),                  /* [49] Reserved */
+    (0UL),                  /* [50] Reserved */
+    isr_spi3,               /* [51] SPI3 global Interrupt */
+    (0UL),                  /* [52] Reserved */
+    (0UL),                  /* [53] Reserved */
+    isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error  interrupts */
+    (0UL),                  /* [55] Reserved */
+    (0UL),                  /* [56] Reserved */
+    (0UL),                  /* [57] Reserved */
+    (0UL),                  /* [58] Reserved */
+    (0UL),                  /* [59] Reserved */
+    (0UL),                  /* [60] Reserved */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    (0UL),                  /* [63] Reserved */
+    isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
+    isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
+    (0UL),                  /* [66] Reserved */
+    (0UL),                  /* [67] Reserved */
+    (0UL),                  /* [68] Reserved */
+    (0UL),                  /* [69] Reserved */
+    (0UL),                  /* [70] Reserved */
+    (0UL),                  /* [71] Reserved */
+    isr_i2c3_ev,            /* [72] I2C3 event interrupt */
+    isr_i2c3_er,            /* [73] I2C3 error interrupt */
+    isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
+    isr_usb_lp,             /* [75] USB Low Priority global Interrupt  remap */
+    isr_usbwakeup_rmp,      /* [76] USB Wakeup Interrupt remap */
+    (0UL),                  /* [77] Reserved */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [80] Reserved */
+    isr_fpu                 /* [81] Floating point Interrupt */
 #elif defined(CPU_MODEL_STM32F303K8)
-    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
-    (void*) (0UL),                  /* [30] Reserved */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
-    (void*) (0UL),                  /* [33] Reserved */
-    (void*) (0UL),                  /* [34] Reserved */
-    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
-    (void*) (0UL),                  /* [36] Reserved */
-    (void*) isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
-    (void*) isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
-    (void*) isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
-    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
-    (void*) (0UL),                  /* [42] Reserved */
-    (void*) (0UL),                  /* [43] Reserved */
-    (void*) (0UL),                  /* [44] Reserved */
-    (void*) (0UL),                  /* [45] Reserved */
-    (void*) (0UL),                  /* [46] Reserved */
-    (void*) (0UL),                  /* [47] Reserved */
-    (void*) (0UL),                  /* [48] Reserved */
-    (void*) (0UL),                  /* [49] Reserved */
-    (void*) (0UL),                  /* [50] Reserved */
-    (void*) (0UL),                  /* [51] Reserved */
-    (void*) (0UL),                  /* [52] Reserved */
-    (void*) (0UL),                  /* [53] Reserved */
-    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error interrupts */
-    (void*) isr_tim7_dac,           /* [55] TIM7 global and DAC2 channel1 underrun error Interrupt */
-    (void*) (0UL),                  /* [56] Reserved */
-    (void*) (0UL),                  /* [57] Reserved */
-    (void*) (0UL),                  /* [58] Reserved */
-    (void*) (0UL),                  /* [59] Reserved */
-    (void*) (0UL),                  /* [60] Reserved */
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) (0UL),                  /* [63] Reserved */
-    (void*) isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
-    (void*) isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
-    (void*) (0UL),                  /* [66] Reserved */
-    (void*) (0UL),                  /* [67] Reserved */
-    (void*) (0UL),                  /* [68] Reserved */
-    (void*) (0UL),                  /* [69] Reserved */
-    (void*) (0UL),                  /* [70] Reserved */
-    (void*) (0UL),                  /* [71] Reserved */
-    (void*) (0UL),                  /* [72] Reserved */
-    (void*) (0UL),                  /* [73] Reserved */
-    (void*) (0UL),                  /* [74] Reserved */
-    (void*) (0UL),                  /* [75] Reserved */
-    (void*) (0UL),                  /* [76] Reserved */
-    (void*) (0UL),                  /* [77] Reserved */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [80] Reserved */
-    (void*) isr_fpu                 /* [81] Floating point Interrupt */
+    isr_tim3,               /* [29] TIM3 global Interrupt */
+    (0UL),                  /* [30] Reserved */
+    isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
+    isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (0UL),                  /* [33] Reserved */
+    (0UL),                  /* [34] Reserved */
+    isr_spi1,               /* [35] SPI1 global Interrupt */
+    (0UL),                  /* [36] Reserved */
+    isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
+    isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
+    isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
+    isr_exti,               /* [40] External Line[15:10] Interrupts */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
+    (0UL),                  /* [42] Reserved */
+    (0UL),                  /* [43] Reserved */
+    (0UL),                  /* [44] Reserved */
+    (0UL),                  /* [45] Reserved */
+    (0UL),                  /* [46] Reserved */
+    (0UL),                  /* [47] Reserved */
+    (0UL),                  /* [48] Reserved */
+    (0UL),                  /* [49] Reserved */
+    (0UL),                  /* [50] Reserved */
+    (0UL),                  /* [51] Reserved */
+    (0UL),                  /* [52] Reserved */
+    (0UL),                  /* [53] Reserved */
+    isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error interrupts */
+    isr_tim7_dac,           /* [55] TIM7 global and DAC2 channel1 underrun error Interrupt */
+    (0UL),                  /* [56] Reserved */
+    (0UL),                  /* [57] Reserved */
+    (0UL),                  /* [58] Reserved */
+    (0UL),                  /* [59] Reserved */
+    (0UL),                  /* [60] Reserved */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    (0UL),                  /* [63] Reserved */
+    isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
+    isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
+    (0UL),                  /* [66] Reserved */
+    (0UL),                  /* [67] Reserved */
+    (0UL),                  /* [68] Reserved */
+    (0UL),                  /* [69] Reserved */
+    (0UL),                  /* [70] Reserved */
+    (0UL),                  /* [71] Reserved */
+    (0UL),                  /* [72] Reserved */
+    (0UL),                  /* [73] Reserved */
+    (0UL),                  /* [74] Reserved */
+    (0UL),                  /* [75] Reserved */
+    (0UL),                  /* [76] Reserved */
+    (0UL),                  /* [77] Reserved */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [80] Reserved */
+    isr_fpu                 /* [81] Floating point Interrupt */
 #elif (CPU_MODEL_STM32F334R8)
-    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
-    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
-    (void*) (0UL),                  /* [33] Reserved */
-    (void*) (0UL),                  /* [34] Reserved */
-    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
-    (void*) (0UL),                  /* [36] Reserved */
-    (void*) isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
-    (void*) isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
-    (void*) isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
-    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
-    (void*) (0UL),                  /* [42] Reserved */
-    (void*) (0UL),                  /* [43] Reserved */
-    (void*) (0UL),                  /* [44] Reserved */
-    (void*) (0UL),                  /* [45] Reserved */
-    (void*) (0UL),                  /* [46] Reserved */
-    (void*) (0UL),                  /* [47] Reserved */
-    (void*) (0UL),                  /* [48] Reserved */
-    (void*) (0UL),                  /* [49] Reserved */
-    (void*) (0UL),                  /* [50] Reserved */
-    (void*) (0UL),                  /* [51] Reserved */
-    (void*) (0UL),                  /* [52] Reserved */
-    (void*) (0UL),                  /* [53] Reserved */
-    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error  interrupts */
-    (void*) isr_tim7_dac,           /* [55] TIM7 global and DAC2 channel1 underrun error Interrupt */
-    (void*) (0UL),                  /* [56] Reserved */
-    (void*) (0UL),                  /* [57] Reserved */
-    (void*) (0UL),                  /* [58] Reserved */
-    (void*) (0UL),                  /* [59] Reserved */
-    (void*) (0UL),                  /* [60] Reserved */
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) (0UL),                  /* [63] Reserved */
-    (void*) isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
-    (void*) isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
-    (void*) (0UL),                  /* [66] Reserved */
-    (void*) isr_hrtim,              /* [67] HRTIM Master Timer global Interrupts */
-    (void*) isr_hrtim_tim_a,        /* [68] HRTIM Timer A global Interrupt */
-    (void*) isr_hrtim_tim_b,        /* [69] HRTIM Timer B global Interrupt */
-    (void*) isr_hrtim_tim_c,        /* [70] HRTIM Timer C global Interrupt */
-    (void*) isr_hrtim_tim_d,        /* [71] HRTIM Timer D global Interrupt */
-    (void*) isr_hrtim_tim_e,        /* [72] HRTIM Timer E global Interrupt */
-    (void*) isr_hrtim_flt,          /* [73] HRTIM Fault global Interrupt */
-    (void*) (0UL),                  /* [74] Reserved */
-    (void*) (0UL),                  /* [75] Reserved */
-    (void*) (0UL),                  /* [76] Reserved */
-    (void*) (0UL),                  /* [77] Reserved */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [80] Reserved */
-    (void*) isr_fpu                 /* [81] Floating point Interrupt */
+    isr_tim3,               /* [29] TIM3 global Interrupt */
+    isr_tim4,               /* [30] TIM4 global Interrupt */
+    isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
+    isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (0UL),                  /* [33] Reserved */
+    (0UL),                  /* [34] Reserved */
+    isr_spi1,               /* [35] SPI1 global Interrupt */
+    (0UL),                  /* [36] Reserved */
+    isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
+    isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
+    isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
+    isr_exti,               /* [40] External Line[15:10] Interrupts */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
+    (0UL),                  /* [42] Reserved */
+    (0UL),                  /* [43] Reserved */
+    (0UL),                  /* [44] Reserved */
+    (0UL),                  /* [45] Reserved */
+    (0UL),                  /* [46] Reserved */
+    (0UL),                  /* [47] Reserved */
+    (0UL),                  /* [48] Reserved */
+    (0UL),                  /* [49] Reserved */
+    (0UL),                  /* [50] Reserved */
+    (0UL),                  /* [51] Reserved */
+    (0UL),                  /* [52] Reserved */
+    (0UL),                  /* [53] Reserved */
+    isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error  interrupts */
+    isr_tim7_dac,           /* [55] TIM7 global and DAC2 channel1 underrun error Interrupt */
+    (0UL),                  /* [56] Reserved */
+    (0UL),                  /* [57] Reserved */
+    (0UL),                  /* [58] Reserved */
+    (0UL),                  /* [59] Reserved */
+    (0UL),                  /* [60] Reserved */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    (0UL),                  /* [63] Reserved */
+    isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
+    isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
+    (0UL),                  /* [66] Reserved */
+    isr_hrtim,              /* [67] HRTIM Master Timer global Interrupts */
+    isr_hrtim_tim_a,        /* [68] HRTIM Timer A global Interrupt */
+    isr_hrtim_tim_b,        /* [69] HRTIM Timer B global Interrupt */
+    isr_hrtim_tim_c,        /* [70] HRTIM Timer C global Interrupt */
+    isr_hrtim_tim_d,        /* [71] HRTIM Timer D global Interrupt */
+    isr_hrtim_tim_e,        /* [72] HRTIM Timer E global Interrupt */
+    isr_hrtim_flt,          /* [73] HRTIM Fault global Interrupt */
+    (0UL),                  /* [74] Reserved */
+    (0UL),                  /* [75] Reserved */
+    (0UL),                  /* [76] Reserved */
+    (0UL),                  /* [77] Reserved */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [80] Reserved */
+    isr_fpu                 /* [81] Floating point Interrupt */
 #else /* CPU_MODEL_STM32F303VC, CPU_MODEL_STM32F303RE, CPU_MODEL_STM32F303ZE */
-    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
-    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt & EXTI Line24 Interrupt (I2C2 wakeup) */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
-    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
-    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
-    (void*) isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
-    (void*) isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
-    (void*) isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
-    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
-    (void*) isr_usbwakeup,          /* [42] USB Wakeup Interrupt */
-    (void*) isr_tim8_brk,           /* [43] TIM8 Break Interrupt */
-    (void*) isr_tim8_up,            /* [44] TIM8 Update Interrupt */
-    (void*) isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
-    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
-    (void*) isr_adc3,               /* [47] ADC3 global Interrupt */
+    isr_tim3,               /* [29] TIM3 global Interrupt */
+    isr_tim4,               /* [30] TIM4 global Interrupt */
+    isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
+    isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    isr_i2c2_ev,            /* [33] I2C2 Event Interrupt & EXTI Line24 Interrupt (I2C2 wakeup) */
+    isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    isr_spi1,               /* [35] SPI1 global Interrupt */
+    isr_spi2,               /* [36] SPI2 global Interrupt */
+    isr_usart1,             /* [37] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
+    isr_usart2,             /* [38] USART2 global Interrupt & EXTI Line26 Interrupt (USART2 wakeup) */
+    isr_usart3,             /* [39] USART3 global Interrupt & EXTI Line28 Interrupt (USART3 wakeup) */
+    isr_exti,               /* [40] External Line[15:10] Interrupts */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line 17 Interrupt */
+    isr_usbwakeup,          /* [42] USB Wakeup Interrupt */
+    isr_tim8_brk,           /* [43] TIM8 Break Interrupt */
+    isr_tim8_up,            /* [44] TIM8 Update Interrupt */
+    isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
+    isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
+    isr_adc3,               /* [47] ADC3 global Interrupt */
 #if defined(CPU_MODEL_STM32F303VC)
-    (void*) (0UL),                  /* [48] Reserved */
+    (0UL),                  /* [48] Reserved */
 #else
-    (void*) isr_fmc,                /* [48] FMC global Interrupt */
+    isr_fmc,                /* [48] FMC global Interrupt */
 #endif
-    (void*) (0UL),                  /* [49] Reserved */
-    (void*) (0UL),                  /* [50] Reserved */
-    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
-    (void*) isr_uart4,              /* [52] UART4 global Interrupt & EXTI Line34 Interrupt (UART4 wakeup) */
-    (void*) isr_uart5,              /* [53] UART5 global Interrupt & EXTI Line35 Interrupt (UART5 wakeup) */
-    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error  interrupts */
-    (void*) isr_tim7,               /* [55] TIM7 global Interrupt */
-    (void*) isr_dma2_channel1,      /* [56] DMA2 Channel 1 global Interrupt */
-    (void*) isr_dma2_channel2,      /* [57] DMA2 Channel 2 global Interrupt */
-    (void*) isr_dma2_channel3,      /* [58] DMA2 Channel 3 global Interrupt */
-    (void*) isr_dma2_channel4,      /* [59] DMA2 Channel 4 global Interrupt */
-    (void*) isr_dma2_channel5,      /* [60] DMA2 Channel 5 global Interrupt */
-    (void*) isr_adc4,               /* [61] ADC4  global Interrupt */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) (0UL),                  /* [63] Reserved */
-    (void*) isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
-    (void*) isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
-    (void*) isr_comp7,              /* [66] COMP7 global Interrupt via EXTI Line33 */
-    (void*) (0UL),                  /* [67] Reserved */
-    (void*) (0UL),                  /* [68] Reserved */
-    (void*) (0UL),                  /* [69] Reserved */
-    (void*) (0UL),                  /* [70] Reserved */
-    (void*) (0UL),                  /* [71] Reserved */
+    (0UL),                  /* [49] Reserved */
+    (0UL),                  /* [50] Reserved */
+    isr_spi3,               /* [51] SPI3 global Interrupt */
+    isr_uart4,              /* [52] UART4 global Interrupt & EXTI Line34 Interrupt (UART4 wakeup) */
+    isr_uart5,              /* [53] UART5 global Interrupt & EXTI Line35 Interrupt (UART5 wakeup) */
+    isr_tim6_dac,           /* [54] TIM6 global and DAC channel 1&2 underrun error  interrupts */
+    isr_tim7,               /* [55] TIM7 global Interrupt */
+    isr_dma2_channel1,      /* [56] DMA2 Channel 1 global Interrupt */
+    isr_dma2_channel2,      /* [57] DMA2 Channel 2 global Interrupt */
+    isr_dma2_channel3,      /* [58] DMA2 Channel 3 global Interrupt */
+    isr_dma2_channel4,      /* [59] DMA2 Channel 4 global Interrupt */
+    isr_dma2_channel5,      /* [60] DMA2 Channel 5 global Interrupt */
+    isr_adc4,               /* [61] ADC4  global Interrupt */
+    (0UL),                  /* [62] Reserved */
+    (0UL),                  /* [63] Reserved */
+    isr_comp1_2_3,          /* [64] COMP1, COMP2 and COMP3 global Interrupt via EXTI Line21, 22 and 29 */
+    isr_comp4_5_6,          /* [65] COMP4, COMP5 and COMP6 global Interrupt via EXTI Line30, 31 and 32 */
+    isr_comp7,              /* [66] COMP7 global Interrupt via EXTI Line33 */
+    (0UL),                  /* [67] Reserved */
+    (0UL),                  /* [68] Reserved */
+    (0UL),                  /* [69] Reserved */
+    (0UL),                  /* [70] Reserved */
+    (0UL),                  /* [71] Reserved */
 #if defined(CPU_MODEL_STM32F303VC)
-    (void*) (0UL),                  /* [72] Reserved */
-    (void*) (0UL),                  /* [73] Reserved */
-    (void*) isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
-    (void*) isr_usb_lp,             /* [75] USB Low Priority global Interrupt  remap */
-    (void*) isr_usbwakeup_rmp,      /* [76] USB Wakeup Interrupt remap */
-    (void*) (0UL),                  /* [77] Reserved */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [80] Reserved */
-    (void*) isr_fpu                 /* [81] Floating point Interrupt */
+    (0UL),                  /* [72] Reserved */
+    (0UL),                  /* [73] Reserved */
+    isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
+    isr_usb_lp,             /* [75] USB Low Priority global Interrupt  remap */
+    isr_usbwakeup_rmp,      /* [76] USB Wakeup Interrupt remap */
+    (0UL),                  /* [77] Reserved */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [80] Reserved */
+    isr_fpu                 /* [81] Floating point Interrupt */
 #else /* CPU_MODEL_STM32F303RE, CPU_MODEL_STM32F303ZE */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event interrupt */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error interrupt */
-    (void*) isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
-    (void*) isr_usb_lp,             /* [75] USB Low Priority global Interrupt  remap */
-    (void*) isr_usbwakeup_rmp,      /* [76] USB Wakeup Interrupt remap */
-    (void*) isr_tim20_brk,          /* [77] TIM20 Break Interrupt */
-    (void*) isr_tim20_up,           /* [78] TIM20 Update Interrupt */
-    (void*) isr_tim20_trg_com,      /* [79] TIM20 Trigger and Commutation Interrupt */
-    (void*) isr_tim8_cc,            /* [80] TIM20 Capture Compare Interrupt */
-    (void*) isr_fpu,                /* [81] Floating point Interrupt */
-    (void*) (0UL),                  /* [82] Reserved */
-    (void*) (0UL),                  /* [83] Reserved */
-    (void*) isr_spi4,               /* [84] SPI4 global Interrupt */
+    isr_i2c3_ev,            /* [72] I2C3 event interrupt */
+    isr_i2c3_er,            /* [73] I2C3 error interrupt */
+    isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
+    isr_usb_lp,             /* [75] USB Low Priority global Interrupt  remap */
+    isr_usbwakeup_rmp,      /* [76] USB Wakeup Interrupt remap */
+    isr_tim20_brk,          /* [77] TIM20 Break Interrupt */
+    isr_tim20_up,           /* [78] TIM20 Update Interrupt */
+    isr_tim20_trg_com,      /* [79] TIM20 Trigger and Commutation Interrupt */
+    isr_tim8_cc,            /* [80] TIM20 Capture Compare Interrupt */
+    isr_fpu,                /* [81] Floating point Interrupt */
+    (0UL),                  /* [82] Reserved */
+    (0UL),                  /* [83] Reserved */
+    isr_spi4,               /* [84] SPI4 global Interrupt */
 #endif
 #endif
 };

--- a/cpu/stm32f3/vectors.c
+++ b/cpu/stm32f3/vectors.c
@@ -109,7 +109,7 @@ WEAK_DEFAULT void isr_fpu(void);
 WEAK_DEFAULT void isr_spi4(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_wwdg,               /* [0] Window WatchDog Interrupt */
     isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
     isr_tamp_stamp,         /* [2] Tamper and TimeStamp interrupts through the EXTI line 19 */

--- a/cpu/stm32f4/vectors.c
+++ b/cpu/stm32f4/vectors.c
@@ -138,7 +138,7 @@ WEAK_DEFAULT void isr_ltdc_er(void);
 WEAK_DEFAULT void isr_dma2d(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_wwdg,               /* [0] Window WatchDog */
     isr_pvd,                /* [1] PVD through EXTI Line detection */
     isr_tamp_stamp,         /* [2] Tamper and TimeStamps through the EXTI line */

--- a/cpu/stm32f4/vectors.c
+++ b/cpu/stm32f4/vectors.c
@@ -32,10 +32,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* STM32F4 specific interrupt vectors */
 WEAK_DEFAULT void isr_wwdg(void);
 WEAK_DEFAULT void isr_pvd(void);
@@ -141,499 +137,478 @@ WEAK_DEFAULT void isr_ltdc(void);
 WEAK_DEFAULT void isr_ltdc_er(void);
 WEAK_DEFAULT void isr_dma2d(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M4 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
-    (void*) hard_fault_default,     /* [-13] hard fault exception */
-    (void*) mem_manage_default,     /* [-12] memory manage exception */
-    (void*) bus_fault_default,      /* [-11] bus fault exception */
-    (void*) usage_fault_default,    /* [-10] usage fault exception */
-    (void*) (0UL),                  /* [-9] Reserved */
-    (void*) (0UL),                  /* [-8] Reserved */
-    (void*) (0UL),                  /* [-7] Reserved */
-    (void*) (0UL),                  /* [-6] Reserved */
-    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
-                                            switching into thread context on boot */
-    (void*) debug_mon_default,      /* [-4] debug monitor exception */
-    (void*) (0UL),                  /* [-3] Reserved */
-    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
-                                            context switching is happening here */
-    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
-    /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* [0] Window WatchDog */
-    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection */
-    (void*) isr_tamp_stamp,         /* [2] Tamper and TimeStamps through the EXTI line */
-    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup through the EXTI line */
-    (void*) isr_flash,              /* [4] FLASH */
-    (void*) isr_rcc,                /* [5] RCC */
-    (void*) isr_exti,               /* [6] EXTI Line0 */
-    (void*) isr_exti,               /* [7] EXTI Line1 */
-    (void*) isr_exti,               /* [8] EXTI Line2 */
-    (void*) isr_exti,               /* [9] EXTI Line3 */
-    (void*) isr_exti,               /* [10] EXTI Line4 */
-    (void*) isr_dma1_stream0,       /* [11] DMA1 Stream 0 */
-    (void*) isr_dma1_stream1,       /* [12] DMA1 Stream 1 */
-    (void*) isr_dma1_stream2,       /* [13] DMA1 Stream 2 */
-    (void*) isr_dma1_stream3,       /* [14] DMA1 Stream 3 */
-    (void*) isr_dma1_stream4,       /* [15] DMA1 Stream 4 */
-    (void*) isr_dma1_stream5,       /* [16] DMA1 Stream 5 */
-    (void*) isr_dma1_stream6,       /* [17] DMA1 Stream 6 */
-    (void*) isr_adc,                /* [18] ADC1, ADC2 and ADC3s */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wwdg,               /* [0] Window WatchDog */
+    isr_pvd,                /* [1] PVD through EXTI Line detection */
+    isr_tamp_stamp,         /* [2] Tamper and TimeStamps through the EXTI line */
+    isr_rtc_wkup,           /* [3] RTC Wakeup through the EXTI line */
+    isr_flash,              /* [4] FLASH */
+    isr_rcc,                /* [5] RCC */
+    isr_exti,               /* [6] EXTI Line0 */
+    isr_exti,               /* [7] EXTI Line1 */
+    isr_exti,               /* [8] EXTI Line2 */
+    isr_exti,               /* [9] EXTI Line3 */
+    isr_exti,               /* [10] EXTI Line4 */
+    isr_dma1_stream0,       /* [11] DMA1 Stream 0 */
+    isr_dma1_stream1,       /* [12] DMA1 Stream 1 */
+    isr_dma1_stream2,       /* [13] DMA1 Stream 2 */
+    isr_dma1_stream3,       /* [14] DMA1 Stream 3 */
+    isr_dma1_stream4,       /* [15] DMA1 Stream 4 */
+    isr_dma1_stream5,       /* [16] DMA1 Stream 5 */
+    isr_dma1_stream6,       /* [17] DMA1 Stream 6 */
+    isr_adc,                /* [18] ADC1, ADC2 and ADC3s */
 #if defined(CPU_MODEL_STM32F401RE)
-    (void*) (0UL),                  /* [19] Reserved */
-    (void*) (0UL),                  /* [20] Reserved */
-    (void*) (0UL),                  /* [21] Reserved */
-    (void*) (0UL),                  /* [22] Reserved */
-    (void*) isr_exti,               /* [23] External Line[9:5]s */
-    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
-    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
-    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
-    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
-    (void*) isr_tim2,               /* [28] TIM2 */
-    (void*) isr_tim3,               /* [29] TIM3 */
-    (void*) isr_tim4,               /* [30] TIM4 */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
-    (void*) isr_spi1,               /* [35] SPI1 */
-    (void*) isr_spi2,               /* [36] SPI2 */
-    (void*) isr_usart1,             /* [37] USART1 */
-    (void*) isr_usart2,             /* [38] USART2 */
-    (void*) (0UL),                  /* [39] Reserved */
-    (void*) isr_exti,               /* [40] External Line[15:10]s */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
-    (void*) (0UL),                  /* [42] Reserved */
-    (void*) (0UL),                  /* [43] Reserved */
-    (void*) (0UL),                  /* [44] Reserved */
-    (void*) (0UL),                  /* [45] Reserved */
-    (void*) (0UL),                  /* [46] Reserved */
-    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
-    (void*) (0UL),                  /* [48] Reserved */
-    (void*) isr_sdio,               /* [49] SDIO */
-    (void*) isr_tim5,               /* [50] TIM5 */
-    (void*) (0UL),                  /* [51] Reserved */
-    (void*) (0UL),                  /* [52] Reserved */
-    (void*) (0UL),                  /* [53] Reserved */
-    (void*) (0UL),                  /* [54] Reserved */
-    (void*) (0UL),                  /* [55] Reserved */
-    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
-    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
-    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
-    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
-    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) (0UL),                  /* [63] Reserved */
-    (void*) (0UL),                  /* [64] Reserved */
-    (void*) (0UL),                  /* [65] Reserved */
-    (void*) (0UL),                  /* [66] Reserved */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) (0UL),                  /* [74] Reserved */
-    (void*) (0UL),                  /* [75] Reserved */
-    (void*) (0UL),                  /* [76] Reserved */
-    (void*) (0UL),                  /* [77] Reserved */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [80] Reserved */
-    (void*) isr_fpu,                /* [81] FPU */
-    (void*) (0UL),                  /* [82] Reserved */
-    (void*) (0UL),                  /* [83] Reserved */
-    (void*) isr_spi4                /* [84] SPI4 */
+    (0UL),                  /* [19] Reserved */
+    (0UL),                  /* [20] Reserved */
+    (0UL),                  /* [21] Reserved */
+    (0UL),                  /* [22] Reserved */
+    isr_exti,               /* [23] External Line[9:5]s */
+    isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    isr_tim2,               /* [28] TIM2 */
+    isr_tim3,               /* [29] TIM3 */
+    isr_tim4,               /* [30] TIM4 */
+    isr_i2c1_ev,            /* [31] I2C1 Event */
+    isr_i2c1_er,            /* [32] I2C1 Error */
+    isr_i2c2_ev,            /* [33] I2C2 Event */
+    isr_i2c2_er,            /* [34] I2C2 Error */
+    isr_spi1,               /* [35] SPI1 */
+    isr_spi2,               /* [36] SPI2 */
+    isr_usart1,             /* [37] USART1 */
+    isr_usart2,             /* [38] USART2 */
+    (0UL),                  /* [39] Reserved */
+    isr_exti,               /* [40] External Line[15:10]s */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    (0UL),                  /* [42] Reserved */
+    (0UL),                  /* [43] Reserved */
+    (0UL),                  /* [44] Reserved */
+    (0UL),                  /* [45] Reserved */
+    (0UL),                  /* [46] Reserved */
+    isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    (0UL),                  /* [48] Reserved */
+    isr_sdio,               /* [49] SDIO */
+    isr_tim5,               /* [50] TIM5 */
+    (0UL),                  /* [51] Reserved */
+    (0UL),                  /* [52] Reserved */
+    (0UL),                  /* [53] Reserved */
+    (0UL),                  /* [54] Reserved */
+    (0UL),                  /* [55] Reserved */
+    isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    (0UL),                  /* [63] Reserved */
+    (0UL),                  /* [64] Reserved */
+    (0UL),                  /* [65] Reserved */
+    (0UL),                  /* [66] Reserved */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    (0UL),                  /* [74] Reserved */
+    (0UL),                  /* [75] Reserved */
+    (0UL),                  /* [76] Reserved */
+    (0UL),                  /* [77] Reserved */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [80] Reserved */
+    isr_fpu,                /* [81] FPU */
+    (0UL),                  /* [82] Reserved */
+    (0UL),                  /* [83] Reserved */
+    isr_spi4                /* [84] SPI4 */
 #elif defined(CPU_MODEL_STM32F410RB)
-    (void*) (0UL),                  /* [19] Reserved */
-    (void*) (0UL),                  /* [20] Reserved */
-    (void*) (0UL),                  /* [21] Reserved */
-    (void*) (0UL),                  /* [22] Reserved */
-    (void*) isr_exti,               /* [23] External Line[9:5]s */
-    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
-    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
-    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
-    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
-    (void*) (0UL),                  /* [28] Reserved */
-    (void*) (0UL),                  /* [29] Reserved */
-    (void*) (0UL),                  /* [30] Reserved */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
-    (void*) isr_spi1,               /* [35] SPI1 */
-    (void*) isr_spi2,               /* [36] SPI2 */
-    (void*) isr_usart1,             /* [37] USART1 */
-    (void*) isr_usart2,             /* [38] USART2 */
-    (void*) (0UL),                  /* [39] Reserved */
-    (void*) isr_exti,               /* [40] External Line[15:10]s */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
-    (void*) (0UL),                  /* [42] Reserved */
-    (void*) (0UL),                  /* [43] Reserved */
-    (void*) (0UL),                  /* [44] Reserved */
-    (void*) (0UL),                  /* [45] Reserved */
-    (void*) (0UL),                  /* [46] Reserved */
-    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
-    (void*) (0UL),                  /* [48] Reserved */
-    (void*) (0UL),                  /* [49] Reserved */
-    (void*) isr_tim5,               /* [50] TIM5 */
-    (void*) (0UL),                  /* [51] Reserved */
-    (void*) (0UL),                  /* [52] Reserved */
-    (void*) (0UL),                  /* [53] Reserved */
-    (void*) isr_tim6_dac,           /* [54] TIM6 and DAC1&2 underrun errors */
-    (void*) (0UL),                  /* [55] Reserved */
-    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
-    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
-    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
-    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
-    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) (0UL),                  /* [63] Reserved */
-    (void*) (0UL),                  /* [64] Reserved */
-    (void*) (0UL),                  /* [65] Reserved */
-    (void*) (0UL),                  /* [66] Reserved */
-    (void*) (0UL),                  /* [67] Reserved */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) (0UL),                  /* [72] Reserved */
-    (void*) (0UL),                  /* [73] Reserved */
-    (void*) (0UL),                  /* [74] Reserved */
-    (void*) (0UL),                  /* [75] Reserved */
-    (void*) (0UL),                  /* [76] Reserved */
-    (void*) (0UL),                  /* [77] Reserved */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) isr_hash_rng,           /* [80] Hash and Rng */
-    (void*) isr_fpu,                /* [81] FPU */
-    (void*) (0UL),                  /* [82] Reserved */
-    (void*) (0UL),                  /* [83] Reserved */
-    (void*) (0UL),                  /* [84] Reserved */
-    (void*) isr_spi5,               /* [85] SPI5 */
-    (void*) (0UL),                  /* [86] Reserved */
-    (void*) (0UL),                  /* [87] Reserved */
-    (void*) (0UL),                  /* [88] Reserved */
-    (void*) (0UL),                  /* [89] Reserved */
-    (void*) (0UL),                  /* [90] Reserved */
-    (void*) (0UL),                  /* [91] Reserved */
-    (void*) (0UL),                  /* [92] Reserved */
-    (void*) (0UL),                  /* [93] Reserved */
-    (void*) (0UL),                  /* [94] Reserved */
-    (void*) isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
-    (void*) isr_fmpi2c1_er,         /* [96] FMPI2C1 Error */
-    (void*) isr_lptim1              /* [97] LP TIM1 */
+    (0UL),                  /* [19] Reserved */
+    (0UL),                  /* [20] Reserved */
+    (0UL),                  /* [21] Reserved */
+    (0UL),                  /* [22] Reserved */
+    isr_exti,               /* [23] External Line[9:5]s */
+    isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    (0UL),                  /* [28] Reserved */
+    (0UL),                  /* [29] Reserved */
+    (0UL),                  /* [30] Reserved */
+    isr_i2c1_ev,            /* [31] I2C1 Event */
+    isr_i2c1_er,            /* [32] I2C1 Error */
+    isr_i2c2_ev,            /* [33] I2C2 Event */
+    isr_i2c2_er,            /* [34] I2C2 Error */
+    isr_spi1,               /* [35] SPI1 */
+    isr_spi2,               /* [36] SPI2 */
+    isr_usart1,             /* [37] USART1 */
+    isr_usart2,             /* [38] USART2 */
+    (0UL),                  /* [39] Reserved */
+    isr_exti,               /* [40] External Line[15:10]s */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    (0UL),                  /* [42] Reserved */
+    (0UL),                  /* [43] Reserved */
+    (0UL),                  /* [44] Reserved */
+    (0UL),                  /* [45] Reserved */
+    (0UL),                  /* [46] Reserved */
+    isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    (0UL),                  /* [48] Reserved */
+    (0UL),                  /* [49] Reserved */
+    isr_tim5,               /* [50] TIM5 */
+    (0UL),                  /* [51] Reserved */
+    (0UL),                  /* [52] Reserved */
+    (0UL),                  /* [53] Reserved */
+    isr_tim6_dac,           /* [54] TIM6 and DAC1&2 underrun errors */
+    (0UL),                  /* [55] Reserved */
+    isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    (0UL),                  /* [63] Reserved */
+    (0UL),                  /* [64] Reserved */
+    (0UL),                  /* [65] Reserved */
+    (0UL),                  /* [66] Reserved */
+    (0UL),                  /* [67] Reserved */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    (0UL),                  /* [72] Reserved */
+    (0UL),                  /* [73] Reserved */
+    (0UL),                  /* [74] Reserved */
+    (0UL),                  /* [75] Reserved */
+    (0UL),                  /* [76] Reserved */
+    (0UL),                  /* [77] Reserved */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    isr_hash_rng,           /* [80] Hash and Rng */
+    isr_fpu,                /* [81] FPU */
+    (0UL),                  /* [82] Reserved */
+    (0UL),                  /* [83] Reserved */
+    (0UL),                  /* [84] Reserved */
+    isr_spi5,               /* [85] SPI5 */
+    (0UL),                  /* [86] Reserved */
+    (0UL),                  /* [87] Reserved */
+    (0UL),                  /* [88] Reserved */
+    (0UL),                  /* [89] Reserved */
+    (0UL),                  /* [90] Reserved */
+    (0UL),                  /* [91] Reserved */
+    (0UL),                  /* [92] Reserved */
+    (0UL),                  /* [93] Reserved */
+    (0UL),                  /* [94] Reserved */
+    isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
+    isr_fmpi2c1_er,         /* [96] FMPI2C1 Error */
+    isr_lptim1              /* [97] LP TIM1 */
 #elif defined(CPU_MODEL_STM32F411RE)
-    (void*) (0UL),                  /* [19] Reserved */
-    (void*) (0UL),                  /* [20] Reserved */
-    (void*) (0UL),                  /* [21] Reserved */
-    (void*) (0UL),                  /* [22] Reserved */
-    (void*) isr_exti,               /* [23] External Line[9:5]s */
-    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
-    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
-    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
-    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
-    (void*) isr_tim2,               /* [28] TIM2 */
-    (void*) isr_tim3,               /* [29] TIM3 */
-    (void*) isr_tim4,               /* [30] TIM4 */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
-    (void*) isr_spi1,               /* [35] SPI1 */
-    (void*) isr_spi2,               /* [36] SPI2 */
-    (void*) isr_usart1,             /* [37] USART1 */
-    (void*) isr_usart2,             /* [38] USART2 */
-    (void*) isr_usart3,             /* [39] USART3 */
-    (void*) isr_exti,               /* [40] External Line[15:10]s */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
-    (void*) isr_otg_fs_wkup,        /* [42] USB OTG FS Wakeup through EXTI line */
-    (void*) (0UL),                  /* [43] Reserved */
-    (void*) (0UL),                  /* [44] Reserved */
-    (void*) (0UL),                  /* [45] Reserved */
-    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare */
-    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
-    (void*) (0UL),                  /* [22] Reserved */
-    (void*) isr_sdio,               /* [49] SDIO */
-    (void*) isr_tim5,               /* [50] TIM5 */
-    (void*) isr_spi3,               /* [51] SPI3 */
-    (void*) (0UL),                  /* [52] Reserved */
-    (void*) (0UL),                  /* [53] Reserved */
-    (void*) (0UL),                  /* [54] Reserved */
-    (void*) (0UL),                  /* [55] Reserved */
-    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
-    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
-    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
-    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
-    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) (0UL),                  /* [63] Reserved */
-    (void*) (0UL),                  /* [64] Reserved */
-    (void*) (0UL),                  /* [65] Reserved */
-    (void*) (0UL),                  /* [66] Reserved */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) (0UL),                  /* [74] Reserved */
-    (void*) (0UL),                  /* [75] Reserved */
-    (void*) (0UL),                  /* [76] Reserved */
-    (void*) (0UL),                  /* [77] Reserved */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [80] Reserved */
-    (void*) isr_fpu,                /* [81] FPU */
-    (void*) (0UL),                  /* [82] Reserved */
-    (void*) (0UL),                  /* [83] Reserved */
-    (void*) isr_spi4,               /* [84] SPI4 */
-    (void*) isr_spi5                /* [85] SPI5 */
+    (0UL),                  /* [19] Reserved */
+    (0UL),                  /* [20] Reserved */
+    (0UL),                  /* [21] Reserved */
+    (0UL),                  /* [22] Reserved */
+    isr_exti,               /* [23] External Line[9:5]s */
+    isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    isr_tim2,               /* [28] TIM2 */
+    isr_tim3,               /* [29] TIM3 */
+    isr_tim4,               /* [30] TIM4 */
+    isr_i2c1_ev,            /* [31] I2C1 Event */
+    isr_i2c1_er,            /* [32] I2C1 Error */
+    isr_i2c2_ev,            /* [33] I2C2 Event */
+    isr_i2c2_er,            /* [34] I2C2 Error */
+    isr_spi1,               /* [35] SPI1 */
+    isr_spi2,               /* [36] SPI2 */
+    isr_usart1,             /* [37] USART1 */
+    isr_usart2,             /* [38] USART2 */
+    isr_usart3,             /* [39] USART3 */
+    isr_exti,               /* [40] External Line[15:10]s */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    isr_otg_fs_wkup,        /* [42] USB OTG FS Wakeup through EXTI line */
+    (0UL),                  /* [43] Reserved */
+    (0UL),                  /* [44] Reserved */
+    (0UL),                  /* [45] Reserved */
+    isr_tim8_cc,            /* [46] TIM8 Capture Compare */
+    isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    (0UL),                  /* [22] Reserved */
+    isr_sdio,               /* [49] SDIO */
+    isr_tim5,               /* [50] TIM5 */
+    isr_spi3,               /* [51] SPI3 */
+    (0UL),                  /* [52] Reserved */
+    (0UL),                  /* [53] Reserved */
+    (0UL),                  /* [54] Reserved */
+    (0UL),                  /* [55] Reserved */
+    isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    (0UL),                  /* [63] Reserved */
+    (0UL),                  /* [64] Reserved */
+    (0UL),                  /* [65] Reserved */
+    (0UL),                  /* [66] Reserved */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    (0UL),                  /* [74] Reserved */
+    (0UL),                  /* [75] Reserved */
+    (0UL),                  /* [76] Reserved */
+    (0UL),                  /* [77] Reserved */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [80] Reserved */
+    isr_fpu,                /* [81] FPU */
+    (0UL),                  /* [82] Reserved */
+    (0UL),                  /* [83] Reserved */
+    isr_spi4,               /* [84] SPI4 */
+    isr_spi5                /* [85] SPI5 */
 #else /* CPU_MODEL_STM32F413ZH, CPU_MODEL_STM32F413VG, CPU_MODEL_STM32F407VG
          CPU_MODEL_STM32F415RG, CPU_MODEL_STM32F412ZG, CPU_MODEL_STM32F446RE,
          CPU_MODEL_STM32F4446ZE */
-    (void*) isr_can1_tx,            /* [19] CAN1 TX */
-    (void*) isr_can1_rx0,           /* [20] CAN1 RX0 */
-    (void*) isr_can1_rx1,           /* [21] CAN1 RX1 */
-    (void*) isr_can1_sce,           /* [22] CAN1 SCE */
-    (void*) isr_exti,               /* [23] External Line[9:5]s */
-    (void*) isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
-    (void*) isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
-    (void*) isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
-    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare */
-    (void*) isr_tim2,               /* [28] TIM2 */
-    (void*) isr_tim3,               /* [29] TIM3 */
-    (void*) isr_tim4,               /* [30] TIM4 */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error */
-    (void*) isr_spi1,               /* [35] SPI1 */
-    (void*) isr_spi2,               /* [36] SPI2 */
-    (void*) isr_usart1,             /* [37] USART1 */
-    (void*) isr_usart2,             /* [38] USART2 */
-    (void*) isr_usart3,             /* [39] USART3 */
-    (void*) isr_exti,               /* [40] External Line[15:10]s */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
-    (void*) isr_otg_fs_wkup,        /* [42] USB OTG FS Wakeup through EXTI line */
-    (void*) isr_tim8_brk_tim12,     /* [43] TIM8 Break and TIM12 */
-    (void*) isr_tim8_up_tim13,      /* [44] TIM8 Update and TIM13 */
-    (void*) isr_tim8_trg_com_tim14, /* [45] TIM8 Trigger and Commutation and TIM14 */
-    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare */
-    (void*) isr_dma1_stream7,       /* [47] DMA1 Stream7 */
-    (void*) isr_fsmc,               /* [48] FSMC */
-    (void*) isr_sdio,               /* [49] SDIO */
-    (void*) isr_tim5,               /* [50] TIM5 */
-    (void*) isr_spi3,               /* [51] SPI3 */
-    (void*) isr_uart4,              /* [52] UART4 */
-    (void*) isr_uart5,              /* [53] UART5 */
-    (void*) isr_tim6_dac,           /* [54] TIM6 and DAC1&2 underrun errors */
-    (void*) isr_tim7,               /* [55] TIM7 */
-    (void*) isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
-    (void*) isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
-    (void*) isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
-    (void*) isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
-    (void*) isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
+    isr_can1_tx,            /* [19] CAN1 TX */
+    isr_can1_rx0,           /* [20] CAN1 RX0 */
+    isr_can1_rx1,           /* [21] CAN1 RX1 */
+    isr_can1_sce,           /* [22] CAN1 SCE */
+    isr_exti,               /* [23] External Line[9:5]s */
+    isr_tim1_brk_tim9,      /* [24] TIM1 Break and TIM9 */
+    isr_tim1_up_tim10,      /* [25] TIM1 Update and TIM10 */
+    isr_tim1_trg_com_tim11, /* [26] TIM1 Trigger and Commutation and TIM11 */
+    isr_tim1_cc,            /* [27] TIM1 Capture Compare */
+    isr_tim2,               /* [28] TIM2 */
+    isr_tim3,               /* [29] TIM3 */
+    isr_tim4,               /* [30] TIM4 */
+    isr_i2c1_ev,            /* [31] I2C1 Event */
+    isr_i2c1_er,            /* [32] I2C1 Error */
+    isr_i2c2_ev,            /* [33] I2C2 Event */
+    isr_i2c2_er,            /* [34] I2C2 Error */
+    isr_spi1,               /* [35] SPI1 */
+    isr_spi2,               /* [36] SPI2 */
+    isr_usart1,             /* [37] USART1 */
+    isr_usart2,             /* [38] USART2 */
+    isr_usart3,             /* [39] USART3 */
+    isr_exti,               /* [40] External Line[15:10]s */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line */
+    isr_otg_fs_wkup,        /* [42] USB OTG FS Wakeup through EXTI line */
+    isr_tim8_brk_tim12,     /* [43] TIM8 Break and TIM12 */
+    isr_tim8_up_tim13,      /* [44] TIM8 Update and TIM13 */
+    isr_tim8_trg_com_tim14, /* [45] TIM8 Trigger and Commutation and TIM14 */
+    isr_tim8_cc,            /* [46] TIM8 Capture Compare */
+    isr_dma1_stream7,       /* [47] DMA1 Stream7 */
+    isr_fsmc,               /* [48] FSMC */
+    isr_sdio,               /* [49] SDIO */
+    isr_tim5,               /* [50] TIM5 */
+    isr_spi3,               /* [51] SPI3 */
+    isr_uart4,              /* [52] UART4 */
+    isr_uart5,              /* [53] UART5 */
+    isr_tim6_dac,           /* [54] TIM6 and DAC1&2 underrun errors */
+    isr_tim7,               /* [55] TIM7 */
+    isr_dma2_stream0,       /* [56] DMA2 Stream 0 */
+    isr_dma2_stream1,       /* [57] DMA2 Stream 1 */
+    isr_dma2_stream2,       /* [58] DMA2 Stream 2 */
+    isr_dma2_stream3,       /* [59] DMA2 Stream 3 */
+    isr_dma2_stream4,       /* [60] DMA2 Stream 4 */
 #if defined(CPU_MODEL_STM32F407VG)
-    (void*) isr_eth,                /* [61] Ethernet */
-    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* [77] USB OTG HS */
-    (void*) isr_dcmi,               /* [78] DCMI */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [80] Reserved */
-    (void*) isr_fpu                 /* [81] FPU */
+    isr_eth,                /* [61] Ethernet */
+    isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    isr_otg_hs,             /* [77] USB OTG HS */
+    isr_dcmi,               /* [78] DCMI */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [80] Reserved */
+    isr_fpu                 /* [81] FPU */
 #elif defined(CPU_MODEL_STM32F415RG)
-    (void*) isr_eth,                /* [61] Ethernet */
-    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* [77] USB OTG HS */
-    (void*) isr_dcmi,               /* [78] DCMI */
-    (void*) isr_cryp,               /* [79] CRYP crypto */
-    (void*) isr_hash_rng,           /* [80] Hash and Rng */
-    (void*) isr_fpu                 /* [81] FPU */
+    isr_eth,                /* [61] Ethernet */
+    isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    isr_otg_hs,             /* [77] USB OTG HS */
+    isr_dcmi,               /* [78] DCMI */
+    isr_cryp,               /* [79] CRYP crypto */
+    isr_hash_rng,           /* [80] Hash and Rng */
+    isr_fpu                 /* [81] FPU */
 #elif defined(CPU_MODEL_STM32F412ZG)
-    (void*) isr_eth,                /* [61] Ethernet */
-    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) (0UL),                  /* [74] Reserved */
-    (void*) (0UL),                  /* [75] Reserved */
-    (void*) (0UL),                  /* [76] Reserved */
-    (void*) (0UL),                  /* [77] Reserved */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) isr_rng,                /* [80] Rng */
-    (void*) isr_fpu,                /* [81] FPU */
-    (void*) (0UL),                  /* [82] Reserved */
-    (void*) (0UL),                  /* [83] Reserved */
-    (void*) isr_spi4,               /* [84] SPI4 */
-    (void*) isr_spi5,               /* [85] SPI5 */
-    (void*) (0UL),                  /* [86] Reserved */
-    (void*) (0UL),                  /* [87] Reserved */
-    (void*) (0UL),                  /* [88] Reserved */
-    (void*) (0UL),                  /* [89] Reserved */
-    (void*) (0UL),                  /* [90] Reserved */
-    (void*) (0UL),                  /* [91] Reserved */
-    (void*) isr_quadspi,            /* [92] QuadSPI */
-    (void*) (0UL),                  /* [93] Reserved */
-    (void*) (0UL),                  /* [94] Reserved */
-    (void*) isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
-    (void*) isr_fmpi2c1_er          /* [96] FMPI2C1 Error */
+    isr_eth,                /* [61] Ethernet */
+    isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    (0UL),                  /* [74] Reserved */
+    (0UL),                  /* [75] Reserved */
+    (0UL),                  /* [76] Reserved */
+    (0UL),                  /* [77] Reserved */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    isr_rng,                /* [80] Rng */
+    isr_fpu,                /* [81] FPU */
+    (0UL),                  /* [82] Reserved */
+    (0UL),                  /* [83] Reserved */
+    isr_spi4,               /* [84] SPI4 */
+    isr_spi5,               /* [85] SPI5 */
+    (0UL),                  /* [86] Reserved */
+    (0UL),                  /* [87] Reserved */
+    (0UL),                  /* [88] Reserved */
+    (0UL),                  /* [89] Reserved */
+    (0UL),                  /* [90] Reserved */
+    (0UL),                  /* [91] Reserved */
+    isr_quadspi,            /* [92] QuadSPI */
+    (0UL),                  /* [93] Reserved */
+    (0UL),                  /* [94] Reserved */
+    isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
+    isr_fmpi2c1_er          /* [96] FMPI2C1 Error */
 #elif defined(CPU_MODEL_STM32F446RE) || defined(CPU_MODEL_STM32F446ZE)
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* [77] USB OTG HS */
-    (void*) isr_dcmi,               /* [78] DCMI */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) isr_fpu,                /* [81] FPU */
-    (void*) (0UL),                  /* [82] Reserved */
-    (void*) (0UL),                  /* [83] Reserved */
-    (void*) isr_spi4,               /* [84] SPI4 */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [86] Reserved */
-    (void*) isr_sai1,               /* [87] SAI1 */
-    (void*) (0UL),                  /* [88] Reserved */
-    (void*) (0UL),                  /* [89] Reserved */
-    (void*) (0UL),                  /* [90] Reserved */
-    (void*) isr_sai2,               /* [91] SAI2 */
-    (void*) isr_quadspi,            /* [92] QuadSPI */
-    (void*) isr_cec,                /* [93] CEC */
-    (void*) isr_spdif_rx,           /* [94] SPDIF-RX */
-    (void*) isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
-    (void*) isr_fmpi2c1_er          /* [96] FMPI2C1 Error */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    isr_otg_hs,             /* [77] USB OTG HS */
+    isr_dcmi,               /* [78] DCMI */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [79] Reserved */
+    isr_fpu,                /* [81] FPU */
+    (0UL),                  /* [82] Reserved */
+    (0UL),                  /* [83] Reserved */
+    isr_spi4,               /* [84] SPI4 */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [86] Reserved */
+    isr_sai1,               /* [87] SAI1 */
+    (0UL),                  /* [88] Reserved */
+    (0UL),                  /* [89] Reserved */
+    (0UL),                  /* [90] Reserved */
+    isr_sai2,               /* [91] SAI2 */
+    isr_quadspi,            /* [92] QuadSPI */
+    isr_cec,                /* [93] CEC */
+    isr_spdif_rx,           /* [94] SPDIF-RX */
+    isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
+    isr_fmpi2c1_er          /* [96] FMPI2C1 Error */
 #elif defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F413VG)
-    (void*) isr_eth,                /* [61] Ethernet */
-    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) isr_can3_tx,            /* [74] CAN3 TX */
-    (void*) isr_can3_rx0,           /* [75] CAN3 RX0 */
-    (void*) isr_can3_rx1,           /* [76] CAN3 RX1 */
-    (void*) isr_can3_sce,           /* [77] CAN3 SCE */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) isr_hash_rng,           /* [80] Hash and Rng */
-    (void*) isr_fpu,                /* [81] FPU */
-    (void*) isr_usart7,             /* [82] USART7 */
-    (void*) isr_usart8,             /* [83] USART8 */
-    (void*) isr_spi4,               /* [84] SPI4 */
-    (void*) isr_spi5,               /* [85] SPI5 */
-    (void*) (0UL),                  /* [86] Reserved */
-    (void*) isr_sai1,               /* [87] SAI1 */
-    (void*) isr_uart9,              /* [88] UART9 */
-    (void*) isr_uart10,             /* [89] UART10 */
-    (void*) (0UL),                  /* [90] Reserved */
-    (void*) (0UL),                  /* [91] Reserved */
-    (void*) isr_quadspi,            /* [92] QuadSPI */
-    (void*) (0UL),                  /* [93] Reserved */
-    (void*) (0UL),                  /* [94] Reserved */
-    (void*) isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
-    (void*) isr_fmpi2c1_er,         /* [96] FMPI2C1 Error */
-    (void*) isr_lptim1,             /* [97] LP TIM1 */
-    (void*) isr_dfsdm2_flt0,        /* [98] DFSDM2 Filter 0 */
-    (void*) isr_dfsdm2_flt1,        /* [99] DFSDM2 Filter 1 */
-    (void*) isr_dfsdm2_flt2,        /* [100] DFSDM2 Filter 2 */
-    (void*) isr_dfsdm2_flt3         /* [101] DFSDM2 Filter 3 */
+    isr_eth,                /* [61] Ethernet */
+    isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    isr_can3_tx,            /* [74] CAN3 TX */
+    isr_can3_rx0,           /* [75] CAN3 RX0 */
+    isr_can3_rx1,           /* [76] CAN3 RX1 */
+    isr_can3_sce,           /* [77] CAN3 SCE */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved */
+    isr_hash_rng,           /* [80] Hash and Rng */
+    isr_fpu,                /* [81] FPU */
+    isr_usart7,             /* [82] USART7 */
+    isr_usart8,             /* [83] USART8 */
+    isr_spi4,               /* [84] SPI4 */
+    isr_spi5,               /* [85] SPI5 */
+    (0UL),                  /* [86] Reserved */
+    isr_sai1,               /* [87] SAI1 */
+    isr_uart9,              /* [88] UART9 */
+    isr_uart10,             /* [89] UART10 */
+    (0UL),                  /* [90] Reserved */
+    (0UL),                  /* [91] Reserved */
+    isr_quadspi,            /* [92] QuadSPI */
+    (0UL),                  /* [93] Reserved */
+    (0UL),                  /* [94] Reserved */
+    isr_fmpi2c1_ev,         /* [95] FMPI2C1 Event */
+    isr_fmpi2c1_er,         /* [96] FMPI2C1 Error */
+    isr_lptim1,             /* [97] LP TIM1 */
+    isr_dfsdm2_flt0,        /* [98] DFSDM2 Filter 0 */
+    isr_dfsdm2_flt1,        /* [99] DFSDM2 Filter 1 */
+    isr_dfsdm2_flt2,        /* [100] DFSDM2 Filter 2 */
+    isr_dfsdm2_flt3         /* [101] DFSDM2 Filter 3 */
 #else /* CPU_MODEL_STM32F429ZI */
-    (void*) isr_eth,                /* [61] Ethernet */
-    (void*) isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
-    (void*) isr_can2_tx,            /* [63] CAN2 TX */
-    (void*) isr_can2_rx0,           /* [64] CAN2 RX0 */
-    (void*) isr_can2_rx1,           /* [65] CAN2 RX1 */
-    (void*) isr_can2_sce,           /* [66] CAN2 SCE */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS */
-    (void*) isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
-    (void*) isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
-    (void*) isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
-    (void*) isr_usart6,             /* [71] USART6 */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error */
-    (void*) isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
-    (void*) isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
-    (void*) isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
-    (void*) isr_otg_hs,             /* [77] USB OTG HS */
-    (void*) isr_dcmi,               /* [78] DCMI */
-    (void*) (0UL),                  /* [79] Reserved */
-    (void*) (0UL),                  /* [80] Reserved */
-    (void*) isr_fpu,                /* [81] FPU */
-    (void*) isr_usart7,             /* [82] USART7 */
-    (void*) isr_usart8,             /* [83] USART8 */
-    (void*) isr_spi4,               /* [84] SPI4 */
-    (void*) isr_spi5,               /* [85] SPI5 */
-    (void*) isr_spi6,               /* [86] SPI6 */
-    (void*) isr_sai1,               /* [87] SAI1 */
-    (void*) isr_ltdc,               /* [88] LDTC */
-    (void*) isr_ltdc_er,            /* [89] LTDC Error */
-    (void*) isr_dma2d               /* [90] Reserved */
+    isr_eth,                /* [61] Ethernet */
+    isr_eth_wkup,           /* [62] Ethernet Wakeup through EXTI line */
+    isr_can2_tx,            /* [63] CAN2 TX */
+    isr_can2_rx0,           /* [64] CAN2 RX0 */
+    isr_can2_rx1,           /* [65] CAN2 RX1 */
+    isr_can2_sce,           /* [66] CAN2 SCE */
+    isr_otg_fs,             /* [67] USB OTG FS */
+    isr_dma2_stream5,       /* [68] DMA2 Stream 5 */
+    isr_dma2_stream6,       /* [69] DMA2 Stream 6 */
+    isr_dma2_stream7,       /* [70] DMA2 Stream 7 */
+    isr_usart6,             /* [71] USART6 */
+    isr_i2c3_ev,            /* [72] I2C3 event */
+    isr_i2c3_er,            /* [73] I2C3 error */
+    isr_otg_hs_ep1_out,     /* [74] USB OTG HS End Point 1 Out */
+    isr_otg_hs_ep1_in,      /* [75] USB OTG HS End Point 1 In */
+    isr_otg_hs_wkup,        /* [76] USB OTG HS Wakeup through EXTI */
+    isr_otg_hs,             /* [77] USB OTG HS */
+    isr_dcmi,               /* [78] DCMI */
+    (0UL),                  /* [79] Reserved */
+    (0UL),                  /* [80] Reserved */
+    isr_fpu,                /* [81] FPU */
+    isr_usart7,             /* [82] USART7 */
+    isr_usart8,             /* [83] USART8 */
+    isr_spi4,               /* [84] SPI4 */
+    isr_spi5,               /* [85] SPI5 */
+    isr_spi6,               /* [86] SPI6 */
+    isr_sai1,               /* [87] SAI1 */
+    isr_ltdc,               /* [88] LDTC */
+    isr_ltdc_er,            /* [89] LTDC Error */
+    isr_dma2d               /* [90] Reserved */
 #endif
 #endif
 };

--- a/cpu/stm32f7/vectors.c
+++ b/cpu/stm32f7/vectors.c
@@ -141,7 +141,7 @@ WEAK_DEFAULT void isr_sdmmc2(void);
 #endif
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_wwdg,                  /* [0] Window WatchDog Interrupt */
     isr_pvd,                   /* [1] PVD through EXTI Line detection Interrupt */
     isr_tamp_stamp,            /* [2] Tamper and TimeStamp interrupts through the EXTI line */

--- a/cpu/stm32f7/vectors.c
+++ b/cpu/stm32f7/vectors.c
@@ -30,10 +30,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* STM32F7 specific interrupt vectors */
 WEAK_DEFAULT void isr_wwdg(void);
 WEAK_DEFAULT void isr_pvd(void);
@@ -144,172 +140,151 @@ WEAK_DEFAULT void isr_mdios(void);
 WEAK_DEFAULT void isr_sdmmc2(void);
 #endif
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),                /* pointer to the top of the stack */
-    /* Cortex-M7 handlers */
-    (void*) reset_handler_default,     /* entry point of the program */
-    (void*) nmi_default,               /* [-14] non maskable interrupt handler */
-    (void*) hard_fault_default,        /* [-13] hard fault exception */
-    (void*) mem_manage_default,        /* [-12] memory manage exception */
-    (void*) bus_fault_default,         /* [-11] bus fault exception */
-    (void*) usage_fault_default,       /* [-10] usage fault exception */
-    (void*) (0UL),                     /* [-9] Reserved */
-    (void*) (0UL),                     /* [-8] Reserved */
-    (void*) (0UL),                     /* [-7] Reserved */
-    (void*) (0UL),                     /* [-6] Reserved */
-    (void*) isr_svc,                   /* [-5] system call interrupt, in RIOT used for
-                                               switching into thread context on boot */
-    (void*) debug_mon_default,         /* [-4] debug monitor exception */
-    (void*) (0UL),                     /* [-3] Reserved */
-    (void*) isr_pendsv,                /* [-2] pendSV interrupt, in RIOT the actual
-                                               context switching is happening here */
-    (void*) isr_systick,               /* [-1] SysTick interrupt, not used in RIOT */
-    /* STM specific peripheral handlers */
-    (void*) isr_wwdg,                  /* [0] Window WatchDog Interrupt */
-    (void*) isr_pvd,                   /* [1] PVD through EXTI Line detection Interrupt */
-    (void*) isr_tamp_stamp,            /* [2] Tamper and TimeStamp interrupts through the EXTI line */
-    (void*) isr_rtc_wkup,              /* [3] RTC Wakeup interrupt through the EXTI line */
-    (void*) isr_flash,                 /* [4] FLASH global Interrupt */
-    (void*) isr_rcc,                   /* [5] RCC global Interrupt */
-    (void*) isr_exti,                  /* [6] EXTI Line0 Interrupt */
-    (void*) isr_exti,                  /* [7] EXTI Line1 Interrupt */
-    (void*) isr_exti,                  /* [8] EXTI Line2 Interrupt */
-    (void*) isr_exti,                  /* [9] EXTI Line3 Interrupt */
-    (void*) isr_exti,                  /* [10] EXTI Line4 Interrupt */
-    (void*) isr_dma1_stream0,          /* [11] DMA1 Stream 0 global Interrupt */
-    (void*) isr_dma1_stream1,          /* [12] DMA1 Stream 1 global Interrupt */
-    (void*) isr_dma1_stream2,          /* [13] DMA1 Stream 2 global Interrupt */
-    (void*) isr_dma1_stream3,          /* [14] DMA1 Stream 3 global Interrupt */
-    (void*) isr_dma1_stream4,          /* [15] DMA1 Stream 4 global Interrupt */
-    (void*) isr_dma1_stream5,          /* [16] DMA1 Stream 5 global Interrupt */
-    (void*) isr_dma1_stream6,          /* [17] DMA1 Stream 6 global Interrupt */
-    (void*) isr_adc,                   /* [18] ADC1, ADC2 and ADC3 global Interrupts */
-    (void*) isr_can1_tx,               /* [19] CAN1 TX Interrupt */
-    (void*) isr_can1_rx0,              /* [20] CAN1 RX0 Interrupt */
-    (void*) isr_can1_rx1,              /* [21] CAN1 RX1 Interrupt */
-    (void*) isr_can1_sce,              /* [22] CAN1 SCE Interrupt */
-    (void*) isr_exti,                  /* [23] External Line[9:5] Interrupts */
-    (void*) isr_tim1_brk_tim9,         /* [24] TIM1 Break interrupt and TIM9 global interrupt */
-    (void*) isr_tim1_up_tim10,         /* [25] TIM1 Update Interrupt and TIM10 global interrupt */
-    (void*) isr_tim1_trg_com_tim11,    /* [26] TIM1 Trigger and Commutation Interrupt and TIM11 global interrupt */
-    (void*) isr_tim1_cc,               /* [27] TIM1 Capture Compare Interrupt */
-    (void*) isr_tim2,                  /* [28] TIM2 global Interrupt */
-    (void*) isr_tim3,                  /* [29] TIM3 global Interrupt */
-    (void*) isr_tim4,                  /* [30] TIM4 global Interrupt */
-    (void*) isr_i2c1_ev,               /* [31] I2C1 Event Interrupt */
-    (void*) isr_i2c1_er,               /* [32] I2C1 Error Interrupt */
-    (void*) isr_i2c2_ev,               /* [33] I2C2 Event Interrupt */
-    (void*) isr_i2c2_er,               /* [34] I2C2 Error Interrupt */
-    (void*) isr_spi1,                  /* [35] SPI1 global Interrupt */
-    (void*) isr_spi2,                  /* [36] SPI2 global Interrupt */
-    (void*) isr_usart1,                /* [37] USART1 global Interrupt */
-    (void*) isr_usart2,                /* [38] USART2 global Interrupt */
-    (void*) isr_usart3,                /* [39] USART3 global Interrupt */
-    (void*) isr_exti,                  /* [40] External Line[15:10] Interrupts */
-    (void*) isr_rtc_alarm,             /* [41] RTC Alarm (A and B) through EXTI Line Interrupt */
-    (void*) isr_otg_fs_wkup,           /* [42] USB OTG FS Wakeup through EXTI line interrupt */
-    (void*) isr_tim8_brk_tim12,        /* [43] TIM8 Break Interrupt and TIM12 global interrupt */
-    (void*) isr_tim8_up_tim13,         /* [44] TIM8 Update Interrupt and TIM13 global interrupt */
-    (void*) isr_tim8_trg_com_tim14,    /* [45] TIM8 Trigger and Commutation Interrupt and TIM14 global interrupt */
-    (void*) isr_tim8_cc,               /* [46] TIM8 Capture Compare Interrupt */
-    (void*) isr_dma1_stream7,          /* [47] DMA1 Stream7 Interrupt */
-    (void*) isr_fmc,                   /* [48] FMC global Interrupt */
-    (void*) isr_sdmmc1,                /* [49] SDMMC1 global Interrupt */
-    (void*) isr_tim5,                  /* [50] TIM5 global Interrupt */
-    (void*) isr_spi3,                  /* [51] SPI3 global Interrupt */
-    (void*) isr_uart4,                 /* [52] UART4 global Interrupt */
-    (void*) isr_uart5,                 /* [53] UART5 global Interrupt */
-    (void*) isr_tim6_dac,              /* [54] TIM6 global and DAC1&2 underrun error interrupts */
-    (void*) isr_tim7,                  /* [55] TIM7 global interrupt */
-    (void*) isr_dma2_stream0,          /* [56] DMA2 Stream 0 global Interrupt */
-    (void*) isr_dma2_stream1,          /* [57] DMA2 Stream 1 global Interrupt */
-    (void*) isr_dma2_stream2,          /* [58] DMA2 Stream 2 global Interrupt */
-    (void*) isr_dma2_stream3,          /* [59] DMA2 Stream 3 global Interrupt */
-    (void*) isr_dma2_stream4,          /* [60] DMA2 Stream 4 global Interrupt */
-    (void*) isr_eth,                   /* [61] Ethernet global Interrupt */
-    (void*) isr_eth_wkup,              /* [62] Ethernet Wakeup through EXTI line Interrupt */
-    (void*) isr_can2_tx,               /* [63] CAN2 TX Interrupt */
-    (void*) isr_can2_rx0,              /* [64] CAN2 RX0 Interrupt */
-    (void*) isr_can2_rx1,              /* [65] CAN2 RX1 Interrupt */
-    (void*) isr_can2_sce,              /* [66] CAN2 SCE Interrupt */
-    (void*) isr_otg_fs,                /* [67] USB OTG FS global Interrupt */
-    (void*) isr_dma2_stream5,          /* [68] DMA2 Stream 5 global interrupt */
-    (void*) isr_dma2_stream6,          /* [69] DMA2 Stream 6 global interrupt */
-    (void*) isr_dma2_stream7,          /* [70] DMA2 Stream 7 global interrupt */
-    (void*) isr_usart6,                /* [71] USART6 global interrupt */
-    (void*) isr_i2c3_ev,               /* [72] I2C3 event interrupt */
-    (void*) isr_i2c3_er,               /* [73] I2C3 error interrupt */
-    (void*) isr_otg_hs_ep1_out,        /* [74] USB OTG HS End Point 1 Out global interrupt */
-    (void*) isr_otg_hs_ep1_in,         /* [75] USB OTG HS End Point 1 In global interrupt */
-    (void*) isr_otg_hs_wkup,           /* [76] USB OTG HS Wakeup through EXTI interrupt */
-    (void*) isr_otg_hs,                /* [77] USB OTG HS global interrupt */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wwdg,                  /* [0] Window WatchDog Interrupt */
+    isr_pvd,                   /* [1] PVD through EXTI Line detection Interrupt */
+    isr_tamp_stamp,            /* [2] Tamper and TimeStamp interrupts through the EXTI line */
+    isr_rtc_wkup,              /* [3] RTC Wakeup interrupt through the EXTI line */
+    isr_flash,                 /* [4] FLASH global Interrupt */
+    isr_rcc,                   /* [5] RCC global Interrupt */
+    isr_exti,                  /* [6] EXTI Line0 Interrupt */
+    isr_exti,                  /* [7] EXTI Line1 Interrupt */
+    isr_exti,                  /* [8] EXTI Line2 Interrupt */
+    isr_exti,                  /* [9] EXTI Line3 Interrupt */
+    isr_exti,                  /* [10] EXTI Line4 Interrupt */
+    isr_dma1_stream0,          /* [11] DMA1 Stream 0 global Interrupt */
+    isr_dma1_stream1,          /* [12] DMA1 Stream 1 global Interrupt */
+    isr_dma1_stream2,          /* [13] DMA1 Stream 2 global Interrupt */
+    isr_dma1_stream3,          /* [14] DMA1 Stream 3 global Interrupt */
+    isr_dma1_stream4,          /* [15] DMA1 Stream 4 global Interrupt */
+    isr_dma1_stream5,          /* [16] DMA1 Stream 5 global Interrupt */
+    isr_dma1_stream6,          /* [17] DMA1 Stream 6 global Interrupt */
+    isr_adc,                   /* [18] ADC1, ADC2 and ADC3 global Interrupts */
+    isr_can1_tx,               /* [19] CAN1 TX Interrupt */
+    isr_can1_rx0,              /* [20] CAN1 RX0 Interrupt */
+    isr_can1_rx1,              /* [21] CAN1 RX1 Interrupt */
+    isr_can1_sce,              /* [22] CAN1 SCE Interrupt */
+    isr_exti,                  /* [23] External Line[9:5] Interrupts */
+    isr_tim1_brk_tim9,         /* [24] TIM1 Break interrupt and TIM9 global interrupt */
+    isr_tim1_up_tim10,         /* [25] TIM1 Update Interrupt and TIM10 global interrupt */
+    isr_tim1_trg_com_tim11,    /* [26] TIM1 Trigger and Commutation Interrupt and TIM11 global interrupt */
+    isr_tim1_cc,               /* [27] TIM1 Capture Compare Interrupt */
+    isr_tim2,                  /* [28] TIM2 global Interrupt */
+    isr_tim3,                  /* [29] TIM3 global Interrupt */
+    isr_tim4,                  /* [30] TIM4 global Interrupt */
+    isr_i2c1_ev,               /* [31] I2C1 Event Interrupt */
+    isr_i2c1_er,               /* [32] I2C1 Error Interrupt */
+    isr_i2c2_ev,               /* [33] I2C2 Event Interrupt */
+    isr_i2c2_er,               /* [34] I2C2 Error Interrupt */
+    isr_spi1,                  /* [35] SPI1 global Interrupt */
+    isr_spi2,                  /* [36] SPI2 global Interrupt */
+    isr_usart1,                /* [37] USART1 global Interrupt */
+    isr_usart2,                /* [38] USART2 global Interrupt */
+    isr_usart3,                /* [39] USART3 global Interrupt */
+    isr_exti,                  /* [40] External Line[15:10] Interrupts */
+    isr_rtc_alarm,             /* [41] RTC Alarm (A and B) through EXTI Line Interrupt */
+    isr_otg_fs_wkup,           /* [42] USB OTG FS Wakeup through EXTI line interrupt */
+    isr_tim8_brk_tim12,        /* [43] TIM8 Break Interrupt and TIM12 global interrupt */
+    isr_tim8_up_tim13,         /* [44] TIM8 Update Interrupt and TIM13 global interrupt */
+    isr_tim8_trg_com_tim14,    /* [45] TIM8 Trigger and Commutation Interrupt and TIM14 global interrupt */
+    isr_tim8_cc,               /* [46] TIM8 Capture Compare Interrupt */
+    isr_dma1_stream7,          /* [47] DMA1 Stream7 Interrupt */
+    isr_fmc,                   /* [48] FMC global Interrupt */
+    isr_sdmmc1,                /* [49] SDMMC1 global Interrupt */
+    isr_tim5,                  /* [50] TIM5 global Interrupt */
+    isr_spi3,                  /* [51] SPI3 global Interrupt */
+    isr_uart4,                 /* [52] UART4 global Interrupt */
+    isr_uart5,                 /* [53] UART5 global Interrupt */
+    isr_tim6_dac,              /* [54] TIM6 global and DAC1&2 underrun error interrupts */
+    isr_tim7,                  /* [55] TIM7 global interrupt */
+    isr_dma2_stream0,          /* [56] DMA2 Stream 0 global Interrupt */
+    isr_dma2_stream1,          /* [57] DMA2 Stream 1 global Interrupt */
+    isr_dma2_stream2,          /* [58] DMA2 Stream 2 global Interrupt */
+    isr_dma2_stream3,          /* [59] DMA2 Stream 3 global Interrupt */
+    isr_dma2_stream4,          /* [60] DMA2 Stream 4 global Interrupt */
+    isr_eth,                   /* [61] Ethernet global Interrupt */
+    isr_eth_wkup,              /* [62] Ethernet Wakeup through EXTI line Interrupt */
+    isr_can2_tx,               /* [63] CAN2 TX Interrupt */
+    isr_can2_rx0,              /* [64] CAN2 RX0 Interrupt */
+    isr_can2_rx1,              /* [65] CAN2 RX1 Interrupt */
+    isr_can2_sce,              /* [66] CAN2 SCE Interrupt */
+    isr_otg_fs,                /* [67] USB OTG FS global Interrupt */
+    isr_dma2_stream5,          /* [68] DMA2 Stream 5 global interrupt */
+    isr_dma2_stream6,          /* [69] DMA2 Stream 6 global interrupt */
+    isr_dma2_stream7,          /* [70] DMA2 Stream 7 global interrupt */
+    isr_usart6,                /* [71] USART6 global interrupt */
+    isr_i2c3_ev,               /* [72] I2C3 event interrupt */
+    isr_i2c3_er,               /* [73] I2C3 error interrupt */
+    isr_otg_hs_ep1_out,        /* [74] USB OTG HS End Point 1 Out global interrupt */
+    isr_otg_hs_ep1_in,         /* [75] USB OTG HS End Point 1 In global interrupt */
+    isr_otg_hs_wkup,           /* [76] USB OTG HS Wakeup through EXTI interrupt */
+    isr_otg_hs,                /* [77] USB OTG HS global interrupt */
 #if defined(CPU_MODEL_STM32F722ZE)
-    (void*) (0UL),                     /* [78] Reserved */
-    (void*) (0UL),                     /* [79] Reserved */
-    (void*) isr_rng,                   /* [80] RNG global interrupt */
-    (void*) isr_fpu,                   /* [81] FPU global interrupt */
-    (void*) isr_uart7,                 /* [82] UART7 global interrupt */
-    (void*) isr_uart8,                 /* [83] UART8 global interrupt */
-    (void*) isr_spi4,                  /* [84] SPI4 global Interrupt */
-    (void*) isr_spi5,                  /* [85] SPI5 global Interrupt */
-    (void*) (0UL),                     /* [86] Reserved */
-    (void*) isr_sai1,                  /* [87] SAI1 global Interrupt */
-    (void*) (0UL),                     /* [88] Reserved */
-    (void*) (0UL),                     /* [89] Reserved */
-    (void*) (0UL),                     /* [90] Reserved */
-    (void*) isr_sai2,                  /* [91] SAI2 global Interrupt */
-    (void*) isr_quadspi,               /* [92] Quad SPI global interrupt */
-    (void*) isr_lptim1,                /* [93] LP TIM1 interrupt */
-    (void*) (0UL),                     /* [94] Reserved */
-    (void*) (0UL),                     /* [95] Reserved */
-    (void*) (0UL),                     /* [96] Reserved */
-    (void*) (0UL),                     /* [97] Reserved */
-    (void*) (0UL),                     /* [98] Reserved */
-    (void*) (0UL),                     /* [99] Reserved */
-    (void*) (0UL),                     /* [100] Reserved */
-    (void*) (0UL),                     /* [101] Reserved */
-    (void*) (0UL),                     /* [102] Reserved */
-    (void*) isr_sdmmc2,                /* [103] SDMMC2 global Interrup */
+    (0UL),                     /* [78] Reserved */
+    (0UL),                     /* [79] Reserved */
+    isr_rng,                   /* [80] RNG global interrupt */
+    isr_fpu,                   /* [81] FPU global interrupt */
+    isr_uart7,                 /* [82] UART7 global interrupt */
+    isr_uart8,                 /* [83] UART8 global interrupt */
+    isr_spi4,                  /* [84] SPI4 global Interrupt */
+    isr_spi5,                  /* [85] SPI5 global Interrupt */
+    (0UL),                     /* [86] Reserved */
+    isr_sai1,                  /* [87] SAI1 global Interrupt */
+    (0UL),                     /* [88] Reserved */
+    (0UL),                     /* [89] Reserved */
+    (0UL),                     /* [90] Reserved */
+    isr_sai2,                  /* [91] SAI2 global Interrupt */
+    isr_quadspi,               /* [92] Quad SPI global interrupt */
+    isr_lptim1,                /* [93] LP TIM1 interrupt */
+    (0UL),                     /* [94] Reserved */
+    (0UL),                     /* [95] Reserved */
+    (0UL),                     /* [96] Reserved */
+    (0UL),                     /* [97] Reserved */
+    (0UL),                     /* [98] Reserved */
+    (0UL),                     /* [99] Reserved */
+    (0UL),                     /* [100] Reserved */
+    (0UL),                     /* [101] Reserved */
+    (0UL),                     /* [102] Reserved */
+    isr_sdmmc2,                /* [103] SDMMC2 global Interrup */
 #else
-    (void*) isr_dcmi,                  /* [78] DCMI global interrupt */
-    (void*) (0UL),                     /* [79] Reserved */
-    (void*) isr_rng,                   /* [80] RNG global interrupt */
-    (void*) isr_fpu,                   /* [81] FPU global interrupt */
-    (void*) isr_uart7,                 /* [82] UART7 global interrupt */
-    (void*) isr_uart8,                 /* [83] UART8 global interrupt */
-    (void*) isr_spi4,                  /* [84] SPI4 global Interrupt */
-    (void*) isr_spi5,                  /* [85] SPI5 global Interrupt */
-    (void*) isr_spi6,                  /* [86] SPI6 global Interrupt */
-    (void*) isr_sai1,                  /* [87] SAI1 global Interrupt */
-    (void*) isr_ltdc,                  /* [88] LTDC global Interrupt */
-    (void*) isr_ltdc_er,               /* [89] LTDC Error global Interrupt */
-    (void*) isr_dma2d,                 /* [90] DMA2D global Interrupt */
-    (void*) isr_sai2,                  /* [91] SAI2 global Interrupt */
-    (void*) isr_quadspi,               /* [92] Quad SPI global interrupt */
-    (void*) isr_lptim1,                /* [93] LP TIM1 interrupt */
-    (void*) isr_cec,                   /* [94] HDMI-CEC global Interrupt */
-    (void*) isr_i2c4_ev,               /* [95] I2C4 Event Interrupt */
-    (void*) isr_i2c4_er,               /* [96] I2C4 Error Interrupt */
-    (void*) isr_spdif_rx,              /* [97] SPDIF-RX global Interrupt */
+    isr_dcmi,                  /* [78] DCMI global interrupt */
+    (0UL),                     /* [79] Reserved */
+    isr_rng,                   /* [80] RNG global interrupt */
+    isr_fpu,                   /* [81] FPU global interrupt */
+    isr_uart7,                 /* [82] UART7 global interrupt */
+    isr_uart8,                 /* [83] UART8 global interrupt */
+    isr_spi4,                  /* [84] SPI4 global Interrupt */
+    isr_spi5,                  /* [85] SPI5 global Interrupt */
+    isr_spi6,                  /* [86] SPI6 global Interrupt */
+    isr_sai1,                  /* [87] SAI1 global Interrupt */
+    isr_ltdc,                  /* [88] LTDC global Interrupt */
+    isr_ltdc_er,               /* [89] LTDC Error global Interrupt */
+    isr_dma2d,                 /* [90] DMA2D global Interrupt */
+    isr_sai2,                  /* [91] SAI2 global Interrupt */
+    isr_quadspi,               /* [92] Quad SPI global interrupt */
+    isr_lptim1,                /* [93] LP TIM1 interrupt */
+    isr_cec,                   /* [94] HDMI-CEC global Interrupt */
+    isr_i2c4_ev,               /* [95] I2C4 Event Interrupt */
+    isr_i2c4_er,               /* [96] I2C4 Error Interrupt */
+    isr_spdif_rx,              /* [97] SPDIF-RX global Interrupt */
 #if defined(CPU_MODEL_STM32F769NI)
-    (void*) isr_dsi,                   /* [98] DSI global Interrupt */
+    isr_dsi,                   /* [98] DSI global Interrupt */
 #elif defined(CPU_MODEL_STM32F767ZI)
-    (void*) (0UL),                     /* [98] Reserved */
+    (0UL),                     /* [98] Reserved */
 #endif
 #if defined(CPU_MODEL_STM32F769NI) || defined(CPU_MODEL_STM32F767ZI)
-    (void*) isr_dfsdm1_flt0,           /* [99] DFSDM1 Filter 0 global Interrupt */
-    (void*) isr_dfsdm1_flt1,           /* [100] DFSDM1 Filter 1 global Interrupt */
-    (void*) isr_dfsdm1_flt2,           /* [101] DFSDM1 Filter 2 global Interrupt */
-    (void*) isr_dfsdm1_flt3,           /* [102] DFSDM1 Filter 3 global Interrupt */
-    (void*) isr_sdmmc2,                /* [103] SDMMC2 global Interrup */
-    (void*) isr_can3_tx,               /* [104] CAN3 TX Interrupt */
-    (void*) isr_can3_rx0,              /* [105] CAN3 RX0 Interrupt */
-    (void*) isr_can3_rx1,              /* [106] CAN3 RX1 Interrupt */
-    (void*) isr_can3_sce,              /* [107] CAN3 SCE Interrupt */
-    (void*) isr_jpeg,                  /* [108] JPEG global Interrupt */
-    (void*) isr_mdios,                 /* [109] MDIO Slave global Interrupt */
+    isr_dfsdm1_flt0,           /* [99] DFSDM1 Filter 0 global Interrupt */
+    isr_dfsdm1_flt1,           /* [100] DFSDM1 Filter 1 global Interrupt */
+    isr_dfsdm1_flt2,           /* [101] DFSDM1 Filter 2 global Interrupt */
+    isr_dfsdm1_flt3,           /* [102] DFSDM1 Filter 3 global Interrupt */
+    isr_sdmmc2,                /* [103] SDMMC2 global Interrup */
+    isr_can3_tx,               /* [104] CAN3 TX Interrupt */
+    isr_can3_rx0,              /* [105] CAN3 RX0 Interrupt */
+    isr_can3_rx1,              /* [106] CAN3 RX1 Interrupt */
+    isr_can3_sce,              /* [107] CAN3 SCE Interrupt */
+    isr_jpeg,                  /* [108] JPEG global Interrupt */
+    isr_mdios,                 /* [109] MDIO Slave global Interrupt */
 #endif
 #endif
 };

--- a/cpu/stm32l0/vectors.c
+++ b/cpu/stm32l0/vectors.c
@@ -65,7 +65,7 @@ WEAK_DEFAULT void isr_lcd(void);
 WEAK_DEFAULT void isr_usb(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_wwdg,               /* [0] windowed watchdog */
     isr_pvd,                /* [1] power control */
     isr_rtc,                /* [2] real time clock */

--- a/cpu/stm32l0/vectors.c
+++ b/cpu/stm32l0/vectors.c
@@ -32,10 +32,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* STM32L0 specific interrupt vectors */
 WEAK_DEFAULT void isr_wwdg(void);
 WEAK_DEFAULT void isr_pvd(void);
@@ -68,109 +64,88 @@ WEAK_DEFAULT void isr_lpuart1(void);
 WEAK_DEFAULT void isr_lcd(void);
 WEAK_DEFAULT void isr_usb(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M0 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
-    (void*) hard_fault_default,     /* [-13] hard fault exception */
-    (void*) (0UL),                  /* [-12] reserved */
-    (void*) (0UL),                  /* [-11] reserved */
-    (void*) (0UL),                  /* [-10] reserved */
-    (void*) (0UL),                  /* [-9] reserved */
-    (void*) (0UL),                  /* [-8] reserved */
-    (void*) (0UL),                  /* [-7] reserved */
-    (void*) (0UL),                  /* [-6] reserved */
-    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
-                                            switching into thread context on boot */
-    (void*) (0UL),                  /* [-4] reserved */
-    (void*) (0UL),                  /* [-3] reserved */
-    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
-                                            context switching is happening here */
-    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
-    /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* [0] windowed watchdog */
-    (void*) isr_pvd,                /* [1] power control */
-    (void*) isr_rtc,                /* [2] real time clock */
-    (void*) isr_flash,              /* [3] flash memory controller */
-    (void*) isr_rcc,                /* [4] reset and clock control */
-    (void*) isr_exti,               /* [5] external interrupt lines 0 and 1 */
-    (void*) isr_exti,               /* [6] external interrupt lines 2 and 3 */
-    (void*) isr_exti,               /* [7] external interrupt lines 4 to 15 */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wwdg,               /* [0] windowed watchdog */
+    isr_pvd,                /* [1] power control */
+    isr_rtc,                /* [2] real time clock */
+    isr_flash,              /* [3] flash memory controller */
+    isr_rcc,                /* [4] reset and clock control */
+    isr_exti,               /* [5] external interrupt lines 0 and 1 */
+    isr_exti,               /* [6] external interrupt lines 2 and 3 */
+    isr_exti,               /* [7] external interrupt lines 4 to 15 */
 #if defined(CPU_MODEL_STM32L031K6)
-    (void*) (0UL),                  /* [8] reserved */
-    (void*) isr_dma1_ch1,           /* [9] direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,         /* [10] direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5_6_7,     /* [11] direct memory access controller 1, channel 4, 5, 6 and 7*/
-    (void*) isr_adc1_comp,          /* [12] analog digital converter */
-    (void*) isr_lptim1,             /* [13] low power timer 1 */
-    (void*) (0UL),                  /* [14] reserved */
-    (void*) isr_tim2,               /* [15] timer 2 */
-    (void*) (0UL),                  /* [16] reserved */
-    (void*) (0UL),                  /* [17] reserved */
-    (void*) (0UL),                  /* [18] reserved */
-    (void*) (0UL),                  /* [19] reserved */
-    (void*) isr_tim21,              /* [20] timer 21 */
-    (void*) (0UL),                  /* [21] reserved */
-    (void*) isr_tim22,              /* [22] timer 22 */
-    (void*) isr_i2c1,               /* [23] I2C 1 */
-    (void*) (0UL),                  /* [24] reserved */
-    (void*) isr_spi1,               /* [25] SPI 1 */
-    (void*) (0UL),                  /* [26] reserved */
-    (void*) (0UL),                  /* [27] reserved */
-    (void*) isr_usart2,             /* [28] USART 2 */
-    (void*) isr_lpuart1             /* [29] Low power UART 1 */
+    (0UL),                  /* [8] reserved */
+    isr_dma1_ch1,           /* [9] direct memory access controller 1, channel 1*/
+    isr_dma1_ch2_3,         /* [10] direct memory access controller 1, channel 2 and 3*/
+    isr_dma1_ch4_5_6_7,     /* [11] direct memory access controller 1, channel 4, 5, 6 and 7*/
+    isr_adc1_comp,          /* [12] analog digital converter */
+    isr_lptim1,             /* [13] low power timer 1 */
+    (0UL),                  /* [14] reserved */
+    isr_tim2,               /* [15] timer 2 */
+    (0UL),                  /* [16] reserved */
+    (0UL),                  /* [17] reserved */
+    (0UL),                  /* [18] reserved */
+    (0UL),                  /* [19] reserved */
+    isr_tim21,              /* [20] timer 21 */
+    (0UL),                  /* [21] reserved */
+    isr_tim22,              /* [22] timer 22 */
+    isr_i2c1,               /* [23] I2C 1 */
+    (0UL),                  /* [24] reserved */
+    isr_spi1,               /* [25] SPI 1 */
+    (0UL),                  /* [26] reserved */
+    (0UL),                  /* [27] reserved */
+    isr_usart2,             /* [28] USART 2 */
+    isr_lpuart1             /* [29] Low power UART 1 */
 #elif defined(CPU_MODEL_STM32L053R8)
-    (void*) isr_ts,                 /* [8] touch sensing input*/
-    (void*) isr_dma1_ch1,           /* [9] direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,         /* [10] direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5_6_7,     /* [11] direct memory access controller 1, channel 4, 5, 6 and 7*/
-    (void*) isr_adc1_comp,          /* [12] analog digital converter */
-    (void*) isr_lptim1,             /* [13] low power timer 1 */
-    (void*) (0UL),                  /* [14] reserved */
-    (void*) isr_tim2,               /* [15] timer 2 */
-    (void*) (0UL),                  /* [16] reserved */
-    (void*) isr_tim6_dac,           /* [17] timer 6 and digital to analog converter */
-    (void*) (0UL),                  /* [18] reserved */
-    (void*) (0UL),                  /* [19] reserved */
-    (void*) isr_tim21,              /* [20] timer 21 */
-    (void*) (0UL),                  /* [21] reserved */
-    (void*) isr_tim22,              /* [22] timer 22 */
-    (void*) isr_i2c1,               /* [23] I2C 1 */
-    (void*) isr_i2c2,               /* [24] I2C 2 */
-    (void*) isr_spi1,               /* [25] SPI 1 */
-    (void*) isr_spi2,               /* [26] SPI 2 */
-    (void*) isr_usart1,             /* [27] USART 1 */
-    (void*) isr_usart2,             /* [28] USART 2 */
-    (void*) isr_rng_lpuart1,        /* [29] RNG and Low power UART 1 */
-    (void*) isr_lcd,                /* [30] LCD */
-    (void*) isr_usb                 /* [31] USB */
+    isr_ts,                 /* [8] touch sensing input*/
+    isr_dma1_ch1,           /* [9] direct memory access controller 1, channel 1*/
+    isr_dma1_ch2_3,         /* [10] direct memory access controller 1, channel 2 and 3*/
+    isr_dma1_ch4_5_6_7,     /* [11] direct memory access controller 1, channel 4, 5, 6 and 7*/
+    isr_adc1_comp,          /* [12] analog digital converter */
+    isr_lptim1,             /* [13] low power timer 1 */
+    (0UL),                  /* [14] reserved */
+    isr_tim2,               /* [15] timer 2 */
+    (0UL),                  /* [16] reserved */
+    isr_tim6_dac,           /* [17] timer 6 and digital to analog converter */
+    (0UL),                  /* [18] reserved */
+    (0UL),                  /* [19] reserved */
+    isr_tim21,              /* [20] timer 21 */
+    (0UL),                  /* [21] reserved */
+    isr_tim22,              /* [22] timer 22 */
+    isr_i2c1,               /* [23] I2C 1 */
+    isr_i2c2,               /* [24] I2C 2 */
+    isr_spi1,               /* [25] SPI 1 */
+    isr_spi2,               /* [26] SPI 2 */
+    isr_usart1,             /* [27] USART 1 */
+    isr_usart2,             /* [28] USART 2 */
+    isr_rng_lpuart1,        /* [29] RNG and Low power UART 1 */
+    isr_lcd,                /* [30] LCD */
+    isr_usb                 /* [31] USB */
 #else /* CPU_MODEL_STM32L073RZ, CPU_MODEL_STM32L072CZ */
-    (void*) isr_ts,                 /* [8] touch sensing input*/
-    (void*) isr_dma1_ch1,           /* [9] direct memory access controller 1, channel 1*/
-    (void*) isr_dma1_ch2_3,         /* [10] direct memory access controller 1, channel 2 and 3*/
-    (void*) isr_dma1_ch4_5_6_7,     /* [11] direct memory access controller 1, channel 4, 5, 6 and 7*/
-    (void*) isr_adc1_comp,          /* [12] analog digital converter */
-    (void*) isr_lptim1,             /* [13] low power timer 1 */
-    (void*) isr_usart4_5,           /* [14] usart 4 to 5 */
-    (void*) isr_tim2,               /* [15] timer 2 */
-    (void*) isr_tim3,               /* [16] timer 3 */
-    (void*) isr_tim6_dac,           /* [17] timer 6 and digital to analog converter */
-    (void*) isr_tim7,               /* [18] timer 7 */
-    (void*) (0UL),                  /* [19] reserved */
-    (void*) isr_tim21,              /* [20] timer 21 */
-    (void*) isr_i2c3,               /* [21] I2C 3 */
-    (void*) isr_tim22,              /* [22] timer 22 */
-    (void*) isr_i2c1,               /* [23] I2C 1 */
-    (void*) isr_i2c2,               /* [24] I2C 2 */
-    (void*) isr_spi1,               /* [25] SPI 1 */
-    (void*) isr_spi2,               /* [26] SPI 2 */
-    (void*) isr_usart1,             /* [27] USART 1 */
-    (void*) isr_usart2,             /* [28] USART 2 */
-    (void*) isr_rng_lpuart1,        /* [29] RNG and Low power UART 1 */
-    (void*) isr_lcd,                /* [30] LCD */
-    (void*) isr_usb                 /* [31] USB */
+    isr_ts,                 /* [8] touch sensing input*/
+    isr_dma1_ch1,           /* [9] direct memory access controller 1, channel 1*/
+    isr_dma1_ch2_3,         /* [10] direct memory access controller 1, channel 2 and 3*/
+    isr_dma1_ch4_5_6_7,     /* [11] direct memory access controller 1, channel 4, 5, 6 and 7*/
+    isr_adc1_comp,          /* [12] analog digital converter */
+    isr_lptim1,             /* [13] low power timer 1 */
+    isr_usart4_5,           /* [14] usart 4 to 5 */
+    isr_tim2,               /* [15] timer 2 */
+    isr_tim3,               /* [16] timer 3 */
+    isr_tim6_dac,           /* [17] timer 6 and digital to analog converter */
+    isr_tim7,               /* [18] timer 7 */
+    (0UL),                  /* [19] reserved */
+    isr_tim21,              /* [20] timer 21 */
+    isr_i2c3,               /* [21] I2C 3 */
+    isr_tim22,              /* [22] timer 22 */
+    isr_i2c1,               /* [23] I2C 1 */
+    isr_i2c2,               /* [24] I2C 2 */
+    isr_spi1,               /* [25] SPI 1 */
+    isr_spi2,               /* [26] SPI 2 */
+    isr_usart1,             /* [27] USART 1 */
+    isr_usart2,             /* [28] USART 2 */
+    isr_rng_lpuart1,        /* [29] RNG and Low power UART 1 */
+    isr_lcd,                /* [30] LCD */
+    isr_usb                 /* [31] USB */
 #endif
 };

--- a/cpu/stm32l1/vectors.c
+++ b/cpu/stm32l1/vectors.c
@@ -31,10 +31,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* STM32L1 specific interrupt vectors */
 WEAK_DEFAULT void isr_wwdg(void);
 WEAK_DEFAULT void isr_pvd(void);
@@ -88,99 +84,78 @@ WEAK_DEFAULT void isr_dma2_ch5(void);
 WEAK_DEFAULT void isr_aes(void);
 WEAK_DEFAULT void isr_comp_acq(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M3 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
-    (void*) hard_fault_default,     /* [-13] hard fault exception */
-    (void*) mem_manage_default,     /* [-12] memory manage exception */
-    (void*) bus_fault_default,      /* [-11] bus fault exception */
-    (void*) usage_fault_default,    /* [-10] usage fault exception */
-    (void*) (0UL),                  /* [-9] Reserved */
-    (void*) (0UL),                  /* [-8] Reserved */
-    (void*) (0UL),                  /* [-7] Reserved */
-    (void*) (0UL),                  /* [-6] Reserved */
-    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
-                                            switching into thread context on boot */
-    (void*) debug_mon_default,      /* [-4] debug monitor exception */
-    (void*) (0UL),                  /* [-3] Reserved */
-    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
-                                            context switching is happening here */
-    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
-    /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* [0] Window WatchDog Interrupt */
-    (void*) isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
-    (void*) isr_tamper_stamp,       /* [2] Tamper and Time Stamp through EXTI Line Interrupts */
-    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup Timer through EXTI Line Interrupt */
-    (void*) isr_flash,              /* [4] FLASH global Interrupt */
-    (void*) isr_rcc,                /* [5] RCC global Interrupt */
-    (void*) isr_exti,               /* [6] EXTI Line0 Interrupt */
-    (void*) isr_exti,               /* [7] EXTI Line1 Interrupt */
-    (void*) isr_exti,               /* [8] EXTI Line2 Interrupt */
-    (void*) isr_exti,               /* [9] EXTI Line3 Interrupt */
-    (void*) isr_exti,               /* [10] EXTI Line4 Interrupt */
-    (void*) isr_dma1_ch1,           /* [11] DMA1 Channel 1 global Interrupt */
-    (void*) isr_dma1_ch2,           /* [12] DMA1 Channel 2 global Interrupt */
-    (void*) isr_dma1_ch3,           /* [13] DMA1 Channel 3 global Interrupt */
-    (void*) isr_dma1_ch4,           /* [14] DMA1 Channel 4 global Interrupt */
-    (void*) isr_dma1_ch5,           /* [15] DMA1 Channel 5 global Interrupt */
-    (void*) isr_dma1_ch6,           /* [16] DMA1 Channel 6 global Interrupt */
-    (void*) isr_dma1_ch7,           /* [17] DMA1 Channel 7 global Interrupt */
-    (void*) isr_adc1,               /* [18] ADC1 global Interrupt */
-    (void*) isr_usb_hp,             /* [19] USB High Priority Interrupt */
-    (void*) isr_usb_lp,             /* [20] USB Low Priority Interrupt */
-    (void*) isr_dac,                /* [21] DAC Interrupt */
-    (void*) isr_comp,               /* [22] Comparator through EXTI Line Interrupt */
-    (void*) isr_exti,               /* [23] External Line[9:5] Interrupts */
-    (void*) isr_lcd,                /* [24] LCD Interrupt */
-    (void*) isr_tim9,               /* [25] TIM9 global Interrupt */
-    (void*) isr_tim10,              /* [26] TIM10 global Interrupt */
-    (void*) isr_tim11,              /* [27] TIM11 global Interrupt */
-    (void*) isr_tim2,               /* [28] TIM2 global Interrupt */
-    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
-    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
-    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
-    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
-    (void*) isr_usart1,             /* [37] USART1 global Interrupt */
-    (void*) isr_usart2,             /* [38] USART2 global Interrupt */
-    (void*) isr_usart3,             /* [39] USART3 global Interrupt */
-    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm through EXTI Line Interrupt */
-    (void*) isr_usb_fs_wkup,        /* [42] USB FS WakeUp from suspend through EXTI Line Interrupt */
-    (void*) isr_tim6,               /* [43] TIM6 global Interrupt */
-    (void*) isr_tim7,               /* [44] TIM7 global Interrupt */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wwdg,               /* [0] Window WatchDog Interrupt */
+    isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
+    isr_tamper_stamp,       /* [2] Tamper and Time Stamp through EXTI Line Interrupts */
+    isr_rtc_wkup,           /* [3] RTC Wakeup Timer through EXTI Line Interrupt */
+    isr_flash,              /* [4] FLASH global Interrupt */
+    isr_rcc,                /* [5] RCC global Interrupt */
+    isr_exti,               /* [6] EXTI Line0 Interrupt */
+    isr_exti,               /* [7] EXTI Line1 Interrupt */
+    isr_exti,               /* [8] EXTI Line2 Interrupt */
+    isr_exti,               /* [9] EXTI Line3 Interrupt */
+    isr_exti,               /* [10] EXTI Line4 Interrupt */
+    isr_dma1_ch1,           /* [11] DMA1 Channel 1 global Interrupt */
+    isr_dma1_ch2,           /* [12] DMA1 Channel 2 global Interrupt */
+    isr_dma1_ch3,           /* [13] DMA1 Channel 3 global Interrupt */
+    isr_dma1_ch4,           /* [14] DMA1 Channel 4 global Interrupt */
+    isr_dma1_ch5,           /* [15] DMA1 Channel 5 global Interrupt */
+    isr_dma1_ch6,           /* [16] DMA1 Channel 6 global Interrupt */
+    isr_dma1_ch7,           /* [17] DMA1 Channel 7 global Interrupt */
+    isr_adc1,               /* [18] ADC1 global Interrupt */
+    isr_usb_hp,             /* [19] USB High Priority Interrupt */
+    isr_usb_lp,             /* [20] USB Low Priority Interrupt */
+    isr_dac,                /* [21] DAC Interrupt */
+    isr_comp,               /* [22] Comparator through EXTI Line Interrupt */
+    isr_exti,               /* [23] External Line[9:5] Interrupts */
+    isr_lcd,                /* [24] LCD Interrupt */
+    isr_tim9,               /* [25] TIM9 global Interrupt */
+    isr_tim10,              /* [26] TIM10 global Interrupt */
+    isr_tim11,              /* [27] TIM11 global Interrupt */
+    isr_tim2,               /* [28] TIM2 global Interrupt */
+    isr_tim3,               /* [29] TIM3 global Interrupt */
+    isr_tim4,               /* [30] TIM4 global Interrupt */
+    isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
+    isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    isr_i2c2_ev,            /* [33] I2C2 Event Interrupt */
+    isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    isr_spi1,               /* [35] SPI1 global Interrupt */
+    isr_spi2,               /* [36] SPI2 global Interrupt */
+    isr_usart1,             /* [37] USART1 global Interrupt */
+    isr_usart2,             /* [38] USART2 global Interrupt */
+    isr_usart3,             /* [39] USART3 global Interrupt */
+    isr_exti,               /* [40] External Line[15:10] Interrupts */
+    isr_rtc_alarm,          /* [41] RTC Alarm through EXTI Line Interrupt */
+    isr_usb_fs_wkup,        /* [42] USB FS WakeUp from suspend through EXTI Line Interrupt */
+    isr_tim6,               /* [43] TIM6 global Interrupt */
+    isr_tim7,               /* [44] TIM7 global Interrupt */
 #if defined(CPU_MODEL_STM32L151RC)
-    (void*) (0UL),                  /* [45] Reserved */
-    (void*) isr_tim5,               /* [46] TIM5 global Interrupt */
-    (void*) isr_spi3,               /* [47] SPI3 global Interrupt */
-    (void*) (0UL),                  /* [48] Reserved */
-    (void*) (0UL),                  /* [49] Reserved */
-    (void*) isr_dma2_ch1,           /* [50] DMA2 Channel 1 global Interrupt */
-    (void*) isr_dma2_ch2,           /* [51] DMA2 Channel 2 global Interrupt */
-    (void*) isr_dma2_ch3,           /* [52] DMA2 Channel 3 global Interrupt */
-    (void*) isr_dma2_ch4,           /* [53] DMA2 Channel 4 global Interrupt */
-    (void*) isr_dma2_ch5,           /* [54] DMA2 Channel 5 global Interrupt */
-    (void*) isr_aes,                /* [55] AES global Interrupt */
-    (void*) isr_comp_acq            /* [56] Comparator Channel Acquisition global Interrupt */
+    (0UL),                  /* [45] Reserved */
+    isr_tim5,               /* [46] TIM5 global Interrupt */
+    isr_spi3,               /* [47] SPI3 global Interrupt */
+    (0UL),                  /* [48] Reserved */
+    (0UL),                  /* [49] Reserved */
+    isr_dma2_ch1,           /* [50] DMA2 Channel 1 global Interrupt */
+    isr_dma2_ch2,           /* [51] DMA2 Channel 2 global Interrupt */
+    isr_dma2_ch3,           /* [52] DMA2 Channel 3 global Interrupt */
+    isr_dma2_ch4,           /* [53] DMA2 Channel 4 global Interrupt */
+    isr_dma2_ch5,           /* [54] DMA2 Channel 5 global Interrupt */
+    isr_aes,                /* [55] AES global Interrupt */
+    isr_comp_acq            /* [56] Comparator Channel Acquisition global Interrupt */
 #elif defined(CPU_MODEL_STM32L152RET6)
-    (void*) (0UL),                  /* [45] Reserved */
-    (void*) isr_tim5,               /* [46] TIM5 global Interrupt */
-    (void*) isr_spi3,               /* [47] SPI3 global Interrupt */
-    (void*) isr_uart4,              /* [48] UART4 global Interrupt */
-    (void*) isr_uart5,              /* [49] UART5 global Interrupt */
-    (void*) isr_dma2_ch1,           /* [50] DMA2 Channel 1 global Interrupt */
-    (void*) isr_dma2_ch2,           /* [51] DMA2 Channel 2 global Interrupt */
-    (void*) isr_dma2_ch3,           /* [52] DMA2 Channel 3 global Interrupt */
-    (void*) isr_dma2_ch4,           /* [53] DMA2 Channel 4 global Interrupt */
-    (void*) isr_dma2_ch5,           /* [54] DMA2 Channel 5 global Interrupt */
-    (void*) isr_aes,                /* [55] AES global Interrupt */
-    (void*) isr_comp_acq            /* [56] Comparator Channel Acquisition global Interrupt */
+    (0UL),                  /* [45] Reserved */
+    isr_tim5,               /* [46] TIM5 global Interrupt */
+    isr_spi3,               /* [47] SPI3 global Interrupt */
+    isr_uart4,              /* [48] UART4 global Interrupt */
+    isr_uart5,              /* [49] UART5 global Interrupt */
+    isr_dma2_ch1,           /* [50] DMA2 Channel 1 global Interrupt */
+    isr_dma2_ch2,           /* [51] DMA2 Channel 2 global Interrupt */
+    isr_dma2_ch3,           /* [52] DMA2 Channel 3 global Interrupt */
+    isr_dma2_ch4,           /* [53] DMA2 Channel 4 global Interrupt */
+    isr_dma2_ch5,           /* [54] DMA2 Channel 5 global Interrupt */
+    isr_aes,                /* [55] AES global Interrupt */
+    isr_comp_acq            /* [56] Comparator Channel Acquisition global Interrupt */
 #endif
 };

--- a/cpu/stm32l1/vectors.c
+++ b/cpu/stm32l1/vectors.c
@@ -85,7 +85,7 @@ WEAK_DEFAULT void isr_aes(void);
 WEAK_DEFAULT void isr_comp_acq(void);
 
 /* CPU specific interrupt vector table */
-ISR_VECTOR(1) const isr_t vector_cpu[] = {
+ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_wwdg,               /* [0] Window WatchDog Interrupt */
     isr_pvd,                /* [1] PVD through EXTI Line detection Interrupt */
     isr_tamper_stamp,       /* [2] Tamper and Time Stamp through EXTI Line Interrupts */

--- a/cpu/stm32l4/vectors.c
+++ b/cpu/stm32l4/vectors.c
@@ -30,10 +30,6 @@ void dummy_handler(void) {
     dummy_handler_default();
 }
 
-/* Cortex-M common interrupt vectors */
-WEAK_DEFAULT void isr_svc(void);
-WEAK_DEFAULT void isr_pendsv(void);
-WEAK_DEFAULT void isr_systick(void);
 /* STM32L4 specific interrupt vectors */
 WEAK_DEFAULT void isr_wwdg(void);
 WEAK_DEFAULT void isr_pvd_pvm(void);
@@ -113,166 +109,145 @@ WEAK_DEFAULT void isr_rng(void);
 WEAK_DEFAULT void isr_fpu(void);
 WEAK_DEFAULT void isr_crs(void);
 
-/* interrupt vector table */
-ISR_VECTORS const void *interrupt_vector[] = {
-    /* Exception stack pointer */
-    (void*) (&_estack),             /* pointer to the top of the stack */
-    /* Cortex-M4 handlers */
-    (void*) reset_handler_default,  /* entry point of the program */
-    (void*) nmi_default,            /* [-14] non maskable interrupt handler */
-    (void*) hard_fault_default,     /* [-13] hard fault exception */
-    (void*) mem_manage_default,     /* [-12] memory manage exception */
-    (void*) bus_fault_default,      /* [-11] bus fault exception */
-    (void*) usage_fault_default,    /* [-10] usage fault exception */
-    (void*) (0UL),                  /* [-9] Reserved */
-    (void*) (0UL),                  /* [-8] Reserved */
-    (void*) (0UL),                  /* [-7] Reserved */
-    (void*) (0UL),                  /* [-6] Reserved */
-    (void*) isr_svc,                /* [-5] system call interrupt, in RIOT used for
-                                            switching into thread context on boot */
-    (void*) debug_mon_default,      /* [-4] debug monitor exception */
-    (void*) (0UL),                  /* [-3] Reserved */
-    (void*) isr_pendsv,             /* [-2] pendSV interrupt, in RIOT the actual
-                                            context switching is happening here */
-    (void*) isr_systick,            /* [-1] SysTick interrupt, not used in RIOT */
-    /* STM specific peripheral handlers */
-    (void*) isr_wwdg,               /* [0] Window WatchDog Interrupt */
-    (void*) isr_pvd_pvm,            /* [1] PVD/PVM1/PVM2/PVM3/PVM4 through EXTI Line detection Interrupts */
-    (void*) isr_tamp_stamp,         /* [2] Tamper and TimeStamp interrupts through the EXTI line */
-    (void*) isr_rtc_wkup,           /* [3] RTC Wakeup interrupt through the EXTI line */
-    (void*) isr_flash,              /* [4] FLASH global Interrupt */
-    (void*) isr_rcc,                /* [5] RCC global Interrupt */
-    (void*) isr_exti,               /* [6] EXTI Line0 Interrupt */
-    (void*) isr_exti,               /* [7] EXTI Line1 Interrupt */
-    (void*) isr_exti,               /* [8] EXTI Line2 Interrupt */
-    (void*) isr_exti,               /* [9] EXTI Line3 Interrupt */
-    (void*) isr_exti,               /* [10] EXTI Line4 Interrupt */
-    (void*) isr_dma1_channel1,      /* [11] DMA1 Channel 1 global Interrupt */
-    (void*) isr_dma1_channel2,      /* [12] DMA1 Channel 2 global Interrupt */
-    (void*) isr_dma1_channel3,      /* [13] DMA1 Channel 3 global Interrupt */
-    (void*) isr_dma1_channel4,      /* [14] DMA1 Channel 4 global Interrupt */
-    (void*) isr_dma1_channel5,      /* [15] DMA1 Channel 5 global Interrupt */
-    (void*) isr_dma1_channel6,      /* [16] DMA1 Channel 6 global Interrupt */
-    (void*) isr_dma1_channel7,      /* [17] DMA1 Channel 7 global Interrupt */
-    (void*) isr_adc1_2,             /* [18] ADC1 global Interrupt */
-    (void*) isr_can1_tx,            /* [19] CAN1 TX Interrupt */
-    (void*) isr_can1_rx0,           /* [20] CAN1 RX0 Interrupt */
-    (void*) isr_can1_rx1,           /* [21] CAN1 RX1 Interrupt */
-    (void*) isr_can1_sce,           /* [22] CAN1 SCE Interrupt */
-    (void*) isr_exti,               /* [23] External Line[9:5] Interrupts */
-    (void*) isr_tim1_brk_tim15,     /* [24] TIM1 Break interrupt and TIM15 global interrupt */
-    (void*) isr_tim1_up_tim16,      /* [25] TIM1 Update Interrupt and TIM16 global interrupt */
-    (void*) isr_tim1_trg_com_tim17, /* [26] TIM1 Trigger and Commutation Interrupt */
-    (void*) isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
-    (void*) isr_tim2,               /* [28] TIM2 global Interrupt */
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1) const isr_t vector_cpu[] = {
+    isr_wwdg,               /* [0] Window WatchDog Interrupt */
+    isr_pvd_pvm,            /* [1] PVD/PVM1/PVM2/PVM3/PVM4 through EXTI Line detection Interrupts */
+    isr_tamp_stamp,         /* [2] Tamper and TimeStamp interrupts through the EXTI line */
+    isr_rtc_wkup,           /* [3] RTC Wakeup interrupt through the EXTI line */
+    isr_flash,              /* [4] FLASH global Interrupt */
+    isr_rcc,                /* [5] RCC global Interrupt */
+    isr_exti,               /* [6] EXTI Line0 Interrupt */
+    isr_exti,               /* [7] EXTI Line1 Interrupt */
+    isr_exti,               /* [8] EXTI Line2 Interrupt */
+    isr_exti,               /* [9] EXTI Line3 Interrupt */
+    isr_exti,               /* [10] EXTI Line4 Interrupt */
+    isr_dma1_channel1,      /* [11] DMA1 Channel 1 global Interrupt */
+    isr_dma1_channel2,      /* [12] DMA1 Channel 2 global Interrupt */
+    isr_dma1_channel3,      /* [13] DMA1 Channel 3 global Interrupt */
+    isr_dma1_channel4,      /* [14] DMA1 Channel 4 global Interrupt */
+    isr_dma1_channel5,      /* [15] DMA1 Channel 5 global Interrupt */
+    isr_dma1_channel6,      /* [16] DMA1 Channel 6 global Interrupt */
+    isr_dma1_channel7,      /* [17] DMA1 Channel 7 global Interrupt */
+    isr_adc1_2,             /* [18] ADC1 global Interrupt */
+    isr_can1_tx,            /* [19] CAN1 TX Interrupt */
+    isr_can1_rx0,           /* [20] CAN1 RX0 Interrupt */
+    isr_can1_rx1,           /* [21] CAN1 RX1 Interrupt */
+    isr_can1_sce,           /* [22] CAN1 SCE Interrupt */
+    isr_exti,               /* [23] External Line[9:5] Interrupts */
+    isr_tim1_brk_tim15,     /* [24] TIM1 Break interrupt and TIM15 global interrupt */
+    isr_tim1_up_tim16,      /* [25] TIM1 Update Interrupt and TIM16 global interrupt */
+    isr_tim1_trg_com_tim17, /* [26] TIM1 Trigger and Commutation Interrupt */
+    isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
+    isr_tim2,               /* [28] TIM2 global Interrupt */
 #if defined(CPU_MODEL_STM32L432KC)
-    (void*) (0UL),                  /* [29] Reserved */
-    (void*) (0UL),                  /* [30] Reserved */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
-    (void*) (0UL),                  /* [33] Reserved */
-    (void*) (0UL),                  /* [34] Reserved */
-    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
-    (void*) (0UL),                  /* [36] Reserved */
-    (void*) isr_usart1,             /* [37] USART1 global Interrupt */
-    (void*) isr_usart2,             /* [38] USART2 global Interrupt */
-    (void*) (0UL),                  /* [39] Reserved */
-    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line Interrupt */
-    (void*) (0UL),                  /* [42] Reserved */
-    (void*) (0UL),                  /* [43] Reserved */
-    (void*) (0UL),                  /* [44] Reserved */
-    (void*) (0UL),                  /* [45] Reserved */
-    (void*) (0UL),                  /* [46] Reserved */
-    (void*) (0UL),                  /* [47] Reserved */
-    (void*) (0UL),                  /* [48] Reserved */
-    (void*) (0UL),                  /* [49] Reserved */
-    (void*) (0UL),                  /* [50] Reserved */
-    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
-    (void*) (0UL),                  /* [52] Reserved */
-    (void*) (0UL),                  /* [53] Reserved */
-    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC1&2 underrun error interrupts */
-    (void*) isr_tim7,               /* [55] TIM7 global interrupt */
-    (void*) isr_dma2_channel1,      /* [56] DMA2 Channel 1 global Interrupt */
-    (void*) isr_dma2_channel2,      /* [57] DMA2 Channel 2 global Interrupt */
-    (void*) isr_dma2_channel3,      /* [58] DMA2 Channel 3 global Interrupt */
-    (void*) isr_dma2_channel4,      /* [59] DMA2 Channel 4 global Interrupt */
-    (void*) isr_dma2_channel5,      /* [60] DMA2 Channel 5 global Interrupt */
-    (void*) (0UL),                  /* [61] Reserved */
-    (void*) (0UL),                  /* [62] Reserved */
-    (void*) (0UL),                  /* [63] Reserved */
-    (void*) isr_comp,               /* [64] COMP1 and COMP2 Interrupts */
-    (void*) isr_lptim1,             /* [65] LP TIM1 interrupt */
-    (void*) isr_lptim2,             /* [66] LP TIM2 interrupt */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS global Interrupt */
-    (void*) isr_dma2_channel6,      /* [68] DMA2 Channel 6 global interrupt */
-    (void*) isr_dma2_channel7,      /* [69] DMA2 Channel 7 global interrupt */
-    (void*) isr_lpuart1,            /* [70] LP UART1 interrupt */
-    (void*) isr_quadspi,            /* [71] Quad SPI global interrupt */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event interrupt */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error interrupt */
-    (void*) isr_sai1,               /* [74] Serial Audio Interface 1 global interrupt */
-    (void*) (0UL),                  /* [75] Reserved */
-    (void*) isr_swpmi1,             /* [76] Serial Wire Interface 1 global interrupt */
-    (void*) isr_tsc,                /* [77] Touch Sense Controller global interrupt */
-    (void*) (0UL),                  /* [78] Reserved */
-    (void*) (0UL),                  /* [79] Reserved*/
-    (void*) isr_rng,                /* [80] RNG global interrupt */
-    (void*) isr_fpu,                /* [81] FPU global interrupt */
-    (void*) isr_crs                 /* [82] CRS global interrupt */
+    (0UL),                  /* [29] Reserved */
+    (0UL),                  /* [30] Reserved */
+    isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
+    isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    (0UL),                  /* [33] Reserved */
+    (0UL),                  /* [34] Reserved */
+    isr_spi1,               /* [35] SPI1 global Interrupt */
+    (0UL),                  /* [36] Reserved */
+    isr_usart1,             /* [37] USART1 global Interrupt */
+    isr_usart2,             /* [38] USART2 global Interrupt */
+    (0UL),                  /* [39] Reserved */
+    isr_exti,               /* [40] External Line[15:10] Interrupts */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line Interrupt */
+    (0UL),                  /* [42] Reserved */
+    (0UL),                  /* [43] Reserved */
+    (0UL),                  /* [44] Reserved */
+    (0UL),                  /* [45] Reserved */
+    (0UL),                  /* [46] Reserved */
+    (0UL),                  /* [47] Reserved */
+    (0UL),                  /* [48] Reserved */
+    (0UL),                  /* [49] Reserved */
+    (0UL),                  /* [50] Reserved */
+    isr_spi3,               /* [51] SPI3 global Interrupt */
+    (0UL),                  /* [52] Reserved */
+    (0UL),                  /* [53] Reserved */
+    isr_tim6_dac,           /* [54] TIM6 global and DAC1&2 underrun error interrupts */
+    isr_tim7,               /* [55] TIM7 global interrupt */
+    isr_dma2_channel1,      /* [56] DMA2 Channel 1 global Interrupt */
+    isr_dma2_channel2,      /* [57] DMA2 Channel 2 global Interrupt */
+    isr_dma2_channel3,      /* [58] DMA2 Channel 3 global Interrupt */
+    isr_dma2_channel4,      /* [59] DMA2 Channel 4 global Interrupt */
+    isr_dma2_channel5,      /* [60] DMA2 Channel 5 global Interrupt */
+    (0UL),                  /* [61] Reserved */
+    (0UL),                  /* [62] Reserved */
+    (0UL),                  /* [63] Reserved */
+    isr_comp,               /* [64] COMP1 and COMP2 Interrupts */
+    isr_lptim1,             /* [65] LP TIM1 interrupt */
+    isr_lptim2,             /* [66] LP TIM2 interrupt */
+    isr_otg_fs,             /* [67] USB OTG FS global Interrupt */
+    isr_dma2_channel6,      /* [68] DMA2 Channel 6 global interrupt */
+    isr_dma2_channel7,      /* [69] DMA2 Channel 7 global interrupt */
+    isr_lpuart1,            /* [70] LP UART1 interrupt */
+    isr_quadspi,            /* [71] Quad SPI global interrupt */
+    isr_i2c3_ev,            /* [72] I2C3 event interrupt */
+    isr_i2c3_er,            /* [73] I2C3 error interrupt */
+    isr_sai1,               /* [74] Serial Audio Interface 1 global interrupt */
+    (0UL),                  /* [75] Reserved */
+    isr_swpmi1,             /* [76] Serial Wire Interface 1 global interrupt */
+    isr_tsc,                /* [77] Touch Sense Controller global interrupt */
+    (0UL),                  /* [78] Reserved */
+    (0UL),                  /* [79] Reserved*/
+    isr_rng,                /* [80] RNG global interrupt */
+    isr_fpu,                /* [81] FPU global interrupt */
+    isr_crs                 /* [82] CRS global interrupt */
 #else /* CPU_MODEL_STM32L476RG */
-    (void*) isr_tim3,               /* [29] TIM3 global Interrupt */
-    (void*) isr_tim4,               /* [30] TIM4 global Interrupt */
-    (void*) isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
-    (void*) isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
-    (void*) isr_i2c2_ev,            /* [33] I2C2 Event Interrupt */
-    (void*) isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
-    (void*) isr_spi1,               /* [35] SPI1 global Interrupt */
-    (void*) isr_spi2,               /* [36] SPI2 global Interrupt */
-    (void*) isr_usart1,             /* [37] USART1 global Interrupt */
-    (void*) isr_usart2,             /* [38] USART2 global Interrupt */
-    (void*) isr_usart3,             /* [39] USART3 global Interrupt */
-    (void*) isr_exti,               /* [40] External Line[15:10] Interrupts */
-    (void*) isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line Interrupt */
-    (void*) isr_dfsdm1_flt3,        /* [42] DFSDM1 Filter 3 global Interrupt */
-    (void*) isr_tim8_brk,           /* [43] TIM8 Break Interrupt */
-    (void*) isr_tim8_up,            /* [44] TIM8 Update Interrupt */
-    (void*) isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
-    (void*) isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
-    (void*) isr_adc3,               /* [47] ADC3 global  Interrupt */
-    (void*) isr_fmc,                /* [48] FMC global Interrupt */
-    (void*) isr_sdmmc1,             /* [49] SDMMC1 global Interrupt */
-    (void*) isr_tim5,               /* [50] TIM5 global Interrupt */
-    (void*) isr_spi3,               /* [51] SPI3 global Interrupt */
-    (void*) isr_uart4,              /* [52] UART4 global Interrupt */
-    (void*) isr_uart5,              /* [53] UART5 global Interrupt */
-    (void*) isr_tim6_dac,           /* [54] TIM6 global and DAC1&2 underrun error interrupts */
-    (void*) isr_tim7,               /* [55] TIM7 global interrupt */
-    (void*) isr_dma2_channel1,      /* [56] DMA2 Channel 1 global Interrupt */
-    (void*) isr_dma2_channel2,      /* [57] DMA2 Channel 2 global Interrupt */
-    (void*) isr_dma2_channel3,      /* [58] DMA2 Channel 3 global Interrupt */
-    (void*) isr_dma2_channel4,      /* [59] DMA2 Channel 4 global Interrupt */
-    (void*) isr_dma2_channel5,      /* [60] DMA2 Channel 5 global Interrupt */
-    (void*) isr_dfsdm1_flt0,        /* [61] DFSDM1 Filter 0 global Interrupt */
-    (void*) isr_dfsdm1_flt1,        /* [62] DFSDM1 Filter 1 global Interrupt */
-    (void*) isr_dfsdm1_flt2,        /* [63] DFSDM1 Filter 2 global Interrupt */
-    (void*) isr_comp,               /* [64] COMP1 and COMP2 Interrupts */
-    (void*) isr_lptim1,             /* [65] LP TIM1 interrupt */
-    (void*) isr_lptim2,             /* [66] LP TIM2 interrupt */
-    (void*) isr_otg_fs,             /* [67] USB OTG FS global Interrupt */
-    (void*) isr_dma2_channel6,      /* [68] DMA2 Channel 6 global interrupt */
-    (void*) isr_dma2_channel7,      /* [69] DMA2 Channel 7 global interrupt */
-    (void*) isr_lpuart1,            /* [70] LP UART1 interrupt */
-    (void*) isr_quadspi,            /* [71] Quad SPI global interrupt */
-    (void*) isr_i2c3_ev,            /* [72] I2C3 event interrupt */
-    (void*) isr_i2c3_er,            /* [73] I2C3 error interrupt */
-    (void*) isr_sai1,               /* [74] Serial Audio Interface 1 global interrupt */
-    (void*) isr_sai2,               /* [75] Serial Audio Interface 2 global interrupt */
-    (void*) isr_swpmi1,             /* [76] Serial Wire Interface 1 global interrupt */
-    (void*) isr_tsc,                /* [77] Touch Sense Controller global interrupt */
-    (void*) isr_lcd,                /* [78] LCD global interrupt */
-    (void*) (0UL),                  /* [79] Reserved*/
-    (void*) isr_rng,                /* [80] RNG global interrupt */
-    (void*) isr_fpu                 /* [81] FPU global interrupt */
+    isr_tim3,               /* [29] TIM3 global Interrupt */
+    isr_tim4,               /* [30] TIM4 global Interrupt */
+    isr_i2c1_ev,            /* [31] I2C1 Event Interrupt */
+    isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
+    isr_i2c2_ev,            /* [33] I2C2 Event Interrupt */
+    isr_i2c2_er,            /* [34] I2C2 Error Interrupt */
+    isr_spi1,               /* [35] SPI1 global Interrupt */
+    isr_spi2,               /* [36] SPI2 global Interrupt */
+    isr_usart1,             /* [37] USART1 global Interrupt */
+    isr_usart2,             /* [38] USART2 global Interrupt */
+    isr_usart3,             /* [39] USART3 global Interrupt */
+    isr_exti,               /* [40] External Line[15:10] Interrupts */
+    isr_rtc_alarm,          /* [41] RTC Alarm (A and B) through EXTI Line Interrupt */
+    isr_dfsdm1_flt3,        /* [42] DFSDM1 Filter 3 global Interrupt */
+    isr_tim8_brk,           /* [43] TIM8 Break Interrupt */
+    isr_tim8_up,            /* [44] TIM8 Update Interrupt */
+    isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
+    isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
+    isr_adc3,               /* [47] ADC3 global  Interrupt */
+    isr_fmc,                /* [48] FMC global Interrupt */
+    isr_sdmmc1,             /* [49] SDMMC1 global Interrupt */
+    isr_tim5,               /* [50] TIM5 global Interrupt */
+    isr_spi3,               /* [51] SPI3 global Interrupt */
+    isr_uart4,              /* [52] UART4 global Interrupt */
+    isr_uart5,              /* [53] UART5 global Interrupt */
+    isr_tim6_dac,           /* [54] TIM6 global and DAC1&2 underrun error interrupts */
+    isr_tim7,               /* [55] TIM7 global interrupt */
+    isr_dma2_channel1,      /* [56] DMA2 Channel 1 global Interrupt */
+    isr_dma2_channel2,      /* [57] DMA2 Channel 2 global Interrupt */
+    isr_dma2_channel3,      /* [58] DMA2 Channel 3 global Interrupt */
+    isr_dma2_channel4,      /* [59] DMA2 Channel 4 global Interrupt */
+    isr_dma2_channel5,      /* [60] DMA2 Channel 5 global Interrupt */
+    isr_dfsdm1_flt0,        /* [61] DFSDM1 Filter 0 global Interrupt */
+    isr_dfsdm1_flt1,        /* [62] DFSDM1 Filter 1 global Interrupt */
+    isr_dfsdm1_flt2,        /* [63] DFSDM1 Filter 2 global Interrupt */
+    isr_comp,               /* [64] COMP1 and COMP2 Interrupts */
+    isr_lptim1,             /* [65] LP TIM1 interrupt */
+    isr_lptim2,             /* [66] LP TIM2 interrupt */
+    isr_otg_fs,             /* [67] USB OTG FS global Interrupt */
+    isr_dma2_channel6,      /* [68] DMA2 Channel 6 global interrupt */
+    isr_dma2_channel7,      /* [69] DMA2 Channel 7 global interrupt */
+    isr_lpuart1,            /* [70] LP UART1 interrupt */
+    isr_quadspi,            /* [71] Quad SPI global interrupt */
+    isr_i2c3_ev,            /* [72] I2C3 event interrupt */
+    isr_i2c3_er,            /* [73] I2C3 error interrupt */
+    isr_sai1,               /* [74] Serial Audio Interface 1 global interrupt */
+    isr_sai2,               /* [75] Serial Audio Interface 2 global interrupt */
+    isr_swpmi1,             /* [76] Serial Wire Interface 1 global interrupt */
+    isr_tsc,                /* [77] Touch Sense Controller global interrupt */
+    isr_lcd,                /* [78] LCD global interrupt */
+    (0UL),                  /* [79] Reserved*/
+    isr_rng,                /* [80] RNG global interrupt */
+    isr_fpu                 /* [81] FPU global interrupt */
 #endif
 };


### PR DESCRIPTION
@kaspar030 and me finally found a very nice solution for sharing the Cortex-M vector table between all the Cortex-M based CPUs in RIOT. We simply split the table into chunks and add them separately to the vector table linker section, adding a numeric value as sub-section name for making sure the correct order is used.

This approach does further enable CPUs to even split up their CPU specific ISR vector table, allowing for more re-use.

Also, this approach enables to define the CPU specific vectors 'out-of-order', so that reserved fields do not have to be defined explicitly. See `cpu/stm32l4/vectors.c` as example.