### PR TITLE
tests/lwip: only enable test for native board [2017.10 backport]

### DIFF
--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -27,5 +27,8 @@ endif
 
 include $(RIOTBASE)/Makefile.include
 
+# Test only implemented for native
+ifeq ($(BOARD),native)
 test:
 	./tests/01-run.py
+endif


### PR DESCRIPTION
Other board are not supported in 01-run.py.

Backport from https://github.com/RIOT-OS/RIOT/pull/7766