### PR TITLE
trickle: correctly reset t

### DIFF
--- a/sys/trickle/trickle.c
+++ b/sys/trickle/trickle.c
@@ -61,7 +61,7 @@ void trickle_reset_timer(trickle_t *trickle)
     assert(trickle->I > trickle->Imin);
 
     trickle_stop(trickle);
-    trickle->I = trickle->Imin;
+    trickle->I = trickle->t = trickle->Imin;
     trickle_interval(trickle);
 }
 


### PR DESCRIPTION
The `t` parameter of trickle is not correctly reset. This has implications on the `DIO` transmission of RPL.

Can be reproduced by starting two native instances of `gnrc_networking` and setting up one as DODAG root. When the second native instance joins, its trickle timer (c.f. `rpl` shell command and the `TC` parameter) is very high. This leads to **heavy** delays in `DIO` transmissions.