### PR TITLE
makefiles: Provide USB UART device serial number matching

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -92,6 +92,7 @@ compile() {
     [ ! -d "boards/$board" ] && error "$0: compile: error: board directory \"boards/$board\" doesn't exist"
 
     CCACHE_BASEDIR="$(pwd)" BOARD=$board RIOT_CI_BUILD=1 \
+        PORT=/dev/null \
         make -C${appdir} clean all -j${JOBS:-4}
     RES=$?
 

--- a/.murdock
+++ b/.murdock
@@ -92,7 +92,6 @@ compile() {
     [ ! -d "boards/$board" ] && error "$0: compile: error: board directory \"boards/$board\" doesn't exist"
 
     CCACHE_BASEDIR="$(pwd)" BOARD=$board RIOT_CI_BUILD=1 \
-        PORT=/dev/null \
         make -C${appdir} clean all -j${JOBS:-4}
     RES=$?
 

--- a/boards/acd52832/Makefile.include
+++ b/boards/acd52832/Makefile.include
@@ -1,7 +1,4 @@
 # define the cpu used by the acd52832
 export CPU_MODEL = nrf52832xxaa
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/airfy-beacon/Makefile.include
+++ b/boards/airfy-beacon/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxaa
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/arduino-duemilanove/Makefile.include
+++ b/boards/arduino-duemilanove/Makefile.include
@@ -4,8 +4,6 @@ export CPU = atmega328p
 USEMODULE += boards_common_arduino-atmega
 
 #export needed for flash rule
-export PORT_LINUX ?= /dev/ttyUSB0
-export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 export PROGRAMMER_SPEED ?= 57600
 
 export FFLAGS += -p m328p

--- a/boards/arduino-mega2560/Makefile.include
+++ b/boards/arduino-mega2560/Makefile.include
@@ -4,8 +4,6 @@ export CPU = atmega2560
 USEMODULE += boards_common_arduino-atmega
 
 #export needed for flash rule
-export PORT_LINUX ?= /dev/ttyACM0
-export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 export PROGRAMMER_SPEED ?= 115200
 
 export FFLAGS += -p m2560

--- a/boards/arduino-uno/Makefile.include
+++ b/boards/arduino-uno/Makefile.include
@@ -4,8 +4,6 @@ export CPU = atmega328p
 USEMODULE += boards_common_arduino-atmega
 
 # export needed for flash rule
-export PORT_LINUX ?= /dev/ttyACM0
-export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 export PROGRAMMER_SPEED ?= 115200
 
 export FFLAGS += -p m328p

--- a/boards/b-l072z-lrwan1/Makefile.include
+++ b/boards/b-l072z-lrwan1/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32l0
 export CPU_MODEL = stm32l072cz
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/b-l475e-iot01a/Makefile.include
+++ b/boards/b-l475e-iot01a/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32l4
 export CPU_MODEL = stm32l475vg
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/bluepill/Makefile.include
+++ b/boards/bluepill/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32f1
 export CPU_MODEL = stm32f103c8
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxab
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/cc2650-launchpad/Makefile.include
+++ b/boards/cc2650-launchpad/Makefile.include
@@ -2,10 +2,6 @@ export CPU       = cc26x0
 export CPU_MODEL = cc26x0f128
 export XDEBUGGER = XDS110
 
-# set default port depending on operating system
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/cc2650stk/Makefile.include
+++ b/boards/cc2650stk/Makefile.include
@@ -2,10 +2,6 @@ export CPU       = cc26x0
 export CPU_MODEL = cc26x0f128
 export XDEBUGGER  = XDS110
 
-# set default port depending on operating system
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/common/arduino-due/Makefile.include
+++ b/boards/common/arduino-due/Makefile.include
@@ -6,10 +6,6 @@ export CPU_MODEL = sam3x8e
 USEMODULE += boards_common_arduino_due
 INCLUDES  += -I$(RIOTBOARD)/common/arduino-due/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/common/arduino-mkr/Makefile.include
+++ b/boards/common/arduino-mkr/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = samd21
 export CPU_MODEL = samd21g18a
 
-#export needed for flash rule
-export PORT_LINUX ?= /dev/ttyACM0
-export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/common/frdm/Makefile.include
+++ b/boards/common/frdm/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # Use the shared OpenOCD configuration
 # Using dap or jlink depends on which firmware the OpenSDA debugger is running
 export DEBUG_ADAPTER ?= dap

--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -2,9 +2,6 @@
 export CPU = msp430fxyz
 export CPU_MODEL = msp430f1612
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/common/nrf52xxxdk/Makefile.include
+++ b/boards/common/nrf52xxxdk/Makefile.include
@@ -8,8 +8,6 @@ ifeq (,$(filter thingy52 acd52832,$(BOARD)))
 endif
 
 # set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup JLink for flashing

--- a/boards/common/nucleo/Makefile.include
+++ b/boards/common/nucleo/Makefile.include
@@ -3,8 +3,6 @@ USEMODULE += boards_common_nucleo
 INCLUDES  += -I$(RIOTBOARD)/common/nucleo/include
 
 # configure the serial terminal
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # all Nucleo boards have an on-board ST-link v2-1 adapter

--- a/boards/common/wsn430/Makefile.include
+++ b/boards/common/wsn430/Makefile.include
@@ -8,8 +8,6 @@ USEMODULE += boards_common_wsn430
 export INCLUDES += -I$(RIOTBOARD)/common/wsn430/include
 
 # configure the serial interface
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # configure the flash tool

--- a/boards/ek-lm4f120xl/Makefile.include
+++ b/boards/ek-lm4f120xl/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = lm4f120
 export CPU_MODEL = LM4F120H5QR
 
-#define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32f4
 export CPU_MODEL = stm32f415rg
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = samd21
 export CPU_MODEL = samd21g18a
 
-#export needed for flash rule
-export PORT_LINUX ?= /dev/ttyACM0
-export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/fox/Makefile.include
+++ b/boards/fox/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32f1
 export CPU_MODEL = stm32f103re
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/ikea-tradfri/Makefile.include
+++ b/boards/ikea-tradfri/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = efm32
 export CPU_MODEL = efr32mg1p132f256gm32
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 export JLINK_DEVICE := EFR32MG1PxxxF256
 include $(RIOTMAKE)/tools/jlink.inc.mk

--- a/boards/limifrog-v1/Makefile.include
+++ b/boards/limifrog-v1/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32l1
 export CPU_MODEL = stm32l151rc
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/maple-mini/Makefile.include
+++ b/boards/maple-mini/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32f1
 export CPU_MODEL = stm32f103cb
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -10,9 +10,5 @@ export HEXFILE = $(ELFFILE:.elf=.bin)
 export FFLAGS =
 export DEBUGGER_FLAGS =
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxab
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/msbiot/Makefile.include
+++ b/boards/msbiot/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32f4
 export CPU_MODEL = stm32f415rg
 
-#define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -21,33 +21,9 @@ export CPU_MODEL
 
 # Default debug adapter choice is to use the Mulle programmer board
 export DEBUG_ADAPTER ?= mulle
-# Host OS name
-OS := $(shell uname)
 
 # Fall back to PROGRAMMER_SERIAL for backwards compatibility
 export DEBUG_ADAPTER_ID ?= $(PROGRAMMER_SERIAL)
-
-ifeq ($(PORT),)
-  # try to find tty name by serial number, only works on Linux currently.
-  ifeq ($(OS),Linux)
-    ifneq ($(DEBUG_ADAPTER_ID),)
-      PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh '^$(DEBUG_ADAPTER_ID)$$'))
-    else
-      # find-tty.sh will return the first USB tty if no serial is given.
-      PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh))
-  endif
-  else ifeq ($(OS),Darwin)
-    ifneq ($(DEBUG_ADAPTER_ID),)
-      PORT := /dev/tty.usbserial-$(DEBUG_ADAPTER_ID)B
-    else
-      PORT := $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
-    endif
-  endif
-endif
-ifeq ($(PORT),)
-  # fall back to a sensible default
-  PORT := /dev/ttyUSB0
-endif
 
 # We need special handling of the watchdog if we want to speed up the flash
 # verification by using the MCU to compute the image checksum after flashing.

