### PR TITLE
dist/tools/testrunner: wait for 'make term' to start

### DIFF
--- a/dist/tools/testrunner/testrunner.py
+++ b/dist/tools/testrunner/testrunner.py
@@ -16,6 +16,7 @@ from traceback import print_tb
 MAKE_TERM_STARTED = {
     'pyterm': r"Type '/exit' to exit.",
     'native': r"main\(\): This is RIOT",
+    'native_noshell': r"RIOT .* hardware initialization complete",
 }
 
 

--- a/dist/tools/testrunner/testrunner.py
+++ b/dist/tools/testrunner/testrunner.py
@@ -7,6 +7,8 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
+from __future__ import unicode_literals
+
 import os, signal, sys, subprocess
 from pexpect import spawnu, TIMEOUT, EOF
 from traceback import print_tb


### PR DESCRIPTION
When used with a booard, 'make term' can take some time to start.
So now wait at max 5 seconds for it to start.

To try to detect that make term is started using its output.
Fast detect supported 'pyterm' and 'native'.