### PR TITLE
tests/ssp: Fix on macOS while compiling w/ clang

### DIFF
--- a/tests/ssp/main.c
+++ b/tests/ssp/main.c
@@ -28,9 +28,13 @@ void test_func(void)
 {
     char buf[16];
 
+    /* clang will detect the buffer overflow
+     * and throw an error if we use `buf` directly */
+    void *buffer_to_confuse_compiler = buf;
+
     /* cppcheck-suppress bufferAccessOutOfBounds
      * (reason: deliberately overflowing stack) */
-    memset(buf, 0, 32);
+    memset(buffer_to_confuse_compiler, 0, 32);
 }
 
 int main(void)


### PR DESCRIPTION
On macOS using Apple LLVM version 9.0.0 this test would
not compile due to clang detecting the buffer overflow.
Since this test is all about having a buffer overflow, I
tricked clang into not detecting this anymore.

This loosely relates to #6473.