### PR TITLE
tests/mcuboot: add documentation about dependencies

### DIFF
--- a/tests/mcuboot/README.md
+++ b/tests/mcuboot/README.md
@@ -12,6 +12,19 @@ information, and TLVs with hash and signing information. This is done through
 the imgtool.py application, which is executed automatically by the build
 system.
 
+Before running the test, be sure that you meet the following Python3
+dependencies:
+
+  - pycrypto
+  - ecdsa
+  - pyasn1
+
+If you don't have one of those, you can install them with the commands:
+
+```console
+pip3 install --user pycrypto ecdsa pyasn1
+```
+
 This test can be called using `make mcuboot` to produce such ELF file,
 which can also be flashed using `make flash-mcuboot`.This command also flashes
 the pre-compiled bootloader.


### PR DESCRIPTION
The current README.md doesn't state explicitly the dependencies required for building mcuboot.

This PR adds the dependency list and the commands to install them.