### PR TITLE
pkg/tinydtls: update version to fix compiler errors

### DIFF
--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -1,12 +1,16 @@
 PKG_NAME=tinydtls
 PKG_URL=https://github.com/rfuentess/TinyDTLS.git
 # PKG_VERSION=RIOT-OS
-PKG_VERSION=d06ad84d3e8bd3e86f7557faee34b68d5f8c0129
+PKG_VERSION=eb6f017ab451bb6cc4428b3e449955a76aeeba19
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
 .PHONY: all
 
 all: git-download
+	@cp $(PKG_BUILDDIR)/Makefile.riot $(PKG_BUILDDIR)/Makefile
+	@cp $(PKG_BUILDDIR)/aes/Makefile.riot $(PKG_BUILDDIR)/aes/Makefile
+	@cp $(PKG_BUILDDIR)/ecc/Makefile.riot $(PKG_BUILDDIR)/ecc/Makefile
+	@cp $(PKG_BUILDDIR)/sha2/Makefile.riot $(PKG_BUILDDIR)/sha2/Makefile
 	$(MAKE) -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
fixes compile error revealed in #8029 