### PR TITLE
cbor: fix definite-length arrays and maps

### DIFF
--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -965,7 +965,10 @@ static size_t cbor_stream_decode_at(cbor_stream_t *stream, size_t offset, int in
                 ++i;
             }
 
-            read_bytes += cbor_at_break(stream, offset);
+            if (is_indefinite) {
+                read_bytes += cbor_at_break(stream, offset);
+            }
+
             return read_bytes;
         }
 
@@ -999,7 +1002,10 @@ static size_t cbor_stream_decode_at(cbor_stream_t *stream, size_t offset, int in
                 ++i;
             }
 
-            read_bytes += cbor_at_break(stream, offset);
+            if (is_indefinite) {
+                read_bytes += cbor_at_break(stream, offset);
+            }
+
             return read_bytes;
         }
 #ifdef MODULE_CBOR_SEMANTIC_TAGGING


### PR DESCRIPTION
Fixes decoding of definite-length arrays and maps. This can be reproduced with the base64 encoded input `gp+A/wo=`. The output of `cbor_stream_decode` for this input without the patch is:

```
Data:
(array, length: 2)
  (array, length: [indefinite])
    (array, length: 0)
  (uint64_t, 0)
```

The output as created by [cbor.me](http://cbor.me) is:

```
82       # array(2)
   9F    # array(*)
      80 # array(0)
      FF # primitive(*)
   0A    # unsigned(10)
```

With this fix the output of the RIOT cbor parser is as follows:

```
Data:
(array, length: 2)
  (array, length: [indefinite])
    (array, length: 0)
  (uint64_t, 10)

```

This patch was originally written by @pyropeter but he believes fixing this broken cbor parser is not worth his time and therefore didn't want to submit a PR.