### PR TITLE
spelling: s/initialise/initialize/

### DIFF
--- a/boards/cc2650stk/board.c
+++ b/boards/cc2650stk/board.c
@@ -21,7 +21,7 @@
 #include "board.h"
 
 /**
- * @brief           initialise the board
+ * @brief           initialize the board
  */
 void board_init(void)
 {

--- a/cpu/mips32r2_common/cpu.c
+++ b/cpu/mips32r2_common/cpu.c
@@ -43,7 +43,7 @@ extern char _edata __attribute__((section("data")));
 void software_init_hook(void)
 {
 #ifdef FLASH_XIP
-    /* copy initialised data from its LMA to VMA */
+    /* copy initialized data from its LMA to VMA */
     memcpy(&_fdata, &_rom_data_copy, (int)&_edata - (int)&_fdata);
 #endif
 

--- a/cpu/mips_pic32_common/reset_mod.S
+++ b/cpu/mips_pic32_common/reset_mod.S
@@ -34,7 +34,7 @@
 	(from the 2016.05-03 version) with a couple of modifications:
 
 	#define SKIP_COPY_TO_RAM - prevents the bootloader copying the whole contents
-	of flash to ram (as we want to XIP from flash), we copy initialised data from
+	of flash to ram (as we want to XIP from flash), we copy initialized data from
 	flash to ram in 'software_init_hook'.
 
 	move .org's to before the labels to make the vector labels appear at the vector

--- a/dist/tools/goodfet/goodfet.bsl
+++ b/dist/tools/goodfet/goodfet.bsl
@@ -296,7 +296,7 @@ class LowLevel:
 
     def comInit(self, port):
         """Tries to open the serial port given and
-        initialises the port and variables.
+        initializes the port and variables.
         The timeout and the number of allowed errors is multiplied by
         'aProlongFactor' after transmission of a command to give
         plenty of time to the micro controller to finish the command.

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -69,7 +69,7 @@ static int _init(netdev_t *netdev)
 {
     at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
 
-    /* initialise GPIOs */
+    /* initialize GPIOs */
     spi_init_cs(dev->params.spi, dev->params.cs_pin);
     gpio_init(dev->params.sleep_pin, GPIO_OUT);
     gpio_clear(dev->params.sleep_pin);

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -56,7 +56,7 @@ static int _init(netdev_t *netdev)
 {
     kw2xrf_t *dev = (kw2xrf_t *)netdev;
 
-    /* initialise SPI and GPIOs */
+    /* initialize SPI and GPIOs */
     if (kw2xrf_init(dev, &_irq_handler)) {
         LOG_ERROR("[kw2xrf] unable to initialize device\n");
         return -1;

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -69,7 +69,7 @@ static int _init(netdev_t *netdev)
 {
     mrf24j40_t *dev = (mrf24j40_t *)netdev;
 
-    /* initialise GPIOs */
+    /* initialize GPIOs */
     spi_init_cs(dev->params.spi, dev->params.cs_pin);
     gpio_init(dev->params.reset_pin, GPIO_OUT);
     gpio_set(dev->params.reset_pin);

--- a/sys/posix/pthread/include/pthread_cond.h
+++ b/sys/posix/pthread/include/pthread_cond.h
@@ -70,7 +70,7 @@ int pthread_cond_condattr_init(pthread_condattr_t *attr);
 int pthread_cond_condattr_destroy(pthread_condattr_t *attr);
 
 /**
- * @brief Get the process-shared attribute in an initialised attributes object referenced by attr
+ * @brief Get the process-shared attribute in an initialized attributes object referenced by attr
  * @note NOT USED since RIOT is a single process OS
  * @param[in] attr pre-allocated condition attribute variable structure.
  * @param[out] pshared the pre-allocated process-shared variable.
@@ -79,7 +79,7 @@ int pthread_cond_condattr_destroy(pthread_condattr_t *attr);
 int pthread_condattr_getpshared(const pthread_condattr_t *attr, int *pshared);
 
 /**
- * @brief Set the process-shared attribute in an initialised attributes object referenced by attr
+ * @brief Set the process-shared attribute in an initialized attributes object referenced by attr
  * @note NOT USED since RIOT is a single process OS
  * @param[in, out] attr pre-allocated condition attribute variable structure.
  * @param[in] pshared pshared the pre-allocated process-shared variable.


### PR DESCRIPTION
Replace use of `initialise` with `initialize` where possible in the code (used git grep for this).