### PR TITLE
examples: only whitelist a few essential boards (dirty hack)

### DIFF
--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -12,9 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini 
                              nucleo32-f303 nucleo32-l031 opencm904 pca10000 \
                              pca10005 spark-core stm32f0discovery yunjia-nrf51822 \
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
-                   msb-430 msb-430h qemu-i386 telosb waspmote-pro wsn430-v1_3b \
-                   wsn430-v1_4 z1 pic32-wifire pic32-clicker
+BOARD_WHITELIST := native samr21-xpro
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the


### PR DESCRIPTION
This is a dirty hack proposed by @kaspar030 offline (with slight adaptations) to allow Murdock to build properly tonight. @kaspar030 revert if the issue is fixed, @miri64 close this one if it isn't merged tonight.