### PR TITLE
tools: Add support for Emul8

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -409,6 +409,13 @@ debug-server:
 		exit 1; }
 	$(DEBUGSERVER) $(DEBUGSERVER_FLAGS)
 
+emulate:
+	@command -v $(EMULATOR) >/dev/null 2>&1 || \
+		{ $(COLOR_ECHO) \
+		'${COLOR_RED}Emulate program $(EMULATOR) not found. Aborting.${COLOR_RESET}'; \
+		exit 1; }
+	$(EMULATOR) $(EMULATOR_FLAGS)
+
 reset:
 	@command -v $(RESET) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -11,6 +11,9 @@ PORT_LINUX ?= $(word 2,$(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh '^$
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# setup emulator
+include $(RIOTMAKE)/tools/emul8.inc.mk
+
 # debugger config
 export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
 export DEBUGSERVER = JLinkGDBServer -device CC2538SF53

--- a/boards/cc2538dk/dist/board.emul8
+++ b/boards/cc2538dk/dist/board.emul8
@@ -1,0 +1,29 @@
+mach create
+using sysbus
+include @platforms/boards/cc2538
+machine SetClockSource cpu
+
+# show the UART output
+showAnalyzer uart0
+
+# get an id value starting with 1
+$id = `next_value 1`
+
+macro reset
+"""
+    # set node address based on the $id variable. 0x00 0x12 0x4B is TI OUI
+    sysbus WriteByte 0x00280028 $id
+    sysbus WriteByte 0x0028002C 0x00
+    sysbus WriteByte 0x00280030 0xAB
+    sysbus WriteByte 0x00280034 0x89
+    sysbus WriteByte 0x00280038 0x00
+    sysbus WriteByte 0x0028003C 0x4B
+    sysbus WriteByte 0x00280040 0x12
+    sysbus WriteByte 0x00280044 0x00
+    sysbus LoadBinary @http://emul8.org/emul8_files/binaries/cc2538_rom_dump.bin-s_524288-0c196cdc21b5397f82e0ff42b206d1cc4b6d7522 0x0
+    sysbus LoadELF $image_file
+    cpu VectorTableOffset 0x200000
+"""
+
+runMacro $reset
+start

--- a/dist/tools/emul8/README.md
+++ b/dist/tools/emul8/README.md
@@ -1,0 +1,24 @@
+# Emulation using Emul8
+
+## Introduction
+[Emul8](http://emul8.org) is an open source embedded systems emulation framework. It offers support for a broad range of processors, including ARM, ARM Cortex, x86 and more. In addition it is an extensible framework that can also emulate peripherals.
+
+## Installation
+
+### From package
+At the time of writing (November 2017), no packages are available.
+
+### From source
+Follow the installation instructions on their [GitHub](https://github.com/emul8/emul8#installation) page.
+
+After compilation is successful, ensure that `emul8` is available on your `PATH`. One way to do so, is symlinking `path/to/emul8/repository/run.sh` to `/usr/local/lib/emul8`.
+
+### Testing
+After installation, verify if Emul8 is working using `emul8 --help`. You should be presented with a help screen.
+
+## Usage
+From within RIOT-OS, you can use `make emulate` to start emulation. It expects a board definition file in `boards/<BOARD>/dist/board.emul8`.
+
+The board definition file will tell Emul8 how to setup an emulation session. The application binary file (`*.elf`) is available using the variable `$image_file`.
+
+For an example, refer to `boards/cc2538dk/dist/board.emul8`.

--- a/dist/tools/emul8/emulate.sh
+++ b/dist/tools/emul8/emulate.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+#
+# Unified Emul8 script for RIOT
+#
+# This script is supposed to be called from RIOTs make system,
+# as it depends on certain environment variables.
+#
+# It will start the Emul8 emulator, providing it with several environment
+# variables:
+# $image_file          Full path to the image file (see $IMAGE_FILE below)
+#
+# Global environment variables used:
+# EMUL8:               Emul8 command name, default: "emul8"
+# EMUL8_CONFIG:        Emul8 configuration file name,
+#                      default: "${RIOTBOARD}/${BOARD}/dist/board.emul8"
+# EMUL8_BIN_CONFIG:    Emul8 intermediate configuration file name,
+#                      default: "${BINDIR}/board.emul8"
+#
+# @author       Bas Stottelaar <basstottelaar@gmail.com>
+
+# Default path to Emul8 configuration file
+: ${EMUL8_CONFIG:=${RIOTBOARD}/${BOARD}/dist/board.emul8}
+# Default path to Emul8 intermediate configuration file
+: ${EMUL8_BIN_CONFIG:=${BINDIR}/board.emul8}
+# Default emul8 command
+: ${EMUL8:=emul8}
+# Image file used for emulation
+# Default is to use $ELFFILE
+: ${IMAGE_FILE:=${ELFFILE}}
+
+#
+# config test section.
+#
+test_config() {
+    if [ ! -f "${EMUL8_CONFIG}" ]; then
+        echo "Error: Unable to locate Emul8 board file"
+        echo "       (${EMUL8_CONFIG})"
+        exit 1
+    fi
+}
+
+#
+# helper section.
+#
+write_config() {
+    echo "\$image_file = '${IMAGE_FILE}'" > "${EMUL8_BIN_CONFIG}"
+    echo "include @${EMUL8_CONFIG}" >> "${EMUL8_BIN_CONFIG}"
+}
+
+#
+# now comes the actual actions
+#
+do_write() {
+    test_config
+    write_config
+    echo "Script written to '${EMUL8_BIN_CONFIG}'"
+}
+
+do_emulate() {
+    test_config
+    write_config
+    sh -c "${EMUL8} '${EMUL8_BIN_CONFIG}'"
+}
+
+#
+# parameter dispatching
+#
+ACTION="$1"
+
+case "${ACTION}" in
+  write)
+    echo "### Writing emulation script ###"
+    do_write
+    ;;
+  emulate)
+    echo "### Starting emulation ###"
+    do_emulate
+    ;;
+  *)
+    echo "Usage: $0 {write|emulate}"
+    exit 2
+    ;;
+esac

--- a/makefiles/tools/emul8.inc.mk
+++ b/makefiles/tools/emul8.inc.mk
@@ -1,0 +1,2 @@
+export EMULATOR ?= $(RIOTBASE)/dist/tools/emul8/emulate.sh
+export EMULATOR_FLAGS ?= emulate


### PR DESCRIPTION
Per #4243, this PR propose integration for Emul8.

It basically adds `make emulate` as an additional target, and on a per-board basis you can configure the emulator to use (similar to debugger, serial etc.)

Current execution is as follows: `make emulate` -> generate intermediate script (to include environment variables like `$ELFFILE`) -> start emul8 using intermediate script.

I've used the [example](https://github.com/antmicro/emul8-sample-riot-project) for the `cc2538dk` board, created by @mgielda, to test this feature.

![schermafbeelding 2017-11-06 om 21 00 26](https://user-images.githubusercontent.com/815976/32461507-5b8fa2d0-c336-11e7-9d2f-071c31b74198.png)

(Installation of emul8 is tricky: compile from source, then symlink `run.sh` to `emul8` on your `PATH`)