### PR TITLE
sys/xtimer: add xtimer_set_timeout_flag64()

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -448,7 +448,14 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
  * @param[in]   t       timer struct to use
  * @param[in]   timeout timeout in usec
  */
-void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
+void xtimer_set_timeout_flag(xtimer_t *timer, uint32_t timeout);
+
+/**
+ * @brief Set timeout thread flag after @p timeout, 64bit version
+ *
+ * See @ref xtimer_set_timeout_flag()
+ */
+void xtimer_set_timeout_flag64(xtimer_t *timer, uint64_t timeout);
 
 /**
  * @brief xtimer backoff value

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -445,7 +445,7 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
  * This function will set THREAD_FLAG_TIMEOUT on the current thread after @p
  * timeout usec have passed.
  *
- * @param[in]   t       timer struct to use
+ * @param[in]   timer   timer struct to use
  * @param[in]   timeout timeout in usec
  */
 void xtimer_set_timeout_flag(xtimer_t *timer, uint32_t timeout);

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -268,11 +268,22 @@ static void _set_timeout_flag_callback(void* arg)
     thread_flags_set(arg, THREAD_FLAG_TIMEOUT);
 }
 
-void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
+static void _set_timeout_flag_common(xtimer_t *t)
 {
     t->callback = _set_timeout_flag_callback;
     t->arg = (thread_t *)sched_active_thread;
     thread_flags_clear(THREAD_FLAG_TIMEOUT);
+}
+
+void xtimer_set_timeout_flag64(xtimer_t *t, uint64_t timeout)
+{
+    _set_timeout_flag_common(t);
+    _xtimer_set64(t, timeout, timeout >> 32);
+}
+
+void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
+{
+    _set_timeout_flag_common(t);
     xtimer_set(t, timeout);
 }
 #endif


### PR DESCRIPTION
This PR adds a 64bit version of xtimer_set_timeout_flag().