### PR TITLE
sys/posix: factor inet_*to* from header into .c file

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -414,6 +414,8 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += bitfield
   USEMODULE += random
   USEMODULE += vfs
+  USEMODULE += posix
+  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter rtt_stdio,$(USEMODULE)))
@@ -429,8 +431,10 @@ ifneq (,$(filter isrpipe,$(USEMODULE)))
   USEMODULE += tsrb
 endif
 
-ifneq (,$(filter posix,$(USEMODULE)))
-  USEMODULE += xtimer
+ifneq (,$(filter shell_commands,$(USEMODULE)))
+  ifneq (,$(filter fib,$(USEMODULE)))
+    USEMODULE += posix
+  endif
 endif
 
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -57,7 +57,6 @@ PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano
 PSEUDOMODULES += openthread
 PSEUDOMODULES += pktqueue
-PSEUDOMODULES += posix
 PSEUDOMODULES += printf_float
 PSEUDOMODULES += prng
 PSEUDOMODULES += prng_%

--- a/sys/posix/Makefile
+++ b/sys/posix/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/posix/include/arpa/inet.h
+++ b/sys/posix/include/arpa/inet.h
@@ -23,14 +23,7 @@
 #ifndef ARPA_INET_H
 #define ARPA_INET_H
 
-#include <errno.h>
-#include <inttypes.h>
-#include <stdio.h>
-
-#include "byteorder.h"
 #include "net/af.h"
-#include "net/ipv4/addr.h"
-#include "net/ipv6/addr.h"
 #include "sys/bytes.h"
 #include "netinet/in.h"
 
@@ -42,14 +35,14 @@ extern "C" {
  * @brief   Size in byte of an IPv4 address
  */
 #ifndef INADDRSZ
-#define INADDRSZ            (sizeof(ipv4_addr_t))
+#define INADDRSZ            (4)
 #endif
 
 /**
  * @brief   Size in byte of an IPv6 address
  */
 #ifndef IN6ADDRSZ
-#define IN6ADDRSZ           (sizeof(ipv6_addr_t))
+#define IN6ADDRSZ           (16)
 #endif
 
 /**
@@ -66,35 +59,8 @@ extern "C" {
  * @return  NULL, if @p size was smaller than needed
  * @return  NULL, if @p src or @p dst was NULL
  */
-static inline const char *inet_ntop(int af, const void *restrict src, char *restrict dst,
-                                    socklen_t size)
-{
-    switch (af) {
-#ifdef MODULE_IPV4_ADDR
-        case AF_INET:
-            if (ipv4_addr_to_str(dst, src, (size_t)size) == NULL) {
-                errno = ENOSPC;
-                return NULL;
-            }
-            break;
-#endif
-#ifdef MODULE_IPV6_ADDR
-        case AF_INET6:
-            if (ipv6_addr_to_str(dst, src, (size_t)size) == NULL) {
-                errno = ENOSPC;
-                return NULL;
-            }
-            break;
-#endif
-        default:
-            (void)src;
-            (void)dst;
-            (void)size;
-            errno = EAFNOSUPPORT;
-            return NULL;
-    }
-    return dst;
-}
+const char *inet_ntop(int af, const void *restrict src, char *restrict dst,
+                      socklen_t size);
 
 /**
  * @brief   Converts an IP address string representation to a byte-represented
@@ -110,31 +76,7 @@ static inline const char *inet_ntop(int af, const void *restrict src, char *rest
  * @return  0, if @p src was malformed or input pointers were NULL.
  * @return  -1, if @p af is not supported.
  */
-static inline int inet_pton(int af, const char *src, void *dst)
-{
-    switch (af) {
-#ifdef MODULE_IPV4_ADDR
-        case AF_INET:
-            if (ipv4_addr_from_str(dst, src) == NULL) {
-                return 0;
-            }
-            break;
-#endif
-#ifdef MODULE_IPV6_ADDR
-        case AF_INET6:
-            if (ipv6_addr_from_str(dst, src) == NULL) {
-                return 0;
-            }
-            break;
-#endif
-        default:
-            (void)src;
-            (void)dst;
-            errno = EAFNOSUPPORT;
-            return -1;
-    }
-    return 1;
-}
+int inet_pton(int af, const char *src, void *dst);
 
 #ifdef __cplusplus
 }

--- a/sys/posix/include/sys/bytes.h
+++ b/sys/posix/include/sys/bytes.h
@@ -20,6 +20,8 @@
 #ifndef SYS_BYTES_H
 #define SYS_BYTES_H
 
+#include <stddef.h>
+
 #include "byteorder.h"
 
 #ifdef __cplusplus

--- a/sys/posix/inet.c
+++ b/sys/posix/inet.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2013-15 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <arpa/inet.h>
+#include <errno.h>
+
+#include "net/ipv4/addr.h"
+#include "net/ipv6/addr.h"
+
+const char *inet_ntop(int af, const void *restrict src, char *restrict dst,
+                      socklen_t size)
+{
+    switch (af) {
+#ifdef MODULE_IPV4_ADDR
+        case AF_INET:
+            if (ipv4_addr_to_str(dst, src, (size_t)size) == NULL) {
+                errno = ENOSPC;
+                return NULL;
+            }
+            break;
+#endif
+#ifdef MODULE_IPV6_ADDR
+        case AF_INET6:
+            if (ipv6_addr_to_str(dst, src, (size_t)size) == NULL) {
+                errno = ENOSPC;
+                return NULL;
+            }
+            break;
+#endif
+        default:
+            (void)src;
+            (void)dst;
+            (void)size;
+            errno = EAFNOSUPPORT;
+            return NULL;
+    }
+    return dst;
+}
+
+int inet_pton(int af, const char *src, void *dst)
+{
+    switch (af) {
+#ifdef MODULE_IPV4_ADDR
+        case AF_INET:
+            if (ipv4_addr_from_str(dst, src) == NULL) {
+                return 0;
+            }
+            break;
+#endif
+#ifdef MODULE_IPV6_ADDR
+        case AF_INET6:
+            if (ipv6_addr_from_str(dst, src) == NULL) {
+                return 0;
+            }
+            break;
+#endif
+        default:
+            (void)src;
+            (void)dst;
+            errno = EAFNOSUPPORT;
+            return -1;
+    }
+    return 1;
+}


### PR DESCRIPTION
Previously, ```inet_ntop()``` and ```inet_pton()``` were defined static inline in ```arpa/inet.h```.

That header thus included a lot of other headers, just in order to fit the implementations of those files.
As it is a standard system header, this can (and does) lead to problems.

This PR moves the implementations of ```inet_*()``` into the posix module, which is now not a pseudomodule anymore.