### PR TITLE
tests/periph_timer: migrate to testrunner

### DIFF
--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -4,3 +4,6 @@ include ../Makefile.tests_common
 FEATURES_REQUIRED = periph_timer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/periph_timer/tests/01-run.py
+++ b/tests/periph_timer/tests/01-run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    child.expect('Available timers: (\d+)')
+    timers_num = int(child.match.group(1))
+    for timer in range(timers_num):
+        child.expect_exact('Testing TIMER_{}'.format(timer))
+        child.expect_exact('TIMER_{}: initialization successful'.format(timer))
+        child.expect_exact('TIMER_{}: stopped'.format(timer))
+        child.expect_exact('TIMER_{}: starting'.format(timer))
+    child.expect('TEST SUCCEEDED')
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
This PR enables `make test` on the `tests/periph_timer` application. Tested on native and arduino-zero.

It reads the number of defined timers and check that they are initialized correctly. It doesn't check the measured timings are correct.