### PR TITLE
xtimer: Add reference point for _xtimer_set_absolute

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -210,11 +210,11 @@ static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup, uint32_
 /**
  * @brief Set a timer that sends a message
  *
- * This function sets a timer that will send a message @p offset ticks
+ * This function sets a timer that will send a message @p offset microseconds
  * from now.
  *
- * The mesage struct specified by msg parameter will not be copied, e.g., it
- * needs to point to valid memory until the message has been delivered.
+ * @attention The message struct pointed to by @p msg will not be copied,
+ * i.e. it needs to point to valid memory until the message has been delivered.
  *
  * @param[in] timer         timer struct to work with.
  *                          Its xtimer_t::target and xtimer_t::long_target
@@ -231,8 +231,8 @@ static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, 
  * This function sets a timer that will send a message @p offset microseconds
  * from now.
  *
- * The mesage struct specified by msg parameter will not be copied, e.g., it
- * needs to point to valid memory until the message has been delivered.
+ * @attention The message struct pointed to by @p msg will not be copied,
+ * i.e. it needs to point to valid memory until the message has been delivered.
  *
  * @param[in] timer         timer struct to work with.
  *                          Its xtimer_t::target and xtimer_t::long_target

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- * Copyright (C) 2016 Eistec AB
+ * Copyright (C) 2016-2017 Eistec AB
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -66,6 +66,7 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target);
 void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset);
 void _xtimer_set(xtimer_t *timer, uint32_t offset);
 void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period);
+void _xtimer_periodic_msg(xtimer_t *timer, uint32_t *last_wakeup, uint32_t period, msg_t *msg, kernel_pid_t target_pid);
 void _xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid);
 void _xtimer_set_msg64(xtimer_t *timer, uint64_t offset, msg_t *msg, kernel_pid_t target_pid);
 void _xtimer_set_wakeup(xtimer_t *timer, uint32_t offset, kernel_pid_t pid);
@@ -191,6 +192,13 @@ static inline void xtimer_tsleep64(xtimer_ticks64_t ticks)
 static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup, uint32_t period)
 {
     _xtimer_periodic_wakeup(&last_wakeup->ticks32, _xtimer_ticks_from_usec(period));
+}
+
+static inline void xtimer_periodic_msg(xtimer_t *timer,
+                                       xtimer_ticks32_t *last_wakeup, uint32_t period,
+                                       msg_t *msg, kernel_pid_t target_pid)
+{
+    _xtimer_periodic_msg(timer, &last_wakeup->ticks32, _xtimer_ticks_from_usec(period), msg, target_pid);
 }
 
 static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid)

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -62,7 +62,7 @@ static inline uint32_t _xtimer_lltimer_mask(uint32_t val)
  * @internal
  */
 uint64_t _xtimer_now64(void);
-int _xtimer_set_absolute(xtimer_t *timer, uint32_t target);
+void _xtimer_set_absolute(xtimer_t *timer, uint32_t target, uint32_t now);
 void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset);
 void _xtimer_set(xtimer_t *timer, uint32_t offset);
 void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period);

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -155,6 +155,12 @@ static inline void _setup_msg(xtimer_t *timer, msg_t *msg, kernel_pid_t target_p
     msg->sender_pid = target_pid;
 }
 
+void _xtimer_periodic_msg(xtimer_t *timer, uint32_t *last_wakeup, uint32_t period, msg_t *msg, kernel_pid_t target_pid)
+{
+    _setup_msg(timer, msg, target_pid);
+    _xtimer_periodic(timer, last_wakeup, period);
+}
+
 void _xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid)
 {
     _setup_msg(timer, msg, target_pid);

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -58,20 +58,19 @@ void _xtimer_tsleep(uint32_t offset, uint32_t long_offset)
     }
 
     xtimer_t timer;
-    mutex_t mutex = MUTEX_INIT;
+    mutex_t mutex = MUTEX_INIT_LOCKED;
 
     timer.callback = _callback_unlock_mutex;
     timer.arg = (void*) &mutex;
     timer.target = timer.long_target = 0;
 
-    mutex_lock(&mutex);
     _xtimer_set64(&timer, offset, long_offset);
     mutex_lock(&mutex);
 }
 
 void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period) {
     xtimer_t timer;
-    mutex_t mutex = MUTEX_INIT;
+    mutex_t mutex = MUTEX_INIT_LOCKED;
 
     timer.callback = _callback_unlock_mutex;
     timer.arg = (void*) &mutex;
@@ -125,7 +124,6 @@ void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period) {
              * be undeterministic. */
             target = _xtimer_now() + offset;
         }
