### PR TITLE
drivers: include board.h in default params files

### DIFF
--- a/drivers/jc42/include/jc42_params.h
+++ b/drivers/jc42/include/jc42_params.h
@@ -21,6 +21,7 @@
 #ifndef JC42_PARAMS_H
 #define JC42_PARAMS_H
 
+#include "board.h"
 #include "jc42.h"
 #include "periph/i2c.h"
 

--- a/drivers/tsl2561/include/tsl2561_params.h
+++ b/drivers/tsl2561/include/tsl2561_params.h
@@ -19,6 +19,7 @@
 #ifndef TSL2561_PARAMS_H
 #define TSL2561_PARAMS_H
 
+#include "board.h"
 #include "saul_reg.h"
 #include "tsl2561.h"
 

--- a/drivers/w5100/include/w5100_params.h
+++ b/drivers/w5100/include/w5100_params.h
@@ -19,6 +19,8 @@
 #ifndef W5100_PARAMS_H
 #define W5100_PARAMS_H
 
+#include "board.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Follow up on #7921

added the board.h include for:
- tsl2561
- jc42
- w5100