### PR TITLE
drivers/mrf24j40: add explicit ack request en/disable

### DIFF
--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -157,9 +157,13 @@ void mrf24j40_tx_exec(mrf24j40_t *dev)
     mrf24j40_reg_write_long(dev, MRF24J40_TX_NORMAL_FIFO, dev->header_len);
 
     if (dev->netdev.flags & NETDEV_IEEE802154_ACK_REQ) {
-        mrf24j40_reg_write_short(dev, MRF24J40_REG_TXNCON, MRF24J40_TXNCON_TXNACKREQ | MRF24J40_TXNCON_TXNTRIG);
+        /* Explicitly set the TXNACKREQ register before sending */
+        mrf24j40_reg_write_short(dev, MRF24J40_REG_TXNCON, MRF24J40_TXNCON_TXNACKREQ);
+        mrf24j40_reg_write_short(dev, MRF24J40_REG_TXNCON, MRF24J40_TXNCON_TXNTRIG);
     }
     else {
+        /* Explicitly clear the TXNACKREQ register before sending */
+        mrf24j40_reg_write_short(dev, MRF24J40_REG_TXNCON, 0x00);
         mrf24j40_reg_write_short(dev, MRF24J40_REG_TXNCON, MRF24J40_TXNCON_TXNTRIG);
     }
     if (netdev->event_callback && (dev->netdev.flags & MRF24J40_OPT_TELL_TX_START)) {


### PR DESCRIPTION
While testing the trickle bug today, I noticed that L2 broadcast are transmitted 4 times when using the mrf24j40. I suspect that the hardware expects an ACK while the ack request in the packet is (correctly) cleared.

I've tested a bit and by setting and clearing the TXNACKREQ (which enables ack requests) before the transmit enable bit is set, the hardware appears to behave correctly as far as I can see.

I'd be really happy if somebody can test and confirm my findings.

- steps to reproduce: While using the mrf24j40, transmit unicast packets, then transmit multicast packets.
- Expected: (up to 4) unicast packets are transmitted until an ACK is received. A single broadcast packet is transmitted.
- Observed: (up to 4) unicast packets are transmitted until an ACK is received. 4 broadcast packet are transmitted.