### PR TITLE
tests/thread_*: migrate to testrunner script

### DIFF
--- a/tests/thread_exit/Makefile
+++ b/tests/thread_exit/Makefile
@@ -6,3 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 DISABLE_MODULE += auto_init
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/thread_exit/tests/01-run.py
+++ b/tests/thread_exit/tests/01-run.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect("main: starting")
+    child.expect("main: exiting")
+    child.expect("2nd: starting")
+    child.expect("3rd: starting")
+    child.expect("3rd: exiting")
+    child.expect("2nd: exiting")
+    child.expect("4th: starting")
+    child.expect("4th: exiting")
+
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/thread_flags/Makefile
+++ b/tests/thread_flags/Makefile
@@ -7,3 +7,6 @@ USEMODULE += core_thread_flags
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/thread_flags/main.c
+++ b/tests/thread_flags/main.c
@@ -19,12 +19,15 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "thread.h"
 #include "xtimer.h"
 
 static char stack[THREAD_STACKSIZE_MAIN];
 
 volatile unsigned done;
+
+#define TIMEOUT   (100UL * US_PER_MS)
 
 static void *_thread(void *arg)
 {
@@ -66,7 +69,7 @@ static void _set(thread_t *thread, thread_flags_t flags)
 
 int main(void)
 {
-    puts("main starting");
+    puts("START");
 
     kernel_pid_t pid = thread_create(stack,
                   sizeof(stack),
@@ -89,12 +92,17 @@ int main(void)
     puts("main: setting 100ms timeout...");
     xtimer_t t;
     uint32_t before = xtimer_now_usec();
-    xtimer_set_timeout_flag(&t, 100000);
+    xtimer_set_timeout_flag(&t, TIMEOUT);
     thread_flags_wait_any(THREAD_FLAG_TIMEOUT);
     uint32_t diff = xtimer_now_usec() - before;
     printf("main: timeout triggered. time passed: %uus\n", (unsigned)diff);
 
-    puts("test finished.");
+    if (abs(diff - TIMEOUT) < 500) {
+        puts("SUCCESS");
+    }
+    else {
+        puts("FAILURE");
+    }
 
     return 0;
 }

--- a/tests/thread_flags/tests/01-run.py
+++ b/tests/thread_flags/tests/01-run.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect("START")
+    child.expect_exact("thread(): waiting for 0x1...")
+    child.expect_exact("main(): setting flag 0x0001")
+    child.expect_exact("thread(): received flags: 0x0001")
+    child.expect_exact("thread(): waiting for 0x1 || 0x64...")
+    child.expect_exact("main(): setting flag 0x0064")
+    child.expect_exact("thread(): received flags: 0x0064")
+    child.expect_exact("thread(): waiting for 0x2 && 0x4...")
+    child.expect_exact("main(): setting flag 0x0001")
+    child.expect_exact("main(): setting flag 0x0008")
+    child.expect_exact("main(): setting flag 0x0002")
+    child.expect_exact("main(): setting flag 0x0004")
+    child.expect_exact("thread(): received flags: 0x0006")
+    child.expect_exact("thread(): waiting for any flag, one by one")
+    child.expect_exact("thread(): received flags: 0x0001")
+    child.expect_exact("thread(): waiting for any flag, one by one")
+    child.expect_exact("thread(): received flags: 0x0008")
+    child.expect_exact("main: setting 100ms timeout...")
+    child.expect("main: timeout triggered. time passed: [0-9]{6}us")
+    child.expect("SUCCESS")
+
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/thread_flags_xtimer/Makefile
+++ b/tests/thread_flags_xtimer/Makefile
@@ -5,3 +5,6 @@ USEMODULE += core_thread_flags
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/thread_flags_xtimer/main.c
+++ b/tests/thread_flags_xtimer/main.c
@@ -24,7 +24,7 @@
 #include "thread_flags.h"
 
 #define TIMEOUT         (100UL * US_PER_MS)
-#define REPEAT          (5)
+#define REPEAT          (5U)
 #define RUNTIME         (TIMEOUT * REPEAT)
 
 static void time_evt(void *arg)
@@ -34,30 +34,30 @@ static void time_evt(void *arg)
 
 int main(void)
 {
-
+    puts("START");
     xtimer_t timer;
     timer.callback = time_evt;
     timer.arg = (void *)sched_active_thread;
     uint32_t last = xtimer_now_usec();
 
-    puts("\nTest setting thread flags from (x)timer callback");
+    puts("Test setting thread flags from (x)timer callback");
     printf("You should see the message '+++ timeout XX +++' printed to the \n"
-           "screen %i times, once every %lu milliseconds\n\n",
+           "screen %u times, once every %lu milliseconds\n\n",
             REPEAT, (TIMEOUT / US_PER_MS));
 
-    for (int i = 1; i <= REPEAT; i++) {
+    for (unsigned i = 1; i <= REPEAT; i++) {
         xtimer_set(&timer, TIMEOUT);
         thread_flags_wait_any(0x1);
-        printf("+++ timeout %2i +++\n", i);
+        printf("+++ timeout %2u +++\n", i);
     }
 
     /* we consider the test successful, if the runtime was above 500ms */
     uint32_t runtime = xtimer_now_usec() - last;
     if (runtime > RUNTIME) {
-        puts("Test finished: SUCCESS\n");
+        puts("SUCCESS");
     }
     else {
-        puts("Test finished: FAILED\n");
+        puts("FAILURE");
     }
 
     return 0;

--- a/tests/thread_flags_xtimer/tests/01-run.py
+++ b/tests/thread_flags_xtimer/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect("START")
+    for i in range(5):
+        child.expect_exact("+++ timeout  {} +++".format(i + 1))
+    child.expect("SUCCESS")
+
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/thread_msg_seq/Makefile
+++ b/tests/thread_msg_seq/Makefile
@@ -1,8 +1,11 @@
 APPLICATION = thread_msg_seq
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
 
 DISABLE_MODULE += auto_init
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/thread_msg_seq/main.c
+++ b/tests/thread_msg_seq/main.c
@@ -51,6 +51,7 @@ void *sub_thread(void *arg)
 
 int main(void)
 {
+    puts("START");
     msg_t msg;
 
     p_main = sched_active_pid;
@@ -70,6 +71,8 @@ int main(void)
         msg_receive(&msg);
         printf("Got msg from pid %" PRIkernel_pid ": \"%s\"\n", msg.sender_pid, (char *)msg.content.ptr);
     }
+
+    puts("SUCCESS");
 
     return 0;
 }

--- a/tests/thread_msg_seq/tests/01-run.py
+++ b/tests/thread_msg_seq/tests/01-run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect("START")
+    child.expect("THREADS CREATED")
+    child.expect("THREAD nr1 \(pid:3\) start")
+    child.expect("THREAD nr1 \(pid:3\) end.")
+    child.expect("THREAD nr2 \(pid:4\) start")
+    child.expect("THREAD nr3 \(pid:5\) start")
+    child.expect("Got msg from pid 3: \"nr1\"")
+    child.expect("THREAD nr2 \(pid:4\) end.")
+    child.expect("Got msg from pid 4: \"nr2\"")
+    child.expect("THREAD nr3 \(pid:5\) end.")
+    child.expect("Got msg from pid 5: \"nr3\"")
+    child.expect("SUCCESS")
+
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
This PR adds testrunner scripts to remaining `thread_*` tests.
Since some tests are already covered by existing PRs (see #6720, #7841 and #7836), they are skipped by this one.