### PR TITLE
cpu/cortex-m variants: Remove _estack declarations

### DIFF
--- a/cpu/cc2538/vectors.c
+++ b/cpu/cc2538/vectors.c
@@ -22,9 +22,6 @@
 #include "board.h"
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/cc26x0/vectors.c
+++ b/cpu/cc26x0/vectors.c
@@ -21,9 +21,6 @@
 #include "board.h"
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/cortexm_common/include/vectors_cortexm.h
+++ b/cpu/cortexm_common/include/vectors_cortexm.h
@@ -61,8 +61,6 @@ typedef struct {
     isr_t vectors[CPU_NONISR_EXCEPTIONS];   /**< shared Cortex-M vectors */
 } cortexm_base_t;
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
 /**
  * @brief   This function is the default entry point after a system reset
  *

--- a/cpu/ezr32wg/vectors.c
+++ b/cpu/ezr32wg/vectors.c
@@ -21,9 +21,6 @@
 #include <stdint.h>
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/kinetis/include/vectors_kinetis.h
+++ b/cpu/kinetis/include/vectors_kinetis.h
@@ -29,11 +29,6 @@ extern "C" {
 #endif
 
 /**
- * @brief memory markers as defined in the linker script
- */
-extern uint32_t _estack;
-
-/**
  * @brief Dummy handler
  */
 void dummy_handler(void);

--- a/cpu/lm4f120/vectors.c
+++ b/cpu/lm4f120/vectors.c
@@ -19,9 +19,6 @@
 #include <stdint.h>
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/lpc1768/vectors.c
+++ b/cpu/lpc1768/vectors.c
@@ -21,9 +21,6 @@
 #include <stdint.h>
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/nrf51/vectors.c
+++ b/cpu/nrf51/vectors.c
@@ -22,9 +22,6 @@
 #include "cpu.h"
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/nrf52/vectors.c
+++ b/cpu/nrf52/vectors.c
@@ -24,9 +24,6 @@
 #include "cpu.h"
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/sam3/vectors.c
+++ b/cpu/sam3/vectors.c
@@ -21,9 +21,6 @@
 #include <stdint.h>
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/samd21/vectors.c
+++ b/cpu/samd21/vectors.c
@@ -22,9 +22,6 @@
 #include <stdint.h>
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/saml21/vectors.c
+++ b/cpu/saml21/vectors.c
@@ -25,9 +25,6 @@
 #include <stdint.h>
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/stm32f3/vectors.c
+++ b/cpu/stm32f3/vectors.c
@@ -21,9 +21,6 @@
 #include <stdint.h>
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/stm32l1/vectors.c
+++ b/cpu/stm32l1/vectors.c
@@ -22,9 +22,6 @@
 #include <stdint.h>
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {

--- a/cpu/stm32l4/vectors.c
+++ b/cpu/stm32l4/vectors.c
@@ -21,9 +21,6 @@
 #include <stdint.h>
 #include "vectors_cortexm.h"
 
-/* get the start of the ISR stack as defined in the linkerscript */
-extern uint32_t _estack;
-
 /* define a local dummy handler as it needs to be in the same compilation unit
  * as the alias definition */
 void dummy_handler(void) {


### PR DESCRIPTION
These are leftovers from before the Cortex-M common ISR vectors were split into vectors_cortexm.c

~~Based on #7882~~