### PR TITLE
boards: initial support for TI CC2650 LaunchPad

### DIFF
--- a/boards/cc2650-launchpad/Makefile
+++ b/boards/cc2650-launchpad/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/cc2650-launchpad/Makefile.features
+++ b/boards/cc2650-launchpad/Makefile.features
@@ -1,0 +1,13 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m3_1
+
+-include $(RIOTCPU)/cc26x0/Makefile.features

--- a/boards/cc2650-launchpad/Makefile.include
+++ b/boards/cc2650-launchpad/Makefile.include
@@ -1,0 +1,34 @@
+export CPU       = cc26x0
+export CPU_MODEL = cc26x0f128
+export XDEBUGGER = XDS110
+
+# set default port depending on operating system
+PORT_LINUX  ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# configure the flash tool
+export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"
+# check which uniflash version is available, either 4.x or 3.x
+ifneq ("$(wildcard $(UNIFLASH_PATH)/dslite.sh)","")
+  export FLASHER ?= $(UNIFLASH_PATH)/dslite.sh
+  export FFLAGS  = --config $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml $(ELFFILE)
+  # configure uniflash for resetting target
+  export RESET = $(UNIFLASH_PATH)/simplelink/gen2/bin/xds110reset
+  export RESET_FLAGS
+else
+  export FLASHER = $(UNIFLASH_PATH)/uniflash.sh
+  export FFLAGS  = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -program $(ELFFILE)
+  # configure uniflash for resetting target
+  export RESET = $(UNIFLASH_PATH)/uniflash.sh
+  export RESET_FLAGS = -ccxml $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).ccxml -reset
+endif
+# configure the debug server
+export DEBUGSERVER = $(UNIFLASH_PATH)/ccs_base/common/uscif/gdb_agent_console
+export DEBUGSERVER_FLAGS = -p 3333 $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_$(XDEBUGGER).dat
+
+# configure the debugging tool
+export DEBUGGER = $(PREFIX)gdb
+export DEBUGGER_FLAGS = -x $(RIOTBOARD)/$(BOARD)/dist/$(CPU_MODEL)_gdb.conf $(ELFFILE)

--- a/boards/cc2650-launchpad/board.c
+++ b/boards/cc2650-launchpad/board.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C)    2016 Nicholas Jackson
+ *                  2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_cc2650_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Board specific implementations for TI CC2650 LaunchPad
+ *
+ * @author          Nicholas Jackson <nicholas.jackson@griffithuni.edu.au>
+ * @author          Sebastian Meiling <s@mlng.net>
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+/**
+ * @brief           Initialise the board.
+ */
+
+void board_init(void)
+{
+    cpu_init();
+
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+}

--- a/boards/cc2650-launchpad/dist/cc26x0f128_XDS100v3.ccxml
+++ b/boards/cc2650-launchpad/dist/cc26x0f128_XDS100v3.ccxml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configurations XML_version="1.2" id="configurations_0">
+<configuration XML_version="1.2" id="Texas Instruments XDS100v3 USB Debug Probe_0">
+        <instance XML_version="1.2" desc="Texas Instruments XDS100v3 USB Debug Probe_0" href="connections/TIXDS100v3_Dot7_Connection.xml" id="Texas Instruments XDS100v3 USB Debug Probe_0" xml="TIXDS100v3_Dot7_Connection.xml" xmlpath="connections"/>
+        <connection XML_version="1.2" id="Texas Instruments XDS100v3 USB Debug Probe_0">
+            <instance XML_version="1.2" href="drivers/tixds100v2icepick_c.xml" id="drivers" xml="tixds100v2icepick_c.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds100v2cs_dap.xml" id="drivers" xml="tixds100v2cs_dap.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds100v2cortexM.xml" id="drivers" xml="tixds100v2cortexM.xml" xmlpath="drivers"/>
+            <property Type="choicelist" Value="1" id="The Converter Usage" />
+            <platform XML_version="1.2" id="platform_0">
+                <instance XML_version="1.2" desc="CC2650F128_0" href="devices/cc2650f128.xml" id="CC2650F128_0" xml="cc2650f128.xml" xmlpath="devices"/>
+            </platform>
+        </connection>
+    </configuration>
+</configurations>

