### PR TITLE
 drivers/nrf24l01p: misc fixed

### DIFF
--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -36,11 +36,11 @@ extern "C" {
  * @brief   Structure that represents the hardware setup of the nrf24l01+ transceiver.
  */
 typedef struct {
-    spi_t spi;      /**< SPI device to initialize */
-    gpio_t ce;      /**< GPIO pin to initialize as chip enable */
-    gpio_t cs;      /**< GPIO pin to initialize as chip select */
-    gpio_t irq;     /**< GPIO pin to initialize as interrupt request */
-    int listener;   /**< Place to store an ID in */
+    spi_t spi;           /**< SPI device to initialize */
+    gpio_t ce;           /**< GPIO pin to initialize as chip enable */
+    gpio_t cs;           /**< GPIO pin to initialize as chip select */
+    gpio_t irq;          /**< GPIO pin to initialize as interrupt request */
+    unsigned listener;   /**< Place to store an ID in */
 } nrf24l01p_t;
 
 /**

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -386,7 +386,7 @@ int nrf24l01p_set_tx_address_long(const nrf24l01p_t *dev, uint64_t saddr, unsign
     char buf[length];
 
     if (length <= INITIAL_ADDRESS_WIDTH) {
-        for (int i = 0; i < length; i++) {
+        for (unsigned int i = 0; i < length; i++) {
 
             buf[i] = (uint8_t)(saddr >> (((length - 1) - i) * sizeof(uint64_t)));
         }
@@ -483,7 +483,7 @@ int nrf24l01p_set_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pi
     char buf[length];
 
     if (length <= INITIAL_ADDRESS_WIDTH) {
-        for (int i = 0; i < length; i++) {
+        for (unsigned int i = 0; i < length; i++) {
 
             buf[i] = (uint8_t)(saddr >> (((length - 1) - i) * 8));
         }

--- a/tests/driver_nrf24l01p_lowlevel/main.c
+++ b/tests/driver_nrf24l01p_lowlevel/main.c
@@ -113,6 +113,7 @@ char rx_handler_stack[THREAD_STACKSIZE_MAIN];
 /* RX handler that waits for a message from the ISR */
 void *nrf24l01p_rx_handler(void *arg)
 {
+    (void)arg;
     msg_t msg_q[1];
     msg_init_queue(msg_q, 1);
     unsigned int pid = thread_getpid();
@@ -209,7 +210,7 @@ int cmd_send(int argc, char **argv)
     char tx_buf[NRF24L01P_MAX_DATA_LENGTH];
 
     /* fill TX buffer with numbers 32..1 */
-    for (int i = 0; i < sizeof(tx_buf); i++) {
+    for (size_t i = 0; i < sizeof(tx_buf); i++) {
         tx_buf[i] = NRF24L01P_MAX_DATA_LENGTH - i;
     }
     /* power on the device */


### PR DESCRIPTION
While compiling tests/driver_nrf24l01p_lowlevel with clang in OS X it discovers several minor issues.

This PR fixes them.