### PR TITLE
test/xtimer_hang: accept 10% timing deviations

### DIFF
--- a/tests/xtimer_hang/tests/01-run.py
+++ b/tests/xtimer_hang/tests/01-run.py
@@ -15,7 +15,9 @@ import testrunner
 def testfunc(child):
     child.expect_exact("[START]")
 
-    for i in range(100):
+    # due to timer inaccuracies, boards might not display exactly 100 steps, so
+    # we accept 10% deviation
+    for i in range(90):
         child.expect(u"Testing \( +\d+%\)")
 
     child.expect_exact("[SUCCESS]")


### PR DESCRIPTION
Just discovered: for some targets the internal timings are not quite precise enough, leading to skipped percentage steps in the output, so there are not exactly 100 output lines. As the timings are not subject for this test (see README), looking for 90 output lines (10% diviation) should do here... Verified on iotlab-m3 and samr21-xpro.