### PR TITLE
ds1307: return error when nothing is read or written on initialization [2017.10 backport] (against 2017.10-branch this time)

### DIFF
--- a/drivers/ds1307/ds1307.c
+++ b/drivers/ds1307/ds1307.c
@@ -64,7 +64,7 @@ int ds1307_init(ds1307_t *dev, const ds1307_params_t *params)
     }
     /* normalize hour format */
     res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_HOUR, &hour);
-    if (res < 0) {
+    if (res <= 0) { /* should be 1 if device is connected */
         i2c_release(dev->i2c);
         DEBUG("ds1307: Error reading HOUR register on init: %i\n", res);
         return -1;
@@ -73,7 +73,7 @@ int ds1307_init(ds1307_t *dev, const ds1307_params_t *params)
                         _convert_12_to_24(hour));
     i2c_release(dev->i2c);
 
-    if (res < 0) {
+    if (res <= 0) {
         DEBUG("ds1307: Error writing HOUR register on init: %i\n", res);
         return -1;
     }

--- a/tests/driver_ds1307/tests/01-run.py
+++ b/tests/driver_ds1307/tests/01-run.py
@@ -13,7 +13,8 @@ sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
 def testfunc(child):
-    child.expect(u"OK \\([0-9]+ tests\\)")
+    child.expect([r"OK \([0-9]+ tests\)",
+                  r"error: unable to initialize RTC \[I2C initialization error\]"])
 
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
Backport to #7788 (and redo against the correct branch of #7807).