### PR TITLE
boards/msp430-based: removed flashpage feature

### DIFF
--- a/boards/msb-430/Makefile.features
+++ b/boards/msb-430/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/msb-430h/Makefile.features
+++ b/boards/msb-430h/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/telosb/Makefile.features
+++ b/boards/telosb/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/wsn430-v1_3b/Makefile.features
+++ b/boards/wsn430-v1_3b/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi

--- a/boards/wsn430-v1_4/Makefile.features
+++ b/boards/wsn430-v1_4/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi

--- a/boards/z1/Makefile.features
+++ b/boards/z1/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer


### PR DESCRIPTION
Same thing as #7964.

This feature is already defined by the (common) CPU implementation, so no need to re-define it for each board.