### PR TITLE
make: cleanup and centralise DEVELHELP setting

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -111,6 +111,14 @@ endif
 
 QQ=
 
+# Set this to 1 to enable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 0
+ifeq ($(DEVELHELP),1)
+  CFLAGS += -DDEVELHELP
+endif
+
 # Fail on warnings. Can be overridden by `make WERROR=0`.
 WERROR ?= 1
 export WERROR

--- a/doc.txt
+++ b/doc.txt
@@ -9,8 +9,11 @@
 
 /**
  * @def DEVELHELP
- * @brief   This global macro activates some behavior that helps you while
- *          developing but is otherwise optimized out.
+ * @brief   This global macro activates functionality to help developers.
+ *
+ *          Additional code parts such as (extensive) debug output and sanity
+ *          checks using assertions. To activate it set environment variable
+ *          `DEVELHELP=1`, or disable explicitly with `DEVELHELP=0`.
  */
 #if DOXYGEN
 #   define DEVELHELP


### PR DESCRIPTION
This PR make the usage of DEVELHELP more consistent and easier to configure (IMHO 😄), i.e.,
its no longer required to explicitly set `CFLAGS += -DDEVELHELP` in Makefiles but rather use `DEVELHELP=1` either in Makefile or as env variable on command line; specifically for the latter its simpler.

Further this PR make usage of DEVELHELP more consistent, as follows:

- remove setting of DEVELHELP for all examples, can be optionally activated as described above
- enable DEVELHELP for all test by default, in `tests/Makefile.test_common`