### PR TITLE
drivers/sx127x: Fix misc variable types and lengths

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -208,7 +208,7 @@ enum {
  */
 typedef struct {
     uint16_t preamble_len;             /**< Length of preamble header */
-    uint8_t power;                     /**< Signal power */
+    int8_t power;                      /**< Signal power */
     uint8_t bandwidth;                 /**< Signal bandwidth */
     uint8_t datarate;                  /**< Spreading factor rate, e.g datarate */
     uint8_t coderate;                  /**< Error coding rate */
@@ -616,7 +616,7 @@ uint8_t sx127x_get_tx_power(const sx127x_t *dev);
  * @param[in] dev                      The sx127x device descriptor
  * @param[in] power                    The TX power
  */
-void sx127x_set_tx_power(sx127x_t *dev, uint8_t power);
+void sx127x_set_tx_power(sx127x_t *dev, int8_t power);
 
 /**
  * @brief   Gets the SX127X preamble length

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -731,7 +731,7 @@ uint8_t sx127x_get_tx_power(const sx127x_t *dev)
     return dev->settings.lora.power;
 }
 
-void sx127x_set_tx_power(sx127x_t *dev, uint8_t power)
+void sx127x_set_tx_power(sx127x_t *dev, int8_t power)
 {
     DEBUG("[DEBUG] Set power: %d\n", power);
 

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -441,9 +441,9 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             return sizeof(uint32_t);
 
         case NETOPT_TX_POWER:
-            assert(len <= sizeof(uint8_t));
-            sx127x_set_tx_power(dev, *((const uint8_t*) val));
-            return sizeof(uint16_t);
+            assert(len <= sizeof(int8_t));
+            sx127x_set_tx_power(dev, *((const int8_t*) val));
+            return sizeof(int8_t);
 
         case NETOPT_FIXED_HEADER:
             assert(len <= sizeof(netopt_enable_t));
@@ -471,7 +471,7 @@ static uint8_t _get_tx_len(const struct iovec *vector, unsigned count)
 {
     uint8_t len = 0;
 
-    for (int i=0 ; i < count ; i++) {
+    for (unsigned i = 0 ; i < count ; i++) {
         len += vector[i].iov_len;
     }
 

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -117,6 +117,9 @@ int lora_setup_cmd(int argc, char **argv) {
 
 int random_cmd(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
+
     printf("random: number from sx127x: %u\n",
            (unsigned int) sx127x_random((sx127x_t*) netdev));
 
@@ -218,7 +221,7 @@ int send_cmd(int argc, char **argv)
         return -1;
     }
 
-    printf("sending \"%s\" payload (%d bytes)\n",
+    printf("sending \"%s\" payload (%zd bytes)\n",
            argv[1], strlen(argv[1]) + 1);
 
     struct iovec vec[1];
@@ -233,6 +236,9 @@ int send_cmd(int argc, char **argv)
 
 int listen_cmd(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
+
     /* Switch to continuous listen mode */
     netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, false, sizeof(uint8_t));
     sx127x_set_rx(&sx127x);
@@ -325,6 +331,8 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
 
 void *_recv_thread(void *arg)
 {
+    (void)arg;
+
     static msg_t _msg_q[SX127X_LORA_MSG_QUEUE];
     msg_init_queue(_msg_q, SX127X_LORA_MSG_QUEUE);
 


### PR DESCRIPTION
While compiling tests/driver_sx127x with clang in OS X it discovers several minor issues.

This PR fixes them.