### PR TITLE
tmp006: optional raw values, low power mode, SAUL type

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -94,6 +94,10 @@ ifneq (,$(filter encx24j600,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter tmp006,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter ethos,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += random

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -91,6 +91,7 @@ enum {
     SAUL_SENSE_PRESS    = 0x89,     /**< sensor: pressure */
     SAUL_SENSE_ANALOG   = 0x8a,     /**< sensor: raw analog value */
     SAUL_SENSE_UV       = 0x8b,     /**< sensor: UV index */
+    SAUL_SENSE_OBJTEMP  = 0x8c,     /**< sensor: object temperature */
     SAUL_CLASS_ANY      = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/include/tmp006.h
+++ b/drivers/include/tmp006.h
@@ -101,6 +101,28 @@ extern "C"
 #endif
 
 /**
+ * @brief   Default low power mode
+ *
+ * If set to 0, the device will be always-on
+ * If set to 1, the device will be put in low power mode between measurements.
+ * This adds a @c TMP006_CONVERSION_TIME us delay to each measurement call
+ * for bringing the device out of standby.
+ */
+#ifndef TMP006_USE_LOW_POWER
+#define TMP006_USE_LOW_POWER (0)
+#endif
+
+/**
+ * @brief   Default raw value mode
+ *
+ * If set to 0, measurements will be converted to Celsius.
+ * If set to 1, raw adc readings will be returned.
+ */
+#ifndef TMP006_USE_RAW_VALUES
+#define TMP006_USE_RAW_VALUES (0)
+#endif
+
+/**
  * @name    Conversion rate and AVG sampling configuration
  * @{
  */

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -47,6 +47,7 @@ const char *saul_class_to_str(const uint8_t class_id)
         case SAUL_SENSE_COLOR:  return "SENSE_COLOR";
         case SAUL_SENSE_PRESS:  return "SENSE_PRESS";
         case SAUL_SENSE_ANALOG: return "SENSE_ANALOG";
+        case SAUL_SENSE_OBJTEMP:return "SENSE_OBJTEMP";
         case SAUL_CLASS_ANY:    return "CLASS_ANY";
         default:                return "CLASS_UNKNOWN";
     }

--- a/drivers/tmp006/tmp006_saul.c
+++ b/drivers/tmp006/tmp006_saul.c
@@ -30,14 +30,18 @@ static int read_temp(const void *dev, phydat_t *res)
         return -ECANCELED;
     }
     res->val[2] = 0;
+#if TMP006_USE_RAW_VALUES
+    res->unit = UNIT_NONE;
+    res->scale = 0;
+#else
     res->unit = UNIT_TEMP_C;
     res->scale = -2;
-
+#endif
     return 2;
 }
 
 const saul_driver_t tmp006_saul_driver = {
     .read = read_temp,
     .write = saul_notsup,
-    .type = SAUL_SENSE_TEMP,
+    .type = SAUL_SENSE_OBJTEMP,
 };

--- a/sys/auto_init/saul/auto_init_tmp006.c
+++ b/sys/auto_init/saul/auto_init_tmp006.c
@@ -60,7 +60,12 @@ void auto_init_tmp006(void)
             LOG_ERROR("[auto_init_saul] error set active tmp006 #%u\n", i);
             continue;
         }
-
+#if TMP006_USE_LOW_POWER
+        if (tmp006_set_standby(&tmp006_devs[i]) != TMP006_OK) {
+            LOG_ERROR("[auto_init_saul] error set standby tmp006 #%u\n", i);
+            continue;
+        }
+#endif
         saul_entries[i].dev = &(tmp006_devs[i]);
         saul_entries[i].name = tmp006_saul_info[i].name;
         saul_entries[i].driver = &tmp006_saul_driver;


### PR DESCRIPTION
This PR handles 
1. Interoperability between SAUL and tmp006 driver in the low power context.
- When SAUL calls tmp006_read_temperature function to read temperature from tmp006. But when this function is called when tmp006 is sleeping, it fails. This PR resolves the problem by waking up tmp006, wait some amount of time, reads from tmp006, and making it sleep.
- What tmp006 gives is radiant temperature, not the air temperature. But SAUL does not have that information type, causing confusion when tmp006 is used with air temperature sensors together (e.g., HDC1000). Since some applications require both types of temperature, this PR adds "SAUL_SENSE_RADTEMP" type.

2. Conversion of tmp006 requires heavy computation. Given that the sensing info is usually not read at the end device but at the server side, this conversion can be done at the server side if the sensing device is battery powered. So this PR adds "COMPUTATION OFFLOADING" option to tmp006 driver.