### PR TITLE
cleanup: fixing (some) special chars

### DIFF
--- a/boards/arduino-atmega-common/Makefile.include
+++ b/boards/arduino-atmega-common/Makefile.include
@@ -3,7 +3,7 @@ include $(RIOTBOARD)/arduino-atmega-common/Makefile.dep
 
 INCLUDES += -I$(RIOTBOARD)/arduino-atmega-common/include
 
-# refine serial port information
+# refine serial port information
 export BAUD ?= 9600
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/msba2-common/tools/armtools.txt
+++ b/boards/msba2-common/tools/armtools.txt
@@ -9,7 +9,7 @@ On reception of a SIGUSR1, it reopens the port and resets the ARM.
 
 "./lpc2k_pgm /dev/ttyUSB1 /path/to/firmware.ihex" will do what you
 expect, but it will additionally run "killall -SIGUSR2 pseudoterm" before
-anѕ "killall -SIGUSR1 pseudoterm" after flashing.
+and "killall -SIGUSR1 pseudoterm" after flashing.
 
 Together, the tools enable you to have a terminal connected to the board
 at all times, but let you flash whenever you feel like.

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -81,7 +81,7 @@
  * mode or the message queue (see below) of the receiving thread is full
  * messages sent this way will be dropped.
  *
- * You can use the example on asynchronous IPC below — but without the queue —
+ * You can use the example on asynchronous IPC below - but without the queue -
  * to get an impression of how to use non-blocking IPC.
  *
  * Synchronous vs Asynchronous

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -247,7 +247,7 @@ typedef enum {
     ADC_RES_14BIT =             (0xc00),    /**< not supported by hardware */
     ADC_RES_16BIT =             (0xd00),    /**< not supported by hardware */
 } adc_res_t;
-/** @} */
+/** @} */
 
 /**
  * @brief ADC configuration wrapper

--- a/cpu/kinetis_common/doc.txt
+++ b/cpu/kinetis_common/doc.txt
@@ -9,7 +9,7 @@
  * @ingroup     cpu_kinetis_common
  * @brief       ADC driver
  *
- *              ### ADC configuration example (for periph_conf.h) ###
+ *              ### ADC configuration example (for periph_conf.h) ###
  *
  *                  static const adc_conf_t adc_config[] = {
  *                      { .dev = ADC0, .pin = GPIO_UNDEF          , .chan =  0 }, // ADC0_DP0
@@ -47,7 +47,7 @@
  * @ingroup     cpu_kinetis_common
  * @brief       I2C driver
  *
- *              ### I2C configuration example (for periph_conf.h) ###
+ *              ### I2C configuration example (for periph_conf.h) ###
  *
  *                  #define I2C_NUMOF               (1U)
  *                  #define I2C_0_EN                1
@@ -85,7 +85,7 @@
  * @ingroup     cpu_kinetis_common
  * @brief       PWM driver
  *
- *              ### PWM configuration example (for periph_conf.h) ###
+ *              ### PWM configuration example (for periph_conf.h) ###
  *
  *                  #define PWM_NUMOF           (1U)
  *                  #define PWM_0_EN            1
@@ -118,7 +118,7 @@
  *              looks random. Reference Manual recommends to use the RNGA as entropy
  *              source.
  *
- *              ### RNGA configuration example (for periph_conf.h) ###
+ *              ### RNGA configuration example (for periph_conf.h) ###
  *
  *                  #define RANDOM_NUMOF         (1U)
  *                  #define KINETIS_RNGA         RNG
@@ -134,7 +134,7 @@
  *              looks random. Reference Manual recommends to use the RNGB as entropy
  *              source.
  *
- *              ### RNGB configuration example (for periph_conf.h) ###
+ *              ### RNGB configuration example (for periph_conf.h) ###
  *
  *                  #define RANDOM_NUMOF         (1U)
  *                  #define KINETIS_RNGB         RNG
@@ -155,7 +155,7 @@
  *              The driver supports alarm, it is stored in the
  *              Time Alarm Registers (TAR) and the unit is seconds.
  *
- *              ### RTC configuration example (for periph_conf.h) ###
+ *              ### RTC configuration example (for periph_conf.h) ###
  *
  *                  #define RTC_NUMOF           (1U)
  *                  #define RTC_DEV             RTC
@@ -200,7 +200,7 @@
  *              extra delays in the transfer because of the additional overhead
  *              of calling gpio_set/clear at every transfer.
  *
- *              ### SPI configuration example (for periph_conf.h): ###
+ *              ### SPI configuration example (for periph_conf.h): ###
  *
  *                  static const uint32_t spi_clk_config[] = {
  *                      // Use cpu/kinetis_common/dist/calc_spi_scalers to
@@ -260,7 +260,7 @@
  *              caused by mixing the clock domains of the bus clock used by the
  *              CPU and the 32kHz reference clock for the LPTMR counter.
  *
- *              ### Timer configuration example (for periph_conf.h) ###
+ *              ### Timer configuration example (for periph_conf.h) ###
  *
  *                  #define PIT_NUMOF               (2U)
  *                  #define PIT_CONFIG {                 \
@@ -299,7 +299,7 @@
  *              using the BRFA field in the UART C4 register.
  *              Currently, only the base TX/RX functionality is available.
  *
- *              ### UART configuration example (for periph_conf.h) ###
+ *              ### UART configuration example (for periph_conf.h) ###
  *
  *                  static const uart_conf_t uart_config[] = {
  *                      {

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -208,7 +208,7 @@ starting point for anyone who is new to RIOT.
 For more information best browse that directory and have a look at the
 `README.md` files that ship with each example.
 
-To create your own application — here or anywhere else — see @ref creating-an-application
+To create your own application - here or anywhere else - see @ref creating-an-application
 
 tests
 -----

--- a/drivers/kw2xrf/kw2xrf_getset.c
+++ b/drivers/kw2xrf/kw2xrf_getset.c
@@ -351,8 +351,8 @@ uint32_t kw2xrf_get_rssi(uint32_t value)
     /* Get rssi (Received Signal Strength Indicator, unit is dBm)
      * from lqi (Link Quality Indicator) value.
      * There are two different equations for RSSI:
-     * RF = (LQI – 286.6) / 2.69333 (MKW2xD Reference Manual)
-     * RF = (LQI – 295.4) / 2.84 (MCR20A Reference Manual)
+     * RF = (LQI - 286.6) / 2.69333 (MKW2xD Reference Manual)
+     * RF = (LQI - 295.4) / 2.84 (MCR20A Reference Manual)
      * The last appears more to match the graphic (Figure 3-10).
      * Since RSSI value is always positive and we want to
      * avoid the floating point computation:

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -236,7 +236,7 @@ void mrf24j40_set_chan(mrf24j40_t *dev, uint8_t channel)
 
     mrf24j40_reg_write_long(dev, MRF24J40_REG_RFCON0, channel_value);
     /*
-     * Note:Perform an RF State Machine Reset (see Section 3.1 “Reset”)
+     * Note: Perform an RF State Machine Reset (see Section 3.1 Reset)
      * after a channel frequency change. Then, delay at least 192 us after
      * the RF State Machine Reset, to allow the RF circuitry to calibrate.
      */
