### PR TITLE
make: cleanup mcuboot support

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -567,6 +567,6 @@ CFLAGS := $(patsubst -D%,,$(CFLAGS))
 CFLAGS := $(patsubst -U%,,$(CFLAGS))
 CFLAGS += -include '$(RIOTBUILD_CONFIG_HEADER_C)'
 
-# include multislot support
-include $(RIOTMAKE)/multislot.mk
+# include mcuboot support
+include $(RIOTMAKE)/mcuboot.mk
 endif # BOARD=none

--- a/cpu/cortexm_common/Makefile.include
+++ b/cpu/cortexm_common/Makefile.include
@@ -1,5 +1,3 @@
 # include module specific includes
 INCLUDES += -I$(RIOTCPU)/cortexm_common/include
 INCLUDES += -I$(RIOTCPU)/cortexm_common/include/vendor
-
-export IMAGE_HDR_SIZE ?= 512

--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -11,6 +11,8 @@ MCUBOOT_BIN ?= $(BINDIR)/mcuboot.bin
 MCUBOOT_BIN_URL ?= http://download.riot-os.org/mynewt.mcuboot.bin
 MCUBOOT_BIN_MD5 ?= 0c71a0589bd3709fc2d90f07a0035ce7
 
+export IMAGE_HDR_SIZE ?= 512
+
 create-key: $(MCUBOOT_KEYFILE)
 
 ifeq ($(BINDIR)/key.pem,$(MCUBOOT_KEYFILE))

--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -13,7 +13,7 @@ MCUBOOT_BIN_MD5 ?= 0c71a0589bd3709fc2d90f07a0035ce7
 
 export IMAGE_HDR_SIZE ?= 512
 
-create-key: $(MCUBOOT_KEYFILE)
+mcuboot-create-key: $(MCUBOOT_KEYFILE)
 
 ifeq ($(BINDIR)/key.pem,$(MCUBOOT_KEYFILE))
 $(MCUBOOT_KEYFILE):
@@ -21,7 +21,7 @@ $(MCUBOOT_KEYFILE):
 	$(Q)$(IMGTOOL) keygen -k $@ -t rsa-2048
 endif
 
-mcuboot: create-key link
+mcuboot: mcuboot-create-key link
 	@$(COLOR_ECHO)
 	@$(COLOR_ECHO) '${COLOR_PURPLE}Re-linking for MCUBoot at $(SLOT0_SIZE)...${COLOR_RESET}'
 	@$(COLOR_ECHO)
@@ -39,14 +39,14 @@ mcuboot: create-key link
 $(MCUBOOT_BIN):
 	$(Q)$(DLCACHE) $(MCUBOOT_BIN_URL) $(MCUBOOT_BIN_MD5) $@
 
-.PHONY: flash-bootloader flash-mcuboot
+.PHONY: mcuboot-flash-bootloader mcuboot-flash
 
-flash-bootloader: HEXFILE = $(MCUBOOT_BIN)
-flash-bootloader: $(MCUBOOT_BIN) $(FLASHDEPS)
+mcuboot-flash-bootloader: HEXFILE = $(MCUBOOT_BIN)
+mcuboot-flash-bootloader: $(MCUBOOT_BIN) $(FLASHDEPS)
 	FLASH_ADDR=0x0 $(FLASHER) $(FFLAGS)
 
-flash-mcuboot: HEXFILE = $(SIGN_BINFILE)
-flash-mcuboot: mcuboot $(FLASHDEPS) flash-bootloader
+mcuboot-flash: HEXFILE = $(SIGN_BINFILE)
+mcuboot-flash: mcuboot $(FLASHDEPS) mcuboot-flash-bootloader
 	FLASH_ADDR=$(SLOT0_SIZE) $(FLASHER) $(FFLAGS)
 
 else

--- a/tests/mcuboot/README.md
+++ b/tests/mcuboot/README.md
@@ -26,7 +26,7 @@ pip3 install --user pycrypto ecdsa pyasn1
 ```
 
 This test can be called using `make mcuboot` to produce such ELF file,
-which can also be flashed using `make flash-mcuboot`.This command also flashes
+which can also be flashed using `make mcuboot-flash`.This command also flashes
 the pre-compiled bootloader.
 
 It's also possible to build and flash MCUBoot by following the instructions on


### PR DESCRIPTION
Minor cleanup PR for RIOT's mcuboot support:

- moves mcuboot specific makefile code into makefiles/mcuboot.mk
- moves mcuboot specific ```IMAGE_HDR_SIZE``` into makefiles/mcuboot.mk
- prefixes all mcuboot make targets with "mcuboot-"