### PR TITLE
kinetis: Implement low power modes

### DIFF
--- a/boards/common/frdm/dist/openocd-klx.cfg
+++ b/boards/common/frdm/dist/openocd-klx.cfg
@@ -16,7 +16,10 @@ transport select swd
 # Kinetis L series CPUs
 source [find target/klx.cfg]
 
-reset_config srst_only
+# The debug module is stopped in low leakage modes, we use connect_assert_srst
+# to hold the device in reset while connecting with OpenOCD to make sure that we
+# always get a connection even when the application uses low power modes.
+reset_config srst_only connect_assert_srst
 
 $_TARGETNAME configure -event gdb-attach {
   halt

--- a/boards/common/frdm/dist/openocd-kx.cfg
+++ b/boards/common/frdm/dist/openocd-kx.cfg
@@ -13,7 +13,10 @@
 # Kinetis K series CPUs
 source [find target/kx.cfg]
 
-reset_config srst_only
+# The debug module is stopped in low leakage modes, we use connect_assert_srst
+# to hold the device in reset while connecting with OpenOCD to make sure that we
+# always get a connection even when the application uses low power modes.
+reset_config srst_only connect_assert_srst
 
 $_TARGETNAME configure -event gdb-attach {
   halt

--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -113,6 +113,7 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC4_UART1_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_UART,
+        .llwu_rx = LLWU_WAKEUP_PIN_PTE1,
     },
 };
 

--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -80,14 +80,15 @@ static const clock_config_t clock_config = {
     },                           \
 }
 #define LPTMR_NUMOF             (1U)
-#define LPTMR_CONFIG {          \
-    {                           \
-        .dev = LPTMR0,          \
-        .irqn = LPTMR0_IRQn,    \
-        .src = 2,               \
-        .base_freq = 32768u,    \
-    },                          \
-}
+#define LPTMR_CONFIG { \
+        { \
+            .dev = LPTMR0, \
+            .base_freq = 32768u, \
+            .llwu = LLWU_WAKEUP_MODULE_LPTMR0, \
+            .src = 2, \
+            .irqn = LPTMR0_IRQn, \
+        } \
+    }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 
 #define PIT_BASECLOCK           (CLOCK_BUSCLOCK)

--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -87,7 +87,7 @@ static const clock_config_t clock_config = {
             .llwu = LLWU_WAKEUP_MODULE_LPTMR0, \
             .src = 2, \
             .irqn = LPTMR0_IRQn, \
-        } \
+        }, \
     }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -70,18 +70,25 @@ static const clock_config_t clock_config = {
  * @{
  */
 #define PIT_NUMOF               (2U)
-#define PIT_CONFIG {                 \
-        {                            \
-            .prescaler_ch = 0,       \
-            .count_ch = 1,           \
-        },                           \
-        {                            \
-            .prescaler_ch = 2,       \
-            .count_ch = 3,           \
-        },                           \
+#define PIT_CONFIG {            \
+        {                       \
+            .prescaler_ch = 0,  \
+            .count_ch = 1,      \
+        },                      \
+        {                       \
+            .prescaler_ch = 2,  \
+            .count_ch = 3,      \
+        },                      \
     }
-#define LPTMR_NUMOF             (0U)
-#define LPTMR_CONFIG {}
+#define LPTMR_NUMOF             (1U)
+#define LPTMR_CONFIG {          \
+    {                           \
+        .dev = LPTMR0,          \
+        .irqn = LPTMR0_IRQn,    \
+        .src = 2,               \
+        .base_freq = 32768u,    \
+    },                          \
+}
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 
 #define PIT_BASECLOCK           (CLOCK_BUSCLOCK)

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -114,6 +114,7 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC4_UART0_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_UART,
+        .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
     },
 };
 

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -81,14 +81,15 @@ static const clock_config_t clock_config = {
         },                      \
     }
 #define LPTMR_NUMOF             (1U)
-#define LPTMR_CONFIG {          \
-    {                           \
-        .dev = LPTMR0,          \
-        .irqn = LPTMR0_IRQn,    \
-        .src = 2,               \
-        .base_freq = 32768u,    \
-    },                          \
-}
+#define LPTMR_CONFIG { \
+        { \
+            .dev = LPTMR0, \
+            .base_freq = 32768u, \
+            .llwu = LLWU_WAKEUP_MODULE_LPTMR0, \
+            .src = 2, \
+            .irqn = LPTMR0_IRQn, \
+        }, \
+    }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 
 #define PIT_BASECLOCK           (CLOCK_BUSCLOCK)

