### PR TITLE
packer: add dfu-util and bluepill udev rules

### DIFF
--- a/dist/tools/packer/preseed.cfg
+++ b/dist/tools/packer/preseed.cfg
@@ -26,7 +26,7 @@ d-i pkgsel/include string openssh-server ntp curl nfs-common build-essential \
     python-setuptools libusb-1.0-0 libusb-1.0-0-dev libudev-dev libftdi1 \
     libftdi-dev libftdipp1-dev libftdipp1-2v5 libhidapi-dev libhidapi-hidraw0 \
     libhidapi-libusb0 cmake autotools-dev autoconf pkg-config jimsh libtool \
-    valgrind openocd python-serial python3-serial xsltproc
+    valgrind openocd python-serial python3-serial xsltproc dfu-util
 
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/update-policy select none

--- a/dist/tools/packer/riot.json
+++ b/dist/tools/packer/riot.json
@@ -48,7 +48,9 @@
         ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "iotlab-m3", "--vendorid", "0x0403", "--productid",  "0x6010"],
         ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "samr21-xpro", "--vendorid", "0x03eb", "--productid",  "0x2111"],
         ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "Arduino Mega 2560", "--vendorid", "0x2341", "--productid",  "0x0042"],
-        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "Phytec phyWAVE KW22", "--vendorid", "0x0d28", "--productid",  "0x0204"]
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "Phytec phyWAVE KW22", "--vendorid", "0x0d28", "--productid",  "0x0204"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "Bluepill", "--vendorid", "0x1d50", "--productid",  "0x6017"],
+        ["usbfilter", "add", "0", "--target", "{{.Name}}", "--name", "Bluepill", "--vendorid", "0x1d50", "--productid",  "0x6018"]
       ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{user `vm_name`}}"

--- a/dist/tools/packer/udev_rules/99-custom.rules
+++ b/dist/tools/packer/udev_rules/99-custom.rules
@@ -7,4 +7,8 @@ ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE="660", GROUP="plugdev", 
 # Arduino Due
 ATTRS{idVendor}=="2341", ATTRS{idProduct}=="003d", MODE="660", GROUP="plugdev", TAG+="uaccess"
 
+# bluepill
+ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6017", MODE="660", GROUP="plugdev", TAG+="uaccess"
+ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6018", MODE="660", GROUP="plugdev", TAG+="uaccess"
+
 LABEL="custom_rules_end"


### PR DESCRIPTION
Includes `dfu-util` in the vagrant box and adds the `bluepill` board udev and the virtualbox usb whitelisting.

Can be tested with:
```diff
diff --git a/Vagrantfile b/Vagrantfile
index c15f8d3d6..9a4d99837 100644
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ RIOTBASE ||= "./"
 Vagrant.configure(2) do |config|
   # For a complete reference, please see the online documentation at https://docs.vagrantup.com.
 
-  config.vm.box = "RIOT/ubuntu1604"
+  config.vm.box = "RIOT/testing-ubuntu1604"
 
   config.vm.provider "virtualbox" do |vb|
     vb.name = "RIOT-VM"
```