### PR TITLE
pm: fix pm fallback selection

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -51,6 +51,14 @@ extern "C" {
 #define STACK_CANARY_WORD   (0xE7FEE7FEu)
 
 /**
+ * @brief   All Cortex-m-based CPUs provide pm_set_lowest
+ *
+ * The pm_set_lowest is provided either by the pm_layered module if used, or
+ * alternatively as fallback by the cortexm's own implementation.
+ */
+#define PROVIDES_PM_SET_LOWEST
+
+/**
  * @brief   Initialization of the CPU
  */
 void cpu_init(void);

--- a/cpu/cortexm_common/periph/pm.c
+++ b/cpu/cortexm_common/periph/pm.c
@@ -24,7 +24,7 @@
 #include "cpu.h"
 #include "periph/pm.h"
 
-#ifndef FEATURE_PERIPH_PM
+#if !defined(MODULE_PM_LAYERED) && !defined(PROVIDES_PM_SET_LOWEST_CORTEXM)
 void pm_set_lowest(void)
 {
     cortexm_sleep(0);

--- a/cpu/kinetis_common/include/periph_cpu.h
+++ b/cpu/kinetis_common/include/periph_cpu.h
@@ -103,12 +103,6 @@ typedef uint16_t gpio_t;
  */
 #define PM_NUM_MODES    (1U)
 
-/**
- * @brief   Override the default initial PM blocker
- * @todo   we block all modes per default, until PM is cleanly implemented
- */
-#define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
-
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -21,7 +21,9 @@
 #ifndef PERIPH_CPU_H
 #define PERIPH_CPU_H
 
-#include "cpu_conf.h"
+
+#include "cpu.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -19,6 +19,7 @@
 #ifndef PERIPH_CPU_H
 #define PERIPH_CPU_H
 
+#include "cpu.h"
 #include "periph/dev_enums.h"
 
 #ifdef __cplusplus

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -5,6 +5,7 @@ export APP_START=0x80000000
 include $(RIOTMAKE)/arch/mips.inc.mk
 
 export USEMODULE += periph
+export USEMODULE += periph_common
 export USEMODULE += newlib
 
 ifeq ($(USE_UHI_SYSCALLS),1)

--- a/cpu/mips32r2_common/include/periph_cpu.h
+++ b/cpu/mips32r2_common/include/periph_cpu.h
@@ -16,10 +16,23 @@
  * or no peripherals
  */
 
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @name    Power management configuration
+ * @{
+ */
+#define PROVIDES_PM_SET_LOWEST
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* PERIPH_CPU_H */
+/** @} */

--- a/cpu/mips32r2_common/periph/pm.c
+++ b/cpu/mips32r2_common/periph/pm.c
@@ -22,17 +22,10 @@
 #include <mips/m32c0.h>
 #include "periph/pm.h"
 
-#ifndef FEATURES_PERIPH_PM
 void pm_set_lowest(void)
 {
     /* Dont wait if interrupts are not enabled - we would never return!*/
     if (mips32_get_c0(C0_STATUS) & SR_IE) {
         __asm volatile ("wait");
     }
-}
-#endif
-
-void pm_off(void)
-{
-   /* No Generic Power off Mechanism */
 }

--- a/cpu/mips_pic32_common/include/periph_cpu_common.h
+++ b/cpu/mips_pic32_common/include/periph_cpu_common.h
@@ -26,7 +26,14 @@
 extern "C" {
 #endif
 
- /**
+/**
+ * @name    Power management configuration
+ * @{
+ */
+#define PROVIDES_PM_SET_LOWEST
+/** @} */
+
+/**
  * @brief   Length of the CPU_ID in bytes
  */
 #define CPUID_LEN           (4U)

--- a/cpu/mips_pic32_common/include/periph_cpu_common.h
+++ b/cpu/mips_pic32_common/include/periph_cpu_common.h
@@ -38,6 +38,9 @@ extern "C" {
  */
 #define CPUID_LEN           (4U)
 
+/**
+ * @brief   Override GPIO pin selection macro
+ */
 #define GPIO_PIN(x,y)       ((x << 4) | (y & 0xf))
 
 /**

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -8,6 +8,7 @@ export CFLAGS += -march=m4k -DSKIP_COPY_TO_RAM
 
 export USEMODULE += mips_pic32_common
 export USEMODULE += periph
+export USEMODULE += periph_common
 export USEMODULE += newlib
 
 ifeq ($(USE_UHI_SYSCALLS),1)

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -9,6 +9,7 @@ export CFLAGS += -DMIPS_MICROMIPS
 
 export USEMODULE += mips_pic32_common
 export USEMODULE += periph
+export USEMODULE += periph_common
 export USEMODULE += newlib
 
 ifeq ($(USE_UHI_SYSCALLS),1)

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -37,6 +37,13 @@ extern "C" {
  */
 #define PERIPH_TIMER_PROVIDES_SET
 
+/**
+ * @name    Power management configuration
+ * @{
+ */
+#define PROVIDES_PM_OFF
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -26,6 +26,13 @@ extern "C" {
 #endif
 
 /**
+ * @name    Power management configuration
+ * @{
+ */
+#define PROVIDES_PM_OFF
+/** @} */
+
+/**
  * @brief   Starting offset of CPU_ID
  */
 #define CPUID_ADDR          (&NRF_FICR->DEVICEID[0])

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -65,8 +65,6 @@ typedef uint32_t gpio_t;
  * @{
  */
 #define PM_NUM_MODES        (3)
-/** @todo   we block all modes per default, until PM is cleanly implemented */
-#define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
 /** @} */
 
 #ifndef DOXYGEN

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -51,6 +51,11 @@ extern "C" {
 #define CPUID_LEN           (12U)
 
 /**
+ * @brief   We provide our own pm_off() function for all STM32-based CPUs
+ */
+#define PROVIDES_PM_LAYERED_OFF
+
+/**
  * @brief   All STM timers have 4 capture-compare channels
  */
 #define TIMER_CHAN          (4U)

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -59,7 +59,7 @@ extern "C" {
 /**
  * @brief   Define the number of available PM modes
  */
-#define PM_NUM_MODES    (2U)
+#define PM_NUM_MODES        (2U)
 
 /**
  * @brief   Override the default initial PM blocker
@@ -70,7 +70,7 @@ extern "C" {
 /**
  * @brief  Define the config flag for stop mode
  */
-#define PM_STOP_CONFIG  (PWR_CR_LPDS)
+#define PM_STOP_CONFIG      (PWR_CR_LPDS)
 
 #ifndef DOXYGEN
 /**

--- a/cpu/x86/include/periph_cpu.h
+++ b/cpu/x86/include/periph_cpu.h
@@ -32,6 +32,13 @@
 extern "C" {
 #endif
 
+/**
+ * @name    Power management configuration
+ * @{
+ */
+#define PROVIDES_PM_OFF
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/pm.h
+++ b/drivers/include/periph/pm.h
@@ -27,8 +27,12 @@
 #include "assert.h"
 #include "periph_cpu.h"
 
+#ifdef MODULE_PM_LAYERED
+#include "pm_layered.h"
+#endif
+
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**

--- a/drivers/periph_common/pm.c
+++ b/drivers/periph_common/pm.c
@@ -24,10 +24,17 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-void __attribute__((weak)) pm_set_lowest(void) {}
-
-void __attribute__((weak)) pm_off(void)
+#ifndef PROVIDES_PM_OFF
+void pm_off(void)
 {
     irq_disable();
     while(1) {};
 }
+#endif
+
+#ifndef PROVIDES_PM_SET_LOWEST
+void pm_set_lowest(void)
+{
+    /* don't do anything here */
+}
+#endif

--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -35,11 +35,14 @@
 #define PM_LAYERED_H
 
 #include "assert.h"
-#include "periph/pm.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
+#endif
+
+#ifndef PROVIDES_PM_OFF
+#define PROVIDES_PM_OFF
 #endif
 
 /**

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -87,9 +87,11 @@ void pm_unblock(unsigned mode)
     irq_restore(state);
 }
 
-void __attribute__((weak)) pm_off(void)
+#ifndef PROVIDES_PM_LAYERED_OFF
+void  pm_off(void)
 {
     pm_blocker.val_u32 = 0;
     pm_set_lowest();
     while(1);
 }
+#endif

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -30,7 +30,7 @@
 #endif
 
 #ifndef PM_BLOCKER_INITIAL
-#define PM_BLOCKER_INITIAL { .val_u32 = 0 }
+#define PM_BLOCKER_INITIAL { .val_u32 = 0x01010101 }
 #endif
 
 /**


### PR DESCRIPTION
Created this PR just to illustrate my ideas for #7648 and I'd rather have the changes merged in #7648 instead of merging this PR...

But anyhow, I think this approach simplifies matters compared to #7648 and could be the way to go? This approach does not depend on any `weak` symbols, nor on the order of the `include` paths, so it should be pretty dependable. What do you think?

`66 additions and 15 deletions` vs. `531 additions and 13 deletions`

