### PR TITLE
boards: initial import of F3-Femto flight controller

### DIFF
--- a/boards/f3-femto/Makefile
+++ b/boards/f3-femto/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/f3-femto/Makefile.features
+++ b/boards/f3-femto/Makefile.features
@@ -1,0 +1,10 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+-include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/f3-femto/Makefile.include
+++ b/boards/f3-femto/Makefile.include
@@ -1,0 +1,23 @@
+## the cpu to build for
+export CPU = stm32f3
+export CPU_MODEL = stm32f303cc
+
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
+# configure the serial interface
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+FLASHER = dfu-util
+FLASHFILE ?= $(BINFILE)
+FFLAGS = -d 0483:df11 -a 0 -s 0x08000000:leave -D $(FLASHFILE)
+
+DEBUGGER = # no debugger
+RESET = # dfu-util has no support for resetting the device
+
+OFLAGS = -O binary
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/f3-femto/board.c
+++ b/boards/f3-femto/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_f3-femto
+ * @{
+ *
+ * @file
+ * @brief       Board specific initialition of the F3-Femto flight controller
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/f3-femto/dist/openocd.cfg
+++ b/boards/f3-femto/dist/openocd.cfg
@@ -1,0 +1,2 @@
+source [find board/st_nucleo_f3.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/f3-femto/doc.txt
+++ b/boards/f3-femto/doc.txt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_f3-femto F3-Femto Flight Controller
+ * @ingroup     boards
+ * @brief       Board specific files for the F3-Femto Flight Controller.
+ */

--- a/boards/f3-femto/include/board.h
+++ b/boards/f3-femto/include/board.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_f3-femto
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the F3-Femto Flight Controller.
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @brief   Macros for controlling the on-board LED
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_B, 8)
+#define LED0_PORT           (GPIOB)
+#define LED0_MASK           (1 << 8)
+
+#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
+#define LED0_OFF            (LED0_PORT->BRR  = LED0_MASK)
+#define LED0_TOGGLE         (LED0_PORT->ODR ^= LED0_MASK)
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+/**
+ * @brief   Use the 2nd UART for STDIO on this board
+ */
+#define UART_STDIO_DEV      UART_DEV(1)
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/f3-femto/include/periph_conf.h
+++ b/boards/f3-femto/include/periph_conf.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_f3-femto
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the F3-Femto Flight Controller.
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 72MHz */
+#define CLOCK_CORECLOCK     (72000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (0U)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+
+/* PLL factors */
+#define CLOCK_PLL_PREDIV     (1)
+#define CLOCK_PLL_MUL        (9)
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (0)
+/** @} */
+
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM2,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim2
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 36000000Hz */
+        7,  /* -> 140625Hz */
+        6,  /* -> 281250Hz */
+        4,  /* -> 1125000Hz */
+        2,  /* -> 4500000Hz */
+        1   /* -> 9000000Hz */
+    },
+    {       /* for APB2 @ 72000000Hz */
+        7,  /* -> 281250Hz */
+        7,  /* -> 281250Hz */
+        5,  /* -> 1125000Hz */
+        3,  /* -> 4500000Hz */
+        2   /* -> 9000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+        .miso_pin = GPIO_PIN(PORT_B, 4),
+        .sclk_pin = GPIO_PIN(PORT_B, 3),
+        .cs_pin   = GPIO_PIN(PORT_B, 9),
+        .af       = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A,  9),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn
+    },
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 15),
+        .tx_pin     = GPIO_PIN(PORT_A, 14),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn
+    },
+    {
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 11),
+        .tx_pin     = GPIO_PIN(PORT_B, 10),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART3_IRQn
+    }
+};
+
+#define UART_0_ISR          (isr_usart1)
+#define UART_1_ISR          (isr_usart2)
+#define UART_2_ISR          (isr_usart3)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/stm32f3/ldscripts/stm32f303cc.ld
+++ b/cpu/stm32f3/ldscripts/stm32f303cc.ld
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_stm32f3
+ * @{
+ *
+ * @file
+ * @brief           Memory definitions for the STM32F303CC
+ *
+ * @author          Sebastian Meiling <s@mlng.net>
+ *
+ * @}
+ */
+
+MEMORY
+{
+    rom (rx)    : ORIGIN = 0x08000000, LENGTH = 256K
+    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 40K
+    ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 8K
+    cpuid (r)   : ORIGIN = 0x1FFFF7AC, LENGTH = 12
+}
+
+_cpuid_address = ORIGIN(cpuid);
+
+INCLUDE cortexm_base.ld

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -27,7 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
                              sodaq-one sodaq-sara-aff stk3600 stm32f3discovery \
                              stm32l0538-disco yunjia-nrf51822 \
                              esp8266-esp-12x esp8266-olimex-mod \
-                             esp8266-sparkfun-thing firefly
+                             esp8266-sparkfun-thing firefly f3-femto
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano arduino-uno \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              cc2650stk \
                              chronos \
                              ek-lm4f120xl \
+                             f3-femto \
                              feather-m0 \
                              hamilton \
                              i-nucleo-lrwan1 \
@@ -106,6 +107,7 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        cc2650-launchpad \
                        cc2650stk \
                        ek-lm4f120xl \
+                       f3-femto \
                        f4vi1 \
                        feather-m0 \
                        firefly \


### PR DESCRIPTION
currently board config only, will add some more documentation hence WIP for now. The F3-Femto is basically a base platform for micro quadcopter which typically run @cleanflight or @betaflight.

It has also an onboard MPU9250 Gyro/Accel/Compass.