### PR TITLE
pkg: fatfs: do not export CFLAGS in dependencies

### DIFF
--- a/pkg/fatfs/Makefile.dep
+++ b/pkg/fatfs/Makefile.dep
@@ -10,7 +10,7 @@ include $(RIOTBASE)/boards/$(BOARD)/Makefile.features
 
 #if periph_rtc is available use it. Otherwise use static timestamps
 ifneq (, $(filter periph_rtc, $(FEATURES_PROVIDED)))
-   export CFLAGS+= -DFATFS_FFCONF_OPT_FS_NORTC=0
+  CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=0
 else
-	export CFLAGS+= -DFATFS_FFCONF_OPT_FS_NORTC=1
+  CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=1
 endif


### PR DESCRIPTION
Same problem as with #7749, just with `fatfs`. Exporting the variable here will lead to multiple (re-)definitions of `CFLAGS` in places they are not supposed to be when running `make -C tests/pkg_fatfs buildtest`.