### PR TITLE
cpu/sam0: fix sercom gclk selection

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -128,7 +128,7 @@ typedef struct {
     uart_rxpad_t rx_pad;    /**< pad selection for RX line */
     uart_txpad_t tx_pad;    /**< pad selection for TX line */
     uint8_t runstdby;       /**< allow SERCOM to run in standby mode */
-    uint8_t gclk_src;       /**< GCLK source which supplys SERCOM */
+    uint32_t gclk_src;      /**< GCLK source which supplys SERCOM */
 } uart_conf_t;
 
 /**


### PR DESCRIPTION
This PR should fix #7605 
If we try to use other values than GCLK_CLKCTRL_GEN_GCLK0 for UART (in boards/include/periph_conf.h), compilation fails (this issue only applies on SAMD21 based board but I cannot reproduce it for SAML21).
Thanks @photonthunder for spotting this :) 