### PR TITLE
cpu/sam0-common: rename mkr ldscript to more a generic name

### DIFF
--- a/boards/arduino-mkr-common/Makefile.include
+++ b/boards/arduino-mkr-common/Makefile.include
@@ -15,8 +15,9 @@ ifeq ($(PROGRAMMER),jlink)
   export JLINK_DEVICE := ${MKR_JLINK_DEVICE}
   include $(RIOTMAKE)/tools/jlink.inc.mk
 else
-  # on default, we use BOSSA to flash this board
-  export LINKER_SCRIPT ?= $(RIOTCPU)/sam0_common/ldscripts/$(CPU_MODEL)_mkr.ld
+  # by default, we use BOSSA to flash this board and take into account the
+  # preinstalled Arduino bootloader.
+  export LINKER_SCRIPT ?= $(RIOTCPU)/sam0_common/ldscripts/$(CPU_MODEL)_arduino_bootloader.ld
   include $(RIOTMAKE)/tools/bossa.inc.mk
 endif
 

--- a/cpu/sam0_common/ldscripts/README.md
+++ b/cpu/sam0_common/ldscripts/README.md
@@ -1,0 +1,16 @@
+### Atmel SAM0 linker scripts notes
+
+This folder contains SAM0 CPU specific linker scripts that are used to generate
+the final binary firmware.
+
+There are 2 kinds of scripts:
+
+* &lt;name of cpu&gt;.ld: used to generate a firmware that starts at the
+beginning of the flash memory. The firmware is copied to the flash memory
+using [OpenOCD](https://github.com/ntfreak/openocd).
+
+* &lt;name of cpu&gt;\_arduino\_bootloader.ld: used to generate a firmware
+that starts after a preflashed Arduino bootloader. The firmware is copied to
+the flash memory using [Bossa](https://github.com/shumatech/BOSSA).
+This is the kind of configuration used with Arduino MKR and Adafruit Feather
+M0 boards.

--- a/cpu/sam0_common/ldscripts/samd21g18a_arduino_bootloader.ld
+++ b/cpu/sam0_common/ldscripts/samd21g18a_arduino_bootloader.ld
@@ -12,7 +12,8 @@
  * @{
  *
  * @file
- * @brief           Memory definitions for the SAMD21DG18A used in Arduino MKR1000 board
+ * @brief           Memory definitions for the SAMD21DG18A when used with a
+ *                  preinstalled bootloader.
  *
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>


### PR DESCRIPTION
This is because this ldscript can be used with any samd21 with an Arduino compatible bootloader preflashed. The idea is just to use a more generic name for the ldscript file.

This is the case for all Arduino MKR boards, Adafruit Feather boards (see #7510) and others.

This PR should address the question of #7645.