### PR TITLE
tests/posix_sleep: migrate to testrunner

### DIFF
--- a/tests/posix_sleep/Makefile
+++ b/tests/posix_sleep/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 USEMODULE += posix
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/posix_sleep/main.c
+++ b/tests/posix_sleep/main.c
@@ -24,7 +24,7 @@
 int main(void)
 {
     puts("usleep 1 x 1000*1000");
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 5; i++) {
         useconds_t us = i*1000u*1000u;
         printf("calling usleep(%u)\n", (unsigned int) us);
         usleep(us);
@@ -32,13 +32,13 @@ int main(void)
     }
 
     puts("sleep 1");
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 5; i++) {
         unsigned int s = i;
         printf("calling sleep(%u)\n", s);
         sleep(s);
         puts("wake up");
     }
 
-    puts("done");
+    puts("SUCCESS");
     return 0;
 }

--- a/tests/posix_sleep/tests/01-run.py
+++ b/tests/posix_sleep/tests/01-run.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def _check_usleep(child):
+    child.expect_exact('usleep 1 x 1000*1000')
+    for i in range(5):
+        child.expect_exact('calling usleep({})'.format(i * 1000 * 1000))
+        child.expect_exact('wake up', timeout=(i+1))
+
+
+def _check_sleep(child):
+    child.expect_exact('sleep 1')
+    for i in range(5):
+        child.expect_exact('calling sleep({})'.format(i))
+        child.expect_exact('wake up', timeout=(i+1))
+
+
+def testfunc(child):
+    _check_usleep(child)
+    _check_sleep(child)
+    child.expect('SUCCESS')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
Partially addresses #7871 and only covers `posix_sleep` test.

Tested on native and nucleo-l073