### PR TITLE
drivers/mrf24j40: fix radio ack request enabling

### DIFF
--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -137,6 +137,7 @@ typedef struct {
     uint8_t idle_state;                     /**< state to return to after sending */
     uint8_t tx_frame_len;                   /**< length of the current TX frame */
     uint8_t header_len;                     /**< length of the header */
+    uint8_t fcf_low;                        /**< Low 8 FCF bits of the current TX frame. */
     uint8_t pending;                        /**< Flags for pending tasks */
     uint8_t irq_flag;                       /**< Flags for IRQs */
     uint8_t tx_retries;                     /**< Number of retries needed for last transmission */

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -156,7 +156,7 @@ void mrf24j40_tx_exec(mrf24j40_t *dev)
      */
     mrf24j40_reg_write_long(dev, MRF24J40_TX_NORMAL_FIFO, dev->header_len);
 
-    if (dev->netdev.flags & NETDEV_IEEE802154_ACK_REQ) {
+    if (dev->fcf_low & IEEE802154_FCF_ACK_REQ) {
         mrf24j40_reg_write_short(dev, MRF24J40_REG_TXNCON, MRF24J40_TXNCON_TXNACKREQ | MRF24J40_TXNCON_TXNTRIG);
     }
     else {

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -106,6 +106,8 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
         len = mrf24j40_tx_load(dev, ptr->iov_base, ptr->iov_len, len);
         if (i == 0) {
             dev->header_len = len;
+            /* Grab the FCF bits from the frame header */
+            dev->fcf_low = *(uint8_t*)(ptr->iov_base);
         }
 
     }


### PR DESCRIPTION
Second attempt at correctly enabling and disabling ACK requests for the mrf24j40. I'm confident that this PR fixes the actual problem. 😄

The comparison in the initial code compares if ACKs are enabled for the radio, not if they are required for the current frame. In the original code, L2 acks were always enabled or disabled depending on the setting of the driver (not dependent on the type of frame transmitted).
This PR changes that to store the relevant FCF bits from the frame and uses those to decide whether the radio should expect an ACK. This is similar to the way the kw2xrf driver enables ACKs in the radio.
Eventually this extra variable can be reused for the security enable bit in an identical way.