### PR TITLE
cpu/sam0: re-work i2c driver

### DIFF
--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -200,23 +200,21 @@ static const spi_conf_t spi_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM3->I2CM),
+        .sda_pin  = GPIO_PIN(PA, 22),
+        .scl_pin  = GPIO_PIN(PA, 23),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .runstdby = 0
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
 
-#define I2C_0_DEV           SERCOM3->I2CM
+#define I2C_IRQ_PRIO        1
 #define I2C_0_IRQ           SERCOM3_IRQn
 #define I2C_0_ISR           isr_sercom3
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM3_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 22)
-#define I2C_0_SCL           GPIO_PIN(PA, 23)
-#define I2C_0_MUX           GPIO_MUX_C
 
 /**
  * @name RTC configuration

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -214,23 +214,21 @@ static const spi_conf_t spi_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM0->I2CM),
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .runstdby = 0
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
 
-#define I2C_0_DEV           SERCOM0->I2CM
+#define I2C_IRQ_PRIO        1
 #define I2C_0_IRQ           SERCOM0_IRQn
 #define I2C_0_ISR           isr_sercom0
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM0_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM0_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 8) /* SERCOM0-SDA, on-board pull-up */
-#define I2C_0_SCL           GPIO_PIN(PA, 9) /* SERCOM0-SCL, on-board pull-up */
-#define I2C_0_MUX           GPIO_MUX_C
 /** @} */
 
 /**

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -205,26 +205,24 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    I2C configuration
+ * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF           (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM3->I2CM),
+        .sda_pin  = GPIO_PIN(PA, 22),
+        .scl_pin  = GPIO_PIN(PA, 23),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .runstdby = 0
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
 
-#define I2C_0_DEV           SERCOM3->I2CM
+#define I2C_IRQ_PRIO        1
 #define I2C_0_IRQ           SERCOM3_IRQn
 #define I2C_0_ISR           isr_sercom3
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM3_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 22) /* SDA pin */
-#define I2C_0_SCL           GPIO_PIN(PA, 23) /* SCL pin */
-#define I2C_0_MUX           GPIO_MUX_C
 /** @} */
 
 /**

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -240,23 +240,22 @@ static const spi_conf_t spi_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
 
-#define I2C_0_DEV           SERCOM2->I2CM
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .mux      = GPIO_MUX_D,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .runstdby = 0
+     }
+ };
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+
+#define I2C_IRQ_PRIO        1
 #define I2C_0_IRQ           SERCOM2_IRQn
 #define I2C_0_ISR           isr_sercom2
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM2_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM2_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 8)
-#define I2C_0_SCL           GPIO_PIN(PA, 9)
-#define I2C_0_MUX           GPIO_MUX_D
 
 /**
  * @name RTC configuration

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -108,23 +108,22 @@ static const spi_conf_t spi_config[] = {
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .mux      = GPIO_MUX_D,
+        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0,
+        .runstdby = 0
+    }
+};
 
-#define I2C_0_DEV           SERCOM2->I2CM
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+
+#define I2C_IRQ_PRIO        1
 #define I2C_0_IRQ           SERCOM2_IRQn
 #define I2C_0_ISR           isr_sercom2
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM2_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM2_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 8)
-#define I2C_0_SCL           GPIO_PIN(PA, 9)
-#define I2C_0_MUX           GPIO_MUX_D
 /** @} */
 
 /**

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -211,23 +211,23 @@ static const spi_conf_t spi_config[] = {
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
 
-#define I2C_0_DEV           SERCOM3->I2CM
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM3->I2CM),
+        .sda_pin  = GPIO_PIN(PA, 16),
+        .scl_pin  = GPIO_PIN(PA, 17),
+        .mux      = GPIO_MUX_D,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .runstdby = 0
+     }
+};
+
+#define I2C_IRQ_PRIO        1
 #define I2C_0_IRQ           SERCOM3_IRQn
 #define I2C_0_ISR           isr_sercom3
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM3_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 16)
-#define I2C_0_SCL           GPIO_PIN(PA, 17)
-#define I2C_0_MUX           GPIO_MUX_D
+
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
 
 /**
  * @name    RTC configuration

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -213,23 +213,21 @@ static const spi_conf_t spi_config[] = {
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF           (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .sda_pin  = GPIO_PIN(PA, 12),
+        .scl_pin  = GPIO_PIN(PA, 13),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .runstdby = 0
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
 
-#define I2C_0_DEV           SERCOM2->I2CM
+#define I2C_IRQ_PRIO        1
 #define I2C_0_IRQ           SERCOM2_IRQn
 #define I2C_0_ISR           isr_sercom2
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM2_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM2_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 12)
-#define I2C_0_SCL           GPIO_PIN(PA, 13)
-#define I2C_0_MUX           GPIO_MUX_C
 
 /**
  * @name    RTC configuration

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -196,34 +196,31 @@ static const spi_conf_t spi_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF          (2U)
-#define I2C_0_EN            1
-#define I2C_1_EN            1
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM1->I2CM),
+        .sda_pin  = GPIO_PIN(PA, 16),
+        .scl_pin  = GPIO_PIN(PA, 17),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .runstdby = 0
+    },
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .runstdby = 0
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
 
-#define I2C_0_DEV           SERCOM1->I2CM
+#define I2C_IRQ_PRIO        1
 #define I2C_0_IRQ           SERCOM1_IRQn
 #define I2C_0_ISR           isr_sercom1
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM1_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM1_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 16)
-#define I2C_0_SCL           GPIO_PIN(PA, 17)
-#define I2C_0_MUX           GPIO_MUX_C
-
-#define I2C_1_DEV           SERCOM2->I2CM
 #define I2C_1_IRQ           SERCOM2_IRQn
 #define I2C_1_ISR           isr_sercom2
-/* I2C 1 GCLK */
-#define I2C_1_GCLK_ID       SERCOM2_GCLK_ID_CORE
-#define I2C_1_GCLK_ID_SLOW  SERCOM2_GCLK_ID_SLOW
-/* I2C 1 pin configuration */
-#define I2C_1_SDA           GPIO_PIN(PA, 8)
-#define I2C_1_SCL           GPIO_PIN(PA, 9)
-#define I2C_1_MUX           GPIO_MUX_C
 /** @} */
 
 /**

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -231,6 +231,34 @@ typedef struct {
     spi_misopad_t miso_pad; /**< pad to use for MISO line */
     spi_mosipad_t mosi_pad; /**< pad to use for MOSI and CLK line */
 } spi_conf_t;
