### PR TITLE
pkg: add LoRaMAC-in-C package (WIP)

### DIFF
--- a/boards/b-l072z-lrwan1/board.c
+++ b/boards/b-l072z-lrwan1/board.c
@@ -27,7 +27,7 @@ void board_init(void)
     /* initialize the CPU */
     cpu_init();
 
-#if defined(MODULE_SX1276)
+#if defined(MODULE_SX1276) || defined(MODULE_LMIC)
     /* Enable TCXO */
     gpio_init(RADIO_TCXO_VCC_PIN, GPIO_OUT);
     gpio_set(RADIO_TCXO_VCC_PIN);

--- a/pkg/lmic/Makefile
+++ b/pkg/lmic/Makefile
@@ -1,0 +1,12 @@
+PKG_NAME=lmic
+PKG_URL=https://github.com/matthijskooijman/arduino-lmic
+PKG_VERSION=9eae2eb8155215f1ff573034d0341f4e5be57bfe
+
+PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+
+.PHONY: all
+
+all: git-download
+	"$(MAKE)" -C $(PKG_BUILDDIR)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lmic/Makefile.include
+++ b/pkg/lmic/Makefile.include
@@ -1,0 +1,7 @@
+INCLUDES += -I$(RIOTBASE)/pkg/lmic/include
+INCLUDES += -I$(BINDIRBASE)/pkg/$(BOARD)/lmic/src/lmic
+
+DIRS += $(BINDIRBASE)/pkg/$(BOARD)/lmic/src/lmic
+DIRS += $(RIOTBASE)/pkg/lmic/contrib
+
+USEMODULE += lmic_contrib

