### PR TITLE
tests/driver_servo/main.c: fix var len

### DIFF
--- a/tests/driver_servo/main.c
+++ b/tests/driver_servo/main.c
@@ -53,7 +53,7 @@ static servo_t servo;
 int main(void)
 {
     int res;
-    int pos = (STEP_LOWER_BOUND + STEP_UPPER_BOUND) / 2;
+    unsigned int pos = (STEP_LOWER_BOUND + STEP_UPPER_BOUND) / 2;
     int step = STEP;
 
     puts("\nRIOT RC servo test");


### PR DESCRIPTION
While compiling tests/driver_servo with clang in OS X it discovers several minor issues.

This PR fixes them.