### PR TITLE
tests: sock: remove timing tests from pexpect script [2017.10 backport]

### DIFF
--- a/tests/gnrc_sock_ip/tests/01-run.py
+++ b/tests/gnrc_sock_ip/tests/01-run.py
@@ -14,9 +14,6 @@ from datetime import datetime
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-class InvalidTimeout(Exception):
-    pass
-
 def testfunc(child):
     child.expect_exact(u"Calling test_sock_ip_create__EAFNOSUPPORT()")
     child.expect_exact(u"Calling test_sock_ip_create__EINVAL_addr()")
@@ -30,20 +27,8 @@ def testfunc(child):
     child.expect_exact(u"Calling test_sock_ip_recv__ENOBUFS()")
     child.expect_exact(u"Calling test_sock_ip_recv__EPROTO()")
     child.expect_exact(u"Calling test_sock_ip_recv__ETIMEDOUT()")
-    child.match         # get to ensure program reached that point
-    start = datetime.now()
     child.expect_exact(u" * Calling sock_ip_recv()")
-    child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-    exp_diff = int(child.match.group(1))
-    stop = datetime.now()
-    diff = (stop - start)
-    diff = (diff.seconds * 1000000) + diff.microseconds
-    # fail within 5% of expected
-    if diff > (exp_diff + (exp_diff * 0.05)) or \
-       diff < (exp_diff - (exp_diff * 0.05)):
-        raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-    else:
-        print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+    child.expect(r" \* \(timed out with timeout \d+\)")
     child.expect_exact(u"Calling test_sock_ip_recv__socketed()")
     child.expect_exact(u"Calling test_sock_ip_recv__socketed_with_remote()")
     child.expect_exact(u"Calling test_sock_ip_recv__unsocketed()")

--- a/tests/gnrc_sock_udp/tests/01-run.py
+++ b/tests/gnrc_sock_udp/tests/01-run.py
@@ -14,9 +14,6 @@ from datetime import datetime
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-class InvalidTimeout(Exception):
-    pass
-
 def testfunc(child):
     child.expect_exact(u"Calling test_sock_udp_create__EADDRINUSE()")
     child.expect_exact(u"Calling test_sock_udp_create__EAFNOSUPPORT()")
@@ -32,20 +29,8 @@ def testfunc(child):
     child.expect_exact(u"Calling test_sock_udp_recv__ENOBUFS()")
     child.expect_exact(u"Calling test_sock_udp_recv__EPROTO()")
     child.expect_exact(u"Calling test_sock_udp_recv__ETIMEDOUT()")
-    child.match         # get to ensure program reached that point
-    start = datetime.now()
     child.expect_exact(u" * Calling sock_udp_recv()")
-    child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-    exp_diff = int(child.match.group(1))
-    stop = datetime.now()
-    diff = (stop - start)
-    diff = (diff.seconds * 1000000) + diff.microseconds
-    # fail within 5% of expected
-    if diff > (exp_diff + (exp_diff * 0.05)) or \
-       diff < (exp_diff - (exp_diff * 0.05)):
-        raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-    else:
-        print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+    child.expect(r" \* \(timed out with timeout \d+\)")
     child.expect_exact(u"Calling test_sock_udp_recv__socketed()")
     child.expect_exact(u"Calling test_sock_udp_recv__socketed_with_remote()")
     child.expect_exact(u"Calling test_sock_udp_recv__unsocketed()")

--- a/tests/lwip_sock_ip/tests/01-run.py
+++ b/tests/lwip_sock_ip/tests/01-run.py
@@ -14,9 +14,6 @@ from datetime import datetime
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-class InvalidTimeout(Exception):
-    pass
-
 def _ipv6_tests(code):
     return code & (1 << 6)
 
@@ -39,20 +36,8 @@ def testfunc(child):
         child.expect_exact(u"Calling test_sock_ip_recv4__EAGAIN()")
         child.expect_exact(u"Calling test_sock_ip_recv4__ENOBUFS()")
         child.expect_exact(u"Calling test_sock_ip_recv4__ETIMEDOUT()")
-        child.match         # get to ensure program reached that point
-        start = datetime.now()
         child.expect_exact(u" * Calling sock_ip_recv()")