--- a/pkg/lmic/contrib/Makefile
+++ b/pkg/lmic/contrib/Makefile
@@ -1,0 +1,3 @@
+MODULE := lmic_contrib
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/lmic/contrib/hal.c
+++ b/pkg/lmic/contrib/hal.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2017 Inria Chile
+ *               2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_lmic
+ * @{
+ *
+ * @file
+ *
+ * @author      Jose Ignacio Alamos <jialamos@uc.cl>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#include "lmic.h"
+#include "hal.h"
+#include "lmic/hal.h"
+
+#include "lmic/params.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+extern const lmic_pinmap lmic_pins;
+
+static void hal_io_init (void) {
+    gpio_init(lmic_pins.nss, GPIO_OUT);
+    gpio_init(lmic_pins.dio[0], GPIO_IN);
+    gpio_init(lmic_pins.dio[1], GPIO_IN);
+    gpio_init(lmic_pins.rst, GPIO_OUT);
+
+    DEBUG("[LMIC] pkg: hal io initialized\n");
+}
+
+/* nothing to do here */
+void hal_pin_rxtx (u1_t val) {
+}
+
+/* set radio RST pin to given value (or keep floating!) */
+void hal_pin_rst (u1_t val) {
+    if (val == 0 || val == 1) { // drive pin
+        gpio_init(lmic_pins.rst, GPIO_OUT);
+        gpio_write(lmic_pins.rst, val);
+    }
+    else { /* keep pin floating */
+        gpio_init(lmic_pins.rst, GPIO_OUT);
+        gpio_set(lmic_pins.rst);
+    }
+
+    DEBUG("[LMIC] pkg: hal pin reset\n");
+}
+
+static bool dio_states[DIO_NUMOF] = {0};
+
+static void hal_io_check(void) {
+    for (unsigned i = 0; i < DIO_NUMOF; ++i) {
+        if (dio_states[i] != (gpio_read(lmic_pins.dio[i]) > 0)) {
+            dio_states[i] = !dio_states[i];
+            if (dio_states[i])
+                radio_irq_handler(i);
+        }
+    }
+}
+
+/* ------------------------------ */
+/*            SPI                 */
+/* ------------------------------ */
+
+static void hal_spi_init (void) {
+    spi_init_cs(LMIC_PARAM_SPI, lmic_pins.nss);
+}
+
+void hal_pin_nss (u1_t val) {
+    gpio_write(lmic_pins.nss, val);
+}
+
+/* perform SPI transaction with radio */
+u1_t hal_spi (u1_t out) {
+    spi_acquire(LMIC_PARAM_SPI, lmic_pins.nss, SPI_MODE_0, SPI_CLK_1MHZ);
+    u1_t res = spi_transfer_byte(LMIC_PARAM_SPI, lmic_pins.nss, true, out);
+    spi_release(LMIC_PARAM_SPI);
+    return res;
+}
+
+/* ------------------------------ */
+/*            TIMINGS             */
+/* ------------------------------ */
+
+static void hal_time_init (void) {
+    /* Nothing to do here */
+}
+
+u4_t hal_ticks (void) {
+    return (xtimer_now().ticks32 >> 4);
+}
+
+/* Returns the number of ticks until time. Negative values indicate that
+   time has already passed. */
+static s4_t delta_time(u4_t time) {
+    return (s4_t)(time - hal_ticks());
+}
+
+void hal_waitUntil (u4_t time) {
+    s4_t delta = delta_time(time);
+    xtimer_ticks32_t ticks;
+    ticks.ticks32 = delta << 4;
+    xtimer_usleep(xtimer_usec_from_ticks(ticks));
+}
+
+/* check and rewind for target time */
+u1_t hal_checkTimer (u4_t time) {
+    /* No need to schedule wakeup, since we're not sleeping */
+    return delta_time(time) <= 0;
+}
+
+static uint8_t irqlevel = 0;
+
+void hal_disableIRQs (void) {
+    irqlevel++;
+}
+
+void hal_enableIRQs (void) {
+    if (--irqlevel == 0) {
+        /* Instead of using proper interrupts (which are a bit tricky
+           and/or not available on all pins on AVR), just poll the pin
+           values. Since os_runloop disables and re-enables interrupts,
+           putting this here makes sure we check at least once every
+           loop.
+           As an additional bonus, this prevents the kind of worms that
+           we would get for running SPI transfers inside ISRs */
+        hal_io_check();
+    }
+}
+
+void hal_sleep (void) {
+    /* Not implemented */
+}
+
+/* ------------------------------ */
+
+#if defined(LMIC_PRINTF_TO)
+static int uart_putchar (char c, FILE *)
+{
+    LMIC_PRINTF_TO.write(c) ;
+    return 0 ;
+}
+
+void hal_printf_init(void) {
+    /* create a FILE structure to reference our UART output function */
+    static FILE uartout;
+    memset(&uartout, 0, sizeof(uartout));
+
+    /* fill in the UART file descriptor with pointer to writer. */
+    fdev_setup_stream (&uartout, uart_putchar, NULL, _FDEV_SETUP_WRITE);
+
+    /* The uart is the standard output device STDOUT. */
+    stdout = &uartout ;
+}
+#endif /* defined(LMIC_PRINTF_TO) */
+
+void hal_init (void) {
+    /* configure radio I/O and interrupt handler */
+    hal_io_init();
+    /* configure radio SPI */
+    hal_spi_init();
+    /* configure timer and interrupt handler */
+    hal_time_init();
+#if defined(LMIC_PRINTF_TO)
+    /* printf support */
+    hal_printf_init();
+#endif
+}
+
+void hal_failed (const char *file, u2_t line) {
+#if defined(LMIC_FAILURE_TO)
+    LMIC_FAILURE_TO.println("FAILURE ");
+    LMIC_FAILURE_TO.print(file);
+    LMIC_FAILURE_TO.print(':');
+    LMIC_FAILURE_TO.println(line);
+    LMIC_FAILURE_TO.flush();
+#else
+    (void) file;
+    (void) line;
+#endif
+    hal_disableIRQs();
+    while(1);
+}

--- a/pkg/lmic/doc.txt
+++ b/pkg/lmic/doc.txt
@@ -1,0 +1,7 @@
+/**
+ * @defgroup pkg_lmic   LoRaMAC-in-C stack
+ * @ingroup  pkg
+ * @ingroup  net
+ * @brief    Provides support for LoRaWAN using LMIC implementation
+ * @see      https://github.com/matthijskooijman/arduino-lmic
+ */

--- a/pkg/lmic/include/lmic/hal.h
+++ b/pkg/lmic/include/lmic/hal.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 Inria Chile
+ *               2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_lmic
+ * @brief       LMIC HAL definitions
+ * @{
+ *
+ * @file
+ * @brief       LMIC HAL definitions
+ *
+ * @author      Jose Ignacio Alamos <jialamos@uc.cl>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef LMIC_HAL_H
+#define LMIC_HAL_H
+
+#include "periph/gpio.h"
+
+#define DIO_NUMOF (3U)
+
+/**
+ * @brief   Configuration for radion device (either SX1276 or SX1272)
+ */
+typedef struct lmic_pinmap_t {
+    gpio_t nss;                  /**< CS pin */
+    gpio_t rxtx;                 /**< RXTX pin */
+    gpio_t rst;                  /**< Reset pin */
+    gpio_t dio[DIO_NUMOF];       /**< Interrupt pins */
+} lmic_pinmap;
+
+/* Declared here, to be defined and initialized by the application */
+extern const lmic_pinmap lmic_pins;
+
+#endif /* LMIC_HAL_H */
+/** @} */

--- a/pkg/lmic/include/lmic/params.h
+++ b/pkg/lmic/include/lmic/params.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_lmic
+ * @brief       LMIC default configuration definitions
+ *
+ *              If a SX1276 or SX1272 is configured for the board, then the
+ *              board parameters or used. Otherwise the configuration for
+ *              Nucleo and MBED LoRa modules is used.
+ *
+ * @{
+ *
+ * @file
+ * @brief       LMIC default configuration definitions
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef LMIC_PARAMS_H
+#define LMIC_PARAMS_H
+
+#include "board.h"
+#include "lmic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef LMIC_PARAM_SPI
+#ifdef SX127X_PARAM_SPI
+#define LMIC_PARAM_SPI                           SX127X_PARAM_SPI
+#else
+#define LMIC_PARAM_SPI                           SPI_DEV(0)
+#endif
+#endif
+
+#ifndef LMIC_PARAM_PIN_NSS
+#ifdef SX127X_PARAM_SPI_NSS
+#define LMIC_PARAM_PIN_NSS                       SX127X_PARAM_SPI_NSS
+#else
+#define LMIC_PARAM_PIN_NSS                       GPIO_PIN(1, 6)
+#endif
+#endif
+
+#ifndef LMIC_PARAM_PIN_RXTX
+#define LMIC_PARAM_PIN_RXTX                      GPIO_UNDEF
+#endif
+
+#ifndef LMIC_PARAM_PIN_RESET
+#ifdef SX127X_PARAM_RESET
+#define LMIC_PARAM_PIN_RESET                     SX127X_PARAM_RESET
+#else
+#define LMIC_PARAM_PIN_RESET                     GPIO_PIN(0, 0)
+#endif
+#endif
+
+#ifndef LMIC_PARAM_PIN_DIO0
+#ifdef SX127X_PARAM_DIO0
+#define LMIC_PARAM_PIN_DIO0                      SX127X_PARAM_DIO0
+#else
+#define LMIC_PARAM_PIN_DIO0                      GPIO_PIN(0, 10)
+#endif
+#endif
+
+#ifndef LMIC_PARAM_PIN_DIO1
+#ifdef SX127X_PARAM_DIO1
+#define LMIC_PARAM_PIN_DIO1                      SX127X_PARAM_DIO1
+#else
+#define LMIC_PARAM_PIN_DIO1                      GPIO_PIN(1, 3)
+#endif
+#endif
+
+#ifndef LMIC_PARAM_PIN_DIO2
+#ifdef SX127X_PARAM_DIO2
+#define LMIC_PARAM_PIN_DIO2                      SX127X_PARAM_DIO2
+#else
+#define LMIC_PARAM_PIN_DIO2                      GPIO_PIN(1, 5)
+#endif
+#endif
+
+#ifndef LMIC_PARAM_DEVEUI
+#define LMIC_PARAM_DEVEUI                        { 0x05, 0x64, 0x00, 0xF0, \
+                                                   0x7E, 0xD5, 0xB3, 0x70 }
+#endif
+
+#ifndef LMIC_PARAM_APPEUI
+#define LMIC_PARAM_APPEUI                        { 0x61, 0x0A, 0x55, 0x9A, \
+                                                   0xCB, 0x42, 0x5B, 0x00 }
+#endif
+
+
+#ifndef LMIC_PARAM_APPKEY
+#define LMIC_PARAM_APPKEY                        { 0xC5, 0xA4, 0x5D, 0x22, \
+                                                   0x89, 0x7D, 0xC0, 0x54, \
+                                                   0xD2, 0x3A, 0x38, 0xD4, \
+                                                   0xC4, 0x44, 0x43, 0xC9 }
+#endif
+
+#ifndef LMIC_PARAM_NWKSKEY
+#define LMIC_PARAM_NWKSKEY                       { 0x4C, 0x78, 0x16, 0xAC, \
+                                                   0xAA, 0x3C, 0x0B, 0xC6, \
+                                                   0xD7, 0xB1, 0x7A, 0xAE, \
+                                                   0xFB, 0x39, 0x92, 0x74 } 
+#endif
+
+#ifndef LMIC_PARAM_APPSKEY
+#define LMIC_PARAM_APPSKEY                       { 0x62, 0x22, 0x05, 0xC8, \
+                                                   0x49, 0xE8, 0xF3, 0x55, \
+                                                   0x40, 0xCC, 0x6F, 0xC7, \
+                                                   0x5A, 0x86, 0x51, 0xA6 }
+#endif
+
+#ifndef LMIC_PARAM_DEVADDR
+#define LMIC_PARAM_DEVADDR                       0x26011D66
+#endif
+
+#ifdef __cplusplus
+extern }
+#endif
+
+#endif /* LMIC_PARAMS_H */
+/** @} */

