### PR TITLE
dist: testrunner: terminate gracefully on ProcessLookupError

### DIFF
--- a/dist/tools/testrunner/testrunner.py
+++ b/dist/tools/testrunner/testrunner.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2017 Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
+#               2016 Kaspar Schleiser <kaspar@schleiser.de>
 #               2014 Martine Lenders <mlenders@inf.fu-berlin.de>
 #
 # This file is subject to the terms and conditions of the GNU Lesser
@@ -54,9 +55,19 @@ def run(testfunc, timeout=10, echo=True, traceback=False):
         if traceback:
             print_tb(sys.exc_info()[2])
         return 1
+    except pexpect.EOF:
+        line, filename, lineno = find_exc_origin(sys.exc_info()[2])
+        print("Unexpected end of file in expect script at \"%s\" (%s:%d)" %
+              (line, filename, lineno))
+        if traceback:
+            print_tb(sys.exc_info()[2])
+        return 1
     finally:
         print("")
-        os.killpg(os.getpgid(child.pid), signal.SIGKILL)
-        child.close()
+        try:
+            os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            print("Process already stopped")
 
+        child.close()
     return 0


### PR DESCRIPTION
#8004 is migrating `ssp` test to testrunner. Due to the nature of this test, the native process segfaults and our testrunner is not able to handle this currently. By adding an exception for `OSError`, we can gracefully terminate the test.