### PR TITLE
cpu/sam0/periph/uart: ensure uart_init() idempotency

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -57,6 +57,9 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         return UART_NODEV;
     }
 
+    /* must disable here first to ensure idempotency */
+    dev(uart)->CTRLA.reg &= ~(SERCOM_USART_CTRLA_ENABLE);
+
     /* configure pins */
     gpio_init(uart_config[uart].rx_pin, GPIO_IN);
     gpio_init_mux(uart_config[uart].rx_pin, uart_config[uart].mux);


### PR DESCRIPTION
While testing OTA, the samr21-xpro would hang in uart_init() waiting for SWRST if called the second time (first from bootloader, second from actual image).

This PR calls uart_poweroff() in uart_init() before attempting initialization.