### PR TITLE
sam0_common/spiclk: add 4MHz and 8MHz options

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -182,7 +182,9 @@ typedef enum {
     SPI_CLK_100KHZ =   100000U, /**< drive the SPI bus with 100KHz */
     SPI_CLK_400KHZ =   400000U, /**< drive the SPI bus with 400KHz */
     SPI_CLK_1MHZ   =  1000000U, /**< drive the SPI bus with 1MHz */
+    SPI_CLK_4MHZ   =  4000000U, /**< drive the SPI bus with 4MHz */
     SPI_CLK_5MHZ   =  5000000U, /**< drive the SPI bus with 5MHz */
+    SPI_CLK_8MHZ   =  8000000U, /**< drive the SPI bus with 8MHz */
     SPI_CLK_10MHZ  = 10000000U  /**< drive the SPI bus with 10MHz */
 } spi_clk_t;
 /** @} */


### PR DESCRIPTION
Current SPICLK options cannot support maximum SPI speed for samr21-xpro.

Maximum SPICLK is 4MHz when using 8MHz main clock.
When using 48MHz clock, SPICLK is bounded by the radio, which is 8MHz. 

This PR adds these two options.