### PR TITLE
cpu, sam0 common: adapt periph-uart to use read-only bit-fields

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -72,7 +72,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
     /* reset the UART device */
     dev(uart)->CTRLA.reg = SERCOM_USART_CTRLA_SWRST;
-    while (dev(uart)->SYNCBUSY.reg & SERCOM_USART_SYNCBUSY_SWRST) {}
+    while (dev(uart)->SYNCBUSY.bit.SWRST) {}
 
     /* configure clock generator */
     sercom_set_gen(dev(uart), uart_config[uart].gclk_src);
@@ -80,10 +80,10 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     /* set asynchronous mode w/o parity, LSB first, TX and RX pad as specified
      * by the board in the periph_conf.h, x16 sampling and use internal clock */
     dev(uart)->CTRLA.reg = (SERCOM_USART_CTRLA_DORD |
-                      SERCOM_USART_CTRLA_SAMPR(0x1) |
-                      SERCOM_USART_CTRLA_TXPO(uart_config[uart].tx_pad) |
-                      SERCOM_USART_CTRLA_RXPO(uart_config[uart].rx_pad) |
-                      SERCOM_USART_CTRLA_MODE(0x1));
+                            SERCOM_USART_CTRLA_SAMPR(0x1) |
+                            SERCOM_USART_CTRLA_TXPO(uart_config[uart].tx_pad) |
+                            SERCOM_USART_CTRLA_RXPO(uart_config[uart].rx_pad) |
+                            SERCOM_USART_CTRLA_MODE(0x1));
     /* Set run in standby mode if enabled */
     if (uart_config[uart].flags & UART_FLAG_RUN_STANDBY) {
         dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_RUNSTDBY;
@@ -95,7 +95,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     dev(uart)->BAUD.FRAC.BAUD = (baud / 10);
 
     /* enable transmitter, and configure 8N1 mode */
-    dev(uart)->CTRLB.reg = (SERCOM_USART_CTRLB_TXEN);
+    dev(uart)->CTRLB.reg = SERCOM_USART_CTRLB_TXEN;
     /* enable receiver and RX interrupt if configured */
     if (rx_cb) {
         uart_ctx[uart].rx_cb = rx_cb;
@@ -108,7 +108,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
             dev(uart)->CTRLB.reg |= SERCOM_USART_CTRLB_SFDE;
         }
     }
-    while (dev(uart)->SYNCBUSY.reg & SERCOM_USART_SYNCBUSY_CTRLB) {}
+    while (dev(uart)->SYNCBUSY.bit.CTRLB) {}
 
     /* and finally enable the device */
     dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_ENABLE;
@@ -119,10 +119,10 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
     for (size_t i = 0; i < len; i++) {
-        while (!(dev(uart)->INTFLAG.reg & SERCOM_USART_INTFLAG_DRE)) {}
+        while (!dev(uart)->INTFLAG.bit.DRE) {}
         dev(uart)->DATA.reg = data[i];
     }
-    while (!(dev(uart)->INTFLAG.reg & SERCOM_USART_INTFLAG_TXC)) {}
+    while (!dev(uart)->INTFLAG.bit.TXC) {}
 }
 
 void uart_poweron(uart_t uart)
@@ -139,12 +139,12 @@ void uart_poweroff(uart_t uart)
 
 static inline void irq_handler(unsigned uartnum)
 {
-    if (dev(uartnum)->INTFLAG.reg & SERCOM_USART_INTFLAG_RXC) {
+    if (dev(uartnum)->INTFLAG.bit.RXC) {
         /* interrupt flag is cleared by reading the data register */
         uart_ctx[uartnum].rx_cb(uart_ctx[uartnum].arg,
                                 (uint8_t)(dev(uartnum)->DATA.reg));
     }
-    else if (dev(uartnum)->INTFLAG.reg & SERCOM_USART_INTFLAG_ERROR) {
+    else if (dev(uartnum)->INTFLAG.bit.ERROR) {
         /* clear error flag */
         dev(uartnum)->INTFLAG.reg = SERCOM_USART_INTFLAG_ERROR;
     }


### PR DESCRIPTION
factored out of #7638, see discussion there.
~~Note: based on and includes #7638.~~