### PR TITLE
pm_layered: make sure no conflict for pm_set_lowest exists

### DIFF
--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -45,6 +45,10 @@ extern "C" {
 #define PROVIDES_PM_OFF
 #endif
 
+#ifndef PROVIDES_PM_SET_LOWEST
+#define PROVIDES_PM_SET_LOWEST
+#endif
+
 /**
  * @brief   Block a power mode
  *


### PR DESCRIPTION
As discussed in #7726 we always want to use pm_set_lowest from pm_layered if pm_layered is used and not be using the one from periph_common.

IMO this should be back ported to the 2017.10 release because it will result in potential conflicts.