### PR TITLE
tests: trickle: extend trickle test to print SUCCESS/FAILURE

### DIFF
--- a/tests/trickle/README.md
+++ b/tests/trickle/README.md
@@ -1,0 +1,7 @@
+# Trickle Test
+
+This test starts a trickle timer and roughly checks the diff between two
+intervals to be greater than the diff of previous intervals.
+After `9` callbacks, the trickle timer is reset and ends after another `11`
+callbacks with either `[SUCCESS]` or `[FAILURE]`. The application exits with
+`[FAILURE]` as soon as one diff is *not* greater than the previous diff.

--- a/tests/trickle/main.c
+++ b/tests/trickle/main.c
@@ -24,18 +24,34 @@
 #include "thread.h"
 #include "msg.h"
 
-#define Q_LEN           (8)
+#define Q_LEN           (1)
 #define TRICKLE_MSG     (0xfeef)
 #define TR_IMIN         (8)
 #define TR_IDOUBLINGS   (20)
 #define TR_REDCONST     (10)
+#define FIRST_ROUND     (9)
+#define SECOND_ROUND    (11)
 
 static msg_t _msg_q[Q_LEN];
+static uint32_t prev_now = 0, prev_diff = 0;
+static bool error = false;
 
 static void callback(void *args)
 {
     (void) args;
-    printf("now: %" PRIu32 "\n", xtimer_now_usec());
+    uint32_t now = xtimer_now_usec();
+    uint32_t diff = (uint32_t) (now - prev_now);
+
+    printf("now: %" PRIu32 ", prev_now = %" PRIu32 ", diff = %" PRIu32
+           "\n", now, prev_now, diff);
+
+    if (prev_diff >= diff) {
+        error = true;
+    }
+
+    prev_now = now;
+    prev_diff = diff;
+
     return;
 }
 
@@ -45,13 +61,28 @@ static trickle_t trickle = { .callback.func = &callback,
 int main(void)
 {
     msg_t msg;
+    bool reset = false;
+    unsigned counter = 0;
 
     msg_init_queue(_msg_q, Q_LEN);
 
     trickle_start(sched_active_pid, &trickle, TRICKLE_MSG, TR_IMIN,
                   TR_IDOUBLINGS, TR_REDCONST);
 
-    while (1) {
+    while (!error) {
+        if (!reset && (counter == FIRST_ROUND)) {
+            counter = prev_diff = 0;
+            reset = true;
+            trickle_reset_timer(&trickle);
+            puts("TRICKLE RESET");
+        }
+        else if (reset && (counter == SECOND_ROUND)) {
+            puts("[SUCCESS]");
+            return 0;
+        }
+
+        counter++;
+
         msg_receive(&msg);
 
         switch (msg.type) {
@@ -63,5 +94,7 @@ int main(void)
         }
     }
 
-    return 0;
+    puts("[FAILURE]");
+
+    return -1;
 }


### PR DESCRIPTION
Extends the trickle test to print either `[FAILURE]` or `[SUCCESS]`.