### PR TITLE
periph: i2c: include note on address alignment.

### DIFF
--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -16,7 +16,7 @@
  * simple as possible, to allow for easy implementation and maximal portability.
  *
  * @note        The current version of this interface only supports the
- *              7-bit addressing mode.
+ *              7-bit addressing mode, right justified.
  *
  * @note        This interface is due for remodeling, hence API changes are to
  *              be expected for upcoming releases.


### PR DESCRIPTION
Very small enhancement to remove any confusion about I2C address alignment (it turns out I implemented this wrong in my drivers).