### PR TITLE
cpu, cc26x0: fix pm, don't go into cortexm_sleep(0)

### DIFF
--- a/cpu/cc26x0/include/periph_cpu.h
+++ b/cpu/cc26x0/include/periph_cpu.h
@@ -34,6 +34,13 @@ extern "C" {
  */
 #define CPUID_LEN           (16U)
 
+/**
+ * @name    Power management configuration
+ * @{
+ */
+#define PROVIDES_PM_SET_LOWEST_CORTEXM
+/** @} */
+
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO mode values

--- a/cpu/cc26x0/periph/pm.c
+++ b/cpu/cc26x0/periph/pm.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de
+ *               2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_pm
+ * @{
+ *
+ * @file
+ * @brief       common periph/pm functions
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/pm.h"
+
+#ifdef PROVIDES_PM_SET_LOWEST_CORTEXM
+void pm_set_lowest(void)
+{
+    /* don't do anything here */
+}
+#endif


### PR DESCRIPTION
followup on #7752.

With changes introduces in #7726 TI based CPUs CC2538 and CC2650 get stuck when entering idle thread never scheduling any other thread again. This PR fixes this behaviour by adding a non-op `pm_set_lowest`. 

For further infos and discussion see #7752 and issue #7746.