### PR TITLE
examples/gnrc_br: revert removal of pca1000x

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -12,8 +12,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini 
                              microbit msb-430 msb-430h nrf51dongle nrf6310 \
                              nucleo32-f031 nucleo32-f042 nucleo32-f303 nucleo32-l031 \
                              nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f302 \
-                             nucleo-f334 nucleo-l053 nucleo-l073 opencm904 \
-                             spark-core stm32f0discovery telosb wsn430-v1_3b \
+                             nucleo-f334 nucleo-l053 nucleo-l073 opencm904 pca10000 \
+                             pca10005 spark-core stm32f0discovery telosb wsn430-v1_3b \
                              wsn430-v1_4 yunjia-nrf51822 z1
 
 BOARD_BLACKLIST += mips-malta pic32-wifire pic32-clicker# No full UART available.


### PR DESCRIPTION
revert the removal of the pca1000x boards from this Makefile to prevent merge conflicts for the gnrc_netif2 integration.

@miri64 promised to remove these entries again once gnrc_netif2 is merged...