### PR TITLE
tests/driver_at86rf2xx: fix var lengths and unused vars

### DIFF
--- a/tests/driver_at86rf2xx/addr.c
+++ b/tests/driver_at86rf2xx/addr.c
@@ -20,7 +20,7 @@
 
 void print_addr(uint8_t *addr, size_t addr_len)
 {
-    for (int i = 0; i < addr_len; i++) {
+    for (size_t i = 0; i < addr_len; i++) {
         if (i != 0) {
             printf(":");
         }

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -71,6 +71,7 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
 
 void *_recv_thread(void *arg)
 {
+    (void)arg;
     while (1) {
         msg_t msg;
         msg_receive(&msg);

--- a/tests/driver_at86rf2xx/recv.c
+++ b/tests/driver_at86rf2xx/recv.c
@@ -98,7 +98,7 @@ void recv(netdev_t *dev)
     printf("Seq.: %u\n", (unsigned)ieee802154_get_seq(buffer));
     od_hex_dump(buffer + mhr_len, data_len - mhr_len, 0);
     printf("txt: ");
-    for (int i = mhr_len; i < data_len; i++) {
+    for (size_t i = mhr_len; i < data_len; i++) {
         if ((buffer[i] > 0x1F) && (buffer[i] < 0x80)) {
             putchar((char)buffer[i]);
         }


### PR DESCRIPTION
While compiling tests/driver_at86rf2xx with clang in OS X it discovers several minor issues.

This PR fixes them.