### PR TITLE
at86rf2xx: Add get `NETOPT_LAST_ED_LEVEL`

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -180,3 +180,31 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev)
         netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
     }
 }
+
+bool at86rf2xx_cca(at86rf2xx_t *dev)
+{
+    uint8_t reg;
+    uint8_t old_state = at86rf2xx_set_state(dev, AT86RF2XX_STATE_TRX_OFF);
+    /* Disable RX path */
+    uint8_t rx_syn = at86rf2xx_reg_read(dev, AT86RF2XX_REG__RX_SYN);
+    reg = rx_syn | AT86RF2XX_RX_SYN__RX_PDT_DIS;
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__RX_SYN, reg);
+    /* Manually triggered CCA is only possible in RX_ON (basic operating mode) */
+    at86rf2xx_set_state(dev, AT86RF2XX_STATE_RX_ON);
+    /* Perform CCA */
+    reg = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_CC_CCA);
+    reg |= AT86RF2XX_PHY_CC_CCA_MASK__CCA_REQUEST;
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__PHY_CC_CCA, reg);
+    /* Spin until done (8 symbols + 12 µs = 128 µs + 12 µs for O-QPSK)*/
+    do {
+        reg = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS);
+    } while ((reg & AT86RF2XX_TRX_STATUS_MASK__CCA_DONE) == 0);
+    /* return true if channel is clear */
+    bool ret = !!(reg & AT86RF2XX_TRX_STATUS_MASK__CCA_STATUS);
+    /* re-enable RX */
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__RX_SYN, rx_syn);
+    /* Step back to the old state */
+    at86rf2xx_set_state(dev, AT86RF2XX_STATE_TRX_OFF);
+    at86rf2xx_set_state(dev, old_state);
+    return ret;
+}

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -328,6 +328,18 @@ void at86rf2xx_set_cca_threshold(at86rf2xx_t *dev, int8_t value)
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__CCA_THRES, value);
 }
 
+int8_t at86rf2xx_get_ed_level(at86rf2xx_t *dev)
+{
+    uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_ED_LEVEL);
+#if MODULE_AT86RF212B
+    /* AT86RF212B has different scale than the other variants */
+    int8_t ed = (int8_t)(((int16_t)tmp * 103) / 100) + RSSI_BASE_VAL;
+#else
+    int8_t ed = (int8_t)tmp + RSSI_BASE_VAL;
+#endif
+    return ed;
+}
+
 void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state)
 {
     uint8_t tmp;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -340,6 +340,12 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             res = sizeof(netopt_enable_t);
             break;
 
+        case NETOPT_LAST_ED_LEVEL:
+            assert(max_len >= sizeof(int8_t));
+            *((int8_t *)val) = at86rf2xx_get_ed_level(dev);
+            res = sizeof(int8_t);
+            break;
+
         default:
             res = -ENOTSUP;
             break;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -334,6 +334,12 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             res = sizeof(int8_t);
             break;
 
+        case NETOPT_IS_CHANNEL_CLR:
+            assert(max_len >= sizeof(netopt_enable_t));
+            *((netopt_enable_t *)val) = at86rf2xx_cca(dev);
+            res = sizeof(netopt_enable_t);
+            break;
+
         default:
             res = -ENOTSUP;
             break;

--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -289,6 +289,15 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Bitfield definitions for the RX_SYN register
+ * @{
+ */
+#define AT86RF2XX_RX_SYN__RX_PDT_DIS                            (0x80)
+#define AT86RF2XX_RX_SYN__RX_OVERRIDE                           (0x70)
+#define AT86RF2XX_RX_SYN__RX_PDT_LEVEL                          (0x0F)
+/** @} */
+
+/**
  * @name    Timing values
  * @{
  */

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -372,6 +372,15 @@ int8_t at86rf2xx_get_cca_threshold(at86rf2xx_t *dev);
 void at86rf2xx_set_cca_threshold(at86rf2xx_t *dev, int8_t value);
 
 /**
+ * @brief   Get the latest ED level measurement
+ *
+ * @param[in] dev           device to read value from
+ *
+ * @return                  the last ED level
+ */
+int8_t at86rf2xx_get_ed_level(at86rf2xx_t *dev);
+
+/**
  * @brief   Enable or disable driver specific options
  *
  * @param[in] dev           device to set/clear option flag for

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -96,12 +96,15 @@ extern "C" {
  * @{
  */
 #define AT86RF2XX_STATE_P_ON           (0x00)     /**< initial power on */
+#define AT86RF2XX_STATE_BUSY_RX        (0x01)     /**< busy receiving data (basic mode) */
+#define AT86RF2XX_STATE_BUSY_TX        (0x02)     /**< busy transmitting data (basic mode) */
 #define AT86RF2XX_STATE_FORCE_TRX_OFF  (0x03)     /**< force transition to idle */
+#define AT86RF2XX_STATE_RX_ON          (0x06)     /**< listen mode (basic mode) */
 #define AT86RF2XX_STATE_TRX_OFF        (0x08)     /**< idle */
 #define AT86RF2XX_STATE_PLL_ON         (0x09)     /**< ready to transmit */
 #define AT86RF2XX_STATE_SLEEP          (0x0f)     /**< sleep mode */
-#define AT86RF2XX_STATE_BUSY_RX_AACK   (0x11)     /**< busy receiving data */
-#define AT86RF2XX_STATE_BUSY_TX_ARET   (0x12)     /**< busy transmitting data */
+#define AT86RF2XX_STATE_BUSY_RX_AACK   (0x11)     /**< busy receiving data (extended mode) */
+#define AT86RF2XX_STATE_BUSY_TX_ARET   (0x12)     /**< busy transmitting data (extended mode) */
 #define AT86RF2XX_STATE_RX_AACK_ON     (0x16)     /**< wait for incoming data */
 #define AT86RF2XX_STATE_TX_ARET_ON     (0x19)     /**< ready for sending data */
 #define AT86RF2XX_STATE_IN_PROGRESS    (0x1f)     /**< ongoing state conversion */
@@ -430,6 +433,18 @@ size_t at86rf2xx_tx_load(at86rf2xx_t *dev, uint8_t *data, size_t len,
  * @param[in] dev           device to trigger
  */
 void at86rf2xx_tx_exec(at86rf2xx_t *dev);
+
+/**
+ * @brief   Perform one manual channel clear assessment (CCA)
+ *
+ * The CCA mode and threshold level depends on the current transceiver settings.
+ *
+ * @param[in]  dev          device to use
+ *
+ * @return                  true if channel is determined clear
+ * @return                  false if channel is determined busy
+ */
+bool at86rf2xx_cca(at86rf2xx_t *dev);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds support for reading out the ED level of the last RX packet, or CCA measurement. Manually triggered ED measurements are not supported by this code.

Based on #7568 