### PR TITLE
tests/unittests: Fix error due to macOS sed incompatibility

### DIFF
--- a/pkg/relic/os_util.sh
+++ b/pkg/relic/os_util.sh
@@ -1,6 +1,8 @@
 OSNAME=`uname -s`
 SEDBIN="sed -i"
 if [ "${OSNAME}" = "Darwin" ] ; then
-    SEDBIN="sed -i ''"
+    command -v gsed >/dev/null 2>&1 || \
+        { echo "\n\033[31mPlease 'brew install gnu-sed'\033[0m\n"; exit 1; }
+    SEDBIN="gsed -i"
     LANG=C
 fi


### PR DESCRIPTION
Since most people™ seem to be developing on linux machines, they
commonly have gnu sed installed. In my experience with cross-platform
projects, it makes sense to require installation of gnu-sed on macOS
since dealing with the incompatibilites of sed is non-trivial.

This commit introduces such a check for the relic package.

For reference, the imcompatible sed call is located in
pkg/relic/fix-util_print_wo_args.sh (e.g. in 775e2071e)

This loosely relates to #6473.