### PR TITLE
boards/wsn430: removed empty 'drivers' dir

### DIFF
--- a/boards/wsn430-common/Makefile
+++ b/boards/wsn430-common/Makefile
@@ -1,5 +1,3 @@
 MODULE = wsn430-common
 
-DIRS = drivers
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/wsn430-common/Makefile.include
+++ b/boards/wsn430-common/Makefile.include
@@ -15,5 +15,3 @@ export FFLAGS = -d $(PORT) -j uif "prog $(HEXFILE)"
 
 # include wsn430-common includes
 export INCLUDES += -I$(RIOTBOARD)/wsn430-common/include
-
-USEMODULE += wsn430-common-drivers

--- a/boards/wsn430-common/drivers/Makefile
+++ b/boards/wsn430-common/drivers/Makefile
@@ -1,5 +1,0 @@
-MODULE = wsn430-common-drivers
-
-include $(RIOTBOARD)/$(BOARD)/Makefile.include
-
-include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
The drivers sub-dir (and module) is completely empty for this board, so I guess no need for keeping it...