### PR TITLE
tests: added some more pexpect scripts

### DIFF
--- a/tests/bitarithm_timings/Makefile
+++ b/tests/bitarithm_timings/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/bitarithm_timings/tests/01-run.py
+++ b/tests/bitarithm_timings/tests/01-run.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+    child.expect_exact("Start.")
+    child.expect('\+ bitarithm_msb: \d+ iterations per second')
+    child.expect('\+ bitarithm_lsb: \d+ iterations per second')
+    child.expect('\+ bitarithm_bits_set: \d+ iterations per second')
+    child.expect_exact("Done.")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc, timeout=30))

--- a/tests/bloom_bytes/Makefile
+++ b/tests/bloom_bytes/Makefile
@@ -12,3 +12,6 @@ USEMODULE += xtimer
 DISABLE_MODULE += auto_init
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/bloom_bytes/tests/01-run.py
+++ b/tests/bloom_bytes/tests/01-run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+    child.expect_exact("Testing Bloom filter.")
+    child.expect_exact("m: 4096 k: 8")
+    child.expect("adding 512 elements took \d+ms")
+    child.expect("checking 10000 elements took \d+ms")
+    child.expect("\d+ elements probably in the filter.")
+    child.expect("\d+ elements not in the filter.")
+    child.expect(".+ false positive rate.")
+    child.expect_exact("All done!")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/buttons/Makefile
+++ b/tests/buttons/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/buttons/tests/01-run.py
+++ b/tests/buttons/tests/01-run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+    child.expect_exact("On-board button test")
+    index = child.expect([
+        r"\[FAILED\] no buttons available!",
+        r" -- Available buttons: \d+"
+    ])
+
+    if index == 1:
+        child.expect_exact("[SUCCESS]")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -24,3 +24,6 @@ USEMODULE += xtimer
 USEMODULE += timex
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/cpp11_condition_variable/tests/01-run.py
+++ b/tests/cpp11_condition_variable/tests/01-run.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2016 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+
+    child.expect_exact("************ C++ condition_variable test ***********")
+    child.expect_exact("Wait with predicate and notify one ...")
+    child.expect_exact("Done")
+    child.expect_exact("Wait and notify all ...")
+    child.expect_exact("Done")
+    child.expect_exact("Wait for ...")
+    child.expect_exact("Done")
+    child.expect_exact("Wait until ...")
+    child.expect_exact("Done")
+    child.expect_exact("Bye, bye.")
+    child.expect_exact("******************************************************")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -23,3 +23,6 @@ USEMODULE += cpp11-compat
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/cpp11_mutex/tests/01-run.py
+++ b/tests/cpp11_mutex/tests/01-run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2016 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+
+    child.expect_exact("************ C++ mutex test ***********")
+    child.expect_exact("Lock and unlock ...")
+    child.expect_exact("Done")
+    child.expect_exact("Try_lock ...")
+    child.expect_exact("Done")
+    child.expect_exact("Bye, bye.")
+    child.expect_exact("*****************************************")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -24,3 +24,6 @@ USEMODULE += xtimer
 USEMODULE += timex
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/cpp11_thread/tests/01-run.py
+++ b/tests/cpp11_thread/tests/01-run.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2016 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+
+    child.expect_exact("************ C++ thread test ***********")
+    child.expect_exact("Creating one thread and passing an argument ...")
+    child.expect_exact("Done")
+    child.expect_exact("Creating detached thread ...")
+    child.expect_exact("Done")
+    child.expect_exact("Join on 'finished' thread ...")
+    child.expect_exact("Done")
+    child.expect_exact("Join on 'running' thread ...")
+    child.expect_exact("Done")
+    child.expect_exact("Testing sleep_for ...")
+    child.expect_exact("Done")
+    child.expect_exact("Testing sleep_until ...")
+    child.expect_exact("Done")
+    child.expect_exact("Swapping two threads ...")
+    child.expect_exact("Done")
+    child.expect_exact("Move constructor ...")
+    child.expect_exact("Done")
+    child.expect_exact("Bye, bye.")
+    child.expect_exact("******************************************")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
I was starting task 2 from the release specs (https://github.com/RIOT-OS/Release-Specs/blob/master/02-tests/02-tests.md). Doing so, I found it not only inconvenient but also a waste of time, to do many of these tests manually... I think we all agree, that the goal must be to fully automate these tests!

So this PR is one small step towards this goal: I started to add `pexpect` scripts for tests, where the test result is more or less clear on the test's result state. If everyone agrees on proceeding on this, it would be nice if others could come to the rescue and help improving our current state so we can up this (and all future) release testing.

EDIT
~~NOTE 1: This PR contains also a small fix to allow for simply switching to a different terminal program (as `pyterm` has some trouble with `EOF` characters). This is essential for running the `make test` targets on actual hardware. With this fix, one can simply run e.g. 
`TERMINAL=picocom BOARD=samr21-xpro make all flash test`
This change is taken and adapted from  #7258 -> thanks to @kaspar030!~~ -> moved to its own PR #7758

NOTE 2: I have written a small script, that tries to run `make test` for every application in `tests/`. It gives a quick overview on the tests that actually support this target and their test results -> https://github.com/haukepetersen/riotsandbox/tree/master/tools/tester