### PR TITLE
examples/pkgs: rename modules with duplicate names

### DIFF
--- a/examples/emcute/Makefile
+++ b/examples/emcute/Makefile
@@ -1,5 +1,5 @@
 # name of your application
-APPLICATION = emcute
+APPLICATION = emcute_example
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -1,7 +1,7 @@
 # Default Makefile, for host native GNRC-based networking
 
 # name of your application
-APPLICATION = gcoap
+APPLICATION = gcoap_example
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -1,5 +1,5 @@
 # name of your application
-APPLICATION = gnrc_tftp
+APPLICATION = gnrc_tftp_example
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/examples/posix_sockets/Makefile
+++ b/examples/posix_sockets/Makefile
@@ -1,5 +1,5 @@
 # name of your application
-APPLICATION = posix_sockets
+APPLICATION = posix_sockets_example
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/examples/saul/Makefile
+++ b/examples/saul/Makefile
@@ -1,5 +1,5 @@
 # name of your application
-APPLICATION = saul
+APPLICATION = saul_example
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native

--- a/pkg/libfixmath/patches/0001-Move-to-RIOT-Makefiles.patch
+++ b/pkg/libfixmath/patches/0001-Move-to-RIOT-Makefiles.patch
@@ -1,7 +1,7 @@
-From 07ab6c2cb9e4b03b3e413a733850f3f8199149d1 Mon Sep 17 00:00:00 2001
+From 0f5bcfdbc93d40c47da70ea6aade3fbe89120b10 Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mail@martine-lenders.eu>
 Date: Thu, 12 May 2016 14:55:13 +0200
-Subject: [PATCH 1/3] Move to RIOT Makefiles
+Subject: [PATCH 1/4] Move to RIOT Makefiles
 
 ---
  Makefile            |  8 ++++++

--- a/pkg/libfixmath/patches/0002-Fix-warnings.patch
+++ b/pkg/libfixmath/patches/0002-Fix-warnings.patch
@@ -1,7 +1,7 @@
-From be24fc7113549d4f7d8b6fa2df298dfd36fb1dd4 Mon Sep 17 00:00:00 2001
+From 14eaa181746c7fe54b554a9dd98c2c37fd41b5bd Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mail@martine-lenders.eu>
 Date: Thu, 12 May 2016 16:07:35 +0200
-Subject: [PATCH 2/3] Fix warnings
+Subject: [PATCH 2/4] Fix warnings
 
 ---
  libfixmath/fix16_str.c           |  8 ++++----
@@ -53,7 +53,7 @@ index eff906f..2c02c21 100644
          
          buf++;
 diff --git a/libfixmath/uint32.c b/libfixmath/uint32.c
