### PR TITLE
make.serial: allow for using picocom as term prog

### DIFF
--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -5,13 +5,18 @@ ifeq ($(OS),Linux)
 else ifeq ($(OS),Darwin)
   PORT ?= $(PORT_DARWIN)
 endif
-
 ifeq ($(PORT),)
   $(info Warning: no PORT set!)
 endif
+export PORT
 
 export BAUD ?= 115200
-export TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
-export TERMPROG ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
 
-export PORT
+TERMINAL ?= pyterm
+ifeq ($(TERMINAL),pyterm)
+    export TERMPROG  ?= $(RIOTBASE)/dist/tools/pyterm/pyterm
+    export TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
+else ifeq ($(TERMINAL),picocom)
+    export TERMPROG  ?= picocom
+    export TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
+endif


### PR DESCRIPTION
When running pexpect scripts on target platforms, it will crash when using `pyterm` due to some handling of `EOF` characters. This PR allows for simple switching of terminal programs (`picocom` in this case).

The changes are picked and adapted from #7258. @kaspar030: are you ok with merging this change separately?