### PR TITLE
[WIP] Generic memory block allocator

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -121,6 +121,9 @@ endif
 ifneq (,$(filter l2filter,$(USEMODULE)))
     DIRS += net/link_layer/l2filter
 endif
+ifneq (,$(filter memarray,$(USEMODULE)))
+    DIRS += memarray
+endif
 
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, ${USEMODULE})))
 

--- a/sys/include/memarray.h
+++ b/sys/include/memarray.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Tobias Heider <heidert@nm.ifi.lmu.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef MEMARRAY_H
+#define MEMARRAY_H
+
+#include "stdint.h"
+#include "stdlib.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup    sys_memarray memory array allocator
+ * @ingroup     sys
+ * @brief       memory array allocator
+ * @{
+ *
+ * @brief       pseudo dynamic allocation in static memory arrays
+ * @author      Tobias Heider <heidert@nm.ifi.lmu.de>
+ */
+typedef struct {
+  size_t size;
+  size_t count;
+  void *first_free;
+  void *data;
+} memarray_t;
+
+/**
+ * Initialize memory
+ */
+#define MEMARRAY(name, structure, num)                                         \
+  static structure _data_##name[num];                                          \
+  static memarray_t name = {.size = sizeof(structure),                         \
+                            .count = num,                                      \
+                            .first_free = _data_##name,                        \
+                            .data = _data_##name};
+
+void memarray_init(memarray_t *mem);
+
+void *memarray_alloc(memarray_t *mem);
+
+uint8_t memarray_free(memarray_t *mem, void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MEMARRAY_H */

--- a/sys/memarray/Makefile
+++ b/sys/memarray/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/memarray/memarray.c
+++ b/sys/memarray/memarray.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 Tobias Heider <heidert@nm.ifi.lmu.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "memarray.h"
+#include "string.h"
+
+void *memarray_alloc(memarray_t *mem) {
+  if (mem->first_free == NULL) {
+    return NULL;
+  }
+  void *free = mem->first_free;
+  mem->first_free = *((void **)mem->first_free);
+  return free;
+}
+
+void memarray_init(memarray_t *mem) {
+  for (size_t i = 0; i < mem->count-1; i++) {
+    void *next = ((char *)mem->data) + ((i + 1) * mem->size);
+    memcpy(((char *)mem->data) + (i * mem->size), &next, sizeof(void *));
+  }
+}
+
+uint8_t memarray_free(memarray_t *mem, void *ptr) {
+  char *iter = mem->data;
+  for (size_t i = 0; i < mem->count; i++) {
+    if (iter == ptr) {
+      memcpy(iter, &mem->first_free, sizeof(void *));
+      mem->first_free = iter;
+      return 0;
+    }
+    iter += mem->size;
+  }
+  return 1;
+}


### PR DESCRIPTION
This PR adds a generic block allocator, allowing "dynamic" allocations of structures of the same size in a static memory pool.
It is meant to replace malloc in cases where only fixed size blocks are allocated and freed (see #7615).

### Example usage
```
// Initialize static memory pool "mem" which can hold 3 somestruct_t
MEMARRAY(mem, somestruct_t, 3);

// Initialize mem as a linked list of free elements
memarray_init(&mem);

// Allocate structure
mem = memarray_alloc(&mem);

// Do whatever needs to be done
...

// Free struct
memarray_free(&mem, mem);
```

### Work in Progress
Things to be done:
- Add documentation
- Add unittests