### PR TITLE
bluepill: dfu-util support

### DIFF
--- a/boards/bluepill/Makefile.include
+++ b/boards/bluepill/Makefile.include
@@ -9,5 +9,22 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# this board uses openocd
+# optionally, use dfu-util to flash via usb
+# note: needs a bootloader flashed before, config below is compatible
+# with blackmagic_dfu, see https://github.com/blacksphere/blackmagic/
+# To stop bootloader from loading an existing firmware, pull down
+# (ground) GPIO B1.
+ifeq ($(PROGRAMMER),dfu-util)
+	export LINKER_SCRIPT = stm32f103c8_bluepill.ld
+	export BINFILE = $(patsubst %.elf,%.bin,$(ELFFILE))
+
+	export FLASHER = dfu-util
+	export DEBUGGER = # no debugger
+	export RESET = # dfu-util has no support for resetting the device
+
+	export OFLAGS = -O binary
+	export FFLAGS = -d 1d50:6017 -s 0x08002000:leave -D "$(HEXFILE)"
+else
+# this board uses openocd by default
 include $(RIOTMAKE)/tools/openocd.inc.mk
+endif

--- a/cpu/stm32f1/ldscripts/stm32f103c8_bluepill.ld
+++ b/cpu/stm32f1/ldscripts/stm32f103c8_bluepill.ld
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 Alexander Melnikov <avmelnikoff@gmail.com>
+ *               2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_stm32f1
+ * @{
+ *
+ * @file
+ * @brief           Memory definitions for the STM32F103C8
+ *
+ * @author          Alexander Melnikov <avmelnikoff@gmail.com>
+ * @author          Sebastian Meiling <s@mlng.net>
+ *
+ * @}
+ */
+
+MEMORY
+{
+    rom (rx)    : ORIGIN = 0x08002000, LENGTH = 64K-0x2000
+    ram (xrw)   : ORIGIN = 0x20000000, LENGTH = 20K
+}
+
+INCLUDE cortexm_base.ld


### PR DESCRIPTION
this PR add optional support to use `dfu-util` to flash RIOT via USB on the bluepill board.

However, this feature require to flash a boot loader before, the configuration supplied here uses the boot loader from [black magic](https://github.com/blacksphere/blackmagic/).

Note: to use this method repeatedly, i.e., when you flashed RIOT ones with dfu-util, you need to pull down (ground) GPIO B1 to stop the boot loader from loading the image and rather stop to reflash.