### PR TITLE
cpu/stm32_common: fix clk_conf

### DIFF
--- a/cpu/stm32_common/dist/clk_conf/clk_conf.c
+++ b/cpu/stm32_common/dist/clk_conf/clk_conf.c
@@ -405,7 +405,7 @@ int main(int argc, char **argv)
             break;
         }
     }
-    if (cfg->family == STM32F0) {
+    if (cfg->family != STM32F0) {
         for (apb2_pre = 1; apb2_pre <= 16; apb2_pre <<= 1) {
             if (coreclock / apb2_pre <= cfg->max_apb2) {
                 break;


### PR DESCRIPTION
This seems to be a simple slip of the key.