### PR TITLE
SAM3: macro LED0_TOGGLE not working

### DIFF
--- a/boards/arduino-due/include/board.h
+++ b/boards/arduino-due/include/board.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #define LED0_ON             (PIOB->PIO_SODR  = PIO_PB27)
 #define LED0_OFF            (PIOB->PIO_CODR  = PIO_PB27)
-#define LED0_TOGGLE         (PIOB->PIO_ODSR ^= PIO_PB27)
+#define LED0_TOGGLE         ((PIOB->PIO_ODSR & PIO_PB27) ? LED0_OFF : LED0_ON)
 /** @} */
 
 /**

--- a/boards/udoo/include/board.h
+++ b/boards/udoo/include/board.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define LED0_ON             (LED_PORT->PIO_SODR =  LED0_MASK)
 #define LED0_OFF            (LED_PORT->PIO_CODR =  LED0_MASK)
-#define LED0_TOGGLE         (LED_PORT->PIO_ODSR ^= LED0_MASK)
+#define LED0_TOGGLE         ((PIOB->PIO_ODSR & LED0_MASK) ? LED0_OFF : LED0_ON)
 /** @} */
 
 /**


### PR DESCRIPTION
The LED0_TOGGLE macro for the **arduino-due (SAM3XE)** uses he PIO_ODSR register to toggle led status:
https://github.com/RIOT-OS/RIOT/blob/a5bdf0a831868a5e965cef664ad3ca540104e9cd/boards/arduino-due/include/board.h#L39
However this register is read-only unless the corresponding bit in **PIO_OWER** is set.

> 31.5.5 Synchronous Data Output
[...] the PIO Controller offers a direct control of PIO outputs by single write access to PIO_ODSR (Output Data Status Register). Only bits unmasked by PIO_OWSR (Output Write Status Register) are
written. The mask bits in PIO_OWSR are set by writing to PIO_OWER (Output Write Enable Register) and cleared by writing to PIO_OWDR (Output Write Disable Register).

[SAM3XE datasheet pg. 623 p. 31.5.5](http://www.atmel.com/Images/Atmel-11057-32-bit-Cortex-M3-Microcontroller-SAM3X-SAM3A_Datasheet.pdf)

This fix enables the PIO_OWSR for **all** pins in PIOB, I don't know whether this is the intended behaviour or not. Other possible solutions could be:
- Enabling PIO_OWSR only for LED0 (0x08000000).
- Changing the macro so it uses only SODR and CODR registers.
- Adding a note on the second tutorial (wich uses this macro)

P.S. `~0l` is quite horrible, and I shuld have defined a constant instead, but i din't know where to put that.