### PR TITLE
cpu/atmega: fixes #7422 - removes MEGA_PRR and uses avr/power.h instead

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+buildtest:
+  tags:
+    - docker
+  image: riot/riotbuild
+  script:
+    - cd examples/hello-world/
+    - make buildtest

--- a/boards/arduino-atmega-common/include/periph_conf.h
+++ b/boards/arduino-atmega-common/include/periph_conf.h
@@ -133,14 +133,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           1           /* set to 0 to disable SPI */
-
-#ifdef CPU_ATMEGA328P
-#define MEGA_PRR            PRR         /* Power Reduction Register is PRR */
-#endif
-
-#ifdef CPU_ATMEGA2560
-#define MEGA_PRR            PRR0        /* Power Reduction Register is PRR0 */
-#endif
 /** @} */
 
 /**

--- a/boards/waspmote-pro/include/periph_conf.h
+++ b/boards/waspmote-pro/include/periph_conf.h
@@ -101,7 +101,6 @@ extern "C" {
  * @{
  */
 #define SPI_NUMOF           1           /* set to 0 to disable SPI */
-#define MEGA_PRR            PRR0        /* Power Reduction Register */
 /** @} */
 
 /**

--- a/cpu/atmega1281/include/periph_cpu.h
+++ b/cpu/atmega1281/include/periph_cpu.h
@@ -48,7 +48,6 @@ enum {
  */
 #define I2C_PORT_REG            PORTD
 #define I2C_PIN_MASK            (1 << PORTD0) | (1 << PORTD1)
-#define I2C_POWER_REG           PRR0
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/atmega2560/include/periph_cpu.h
+++ b/cpu/atmega2560/include/periph_cpu.h
@@ -50,7 +50,6 @@ enum {
  */
 #define I2C_PORT_REG            PORTD
 #define I2C_PIN_MASK            (1 << PORTD0) | (1 << PORTD1)
-#define I2C_POWER_REG           PRR0
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/atmega328p/include/periph_cpu.h
+++ b/cpu/atmega328p/include/periph_cpu.h
@@ -47,7 +47,6 @@ enum {
  */
 #define I2C_PORT_REG            PORTC
 #define I2C_PIN_MASK            (1 << PORTC4) | (1 << PORTC5)
-#define I2C_POWER_REG           PRR
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/atmega_common/include/atmega_regs_common.h
+++ b/cpu/atmega_common/include/atmega_regs_common.h
@@ -22,6 +22,7 @@
 #define ATMEGA_REGS_COMMON_H
 
 #include <avr/io.h>
+#include <avr/power.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/atmega_common/periph/i2c.c
+++ b/cpu/atmega_common/periph/i2c.c
@@ -251,13 +251,13 @@ int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, in
 void i2c_poweron(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
-    I2C_POWER_REG &= ~(1 << PRTWI);
+    power_twi_enable();
 }
 
 void i2c_poweroff(i2c_t dev)
 {
     assert(dev < I2C_NUMOF);
-    I2C_POWER_REG |= (1 << PRTWI);
+    power_twi_disable();
 }
 
 static int _start(uint8_t address, uint8_t rw_flag)

--- a/cpu/atmega_common/periph/spi.c
+++ b/cpu/atmega_common/periph/spi.c
@@ -42,7 +42,7 @@ void spi_init(spi_t bus)
 {
     assert(bus == 0);
     /* power off the SPI peripheral */
-    MEGA_PRR |= (1 << PRSPI);
+    power_spi_disable();
     /* trigger the pin configuration */
     spi_init_pins(bus);
 }
@@ -64,12 +64,11 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 
     /* lock the bus and power on the SPI peripheral */
     mutex_lock(&lock);
-    MEGA_PRR &= ~(1 << PRSPI);
+    power_spi_enable();
 
     /* configure as master, with given mode and clock */
     SPSR = (clk >> S2X_SHIFT);
     SPCR = ((1 << SPE) | (1 << MSTR) | mode | (clk & CLK_MASK));
-    SPCR |= (1 << SPE);
 
     /* clear interrupt flag by reading SPSR and data register by reading SPDR */
     (void)SPSR;
@@ -82,7 +81,7 @@ void spi_release(spi_t bus)
 {
     /* power off and release the bus */
     SPCR &= ~(1 << SPE);
-    MEGA_PRR |= (1 << PRSPI);
+    power_spi_disable();
     mutex_unlock(&lock);
 }
 


### PR DESCRIPTION
Clean commit to solve some power management issues in the atmega_common platform