--- a/boards/nrf51dongle/Makefile.include
+++ b/boards/nrf51dongle/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxab
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup JLink for flashing
 export JLINK_DEVICE := nrf51822
 include $(RIOTMAKE)/tools/jlink.inc.mk

--- a/boards/nrf6310/Makefile.include
+++ b/boards/nrf6310/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxaa
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # define flash and debugging environment
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
 export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32l1
 export CPU_MODEL = stm32l151rc
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # set the default id
 export ID ?= 0483:df11
 

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -12,10 +12,6 @@ export HEXFILE = $(ELFFILE:.elf=.bin)
 export FFLAGS =
 export DEBUGGER_FLAGS =
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # Skip the space needed by the embedded bootloader
 export ROM_OFFSET ?= 0x3000
 

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = cc2538
 export CPU_MODEL = cc2538sf53
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
-
 # Set default flash tool
 export PROGRAMMER ?= cc2538-bsl
 

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -30,16 +30,13 @@ export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/$(CPU)/dist/check-fcfield-elf.sh
 
 export DEBUG_ADAPTER ?= dap
 
-# Add board selector (USB serial) to OpenOCD options if specified.
-# Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
-#   Usage: SERIAL="0200..." BOARD="pba-d-01-kw2x" make flash
+# Use DEBUG_ADAPTER_ID to specify the programmer serial number to use:
+# export DEBUG_ADAPTER_ID="0020..."
+
+# The SERIAL setting is only available for backwards compatibility with older
+# settings.
 ifneq (,$(SERIAL))
