### PR TITLE
drivers/srf08: correct value for max gain

### DIFF
--- a/drivers/include/srf08.h
+++ b/drivers/include/srf08.h
@@ -62,7 +62,7 @@ extern "C" {
 #define SRF08_MAX_RANGE_6M              0x8C
 
 /** @brief   Maximum gain of the sensor (1025)*/
-#define SRF08_MAX_GAIN                  0x25
+#define SRF08_MAX_GAIN                  0x1F
 
 /**
  * @brief   Device descriptor for SRF08 sensors


### PR DESCRIPTION
This PR tries to address #6451. I'm pretty convinced this reference 

[http://www.robot-electronics.co.uk/htm/srf08tech.html](http://www.robot-electronics.co.uk/htm/srf08tech.html) 

does not document correct values for max. gain setup whereas a couple of others seem more reasonable and consistent:

[http://www.robot-electronics.co.uk/htm/srf08tech.html](http://www.robot-electronics.co.uk/htm/srf08tech.html)
[http://www.blog.emmeshop.eu/node/4049](http://www.blog.emmeshop.eu/node/4049)

PR works although I can not fully confirm the actual gain value.