### PR TITLE
[2017.10 backport] pm_layered: make sure no conflict for pm_set_lowest exists

### DIFF
--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -45,6 +45,10 @@ extern "C" {
 #define PROVIDES_PM_OFF
 #endif
 
+#ifndef PROVIDES_PM_SET_LOWEST
+#define PROVIDES_PM_SET_LOWEST
+#endif
+
 /**
  * @brief   Block a power mode
  *


### PR DESCRIPTION
Backport of #7863

@miri64 