### PR TITLE
doxygen: fall back to lesscpy if lessc is not found

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -5,6 +5,16 @@ export STRIP_FROM_INC_PATH_LIST=$(shell \
     grep '/include$$' |\
     sed 's/.*/\"$(subst /,\/,${RIOTBASE})\/\0\"/')
 
+# use lessc (http://lesscss.org/#using-less) for compiling CSS, alternatively
+# fall back to lesscpy (https://github.com/lesscpy/lesscpy)
+ifeq (,$(LESSC))
+  ifneq (,$(shell command -v lessc 2>/dev/null))
+    LESSC=lessc
+  else ifneq (,$(shell command -v lesscpy 2>/dev/null))
+    LESSC=lesscpy
+  endif
+endif
+
 .PHONY: doc
 doc: html
 
@@ -17,10 +27,9 @@ html: src/css/riot.css src/changelog.md
 man: src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
 
-ifneq (,$(shell which lessc))
-# use lessc (http://lesscss.org/#using-less) for compiling CSS
+ifneq (,$(LESSC))
 src/css/riot.css: src/css/riot.less src/css/variables.less
-	@lessc $< $@
+	@$(LESSC) $< $@
 
 src/css/variables.less: src/config.json
 	@grep "^\s*\"@" $< | sed -e 's/^\s*"//g' -e 's/":\s*"/: /g' \


### PR DESCRIPTION
 - Searches for lesscpy if lessc is not installed. (https://github.com/lesscpy/lesscpy)
 - Changed `which` to `command -v`, avoids messages like `which: no lessc in (/bin:/usr/bin:...[long path list])`
 - Removed `@` for documentation commands, lets us see which command is invoked when make runs the preprocessing stages