### PR TITLE
gnrc_ipv6_nib_pl: doc: add comment about changes during iteration

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -114,6 +114,8 @@ void gnrc_ipv6_nib_pl_del(unsigned iface,
  * }
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
+ * @note    The list may change during iteration.
+ *
  * @return  true, if iteration can be continued.
  * @return  false, if @p ple is the last prefix list ple in the NIB.
  */


### PR DESCRIPTION
Adds same information all the other NIB iterators have.