### PR TITLE
core: clist: improve clist_foreach()

### DIFF
--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -322,13 +322,16 @@ static inline clist_node_t *clist_remove(clist_node_t *list, clist_node_t *node)
 /**
  * @brief Traverse clist, call function for each member
  *
+ * The pointer supplied by @p arg will be passed to every call to @p func.
+ *
  * If @p func returns non-zero, traversal will be aborted like when calling
  * break within a for loop.
  *
  * @param[in]       list        List to traverse.
  * @param[in]       func        Function to call for each member.
+ * @param[in]       arg         Pointer to pass to every call to @p func
  */
-static inline void clist_foreach(clist_node_t *list, int(*func)(clist_node_t *))
+static inline void clist_foreach(clist_node_t *list, int(*func)(clist_node_t *, void *), void *arg)
 {
     clist_node_t *node = list->next;
     if (! node) {
@@ -336,7 +339,7 @@ static inline void clist_foreach(clist_node_t *list, int(*func)(clist_node_t *))
     }
     do {
         node = node->next;
-        if (func(node)) {
+        if (func(node, arg)) {
             return;
         }
     } while (node != list->next);

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -223,8 +223,9 @@ static void _foreach_test(clist_node_t *node)
 
 /* embunit test macros only work within void returning functions, so this
  * trampoline function is needed */
-static int _foreach_test_trampoline(clist_node_t *node)
+static int _foreach_test_trampoline(clist_node_t *node, void *arg)
 {
+    (void)arg;
     _foreach_test(node);
     if (_foreach_called == _foreach_abort_after) {
         return 1;
@@ -242,7 +243,7 @@ static void test_clist_foreach(void)
         clist_rpush(list, &tests_clist_buf[i]);
     }
 
-    clist_foreach(list, _foreach_test_trampoline);
+    clist_foreach(list, _foreach_test_trampoline, NULL);
 
     TEST_ASSERT(_foreach_called == _foreach_abort_after);
 
@@ -252,7 +253,7 @@ static void test_clist_foreach(void)
     }
 
     _foreach_abort_after = (TEST_CLIST_LEN + 1);
-    clist_foreach(list, _foreach_test_trampoline);
+    clist_foreach(list, _foreach_test_trampoline, NULL);
 
     TEST_ASSERT(_foreach_called == TEST_CLIST_LEN);
 }


### PR DESCRIPTION
previously, ```clist_foreach()``` allowed to iterate a list, executing a function for every member, and possibly aborting.

This PR adds an opaque ```void*``` argument to the function call, allowing ```clist_foreach()``` to be used in more flexible ways.

~~Waiting for #7655. (not directly dependent on it, but I'd like to save the hassle of rebasing, and they modify the same files)~~