### PR TITLE
mulle: Remove second flash bank declaration from OpenOCD configuration

### DIFF
--- a/boards/mulle/dist/openocd/mulle-programmer-0.70.conf
+++ b/boards/mulle/dist/openocd/mulle-programmer-0.70.conf
@@ -42,7 +42,6 @@ source [find target/k60.cfg]
 # not OpenOCD 0.8.0 and earlier.
 #
 catch {flash bank $_CHIPNAME.flash kinetis 0 0 0 0 $_TARGETNAME}
-catch {flash bank $_CHIPNAME.flash2 kinetis 0 0 0 0 $_TARGETNAME}
 
 # Work-area is a space in RAM used for flash programming
 # By default use 4 kB


### PR DESCRIPTION
This line is no longer required and causes problems with modern OpenOCD which will automatically add all flash banks when probing Kinetis CPUs.

Without this change, probing the CPU fails on current development version of OpenOCD. On ancient OpenOCD versions (<= 0.8.0), the second line was required in order to be able to place anything in the upper half of ROM.

The scripts will need more updating in the future, but this PR fixes the immediate problem with the error message about too many flash banks specified.