### PR TITLE
boards/sodaq-explorer: add initial support

### DIFF
--- a/boards/sodaq-explorer/Makefile
+++ b/boards/sodaq-explorer/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/sodaq-explorer/Makefile.dep
+++ b/boards/sodaq-explorer/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/sodaq-explorer/Makefile.features
+++ b/boards/sodaq-explorer/Makefile.features
@@ -1,0 +1,16 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/sodaq-explorer/Makefile.include
+++ b/boards/sodaq-explorer/Makefile.include
@@ -1,0 +1,19 @@
+# define the cpu used by the SODAQ ExpLoRer board
+export CPU = samd21
+export CPU_MODEL = samd21j18a
+
+#export needed for flash rule
+export PORT_LINUX ?= /dev/ttyACM0
+export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# setup the flash tool used
+# we use BOSSA to flash this board since there's an Arduino bootloader
+# preflashed on it
+export LINKER_SCRIPT ?= $(RIOTCPU)/sam0_common/ldscripts/$(CPU_MODEL)_arduino_bootloader.ld
+include $(RIOTMAKE)/tools/bossa.inc.mk
+
+# setup the boards dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/sodaq-explorer/board.c
+++ b/boards/sodaq-explorer/board.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C)  2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-explorer
+ *
+ * @file
+ * @brief       Board common implementations for the SODAQ ExpLoRer board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+    /* initialize the on-board LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+}

--- a/boards/sodaq-explorer/doc.txt
+++ b/boards/sodaq-explorer/doc.txt
@@ -1,0 +1,29 @@
+/**
+ * @defgroup    boards_sodaq-explorer SODAQ ExpLoRer
+ * @ingroup     boards
+ * @brief       Support for the SODAQ ExpLoRer board
+ *
+ * ### General information
+ *
+ * General information about this board can be found on the
+ * [SODAQ support](http://support.sodaq.com/sodaq-one/explorer/) website.
+ *
+ * ### Flash the board
+ *
+ * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
+ *    When the board is in bootloader mode, the user led (blue) oscillates
+ *    smoothly.
+ *
+ *
+ * 2. Use `BOARD=sodaq-explorer` with the `make` command.<br/>
+ *    Example with `hello-world` application:
+ * ```
+ *      make BOARD=sodaq-explorer -C examples/hello-world flash
+ * ```
+ *
+ * ### Accessing STDIO via UART
+ *
+ * To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
+ * the RX/TX pins on the board.
+ *
+ */

