### PR TITLE
cc110x: fix netdev get/set according to `netopt_t` doc

### DIFF
--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -104,15 +104,15 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t value_len)
         case NETOPT_CHANNEL:
             assert(value_len > 1);
             *((uint16_t *)value) = (uint16_t)cc110x->radio_channel;
-            return 2;
+            return sizeof(uint16_t);
         case NETOPT_ADDRESS:
             assert(value_len > 0);
             *((uint8_t *)value) = cc110x->radio_address;
-            return 1;
+            return sizeof(uint8_t);
         case NETOPT_MAX_PACKET_SIZE:
             assert(value_len > 0);
-            *((uint8_t *)value) = CC110X_PACKET_LENGTH;
-            return 1;
+            *((uint16_t *)value) = CC110X_PACKET_LENGTH;
+            return sizeof(uint16_t);
         case NETOPT_IPV6_IID:
             return _get_iid(dev, value, value_len);
         case NETOPT_ADDR_LEN:
@@ -133,8 +133,8 @@ static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len
     switch (opt) {
         case NETOPT_CHANNEL:
             {
-                const uint8_t *arg = value;
-                uint8_t channel = arg[value_len-1];
+                const uint16_t *arg = value;
+                uint8_t channel = (uint8_t)(*arg);
             #if CC110X_MIN_CHANNR
                 if (channel < CC110X_MIN_CHANNR) {
                     return -EINVAL;
@@ -146,7 +146,7 @@ static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len
                 if (cc110x_set_channel(cc110x, channel) == -1) {
                     return -EINVAL;
                 }
-                return 1;
+                return sizeof(uint16_t);
             }
         case NETOPT_ADDRESS:
             if (value_len < 1) {
@@ -155,7 +155,7 @@ static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len
             if (!cc110x_set_address(cc110x, *(const uint8_t*)value)) {
                 return -EINVAL;
             }
-            return 1;
+            return sizeof(uint8_t);
 #ifdef MODULE_GNRC_NETIF
         case NETOPT_PROTO:
             if (value_len != sizeof(gnrc_nettype_t)) {


### PR DESCRIPTION
According to [the doc of `NETOPT_MAX_PACKET_SIZE`](http://doc.riot-os.org/group__net__netopt.html#gga19e30424c1ab107c9c84dc0cb29d9906a4e7628bc2c06235aae569968f17a6817) the type should be `uint16_t` and thus `gnrc_netif2` assumes that. The cc110x radio currently returns this option as a `uint8_t` which causes `gnrc_netif2` to work with it error-prone. This PR fixes that.

Edit: as @cgundogan pointed out: other options were also wrong/defined by magic numbers, so I changed the topic of this PR to reflect the other changes.