### PR TITLE
drivers/sx127x: drivers cleanup + move lora definitions in extra header file

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -77,23 +77,8 @@ extern "C" {
 #define SX127X_CHANNEL_DEFAULT           (868300000UL)          /**< Default channel frequency, 868.3MHz (Europe) */
 #define SX127X_HF_CHANNEL_DEFAULT        (868000000UL)          /**< Use to calibrate RX chain for LF and HF bands */
 #define SX127X_RF_MID_BAND_THRESH        (525000000UL)          /**< Mid-band threshold */
-#define SX127X_FREQUENCY_RESOLUTION      (61.03515625)          /**< Frequency resolution in Hz */
 #define SX127X_XTAL_FREQ                 (32000000UL)           /**< Internal oscillator frequency, 32MHz */
 #define SX127X_RADIO_WAKEUP_TIME         (1000U)                /**< In microseconds [us] */
-
-#define SX127X_PREAMBLE_LENGTH           (8U)                   /**< Preamble length, same for Tx and Rx */
-#define SX127X_SYMBOL_TIMEOUT            (10U)                  /**< Symbols timeout (s) */
-
-#define SX127X_BW_DEFAULT                (SX127X_BW_125_KHZ)    /**< Set default bandwidth to 125kHz */
-#define SX127X_SF_DEFAULT                (SX127X_SF12)          /**< Set default spreading factor to 12 */
-#define SX127X_CR_DEFAULT                (SX127X_CR_4_8)        /**< Set default coding rate to 8 */
-#define SX127X_FIX_LENGTH_PAYLOAD_ON     (false)                /**< Set fixed payload length on */
-#define SX127X_IQ_INVERSION              (false)                /**< Set inverted IQ on */
-#define SX127X_FREQUENCY_HOPPING         (false)                /**< Frequency hopping on */
-#define SX127X_FREQUENCY_HOPPING_PERIOD  (0U)                   /**< Frequency hopping period */
-#define SX127X_FIXED_HEADER_LEN_MODE     (false)                /**< Set fixed header length mode (implicit header) */
-#define SX127X_PAYLOAD_CRC_ON            (true)                 /**< Enable payload CRC, optional */
-#define SX127X_PAYLOAD_LENGTH            (0U)                   /**< Set payload length, unused with implicit header */
 
 #define SX127X_TX_TIMEOUT_DEFAULT        (1000U * 1000U * 30UL) /**< TX timeout, 30s */
 #define SX127X_RX_SINGLE                 (false)                /**< Single byte receive mode => continuous by default */
@@ -134,38 +119,6 @@ enum {
 enum {
     SX127X_MODEM_FSK = 0,              /**< FSK modem driver */
     SX127X_MODEM_LORA,                 /**< LoRa modem driver */
-};
-
-/**
- * @brief   LoRa signal bandwidth.
- */
-enum {
-    SX127X_BW_125_KHZ = 0,             /**< 125 kHz bandwidth */
-    SX127X_BW_250_KHZ,                 /**< 250 kHz bandwidth */
-    SX127X_BW_500_KHZ                  /**< 500 kHz bandwidth */
-};
-
-/**
- * @brief   LoRa spreading factor rate
- */
-enum {
-    SX127X_SF6 = 6,                    /**< spreading factor 6 */
-    SX127X_SF7,                        /**< spreading factor 7 */
-    SX127X_SF8,                        /**< spreading factor 8 */
-    SX127X_SF9,                        /**< spreading factor 9 */
-    SX127X_SF10,                       /**< spreading factor 10 */
-    SX127X_SF11,                       /**< spreading factor 11 */
-    SX127X_SF12                        /**< spreading factor 12 */
-};
-
-/**
- * @brief   LoRa error coding rate.
- */
-enum {
-    SX127X_CR_4_5 = 1,                 /**< coding rate 4/5 */
-    SX127X_CR_4_6,                     /**< coding rate 4/6 */
-    SX127X_CR_4_7,                     /**< coding rate 4/7 */
-    SX127X_CR_4_8                      /**< coding rate 4/8 */
 };
 
 /**
@@ -321,34 +274,6 @@ void sx127x_init_radio_settings(sx127x_t *dev);
  * @return random 32 bits value
  */
 uint32_t sx127x_random(sx127x_t *dev);
-
-/**
- * @brief   sx127x DIO0 IRQ handler.
- *
- * @param[in] arg                      An sx127x device instance
- */
-void sx127x_on_dio0(void *arg);
-
-/**
- * @brief   sx127x DIO1 IRQ handler.
- *
- * @param[in] arg                      An sx127x device instance
- */
-void sx127x_on_dio1(void *arg);
-
-/**
- * @brief   sx127x DIO2 IRQ handler.
- *
- * @param[in] arg                      An sx127x device instance
- */
-void sx127x_on_dio2(void *arg);
-
-/**
- * @brief   sx127x DIO3 IRQ handler.
- *
- * @param[in] arg                      An sx127x device instance
- */
-void sx127x_on_dio3(void *arg);
 
 /**
  * @brief   Start a channel activity detection.

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -30,6 +30,8 @@
 #include "periph/gpio.h"
 #include "periph/spi.h"
 
+#include "net/lora.h"
+
 #include "sx127x.h"
 #include "sx127x_internal.h"
 #include "sx127x_registers.h"
@@ -113,23 +115,22 @@ int sx127x_init(sx127x_t *dev)
 
 void sx127x_init_radio_settings(sx127x_t *dev)
 {
-    sx127x_set_freq_hop(dev, SX127X_FREQUENCY_HOPPING);
-    sx127x_set_iq_invert(dev, SX127X_IQ_INVERSION);
+    sx127x_set_freq_hop(dev, LORA_FREQUENCY_HOPPING);
+    sx127x_set_iq_invert(dev, LORA_IQ_INVERSION);
+    sx127x_set_bandwidth(dev, LORA_BW_DEFAULT);
+    sx127x_set_spreading_factor(dev, LORA_SF_DEFAULT);
+    sx127x_set_coding_rate(dev, LORA_CR_DEFAULT);
+    sx127x_set_fixed_header_len_mode(dev, LORA_FIXED_HEADER_LEN_MODE);
+    sx127x_set_crc(dev, LORA_PAYLOAD_CRC_ON);
+    sx127x_set_symbol_timeout(dev, LORA_SYMBOL_TIMEOUT);
+    sx127x_set_preamble_length(dev, LORA_PREAMBLE_LENGTH);
+    sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH);
+    sx127x_set_hop_period(dev, LORA_FREQUENCY_HOPPING_PERIOD);
+
     sx127x_set_rx_single(dev, SX127X_RX_SINGLE);
     sx127x_set_tx_timeout(dev, SX127X_TX_TIMEOUT_DEFAULT);
     sx127x_set_modem(dev, SX127X_MODEM_DEFAULT);
     sx127x_set_channel(dev, SX127X_CHANNEL_DEFAULT);
-    sx127x_set_bandwidth(dev, SX127X_BW_DEFAULT);
-    sx127x_set_spreading_factor(dev, SX127X_SF_DEFAULT);
-    sx127x_set_coding_rate(dev, SX127X_CR_DEFAULT);
-
-    sx127x_set_fixed_header_len_mode(dev, SX127X_FIXED_HEADER_LEN_MODE);
-    sx127x_set_crc(dev, SX127X_PAYLOAD_CRC_ON);
-    sx127x_set_symbol_timeout(dev, SX127X_SYMBOL_TIMEOUT);
-    sx127x_set_preamble_length(dev, SX127X_PREAMBLE_LENGTH);
-    sx127x_set_payload_length(dev, SX127X_PAYLOAD_LENGTH);
-    sx127x_set_hop_period(dev, SX127X_FREQUENCY_HOPPING_PERIOD);
-
     sx127x_set_tx_power(dev, SX127X_RADIO_TX_POWER);
 }
 
@@ -201,158 +202,6 @@ static void sx127x_on_dio3_isr(void *arg)
 }
 
 /* Internal event handlers */
-void sx127x_on_dio0(void *arg)
-{
-    sx127x_t *dev = (sx127x_t *) arg;
-    netdev_t *netdev = (netdev_t*) &dev->netdev;
-
-    switch (dev->settings.state) {
-        case SX127X_RF_RX_RUNNING:
-            netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
-            break;
-        case SX127X_RF_TX_RUNNING:
-            xtimer_remove(&dev->_internal.tx_timeout_timer);
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_LORA:
-                    /* Clear IRQ */
-                    sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                                     SX127X_RF_LORA_IRQFLAGS_TXDONE);
-                /* Intentional fall-through */
-                case SX127X_MODEM_FSK:
-                default:
-                    sx127x_set_state(dev, SX127X_RF_IDLE);
-                    netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
-                    break;
-            }
-            break;
-        case SX127X_RF_IDLE:
-            printf("sx127x_on_dio0: IDLE state\n");
-            break;
-        default:
-            printf("sx127x_on_dio0: Unknown state [%d]\n", dev->settings.state);
-            break;
-    }
-}
-
-void sx127x_on_dio1(void *arg)
-{
-    /* Get interrupt context */
-    sx127x_t *dev = (sx127x_t *) arg;
-    netdev_t *netdev = (netdev_t*) &dev->netdev;
-
-    switch (dev->settings.state) {
-        case SX127X_RF_RX_RUNNING:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    /* todo */
-                    break;
-                case SX127X_MODEM_LORA:
-                    xtimer_remove(&dev->_internal.rx_timeout_timer);
-                    /*  Clear Irq */
-                    sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS, SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT);
-                    sx127x_set_state(dev, SX127X_RF_IDLE);
-                    netdev->event_callback(netdev, NETDEV_EVENT_RX_TIMEOUT);
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case SX127X_RF_TX_RUNNING:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    /* todo */
-                    break;
-                case SX127X_MODEM_LORA:
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            puts("sx127x_on_dio1: Unknown state");
-            break;
-    }
-}
-
-void sx127x_on_dio2(void *arg)
-{
-    /* Get interrupt context */
-    sx127x_t *dev = (sx127x_t *) arg;
-    netdev_t *netdev = (netdev_t*) dev;
-
-    switch (dev->settings.state) {
-        case SX127X_RF_RX_RUNNING:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    /* todo */
-                    break;
-                case SX127X_MODEM_LORA:
-                    if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
-                        /* Clear IRQ */
-                        sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                                         SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL);
-
-                        dev->_internal.last_channel = (sx127x_reg_read(dev, SX127X_REG_LR_HOPCHANNEL) &
-                                                       SX127X_RF_LORA_HOPCHANNEL_CHANNEL_MASK);
-                        netdev->event_callback(netdev, NETDEV_EVENT_FHSS_CHANGE_CHANNEL);
-                    }
-
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case SX127X_RF_TX_RUNNING:
-            switch (dev->settings.modem) {
-                case SX127X_MODEM_FSK:
-                    break;
-                case SX127X_MODEM_LORA:
-                    if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
-                        /* Clear IRQ */
-                        sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                                         SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL);
-
-                        dev->_internal.last_channel = (sx127x_reg_read(dev, SX127X_REG_LR_HOPCHANNEL) &
-                                                       SX127X_RF_LORA_HOPCHANNEL_CHANNEL_MASK);
-                        netdev->event_callback(netdev, NETDEV_EVENT_FHSS_CHANGE_CHANNEL);
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        default:
-            puts("sx127x_on_dio2: Unknown state");
-            break;
-    }
-}
-
-void sx127x_on_dio3(void *arg)
-{
-    /* Get interrupt context */
-    sx127x_t *dev = (sx127x_t *) arg;
-    netdev_t *netdev = (netdev_t *) dev;
-
-    switch (dev->settings.modem) {
-        case SX127X_MODEM_FSK:
-            break;
-        case SX127X_MODEM_LORA:
-            /* Clear IRQ */
-            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
-                             SX127X_RF_LORA_IRQFLAGS_CADDETECTED |
-                             SX127X_RF_LORA_IRQFLAGS_CADDONE);
-
-            /* Send event message */
-            dev->_internal.is_last_cad_success = (sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS) &
-                                                  SX127X_RF_LORA_IRQFLAGS_CADDETECTED) == SX127X_RF_LORA_IRQFLAGS_CADDETECTED;
-            netdev->event_callback(netdev, NETDEV_EVENT_CAD_DONE);
-            break;
-        default:
-            puts("sx127x_on_dio3: Unknown modem");
-            break;
-    }
-}
-
 static void _init_isrs(sx127x_t *dev)
 {
     if (gpio_init_int(dev->params.dio0_pin, GPIO_IN, GPIO_RISING, sx127x_on_dio0_isr, dev) < 0) {

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -26,6 +26,8 @@
 #include <stdbool.h>
 #include <inttypes.h>
 
+#include "net/lora.h"
+
 #include "sx127x.h"
 #include "sx127x_registers.h"
 #include "sx127x_internal.h"
@@ -102,7 +104,7 @@ uint32_t sx127x_get_channel(const sx127x_t *dev)
 {
     return (((uint32_t)sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16) |
             (sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8) |
-            (sx127x_reg_read(dev, SX127X_REG_FRFLSB))) * SX127X_FREQUENCY_RESOLUTION;
+            (sx127x_reg_read(dev, SX127X_REG_FRFLSB))) * LORA_FREQUENCY_RESOLUTION;
 }
 
 void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
@@ -112,7 +114,7 @@ void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
     /* Save current operating mode */
     dev->settings.channel = channel;
 
-    channel = (uint32_t)((double) channel / (double) SX127X_FREQUENCY_RESOLUTION);
+    channel = (uint32_t)((double) channel / (double)LORA_FREQUENCY_RESOLUTION);
 
     /* Write frequency settings into chip */
     sx127x_reg_write(dev, SX127X_REG_FRFMSB, (uint8_t)((channel >> 16) & 0xFF));
@@ -134,13 +136,13 @@ uint32_t sx127x_get_time_on_air(const sx127x_t *dev, uint8_t pkt_len)
 
             /* Note: When using LoRa modem only bandwidths 125, 250 and 500 kHz are supported. */
             switch (dev->settings.lora.bandwidth) {
-                case SX127X_BW_125_KHZ:
+                case LORA_BW_125_KHZ:
                     bw = 125e3;
                     break;
-                case SX127X_BW_250_KHZ:
+                case LORA_BW_250_KHZ:
                     bw = 250e3;
                     break;
-                case SX127X_BW_500_KHZ:
+                case LORA_BW_500_KHZ:
                     bw = 500e3;
                     break;
                 default:
@@ -225,10 +227,10 @@ void sx127x_set_rx(sx127x_t *dev)
                                  sx127x_reg_read(dev, SX127X_REG_LR_DETECTOPTIMIZE) & 0x7F);
                 sx127x_reg_write(dev, SX127X_REG_LR_TEST30, 0x00);
                 switch (dev->settings.lora.bandwidth) {
-                    case SX127X_BW_125_KHZ: /* 125 kHz */
+                    case LORA_BW_125_KHZ: /* 125 kHz */
                         sx127x_reg_write(dev, SX127X_REG_LR_TEST2F, 0x40);
                         break;
-                    case SX127X_BW_250_KHZ: /* 250 kHz */
+                    case LORA_BW_250_KHZ: /* 250 kHz */
                         sx127x_reg_write(dev, SX127X_REG_LR_TEST2F, 0x40);
                         break;
 
@@ -425,11 +427,11 @@ uint8_t sx127x_get_bandwidth(const sx127x_t *dev)
 
 inline void _low_datarate_optimize(sx127x_t *dev)
 {
-    if ( ((dev->settings.lora.bandwidth == SX127X_BW_125_KHZ) &&
-          ((dev->settings.lora.datarate == SX127X_SF11) ||
-           (dev->settings.lora.datarate == SX127X_SF12))) ||
-         ((dev->settings.lora.bandwidth == SX127X_BW_250_KHZ) &&
-          (dev->settings.lora.datarate == SX127X_SF12))) {
+    if ( ((dev->settings.lora.bandwidth == LORA_BW_125_KHZ) &&
+          ((dev->settings.lora.datarate == LORA_SF11) ||
+           (dev->settings.lora.datarate == LORA_SF12))) ||
+         ((dev->settings.lora.bandwidth == LORA_BW_250_KHZ) &&
+          (dev->settings.lora.datarate == LORA_SF12))) {
         dev->settings.lora.flags |= SX127X_LOW_DATARATE_OPTIMIZE_FLAG;
     } else {
         dev->settings.lora.flags &= ~SX127X_LOW_DATARATE_OPTIMIZE_FLAG;
@@ -470,13 +472,13 @@ inline void _update_bandwidth(const sx127x_t *dev)
 #else /* MODULE_SX1276 */
     config1_reg &= SX1276_RF_LORA_MODEMCONFIG1_BW_MASK;
     switch (dev->settings.lora.bandwidth) {
-    case SX127X_BW_125_KHZ:
+    case LORA_BW_125_KHZ:
         config1_reg |= SX1276_RF_LORA_MODEMCONFIG1_BW_125_KHZ;
         break;
-    case SX127X_BW_250_KHZ:
+    case LORA_BW_250_KHZ:
         config1_reg |=  SX1276_RF_LORA_MODEMCONFIG1_BW_250_KHZ;
         break;
-    case SX127X_BW_500_KHZ:
+    case LORA_BW_500_KHZ:
         config1_reg |=  SX1276_RF_LORA_MODEMCONFIG1_BW_500_KHZ;
         break;
     default:
@@ -498,13 +500,13 @@ void sx127x_set_bandwidth(sx127x_t *dev, uint8_t bandwidth)
     _low_datarate_optimize(dev);
 
     /* ERRATA sensitivity tweaks */
-    if ((dev->settings.lora.bandwidth == SX127X_BW_500_KHZ) &&
+    if ((dev->settings.lora.bandwidth == LORA_BW_500_KHZ) &&
         (dev->settings.channel > SX127X_RF_MID_BAND_THRESH)) {
         /* ERRATA 2.1 - Sensitivity Optimization with a 500 kHz Bandwidth */
         sx127x_reg_write(dev, SX127X_REG_LR_TEST36, 0x02);
         sx127x_reg_write(dev, SX127X_REG_LR_TEST3A, 0x64);
     }
-    else if (dev->settings.lora.bandwidth == SX127X_BW_500_KHZ) {
+    else if (dev->settings.lora.bandwidth == LORA_BW_500_KHZ) {
         /* ERRATA 2.1 - Sensitivity Optimization with a 500 kHz Bandwidth */
         sx127x_reg_write(dev, SX127X_REG_LR_TEST36, 0x02);
         sx127x_reg_write(dev, SX127X_REG_LR_TEST3A, 0x7F);
@@ -524,7 +526,7 @@ void sx127x_set_spreading_factor(sx127x_t *dev, uint8_t datarate)
 {
     DEBUG("[DEBUG] Set spreading factor: %d\n", datarate);
 
-    if (datarate == SX127X_SF6 &&
+    if (datarate == LORA_SF6 &&
         !(dev->settings.lora.flags & SX127X_ENABLE_FIXED_HEADER_LENGTH_FLAG)) {
         /* SF 6 is only valid when using explicit header mode */
         DEBUG("Spreading Factor 6 can only be used when explicit header "
@@ -543,7 +545,7 @@ void sx127x_set_spreading_factor(sx127x_t *dev, uint8_t datarate)
     _low_datarate_optimize(dev);
 
     switch(dev->settings.lora.datarate) {
-    case SX127X_SF6:
+    case LORA_SF6:
         sx127x_reg_write(dev, SX127X_REG_LR_DETECTOPTIMIZE,
                          SX127X_RF_LORA_DETECTIONOPTIMIZE_SF6);
         sx127x_reg_write(dev, SX127X_REG_LR_DETECTIONTHRESHOLD,

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -27,6 +27,8 @@
 
 #include "irq.h"
 
+#include "net/lora.h"
+
 #include "sx127x.h"
 #include "sx127x_registers.h"
 #include "sx127x_internal.h"
@@ -131,7 +133,7 @@ void sx127x_rx_chain_calibration(sx127x_t *dev)
     reg_pa_config_init_val = sx127x_reg_read(dev, SX127X_REG_PACONFIG);
     initial_freq = (double) (((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFMSB) << 16)
                              | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFMID) << 8)
-                             | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFLSB))) * (double) SX127X_FREQUENCY_RESOLUTION;
+                             | ((uint32_t) sx127x_reg_read(dev, SX127X_REG_FRFLSB))) * (double)LORA_FREQUENCY_RESOLUTION;
 
     /* Cut the PA just in case, RFO output, power = -1 dBm */
     sx127x_reg_write(dev, SX127X_REG_PACONFIG, 0x00);

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -23,6 +23,8 @@
 
 #include "net/netopt.h"
 #include "net/netdev.h"
+#include "net/lora.h"
+
 #include "sx127x_registers.h"
 #include "sx127x_internal.h"
 #include "sx127x_netdev.h"
@@ -35,6 +37,10 @@
 static uint8_t _get_tx_len(const struct iovec *vector, unsigned count);
 static int _set_state(sx127x_t *dev, netopt_state_t state);
 static int _get_state(sx127x_t *dev, void *val);
+void _on_dio0_irq(void *arg);
+void _on_dio1_irq(void *arg);
+void _on_dio2_irq(void *arg);
+void _on_dio3_irq(void *arg);
 
 /* Netdev driver api functions */
 static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count);
@@ -58,7 +64,7 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
     sx127x_t *dev = (sx127x_t*) netdev;
 
     if (sx127x_get_state(dev) == SX127X_RF_TX_RUNNING) {
-        DEBUG("[WARNING] Cannot send packet: radio alredy in transmitting "
+        DEBUG("[WARNING] Cannot send packet: radio already in transmitting "
               "state.\n");
         return -ENOTSUP;
     }
@@ -254,19 +260,19 @@ static void _isr(netdev_t *netdev)
 
     switch (irq) {
         case SX127X_IRQ_DIO0:
-            sx127x_on_dio0(dev);
+            _on_dio0_irq(dev);
             break;
 
         case SX127X_IRQ_DIO1:
-            sx127x_on_dio1(dev);
+            _on_dio1_irq(dev);
             break;
 
         case SX127X_IRQ_DIO2:
-            sx127x_on_dio2(dev);
+            _on_dio2_irq(dev);
             break;
 
         case SX127X_IRQ_DIO3:
-            sx127x_on_dio3(dev);
+            _on_dio3_irq(dev);
             break;
 
         default:
@@ -371,8 +377,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         case NETOPT_BANDWIDTH:
             assert(len <= sizeof(uint8_t));
             uint8_t bw = *((const uint8_t *)val);
-            if (bw < SX127X_BW_125_KHZ ||
-                bw > SX127X_BW_500_KHZ) {
+            if (bw < LORA_BW_125_KHZ ||
+                bw > LORA_BW_500_KHZ) {
                 res = -EINVAL;
                 break;
             }
@@ -382,8 +388,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         case NETOPT_SPREADING_FACTOR:
             assert(len <= sizeof(uint8_t));
             uint8_t sf = *((const uint8_t *)val);
-            if (sf < SX127X_SF6 ||
-                sf > SX127X_SF12) {
+            if (sf < LORA_SF6 ||
+                sf > LORA_SF12) {
                 res = -EINVAL;
                 break;
             }
@@ -393,8 +399,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         case NETOPT_CODING_RATE:
             assert(len <= sizeof(uint8_t));
             uint8_t cr = *((const uint8_t *)val);
-            if (cr < SX127X_CR_4_5 ||
-                cr > SX127X_CR_4_8) {
+            if (cr < LORA_CR_4_5 ||
+                cr > LORA_CR_4_8) {
                 res = -EINVAL;
                 break;
             }
@@ -537,4 +543,156 @@ static int _get_state(sx127x_t *dev, void *val)
     }
     memcpy(val, &state, sizeof(netopt_state_t));
     return sizeof(netopt_state_t);
+}
+
+void _on_dio0_irq(void *arg)
+{
+    sx127x_t *dev = (sx127x_t *) arg;
+    netdev_t *netdev = (netdev_t*) &dev->netdev;
+
+    switch (dev->settings.state) {
+        case SX127X_RF_RX_RUNNING:
+            netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
+            break;
+        case SX127X_RF_TX_RUNNING:
+            xtimer_remove(&dev->_internal.tx_timeout_timer);
+            switch (dev->settings.modem) {
+                case SX127X_MODEM_LORA:
+                    /* Clear IRQ */
+                    sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                                     SX127X_RF_LORA_IRQFLAGS_TXDONE);
+                /* Intentional fall-through */
+                case SX127X_MODEM_FSK:
+                default:
+                    sx127x_set_state(dev, SX127X_RF_IDLE);
+                    netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
+                    break;
+            }
+            break;
+        case SX127X_RF_IDLE:
+            printf("sx127x_on_dio0: IDLE state\n");
+            break;
+        default:
+            printf("sx127x_on_dio0: Unknown state [%d]\n", dev->settings.state);
+            break;
+    }
+}
+
+void _on_dio1_irq(void *arg)
+{
+    /* Get interrupt context */
+    sx127x_t *dev = (sx127x_t *) arg;
+    netdev_t *netdev = (netdev_t*) &dev->netdev;
+
+    switch (dev->settings.state) {
+        case SX127X_RF_RX_RUNNING:
+            switch (dev->settings.modem) {
+                case SX127X_MODEM_FSK:
+                    /* todo */
+                    break;
+                case SX127X_MODEM_LORA:
+                    xtimer_remove(&dev->_internal.rx_timeout_timer);
+                    /*  Clear Irq */
+                    sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS, SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT);
+                    sx127x_set_state(dev, SX127X_RF_IDLE);
+                    netdev->event_callback(netdev, NETDEV_EVENT_RX_TIMEOUT);
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case SX127X_RF_TX_RUNNING:
+            switch (dev->settings.modem) {
+                case SX127X_MODEM_FSK:
+                    /* todo */
+                    break;
+                case SX127X_MODEM_LORA:
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            puts("sx127x_on_dio1: Unknown state");
+            break;
+    }
+}
+
+void _on_dio2_irq(void *arg)
+{
+    /* Get interrupt context */
+    sx127x_t *dev = (sx127x_t *) arg;
+    netdev_t *netdev = (netdev_t*) dev;
+
+    switch (dev->settings.state) {
+        case SX127X_RF_RX_RUNNING:
+            switch (dev->settings.modem) {
+                case SX127X_MODEM_FSK:
+                    /* todo */
+                    break;
+                case SX127X_MODEM_LORA:
+                    if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
+                        /* Clear IRQ */
+                        sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                                         SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL);
+
+                        dev->_internal.last_channel = (sx127x_reg_read(dev, SX127X_REG_LR_HOPCHANNEL) &
+                                                       SX127X_RF_LORA_HOPCHANNEL_CHANNEL_MASK);
+                        netdev->event_callback(netdev, NETDEV_EVENT_FHSS_CHANGE_CHANNEL);
+                    }
+
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case SX127X_RF_TX_RUNNING:
+            switch (dev->settings.modem) {
+                case SX127X_MODEM_FSK:
+                    break;
+                case SX127X_MODEM_LORA:
+                    if (dev->settings.lora.flags & SX127X_CHANNEL_HOPPING_FLAG) {
+                        /* Clear IRQ */
+                        sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                                         SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL);
+
+                        dev->_internal.last_channel = (sx127x_reg_read(dev, SX127X_REG_LR_HOPCHANNEL) &
+                                                       SX127X_RF_LORA_HOPCHANNEL_CHANNEL_MASK);
+                        netdev->event_callback(netdev, NETDEV_EVENT_FHSS_CHANGE_CHANNEL);
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+        default:
+            puts("sx127x_on_dio2: Unknown state");
+            break;
+    }
+}
+
+void _on_dio3_irq(void *arg)
+{
+    /* Get interrupt context */
+    sx127x_t *dev = (sx127x_t *) arg;
+    netdev_t *netdev = (netdev_t *) dev;
+
+    switch (dev->settings.modem) {
+        case SX127X_MODEM_FSK:
+            break;
+        case SX127X_MODEM_LORA:
+            /* Clear IRQ */
+            sx127x_reg_write(dev, SX127X_REG_LR_IRQFLAGS,
+                             SX127X_RF_LORA_IRQFLAGS_CADDETECTED |
+                             SX127X_RF_LORA_IRQFLAGS_CADDONE);
+
+            /* Send event message */
+            dev->_internal.is_last_cad_success = (sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS) &
+                                                  SX127X_RF_LORA_IRQFLAGS_CADDETECTED) == SX127X_RF_LORA_IRQFLAGS_CADDETECTED;
+            netdev->event_callback(netdev, NETDEV_EVENT_CAD_DONE);
+            break;
+        default:
+            puts("sx127x_on_dio3: Unknown modem");
+            break;
+    }
 }

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_lora LoRa modulation
+ * @ingroup     net
+ * @brief       LoRa modulation header definitions
+ * @{
+ *
+ * @file
+ * @brief       LoRa modulation header definitions
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef NET_LORA_H
+#define NET_LORA_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LoRa modulation default values
+ * @{
+ */
+#define LORA_FREQUENCY_RESOLUTION      (61.03515625)     /**< Frequency resolution in Hz */
+#define LORA_PREAMBLE_LENGTH           (8U)              /**< Preamble length, same for Tx and Rx */
+#define LORA_SYMBOL_TIMEOUT            (10U)             /**< Symbols timeout (s) */
+#define LORA_BW_DEFAULT                (LORA_BW_125_KHZ) /**< Set default bandwidth to 125kHz */
+#define LORA_SF_DEFAULT                (LORA_SF12)       /**< Set default spreading factor to 12 */
+#define LORA_CR_DEFAULT                (LORA_CR_4_8)     /**< Set default coding rate to 8 */
+#define LORA_FIX_LENGTH_PAYLOAD_ON     (false)           /**< Set fixed payload length on */
+#define LORA_IQ_INVERSION              (false)           /**< Set inverted IQ on */
+#define LORA_FREQUENCY_HOPPING         (false)           /**< Frequency hopping on */
+#define LORA_FREQUENCY_HOPPING_PERIOD  (0U)              /**< Frequency hopping period */
+#define LORA_FIXED_HEADER_LEN_MODE     (false)           /**< Set fixed header length mode (implicit header) */
+#define LORA_PAYLOAD_CRC_ON            (true)            /**< Enable payload CRC, optional */
+#define LORA_PAYLOAD_LENGTH            (0U)              /**< Set payload length, unused with implicit header */
+#define LORA_SYNCWORD_PUBLIC           (0x34)            /**< Syncword used for public networks */
+#define LORA_SYNCWORD_PRIVATE          (0x12)            /**< Syncword used for private networks */
+/** @} */
+
+/**
+ * @name    LoRa modulation available values
+ *
+ */
+/**
+ * @brief   LoRa modulation bandwidth.
+ */
+enum {
+    LORA_BW_125_KHZ = 0,               /**< 125 kHz bandwidth */
+    LORA_BW_250_KHZ,                   /**< 250 kHz bandwidth */
+    LORA_BW_500_KHZ                    /**< 500 kHz bandwidth */
+};
+
+/**
+ * @brief   LoRa modulation spreading factor rate
+ */
+enum {
+    LORA_SF6 = 6,                      /**< spreading factor 6 */
+    LORA_SF7,                          /**< spreading factor 7 */
+    LORA_SF8,                          /**< spreading factor 8 */
+    LORA_SF9,                          /**< spreading factor 9 */
+    LORA_SF10,                         /**< spreading factor 10 */
+    LORA_SF11,                         /**< spreading factor 11 */
+    LORA_SF12                          /**< spreading factor 12 */
+};
+
+/**
+ * @brief   LoRa modulation error coding rate.
+ */
+enum {
+    LORA_CR_4_5 = 1,                   /**< coding rate 4/5 */
+    LORA_CR_4_6,                       /**< coding rate 4/6 */
+    LORA_CR_4_7,                       /**< coding rate 4/7 */
+    LORA_CR_4_8                        /**< coding rate 4/8 */
+};
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_LORA_H */
+/** @} */

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -31,6 +31,7 @@
 
 #include "net/gnrc/netdev.h"
 #include "net/netdev.h"
+#include "net/lora.h"
 
 #include "board.h"
 #include "periph/rtc.h"
@@ -67,17 +68,17 @@ int lora_setup_cmd(int argc, char **argv) {
     switch (bw) {
         case 125:
             puts("setup: setting 125KHz bandwidth");
-            lora_bw = SX127X_BW_125_KHZ;
+            lora_bw = LORA_BW_125_KHZ;
             break;
 
         case 250:
             puts("setup: setting 250KHz bandwidth");
-            lora_bw = SX127X_BW_250_KHZ;
+            lora_bw = LORA_BW_250_KHZ;
             break;
 
         case 500:
             puts("setup: setting 500KHz bandwidth");
-            lora_bw = SX127X_BW_500_KHZ;
+            lora_bw = LORA_BW_500_KHZ;
             break;
 
         default:


### PR DESCRIPTION
This PR moves common LoRa definitions to an extra header file (considered useful for future reuse) and does some cleanup in the driver.