### PR TITLE
Makefile.base: fix AR keeping removed source files objects

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -68,7 +68,9 @@ $(BINDIR)/$(MODULE)/:
 $(BINDIR)/$(MODULE).a $(OBJ): | $(BINDIR)/$(MODULE)/
 
 $(BINDIR)/$(MODULE).a: $(OBJ) | ${DIRS:%=ALL--%}
-	$(Q)$(AR) $(ARFLAGS) $@ $?
+	@# Recreate archive to cleanup deleted/non selected source files objects
+	$(Q)$(RM) $@
+	$(Q)$(AR) $(ARFLAGS) $@ $^
 
 CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
 CCASFLAGS = $(filter-out $(CCASUWFLAGS), $(CFLAGS)) $(CCASEXFLAGS)

--- a/doc/doxygen/src/creating-modules.md
+++ b/doc/doxygen/src/creating-modules.md
@@ -34,6 +34,20 @@ current configuration or not.
 Modules can be used by adding their name to the `USEMODULE` macro of your
 application's Makefile.
 
+### Pitfalls ###
+
+The `MODULE` name should be unique or build breaks as modules overwrite the
+same output file.
+
+This problem happened in the past for:
+
+ * Packages root directory (libfixmath/u8g2)
+ * boards/cpu/periph and their common boards/cpu/periph
+
+Note: even if all boards and cpus implement the `board` and `cpu` modules, only
+      one is used in an application so there is no conflict.
+
+
 Module dependencies
 ===================
 Your module may depend on other modules to minimize code duplication. These


### PR DESCRIPTION
AR incrementally adds file without removing files.
If a c file is deleted or disabled(submodule removal) it is not removed from
archive and still ends up in the final elf file.

This fix removes the need to do 'make clean' for this case.

However it will break cases where an APPLICATION and a MODULE or two modules
have the same name and only worked because source files names where different.

This requires: ~~https://github.com/RIOT-OS/RIOT/pull/7951~~ to not break compilation. I only tested native and samr21-xpro right now.

Edit: This also requires ~~https://github.com/RIOT-OS/RIOT/issues/8019~~, I added a fix that will be proposed as a separate PR. The only important file change for this PR is `Makefile.base`.