### PR TITLE
make: reorganize makefile features

### DIFF
--- a/boards/airfy-beacon/Makefile.features
+++ b/boards/airfy-beacon/Makefile.features
@@ -1,9 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
@@ -11,7 +8,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/arduino-due/Makefile.features
+++ b/boards/arduino-due/Makefile.features
@@ -1,16 +1,13 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += arduino
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/arduino-mkr-common/Makefile.features
+++ b/boards/arduino-mkr-common/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -11,7 +10,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += arduino
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/arduino-zero/Makefile.features
+++ b/boards/arduino-zero/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -10,7 +9,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += arduino
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -1,13 +1,8 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Load extra provided features
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1

--- a/boards/bluepill/Makefile.features
+++ b/boards/bluepill/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
@@ -7,8 +6,7 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
+
+-include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/calliope-mini/Makefile.features
+++ b/boards/calliope-mini/Makefile.features
@@ -1,14 +1,11 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/cc2538dk/Makefile.features
+++ b/boards/cc2538dk/Makefile.features
@@ -1,15 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/cc2650-launchpad/Makefile.features
+++ b/boards/cc2650-launchpad/Makefile.features
@@ -1,11 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/cc2650stk/Makefile.features
+++ b/boards/cc2650stk/Makefile.features
@@ -1,11 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/ek-lm4f120xl/Makefile.features
+++ b/boards/ek-lm4f120xl/Makefile.features
@@ -5,9 +5,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1
 

--- a/boards/f4vi1/Makefile.features
+++ b/boards/f4vi1/Makefile.features
@@ -1,9 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += periph_gpio
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1

--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -1,15 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/frdm-k22f/Makefile.features
+++ b/boards/frdm-k22f/Makefile.features
@@ -1,8 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -10,9 +8,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1

--- a/boards/frdm-k64f/Makefile.features
+++ b/boards/frdm-k64f/Makefile.features
@@ -1,8 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -10,9 +8,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1

--- a/boards/iotlab-common/Makefile.features
+++ b/boards/iotlab-common/Makefile.features
@@ -1,15 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/limifrog-v1/Makefile.features
+++ b/boards/limifrog-v1/Makefile.features
@@ -1,13 +1,9 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/maple-mini/Makefile.features
+++ b/boards/maple-mini/Makefile.features
@@ -1,13 +1,9 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/mbed_lpc1768/Makefile.features
+++ b/boards/mbed_lpc1768/Makefile.features
@@ -1,10 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/microbit/Makefile.features
+++ b/boards/microbit/Makefile.features
@@ -1,15 +1,11 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/mips-malta/Makefile.features
+++ b/boards/mips-malta/Makefile.features
@@ -2,9 +2,6 @@
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = mips32r2
 

--- a/boards/msb-430-common/Makefile.features
+++ b/boards/msb-430-common/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -6,10 +6,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
-FEATURES_PROVIDED += config
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = arm7
 

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -2,15 +2,11 @@
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1

--- a/boards/mulle/Makefile.features
+++ b/boards/mulle/Makefile.features
@@ -1,9 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -11,9 +9,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -1,14 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_gpio
 
 # Various other features (if any)
-FEATURES_PROVIDED += config
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += ethernet
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/nrf51dongle/Makefile.features
+++ b/boards/nrf51dongle/Makefile.features
@@ -1,14 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/nrf52840dk/Makefile.features
+++ b/boards/nrf52840dk/Makefile.features
@@ -1,15 +1,11 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/nrf52dk/Makefile.features
+++ b/boards/nrf52dk/Makefile.features
@@ -1,15 +1,11 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/nrf6310/Makefile.features
+++ b/boards/nrf6310/Makefile.features
@@ -1,15 +1,11 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/nucleo-common/Makefile.features
+++ b/boards/nucleo-common/Makefile.features
@@ -1,3 +1,2 @@
 # Various common features of Nucleo boards
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += arduino

--- a/boards/nucleo-f410/Makefile.features
+++ b/boards/nucleo-f410/Makefile.features
@@ -1,16 +1,11 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/nucleo-f411/Makefile.features
+++ b/boards/nucleo-f411/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
@@ -8,9 +7,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/nucleo144-common/Makefile.features
+++ b/boards/nucleo144-common/Makefile.features
@@ -1,3 +1,2 @@
 # Various common features of Nucleo-144 boards
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += arduino

--- a/boards/nucleo32-common/Makefile.features
+++ b/boards/nucleo32-common/Makefile.features
@@ -1,3 +1,2 @@
 # Various common features of Nucleo boards
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += arduino

--- a/boards/nz32-sc151/Makefile.features
+++ b/boards/nz32-sc151/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
@@ -9,9 +8,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/opencm904/Makefile.features
+++ b/boards/opencm904/Makefile.features
@@ -1,11 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various common features of Nucleo boards
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/openmote-cc2538/Makefile.features
+++ b/boards/openmote-cc2538/Makefile.features
@@ -1,15 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/pba-d-01-kw2x/Makefile.features
+++ b/boards/pba-d-01-kw2x/Makefile.features
@@ -1,8 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -10,9 +8,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/pca10000/Makefile.features
+++ b/boards/pca10000/Makefile.features
@@ -1,14 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/pca10005/Makefile.features
+++ b/boards/pca10005/Makefile.features
@@ -1,16 +1,12 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/pic32-clicker/Makefile.features
+++ b/boards/pic32-clicker/Makefile.features
@@ -1,11 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = mips32r2

