### PR TITLE
timer: remove usage of TIMER_X_MAX_VALUE

### DIFF
--- a/boards/arduino-mkr-common/include/board_common.h
+++ b/boards/arduino-mkr-common/include/board_common.h
@@ -31,6 +31,13 @@ extern "C" {
 #endif
 
 /**
+ * @name    xtimer configuration values
+ * @{
+ */
+#define XTIMER_WIDTH                (16)
+/** @} */
+
+/**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/boards/arduino-mkr-common/include/periph_conf.h
+++ b/boards/arduino-mkr-common/include/periph_conf.h
@@ -88,13 +88,11 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TC3->COUNT16
 #define TIMER_0_CHANNELS    2
-#define TIMER_0_MAX_VALUE   (0xffff)
 #define TIMER_0_ISR         isr_tc3
 
 /* Timer 1 configuration */
 #define TIMER_1_DEV         TC4->COUNT32
 #define TIMER_1_CHANNELS    2
-#define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_ISR         isr_tc4
 /** @} */
 

--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -90,13 +90,11 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TC3->COUNT16
 #define TIMER_0_CHANNELS    2
-#define TIMER_0_MAX_VALUE   (0xffff)
 #define TIMER_0_ISR         isr_tc3
 
 /* Timer 1 configuration */
 #define TIMER_1_DEV         TC4->COUNT32
 #define TIMER_1_CHANNELS    2
-#define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_ISR         isr_tc4
 
 /** @} */

--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -52,7 +52,6 @@ extern "C" {
  * We use timer_a as TIMER_0
  */
 #define TIMER_0_CHANNELS    1
-#define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_ISR         isr_wtimer0a
 #define TIMER_0_IRQ_CHAN    Timer0A_IRQn
 
@@ -63,7 +62,6 @@ extern "C" {
  */
 
 #define TIMER_1_CHANNELS    1
-#define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_ISR         isr_wtimer1a
 #define TIMER_1_IRQ_CHAN    Timer1A_IRQn
 /** @} */

--- a/boards/mbed_lpc1768/include/periph_conf.h
+++ b/boards/mbed_lpc1768/include/periph_conf.h
@@ -35,7 +35,6 @@ extern "C" {
 #define TIMER_0_DEV         LPC_TIM0
 #define TIMER_0_CHANNELS    4
 #define TIMER_0_FREQ        (96000000ul)
-#define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (LPC_SC->PCONP |= (1 << 1))
 #define TIMER_0_CLKDIS()    (LPC_SC->PCONP &= ~(1 << 1))
 #define TIMER_0_PLKSEL()    (LPC_SC->PCLKSEL0 |= (1 << 2))

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -96,13 +96,11 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TC3->COUNT16
 #define TIMER_0_CHANNELS    2
-#define TIMER_0_MAX_VALUE   (0xffff)
 #define TIMER_0_ISR         isr_tc3
 
 /* Timer 1 configuration */
 #define TIMER_1_DEV         TC4->COUNT32
 #define TIMER_1_CHANNELS    2
-#define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_ISR         isr_tc4
 /** @} */
 

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -44,7 +44,6 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV        TC0->COUNT32
 #define TIMER_0_CHANNELS   1
-#define TIMER_0_MAX_VALUE  (0xffffffff)
 #define TIMER_0_ISR        isr_tc0
 /** @} */
 

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -96,13 +96,11 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TC3->COUNT16
 #define TIMER_0_CHANNELS    2
-#define TIMER_0_MAX_VALUE   (0xffff)
 #define TIMER_0_ISR         isr_tc3
 
 /* Timer 1 configuration */
 #define TIMER_1_DEV         TC4->COUNT32
 #define TIMER_1_CHANNELS    2
-#define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_ISR         isr_tc4
 /** @} */
 

--- a/boards/seeeduino_arch-pro/include/periph_conf.h
+++ b/boards/seeeduino_arch-pro/include/periph_conf.h
@@ -36,7 +36,6 @@ extern "C" {
 #define TIMER_0_DEV         LPC_TIM0
 #define TIMER_0_CHANNELS    4
 #define TIMER_0_FREQ        (96000000ul)
-#define TIMER_0_MAX_VALUE   (0xffffffff)
 #define TIMER_0_CLKEN()     (LPC_SC->PCONP |= (1 << 1))
 #define TIMER_0_CLKDIS()    (LPC_SC->PCONP &= ~(1 << 1))
 #define TIMER_0_PLKSEL()    (LPC_SC->PCLKSEL0 |= (1 << 2))

--- a/boards/slwstk6220a/include/board.h
+++ b/boards/slwstk6220a/include/board.h
@@ -36,6 +36,13 @@ extern "C" {
 #define HW_TIMER            TIMER_DEV(0)
 
 /**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH		(16)
+/** @} */
+
+/**
  * @name    Connection to the on-board temperature/humidity sensor (Si7021)
  * @{
  */

--- a/boards/slwstk6220a/include/periph_conf.h
+++ b/boards/slwstk6220a/include/periph_conf.h
@@ -62,7 +62,6 @@ static const timer_conf_t timer_config[] = {
 };
 
 #define TIMER_0_ISR         isr_timer1
-#define TIMER_0_MAX_VALUE   (0xffff)            /* 16-bit timer */
 #define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
 /** @} */
 

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -86,13 +86,11 @@ extern "C" {
 /* Timer 0 configuration */
 #define TIMER_0_DEV         TC3->COUNT16
 #define TIMER_0_CHANNELS    2
-#define TIMER_0_MAX_VALUE   (0xffff)
 #define TIMER_0_ISR         isr_tc3
 
 /* Timer 1 configuration */
 #define TIMER_1_DEV         TC4->COUNT32
 #define TIMER_1_CHANNELS    2
-#define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_ISR         isr_tc4
 /** @} */
 

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -32,6 +32,7 @@
 /* guard file in case no timers are defined */
 #if TIMER_NUMOF
 
+#define TIMER_MAX_VALUE   (0xffffffff)
 /**
  * @brief Struct holding the configuration data
  * @{
@@ -91,20 +92,18 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     case TIMER_0:
         sysctl_timer = SYSCTL_PERIPH_WTIMER0;
         timer_base = WTIMER0_BASE;
-        timer_max_val = TIMER_0_MAX_VALUE;
         break;
 #endif
 #if TIMER_1_EN
     case TIMER_1:
         sysctl_timer = SYSCTL_PERIPH_WTIMER1;
         timer_base = WTIMER1_BASE;
-        timer_max_val = TIMER_1_MAX_VALUE;
         break;
 #endif
     default:
         return -1; /* unreachable */
     }
-
+    timer_max_val = TIMER_MAX_VALUE;
 
     ROM_SysCtlPeripheralEnable(sysctl_timer);
 

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -532,13 +532,6 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
  * @brief Underlying hardware timer channel to assign to xtimer
  */
 #define XTIMER_CHAN (0)
-
-#if (TIMER_0_MAX_VALUE) == 0xfffffful
-#define XTIMER_WIDTH (24)
-#elif (TIMER_0_MAX_VALUE) == 0xffff
-#define XTIMER_WIDTH (16)
-#endif
-
 #endif
 
 #ifndef XTIMER_WIDTH


### PR DESCRIPTION
followup on #7692 and #6702 

This PR removes any remaining usage (and definition) of `TIMER_[0|1]_MAX_VALUE`, i.e., it was only use by the periph/timer implementation of cpu/lm4f120; and by xtimer to infer `XTIMER_WIDTH` if not explicitly set. The latter caused an annoying bug (see #7692).

All boards are adapted, i.e. remove definitions of `TIMER_X_MAX_VALUE` and set `XTIMER_WIDTH` explicitly where needed.

