### PR TITLE
tests: xtimer_usleep failure case relative to expected duration

### DIFF
--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -40,9 +40,8 @@ def testfunc(child):
             stop = datetime.now()
             diff = (stop - start)
             diff = (diff.seconds * 1000000) + diff.microseconds
-            # fail within 5% of expected
-            if diff > (exp_diff + (exp_diff1 * 0.05)) or \
-               diff < (exp_diff - (exp_diff1 * 0.05)):
+            # fail if deviation greater than 5% of expected
+            if abs(exp_diff - diff) > (exp_diff * 0.05):
                 raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
             else:
                 print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))


### PR DESCRIPTION
As per the code comment, which was worded the other way round, the deviation should remain below 5%, but of the expected time difference, not the 1 second duration. For example this will fail in case of 10 seconds sleeps and a drift of 0.2 seconds.
Currently the error can not be more than 5% of one second for all testcases 1, 5 and 10 seconds sleep.

On the other hand, if this is the intended behavior, the comment should point this out.

Might has to be taken into consideration for #7258.