### PR TITLE
sys: net: ieee802154: add fallthrough comment

### DIFF
--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -275,6 +275,7 @@ static inline eui64_t *ieee802154_get_iid(eui64_t *eui64, const uint8_t *addr,
             eui64->uint8[0] = addr[i++] ^ 0x02;
             eui64->uint8[1] = addr[i++];
 
+            /* Falls through. */
         case 2:
             eui64->uint8[2] = 0;
             eui64->uint8[3] = 0xff;


### PR DESCRIPTION
Hi,

When trying to run the unit tests on the native arch (`cd tests/unittests && make && make term`), I noticed that compilation failed due to an implicit fallthrough warning in `sys/include/net/ieee802154.h`. This commit adds a comment to silence it.

FWIW, the unit tests only pass when the fallthrough is left as-is, replacing it with a `break;` statement causes a test case to fail. So I assume that the fallthrough is indeed the intended behaviour here.