-        child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-        exp_diff = int(child.match.group(1))
-        stop = datetime.now()
-        diff = (stop - start)
-        diff = (diff.seconds * 1000000) + diff.microseconds
-        # fail within 5% of expected
-        if diff > (exp_diff + (exp_diff * 0.05)) or \
-           diff < (exp_diff - (exp_diff * 0.05)):
-            raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-        else:
-            print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+        child.expect(r" \* \(timed out with timeout \d+\)")
         child.expect_exact(u"Calling test_sock_ip_recv4__socketed()")
         child.expect_exact(u"Calling test_sock_ip_recv4__socketed_with_remote()")
         child.expect_exact(u"Calling test_sock_ip_recv4__unsocketed()")
@@ -87,20 +72,8 @@ def testfunc(child):
         child.expect_exact(u"Calling test_sock_ip_recv6__EAGAIN()")
         child.expect_exact(u"Calling test_sock_ip_recv6__ENOBUFS()")
         child.expect_exact(u"Calling test_sock_ip_recv6__ETIMEDOUT()")
-        child.match         # get to ensure program reached that point
-        start = datetime.now()
         child.expect_exact(u" * Calling sock_ip_recv()")
-        child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-        exp_diff = int(child.match.group(1))
-        stop = datetime.now()
-        diff = (stop - start)
-        diff = (diff.seconds * 1000000) + diff.microseconds
-        # fail within 5% of expected
-        if diff > (exp_diff + (exp_diff * 0.05)) or \
-           diff < (exp_diff - (exp_diff * 0.05)):
-            raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-        else:
-            print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+        child.expect(r" \* \(timed out with timeout \d+\)")
         child.expect_exact(u"Calling test_sock_ip_recv6__socketed()")
         child.expect_exact(u"Calling test_sock_ip_recv6__socketed_with_remote()")
         child.expect_exact(u"Calling test_sock_ip_recv6__unsocketed()")

--- a/tests/lwip_sock_tcp/tests/01-run.py
+++ b/tests/lwip_sock_tcp/tests/01-run.py
@@ -14,9 +14,6 @@ from datetime import datetime
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-class InvalidTimeout(Exception):
-    pass
-
 def _reuse_tests(code):
     return code & 1
 
@@ -46,37 +43,15 @@ def testfunc(child):
         child.expect_exact("Calling test_tcp_accept4__EAGAIN()")
         child.expect_exact("Calling test_tcp_accept4__EINVAL()")
         child.expect_exact("Calling test_tcp_accept4__ETIMEDOUT()")
-        start = datetime.now()
         child.expect_exact(" * Calling sock_tcp_accept()")
-        child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-        exp_diff = int(child.match.group(1))
-        stop = datetime.now()
-        diff = (stop - start)
-        diff = (diff.seconds * 1000000) + diff.microseconds
-        # fail within 5% of expected
-        if diff > (exp_diff + (exp_diff * 0.05)) or \
-           diff < (exp_diff - (exp_diff * 0.05)):
-            raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-        else:
-            print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+        child.expect(r" \* \(timed out with timeout \d+\)")
         child.expect_exact("Calling test_tcp_accept4__success()")
         child.expect_exact("Calling test_tcp_read4__EAGAIN()")
         child.expect_exact("Calling test_tcp_read4__ECONNRESET()")
         child.expect_exact("Calling test_tcp_read4__ENOTCONN()")
         child.expect_exact("Calling test_tcp_read4__ETIMEDOUT()")
-        start = datetime.now()
         child.expect_exact(" * Calling sock_tcp_read()")
-        child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-        exp_diff = int(child.match.group(1))
-        stop = datetime.now()
-        diff = (stop - start)
-        diff = (diff.seconds * 1000000) + diff.microseconds
-        # fail within 5% of expected
-        if diff > (exp_diff + (exp_diff * 0.05)) or \
-           diff < (exp_diff - (exp_diff * 0.05)):
-            raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-        else:
-            print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+        child.expect(r" \* \(timed out with timeout \d+\)")
         child.expect_exact("Calling test_tcp_read4__success()")
         child.expect_exact("Calling test_tcp_read4__success_with_timeout()")
         child.expect_exact("Calling test_tcp_read4__success_non_blocking()")
@@ -99,37 +74,15 @@ def testfunc(child):
         child.expect_exact("Calling test_tcp_accept6__EAGAIN()")
         child.expect_exact("Calling test_tcp_accept6__EINVAL()")
         child.expect_exact("Calling test_tcp_accept6__ETIMEDOUT()")
-        start = datetime.now()
         child.expect_exact(" * Calling sock_tcp_accept()")
