### PR TITLE
frdm-k22f: Correct copy pasta in LEDx macros

### DIFF
--- a/boards/frdm-k22f/include/board.h
+++ b/boards/frdm-k22f/include/board.h
@@ -41,17 +41,17 @@ extern "C"
 #define LED1_MASK           (1 <<  2)
 #define LED2_MASK           (1 <<  5)
 
-#define LED0_ON            (GPIOB->PCOR = LED0_MASK)
-#define LED0_OFF           (GPIOB->PSOR = LED0_MASK)
-#define LED0_TOGGLE        (GPIOB->PTOR = LED0_MASK)
+#define LED0_ON            (GPIOA->PCOR = LED0_MASK)
+#define LED0_OFF           (GPIOA->PSOR = LED0_MASK)
+#define LED0_TOGGLE        (GPIOA->PTOR = LED0_MASK)
 
-#define LED1_ON            (GPIOE->PCOR = LED1_MASK)
-#define LED1_OFF           (GPIOE->PSOR = LED1_MASK)
-#define LED1_TOGGLE        (GPIOE->PTOR = LED1_MASK)
+#define LED1_ON            (GPIOA->PCOR = LED1_MASK)
+#define LED1_OFF           (GPIOA->PSOR = LED1_MASK)
+#define LED1_TOGGLE        (GPIOA->PTOR = LED1_MASK)
 
-#define LED2_ON            (GPIOB->PCOR = LED2_MASK)
-#define LED2_OFF           (GPIOB->PSOR = LED2_MASK)
-#define LED2_TOGGLE        (GPIOB->PTOR = LED2_MASK)
+#define LED2_ON            (GPIOD->PCOR = LED2_MASK)
+#define LED2_OFF           (GPIOD->PSOR = LED2_MASK)
+#define LED2_TOGGLE        (GPIOD->PTOR = LED2_MASK)
 /** @} */
 
 /**


### PR DESCRIPTION
Trivially fixed mistake that occurred when the board.h was initially copied from another board.