### PR TITLE
nrf51: fix returns and error codes in periph/i2c

### DIFF
--- a/cpu/nrf51/periph/i2c.c
+++ b/cpu/nrf51/periph/i2c.c
@@ -67,9 +67,13 @@ static int error(i2c_t bus)
 
 static int write(i2c_t bus, uint8_t addr, const void *data, int len, int stop)
 {
+    assert(len > 0);
+    if (!(bus < I2C_NUMOF)) {
+        return -1;
+    }
+
     uint8_t *buf = (uint8_t *)data;
 
-    assert((bus <= I2C_NUMOF) && (len > 0));
     DEBUG("i2c: writing %i byte to the bus\n", len);
 
     dev(bus)->ADDRESS = (addr & 0x7f);
@@ -98,7 +102,7 @@ static int write(i2c_t bus, uint8_t addr, const void *data, int len, int stop)
 
 int i2c_init_master(i2c_t bus, i2c_speed_t speed)
 {
-    if (bus >= I2C_NUMOF) {
+    if (!(bus < I2C_NUMOF)) {
         return -1;
     }
     if (speed & INVALID_SPEED_MASK) {
@@ -128,14 +132,18 @@ int i2c_init_master(i2c_t bus, i2c_speed_t speed)
 
 int i2c_acquire(i2c_t bus)
 {
-    assert(bus <= I2C_NUMOF);
+    if (!(bus < I2C_NUMOF)) {
+        return -1;
+    }
     mutex_lock(&locks[bus]);
     return 0;
 }
 
 int i2c_release(i2c_t bus)
 {
-    assert(bus <= I2C_NUMOF);
+    if (!(bus < I2C_NUMOF)) {
+        return -1;
+    }
     mutex_unlock(&locks[bus]);
     return 0;
 }
@@ -147,9 +155,12 @@ int i2c_read_byte(i2c_t bus, uint8_t address, void *data)
 
 int i2c_read_bytes(i2c_t bus, uint8_t address, void *data, int length)
 {
+    assert(length > 0);
+    if (!(bus < I2C_NUMOF)) {
+        return -1;
+    }
     uint8_t *in_buf = (uint8_t *)data;
 
-    assert((bus <= I2C_NUMOF) && (length > 0));
     DEBUG("[i2c] reading %i byte from the bus\n", length);
 
     /* set the client address */


### PR DESCRIPTION
as requested in #7995 this fixes returns and error codes of periph/i2c to match API specs.