--- a/boards/frdm-kw41z/board.c
+++ b/boards/frdm-kw41z/board.c
@@ -23,6 +23,42 @@
 
 void board_init(void)
 {
+    bit_set32(&SIM->SCGC5, SIM_SCGC5_DCDC_SHIFT);
+
+    /* We don't have a status bit for checking if the DCDC is in bypass mode
+     * so we check if the PSWITCH bit is set, assuming that the power switch
+     * has not been released since the DCDC was started. This is run early in
+     * the boot process so it should be fine. */
+    if (DCDC->REG0 & DCDC_REG0_PSWITCH_STATUS_MASK) {
+        /* DCDC is on */
+        /* Spin until DCDC output is stable */
+        while (!(DCDC->REG0 & DCDC_REG0_DCDC_STS_DC_OK_MASK)) {}
+        /* Set up DCDC for pulsed mode in VLPS, LLS */
+        DCDC->REG0 = (DCDC->REG0 & ~(DCDC_REG0_DCDC_VBAT_DIV_CTRL_MASK | DCDC_REG0_VLPS_CONFIG_DCDC_HP_MASK)) |
+            DCDC_REG0_DCDC_VBAT_DIV_CTRL(0b10) | /* provide VBAT/2 to ADC input to measure battery level */
+            DCDC_REG0_DCDC_LP_DF_CMP_ENABLE_MASK;
+        DCDC->REG1 = DCDC->REG1 |
+            DCDC_REG1_DCDC_LOOPCTRL_EN_CM_HYST_MASK |
+            DCDC_REG1_DCDC_LOOPCTRL_EN_DF_HYST_MASK;
+        DCDC->REG2 = DCDC->REG2 |
+            DCDC_REG2_DCDC_LOOPCTRL_HYST_SIGN_MASK;
+        DCDC->REG3 = (DCDC->REG3 &
+            ~(DCDC_REG3_DCDC_MINPWR_HALF_FETS_MASK |
+              DCDC_REG3_DCDC_MINPWR_DOUBLE_FETS_MASK |
+              DCDC_REG3_DCDC_MINPWR_DOUBLE_FETS_PULSED_MASK)) |
+            DCDC_REG3_DCDC_MINPWR_HALF_FETS_PULSED_MASK;
+
+        /* Spin until DCDC is stable */
+        while (!(DCDC->REG0 & DCDC_REG0_DCDC_STS_DC_OK_MASK)) {}
+
+        /* DCDC has stabilized, halt stepping
+         * This must be set before entering low power modes */
+        DCDC->REG3 |= DCDC_REG3_DCDC_VDD1P5CTRL_DISABLE_STEP_MASK |
+            DCDC_REG3_DCDC_VDD1P8CTRL_DISABLE_STEP_MASK;
+
+        /* Spin until DCDC is stable */
+        while (!(DCDC->REG0 & DCDC_REG0_DCDC_STS_DC_OK_MASK)) {}
+    }
     /* initialize the CPU core */
     cpu_init();
 

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -87,9 +87,10 @@ static const clock_config_t clock_config = {
 #define LPTMR_CONFIG { \
         { \
             .dev = LPTMR0, \
-            .irqn = LPTMR0_IRQn, \
-            .src = 2, \
             .base_freq = 32768u, \
+            .llwu = LLWU_WAKEUP_MODULE_LPTMR0, \
+            .src = 2, \
+            .irqn = LPTMR0_IRQn, \
         } \
     }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -114,6 +114,9 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC5_LPUART0_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_LPUART,
+        /* Using LLWU requires using lower baud rates */
+        /* LLWU_WAKEUP_PIN_PTC6 is the correct setting on this dev board if using LLWU */
+        .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
     },
 };
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -91,7 +91,7 @@ static const clock_config_t clock_config = {
             .llwu = LLWU_WAKEUP_MODULE_LPTMR0, \
             .src = 2, \
             .irqn = LPTMR0_IRQn, \
-        } \
+        }, \
     }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 #define PIT_BASECLOCK           (CLOCK_BUSCLOCK)

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -115,8 +115,12 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC5_LPUART0_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_LPUART,
-        /* Using LLWU requires using lower baud rates */
-        /* LLWU_WAKEUP_PIN_PTC6 is the correct setting on this dev board if using LLWU */
+        /* Undocumented behavior: LPUART fails to detect the START bit at wake up
+         * with LLWU sometimes. This seem to be related to using the builtin
+         * DCDC for powering the MCU. */
+        /* LLWU_WAKEUP_PIN_PTC6 is the correct setting on this dev board if you
+         * want to try using LLS mode, or if it does not matter that the UART RX
+         * byte is sometimes is corrupt */
         .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
     },
 };

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -137,6 +137,7 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC4_UART0_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_UART,
+        .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
     },
     {
         .dev    = UART1,
@@ -150,6 +151,7 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC4_UART1_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_UART,
+        .llwu_rx = LLWU_WAKEUP_PIN_PTC3,
     },
 };
 

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -106,9 +106,10 @@ static const clock_config_t clock_config = {
 #define LPTMR_CONFIG { \
         { \
             .dev = LPTMR0, \
-            .irqn = LPTMR0_IRQn, \
-            .src = 2, \
             .base_freq = 32768u, \
+            .llwu = LLWU_WAKEUP_MODULE_LPTMR0, \
+            .src = 2, \
+            .irqn = LPTMR0_IRQn, \
         } \
     }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -110,7 +110,7 @@ static const clock_config_t clock_config = {
             .llwu = LLWU_WAKEUP_MODULE_LPTMR0, \
             .src = 2, \
             .irqn = LPTMR0_IRQn, \
-        } \
+        }, \
     }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -108,6 +108,7 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC4_UART2_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_UART,
+        .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
     },
     {
         .dev    = UART0,
@@ -121,6 +122,7 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC4_UART0_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_UART,
+        .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
     }
 };
 

--- a/boards/teensy31/include/periph_conf.h
+++ b/boards/teensy31/include/periph_conf.h
@@ -113,6 +113,7 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC4_UART0_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_UART,
+        .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
     },
     {
         .dev    = UART1,
@@ -126,6 +127,7 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC4_UART1_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_UART,
+        .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
     },
 };
 

--- a/boards/teensy31/include/periph_conf.h
+++ b/boards/teensy31/include/periph_conf.h
@@ -127,7 +127,7 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC4_UART1_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_UART,
-        .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
+        .llwu_rx = LLWU_WAKEUP_PIN_PTC3,
     },
 };
 

--- a/boards/usb-kw41z/include/periph_conf.h
+++ b/boards/usb-kw41z/include/periph_conf.h
@@ -87,10 +87,11 @@ static const clock_config_t clock_config = {
 #define LPTMR_CONFIG { \
         { \
             .dev = LPTMR0, \
-            .irqn = LPTMR0_IRQn, \
-            .src = 2, \
             .base_freq = 32768u, \
-        } \
+            .llwu = LLWU_WAKEUP_MODULE_LPTMR0, \
+            .src = 2, \
+            .irqn = LPTMR0_IRQn, \
+        }, \
     }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 #define PIT_BASECLOCK           (CLOCK_BUSCLOCK)
