### PR TITLE
gnrc_lwmac: adjust error use of csma flag for transmit packet.

### DIFF
--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -24,7 +24,6 @@
 #include "periph/rtt.h"
 #include "net/gnrc.h"
 #include "net/gnrc/mac/mac.h"
-#include "net/gnrc/netdev.h"
 #include "net/gnrc/lwmac/lwmac.h"
 #include "include/lwmac_internal.h"
 #include "net/gnrc/netif2/ieee802154.h"
@@ -100,7 +99,7 @@ int _gnrc_lwmac_transmit(gnrc_netif2_t *netif, gnrc_pktsnip_t *pkt)
         }
 #endif
 #ifdef MODULE_GNRC_MAC
-        if (netif->mac.mac_info & GNRC_NETDEV_MAC_INFO_CSMA_ENABLED) {
+        if (netif->mac.mac_info & GNRC_NETIF2_MAC_INFO_CSMA_ENABLED) {
             res = csma_sender_csma_ca_send(dev, vector, n, &netif->mac.csma_conf);
         }
         else {


### PR DESCRIPTION
As title, this PR adjusts a error use of csma flag for transmit packet when using the `csma_sender` module. 
It replaces `GNRC_NETDEV_MAC_INFO_CSMA_ENABLED` with `GNRC_NETIF2_MAC_INFO_CSMA_ENABLED`.