### PR TITLE
drivers/tps6274x: Initial support for the step-down converter

### DIFF
--- a/boards/jiminy-mega256rfr2/include/board.h
+++ b/boards/jiminy-mega256rfr2/include/board.h
@@ -125,6 +125,19 @@ extern "C" {
 /** @} */
 
 /**
+ * @name TPS6274x Stepdown config
+ * @{
+ */
+#define TPS6274X_PARAMS { .vsel = { GPIO_PIN(PORT_D, 6), \
+                                    GPIO_PIN(PORT_D, 7), \
+                                    GPIO_PIN(PORT_G, 0), \
+                                    GPIO_PIN(PORT_G, 2), \
+                                   },                    \
+                         .ctrl_pin = GPIO_PIN(PORT_G, 5) \
+                        }
+/** @} */
+
+/**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -452,6 +452,10 @@ ifneq (,$(filter tcs37727,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter tps6274x,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 ifneq (,$(filter tja1042,$(USEMODULE)))
   USEMODULE += can_trx
   FEATURES_REQUIRED += periph_gpio

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -250,6 +250,10 @@ ifneq (,$(filter tmp006,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/tmp006/include
 endif
 
+ifneq (,$(filter tps6274x,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/tps6274x/include
+endif
+
 ifneq (,$(filter tsl2561,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/tsl2561/include
 endif

--- a/drivers/doc.txt
+++ b/drivers/doc.txt
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 Freie Universität Berlin
- * Copyright (C) 2015 INRIA
+ *               2015 INRIA
+ *               2018 RWTH
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -48,4 +49,13 @@
  * @defgroup    drivers_soft_periph Soft Peripheral Driver Interface
  * @ingroup     drivers
  * @brief       Software emulated @ref drivers_periph for UART, SPI, etc
+ */
+
+ /**
+ * @defgroup    drivers_power Power Supply Drivers
+ * @ingroup     drivers
+ * @brief       Drivers for power supply devices
+ *
+ * The group of power supply drivers indludes all kinds of AC/DC, DC/DC supply devices
+ * or charger ICs which can be controlled from the host e.g by config pin settings or by bus.
  */

--- a/drivers/include/tps6274x.h
+++ b/drivers/include/tps6274x.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2017 RWTH Aachen
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_tps6274x TPS6274x
+ * @ingroup     drivers_power
+ * @brief       Device driver interface for the TPS6274x DC-DC Converter
+ * @{
+ *
+ * @file
+ * @brief       Device driver interface for the TPS6274x DC-DC Converter
+ *
+ * @author      Steffen Robertz <steffen.robertz@rwth-aachen.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
+ */
+
+#ifndef TPS6274X_H
+#define TPS6274X_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <inttypes.h>
+#include "periph/gpio.h"
+
+/**
+ * @brief   TPS6274x Configuration struct
+ */
+typedef struct {
+    gpio_t vsel[4];            /**< select line pin mapping */
+    gpio_t ctrl_pin;           /**< ctrl pin  mapping */
+} tps6274x_params_t;
+
+/**
+ * @brief   Device descriptor for the TPS6274x
+ */
+typedef struct {
+    tps6274x_params_t  params; /**< device initialization parameters */
+} tps6274x_t;
+
+/**
+ * @brief   Status and error return codes
+ */
+enum {
+    TPS6274X_OK = 0,           /**< everything was fine */
+    TPS6274X_ERR_INIT,         /**< error during init */
+};
+
+/**
+ * @brief   Init converter
+ *
+ * @param[in] dev      Initialized device descriptor for TPS6274x device
+ * @param[in] params   Initialization parameters
+ *
+ * @return              set voltage in mV
+ */
+int tps6274x_init(tps6274x_t *dev, const tps6274x_params_t *params);
+
+/**
+ * @brief   Switch to different voltage level
+ *
+ * @param[in] dev       Device descriptor for TPS6274x device
+ * @param[in] voltage   Voltage to set in mV (needs to be between 1.8V-3.3V
+ * @return              the voltage that was set in mV
+ */
+uint16_t tps6274x_switch_voltage(tps6274x_t *dev, uint16_t voltage);
+
+/**
+ * @brief   Sets ctrl pin high to power a subsystem connected on the load pin
+ *
+ * @param[in] dev       Device descriptor for TPS6274x device
+ * @param[in] status    0 will disable the load, everything else will activate it
+ */
+void tps6274x_load_ctrl(tps6274x_t *dev, int status);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* TPS6274X_H */
+/** @} */

--- a/drivers/tps6274x/Makefile
+++ b/drivers/tps6274x/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/tps6274x/include/tps6274x_params.h
+++ b/drivers/tps6274x/include/tps6274x_params.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_tps6274x
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for TPS6274x DC-DC Converter
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ */
+
+#ifndef TPS6274X_PARAMS_H
+#define TPS6274X_PARAMS_H
+
+#include "board.h"
+#include "tps6274x.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the TPS6274x
+ * @{
+ */
+#ifndef TPS6274X_PARAMS
+#define TPS6274X_PARAMS { .vsel = { GPIO_PIN(0, 0), \
+                                    GPIO_PIN(0, 1), \
+                                    GPIO_PIN(0, 2), \
+                                    GPIO_PIN(0, 3), \
+                                   },               \
+                         .ctrl_pin = GPIO_PIN(0, 4) \
+                        }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configure TPS6274X
+ */
+static const tps6274x_params_t tps6274x_params[] =
+{
+    TPS6274X_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TPS6274X_PARAMS_H */
+/** @} */

--- a/drivers/tps6274x/tps6274x.c
+++ b/drivers/tps6274x/tps6274x.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2017 RWTH Aachen
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_tps6274x
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the TPS6274x family DC/DC-converter.
+ *
+ * @author      Steffen Robertz <steffen.robertz@rwth-aachen.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
+ *
+ * @}
+ */
+
+#include "tps6274x.h"
+#include "periph/gpio.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+int tps6274x_init(tps6274x_t *dev, const tps6274x_params_t *params)
+{
+    int ret;
+
+    dev->params = *params;
+    for (uint8_t i = 0; i < 4; i++) {
+        if (dev->params.vsel[i] != GPIO_UNDEF) {
+            ret = gpio_init(dev->params.vsel[i], GPIO_OUT);
+            if(ret < 0) {
+                return TPS6274X_ERR_INIT;
+            }
+        }
+    }
+    if (dev->params.ctrl_pin != GPIO_UNDEF) {
+        ret = gpio_init(dev->params.ctrl_pin, GPIO_OUT);
+        if(ret < 0) {
+            return TPS6274X_ERR_INIT;
+        }
+    }
+    return TPS6274X_OK;
+}
+
+uint16_t tps6274x_switch_voltage(tps6274x_t *dev, uint16_t voltage)
+{
+    if (voltage < 1800) {
+        voltage = 1800;
+    }
+    else if (voltage > 3300) {
+        voltage = 3300;
+    }
+    uint8_t vsel = (voltage - 1800) / 100;
+    uint8_t vsel_set = 0;
+    for (uint8_t i = 0; i < 4; i++) {
+        if (dev->params.vsel[i] != GPIO_UNDEF) {
+            gpio_write(dev->params.vsel[i], (vsel & (0x01 << i)));
+            /* mark pins that could and had to be set */
+            vsel_set |= vsel & (1 << i);
+        }
+#if ENABLE_DEBUG
+        else {
+            printf("[tps6274x] Pin vsel%u is not connected but is required for \
+                selected voltage level\n", i + 1);
+        }
+#endif
+    }
+    return ((uint16_t)vsel_set) * 100 + 1800;
+}
+
+void tps6274x_load_ctrl(tps6274x_t *dev, int status)
+{
+    if (dev->params.ctrl_pin != GPIO_UNDEF) {
+        gpio_write(dev->params.ctrl_pin, status);
+    }
+#if ENABLE_DEBUG
+    else {
+        printf("[TPS6274x] CTRL Pin not defined, no load activation possible\n");
+    }
+#endif
+}

