### PR TITLE
make: allow alias for board names

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -4,6 +4,9 @@
 # include Makefile.local if it exists
 -include Makefile.local
 
+# map given board name to actual board folder (resolve potential alias)
+include $(RIOTBASE)/makefiles/boards/alias.inc.mk
+
 # set undefined variables
 RIOTBASE       ?= $(dir $(lastword $(MAKEFILE_LIST)))
 CCACHE_BASEDIR ?= $(RIOTBASE)

--- a/Makefile.include
+++ b/Makefile.include
@@ -391,7 +391,11 @@ endef
 	$(call check_cmd,$(CC),Compiler)
 
 ..build-message:
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
+ifeq (,$(ALIAS))
+	@$(COLOR_ECHO) '${COLOR_GREEN}Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".${COLOR_RESET}'
+else
+	@$(COLOR_ECHO) '${COLOR_GREEN}Building application "$(APPLICATION)" for "$(ALIAS) -> $(BOARD)" with MCU "$(MCU)".${COLOR_RESET}'
+endif
 	@$(COLOR_ECHO)
 
 # add extra include paths for packages in $(USEMODULE)

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -7,6 +7,10 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+# allow board aliases for this example (needed because we use the BOARD
+# variable in this Makefile)
+include $(RIOTBASE)/makefiles/boards/alias.inc.mk
+
 # Uncomment these lines if you want to use platform support from external
 # repositories:
 #RIOTCPU ?= $(CURDIR)/../../RIOT/thirdparty_cpu

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -7,6 +7,10 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+# allow board aliases for this example (needed because we use the BOARD
+# variable in this Makefile)
+include $(RIOTBASE)/makefiles/boards/alias.inc.mk
+
 # TinyDTLS only has support for 32-bit architectures ATM
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 \

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -7,6 +7,10 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+# allow board aliases for this example (needed because we use the BOARD
+# variable in this Makefile)
+include $(RIOTBASE)/makefiles/boards/alias.inc.mk
+
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk hifive1 maple-mini \
                              microbit msb-430 msb-430h nrf51dongle nrf6310 \

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -7,6 +7,10 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+# allow board aliases for this example (needed because we use the BOARD
+# variable in this Makefile)
+include $(RIOTBASE)/makefiles/boards/alias.inc.mk
+
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk hifive1 maple-mini \
                              microbit nrf51dongle nrf6310 nucleo-f030r8 nucleo-f070rb \

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -7,6 +7,10 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+# allow board aliases for this example (needed because we use the BOARD
+# variable in this Makefile)
+include $(RIOTBASE)/makefiles/boards/alias.inc.mk
+
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-l053r8 stm32f0discovery \
                              telosb z1

--- a/makefiles/boards/alias.inc.mk
+++ b/makefiles/boards/alias.inc.mk
@@ -1,0 +1,9 @@
+ALIAS = linux phynode
+
+# this basically implements a look-up table, is there a nicer way in make?
+ifneq (,$(filter phynode,$(BOARD)))
+  BOARD := pba-d-01-kw2x
+endif
+ifneq (,$(filter linux,$(BOARD)))
+  BOARD := native
+endif

--- a/makefiles/boards/alias.inc.mk
+++ b/makefiles/boards/alias.inc.mk
@@ -5,6 +5,6 @@ ALIAS.linux     = native
 
 # this temporary variable is needed as we can not use BOARD when assigning BOARD
 ALIAS_TARGET := $(ALIAS.$(BOARD))
-ifdef ALIAS_TARGET
+ifneq (,$(ALIAS_TARGET))
   override BOARD = $(ALIAS_TARGET)
 endif

--- a/makefiles/boards/alias.inc.mk
+++ b/makefiles/boards/alias.inc.mk
@@ -7,4 +7,5 @@ ALIAS.linux     = native
 ALIAS_TARGET := $(ALIAS.$(BOARD))
 ifneq (,$(ALIAS_TARGET))
   override BOARD = $(ALIAS_TARGET)
+  MAKEOVERRIDES += BOARD=$(BOARD)
 endif

--- a/makefiles/boards/alias.inc.mk
+++ b/makefiles/boards/alias.inc.mk
@@ -6,6 +6,6 @@ ALIAS.linux     = native
 # this temporary variable is needed as we can not use BOARD when assigning BOARD
 ALIAS_TARGET := $(ALIAS.$(BOARD))
 ifneq (,$(ALIAS_TARGET))
-  override BOARD = $(ALIAS_TARGET)
+  override BOARD := $(ALIAS_TARGET)
   MAKEOVERRIDES += BOARD=$(BOARD)
 endif

--- a/makefiles/boards/alias.inc.mk
+++ b/makefiles/boards/alias.inc.mk
@@ -1,9 +1,10 @@
 # list of known alias
 ALIAS.phynode   = pba-d-01-kw2x
+#TODO remove this line (as its just for show)
 ALIAS.linux     = native
 
 # this temporary variable is needed as we can not use BOARD when assigning BOARD
 ALIAS_TARGET := $(ALIAS.$(BOARD))
-ifneq (,($(ALIAS_TARGET)))
+ifdef ALIAS_TARGET
   override BOARD = $(ALIAS_TARGET)
 endif

--- a/makefiles/boards/alias.inc.mk
+++ b/makefiles/boards/alias.inc.mk
@@ -6,6 +6,7 @@ ALIAS.linux     = native
 # this temporary variable is needed as we can not use BOARD when assigning BOARD
 ALIAS_TARGET := $(ALIAS.$(BOARD))
 ifneq (,$(ALIAS_TARGET))
+  ALIAS := $(BOARD)
   override BOARD := $(ALIAS_TARGET)
   MAKEOVERRIDES += BOARD=$(BOARD)
 endif

--- a/makefiles/boards/alias.inc.mk
+++ b/makefiles/boards/alias.inc.mk
@@ -1,9 +1,9 @@
-ALIAS = linux phynode
+# list of known alias
+ALIAS.phynode   = pba-d-01-kw2x
+ALIAS.linux     = native
 
-# this basically implements a look-up table, is there a nicer way in make?
-ifneq (,$(filter phynode,$(BOARD)))
-  BOARD := pba-d-01-kw2x
-endif
-ifneq (,$(filter linux,$(BOARD)))
-  BOARD := native
+# this temporary variable is needed as we can not use BOARD when assigning BOARD
+ALIAS_TARGET := $(ALIAS.$(BOARD))
+ifneq (,($(ALIAS_TARGET)))
+  override BOARD = $(ALIAS_TARGET)
 endif


### PR DESCRIPTION
Some boards have unique, but quite ugly names (e.g. `pba-d-01-kw2x`) and we use different names in the day-to-day operation (e.g. `phynode` for the former). Event though this 'nicer' name ist not a 100% correct (as there are also phynodes based on other CPUs out there, just not in the RIOT universe...), it is sometimes much easier to remember and use. Also, there are some boards that have a specific, cryptic name (e.g. `SLTB001A`), but also a nice user friendly one (`thunderboard-sense` in that case). So I think it would be nice, to be able to use both (or even more?) aliases for a certain board.

This PR contains a quick draft, on how this could be implemented. It works, but is it nice enough?
```
BOARD=phynode make ...   -> will build `BOARD=pba-d-01-kw2x`
BOARD=linux make ... -> will build 'BOARD=native`, just for demo purposes...
```

Maybe we can even think of something that combines this approach with my idea about board revisions ( #7975). What do you think?