### PR TITLE
cpu: stm32l1: add flashpage writing support

### DIFF
--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -27,6 +27,8 @@
 
 #include "periph/flashpage.h"
 
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
+    defined(CPU_FAM_STM32F3)
 void flashpage_write(int page, void *data)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
@@ -88,3 +90,82 @@ void flashpage_write(int page, void *data)
         while (RCC->CR & RCC_CR_HSIRDY) {}
     }
 }
+#elif defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
+/* Flash program erase key1 */
+#define PEKEY1                    (0x89ABCDEF)
+
+/* Flash program erase key: used with FLASH_PEKEY2 to unlock the write
+ * access to the FLASH_PECR register and data EEPROM
+ */
+#define PEKEY2                    (0x02030405)
+
+/* Flash program memory key1 */
+#define PRGKEY1                   (0x8C9DAEBF)
+
+/* Flash program memory key2: used with FLASH_PRGKEY2 to unlock
+ * the program memory
+ */
+#define PRGKEY2                   (0x13141516)
+
+void flashpage_write(int page, void *data)
+{
+    assert(page < (int)FLASHPAGE_NUMOF);
+
+    /* Using 32bit addresses since we are attempting fast-word erasing/writing*/
+    uint32_t *page_addr = flashpage_addr(page);
+    uint32_t *data_addr = (uint32_t*)data;
+
+    DEBUG("[flashpage] unlocking the flash module\n");
+    /* Unlocking the Data memory and FLASH_PECR register access*/
+    if(FLASH->PECR & FLASH_PECR_PRGLOCK)
+    {
+        /* Unlock for erase */
+        FLASH->PEKEYR = PEKEY1;
+        FLASH->PEKEYR = PEKEY2;
+
+        /* Unlock flash registers */
+        FLASH->PRGKEYR = PRGKEY1;
+        FLASH->PRGKEYR = PRGKEY2;
+    }
+
+    /* ERASE sequence */
+    /* make sure no flash operation is ongoing */
+    DEBUG("[flashpage] erase: waiting for any operation to finish\n");
+    while (FLASH->SR & FLASH_SR_BSY) {}
+
+    DEBUG("[flashpage] erase: setting the erase and program bits\n");
+    /* Set the ERASE bit */
+    FLASH->PECR |= FLASH_PECR_ERASE;
+    /* Set PROG bit */
+    FLASH->PECR |= FLASH_PECR_PROG;
+
+    DEBUG("address to erase: %p\n", flashpage_addr(page));
+    DEBUG("[flashpage] erase: trigger the page erase\n");
+    /* Write 00000000h to the first word of the program page to erase */
+    *page_addr = 0x00000000;
+    /* Wait for it to be finished */
+    DEBUG("[flashpage] erase: wait as long as device is busy\n");
+    while (FLASH->SR & FLASH_SR_BSY) {}
+
+    /* If the erase operation is completed, disable the ERASE and PROG bits */
+    DEBUG("[flashpage] erase: resetting the page erase and prog bit\n");
+    FLASH->PECR &= (uint32_t)(~FLASH_PECR_PROG);
+    FLASH->PECR &= (uint32_t)(~FLASH_PECR_ERASE);
+
+    if (data != NULL) {
+        DEBUG("[flashpage] write: now writing the data\n");
+        for (unsigned i = 0; i < (FLASHPAGE_SIZE / 4); i++) {
+            DEBUG("[flashpage] writing %c to %p\n", (char)data_addr[i], page_addr);
+            *page_addr++ = data_addr[i];
+            while (FLASH->SR & FLASH_SR_BSY) {}
+        }
+        DEBUG("[flashpage] write: done writing data\n");
+    }
+
+    DEBUG("flashpage] now locking the flash module again\n");
+    /* Set the PRGLOCK and PELOCK Bit to lock the program memory access */
+    FLASH->PECR |= FLASH_PECR_PRGLOCK;
+    FLASH->PECR |= FLASH_PECR_PELOCK;
+}
+
+#endif /* defined(FLASHPAGE_SIZE) && defined(FLASHPAGE_NUMOF) */

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -107,15 +107,8 @@ void flashpage_write(int page, void *data)
  */
 #define PRGKEY2                   (0x13141516)
 
