### PR TITLE
cpu/stm32_common: use pseudomodule for UART hardware flow control

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -263,7 +263,7 @@ typedef struct {
     uint8_t dma_stream;     /**< DMA stream used for TX */
     uint8_t dma_chan;       /**< DMA channel used for TX */
 #endif
-#ifdef UART_USE_HW_FC
+#ifdef MODULE_STM32_PERIPH_UART_HW_FC
     gpio_t cts_pin;         /**< CTS pin - set to GPIO_UNDEF when not using HW flow control */
     gpio_t rts_pin;         /**< RTS pin */
 #ifndef CPU_FAM_STM32F1

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -73,7 +73,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         gpio_init_af(uart_config[uart].rx_pin, uart_config[uart].rx_af);
 #endif
     }
-#ifdef UART_USE_HW_FC
+#ifdef MODULE_STM32_PERIPH_UART_HW_FC
     if (uart_config[uart].cts_pin != GPIO_UNDEF) {
         gpio_init(uart_config[uart].cts_pin, GPIO_IN);
         gpio_init(uart_config[uart].rts_pin, GPIO_OUT);
@@ -109,7 +109,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         dev(uart)->CR1 = (USART_CR1_UE | USART_CR1_TE);
     }
 
-#ifdef UART_USE_HW_FC
+#ifdef MODULE_STM32_PERIPH_UART_HW_FC
     if (uart_config[uart].cts_pin != GPIO_UNDEF) {
         /* configure hardware flow control */
         dev(uart)->CR3 = (USART_CR3_RTSE | USART_CR3_CTSE);

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -87,3 +87,6 @@ PSEUDOMODULES += sx1276
 
 # add all pseudo random number generator variants as pseudomodules
 PSEUDOMODULES += prng_%
+
+# STM32 periph pseudomodules
+PSEUDOMODULES += stm32_periph_%


### PR DESCRIPTION
This makes it more convenient to use from the app point of view.