### PR TITLE
netopt: Add NETOPT_MAC_NO_SLEEP

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -194,6 +194,16 @@ typedef enum {
     NETOPT_CSMA_MINBE,
 
     /**
+     * @brief en/disable blocking of radio sleep when running a duty cycling MAC layer
+     *
+     * (netopt_enable_t) Enabling this option tells the MAC layer to never put
+     * the radio to sleep. Useful in gateways and routers not running on
+     * batteries to improve responsiveness and allow battery powered nodes on
+     * the same network to sleep more often.
+     */
+    NETOPT_MAC_NO_SLEEP,
+
+    /**
      * @brief read-only check for a wired interface.
      *
      * If the interface is wireless this function will return -ENOTSUP, a

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -51,6 +51,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_CSMA_RETRIES]          = "NETOPT_CSMA_RETRIES",
     [NETOPT_CSMA_MAXBE]            = "NETOPT_CSMA_MAXBE",
     [NETOPT_CSMA_MINBE]            = "NETOPT_CSMA_MINBE",
+    [NETOPT_MAC_NO_SLEEP]          = "NETOPT_MAC_NO_SLEEP",
     [NETOPT_IS_WIRED]              = "NETOPT_IS_WIRED",
     [NETOPT_DEVICE_TYPE]           = "NETOPT_DEVICE_TYPE",
     [NETOPT_CHANNEL_PAGE]          = "NETOPT_CHANNEL_PAGE",

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -175,7 +175,7 @@ static void _hl_usage(char *cmd_name)
 
 static void _flag_usage(char *cmd_name)
 {
-    printf("usage: %s <if_id> [-]{promisc|autoack|ack_req|csma|autocca|cca_threshold|preload|iphc|rtr_adv}\n", cmd_name);
+    printf("usage: %s <if_id> [-]{promisc|autoack|ack_req|csma|autocca|cca_threshold|preload|mac_no_sleep|iphc|rtr_adv}\n", cmd_name);
 }
 
 static void _add_usage(char *cmd_name)
@@ -422,6 +422,13 @@ static void _netif_list(kernel_pid_t dev)
 
     if ((res >= 0) && (enable == NETOPT_ENABLE)) {
         printf("AUTOCCA  ");
+        linebreak = true;
+    }
+
+    res = gnrc_netapi_get(dev, NETOPT_MAC_NO_SLEEP, 0, &enable, sizeof(enable));
+
+    if ((res >= 0) && (enable == NETOPT_ENABLE)) {
+        printf("MAC_NO_SLEEP  ");
         linebreak = true;
     }
 
@@ -911,6 +918,9 @@ static int _netif_flag(char *cmd, kernel_pid_t dev, char *flag)
     }
     else if (strcmp(flag, "autocca") == 0) {
         return _netif_set_flag(dev, NETOPT_AUTOCCA, set);
+    }
+    else if (strcmp(flag, "mac_no_sleep") == 0) {
+        return _netif_set_flag(dev, NETOPT_MAC_NO_SLEEP, set);
     }
     else if (strcmp(flag, "iphc") == 0) {
 #if defined(MODULE_GNRC_SIXLOWPAN_NETIF) && defined(MODULE_GNRC_SIXLOWPAN_IPHC)


### PR DESCRIPTION
Tell a duty cycling MAC layer to remain always on

This option tells the MAC layer to never put the radio to sleep. Useful in gateways and routers not running on batteries to improve responsiveness and allow battery powered nodes on the same network to sleep more often.