### PR TITLE
tests/lwmac: cleaned up used modules and Makefile

### DIFF
--- a/tests/lwmac/Makefile
+++ b/tests/lwmac/Makefile
@@ -1,49 +1,26 @@
 # name of your application
 APPLICATION = lwmac
 
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
 # If no BOARD is found in the environment, use this default:
 BOARD ?= samr21-xpro
 
 # Currently, LWMAC is only tested and evaluated through on samr21-xpro.
-# Once LWMAC has also been tested through on other boards, the whitelist should be
-# then accordingly extended.
+# Once LWMAC has also been tested through on other boards, the whitelist should
+# be then accordingly extended.
 BOARD_WHITELIST := samr21-xpro
-
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../..
-
-# Uncomment these lines if you want to use platform support from external
-# repositories:
-#RIOTCPU ?= $(CURDIR)/../../RIOT/thirdparty_cpu
-#RIOTBOARD ?= $(CURDIR)/../../RIOT/thirdparty_boards
-
-# Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
-
-# If you want to use native with valgrind, you should recompile native
-# with the target all-valgrind instead of all:
-# make -B clean all-valgrind
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
 CFLAGS += -DDEVELHELP
 
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
-
 # Modules to include:
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
-# include and auto-initialize all available sensors
-USEMODULE += saul_default
-
-BOARD_PROVIDES_NETIF := airfy-beacon cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
-        microbit native nrf51dongle nrf52dk nrf6310 openmote-cc2538 pba-d-01-kw2x \
-        remote-pa remote-reva saml21-xpro samr21-xpro \
-        spark-core telosb yunjia-nrf51822 z1
-
 # Use modules for networking
 # gnrc is a meta module including all required, basic gnrc networking modules
 USEMODULE += gnrc
@@ -57,14 +34,13 @@ USEMODULE += gnrc_txtsnd
 USEMODULE += gnrc_pktdump
 # Use LWMAC
 USEMODULE += gnrc_lwmac
+
 # We use only the lower layers of the GNRC network stack, hence, we can
 # reduce the size of the packet buffer a bit
 CFLAGS += -DGNRC_PKTBUF_SIZE=512
 
-FEATURES_OPTIONAL += config
-
-include $(RIOTBASE)/Makefile.include
-
 # Set a custom channel if needed
 DEFAULT_CHANNEL ?= 26
 CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/lwmac/main.c
+++ b/tests/lwmac/main.c
@@ -9,11 +9,11 @@
  */
 
 /**
- * @ingroup     examples
+ * @ingroup     tests
  * @{
  *
  * @file
- * @brief       Default application that shows a lot of functionality of RIOT
+ * @brief       Test application for testing the LWMAC implementation
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
@@ -29,36 +29,16 @@
 #include "shell.h"
 #include "shell_commands.h"
 
-#if FEATURE_PERIPH_RTC
-#include "periph/rtc.h"
-#endif
-
-#ifdef MODULE_LTC4150
-#include "ltc4150.h"
-#endif
-
-#ifdef MODULE_NETIF
 #include "net/gnrc/pktdump.h"
 #include "net/gnrc.h"
-#endif
 
 int main(void)
 {
-#ifdef MODULE_LTC4150
-    ltc4150_start();
-#endif
+    puts("LWMAC test application");
 
-#ifdef FEATURE_PERIPH_RTC
-    rtc_init();
-#endif
-
-#ifdef MODULE_NETIF
     gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                           gnrc_pktdump_pid);
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
-#endif
-
-    (void) puts("Welcome to RIOT!");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);


### PR DESCRIPTION
The test application was to large parts a 'dont-ask' copy from the `default` example. This PR removes some of the left-overs and unrealted modules: `ltc4150`, `SAUL`, etc. The RTC does not need to be initialized, this is done by auto-init (or soon by periph_init..). Also there is no need for differentiating platforms with and without radio, as the test is only whitelisted for a single board...