### PR TITLE
makefiles: tools/renode: add support for Renode

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -409,6 +409,13 @@ debug-server:
 		exit 1; }
 	$(DEBUGSERVER) $(DEBUGSERVER_FLAGS)
 
+emulate:
+	@command -v $(EMULATOR) >/dev/null 2>&1 || \
+		{ $(COLOR_ECHO) \
+		'${COLOR_RED}Emulation program $(EMULATOR) not found. Aborting.${COLOR_RESET}'; \
+		exit 1; }
+	$(EMULATOR) $(EMULATOR_FLAGS)
+
 reset:
 	@command -v $(RESET) >/dev/null 2>&1 || \
 		{ $(COLOR_ECHO) \

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -11,6 +11,9 @@ PORT_LINUX ?= $(word 2,$(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh '^$
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# setup emulator
+include $(RIOTMAKE)/tools/renode.inc.mk
+
 # debugger config
 export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
 export DEBUGSERVER = JLinkGDBServer -device CC2538SF53

--- a/boards/cc2538dk/dist/board.resc
+++ b/boards/cc2538dk/dist/board.resc
@@ -1,0 +1,31 @@
+mach create
+using sysbus
+machine LoadPlatformDescription @platforms/cpus/cc2538.repl
+machine SetClockSource cpu
+
+machine PyDevFromFile @scripts/pydev/rolling-bit.py 0x400D2004 0x4 True "sysctrl"
+
+# show the UART output
+showAnalyzer uart0
+
+# get an id value starting with 1
+$id = `next_value 1`
+
+macro reset
+"""
+    # set node address based on the $id variable. 0x00 0x12 0x4B is TI OUI
+    sysbus WriteByte 0x00280028 $id
+    sysbus WriteByte 0x0028002C 0x00
+    sysbus WriteByte 0x00280030 0xAB
+    sysbus WriteByte 0x00280034 0x89
+    sysbus WriteByte 0x00280038 0x00
+    sysbus WriteByte 0x0028003C 0x4B
+    sysbus WriteByte 0x00280040 0x12
+    sysbus WriteByte 0x00280044 0x00
+    sysbus LoadBinary @http://antmicro.com/projects/renode/cc2538_rom_dump.bin-s_524288-0c196cdc21b5397f82e0ff42b206d1cc4b6d7522 0x0
+    sysbus LoadELF $image_file
+    cpu VectorTableOffset 0x200000
+"""
+
+runMacro $reset
+start

--- a/dist/tools/renode/README.md
+++ b/dist/tools/renode/README.md
@@ -12,10 +12,13 @@ Packages for macOS, deb-based and rpm-based systems, for Windows and for Arch Li
 ### From source
 Follow the installation instructions on Renode's [GitHub](https://github.com/renode/renode#installation) page.
 
-After compilation is successful, ensure that `renode` is available on your `PATH`. One way to do so, is via symlink: `sudo ln -s path/to/renode/repository/run.sh /usr/local/bin/renode`.
+After compilation is successful, ensure that `renode` is available on your `PATH`. One way to do so, is via symlink: `sudo ln -s path/to/renode/repository/renode /usr/local/bin/renode`.
 
 ### Testing
 After installation, verify if Renode is working using `renode --help`. You should be presented with a help screen.
+
+## Documentation
+Documentation for Renode can be found on [Read The Docs](https://renode.readthedocs.io).
 
 ## Usage
 From within RIOT-OS, you can use `make emulate` to start emulation. It expects a board definition file in `boards/<BOARD>/dist/board.resc`.

--- a/dist/tools/renode/README.md
+++ b/dist/tools/renode/README.md
@@ -1,0 +1,25 @@
+# Emulation using Renode
+
+## Introduction
+[Renode](http://renode.io) is a virtual development tool for multinode embedded networks (both wired and wireless) enabling a scalable workflow for building effective, tested and secure IoT systems, created by [Antmicro](http://antmicro.com/blog/2017/08/renode-press-release/).
+It can easily be used to run applications on a broad range of embedded platforms without any changes in the code itself, as if you were running on real hardware - but with more possibilities.
+
+## Installation
+
+### From package
+Packages for macOS, deb-based and rpm-based systems, for Windows and for Arch Linux are available on [GitHub](https://github.com/renode/renode/releases/latest).
+
+### From source
+Follow the installation instructions on Renode's [GitHub](https://github.com/renode/renode#installation) page.
+
+After compilation is successful, ensure that `renode` is available on your `PATH`. One way to do so, is via symlink: `sudo ln -s path/to/renode/repository/run.sh /usr/local/bin/renode`.
+
+### Testing
+After installation, verify if Renode is working using `renode --help`. You should be presented with a help screen.
+
+## Usage
+From within RIOT-OS, you can use `make emulate` to start emulation. It expects a board definition file in `boards/<BOARD>/dist/board.resc`.
+
+The board definition file will tell Renode how to setup an emulation session. The application binary file (`*.elf`) is available using the variable `$image_file`.
+
+For an example, refer to `boards/cc2538dk/dist/board.resc`.

--- a/dist/tools/renode/run-renode.sh
+++ b/dist/tools/renode/run-renode.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+#
+# Unified Renode script for RIOT
+#
+# This script is supposed to be called from RIOTs make system,
+# as it depends on certain environment variables.
+#
+# It will start the Renode emulator, providing it with several environment
+# variables:
+# $image_file          Full path to the image file (see $IMAGE_FILE below)
+#
+# Global environment variables used:
+# RENODE:              Renode command name, default: "renode"
+# RENODE_CONFIG:       Renode configuration file name,
+#                      default: "${RIOTBOARD}/${BOARD}/dist/board.resc"
+# RENODE_BIN_CONFIG:   Renode intermediate configuration file name,
+#                      default: "${BINDIR}/board.resc"
+#
+# @author       Bas Stottelaar <basstottelaar@gmail.com>
+
+# Default path to Renode configuration file
+: ${RENODE_CONFIG:=${RIOTBOARD}/${BOARD}/dist/board.resc}
+# Default path to Renode intermediate configuration file
+: ${RENODE_BIN_CONFIG:=${BINDIR}/board.resc}
+# Default Renode command
+: ${RENODE:=renode}
+# Image file used for emulation
+# Default is to use $ELFFILE
+: ${IMAGE_FILE:=${ELFFILE}}
+
+#
+# config test section.
+#
+test_config() {
+    if [ ! -f "${RENODE_CONFIG}" ]; then
+        echo "Error: Unable to locate Renode board file"
+        echo "       (${RENODE_CONFIG})"
+        exit 1
+    fi
+}
+
+#
+# helper section.
+#
+write_config() {
+    echo "\$image_file = '${IMAGE_FILE}'" > "${RENODE_BIN_CONFIG}"
+    echo "include @${RENODE_CONFIG}" >> "${RENODE_BIN_CONFIG}"
+}
+
+#
+# now comes the actual actions
+#
+do_write() {
+    test_config
+    write_config
+    echo "Script written to '${RENODE_BIN_CONFIG}'"
+}
+
+do_start() {
+    test_config
+    write_config
+    sh -c "${RENODE} '${RENODE_BIN_CONFIG}'"
+}
+
+#
+# parameter dispatching
+#
+ACTION="$1"
+
+case "${ACTION}" in
+  write)
+    echo "### Writing emulation script ###"
+    do_write
+    ;;
+  start)
+    echo "### Starting Renode ###"
+    do_start
+    ;;
+  *)
+    echo "Usage: $0 {write|start}"
+    exit 2
+    ;;
+esac

--- a/makefiles/tools/renode.inc.mk
+++ b/makefiles/tools/renode.inc.mk
@@ -1,0 +1,2 @@
+export EMULATOR ?= $(RIOTBASE)/dist/tools/renode/run-renode.sh
+export EMULATOR_FLAGS ?= start


### PR DESCRIPTION
Thanks to @basilfx's contribution, this is an integration with the [Renode framework](https://github.com/renode/renode), which adds `make emulate` as an additional target. 

Current execution is as follows: `make emulate` -> generate intermediate script (to include environment variables like `$ELFFILE`) -> start Renode using intermediate script.

Improving on the original integration, Renode can be installed from [packages for different OSs/distributions](https://github.com/renode/renode/releases/latest).

As for now, the `hello-world` example has been tested to work, while e.g. `gnrc_networking` is known to fail on an assert in the radio driver - this will be fixed soon.