### PR TITLE
cortexm_common: Correct offset for hardfault stack

### DIFF
--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -144,7 +144,7 @@ SECTIONS
     _sheap = . ;
     _eheap = ORIGIN(ram) + LENGTH(ram);
 
-    /* Populate information abour ram size */
+    /* Populate information about ram size */
     _sram = ORIGIN(ram);
     _eram = ORIGIN(ram) + LENGTH(ram);
 }

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -49,8 +49,8 @@ extern uint32_t _szero;
 extern uint32_t _ezero;
 extern uint32_t _sstack;
 extern uint32_t _estack;
-extern uint32_t _sram;
-extern uint32_t _eram;
+extern uint8_t _sram;
+extern uint8_t _eram;
 /** @} */
 
 /**


### PR DESCRIPTION
The required space for the hardfault handler is defined by
HARDFAULT_HANDLER_REQUIRED_STACK_SPACE, which is given in bytes,
this length is added to &_sram to find a lower limit on the amount of
stack space that the hard fault handler can work with. The _sram
variable, was mistakenly defined as a uint32_t, which makes &_sram into
a uint32_t*, which through pointer addition, made the required space 4
times as big as it was supposed to. By changing the type of _sram to
uint8_t, the required stack space is correctly computed.

The symptom was that the hardfault handler always reported that the
stack pointer had been corrupted and it was impossible to get any useful
information from the crash text.