### PR TITLE
linux_can: fix library dependency [2017.10 backport]

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -597,7 +597,7 @@ ifneq (,$(filter evtimer,$(USEMODULE)))
 endif
 
 ifneq (,$(filter can_linux,$(USEMODULE)))
-  export LINKFLAGS += -lsocketcan
+  LINKFLAGS += -lsocketcan
 endif
 
 ifneq (,$(filter can,$(USEMODULE)))


### PR DESCRIPTION
Exporting the `LINKFLAGS` messes with the buildtest environment
somehow.

It is however not required to export them here (as a still successful
build of `tests/conn_can` on native proves)

Backport of https://github.com/RIOT-OS/RIOT/pull/7749