### PR TITLE
drivers/Makefile.dep: Remove already fulfilled 'gnrc_netdev' dependency

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -20,11 +20,6 @@ ifneq (,$(filter at86rf2%,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
-  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-    # XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
-    # as all drivers are ported to netdev
-    USEMODULE += gnrc_netdev
-  endif
 endif
 
 ifneq (,$(filter mrf24j40,$(USEMODULE)))
@@ -33,11 +28,6 @@ ifneq (,$(filter mrf24j40,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
-  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-    # XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
-    # as all drivers are ported to netdev
-    USEMODULE += gnrc_netdev
-  endif
 endif
 
 ifneq (,$(filter bh1750fvi,$(USEMODULE)))
@@ -62,9 +52,6 @@ ifneq (,$(filter cc110x,$(USEMODULE)))
   USEMODULE += xtimer
   ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += gnrc_cc110x
-    # XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
-    # as all drivers are ported to netdev
-    USEMODULE += gnrc_netdev
   endif
 endif
 
@@ -74,11 +61,6 @@ ifneq (,$(filter cc2420,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
-  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-    # XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
-    # as all drivers are ported to netdev
-    USEMODULE += gnrc_netdev
-  endif
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_spi
 endif
@@ -137,11 +119,6 @@ ifneq (,$(filter kw2xrf,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
-  ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
-    # XXX: this can be modelled as a dependency for gnrc_netdev_default as soon
-    # as all drivers are ported to netdev
-    USEMODULE += gnrc_netdev
-  endif
 endif
 
 ifneq (,$(filter hd44780,$(USEMODULE)))


### PR DESCRIPTION
`gnrc_netdev` is already set as a dependency to `gnrc_netdev_default` in the
general `Makefile.dep`.

https://github.com/RIOT-OS/RIOT/blob/2017.07/Makefile.dep#L32