### PR TITLE
boards: add missing XTIMER_WIDTH

### DIFF
--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -44,6 +44,13 @@ extern "C" {
 #define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
  /** @} */
 
+ /**
+  * @name    xtimer configuration
+  * @{
+  */
+ #define XTIMER_WIDTH        (16U)
+ /** @} */
+
 /**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */

--- a/boards/nucleo32-l031/include/board.h
+++ b/boards/nucleo32-l031/include/board.h
@@ -25,6 +25,13 @@
 
 #include "board_common.h"
 
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16U)
+/** @} */
+
 #ifdef __cplusplus
 extern "C" {}
 #endif


### PR DESCRIPTION
add/set missing XTIMER_WIDTH for 16Bit timer, i.e., for nucleo32-l031 and limifrog-v1