### PR TITLE
make: fix nproc for buildtest

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -72,6 +72,9 @@ include $(RIOTMAKE)/docker.inc.mk
 # include color echo macros
 include $(RIOTMAKE)/color.inc.mk
 
+# include concurrency helpers
+include $(RIOTMAKE)/info-nproc.inc.mk
+
 GLOBAL_GOALS := buildtest info-boards-supported info-boards-features-missing info-buildsizes info-buildsizes-diff
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
   BOARD=none

--- a/makefiles/info-nproc.inc.mk
+++ b/makefiles/info-nproc.inc.mk
@@ -1,0 +1,33 @@
+ifneq (, $(filter buildtest info-concurrency, $(MAKECMDGOALS)))
+  ifeq (, $(strip $(NPROC)))
+    # Linux (utility program)
+    NPROC := $(shell nproc 2>/dev/null)
+
+    ifeq (, $(strip $(NPROC)))
+      # Linux (generic)
+      NPROC := $(shell grep -c ^processor /proc/cpuinfo 2>/dev/null)
+    endif
+    ifeq (, $(strip $(NPROC)))
+      # BSD (at least FreeBSD and Mac OSX)
+      NPROC := $(shell sysctl -n hw.ncpu 2>/dev/null)
+    endif
+    ifeq (, $(strip $(NPROC)))
+      # Fallback
+      NPROC := 1
+    endif
+
+    NPROC := $(shell echo $$(($(NPROC) + 1)))
+
+    ifneq (, $(NPROC_MAX))
+      NPROC := $(shell if [ ${NPROC} -gt $(NPROC_MAX) ]; then echo $(NPROC_MAX); else echo ${NPROC}; fi)
+    endif
+    ifneq (, $(NPROC_MIN))
+      NPROC := $(shell if [ ${NPROC} -lt $(NPROC_MIN) ]; then echo $(NPROC_MIN); else echo ${NPROC}; fi)
+    endif
+  endif
+endif
+
+.PHONY: info-concurrency
+
+info-concurrency:
+	@echo "$(NPROC)"

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -90,38 +90,6 @@ info-build:
 	@echo ''
 	@echo -e 'MAKEFILE_LIST:$(patsubst %, \n\t%, $(abspath $(MAKEFILE_LIST)))'
 
-ifneq (, $(filter buildtest info-concurrency, $(MAKECMDGOALS)))
-  ifeq (, $(strip $(NPROC)))
-    # Linux (utility program)
-    NPROC := $(shell nproc 2>/dev/null)
-
-    ifeq (, $(strip $(NPROC)))
-      # Linux (generic)
-      NPROC := $(shell grep -c ^processor /proc/cpuinfo 2>/dev/null)
-    endif
-    ifeq (, $(strip $(NPROC)))
-      # BSD (at least FreeBSD and Mac OSX)
-      NPROC := $(shell sysctl -n hw.ncpu 2>/dev/null)
-    endif
-    ifeq (, $(strip $(NPROC)))
-      # Fallback
-      NPROC := 1
-    endif
-
-    NPROC := $(shell echo $$(($(NPROC) + 1)))
-
-    ifneq (, $(NPROC_MAX))
-      NPROC := $(shell if [ ${NPROC} -gt $(NPROC_MAX) ]; then echo $(NPROC_MAX); else echo ${NPROC}; fi)
-    endif
-    ifneq (, $(NPROC_MIN))
-      NPROC := $(shell if [ ${NPROC} -lt $(NPROC_MIN) ]; then echo $(NPROC_MIN); else echo ${NPROC}; fi)
-    endif
-  endif
-endif
-
-info-concurrency:
-	@echo "$(NPROC)"
-
 info-files: QUIET := 0
 info-files:
 	@( \


### PR DESCRIPTION
The latest makefile refactoring made NPROC unavailable for bulidtests, causing ```NPROC``` to be empty, causing buildtest's make invocations to have only ```-j``` as parameter.

This PR factors out NPROC variable definition into its own makefile, and always includes it in Makefile.include.

Fixes #7626.