### PR TITLE
can/device: improve bus-off management

### DIFF
--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -159,7 +159,10 @@ static int power_down(candev_dev_t *candev_dev)
 #endif
     canopt_state_t state = CANOPT_STATE_SLEEP;
     int res = dev->driver->set(dev, CANOPT_STATE, &state, sizeof(state));
-    dev->state = CAN_STATE_SLEEPING;
+
+    if (dev->state != CAN_STATE_BUS_OFF) {
+        dev->state = CAN_STATE_SLEEPING;
+    }
 
 #ifdef MODULE_CAN_PM
     xtimer_remove(&candev_dev->pm_timer);
@@ -211,6 +214,9 @@ static void *_can_device_thread(void *args)
 
     candev_dev->pid = thread_getpid();
 
+#ifdef MODULE_CAN_TRX
+    can_trx_init(candev_dev->trx);
+#endif
 #ifdef MODULE_CAN_PM
     if (candev_dev->rx_inactivity_timeout == 0) {
         candev_dev->rx_inactivity_timeout = CAN_DEVICE_PM_DEFAULT_RX_TIMEOUT;
@@ -221,9 +227,6 @@ static void *_can_device_thread(void *args)
     candev_dev->pm_timer.callback = pm_cb;
     candev_dev->pm_timer.arg = candev_dev;
     pm_reset(candev_dev, candev_dev->rx_inactivity_timeout);
-#endif
-#ifdef MODULE_CAN_TRX
-    can_trx_init(candev_dev->trx);
 #endif
 
     int res;
@@ -240,7 +243,7 @@ static void *_can_device_thread(void *args)
     candev_dev->ifnum = can_dll_register_candev(candev_dev);
 
     dev->driver->init(dev);
-    dev->state = CAN_STATE_ERROR_ACTIVE;
+    power_up(candev_dev);
 
     while (1) {
         msg_receive(&msg);


### PR DESCRIPTION
This is a small fix to improve bus-off management and recovery.
Previously the bus-off status were lost when powering down the controller, it now remains.

The initial state of the controller was also wrong.