-        child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-        exp_diff = int(child.match.group(1))
-        stop = datetime.now()
-        diff = (stop - start)
-        diff = (diff.seconds * 1000000) + diff.microseconds
-        # fail within 5% of expected
-        if diff > (exp_diff + (exp_diff * 0.05)) or \
-           diff < (exp_diff - (exp_diff * 0.05)):
-            raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-        else:
-            print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+        child.expect(r" \* \(timed out with timeout \d+\)")
         child.expect_exact("Calling test_tcp_accept6__success()")
         child.expect_exact("Calling test_tcp_read6__EAGAIN()")
         child.expect_exact("Calling test_tcp_read6__ECONNRESET()")
         child.expect_exact("Calling test_tcp_read6__ENOTCONN()")
         child.expect_exact("Calling test_tcp_read6__ETIMEDOUT()")
-        start = datetime.now()
         child.expect_exact(" * Calling sock_tcp_read()")
-        child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-        exp_diff = int(child.match.group(1))
-        stop = datetime.now()
-        diff = (stop - start)
-        diff = (diff.seconds * 1000000) + diff.microseconds
-        # fail within 5% of expected
-        if diff > (exp_diff + (exp_diff * 0.05)) or \
-           diff < (exp_diff - (exp_diff * 0.05)):
-            raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-        else:
-            print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+        child.expect(r" \* \(timed out with timeout \d+\)")
         child.expect_exact("Calling test_tcp_read6__success()")
         child.expect_exact("Calling test_tcp_read6__success_with_timeout()")
         child.expect_exact("Calling test_tcp_read6__success_non_blocking()")

--- a/tests/lwip_sock_udp/tests/01-run.py
+++ b/tests/lwip_sock_udp/tests/01-run.py
@@ -14,9 +14,6 @@ from datetime import datetime
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-class InvalidTimeout(Exception):
-    pass
-
 def _reuse_tests(code):
     return code & 1
 
@@ -44,20 +41,8 @@ def testfunc(child):
         child.expect_exact(u"Calling test_sock_udp_recv4__EAGAIN()")
         child.expect_exact(u"Calling test_sock_udp_recv4__ENOBUFS()")
         child.expect_exact(u"Calling test_sock_udp_recv4__ETIMEDOUT()")
-        child.match         # get to ensure program reached that point
-        start = datetime.now()
         child.expect_exact(u" * Calling sock_udp_recv()")
-        child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-        exp_diff = int(child.match.group(1))
-        stop = datetime.now()
-        diff = (stop - start)
-        diff = (diff.seconds * 1000000) + diff.microseconds
-        # fail within 5% of expected
-        if diff > (exp_diff + (exp_diff * 0.05)) or \
-           diff < (exp_diff - (exp_diff * 0.05)):
-            raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-        else:
-            print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+        child.expect(r" \* \(timed out with timeout \d+\)")
         child.expect_exact(u"Calling test_sock_udp_recv4__socketed()")
         child.expect_exact(u"Calling test_sock_udp_recv4__socketed_with_remote()")
         child.expect_exact(u"Calling test_sock_udp_recv4__unsocketed()")
@@ -96,20 +81,8 @@ def testfunc(child):
         child.expect_exact(u"Calling test_sock_udp_recv6__EAGAIN()")
         child.expect_exact(u"Calling test_sock_udp_recv6__ENOBUFS()")
         child.expect_exact(u"Calling test_sock_udp_recv6__ETIMEDOUT()")
-        child.match         # get to ensure program reached that point
-        start = datetime.now()
         child.expect_exact(u" * Calling sock_udp_recv()")
-        child.expect(u" \\* \\(timed out with timeout (\\d+)\\)")
-        exp_diff = int(child.match.group(1))
-        stop = datetime.now()
-        diff = (stop - start)
-        diff = (diff.seconds * 1000000) + diff.microseconds
-        # fail within 5% of expected
-        if diff > (exp_diff + (exp_diff * 0.05)) or \
-           diff < (exp_diff - (exp_diff * 0.05)):
-            raise InvalidTimeout("Invalid timeout %d (expected %d)" % (diff, exp_diff));
-        else:
-            print("Timed out correctly: %d (expected %d)" % (diff, exp_diff))
+        child.expect(r" \* \(timed out with timeout \d+\)")
         child.expect_exact(u"Calling test_sock_udp_recv6__socketed()")
         child.expect_exact(u"Calling test_sock_udp_recv6__socketed_with_remote()")
         child.expect_exact(u"Calling test_sock_udp_recv6__unsocketed()")


### PR DESCRIPTION
Backport of #7816