### PR TITLE
cpu: cortexm: fix LTO issue for shared vector table

### DIFF
--- a/cpu/cortexm_common/Makefile
+++ b/cpu/cortexm_common/Makefile
@@ -1,6 +1,9 @@
 # thread_arch.c's inline assembler breaks when compiling with link time
-# optimization. see #5774.
+# optimization. see https://github.com/RIOT-OS/RIOT/issues/5774.
 SRC_NOLTO += thread_arch.c
+
+# see https://github.com/RIOT-OS/RIOT/issues/5775.
+SRC_NOLTO += vectors_cortexm.c
 
 DIRS = periph
 


### PR DESCRIPTION
#7535 introduced a regression where previously excluded vector weak definitions are now compiled with LTO again. 

See https://github.com/RIOT-OS/RIOT/issues/5775.

This PR excludes the corresponding file from being compiled with LTO.