### PR TITLE
tests: migrate simple tests to testrunner

### DIFF
--- a/tests/netdev_test/Makefile
+++ b/tests/netdev_test/Makefile
@@ -17,3 +17,6 @@ USEMODULE += od
 CFLAGS += -DGNRC_PKTBUF_SIZE=200
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/netdev_test/tests/01-run.py
+++ b/tests/netdev_test/tests/01-run.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('Executing test_get_addr()')
+    child.expect_exact(' + succeeded.')
+    child.expect_exact('Executing test_send()')
+    child.expect_exact(' + succeeded.')
+    child.expect_exact('Executing test_receive()')
+    child.expect_exact(' + succeeded.')
+    child.expect_exact('Executing test_set_addr()')
+    child.expect_exact(' + succeeded.')
+    child.expect_exact('ALL TESTS SUCCESSFUL')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -12,3 +12,6 @@ USEMODULE += gnrc_sock_udp
 USEMODULE += nhdp
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/nhdp/main.c
+++ b/tests/nhdp/main.c
@@ -18,6 +18,6 @@
 
 int main(void)
 {
-    puts("NHDP compiled!");
+    puts("SUCCESS: NHDP compiled!");
     return 0;
 }

--- a/tests/nhdp/tests/01-run.py
+++ b/tests/nhdp/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('SUCCESS: NHDP compiled!')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/pipe/Makefile
+++ b/tests/pipe/Makefile
@@ -6,3 +6,6 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 USEMODULE += pipe
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/pipe/tests/01-run.py
+++ b/tests/pipe/tests/01-run.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import math
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('Start.')
+    child.expect_exact('Middle read: <ABCD> [0:4]')
+    child.expect_exact('Middle read: <EF> [4:6]')
+    child.expect_exact('End read: <ABC> [0:3]')
+    child.expect_exact('End read: <DEF> [3:6]')
+    child.expect_exact('Middle read: <GHIJ> [6:10]')
+    child.expect_exact('Middle read: <KL> [10:12]')
+    child.expect_exact('End read: <GHI> [6:9]')
+    child.expect_exact('End read: <JKL> [9:12]')
+    child.expect_exact('Middle read: <MNOP> [12:16]')
+    child.expect_exact('Middle read: <QR> [16:18]')
+    child.expect_exact('End read: <MNO> [12:15]')
+    child.expect_exact('End read: <PQR> [15:18]')
+    child.expect_exact('Middle read: <STUV> [18:22]')
+    child.expect_exact('Middle read: <WX> [22:24]')
+    child.expect_exact('Main done.')
+    child.expect_exact('End read: <STU> [18:21]')
+    child.expect_exact('End read: <VWX> [21:24]')
+    child.expect_exact('Middle read: <YZ> [24:26]')
+    child.expect_exact('Middle done.')
+    child.expect_exact('End read: <YZ> [24:26]')
+    child.expect_exact('End done.')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/pkg_jsmn/Makefile
+++ b/tests/pkg_jsmn/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 USEPKG += jsmn
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/pkg_jsmn/tests/01-run.py
+++ b/tests/pkg_jsmn/tests/01-run.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import math
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('- User: johndoe')
+    child.expect_exact('- Admin: false')
+    child.expect_exact('- UID: 1000')
+    child.expect_exact('- Groups:')
+    child.expect_exact('  * users')
+    child.expect_exact('  * wheel')
+    child.expect_exact('  * audio')
+    child.expect_exact('  * video')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -14,3 +14,6 @@ USEMODULE += gnrc_sock_udp
 USEPKG += libcoap
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/pkg_libcoap/main.c
+++ b/tests/pkg_libcoap/main.c
@@ -18,6 +18,6 @@
 
 int main(void)
 {
-    puts("Libcoap compiled!");
+    puts("SUCCESS: Libcoap compiled!");
     return 0;
 }

--- a/tests/pkg_libcoap/tests/01-run.py
+++ b/tests/pkg_libcoap/tests/01-run.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import math
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('SUCCESS: Libcoap compiled!')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/pkg_micro-ecc-with-hwrng/Makefile
+++ b/tests/pkg_micro-ecc-with-hwrng/Makefile
@@ -8,3 +8,6 @@ USEPKG += micro-ecc
 CFLAGS += -DFEATURE_PERIPH_HWRNG
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/pkg_micro-ecc-with-hwrng/main.c
+++ b/tests/pkg_micro-ecc-with-hwrng/main.c
@@ -113,10 +113,12 @@ int main(void)
 
     printf(" done with %d error(s)\n", errorc);
 
-    if (errorc == 0) {
-        return 0;
+    if (errorc) {
+        puts("FAILURE");
+        return 1;
     }
     else {
-        return 1;
+        puts("SUCCESS");
+        return 0;
     }
 }

--- a/tests/pkg_micro-ecc-with-hwrng/tests/01-run.py
+++ b/tests/pkg_micro-ecc-with-hwrng/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import math
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('micro-ecc compiled!')
+    child.expect_exact('Testing 16 random private key pairs and signature '
+                       'using HWRNG')
+    child.expect_exact('................ done with 0 error(s)')
+    child.expect_exact('SUCCESS')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc, timeout=60))

--- a/tests/pkg_micro-ecc/Makefile
+++ b/tests/pkg_micro-ecc/Makefile
@@ -5,3 +5,6 @@ USEMODULE += hashes
 USEPKG += micro-ecc
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/pkg_micro-ecc/main.c
+++ b/tests/pkg_micro-ecc/main.c
@@ -164,10 +164,12 @@ int main(void)
 
     printf(" done with %d error(s)\n", errorc);
 
