### PR TITLE
gnrc_mac: fix non-obvious recursive include

### DIFF
--- a/sys/include/net/gnrc/mac/internal.h
+++ b/sys/include/net/gnrc/mac/internal.h
@@ -24,7 +24,6 @@
 #include <stdint.h>
 
 #include "net/ieee802154.h"
-#include "net/gnrc/mac/types.h"
 #include "net/gnrc/netif2.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
`net/gnrc/mac/types.h` is already included by `net/gnrc/netif2.h`. Likewise, `net/gnrc/mac/types.h` is including `net/gnrc.h` which in turn includes also `net/gnrc/netif2.h`. This recursive inclusion causes some confusion to the compiler who than in some instances can't find the `gnrc_mac` types in `net/gnrc/netif2.h`. This PR takes care of that by removing one redundant include of `net/gnrc/mac/types.h`.