--- a/boards/sodaq-explorer/include/board.h
+++ b/boards/sodaq-explorer/include/board.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-explorer
+ * @brief       Board specific definitions for the SODAQ ExpLoRer board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the SODAQ ExpLoRer board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+/** @} */
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 21)
+
+#define LED0_PORT           PORT->Group[PA]
+#define LED0_MASK           (1 << 21)
+
+#define LED0_ON             (LED0_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_OFF            (LED0_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED0_PORT.OUTTGL.reg = LED0_MASK)
+/** @} */
+
+/**
+ * @name    User button
+ */
+#define BTN0_PIN            GPIO_PIN(PA, 14)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/sodaq-explorer/include/gpio_params.h
+++ b/boards/sodaq-explorer/include/gpio_params.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C)  2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_sodaq-explorer
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Button",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C)  2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-explorer
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the Sodaq LoRaWAN Explorer board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    External oscillator and clock configuration
+ *
+ * For selection of the used CORECLOCK, we have implemented two choices:
+ *
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why we use this option as default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL       (1)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+/* generate the actual used core clock frequency */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+#define TIMER_NUMOF         (2U)
+#define TIMER_0_EN          1
+#define TIMER_1_EN          1
+
+/* Timer 0 configuration */
+#define TIMER_0_DEV         TC3->COUNT16
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_MAX_VALUE   (0xffff)
+#define TIMER_0_ISR         isr_tc3
+
+/* Timer 1 configuration */
+#define TIMER_1_DEV         TC4->COUNT32
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_MAX_VALUE   (0xffffffff)
+#define TIMER_1_ISR         isr_tc4
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = &SERCOM5->USART,
+        .rx_pin   = GPIO_PIN(PB,31),  /* D0, RX Pin */
+        .tx_pin   = GPIO_PIN(PB,30),  /* D1, TX Pin */
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0_RTS_2_CTS_3,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+    },
+    {
+        .dev      = &SERCOM4->USART,
+        .rx_pin   = GPIO_PIN(PB,13),
+        .tx_pin   = GPIO_PIN(PB,14),
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+    },
+    { /* Connected to RN2483 */
+        .dev      = &SERCOM0->USART,
+        .rx_pin   = GPIO_PIN(PA,5),
+        .tx_pin   = GPIO_PIN(PA,6),
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom5
+#define UART_1_ISR          isr_sercom4
+#define UART_2_ISR          isr_sercom0
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_0_EN                           1
+#define ADC_MAX_CHANNELS                   17
+/* ADC 0 device configuration */
+#define ADC_0_DEV                          ADC
+#define ADC_0_IRQ                          ADC_IRQn
+
+/* ADC 0 Default values */
+#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
+#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+
+#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
+#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},     /* A0 */
+    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},     /* A1 */
+    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A2 */
+    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A3 */
+    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},    /* A4 */
+    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},    /* A5 */
+    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},     /* A6 (temperature) */
+};
+
+#define ADC_0_CHANNELS                     (7U)
+#define ADC_NUMOF                          ADC_0_CHANNELS
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &SERCOM3->SPI,
+        .miso_pin = GPIO_PIN(PA, 22),
+        .mosi_pin = GPIO_PIN(PA, 20),
+        .clk_pin  = GPIO_PIN(PA, 21),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF          (2U)
+#define I2C_0_EN            1
+#define I2C_1_EN            1
+#define I2C_2_EN            0
+#define I2C_3_EN            0
+#define I2C_IRQ_PRIO        1
+
+#define I2C_0_DEV           SERCOM1->I2CM
+#define I2C_0_IRQ           SERCOM1_IRQn
+#define I2C_0_ISR           isr_sercom1
+/* I2C 0 GCLK */
+#define I2C_0_GCLK_ID       SERCOM1_GCLK_ID_CORE
+#define I2C_0_GCLK_ID_SLOW  SERCOM1_GCLK_ID_SLOW
+/* I2C 0 pin configuration */
+#define I2C_0_SDA           GPIO_PIN(PA, 16)
+#define I2C_0_SCL           GPIO_PIN(PA, 17)
+#define I2C_0_MUX           GPIO_MUX_C
+
+#define I2C_1_DEV           SERCOM2->I2CM
+#define I2C_1_IRQ           SERCOM2_IRQn
+#define I2C_1_ISR           isr_sercom2
+/* I2C 1 GCLK */
+#define I2C_1_GCLK_ID       SERCOM2_GCLK_ID_CORE
+#define I2C_1_GCLK_ID_SLOW  SERCOM2_GCLK_ID_SLOW
+/* I2C 1 pin configuration */
+#define I2C_1_SDA           GPIO_PIN(PA, 8)
+#define I2C_1_SCL           GPIO_PIN(PA, 9)
+#define I2C_1_MUX           GPIO_MUX_C
+/** @} */
+
+/**
+ * @name RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1U)
+#define RTC_DEV             RTC->MODE2
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             RTC->MODE0
+#define RTT_IRQ             RTC_IRQn
+#define RTT_IRQ_PRIO        10
+#define RTT_ISR             isr_rtc
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
+#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/sam0_common/ldscripts/samd21j18a_arduino_bootloader.ld
+++ b/cpu/sam0_common/ldscripts/samd21j18a_arduino_bootloader.ld
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_samd21
+ * @{
+ *
+ * @file
+ * @brief           Memory definitions for the SAMD21J18A with Arduino bootloader
+ *
+ * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+MEMORY
+{
+    rom (rx)    : ORIGIN = 0x00002000, LENGTH = 256K-0x2000
+    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 32K
+}
+
+INCLUDE cortexm_base.ld

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -53,6 +53,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              seeeduino_arch-pro \
                              slwstk6220a \
                              sodaq-autonomo \
+                             sodaq-explorer \
                              spark-core \
                              stm32f0discovery \
                              stm32f3discovery \
@@ -128,6 +129,7 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        samr21-xpro \
                        slwstk6220a \
                        sodaq-autonomo \
+                       sodaq-explorer \
                        spark-core \
                        stm32f0discovery \
                        stm32f3discovery \


### PR DESCRIPTION
This PR adds a basic support for the [Sodaq LoRaWAN ExpLoRer kit](http://support.sodaq.com/sodaq-one/explorer/) board.

What has been tested with success:
* UARTs
* GPIOs via SAUL (on-board LED and button)
* RTT with tests/periph_rtt
* RTC with tests/periph_rtc
* ADC with tests/periph_adc

I2C and SPI have not been tested.

Since no PWM is defined, this PR relies on #7724 