--- a/pkg/lmic/patches/01-add-riot-makefiles.patch
+++ b/pkg/lmic/patches/01-add-riot-makefiles.patch
@@ -1,0 +1,29 @@
+From da2cf36c6c22c5f885f68b22eac95a5958f93dba Mon Sep 17 00:00:00 2001
+From: Alexandre Abadie <alexandre.abadie@inria.fr>
+Date: Wed, 20 Sep 2017 17:00:08 +0200
+Subject: [PATCH] adding RIOT compatible makefiles
+
+---
+ Makefile          | 1 +
+ src/lmic/Makefile | 1 +
+ 2 files changed, 2 insertions(+)
+ create mode 100644 Makefile
+ create mode 100644 src/lmic/Makefile
+
+diff --git a/Makefile b/Makefile
+new file mode 100644
+index 0000000..48422e9
+--- /dev/null
++++ b/Makefile
+@@ -0,0 +1 @@
++include $(RIOTBASE)/Makefile.base
+diff --git a/src/lmic/Makefile b/src/lmic/Makefile
+new file mode 100644
+index 0000000..48422e9
+--- /dev/null
++++ b/src/lmic/Makefile
+@@ -0,0 +1 @@
++include $(RIOTBASE)/Makefile.base
+-- 
+2.11.0
+

