### PR TITLE
tests/sx127x: remove unused periph/rtc.h include

### DIFF
--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -33,7 +33,6 @@
 #include "net/netdev.h"
 
 #include "board.h"
-#include "periph/rtc.h"
 
 #include "sx127x_internal.h"
 #include "sx127x_params.h"


### PR DESCRIPTION
The `periph/rtc.h` include doesn't get used as far as I can find.

There should be a `FEATURES_REQUIRED += periph_rtc` in the case that I'm wrong on this one.