### PR TITLE
drivers: bmx280: include board.h for board parameters.

### DIFF
--- a/drivers/bmx280/include/bmx280_params.h
+++ b/drivers/bmx280/include/bmx280_params.h
@@ -21,6 +21,7 @@
 #ifndef BMX280_PARAMS_H
 #define BMX280_PARAMS_H
 
+#include "board.h"
 #include "bmx280.h"
 #include "saul_reg.h"
 


### PR DESCRIPTION
`board.h` is not included, so one cannot override any of the defines. Drivers like Si70xx and DHT do the same.