### PR TITLE
drivers: several fixes for drivers using I2C on 8Bit MCUs

### DIFF
--- a/drivers/bh1750fvi/bh1750fvi.c
+++ b/drivers/bh1750fvi/bh1750fvi.c
@@ -71,7 +71,7 @@ uint16_t bh1750fvi_sample(const bh1750fvi_t *dev)
     i2c_release(dev->i2c);
 
     /* and finally we calculate the actual LUX value */
-    tmp = (raw[0] << 24) | (raw[1] << 16);
+    tmp = ((uint32_t)raw[0] << 24) | ((uint32_t)raw[1] << 16);
     tmp /= RES_DIV;
     return (uint16_t)(tmp);
 }

--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -198,7 +198,7 @@ static int _read_ut(const bmp180_t *dev, int32_t *output)
         i2c_release(DEV_I2C);
         return -1;
     }
-    *output = ( ut[0] << 8 ) | ut[1];
+    *output = ((uint16_t)ut[0] << 8) | ut[1];
 
     DEBUG("UT: %i\n", (int)*output);
 
@@ -234,7 +234,8 @@ static int _read_up(const bmp180_t *dev, int32_t *output)
         return -1;
     }
 
-    *output = ((up[0] << 16) | (up[1] << 8) | up[2]) >> (8 - OVERSAMPLING);
+    *output = (((uint32_t)up[0] << 16) |
+               ((uint32_t)up[1] <<  8) | up[2]) >> (8 - OVERSAMPLING);
 
     DEBUG("UP: %i\n", (int)*output);
 

--- a/drivers/hih6130/hih6130.c
+++ b/drivers/hih6130/hih6130.c
@@ -52,7 +52,7 @@ enum {
 };
 
 /** @brief Delay between requesting a measurement and data becoming ready */
-#define MEASUREMENT_DELAY   (50*1000)
+#define MEASUREMENT_DELAY   (50LU * US_PER_MS)
 
 /** @brief Trigger a new measurement on the sensor */
 static inline int hih6130_measurement_request(const hih6130_t *dev)

--- a/drivers/mpu9150/mpu9150.c
+++ b/drivers/mpu9150/mpu9150.c
@@ -375,8 +375,8 @@ int mpu9150_read_temperature(const mpu9150_t *dev, int32_t *output)
     /* Release the bus */
     i2c_release(dev->i2c_dev);
 
-    temp = (data[0] << 8) | data[1];
-    *output = ((((int32_t)temp) * 1000) / 340) + (35*1000);
+    temp = ((uint16_t)data[0] << 8) | data[1];
+    *output = (((int32_t)temp * 1000LU) / 340) + (35 * 1000LU);
 
     return 0;
 }

--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -379,10 +379,10 @@ int pn532_fw_version(pn532_t *dev, uint32_t *fw_ver)
     buff[BUFF_CMD_START] = CMD_FIRMWARE_VERSION;
 
     if (send_rcv(dev, buff, 0, 4) == 4) {
-        *fw_ver = (buff[0] << 24);  /* ic version */
-        *fw_ver += (buff[1] << 16); /* fw ver */
-        *fw_ver += (buff[2] << 8);  /* fw rev */
-        *fw_ver += (buff[3]);       /* feature support */
+        *fw_ver =  ((uint32_t)buff[0] << 24);   /* ic version */
+        *fw_ver += ((uint32_t)buff[1] << 16);   /* fw ver */
+        *fw_ver += ((uint32_t)buff[2] << 8);    /* fw rev */
+        *fw_ver += (buff[3]);                   /* feature support */
         ret = 0;
     }
 


### PR DESCRIPTION
this PR fixes several issues, i.e., overflow and over shift, in multiple drivers observed when using them with I2C on 8Bit MCUs like Arduino Atmega based boards. 

This PR is required to make #7229 work.