### PR TITLE
cpu, cc2538: fix pm, don't go into  cortexm_sleep(0) [2017.10 backport]

### DIFF
--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -48,6 +48,13 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @name    Power management configuration
+ * @{
+ */
+#define PROVIDES_PM_SET_LOWEST_CORTEXM
+/** @} */
+
+/**
  * @name Internal GPIO shift and masking
  * @{
  */

--- a/cpu/cc2538/periph/pm.c
+++ b/cpu/cc2538/periph/pm.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de
+ *               2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_pm
+ * @{
+ *
+ * @file
+ * @brief       common periph/pm functions
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/pm.h"
+
+#ifdef PROVIDES_PM_SET_LOWEST_CORTEXM
+void pm_set_lowest(void)
+{
+    /* don't do anything here */
+}
+#endif


### PR DESCRIPTION
back port of #7752 