### PR TITLE
readme: bump supported boards count

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ but not limited to:
 * a preemptive, tickless scheduler with priorities
 * flexible memory management
 * high resolution, long-term timers
-* support for AVR, MSP430, MIPS, ARM7, and ARM Cortex-M on over 80 boards
+* support 100+ boards based on AVR, MSP430, MIPS, ARM7 and ARM Cortex-M
 * the native port allows to run RIOT as-is on Linux, BSD, and MacOS. Multiple
   instances of RIOT running on a single machine can also be interconnected via
   a simple virtual Ethernet bridge


### PR DESCRIPTION
I was surprised to see in one talk at the summit that RIOT is now supporting over 110 boards.

But using this command from the RIOT base directory:
```
     find boards -mindepth 1 -maxdepth 1 -type d -not -path "boards/*-common" | wc -l
```
returns 98. The README is updated accordingly by this PR.

By the way, only 2 boards are missing now to reach the 100th supported board :)

There are good candidates (and probably others that I missed) ~~#7510~~, ~~#7727~~, #7306, #6995 that could be merged to get there.
