### PR TITLE
cleanup: remove leftover AUTO_INIT_MODULES

### DIFF
--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -1,5 +1,3 @@
-DIRS += $(AUTO_INIT_MODULES)
-
 ifneq (,$(filter auto_init_gnrc_netif,$(USEMODULE)))
 DIRS += netif
 endif


### PR DESCRIPTION
`AUTO_INIT_MODULES` was introduced by a4358bfdeea19f34bd459a83e9027d72b25bf204 and removed by e655137d7235bdc6af69a13e61495fe7931f89b8 and is unused since then.

`git grep AUTO_INIT_MODULES` only returns this instance and `git log -G AUTO_INIT_MODULES` only shows these two commits.