### PR TITLE
tests: remove setting TERMFLAGS= before running test [2017.10 backport]

### DIFF
--- a/tests/cbor/Makefile
+++ b/tests/cbor/Makefile
@@ -21,6 +21,4 @@ USEMODULE += cbor_semantic_tagging
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/evtimer_msg/Makefile
+++ b/tests/evtimer_msg/Makefile
@@ -8,6 +8,4 @@ USEMODULE += evtimer
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/evtimer_underflow/Makefile
+++ b/tests/evtimer_underflow/Makefile
@@ -8,6 +8,4 @@ USEMODULE += evtimer
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -32,6 +32,4 @@ include $(RIOTBASE)/Makefile.include
 
 # This requires ENABLE_DEBUG in gnrc_ipv6.c to be 1
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/gnrc_ipv6_nib/Makefile
+++ b/tests/gnrc_ipv6_nib/Makefile
@@ -16,6 +16,4 @@ CFLAGS += -DTEST_SUITES
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/gnrc_ipv6_nib_6ln/Makefile
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile
@@ -19,6 +19,4 @@ CFLAGS += -DTEST_SUITES
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/gnrc_ndp2/Makefile
+++ b/tests/gnrc_ndp2/Makefile
@@ -14,6 +14,4 @@ CFLAGS += -DTEST_SUITES
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/gnrc_netif2/Makefile
+++ b/tests/gnrc_netif2/Makefile
@@ -33,6 +33,4 @@ CFLAGS += -DTEST_SUITES
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -28,6 +28,4 @@ CFLAGS += -DDEVELHELP
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -292,7 +292,6 @@ def test_triple_send(board_group, application, env=None):
         receiver.expect(u"00000000  DE  AD  BE  EF")
 
 if __name__ == "__main__":
-    del os.environ['TERMFLAGS']
     TestStrategy().execute([BoardGroup((Board("native", "tap0"), \
                             Board("native", "tap1")))], \
                            [test_ipv6_send, test_udpv6_send, test_tcpv6_send,

--- a/tests/mutex_order/Makefile
+++ b/tests/mutex_order/Makefile
@@ -7,6 +7,4 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f0
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/od/Makefile
+++ b/tests/od/Makefile
@@ -12,6 +12,4 @@ CFLAGS += -DDEVELHELP
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/rmutex/Makefile
+++ b/tests/rmutex/Makefile
@@ -7,6 +7,4 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f0
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/thread_flood/Makefile
+++ b/tests/thread_flood/Makefile
@@ -6,6 +6,4 @@ DISABLE_MODULE += auto_init
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/test_thread.py
+	tests/test_thread.py


### PR DESCRIPTION
Remove setting TERMFLAGS to an empty value as its value will not be set by
`serial.inc.mk` as it is already defined.

Backported from https://github.com/RIOT-OS/RIOT/pull/7770