### PR TITLE
boards: remove non-existent feature 'config'

### DIFF
--- a/boards/msb-430h/Makefile.features
+++ b/boards/msb-430h/Makefile.features
@@ -4,9 +4,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += config
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430
 

--- a/boards/wsn430-v1_3b/Makefile.features
+++ b/boards/wsn430-v1_3b/Makefile.features
@@ -4,9 +4,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += config
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430
 

--- a/boards/wsn430-v1_4/Makefile.features
+++ b/boards/wsn430-v1_4/Makefile.features
@@ -4,9 +4,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
-FEATURES_PROVIDED += config
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430
 


### PR DESCRIPTION
The config feature is as far as I can see not used anywhere. So I propose dropping it...