--- a/tests/driver_tps6274x/Makefile
+++ b/tests/driver_tps6274x/Makefile
@@ -1,0 +1,7 @@
+APPLICATION = driver_tps6274x
+include ../Makefile.tests_common
+
+USEMODULE += tps6274x
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tps6274x/README.md
+++ b/tests/driver_tps6274x/README.md
@@ -1,0 +1,11 @@
+## About
+Tests the tps6274x step-down converter
+
+## Usage
+Build the test by using the `make BOARD=??? flash` command in the `test/driver_tps6274x/` folder.
+
+## Results
+The stepdown converter will step from 1.8V to 3.3V in 100mV steps.
+Each voltage will be set for 3 seconds and can be measured at the VOUT Pin.
+After 1 second also the LOAD output pin will be enabled for 2 seconds
+untill the next voltage is set.

--- a/tests/driver_tps6274x/main.c
+++ b/tests/driver_tps6274x/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 RWTH Aachen, Josua Arndt, Steffen Robertz
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the tps6274x Step-Down converter
+ *
+ * @author      Steffen Robertz <steffen.robertz@rwth-aachen.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
+ *
+ * @}
+ */
+#include <stdio.h>
+
+#include "board.h"
+#include "xtimer.h"
+#include "tps6274x.h"
+#include "tps6274x_params.h"
+
+int main(void)
+{
+    tps6274x_t dev;
+
+    puts("This application will test the tps6274x step down converter by switching through all voltages.");
+    puts("Every voltage will be active for 3s and can be verified with a multimeter");
+
+    tps6274x_init(&dev, &tps6274x_params[0]);
+    for (unsigned int voltage = 1800; voltage <= 3300; voltage += 100) {
+        printf("%u mV \n", voltage);
+        if (voltage != tps6274x_switch_voltage(&dev, voltage)) {
+            printf("Not all Selector lines are connected in order to set a level of %umV.", voltage);
+        }
+        xtimer_sleep(1);
+        puts("Load PIN will be enabled for 2s");
+        tps6274x_load_ctrl(&dev, 1);
+        xtimer_sleep(2);
+        puts("Load PIN will be shut off");
+        tps6274x_load_ctrl(&dev, 0);
+    }
+    printf("Test Done");
+    return 0;
+}


### PR DESCRIPTION
This commit adds a driver for the tps6274x step-down converter. The ouput voltage can be switched over 4 GPIO pins. Voltages from 1.8V - 3.3V are possible. A 5th GPIO pin can be used to enable a "LOAD" pin. It can be used to e.g. power external add-on boards that do not need to be connected at all times.

A test case is provided and will step through all voltages possible. They can be verified with a multimeter.