### PR TITLE
tests/gnrc_ipv6_nib: Fix unused function error w/ clang/macOS

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -290,6 +290,9 @@ void _nib_nc_get(const _nib_onl_entry_t *node, gnrc_ipv6_nib_nc_t *nce)
             return;
         }
     }
+#else
+    /* Prevent unused function error thrown by clang */
+    (void)_get_l2addr_from_ipv6;
 #endif
     nce->l2addr_len = node->l2addr_len;
     memcpy(&nce->l2addr, &node->l2addr, node->l2addr_len);


### PR DESCRIPTION
In the case that GNRC_IPV6_NIB_CONF_ARSM is set but
GNRC_IPV6_NIB_CONF_6LN is not, clang complains about
the function _get_l2addr_from_ipv6 never being used.
I couldn't easily figure out why this passes in Murdock,
but I'm guessing that clang is simply being smarter than
GCC. Can someone comment on whether there is a better fix
for this?

Relates to #6473