### PR TITLE
sys/cbor: fix compilation with newlib

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -8,6 +8,12 @@ OLD_USEPKG := $(sort $(USEPKG))
 # pull dependencies from drivers
 include $(RIOTBASE)/drivers/Makefile.dep
 
+ifneq (,$(filter cbor_ctime,$(USEMODULE)))
+  ifneq (,$(filter newlib,$(USEMODULE)))
+    USEMODULE += newlib_gnu_source
+  endif
+endif
+
 ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += xtimer
@@ -379,6 +385,10 @@ endif
 
 ifneq (,$(filter od,$(USEMODULE)))
   USEMODULE += fmt
+endif
+
+ifneq (,$(filter newlib_gnu_source,$(USEMODULE)))
+  USEMODULE += newlib
 endif
 
 ifneq (,$(filter newlib_nano,$(USEMODULE)))

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -9,6 +9,10 @@ ifneq (,$(filter newlib_nano,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter newlib_gnu_source,$(USEMODULE)))
+  CFLAGS += -D_GNU_SOURCE=1
+endif
+
 ifeq (1,$(USE_NEWLIB_NANO))
   export LINKFLAGS += -specs=nano.specs
 endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -52,6 +52,7 @@ PSEUDOMODULES += netstats_l2
 PSEUDOMODULES += netstats_ipv6
 PSEUDOMODULES += netstats_rpl
 PSEUDOMODULES += newlib
+PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano
 PSEUDOMODULES += openthread
 PSEUDOMODULES += pktqueue

--- a/sys/cbor/Makefile
+++ b/sys/cbor/Makefile
@@ -1,7 +1,7 @@
 MODULE = cbor
 
 ifneq ($(shell uname -s),Darwin)
-	CFLAGS += -D_XOPEN_SOURCE=600
+  CFLAGS += -D_XOPEN_SOURCE=600
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -24,6 +24,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef MODULE_CBOR_CTIME
+#include <time.h>
+#endif
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 


### PR DESCRIPTION
Fixes #7411 and maybe #7287.

In some arm-none-eabi-gcc libc `strptime` in`<time.h>` is guarded by `__GNU_VISIBLE` define, which is defined while setting the define `_GNU_SOURCE`, otherwise `strptime` is not defined and thus any usage of it fails to compile.

This is the case in cbor, which doesn't include `<time.h>` explicitly, as well as setting the define `_GNU_SOURCE` is missing.

This PR fixes that.