### PR TITLE
conn_can: fix conn_can_raw_send and improve doc

### DIFF
--- a/sys/can/conn/raw.c
+++ b/sys/can/conn/raw.c
@@ -153,12 +153,11 @@ int conn_can_raw_send(conn_can_raw_t *conn, const struct can_frame *frame, int f
         int timeout = 5;
         while (1) {
             mbox_get(&conn->mbox, &msg);
+            xtimer_remove(&timer);
             switch (msg.type) {
             case CAN_MSG_TX_ERROR:
-                xtimer_remove(&timer);
                 return -EIO;
             case CAN_MSG_TX_CONFIRMATION:
-                xtimer_remove(&timer);
                 if ((int)msg.content.value == handle) {
                     DEBUG("conn_can_raw_send: frame sent correctly\n");
                     return 0;
@@ -170,6 +169,7 @@ int conn_can_raw_send(conn_can_raw_t *conn, const struct can_frame *frame, int f
                 break;
             case _TIMEOUT_TX_MSG_TYPE:
                 DEBUG("conn_can_raw_send: timeout\n");
+                raw_can_abort(conn->ifnum, handle);
                 return -ETIMEDOUT;
                 break;
             default:
@@ -178,6 +178,7 @@ int conn_can_raw_send(conn_can_raw_t *conn, const struct can_frame *frame, int f
                 if (!timeout--) {
                     return -EINTR;
                 }
+                xtimer_set(&timer, CONN_CAN_RAW_TIMEOUT_TX_CONF);
                 break;
             }
         }

--- a/sys/include/can/conn/raw.h
+++ b/sys/include/can/conn/raw.h
@@ -72,6 +72,8 @@ typedef struct conn_can_raw {
  * @param[in] ifnum         can device Interface
  * @param[in] flags         conn flags to set (CONN_CAN_RECVONLY)
  *
+ * @post   @p filter must remain allocated until @p conn is closed
+ *
  * @return 0 if socket was successfully connected
  * @return any other negative number in case of an error
  */
@@ -122,6 +124,10 @@ int conn_can_raw_send(conn_can_raw_t *conn, const struct can_frame *frame, int f
  * @param[in] conn          CAN connection
  * @param[in] filter        list of filters to set
  * @param[in] count         number of filters in @p filter
+ *
+ * @pre    previously set filters must be allocated until the end of the call
+ * @post   @p filter must remain allocated until @p conn is closed or
+ * conn_can_raw_set_filter() is called
  *
  * @return 0 if can filters were successfully set
  * @return any other negative number in case of an error


### PR DESCRIPTION
This fixes 2 bad behaviors in `conn_can_raw_send`:
- missing `abort` on tx timeout
- missing timer removal in default case

It also slightly improve the documentation.