### PR TITLE
cpu/stm32: optimized definition of CPUID_ADDR

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -44,15 +44,9 @@ extern "C" {
 #endif
 
 /**
- * @brief   Linker script provided symbol for CPUID location
- */
-extern uint32_t _cpuid_address;
-/**
- * @brief   Starting offset of CPU_ID
- */
-#define CPUID_ADDR          (&_cpuid_address)
-/**
  * @brief   Length of the CPU_ID in octets
+ *
+ * This is the same for all members of the stm32 family
  */
 #define CPUID_LEN           (12U)
 

--- a/cpu/stm32f0/include/periph_cpu.h
+++ b/cpu/stm32f0/include/periph_cpu.h
@@ -26,6 +26,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the CPU ID
+ */
+#define CPUID_ADDR          (0x1ffff7ac)
+
+/**
  * @brief   Available ports on the STM32F0 family
  */
 enum {

--- a/cpu/stm32f0/ldscripts/stm32f030r8.ld
+++ b/cpu/stm32f0/ldscripts/stm32f030r8.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 64K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 8K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f0/ldscripts/stm32f031k6.ld
+++ b/cpu/stm32f0/ldscripts/stm32f031k6.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 32K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 4K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f0/ldscripts/stm32f042k6.ld
+++ b/cpu/stm32f0/ldscripts/stm32f042k6.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 32K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 6K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f0/ldscripts/stm32f051r8.ld
+++ b/cpu/stm32f0/ldscripts/stm32f051r8.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 64K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 8K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f0/ldscripts/stm32f070rb.ld
+++ b/cpu/stm32f0/ldscripts/stm32f070rb.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 128K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 16K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f0/ldscripts/stm32f072rb.ld
+++ b/cpu/stm32f0/ldscripts/stm32f072rb.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 128K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 16K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f0/ldscripts/stm32f091rc.ld
+++ b/cpu/stm32f0/ldscripts/stm32f091rc.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 256K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 32K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -31,6 +31,11 @@ extern "C" {
 #define ADC_DEVS            (2U)
 
 /**
+ * @brief   Starting address of the CPU ID
+ */
+#define CPUID_ADDR          (0x1ffff7e8)
+
+/**
  * @brief   All timers for the STM32F1 have 4 CC channels
  */
 #define TIMER_CHANNELS      (4U)

--- a/cpu/stm32f1/ldscripts/stm32f103c8.ld
+++ b/cpu/stm32f1/ldscripts/stm32f103c8.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 64K
     ram (xrw)   : ORIGIN = 0x20000000, LENGTH = 20K
-    cpuid (r)   : ORIGIN = 0x1ffff7e8, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f1/ldscripts/stm32f103cb.ld
+++ b/cpu/stm32f1/ldscripts/stm32f103cb.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 128K
     ram (xrw)   : ORIGIN = 0x20000000, LENGTH = 20K
-    cpuid (r)   : ORIGIN = 0x1ffff7e8, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f1/ldscripts/stm32f103cb_opencm904.ld
+++ b/cpu/stm32f1/ldscripts/stm32f103cb_opencm904.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08003000, LENGTH = 128K-0x3000
     ram (xrw)   : ORIGIN = 0x20000000, LENGTH = 20K
-    cpuid (r)   : ORIGIN = 0x1ffff7e8, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f1/ldscripts/stm32f103cb_sparkcore.ld
+++ b/cpu/stm32f1/ldscripts/stm32f103cb_sparkcore.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08005000, LENGTH = 128K-0x5000
     ram (xrw)   : ORIGIN = 0x20000000, LENGTH = 20K
-    cpuid (r)   : ORIGIN = 0x1ffff7e8, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f1/ldscripts/stm32f103rb.ld
+++ b/cpu/stm32f1/ldscripts/stm32f103rb.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 128K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 20K
-    cpuid (r)       : ORIGIN = 0x1ffff7e8, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f1/ldscripts/stm32f103re.ld
+++ b/cpu/stm32f1/ldscripts/stm32f103re.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 512K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 64K
-    cpuid (r)       : ORIGIN = 0x1ffff7e8, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f2/include/periph_cpu.h
+++ b/cpu/stm32f2/include/periph_cpu.h
@@ -28,6 +28,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the CPU ID
+ */
+#define CPUID_ADDR          (0x1fff7a10)
+
+/**
  * @brief   Available ports on the STM32F2 family
  */
 enum {

--- a/cpu/stm32f2/ldscripts/stm32f205rg.ld
+++ b/cpu/stm32f2/ldscripts/stm32f205rg.ld
@@ -24,9 +24,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)       : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f2/ldscripts/stm32f207zg.ld
+++ b/cpu/stm32f2/ldscripts/stm32f207zg.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)       : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f2/ldscripts/stm32f215rg.ld
+++ b/cpu/stm32f2/ldscripts/stm32f215rg.ld
@@ -24,9 +24,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)       : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f2/ldscripts/stm32f215ve.ld
+++ b/cpu/stm32f2/ldscripts/stm32f215ve.ld
@@ -24,9 +24,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 512K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)       : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f2/ldscripts/stm32f215vg.ld
+++ b/cpu/stm32f2/ldscripts/stm32f215vg.ld
@@ -24,9 +24,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)       : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f2/ldscripts/stm32f217zg.ld
+++ b/cpu/stm32f2/ldscripts/stm32f217zg.ld
@@ -24,9 +24,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)       : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f3/include/periph_cpu.h
+++ b/cpu/stm32f3/include/periph_cpu.h
@@ -26,6 +26,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the CPU ID
+ */
+#define CPUID_ADDR          (0x1ffff7ac)
+
+/**
  * @brief   Available ports on the STM32F3 family
  */
 enum {

--- a/cpu/stm32f3/ldscripts/stm32f302r8.ld
+++ b/cpu/stm32f3/ldscripts/stm32f302r8.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 64K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 16K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f3/ldscripts/stm32f303k8.ld
+++ b/cpu/stm32f3/ldscripts/stm32f303k8.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 64K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 16K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f3/ldscripts/stm32f303re.ld
+++ b/cpu/stm32f3/ldscripts/stm32f303re.ld
@@ -25,9 +25,6 @@ MEMORY
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 512K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 64K
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 16K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f3/ldscripts/stm32f303vc.ld
+++ b/cpu/stm32f3/ldscripts/stm32f303vc.ld
@@ -23,9 +23,6 @@ MEMORY
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 256K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 40K
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 8K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f3/ldscripts/stm32f303ze.ld
+++ b/cpu/stm32f3/ldscripts/stm32f303ze.ld
@@ -23,9 +23,6 @@ MEMORY
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 512K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 64K
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 16K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f3/ldscripts/stm32f334r8.ld
+++ b/cpu/stm32f3/ldscripts/stm32f334r8.ld
@@ -23,9 +23,6 @@ MEMORY
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 64K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 12K
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 4K
-    cpuid (r)   : ORIGIN = 0x1ffff7ac, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -26,6 +26,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the CPU ID
+ */
+#define CPUID_ADDR          (0x1fff7a10)
+
+/**
  * @brief   Available ports on the STM32F4 family
  */
 enum {

--- a/cpu/stm32f4/ldscripts/stm32f401re.ld
+++ b/cpu/stm32f4/ldscripts/stm32f401re.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 512K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 96K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f407vg.ld
+++ b/cpu/stm32f4/ldscripts/stm32f407vg.ld
@@ -23,9 +23,6 @@ MEMORY
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 128K
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 64K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f410rb.ld
+++ b/cpu/stm32f4/ldscripts/stm32f410rb.ld
@@ -24,9 +24,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 128K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 32K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f411re.ld
+++ b/cpu/stm32f4/ldscripts/stm32f411re.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 512K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f412zg.ld
+++ b/cpu/stm32f4/ldscripts/stm32f412zg.ld
@@ -24,9 +24,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f413vg.ld
+++ b/cpu/stm32f4/ldscripts/stm32f413vg.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1M
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 320K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f413zh.ld
+++ b/cpu/stm32f4/ldscripts/stm32f413zh.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1536K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 320K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f415rg.ld
+++ b/cpu/stm32f4/ldscripts/stm32f415rg.ld
@@ -23,9 +23,6 @@ MEMORY
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 128K
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 64K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f429zi.ld
+++ b/cpu/stm32f4/ldscripts/stm32f429zi.ld
@@ -23,9 +23,6 @@ MEMORY
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 2M
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
     ccmram (rwx): ORIGIN = 0x10000000, LENGTH = 64K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f446re.ld
+++ b/cpu/stm32f4/ldscripts/stm32f446re.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 512K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f4/ldscripts/stm32f446ze.ld
+++ b/cpu/stm32f4/ldscripts/stm32f446ze.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 512K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)   : ORIGIN = 0x1fff7a10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f7/include/periph_cpu.h
+++ b/cpu/stm32f7/include/periph_cpu.h
@@ -28,6 +28,15 @@ extern "C" {
 #endif
 
 /**
+ * @name    Starting address of the CPU ID
+ */
+#ifdef CPU_MODEL_STM32F722ZE
+#define CPUID_ADDR          (0x1ff07a10)
+#else
+#define CPUID_ADDR          (0x1ff0f420)
+#endif
+
+/**
  * @brief   Available ports
  */
 enum {

--- a/cpu/stm32f7/ldscripts/stm32f722ze.ld
+++ b/cpu/stm32f7/ldscripts/stm32f722ze.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 512K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
-    cpuid (r)   : ORIGIN = 0x1ff07A10, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f7/ldscripts/stm32f746zg.ld
+++ b/cpu/stm32f7/ldscripts/stm32f746zg.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 320K
-    cpuid (r)   : ORIGIN = 0x1ff0f420, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f7/ldscripts/stm32f767zi.ld
+++ b/cpu/stm32f7/ldscripts/stm32f767zi.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 2M
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 512K
-    cpuid (r)   : ORIGIN = 0x1ff0f420, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32f7/ldscripts/stm32f769ni.ld
+++ b/cpu/stm32f7/ldscripts/stm32f769ni.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 2048K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 512K
-    cpuid (r)   : ORIGIN = 0x1ff0f420, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l0/include/periph_cpu.h
+++ b/cpu/stm32l0/include/periph_cpu.h
@@ -29,6 +29,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the CPU ID
+ */
+#define CPUID_ADDR          (0x1ff80050)
+
+/**
  * @brief   Available ports on the STM32L0 family
  */
 enum {

--- a/cpu/stm32l0/ldscripts/stm32l031k6.ld
+++ b/cpu/stm32l0/ldscripts/stm32l031k6.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 32K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 8K
-    cpuid (r)   : ORIGIN = 0x1ff80050, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l0/ldscripts/stm32l053r8.ld
+++ b/cpu/stm32l0/ldscripts/stm32l053r8.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 64K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 8K
-    cpuid (r)   : ORIGIN = 0x1ff80050, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l0/ldscripts/stm32l072cz.ld
+++ b/cpu/stm32l0/ldscripts/stm32l072cz.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 192K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 20K
-    cpuid (r)   : ORIGIN = 0x1ff80050, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l0/ldscripts/stm32l073rz.ld
+++ b/cpu/stm32l0/ldscripts/stm32l073rz.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 192K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 20K
-    cpuid (r)   : ORIGIN = 0x1ff80050, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -28,6 +28,15 @@ extern "C" {
 #endif
 
 /**
+ * @name    Starting address of the CPU ID
+ */
+#ifdef CPU_MODEL_STM32L151RBA
+#define CPUID_ADDR          (0x1ff80050)
+#else
+#define CPUID_ADDR          (0x1ff800d0)
+#endif
+
+/**
  * @brief   Available ports on the STM32L1 family
  */
 enum {

--- a/cpu/stm32l1/ldscripts/stm32l151rba.ld
+++ b/cpu/stm32l1/ldscripts/stm32l151rba.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 128K
     ram (rw)        : ORIGIN = 0x20000000, LENGTH = 32K
-    cpuid (r)       : ORIGIN = 0x1ff80050, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l1/ldscripts/stm32l151rc.ld
+++ b/cpu/stm32l1/ldscripts/stm32l151rc.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 256K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 32K
-    cpuid (r)       : ORIGIN = 0x1ff800d0, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l1/ldscripts/stm32l152ret6.ld
+++ b/cpu/stm32l1/ldscripts/stm32l152ret6.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)        : ORIGIN = 0x08000000, LENGTH = 512K
     ram (xrw)       : ORIGIN = 0x20000000, LENGTH = 80K
-    cpuid (r)       : ORIGIN = 0x1ff800d0, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l4/include/periph_cpu.h
+++ b/cpu/stm32l4/include/periph_cpu.h
@@ -27,6 +27,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the CPU ID
+ */
+#define CPUID_ADDR          (0x1fff7590)
+
+/**
  * @brief   Available ports
  */
 enum {

--- a/cpu/stm32l4/ldscripts/stm32l432kc.ld
+++ b/cpu/stm32l4/ldscripts/stm32l432kc.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 256K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 64K
-    cpuid (r)   : ORIGIN = 0x1fff7590, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32l4/ldscripts/stm32l476rg.ld
+++ b/cpu/stm32l4/ldscripts/stm32l476rg.ld
@@ -22,9 +22,6 @@ MEMORY
 {
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 1024K
     ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 128K
-    cpuid (r)   : ORIGIN = 0x1fff7590, LENGTH = 12
 }
-
-_cpuid_address = ORIGIN(cpuid);
 
 INCLUDE cortexm_base.ld


### PR DESCRIPTION
This PR removes a lot of redundant information, as (with very few exceptions) the members of the stm32 families use the same CPUID offset address. So no need to specify if for each CPU_MODEL.

Further: removing this value from the linker scripts takes away a difference between stm32 and other cortex CPU families, so we can actually used shared linkerscripts (see  #7729).