### PR TITLE
cpu/stm32: removed file guards from periph drivers

### DIFF
--- a/cpu/stm32_common/periph/dac.c
+++ b/cpu/stm32_common/periph/dac.c
@@ -25,9 +25,6 @@
 #include "assert.h"
 #include "periph/dac.h"
 
-/* only compile this, if the CPU has a DAC */
-#ifdef DAC_NUMOF
-
 /* DAC channel enable bits */
 #ifdef DAC_CR_EN2
 #define EN_MASK             (DAC_CR_EN1 | DAC_CR_EN2)
@@ -122,7 +119,3 @@ void dac_poweroff(dac_t line)
 #endif
     }
 }
-
-#else
-typedef int dont_be_pedantic;
-#endif /* DAC */

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -25,7 +25,6 @@
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-#if defined(FLASHPAGE_SIZE) && defined(FLASHPAGE_NUMOF)
 #include "periph/flashpage.h"
 
 void flashpage_write(int page, void *data)
@@ -89,5 +88,3 @@ void flashpage_write(int page, void *data)
         while (RCC->CR & RCC_CR_HSIRDY) {}
     }
 }
-
-#endif /* defined(FLASHPAGE_SIZE) && defined(FLASHPAGE_NUMOF) */

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -26,11 +26,13 @@
  * @}
  */
 
-#ifndef CPU_FAM_STM32F1
 
 #include "cpu.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
+
+/* this implementation is not valid for the stm32f1 */
+#ifndef CPU_FAM_STM32F1
 
 /**
  * @brief   The STM32F0 family has 16 external interrupt lines

--- a/cpu/stm32_common/periph/pwm.c
+++ b/cpu/stm32_common/periph/pwm.c
@@ -29,8 +29,6 @@
 #include "periph/pwm.h"
 #include "periph/gpio.h"
 
-#ifdef PWM_NUMOF
-
 #define CCMR_LEFT           (TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 | \
                              TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2)
 #define CCMR_RIGHT          (TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_1 | \
@@ -138,5 +136,3 @@ void pwm_poweroff(pwm_t pwm)
     dev(pwm)->CR1 &= ~TIM_CR1_CEN;
     periph_clk_dis(pwm_config[pwm].bus, pwm_config[pwm].rcc_mask);
 }
-
-#endif /* PWM_NUMOF */

--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -27,8 +27,8 @@
 #include "stmclk.h"
 #include "periph/rtc.h"
 
-/* guard file in case no RTC device was specified */
-#if defined(RTC) && !defined(CPU_FAM_STM32F1)
+/* this implementation does not work for the stm32f1 */
+#if !defined(CPU_FAM_STM32F1)
 
 /* map some CPU specific register names */
 #if defined (CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
@@ -322,4 +322,4 @@ void ISR_NAME(void)
     cortexm_isr_end();
 }
 
-#endif /* RTC */
+#endif /* !CPU_FAM_STM32F1 */

--- a/cpu/stm32_common/periph/rtt.c
+++ b/cpu/stm32_common/periph/rtt.c
@@ -24,7 +24,7 @@
 #include "periph/rtt.h"
 
 /* this driver is only valid for STM CPUs that provide LPTIMERs */
-#if (defined(LPTIM1) && RTT_NUMOF)
+#if defined(LPTIM1)
 
 /* figure out the used pre-scaler */
 #if (RTT_FREQUENCY == 32768)

--- a/cpu/stm32_common/periph/spi.c
+++ b/cpu/stm32_common/periph/spi.c
@@ -31,9 +31,6 @@
 #include "assert.h"
 #include "periph/spi.h"
 
-/* Remove this ugly guard once we selectively build the periph drivers */
-#ifdef SPI_NUMOF
-
 /**
  * @brief   Number of bits to shift the BR value in the CR1 register
  */
@@ -209,5 +206,3 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
         }
     }
 }
-
-#endif /* SPI_NUMOF */

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -31,8 +31,6 @@
 #include "periph/uart.h"
 #include "periph/gpio.h"
 
-#ifdef UART_NUMOF
-
 #define RXENABLE            (USART_CR1_RE | USART_CR1_RXNEIE)
 
 /**
@@ -231,5 +229,3 @@ void UART_5_ISR(void)
     irq_handler(UART_DEV(5));
 }
 #endif
-
-#endif /* UART_NUMOF */