--- a/boards/cc2650-launchpad/dist/cc26x0f128_XDS100v3.dat
+++ b/boards/cc2650-launchpad/dist/cc26x0f128_XDS100v3.dat
@@ -1,0 +1,68 @@
+# config version=3.5
+$ sepk
+  pod_drvr=libjioserdesusbv3.so
+  pod_port=0
+$ /
+$ product
+  title="Texas Instruments XDS100v3 USB"
+  alias=TI_XDS100v3_USB
+  name=FTDI_FT2232
+$ /
+$ ftdi_ft2232
+  usb_vid=0x0403
+  usb_pid=0xa6d1
+  gpio_l0="TRSTn,Active_Low"
+  gpio_l1="EMU_Pin_Enable,Active_Low"
+  gpio_l2="EMU_Pin_0,Active_Low"
+  gpio_l3="Adaptive_Clock,Active_High"
+  gpio_h0="SRSTn,Active_High"
+  gpio_h1="Clock_Fail_Detect,Active_High"
+  gpio_h2="Power_Loss_Detect,Active_Low"
+  gpio_h3="Power_Loss_Reset,Active_High"
+  gpio_h4="EMU_Pin_1,Active_Low"
+  gpio_h5="Cable_Disconnect,Active_High"
+  gpio_h6="Dot7_Bypass,Active_Low"
+  gpio_h7="Alternate_Io,Active_Low"
+  apio_l0=Unused
+  apio_l1="Jtag_Isolate,Active_High"
+  apio_l2="Clock_Fail_Enable,Active_High"
+  apio_l3=Unused
+  apio_h0=Unused
+  apio_h1="Status_0,Active_High"
+  apio_h2="Status_2,Active_High"
+  apio_h3=Unused
+  apio_h4="Jtag_Loopback,Active_High"
+  apio_h5="Status_1,Active_High"
+  apio_h6=Unused
+  apio_h7=Unused
+$ /
+$ uscif
+  tdoedge=FALL
+  jtagboot_mode=disable
+  jtagboot_value=hiz
+  powerboot_mode=disable
+  powerboot_value=hiz
+  jtag_isolate=disable
+$ /
+$ dot7
+  dts_usage=enable
+  dts_type=xds100v3
+  ts_pin_width=all_four
+$ /
+$ uscif
+  tclk_program=adaptive
+  tclk_frequency=3.0
+$ /
+$ dot7
+  dts_program=emulator
+  dts_frequency=16.7MHz
+  ts_format=jscan0
+$ /
+@ icepick_c family=icepick_c irbits=6 drbits=1 subpaths=1
+  & subpath_0 address=16 default=no custom=yes force=yes pseudo=no
+    @ cs_dap_0 family=cs_dap irbits=4 drbits=1 subpaths=1 identify=0x4BA00477
+      & subpath_1 type=debug address=0 default=no custom=yes force=yes pseudo=no
+        @ cortex_m3_0 family=cortex_mxx irbits=0 drbits=0 identify=0x02000000 traceid=0x0
+      & /
+  & /
+# /

--- a/boards/cc2650-launchpad/dist/cc26x0f128_XDS110.ccxml
+++ b/boards/cc2650-launchpad/dist/cc26x0f128_XDS110.ccxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configurations XML_version="1.2" id="configurations_0">
+    <configuration XML_version="1.2" id="configuration_0">
+        <instance XML_version="1.2" desc="Texas Instruments XDS110 USB Debug Probe" href="connections/TIXDS110_Connection.xml" id="Texas Instruments XDS110 USB Debug Probe" xml="TIXDS110_Connection.xml" xmlpath="connections"/>
+        <connection XML_version="1.2" id="Texas Instruments XDS110 USB Debug Probe">
+            <instance XML_version="1.2" href="drivers/tixds510icepick_c.xml" id="drivers" xml="tixds510icepick_c.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cs_dap.xml" id="drivers" xml="tixds510cs_dap.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cortexM.xml" id="drivers" xml="tixds510cortexM.xml" xmlpath="drivers"/>
+            <platform XML_version="1.2" id="platform_0">
+                <instance XML_version="1.2" desc="CC2650F128" href="devices/cc2650f128.xml" id="CC2650F128" xml="cc2650f128.xml" xmlpath="devices"/>
+            </platform>
+        </connection>
+    </configuration>
+</configurations>

