### PR TITLE
tests, thread_flood: update test script and output

### DIFF
--- a/tests/thread_flood/main.c
+++ b/tests/thread_flood/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Hamburg University of Applied Sciences
+ * Copyright (C) 2015-2017 Hamburg University of Applied Sciences
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,16 +16,19 @@
  * Spawns sleeping threads till the scheduler's capacity is exhausted.
  *
  * @author  Andreas "Paul" Pauli <andreas.pauli@haw-hamburg.de>
+ * @author  Sebastian Meiling <s@mlng.net>
  *
  * @}
  */
 
 #include <errno.h>
 #include <stdio.h>
+
 #include "thread.h"
+#include "kernel_types.h"
 
 /* One stack for all threads. DON'T TRY THIS AT HOME!! */
-static char dummy_stack[THREAD_STACKSIZE_DEFAULT];
+static char dummy_stack[THREAD_STACKSIZE_IDLE];
 
 static void *thread_func(void *arg)
 {
@@ -35,6 +38,7 @@ static void *thread_func(void *arg)
 int main(void)
 {
     kernel_pid_t thr_id = KERNEL_PID_UNDEF;
+    unsigned thr_cnt = 0;
 
     puts("[START] Spawning threads");
     do {
@@ -43,11 +47,21 @@ int main(void)
             THREAD_PRIORITY_MAIN - 1,
             THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,
             thread_func, NULL, "dummy");
+            ++thr_cnt;
+            printf(".");
     } while (-EOVERFLOW != thr_id);
+    puts("");
+    /* decrease by 1 because last thread_create failed */
+    --thr_cnt;
 
-    if (-EOVERFLOW == thr_id) {
-        puts("[SUCCESS] Thread creation successfully aborted");
+    /* expect (MAXTHREADS - 2), as main and idle thread take a PID each */
+    if (thr_cnt == (MAXTHREADS - 2)) {
+        printf("[SUCCESS]");
     }
+    else {
+        printf("[ERROR] expected %u,", (MAXTHREADS - 2));
+    }
+    printf(" created %u\n", thr_cnt);
 
     return 0;
 }

--- a/tests/thread_flood/tests/01-run.py
+++ b/tests/thread_flood/tests/01-run.py
@@ -9,7 +9,8 @@ import testrunner
 
 def testfunc(child):
     child.expect_exact(u'[START] Spawning threads')
-    child.expect_exact(u'[SUCCESS] Thread creation')
+    child.expect(r'\.+')
+    child.expect(r'\[SUCCESS\] created \d+')
 
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
I had an issue when running `make test` for `thread_flood` on macOS, because it used plain `#!/usr/bin/python`.

As the test script didn't use our `testrunner` at all, I updated it accordingly. Further, test output and checks are enhanced, too.