### PR TITLE
sam0:adc config struct for clock source

### DIFF
--- a/boards/arduino-mkr-common/include/periph_conf.h
+++ b/boards/arduino-mkr-common/include/periph_conf.h
@@ -156,12 +156,15 @@ static const pwm_conf_t pwm_config[] = {
 #define ADC_0_IRQ                          ADC_IRQn
 
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
 #define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
 
 #define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_t adc_config = {
+    .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+};
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -160,12 +160,15 @@ static const pwm_conf_t pwm_config[] = {
 #define ADC_0_IRQ                          ADC_IRQn
 
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
 #define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
 
 #define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_t adc_config = {
+    .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+};
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -291,12 +291,15 @@ static const spi_conf_t spi_config[] = {
 #define ADC_0_IRQ                          ADC_IRQn
 
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
 #define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
 
 #define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_t adc_config = {
+    .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+};
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -153,8 +153,11 @@ static const spi_conf_t spi_config[] = {
 #define ADC_NUMOF                          (3U)
 
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
 #define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV256
+
+static const adc_conf_t adc_config = {
+    .gclk_src = GCLK_PCHCTRL_GEN_GCLK0
+};
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -262,12 +262,15 @@ static const spi_conf_t spi_config[] = {
 #define ADC_0_IRQ                          ADC_IRQn
 
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
 #define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
 
 #define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_t adc_config = {
+    .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+};
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -149,12 +149,15 @@ static const uart_conf_t uart_config[] = {
 #define ADC_0_IRQ                          ADC_IRQn
 
 /* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
 #define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
 
 #define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_t adc_config = {
+    .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+};
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -279,6 +279,13 @@ static inline void sercom_set_gen(void *sercom, uint32_t gclk)
 }
 
 /**
+ * @brief ADC Configuration
+ */
+typedef struct {
+    uint32_t gclk_src;      /**< GCLK source which supplys ADC */
+} adc_conf_t;
+
+/**
  * @brief ADC Channel Configuration
  */
 typedef struct {

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -102,8 +102,8 @@ static int _adc_configure(adc_res_t res)
     /* Power On */
     PM->APBCMASK.reg |= PM_APBCMASK_ADC;
     /* GCLK Setup */
-    GCLK->CLKCTRL.reg = (uint32_t)(GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 |
-                        (GCLK_CLKCTRL_ID(ADC_GCLK_ID)));
+    GCLK->CLKCTRL =
+        (GCLK_CLKCTRL_Type){{.CLKEN=true, .GEN=adc_config.gclk_src, .ID=(uint16_t)GCLK_CLKCTRL_ID_ADC_Val}};
     /* Configure CTRLB Register HERE IS THE RESOLUTION SET! */
     ADC_0_DEV->CTRLB.reg = ADC_0_PRESCALER | res;
     /* Load the fixed device calibration constants */
@@ -126,7 +126,7 @@ static int _adc_configure(adc_res_t res)
     /* Power on */
     MCLK->APBDMASK.reg |= MCLK_APBDMASK_ADC;
     /* GCLK Setup */
-    GCLK->PCHCTRL[ADC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
+    GCLK->PCHCTRL[ADC_GCLK_ID] = (GCLK_PCHCTRL_Type){{.CHEN=true, .GEN=adc_config.gclk_src}};
     /* Set Voltage Reference */
     ADC_0_DEV->REFCTRL.reg = ADC_0_REF_DEFAULT;
     /* Configure CTRLB & CTRLC Register */


### PR DESCRIPTION
This is meant as a first cut at a proof of concept to begin allowing all of the sam0 peripherals to specify their clock source. This is a small baby step in the basic roadmap discussed in #7944 .

It has been tested on a samd21xpro. All the other compilation paths have at least been shown to compile (I don't have those boards).

There was an original #define placed in all of these files, but it was never used in the driver. In following PRs, the config structure would be used to assume more of the other configuration roles (standby, on demand, etc).

@dylad, hope you see this. :)