### PR TITLE
sys/xtimer: fix default config / XTIMER_WIDTH

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -533,14 +533,15 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
  */
 #define XTIMER_CHAN (0)
 
-#endif
-
-#ifndef XTIMER_WIDTH
 #if (TIMER_0_MAX_VALUE) == 0xfffffful
 #define XTIMER_WIDTH (24)
 #elif (TIMER_0_MAX_VALUE) == 0xffff
 #define XTIMER_WIDTH (16)
-#else
+#endif
+
+#endif
+
+#ifndef XTIMER_WIDTH
 /**
  * @brief xtimer timer width
  *
@@ -548,7 +549,6 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
  * Default is 32.
  */
 #define XTIMER_WIDTH (32)
-#endif
 #endif
 
 #if (XTIMER_WIDTH != 32) || DOXYGEN


### PR DESCRIPTION
#6702 breaks some boards (notably samr21-xpro):

Before #6702, if no xtimer device was set, xtimer would use TIMER_0, and set XTIMER_WIDTH according to TIMER_0_MAX_VALUE.

#6702 changed that semantic to *always* use TIMER_0_MAX_VALUE for setting XTIMER_WIDTH if unset.

Some boards (e.g., samr21-xpro) use TIMER_1 as device, but don't set XTIMER_WIDTH, expecting a default of 32. With #6702, xtimer now uses TIMER_0 values, which happens to only have 16bit width.

This PR restores the logic before #6702.