### PR TITLE
tests: pkg_fatfs: add periph_rtc to required features

### DIFF
--- a/tests/pkg_fatfs/Makefile
+++ b/tests/pkg_fatfs/Makefile
@@ -5,6 +5,8 @@ USEMODULE += shell
 
 BOARD ?= native
 
+FEATURES_OPTIONAL += periph_rtc
+
 # whitelist can be removed when the problem described in #6063 was resolved
 # this list is composed of boards that support spi + native
 BOARD_WHITELIST := native airfy-beacon arduino-due arduino-duemilanove arduino-mega2560 \


### PR DESCRIPTION
The tests reqiures a periph/rtc implementation to be available.
This is currently insured through whitelisting, but the whitelist will go as soon as #6063 is resolved.

This PR adds an explicit requirement.