-index 2980ab9..c1adc4f 100644
+index 2980ab9..855774d 100644
 --- a/libfixmath/uint32.c
 +++ b/libfixmath/uint32.c
 @@ -6,10 +6,10 @@ uint32_t uint32_log2(uint32_t inVal) {

--- a/pkg/libfixmath/patches/0003-Adapt-unittests-for-RIOT.patch
+++ b/pkg/libfixmath/patches/0003-Adapt-unittests-for-RIOT.patch
@@ -1,7 +1,7 @@
-From 341e82f96ca2cf6d1cedba8d3610c108ba5153dd Mon Sep 17 00:00:00 2001
+From bf974ff27fd48b8964bbe4813511adbe4c673a98 Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mail@martine-lenders.eu>
 Date: Thu, 12 May 2016 15:08:39 +0200
-Subject: [PATCH 3/3] Adapt unittests for RIOT
+Subject: [PATCH 3/4] Adapt unittests for RIOT
 
 ---
  unittests/fix16_exp_unittests.c    | 12 ++++++------

--- a/pkg/libfixmath/patches/0004-Change-conflicting-module-name-for-pkg-root-director.patch
+++ b/pkg/libfixmath/patches/0004-Change-conflicting-module-name-for-pkg-root-director.patch
@@ -1,0 +1,23 @@
+From a32404a5acb702ffb28bada70cd6204ab74a771d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ga=C3=ABtan=20Harter?= <gaetan.harter@fu-berlin.de>
+Date: Tue, 7 Nov 2017 16:42:27 +0100
+Subject: [PATCH 4/4] Change conflicting module name for pkg root directory
+
+Root directory and libfixmath both had 'libfixmath' module name.
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index b65e4b5..2cc24d1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,3 +1,5 @@
++MODULE = pkg-libfixmath
++
+ ifneq (,$(filter libfixmath,$(USEMODULE)))
+     DIRS += libfixmath
+ endif
+-- 
+2.7.4
+

--- a/pkg/u8g2/patches/0001-u8g2-add-RIOT-makefiles.patch
+++ b/pkg/u8g2/patches/0001-u8g2-add-RIOT-makefiles.patch
@@ -1,7 +1,7 @@
-From 1e2d232135cb2ecbc4ea1668a668b74e242ba3fd Mon Sep 17 00:00:00 2001
+From 5c168fc6d96d8dc84907e667a70b3a85b8402270 Mon Sep 17 00:00:00 2001
 From: Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
 Date: Wed, 6 Sep 2017 20:23:56 +0200
-Subject: [PATCH 1/2] u8g2: add RIOT  makefiles
+Subject: [PATCH 1/3] u8g2: add RIOT makefiles
 
 ---
  Makefile                 | 22 ++++++++++++++++++++++
@@ -72,5 +72,5 @@ index 0000000..32e7913
 +
 +include $(RIOTBASE)/Makefile.base
 -- 
-2.18.2
+2.7.4
 

--- a/pkg/u8g2/patches/0002-add-RIOT-interface.patch
+++ b/pkg/u8g2/patches/0002-add-RIOT-interface.patch
@@ -1,7 +1,7 @@
-From 452712c6a749a2d513c366abd9e819a2f68eacbd Mon Sep 17 00:00:00 2001
+From 6a09e7bee194681f63781dd0af6c154f2f4e519c Mon Sep 17 00:00:00 2001
 From: Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
 Date: Wed, 6 Sep 2017 20:26:46 +0200
-Subject: [PATCH 2/2] add RIOT interface
+Subject: [PATCH 2/3] add RIOT interface
 
 ---
  csrc/u8g2.h        |   3 +
@@ -11,7 +11,7 @@ Subject: [PATCH 2/2] add RIOT interface
  create mode 100644 csrc/u8g2_riotos.c
 
 diff --git a/csrc/u8g2.h b/csrc/u8g2.h
-index 46dcec3..bc76480 100644
+index 6ff3f91..d284619 100644
 --- a/csrc/u8g2.h
 +++ b/csrc/u8g2.h
 @@ -387,6 +387,9 @@ void u8g2_ClearDisplay(u8g2_t *u8g2);
@@ -195,7 +195,7 @@ index 0000000..bd06ccb
 +}
 +#endif /* I2C_NUMOF */
 diff --git a/csrc/u8x8.h b/csrc/u8x8.h
-index 2c93c87..b434893 100644
+index a4a99b7..e508664 100644
 --- a/csrc/u8x8.h
 +++ b/csrc/u8x8.h
 @@ -111,6 +111,8 @@
@@ -240,7 +240,7 @@ index 2c93c87..b434893 100644
  
  /*==========================================*/
  
-@@ -939,6 +947,9 @@ extern const uint8_t u8x8_font_pxplustandynewtv_u[] U8X8_FONT_SECTION("u8x8_font
+@@ -943,6 +951,9 @@ extern const uint8_t u8x8_font_pxplustandynewtv_u[] U8X8_FONT_SECTION("u8x8_font
  
  /* end font list */
  

--- a/pkg/u8g2/patches/0003-Change-conflicting-module-name-for-pkg-root-director.patch
+++ b/pkg/u8g2/patches/0003-Change-conflicting-module-name-for-pkg-root-director.patch
@@ -1,0 +1,23 @@
+From 4783fcb666569eda64bbba7c4923fb0320ba7bcd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ga=C3=ABtan=20Harter?= <gaetan.harter@fu-berlin.de>
+Date: Tue, 7 Nov 2017 16:51:11 +0100
+Subject: [PATCH 3/3] Change conflicting module name for pkg root directory
+
+Root directory and csrc both had 'u8g2' module name.
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index ec64fab..419ebdb 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,3 +1,5 @@
++MODULE = pkg-u8g2
++
+ DIRS += csrc
+ 
+ # SDL can be used as a virtual display, but is for native target only.
+-- 
+2.7.4
+


### PR DESCRIPTION
Some examples and packages root directory use a module name that is already defined somewhere else.

Building works right now because when both an APPLICATION an a MODULE have the same
name AR just adds objects for both to the same library MODULE.a.

It currently works because they do not have conflicting file names.