-void flashpage_write(int page, void *data)
+static void _unlock(void)
 {
-    assert(page < (int)FLASHPAGE_NUMOF);
-
-    /* Using 32bit addresses since we are attempting fast-word erasing/writing*/
-    uint32_t *page_addr = flashpage_addr(page);
-    uint32_t *data_addr = (uint32_t*)data;
-
-    DEBUG("[flashpage] unlocking the flash module\n");
     /* Unlocking the Data memory and FLASH_PECR register access*/
     if(FLASH->PECR & FLASH_PECR_PRGLOCK)
     {
@@ -127,6 +120,60 @@ void flashpage_write(int page, void *data)
         FLASH->PRGKEYR = PRGKEY1;
         FLASH->PRGKEYR = PRGKEY2;
     }
+}
+
+static void _lock(void)
+{
+    /* Set the PRGLOCK and PELOCK Bit to lock the program memory access */
+    FLASH->PECR |= FLASH_PECR_PRGLOCK;
+    FLASH->PECR |= FLASH_PECR_PELOCK;
+}
+
+void flashpage_write_raw(void *target_addr, void *data, size_t len)
+{
+    /* The actual minimal block size for writing is 16B, thus we
+     * assert we write on multiples and no less of that length.
+     */
+    assert(!(len % FLASHPAGE_RAW_BLOCKSIZE));
+
+    /* ensure 4 byte aligned writes */
+    assert(!(((unsigned)target_addr % FLASHPAGE_RAW_ALIGNMENT) ||
+            ((unsigned)data % FLASHPAGE_RAW_ALIGNMENT)));
+
+    /* ensure the length doesn't exceed the actual flash size */
+    assert(((unsigned)target_addr + len) <
+           (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)));
+
+    uint32_t *dst = (uint32_t *)target_addr;
+    uint32_t *data_addr = (uint32_t *)data;
+
+    /* write 4 bytes in one go */
+    len /= 4;
+
+    DEBUG("[flashpage_raw] unlocking the flash module\n");
+    _unlock();
+
+    DEBUG("[flashpage_raw] write: now writing the data\n");
+    for (size_t i = 0; i < len; i++) {
+        DEBUG("[flashpage_raw] writing %c to %p\n", (char)data_addr[i], dst);
+        *dst++ = *data_addr++;
+        while (FLASH->SR & FLASH_SR_BSY) {}
+    }
+    DEBUG("[flashpage_raw] write: done writing data\n");
+
+    DEBUG("flashpage_raw] now locking the flash module again\n");
+    _lock();
+}
+
+void flashpage_write(int page, void *data)
+{
+    assert(page < (int)FLASHPAGE_NUMOF);
+
+    /* Using 32bit addresses since we are attempting fast-word erasing/writing*/
+    uint32_t *page_addr = flashpage_addr(page);
+
+    DEBUG("[flashpage] unlocking the flash module\n");
+    _unlock();
 
     /* ERASE sequence */
     /* make sure no flash operation is ongoing */
@@ -153,19 +200,11 @@ void flashpage_write(int page, void *data)
     FLASH->PECR &= (uint32_t)(~FLASH_PECR_ERASE);
 
     if (data != NULL) {
-        DEBUG("[flashpage] write: now writing the data\n");
-        for (unsigned i = 0; i < (FLASHPAGE_SIZE / 4); i++) {
-            DEBUG("[flashpage] writing %c to %p\n", (char)data_addr[i], page_addr);
-            *page_addr++ = data_addr[i];
-            while (FLASH->SR & FLASH_SR_BSY) {}
-        }
-        DEBUG("[flashpage] write: done writing data\n");
+        flashpage_write_raw(page_addr, data, FLASHPAGE_SIZE);
     }
 
     DEBUG("flashpage] now locking the flash module again\n");
-    /* Set the PRGLOCK and PELOCK Bit to lock the program memory access */
-    FLASH->PECR |= FLASH_PECR_PRGLOCK;
-    FLASH->PECR |= FLASH_PECR_PELOCK;
+    _lock();
 }
 
 #endif /* defined(FLASHPAGE_SIZE) && defined(FLASHPAGE_NUMOF) */

--- a/cpu/stm32l1/Makefile.features
+++ b/cpu/stm32l1/Makefile.features
@@ -1,1 +1,3 @@
+FEATURES_PROVIDED += periph_flashpage
+
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32l1/Makefile.features
+++ b/cpu/stm32l1/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_flashpage_raw
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -73,12 +73,17 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Flash page configuration
+ * @name   Flash page configuration
  * @{
  */
-#if defined(CPU_MODEL_STM32L152RE)
+#if defined(CPU_MODEL_STM32L152RE) || defined(CPU_MODEL_STM32L151RC)
 #define FLASHPAGE_SIZE      (256U)
-#define FLASHPAGE_NUMOF     (2048U)
+#if defined(CPU_MODEL_STM32L152RE)
+#define FLASHPAGE_NUMOF     (2048U)    /* 512KB */
+#endif
+#if defined(CPU_MODEL_STM32L151RC)
+#define FLASHPAGE_NUMOF     (1024U)    /* 256KB */
+#endif
 #endif
 /* The minimum block size which can be written is 4B. However, the erase
  * block is always FLASHPAGE_SIZE.

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -72,6 +72,15 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
+/**
+ * @brief   Flash page configuration
+ * @{
+ */
+#if defined(CPU_MODEL_STM32L152RE)
+#define FLASHPAGE_SIZE      (256U)
+#define FLASHPAGE_NUMOF     (2048U)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -80,7 +80,12 @@ extern "C" {
 #define FLASHPAGE_SIZE      (256U)
 #define FLASHPAGE_NUMOF     (2048U)
 #endif
-
+/* The minimum block size which can be written is 4B. However, the erase
+ * block is always FLASHPAGE_SIZE.
+ */
+#define FLASHPAGE_RAW_BLOCKSIZE    (4)
+/* Writing should be always 4 byte aligned */
+#define FLASHPAGE_RAW_ALIGNMENT    (4)
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Just added flashpage write support for stm32l1 cpu's, which can be tested with tests/periph_flashpage.