### PR TITLE
cpu, sam0_common: fix uart TXC check

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -121,8 +121,8 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     for (size_t i = 0; i < len; i++) {
         while (!(dev(uart)->INTFLAG.reg & SERCOM_USART_INTFLAG_DRE)) {}
         dev(uart)->DATA.reg = data[i];
-        while (dev(uart)->INTFLAG.reg & SERCOM_USART_INTFLAG_TXC) {}
     }
+    while (!(dev(uart)->INTFLAG.reg & SERCOM_USART_INTFLAG_TXC)) {}
 }
 
 void uart_poweron(uart_t uart)


### PR DESCRIPTION
should fix #7617, and also adapts some register checks to use read-only bits where possible.

Tested with `samr21-xpro`. @travisgriggs please try this one and verify if that resolves your issue reported in #7617.