### PR TITLE
test/unittests: set pexpect timeout to 60s

### DIFF
--- a/tests/unittests/tests/01-run.py
+++ b/tests/unittests/tests/01-run.py
@@ -16,4 +16,4 @@ def testfunc(child):
     child.expect(u"OK \\([0-9]+ tests\\)")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.exit(testrunner.run(testfunc, timeout=60))


### PR DESCRIPTION
Some boards (e.g. the `iotlab-m3`) need more than the default timeout to run all the tests. Setting the timeout to 60s should be a save value here and give the boards enough time to excecute all tests.