### PR TITLE
pkg/libfixmath: upgrade version to work with gcc6

### DIFF
--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME     := libfixmath
-PKG_VERSION  := ad9ed940e57d43432b276e95aee6ca9df6f23ccd
+PKG_VERSION  := 7f9c966b5c473770dc93940e3e6e5323f3c1ad69
 PKG_URL      := https://github.com/PetteriAimonen/libfixmath
 PKG_LICENSE  := MIT
 


### PR DESCRIPTION
With gcc6, libfixmath unittests do not compile because of a negative value left shift error `-Werror=shift-negative-value`. In practice all uses of F16C with negative value are affected.

Changelog:

 * Fix '-Werror=shift-negative-value' for gcc 6
 * make some member functions const

https://github.com/PetteriAimonen/libfixmath/compare/ad9ed940e57d43432b276e95aee6ca9df6f23ccd...7f9c966b5c473770dc93940e3e6e5323f3c1ad69

This is related to #7642 issue.