--- a/boards/pic32-wifire/Makefile.features
+++ b/boards/pic32-wifire/Makefile.features
@@ -1,12 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = mips32r2

--- a/boards/remote-pa/Makefile.features
+++ b/boards/remote-pa/Makefile.features
@@ -1,15 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/remote-reva/Makefile.features
+++ b/boards/remote-reva/Makefile.features
@@ -1,15 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/remote-revb/Makefile.features
+++ b/boards/remote-revb/Makefile.features
@@ -1,15 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/samd21-xpro/Makefile.features
+++ b/boards/samd21-xpro/Makefile.features
@@ -1,7 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -10,9 +8,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/saml21-xpro/Makefile.features
+++ b/boards/saml21-xpro/Makefile.features
@@ -1,7 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
@@ -9,9 +7,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -1,7 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -10,9 +8,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/seeeduino_arch-pro/Makefile.features
+++ b/boards/seeeduino_arch-pro/Makefile.features
@@ -1,10 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1

--- a/boards/slwstk6220a/Makefile.features
+++ b/boards/slwstk6220a/Makefile.features
@@ -1,10 +1,9 @@
-FEATURES_PROVIDED += cpp
-
-FEATURES_PROVIDED += periph_cpuid
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# The board MCU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1
 
 -include $(RIOTCPU)/ezr32wg/Makefile.features

--- a/boards/sodaq-autonomo/Makefile.features
+++ b/boards/sodaq-autonomo/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
@@ -8,9 +7,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/sodaq-explorer/Makefile.features
+++ b/boards/sodaq-explorer/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
@@ -9,8 +8,7 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
+
+-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/spark-core/Makefile.features
+++ b/boards/spark-core/Makefile.features
@@ -4,9 +4,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 

--- a/boards/stm32f0discovery/Makefile.features
+++ b/boards/stm32f0discovery/Makefile.features
@@ -1,15 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1

--- a/boards/stm32f3discovery/Makefile.features
+++ b/boards/stm32f3discovery/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
@@ -8,9 +7,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -1,9 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -12,7 +10,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += arduino
 
 # The board MPU family (used for grouping by the CI system)

--- a/boards/stm32f7discovery/Makefile.features
+++ b/boards/stm32f7discovery/Makefile.features
@@ -1,14 +1,8 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-#FEATURES_PROVIDED += cpp
-#FEATURES_PROVIDED += arduino
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m7

--- a/boards/udoo/Makefile.features
+++ b/boards/udoo/Makefile.features
@@ -1,13 +1,8 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/yunjia-nrf51822/Makefile.features
+++ b/boards/yunjia-nrf51822/Makefile.features
@@ -1,9 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
@@ -12,7 +9,6 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 FEATURES_PROVIDED += radio_nrfmin
-FEATURES_PROVIDED += cpp
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2

--- a/cpu/arm7_common/Makefile.features
+++ b/cpu/arm7_common/Makefile.features
@@ -1,0 +1,2 @@
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += periph_pm

--- a/cpu/atmega1281/Makefile.features
+++ b/cpu/atmega1281/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/atmega_common/Makefile.features

--- a/cpu/atmega2560/Makefile.features
+++ b/cpu/atmega2560/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/atmega_common/Makefile.features

--- a/cpu/atmega328p/Makefile.features
+++ b/cpu/atmega328p/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/atmega_common/Makefile.features

--- a/cpu/atmega_common/Makefile.features
+++ b/cpu/atmega_common/Makefile.features
@@ -1,0 +1,1 @@
+FEATURES_PROVIDED += periph_pm

--- a/cpu/cc2538/Makefile.features
+++ b/cpu/cc2538/Makefile.features
@@ -1,1 +1,5 @@
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm
+
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/cc26x0/Makefile.features
+++ b/cpu/cc26x0/Makefile.features
@@ -1,1 +1,4 @@
+FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_pm
+
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/cc430/Makefile.features
+++ b/cpu/cc430/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/msp430_common/Makefile.features

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -1,0 +1,1 @@
+FEATURES_PROVIDED += cpp

--- a/cpu/ezr32wg/Makefile.features
+++ b/cpu/ezr32wg/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += periph_cpuid
+
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/k22f/Makefile.features
+++ b/cpu/k22f/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/kinetis_common/Makefile.features

--- a/cpu/k60/Makefile.features
+++ b/cpu/k60/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/kinetis_common/Makefile.features

--- a/cpu/k64f/Makefile.features
+++ b/cpu/k64f/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/kinetis_common/Makefile.features

