### PR TITLE
Made ringbuffer indices volatile so ringbuf can be used with ISR

### DIFF
--- a/core/include/ringbuffer.h
+++ b/core/include/ringbuffer.h
@@ -30,8 +30,8 @@ extern "C" {
 typedef struct {
     char *buf;          /**< Buffer to operate on. */
     unsigned int size;  /**< Size of buf. */
-    unsigned int start; /**< Current read position in the ring buffer. */
-    unsigned int avail; /**< Number of elements available for reading. */
+    volatile unsigned int start; /**< Current read position in the ring buffer. */
+    volatile unsigned int avail; /**< Number of elements available for reading. */
 } ringbuffer_t;
 
 /**


### PR DESCRIPTION
I tried to use a ringbuffer, adding from non-interrupt driver code, removing from a peripheral ISR.  Compiler was optimizing out the reads of ringbuffer structure fields in a while(ringbuffer_full) loop and it was hanging forever.  Making the ringbuffer structure elements volatile solves this problem.