### PR TITLE
make: add feature dependencies to drivers/Makefile.dep

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -418,6 +418,7 @@ endif
 
 ifneq (,$(filter uart_stdio,$(USEMODULE)))
   USEMODULE += isrpipe
+  FEATURES_REQUIRED += periph_uart
 endif
 
 ifneq (,$(filter isrpipe,$(USEMODULE)))
@@ -504,6 +505,10 @@ endif
 ifneq (,$(filter libfixmath-unittests,$(USEMODULE)))
   USEPKG += libfixmath
   USEMODULE += libfixmath
+endif
+
+ifneq (,$(filter luid,$(USEMODULE)))
+  FEATURES_OPTIONAL += periph_cpuid
 endif
 
 ifneq (,$(filter fib,$(USEMODULE)))

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -20,6 +20,8 @@ ifneq (,$(filter at86rf2%,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
 endif
 
 ifneq (,$(filter mrf24j40,$(USEMODULE)))
@@ -53,6 +55,7 @@ ifneq (,$(filter cc110x,$(USEMODULE)))
   ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += gnrc_cc110x
   endif
+  FEATURES_REQUIRED += periph_spi
 endif
 
 ifneq (,$(filter cc2420,$(USEMODULE)))
@@ -99,6 +102,7 @@ endif
 
 ifneq (,$(filter hdc1000,$(USEMODULE)))
   USEMODULE += xtimer
+  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter hih6130,$(USEMODULE)))
@@ -119,11 +123,16 @@ ifneq (,$(filter kw2xrf,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+  FEATURES_REQUIRED += periph_spi
 endif
 
 ifneq (,$(filter hd44780,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += xtimer
+endif
+
+ifneq (,$(filter l3g4200d,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter lis3dh,$(USEMODULE)))
@@ -138,6 +147,22 @@ endif
 ifneq (,$(filter lpd8808,$(USEMODULE)))
   USEMODULE += color
   FEATURES_REQUIRED += periph_gpio
+endif
+
+ifneq (,$(filter mag3110,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter mma8x5x,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter my9221,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+endif
+
+ifneq (,$(filter mpl3115a2,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter mpu9150,$(USEMODULE)))
@@ -205,6 +230,14 @@ ifneq (,$(filter sx127%,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
   USEMODULE += xtimer
   USEMODULE += sx127x
+endif
+
+ifneq (,$(filter tcs37727,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter tmp006,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter veml6070,$(USEMODULE)))


### PR DESCRIPTION
Many drivers depend on certain features (e.g., ```periph_spi```) without explicitly stating so.

This PR tries to add the missing dependencies.

~~WIP for now, help welcome! ;)~~