### PR TITLE
cpu/sam0_common/periph/uart - don’t setup receive if no pin is selected

### DIFF
--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -61,8 +61,10 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     dev(uart)->CTRLA.reg &= ~(SERCOM_USART_CTRLA_ENABLE);
 
     /* configure pins */
-    gpio_init(uart_config[uart].rx_pin, GPIO_IN);
-    gpio_init_mux(uart_config[uart].rx_pin, uart_config[uart].mux);
+    if (uart_config[uart].rx_pin != GPIO_UNDEF) {
+        gpio_init(uart_config[uart].rx_pin, GPIO_IN);
+        gpio_init_mux(uart_config[uart].rx_pin, uart_config[uart].mux);
+    }
     gpio_init(uart_config[uart].tx_pin, GPIO_OUT);
     gpio_set(uart_config[uart].tx_pin);
     gpio_init_mux(uart_config[uart].tx_pin, uart_config[uart].mux);
@@ -97,7 +99,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     /* enable transmitter, and configure 8N1 mode */
     dev(uart)->CTRLB.reg = (SERCOM_USART_CTRLB_TXEN);
     /* enable receiver and RX interrupt if configured */
-    if (rx_cb) {
+    if ((rx_cb) && (uart_config[uart].rx_pin != GPIO_UNDEF)) {
         uart_ctx[uart].rx_cb = rx_cb;
         uart_ctx[uart].arg = arg;
         NVIC_EnableIRQ(SERCOM0_IRQn + sercom_id(dev(uart)));


### PR DESCRIPTION
When using printf/stdio it is common not to use the RX so added code to keep RX from being setup if the pin is set as GPIO_UNDEF in periph_conf.h:

```
static const uart_conf_t uart_config[] = {
	{
		.dev    = &SERCOM3->USART,
		.rx_pin = GPIO_UNDEF,
		.tx_pin = GPIO_PIN(PA,24),
		.mux    = GPIO_MUX_C,
		.rx_pad = UART_PAD_RX_3,
		.tx_pad = UART_PAD_TX_2,
                .flags = UART_FLAG_NONE,
		.gclk_src = GCLK_CLKCTRL_GEN_GCLK0
	}
};
```