--- a/cpu/stm32f0/periph/adc.c
+++ b/cpu/stm32f0/periph/adc.c
@@ -23,8 +23,6 @@
 #include "mutex.h"
 #include "periph/adc.h"
 
-#ifdef ADC_CONFIG
-
 /**
  * @brief   Maximum allowed ADC clock speed
  */
@@ -103,7 +101,3 @@ int adc_sample(adc_t line,  adc_res_t res)
 
     return sample;
 }
-
-#else
-typedef int dont_be_pedantic;
-#endif /* ADC_CONFIG */

--- a/cpu/stm32f1/periph/adc.c
+++ b/cpu/stm32f1/periph/adc.c
@@ -25,8 +25,6 @@
 #include "periph/adc.h"
 #include "periph_conf.h"
 
-#ifdef ADC_CONFIG
-
 /**
  * @brief   Maximum allowed ADC clock speed
  */
@@ -157,7 +155,3 @@ int adc_sample(adc_t line, adc_res_t res)
 
     return sample;
 }
-
-#else
-typedef int dont_be_pedantic;
-#endif /* ADC_CONFIG */

--- a/cpu/stm32f1/periph/i2c.c
+++ b/cpu/stm32f1/periph/i2c.c
@@ -37,9 +37,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/* guard file in case no I2C device is defined */
-#if I2C_0_EN || I2C_1_EN
-
 /* static function definitions */
 static void _i2c_init(I2C_TypeDef *i2c, int ccr);
 static void _pin_config(gpio_t pin_scl, gpio_t pin_sda);
@@ -548,5 +545,3 @@ void I2C_1_ERR_ISR(void)
     i2c_irq_handler(I2C_1, I2C_1_DEV);
 }
 #endif
-
-#endif /* I2C_0_EN || I2C_1_EN */

--- a/cpu/stm32f1/periph/rtt.c
+++ b/cpu/stm32f1/periph/rtt.c
@@ -23,9 +23,6 @@
 #include "periph/rtt.h"
 #include "periph_conf.h"
 
-/* guard file in case no RTT device was specified */
-#if RTT_NUMOF
-
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -198,5 +195,3 @@ void RTT_ISR(void)
     }
     cortexm_isr_end();
 }
-
-#endif /* RTT_NUMOF */

--- a/cpu/stm32f2/periph/i2c.c
+++ b/cpu/stm32f2/periph/i2c.c
@@ -33,9 +33,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/* guard file in case no I2C device is defined */
-#if I2C_NUMOF
-
 #define I2C_MAX_LOOP_CNT 10000
 
 /* static function definitions */
@@ -727,5 +724,3 @@ void I2C_0_ERR_ISR(void)
     i2c_irq_handler(I2C_0, I2C_0_DEV);
 }
 #endif
-
-#endif /* I2C_NUMOF */

--- a/cpu/stm32f2/periph/i2c.c
+++ b/cpu/stm32f2/periph/i2c.c
@@ -593,12 +593,12 @@ void i2c_poweron(i2c_t dev)
 
 void i2c_poweroff(i2c_t dev)
 {
-    int cnt = 0;
-
     switch (dev) {
 #if I2C_0_EN
     case I2C_0:
-        while ((I2C_0_DEV->SR2 & I2C_SR2_BUSY) && cnt++ < I2C_MAX_LOOP_CNT) {}
+        for (int cnt = 0;
+             ((I2C_0_DEV->SR2 & I2C_SR2_BUSY) && (cnt < I2C_MAX_LOOP_CNT));
+             cnt++) {}
 
         I2C_0_CLKDIS();
         break;

--- a/cpu/stm32f3/periph/i2c.c
+++ b/cpu/stm32f3/periph/i2c.c
@@ -36,9 +36,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/* guard file in case no I2C device is defined */
-#if I2C_NUMOF
-
 /* static function definitions */
 static void _i2c_init(I2C_TypeDef *i2c, uint32_t presc, uint32_t scll,
                       uint32_t sclh, uint32_t sdadel, uint32_t scldel,
@@ -537,5 +534,3 @@ void I2C_0_ERR_ISR(void)
     core_panic(PANIC_GENERAL_ERROR, "I2C FAULT");
 }
 #endif /* I2C_0_EN */
-
-#endif /* I2C_NUMOF */

--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -24,8 +24,6 @@
 #include "periph/adc.h"
 #include "periph_conf.h"
 
-#ifdef ADC_CONFIG
-
 /**
  * @brief   Maximum allowed ADC clock speed
  */
@@ -122,7 +120,3 @@ int adc_sample(adc_t line, adc_res_t res)
 
     return sample;
 }
-
-#else
-typedef int dont_be_pedantic;
-#endif /* ADC_CONFIG */

--- a/cpu/stm32f4/periph/i2c.c
+++ b/cpu/stm32f4/periph/i2c.c
@@ -36,9 +36,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/* guard file in case no I2C device is defined */
-#if I2C_NUMOF
-
 /* static function definitions */
 static void _i2c_init(I2C_TypeDef *i2c, int ccr);
 static void _toggle_pins(GPIO_TypeDef *port_scl, GPIO_TypeDef *port_sda, int pin_scl, int pin_sda);
@@ -504,5 +501,3 @@ void I2C_0_ERR_ISR(void)
     while (1) {}
 }
 #endif /* I2C_0_EN */
