### PR TITLE
boards/z1: fixed LEDx_PIN definitions

### DIFF
--- a/boards/z1/include/board.h
+++ b/boards/z1/include/board.h
@@ -70,14 +70,14 @@ extern "C" {
  * @name    LED pin definitions and handlers
  * @{
  */
-#define LED0_PIN                    GPIO_PIN(4, 0)
-#define LED1_PIN                    GPIO_PIN(4, 1)
-#define LED2_PIN                    GPIO_PIN(4, 2)
+#define LED0_PIN                    GPIO_PIN(5, 4)
+#define LED1_PIN                    GPIO_PIN(5, 6)
+#define LED2_PIN                    GPIO_PIN(5, 5)
 
 #define LED_OUT_REG                 P5OUT
 #define LED0_MASK                   (0x10)
-#define LED1_MASK                   (0x20)
-#define LED2_MASK                   (0x40)
+#define LED1_MASK                   (0x40)
+#define LED2_MASK                   (0x20)
 
 #define LED0_ON                     (LED_OUT_REG &=~LED0_MASK)
 #define LED0_OFF                    (LED_OUT_REG |= LED0_MASK)


### PR DESCRIPTION
The LEDx_PIN defines were broken and are now fixed.