### PR TITLE
LWMAC: add re-initialize radio support.

### DIFF
--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -317,6 +317,19 @@ extern "C" {
 /** @} */
 
 /**
+* @brief Maximum preamble attempts before re-initialize radio in LWMAC.
+*
+* After a long period of run time, a radio may be in wrong condition which needs to be
+* re-calibrated. This is indicated by having a series of continuous preamble failure (no WA)
+* in LWMAC. In case we have @ref CONFIG_GNRC_LWMAC_RADIO_REINIT_THRESHOLD number of preamble
+* failure, then we re-initialize the radio, trying to re-calibrate the radio for bringing it
+* back to normal condition.
+*/
+#ifndef CONFIG_GNRC_LWMAC_RADIO_REINIT_THRESHOLD
+#define CONFIG_GNRC_LWMAC_RADIO_REINIT_THRESHOLD     (10U)
+#endif
+
+/**
  * @brief   Creates an IEEE 802.15.4 LWMAC network interface
  *
  * @param[out] netif    The interface. May not be `NULL`.

--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -197,6 +197,7 @@ typedef struct {
     uint8_t bcast_seqnr;               /**< Sequence number for broadcast data to filter at receiver */
     uint8_t tx_burst_count;            /**< Count how many consecutive packets have been transmitted */
     uint8_t tx_retry_count;            /**< Count how many Tx-retrials have been executed before packet drop */
+    uint8_t preamble_fail_counts;      /**< Preamble trial failure count. */
 #endif
 
 #ifdef MODULE_GNRC_GOMACH

--- a/sys/net/gnrc/link_layer/lwmac/Kconfig
+++ b/sys/net/gnrc/link_layer/lwmac/Kconfig
@@ -138,5 +138,16 @@ config GNRC_LWMAC_TIMEOUT_COUNT
     help
         Configure 'CONFIG_GNRC_LWMAC_TIMEOUT_COUNT', the default value for the
         maximum number of parallel timeouts in LWMAC.
+config GNRC_LWMAC_RADIO_REINIT_THRESHOLD
+    int "Maximum preamble attempts before re-initialize radio"
+    default 10
+    help
+        Configure 'CONFIG_GNRC_LWMAC_RADIO_REINIT_THRESHOLD', the maximum preamble
+        attempts before re-initialize radio. After a long period of run time, a radio
+        may be in wrong condition which needs to be re-calibrated. This is indicated
+        by having a series of continuous preamble failure (no WA) in LWMAC. In case
+        we have @ref GNRC_LWMAC_RADIO_REINI_THRESHOLD number of preamble failure,
+        then we re-initialize the radio, trying to re-calibrate the radio for bringing
+        it back to normal condition.
 
 endif # KCONFIG_MODULE_GNRC_LWMAC

--- a/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
@@ -685,6 +685,7 @@ static bool _lwmac_tx_update(gnrc_netif_t *netif)
                 LOG_WARNING("WARNING: [LWMAC-tx] No response from destination\n");
                 netif->mac.tx.state = GNRC_LWMAC_TX_STATE_FAILED;
                 reschedule = true;
+                netif->mac.tx.preamble_fail_counts++;
                 break;
             }
 
@@ -735,6 +736,7 @@ static bool _lwmac_tx_update(gnrc_netif_t *netif)
             if (tx_info & GNRC_LWMAC_TX_SUCCESS) {
                 netif->mac.tx.state = GNRC_LWMAC_TX_STATE_SEND_DATA;
                 reschedule = true;
+                netif->mac.tx.preamble_fail_counts = 0;
                 break;
             }
             else {


### PR DESCRIPTION
 During my long-time experiment on [GoMacH](https://github.com/RIOT-OS/RIOT/pull/5618) protocol, I found that: after a long period of run time, a radio may be in wrong condition which (I believe) needs to be re-calibrated. When the node (radio) is in this abnormal condition, it can not receive any incoming packet, which disable normal communications. 

This will be indicated by having a series of continuous preamble failure (no WA) in LWMAC. In case we have continuous [GNRC_LWMAC_RADIO_REINI_THRESHOLD](https://github.com/RIOT-OS/RIOT/compare/master...zhuoshuguo:lwmac_radio_reinit?expand=1#diff-a69ff1fb011163871bf1b36b5de23f35R310) number of preamble failure, then we re-initiate the radio, trying to re-calibrate the radio for bringing it back to normal condition. This has been verified to work on samr21-xpro boards in my GoMacH experiments.