-  export OPENOCD_EXTRA_INIT += "-c cmsis_dap_serial $(SERIAL)"
-  SERIAL_TTY = $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL)))
-  ifeq (,$(SERIAL_TTY))
-    $(error Did not find a device with serial $(SERIAL))
-  endif
-  PORT_LINUX := $(SERIAL_TTY)
+  export DEBUG_ADAPTER_ID ?= $(SERIAL)
 endif
 
 # setup serial terminal

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -8,10 +8,6 @@ export CPU_MODEL ?= mkw21d256vha5
 
 export MCPU = cortex-m4
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 .PHONY: flash
 flash: $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
 

--- a/boards/remote-pa/Makefile.include
+++ b/boards/remote-pa/Makefile.include
@@ -1,7 +1,3 @@
 USEMODULE += boards_common_remote
 
-# define the default port depending on the host OS
-PORT_LINUX  ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
-
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/remote-reva/Makefile.include
+++ b/boards/remote-reva/Makefile.include
@@ -1,7 +1,3 @@
 USEMODULE += boards_common_remote
 
-# define the default port depending on the host OS
-PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/remote-revb/Makefile.include
+++ b/boards/remote-revb/Makefile.include
@@ -1,7 +1,3 @@
 USEMODULE += boards_common_remote
 
-# define the default port depending on the host OS
-PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -1,10 +1,6 @@
 # define the used CPU
 export CPU = lpc1768
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/sltb001a/Makefile.include
+++ b/boards/sltb001a/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = efm32
 export CPU_MODEL = efr32mg1p132f256gm48
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 export JLINK_DEVICE := EFR32MG1PxxxF256
 include $(RIOTMAKE)/tools/jlink.inc.mk

--- a/boards/slwstk6220a/Makefile.include
+++ b/boards/slwstk6220a/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = ezr32wg
 export CPU_MODEL = ezr32wg330f256r60
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 export JLINK_DEVICE := ezr32wg330f256
 include $(RIOTMAKE)/tools/jlink.inc.mk

--- a/boards/sodaq-explorer/Makefile.include
+++ b/boards/sodaq-explorer/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = samd21
 export CPU_MODEL = samd21j18a
 
