### PR TITLE
gnrc_uhcpc: fix dependencies

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -45,6 +45,10 @@ ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
+ifneq (,$(filter uhcpc,$(USEMODULE)))
+  USEMODULE += posix
+endif
+
 ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
   USEMODULE += softdevice_handler
   USEMODULE += ble_common

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -32,18 +32,21 @@ static void set_interface_roles(void)
         kernel_pid_t dev = ifs[i];
         int is_wired = gnrc_netapi_get(dev, NETOPT_IS_WIRED, 0, NULL, 0);
         if ((!gnrc_border_interface) && (is_wired == 1)) {
-            ipv6_addr_t addr, defroute;
+            ipv6_addr_t addr;
             gnrc_border_interface = dev;
 
             ipv6_addr_from_str(&addr, "fe80::2");
             gnrc_ipv6_netif_add_addr(dev, &addr, 64,
                                      GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST);
 
-            ipv6_addr_from_str(&defroute, "::");
+#ifdef MODULE_FIB
+            ipv6_addr_t defroute = IPV6_ADDR_UNSPECIFIED;
+
             ipv6_addr_from_str(&addr, "fe80::1");
             fib_add_entry(&gnrc_ipv6_fib_table, dev, defroute.u8, 16,
                     0x00, addr.u8, 16, 0,
                     (uint32_t)FIB_LIFETIME_NO_EXPIRE);
+#endif
         }
         else if ((!gnrc_wireless_interface) && (is_wired != 1)) {
             gnrc_wireless_interface = dev;


### PR DESCRIPTION
#7721 showed, that `posix` is required to include the `arpa/inet.h`
header into the include path of an application using the `uhcpc`
module.

Additionally this PR makes the FIB an optional dependency of
`gnrc_uhcpc`.