### PR TITLE
tests/gnrc_ipv6_ext: fix documentation on ENABLE_DEBUG for test

### DIFF
--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -30,6 +30,6 @@ CFLAGS += -DDEVELHELP
 
 include $(RIOTBASE)/Makefile.include
 
-# This requires ENABLE_DEBUG in gnrc_ipv6.c to be 1
+# The test can check more things with ENABLE_DEBUG set to 1 in gnrc_ipv6.c
 test:
 	tests/01-run.py


### PR DESCRIPTION
The test can handle both with and without ENABLE_DEBUG.

This replaces https://github.com/RIOT-OS/RIOT/pull/7784