### PR TITLE
gnrc_rpl: port to nib

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -105,7 +105,6 @@ ifneq (,$(filter gnrc_rpl_p2p,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
-  USEMODULE += fib
   USEMODULE += gnrc_ipv6_router_default
   USEMODULE += trickle
   USEMODULE += xtimer

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1216,7 +1216,7 @@ static void *_gnrc_netif_thread(void *args)
                 DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_SET received. opt=%s\n",
                       netopt2str(opt->opt));
 #else
-                DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_SET received. opt=%s\n",
+                DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_SET received. opt=%d\n",
                       opt->opt);
 #endif
                 /* set option for device driver */
@@ -1231,7 +1231,7 @@ static void *_gnrc_netif_thread(void *args)
                 DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_GET received. opt=%s\n",
                       netopt2str(opt->opt));
 #else
-                DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_GET received. opt=%s\n",
+                DEBUG("gnrc_netif: GNRC_NETAPI_MSG_TYPE_GET received. opt=%d\n",
                       opt->opt);
 #endif
                 /* get option from device driver */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -281,7 +281,7 @@ void _handle_snd_ns(_nib_onl_entry_t *nbr)
                 _set_nud_state(netif, nbr,
                                GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE);
             }
-            /* falls through intentionally */
+            /* intentionally falls through */
         case GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE:
             _probe_nbr(nbr, false);
             break;
@@ -298,7 +298,7 @@ void _handle_state_timeout(_nib_onl_entry_t *nbr)
         case GNRC_IPV6_NIB_NC_INFO_NUD_STATE_REACHABLE:
             DEBUG("nib: Timeout reachability\n");
             new_state = GNRC_IPV6_NIB_NC_INFO_NUD_STATE_STALE;
-            /* falls through intentionally */
+            /* intentionally falls through */
         case GNRC_IPV6_NIB_NC_INFO_NUD_STATE_DELAY: {
             gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(nbr));
 

--- a/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
+++ b/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
@@ -346,11 +346,9 @@ void gnrc_rpl_p2p_recv_DRO(gnrc_pktsnip_t *pkt, ipv6_addr_t *src)
     }
 
     if (gnrc_ipv6_netif_find_by_addr(&me, &addr) == dodag->iface) {
-        fib_add_entry(&gnrc_ipv6_fib_table, dodag->iface, p2p_ext->target.u8,
-                      sizeof(ipv6_addr_t), 0x0, src->u8,
-                      sizeof(ipv6_addr_t), FIB_FLAG_RPL_ROUTE,
-                      p2p_ext->dodag->default_lifetime *
-                      p2p_ext->dodag->lifetime_unit * MS_PER_SEC);
+        gnrc_ipv6_nib_ft_add(&p2p_ext->target, IPV6_ADDR_BIT_LEN, src, dodag->iface,
+                             p2p_ext->dodag->default_lifetime *
+                             p2p_ext->dodag->lifetime_unit);
 
         if (p2p_ext->dodag->node_status != GNRC_RPL_ROOT_NODE) {
             if ((rdo_snip = gnrc_pktbuf_start_write(rdo_snip)) == NULL) {


### PR DESCRIPTION
replaces fib with nib/ft

WIP for now. There are still some modifications missing in the tests for `gnrc_ipv6_nib_ft_add` e.g.
Also, I have to re-evaluate the netif2 changes ..
Will continue tomorrow with that.

This PR is part of the network layer remodelling effort:
![PR dependencies](https://miri64.github.io/riot-ndp-model/PR%20overview.svg)

depends on #8083