### PR TITLE
drivers/dht: remove useless auto_init declaration

### DIFF
--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -78,11 +78,6 @@ typedef struct {
 typedef dht_t dht_params_t;
 
 /**
- * @brief auto-initialize all configured DHT devices
- */
-void dht_auto_init(void);
-
-/**
  * @brief initialize a new DHT device
  *
  * @param[out] dev      device descriptor of a DHT device


### PR DESCRIPTION
Found the `dht_auto_init()` declaration but it's not implemented in the .c file.
Probably a left over from a previous cleanup.