### PR TITLE
dist/tools: check DBG env var.

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -25,7 +25,7 @@
 #               options:
 #               BINFILE: path to the binary file that is flashed
 #
-# debug:        starts OpenOCD as GDB server in the background and
+# debug:        starts JLink as GDB server in the background and
 #               connects to the server with the GDB client specified by
 #               the board (DBG environment variable)
 #
@@ -35,7 +35,7 @@
 #               TUI:            if TUI!=null, the -tui option will be used
 #               ELFFILE:        path to the ELF file to debug
 #
-# debug-server: starts OpenOCD as GDB server, but does not connect to
+# debug-server: starts JLink as GDB server, but does not connect to
 #               to it with any frontend. This might be useful when using
 #               IDEs.
 #
@@ -128,6 +128,13 @@ test_serial() {
     fi
 }
 
+test_dbg() {
+    if [ -z "${DBG}" ]; then
+        echo "Error: No debugger defined in DBG env var"
+        exit 1
+    fi
+}
+
 #
 # now comes the actual actions
 #
@@ -161,6 +168,7 @@ do_debug() {
     test_elffile
     test_ports
     test_tui
+    test_dbg
     # start the JLink GDB server
     sh -c "${JLINK_SERVER} ${JLINK_SERIAL_SERVER} \
                            -device '${JLINK_DEVICE}' \


### PR DESCRIPTION
I wanted to debug my target, but it threw a cryptic error message because I now have to define `DBG`:

```
/Users/basilfx/Desktop/RIOT/dist/tools/jlink/jlink.sh debug
### Starting Debugging ###
HEXFILE found
/Users/basilfx/Desktop/RIOT/dist/tools/jlink/jlink.sh: line 174: -q: command not found
make: *** [debug] Terminated: 15
[1]    15385 terminated  BOARD=slstk3401a make -j8 debug
```

I've added a error that should point you into the right direction.

Also took the liberty to replace OpenOCD references with JLink :-)