### PR TITLE
cbor: fix integer overflow in decode_bytes

### DIFF
--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -400,7 +400,7 @@ static size_t decode_bytes(const cbor_stream_t *s, size_t offset, char *out, siz
         return 0;
     }
 
-    if (length < bytes_length + 1) {
+    if (bytes_length == SIZE_MAX || length < bytes_length + 1) {
         return 0;
     }
 


### PR DESCRIPTION
An example input triggering this issue is:

```
$ hexdump -C int-overflow.dat
00000000  5b ff ff ff ff ff ff ff  ff                       |[........|
00000009
$ base64 < int-overflow.dat
W///////////
```

The input above triggers a denial of service.