### PR TITLE
sys: random: use luid for random seed initalization

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -715,6 +715,10 @@ USEPKG += nanocoap
 USEMODULE += gnrc_sock_udp
 endif
 
+ifneq (,$(filter luid,$(USEMODULE)))
+  FEATURES_OPTIONAL += periph_cpuid
+endif
+
 # always select gpio (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio
 

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -656,6 +656,8 @@ ifneq (,$(filter random,$(USEMODULE)))
   ifneq (,$(filter prng_tinymt32,$(USEMODULE)))
     USEMODULE += tinymt32
   endif
+
+  USEMODULE += luid
 endif
 
 ifneq (,$(filter openthread_contrib,$(USEMODULE)))

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -80,10 +80,6 @@
 #include "net/fib.h"
 #endif
 
-#ifdef MODULE_PRNG
-#include "random.h"
-#endif
-
 #ifdef MODULE_GCOAP
 #include "net/gcoap.h"
 #endif
@@ -99,7 +95,8 @@
 void auto_init(void)
 {
 #ifdef MODULE_PRNG
-    random_init(0);
+    void auto_init_random(void);
+    auto_init_random();
 #endif
 #ifdef MODULE_XTIMER
     DEBUG("Auto init xtimer module.\n");

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -32,6 +32,14 @@
 extern "C" {
 #endif
 
+#ifndef RANDOM_DEFAULT_SEED
+/**
+ * @brief   Seed selected when all tries to collect seeds from a random source
+ *          failed
+ */
+#define RANDOM_DEFAULT_SEED (1)
+#endif
+
 /**
  * @brief Enables support for floating point random number generation
  */

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -32,12 +32,12 @@
 extern "C" {
 #endif
 
-#ifndef RANDOM_DEFAULT_SEED
+#ifndef RANDOM_SEED_DEFAULT
 /**
  * @brief   Seed selected when all tries to collect seeds from a random source
  *          failed
  */
-#define RANDOM_DEFAULT_SEED (1)
+#define RANDOM_SEED_DEFAULT (1)
 #endif
 
 /**

--- a/sys/random/Makefile
+++ b/sys/random/Makefile
@@ -1,3 +1,5 @@
+SRC := seed.c
+
 BASE_MODULE := prng
 SUBMODULES := 1
 

--- a/sys/random/seed.c
+++ b/sys/random/seed.c
@@ -34,7 +34,7 @@ void auto_init_random(void)
     luid_get(&seed, 4);
 #else
     LOG_WARNING("random: NO SEED AVAILABLE!\n");
-    seed = 1;
+    seed = RANDOM_SEED_DEFAULT;
 #endif
     DEBUG("random: using seed value %u\n", (unsigned)seed);
     random_init(seed);

--- a/sys/random/seed.c
+++ b/sys/random/seed.c
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+ /**
+ * @ingroup sys_random
+ * @{
+ * @file
+ *
+ * @brief PRNG seeding
+ *
+ * @author Kaspar Schleiser <kaspar@schleiser.de>
+ * @}
+ */
+
+#include <stdint.h>
+
+#include "log.h"
+#include "luid.h"
+#include "periph/cpuid.h"
+#include "random.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+void auto_init_random(void)
+{
+    uint32_t seed;
+#ifdef MODULE_PERIPH_CPUID
+    luid_get(&seed, 4);
+#else
+    LOG_WARNING("random: NO SEED AVAILABLE!\n");
+    seed = 1;
+#endif
+    DEBUG("random: using seed value %u\n", (unsigned)seed);
+    random_init(seed);
+}


### PR DESCRIPTION
This PR uses luid as random seed source, *if* cpuid is available.
This should provide node-unique random seeds.
If cpuid is not available, prints a big warning at boot time.

See #6727 for discussion.

~~Depends on #7544.~~