-
-#endif /* I2C_NUMOF */

--- a/cpu/stm32f4/periph/i2c.c
+++ b/cpu/stm32f4/periph/i2c.c
@@ -248,6 +248,7 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
 {
     int n = length;
     I2C_TypeDef *i2c;
+    char *in = (char *)data;
 
     switch (dev) {
 #if I2C_0_EN
@@ -282,7 +283,7 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
         }
 
         /* read byte */
-        *(char*)data++ = i2c->DR;
+        *in++ = i2c->DR;
     }
 
     /* set STOP */

--- a/cpu/stm32l0/periph/adc.c
+++ b/cpu/stm32l0/periph/adc.c
@@ -23,8 +23,6 @@
 #include "mutex.h"
 #include "periph/adc.h"
 
-#ifdef ADC_NUMOF
-
 /**
  * @brief   Maximum allowed ADC clock speed
  */
@@ -179,6 +177,3 @@ int adc_sample(adc_t line,  adc_res_t res)
 
     return sample;
 }
-#else
-typedef int dont_be_pedantic;
-#endif /* ADC_CONFIG */

--- a/cpu/stm32l0/periph/i2c.c
+++ b/cpu/stm32l0/periph/i2c.c
@@ -40,9 +40,6 @@
 
 #define ERROR_FLAG                 (I2C_ISR_NACKF | I2C_ISR_ARLO | I2C_ISR_BERR)
 
-/* guard file in case no I2C device is defined */
-#if I2C_NUMOF
-
 /* static function definitions */
 static void _i2c_init(I2C_TypeDef *i2c, uint32_t presc, uint32_t scll,
                       uint32_t sclh, uint32_t sdadel, uint32_t scldel,
@@ -565,4 +562,3 @@ static inline void _stop(I2C_TypeDef *dev)
     DEBUG("Generate stop condition\n");
     dev->CR2 |= I2C_CR2_STOP;
 }
-#endif /* I2C_NUMOF */

--- a/cpu/stm32l1/periph/adc.c
+++ b/cpu/stm32l1/periph/adc.c
@@ -25,8 +25,6 @@
 #include "mutex.h"
 #include "periph/adc.h"
 
-#ifdef ADC_CONFIG
-
 /**
  * @brief   Maximum allowed ADC clock speed
  */
@@ -132,7 +130,3 @@ int adc_sample(adc_t line, adc_res_t res)
 
     return sample;
 }
-
-#else
-typedef int dont_be_pedantic;
-#endif /* ADC_CONFIG */

--- a/cpu/stm32l1/periph/i2c.c
+++ b/cpu/stm32l1/periph/i2c.c
@@ -36,10 +36,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-
-/* guard file in case no I2C device is defined */
-#if I2C_NUMOF
-
 /* static function definitions */
 static void _i2c_init(I2C_TypeDef *i2c, int ccr);
 static void _start(I2C_TypeDef *i2c, uint8_t address, uint8_t rw_flag);
@@ -475,5 +471,3 @@ void I2C_1_ERR_ISR(void)
     while (1) {}
 }
 #endif /* I2C_1_EN */
-
-#endif /* I2C_NUMOF */


### PR DESCRIPTION
addresses #7981
same as #7982 