### PR TITLE
drivers/hdc1000: add caching capability

### DIFF
--- a/drivers/hdc1000/hdc1000_saul.c
+++ b/drivers/hdc1000/hdc1000_saul.c
@@ -25,7 +25,7 @@
 
 static int read_temp(const void *dev, phydat_t *res)
 {
-    if (hdc1000_read((const hdc1000_t *)dev, &(res->val[0]), NULL) != HDC1000_OK) {
+    if (hdc1000_read_cached((const hdc1000_t *)dev, &(res->val[0]), NULL) != HDC1000_OK) {
         return -ECANCELED;
     }
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
@@ -37,7 +37,7 @@ static int read_temp(const void *dev, phydat_t *res)
 
 static int read_hum(const void *dev, phydat_t *res)
 {
-    if (hdc1000_read((const hdc1000_t *)dev, NULL, &(res->val[0])) != HDC1000_OK) {
+    if (hdc1000_read_cached((const hdc1000_t *)dev, NULL, &(res->val[0])) != HDC1000_OK) {
         return -ECANCELED;
     }
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -153,6 +153,22 @@ int hdc1000_get_results(const hdc1000_t *dev, int16_t *temp, int16_t *hum);
  */
 int hdc1000_read(const hdc1000_t *dev, int16_t *temp, int16_t *hum);
 
+/**
+ * @brief   Extended read function including caching capability
+ *
+ * This function will return cached values if they are within the sampling
+ * period (HDC1000_RENEW_INTERVAL), or will trigger a new conversion, wait for
+ * the conversion to be finished and the get the results from the device.
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] temp         temperature [in 100 * degree centigrade]
+ * @param[out] hum          humidity [in 100 * percent relative]
+ *
+ * @return                  HDC1000_OK on success
+ * @return                  HDC1000_BUSERR on I2C communication failures
+ */
+int hdc1000_read_cached(const hdc1000_t *dev, int16_t *temp, int16_t *hum);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
HDC1000 sensor can read temperature and humidity at once.
But saul interface allows to an application to read one HDC1000 information at once.

To improve efficiency, this PR adds caching capability to HDC driver.
1. When an information is requested, HDC senses both temp and hum at once.
2. HDC returns only the requested information and cache the other.
3. When a cached information is requested, HDC returns the cached value without sensing.
4. If the cached information is outdated, HDC removes the information.