### PR TITLE
saul_reg: make ptr to device descriptor non const

### DIFF
--- a/sys/auto_init/saul/auto_init_gpio.c
+++ b/sys/auto_init/saul/auto_init_gpio.c
@@ -55,7 +55,7 @@ void auto_init_gpio(void)
 
         LOG_DEBUG("[auto_init_saul] initializing GPIO #%u\n", i);
 
-        saul_reg_entries[i].dev = p;
+        saul_reg_entries[i].dev = (void *)p;
         saul_reg_entries[i].name = p->name;
         if ((p->mode == GPIO_IN) || (p->mode == GPIO_IN_PD) ||
             (p->mode == GPIO_IN_PU)) {

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -38,7 +38,7 @@ extern "C" {
  */
 typedef struct saul_reg {
     struct saul_reg *next;          /**< pointer to the next device */
-    const void *dev;                /**< pointer to the device descriptor */
+    void *dev;                      /**< pointer to the device descriptor */
     const char *name;               /**< string identifier for the device */
     saul_driver_t const *driver;    /**< the devices read callback */
 } saul_reg_t;


### PR DESCRIPTION
fixes #7719

Rationale: all devices are identified by their device descriptor, which points to the run-time data of devices. So typically, the device descriptor points into RAM (using a non-const pointer). Now for some devices, we have the case that they don't need/have any dynamic run-time data (e.g. the SAUL gpio driver). For these devices we can optimize their memory usage by keeping their device descriptor in ROM (e.g. by using their static configuration data as device descriptor). This would call for their device descriptor being a const pointer.

In the end, we need to cast in any way, but it seems to me, that the first case is the default case (as before #7586) and thus we should not make the pointer to the device descriptor from the SAUL registry const.