@@ -114,6 +115,10 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC5_LPUART0_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_LPUART,
+        /* LLWU_WAKEUP_PIN_PTC6 is the correct setting on this dev board if you
+         * want to try using LLS mode. The current setting will block LLS mode
+         * if UART RX is used, which is true in most applications */
+        .llwu_rx = LLWU_WAKEUP_PIN_UNDEF,
     },
 };
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))

--- a/cpu/kinetis/Makefile.features
+++ b/cpu/kinetis/Makefile.features
@@ -2,6 +2,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq
+FEATURES_PROVIDED += periph_llwu
 FEATURES_PROVIDED += periph_mcg
 
 include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -36,9 +36,13 @@ export UNDEF += $(BINDIR)/cpu/fcfield.o
 # include common periph drivers
 USEMODULE += periph_common
 
-# select kinetis periph drivers
+# select Kinetis periph drivers
+USEMODULE += periph_llwu
 USEMODULE += periph_mcg
 USEMODULE += periph_wdog
+
+# Enable power management by default
+USEMODULE += pm_layered
 
 # Define a recipe to build the watchdog disable binary, used when flashing
 $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin: $(RIOTCPU)/$(CPU)/dist/wdog-disable.s

--- a/cpu/kinetis/cpu.c
+++ b/cpu/kinetis/cpu.c
@@ -22,6 +22,11 @@
 #ifdef MODULE_PERIPH_MCG
 #include "mcg.h"
 #endif
+#if defined(MODULE_PERIPH_LLWU)
+#include "llwu.h"
+#elif defined(MODULE_PM_LAYERED)
+#include "pm_layered.h"
+#endif
 
 /**
  * @brief Initialize the CPU, set IRQ priorities
@@ -39,6 +44,16 @@ void cpu_init(void)
     /* initialize the CPU clocking provided by the MCG module */
     kinetis_mcg_init();
 #endif
+
+#if defined(MODULE_PERIPH_LLWU)
+    /* initialize the LLWU module for sleep/wakeup management */
+    llwu_init();
+#elif defined(MODULE_PM_LAYERED)
+    /* Block LLS mode since we are not using the LLWU module, which is required
+     * to be able to wake up from LLS */
+    pm_block(KINETIS_PM_LLS);
+#endif
+
     /* trigger static peripheral initialization */
     periph_init();
 }

--- a/cpu/kinetis/include/cpu_conf_kinetis.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis.h
@@ -62,6 +62,93 @@ extern "C"
 /** @} */
 
 /**
+ * @brief Mapping internal module interrupts to LLWU wake up sources
+ *
+ * @note Modules not listed here CAN NOT be used to wake the CPU from LLS or
+ * VLLSx power modes.
+ *
+ * The numbers are hardware specific, but have the same values across all the
+ * supported Kinetis CPUs
+ */
+typedef enum llwu_wakeup_module {
+    LLWU_WAKEUP_MODULE_LPTMR0      = 0,
+    LLWU_WAKEUP_MODULE_CMP0        = 1,
+    LLWU_WAKEUP_MODULE_RADIO       = 2, /* KWx1Z devices */
+    LLWU_WAKEUP_MODULE_CMP1        = 2, /* others */
+    LLWU_WAKEUP_MODULE_DCDC        = 3, /* KWx1Z devices */
+    LLWU_WAKEUP_MODULE_CMP2        = 3, /* others */
+    LLWU_WAKEUP_MODULE_TSI         = 4,
+    LLWU_WAKEUP_MODULE_RTC_ALARM   = 5,
+    LLWU_WAKEUP_MODULE_RESERVED    = 6,
+    LLWU_WAKEUP_MODULE_RTC_SECONDS = 7,
+    LLWU_WAKEUP_MODULE_NUMOF
+} llwu_wakeup_module_t;
+
+/**
+ * @brief Mapping physical pins to LLWU wakeup pin source numbers
+ *
+ * @note Pins not listed here CAN NOT be used to wake the CPU from LLS or
+ * VLLSx power modes.
+ *
+ * The numbers are hardware specific, but have the same values across all the
+ * supported Kinetis CPUs.
+ */
+#if defined(KINETIS_SERIES_W) && defined(KINETIS_CORE_Z) && (KINETIS_SUBFAMILY == 1)
+/* KW41Z has different LLWU pins */
+typedef enum llwu_wakeup_pin {
+    LLWU_WAKEUP_PIN_PTC16 =  0,
+    LLWU_WAKEUP_PIN_PTC17 =  1,
+    LLWU_WAKEUP_PIN_PTC18 =  2,
+    LLWU_WAKEUP_PIN_PTC19 =  3,
+    LLWU_WAKEUP_PIN_PTA16 =  4,
+    LLWU_WAKEUP_PIN_PTA17 =  5,
+    LLWU_WAKEUP_PIN_PTA18 =  6,
+    LLWU_WAKEUP_PIN_PTA19 =  7,
+    LLWU_WAKEUP_PIN_PTB0  =  8,
+    LLWU_WAKEUP_PIN_PTC0  =  9,
+    LLWU_WAKEUP_PIN_PTC2  = 10,
+    LLWU_WAKEUP_PIN_PTC3  = 11,
+    LLWU_WAKEUP_PIN_PTC4  = 12,
+    LLWU_WAKEUP_PIN_PTC5  = 13,
+    LLWU_WAKEUP_PIN_PTC6  = 14,
+    LLWU_WAKEUP_PIN_PTC7  = 15,
+    LLWU_WAKEUP_PIN_NUMOF,
+    LLWU_WAKEUP_PIN_UNDEF
+} llwu_wakeup_pin_t;
+#else
+typedef enum llwu_wakeup_pin {
+    LLWU_WAKEUP_PIN_PTE1  =  0,
+    LLWU_WAKEUP_PIN_PTE2  =  1,
+    LLWU_WAKEUP_PIN_PTE4  =  2,
+    LLWU_WAKEUP_PIN_PTA4  =  3,
+    LLWU_WAKEUP_PIN_PTA13 =  4,
+    LLWU_WAKEUP_PIN_PTB0  =  5,
+    LLWU_WAKEUP_PIN_PTC1  =  6,
+    LLWU_WAKEUP_PIN_PTC3  =  7,
+    LLWU_WAKEUP_PIN_PTC4  =  8,
+    LLWU_WAKEUP_PIN_PTC5  =  9,
+    LLWU_WAKEUP_PIN_PTC6  = 10,
+    LLWU_WAKEUP_PIN_PTC11 = 11,
+    LLWU_WAKEUP_PIN_PTD0  = 12,
+    LLWU_WAKEUP_PIN_PTD2  = 13,
+    LLWU_WAKEUP_PIN_PTD4  = 14,
+    LLWU_WAKEUP_PIN_PTD6  = 15,
+    LLWU_WAKEUP_PIN_NUMOF,
+    LLWU_WAKEUP_PIN_UNDEF
+} llwu_wakeup_pin_t;
+#endif
+
+/**
+ * @brief LLWU wakeup pin edge settings
+ */
+typedef enum llwu_wakeup_edge {
+    LLWU_WAKEUP_EDGE_NONE = 0,
+    LLWU_WAKEUP_EDGE_RISING = 1,
+    LLWU_WAKEUP_EDGE_FALLING = 2,
+    LLWU_WAKEUP_EDGE_BOTH = 3,
+} llwu_wakeup_edge_t;
+
+/**
  * @name Compatibility definitions between vendor headers
  * @{
  */

