### PR TITLE
saul: add PWM config for use in SAUL

### DIFF
--- a/boards/samr21-xpro/Makefile.dep
+++ b/boards/samr21-xpro/Makefile.dep
@@ -4,4 +4,5 @@ endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_pwm
 endif

--- a/boards/samr21-xpro/include/pwm_params.h
+++ b/boards/samr21-xpro/include/pwm_params.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_samr21-xpro
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped PWM
+ *
+ * @author    Fracisco Acosta <francisco.acosta@inria.fr>
+ */
+
+#ifndef PWM_PARAMS_H
+#define PWM_PARAMS_H
+
+#include "board.h"
+#include "periph/pwm.h"
+#include "saul/periph.h"
+
+#define MODE        PWM_LEFT
+#define FREQU       (1000U)
+#define STEPS       (1000U)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    PWM pin configuration
+ */
+static const  saul_pwm_params_t saul_pwm_params[] =
+{
+    {
+        .name = "PWM(PA06)",
+        .line = PWM_DEV(0),
+        .mode = MODE,
+        .freq = FREQU,
+        .res = STEPS,
+        .channel = 0
+    },
+    {
+        .name = "PWM(PA07)",
+        .line = PWM_DEV(0),
+        .mode = MODE,
+        .freq = FREQU,
+        .res = STEPS,
+        .channel = 1
+    },
+    {
+        .name = "PWM(PA16)",
+        .line = PWM_DEV(1),
+        .mode = MODE,
+        .freq = FREQU,
+        .res = STEPS,
+        .channel = 0
+    },
+    {
+        .name = "PWM(PA18)",
+        .line = PWM_DEV(1),
+        .mode = MODE,
+        .freq = FREQU,
+        .res = STEPS,
+        .channel = 1
+    },
+    {
+        .name = "PWM(PA19)",
+        .line = PWM_DEV(1),
+        .mode = MODE,
+        .freq = FREQU,
+        .res = STEPS,
+        .channel = 2
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PWM_PARAMS_H */
+/** @} */

--- a/drivers/include/saul/periph.h
+++ b/drivers/include/saul/periph.h
@@ -27,6 +27,10 @@
 #include "periph/adc.h"
 #endif /* MODULE_SAUL_ADC */
 
+#ifdef MODULE_SAUL_PWM
+#include "periph/pwm.h"
+#endif /* MODULE_SAUL_PWM */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -51,6 +55,20 @@ typedef struct {
     adc_t line;             /**< ADC line to initialize and expose */
     adc_res_t res;          /**< ADC resolution */
 } saul_adc_params_t;
+#endif /* MODULE_SAUL_ADC */
+
+#ifdef MODULE_SAUL_PWM
+/**
+ * @brief   Direct mapped PWM configuration values
+ */
+typedef struct {
+    const char *name;       /**< name of the device connected to this pin */
+    pwm_t line;             /**< PWM line to initialize and expose */
+    pwm_mode_t mode;        /**< PWM mode */
+    uint32_t freq;          /**< PWM frequency */
+    uint16_t res;           /**< PWM resolution */
+    uint8_t channel;        /**< PWM channel */
+} saul_pwm_params_t;
 #endif /* MODULE_SAUL_ADC */
 
 #ifdef __cplusplus

--- a/drivers/saul/Makefile
+++ b/drivers/saul/Makefile
@@ -6,5 +6,8 @@ endif
 ifneq (,$(filter saul_adc,$(USEMODULE)))
   SRC += adc_saul.c
 endif
+ifneq (,$(filter saul_pwm,$(USEMODULE)))
+  SRC += pwm_saul.c
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/drivers/saul/pwm_saul.c
+++ b/drivers/saul/pwm_saul.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_saul
+ * @{
+ *
+ * @file
+ * @brief       SAUL wrapper for direct access to PWM pins
+ *
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "saul/periph.h"
+#include "phydat.h"
+#include "periph/pwm.h"
+
+static int set_pwm(const void *dev, phydat_t *value)
+{
+    const saul_pwm_params_t *params = *((const saul_pwm_params_t **)dev);
+    uint32_t freq;
+    uint16_t res;
+
+    if (value->val[1] > 0) {
+        freq = value->val[1];
+    }
+    else {
+        freq = params->freq;
+    }
+
+    if (value->val[2] > 0) {
+        res = value->val[2];
+    }
+    else {
+        res = params->res;
+    }
+
+    pwm_init(params->line, params->mode, freq, res);
+    pwm_set(params->line, params->channel, value->val[0]);
+
+    /* PWM unit contains (in order) duty cycle, frequency and resolution */
+    value->unit = UNIT_PWM;
+    value->scale = 0;
+    return 1;
+}
+
+const saul_driver_t pwm_saul_driver = {
+    .read = saul_notsup,
+    .write = set_pwm,
+    .type = SAUL_ACT_ANY,
+};

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -54,6 +54,7 @@ PSEUDOMODULES += pktqueue
 PSEUDOMODULES += posix
 PSEUDOMODULES += printf_float
 PSEUDOMODULES += saul_adc
+PSEUDOMODULES += saul_pwm
 PSEUDOMODULES += saul_default
 PSEUDOMODULES += saul_gpio
 PSEUDOMODULES += schedstatistics

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -255,6 +255,10 @@ void auto_init(void)
     extern void auto_init_gpio(void);
     auto_init_gpio();
 #endif
+#ifdef MODULE_SAUL_PWM
+    extern void auto_init_pwm(void);
+    auto_init_pwm();
+#endif
 #ifdef MODULE_SAUL_ADC
     extern void auto_init_adc(void);
     auto_init_adc();

--- a/sys/auto_init/saul/auto_init_pwm.c
+++ b/sys/auto_init/saul/auto_init_pwm.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of PWM pins directly mapped to SAUL reg
+ *
+ * @author      Francisco Acosta <francisco. acosta@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_SAUL_PWM
+
+#include "log.h"
+#include "saul_reg.h"
+#include "saul/periph.h"
+#include "pwm_params.h"
+#include "periph/pwm.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define SAUL_PWM_NUMOF    (sizeof(saul_pwm_params)/sizeof(saul_pwm_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static const saul_pwm_params_t *saul_pwms[SAUL_PWM_NUMOF];
+
+/**
+ * @brief   Memory for the registry entries
+ */
+static saul_reg_t saul_reg_entries[SAUL_PWM_NUMOF];
+
+/**
+ * @brief   Reference the driver struct
+ */
+extern saul_driver_t pwm_saul_driver;
+
+void auto_init_pwm(void)
+{
+    for (unsigned int i = 0; i < SAUL_PWM_NUMOF; i++) {
+        const saul_pwm_params_t *p = &saul_pwm_params[i];
+
+        LOG_DEBUG("[auto_init_saul] initializing PWM #%u\n", i);
+
+        saul_pwms[i] = p;
+        saul_reg_entries[i].dev = &(saul_pwms[i]);
+        saul_reg_entries[i].name = p->name;
+        saul_reg_entries[i].driver = &pwm_saul_driver;
+
+        /* initialize the PWM pin */
+        pwm_init(p->line, p->mode, p->freq, p->res);
+        /* add to registry */
+        saul_reg_add(&(saul_reg_entries[i]));
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_SAUL_PWM */

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -107,7 +107,8 @@ enum {
     UNIT_PPM,       /**< part per million */
     /* aggregate values */
     UNIT_TIME,      /**< the three dimensions contain sec, min, and hours */
-    UNIT_DATE       /**< the 3 dimensions contain days, months and years */
+    UNIT_DATE,      /**< the 3 dimensions contain days, months and years */
+    UNIT_PWM        /**< the 3 dimensions contain duty cycle, frequency and resolution */
     /* extend this list as needed */
 };
 


### PR DESCRIPTION
I noticed that the PWM configuration was not available for SAUL.

This PR adds the support and also a config file for the samr21-xpro board. The latter is optional since there are no other SAUL config files (e.g. ADC) besides the onboard LED and button, but it was useful while testing. Thus, it might be removed.

The driver can take four parameters: channel (implicit), frequency, resolution and duty cycle.