### PR TITLE
cpu/stm32: fix header files to be able to use DMA again

### DIFF
--- a/cpu/stm32f2/include/vendor/stm32f205xx.h
+++ b/cpu/stm32f2/include/vendor/stm32f205xx.h
@@ -347,10 +347,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 

--- a/cpu/stm32f2/include/vendor/stm32f207xx.h
+++ b/cpu/stm32f2/include/vendor/stm32f207xx.h
@@ -368,10 +368,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 

--- a/cpu/stm32f2/include/vendor/stm32f215xx.h
+++ b/cpu/stm32f2/include/vendor/stm32f215xx.h
@@ -348,10 +348,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 

--- a/cpu/stm32f2/include/vendor/stm32f217xx.h
+++ b/cpu/stm32f2/include/vendor/stm32f217xx.h
@@ -369,10 +369,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 

--- a/cpu/stm32f4/include/vendor/stm32f401xe.h
+++ b/cpu/stm32f4/include/vendor/stm32f401xe.h
@@ -240,10 +240,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**

--- a/cpu/stm32f4/include/vendor/stm32f407xx.h
+++ b/cpu/stm32f4/include/vendor/stm32f407xx.h
@@ -369,10 +369,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**

--- a/cpu/stm32f4/include/vendor/stm32f410rx.h
+++ b/cpu/stm32f4/include/vendor/stm32f410rx.h
@@ -258,10 +258,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**

--- a/cpu/stm32f4/include/vendor/stm32f411xe.h
+++ b/cpu/stm32f4/include/vendor/stm32f411xe.h
@@ -241,10 +241,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**

--- a/cpu/stm32f4/include/vendor/stm32f412zx.h
+++ b/cpu/stm32f4/include/vendor/stm32f412zx.h
@@ -362,10 +362,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**

--- a/cpu/stm32f4/include/vendor/stm32f413xx.h
+++ b/cpu/stm32f4/include/vendor/stm32f413xx.h
@@ -400,10 +400,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**

--- a/cpu/stm32f4/include/vendor/stm32f415xx.h
+++ b/cpu/stm32f4/include/vendor/stm32f415xx.h
@@ -350,10 +350,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**

--- a/cpu/stm32f4/include/vendor/stm32f429xx.h
+++ b/cpu/stm32f4/include/vendor/stm32f429xx.h
@@ -378,10 +378,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**

--- a/cpu/stm32f4/include/vendor/stm32f446xx.h
+++ b/cpu/stm32f4/include/vendor/stm32f446xx.h
@@ -389,10 +389,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**

--- a/cpu/stm32f7/include/vendor/stm32f722xx.h
+++ b/cpu/stm32f7/include/vendor/stm32f722xx.h
@@ -355,10 +355,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 

--- a/cpu/stm32f7/include/vendor/stm32f746xx.h
+++ b/cpu/stm32f7/include/vendor/stm32f746xx.h
@@ -399,12 +399,9 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
-
 /**
   * @brief DMA2D Controller
   */

--- a/cpu/stm32f7/include/vendor/stm32f767xx.h
+++ b/cpu/stm32f7/include/vendor/stm32f767xx.h
@@ -444,10 +444,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 

--- a/cpu/stm32f7/include/vendor/stm32f769xx.h
+++ b/cpu/stm32f7/include/vendor/stm32f769xx.h
@@ -445,10 +445,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
 
 /**


### PR DESCRIPTION
The refactoring of the vendor headers caused that the DMA implementation doesn't work anymore for the implemented stm32s. The diff hangs in Github I guess because of the size of the files. An example of the diff follows:

```diff
 typedef struct
 {
-  __IO uint32_t LISR;   /*!< DMA low interrupt status register,      Address offset: 0x00 */
-  __IO uint32_t HISR;   /*!< DMA high interrupt status register,     Address offset: 0x04 */
-  __IO uint32_t LIFCR;  /*!< DMA low interrupt flag clear register,  Address offset: 0x08 */
-  __IO uint32_t HIFCR;  /*!< DMA high interrupt flag clear register, Address offset: 0x0C */
+  __IO uint32_t ISR[2]; /*!< DMA low interrupt status register */
+  __IO uint32_t IFCR[2];  /*!< DMA low interrupt flag clear register */
 } DMA_TypeDef;
```

DMA is required by #5643