--- a/pkg/lmic/patches/02-lmic.patch
+++ b/pkg/lmic/patches/02-lmic.patch
@@ -1,0 +1,254 @@
+From 8021e254ab6423128902c96d004981a4dfe199e7 Mon Sep 17 00:00:00 2001
+From: Alexandre Abadie <alexandre.abadie@inria.fr>
+Date: Wed, 20 Sep 2017 17:05:20 +0200
+Subject: [PATCH] patching lmic sources
+
+Signed-off-by: Alexandre Abadie <alexandre.abadie@inria.fr>
+---
+ src/{aes/lmic.c => lmic/aes.c} |  9 ++++++---
+ src/lmic/config.h              |  2 ++
+ src/lmic/lmic.c                |  6 ++++--
+ src/lmic/oslmic.c              | 10 ++++++----
+ src/lmic/radio.c               | 22 +++++++++++-----------
+ 5 files changed, 29 insertions(+), 20 deletions(-)
+ rename src/{aes/lmic.c => lmic/aes.c} (99%)
+
+diff --git a/src/aes/lmic.c b/src/lmic/aes.c
+similarity index 99%
+rename from src/aes/lmic.c
+rename to src/lmic/aes.c
+index 0da7c80..d58b898 100644
+--- a/src/aes/lmic.c
++++ b/src/lmic/aes.c
+@@ -11,7 +11,7 @@
+ 
+ #include "../lmic/oslmic.h"
+ 
+-#if defined(USE_ORIGINAL_AES)
++// #if defined(USE_ORIGINAL_AES)
+ 
+ #define AES_MICSUB 0x30 // internal use only
+ 
+@@ -207,7 +207,7 @@ u4_t AESKEY[11*16/sizeof(u4_t)];
+ 
+ // generate 1+10 roundkeys for encryption with 128-bit key
+ // read 128-bit key from AESKEY in MSBF, generate roundkey words in place
+-static void aesroundkeys () {
++static void aesroundkeys (void) {
+     int i;
+     u4_t b;
+ 
+@@ -247,6 +247,9 @@ u4_t os_aes (u1_t mode, xref2u1_t buf, u2_t len) {
+             u4_t t0, t1, t2, t3;
+             u4_t *ki, *ke;
+ 
++            a0 = a1 = a2 = a3 = 0;
++            t0 = t1 = t2 = t3 = 0;
++
+             // load input block
+             if( (mode & AES_CTR) || ((mode & AES_MIC) && (mode & AES_MICNOAUX)==0) ) { // load CTR block or first MIC block
+                 a0 = AESAUX[0];
+@@ -367,4 +370,4 @@ u4_t os_aes (u1_t mode, xref2u1_t buf, u2_t len) {
+         return AESAUX[0];
+ }
+ 
+-#endif
++//#endif
+diff --git a/src/lmic/config.h b/src/lmic/config.h
+index 23e705b..ff03eb8 100644
+--- a/src/lmic/config.h
++++ b/src/lmic/config.h
+@@ -1,3 +1,4 @@
++#if 0
+ #ifndef _lmic_config_h_
+ #define _lmic_config_h_
+ 
+@@ -81,3 +82,4 @@
+ #define USE_IDEETRON_AES
+ 
+ #endif // _lmic_config_h_
++#endif
+diff --git a/src/lmic/lmic.c b/src/lmic/lmic.c
+index 3802028..a870bb6 100644
+--- a/src/lmic/lmic.c
++++ b/src/lmic/lmic.c
+@@ -637,7 +637,7 @@ static void updateTx (ostime_t txbeg) {
+     if( LMIC.globalDutyRate != 0 )
+         LMIC.globalDutyAvail = txbeg + (airtime<<LMIC.globalDutyRate);
+     #if LMIC_DEBUG_LEVEL > 1
+-        lmic_printf("%lu: Updating info for TX at %lu, airtime will be %lu. Setting available time for band %d to %lu\n", os_getTime(), txbeg, airtime, freq & 0x3, band->avail);
++        lmic_printf("%lu: Updating info for TX at %lu, airtime will be %lu. Setting available time for band %lu to %lu\n", os_getTime(), txbeg, airtime, freq & 0x3, band->avail);
+         if( LMIC.globalDutyRate != 0 )
+             lmic_printf("%lu: Updating global duty avail to %lu\n", os_getTime(), LMIC.globalDutyAvail);
+     #endif
+@@ -1037,7 +1037,9 @@ static bit_t decodeFrame (void) {
+     u1_t hdr    = d[0];
+     u1_t ftype  = hdr & HDR_FTYPE;
+     int  dlen   = LMIC.dataLen;
++#if LMIC_DEBUG_LEVEL > 0
+     const char *window = (LMIC.txrxFlags & TXRX_DNW1) ? "RX1" : ((LMIC.txrxFlags & TXRX_DNW2) ? "RX2" : "Other");
++#endif
+     if( dlen < OFF_DAT_OPTS+4 ||
+         (hdr & HDR_MAJOR) != HDR_MAJOR_V1 ||
+         (ftype != HDR_FTYPE_DADN  &&  ftype != HDR_FTYPE_DCDN) ) {
+@@ -1464,7 +1466,7 @@ static bit_t processJoinAccept (void) {
+     }
+     u1_t hdr  = LMIC.frame[0];
+     u1_t dlen = LMIC.dataLen;
+-    u4_t mic  = os_rlsbf4(&LMIC.frame[dlen-4]); // safe before modified by encrypt!
++    os_rlsbf4(&LMIC.frame[dlen-4]); // safe before modified by encrypt!
+     if( (dlen != LEN_JA && dlen != LEN_JAEXT)
+         || (hdr & (HDR_FTYPE|HDR_MAJOR)) != (HDR_FTYPE_JACC|HDR_MAJOR_V1) ) {
+         EV(specCond, ERR, (e_.reason = EV::specCond_t::UNEXPECTED_FRAME,
+diff --git a/src/lmic/oslmic.c b/src/lmic/oslmic.c
+index ec6c19f..5a2328e 100644
+--- a/src/lmic/oslmic.c
++++ b/src/lmic/oslmic.c
+@@ -18,14 +18,14 @@ static struct {
+     osjob_t* runnablejobs;
+ } OS;
+ 
+-void os_init () {
++void os_init (void) {
+     memset(&OS, 0x00, sizeof(OS));
+     hal_init();
+     radio_init();
+     LMIC_init();
+ }
+ 
+-ostime_t os_getTime () {
++ostime_t os_getTime (void) {
+     return hal_ticks();
+ }
+ 
+@@ -47,6 +47,8 @@ void os_clearCallback (osjob_t* job) {
+     #if LMIC_DEBUG_LEVEL > 1
+         if (res)
+             lmic_printf("%lu: Cleared job %p\n", os_getTime(), job);
++    #else
++        (void) res;
+     #endif
+ }
+ 
+@@ -94,13 +96,13 @@ void os_setTimedCallback (osjob_t* job, ostime_t time, osjobcb_t cb) {
+ }
+ 
+ // execute jobs from timer and from run queue
+-void os_runloop () {
++void os_runloop (void) {
+     while(1) {
+         os_runloop_once();
+     }
+ }
+ 
+-void os_runloop_once() {
++void os_runloop_once(void) {
+     #if LMIC_DEBUG_LEVEL > 1
+         bool has_deadline = false;
+     #endif
+diff --git a/src/lmic/radio.c b/src/lmic/radio.c
+index c394754..e2211ff 100644
+--- a/src/lmic/radio.c
++++ b/src/lmic/radio.c
+@@ -297,7 +297,7 @@ static void opmode (u1_t mode) {
+     writeReg(RegOpMode, (readReg(RegOpMode) & ~OPMODE_MASK) | mode);
+ }
+ 
+-static void opmodeLora() {
++static void opmodeLora(void) {
+     u1_t u = OPMODE_LORA;
+ #ifdef CFG_sx1276_radio
+     u |= 0x8;   // TBD: sx1276 high freq
+@@ -305,7 +305,7 @@ static void opmodeLora() {
+     writeReg(RegOpMode, u);
+ }
+ 
+-static void opmodeFSK() {
++static void opmodeFSK(void) {
+     u1_t u = 0;
+ #ifdef CFG_sx1276_radio
+     u |= 0x8;   // TBD: sx1276 high freq
+@@ -314,7 +314,7 @@ static void opmodeFSK() {
+ }
+ 
+ // configure LoRa modem (cfg1, cfg2)
+-static void configLoraModem () {
++static void configLoraModem (void) {
+     sf_t sf = getSf(LMIC.rps);
+ 
+ #ifdef CFG_sx1276_radio
+@@ -386,7 +386,7 @@ static void configLoraModem () {
+ #endif /* CFG_sx1272_radio */
+ }
+ 
+-static void configChannel () {
++static void configChannel (void) {
+     // set frequency: FQ = (FRF * 32 Mhz) / (2 ^ 19)
+     uint64_t frf = ((uint64_t)LMIC.freq << 19) / 32000000;
+     writeReg(RegFrfMsb, (u1_t)(frf>>16));
+@@ -396,7 +396,7 @@ static void configChannel () {
+ 
+ 
+ 
+-static void configPower () {
++static void configPower (void) {
+ #ifdef CFG_sx1276_radio
+     // no boost used for now
+     s1_t pw = (s1_t)LMIC.txpow;
+@@ -423,7 +423,7 @@ static void configPower () {
+ #endif /* CFG_sx1272_radio */
+ }
+ 
+-static void txfsk () {
++static void txfsk (void) {
+     // select FSK modem (from sleep mode)
+     writeReg(RegOpMode, 0x10); // FSK, BT=0.5
+     ASSERT(readReg(RegOpMode) == 0x10);
+@@ -466,7 +466,7 @@ static void txfsk () {
+     opmode(OPMODE_TX);
+ }
+ 
+-static void txlora () {
++static void txlora (void) {
+     // select LoRa modem (from sleep mode)
+     //writeReg(RegOpMode, OPMODE_LORA);
+     opmodeLora();
+@@ -519,7 +519,7 @@ static void txlora () {
+ }
+ 
+ // start transmitter (buf=LMIC.frame, len=LMIC.dataLen)
+-static void starttx () {
++static void starttx (void) {
+     ASSERT( (readReg(RegOpMode) & OPMODE_MASK) == OPMODE_SLEEP );
+     if(getSf(LMIC.rps) == FSK) { // FSK modem
+         txfsk();
+@@ -668,7 +668,7 @@ static void startrx (u1_t rxmode) {
+ }
+ 
+ // get random seed from wideband noise rssi
+-void radio_init () {
++void radio_init (void) {
+     hal_disableIRQs();
+ 
+     // manually reset radio
+@@ -730,7 +730,7 @@ void radio_init () {
+ 
+ // return next random byte derived from seed buffer
+ // (buf[0] holds index of next byte to be returned)
+-u1_t radio_rand1 () {
++u1_t radio_rand1 (void) {
+     u1_t i = randbuf[0];
+     ASSERT( i != 0 );
+     if( i==16 ) {
+@@ -742,7 +742,7 @@ u1_t radio_rand1 () {
+     return v;
+ }
+ 
+-u1_t radio_rssi () {
++u1_t radio_rssi (void) {
+     hal_disableIRQs();
+     u1_t r = readReg(LORARegRssiValue);
+     hal_enableIRQs();
+-- 
+2.11.0
+

--- a/tests/pkg_lmic/Makefile
+++ b/tests/pkg_lmic/Makefile
@@ -1,0 +1,43 @@
+APPLICATION = pkg_lmic
+
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_spi periph_gpio
+
+USEMODULE += xtimer
+USEPKG += lmic
+
+# Can be either sx1276 or sx1272
+LMIC_DRIVER ?= sx1276
+
+# Can be either eu868 or us915
+LMIC_ISM_BAND ?= eu868
+
+# Can be either OTAA or ABP
+LMIC_JOIN_PROCEDURE ?= ABP
+
+CFLAGS += -DLMIC_DEBUG_LEVEL=0
+CFLAGS += -DOSTICKS_PER_SEC=62500UL
+
+ifeq ($(LMIC_DRIVER), sx1272)
+  CFLAGS += -DCFG_sx1272_radio
+else
+  # SX1276
+  CFLAGS += -DCFG_sx1276_radio
+endif
+
+ifeq ($(LMIC_ISM_BAND), us915)
+  CFLAGS += -DCFG_us915
+else
+  # EU868
+  CFLAGS += -DCFG_eu868
+endif
+
+ifeq ($(LMIC_JOIN_PROCEDURE), ABP)
+  CFLAGS += -DLMIC_JOIN_ABP
+else
+  # OTAA
+  CFLAGS += -DLMIC_JOIN_OTAA
+endif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_lmic/main.c
+++ b/tests/pkg_lmic/main.c
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2017 Inria Chile
+ *               2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for LMIC LoRaMAC package
+ *
+ * @author      Jose Ignacio Alamos <jialamos@uc.cl>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "periph/gpio.h"
+
+#include "lmic.h"
+#include "lmic/hal.h"
+#include "lmic/params.h"
+#include "hal.h"
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+const unsigned TX_INTERVAL = 1;
+
+static uint8_t mydata[] = "Hello, world!";
+static osjob_t sendjob;
+
+/* Radio device configuration */
+const lmic_pinmap lmic_pins = {
+    .nss = LMIC_PARAM_PIN_NSS,
+    .rxtx = LMIC_PARAM_PIN_RXTX,
+    .rst = LMIC_PARAM_PIN_RESET,
+    .dio = {
+        LMIC_PARAM_PIN_DIO0,
+        LMIC_PARAM_PIN_DIO0,
+        LMIC_PARAM_PIN_DIO0
+    },
+};
+
+
+/* LoRaWAN required parameters */
+
+/* unique device ID (LSBF) */
+static u1_t DEVEUI[8]  = LMIC_PARAM_DEVEUI;
+
+/* application router ID (LSBF) */
+static u1_t APPEUI[8]  = LMIC_PARAM_APPEUI;
+
+/* application AES key (derived from device EUI) */
+static u1_t APPKEY[16] = LMIC_PARAM_APPKEY;
+
+static u4_t DEVADDR = LMIC_PARAM_DEVADDR;
+
+/* LoRaWAN NwkSKey, network session key */
+static u1_t NWKSKEY[16] = LMIC_PARAM_NWKSKEY;
+
+/* LoRaWAN AppSKey, application session key */
+static u1_t APPSKEY[16] = LMIC_PARAM_APPSKEY;
+
+/* utility functions */
+void do_send(osjob_t* j) {
+    DEBUG("[LMIC] test: do send\n");
+    /* Check if there is not a current TX/RX job running */
+    if (LMIC.opmode & OP_TXRXPEND) {
+        puts("[LMIC] test: OP_TXRXPEND, not sending");
+    }
+    else {
+        /* Prepare upstream data transmission at the next possible time. */
+        LMIC_setTxData2(1, mydata, sizeof(mydata) - 1, 0);
+        puts("[LMIC] test: Packet queued");
+    }
+    /* Next TX is scheduled after TX_COMPLETE event. */
+}
+
+/* provide application router ID (8 bytes, LSBF) */
+void os_getArtEui (u1_t* buf) {
+    memcpy(buf, APPEUI, 8);
+}
+
+/* provide device ID (8 bytes, LSBF) */
+void os_getDevEui (u1_t* buf) {
+    memcpy(buf, DEVEUI, 8);
+}
+
+/* provide device key (16 bytes) */
+void os_getDevKey (u1_t* buf) {
+    memcpy(buf, APPKEY, 16);
+}
+
+
+int main (void) {
+    /* LMIC init */
+    os_init();
+
+    /* Reset the MAC state.
+       Session and pending data transfers will be discarded. */
+    LMIC_reset();
+
+#ifdef LMIC_JOIN_ABP
+    (void) APPKEY;
+    LMIC_setSession (0x1, DEVADDR, NWKSKEY, APPSKEY);
+
+    LMIC_setDrTxpow(DR_SF12,2);
+    LMIC_setLinkCheckMode(0);
+    // printf("%i\n", LMIC.dn2Dr);
+#else
+    (void) DEVADDR;
+    (void) NWKSKEY;
+    (void) APPSKEY;
+#endif
+    DEBUG("[LMIC] test: initialized\n");
+
+    /* Start job */
+    do_send(&sendjob);
+    os_runloop();
+    return 0;
+}
+
+
+/* LMIC EVENT CALLBACK */
+void onEvent (ev_t ev) {
+    printf("[LMIC] test: ");
+    switch(ev) {
+        case EV_SCAN_TIMEOUT:
+            puts("EV_SCAN_TIMEOUT");
+            break;
+
+        case EV_BEACON_FOUND:
+            puts("EV_BEACON_FOUND");
+            break;
+
+        case EV_BEACON_MISSED:
+            puts("EV_BEACON_MISSED");
+            break;
+
+        case EV_BEACON_TRACKED:
+            puts("EV_BEACON_TRACKED");
+            break;
+
+        case EV_JOINING:
+            puts("EV_JOINING");
+            break;
+
+        case EV_JOINED:
+            puts("EV_JOINED");
+
+            /* Disable link check validation. */
+            LMIC_setLinkCheckMode(0);
+            break;
+
+        case EV_RFU1:
+            puts("EV_RFU1");
+            break;
+
+        case EV_JOIN_FAILED:
+            puts("EV_JOIN_FAILED");
+            break;
+
+        case EV_REJOIN_FAILED:
+            puts("EV_REJOIN_FAILED");
+            break;
+
+        case EV_LOST_TSYNC:
+            puts("EV_LOST_TSYNC");
+            break;
+
+        case EV_RESET:
+            puts("EV_RESET");
+            break;
+
+        case EV_RXCOMPLETE:
+            /* data received in ping slot */
+            puts("EV_RXCOMPLETE");
+            break;
+
+        case EV_LINK_DEAD:
+            puts("EV_LINK_DEAD");
+            break;
+
+        case EV_LINK_ALIVE:
+            puts("EV_LINK_ALIVE");
+            break;
+
+        case EV_TXCOMPLETE:
+            puts("EV_TXCOMPLETE (includes waiting for RX windows)");
+            if (LMIC.txrxFlags & TXRX_ACK)
+                puts("Received ack");
+            if (LMIC.dataLen) {
+                printf("Received ");
+                printf("%i ", (int) LMIC.dataLen);
+                puts(" bytes of payload");
+            }
+
+            /* Schedule next transmission */
+            os_setTimedCallback(&sendjob,
+                                os_getTime() + sec2osticks(TX_INTERVAL),
+                                do_send);
+            break;
+
+      default:
+          break;
+    }
+}


### PR DESCRIPTION
This is an initial port of the [LoRaMAC-in-C](https://github.com/matthijskooijman/arduino-lmic) stack with a very minimal test application.

Only the build works on STM32 b-l072z-lrwan1 and Nucleo-boards with the MBED extensions.

Unfortunately I couldn't make it work with a LoRaWAN network (either using OTAA or ABP join procedures failed). It seems there are timing issues that I can't fix. That's why I open this PR: I would like to get some help for debugging them.