### PR TITLE
Board: initial support for the STM32F103C8T6

### DIFF
--- a/boards/stm32f103c8t6/Makefile
+++ b/boards/stm32f103c8t6/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/stm32f103c8t6/Makefile.dep
+++ b/boards/stm32f103c8t6/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/stm32f103c8t6/Makefile.features
+++ b/boards/stm32f103c8t6/Makefile.features
@@ -1,0 +1,16 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various common features of Nucleo boards
+FEATURES_PROVIDED += cpp
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m3_2
+
+-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/stm32f103c8t6/Makefile.include
+++ b/boards/stm32f103c8t6/Makefile.include
@@ -1,0 +1,13 @@
+# define the cpu used by the stm32f103c8t6 board
+export CPU = stm32f1
+export CPU_MODEL = stm32f103c8
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/stm32f103c8t6/board.c
+++ b/boards/stm32f103c8t6/board.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_stm32f130c8t6
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the STM32F103C8T6 demo board
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+#include <stdio.h>
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the boards LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+}

--- a/boards/stm32f103c8t6/dist/openocd.cfg
+++ b/boards/stm32f103c8t6/dist/openocd.cfg
@@ -1,0 +1,2 @@
+source [find interface/stlink-v2.cfg]
+source [find target/stm32f1x.cfg]

--- a/boards/stm32f103c8t6/doc.txt
+++ b/boards/stm32f103c8t6/doc.txt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_stm32f130c8t6 STM32F103C8T6 Demo Board
+ * @ingroup     boards
+ * @brief       Board specific files for the STM32F103C8T6 Demo Board
+ */

