### PR TITLE
cpu/sam0: share GPIO configuration

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -61,6 +61,25 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
 
 /**
+ * @brief   Available ports on the SAMD21 & SAML21
+ */
+enum {
+    PA = 0,                 /**< port A */
+    PB = 1,                 /**< port B */
+    PC = 2,                 /**< port C */
+};
+
+/**
+ * @brief   Generate GPIO mode bitfields
+ *
+ * We use 3 bit to determine the pin functions:
+ * - bit 0: PD(0) or PU(1)
+ * - bit 1: input enable
+ * - bit 2: pull enable
+ */
+#define GPIO_MODE(pr, ie, pe)   (pr | (ie << 1) | (pe << 2))
+
+/**
  * @name    Power mode configuration
  * @{
  */
@@ -68,6 +87,19 @@ typedef uint32_t gpio_t;
 /** @} */
 
 #ifndef DOXYGEN
+/**
+ * @brief   Override GPIO modes
+ */
+#define HAVE_GPIO_MODE_T
+typedef enum {
+    GPIO_IN    = GPIO_MODE(0, 1, 0),    /**< IN */
+    GPIO_IN_PD = GPIO_MODE(0, 1, 1),    /**< IN with pull-down */
+    GPIO_IN_PU = GPIO_MODE(1, 1, 1),    /**< IN with pull-up */
+    GPIO_OUT   = GPIO_MODE(0, 0, 0),    /**< OUT (push-pull) */
+    GPIO_OD    = 0xfe,                  /**< not supported by HW */
+    GPIO_OD_PU = 0xff                   /**< not supported by HW */
+} gpio_mode_t;
+
 /**
  * @brief   Override active flank configuration values
  * @{

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -101,8 +101,11 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     port->PINCFG[pin_pos].reg = (mode & MODE_PINCFG_MASK);
 
     /* and set pull-up/pull-down if applicable */
-    if (mode == 0x7) {
+    if (mode == GPIO_IN_PU) {
         port->OUTSET.reg = pin_mask;
+    }
+    else if (mode == GPIO_IN_PD) {
+        port->OUTCLR.reg = pin_mask;
     }
 
     return 0;

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -58,47 +58,11 @@ static const int8_t exti_config[2][32] = {
 };
 
 /**
- * @brief   Available ports on the SAMD21
- */
-enum {
-    PA = 0,                 /**< port A */
-    PB = 1,                 /**< port B */
-    PC = 2,                 /**< port C */
-};
-
-/**
- * @brief   Generate GPIO mode bitfields
- *
- * We use 3 bit to determine the pin functions:
- * - bit 0: PD(0) or PU(1)
- * - bit 1: input enable
- * - bit 2: pull enable
- */
-#define GPIO_MODE(pr, ie, pe)   (pr | (ie << 1) | (pe << 2))
-
-/**
  * @brief   Override SPI hardware chip select macro
  *
  * As of now, we do not support HW CS, so we always set it to a fixed value
  */
 #define SPI_HWCS(x)     (UINT_MAX - 1)
-
-#ifndef DOXYGEN
-/**
- * @brief   Override GPIO modes
- * @{
- */
-#define HAVE_GPIO_MODE_T
-typedef enum {
-    GPIO_IN    = GPIO_MODE(0, 1, 0),    /**< IN */
-    GPIO_IN_PD = GPIO_MODE(0, 1, 1),    /**< IN with pull-down */
-    GPIO_IN_PU = GPIO_MODE(1, 1, 1),    /**< IN with pull-up */
-    GPIO_OUT   = GPIO_MODE(0, 0, 0),    /**< OUT (push-pull) */
-    GPIO_OD    = 0xfe,                  /**< not supported by HW */
-    GPIO_OD_PU = 0xff                   /**< not supported by HW */
-} gpio_mode_t;
-/** @} */
-#endif /* ndef DOXYGEN */
 
 /**
  * @brief   PWM channel configuration data structure

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -36,41 +36,6 @@ static const int8_t exti_config[2][32] = {
       0,  1, -1, -1, -1, -1,  6,  7, -1, -1, -1, -1, -1, -1, 14, 15},
 };
 
-/**
- * @brief   Available ports on the SAML21 for convenient access
- */
-enum {
-    PA = 0,                 /**< port A */
-    PB = 1,                 /**< port B */
-};
-
-/**
- * @brief   Generate GPIO mode bitfields
- *
- * We use 3 bit to determine the pin functions:
- * - bit 0: PU or PU
- * - bit 1: input enable
- * - bit 2: pull enable
- */
-#define GPIO_MODE(pr, ie, pe)   (pr | (ie << 1) | (pe << 2))
-
-#ifndef DOXYGEN
-/**
- * @brief   Override GPIO modes
- * @{
- */
-#define HAVE_GPIO_MODE_T
-typedef enum {
-    GPIO_IN    = GPIO_MODE(0, 1, 0),    /**< IN */
-    GPIO_IN_PD = GPIO_MODE(0, 1, 1),    /**< IN with pull-down */
-    GPIO_IN_PU = GPIO_MODE(1, 1, 1),    /**< IN with pull-up */
-    GPIO_OUT   = GPIO_MODE(0, 0, 0),    /**< OUT (push-pull) */
-    GPIO_OD    = 0xfe,                  /**< not supported by HW */
-    GPIO_OD_PU = 0xff                   /**< not supported by HW */
-} gpio_mode_t;
-/** @} */
-#endif /* ndef DOXYGEN */
-
 #define HAVE_ADC_RES_T
 typedef enum {
     ADC_RES_6BIT  = 0xff,                       /**< not supported */


### PR DESCRIPTION
This PR removes some duplicate lines between SAMD21 & SAML21
I also add a check to ensure pull-down configuration is selected when requested.

This should be very easy to review :)