### PR TITLE
sys: make uart_stdio RX optional

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -416,12 +416,20 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += vfs
 endif
 
+ifneq (,$(filter shell,$(USEMODULE)))
+  USEMODULE += uart_stdio_rx
+endif
+
 ifneq (,$(filter rtt_stdio,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter uart_stdio,$(USEMODULE)))
+ifneq (,$(filter uart_stdio_rx,$(USEMODULE)))
   USEMODULE += isrpipe
+  USEMODULE += uart_stdio
+endif
+
+ifneq (,$(filter uart_stdio,$(USEMODULE)))
   FEATURES_REQUIRED += periph_uart
 endif
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -69,6 +69,7 @@ PSEUDOMODULES += sock
 PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp
 PSEUDOMODULES += sock_udp
+PSEUDOMODULES += uart_stdio_rx
 
 # include variants of the AT86RF2xx drivers as pseudo modules
 PSEUDOMODULES += at86rf23%


### PR DESCRIPTION
Previously, uart_stdio always set up receiving data from serial.

This led to blocking powermodes (see #7947), and also used memory for the incoming buffer, even if unused.

This PR makes the RX side of uart_stdio available as pseudomodule (uart_stdio_rx).