### PR TITLE
dist/tools/edbg: clear INCLUDES and LINK env vars before building

### DIFF
--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -4,16 +4,13 @@ PKG_VERSION=76f85abdea212ba23760723cce15e00ca4ae4b76
 PKG_LICENSE=BSD-3-Clause
 PKG_BUILDDIR=$(CURDIR)/bin
 
-# CC and CXX variables are set by RIOT's build process to cross compiling for
-# a specific target platfrom. Thus, we have to unset them to build edgb using
-# the system C/C++ compilers - i.e, to avoid conflicts on macOS systems
-CC=
-CXX=
-
 .PHONY: all
 
 all: git-download
-	"$(MAKE)" -C $(PKG_BUILDDIR)
+# Start edbg build in a clean environment, so variables set by RIOT's build process
+# for cross compiling a specific target platfrom are reset and edbg can
+# be built cleanly for the native platform.
+	env -i PATH=$(PATH) TERM=$(TERM) "$(MAKE)" -C $(PKG_BUILDDIR)
 	mv $(PKG_BUILDDIR)/edbg .
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
This fixes compilation on macOS. Without this it autoconf
might pick up INCLUDES and LINKER variables causing compilation
and linking errors.