### PR TITLE
drivers/lis3mdl: adopt new parameters scheme and provide SAUL adaption

### DIFF
--- a/boards/limifrog-v1/Makefile.dep
+++ b/boards/limifrog-v1/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += lis3mdl
+endif

--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -51,6 +51,14 @@ extern "C" {
  #define XTIMER_WIDTH        (16U)
  /** @} */
 
+ /**
+ * @name Define the interface to the LIS3MDL 3-axis magnetometer
+ * @{
+ */
+#define LIS3MDL_PARAM_I2C        (I2C_DEV(1))
+#define LIS3MDL_PARAM_ADDR       (0x28)
+/** @} */
+
 /**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -301,3 +301,8 @@ ifneq (,$(filter xbee,$(USEMODULE)))
   USEMODULE += xtimer
   USEMODULE += netif
 endif
+
+ifneq (,$(filter lis3mdl,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += xtimer
+endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -151,3 +151,6 @@ endif
 ifneq (,$(filter hts221,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/hts221/include
 endif
+ifneq (,$(filter lis3mdl,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/lis3mdl/include
+endif

--- a/drivers/include/lis3mdl.h
+++ b/drivers/include/lis3mdl.h
@@ -39,14 +39,6 @@ typedef struct {
 } lis3mdl_3d_data_t;
 
 /**
- * @brief   Device descriptor for LIS3MDL sensor
- */
-typedef struct {
-    i2c_t i2c;                       /**< I2C device */
-    uint8_t addr;                    /**< Magnometer I2C address */
-} lis3mdl_t;
-
-/**
  * @brief   Operating mode of x- and y-axis for LIS3MDL
  */
 typedef enum {
@@ -99,24 +91,36 @@ typedef enum {
 } lis3mdl_op_t;
 
 /**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    i2c_t i2c;                       /**< I2C device */
+    uint8_t addr;                    /**< Magnometer I2C address */
+    lis3mdl_xy_mode_t xy_mode;       /**< Power mode of x- and y-axis */
+    lis3mdl_z_mode_t z_mode;         /**< Power mode of z-axis */
+    lis3mdl_odr_t odr;               /**< Output data rate */
+    lis3mdl_scale_t scale;           /**< Scale factor */
+    lis3mdl_op_t op_mode;            /**< Operation mode */
+} lis3mdl_params_t;
+
+
+/**
+ * @brief   Device descriptor for LIS3MDL sensor
+ */
+typedef struct {
+    lis3mdl_params_t params;         /**< Initialization parameters */
+} lis3mdl_t;
+
+/**
  * @brief   Initialize a new LIS3DML device.
  *
  * @param[in] dev          device descriptor of LIS3MDL
- * @param[in] i2c          I2C device connected to
- * @param[in] address      I2C address of the magnometer
- * @param[in] xy_mode      power mode of x- and y-axis
- * @param[in] z_mode       power mode of z-axis
- * @param[in] odr          output data rate of magnometer
- * @param[in] scale        scale configuration of magnometer
- * @param[in] op_mode      operation mode of the device
+ * @param[in] params       initialization parameters
  *
  * @return                   0 on success
  * @return                  -1 on error
  */
-int lis3mdl_init(lis3mdl_t *dev, i2c_t i2c, uint8_t address,
-                 lis3mdl_xy_mode_t xy_mode, lis3mdl_z_mode_t z_mode,
-                 lis3mdl_odr_t odr, lis3mdl_scale_t scale,
-                 lis3mdl_op_t op_mode);
+int lis3mdl_init(lis3mdl_t *dev, const lis3mdl_params_t *params);
 
 /**
  * @brief   Reads the magnometer value of LIS3MDL.

--- a/drivers/lis3mdl/include/lis3mdl_params.h
+++ b/drivers/lis3mdl/include/lis3mdl_params.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_lis3mdl
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for LIS3MDL devices
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef LIS3MDL_PARAMS_H
+#define LIS3MDL_PARAMS_H
+
+#include "board.h"
+#include "lis3mdl.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters
+ * @{
+ */
+#ifndef LIS3MDL_PARAM_I2C
+#define LIS3MDL_PARAM_I2C           (I2C_DEV(0))
+#endif
+#ifndef LIS3MDL_PARAM_ADDR
+#define LIS3MDL_PARAM_ADDR          (0x1E)
+#endif
+#ifndef LIS3MDL_PARAM_XYMODE
+#define LIS3MDL_PARAM_XYMODE        (LIS3MDL_XY_MODE_HIGH)
+#endif
+#ifndef LIS3MDL_PARAM_ZMODE
+#define LIS3MDL_PARAM_ZMODE         (LIS3MDL_Z_MODE_HIGH)
+#endif
+#ifndef LIS3MDL_PARAM_ODR
+#define LIS3MDL_PARAM_ODR           (LIS3MDL_ODR_10Hz)
+#endif
+#ifndef LIS3MDL_PARAM_SCALE
+#define LIS3MDL_PARAM_SCALE         (4)
+#endif
+#ifndef LIS3MDL_PARAM_OPMODE
+#define LIS3MDL_PARAM_OPMODE        (LIS3MDL_OP_CONT_CONV)
+#endif
+
+#ifndef LIS3MDL_PARAMS
+#define LIS3MDL_PARAMS               { .i2c     = LIS3MDL_PARAM_I2C,    \
+                                       .addr    = LIS3MDL_PARAM_ADDR,   \
+                                       .xy_mode = LIS3MDL_PARAM_XYMODE, \
+                                       .z_mode  = LIS3MDL_PARAM_ZMODE,  \
+                                       .odr     = LIS3MDL_PARAM_SCALE,  \
+                                       .scale   = LIS3MDL_PARAM_ODR,    \
+                                       .op_mode = LIS3MDL_PARAM_OPMODE }
+#endif
+#ifndef LIS3MDL_SAUL_INFO
+#define LIS3MDL_SAUL_INFO            { .name = "lis3mdl" }
+#endif
+/**@}*/
+
+/**
+ * @brief   Allocate some memory to store the actual configuration
+ */
+static const lis3mdl_params_t lis3mdl_params[] =
+{
+    LIS3MDL_PARAMS
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t lis3mdl_saul_info[] =
+{
+    LIS3MDL_SAUL_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS3MDL_PARAMS_H */
+/** @} */

--- a/drivers/lis3mdl/lis3mdl_saul.c
+++ b/drivers/lis3mdl/lis3mdl_saul.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_lis3mdl
+ * @{
+ *
+ * @file
+ * @brief       LIS3MDL adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "lis3mdl.h"
+
+static int read_mag(const void *dev, phydat_t *res)
+{
+    const lis3mdl_t *d = (const lis3mdl_t *)dev;
+
+    lis3mdl_read_mag(d, (lis3mdl_3d_data_t *)res);
+
+    res->unit = UNIT_GS;
+    res->scale = -3;
+    return 3;
+}
+
+const saul_driver_t lis3mdl_saul_mag_driver = {
+    .read = read_mag,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_MAG,
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -274,6 +274,10 @@ void auto_init(void)
     extern void auto_init_lis3dh(void);
     auto_init_lis3dh();
 #endif
+#ifdef MODULE_LIS3MDL
+extern void auto_init_lis3mdl(void);
+auto_init_lis3mdl();
+#endif
 #ifdef MODULE_MAG3110
     extern void auto_init_mag3110(void);
     auto_init_mag3110();

--- a/sys/auto_init/saul/auto_init_lis3mdl.c
+++ b/sys/auto_init/saul/auto_init_lis3mdl.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of LIS3MDL magnetometer
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_LIS3MDL
+
+#include "log.h"
+#include "saul_reg.h"
+#include "lis3mdl.h"
+#include "lis3mdl_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define LIS3MDL_NUM    (sizeof(lis3mdl_params)/sizeof(lis3mdl_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static lis3mdl_t lis3mdl_devs[LIS3MDL_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[LIS3MDL_NUM];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define LIS3MDL_INFO_NUM    (sizeof(lis3mdl_saul_info)/sizeof(lis3mdl_saul_info[0]))
+
+/**
+ * @brief   Reference the driver structs
+ */
+extern saul_driver_t lis3mdl_saul_mag_driver;
+
+void auto_init_lis3mdl(void)
+{
+    assert(LIS3MDL_NUM == LIS3MDL_INFO_NUM);
+
+    for (unsigned int i = 0; i < LIS3MDL_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing lis3mdl #%u\n", i);
+
+        if (lis3mdl_init(&lis3mdl_devs[i], &lis3mdl_params[i]) < 0) {
+            LOG_ERROR("[auto_init_saul] error initializing lis3mdl #%u\n", i);
+            continue;
+        }
+
+        saul_entries[i].dev = &(lis3mdl_devs[i]);
+        saul_entries[i].name = lis3mdl_saul_info[i].name;
+        saul_entries[i].driver = &lis3mdl_saul_mag_driver;
+        saul_reg_add(&(saul_entries[i]));
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_LIS3MDL */

--- a/tests/driver_lis3mdl/Makefile
+++ b/tests/driver_lis3mdl/Makefile
@@ -1,25 +1,7 @@
 BOARD ?= limifrog-v1
 include ../Makefile.tests_common
 
-# only this board is known (yet) to provide the sensor LIS3MDL
-BOARD_WHITELIST = limifrog-v1
-
-FEATURES_REQUIRED = periph_i2c periph_gpio
-
 USEMODULE += lis3mdl
 USEMODULE += xtimer
-
-ifneq (,$(TEST_LIS3MDL_I2C))
-	CFLAGS += -DTEST_LIS3MDL_I2C=$(TEST_LIS3MDL_I2C)
-else
-	# set random default
-	CFLAGS += -DTEST_LIS3MDL_I2C=I2C_DEV\(1\)
-endif
-ifneq (,$(TEST_LIS3MDL_MAG_ADDR))
-	CFLAGS += -DTEST_LIS3MDL_MAG_ADDR=$(TEST_LIS3MDL_MAG_ADDR)
-else
-	# set random default 7 bit address
-	CFLAGS += -DTEST_LIS3MDL_MAG_ADDR=28
-endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lis3mdl/main.c
+++ b/tests/driver_lis3mdl/main.c
@@ -18,33 +18,23 @@
  *
  * @}
  */
-#ifndef TEST_LIS3MDL_I2C
-#error "TEST_LIS3MDL_I2C not defined"
-#endif
-#ifndef TEST_LIS3MDL_MAG_ADDR
-#error "TEST_LIS3MDL_MAG_ADDR not defined"
-#endif
 
 #include <stdio.h>
 
 #include "xtimer.h"
 #include "lis3mdl.h"
+#include "lis3mdl_params.h"
 
 #define SLEEP       (800 * 800U)
 
 int main(void)
 {
     lis3mdl_t dev;
-    lis3mdl_3d_data_t mag_value;
-    int16_t temp_value = 0;
 
-    puts("\nLIS3MDL test application");
-    printf("Initializing LIS3MDL sensor at I2C_%i ... \n", TEST_LIS3MDL_I2C);
+    puts("LIS3MDL test application");
+    puts("Initializing LIS3MDL sensor");
 
-    if (lis3mdl_init(&dev, TEST_LIS3MDL_I2C, TEST_LIS3MDL_MAG_ADDR,
-                     LIS3MDL_XY_MODE_MEDIUM,
-                     LIS3MDL_Z_MODE_MEDIUM, LIS3MDL_ODR_10Hz,
-                     LIS3MDL_SCALE_4G, LIS3MDL_OP_CONT_CONV) == 0) {
+    if (lis3mdl_init(&dev, &lis3mdl_params[0]) == 0) {
         puts("[ OK ]\n");
     }
     else {
@@ -52,11 +42,15 @@ int main(void)
         return 1;
     }
 
-    while(1){
+    while(1) {
+        lis3mdl_3d_data_t mag_value;
         lis3mdl_read_mag(&dev, &mag_value);
-        printf("Magnetometer [G]:\tX: %2d\tY: %2d\tZ: %2d\n", mag_value.x_axis,
-                                                         mag_value.y_axis,
-                                                         mag_value.z_axis);
+        printf("Magnetometer [G]:\tX: %2d\tY: %2d\tZ: %2d\n",
+               mag_value.x_axis,
+               mag_value.y_axis,
+               mag_value.z_axis);
+
+        int16_t temp_value;
         lis3mdl_read_temp(&dev, &temp_value);
         printf("Temperature:\t\t%i°C\n", temp_value);
 


### PR DESCRIPTION
While working on #7937, I noticed that some drivers implementation where very incomplete regarding new initialization parameter scheme and SAUL adaption.

This PR provides an update of the init API and SAUL adaption for LIS3MDL 3-axis magnetometer device.

It also enables it for the limifrog-v1 board when the saul module is loaded.

Also related to #7519 