### PR TITLE
travis: enable static test in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+dist: trusty
+
+before_install:
+  - sudo apt-get install coreutils realpath doxygen graphviz python-lesscpy cppcheck coccinelle pcregrep
+
+script:
+  - make static-test


### PR DESCRIPTION
As reported in the [summit roadmap](https://github.com/RIOT-OS/RIOT/wiki/RIOT-Summit-roadmap-session-2017#testing), the idea of this PR is to enable Travis CI to only check if the `make static-test` is passing. It will be a first round for checks required on code quality (documentation, cppcheck, etc).
Since it runs quite fast, it should be ok with travis.