### PR TITLE
Revert "gnrc_uhcpc: fix dependencies"

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -51,10 +51,6 @@ ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
-ifneq (,$(filter uhcpc,$(USEMODULE)))
-  USEMODULE += posix
-endif
-
 ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
   USEMODULE += softdevice_handler
   USEMODULE += ble_common

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -32,21 +32,18 @@ static void set_interface_roles(void)
         kernel_pid_t dev = ifs[i];
         int is_wired = gnrc_netapi_get(dev, NETOPT_IS_WIRED, 0, NULL, 0);
         if ((!gnrc_border_interface) && (is_wired == 1)) {
-            ipv6_addr_t addr;
+            ipv6_addr_t addr, defroute;
             gnrc_border_interface = dev;
 
             ipv6_addr_from_str(&addr, "fe80::2");
             gnrc_ipv6_netif_add_addr(dev, &addr, 64,
                                      GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST);
 
-#ifdef MODULE_FIB
-            ipv6_addr_t defroute = IPV6_ADDR_UNSPECIFIED;
-
+            ipv6_addr_from_str(&defroute, "::");
             ipv6_addr_from_str(&addr, "fe80::1");
             fib_add_entry(&gnrc_ipv6_fib_table, dev, defroute.u8, 16,
                     0x00, addr.u8, 16, 0,
                     (uint32_t)FIB_LIFETIME_NO_EXPIRE);
-#endif
         }
         else if ((!gnrc_wireless_interface) && (is_wired != 1)) {
             gnrc_wireless_interface = dev;


### PR DESCRIPTION
I moved it as a backport to #7925 (see https://github.com/RIOT-OS/RIOT/pull/7960) but the conflict stayed. Let's hope this revert brings the desired resolution.

I know it is not nice to add reverts, but merging #7722 during the GNRC embargo was an error anyways.