### PR TITLE
board/calliope: fix board calliope rev1

### DIFF
--- a/boards/calliope-mini/include/board.h
+++ b/boards/calliope-mini/include/board.h
@@ -61,7 +61,7 @@ extern "C" {
  */
 #define BTN0_PIN                    GPIO_PIN(0, 17)
 #define BTN0_MODE                   GPIO_IN
-#define BTN1_PIN                    GPIO_PIN(0, 26)
+#define BTN1_PIN                    GPIO_PIN(0, 16)
 #define BTN1_MODE                   GPIO_IN
 /** @} */
 

--- a/boards/calliope-mini/include/board.h
+++ b/boards/calliope-mini/include/board.h
@@ -10,6 +10,8 @@
  * @defgroup    boards_calliope-mini Calliope mini
  * @ingroup     boards
  * @brief       Board specific files for the Calliope mini
+ *
+ * This board is for calliope-mini revision 1.0.
  * @{
  *
  * @file

--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2016-2017 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +14,7 @@
  * @brief       Peripheral configuration for the Calliope mini
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Semjon Kerner <semjon.kerner@fu-berlin.de>
  */
 
 #ifndef PERIPH_CONF_H
@@ -100,8 +101,8 @@ static const timer_conf_t timer_config[] = {
 static const i2c_conf_t i2c_config[] = {
     {
         .dev     = NRF_TWI0,
-        .pin_scl = 0,
-        .pin_sda = 30,
+        .pin_scl = 19,
+        .pin_sda = 20,
         .ppi     = 0
     }
 };


### PR DESCRIPTION
Since the old revision 0.3 of calliope mini is no longer produced and not commonly used, the old revision is obsolete and may be replaced by the implementation of revision 1.0. In the new version the pin layout changed, so this PR fixes those.