### PR TITLE
tests/libfixmath_*: migrate to testrunner

### DIFF
--- a/tests/libfixmath/Makefile
+++ b/tests/libfixmath/Makefile
@@ -5,3 +5,6 @@ USEPKG += libfixmath
 USEMODULE += libfixmath
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/libfixmath/main.c
+++ b/tests/libfixmath/main.c
@@ -190,6 +190,6 @@ int main(void)
     puts("Binary.");
     binary_ops();
 
-    puts("Done.");
+    puts("SUCCESS");
     return 0;
 }

--- a/tests/libfixmath/tests/01-run.py
+++ b/tests/libfixmath/tests/01-run.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def expect_unary(child):
+    for _ in range(20):
+        for op_name in ('abs', 'sq', 'atan', 'exp'):
+            child.expect('{}\(-?\d+\.\d+\) = -?\d+\.\d+'.format(op_name))
+
+    for _ in range(20):
+        for op_name in ('sin', 'cos', 'tan'):
+            child.expect('{}\(-?\d+.\d+\) = -?\d+.\d+'.format(op_name))
+
+    for _ in range(20):
+        for op_name in ('asin', 'acos'):
+            child.expect('{}\(-?\d+.\d+\) = -?\d+.\d+'.format(op_name))
+
+    for _ in range(20):
+        for op_name in ('sqrt', 'log', 'log2', 'slog2'):
+            child.expect('{}\(-?\d+.\d+\) = -?\d+.\d+'.format(op_name))
+
+
+def expect_binary(child):
+    for _ in range(20):
+        for op_name in ('add', 'sub', 'mul', 'div', 'mod', 'sadd', 'ssub',
+                        'smul', 'sdiv', 'min', 'max'):
+            child.expect('{}\(-?\d+.\d+\, -?\d+.\d+\) = -?\d+.\d+'
+                         .format(op_name))
+
+
+def testfunc(child):
+    child.expect_exact('Unary.')
+    expect_unary(child)
+    child.expect_exact('Binary.')
+    expect_binary(child)
+    child.expect_exact('SUCCESS')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -17,3 +17,6 @@ ifneq (,$(filter native qemu-i386,$(BOARD)))
 endif
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/libfixmath_unittests/main.c
+++ b/tests/libfixmath_unittests/main.c
@@ -40,6 +40,6 @@ int main(void)
     RUN(fix16_str_unittests);
     RUN(fix16_unittests);
 
-    puts("All tests executed.");
+    puts("SUCCESS");
     return 0;
 }

--- a/tests/libfixmath_unittests/tests/01-run.py
+++ b/tests/libfixmath_unittests/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect('SUCCESS')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
Partially addresses #7871.

This PR covers the libfixmath tests.

For the libfixmath test, I initially tried to use an exhaustive strategy: compare the results of libfixmath computations with the ones computed by the python script (using `math` module and `numpy`) but there were too many differences and I couldn't make the pexpect script pass.
So I came up with a simplified version that just check the 'format' of the output: it checks that the correct list of operators is used and is using a generic regexp on the output.