### PR TITLE
drivers/sx127x: remove duplicate CS init

### DIFF
--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -256,15 +256,6 @@ static int _init_peripherals(sx127x_t *dev)
         return 0;
     }
 
-    res = gpio_init(dev->params.nss_pin, GPIO_OUT);
-    if (res < 0) {
-        DEBUG("sx127x: error initializing GPIO_%ld as CS line (code %i)\n",
-                  (long)dev->params.nss_pin, res);
-        return 0;
-    }
-
-    gpio_set(dev->params.nss_pin);
-
     DEBUG("sx127x: peripherals initialized with success\n");
     return 1;
 }


### PR DESCRIPTION
Remove SPI CS init since this is already done within spi_init_cs.
I've no idea why we didn't spot it sooner.