### PR TITLE
xtimer: Set XTIMER_SHIFT to 0 if underlying timer is 32768 Hz

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -579,7 +579,11 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 #endif
 
 #ifndef XTIMER_SHIFT
-#if (XTIMER_HZ == XTIMER_HZ_BASE)
+#if (XTIMER_HZ == 32768ul)
+/* No shift necessary, the conversion is not a power of two and is handled by
+ * functions in tick_conversion.h */
+#define XTIMER_SHIFT (0)
+#elif (XTIMER_HZ == XTIMER_HZ_BASE)
 /**
  * @brief   xtimer prescaler value
  *


### PR DESCRIPTION
The error message "XTIMER_SHIFT cannot be derived for given XTIMER_HZ, verify settings!" is triggered if XTIMER_HZ is not a power of two multiple of 1 MHz. If XTIMER_SHIFT is defined to 0, then the other error message "XTIMER_SHIFT is set relative to XTIMER_HZ, no manual define required!" is triggered instead. This change was introduced by #6702 