### PR TITLE
tests/ssp: migrate to testrunner

### DIFF
--- a/tests/ssp/Makefile
+++ b/tests/ssp/Makefile
@@ -12,3 +12,6 @@ USEMODULE += ssp
 CFLAGS += -DDEVELHELP
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/ssp/tests/01-run.py
+++ b/tests/ssp/tests/01-run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect_exact('calling stack corruption function')
+    child.expect('.*stack smashing detected.*')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
partially addresses #7871: add support for stack smashing protection test.

Note that it doesn't work on native because the RIOT process is killed before the python pexpect script is launched. I don't know how to fix that. Good idea are welcome.
Otherwise I tested on a nucleo l073 board and it works like a charm.