### PR TITLE
git: mailmap: deduplicate @jia200x

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -4,6 +4,7 @@ Hauke Petersen <devel@haukepetersen.de> <hauke.petersen@fu-berlin.de>
 Hauke Petersen <devel@haukepetersen.de> <mail@haukepetersen.de>
 Joakim Nohlgård <joakim.nohlgard@eistec.se> <joakim.gebart@eistec.se>
 Joakim Nohlgård <joakim.nohlgard@eistec.se> <joakim@gebart.se>
+José Ignacio Alamos Aste <jialamos@uc.cl>
 Kaspar Schleiser <kaspar@schleiser.de>
 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de> <ludwig.ortmann@fu-berlin.de>
 Martine Lenders <m.lenders@fu-berlin.de> <authmillenon@gmail.com>


### PR DESCRIPTION
During the release I noticed, that @jia200x has two different versions of his name in the repository. This can lead to him being counted as to separate contributors. This PR fixes that.