### PR TITLE
tests/xtimer_x: added pexpect scripts

### DIFF
--- a/tests/xtimer_hang/Makefile
+++ b/tests/xtimer_hang/Makefile
@@ -6,3 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/xtimer_hang/tests/01-run.py
+++ b/tests/xtimer_hang/tests/01-run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+    child.expect_exact("[START]")
+
+    for i in range(100):
+        child.expect(u"Testing \( +\d+%\)")
+
+    child.expect_exact("[SUCCESS]")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -5,3 +5,6 @@ USEMODULE += fmt
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/xtimer_now64_continuity/tests/01-run.py
+++ b/tests/xtimer_now64_continuity/tests/01-run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+    child.expect_exact("[START]")
+    child.expect(u"\[RESULTS\] min=\d+, avg=\d+, max=\d+")
+    child.expect_exact("[SUCCESS]")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_periodic_wakeup/Makefile
+++ b/tests/xtimer_periodic_wakeup/Makefile
@@ -6,3 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := chronos
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/xtimer_periodic_wakeup/tests/01-run.py
+++ b/tests/xtimer_periodic_wakeup/tests/01-run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+    child.expect_exact("xtimer_periodic_wakeup test application.")
+
+    for i in range(256):
+        child.expect(u"Testing interval \d+... \(now=\d+\)")
+    for i in range(256):
+        child.expect(u" +\d+ diff=\d+")
+
+    child.expect(u"Min/max error: \d+/\d+")
+    child.expect_exact("Test complete.")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_remove/Makefile
+++ b/tests/xtimer_remove/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/xtimer_remove/tests/01-run.py
+++ b/tests/xtimer_remove/tests/01-run.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+    child.expect_exact("xtimer_remove test application.")
+    child.expect_exact("Setting 3 timers, removing timer 0/3")
+    child.expect_exact("timer 1 triggered.")
+    child.expect_exact("timer 2 triggered.")
+    child.expect_exact("Setting 3 timers, removing timer 1/3")
+    child.expect_exact("timer 0 triggered.")
+    child.expect_exact("timer 2 triggered.")
+    child.expect_exact("Setting 3 timers, removing timer 2/3")
+    child.expect_exact("timer 0 triggered.")
+    child.expect_exact("timer 1 triggered.")
+    child.expect_exact("test successful.")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_reset/Makefile
+++ b/tests/xtimer_reset/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/xtimer_reset/tests/01-run.py
+++ b/tests/xtimer_reset/tests/01-run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+def testfunc(child):
+    child.expect_exact("This test tests re-setting of an already active timer.")
+    child.expect_exact("It should print three times \"now=<value>\", with "
+                       "values approximately 100ms (100000us) apart.")
+    child.expect(u"now=\d+")
+    child.expect(u"now=\d+")
+    child.expect(u"now=\d+")
+    child.expect_exact("Test completed!")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
Some of the `xtimer` tests define their success state clearly and can thereby easily be tested automatically using simple `pexpect` scripts, which are added with this PR.