### PR TITLE
cpu/stm32_common/periph: fix doxygen parent group

### DIFF
--- a/cpu/stm32_common/periph/dac.c
+++ b/cpu/stm32_common/periph/dac.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_stm32_common
  * @ingroup     drivers_periph_dac
  * @{
  *

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -10,7 +10,7 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_stm32_common
  * @ingroup     drivers_periph_gpio
  * @{
  *

--- a/cpu/stm32_common/periph/hwrng.c
+++ b/cpu/stm32_common/periph/hwrng.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_stm32_common
  * @ingroup     drivers_periph_hwrng
  * @{
  *

--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -9,7 +9,7 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_stm32_common
  * @ingroup     drivers_periph_pm
  * @{
  *

--- a/cpu/stm32_common/periph/pwm.c
+++ b/cpu/stm32_common/periph/pwm.c
@@ -9,7 +9,7 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_stm32_common
  * @ingroup     drivers_periph_pwm
  * @{
  *

--- a/cpu/stm32_common/periph/rtt_lptim.c
+++ b/cpu/stm32_common/periph/rtt_lptim.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_stm32_common
  * @ingroup     drivers_periph_rtt
  * @{
  *

--- a/cpu/stm32_common/periph/spi.c
+++ b/cpu/stm32_common/periph/spi.c
@@ -9,7 +9,7 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_stm32_common
  * @ingroup     drivers_periph_spi
  * @{
  *

--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_stm32_common
  * @ingroup     drivers_periph_timer
  * @{
  *

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     cpu_cortexm_common
+ * @ingroup     cpu_stm32_common
  * @ingroup     drivers_periph_uart
  * @{
  *


### PR DESCRIPTION
As noticed while reviewing #7658, I think the stm32 periph drivers implementations are not link to the right group. This is fixed by this PR.