@@ -373,7 +373,7 @@ void mrf24j40_set_option(mrf24j40_t *dev, uint16_t option, bool state)
                 tmp |= MRF24J40_TXMCR_NOCSMA;
                 /* MACMINBE<1:0>: The minimum value of the backoff exponent
                  * in the CSMA-CA algorithm. Note that if this value is set
-                 * to ‘0’, collision avoidance is disabled. */
+                 * to 0, collision avoidance is disabled. */
                 mrf24j40_reg_write_short(dev, MRF24J40_REG_TXMCR, tmp);
                 break;
             case MRF24J40_OPT_PROMISCUOUS:

--- a/drivers/tcs37727/include/tcs37727-internal.h
+++ b/drivers/tcs37727/include/tcs37727-internal.h
@@ -102,10 +102,10 @@ extern "C"
 #define TCS37727_CONTROL_PDRIVE_25      0x08 /**< 25 mA LED Drive Strength */
 #define TCS37727_CONTROL_PDRIVE_12      0x0C /**< 12.5 mA LED Drive Strength */
 #define TCS37727_CONTROL_PDRIVE_MASK    0x0C /**< PDRIVE Mask */
-#define TCS37727_CONTROL_AGAIN_1        0x00 /**< 1 × gain RGBC Gain Value */
-#define TCS37727_CONTROL_AGAIN_4        0x01 /**< 4 × gain RGBC Gain Value */
-#define TCS37727_CONTROL_AGAIN_16       0x02 /**< 16 × gain RGBC Gain Value */
-#define TCS37727_CONTROL_AGAIN_60       0x03 /**< 60 × gain RGBC Gain Value */
+#define TCS37727_CONTROL_AGAIN_1        0x00 /**<  1x gain RGBC Gain Value */
+#define TCS37727_CONTROL_AGAIN_4        0x01 /**<  4x gain RGBC Gain Value */
+#define TCS37727_CONTROL_AGAIN_16       0x02 /**< 16x gain RGBC Gain Value */
+#define TCS37727_CONTROL_AGAIN_60       0x03 /**< 60x gain RGBC Gain Value */
 #define TCS37727_CONTROL_AGAIN_MASK     0x03 /**< AGAIN Mask */
 /** @} */
 

