### PR TITLE
examples/default: remove usage of config module

### DIFF
--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -57,7 +57,6 @@ ifneq (,$(filter $(BOARD),$(BOARD_PROVIDES_NETIF)))
   CFLAGS += -DGNRC_PKTBUF_SIZE=512
 endif
 
-FEATURES_OPTIONAL += config
 FEATURES_OPTIONAL += periph_rtc
 
 ifneq (,$(filter msb-430,$(BOARD)))


### PR DESCRIPTION
As pointed out in #7971: the `config` module was removed some time ago, so time to remove this (last?) leftover.