### PR TITLE
boards: add support for bluepill board

### DIFF
--- a/boards/bluepill/Makefile
+++ b/boards/bluepill/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/bluepill/Makefile.dep
+++ b/boards/bluepill/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/bluepill/Makefile.features
+++ b/boards/bluepill/Makefile.features
@@ -1,0 +1,14 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
+
+# Various other features (if any)
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/bluepill/Makefile.include
+++ b/boards/bluepill/Makefile.include
@@ -1,0 +1,13 @@
+## the cpu to build for
+export CPU = stm32f1
+export CPU_MODEL = stm32f103c8
+
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/bluepill/board.c
+++ b/boards/bluepill/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 TriaGnoSys GmbH
+ *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_bluepill
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the bluepill board
+ *
+ * @author      Víctor Ariño <victor.arino@triagnosys.com>
+ * @author      Sören Tempel <tempel@uni-bremen.de>
+ * @author      Tristan Bruns <tbruns@uni-bremen.de>
+ * @author      Alexander Kurth <kurth1@uni-bremen.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    cpu_init();
+    gpio_init(LED0_PIN, GPIO_OUT);
+}

--- a/boards/bluepill/dist/openocd.cfg
+++ b/boards/bluepill/dist/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink-v2.cfg]
+transport select hla_swd
+
+source [find target/stm32f1x.cfg]
+reset_config none separate
+
+$_TARGETNAME configure -rtos auto

