### PR TITLE
cpu/native: add missing breaks in option parser

### DIFF
--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -253,8 +253,10 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
     while ((c = getopt_long(argc, argv, short_opts, long_opts, &opt_idx)) >= 0) {
         switch (c) {
             case 0:
+                /* fall through to 'h' */
             case 'h':
                 usage_exit(EXIT_SUCCESS);
+                break;
             case 'i':
                 _native_id = atol(optarg);
                 break;
@@ -287,6 +289,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv)
                 break;
             default:
                 usage_exit(EXIT_FAILURE);
+                break;
         }
     }
 #ifdef MODULE_NETDEV2_TAP


### PR DESCRIPTION
My compiler was complaining about potential fall-through cases - made all cases explicit