+/** @} */
+
+/**
+ * @brief   Override SPI clock speed values
+ * @{
+ */
+#define HAVE_I2C_SPEED_T
+typedef enum {
+    I2C_SPEED_LOW       = 10000U,      /**< low speed mode:    ~10kbit/s */
+    I2C_SPEED_NORMAL    = 100000U,     /**< normal mode:       ~100kbit/s */
+    I2C_SPEED_FAST      = 400000U,     /**< fast mode:         ~400kbit/sj */
+    I2C_SPEED_FAST_PLUS = 1000000U,    /**< fast plus mode:    ~1Mbit/s */
+    I2C_SPEED_HIGH      = 3400000U,    /**< high speed mode:   ~3.4Mbit/s */
+} i2c_speed_t;
+/** @} */
+
+/**
+ * @brief   I2C device configuration
+ */
+typedef struct {
+    SercomI2cm *dev;        /**< pointer to the used I2C device */
+    gpio_t scl_pin;         /**< used SCL pin */
+    gpio_t sda_pin;         /**< used MOSI pin */
+    gpio_mux_t mux;         /**< alternate function (mux) */
+    uint8_t gclk_src;       /**< GCLK source which supplys SERCOM */
+    uint8_t runstdby;       /**< allow SERCOM to run in standby mode */
+} i2c_conf_t;
+/** @} */
 
 /**
  * @brief   Set up alternate function (PMUX setting) for a PORT pin
@@ -307,6 +335,7 @@ static inline void sercom_set_gen(void *sercom, uint32_t gclk)
 #elif defined(CPU_FAM_SAML21)
     GCLK->PCHCTRL[SERCOM0_GCLK_ID_CORE + sercom_id(sercom)].reg =
                                                     (GCLK_PCHCTRL_CHEN | gclk);
+    while (GCLK->SYNCBUSY.bit.GENCTRL) {}
 #endif
 }
 

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -56,7 +56,14 @@ static inline int _wait_for_response(SercomI2cm *dev, uint32_t max_timeout_cnt);
 /**
  * @brief Array holding one pre-initialized mutex for each I2C device
  */
-static mutex_t locks[I2C_NUMOF];
+static mutex_t locks[] = {
+    MUTEX_INIT,
+    MUTEX_INIT,
+    MUTEX_INIT,
+    MUTEX_INIT,
+    MUTEX_INIT,
+    MUTEX_INIT
+};
 
 /**
  * @brief   Shortcut for accessing the used I2C SERCOM device


### PR DESCRIPTION
This PR introduces a common i2c_config struct in `periph_conf.h` for all sam0 based boards. Additionnal I2C SERCOM can be add more easily.
SAML21 can know use SERCOM5 if desired.

I'm wondering if I can remove the init of GCLK_SLOW because it is only for some SMBus timeout (no used yet by RIOT). Should I remove it ? This should not impact the current driver state but I want the community's opinion first :)

I also tried to keep the 80 characters limit per lines.