### PR TITLE
Make: enable -Werror -Wall -Wextra by default

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -123,7 +123,13 @@ endif
 WERROR ?= 1
 export WERROR
 ifeq ($(WERROR),1)
-  CFLAGS += -Werror
+  CFLAGS += -Wall -Werror -Wextra
+endif
+
+WPEDANTIC ?= 0
+export WPEDANTIC
+ifeq ($(WPEDANTIC),1)
+    CFLAGS += -Wpedantic -pedantic-errors
 endif
 
 ifneq (10,$(if ${RIOT_VERSION},1,0)$(if ${__RIOTBUILD_FLAG},1,0))

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -106,7 +106,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA, 10), /* TX pin */
         .mux    = GPIO_MUX_C,
         .rx_pad = UART_PAD_RX_3,
-        .tx_pad = UART_PAD_TX_2
+        .tx_pad = UART_PAD_TX_2,
+        .flags  = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
     }
 };
 

--- a/boards/mips-malta/Makefile.features
+++ b/boards/mips-malta/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = mips32r2

--- a/boards/mips-malta/include/periph_conf.h
+++ b/boards/mips-malta/include/periph_conf.h
@@ -35,12 +35,6 @@ extern "C" {
 #define TIMER_0_CHANNELS    (3)
 /** @} */
 
-/**
- * @brief   No UART driver for this board currently
- *          Note this value must be set though (to 0)
- */
-#define UART_NUMOF          (0)
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo32-common/include/gpio_params.h
+++ b/boards/nucleo32-common/include/gpio_params.h
@@ -26,19 +26,21 @@
 extern "C" {
 #endif
 
+#ifndef AUTO_INIT_LED0
+#define SAUL_GPIO_NUMOF (0U)
+#else
 /**
  * @brief    GPIO pin configuration
  */
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
-#ifdef AUTO_INIT_LED0
     {
         .name = "LD3(green)",
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     }
-#endif
 };
+#endif /* AUTO_INIT_LED0 */
 
 #ifdef __cplusplus
 }

--- a/boards/wsn430-common/board_init.c
+++ b/boards/wsn430-common/board_init.c
@@ -14,7 +14,7 @@
 #include "debug.h"
 #include "uart_stdio.h"
 
-volatile static uint32_t __msp430_cpu_speed = MSP430_INITIAL_CPU_SPEED;
+static volatile uint32_t __msp430_cpu_speed = MSP430_INITIAL_CPU_SPEED;
 
 void msp430_init_dco(void);
 

--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -132,16 +132,16 @@ static inline tim_t _lptmr_tim_t(uint8_t dev) {
 /* ****** PIT module functions ****** */
 
 /* Forward declarations */
-inline static int pit_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg);
-inline static int pit_set(uint8_t dev, uint32_t timeout);
-inline static int pit_set_absolute(uint8_t dev, uint32_t target);
-inline static int pit_clear(uint8_t dev);
-inline static uint32_t pit_read(uint8_t dev);
-inline static void pit_start(uint8_t dev);
-inline static void pit_stop(uint8_t dev);
-inline static void pit_irq_handler(tim_t dev);
+static inline int pit_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg);
+static inline int pit_set(uint8_t dev, uint32_t timeout);
+static inline int pit_set_absolute(uint8_t dev, uint32_t target);
+static inline int pit_clear(uint8_t dev);
+static inline uint32_t pit_read(uint8_t dev);
+static inline void pit_start(uint8_t dev);
+static inline void pit_stop(uint8_t dev);
+static inline void pit_irq_handler(tim_t dev);
 
-inline static void _pit_set_cb_config(uint8_t dev, timer_cb_t cb, void *arg)
+static inline void _pit_set_cb_config(uint8_t dev, timer_cb_t cb, void *arg)
 {
     /* set callback function */
     pit[dev].isr_ctx.cb = cb;
@@ -149,7 +149,7 @@ inline static void _pit_set_cb_config(uint8_t dev, timer_cb_t cb, void *arg)
 }
 
 /** use channel n-1 as prescaler */
-inline static void _pit_set_prescaler(uint8_t ch, uint32_t freq)
+static inline void _pit_set_prescaler(uint8_t ch, uint32_t freq)
 {
     /* Disable channel completely */
     PIT->CHANNEL[ch].TCTRL = 0x0;
@@ -158,7 +158,7 @@ inline static void _pit_set_prescaler(uint8_t ch, uint32_t freq)
     PIT->CHANNEL[ch].TCTRL = (PIT_TCTRL_TEN_MASK);
 }
 
-inline static void _pit_set_counter(uint8_t dev)
+static inline void _pit_set_counter(uint8_t dev)
 {
     const uint8_t ch = pit_config[dev].count_ch;
     /* Disable channel completely */
@@ -169,7 +169,7 @@ inline static void _pit_set_counter(uint8_t dev)
     PIT->CHANNEL[ch].TCTRL = pit[dev].tctrl;
 }
 
-inline static int pit_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg)
+static inline int pit_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     /* Turn on module clock gate */
     PIT_CLKEN();
@@ -204,7 +204,7 @@ inline static int pit_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     return 0;
 }
 
-inline static int pit_set(uint8_t dev, uint32_t timeout)
+static inline int pit_set(uint8_t dev, uint32_t timeout)
 {
     const uint8_t ch = pit_config[dev].count_ch;
     /* Disable IRQs to minimize the number of lost ticks */
@@ -224,7 +224,7 @@ inline static int pit_set(uint8_t dev, uint32_t timeout)
     return 0;
 }
 
-inline static int pit_set_absolute(uint8_t dev, uint32_t target)
+static inline int pit_set_absolute(uint8_t dev, uint32_t target)
 {
     uint8_t ch = pit_config[dev].count_ch;
     /* Disable IRQs to minimize the number of lost ticks */
@@ -243,7 +243,7 @@ inline static int pit_set_absolute(uint8_t dev, uint32_t target)
     return 0;
 }
 
-inline static int pit_clear(uint8_t dev)
+static inline int pit_clear(uint8_t dev)
 {
     uint8_t ch = pit_config[dev].count_ch;
     /* Disable IRQs to minimize the number of lost ticks */
@@ -266,7 +266,7 @@ inline static int pit_clear(uint8_t dev)
     return 0;
 }
 
-inline static uint32_t pit_read(uint8_t dev)
+static inline uint32_t pit_read(uint8_t dev)
 {
     uint8_t ch = pit_config[dev].count_ch;
     if ((PIT->CHANNEL[ch].TCTRL & PIT_TCTRL_TEN_MASK) != 0) {
@@ -279,7 +279,7 @@ inline static uint32_t pit_read(uint8_t dev)
     }
 }
 
