### PR TITLE
periph/flashpage: add flashpage_write_raw interface

### DIFF
--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_flashpage_raw
 
 -include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/sam0_common/include/cpu_conf.h
+++ b/cpu/sam0_common/include/cpu_conf.h
@@ -42,9 +42,15 @@ extern "C" {
  * @{
  */
 /* a flashpage in RIOT is mapped to a flash row on the SAM0s */
-#define FLASHPAGE_SIZE      (256U)
+#define FLASHPAGE_SIZE             (256U)
 /* one SAM0 row contains 4 SAM0 pages -> 4x the amount of RIOT flashpages */
-#define FLASHPAGE_NUMOF     (FLASH_NB_OF_PAGES / 4)
+#define FLASHPAGE_NUMOF            (FLASH_NB_OF_PAGES / 4)
+/* The minimum block size which can be written is 16B. However, the erase
+ * block is always FLASHPAGE_SIZE (SAM0 row).
+ */
+#define FLASHPAGE_RAW_BLOCKSIZE    (16)
+/* Writing should be always 4 byte aligned */
+#define FLASHPAGE_RAW_ALIGNMENT    (4)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -58,19 +58,18 @@ static void _lock(void)
 
 void flashpage_write_raw(void *target_addr, void *data, size_t len)
 {
-    /* sam[dlr]21 can only write whole flash pages.
-     * Mind the use of the ATMEL FLASH_PAGE_SIZE (64B) define vs.
-     * FLASHPAGE_SIZE (256B) as defined by RIOT.
-     * The actual minimal block size for writing is 16B, thus we
-     * assert we don't write less than that.
+    /* The actual minimal block size for writing is 16B, thus we
+     * assert we write on multiples and no less of that length.
      */
-    assert(!(len % (FLASH_PAGE_SIZE / 4)));
+    assert(!(len % FLASHPAGE_RAW_BLOCKSIZE));
 
     /* ensure 4 byte aligned writes */
-    assert(!(((unsigned)target_addr & 0x3) || ((unsigned)data & 0x3)));
+    assert(!(((unsigned)target_addr % FLASHPAGE_RAW_ALIGNMENT) ||
+            ((unsigned)data % FLASHPAGE_RAW_ALIGNMENT)));
 
     /* ensure the length doesn't exceed the actual flash size */
-    assert((target_addr + len) < (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)));
+    assert(((uint8_t*)target_addr + len) <
+           (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)));
 
     uint32_t *dst = (uint32_t *)target_addr;
     uint32_t *data_addr = (uint32_t *)data;

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -17,7 +17,7 @@
  * The sam0 has its flash memory organized in pages and rows, where each row
  * consists of 4 pages. While pages are writable one at a time, it is only
  * possible to delete a complete row. This implementation abstracts this
- * behavior by only writing complete rows at a time, so the FLASH_PAGE_SIZE we
+ * behavior by only writing complete rows at a time, so the FLASHPAGE_SIZE we
  * use in RIOT is actually the row size as specified in the datasheet.
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
@@ -25,18 +25,15 @@
  * @}
  */
 
+#include <assert.h>
+
 #include "cpu.h"
-#include "assert.h"
 #include "periph/flashpage.h"
 
 #define NVMCTRL_PAC_BIT     (0x00000002)
 
-void flashpage_write(int page, void *data)
+static void _unlock(void)
 {
-    assert(page < FLASHPAGE_NUMOF);
-
-    uint32_t *page_addr = (uint32_t *)flashpage_addr(page);
-
     /* remove peripheral access lock for the NVMCTRL peripheral */
 #ifdef CPU_FAM_SAML21
     PAC->WRCTRL.reg = (PAC_WRCTRL_KEY_CLR | ID_NVMCTRL);
@@ -45,19 +42,69 @@ void flashpage_write(int page, void *data)
         PAC1->WPCLR.reg = NVMCTRL_PAC_BIT;
     }
 #endif
+}
+
+static void _lock(void)
+{
+    /* put peripheral access lock for the NVMCTRL peripheral */
+#ifdef CPU_FAM_SAML21
+    PAC->WRCTRL.reg = (PAC_WRCTRL_KEY_SET | ID_NVMCTRL);
+#else
+    if (PAC1->WPCLR.reg & NVMCTRL_PAC_BIT) {
+        PAC1->WPSET.reg = NVMCTRL_PAC_BIT;
+    }
+#endif
+}
+
+void flashpage_write_raw(void *target_addr, void *data, size_t len)
+{
+    /* sam[dlr]21 can only write whole flash pages.
+     * Mind the use of the ATMEL FLASH_PAGE_SIZE (64B) define vs.
+     * FLASHPAGE_SIZE (256B) as defined by RIOT.
+     * The actual minimal block size for writing is 16B, thus we
+     * assert we don't write less than that.
+     */
+    assert(!(len % (FLASH_PAGE_SIZE / 4)));
+
+    /* ensure 4 byte aligned writes */
+    assert(!(((unsigned)target_addr & 0x3) || ((unsigned)data & 0x3)));
+
+    /* ensure the length doesn't exceed the actual flash size */
+    assert((target_addr + len) < (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)));
+
+    uint32_t *dst = (uint32_t *)target_addr;
+    uint32_t *data_addr = (uint32_t *)data;
+
+    /* write 4 bytes in one go */
+    len /= 4;
+
+    _unlock();
+
+    NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_PBC);
+    for (unsigned i = 0; i < len; i++) {
+        *dst++ = *data_addr++;
+    }
+    NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
+
+    _lock();
+}
+
+void flashpage_write(int page, void *data)
+{
+    assert(page < FLASHPAGE_NUMOF);
+
+    uint32_t *page_addr = (uint32_t *)flashpage_addr(page);
 
     /* erase given page (the ADDR register uses 16-bit addresses) */
+    _unlock();
     NVMCTRL->ADDR.reg = (((uint32_t)page_addr) >> 1);
     NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER);
     while (!NVMCTRL->INTFLAG.bit.READY) {}
+    _lock();
 
     /* write data to page */
     if (data != NULL) {
-        uint32_t *data_addr = (uint32_t *)data;
-        NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_PBC);
-        for (unsigned i = 0; i < (FLASHPAGE_SIZE / 4); i++) {
-            *page_addr++ = data_addr[i];
-        }
-        NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
+        flashpage_write_raw(page_addr, data, FLASHPAGE_SIZE);
     }
+
 }

--- a/tests/periph_flashpage/Makefile
+++ b/tests/periph_flashpage/Makefile
@@ -2,7 +2,8 @@ APPLICATION = periph_flashpage
 BOARD ?= iotlab-m3
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_flashpage
+FEATURES_REQUIRED += periph_flashpage
+FEATURES_OPTIONAL += periph_flashpage_raw
 
 USEMODULE += shell
 


### PR DESCRIPTION
This PR adds the possibility to write the smallest possible block to the internal flash.

The smallest writable block varies from CPU to CPU. This PR adds the implementation for the sam[dlr]21 CPU, and extends tests/periph_flashpage to allow writing data of this minimal block length to any minimal-block-size aligned address.

Other implementations for other CPUs will come shortly.