### PR TITLE
gcoap: DEVELHELP checks resources are sorted

### DIFF
--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -570,6 +570,37 @@ static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
 }
 
 /*
+ * Check listener structure
+ *
+ *  - resources should be sorted alphabetically
+ *
+ * returns 0 if check successful
+ */
+#ifdef DEVELHELP
+static int _check_listener(gcoap_listener_t *listener)
+{
+    const char *prev_path = "";
+    const char *path = NULL;
+    int ret = 0;
+
+    for (size_t i = 0; i < listener->resources_len; i++) {
+        coap_resource_t *resource = &listener->resources[i];
+        path = resource->path;
+
+        if (strcmp(prev_path, path) > 0) {
+            DEBUG_PRINT("WARN: [gcoap] resources not sorted %s > %s\n",
+                        prev_path, path);
+            ret = 1;
+        }
+        prev_path = path;
+    }
+    return ret;
+}
+#else
+static int _check_listener(gcoap_listener_t *listener) {(void) listener; return 0;}
+#endif
+
+/*
  * gcoap interface functions
  */
 
@@ -594,6 +625,8 @@ kernel_pid_t gcoap_init(void)
 
 void gcoap_register_listener(gcoap_listener_t *listener)
 {
+    _check_listener(listener);
+
     /* Add the listener to the end of the linked list. */
     gcoap_listener_t *_last = _coap_state.listeners;
     while (_last->next) {

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -229,6 +229,7 @@ ifeq (, $(UNIT_TESTS))
 else
   CFLAGS += -DTEST_SUITES='$(subst $() $(),$(charCOMMA),$(UNIT_TESTS:tests-%=%))'
 endif
+CFLAGS += -DDEVELHELP
 
 test:
 	./tests/01-run.py

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -25,7 +25,7 @@
 /*
  * A test set of dummy resources. The resource handlers are set to NULL.
  */
-static const coap_resource_t ressources[] = {
+static const coap_resource_t resources[] = {
     { "/test/info/all", (COAP_GET), NULL },
     { "/sensor/temp", (COAP_GET), NULL },
     { "/act/switch", (COAP_GET | COAP_POST), NULL }
@@ -36,8 +36,8 @@ static const coap_resource_t resources_second[] = {
 };
 
 static gcoap_listener_t listener = {
-    .resources     = (coap_resource_t *)&ressources[0],
-    .resources_len = (sizeof(ressources) / sizeof(ressources[0])),
+    .resources     = (coap_resource_t *)&resources[0],
+    .resources_len = (sizeof(resources) / sizeof(resources[0])),
     .next          = NULL
 };
 

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -26,9 +26,9 @@
  * A test set of dummy resources. The resource handlers are set to NULL.
  */
 static const coap_resource_t resources[] = {
-    { "/test/info/all", (COAP_GET), NULL },
+    { "/act/switch", (COAP_GET | COAP_POST), NULL },
     { "/sensor/temp", (COAP_GET), NULL },
-    { "/act/switch", (COAP_GET | COAP_POST), NULL }
+    { "/test/info/all", (COAP_GET), NULL },
 };
 
 static const coap_resource_t resources_second[] = {
@@ -47,7 +47,7 @@ static gcoap_listener_t listener_second = {
     .next          = NULL
 };
 
-static const char *resource_list_str = "</test/info/all>,</sensor/temp>,</act/switch>,</second/part>";
+static const char *resource_list_str = "</act/switch>,</sensor/temp>,</test/info/all>,</second/part>";
 
 /*
  * Client GET request success case. Test request generation.


### PR DESCRIPTION
gcoap requires resources to be sorted alphabetically, but currently nothing verifies it.
I added a runtime check that warns if not the case, only enable when DEVELHELP is.

Also, in tests-gcoap, the test resources where not sorted.

To make it visible, without adding many tests, I needed to enable DEVELHELP in unittests makefile.

I also fixed an unused variable enclosing ifdef, as its NDEBUG that controls assert.
NDEBUG should be enabled when DEVELHELP is, but if you enable it with -DDEVELHELP=1, NDEBUG is not and it did not compile anymore.