### PR TITLE
net/gcoap: Add detailed message init options

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Ken Bannister. All rights reserved.
+ * Copyright (c) 2015-2017 Ken Bannister. All rights reserved.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -201,19 +201,23 @@ int gcoap_cli_cmd(int argc, char **argv)
     }
 
     /* parse options */
-    int apos          = 2;               /* position of address argument */
-    unsigned msg_type = COAP_TYPE_NON;
+    int apos = 2;               /* position of address argument */
+    gcoap_send_opts_t opts;
     if (argc > apos && strcmp(argv[apos], "-c") == 0) {
-        msg_type = COAP_TYPE_CON;
+        opts.msg_type = COAP_TYPE_CON;
         apos++;
+    } else {
+        opts.msg_type = COAP_TYPE_NON;
     }
 
     if (argc == apos + 3 || argc == apos + 4) {
-        gcoap_req_init(&pdu, &buf[0], GCOAP_PDU_BUF_SIZE, code_pos+1, argv[apos+2]);
+        opts.msg_code = code_pos + 1;
+        opts.req_path = argv[apos + 2];
+
+        gcoap_req_init_opts(&pdu, &buf[0], GCOAP_PDU_BUF_SIZE, &opts);
         if (argc == apos + 4) {
             memcpy(pdu.payload, argv[apos+3], strlen(argv[apos+3]));
         }
-        coap_hdr_set_type(pdu.hdr, msg_type);
 
         if (argc == apos + 4) {
             len = gcoap_finish(&pdu, strlen(argv[apos+3]), COAP_FORMAT_TEXT);

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -92,9 +92,11 @@
  *
  * Allocate a buffer and a coap_pkt_t for the request.
  *
- * If there is a payload, follow the three steps below.
+ * If there is a payload, follow the steps below.
  *
  * -# Call gcoap_req_init() to initialize the request.
+ *    -# Optionally, mark the request confirmable by calling
+ *       coap_hdr_set_type() with COAP_TYPE_CON.
  * -# Write the request payload, starting at the updated _payload_ pointer
  *    in the coap_pkt_t.
  * -# Call gcoap_finish(), which updates the packet for the payload.

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Ken Bannister. All rights reserved.
+ * Copyright (c) 2015-2017 Ken Bannister. All rights reserved.
  *               2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -303,6 +303,11 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Value for send_limit in request memo when non-confirmable type
+ */
+#define GCOAP_SEND_LIMIT_NON    (-1)
+
+/**
  * @brief   Time in usec that the event loop waits for an incoming CoAP message
  */
 #ifndef GCOAP_RECV_TIMEOUT
@@ -425,12 +430,27 @@ typedef void (*gcoap_resp_handler_t)(unsigned req_state, coap_pkt_t* pdu,
                                      sock_udp_ep_t *remote);
 
 /**
+ * @brief  Extends request memo for resending a confirmable request.
+ */
+typedef struct {
+    sock_udp_ep_t remote_ep;            /**< Remote endpoint */
+    uint8_t *pdu_buf;                   /**< Buffer containing the PDU */
+    size_t pdu_len;                     /**< Length of pdu_buf */
+} gcoap_resend_t;
+
+/**
  * @brief   Memo to handle a response for a request
  */
 typedef struct {
     unsigned state;                     /**< State of this memo, a GCOAP_MEMO... */
-    uint8_t hdr_buf[GCOAP_HEADER_MAXLEN];
-                                        /**< Stores a copy of the request header */
+    int send_limit;                     /**< Remaining resends, 0 if none;
+                                             GCOAP_SEND_LIMIT_NON if non-confirmable */
+    union {
+        uint8_t hdr_buf[GCOAP_HEADER_MAXLEN];
+                                        /**< Copy of PDU header, if no resends */
+        gcoap_resend_t data;            /**< Endpoint and PDU buffer, for resend */
+    } msg;                              /**< Request message data; if confirmable,
+                                             supports resending message */
     gcoap_resp_handler_t resp_handler;  /**< Callback for the response */
     xtimer_t response_timer;            /**< Limits wait for response */
     msg_t timeout_msg;                  /**< For response timer */

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -447,6 +447,15 @@ typedef void (*gcoap_resp_handler_t)(unsigned req_state, coap_pkt_t* pdu,
                                      sock_udp_ep_t *remote);
 
 /**
+ * @brief  Options for initialization of a request to be sent.
+ */
+typedef struct {
+    unsigned msg_code;                  /**< Message code, a COAP_CODE_* */
+    unsigned msg_type;                  /**< Message type, a COAP_TYPE_* */
+    char *req_path;                     /**< URL path for a request */
+} gcoap_send_opts_t;
+
+/**
  * @brief  Extends request memo for resending a confirmable request.
  */
 typedef struct {
@@ -522,6 +531,21 @@ kernel_pid_t gcoap_init(void);
  * @param[in] listener  Listener containing the resources.
  */
 void gcoap_register_listener(gcoap_listener_t *listener);
+
+/**
+ * @brief   Initializes a CoAP request PDU on a buffer, including options for
+ *          the request.
+ *
+ * @param[out] pdu      Request metadata
+ * @param[out] buf      Buffer containing the PDU
+ * @param[in] len       Length of the buffer
+ * @param[in] opts      Request options; must include msg code and resource path
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gcoap_req_init_opts(coap_pkt_t *pdu, uint8_t *buf, size_t len,
+                        const gcoap_send_opts_t *opts);
 
 /**
  * @brief   Initializes a CoAP request PDU on a buffer.

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -411,6 +411,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Count of PDU buffers available for resending confirmable messages
+ */
+#ifndef GCOAP_RESEND_BUFS_MAX
+#define GCOAP_RESEND_BUFS_MAX      (1)
+#endif
+
+/**
  * @brief   A modular collection of resources for a server
  */
 typedef struct gcoap_listener {
@@ -482,6 +489,10 @@ typedef struct {
                                              observe memos */
     gcoap_observe_memo_t observe_memos[GCOAP_OBS_REGISTRATIONS_MAX];
                                         /**< Observed resource registrations */
+    uint8_t resend_bufs[GCOAP_RESEND_BUFS_MAX * GCOAP_PDU_BUF_SIZE];
+                                        /**< Buffers for PDU for request resends;
+                                             if first byte of an entry is zero,
+                                             the entry is available */
 } gcoap_state_t;
 
 /**

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -339,6 +339,14 @@ extern "C" {
 #define GCOAP_MSG_TYPE_INTR     (0x1502)
 
 /**
+ * @name    Options for _find_req_memo() -- search on token or message ID
+ * @{
+ */
+#define GCOAP_FIND_REQ_TOKEN    (1)
+#define GCOAP_FIND_REQ_MSGID    (2)
+/** @} */
+
+/**
  * @brief   Maximum number of Observe clients; use 2 if not defined
  */
 #ifndef GCOAP_OBS_CLIENTS_MAX

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -272,6 +272,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Message type used by default when creating a request
+ */
+#ifndef GCOAP_REQ_DEFAULT_MSG_TYPE
+#define GCOAP_REQ_DEFAULT_MSG_TYPE (COAP_TYPE_NON)
+#endif
+
+/**
  * @brief   Maximum length in bytes for a token
  */
 #define GCOAP_TOKENLEN_MAX      (8)
@@ -369,6 +376,13 @@ extern "C" {
 #define GCOAP_OBS_MEMO_IDLE     (1) /**< Registration OK; no current activity */
 #define GCOAP_OBS_MEMO_PENDING  (2) /**< Resource changed; notification pending */
 /** @} */
+
+/**
+ * @brief   Message type used by default when creating a notification
+ */
+#ifndef GCOAP_OBS_DEFAULT_MSG_TYPE
+#define GCOAP_OBS_DEFAULT_MSG_TYPE (COAP_TYPE_NON)
+#endif
 
 /**
  * @brief   Width in bytes of the Observe option value for a notification

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -158,8 +158,8 @@
  * GCOAP_OBS_VALUE_WIDTH.
  *
  * To cancel a notification, the server expects to receive a GET request with
- * the Observe option value set to 1. The server does not support cancellation
- * via a reset (RST) response to a non-confirmable notification.
+ * the Observe option value set to 1. A confirmable notification also may be
+ * cancelled by a reset (RST) response from the client.
  *
  * ## Implementation Notes ##
  *

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -447,12 +447,14 @@ typedef void (*gcoap_resp_handler_t)(unsigned req_state, coap_pkt_t* pdu,
                                      sock_udp_ep_t *remote);
 
 /**
- * @brief  Options for initialization of a request to be sent.
+ * @brief  Options for initialization of a request or an observe notification
+ *         to be sent.
  */
 typedef struct {
     unsigned msg_code;                  /**< Message code, a COAP_CODE_* */
     unsigned msg_type;                  /**< Message type, a COAP_TYPE_* */
     char *req_path;                     /**< URL path for a request */
+    const coap_resource_t *obs_resource; /**< Observation resource */
 } gcoap_send_opts_t;
 
 /**
@@ -663,6 +665,25 @@ static inline ssize_t gcoap_response(coap_pkt_t *pdu, uint8_t *buf,
                 ? gcoap_finish(pdu, 0, COAP_FORMAT_NONE)
                 : -1;
 }
+
+/**
+ * @brief   Initializes a CoAP Observe notification packet on a buffer, for the
+ *          observer registered for a resource
+ *
+ * Uses options to specify details for the request. First verifies that an
+ * observer has been registered for the resource.
+ *
+ * @param[out] pdu      Notification metadata
+ * @param[out] buf      Buffer containing the PDU
+ * @param[in] len       Length of the buffer
+ * @param[in] opts      Notification options; must include resource
+ *
+ * @return  GCOAP_OBS_INIT_OK     on success
+ * @return  GCOAP_OBS_INIT_ERR    on error
+ * @return  GCOAP_OBS_INIT_UNUSED if no observer for resource
+ */
+int gcoap_obs_init_opts(coap_pkt_t *pdu, uint8_t *buf, size_t len,
+                        const gcoap_send_opts_t *opts);
 
 /**
  * @brief   Initializes a CoAP Observe notification packet on a buffer, for the

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Ken Bannister. All rights reserved.
+ * Copyright (c) 2015-2017 Ken Bannister. All rights reserved.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -347,7 +347,7 @@ static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu,
 
         /* setup memo PDU from memo header */
         memo                 = &_coap_state.open_reqs[i];
-        coap_hdr_t *memo_hdr = (coap_hdr_t *) &memo->hdr_buf[0];
+        coap_hdr_t *memo_hdr = (coap_hdr_t *) &memo->msg.hdr_buf[0];
         memo_pdu.hdr         = memo_hdr;
         if (coap_get_token_len(&memo_pdu)) {
             memo_pdu.token = &memo_hdr->data[0];
@@ -379,7 +379,7 @@ static void _expire_request(gcoap_request_memo_t *memo)
         memo->state = GCOAP_MEMO_TIMEOUT;
         /* Pass response to handler */
         if (memo->resp_handler) {
-            req.hdr = (coap_hdr_t *)&memo->hdr_buf[0];   /* for reference */
+            req.hdr = (coap_hdr_t *)&memo->msg.hdr_buf[0];   /* for reference */
             memo->resp_handler(memo->state, &req, NULL);
         }
         memo->state = GCOAP_MEMO_UNUSED;
@@ -692,7 +692,8 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
     mutex_unlock(&_coap_state.lock);
 
     if (memo) {
-        memcpy(&memo->hdr_buf[0], buf, GCOAP_HEADER_MAXLEN);
+        memo->send_limit = GCOAP_SEND_LIMIT_NON;
+        memcpy(&memo->msg.hdr_buf[0], buf, GCOAP_HEADER_MAXLEN);
         memo->resp_handler = resp_handler;
 
         size_t res = sock_udp_send(&_sock, buf, len, remote);

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -35,8 +35,7 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                                          sock_udp_ep_t *remote);
 static ssize_t _finish_pdu(coap_pkt_t *pdu, uint8_t *buf, size_t len);
 static void _expire_request(gcoap_request_memo_t *memo);
-static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *pdu,
-                                                            uint8_t *buf, size_t len);
+static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *pdu);
 static void _find_resource(coap_pkt_t *pdu, coap_resource_t **resource_ptr,
                                             gcoap_listener_t **listener_ptr);
 static int _find_observer(sock_udp_ep_t **observer, sock_udp_ep_t *remote);
@@ -156,7 +155,7 @@ static void _listen(sock_udp_t *sock)
 
     /* incoming response */
     else {
-        _find_req_memo(&memo, &pdu, buf, sizeof(buf));
+        _find_req_memo(&memo, &pdu);
         if (memo) {
             xtimer_remove(&memo->response_timer);
             memo->state = GCOAP_MEMO_RESP;
@@ -331,39 +330,41 @@ static ssize_t _finish_pdu(coap_pkt_t *pdu, uint8_t *buf, size_t len)
  * Finds the memo for an outstanding request within the _coap_state.open_reqs
  * array. Matches on token.
  *
- * src_pdu Source for the match token
+ * memo_ptr[out] -- Registered request memo, or NULL if not found
+ * src_pdu[in] -- PDU for token to match
  */
-static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu,
-                                                            uint8_t *buf, size_t len)
+static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu)
 {
-    gcoap_request_memo_t *memo;
-    coap_pkt_t memo_pdu = { .token = NULL };
-    (void) buf;
-    (void) len;
+    *memo_ptr = NULL;
+    /* no need to initialize struct; we only care about buffer contents below */
+    coap_pkt_t memo_pdu_data;
+    coap_pkt_t *memo_pdu = &memo_pdu_data;
+    unsigned cmplen      = coap_get_token_len(src_pdu);
 
     for (int i = 0; i < GCOAP_REQ_WAITING_MAX; i++) {
         if (_coap_state.open_reqs[i].state == GCOAP_MEMO_UNUSED)
             continue;
 
-        /* setup memo PDU from memo header */
-        memo                 = &_coap_state.open_reqs[i];
-        coap_hdr_t *memo_hdr = (coap_hdr_t *) &memo->msg.hdr_buf[0];
-        memo_pdu.hdr         = memo_hdr;
-        if (coap_get_token_len(&memo_pdu)) {
-            memo_pdu.token = &memo_hdr->data[0];
+        gcoap_request_memo_t *memo = &_coap_state.open_reqs[i];
+        if (memo->send_limit == GCOAP_SEND_LIMIT_NON) {
+            memo_pdu->hdr = (coap_hdr_t *) &memo->msg.hdr_buf[0];
         }
-        /* match on token */
-        if (coap_get_token_len(src_pdu) == coap_get_token_len(&memo_pdu)) {
-            uint8_t *src_byte  = src_pdu->token;
-            uint8_t *memo_byte = memo_pdu.token;
-            size_t j;
-            for (j = 0; j < coap_get_token_len(src_pdu); j++) {
-                if (*src_byte++ != *memo_byte++) {
-                    break;      /* token mismatch */
+        else {
+            memo_pdu->hdr = (coap_hdr_t *) memo->msg.data.pdu_buf;
+        }
+
+        if (coap_get_token_len(memo_pdu) == cmplen) {
+            if (cmplen) {
+                memo_pdu->token = &memo_pdu->hdr->data[0];
+                if (memcmp(src_pdu->token, memo_pdu->token, cmplen) == 0) {
+                    *memo_ptr = memo;
+                    break;
                 }
             }
-            if (j == coap_get_token_len(src_pdu)) {
+            /* if no token, just match the first memo */
+            else {
                 *memo_ptr = memo;
+                break;
             }
         }
     }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -160,6 +160,10 @@ static void _listen(sock_udp_t *sock)
             xtimer_remove(&memo->response_timer);
             memo->state = GCOAP_MEMO_RESP;
             memo->resp_handler(memo->state, &pdu, &remote);
+
+            if (memo->send_limit >= 0) {        /* if confirmable */
+                *memo->msg.data.pdu_buf = 0;    /* clear resend PDU buffer */
+            }
             memo->state = GCOAP_MEMO_UNUSED;
         }
     }
@@ -587,6 +591,7 @@ kernel_pid_t gcoap_init(void)
     memset(&_coap_state.open_reqs[0], 0, sizeof(_coap_state.open_reqs));
     memset(&_coap_state.observers[0], 0, sizeof(_coap_state.observers));
     memset(&_coap_state.observe_memos[0], 0, sizeof(_coap_state.observe_memos));
+    memset(&_coap_state.resend_bufs[0], 0, sizeof(_coap_state.resend_bufs));
     /* randomize initial value */
     atomic_init(&_coap_state.next_message_id, (unsigned)random_uint32());
 
@@ -690,41 +695,81 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
             break;
         }
     }
-    mutex_unlock(&_coap_state.lock);
-
-    if (memo) {
-        memo->send_limit = GCOAP_SEND_LIMIT_NON;
-        memcpy(&memo->msg.hdr_buf[0], buf, GCOAP_HEADER_MAXLEN);
-        memo->resp_handler = resp_handler;
-
-        size_t res = sock_udp_send(&_sock, buf, len, remote);
-
-        if (res && (GCOAP_NON_TIMEOUT > 0)) {
-            /* interrupt sock listening (to set a listen timeout) */
-            msg_t mbox_msg;
-            mbox_msg.type          = GCOAP_MSG_TYPE_INTR;
-            mbox_msg.content.value = 0;
-            if (mbox_try_put(&_sock.reg.mbox, &mbox_msg)) {
-                /* start response wait timer */
-                memo->timeout_msg.type        = GCOAP_MSG_TYPE_TIMEOUT;
-                memo->timeout_msg.content.ptr = (char *)memo;
-                xtimer_set_msg(&memo->response_timer, GCOAP_NON_TIMEOUT,
-                                                      &memo->timeout_msg, _pid);
-            }
-            else {
-                memo->state = GCOAP_MEMO_UNUSED;
-                DEBUG("gcoap: can't wake up mbox; no timeout for msg\n");
-            }
-        }
-        else if (!res) {
-            memo->state = GCOAP_MEMO_UNUSED;
-            DEBUG("gcoap: sock send failed: %d\n", res);
-        }
-        return res;
-    } else {
+    if (!memo) {
+        mutex_unlock(&_coap_state.lock);
         DEBUG("gcoap: dropping request; no space for response tracking\n");
         return 0;
     }
+
+    unsigned msg_type  = (*buf & 0x30) >> 4;
+    uint32_t timeout   = 0;
+    memo->resp_handler = resp_handler;
+
+    switch (msg_type) {
+    case COAP_TYPE_CON:
+        /* copy buf to resend_bufs record */
+        memo->msg.data.pdu_buf = NULL;
+        for (int i = 0; i < GCOAP_RESEND_BUFS_MAX; i++) {
+            if (!_coap_state.resend_bufs[i*GCOAP_PDU_BUF_SIZE]) {
+                memo->msg.data.pdu_buf = &_coap_state.resend_bufs[i*GCOAP_PDU_BUF_SIZE];
+                memcpy(memo->msg.data.pdu_buf, buf, GCOAP_PDU_BUF_SIZE);
+                memo->msg.data.pdu_len = GCOAP_PDU_BUF_SIZE;
+            }
+        }
+        if (memo->msg.data.pdu_buf) {
+            memcpy(&memo->msg.data.remote_ep, remote, sizeof(sock_udp_ep_t));
+            memo->send_limit = COAP_MAX_RETRANSMIT;
+            /* TODO: incorporate ACK_RANDOM_FACTOR in timeout calculation */
+            timeout = COAP_ACK_TIMEOUT * US_PER_SEC;
+        }
+        else {
+            memo->state = GCOAP_MEMO_UNUSED;
+            DEBUG("gcoap: no space for PDU in resend bufs\n");
+        }
+        break;
+
+    case COAP_TYPE_NON:
+        memo->send_limit = GCOAP_SEND_LIMIT_NON;
+        memcpy(&memo->msg.hdr_buf[0], buf, GCOAP_HEADER_MAXLEN);
+        timeout = GCOAP_NON_TIMEOUT;
+        break;
+    default:
+        memo->state = GCOAP_MEMO_UNUSED;
+        DEBUG("gcoap: illegal msg type %u\n", msg_type);
+        break;
+    }
+    mutex_unlock(&_coap_state.lock);
+    if (memo->state == GCOAP_MEMO_UNUSED) {
+        return 0;
+    }
+
+    /* Memos complete; send msg and start timer */
+    size_t res = sock_udp_send(&_sock, buf, len, remote);
+
+    if (res && timeout > 0) {     /* timeout may be zero for non-confirmable */
+        /* interrupt sock listening (to set a listen timeout) */
+        msg_t mbox_msg;
+        mbox_msg.type          = GCOAP_MSG_TYPE_INTR;
+        mbox_msg.content.value = 0;
+        if (mbox_try_put(&_sock.reg.mbox, &mbox_msg)) {
+            /* start response wait timer */
+            memo->timeout_msg.type        = GCOAP_MSG_TYPE_TIMEOUT;
+            memo->timeout_msg.content.ptr = (char *)memo;
+            xtimer_set_msg(&memo->response_timer, timeout, &memo->timeout_msg, _pid);
+        }
+        else {
+            res = 0;
+            DEBUG("gcoap: can't wake up mbox; no timeout for msg\n");
+        }
+    }
+    if (!res) {
+        if (msg_type == COAP_TYPE_CON) {
+            *memo->msg.data.pdu_buf = 0;    /* clear resend buffer */
+        }
+        memo->state = GCOAP_MEMO_UNUSED;
+        DEBUG("gcoap: sock send failed: %d\n", res);
+    }
+    return res;
 }
 
 int gcoap_resp_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code)

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -137,9 +137,13 @@ static void _listen(sock_udp_t *sock)
     if (pdu.hdr->code == COAP_CODE_EMPTY) {
         DEBUG("gcoap: empty messages not handled yet\n");
         return;
+    }
+
+    /* validate class and type for incoming */
+    switch (coap_get_code_class(&pdu)) {
 
     /* incoming request */
-    } else if (coap_get_code_class(&pdu) == COAP_CLASS_REQ) {
+    case COAP_CLASS_REQ:
         if (coap_get_type(&pdu) == COAP_TYPE_NON
                 || coap_get_type(&pdu) == COAP_TYPE_CON) {
             size_t pdu_len = _handle_req(&pdu, buf, sizeof(buf), &remote);
@@ -149,23 +153,41 @@ static void _listen(sock_udp_t *sock)
         }
         else {
             DEBUG("gcoap: illegal request type: %u\n", coap_get_type(&pdu));
-            return;
         }
-    }
+        break;
 
     /* incoming response */
-    else {
+    case COAP_CLASS_SUCCESS:
+    case COAP_CLASS_CLIENT_FAILURE:
+    case COAP_CLASS_SERVER_FAILURE:
         _find_req_memo(&memo, &pdu);
         if (memo) {
-            xtimer_remove(&memo->response_timer);
-            memo->state = GCOAP_MEMO_RESP;
-            memo->resp_handler(memo->state, &pdu, &remote);
+            switch (coap_get_type(&pdu)) {
+            case COAP_TYPE_NON:
+            case COAP_TYPE_ACK:
+                xtimer_remove(&memo->response_timer);
+                memo->state = GCOAP_MEMO_RESP;
+                memo->resp_handler(memo->state, &pdu, &remote);
 
-            if (memo->send_limit >= 0) {        /* if confirmable */
-                *memo->msg.data.pdu_buf = 0;    /* clear resend PDU buffer */
+                if (memo->send_limit >= 0) {        /* if confirmable */
+                    *memo->msg.data.pdu_buf = 0;    /* clear resend PDU buffer */
+                }
+                memo->state = GCOAP_MEMO_UNUSED;
+                break;
+            case COAP_TYPE_CON:
+                DEBUG("gcoap: separate CON response not handled yet\n");
+                break;
+            default:
+                DEBUG("gcoap: illegal response type: %u\n", coap_get_type(&pdu));
+                break;
             }
-            memo->state = GCOAP_MEMO_UNUSED;
         }
+        else {
+            DEBUG("gcoap: msg not found for ID: %u\n", coap_get_id(&pdu));
+        }
+        break;
+    default:
+        DEBUG("gcoap: illegal code class: %u\n", coap_get_code_class(&pdu));
     }
 }
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -785,7 +785,7 @@ int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code,
     gcoap_send_opts_t opts = {
         .msg_code = code,
         .req_path = path,
-        .msg_type = COAP_TYPE_NON
+        .msg_type = GCOAP_REQ_DEFAULT_MSG_TYPE
     };
     return gcoap_req_init_opts(pdu, buf, len, &opts);
 }
@@ -971,7 +971,7 @@ int gcoap_obs_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 {
     gcoap_send_opts_t opts = {
         .obs_resource = resource,
-        .msg_type     = COAP_TYPE_NON
+        .msg_type     = GCOAP_OBS_DEFAULT_MSG_TYPE
     };
     return gcoap_obs_init_opts(pdu, buf, len, &opts);
 }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -41,7 +41,7 @@ static void _find_resource(coap_pkt_t *pdu, coap_resource_t **resource_ptr,
                                             gcoap_listener_t **listener_ptr);
 static int _find_observer(sock_udp_ep_t **observer, sock_udp_ep_t *remote);
 static int _find_obs_memo(gcoap_observe_memo_t **memo, sock_udp_ep_t *remote,
-                                                       coap_pkt_t *pdu);
+                          uint8_t *token, int token_len);
 static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
                                    const coap_resource_t *resource);
 
@@ -246,7 +246,8 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     }
 
     if (coap_get_observe(pdu) == COAP_OBS_REGISTER) {
-        int empty_slot = _find_obs_memo(&memo, remote, pdu);
+        int empty_slot = _find_obs_memo(&memo, remote, pdu->token,
+                                        coap_get_token_len(pdu));
         /* record observe memo */
         if (memo == NULL) {
             if (empty_slot >= 0 && resource_memo == NULL) {
@@ -284,13 +285,13 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
         }
 
     } else if (coap_get_observe(pdu) == COAP_OBS_DEREGISTER) {
-        _find_obs_memo(&memo, remote, pdu);
+        _find_obs_memo(&memo, remote, pdu->token, coap_get_token_len(pdu));
         /* clear memo, and clear observer if no other memos */
         if (memo != NULL) {
             DEBUG("gcoap: Deregistering observer for: %s\n", memo->resource->path);
             memo->observer = NULL;
             memo           = NULL;
-            _find_obs_memo(&memo, remote, NULL);
+            _find_obs_memo(&memo, remote, NULL, -1);
             if (memo == NULL) {
                 _find_observer(&observer, remote);
                 if (observer != NULL) {
@@ -580,16 +581,18 @@ static int _find_observer(sock_udp_ep_t **observer, sock_udp_ep_t *remote)
  *
  * memo[out] -- Registered observe memo, or NULL if not found
  * remote[in] -- Endpoint for address to match
- * pdu[in] -- PDU for token to match, or NULL to match only on remote address
+ * token[in] -- Token to match; NULL if zero-length
+ * token_len[in] -- Length of token, or -1 to match only on remote address
  *
  * return Index of empty slot, suitable for registering new memo; or -1 if no
  *        empty slots. Undefined if memo found.
  */
 static int _find_obs_memo(gcoap_observe_memo_t **memo, sock_udp_ep_t *remote,
-                                                       coap_pkt_t *pdu)
+                          uint8_t *token, int token_len)
 {
     int empty_slot = -1;
     *memo          = NULL;
+    assert(token_len >= -1);
 
     sock_udp_ep_t *remote_observer = NULL;
     _find_observer(&remote_observer, remote);
@@ -601,16 +604,15 @@ static int _find_obs_memo(gcoap_observe_memo_t **memo, sock_udp_ep_t *remote,
         }
 
         if (_coap_state.observe_memos[i].observer == remote_observer) {
-            if (pdu == NULL) {
+            if (token_len == -1) {
                 *memo = &_coap_state.observe_memos[i];
                 break;
             }
 
-            if (_coap_state.observe_memos[i].token_len == coap_get_token_len(pdu)) {
-                unsigned cmplen = _coap_state.observe_memos[i].token_len;
-                if (cmplen &&
-                        memcmp(&_coap_state.observe_memos[i].token[0], &pdu->token[0],
-                                                                       cmplen) == 0) {
+            if ((int)_coap_state.observe_memos[i].token_len == token_len) {
+                if (!token_len ||
+                        memcmp(&_coap_state.observe_memos[i].token[0], token,
+                               token_len) == 0) {
                     *memo = &_coap_state.observe_memos[i];
                     break;
                 }


### PR DESCRIPTION
This PR implements the fifth step in the confirmable messaging plan in #7192, and depends on #7548. Presently, the gcoap_xxx_init() functions accept parameters that can change from message to message, for example the message code (GET, PUT, etc). On the other hand, some parameters, like message type, expect a default value and are not included in the init functions. 

For control over _all_ useful parameters, this PR adds gcoap_req_init_opts() for requests and gcoap_obs_init_opts() for observe notifications. The init opts functions accept a gcoap_send_opts_t structure, which includes all of the available attributes. The documentation for each function describes which attributes are read. This infrastructure will be used in the remaining PRs for confirmable messaging -- synchronous messaging and separate ACK response PRs.

My approach with this PR has been to keep 'simple things easy' while allowing 'difficult things to be possible'. The existing (easy) ...init() functions are unchanged and still useful for many use cases, but when you need full control (difficult), all of the parameters are available to be set in ...init_opts(). The ...init() functions were refactored to use the ...init_opts() functions.