### PR TITLE
cpu/stm32_common: fix isr_exti infinite loop

### DIFF
--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -243,8 +243,8 @@ void isr_exti(void)
     uint32_t pending_isr = (EXTI->PR & EXTI->IMR);
     for (size_t i = 0; i < EXTI_NUMOF; i++) {
         if (pending_isr & (1 << i)) {
-            EXTI->PR = (1 << i);        /* clear by writing a 1 */
             isr_ctx[i].cb(isr_ctx[i].arg);
+            EXTI->PR = (1 << i);        /* clear by writing a 1 */
         }
     }
     cortexm_isr_end();


### PR DESCRIPTION
While playing with CAN and power management (#6178) I stumbled upon this issue with `exti` interrupt on stm32, my code gets stuck in `isr_exti` interrupt when the interrupt occurs.

This fix clears the interrupt flag after calling the interrupt callback instead of before.

Not sure if it's the best fix, but it works for me...