--- a/boards/bluepill/include/board.h
+++ b/boards/bluepill/include/board.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 TriaGnoSys GmbH
+ *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_bluepill Bluepill board
+ * @ingroup     boards
+ * @brief       Support for the stm32f103c8 based bluepill board.
+ *
+ * This board can be bought very cheaply on sides like eBay or
+ * AliExpress. Although the MCU nominally has 64 KiB ROM, most of them
+ * have 128 KiB ROM. For more information see:
+ * http://wiki.stm32duino.com/index.php?title=Blue_Pill
+ *
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the bluepill board
+ *
+ * @author      Víctor Ariño <victor.arino@triagnosys.com>
+ * @author      Sören Tempel <tempel@uni-bremen.de>
+ * @author      Tristan Bruns <tbruns@uni-bremen.de>
+ * @author      Alexander Kurth <kurth1@uni-bremen.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Macros for controlling the on-board LED.
+ * @{
+ */
+#define LED0_PORT           GPIOC
+#define LED0_PIN            GPIO_PIN(PORT_C, 13)
+#define LED0_MASK           (1 << 13)
+
+#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
+#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
+#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+/**
+ * @brief   Use the 2nd UART for STDIO on this board
+ */
+#define UART_STDIO_DEV      UART_DEV(1)
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      5
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/bluepill/include/gpio_params.h
+++ b/boards/bluepill/include/gpio_params.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f130c8t6
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/bluepill/include/periph_conf.h
+++ b/boards/bluepill/include/periph_conf.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2015 TriaGnoSys GmbH
+ *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_bluepill
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the bluepill board
+ *
+ * @author      Víctor Ariño <victor.arino@triagnosys.com>
+ * @author      Sören Tempel <tempel@uni-bremen.de>
+ * @author      Tristan Bruns <tbruns@uni-bremen.de>
+ * @author      Alexander Kurth <kurth1@uni-bremen.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 72MHz */
+#define CLOCK_CORECLOCK     (72000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (1U)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+
+/* PLL factors */
+#define CLOCK_PLL_PREDIV     (1)
+#define CLOCK_PLL_MUL        (9)
+/** @} */
+
+/**
+ * @name    ADC configuration
+ * @{
+ */
+#define ADC_CONFIG {                                     \
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 0), .chan = 0 }, \
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 1), .chan = 1 }, \
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 2), .chan = 2 }, \
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 3), .chan = 3 }, \
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 4), .chan = 4 }, \
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 5), .chan = 5 }, \
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 6), .chan = 6 }, \
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 7), .chan = 7 }, \
+    { .dev = 0, .pin = GPIO_PIN(PORT_B, 0), .chan = 8 }, \
+    { .dev = 0, .pin = GPIO_PIN(PORT_B, 1), .chan = 9 }, \
+}
+
+#define ADC_NUMOF           10
+/** @} */
+
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM2,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
+    },
+    {
+        .dev      = TIM3,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    },
+    {
+        .dev      = TIM4,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .bus      = APB1,
+        .irqn     = TIM4_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim3
+#define TIMER_2_ISR         isr_tim4
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .bus        = APB2,
+        .irqn       = USART1_IRQn
+    },
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .bus        = APB1,
+        .irqn       = USART2_IRQn
+    },
+    {
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 11),
+        .tx_pin     = GPIO_PIN(PORT_B, 10),
+        .bus        = APB1,
+        .irqn       = USART3_IRQn
+    }
+};
+
+#define UART_0_ISR          (isr_usart1)
+#define UART_1_ISR          (isr_usart2)
+#define UART_2_ISR          (isr_usart3)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 8),  .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_A, 9),  .cc_chan = 1 },
+                      { .pin = GPIO_PIN(PORT_A, 10), .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_A, 11), .cc_chan = 3 } },
+        .af       = GPIO_AF_OUT_PP,
+        .bus      = APB2
+    }
+};
+
+#define PWM_NUMOF (sizeof(pwm_config) / sizeof(pwm_config[0]))
+/** @} */
+
+/**
+ * @name   SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 36000000Hz */
+        7,  /* -> 140625Hz */
+        6,  /* -> 281250Hz */
+        4,  /* -> 1125000Hz */
+        2,  /* -> 4500000Hz */
+        1   /* -> 9000000Hz */
+    },
+    {       /* for APB2 @ 72000000Hz */
+        7,  /* -> 281250Hz */
+        7,  /* -> 281250Hz */
+        5,  /* -> 1125000Hz */
+        3,  /* -> 4500000Hz */
+        2   /* -> 9000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_PIN(PORT_A, 4),
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    },
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 15),
+        .miso_pin = GPIO_PIN(PORT_B, 14),
+        .sclk_pin = GPIO_PIN(PORT_B, 13),
+        .cs_pin   = GPIO_PIN(PORT_B, 12),
+        .rccmask  = RCC_APB1ENR_SPI2EN,
+        .apbbus   = APB1
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -25,7 +25,7 @@
 
 #include "cpu_conf_common.h"
 
-#if defined(CPU_MODEL_STM32F103CB) || defined(CPU_MODEL_STM32F103RB)
+#if defined(CPU_MODEL_STM32F103C8) || defined(CPU_MODEL_STM32F103CB) || defined(CPU_MODEL_STM32F103RB)
 #include "vendor/stm32f103xb.h"
 #elif defined(CPU_MODEL_STM32F103RE)
 #include "vendor/stm32f103xe.h"

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -12,7 +12,7 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 \
                    z1
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk maple-mini \
                              microbit nrf51dongle nrf6310 nucleo32-f031 \
                              nucleo32-f042 nucleo32-f303 nucleo32-l031 nucleo-f030 \

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -7,7 +7,7 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk maple-mini \
                              microbit msb-430 msb-430h nrf51dongle nrf6310 \
                              nucleo32-f031 nucleo32-f042 nucleo32-f303 nucleo32-l031 \

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -4,7 +4,7 @@ APPLICATION = riot_javascript
 # default BOARD environment
 BOARD ?= native
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk maple-mini \
                              microbit nrf51dongle nrf6310 nucleo-f030 nucleo-f070 \
                              nucleo-f072 nucleo-f103 nucleo-f302 nucleo-f334 nucleo-f410 \

--- a/tests/gnrc_netif2/Makefile
+++ b/tests/gnrc_netif2/Makefile
@@ -2,7 +2,7 @@
 APPLICATION = gnrc_ipv6_nib
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk chronos maple-mini \
                              microbit msb-430 msb-430h nrf51dongle nrf6310 \
                              nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 \

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,7 +1,7 @@
 APPLICATION = thread_cooperation
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk chronos \
                              maple-mini mbed_lpc1768 microbit msb-430 msb-430h nrf51dongle \
                              nrf6310 nucleo32-f031 nucleo32-f042 nucleo32-f303 \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-uno \
                              arduino-zero \
                              b-l072z-lrwan1 \
+                             bluepill \
                              calliope-mini \
                              cc2538dk \
                              cc2650-launchpad \


### PR DESCRIPTION
This pull request adds support for the stm32 based bluepill board. This board is widely available at a very low cost on sites like AliExpress and others.

Initial work was done by @obgm but his [RIOT fork](https://github.com/obgm/riot) was outdated and incomplete thus we started from scratch based on the nucleon-f103 board. However, we noticed that some peripheral configuration options were missing in the nucleon-f103 `periph_conf.h` header file. For instance, the general purpose timer four wasn't configured and the `cs_pin` for the SPI devices wasn't set. In addition to that PWM and ADC support was missing on the nucleon-f103. Compared to the nucleon-f103 we didn't configure i2c in the `periph_conf.h` file for the bluepill board because we couldn't test it yet, but it is very likely that the i2c configuration from the nucleon-f103 can simply be copied for this board.

All other peripherals were tested using the tests available in `tests/`. We are also planning to expand support for this board in the future. Apart from i2c we would also like to add support for CAN available on the device.

This was a group effort involving Alexander Kurth, Tristan Bruns, Christian Manal and myself.  