### PR TITLE
dist/tools/pr_check: fix regex pattern to recognize any SHA

### DIFF
--- a/dist/tools/pr_check/pr_check.sh
+++ b/dist/tools/pr_check/pr_check.sh
@@ -25,7 +25,7 @@ else
 fi
 
 SQUASH_COMMITS="$(git log $(git merge-base HEAD "${RIOT_MASTER}")...HEAD --pretty=format:"    %h %s" | \
-                  grep -i -e "^    [0-9a-f]\{7\} .\{0,2\}SQUASH" -e "^    [0-9a-f]\{7\} .\{0,2\}FIX")"
+                  grep -i -e "^    [0-9a-f]\+ .\{0,2\}SQUASH" -e "^    [0-9a-f]\+ .\{0,2\}FIX")"
 
 if [ -n "${SQUASH_COMMITS}" ]; then
     echo -e "${CERROR}Pull request needs squashing:${CRESET}" 1>&2


### PR DESCRIPTION
While working on #8020, I noticed that `make static-test` was not detecting that my working branch needed squashing (according to some of the commit messages containing `fixup`).
This was because the commit hash was 9 characters long and the detection regexp is expecting 7. On travis it's 8.
I guess it depends on the git version.

This PR solves this by update the regexp to detect hash having 7 to 9 characters.