### PR TITLE
tests/msg_try_receive: migrate to testrunner

### DIFF
--- a/tests/msg_try_receive/Makefile
+++ b/tests/msg_try_receive/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/msg_try_receive/tests/01-run.py
+++ b/tests/msg_try_receive/tests/01-run.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect('main starting')
+    child.expect('msg available: 1 \(should be 1\!\)')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
Another obvious migration of a test to the testrunner.

Partially addresses #7871 