### PR TITLE
board/calliope: add inverse flag to SAUL gpio conf

### DIFF
--- a/boards/calliope-mini/include/gpio_params.h
+++ b/boards/calliope-mini/include/gpio_params.h
@@ -33,14 +33,16 @@ extern "C" {
 static const saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "Button A",
-        .pin  = BTN0_PIN,
-        .mode = BTN0_MODE
+        .name  = "Button A",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
     },
     {
-        .name = "Button B",
-        .pin  = BTN1_PIN,
-        .mode = BTN1_MODE
+        .name  = "Button B",
+        .pin   = BTN1_PIN,
+        .mode  = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
     },
 };
 


### PR DESCRIPTION
The buttons on the `calliope-mini` are active low, hence it makes sense to set the inversion flag in the SAUL gpio configuration, so they read `1` when they are pressed.