### PR TITLE
 gnrc_ipv6_nib: fix for 'holey' NIB

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
@@ -100,8 +100,9 @@ bool gnrc_ipv6_nib_ft_iter(const ipv6_addr_t *next_hop, unsigned iface,
         _nib_offl_entry_t *offl = *state;
 
         while ((offl = _nib_offl_iter(offl))) {
-            assert((offl->mode != 0) || (offl->next_hop != NULL));
-            if (((iface == 0) || (iface == _nib_onl_get_if(offl->next_hop))) &&
+            assert(offl->mode != 0);
+            if ((offl->next_hop != NULL) &&
+                ((iface == 0) || (iface == _nib_onl_get_if(offl->next_hop))) &&
                 ((next_hop == NULL) || ipv6_addr_equal(&offl->next_hop->ipv6,
                                                        next_hop))) {
                 _nib_ft_get(offl, fte);
@@ -113,8 +114,8 @@ bool gnrc_ipv6_nib_ft_iter(const ipv6_addr_t *next_hop, unsigned iface,
     }
     entry = *state;
     while ((entry = _nib_drl_iter(entry))) {
-        assert((entry->next_hop != NULL));
-        if (((iface == 0) || (iface == _nib_onl_get_if(entry->next_hop))) &&
+        if ((entry->next_hop != NULL) &&
+            ((iface == 0) || (iface == _nib_onl_get_if(entry->next_hop))) &&
             ((next_hop == NULL) || ipv6_addr_equal(&entry->next_hop->ipv6,
                                                    next_hop))) {
             _nib_drl_ft_get(entry, fte);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -81,8 +81,7 @@ bool gnrc_ipv6_nib_pl_iter(unsigned iface, void **state,
     mutex_lock(&_nib_mutex);
     while ((dst = _nib_offl_iter(dst)) != NULL) {
         const _nib_onl_entry_t *node = dst->next_hop;
-        assert(node != NULL);
-        if ((dst->mode & _PL) &&
+        if ((node != NULL) && (dst->mode & _PL) &&
             ((iface == 0) || (_nib_onl_get_if(node) == iface))) {
             entry->pfx_len = dst->pfx_len;
             ipv6_addr_set_unspecified(&entry->pfx);

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-pl.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-pl.c
@@ -377,6 +377,46 @@ static void test_nib_pl_del__success(void)
     TEST_ASSERT(!gnrc_ipv6_nib_pl_iter(0, &iter_state, &ple));
 }
 
+/**
+ * Creates three prefix list entries and removes the second one.
+ * The prefix list is then iterated.
+ * Expected result: there should be two prefix list entries returned, the first
+ * and the third one
+ */
+static void test_nib_pl_iter__empty_in_the_middle(void)
+{
+    gnrc_ipv6_nib_pl_t ple;
+    void *iter_state = NULL;
+    ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
+                               { .u64 = TEST_UINT64 } } };
+    int count = 0;
+
+    TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
+                                                  GLOBAL_PREFIX_LEN,
+                                                  UINT32_MAX, UINT32_MAX));
+    pfx.u16[0].u16++;
+    TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
+                                                  GLOBAL_PREFIX_LEN,
+                                                  UINT32_MAX, UINT32_MAX));
+    pfx.u16[0].u16++;
+    TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
+                                                  GLOBAL_PREFIX_LEN,
+                                                  UINT32_MAX, UINT32_MAX));
+    pfx.u16[0].u16--;
+    gnrc_ipv6_nib_pl_del(IFACE, &pfx, GLOBAL_PREFIX_LEN);
+    pfx.u16[0].u16--;
+    while (gnrc_ipv6_nib_pl_iter(0, &iter_state, &ple)) {
+        TEST_ASSERT(ipv6_addr_match_prefix(&ple.pfx, &pfx) >= GLOBAL_PREFIX_LEN);
+        TEST_ASSERT_EQUAL_INT(GLOBAL_PREFIX_LEN, ple.pfx_len);
+        TEST_ASSERT_EQUAL_INT(IFACE, ple.iface);
+        TEST_ASSERT_EQUAL_INT(UINT32_MAX, ple.valid_until);
+        TEST_ASSERT_EQUAL_INT(UINT32_MAX, ple.pref_until);
+        count++;
+        pfx.u16[0].u16 += 2; /* we skip the second address */
+    }
+    TEST_ASSERT_EQUAL_INT(2, count);
+}
+
 Test *tests_gnrc_ipv6_nib_pl_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -396,7 +436,8 @@ Test *tests_gnrc_ipv6_nib_pl_tests(void)
         new_TestFixture(test_nib_pl_set__success),
         new_TestFixture(test_nib_pl_del__unknown),
         new_TestFixture(test_nib_pl_del__success),
-        /* gnrc_ipv6_nib_pl_iter() is tested during all the tests above */
+        /* most of gnrc_ipv6_nib_pl_iter() is tested during all the tests above */
+        new_TestFixture(test_nib_pl_iter__empty_in_the_middle),
     };
 
     EMB_UNIT_TESTCALLER(tests, set_up, NULL,


### PR DESCRIPTION
When there are holes in the NIB (e.g. when entries were removed) currently the NIB crashes the system due to a failed assertion (`DEVELHELP` needs to be activated to test this behavior).

This fixes this behavior by making the assertion a check that is always compiled in.

Test cases to show the bug before this fix are provided (again: `DEVELHELP` needs to be activated to show the crash).