### PR TITLE
drivers/rgbled: fix PWM resolution

### DIFF
--- a/drivers/rgbled/rgbled.c
+++ b/drivers/rgbled/rgbled.c
@@ -29,7 +29,7 @@
 /**
  * @name Set the default resolution to 8-bit per color (for a 24-bit color space)
  */
-#define PWM_RES         (255)
+#define PWM_RES         (256)
 
 
 void rgbled_init(rgbled_t *led, pwm_t pwm, int channel_r, int channel_g, int channel_b)


### PR DESCRIPTION
This patch fixes a minor issue in the RGB LED driver. The PWM resolution was set to the maximum value instead of the number of steps. Most likely, it caused no issues in real life. However as the code might be used by others as a reference on how to interact with the PWM driver, I think it's worth fixing.