-inline static void pit_start(uint8_t dev)
+static inline void pit_start(uint8_t dev)
 {
     uint8_t ch = pit_config[dev].count_ch;
     if ((PIT->CHANNEL[ch].TCTRL & PIT_TCTRL_TEN_MASK) != 0) {
@@ -291,7 +291,7 @@ inline static void pit_start(uint8_t dev)
     PIT->CHANNEL[ch].TCTRL = pit[dev].tctrl;
 }
 
-inline static void pit_stop(uint8_t dev)
+static inline void pit_stop(uint8_t dev)
 {
     uint8_t ch = pit_config[dev].count_ch;
     if ((PIT->CHANNEL[ch].TCTRL & PIT_TCTRL_TEN_MASK) == 0) {
@@ -305,7 +305,7 @@ inline static void pit_stop(uint8_t dev)
     pit[dev].ldval = cval;
 }
 
-inline static void pit_irq_handler(tim_t dev)
+static inline void pit_irq_handler(tim_t dev)
 {
     uint8_t ch = pit_config[_pit_index(dev)].count_ch;
     pit_t *pit_ctx = &pit[_pit_index(dev)];
@@ -326,19 +326,19 @@ inline static void pit_irq_handler(tim_t dev)
 /* ****** LPTMR module functions ****** */
 
 /* Forward declarations */
-inline static int lptmr_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg);
-inline static int lptmr_set(uint8_t dev, uint16_t timeout);
-inline static int lptmr_set_absolute(uint8_t dev, uint16_t target);
-inline static int lptmr_clear(uint8_t dev);
-inline static uint16_t lptmr_read(uint8_t dev);
-inline static void lptmr_start(uint8_t dev);
-inline static void lptmr_stop(uint8_t dev);
-inline static void lptmr_irq_handler(tim_t tim);
+static inline int lptmr_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg);
+static inline int lptmr_set(uint8_t dev, uint16_t timeout);
+static inline int lptmr_set_absolute(uint8_t dev, uint16_t target);
+static inline int lptmr_clear(uint8_t dev);
+static inline uint16_t lptmr_read(uint8_t dev);
+static inline void lptmr_start(uint8_t dev);
+static inline void lptmr_stop(uint8_t dev);
+static inline void lptmr_irq_handler(tim_t tim);
 
 /**
  * @brief Read the prescaler register from the RTC as a reliable 47 bit time counter
  */
-inline static uint32_t _rtt_get_subtick(void)
+static inline uint32_t _rtt_get_subtick(void)
 {
     uint32_t tpr;
     uint32_t tsr;
@@ -364,7 +364,7 @@ inline static uint32_t _rtt_get_subtick(void)
     return (tsr << TIMER_RTC_SUBTICK_BITS) | tpr;
 }
 
-inline static void _lptmr_set_cb_config(uint8_t dev, timer_cb_t cb, void *arg)
+static inline void _lptmr_set_cb_config(uint8_t dev, timer_cb_t cb, void *arg)
 {
     /* set callback function */
     lptmr[dev].isr_ctx.cb = cb;
@@ -374,7 +374,7 @@ inline static void _lptmr_set_cb_config(uint8_t dev, timer_cb_t cb, void *arg)
 /**
  * @brief  Compute the LPTMR prescaler setting, see reference manual for details
  */
-inline static int32_t _lptmr_compute_prescaler(uint32_t freq) {
+static inline int32_t _lptmr_compute_prescaler(uint32_t freq) {
     uint32_t prescale = 0;
     if ((freq > LPTMR_BASE_FREQ) || (freq == 0)) {
         /* Frequency out of range */
@@ -402,7 +402,7 @@ inline static int32_t _lptmr_compute_prescaler(uint32_t freq) {
 /**
  * @brief  Update the offset between RTT and LPTMR
  */
-inline static void _lptmr_update_rtt_offset(uint8_t dev)
+static inline void _lptmr_update_rtt_offset(uint8_t dev)
 {
     lptmr[dev].rtt_offset = _rtt_get_subtick();
 }
@@ -410,12 +410,12 @@ inline static void _lptmr_update_rtt_offset(uint8_t dev)
 /**
  * @brief  Update the reference time point (CNR=0)
  */
-inline static void _lptmr_update_reference(uint8_t dev)
+static inline void _lptmr_update_reference(uint8_t dev)
 {
     lptmr[dev].reference = _rtt_get_subtick() + LPTMR_RELOAD_OVERHEAD - lptmr[dev].rtt_offset;
 }
 
-inline static void _lptmr_set_counter(uint8_t dev)
+static inline void _lptmr_set_counter(uint8_t dev)
 {
     _lptmr_update_reference(dev);
     LPTMR_Type *hw = lptmr_config[dev].dev;
@@ -425,7 +425,7 @@ inline static void _lptmr_set_counter(uint8_t dev)
     hw->CSR = lptmr[dev].csr;
 }
 
-inline static int lptmr_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg)
+static inline int lptmr_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 {
     int32_t prescale = _lptmr_compute_prescaler(freq);
     if (prescale < 0) {
@@ -460,7 +460,7 @@ inline static int lptmr_init(uint8_t dev, uint32_t freq, timer_cb_t cb, void *ar
     return 0;
 }
 
-inline static uint16_t lptmr_read(uint8_t dev)
+static inline uint16_t lptmr_read(uint8_t dev)
 {
     LPTMR_Type *hw = lptmr_config[dev].dev;
     /* latch the current timer value into CNR */
@@ -468,7 +468,7 @@ inline static uint16_t lptmr_read(uint8_t dev)
     return lptmr[dev].reference + hw->CNR;
 }
 
-inline static int lptmr_set(uint8_t dev, uint16_t timeout)
+static inline int lptmr_set(uint8_t dev, uint16_t timeout)
 {
     /* Disable IRQs to minimize jitter */
     unsigned int mask = irq_disable();
@@ -484,7 +484,7 @@ inline static int lptmr_set(uint8_t dev, uint16_t timeout)
     return 0;
 }
 
-inline static int lptmr_set_absolute(uint8_t dev, uint16_t target)
+static inline int lptmr_set_absolute(uint8_t dev, uint16_t target)
 {
     /* Disable IRQs to minimize jitter */
     unsigned int mask = irq_disable();
@@ -501,7 +501,7 @@ inline static int lptmr_set_absolute(uint8_t dev, uint16_t target)
     return 0;
 }
 
-inline static int lptmr_clear(uint8_t dev)
+static inline int lptmr_clear(uint8_t dev)
 {
     /* Disable IRQs to minimize jitter */
     unsigned int mask = irq_disable();
@@ -517,7 +517,7 @@ inline static int lptmr_clear(uint8_t dev)
     return 0;
 }
 
-inline static void lptmr_start(uint8_t dev)
+static inline void lptmr_start(uint8_t dev)
 {
     if (lptmr[dev].running != 0) {
         /* Timer already running */
@@ -527,7 +527,7 @@ inline static void lptmr_start(uint8_t dev)
     _lptmr_set_counter(dev);
 }
 
-inline static void lptmr_stop(uint8_t dev)
+static inline void lptmr_stop(uint8_t dev)
 {
     if (lptmr[dev].running == 0) {
         /* Timer already stopped */
@@ -550,7 +550,7 @@ inline static void lptmr_stop(uint8_t dev)
     irq_restore(mask);
 }
 
-inline static void lptmr_irq_handler(tim_t tim)
+static inline void lptmr_irq_handler(tim_t tim)
 {
     uint8_t dev = _lptmr_index(tim);
     LPTMR_Type *hw = lptmr_config[dev].dev;

--- a/cpu/saml21/periph/timer.c
+++ b/cpu/saml21/periph/timer.c
@@ -48,6 +48,10 @@ static inline void _irq_enable(tim_t dev);
  */
 int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
+    /* at the moment, the timer can only run at 1MHz */
+    if (freq != 1000000ul) {
+        return -1;
+    }
     /* configure GCLK0 to feed TC0 & TC1*/;
     GCLK->PCHCTRL[TC0_GCLK_ID].reg |= GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
     while (!(GCLK->PCHCTRL[TC0_GCLK_ID].reg & GCLK_PCHCTRL_CHEN)) {}

--- a/cpu/stm32_common/periph/spi.c
+++ b/cpu/stm32_common/periph/spi.c
@@ -117,8 +117,6 @@ int spi_init_cs(spi_t bus, spi_cs_t cs)
 
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
-    assert((clk >= SPI_CLK_100KHZ) && (clk <= SPI_CLK_10MHZ));
-
     /* lock bus */
     mutex_lock(&locks[bus]);
     /* enable SPI device clock */

--- a/cpu/stm32f4/periph/i2c.c
+++ b/cpu/stm32f4/periph/i2c.c
@@ -283,7 +283,7 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
         }
 
         /* read byte */
-        *in++ = i2c->DR;
+        *(in++) = i2c->DR;
     }
 
     /* set STOP */

--- a/drivers/at30tse75x/at30tse75x.c
+++ b/drivers/at30tse75x/at30tse75x.c
@@ -110,11 +110,6 @@ int at30tse75x_set_resolution(const at30tse75x_t *dev, at30tse75x_resolution_t r
 {
     uint8_t config;
 
-    if(resolution < AT30TSE75X_RESOLUTION_9BIT ||
-       resolution > AT30TSE75X_RESOLUTION_12BIT) {
-        return -2;
-    }
-
     if(at30tse75x_get_config(dev, &config) != 0) {
         return -1;
     }
@@ -187,11 +182,6 @@ int at30tse75x_set_alarm_polarity(const at30tse75x_t *dev, at30tse75x_alarm_pola
 
 int at30tse75x_set_fault_tolerance(const at30tse75x_t *dev, at30tse75x_fault_tolerance_t tolerance)
 {
-    if(tolerance < AT30TSE75X_ALARM_AFTER_1 ||
-       tolerance > AT30TSE75X_ALARM_AFTER_6) {
-        return -2;
-    }
-
     uint8_t config;
     if(at30tse75x_get_config(dev, &config) != 0) {
         return -1;

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -139,8 +139,10 @@ uint8_t at86rf2xx_get_chan(const at86rf2xx_t *dev)
 
 void at86rf2xx_set_chan(at86rf2xx_t *dev, uint8_t channel)
 {
-    if ((channel < AT86RF2XX_MIN_CHANNEL) ||
-        (channel > AT86RF2XX_MAX_CHANNEL) ||
+    if ((channel > AT86RF2XX_MAX_CHANNEL) ||
+#if AT86RF2XX_MIN_CHANNEL /* is zero for sub-GHz */
+        (channel < AT86RF2XX_MIN_CHANNEL) ||
+#endif
         (dev->netdev.chan == channel)) {
         return;
     }

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -428,8 +428,11 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         case NETOPT_CHANNEL:
             assert(len == sizeof(uint16_t));
             uint8_t chan = (((const uint16_t *)val)[0]) & UINT8_MAX;
-            if ((chan < AT86RF2XX_MIN_CHANNEL)
-                || (chan > AT86RF2XX_MAX_CHANNEL)) {
+#if AT86RF2XX_MIN_CHANNEL
+            if (chan < AT86RF2XX_MIN_CHANNEL || chan > AT86RF2XX_MAX_CHANNEL) {
+#else
+            if (chan > AT86RF2XX_MAX_CHANNEL) {
+#endif /* AT86RF2XX_MIN_CHANNEL */
                 res = -EINVAL;
                 break;
             }

--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -41,6 +41,8 @@ static int _send(netdev_t *dev, const struct iovec *vector, unsigned count)
 {
     DEBUG("%s:%u\n", __func__, __LINE__);
 
+    (void)count;
+
     netdev_cc110x_t *netdev_cc110x = (netdev_cc110x_t*) dev;
     cc110x_pkt_t *cc110x_pkt = vector[0].iov_base;
 
@@ -135,7 +137,12 @@ static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len
             {
                 const uint8_t *arg = value;
                 uint8_t channel = arg[value_len-1];
-                if ((channel < CC110X_MIN_CHANNR) || (channel > CC110X_MAX_CHANNR)) {
+            #if CC110X_MIN_CHANNR
+                if (channel < CC110X_MIN_CHANNR) {
+                    return -EINVAL;
+                }
+            #endif /* CC110X_MIN_CHANNR */
+                if (channel > CC110X_MAX_CHANNR) {
                     return -EINVAL;
                 }
                 if (cc110x_set_channel(cc110x, channel) == -1) {

--- a/drivers/cc110x/cc110x-rxtx.c
+++ b/drivers/cc110x/cc110x-rxtx.c
@@ -247,7 +247,7 @@ int cc110x_send(cc110x_t *dev, cc110x_pkt_t *packet)
 {
     DEBUG("cc110x: snd pkt to %u payload_length=%u\n",
             (unsigned)packet->address, (unsigned)packet->length-3);
-    uint8_t size;
+    unsigned size;
 
     switch (dev->radio_state) {
         case RADIO_RX_BUSY:
@@ -293,5 +293,5 @@ int cc110x_send(cc110x_t *dev, cc110x_pkt_t *packet)
 
     _tx_continue(dev);
 
-    return size;
+    return (int)size;
 }

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -96,7 +96,7 @@ uint8_t cc110x_set_address(cc110x_t *dev, uint8_t address)
 {
     DEBUG("%s:%s:%u setting address %u\n", RIOT_FILE_RELATIVE, __func__,
             __LINE__, (unsigned)address);
-    if (!(address < MIN_UID) || (address > MAX_UID)) {
+    if (!(address < MIN_UID)) {
         if (dev->radio_state != RADIO_UNKNOWN) {
             cc110x_write_register(dev, CC110X_ADDR, address);
             dev->radio_address = address;

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -473,7 +473,7 @@ static int nd_set(netdev_t *netdev, netopt_t opt, const void *value, size_t valu
     }
 }
 
-const static netdev_driver_t netdev_driver_enc28j60 = {
+static const netdev_driver_t netdev_driver_enc28j60 = {
     .send = nd_send,
     .recv = nd_recv,
     .init = nd_init,

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -70,7 +70,7 @@ static int _init(netdev_t *dev);
 static void _isr(netdev_t *dev);
 static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
 
-const static netdev_driver_t netdev_driver_encx24j600 = {
+static const netdev_driver_t netdev_driver_encx24j600 = {
     .send = _send,
     .recv = _recv,
     .init = _init,

--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -322,7 +322,8 @@ int nrf24l01p_set_address_width(const nrf24l01p_t *dev, nrf24l01p_aw_t aw);
 * @return           0 on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_payload_width(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char width);
+int nrf24l01p_set_payload_width(const nrf24l01p_t *dev,
+                                nrf24l01p_rx_pipe_t pipe, uint8_t width);
 
 /**
 * @brief   Set the TX address for the nrf24l01+ transceiver (byte array).

--- a/drivers/include/sdcard_spi.h
+++ b/drivers/include/sdcard_spi.h
@@ -39,7 +39,7 @@ extern "C" {
 /**
  * @brief   CID register see section 5.2 in SD-Spec v5.00
  */
-struct {
+typedef struct {
     uint8_t MID;              /**< Manufacturer ID */
     char OID[SD_SIZE_OF_OID]; /**< OEM/Application ID*/
     char PNM[SD_SIZE_OF_PNM]; /**< Product name */
@@ -47,13 +47,13 @@ struct {
     uint32_t PSN;             /**< Product serial number */
     uint16_t MDT;             /**< Manufacturing date */
     uint8_t CID_CRC;          /**< CRC7 checksum */
-} typedef cid_t;
+} cid_t;
 
 /**
  * @brief   CSD register with csd structure version 1.0
  *          see section 5.3.2 in SD-Spec v5.00
  */
-struct {
+typedef struct {
     uint8_t CSD_STRUCTURE : 2;        /**< see section 5.3.2 in SD-Spec v5.00 */
     uint8_t TAAC : 8;                 /**< see section 5.3.2 in SD-Spec v5.00 */
     uint8_t NSAC : 8;                 /**< see section 5.3.2 in SD-Spec v5.00 */
@@ -83,13 +83,13 @@ struct {
     uint8_t TMP_WRITE_PROTECT : 1;    /**< see section 5.3.2 in SD-Spec v5.00 */
     uint8_t FILE_FORMAT : 2;          /**< see section 5.3.2 in SD-Spec v5.00 */
     uint8_t CSD_CRC : 8;              /**< see section 5.3.2 in SD-Spec v5.00 */
-} typedef csd_v1_t;
+} csd_v1_t;
 
 /**
  * @brief   CSD register with csd structure version 2.0
  *          see section 5.3.3 in SD-Spec v5.00
  */
-struct {
+typedef struct {
     uint8_t CSD_STRUCTURE : 2;        /**< see section 5.3.3 in SD-Spec v5.00 */
     uint8_t TAAC : 8;                 /**< see section 5.3.3 in SD-Spec v5.00 */
     uint8_t NSAC : 8;                 /**< see section 5.3.3 in SD-Spec v5.00 */
@@ -114,20 +114,20 @@ struct {
     uint8_t TMP_WRITE_PROTECT : 1;    /**< see section 5.3.3 in SD-Spec v5.00 */
     uint8_t FILE_FORMAT : 2;          /**< see section 5.3.3 in SD-Spec v5.00 */
     uint8_t CSD_CRC : 8;              /**< see section 5.3.3 in SD-Spec v5.00 */
-} typedef csd_v2_t;
+} csd_v2_t;
 
 /**
  * @brief   CSD register (see section 5.3 in SD-Spec v5.00)
  */
-union {
+typedef union {
     csd_v1_t v1;   /**< see section 5.3.2 in SD-Spec v5.00 */
     csd_v2_t v2;   /**< see section 5.3.3 in SD-Spec v5.00 */
-} typedef csd_t;
+} csd_t;
 
 /**
  * @brief   SD status register (see section 4.10.2 in SD-Spec v5.00)
  */
-struct {
+typedef struct {
     uint32_t SIZE_OF_PROTECTED_AREA : 32;   /**< see section 4.10.2 in SD-Spec v5.00 */
     uint32_t SUS_ADDR : 22;                 /**< see section 4.10.2.12 in SD-Spec v5.00 */
     uint32_t VSC_AU_SIZE : 10;              /**< see section 4.10.2.11 in SD-Spec v5.00 */
@@ -143,7 +143,7 @@ struct {
     uint8_t  AU_SIZE : 4;                   /**< see section 4.10.2.4 in SD-Spec v5.00 */
     uint8_t  DAT_BUS_WIDTH : 2;             /**< see section 4.10.2 in SD-Spec v5.00 */
     uint8_t  SECURED_MODE : 1;              /**< see section 4.10.2 in SD-Spec v5.00 */
-} typedef sd_status_t;
+} sd_status_t;
 
 /**
  * @brief   version type of SD-card
@@ -184,7 +184,7 @@ typedef struct {
 /**
  * @brief   Device descriptor for sdcard_spi
  */
-struct {
+typedef struct {
     sdcard_spi_params_t params;     /**< parameters for pin and spi config */
     spi_clk_t spi_clk;              /**< active SPI clock speed */
     bool use_block_addr;            /**< true if block adressing (vs. byte adressing) is used */
@@ -193,7 +193,7 @@ struct {
     int csd_structure;              /**< version of the CSD register structure */
     cid_t cid;                      /**< CID register */
     csd_t csd;                      /**< CSD register */
-} typedef sdcard_spi_t;
+} sdcard_spi_t;
 
 /**
  * @brief              Initializes the sd-card with the given parameters in sdcard_spi_t structure.

--- a/drivers/kw2xrf/kw2xrf_tm.c
+++ b/drivers/kw2xrf/kw2xrf_tm.c
@@ -23,7 +23,7 @@
 
 #ifdef KW2XRF_TESTMODE
 
-inline static void enable_xcvr_test_mode(kw2xrf_t *dev)
+static inline void enable_xcvr_test_mode(kw2xrf_t *dev)
 {
     uint8_t reg;
 
@@ -36,7 +36,7 @@ inline static void enable_xcvr_test_mode(kw2xrf_t *dev)
     kw2xrf_write_iregs(dev, MKW2XDMI_TESTMODE_CTRL, &reg, 1);
 }
 
-inline static void disable_xcvr_test_mode(kw2xrf_t *dev)
+static inline void disable_xcvr_test_mode(kw2xrf_t *dev)
 {
     uint8_t reg;
 

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -320,7 +320,8 @@ int nrf24l01p_set_address_width(const nrf24l01p_t *dev, nrf24l01p_aw_t aw)
     return nrf24l01p_write_reg(dev, REG_SETUP_AW, aw_setup);
 }
 
-int nrf24l01p_set_payload_width(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, char width)
+int nrf24l01p_set_payload_width(const nrf24l01p_t *dev,
+                                nrf24l01p_rx_pipe_t pipe, uint8_t width)
 {
     char pipe_pw_address;
 
@@ -353,7 +354,7 @@ int nrf24l01p_set_payload_width(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe
             return -1;
     }
 
-    if (width < 0) {
+    if (width == 0) {
         return -1;
     }
 

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -354,10 +354,6 @@ int nrf24l01p_set_payload_width(const nrf24l01p_t *dev,
             return -1;
     }
 
-    if (width == 0) {
-        return -1;
-    }
-
     if (width > 32) {
         width = 32;
     }

--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -144,9 +144,9 @@ int pn532_init(pn532_t *dev, const pn532_params_t *params, pn532_mode_t mode)
     return 0;
 }
 
-static unsigned char chksum(char *b, unsigned len)
+static uint8_t chksum(uint8_t *b, unsigned len)
 {
-    unsigned char c = 0x00;
+    uint8_t c = 0x00;
 
     while (len--) {
         c -= *b++;
@@ -165,7 +165,7 @@ static void reverse(char *buff, unsigned len)
 }
 #endif
 
-static int _write(const pn532_t *dev, char *buff, unsigned len)
+static int _write(const pn532_t *dev, uint8_t *buff, unsigned len)
 {
     int ret = -1;
 
@@ -197,7 +197,7 @@ static int _write(const pn532_t *dev, char *buff, unsigned len)
     return ret;
 }
 
-static int _read(const pn532_t *dev, char *buff, unsigned len)
+static int _read(const pn532_t *dev, uint8_t *buff, unsigned len)
 {
     int ret = -1;
 
@@ -231,9 +231,10 @@ static int _read(const pn532_t *dev, char *buff, unsigned len)
     return ret;
 }
 
-static int send_cmd(const pn532_t *dev, char *buff, unsigned len)
+static int send_cmd(const pn532_t *dev, uint8_t *buff, unsigned len)
 {
-    unsigned pos, checksum;
+    unsigned pos;
+    uint8_t checksum;
 
     buff[0] = 0x00;
     buff[1] = 0x00;
@@ -271,7 +272,7 @@ static void wait_ready(pn532_t *dev)
 }
 
 /* Returns >0 payload len (or <0 received len but not as expected) */
-static int read_command(const pn532_t *dev, char *buff, unsigned len, int expected_cmd)
+static int read_command(const pn532_t *dev, uint8_t *buff, unsigned len, int expected_cmd)
 {
     int r;
     unsigned j, fi, lp, lc;
@@ -335,7 +336,7 @@ static int read_command(const pn532_t *dev, char *buff, unsigned len, int expect
 }
 
 /* Returns 0 if OK, <0 otherwise */
-static int send_check_ack(pn532_t *dev, char *buff, unsigned len)
+static int send_check_ack(pn532_t *dev, uint8_t *buff, unsigned len)
 {
     if (send_cmd(dev, buff, len) > 0) {
         static char ack[] = { 0x00, 0x00, 0xff, 0x00, 0xff, 0x00 };
@@ -357,7 +358,7 @@ static int send_check_ack(pn532_t *dev, char *buff, unsigned len)
 }
 
 /* sendl: send length, recvl: receive payload length */
-static int send_rcv(pn532_t *dev, char *buff, unsigned sendl, unsigned recvl)
+static int send_rcv(pn532_t *dev, uint8_t *buff, unsigned sendl, unsigned recvl)
 {
     assert(dev != NULL);
 
@@ -374,7 +375,7 @@ static int send_rcv(pn532_t *dev, char *buff, unsigned sendl, unsigned recvl)
 int pn532_fw_version(pn532_t *dev, uint32_t *fw_ver)
 {
     unsigned ret = -1;
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     buff[BUFF_CMD_START] = CMD_FIRMWARE_VERSION;
 
@@ -392,7 +393,7 @@ int pn532_fw_version(pn532_t *dev, uint32_t *fw_ver)
 int pn532_read_reg(pn532_t *dev, char *out, unsigned addr)
 {
     int ret = -1;
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     buff[BUFF_CMD_START     ] = CMD_READ_REG;
     buff[BUFF_DATA_START    ] = (addr >> 8) & 0xff;
@@ -408,7 +409,7 @@ int pn532_read_reg(pn532_t *dev, char *out, unsigned addr)
 
 int pn532_write_reg(pn532_t *dev, unsigned addr, char val)
 {
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     buff[BUFF_CMD_START     ] = CMD_WRITE_REG;
     buff[BUFF_DATA_START    ] = (addr >> 8) & 0xff;
@@ -418,7 +419,7 @@ int pn532_write_reg(pn532_t *dev, unsigned addr, char val)
     return send_rcv(dev, buff, 3, 0);
 }
 
-static int _rf_configure(pn532_t *dev, char *buff, unsigned cfg_item, char *config,
+static int _rf_configure(pn532_t *dev, uint8_t *buff, unsigned cfg_item, char *config,
                          unsigned cfg_len)
 {
     buff[BUFF_CMD_START ] = CMD_RF_CONFIG;
@@ -430,7 +431,7 @@ static int _rf_configure(pn532_t *dev, char *buff, unsigned cfg_item, char *conf
     return send_rcv(dev, buff, cfg_len + 1, 0);
 }
 
-static int _set_act_retries(pn532_t *dev, char *buff, unsigned max_retries)
+static int _set_act_retries(pn532_t *dev, uint8_t *buff, unsigned max_retries)
 {
     char rtrcfg[] = { 0xff, 0x01, max_retries & 0xff };
 
@@ -439,7 +440,7 @@ static int _set_act_retries(pn532_t *dev, char *buff, unsigned max_retries)
 
 int pn532_sam_configuration(pn532_t *dev, pn532_sam_conf_mode_t mode, unsigned timeout)
 {
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     buff[BUFF_CMD_START     ] = CMD_SAM_CONFIG;
     buff[BUFF_DATA_START    ] = (char)mode;
@@ -449,7 +450,7 @@ int pn532_sam_configuration(pn532_t *dev, pn532_sam_conf_mode_t mode, unsigned t
     return send_rcv(dev, buff, 3, 0);
 }
 
-static int _list_passive_targets(pn532_t *dev, char *buff, pn532_target_t target,
+static int _list_passive_targets(pn532_t *dev, uint8_t *buff, pn532_target_t target,
                                  unsigned max, unsigned recvl)
 {
     buff[BUFF_CMD_START] = CMD_LIST_PASSIVE;
@@ -464,7 +465,7 @@ int pn532_get_passive_iso14443a(pn532_t *dev, nfc_iso14443a_t *out,
                                 unsigned max_retries)
 {
     int ret = -1;
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     if (_set_act_retries(dev, buff, max_retries) == 0) {
         ret = _list_passive_targets(dev, buff, PN532_BR_106_ISO_14443_A, 1,
@@ -504,7 +505,7 @@ int pn532_get_passive_iso14443a(pn532_t *dev, nfc_iso14443a_t *out,
 
 void pn532_deselect_passive(pn532_t *dev, unsigned target_id)
 {
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     buff[BUFF_CMD_START ] = CMD_DESELECT;
     buff[BUFF_DATA_START] = target_id;
@@ -514,7 +515,7 @@ void pn532_deselect_passive(pn532_t *dev, unsigned target_id)
 
 void pn532_release_passive(pn532_t *dev, unsigned target_id)
 {
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     buff[BUFF_CMD_START ] = CMD_RELEASE;
     buff[BUFF_DATA_START] = target_id;
@@ -526,7 +527,7 @@ int pn532_mifareclassic_authenticate(pn532_t *dev, nfc_iso14443a_t *card,
                                      pn532_mifare_key_t keyid, char *key, unsigned block)
 {
     int ret = -1;
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     buff[BUFF_CMD_START     ] = CMD_DATA_EXCHANGE;
     buff[BUFF_DATA_START    ] = card->target;
@@ -558,7 +559,7 @@ int pn532_mifareclassic_write(pn532_t *dev, char *idata, nfc_iso14443a_t *card,
                               unsigned block)
 {
     int ret = -1;
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     if (card->auth) {
 
@@ -580,7 +581,7 @@ static int pn532_mifare_read(pn532_t *dev, char *odata, nfc_iso14443a_t *card,
                              unsigned block, unsigned len)
 {
     int ret = -1;
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     buff[BUFF_CMD_START     ] = CMD_DATA_EXCHANGE;
     buff[BUFF_DATA_START    ] = card->target;
@@ -612,7 +613,7 @@ int pn532_mifareulight_read(pn532_t *dev, char *odata, nfc_iso14443a_t *card,
     return pn532_mifare_read(dev, odata, card, page, 32);
 }
 
-static int send_rcv_apdu(pn532_t *dev, char *buff, unsigned slen, unsigned rlen)
+static int send_rcv_apdu(pn532_t *dev, uint8_t *buff, unsigned slen, unsigned rlen)
 {
     int ret;
 
@@ -635,7 +636,7 @@ static int send_rcv_apdu(pn532_t *dev, char *buff, unsigned slen, unsigned rlen)
 int pn532_iso14443a_4_activate(pn532_t *dev, nfc_iso14443a_t *card)
 {
     int ret;
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     /* select app ndef tag */
     buff[BUFF_CMD_START      ] = CMD_DATA_EXCHANGE;
@@ -680,7 +681,7 @@ int pn532_iso14443a_4_read(pn532_t *dev, char *odata, nfc_iso14443a_t *card,
                            unsigned offset, char len)
 {
     int ret;
-    char buff[PN532_BUFFER_LEN];
+    uint8_t buff[PN532_BUFFER_LEN];
 
     buff[BUFF_CMD_START     ] = CMD_DATA_EXCHANGE;
     buff[BUFF_DATA_START    ] = card->target;

--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -207,7 +207,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
                     return SD_INIT_SEND_CMD58;
                 }
                 acmd41_hcs_retries++;
-            } while (INIT_CMD_RETRY_CNT < 0 || acmd41_hcs_retries <= INIT_CMD_RETRY_CNT);;
+            } while ((INIT_CMD_RETRY_CNT < 0) || (acmd41_hcs_retries <= (int)INIT_CMD_RETRY_CNT));
             _unselect_card_spi(card);
             return SD_INIT_CARD_UNKNOWN;
 
@@ -223,7 +223,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
                     return SD_INIT_SEND_CMD16;
                 }
                 acmd41_retries++;
-            } while (INIT_CMD_RETRY_CNT < 0 || acmd41_retries <= INIT_CMD_RETRY_CNT);
+            } while ((INIT_CMD_RETRY_CNT < 0) || (acmd41_retries <= (int)INIT_CMD_RETRY_CNT));
 
             DEBUG("ACMD41: [ERROR]\n");
             return SD_INIT_SEND_CMD1;
@@ -373,7 +373,7 @@ static inline bool _wait_for_not_busy(sdcard_spi_t *card, int32_t max_retries)
 
     do {
         if (_dyn_spi_rxtx_byte(card, SD_CARD_DUMMY_BYTE, &read_byte) == 1) {
-            if (read_byte == 0xFF) {
+            if ((uint8_t)read_byte == 0xFF) {
                 DEBUG("_wait_for_not_busy: [OK]\n");
                 return true;
             }

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -361,6 +361,8 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
 static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 {
+    (void)len; /* unused when compiled without debug, assert empty */
+
     sx127x_t *dev = (sx127x_t*) netdev;
     int res = -ENOTSUP;
 
@@ -386,8 +388,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         case NETOPT_BANDWIDTH:
             assert(len <= sizeof(uint8_t));
             uint8_t bw = *((const uint8_t *)val);
-            if (bw < LORA_BW_125_KHZ ||
-                bw > LORA_BW_500_KHZ) {
+            if (bw > LORA_BW_500_KHZ) {
                 res = -EINVAL;
                 break;
             }
@@ -397,8 +398,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         case NETOPT_SPREADING_FACTOR:
             assert(len <= sizeof(uint8_t));
             uint8_t sf = *((const uint8_t *)val);
-            if (sf < LORA_SF6 ||
-                sf > LORA_SF12) {
+            if ((sf < LORA_SF6) || (sf > LORA_SF12)) {
                 res = -EINVAL;
                 break;
             }
@@ -408,8 +408,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
         case NETOPT_CODING_RATE:
             assert(len <= sizeof(uint8_t));
             uint8_t cr = *((const uint8_t *)val);
-            if (cr < LORA_CR_4_5 ||
-                cr > LORA_CR_4_8) {
+            if ((cr < LORA_CR_4_5) || (cr > LORA_CR_4_8)) {
                 res = -EINVAL;
                 break;
             }

--- a/drivers/tcs37727/tcs37727.c
+++ b/drivers/tcs37727/tcs37727.c
@@ -106,7 +106,7 @@ void tcs37727_set_rgbc_standby(const tcs37727_t *dev)
     i2c_release(BUS);
 }
 
-static uint8_t tcs37727_trim_gain(tcs37727_t *dev, int rawc)
+static uint8_t tcs37727_trim_gain(tcs37727_t *dev, int32_t rawc)
 {
     uint8_t reg_again = 0;
     int val_again = dev->again;

--- a/pkg/emb6/Makefile.include
+++ b/pkg/emb6/Makefile.include
@@ -5,6 +5,9 @@ EMB6_CONTRIB := $(RIOTBASE)/pkg/emb6/contrib
 INCLUDES += -I$(PKG_BUILDDIR)/target
 INCLUDES += -I$(RIOTBASE)/pkg/emb6/include
 
+CFLAGS += -Wno-unused-parameter -Wno-unused-function -Wno-type-limits
+CFLAGS += -Wno-sign-compare -Wno-missing-field-initializers
+
 ifeq (,$(filter emb6_router,$(USEMODULE)))
   CFLAGS += -DEMB6_CONF_ROUTER=FALSE
 endif

--- a/pkg/nordic_softdevice_ble/Makefile.include
+++ b/pkg/nordic_softdevice_ble/Makefile.include
@@ -20,6 +20,8 @@ CFLAGS += -DNRF52 \
 		  -DSOFTDEVICE_PRESENT \
 		  -DS132
 
+CFLAGS += -Wno-pedantic -Wno-unused-parameter -Wno-sign-compare
+
 # Nordic's ble_6lowpan.a is compiled with hard-float
 # so set this, otherwise linking fails
 CFLAGS_FPU := -mfloat-abi=hard -mfpu=fpv4-sp-d16
@@ -29,4 +31,3 @@ DIRS += \
 		$(NORDIC_SRCS)/components/softdevice/common/softdevice_handler \
 		$(NORDIC_SRCS)/components/ble/common \
 		$(NORDIC_SRCS)/components/iot/ble_ipsp
-

--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -71,6 +71,7 @@ void otTaskletsSignalPending(otInstance *aInstance) {
 }
 
 static void *_openthread_event_loop(void *arg) {
+    (void)arg;
     _pid = thread_getpid();
 
     /* enable OpenThread UART */

--- a/pkg/openthread/contrib/platform_alarm.c
+++ b/pkg/openthread/contrib/platform_alarm.c
@@ -40,6 +40,9 @@ static msg_t ot_alarm_msg;
  */
 void otPlatAlarmStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 {
+    (void)aInstance;
+    (void)aT0;
+
     DEBUG("openthread: otPlatAlarmStartAt: aT0: %" PRIu32 ", aDT: %" PRIu32 "\n", aT0, aDt);
     ot_alarm_msg.type = OPENTHREAD_XTIMER_MSG_TYPE_EVENT;
 
@@ -55,6 +58,7 @@ void otPlatAlarmStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
 /* OpenThread will call this to stop alarms */
 void otPlatAlarmStop(otInstance *aInstance)
 {
+    (void)aInstance;
     DEBUG("openthread: otPlatAlarmStop\n");
     xtimer_remove(&ot_timer);
 }

--- a/pkg/openthread/contrib/platform_diag.c
+++ b/pkg/openthread/contrib/platform_diag.c
@@ -25,6 +25,9 @@ void otPlatDiagProcess(int argc, char *argv[], char *aOutput, size_t aOutputMaxL
 {
     /* add more plarform specific diagnostics features here */
     (void)argc;
+    (void)argv;
+    (void)aOutput;
+    (void)aOutputMaxLen;
 }
 
 void otPlatDiagModeSet(bool aMode)

--- a/pkg/openthread/contrib/platform_functions_wrapper.c
+++ b/pkg/openthread/contrib/platform_functions_wrapper.c
@@ -98,11 +98,17 @@ uint8_t ot_exec_command(otInstance *ot_instance, const char* command, void *arg,
 
 void output_bytes(const char* name, const uint8_t *aBytes, uint8_t aLength)
 {
+#if ENABLE_DEBUG
     DEBUG("%s: ", name);
     for (int i = 0; i < aLength; i++) {
         DEBUG("%02x", aBytes[i]);
     }
     DEBUG("\n");
+#else
+    (void)name;
+    (void)aBytes;
+    (void)aLength;
+#endif
 }
 
 OT_COMMAND ot_channel(otInstance* ot_instance, void* arg, void* answer) {
@@ -119,6 +125,8 @@ OT_COMMAND ot_channel(otInstance* ot_instance, void* arg, void* answer) {
 }
 
 OT_COMMAND ot_eui64(otInstance* ot_instance, void* arg, void* answer) {
+    (void)arg;
+
     if (answer != NULL) {
         otExtAddress address;
         otLinkGetFactoryAssignedIeeeEui64(ot_instance, &address);
@@ -132,6 +140,8 @@ OT_COMMAND ot_eui64(otInstance* ot_instance, void* arg, void* answer) {
 
 
 OT_COMMAND ot_extaddr(otInstance* ot_instance, void* arg, void* answer) {
+    (void)arg;
+
     if (answer != NULL) {
         answer = (void*)otLinkGetExtendedAddress(ot_instance);
         output_bytes("extaddr", (const uint8_t *)answer, OT_EXT_ADDRESS_SIZE);
@@ -172,6 +182,8 @@ OT_COMMAND ot_masterkey(otInstance* ot_instance, void* arg, void* answer) {
 }
 
 OT_COMMAND ot_mode(otInstance* ot_instance, void* arg, void* answer) {
+    (void)answer;
+
     if (arg != NULL) {
         otLinkModeConfig link_mode;
         memset(&link_mode, 0, sizeof(otLinkModeConfig));
@@ -233,6 +245,8 @@ OT_COMMAND ot_panid(otInstance* ot_instance, void* arg, void* answer) {
 }
 
 OT_COMMAND ot_parent(otInstance* ot_instance, void* arg, void* answer) {
+    (void)arg;
+
     if (answer != NULL) {
         otRouterInfo parentInfo;
         otThreadGetParentInfo(ot_instance, &parentInfo);
@@ -246,6 +260,8 @@ OT_COMMAND ot_parent(otInstance* ot_instance, void* arg, void* answer) {
 }
 
 OT_COMMAND ot_state(otInstance* ot_instance, void* arg, void* answer) {
+    (void)arg;
+
     if (answer != NULL) {
         uint8_t state = otThreadGetDeviceRole(ot_instance);
         *((uint8_t *) answer) = state;
@@ -280,6 +296,8 @@ OT_COMMAND ot_state(otInstance* ot_instance, void* arg, void* answer) {
 }
 
 OT_COMMAND ot_thread(otInstance* ot_instance, void* arg, void* answer) {
+    (void)answer;
+
     if (arg != NULL) {
         if (strcmp((char*)arg, "start") == 0) {
             otThreadSetEnabled(ot_instance, true);

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -132,8 +132,8 @@ void recv_pkt(otInstance *aInstance, netdev_t *dev)
     int len = dev->driver->recv(dev, NULL, 0, NULL);
 
     /* very unlikely */
-    if ((len > (unsigned) UINT16_MAX)) {
-        DEBUG("Len too high: %d\n", len);
+    if ((len < 0) || ((uint32_t)len > UINT16_MAX)) {
+        DEBUG("Invalid len: %d\n", len);
         otPlatRadioReceiveDone(aInstance, NULL, kThreadError_Abort);
         return;
     }
@@ -163,6 +163,8 @@ void recv_pkt(otInstance *aInstance, netdev_t *dev)
 /* Called upon TX event */
 void send_pkt(otInstance *aInstance, netdev_t *dev, netdev_event_t event)
 {
+    (void)dev;
+
     /* Tell OpenThread transmission is done depending on the NETDEV event */
     switch (event) {
         case NETDEV_EVENT_TX_COMPLETE:
@@ -189,6 +191,7 @@ void send_pkt(otInstance *aInstance, netdev_t *dev, netdev_event_t event)
 /* OpenThread will call this for setting PAN ID */
 void otPlatRadioSetPanId(otInstance *aInstance, uint16_t panid)
 {
+    (void)aInstance;
     DEBUG("openthread: otPlatRadioSetPanId: setting PAN ID to %04x\n", panid);
     _set_panid(panid);
 }
@@ -196,9 +199,10 @@ void otPlatRadioSetPanId(otInstance *aInstance, uint16_t panid)
 /* OpenThread will call this for setting extended address */
 void otPlatRadioSetExtendedAddress(otInstance *aInstance, uint8_t *aExtendedAddress)
 {
+    (void)aInstance;
     DEBUG("openthread: otPlatRadioSetExtendedAddress\n");
     uint8_t reversed_addr[IEEE802154_LONG_ADDRESS_LEN];
-    for (int i = 0; i < IEEE802154_LONG_ADDRESS_LEN; i++) {
+    for (unsigned i = 0; i < IEEE802154_LONG_ADDRESS_LEN; i++) {
         reversed_addr[i] = aExtendedAddress[IEEE802154_LONG_ADDRESS_LEN - 1 - i];
     }
     _set_long_addr(reversed_addr);
@@ -207,6 +211,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, uint8_t *aExtendedAddr
 /* OpenThread will call this for setting short address */
 void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t aShortAddress)
 {
+    (void) aInstance;
     DEBUG("openthread: otPlatRadioSetShortAddress: setting address to %04x\n", aShortAddress);
     _set_addr(((aShortAddress & 0xff) << 8) | ((aShortAddress >> 8) & 0xff));
 }
@@ -275,6 +280,7 @@ ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 /* OpenThread will call this function to get the transmit buffer */
 RadioPacket *otPlatRadioGetTransmitBuffer(otInstance *aInstance)
 {
+    (void) aInstance;
     DEBUG("openthread: otPlatRadioGetTransmitBuffer\n");
     return &sTransmitFrame;
 }
@@ -318,6 +324,7 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
 /* OpenThread will call this for getting the radio caps */
 otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 {
+    (void) aInstance;
     DEBUG("openthread: otPlatRadioGetCaps\n");
     /* all drivers should handle ACK, including call of NETDEV_EVENT_TX_NOACK */
     return kRadioCapsNone;
@@ -326,6 +333,7 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 /* OpenThread will call this for getting the state of promiscuous mode */
 bool otPlatRadioGetPromiscuous(otInstance *aInstance)
 {
+    (void) aInstance;
     DEBUG("openthread: otPlatRadioGetPromiscuous\n");
     return _is_promiscuous();
 }
@@ -333,6 +341,7 @@ bool otPlatRadioGetPromiscuous(otInstance *aInstance)
 /* OpenThread will call this for setting the state of promiscuous mode */
 void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
 {
+    (void) aInstance;
     DEBUG("openthread: otPlatRadioSetPromiscuous\n");
     _set_promiscuous((aEnable) ? NETOPT_ENABLE : NETOPT_DISABLE);
 }
@@ -406,10 +415,12 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
 
 void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeee64Eui64)
 {
+    (void) aInstance;
     _dev->driver->get(_dev, NETOPT_IPV6_IID, aIeee64Eui64, sizeof(eui64_t));
 }
 
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 {
+    (void) aInstance;
     return -100;
 }

--- a/pkg/openthread/contrib/platform_settings.c
+++ b/pkg/openthread/contrib/platform_settings.c
@@ -24,6 +24,7 @@
 
 void otPlatSettingsInit(otInstance *aInstance)
 {
+    (void)aInstance;
 }
 
 ThreadError otPlatSettingsBeginChange(otInstance *aInstance)
@@ -47,6 +48,11 @@ ThreadError otPlatSettingsAbandonChange(otInstance *aInstance)
 
 ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
 {
+    (void)aInstance;
+    (void)aKey;
+    (void)aIndex;
+    (void)aValue;
+
     DEBUG("openthread: otPlatSettingsGet\n");
     *aValueLength = 0;
     return kThreadError_NotImplemented;
@@ -54,19 +60,34 @@ ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, 
 
 ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
+    (void)aInstance;
+    (void)aKey;
+    (void)aValue;
+    (void)aValueLength;
+
     return kThreadError_None;
 }
 
 ThreadError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
+    (void)aInstance;
+    (void)aKey;
+    (void)aValue;
+    (void)aValueLength;
+
     return kThreadError_None;
 }
 
 ThreadError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
 {
+    (void)aInstance;
+    (void)aKey;
+    (void)aIndex;
+
     return kThreadError_None;
 }
 
 void otPlatSettingsWipe(otInstance *aInstance)
 {
+    (void)aInstance;
 }

--- a/sys/auto_init/saul/auto_init_gpio.c
+++ b/sys/auto_init/saul/auto_init_gpio.c
@@ -30,7 +30,15 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define SAUL_GPIO_NUMOF    (sizeof(saul_gpio_params)/sizeof(saul_gpio_params[0]))
+#if defined(SAUL_GPIO_NUMOF) && !(SAUL_GPIO_NUMOF > 0)
+void auto_init_gpio(void)
+{
+    /* do nothing, no GPIO configured for SAUL */
+    LOG_DEBUG("[auto_init_saul] no SAUL GPIO configured!\n");
+}
+#else
+#define SAUL_GPIO_NUMOF (sizeof(saul_gpio_params)/sizeof(saul_gpio_params[0]))
+
 
 /**
  * @brief   Memory for the registry entries
@@ -76,7 +84,7 @@ void auto_init_gpio(void)
         saul_reg_add(&(saul_reg_entries[i]));
     }
 }
-
+#endif
 #else
 typedef int dont_be_pedantic;
 #endif /* MODULE_SAUL_GPIO */

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -39,19 +39,19 @@ extern "C" {
 #endif
 /* XTIMER_HZ is a power-of-two multiple of 1 MHz */
 /* e.g. cc2538 uses a 16 MHz timer */
-inline static uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
     return (usec << XTIMER_SHIFT); /* multiply by power of two */
 }
 
-inline static uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
     return (usec << XTIMER_SHIFT); /* multiply by power of two */
 }
 
-inline static uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
     return (ticks >> XTIMER_SHIFT); /* divide by power of two */
 }
 
-inline static uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
     return (ticks >> XTIMER_SHIFT); /* divide by power of two */
 }
 
@@ -61,38 +61,38 @@ inline static uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
 #endif
 /* 1 MHz is a power-of-two multiple of XTIMER_HZ */
 /* e.g. ATmega2560 uses a 250 kHz timer */
-inline static uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
     return (usec >> XTIMER_SHIFT); /* divide by power of two */
 }
 
-inline static uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
     return (usec >> XTIMER_SHIFT); /* divide by power of two */
 }
 
-inline static uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
     return (ticks << XTIMER_SHIFT); /* multiply by power of two */
 }
 
-inline static uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
     return (ticks << XTIMER_SHIFT); /* multiply by power of two */
 }
 #endif /* defined(XTIMER_SHIFT) && (XTIMER_SHIFT != 0) */
 #elif XTIMER_HZ == (1000000ul)
 /* This is the most straightforward as the xtimer API is based around
  * microseconds for representing time values. */
-inline static uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
     return ticks; /* no-op */
 }
 
-inline static uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
     return ticks; /* no-op */
 }
 
-inline static uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
     return usec; /* no-op */
 }
 
-inline static uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
     return usec; /* no-op */
 }
 
@@ -101,22 +101,22 @@ inline static uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
  * greatest common divisor between 32768 and 1000000 is 64, so instead of
  * multiplying by the fraction (32768 / 1000000), we will instead use
  * (512 / 15625), which reduces the truncation caused by the integer widths */
-inline static uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
     return div_u32_by_15625div512(usec);
 }
 
-inline static uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
     return div_u64_by_15625div512(usec);
 }
 
-inline static uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
     /* return (usec * 15625) / 512; */
     /* Using 64 bit multiplication to avoid truncating the top 9 bits */
     uint64_t usec = (uint64_t)ticks * 15625ul;
     return (usec >> 9); /* equivalent to (usec / 512) */
 }
 
-inline static uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
     /* return (usec * 15625) / 512; */
     uint64_t usec = (uint64_t)ticks * 15625ul;
     return (usec >> 9); /* equivalent to (usec / 512) */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -132,7 +132,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
 
                 res = 0;
                 for (unsigned i = 0;
-                     (res < opt->data_len) && (i < GNRC_NETIF_IPV6_ADDRS_NUMOF);
+                     (res < (int)opt->data_len) && (i < GNRC_NETIF_IPV6_ADDRS_NUMOF);
                      i++) {
                     if (netif->ipv6.addrs_flags[i] != 0) {
                         memcpy(tgt, &netif->ipv6.addrs[i], sizeof(ipv6_addr_t));
@@ -148,7 +148,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
 
                 res = 0;
                 for (unsigned i = 0;
-                     (res < opt->data_len) && (i < GNRC_NETIF_IPV6_ADDRS_NUMOF);
+                     (res < (int)opt->data_len) && (i < GNRC_NETIF_IPV6_ADDRS_NUMOF);
                      i++) {
                     if (netif->ipv6.addrs_flags[i] != 0) {
                         *tgt = netif->ipv6.addrs_flags[i];
@@ -164,7 +164,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
 
                 res = 0;
                 for (unsigned i = 0;
-                     (res < opt->data_len) && (i < GNRC_NETIF_IPV6_GROUPS_NUMOF);
+                     (res < (int)opt->data_len) && (i < GNRC_NETIF_IPV6_GROUPS_NUMOF);
                      i++) {
                     if (!ipv6_addr_is_unspecified(&netif->ipv6.groups[i])) {
                         memcpy(tgt, &netif->ipv6.groups[i], sizeof(ipv6_addr_t));

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -222,11 +222,11 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
                     break;
                 }
             }
-            if ((netif != NULL) && (netif->pid != route.iface)) {
+            if ((netif != NULL) && (netif->pid != (int)route.iface)) {
                 /* drop pre-assumed netif */
                 gnrc_netif_release(netif);
             }
-            if ((netif == NULL) || (netif->pid != route.iface)) {
+            if ((netif == NULL) || (netif->pid != (int)route.iface)) {
                 /* get actual netif */
                 netif = gnrc_netif_get_by_pid(route.iface);
                 gnrc_netif_acquire(netif);

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -111,7 +111,7 @@ static inline bool _context_overlaps_iid(gnrc_sixlowpan_ctx_t *ctx,
 }
 
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC_NHC
-inline static size_t iphc_nhc_udp_decode(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t **dec_hdr,
+static inline size_t iphc_nhc_udp_decode(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t **dec_hdr,
                                          size_t datagram_size, size_t offset)
 {
     uint8_t *payload = pkt->data;
@@ -520,7 +520,7 @@ size_t gnrc_sixlowpan_iphc_decode(gnrc_pktsnip_t **dec_hdr, gnrc_pktsnip_t *pkt,
 }
 
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC_NHC
-inline static size_t iphc_nhc_udp_encode(gnrc_pktsnip_t *udp, ipv6_hdr_t *ipv6_hdr)
+static inline size_t iphc_nhc_udp_encode(gnrc_pktsnip_t *udp, ipv6_hdr_t *ipv6_hdr)
 {
     udp_hdr_t *udp_hdr = udp->data;
     network_uint16_t *src_port = &(udp_hdr->src_port);

--- a/sys/net/gnrc/transport_layer/tcp/internal/option.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/option.h
@@ -38,7 +38,7 @@ extern "C" {
  *
  * @returns   MSS option value.
  */
-inline static uint32_t _option_build_mss(uint16_t mss)
+static inline uint32_t _option_build_mss(uint16_t mss)
 {
     return (((uint32_t) TCP_OPTION_KIND_MSS << 24) |
             ((uint32_t) TCP_OPTION_LENGTH_MSS << 16) | mss);
@@ -52,7 +52,7 @@ inline static uint32_t _option_build_mss(uint16_t mss)
  *
  * @returns   Bitfield with encoded control bits and number of options.
  */
-inline static uint16_t _option_build_offset_control(uint16_t nopts, uint16_t ctl)
+static inline uint16_t _option_build_offset_control(uint16_t nopts, uint16_t ctl)
 {
     assert(TCP_HDR_OFFSET_MIN <= nopts && nopts <= TCP_HDR_OFFSET_MAX);
     return (nopts << 12) | ctl;

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -48,7 +48,7 @@ volatile pm_blocker_t pm_blocker = PM_BLOCKER_INITIAL;
 
 void pm_set_lowest(void)
 {
-    pm_blocker_t blocker = (pm_blocker_t) pm_blocker;
+    pm_blocker_t blocker = pm_blocker;
     unsigned mode = PM_NUM_MODES;
     while (mode) {
         if (blocker.val_u8[mode-1]) {

--- a/sys/posix/pthread/pthread_cond.c
+++ b/sys/posix/pthread/pthread_cond.c
@@ -122,7 +122,7 @@ int pthread_cond_wait(pthread_cond_t *cond, mutex_t *mutex)
 
 int pthread_cond_timedwait(pthread_cond_t *cond, mutex_t *mutex, const struct timespec *abstime)
 {
-    if ((cond == NULL) || (abstime->tv_sec < 0)) {
+    if (cond == NULL) {
         return EINVAL;
     }
 

--- a/sys/random/tinymt32/tinymt32.h
+++ b/sys/random/tinymt32/tinymt32.h
@@ -46,7 +46,7 @@ void tinymt32_init(tinymt32_t *random, uint32_t seed);
 void tinymt32_init_by_array(tinymt32_t *random, uint32_t init_key[],
                             int key_length);
 
-inline static int tinymt32_get_mexp(tinymt32_t *random)
+static inline int tinymt32_get_mexp(tinymt32_t *random)
 {
     (void) random;
     return TINYMT32_MEXP;
@@ -57,7 +57,7 @@ inline static int tinymt32_get_mexp(tinymt32_t *random)
  * Users should not call this function directly.
  * @param random tinymt internal status
  */
-inline static void tinymt32_next_state(tinymt32_t *random)
+static inline void tinymt32_next_state(tinymt32_t *random)
 {
     uint32_t x;
     uint32_t y;
@@ -82,7 +82,7 @@ inline static void tinymt32_next_state(tinymt32_t *random)
  * @param random tinymt internal status
  * @return 32-bit unsigned pseudorandom number
  */
-inline static uint32_t tinymt32_temper(tinymt32_t *random)
+static inline uint32_t tinymt32_temper(tinymt32_t *random)
 {
     uint32_t t0, t1;
 
@@ -99,7 +99,7 @@ inline static uint32_t tinymt32_temper(tinymt32_t *random)
  * @param random tinymt internal status
  * @return floating point number r (1.0 <= r < 2.0)
  */
-inline static float tinymt32_temper_conv(tinymt32_t *random)
+static inline float tinymt32_temper_conv(tinymt32_t *random)
 {
     uint32_t t0, t1;
 
@@ -122,7 +122,7 @@ inline static float tinymt32_temper_conv(tinymt32_t *random)
  * @param random tinymt internal status
  * @return floating point number r (1.0 < r < 2.0)
  */
-inline static float tinymt32_temper_conv_open(tinymt32_t *random)
+static inline float tinymt32_temper_conv_open(tinymt32_t *random)
 {
     uint32_t t0, t1;
 
@@ -144,7 +144,7 @@ inline static float tinymt32_temper_conv_open(tinymt32_t *random)
  * @param random tinymt internal status
  * @return 32-bit unsigned integer r (0 <= r < 2^32)
  */
-inline static uint32_t tinymt32_generate_uint32(tinymt32_t *random)
+static inline uint32_t tinymt32_generate_uint32(tinymt32_t *random)
 {
     tinymt32_next_state(random);
     return tinymt32_temper(random);
@@ -158,7 +158,7 @@ inline static uint32_t tinymt32_generate_uint32(tinymt32_t *random)
  * @param random tinymt internal status
  * @return floating point number r (0.0 <= r < 1.0)
  */
-inline static float tinymt32_generate_float(tinymt32_t *random)
+static inline float tinymt32_generate_float(tinymt32_t *random)
 {
     tinymt32_next_state(random);
     return (tinymt32_temper(random) >> 8) * TINYMT32_MUL;
@@ -170,7 +170,7 @@ inline static float tinymt32_generate_float(tinymt32_t *random)
  * @param random tinymt internal status
  * @return floating point number r (1.0 <= r < 2.0)
  */
-inline static float tinymt32_generate_float12(tinymt32_t *random)
+static inline float tinymt32_generate_float12(tinymt32_t *random)
 {
     tinymt32_next_state(random);
     return tinymt32_temper_conv(random);
@@ -182,7 +182,7 @@ inline static float tinymt32_generate_float12(tinymt32_t *random)
  * @param random tinymt internal status
  * @return floating point number r (0.0 <= r < 1.0)
  */
-inline static float tinymt32_generate_float01(tinymt32_t *random)
+static inline float tinymt32_generate_float01(tinymt32_t *random)
 {
     tinymt32_next_state(random);
     return tinymt32_temper_conv(random) - 1.0f;
@@ -194,7 +194,7 @@ inline static float tinymt32_generate_float01(tinymt32_t *random)
  * @param random tinymt internal status
  * @return floating point number r (0.0 < r <= 1.0)
  */
-inline static float tinymt32_generate_floatOC(tinymt32_t *random)
+static inline float tinymt32_generate_floatOC(tinymt32_t *random)
 {
     tinymt32_next_state(random);
     return 1.0f - tinymt32_generate_float(random);
@@ -206,7 +206,7 @@ inline static float tinymt32_generate_floatOC(tinymt32_t *random)
  * @param random tinymt internal status
  * @return floating point number r (0.0 < r < 1.0)
  */
-inline static float tinymt32_generate_floatOO(tinymt32_t *random)
+static inline float tinymt32_generate_floatOO(tinymt32_t *random)
 {
     tinymt32_next_state(random);
     return tinymt32_temper_conv_open(random) - 1.0f;
@@ -220,7 +220,7 @@ inline static float tinymt32_generate_floatOO(tinymt32_t *random)
  * @param random tinymt internal status
  * @return floating point number r (0.0 < r <= 1.0)
  */
-inline static double tinymt32_generate_32double(tinymt32_t *random)
+static inline double tinymt32_generate_32double(tinymt32_t *random)
 {
     tinymt32_next_state(random);
     return tinymt32_temper(random) * (1.0 / 4294967296.0);

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -517,7 +517,7 @@ static void _netif_list(kernel_pid_t iface)
 static int _netif_set_u16(kernel_pid_t iface, netopt_t opt, uint16_t context,
                           char *u16_str)
 {
-    unsigned int res;
+    unsigned long int res;
     bool hex = false;
 
     if (_is_number(u16_str)) {
@@ -556,10 +556,10 @@ static int _netif_set_u16(kernel_pid_t iface, netopt_t opt, uint16_t context,
     printf(" on interface %" PRIkernel_pid " to ", iface);
 
     if (hex) {
-        printf("0x%04x\n", res);
+        printf("0x%04lx\n", res);
     }
     else {
-        printf("%u\n", res);
+        printf("%lu\n", res);
     }
 
     return 0;

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -75,7 +75,7 @@ static clist_node_t _vfs_mounts_list;
  * @return fd on success
  * @return <0 on error
  */
-inline static int _allocate_fd(int fd);
+static inline int _allocate_fd(int fd);
 
 /**
  * @internal
@@ -83,7 +83,7 @@ inline static int _allocate_fd(int fd);
  *
  * @param[in]  fd     fd to free
  */
-inline static void _free_fd(int fd);
+static inline void _free_fd(int fd);
 
 /**
  * @internal
@@ -98,7 +98,7 @@ inline static void _free_fd(int fd);
  * @return fd on success
  * @return <0 on error
  */
-inline static int _init_fd(int fd, const vfs_file_ops_t *f_op, vfs_mount_t *mountp, int flags, void *private_data);
+static inline int _init_fd(int fd, const vfs_file_ops_t *f_op, vfs_mount_t *mountp, int flags, void *private_data);
 
 /**
  * @internal
@@ -115,7 +115,7 @@ inline static int _init_fd(int fd, const vfs_file_ops_t *f_op, vfs_mount_t *moun
  * @return mount index on success
  * @return <0 on error
  */
-inline static int _find_mount(vfs_mount_t **mountpp, const char *name, const char **rel_path);
+static inline int _find_mount(vfs_mount_t **mountpp, const char *name, const char **rel_path);
 
 /**
  * @internal
@@ -126,7 +126,7 @@ inline static int _find_mount(vfs_mount_t **mountpp, const char *name, const cha
  * @return 0 if the fd is valid
  * @return <0 if the fd is not valid
  */
-inline static int _fd_is_valid(int fd);
+static inline int _fd_is_valid(int fd);
 
 static mutex_t _mount_mutex = MUTEX_INIT;
 static mutex_t _open_mutex = MUTEX_INIT;
@@ -810,7 +810,7 @@ const vfs_mount_t *vfs_iterate_mounts(const vfs_mount_t *cur)
     return container_of(node, vfs_mount_t, list_entry);
 }
 
-inline static int _allocate_fd(int fd)
+static inline int _allocate_fd(int fd)
 {
     if (fd < 0) {
         for (fd = 0; fd < VFS_MAX_OPEN_FILES; ++fd) {
@@ -837,7 +837,7 @@ inline static int _allocate_fd(int fd)
     return fd;
 }
 
-inline static void _free_fd(int fd)
+static inline void _free_fd(int fd)
 {
     DEBUG("_free_fd: %d, pid=%d\n", fd, _vfs_open_files[fd].pid);
     if (_vfs_open_files[fd].mp != NULL) {
@@ -846,7 +846,7 @@ inline static void _free_fd(int fd)
     _vfs_open_files[fd].pid = KERNEL_PID_UNDEF;
 }
 
-inline static int _init_fd(int fd, const vfs_file_ops_t *f_op, vfs_mount_t *mountp, int flags, void *private_data)
+static inline int _init_fd(int fd, const vfs_file_ops_t *f_op, vfs_mount_t *mountp, int flags, void *private_data)
 {
     fd = _allocate_fd(fd);
     if (fd < 0) {
@@ -861,7 +861,7 @@ inline static int _init_fd(int fd, const vfs_file_ops_t *f_op, vfs_mount_t *moun
     return fd;
 }
 
-inline static int _find_mount(vfs_mount_t **mountpp, const char *name, const char **rel_path)
+static inline int _find_mount(vfs_mount_t **mountpp, const char *name, const char **rel_path)
 {
     size_t longest_match = 0;
     size_t name_len = strlen(name);
@@ -914,7 +914,7 @@ inline static int _find_mount(vfs_mount_t **mountpp, const char *name, const cha
     return 0;
 }
 
-inline static int _fd_is_valid(int fd)
+static inline int _fd_is_valid(int fd)
 {
     if ((unsigned int)fd >= VFS_MAX_OPEN_FILES) {
         return -EBADF;

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -39,4 +39,7 @@ DRIVER ?= at86rf231
 # include the selected driver
 USEMODULE += $(DRIVER)
 
+CFLAGS += -Wno-unused-parameter -Wno-unused-function -Wno-type-limits
+CFLAGS += -Wno-sign-compare -Wno-missing-field-initializers
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread_cooperation/main.c
+++ b/tests/pthread_cooperation/main.c
@@ -28,7 +28,7 @@
 pthread_t ths[NUM_THREADS];
 
 pthread_mutex_t mtx;
-volatile int storage = 1;
+volatile uint32_t storage = 1;
 
 void *run(void *parameter)
 {
@@ -43,7 +43,7 @@ void *run(void *parameter)
     }
 
     storage *= arg;
-    printf("val = %d\n", storage);
+    printf("val = %"PRIu32"\n", storage);
     pthread_mutex_unlock(&mtx);
 
     return NULL;
@@ -66,7 +66,7 @@ int main(void)
         pthread_join(ths[i], NULL);
     }
 
-    printf("Factorial: %d\n", storage);
+    printf("Factorial: %"PRIu32"\n", storage);
 
     pthread_mutex_destroy(&mtx);
     pthread_attr_destroy(&th_attr);

--- a/tests/trickle/main.c
+++ b/tests/trickle/main.c
@@ -53,15 +53,13 @@ static void callback(void *args)
     return;
 }
 
-static trickle_t trickle;
+static trickle_t trickle = { .callback = { .func = &callback,
+                                           .args = NULL } };
 
 int main(void)
 {
     msg_t msg;
     unsigned counter = 0;
-
-    trickle.callback.func = &callback;
-    trickle.callback.args = NULL;
 
     trickle_start(sched_active_pid, &trickle, TRICKLE_MSG, TR_IMIN,
                   TR_IDOUBLINGS, TR_REDCONST);

--- a/tests/trickle/main.c
+++ b/tests/trickle/main.c
@@ -53,13 +53,15 @@ static void callback(void *args)
     return;
 }
 
-static trickle_t trickle = { .callback.func = &callback,
-                             .callback.args = NULL };
+static trickle_t trickle;
 
 int main(void)
 {
     msg_t msg;
     unsigned counter = 0;
+
+    trickle.callback.func = &callback;
+    trickle.callback.args = NULL;
 
     trickle_start(sched_active_pid, &trickle, TRICKLE_MSG, TR_IMIN,
                   TR_IDOUBLINGS, TR_REDCONST);


### PR DESCRIPTION
This picks up the idea of #1121 (which isn't mergeable anymore, because of considerable changes since then) to enable more compiler warnings and make them errors to fail. This PR also ships several fixes to make things work.

It also provides an option to turn on `-Wpedantic` too, however, that would require even more work and also some agreement (e.g., usage of gcc extensions, see #7918).

may need #7860 and other existing PR that solve open issues.