### PR TITLE
core: optimize bitarithm_lsb()

### DIFF
--- a/core/bitarithm.c
+++ b/core/bitarithm.c
@@ -21,6 +21,8 @@
 
 #include <stdio.h>
 
+#include "bitarithm.h"
+
 unsigned bitarithm_msb(unsigned v)
 {
     register unsigned r; // result of log2(v) will go here
@@ -43,19 +45,7 @@ unsigned bitarithm_msb(unsigned v)
 
     return r;
 }
-/*---------------------------------------------------------------------------*/
-unsigned bitarithm_lsb(register unsigned v)
-{
-    register unsigned r = 0;
 
-    while ((v & 0x01) == 0) {
-        v >>= 1;
-        r++;
-    };
-
-    return r;
-}
-/*---------------------------------------------------------------------------*/
 unsigned bitarithm_bits_set(unsigned v)
 {
     unsigned c; // c accumulates the total bits set in v
@@ -66,3 +56,9 @@ unsigned bitarithm_bits_set(unsigned v)
 
     return c;
 }
+
+const uint8_t MultiplyDeBruijnBitPosition[32] =
+{
+    0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
+    31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
+};

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2014 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -19,6 +20,10 @@
 
 #ifndef BITARITHM_H
 #define BITARITHM_H
+
+#include <stdint.h>
+
+#include "cpu_conf.h"
 
 #ifdef __cplusplus
  extern "C" {
@@ -105,18 +110,43 @@ unsigned bitarithm_msb(unsigned v);
  *                  function will produce an infinite loop
  * @return          Bit Number
  *
- * Source: http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
  */
-unsigned bitarithm_lsb(register unsigned v);
+static inline unsigned bitarithm_lsb(unsigned v);
 
 /**
  * @brief   Returns the number of bits set in a value
  * @param[in]   v   Input value
  * @return          Number of set bits
  *
- * Source: http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
  */
 unsigned bitarithm_bits_set(unsigned v);
+
+/* implementations */
+
+static inline unsigned bitarithm_lsb(unsigned v)
+#if defined(BITARITHM_LSB_BUILTIN)
+{
+    return __builtin_ffs(v) - 1;
+}
+#elif defined(BITARITHM_LSB_LOOKUP)
+{
+/* Source: http://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup */
+    extern const uint8_t MultiplyDeBruijnBitPosition[32];
+    return MultiplyDeBruijnBitPosition[((uint32_t)((v & -v) * 0x077CB531U)) >> 27];
+}
+#else
+{
+/* Source: http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious */
+    unsigned r = 0;
+
+    while ((v & 0x01) == 0) {
+        v >>= 1;
+        r++;
+    };
+
+    return r;
+}
+#endif
 
 #ifdef __cplusplus
 }

--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -57,6 +57,17 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @brief   Select fastest bitarithm_lsb implementation
+ * @{
+ */
+#ifdef __ARM_FEATURE_CLZ
+#define BITARITHM_LSB_BUILTIN
+#else
+#define BITARITHM_LSB_LOOKUP
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
As pointed out in #5200, we're currently using a rather naive implementation for finding the least significant bit set in a word.

While quite fast on all CPU's on average, it's runtime depends on the actual LSB set. The most prominent user of ```bitarithm_lsb()``` is the scheduler, where it is used to find the highest-priority runqueue, at each context switch. As we have only 16 priority levels (by default), the current ```bitarithm_lsb()``` implementation wastes basically 16 loop iterations on every context switch.

This PR adds two alternative implementations for bitarithm_lsb():

- one that uses ```__builtin_ffs()```, which on ARM > CortexM0+ uses the CLZ instruction (most probably using constant time)
- one that uses a lookup table and black magic, also using constant time

The implementations can be chosen by defining ```BITARITHM_LSB_BUILTIN``` or ```BITARITHM_LSB_LOOKUP```. ```bitarithm.h``` now includes ```cpu_conf.h```, which would be the place to configure this. If no such define is present, the default (our old naive implementation) will be used.

This PR adds another commit which actually choses the fastest implementation for cortexm_common, depending whether the CPU sports the CLZ instruction. All other platforms will use the old version. Once we got proper benchmarking in place, we can switch them to what works best.

Crude testing shows ~10% context switch time improvement on samr21-xpro (Cortex M0+, thus using the lookup table version), and ~15% improvement on Nucleo F411 (Cortex-M4, thus using the __builtin_ffs() version).

Codesize-wise, the builtin version uses the same amount of code as the old implementation, while the lookup table based implementation adds 28b, both measured using hello-world.