### PR TITLE
pkg/jerryscript: bump jerryscript version

### DIFF
--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -24,11 +24,24 @@ CFLAGS += -DDEVELHELP
 # Set stack size to something (conservatively) enormous
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=9092
 
-# Add the shell and some shell commands
-USEMODULE += shell
-USEMODULE += shell_commands
-
 # Add the package for Jerryscript
 USEPKG += jerryscript
 
 include $(CURDIR)/../../Makefile.include
+
+JS_PATH := $(BINDIR)/js/$(MODULE)
+# add directory of generated *.js.h files to include path
+CFLAGS += -I$(JS_PATH)
+
+# generate .js.h header files of .js files
+JS = $(wildcard *.js)
+JS_H := $(JS:%.js=$(JS_PATH)/%.js.h)
+
+$(JS_PATH)/:
+	@mkdir -p $@
+
+$(JS_H): | $(JS_PATH)/
+$(JS_H): $(JS_PATH)/%.js.h: %.js
+	xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@
+
+$(RIOTBUILD_CONFIG_HEADER_C): $(JS_H)

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -1,39 +1,23 @@
 ### About
 
-This example enables to execute arbitrary Javascript directly from the command line on the RIOT shell.
+This example shows how to write IoT applications using javascript.
 
 ### Acknowledgement
 This example is based on [Jerryscript](https://github.com/jerryscript-project/jerryscript) which does all the heavy lifting, providing full ECMAScript 5.1 profile on your IoT device (kudos guys!).
 
 ### Caveats
 
-- On your local board: best used with a serial communication program such [minicom](https://help.ubuntu.com/community/Minicom) instead of PyTerm (see why below).
+- currently, the only actual function available is "print"
 
-- On a testbed: you can try it on [IoT-lab](https://www.iot-lab.info). Tested and works so far on [IoT-lab M3](https://www.iot-lab.info/hardware/m3/), upload and flash the .elf, ssh into the node, and script away!
+### How to use
 
-- Except in the `print` instruction in your script, you have to replace single brackets `'` with `\'`.
+Just put your javascript code in "main.js" (check the example). The file will
+automatically be included when compiling the application, which will execute
+the file right after booting.
 
-- Expect some issues with PyTerm which interprets by default the first `;` as the end of the script command. Furthermore, if the script is long, PyTerm seems to get confused (hence the recommended use of minicom). To start playing with PyTerm, first edit `;` line 256 of RIOT/dist/tools/pyterm/pyterm
+### How to run
 
-### How to build
+Type `make flash term`.
 
-Type `make flash`. Then use your preferred serial communication tool to land in the RIOT shell.
-Note: you may have to type `reboot` or to press `RESET` on the board (after the flash).
-
-### Running the example
-
-In the RIOT shell, `help` will provide the list of available commands.
-
-The `script` command will run the test script code that you input in the command line.
-Some examples of scripts you can try:
-```
-script print ('hello');
-```
-```
-script var x = Math.sqrt (64); var txt = \'\'; while (x>1) { txt += --x + \'\\n\';} print (txt);
-```
-```
-script var person = { fname:\'John\', lname:\'Doe\', age:25 }; var text = \'\'; var x; for (x in person) { text += person[x] + \'\\n\'; } print (text);
-```
-
-Remark: outside of the print command, you may have to replace single brackets ' with \'.
+Note: you may have to press `RESET` on the board (after the flash) if the board
+reboots faster than the terminal program can start..

--- a/examples/javascript/main.js
+++ b/examples/javascript/main.js
@@ -1,0 +1,1 @@
+print("Hello from JerryScript!");

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -1,9 +1,11 @@
 PKG_NAME=jerryscript
 PKG_URL=https://github.com/jerryscript-project/jerryscript.git
-PKG_VERSION=56802c22a10b0d684ac93921ac28df891e320b4a
+PKG_VERSION=e62b5b601bc1caa3e4d8172824988536ed6138f3
 PKG_LICENSE=Apache-2.0
 
 .PHONY: all
+
+CFLAGS += -Wno-implicit-fallthrough
 
 all: git-download
 	@cp Makefile.jerryscript $(PKG_BUILDDIR)/Makefile

--- a/pkg/jerryscript/Makefile.dep
+++ b/pkg/jerryscript/Makefile.dep
@@ -1,3 +1,4 @@
 ifneq (,$(filter jerryscript,$(USEPKG)))
   USEMODULE += jerryport-minimal
+  USEMODULE += jerryscript-ext
 endif

--- a/pkg/jerryscript/Makefile.include
+++ b/pkg/jerryscript/Makefile.include
@@ -1,1 +1,2 @@
-INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-core/
+INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-core/include
+INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-ext/include

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -26,8 +26,9 @@ libjerry:
 	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP)
 
-	make -C $(BUILD_DIR) jerry-core jerry-port-default-minimal
+	make -C $(BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal
 	cp $(BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
+	cp $(BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
 	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
This PR updates the jerryscript package to the current upstream version.

It also changes the example to execute a compiled-in "main.js" and removes the (IMO kinda fiddly) shell handler that was used before.

This is the first of a series of Javascript related PRs.