--- a/boards/stm32f103c8t6/include/board.h
+++ b/boards/stm32f103c8t6/include/board.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f130c8t6
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the STM32F103C8T6 demo board
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ */
+#define XTIMER_WIDTH        (16U)
+/** @} */
+
+/**
+ * @name Macros for controlling the on-board LED.
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_C, 13)
+
+#define LED0_PORT           GPIOC
+
+#define LED0_MASK           (1 << 13)
+
+#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
+#define LED0_OFF            (LED0_PORT->BSRR = (LED0_MASK << 16))
+#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/stm32f103c8t6/include/gpio_params.h
+++ b/boards/stm32f103c8t6/include/gpio_params.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f130c8t6
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/stm32f103c8t6/include/periph_conf.h
+++ b/boards/stm32f103c8t6/include/periph_conf.h
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f130c8t6
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the STM32F103C8T6 demo board
+ *
+ * @author      Sebastian Meiling <s@mlng.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 72MHz */
+#define CLOCK_CORECLOCK     (72000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (1U)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+
+/* PLL factors */
+#define CLOCK_PLL_PREDIV     (1)
+#define CLOCK_PLL_MUL        (9)
+/** @} */
+
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM2,
+        .max      = 0x0000ffff,             /* 16bit */
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
+    },
+    {
+        .dev      = TIM3,
+        .max      = 0x0000ffff,             /* 16bit */
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim2
+#define TIMER_1_ISR         isr_tim3
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .bus        = APB1,
+        .irqn       = USART2_IRQn
+    },
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .bus        = APB2,
+        .irqn       = USART1_IRQn
+    },
+    {
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 11),
+        .tx_pin     = GPIO_PIN(PORT_B, 10),
+        .bus        = APB1,
+        .irqn       = USART3_IRQn
+    }
+};
+
+#define UART_0_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart3)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF           (2U)
+#define I2C_0_EN            1
+#define I2C_1_EN            0
+#define I2C_IRQ_PRIO        1
+#define I2C_APBCLK          (CLOCK_APB1)
+
+/* I2C 0 device configuration */
+#define I2C_0_DEV           I2C1
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_EVT_IRQ       I2C1_EV_IRQn
+#define I2C_0_EVT_ISR       isr_i2c1_ev
+#define I2C_0_ERR_IRQ       I2C1_ER_IRQn
+#define I2C_0_ERR_ISR       isr_i2c1_er
+/* I2C 0 pin configuration */
+#define I2C_0_SCL_PIN       GPIO_PIN(PORT_B, 8) /* remapped */
+#define I2C_0_SDA_PIN       GPIO_PIN(PORT_B, 9) /* remapped */
+
+/* I2C 1 device configuration */
+#define I2C_1_DEV           I2C2
+#define I2C_1_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C2EN))
+#define I2C_1_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C2EN))
+#define I2C_1_EVT_IRQ       I2C2_EV_IRQn
+#define I2C_1_EVT_ISR       isr_i2c2_ev
+#define I2C_1_ERR_IRQ       I2C2_ER_IRQn
+#define I2C_1_ERR_ISR       isr_i2c2_er
+/* I2C 1 pin configuration */
+#define I2C_1_SCL_PIN       GPIO_PIN(PORT_B, 10)
+#define I2C_1_SDA_PIN       GPIO_PIN(PORT_B, 11)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 36000000Hz */
+        7,  /* -> 140625Hz */
+        6,  /* -> 281250Hz */
+        4,  /* -> 1125000Hz */
+        2,  /* -> 4500000Hz */
+        1   /* -> 9000000Hz */
+    },
+    {       /* for APB2 @ 72000000Hz */
+        7,  /* -> 281250Hz */
+        7,  /* -> 281250Hz */
+        5,  /* -> 1125000Hz */
+        3,  /* -> 4500000Hz */
+        2   /* -> 9000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_PIN(PORT_A, 4),
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    },
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 15),
+        .miso_pin = GPIO_PIN(PORT_B, 14),
+        .sclk_pin = GPIO_PIN(PORT_B, 13),
+        .cs_pin   = GPIO_PIN(PORT_B, 12),
+        .rccmask  = RCC_APB1ENR_SPI2EN,
+        .apbbus   = APB1
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name    ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (0)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -25,7 +25,7 @@
 
 #include "cpu_conf_common.h"
 
-#if defined(CPU_MODEL_STM32F103CB) || defined(CPU_MODEL_STM32F103RB)
+#if defined(CPU_MODEL_STM32F103C8) || defined(CPU_MODEL_STM32F103CB) || defined(CPU_MODEL_STM32F103RB)
 #include "vendor/stm32f103xb.h"
 #elif defined(CPU_MODEL_STM32F103RE)
 #include "vendor/stm32f103xe.h"

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -18,7 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
                              nucleo32-f042 nucleo32-f303 nucleo32-l031 nucleo-f030 \
                              nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f302 nucleo-f334 \
                              nucleo-l053 nucleo-l073 opencm904 pca10000 pca10005 \
-                             spark-core stm32f0discovery yunjia-nrf51822
+                             spark-core stm32f0discovery stm32f103c8t6 yunjia-nrf51822
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -13,8 +13,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
                              nucleo32-f031 nucleo32-f042 nucleo32-f303 nucleo32-l031 \
                              nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f302 \
                              nucleo-f334 nucleo-l053 nucleo-l073 opencm904 pca10000 \
-                             pca10005 spark-core stm32f0discovery telosb wsn430-v1_3b \
-                             wsn430-v1_4 yunjia-nrf51822 z1
+                             pca10005 spark-core stm32f0discovery stm32f103c8t6 \
+                             telosb wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 BOARD_BLACKLIST += mips-malta pic32-wifire pic32-clicker# No full UART available.
 

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -10,7 +10,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
                              nucleo-f072 nucleo-f103 nucleo-f302 nucleo-f334 nucleo-f410 \
                              nucleo-l053 nucleo-l073 nucleo32-f031 nucleo32-f042 \
                              nucleo32-f303 nucleo32-l031 opencm904 pca10000 \
-                             pca10005 spark-core stm32f0discovery yunjia-nrf51822 \
+                             pca10005 spark-core stm32f0discovery \
+                             stm32f103c8t6 yunjia-nrf51822 \
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
                    msb-430 msb-430h qemu-i386 telosb waspmote-pro wsn430-v1_3b \

--- a/tests/gnrc_netif2/Makefile
+++ b/tests/gnrc_netif2/Makefile
@@ -9,7 +9,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
                              nucleo-f302 nucleo-f334 nucleo-l053 nucleo-l073 \
                              nucleo32-f031 nucleo32-f042 nucleo32-f303 \
                              nucleo32-l031 opencm904 pca10000 pca10005 \
-                             spark-core stm32f0discovery telosb wsn430-v1_3b \
+                             spark-core stm32f0discovery stm32f103c8t6 \
+                             telosb wsn430-v1_3b \
                              wsn430-v1_4 yunjia-nrf51822 z1 \
 
 USEMODULE += embunit

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -8,7 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
                              nucleo32-l031 nucleo-f030 nucleo-f070 nucleo-f072 \
                              nucleo-f103 nucleo-f302 nucleo-f334 nucleo-l053 nucleo-l073 \
                              opencm904 pca10000 pca10005 spark-core stm32f0discovery \
-                             yunjia-nrf51822
+                             stm32f103c8t6 yunjia-nrf51822
 
 DISABLE_MODULE += auto_init
 

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -55,6 +55,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              sodaq-autonomo \
                              spark-core \
                              stm32f0discovery \
+                             stm32f103c8t6 \
                              stm32f3discovery \
                              telosb \
                              waspmote-pro \


### PR DESCRIPTION
This adds support for the STM32F103C8T6 demo board. Its a rather cheap board (i.e., approx. 2 EUR on ebay), and because of that kind of popular with lots of resources on-line - now users can switch and use RIOT 🎉 