### PR TITLE
tests/lwip: only enable test for native board

### DIFF
--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -27,5 +27,8 @@ endif
 
 include $(RIOTBASE)/Makefile.include
 
+# Test only implemented for native
+ifeq ($(BOARD),native)
 test:
 	./tests/01-run.py
+endif


### PR DESCRIPTION
Other board are not supported in 01-run.py.