### PR TITLE
drivers, lps331ap: fix overshift error on 8Bit MCUs

### DIFF
--- a/drivers/lps331ap/lps331ap.c
+++ b/drivers/lps331ap/lps331ap.c
@@ -86,7 +86,7 @@ int lps331ap_read_temp(const lps331ap_t *dev)
     val |= tmp;
     i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_TEMP_OUT_H, &tmp);
     i2c_release(dev->i2c);
-    val |= (tmp << 8);
+    val |= ((uint16_t)tmp << 8);
 
     /* compute actual temperature value in °C */
     res += ((float)val) / TEMP_DIVIDER;
@@ -105,13 +105,13 @@ int lps331ap_read_pres(const lps331ap_t *dev)
     i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_XL, &tmp);
     val |= tmp;
     i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_L, &tmp);
-    val |= (tmp << 8);
+    val |= ((uint32_t)tmp << 8);
     i2c_read_reg(dev->i2c, dev->address, LPS331AP_REG_PRESS_OUT_H, &tmp);
     i2c_release(dev->i2c);
-    val |= (tmp << 16);
+    val |= ((uint32_t)tmp << 16);
     /* see if value is negative */
     if (tmp & 0x80) {
-        val |= (0xff << 24);
+        val |= ((uint32_t)0xff << 24);
     }
 
     /* compute actual pressure value in mbar */


### PR DESCRIPTION
followup on #7539, missed one driver using i2c on 8bit MCUs like atmega328p. 