--- a/pkg/openthread/include/ot.h
+++ b/pkg/openthread/include/ot.h
@@ -17,7 +17,7 @@
  *
  * @file
  *
- * @author  José Ignacio Alamos <jialamos@uc.cl>
+ * @author  JosÃ© Ignacio Alamos <jialamos@uc.cl>
  */
 
 #ifndef OT_H

--- a/sys/cpp11-compat/include/riot/thread.hpp
+++ b/sys/cpp11-compat/include/riot/thread.hpp
@@ -76,7 +76,7 @@ struct thread_data {
  */
 struct thread_data_deleter {
   /**
-   * @brief Called by the deleter of a thread object to manage the lifetime of
+   * @brief Called by the deleter of a thread object to manage the lifetime of
    *        the thread internal management data.
    */
   void operator()(thread_data* ptr) {

--- a/sys/hashes/doc.txt
+++ b/sys/hashes/doc.txt
@@ -26,7 +26,7 @@
  * * Kernighan and Ritchie
  * * Shift, And, Xor
  * * Donald E. Knuth
- * * Fowler–Noll–Vo hash function
+ * * Fowler-Noll-Vo hash function
  * * Rotating Hash
  * * One at a time Hash
  *

--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -45,7 +45,7 @@ static inline int _get_set(kernel_pid_t pid, uint16_t type,
     msg_t cmd;
     msg_t ack;
     gnrc_netapi_opt_t o;
-    /* set ńetapi's option struct */
+    /* set netapi's option struct */
     o.opt = opt;
     o.context = context;
     o.data = data;

--- a/sys/posix/pthread/include/pthread_mutex.h
+++ b/sys/posix/pthread/include/pthread_mutex.h
@@ -44,7 +44,7 @@ int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *mutexa
 /**
  * @brief           Destroy a mutex.
  * @details         This is currently a no-op.
- *                  Destroying a mutex locked is undefined behavior.
+ *                  Destroying a mutex locked is undefined behavior.
  * @param[in,out]   mutex   Datum to destroy.
  * @returns         0, this invocation is a no-op that cannot fail.
  */

--- a/tests/driver_hd44780/README.md
+++ b/tests/driver_hd44780/README.md
@@ -13,12 +13,12 @@ your board use the following minimal pinout for the LCD (i.e., Arduino here):
 - Pin 1 is connected directly to GND.
 - Pin 2 is connected directly to VCC +5V.
 - Pin 3 is used to set LCD contrast, for max use +5V or a 10k potentiometer.
-- Pin 4 (RS or “register select”) is connected to pin 2 on the Arduino
-- Pin 5 (RW or “read/write”) is connected directly to GND, i.e., unused.
+- Pin 4 (RS or "register select") is connected to pin 2 on the Arduino
+- Pin 5 (RW or "read/write") is connected directly to GND, i.e., unused.
   Also note: if you connect RW to your board that the LCD is driven by 5V, while
   many boards internally run at 3.3V - so this could fry the board :/
-- Pin 6 (EN or “enable”) is connected to pin 3 on the Arduino.
-- Pins 7 – 10: Not connected.
+- Pin 6 (EN or "enable") is connected to pin 3 on the Arduino.
+- Pins 7 - 10: Not connected.
 - Pin 11 on the LCD is connected to pin 4 on the Arduino.
 - Pin 12 on the LCD is connected to pin 5 on the Arduino.
 - Pin 13 on the LCD is connected to pin 6 on the Arduino.

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -45,7 +45,7 @@ static int print_testend(int argc, char **argv)
 static int print_echo(int argc, char **argv)
 {
     for (int i = 0; i < argc; ++i) {
-        printf("“%s” ", argv[i]);
+        printf("\"%s\"", argv[i]);
     }
     puts("");
 


### PR DESCRIPTION
    Specifically the following things were addressed:
    - replacing special dashes with simple '-'
    - fixing non-ascii whitespaces to plain ' '
    - removing other not correctly displayed chars

    Author names, greek symbols in units, and other commonly used
    UTF8 chars were not adapted.