### PR TITLE
cpu/stm32f1: add support for STM32F103ZE

### DIFF
--- a/cpu/stm32f1/include/cpu_conf.h
+++ b/cpu/stm32f1/include/cpu_conf.h
@@ -27,7 +27,7 @@
 
 #if defined(CPU_MODEL_STM32F103C8) || defined(CPU_MODEL_STM32F103CB) || defined(CPU_MODEL_STM32F103RB)
 #include "vendor/stm32f103xb.h"
-#elif defined(CPU_MODEL_STM32F103RE)
+#elif defined(CPU_MODEL_STM32F103RE) || defined(CPU_MODEL_STM32F103ZE)
 #include "vendor/stm32f103xe.h"
 #endif
 
@@ -40,7 +40,7 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(CPU_MODEL_STM32F103RE)
+#if defined(CPU_MODEL_STM32F103RE) || defined(CPU_MODEL_STM32F103ZE)
 #define CPU_IRQ_NUMOF                   (60U)
 #else
 #define CPU_IRQ_NUMOF                   (43U)
@@ -58,7 +58,7 @@ extern "C" {
 #define FLASHPAGE_NUMOF     (32U)
 #elif defined(CPU_MODEL_STM32F103CB) || defined(CPU_MODEL_STM32F103RB)
 #define FLASHPAGE_NUMOF     (64U)
-#elif defined(CPU_MODEL_STM32F103RE)
+#elif defined(CPU_MODEL_STM32F103RE) || defined(CPU_MODEL_STM32F103ZE)
 #define FLASHPAGE_NUMOF     (256U)
 #endif
 /** @} */

--- a/cpu/stm32f1/vectors.c
+++ b/cpu/stm32f1/vectors.c
@@ -130,7 +130,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [41] = isr_rtc_alarm,            /* [41] RTC Alarm through EXTI Line Interrupt */
     [42] = isr_usbwakeup,            /* [42] USB Device WakeUp from suspend through EXTI Line Interrupt */
 
-#if defined(CPU_MODEL_STM32F103RE)
+#if defined(CPU_MODEL_STM32F103RE) || defined(CPU_MODEL_STM32F103ZE)
     [43] = isr_tim8_brk,             /* [43] TIM8 Break Interrupt */
     [44] = isr_tim8_up,              /* [44] TIM8 Update Interrupt */
     [45] = isr_tim8_trg_com,         /* [45] TIM8 Trigger and Commutation Interrupt */


### PR DESCRIPTION
This patch adds support for STM32F103ZE which is mostly identical to the existing STM32F103RE. However, due to the larger package (144 vs. 64 pins) more GPIOs and ADC channels are available.