### PR TITLE
tests/fmt_print: migrate to testrunner

### DIFF
--- a/tests/fmt_print/Makefile
+++ b/tests/fmt_print/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 USEMODULE += fmt
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/fmt_print/tests/01-run.py
+++ b/tests/fmt_print/tests/01-run.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('If you can read this:')
+    child.expect_exact('Test successful.')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
Straight forward migration of this simple test.

Partially addresses #7871 