### PR TITLE
sys/can: fix building errors on native OS X

### DIFF
--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -49,24 +49,6 @@ static void pm_cb(void *arg);
 static void pm_reset(candev_dev_t *candev_dev, uint32_t value);
 #endif
 
-static inline enum can_msg _can_event_error_to_msg(candev_event_t error)
-{
-    switch (error) {
-    case CANDEV_EVENT_TX_ERROR:
-        return CAN_MSG_TX_ERROR;
-    case CANDEV_EVENT_RX_ERROR:
-        return CAN_MSG_RX_ERROR;
-    case CANDEV_EVENT_BUS_OFF:
-        return CAN_MSG_BUS_OFF;
-    case CANDEV_EVENT_ERROR_PASSIVE:
-        return CAN_MSG_ERROR_PASSIVE;
-    case CANDEV_EVENT_ERROR_WARNING:
-        return CAN_MSG_ERROR_WARNING;
-    default:
-        return 0;
-    }
-}
-
 static void _can_event(candev_t *dev, candev_event_t event, void *arg)
 {
     msg_t msg;

--- a/sys/include/can/device.h
+++ b/sys/include/can/device.h
@@ -46,7 +46,7 @@ extern "C" {
 /**
  * Maximum number of interfaces which can be registered on DLL
  */
-#define CAN_DLL_NUMOF       (1U)
+#define CAN_DLL_NUMOF       (1)
 #endif
 
 /**


### PR DESCRIPTION
Building tests/conn_can lead to the following error(s):
```console
/Users/facosta/git/RIOT-OS/RIOT/tests/conn_can/main.c:91:23: error: comparison of integers of different signs: 'int' and 'unsigned int'
      [-Werror,-Wsign-compare]
    for (int i = 0; i < CAN_DLL_NUMOF; i++) {
                    ~ ^ ~~~~~~~~~~~~~
/Users/facosta/git/RIOT-OS/RIOT/tests/conn_can/main.c:112:15: error: comparison of integers of different signs: 'int' and 'unsigned int'
      [-Werror,-Wsign-compare]
    if (ifnum >= CAN_DLL_NUMOF) {
        ~~~~~ ^  ~~~~~~~~~~~~~
/Users/facosta/git/RIOT-OS/RIOT/tests/conn_can/main.c:143:15: error: comparison of integers of different signs: 'int' and 'unsigned int'
      [-Werror,-Wsign-compare]
    if (ifnum >= CAN_DLL_NUMOF) {
        ~~~~~ ^  ~~~~~~~~~~~~~
/Users/facosta/git/RIOT-OS/RIOT/tests/conn_can/main.c:206:15: error: comparison of integers of different signs: 'int' and 'unsigned int'
      [-Werror,-Wsign-compare]
    if (ifnum >= CAN_DLL_NUMOF) {
        ~~~~~ ^  ~~~~~~~~~~~~~
/Users/facosta/git/RIOT-OS/RIOT/tests/conn_can/main.c:347:15: error: comparison of integers of different signs: 'int' and 'unsigned int'
      [-Werror,-Wsign-compare]
    if (ifnum >= CAN_DLL_NUMOF) {
        ~~~~~ ^  ~~~~~~~~~~~~~
/Users/facosta/git/RIOT-OS/RIOT/tests/conn_can/main.c:411:15: error: comparison of integers of different signs: 'int' and 'unsigned int'
      [-Werror,-Wsign-compare]
    if (ifnum >= CAN_DLL_NUMOF) {
        ~~~~~ ^  ~~~~~~~~~~~~~
/Users/facosta/git/RIOT-OS/RIOT/tests/conn_can/main.c:454:15: error: comparison of integers of different signs: 'int' and 'unsigned int'
      [-Werror,-Wsign-compare]
    if (ifnum >= CAN_DLL_NUMOF) {
        ~~~~~ ^  ~~~~~~~~~~~~~
/Users/facosta/git/RIOT-OS/RIOT/tests/conn_can/main.c:477:15: error: comparison of integers of different signs: 'int' and 'unsigned int'
      [-Werror,-Wsign-compare]
    if (ifnum >= CAN_DLL_NUMOF) {
        ~~~~~ ^  ~~~~~~~~~~~~~
8 errors generated.
```

This PR fix those errors, plus another error about unused function `_can_event_error_to_msg`.

@vincent-d I didn't find any usage in the whole RIOT basecode of the function `_can_event_error_to_msg` thus I removed it. Can you check if it's correct?