### PR TITLE
make: Do not attempt to use color if the terminal cannot support it

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -27,7 +27,6 @@ endif
 
 # Use colored compiler output if the compiler supports this and if this is not
 # disabled by the user
-CC_NOCOLOR ?= 0
 ifeq ($(CC_NOCOLOR),0)
   ifeq ($(shell $(CC) -fdiagnostics-color -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
     CFLAGS += -fdiagnostics-color

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -1,10 +1,26 @@
+# Set colored output control sequences if the terminal supports it and if
+# not disabled by the user
+
 COLOR_GREEN  :=
 COLOR_RED    :=
 COLOR_PURPLE :=
 COLOR_RESET  :=
 COLOR_ECHO   := /bin/echo
 
-ifeq (0,  $(shell tput colors 2>&1 > /dev/null; echo $$?))
+ifeq ($(CC_NOCOLOR),)
+  available_colors:=$(shell tput colors 2> /dev/null)
+  ifeq ($(available_colors),)
+    CC_NOCOLOR = 1
+  else ifeq ($(available_colors),-1)
+    CC_NOCOLOR = 1
+  else ifeq ($(available_colors),0)
+    CC_NOCOLOR = 1
+  else
+    CC_NOCOLOR = 0
+  endif
+endif
+
+ifeq ($(CC_NOCOLOR),0)
   COLOR_GREEN  := \033[1;32m
   COLOR_RED    := \033[1;31m
   COLOR_YELLOW := \033[1;33m


### PR DESCRIPTION
This trivial change avoids annoying control codes damaging the screen if the terminal does not support color.