-#export needed for flash rule
-export PORT_LINUX ?= /dev/ttyACM0
-export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -3,8 +3,6 @@ export CPU = stm32f1
 export CPU_MODEL = stm32f103cb
 
 # configure the serial interface
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 export BINFILE = $(patsubst %.elf,%.bin,$(ELFFILE))

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32f0
 export CPU_MODEL = stm32f051r8
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32f3
 export CPU_MODEL = stm32f303vc
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32f4
 export CPU_MODEL = stm32f407vg
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/stm32f7discovery/Makefile.include
+++ b/boards/stm32f7discovery/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32f7
 export CPU_MODEL = stm32f769ni
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/teensy31/Makefile.include
+++ b/boards/teensy31/Makefile.include
@@ -15,10 +15,6 @@ ifeq ($(TEENSY_LOADER),$(FLASHER))
   FLASHDEPS += $(TEENSY_LOADER)
 endif
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-*)))
-
 $(TEENSY_LOADER):
 	@echo "[INFO] teensy_loader binary not found - building it from source now"
 	CC= CFLAGS= make -C $(RIOTBASE)/dist/tools/teensy-loader-cli

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -2,9 +2,6 @@
 export CPU = msp430fxyz
 export CPU_MODEL = msp430f1611
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-MXV*)))
 # setup serial terminal
 export BAUD ?= 9600
 include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -2,8 +2,6 @@
 export CPU = atmega1281
 
 # configure the terminal program
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 BAUD        ?= 9600
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/yunjia-nrf51822/Makefile.include
+++ b/boards/yunjia-nrf51822/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxaa
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -2,9 +2,6 @@
 export CPU = msp430fxyz
 export CPU_MODEL = msp430f2617
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -1,6 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # Use DEBUG_ADAPTER_ID to specify the programmer serial number to use:
 # export DEBUG_ADAPTER_ID="ATML..."
 

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -31,7 +31,7 @@ ifeq (,$(PORT))
       endif
       ifeq (,$(PORT_DARWIN))
         # Look for any USB to serial adapter by default
-        PORT_DARWIN := $(firstword $(sort $(wildcard /dev/tty.usbmodem* /dev/tty.usbserial-*)))
+        PORT_DARWIN := $(firstword $(sort $(wildcard /dev/tty.usbmodem* /dev/tty.usbserial-* /dev/tty.SLAB_USBtoUART*)))
       endif
     endif
     PORT := $(PORT_DARWIN)

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -1,9 +1,41 @@
 # set default port depending on operating system
+# If the board does not provide a configuration, we assume that the serial port
+# is some kind of USB to serial adapter and try to search for a device with a
+# serial number matching the variable USB_UART_ID, falling back to
+# DEBUG_ADAPTER_ID if USB_UART_ID is not given.
+# If no serial number is given, then we pick the first USB tty we can find
 OS := $(shell uname)
-ifeq ($(OS),Linux)
-  PORT ?= $(PORT_LINUX)
-else ifeq ($(OS),Darwin)
-  PORT ?= $(PORT_DARWIN)
+ifeq (,$(PORT))
+  ifeq (,$(USB_UART_ID))
+    USB_UART_ID := $(DEBUG_ADAPTER_ID)
+  endif
+  ifeq ($(OS),Linux)
+    ifeq (,$(PORT_LINUX))
+      # Search for a USB to serial adapter with the same USB serial number as the
+      # debug adapter, fall back to searching for any USB TTY
+      ifneq (,$(USB_UART_ID))
+        # Match only exact serial number
+        SERIAL_PATTERN := '^$(USB_UART_ID)$$'
+      endif
+      # if SERIAL_PATTERN is not set, we will get the first port of the first USB
+      # to serial adapter
+      PORT_LINUX := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL_PATTERN)))
+    endif
+    PORT := $(PORT_LINUX)
+  else ifeq ($(OS),Darwin)
+    ifeq (,$(PORT_DARWIN))
+      ifneq (,$(USB_UART_ID))
+        # Try to match with a USB serial number
+        PORT_DARWIN := $(firstword $(sort $(wildcard /dev/tty.usbserial-$(USB_UART_ID)*)))
+        # There may be other patterns which should be tried as well.
+      endif
+      ifeq (,$(PORT_DARWIN))
+        # Look for any USB to serial adapter by default
+        PORT_DARWIN := $(firstword $(sort $(wildcard /dev/tty.usbmodem* /dev/tty.usbserial-*)))
+      endif
+    endif
+    PORT := $(PORT_DARWIN)
+  endif
 endif
 ifeq ($(PORT),)
   $(info Warning: no PORT set!)

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -7,7 +7,7 @@
 OS := $(shell uname)
 ifeq (,$(PORT))
   ifeq (,$(USB_UART_ID))
-    USB_UART_ID := $(DEBUG_ADAPTER_ID)
+    USB_UART_ID = $(DEBUG_ADAPTER_ID)
   endif
   ifeq ($(OS),Linux)
     ifeq (,$(PORT_LINUX))
