### PR TITLE
github: add pull request and issue template files

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+If your issue is a usage question, please submit it to the user mailing-list
+users@riot-os.org or to the developer mailing-list devel@riot-os.org.
+If your issue is related to security, please submit it to the security
+mailing-list security@riot-os.org.
+-->
+
+#### Description
+<!--
+Example: Cannot build gnrc_networking application for samr21-xpro board.
+-->
+
+#### Steps to reproduce the issue
+<!--
+Try to describe as precisely as possible here the steps required to reproduce
+the issue. Here you can also describe your hardware configuration, the network
+setup, etc.
+-->
+
+#### Expected results
+<!--
+Example: The gnrc_networking application builds on samr21-xpro.
+-->
+
+#### Actual results
+<!--
+Please paste or specifically describe the actual output.
+-->
+
+#### Versions
+<!--
+Operating system: Mac OSX, Linux, Vagrant VM
+Build environment: GCC, CLang versions (you can run the following command from
+the RIOT base directory: ./dist/tools/ci/print_toolchain_versions.sh).
+-->
+
+<!-- Thanks for contributing! -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+The RIOT community cares a lot about code quality.
+Therefore, before describing what your contribution is about, we would like
+you to make sure that your modifications are compliant with the RIOT
+coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
+-->
+
+### Contribution description
+
+<!--
+Put here the description of your contribution:
+- describe which part(s) of RIOT is (are) involved
+- if it's a bug fix, describe the bug that it solves and how it is solved
+- you can also give more information to reviewers about how to test your changes
+-->
+
+
+### Issues/PRs references
+
+<!--
+Examples: Fixes #1234. See also #5678. Depends on PR #9876.
+
+Please use keywords (e.g., fixes, resolve) with the links to the issues you
+resolved, this way they will be automatically closed when your pull request
+is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
+-->


### PR DESCRIPTION
This is related to the discussion about how to improve initial quality state of contributed PRs, especially from newcomers.

GitHub proposes a feature for setting up an initial PR comment, using a template file. See their documentation [here](https://github.com/blog/2111-issue-and-pull-request-templates) and [here](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/)

Any comment about the content of this template is welcomed.