### PR TITLE
sys: xtimer: add xtimer_set_timeout_flag()

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -440,6 +440,17 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b);
 int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
 
 /**
+ * @brief    Set timeout thread flag after @p timeout
+ *
+ * This function will set THREAD_FLAG_TIMEOUT on the current thread after @p
+ * timeout usec have passed.
+ *
+ * @param[in]   t       timer struct to use
+ * @param[in]   timeout timeout in usec
+ */
+void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
+
+/**
  * @brief xtimer backoff value
  *
  * All timers that are less than XTIMER_BACKOFF microseconds in the future will

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -30,6 +30,10 @@
 
 #include "timex.h"
 
+#ifdef MODULE_CORE_THREAD_FLAGS
+#include "thread_flags.h"
+#endif
+
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
@@ -257,3 +261,18 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t timeout)
     xtimer_remove(&t);
     return -mt.timeout;
 }
+
+#ifdef MODULE_CORE_THREAD_FLAGS
+static void _set_timeout_flag_callback(void* arg)
+{
+    thread_flags_set(arg, THREAD_FLAG_TIMEOUT);
+}
+
+void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
+{
+    t->callback = _set_timeout_flag_callback;
+    t->arg = (thread_t *)sched_active_thread;
+    thread_flags_clear(THREAD_FLAG_TIMEOUT);
+    xtimer_set(t, timeout);
+}
+#endif

--- a/tests/thread_flags/Makefile
+++ b/tests/thread_flags/Makefile
@@ -4,5 +4,6 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 
 USEMODULE += core_thread_flags
+USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_flags/main.c
+++ b/tests/thread_flags/main.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include "thread.h"
+#include "xtimer.h"
 
 static char stack[THREAD_STACKSIZE_MAIN];
 
@@ -84,6 +85,14 @@ int main(void)
     _set(thread, 0x4);
 
     while(!done) {};
+
+    puts("main: setting 100ms timeout...");
+    xtimer_t t;
+    uint32_t before = xtimer_now_usec();
+    xtimer_set_timeout_flag(&t, 100000);
+    thread_flags_wait_any(THREAD_FLAG_TIMEOUT);
+    uint32_t diff = xtimer_now_usec() - before;
+    printf("main: timeout triggered. time passed: %uus\n", (unsigned)diff);
 
     puts("test finished.");
 


### PR DESCRIPTION
This PR adds an xtimer convenience function to set the timeout flag after a certain period.

This intentionally does not allow to set any flag (only THREAD_FLAG_TIMEOUT), or set a flag on any thread (not the calling one), for simplicity and performance reasons.

The thread_flags test is updated with a simple test of the new function.