### PR TITLE
cortexm_common: Add CPU_NOSLEEP for disabling all sleep

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -42,6 +42,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Set this to 1 to disable all sleep (useful for debugging)
+ *
+ * Example: CFLAGS=-DCPU_NOSLEEP make flash
+ */
+#ifndef CPU_NOSLEEP
+#define CPU_NOSLEEP 0
+#endif
+
+/**
  * @brief Interrupt stack canary value
  *
  * @note 0xe7fe is the ARM Thumb machine code equivalent of asm("bl #-2\n") or
@@ -96,6 +105,9 @@ static inline void cortexm_sleep_until_event(void)
  */
 static inline void cortexm_sleep(int deep)
 {
+    if (CPU_NOSLEEP) {
+        return;
+    }
     if (deep) {
         SCB->SCR |=  (SCB_SCR_SLEEPDEEP_Msk);
     }

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -88,10 +88,10 @@ void pm_unblock(unsigned mode)
 }
 
 #ifndef PROVIDES_PM_LAYERED_OFF
-void  pm_off(void)
+void pm_off(void)
 {
     pm_blocker.val_u32 = 0;
     pm_set_lowest();
-    while(1);
+    while(1) {}
 }
 #endif


### PR DESCRIPTION
Purely for debugging purposes. OpenOCD has trouble connecting if the CPU is in the lowest power modes, making debugging impossible, sometimes the debugger can even lose the connection in the middle of a debugging session if the CPU enters the lowest power mode while running in GDB. 

This PR adds a new preprocessor macro CPU_NOSLEEP which when defined to 1 will skip past the `__WFI()` call in the cortexm_sleep function, resulting in the CPU continues running. By placing the condition at this low level location we can still inspect the higher levels of the pm subsystem while debugging.