--- a/cpu/kinetis/include/cpu_conf_kinetis.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis.h
@@ -85,7 +85,15 @@ typedef enum llwu_wakeup_module {
 } llwu_wakeup_module_t;
 
 /**
- * @brief Mapping physical pins to LLWU wakeup pin source numbers
+ * @brief   Mapping LLWU wakeup pin sources to PORT interrupt numbers
+ */
+typedef struct {
+    PORT_Type *port; /**< PORT register */
+    uint32_t isfr_mask; /**< ISFR bitmask */
+} llwu_wakeup_pin_to_port_t;
+
+/**
+ * @brief   Mapping physical pins to LLWU wakeup pin source numbers
  *
  * @note Pins not listed here CAN NOT be used to wake the CPU from LLS or
  * VLLSx power modes.
@@ -115,6 +123,28 @@ typedef enum llwu_wakeup_pin {
     LLWU_WAKEUP_PIN_NUMOF,
     LLWU_WAKEUP_PIN_UNDEF
 } llwu_wakeup_pin_t;
+
+/**
+ * @brief   Mapping LLWU wakeup pin number to PORT module interrupt flags
+ */
+static const llwu_wakeup_pin_to_port_t llwu_wakeup_pin_to_port[LLWU_WAKEUP_PIN_NUMOF] = {
+    [LLWU_WAKEUP_PIN_PTC16] = { .port = PORTC, .isfr_mask = (1u << 16), },
+    [LLWU_WAKEUP_PIN_PTC17] = { .port = PORTC, .isfr_mask = (1u << 17), },
+    [LLWU_WAKEUP_PIN_PTC18] = { .port = PORTC, .isfr_mask = (1u << 18), },
+    [LLWU_WAKEUP_PIN_PTC19] = { .port = PORTC, .isfr_mask = (1u << 19), },
+    [LLWU_WAKEUP_PIN_PTA16] = { .port = PORTA, .isfr_mask = (1u << 16), },
+    [LLWU_WAKEUP_PIN_PTA17] = { .port = PORTA, .isfr_mask = (1u << 17), },
+    [LLWU_WAKEUP_PIN_PTA18] = { .port = PORTA, .isfr_mask = (1u << 18), },
+    [LLWU_WAKEUP_PIN_PTA19] = { .port = PORTA, .isfr_mask = (1u << 19), },
+    [LLWU_WAKEUP_PIN_PTB0 ] = { .port = PORTB, .isfr_mask = (1u <<  0), },
+    [LLWU_WAKEUP_PIN_PTC0 ] = { .port = PORTC, .isfr_mask = (1u <<  0), },
+    [LLWU_WAKEUP_PIN_PTC2 ] = { .port = PORTC, .isfr_mask = (1u <<  2), },
+    [LLWU_WAKEUP_PIN_PTC3 ] = { .port = PORTC, .isfr_mask = (1u <<  3), },
+    [LLWU_WAKEUP_PIN_PTC4 ] = { .port = PORTC, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTC5 ] = { .port = PORTC, .isfr_mask = (1u <<  5), },
+    [LLWU_WAKEUP_PIN_PTC6 ] = { .port = PORTC, .isfr_mask = (1u <<  6), },
+    [LLWU_WAKEUP_PIN_PTC7 ] = { .port = PORTC, .isfr_mask = (1u <<  7), },
+};
 #else
 typedef enum llwu_wakeup_pin {
     LLWU_WAKEUP_PIN_PTE1  =  0,
@@ -136,10 +166,32 @@ typedef enum llwu_wakeup_pin {
     LLWU_WAKEUP_PIN_NUMOF,
     LLWU_WAKEUP_PIN_UNDEF
 } llwu_wakeup_pin_t;
+
+/**
+ * @brief   Mapping LLWU wakeup pin number to PORT module interrupt flags
+ */
+static const llwu_wakeup_pin_to_port_t llwu_wakeup_pin_to_port[LLWU_WAKEUP_PIN_NUMOF] = {
+    [LLWU_WAKEUP_PIN_PTE1 ] = { .port = PORTE, .isfr_mask = (1u <<  1), },
+    [LLWU_WAKEUP_PIN_PTE2 ] = { .port = PORTE, .isfr_mask = (1u <<  2), },
+    [LLWU_WAKEUP_PIN_PTE4 ] = { .port = PORTE, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTA4 ] = { .port = PORTA, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTA13] = { .port = PORTA, .isfr_mask = (1u << 13), },
+    [LLWU_WAKEUP_PIN_PTB0 ] = { .port = PORTB, .isfr_mask = (1u <<  0), },
+    [LLWU_WAKEUP_PIN_PTC1 ] = { .port = PORTC, .isfr_mask = (1u <<  1), },
+    [LLWU_WAKEUP_PIN_PTC3 ] = { .port = PORTC, .isfr_mask = (1u <<  3), },
+    [LLWU_WAKEUP_PIN_PTC4 ] = { .port = PORTC, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTC5 ] = { .port = PORTC, .isfr_mask = (1u <<  5), },
+    [LLWU_WAKEUP_PIN_PTC6 ] = { .port = PORTC, .isfr_mask = (1u <<  6), },
+    [LLWU_WAKEUP_PIN_PTC11] = { .port = PORTC, .isfr_mask = (1u << 11), },
+    [LLWU_WAKEUP_PIN_PTD0 ] = { .port = PORTD, .isfr_mask = (1u <<  0), },
+    [LLWU_WAKEUP_PIN_PTD2 ] = { .port = PORTD, .isfr_mask = (1u <<  2), },
+    [LLWU_WAKEUP_PIN_PTD4 ] = { .port = PORTD, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTD6 ] = { .port = PORTD, .isfr_mask = (1u <<  6), },
+};
 #endif
 
 /**
- * @brief LLWU wakeup pin edge settings
+ * @brief   LLWU wakeup pin edge settings
  */
 typedef enum llwu_wakeup_edge {
     LLWU_WAKEUP_EDGE_NONE = 0,

--- a/cpu/kinetis/include/llwu.h
+++ b/cpu/kinetis/include/llwu.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2017 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    cpu_kinetis_llwu Kinetis LLWU
+ * @ingroup     cpu_kinetis
+ * @brief       Kinetis low leakage wakeup unit (LLWU) driver
+
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the Kinetis LLWU driver.
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef LLWU_H
+#define LLWU_H
+
+#include "cpu.h"
+#include "bit.h"
+#include "periph_conf.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief Initialize the Low-Leakage Wake Up (LLWU) hardware module
+ */
+void llwu_init(void);
+
+/**
+ * @brief Enable a wakeup module in the LLWU
+ */
+inline static void llwu_wakeup_module_enable(llwu_wakeup_module_t mod)
+{
+    assert(mod < LLWU_WAKEUP_MODULE_NUMOF);
+    bit_set8(&LLWU->ME, mod);
+}
+
+/**
+ * @brief Disable a wakeup module in the LLWU
+ */
+inline static void llwu_wakeup_module_disable(llwu_wakeup_module_t mod)
+{
+    assert(mod < LLWU_WAKEUP_MODULE_NUMOF);
+    bit_clear8(&LLWU->ME, mod);
+}
+
+/**
+ * @brief Set the mode for a wakeup pin in the LLWU
+ *
+ * If @p cb is NULL when the pin edge is detected, the CPU will wake up for a
+ * few cycles which can allow other hardware modules to detect other interrupts.
+ * This may be particularily useful when using the wakeup pin for communication
+ * functions such as UART RX etc.
+ *
+ * @param[in]  pin  The pin to modify
+ * @param[in]  edge Edge detection setting (rising, falling, both, none)
+ * @param[in]  cb   Callback function to execute when woken with this pin
+ * @param[in]  arg  Argument that will be passed to the callback
+ */
+void llwu_wakeup_pin_set(llwu_wakeup_pin_t pin, llwu_wakeup_edge_t edge, gpio_cb_t cb, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* LLWU_H */

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -110,9 +110,18 @@ typedef uint16_t gpio_t;
 #define PERIPH_TIMER_PROVIDES_SET
 
 /**
- * @brief   number of usable power modes
+ * @name    Kinetis power mode configuration
+ * @{
  */
-#define PM_NUM_MODES    (1U)
+#define PM_NUM_MODES    (4U)
+enum {
+    KINETIS_PM_LLS  = 0,
+    KINETIS_PM_VLPS = 1,
+    KINETIS_PM_STOP = 2,
+    KINETIS_PM_WAIT = 3,
+};
+#define PM_BLOCKER_INITIAL  { .val_u32 = 0 }
+/** @} */
 
 #ifdef RTC
 /* All Kinetis CPUs have exactly one RTC hardware module, except for the KL02
@@ -337,6 +346,8 @@ typedef struct {
     LPTMR_Type *dev;
     /** Input clock frequency */
     uint32_t base_freq;
+    /** LLWU wakeup module number for this timer */
+    llwu_wakeup_module_t llwu;
     /** Clock source setting */
     uint8_t src;
     /** IRQn interrupt number */
@@ -447,8 +458,20 @@ typedef struct {
     volatile uint32_t *scgc_addr; /**< Clock enable register, in SIM module */
     uint8_t scgc_bit;             /**< Clock enable bit, within the register */
     uart_mode_t mode;             /**< UART mode: data bits, parity, stop bits */
-    uart_type_t type;             /**< Hardware module type (KINETIS_UART or KINETIS_LPUART)*/
+    uart_type_t type;             /**< Hardware module type (KINETIS_UART or KINETIS_LPUART) */
+    /**
+     * @brief LLWU wakeup source RX pin to allow RX while in LLS mode
+     *
+     * Set to @c LLWU_WAKEUP_PIN_UNDEF if the chosen RX pin is not available to
+     * the LLWU.
+     */
+    llwu_wakeup_pin_t llwu_rx;
 } uart_conf_t;
+
+/**
+ * @brief  Override the default uart_isr_ctx_t in uart.c
+ */
+#define HAVE_UART_ISR_CTX_T
 
 #if !defined(KINETIS_HAVE_PLL)
 #if defined(MCG_C6_PLLS_MASK) || DOXYGEN

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -26,6 +26,22 @@
 
 #include "cpu.h"
 
+#if MODULE_PM_LAYERED
+#include "pm_layered.h"
+/**
+ * @brief   pm_block iff pm_layered is used
+ */
+#define PM_BLOCK(x) pm_block(x)
+/**
+ * @brief   pm_unblock iff pm_layered is used
+ */
+#define PM_UNBLOCK(x) pm_unblock(x)
+#else
+/* ignore these calls when not using pm_layered */
+#define PM_BLOCK(x)
+#define PM_UNBLOCK(x)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/kinetis/periph/llwu.c
+++ b/cpu/kinetis/periph/llwu.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2017 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_kinetis
+ * @{
+ *
+ * @file
+ * @brief       Low-leakage wakeup unit (LLWU) driver
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "bit.h"
+#include "llwu.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+struct {
+    gpio_cb_t cb;
+    void *arg;
+} config[LLWU_WAKEUP_PIN_NUMOF];
+
+void llwu_init(void)
+{
+    /* Setup Low Leakage Wake-up Unit (LLWU) */
+#ifdef SIM_SCGC4_LLWU_SHIFT
+    /* Only the first generation Kinetis K CPUs have a clock gate for the LLWU,
+     * for all others the LLWU is always on */
+    bit_set32(&SIM->SCGC4, SIM_SCGC4_LLWU_SHIFT);   /* Enable LLWU clock gate */
+#endif
+
+    /* Enable LLWU interrupt, or else we can never resume from LLS */
+    NVIC_EnableIRQ(LLWU_IRQn);
+    /* LLWU needs to have the lowest possible priority, or it will block the
+     * other modules from performing their IRQ handling */
+    NVIC_SetPriority(LLWU_IRQn, 0xff);
+}
+
+void llwu_wakeup_pin_set(llwu_wakeup_pin_t pin, llwu_wakeup_edge_t edge, gpio_cb_t cb, void *arg)
+{
+    assert(pin < LLWU_WAKEUP_PIN_NUMOF);
+    config[pin].cb = cb;
+    config[pin].arg = arg;
+
+    /* The fields are two bits per pin, and the setting registers are 8 bits wide */
+    if(pin < 4) {
+        unsigned field_offset = pin * 2;
+        LLWU->PE1 = (LLWU->PE1 & (~(0b11 << field_offset))) | (edge << field_offset);
+    }
+    else if(pin < 8) {
+        unsigned field_offset = (pin - 4) * 2;
+        LLWU->PE2 = (LLWU->PE2 & (~(0b11 << field_offset))) | (edge << field_offset);
+    }
+    else if(pin < 12) {
+        unsigned field_offset = (pin - 8) * 2;
+        LLWU->PE3 = (LLWU->PE3 & (~(0b11 << field_offset))) | (edge << field_offset);
+    }
+    else {
+        unsigned field_offset = (pin - 12) * 2;
+        LLWU->PE4 = (LLWU->PE4 & (~(0b11 << field_offset))) | (edge << field_offset);
+    }
+}
+
+void isr_llwu(void)
+{
+    DEBUG("LLWU IRQ\n");
+
+    for (unsigned reg = 0; reg < ((LLWU_WAKEUP_PIN_NUMOF + 7) / 8); ++reg) {
+        uint8_t flags = *(&LLWU->F1 + reg);
+        if (flags == 0) {
+            continue;
+        }
+        /* Clear pin interrupt flags */
+        *(&LLWU->F1 + reg) = flags;
+        DEBUG("llwu: F%u = %02x\n", reg + 1, (unsigned) flags);
+        for (unsigned i = 0; i < 8; ++i) {
+            if (flags & 1) {
+                DEBUG("llwu: pin %u\n", reg * 8 + i);
+                if (config[i].cb != NULL) {
+                    config[i].cb(config[i].arg);
+                }
+            }
+            flags >>= 1;
+        }
+    }
+    DEBUG("llwu: F3 = %02x\n", LLWU->F3);
+    /* Read only register F3, the flag will need to be cleared in the peripheral
+     * instead of writing a 1 to the MWUFx bit. */
+
+    cortexm_isr_end();
+}

--- a/cpu/kinetis/periph/llwu.c
+++ b/cpu/kinetis/periph/llwu.c
@@ -83,14 +83,16 @@ void isr_llwu(void)
         /* Clear pin interrupt flags */
         *(&LLWU->F1 + reg) = flags;
         DEBUG("llwu: F%u = %02x\n", reg + 1, (unsigned) flags);
-        for (unsigned i = 0; i < 8; ++i) {
+        unsigned pin = reg * 8;
+        while (flags) {
             if (flags & 1) {
-                DEBUG("llwu: pin %u\n", reg * 8 + i);
-                if (config[i].cb != NULL) {
-                    config[i].cb(config[i].arg);
+                DEBUG("llwu: wakeup pin %u\n", pin);
+                if (config[pin].cb != NULL) {
+                    config[pin].cb(config[pin].arg);
                 }
             }
             flags >>= 1;
+            ++pin;
         }
     }
     DEBUG("llwu: F3 = %02x\n", LLWU->F3);

--- a/cpu/kinetis/periph/pm.c
+++ b/cpu/kinetis/periph/pm.c
@@ -26,17 +26,60 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/**
- * @note    The current PM implementation is very much simplified down to only
- *          using the 'WAIT' mode. This implementation must be further expanded
- *          to make use of the available and more efficient (deep) sleep modes
- *          of the Kinetis CPUs.
- */
+/* Set to 1 to use the LEDx macros to show which sleep mode is entered */
+#define ENABLE_LEDS (0)
+
+#if ENABLE_LEDS
+#include "board.h"
+#define PM_LED(x, state) LED ## x ## _ ## state
+#else
+#define PM_LED(x, state)
+#endif
+
+/* SMC_PMCTRL_STOPM masks */
+enum {
+    SMC_PMCTRL_STOPM_STOP = 0,
+    /* 1 is reserved */
+    SMC_PMCTRL_STOPM_VLPS = 2,
+    SMC_PMCTRL_STOPM_LLS  = 3,
+    /* VLLS is not supported */
+};
+
+/** Configure which stop mode will be entered when cortexm_sleep(1) is called */
+static inline void pm_stopm(uint8_t stopm)
+{
+    SMC->PMCTRL = (SMC->PMCTRL & ~(SMC_PMCTRL_STOPM_MASK)) | SMC_PMCTRL_STOPM(stopm);
+}
+
 void pm_set(unsigned mode)
 {
+    unsigned deep = 1;
     switch (mode) {
-        case 0:
-            cortexm_sleep(0);
+        case KINETIS_PM_WAIT:
+            /* WAIT */
+            deep = 0;
+            PM_LED(0, ON);
+            break;
+        case KINETIS_PM_STOP:
+            /* STOP */
+            pm_stopm(SMC_PMCTRL_STOPM_STOP);
+            PM_LED(1, ON);
+            break;
+        case KINETIS_PM_VLPS:
+            /* VLPS */
+            pm_stopm(SMC_PMCTRL_STOPM_VLPS);
+            PM_LED(2, ON);
+            break;
+        case KINETIS_PM_LLS:
+            /* LLSx */
+            pm_stopm(SMC_PMCTRL_STOPM_LLS);
+            PM_LED(0, ON);
+            PM_LED(2, ON);
             break;
     }
+    DEBUG("pm_set(%u)\n", mode);
+    cortexm_sleep(deep);
+    PM_LED(0, OFF);
+    PM_LED(1, OFF);
+    PM_LED(2, OFF);
 }

--- a/cpu/kinetis/periph/pm.c
+++ b/cpu/kinetis/periph/pm.c
@@ -75,6 +75,8 @@ void pm_set(unsigned mode)
             pm_stopm(SMC_PMCTRL_STOPM_LLS);
             PM_LED(0, ON);
             PM_LED(2, ON);
+            /* Enable LLWU interrupt, or else we can never resume from LLS */
+            NVIC_EnableIRQ(LLWU_IRQn);
             break;
     }
     DEBUG("pm_set(%u)\n", mode);

--- a/cpu/kinetis/periph/pm.c
+++ b/cpu/kinetis/periph/pm.c
@@ -76,6 +76,10 @@ void pm_set(unsigned mode)
             PM_LED(0, ON);
             PM_LED(2, ON);
             /* Enable LLWU interrupt, or else we can never resume from LLS */
+            /* Clear pending flag first, the LLWU has no purpose in RUN mode, so
+             * if the flag is set then it must be a remainder from handling the
+             * previous wakeup. */
+            NVIC_ClearPendingIRQ(LLWU_IRQn);
             NVIC_EnableIRQ(LLWU_IRQn);
             break;
     }

--- a/cpu/kinetis/periph/pm.c
+++ b/cpu/kinetis/periph/pm.c
@@ -79,6 +79,8 @@ void pm_set(unsigned mode)
             /* Clear pending flag first, the LLWU has no purpose in RUN mode, so
              * if the flag is set then it must be a remainder from handling the
              * previous wakeup. */
+            LLWU->F1 = 0xffu;
+            LLWU->F2 = 0xffu;
             NVIC_ClearPendingIRQ(LLWU_IRQn);
             NVIC_EnableIRQ(LLWU_IRQn);
             break;

--- a/cpu/kinetis/periph/rtt.c
+++ b/cpu/kinetis/periph/rtt.c
@@ -31,6 +31,9 @@
 #include "cpu.h"
 #include "bit.h"
 #include "periph/rtt.h"
+#ifdef MODULE_PERIPH_LLWU
+#include "llwu.h"
+#endif
 #include "periph_conf.h"
 
 #define ENABLE_DEBUG (0)
@@ -65,7 +68,7 @@ void rtt_init(void)
         /* Time Invalid Flag is set, clear TIF by writing TSR */
 
         /* Stop counter to make TSR writable */
-        bit_clear32(&RTC->SR, RTC_SR_TCE_SHIFT);
+        rtt_poweroff();
 
         RTC->TSR = 0;
     }
@@ -76,6 +79,10 @@ void rtt_init(void)
     /* Enable RTC interrupts */
     NVIC_EnableIRQ(RTC_IRQn);
 
+#ifdef MODULE_PERIPH_LLWU
+    /* Enable RTC wake from LLS */
+    llwu_wakeup_module_enable(LLWU_WAKEUP_MODULE_RTC_ALARM);
+#endif
     rtt_poweron();
 }
 