--- a/boards/cc2650-launchpad/dist/cc26x0f128_XDS110.dat
+++ b/boards/cc2650-launchpad/dist/cc26x0f128_XDS110.dat
@@ -1,0 +1,31 @@
+# config version=3.5
+$ sepk
+  pod_drvr=libjioxds110.so
+  pod_port=0
+$ /
+$ product
+  title="Texas Instruments XDS110 USB"
+  alias=TI_XDS110_USB
+  name=XDS110
+$ /
+$ uscif
+  tdoedge=FALL
+  tclk_program=DEFAULT
+  tclk_frequency=2.5MHz
+  jtag_isolate=enable
+$ /
+$ dot7
+  dts_usage=nothing
+$ /
+$ swd
+  swd_debug=disabled
+  swo_data=aux_uart
+$ /
+@ icepick_c family=icepick_c irbits=6 drbits=1 subpaths=1
+  & subpath_0 address=16 default=no custom=yes force=yes pseudo=no
+    @ cs_dap_0 family=cs_dap irbits=4 drbits=1 subpaths=1 identify=0x4BA00477
+      & subpath_1 type=debug address=0 default=no custom=yes force=yes pseudo=no
+        @ cortex_m3_0 family=cortex_mxx irbits=0 drbits=0 identify=0x02000000 traceid=0x0
+      & /
+  & /
+# /

--- a/boards/cc2650-launchpad/dist/cc26x0f128_gdb.conf
+++ b/boards/cc2650-launchpad/dist/cc26x0f128_gdb.conf
@@ -1,0 +1,6 @@
+mem 0x00 0x20000 ro 32 nocache
+mem 0x10000000 0x10020000 ro 32 nocache
+mem 0x20000000 0x20005000 rw 32 nocache
+mem 0x40000000 0x400E1028 rw 32 nocache
+mem 0xE000E000 0xE000F000 rw 32 nocache
+target remote localhost:3333

--- a/boards/cc2650-launchpad/dist/openocd.cfg
+++ b/boards/cc2650-launchpad/dist/openocd.cfg
@@ -1,0 +1,43 @@
+# Config for Texas Instruments low power SoC CC26xx family
+
+adapter_khz 100
+
+source [find target/icepick.cfg]
+source [find target/ti-cjtag.cfg]
+
+if { [info exists CHIPNAME] } {
+   set _CHIPNAME $CHIPNAME
+} else {
+   set _CHIPNAME cc26xx
+}
+
+#
+# Main DAP
+#
+if { [info exists DAP_TAPID] } {
+   set _DAP_TAPID $DAP_TAPID
+} else {
+   set _DAP_TAPID 0x4BA00477
+}
+jtag newtap $_CHIPNAME dap -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_DAP_TAPID -disable
+jtag configure $_CHIPNAME.dap -event tap-enable "icepick_c_tapenable $_CHIPNAME.jrc 0"
+
+#
+# ICEpick-C (JTAG route controller)
+#
+if { [info exists JRC_TAPID] } {
+   set _JRC_TAPID $JRC_TAPID
+} else {
+   set _JRC_TAPID 0x1B99A02F
+}
+jtag newtap $_CHIPNAME jrc -irlen 6 -ircapture 0x1 -irmask 0x3f -expected-id $_JRC_TAPID -ignore-version
+# A start sequence is needed to change from cJTAG (Compact JTAG) to
+# 4-pin JTAG before talking via JTAG commands
+jtag configure $_CHIPNAME.jrc -event setup "jtag tapenable $_CHIPNAME.dap"
+jtag configure $_CHIPNAME.jrc -event post-reset "ti_cjtag_to_4pin_jtag $_CHIPNAME.jrc"
+
+#
+# Cortex M3 target
+#
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME cortex_m -chain-position $_CHIPNAME.dap

--- a/boards/cc2650-launchpad/doc.txt
+++ b/boards/cc2650-launchpad/doc.txt
@@ -1,0 +1,5 @@
+/**
+ * @defgroup        boards_cc2650_launchpad TI CC2650 LaunchPad XL
+ * @ingroup         boards
+ * @brief           Texas Instruments SimpleLink(TM) CC2650 Wireless MCU LaunchPad(TM) Kit
+ */

