### PR TITLE
tests/driver_adcxx1c: fix warning unused  argument

### DIFF
--- a/tests/driver_adcxx1c/main.c
+++ b/tests/driver_adcxx1c/main.c
@@ -30,6 +30,7 @@ static adcxx1c_t dev;
 
 static void alert_cb(void *arg)
 {
+    (void)arg;
     puts("[Alert]\n");
 }
 


### PR DESCRIPTION
While compiling tests/driver_adcxx1c with clang in OS X it discovers a minor issue.

This PR fixes it.