### PR TITLE
examples/gnrc_border_router: Use STDIO UART for ethos

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -26,7 +26,7 @@ ifeq (,$(filter native,$(BOARD)))
 
   # ethos baudrate can be configured from make command
   ETHOS_BAUDRATE ?= 115200
-  CFLAGS += '-DETHOS_UART=UART_DEV(0)' -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
+  CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
   FEATURES_REQUIRED += periph_uart
 endif
 


### PR DESCRIPTION
If `ETHOS_UART` is not defined, then the default behaviour is to fall back to `UART_STDIO_DEV`.

Fixes broken default configuration on boards which are not using UART0 for STDIO (e.g. Mulle)