### PR TITLE
makefiles: fix (and add) info targets

### DIFF
--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -26,7 +26,7 @@ define board_missing_features
 
   include $(RIOTBASE)/Makefile.dep
 
-  FEATURES_MISSING := $$(filter-out $$(FEATURES_PROVIDED), $$(FEATURES_REQUIRED))
+  FEATURES_MISSING := $$(sort $$(filter-out $$(FEATURES_PROVIDED), $$(FEATURES_REQUIRED)))
   ifneq (, $${FEATURES_MISSING})
     BOARDS_FEATURES_MISSING += "${1} $${FEATURES_MISSING}"
     ifneq (, $$(filter-out $$(FEATURES_OPTIONAL), $$(FEATURES_MISSING)))

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -115,4 +115,4 @@ info-cpu:
 	@echo $(CPU)
 
 info-features-missing:
-	@echo $(filter-out $(FEATURES_PROVIDED), $(FEATURES_REQUIRED))
+	@for i in $(sort $(filter-out $(FEATURES_PROVIDED), $(FEATURES_REQUIRED))); do echo $$i; done

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -1,5 +1,6 @@
 .PHONY: info-objsize info-buildsizes info-build info-boards-supported \
-        info-features-missing info-modules info-cpu
+        info-features-missing info-modules info-cpu \
+        info-features-provided info-features-required
 
 info-objsize:
 	@case "${SORTROW}" in \
@@ -113,6 +114,12 @@ info-modules:
 
 info-cpu:
 	@echo $(CPU)
+
+info-features-provided:
+	@for i in $(sort $(FEATURES_PROVIDED)); do echo $$i; done
+
+info-features-required:
+	@for i in $(sort $(FEATURES_REQUIRED)); do echo $$i; done
 
 info-features-missing:
 	@for i in $(sort $(filter-out $(FEATURES_PROVIDED), $(FEATURES_REQUIRED))); do echo $$i; done


### PR DESCRIPTION
This PR fixes two `make info-*` targets by removing duplicates, namely `info-boards-features-missing` and `info-features-missing`. For instance on current master, output is:

```
xtimer_hang $ make info-boards-features-missing
qemu-i386  periph_timer  periph_timer
```

where `periph_timer` is mentioned twice, with this PR it is:

```
xtimer_hang $ make info-boards-features-missing
qemu-i386  periph_timer
```

Further this PR adds two additional targets for features, namely `info-features-required` and `info-features-provided`. They might be handy, e.g., pre-checks for automated testing.