@@ -15,7 +15,7 @@ ifeq (,$(PORT))
       # debug adapter, fall back to searching for any USB TTY
       ifneq (,$(USB_UART_ID))
         # Match only exact serial number
-        SERIAL_PATTERN := '^$(USB_UART_ID)$$'
+        SERIAL_PATTERN = '^$(USB_UART_ID)$$'
       endif
       # if SERIAL_PATTERN is not set, we will get the first port of the first USB
       # to serial adapter

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -37,9 +37,6 @@ ifeq (,$(PORT))
     PORT := $(PORT_DARWIN)
   endif
 endif
-ifeq ($(PORT),)
-  $(info Warning: no PORT set!)
-endif
 export BAUD ?= 115200
 
 RIOT_TERMINAL ?= pyterm

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -40,15 +40,13 @@ endif
 ifeq ($(PORT),)
   $(info Warning: no PORT set!)
 endif
-export PORT
-
 export BAUD ?= 115200
 
 RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
-    export TERMPROG  ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
-    export TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
+    TERMPROG  ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
+    TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
 else ifeq ($(RIOT_TERMINAL),picocom)
-    export TERMPROG  ?= picocom
-    export TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
+    TERMPROG  ?= picocom
+    TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
 endif

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -19,22 +19,22 @@ ifeq (,$(PORT))
       endif
       # if SERIAL_PATTERN is not set, we will get the first port of the first USB
       # to serial adapter
-      PORT_LINUX := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL_PATTERN)))
+      PORT_LINUX = $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL_PATTERN)))
     endif
-    PORT := $(PORT_LINUX)
+    PORT = $(PORT_LINUX)
   else ifeq ($(OS),Darwin)
     ifeq (,$(PORT_DARWIN))
       ifneq (,$(USB_UART_ID))
         # Try to match with a USB serial number
-        PORT_DARWIN := $(firstword $(sort $(wildcard /dev/tty.usbserial-$(USB_UART_ID)*)))
+        PORT_DARWIN = $(firstword $(sort $(wildcard /dev/tty.usbserial-$(USB_UART_ID)*)))
         # There may be other patterns which should be tried as well.
       endif
       ifeq (,$(PORT_DARWIN))
         # Look for any USB to serial adapter by default
-        PORT_DARWIN := $(firstword $(sort $(wildcard /dev/tty.usbmodem* /dev/tty.usbserial-* /dev/tty.SLAB_USBtoUART*)))
+        PORT_DARWIN = $(firstword $(sort $(wildcard /dev/tty.usbmodem* /dev/tty.usbserial-* /dev/tty.SLAB_USBtoUART*)))
       endif
     endif
-    PORT := $(PORT_DARWIN)
+    PORT = $(PORT_DARWIN)
   endif
 endif
 export BAUD ?= 115200

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -61,9 +61,9 @@ export GITCACHE              # path to git-cache executable
 export FLASHER               # The command to call on "make flash".
 export FFLAGS                # The parameters to supply to FLASHER.
 export FLASH_ADDR          # Define an offset to flash code into ROM memory.
-export TERMPROG              # The command to call on "make term".
-export TERMFLAGS             # Additional parameters to supply to TERMPROG.
-export PORT                  # The port to connect the TERMPROG to.
+# TERMPROG                   # The command to call on "make term".
+# TERMFLAGS                  # Additional parameters to supply to TERMPROG.
+# PORT                       # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The stripped result of the compilation.
 export DEBUGGER              # The command to call on "make debug", usually a script starting the GDB front-end.


### PR DESCRIPTION
~~Based on #7686~~
In the present master branch, each board provides its own way of guessing the name of any USB to UART adapter to use for `make term` by setting the PORT environment variable. This PR centralizes this in makefiles/tools/serial.inc.mk and adds USB serial number matching. If PORT is given, then nothing changes, the make term command will still use the port specified.
Otherwise, if USB_UART_ID is given as an environment variable, then that string is searched for as a USB serial number. If no USB_UART_ID is given, fall back to using DEBUG_ADAPTER_ID instead. Last resort is to pick the first found USB tty device.

All USB serial device scanning is handled by find-tty.sh on Linux, and a wildcard matching method on Darwin (Mac OS)