--- a/boards/cc2650-launchpad/include/board.h
+++ b/boards/cc2650-launchpad/include/board.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C)    2016 Nicholas Jackson
+ *                  2017 Sebastian Meiling
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_cc2650_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Board specific definitions for TI CC2650 LaunchPad
+ *
+ * @author          Nicholas Jackson <nicholas.jackson@griffithuni.edu.au>
+ * @author          Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      (25)
+#define XTIMER_ISR_BACKOFF  (20)
+/** @} */
+
+/**
+ * @name    On-board button configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 13)
+#define BTN0_MODE           GPIO_IN_PU
+
+#define BTN1_PIN            GPIO_PIN(0, 14)
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief   On-board LED configuration and controlling
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 6)          /**< red   */
+#define LED1_PIN            GPIO_PIN(0, 7)          /**< green */
+
+#define LED0_ON             gpio_set(LED0_PIN)
+#define LED0_OFF            gpio_clear(LED0_PIN)
+#define LED0_TOGGLE         gpio_toggle(LED0_PIN)
+
+#define LED1_ON             gpio_set(LED1_PIN)
+#define LED1_OFF            gpio_clear(LED1_PIN)
+#define LED1_TOGGLE         gpio_toggle(LED1_PIN)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/cc2650-launchpad/include/periph_conf.h
+++ b/boards/cc2650-launchpad/include/periph_conf.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C)    2016 Nicholas Jackson
+ *                  2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         boards_cc2650_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Peripheral MCU configuration for TI CC2650 LaunchPad
+ *
+ * @author          Nicholas Jackson <nicholas.jackson@griffithuni.edu.au>
+ * @author          Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* @name    Clock configuration
+* @{
+*/
+/* the main clock is fixed to 48MHZ */
+#define CLOCK_CORECLOCK     (48000000U)
+/** @} */
+
+/**
+* @name    Timer configuration
+*
+* General purpose timers (GPT[0-3]) are configured consecutively and in order
+* (without gaps) starting from GPT0, i.e. if multiple timers are enabled.
+*
+* @{
+*/
+static const timer_conf_t timer_config[] = {
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ },
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ }
+};
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+* @name    UART configuration
+*
+* The used CC26x0 CPU only supports a single UART device, so all we need to
+* configure are the RX and TX pins.
+*
+* Optionally we can enable hardware flow control, by setting UART_HW_FLOW_CTRL
+* to 1 and defining pins for UART_CTS_PIN and UART_RTS_PIN.
+* @{
+*/
+#define UART_NUMOF          (1)
+#define UART_RX_PIN         (2)
+#define UART_TX_PIN         (3)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -12,8 +12,8 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 \
                    z1
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 \
-                             calliope-mini cc2650stk maple-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+                             cc2650-launchpad cc2650stk maple-mini \
                              microbit nrf51dongle nrf6310 nucleo32-f031 \
                              nucleo32-f042 nucleo32-f303 nucleo32-l031 nucleo-f030 \
                              nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f302 nucleo-f334 \

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -7,8 +7,8 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 \
-                             calliope-mini cc2650stk maple-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+                             cc2650-launchpad cc2650stk maple-mini \
                              microbit msb-430 msb-430h nrf51dongle nrf6310 \
                              nucleo32-f031 nucleo32-f042 nucleo32-f303 nucleo32-l031 \
                              nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f302 \

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -4,8 +4,8 @@ APPLICATION = riot_javascript
 # default BOARD environment
 BOARD ?= native
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 \
-                             calliope-mini cc2650stk maple-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+                             cc2650-launchpad cc2650stk maple-mini \
                              microbit nrf51dongle nrf6310 nucleo-f030 nucleo-f070 \
                              nucleo-f072 nucleo-f103 nucleo-f302 nucleo-f334 nucleo-f410 \
                              nucleo-l053 nucleo-l073 nucleo32-f031 nucleo32-f042 \

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,7 +1,8 @@
 APPLICATION = thread_cooperation
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini cc2650stk chronos \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+                             cc2650-launchpad cc2650stk chronos \
                              maple-mini mbed_lpc1768 microbit msb-430 msb-430h nrf51dongle \
                              nrf6310 nucleo32-f031 nucleo32-f042 nucleo32-f303 \
                              nucleo32-l031 nucleo-f030 nucleo-f070 nucleo-f072 \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              b-l072z-lrwan1 \
                              calliope-mini \
                              cc2538dk \
+                             cc2650-launchpad \
                              cc2650stk \
                              chronos \
                              ek-lm4f120xl \


### PR DESCRIPTION
adopted from #5416 - it should work as it is currently basically a refined version of the previous PR and heavily borrows from cc2650stk. There is definitely room for improvement and code/config deduplication here, but that should be done in a separate PR.

@A-Paul, @360disrupt, and @nicholas-c-jackson could you please test if basic support works, i.e., `examples/default`, `tests/periph_timer`, and maybe some of the `xtimer_*` tests and certainly if LEDs and buttons work as expected - for the latter I'm not sure if they need a pull-up like in cc2650stk or not.  