### PR TITLE
pkg/libcoap: adapt Makefile to fix compile error

### DIFF
--- a/pkg/libcoap/patches/0001-Add-RIOT-Makefile.patch
+++ b/pkg/libcoap/patches/0001-Add-RIOT-Makefile.patch
@@ -15,9 +15,8 @@ index 0000000..7f37ccc
 +++ b/Makefile
 @@ -0,0 +1,4 @@
 +MODULE:=$(shell basename $(CURDIR))
-+CFLAGS += -DWITH_POSIX
++CFLAGS += -DWITH_POSIX -D_GNU_SOURCE=1
 +
 +include $(RIOTBASE)/Makefile.base
--- 
+--
 1.9.1
-


### PR DESCRIPTION
fixes compile error in pkg/libcoap revealed in #8029 