### PR TITLE
core: thread_flags: Set sched_status_switch_request after waking a waiting thread

### DIFF
--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -112,8 +112,9 @@ inline int __attribute__((always_inline)) thread_flags_wake(thread_t *thread)
     }
 
     if (wakeup) {
-        DEBUG("_thread_flags_wake(): wakeing up pid %"PRIkernel_pid"\n", thread->pid);
-        sched_set_status(thread, STATUS_RUNNING);
+        DEBUG("_thread_flags_wake(): waking up pid %"PRIkernel_pid"\n", thread->pid);
+        sched_set_status(thread, STATUS_PENDING);
+        sched_context_switch_request = 1;
     }
 
     return wakeup;


### PR DESCRIPTION
Setting the thread status to running is not enough to trigger a context switch.
The symptoms were that just setting flags to wake a thread did not actually wake that thread until any other event (e.g. IPC traffic) in the system triggered a context switch.
Also, the correct status for waking up threads is STATUS_PENDING, otherwise there may be more than one thread with status running, this could even be observed in the `ps` shell command output in certain situations.

Compare this PR with what is done in the message passing code: https://github.com/RIOT-OS/RIOT/blob/ef01efc387ab7d346d01671c1b37055ff397381e/core/msg.c#L209-L211