### PR TITLE
gnrc_ipv6_nib: return registration state on upstream registration

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
@@ -68,7 +68,7 @@ uint8_t _reg_addr_upstream(kernel_pid_t iface, const ipv6_hdr_t *ipv6,
 #endif
             if (byteorder_ntohs(aro->ltime) != 0) {
                 _handle_sl2ao(iface, ipv6, icmpv6, sl2ao);
-                _update_nce_ar_state(aro, nce);
+                return _update_nce_ar_state(aro, nce);
             }
             else if (nce != NULL) {
                 _nib_nc_remove(nce);


### PR DESCRIPTION
The function `_update_nce_ar_state()` was introduced during the review
of \#7424, but it's return value never used, causing faulty behavior.