### PR TITLE
cpu/nrf51: remove guards from periph drivers

### DIFF
--- a/cpu/nrf51/periph/adc.c
+++ b/cpu/nrf51/periph/adc.c
@@ -23,7 +23,6 @@
 #include "periph/adc.h"
 #include "periph_conf.h"
 
-#ifdef ADC_CONFIG
 /**
  * @brief   Load the ADC configuration
  */
@@ -85,7 +84,3 @@ int adc_sample(adc_t line, adc_res_t res)
 
     return val;
 }
-
-#else
-typedef int dont_be_pedantic;
-#endif /* ADC_CONFIG */

--- a/cpu/nrf51/periph/i2c.c
+++ b/cpu/nrf51/periph/i2c.c
@@ -37,8 +37,6 @@
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-#ifdef I2C_NUMOF
-
 /**
  * @brief   If any of the 4 lower bits are set, the speed value is invalid
  */
@@ -230,5 +228,3 @@ int i2c_write_regs(i2c_t bus, uint8_t address, uint8_t reg,
     write(bus, address, &reg, 1, 0);
     return write(bus, address, data, length, 1);
 }
-
-#endif /* I2C_NUMOF */

--- a/cpu/nrf5x_common/periph/spi.c
+++ b/cpu/nrf5x_common/periph/spi.c
@@ -27,8 +27,6 @@
 #include "periph/spi.h"
 #include "periph/gpio.h"
 
-#ifdef SPI_NUMOF
-
 /**
  * @brief   array holding one pre-initialized mutex for each SPI device
  */
@@ -116,5 +114,3 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
         gpio_set((gpio_t)cs);
     }
 }
-
-#endif /* SPI_NUMOF */


### PR DESCRIPTION
addresses #7981

Removing header guards from all 'nrf5x' periph drivers. IMHO, if Murdock is happy, the changes should be valid, right?