--- a/cpu/kinetis/periph/uart.c
+++ b/cpu/kinetis/periph/uart.c
@@ -591,15 +591,12 @@ static inline void irq_handler_lpuart(uart_t uart)
     if (stat & LPUART_STAT_RDRF_MASK) {
         /* RDRF flag will be cleared when LPUART_DATA is read */
         uint8_t data = dev->DATA;
-        if (stat & (LPUART_STAT_FE_MASK | LPUART_STAT_PF_MASK | LPUART_STAT_NF_MASK)) {
+        if (stat & (LPUART_STAT_FE_MASK | LPUART_STAT_PF_MASK)) {
             if (stat & LPUART_STAT_FE_MASK) {
                 DEBUG("LPUART framing error %08" PRIx32 "\n", stat);
             }
             if (stat & LPUART_STAT_PF_MASK) {
                 DEBUG("LPUART parity error %08" PRIx32 "\n", stat);
-            }
-            if (stat & LPUART_STAT_NF_MASK) {
-                DEBUG("LPUART noise flag %08" PRIx32 "\n", stat);
             }
             /* FE is set whenever the next character to be read from LPUART_DATA
              * was received with logic 0 detected where a stop bit was expected. */

--- a/cpu/kinetis/periph/uart.c
+++ b/cpu/kinetis/periph/uart.c
@@ -591,12 +591,15 @@ static inline void irq_handler_lpuart(uart_t uart)
     if (stat & LPUART_STAT_RDRF_MASK) {
         /* RDRF flag will be cleared when LPUART_DATA is read */
         uint8_t data = dev->DATA;
-        if (stat & (LPUART_STAT_FE_MASK | LPUART_STAT_PF_MASK)) {
+        if (stat & (LPUART_STAT_FE_MASK | LPUART_STAT_PF_MASK | LPUART_STAT_NF_MASK)) {
             if (stat & LPUART_STAT_FE_MASK) {
                 DEBUG("LPUART framing error %08" PRIx32 "\n", stat);
             }
             if (stat & LPUART_STAT_PF_MASK) {
                 DEBUG("LPUART parity error %08" PRIx32 "\n", stat);
+            }
+            if (stat & LPUART_STAT_NF_MASK) {
+                DEBUG("LPUART noise flag %08" PRIx32 "\n", stat);
             }
             /* FE is set whenever the next character to be read from LPUART_DATA
              * was received with logic 0 detected where a stop bit was expected. */

--- a/cpu/kinetis/periph/uart.c
+++ b/cpu/kinetis/periph/uart.c
@@ -363,6 +363,9 @@ static inline void uart_init_uart(uart_t uart, uint32_t baudrate)
         /* enable interrupts on failure flags */
         dev->C3 |= UART_C3_ORIE_MASK | UART_C3_PEIE_MASK | UART_C3_FEIE_MASK | UART_C3_NEIE_MASK;
     }
+    /* clear interrupt flags */
+    uint8_t s = dev->S2;
+    dev->S2 = s;
 }
 
 KINETIS_UART_WRITE_INLINE void uart_write_uart(uart_t uart, const uint8_t *data, size_t len)
@@ -555,6 +558,9 @@ static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate)
             LPUART_CTRL_ORIE_MASK | LPUART_CTRL_PEIE_MASK |
             LPUART_CTRL_FEIE_MASK | LPUART_CTRL_NEIE_MASK;
     }
+    /* clear interrupt flags */
+    uint32_t s = dev->STAT;
+    dev->STAT = s;
 }
 
 KINETIS_UART_WRITE_INLINE void uart_write_lpuart(uart_t uart, const uint8_t *data, size_t len)

--- a/cpu/kinetis/periph/uart.c
+++ b/cpu/kinetis/periph/uart.c
@@ -31,14 +31,6 @@
 #if MODULE_PERIPH_LLWU
 #include "llwu.h"
 #endif
-#if MODULE_PM_LAYERED
-#include "pm_layered.h"
-#define PM_BLOCK(x) pm_block(x)
-#define PM_UNBLOCK(x) pm_unblock(x)
-#else
-#define PM_BLOCK(x)
-#define PM_UNBLOCK(x)
-#endif
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"


### PR DESCRIPTION
~~Based on #7882~~
Depends on ~#10320~, ~~#9930~~ 

Low power modes using pm_layered with automatic blocking of modes depending on what peripherals are in use.
The UART peripheral driver has been enhanced with checking of error indication flags in the RX interrupt.

TODO
 - [x] board configuration updates for LLWU
 - [ ] Measure power consumption
 - [ ] Test peripherals
 - [x] LPUART LLS operation similar to UART
 - [x] Make pm_layered usage conditional on USEMODULE

Tested on FRDM-K22F, both with PIT and with LPTMR for xtimer.

The UART on the FRDM-K22F seem to collect some garbage during boot when using low power modes, resulting in the first one or two commands entered over pyterm to return error messages about command not found. Typing the same command again (by hitting enter again in pyterm) always seem to work. It does not seem to be dependent on how long we wait after boot, but rather there's some junk being collected in the internal stdio_uart RX buffer and the buffer being flushed when the first newline is received.
Tested with pyterm, picocom, and minicom to ensure that the UART is working properly both with long RX sequences (pyterm) and with single keystroke transmissions (minicom).

Example terminal output with boot garbage after flashing:
```
2017-10-28 15:46:08,467 - INFO # �����main(): This is RIOT! (Version: 2018.01-devel-149-g6d3d3-cheesecake-pr/kinetis-pm)
2017-10-28 15:46:08,469 - INFO # Welcome to RIOT!
> ps

2017-10-28 15:46:10,825 - INFO #  �.�ps
2017-10-28 15:46:10,828 - INFO # shell: command not found: �.�ps
> 
2017-10-28 15:46:11,411 - INFO #  ps
2017-10-28 15:46:11,420 - INFO # 	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
2017-10-28 15:46:11,427 - INFO # 	  - | isr_stack            | -        - |   - |   1024 (  116) | 0x1fff0000 | 0x1fff03c8
2017-10-28 15:46:11,436 - INFO # 	  1 | idle                 | pending  Q |  15 |    768 (  128) | 0x1fff0714 | 0x1fff0994 
2017-10-28 15:46:11,444 - INFO # 	  2 | main                 | running  Q |   7 |   1536 (  632) | 0x1fff0a14 | 0x1fff0e8c 
2017-10-28 15:46:11,450 - INFO # 	    | SUM                  |            |     |   3328 (  876)
```