-        mutex_lock(&mutex);
         DEBUG("xps, abs: %" PRIu32 "\n", target);
         _xtimer_set_absolute(&timer, target);
         mutex_lock(&mutex);

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -92,22 +92,22 @@ void _xtimer_periodic(xtimer_t *timer, uint32_t *last_wakeup, uint32_t period)
         }
 
         /*
-        * For large offsets, set an absolute target time.
-        * As that might cause an underflow, for small offsets, set a relative
-        * target time.
-        * For very small offsets, spin.
-        */
+         * For large offsets, set an absolute target time.
+         * As that might cause an underflow, for small offsets, set a relative
+         * target time.
+         * For very small offsets, spin.
+         */
         /*
-        * Note: last_wakeup _must never_ specify a time in the future after
-        * _xtimer_periodic_sleep returns.
-        * If this happens, last_wakeup may specify a time in the future when the
-        * next call to _xtimer_periodic_sleep is made, which in turn will trigger
-        * the overflow logic above and make the next timer fire too early, causing
-        * last_wakeup to point even further into the future, leading to a chain
-        * reaction.
-        *
-        * tl;dr Don't return too early!
-        */
+         * Note: last_wakeup _must never_ specify a time in the future after
+         * _xtimer_periodic_sleep returns.
+         * If this happens, last_wakeup may specify a time in the future when the
+         * next call to _xtimer_periodic_sleep is made, which in turn will trigger
+         * the overflow logic above and make the next timer fire too early, causing
+         * last_wakeup to point even further into the future, leading to a chain
+         * reaction.
+         *
+         * tl;dr Don't return too early!
+         */
         uint32_t offset = target - now;
         DEBUG("xps, now: %9" PRIu32 ", tgt: %9" PRIu32 ", off: %9" PRIu32 "\n", now, target, offset);
         if (offset < XTIMER_PERIODIC_SPIN) {
@@ -117,10 +117,10 @@ void _xtimer_periodic(xtimer_t *timer, uint32_t *last_wakeup, uint32_t period)
         else {
             if (offset < XTIMER_PERIODIC_RELATIVE) {
                 /* NB: This will overshoot the target by the amount of time it took
-                * to get here from the beginning of xtimer_periodic_wakeup()
-                *
-                * Since interrupts are normally enabled inside this function, this time may
-                * be undeterministic. */
+                 * to get here from the beginning of xtimer_periodic_wakeup()
+                 *
+                 * Since interrupts are normally enabled inside this function, this time may
+                 * be nondeterministic. */
                 target = _xtimer_now() + offset;
             }
             DEBUG("xps, abs: %" PRIu32 "\n", target);

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -124,7 +124,7 @@ void _xtimer_periodic(xtimer_t *timer, uint32_t *last_wakeup, uint32_t period)
                 target = _xtimer_now() + offset;
             }
             DEBUG("xps, abs: %" PRIu32 "\n", target);
-            _xtimer_set_absolute(timer, target);
+            _xtimer_set_absolute(timer, target, now);
         }
     } while (0);
     *last_wakeup = target;

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -176,7 +176,9 @@ int _xtimer_set_absolute(xtimer_t *timer, uint32_t target)
     DEBUG("timer_set_absolute(): now=%" PRIu32 " target=%" PRIu32 "\n", now, target);
 
     timer->next = NULL;
-    if ((target >= now) && ((target - XTIMER_BACKOFF) < now)) {
+    /* The (target - now) difference works across the long tick rollover, there
+     * is no need to check for (target > now) first. */
+    if ((target - now) < XTIMER_BACKOFF) {
         /* backoff */
         xtimer_spin_until(target + XTIMER_BACKOFF);
         _shoot(timer);

--- a/tests/xtimer_periodic_msg/Makefile
+++ b/tests/xtimer_periodic_msg/Makefile
@@ -1,0 +1,6 @@
+APPLICATION = xtimer_periodic_msg
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_periodic_msg/main.c
+++ b/tests/xtimer_periodic_msg/main.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2017 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       timer test application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "thread.h"
+#include "msg.h"
+#include "xtimer.h"
+
+#ifndef NUMOF
+#define NUMOF   (256)
+#endif
+
+int32_t res[NUMOF];
+
+int main(void)
+{
+    puts("xtimer_periodic_msg test application.\n");
+    msg_t msg_q[1];
+    msg_init_queue(msg_q, 1);
+
+    uint32_t interval = NUMOF;
+    int32_t max_diff = INT32_MIN;
+    int32_t min_diff = INT32_MAX;
+
+    for (int i = 0; i < NUMOF; i++) {
+        xtimer_ticks32_t now = xtimer_now();
+        printf("Testing interval %" PRIu32 "... (now=%" PRIu32 ")\n", interval, xtimer_usec_from_ticks(now));
+        xtimer_ticks32_t last_wakeup = xtimer_now();
+        xtimer_ticks32_t before = last_wakeup;
+        xtimer_t timer = { .target = 0, .long_target = 0 };
+        msg_t msg_out = { .type = 0xffff - interval, .content.value = interval };
+        xtimer_periodic_msg(&timer, &last_wakeup, interval, &msg_out, thread_getpid());
+        msg_t msg_in;
+        msg_receive(&msg_in);
+        now = xtimer_now();
+        assert(msg_in.type == msg_out.type);
+        assert(msg_in.content.value == msg_out.content.value);
+        res[i] = (xtimer_usec_from_ticks(now) - xtimer_usec_from_ticks(before)) - interval;
+        interval -= 1;
+    }
+
+    for (int i = 0; i < NUMOF; i++) {
+        printf("%4d diff=%" PRIi32 "\n", NUMOF - i, res[i]);
+
+        if (res[i] > max_diff) {
+            max_diff = res[i];
+        }
+        if (res[i] < min_diff) {
+            min_diff = res[i];
+        }
+    }
+    printf("\nMin/max error: %" PRId32 "/%" PRId32 "\n", min_diff, max_diff);
+
+    if (min_diff < -1000 || max_diff > 1000) {
+        puts("too large difference.\n");
+        puts("Test Failed.\n");
+        return 1;
+    }
+
+    printf("\nTest complete.\n");
+    return 0;
+}

--- a/tests/xtimer_periodic_wakeup/Makefile
+++ b/tests/xtimer_periodic_wakeup/Makefile
@@ -1,8 +1,6 @@
 APPLICATION = xtimer_periodic_wakeup
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := chronos
-
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
Avoids a possible race condition in xtimer_set, xtimer_periodic where the target time will have already passed when execution reaches the _xtimer_now() call inside _xtimer_set_absolute.  The race condition is more easily triggered in xtimer_periodic because of the longer execution time, but it is possible inside xtimer_set as well if an interrupt arrives before the _xtimer_set_absolute call and the ISR is non-trivial, and/or a context switch is triggered by the ISR.

Based on top of #7496, #7628 