### PR TITLE
pkg: relic: fix compiling on OS X

### DIFF
--- a/pkg/relic/os_util.sh
+++ b/pkg/relic/os_util.sh
@@ -3,4 +3,5 @@ SEDBIN="sed -i"
 if [ "${OSNAME}" = "Darwin" ] ; then
     SEDBIN="sed -i ''"
     LANG=C
+    LC_CTYPE=C
 fi


### PR DESCRIPTION
Fixes #4590 

An alternative of #7780 which uses the native `sed` command on OS X, which is the cause of compile failure in some OS X installations.