### PR TITLE
tests/thread_msg: migrate to testrunner

### DIFF
--- a/tests/thread_msg/Makefile
+++ b/tests/thread_msg/Makefile
@@ -1,8 +1,11 @@
 APPLICATION = thread_msg
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
 
 DISABLE_MODULE += auto_init
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/thread_msg/main.c
+++ b/tests/thread_msg/main.c
@@ -28,7 +28,7 @@ char t1_stack[THREAD_STACKSIZE_MAIN];
 char t2_stack[THREAD_STACKSIZE_MAIN];
 char t3_stack[THREAD_STACKSIZE_MAIN];
 
-kernel_pid_t p1, p2, p3;
+kernel_pid_t p_main, p1, p2, p3;
 
 void *thread1(void *arg)
 {
@@ -47,13 +47,15 @@ void *thread1(void *arg)
     }
 
     puts("THREAD 1 end\n");
+    msg_t msg;
+    msg_send(&msg, p_main);
     return NULL;
 }
 
 void *thread2(void *arg)
 {
     (void) arg;
-    puts("THREAD 2\n");
+    puts("THREAD 2 start\n");
 
     for (int i = 0;; ++i) {
         msg_t msg, reply;
@@ -70,7 +72,7 @@ void *thread2(void *arg)
 void *thread3(void *arg)
 {
     (void) arg;
-    puts("THREAD 3\n");
+    puts("THREAD 3 start\n");
 
     for (int i = 0;; ++i) {
         msg_t msg;
@@ -83,6 +85,7 @@ void *thread3(void *arg)
 
 int main(void)
 {
+    p_main = sched_active_pid;
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
                        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
                        thread1, NULL, "nr1");
@@ -93,5 +96,12 @@ int main(void)
                        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
                        thread3, NULL, "nr3");
     puts("THREADS CREATED\n");
+
+    msg_t msg;
+    /* Wait until thread 1 is done */
+    msg_receive(&msg);
+
+    puts("SUCCESS");
+
     return 0;
 }

--- a/tests/thread_msg/tests/01-run.py
+++ b/tests/thread_msg/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('THREADS CREATED')
+    child.expect_exact('THREAD 1 start')
+    child.expect_exact('THREAD 2 start')
+    child.expect_exact('THREAD 3 start')
+    child.expect_exact('THREAD 1 end')
+    child.expect_exact('SUCCESS')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
Since there's some work on that direction, here is another test migrated to the testrunner.

Partially addresses #7871 