--- a/cpu/kinetis_common/Makefile.features
+++ b/cpu/kinetis_common/Makefile.features
@@ -1,1 +1,5 @@
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm
+
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/kw2xd/Makefile.features
+++ b/cpu/kw2xd/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/kinetis_common/Makefile.features

--- a/cpu/lm4f120/Makefile.features
+++ b/cpu/lm4f120/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/lpc1768/Makefile.features
+++ b/cpu/lpc1768/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += periph_cpuid
+
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/lpc2387/Makefile.features
+++ b/cpu/lpc2387/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/arm7_common/Makefile.features

--- a/cpu/mips32r2_common/Makefile.features
+++ b/cpu/mips32r2_common/Makefile.features
@@ -1,0 +1,2 @@
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += periph_pm

--- a/cpu/mips_pic32_common/Makefile.features
+++ b/cpu/mips_pic32_common/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += periph_cpuid
+
+-include $(RIOTCPU)/mips32r2_common/Makefile.features

--- a/cpu/mips_pic32mx/Makefile.features
+++ b/cpu/mips_pic32mx/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/mips_pic32_common/Makefile.features

--- a/cpu/mips_pic32mz/Makefile.features
+++ b/cpu/mips_pic32mz/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += periph_hwrng
+
+-include $(RIOTCPU)/mips_pic32_common/Makefile.features

--- a/cpu/msp430_common/Makefile.features
+++ b/cpu/msp430_common/Makefile.features
@@ -1,0 +1,2 @@
+FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_pm

--- a/cpu/msp430fxyz/Makefile.features
+++ b/cpu/msp430fxyz/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/msp430_common/Makefile.features

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -1,1 +1,4 @@
+FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm

--- a/cpu/nrf51/Makefile.features
+++ b/cpu/nrf51/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/nrf5x_common/Makefile.features

--- a/cpu/nrf52/Makefile.features
+++ b/cpu/nrf52/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/nrf5x_common/Makefile.features

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -1,0 +1,6 @@
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_pm
+
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -1,0 +1,4 @@
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_flashpage
+
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/sam3/Makefile.features
+++ b/cpu/sam3/Makefile.features
@@ -1,0 +1,4 @@
+FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_hwrng
+
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/samd21/Makefile.features
+++ b/cpu/samd21/Makefile.features
@@ -1,1 +1,3 @@
 FEATURES_PROVIDED += periph_pm
+
+-include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml21/Makefile.features
+++ b/cpu/saml21/Makefile.features
@@ -1,1 +1,3 @@
 FEATURES_PROVIDED += periph_pm
+
+-include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/stm32_common/Makefile.features
+++ b/cpu/stm32_common/Makefile.features
@@ -1,0 +1,7 @@
+FEATURES_PROVIDED += periph_cpuid
+
+ifneq (,$(filter $(BOARDS_WITHOUT_HWRNG),$(BOARD)))
+  FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))
+endif
+
+-include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/stm32f0/Makefile.features
+++ b/cpu/stm32f0/Makefile.features
@@ -1,0 +1,5 @@
+ifeq (,$(filter nucleo32-f031,$(BOARD)))
+  FEATURES_PROVIDED += periph_flashpage
+endif
+
+-include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f1/Makefile.features
+++ b/cpu/stm32f1/Makefile.features
@@ -1,1 +1,4 @@
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_pm
+
+-include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f3/Makefile.features
+++ b/cpu/stm32f3/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f4/Makefile.features
+++ b/cpu/stm32f4/Makefile.features
@@ -1,1 +1,14 @@
+FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm
+
+# the granularity of provided feature definition for STMs is currently by CPU
+# sub-family (e.g., stm32f[1234]).  Unfortunately, only some of e.g., the
+# stm32f4 have an RNG peripheral.  As during evaluation of the features , no
+# CPU variable is available, we need to filter by board.
+#
+BOARDS_WITHOUT_HWRNG += nucleo-f401
+BOARDS_WITHOUT_HWRNG += nucleo-f411
+BOARDS_WITHOUT_HWRNG += nucleo-f446
+BOARDS_WITHOUT_HWRNG += nucleo144-f446
+
+-include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f7/Makefile.features
+++ b/cpu/stm32f7/Makefile.features
@@ -1,4 +1,2 @@
 FEATURES_PROVIDED += periph_hwrng
-FEATURES_PROVIDED += periph_pm
-
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32l0/Makefile.features
+++ b/cpu/stm32l0/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += periph_hwrng
-FEATURES_PROVIDED += periph_pm
+
+BOARDS_WITHOUT_HWRNG += nucleo32-l031
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32l1/Makefile.features
+++ b/cpu/stm32l1/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32l4/Makefile.features
+++ b/cpu/stm32l4/Makefile.features
@@ -1,4 +1,3 @@
 FEATURES_PROVIDED += periph_hwrng
-FEATURES_PROVIDED += periph_pm
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-mkrzero \
                              arduino-uno \
                              arduino-zero \
+                             avsextrem \
                              b-l072z-lrwan1 \
                              bluepill \
                              calliope-mini \


### PR DESCRIPTION
This PR implements a chain ```Makefile.features``` taking any cpu, shared board and shared cpu file into account.