### PR TITLE
drivers/encx24j600/encx24j600.c : fix counter var length

### DIFF
--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -301,7 +301,7 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count) {
     /* copy packet to SRAM */
     size_t len = 0;
 
-    for (int i = 0; i < count; i++) {
+    for (unsigned i = 0; i < count; i++) {
         sram_op(dev, ENC_WGPDATA, (i ? 0xFFFF : TX_BUFFER_START), vector[i].iov_base, vector[i].iov_len);
         len += vector[i].iov_len;
     }


### PR DESCRIPTION
While compiling tests/driver_encx24j600 with clang in OS X it discovers a minor issue.

This PR fixes it.