-    if (errorc == 0) {
-        return 0;
+    if (errorc) {
+        puts("FAILURE");
+        return 1;
     }
     else {
-        return 1;
+        puts("SUCCESS");
+        return 0;
     }
 }

--- a/tests/pkg_micro-ecc/tests/01-run.py
+++ b/tests/pkg_micro-ecc/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import math
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('micro-ecc compiled!')
+    child.expect_exact('Testing 16 random private key pairs and signature '
+                       'without using HWRNG')
+    child.expect_exact('................ done with 0 error(s)')
+    child.expect_exact('SUCCESS')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc, timeout=60))

--- a/tests/pkg_minmea/Makefile
+++ b/tests/pkg_minmea/Makefile
@@ -7,3 +7,6 @@ USEPKG += minmea
 BOARD_BLACKLIST := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/pkg_minmea/main.c
+++ b/tests/pkg_minmea/main.c
@@ -26,16 +26,18 @@ static const char *_gll = "$GNGLL,5229.0178,N,01326.7605,E,114350.000,A,A*45";
 
 int main(void)
 {
+    puts("START");
     struct minmea_sentence_gll frame;
 
     int res = minmea_parse_gll(&frame, _gll);
     if (!res) {
-        puts("error parsing GPS sentence");
+        puts("FAILURE: error parsing GPS sentence");
     }
     else {
         printf("parsed coordinates: lat=%f lon=%f\n",
                 minmea_tocoord(&frame.latitude),
                 minmea_tocoord(&frame.longitude));
+        puts("SUCCESS");
     }
 
     return 0;

--- a/tests/pkg_minmea/tests/01-run.py
+++ b/tests/pkg_minmea/tests/01-run.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import math
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('START')
+    child.expect_exact('SUCCESS')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/ps_schedstatistics/Makefile
+++ b/tests/ps_schedstatistics/Makefile
@@ -14,3 +14,6 @@ USEMODULE += schedstatistics
 USEMODULE += printf_float
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+PS_EXPECTED = (
+    ('\tpid | name                 | state    Q | pri | stack  ( used) | '
+     'base addr  | current     | runtime  | switches'),
+    ('\t  - | isr_stack            | -        - |   - | \d+  ( -?\d+) | '
+     '0x\d+ | 0x\d+'),
+    ('\t  1 | idle                 | pending  Q |  15 | \d+  ( -?\d+) | '
+     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    ('\t  2 | main                 | running  Q |   7 | \d+  ( -?\d+) | '
+     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    ('\t  3 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    ('\t  4 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    ('\t  5 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    ('\t  6 | thread               | bl mutex _ |   6 | \d+  ( -?\d+) | '
+     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    ('\t  7 | thread               | bl rx    _ |   6 | \d+  ( -?\d+) | '
+     '0x\d+ | 0x\d+  | \d+\.\d+% |      \d+'),
+    ('\t    | SUM                  |            |     | \d+  (\d+)')
+)
+
+def _check_startup(child):
+    for i in range(5):
+        child.expect_exact('Creating thread #{}, next={}'
+                           .format(i, (i + 1) % 5))
+
+
+def _check_help(child):
+    child.sendline('help')
+    child.expect_exact('Command              Description')
+    child.expect_exact('---------------------------------------')
+    child.expect_exact('reboot               Reboot the node')
+    child.expect_exact('ps                   Prints information about '
+                       'running threads.')
+
+
+def _check_ps(child):
+    child.sendline('ps')
+    for line in PS_EXPECTED:
+        child.expect(line)
+
+
+def testfunc(child):
+    _check_startup(child)
+    _check_help(child)
+    _check_ps(child)
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/sched_testing/Makefile
+++ b/tests/sched_testing/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/sched_testing/tests/01-run.py
+++ b/tests/sched_testing/tests/01-run.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import math
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('The output should be: yield 1, snd_thread running, '
+                       'yield 2, done')
+    child.expect_exact('---------------------------------------------------'
+                       '-------------')
+    child.expect_exact('yield 1')
+    child.expect_exact('snd_thread running')
+    child.expect_exact('yield 2')
+    child.expect_exact('done')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/sizeof_tcb/Makefile
+++ b/tests/sizeof_tcb/Makefile
@@ -10,3 +10,6 @@ include ../Makefile.tests_common
 # DISABLE_MODULE += core_msg
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/sizeof_tcb/main.c
+++ b/tests/sizeof_tcb/main.c
@@ -58,6 +58,6 @@ int main(void)
     P(stack_size);
 #endif
 
-    puts("Done.");
+    puts("SUCCESS");
     return 0;
 }

--- a/tests/sizeof_tcb/tests/01-run.py
+++ b/tests/sizeof_tcb/tests/01-run.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('\tmember, sizeof, offsetof')
+    child.expect_exact('sizeof(thread_t): 36')
+    child.expect_exact('\tsp            4   0')
+    child.expect_exact('\tstatus        1   4')
+    child.expect_exact('\tpriority      1   5')
+    child.expect_exact('\tpid           2   6')
+    child.expect_exact('\trq_entry      4   8')
+    child.expect_exact('\twait_data     4  12')
+    child.expect_exact('\tmsg_waiters   4  16')
+    child.expect_exact('\tmsg_queue    12  20')
+    child.expect_exact('\tmsg_array     4  32')
+    child.expect_exact('SUCCESS')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
Partially addresses #7871. 

`pipe`, `nhdp`,  `netdev_test`, `sched_testing`, `ps_schedstatistics`, `pkg_jsmn`, `pkg_libcoap`, `pkg_micro-ecc`, `pkg_micro-ecc-with-hwrng` and `pkg_minmea` are covered.

~~I also started to have a look at libfixmath comparing computation with python results but I have issues with the pexpect script (the output this test is very long).~~