### PR TITLE
cpu/mips: make `mips32r2_common` only a common cpu and remove cpu/periph module duplicate names.

### DIFF
--- a/boards/mips-malta/Makefile.include
+++ b/boards/mips-malta/Makefile.include
@@ -1,4 +1,4 @@
-export CPU = mips32r2_common
+export CPU = mips32r2_generic
 export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 #export USE_HARD_FLOAT = 1
 export USE_DSP = 1

--- a/cpu/mips32r2_common/Makefile
+++ b/cpu/mips32r2_common/Makefile
@@ -1,4 +1,4 @@
-MODULE = cpu
+MODULE = mips32r2_common
 
 DIRS = periph
 

--- a/cpu/mips32r2_common/Makefile
+++ b/cpu/mips32r2_common/Makefile
@@ -1,4 +1,9 @@
 MODULE = cpu
-DIRS = periph newlib_syscalls_mips_uhi
+
+DIRS = periph
+
+ifneq (,$(filter newlib_syscalls_mips_uhi,$(USEMODULE)))
+  DIRS += newlib_syscalls_mips_uhi
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -1,22 +1,13 @@
-export MEMORY_BASE=0x80000000
-export MEMORY_SIZE=1M
-export APP_START=0x80000000
-
-include $(RIOTMAKE)/arch/mips.inc.mk
 
 export USEMODULE += periph
 export USEMODULE += periph_common
 export USEMODULE += newlib
 
-# mips32 needs periph_timer for its gettimeofday() implementation
-export USEMODULE += periph_timer
-
 ifeq ($(USE_UHI_SYSCALLS),1)
   #Use UHI to handle syscalls
-  export LINKFLAGS += -luhi -Tuhi32.ld
+  export LINKFLAGS += -luhi
   export USEMODULE += newlib_syscalls_mips_uhi
 else
   #Use RIOT to handle syscalls (default)
-  export LINKFLAGS += -Tuhi32.ld
   export USEMODULE += newlib_syscalls_default
 endif

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -1,3 +1,4 @@
+export INCLUDES += -I$(RIOTCPU)/mips32r2_common/include
 
 export USEMODULE += periph
 export USEMODULE += periph_common

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -5,6 +5,9 @@ export USEMODULE += mips32r2_common_periph
 export USEMODULE += periph_common
 export USEMODULE += newlib
 
+# mips32 needs periph_timer for its gettimeofday() implementation
+export USEMODULE += periph_timer
+
 ifeq ($(USE_UHI_SYSCALLS),1)
   #Use UHI to handle syscalls
   export LINKFLAGS += -luhi

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -1,6 +1,7 @@
 export INCLUDES += -I$(RIOTCPU)/mips32r2_common/include
 
-export USEMODULE += periph
+export USEMODULE += mips32r2_common
+export USEMODULE += mips32r2_common_periph
 export USEMODULE += periph_common
 export USEMODULE += newlib
 

--- a/cpu/mips32r2_common/periph/Makefile
+++ b/cpu/mips32r2_common/periph/Makefile
@@ -1,1 +1,3 @@
+MODULE = mips32r2_common_periph
+
 include $(RIOTMAKE)/periph.mk

--- a/cpu/mips32r2_common/periph/timer.c
+++ b/cpu/mips32r2_common/periph/timer.c
@@ -35,7 +35,7 @@
 #include <sys/time.h>
 
 #ifdef EIC_IRQ
-#include "../include/eic_irq.h"
+#include "eic_irq.h"
 #endif
 
 /*

--- a/cpu/mips32r2_generic/Makefile
+++ b/cpu/mips32r2_generic/Makefile
@@ -1,0 +1,5 @@
+MODULE = cpu
+
+DIRS += $(RIOTCPU)/mips32r2_common
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/mips32r2_generic/Makefile.features
+++ b/cpu/mips32r2_generic/Makefile.features
@@ -1,0 +1,1 @@
+-include $(RIOTCPU)/mips32r2_common/Makefile.features

--- a/cpu/mips32r2_generic/Makefile.include
+++ b/cpu/mips32r2_generic/Makefile.include
@@ -1,0 +1,21 @@
+export MEMORY_BASE=0x80000000
+export MEMORY_SIZE=1M
+export APP_START=0x80000000
+
+include $(RIOTMAKE)/arch/mips.inc.mk
+
+export USEMODULE += periph
+export USEMODULE += periph_common
+export USEMODULE += newlib
+
+export USEMODULE += periph_timer
+
+ifeq ($(USE_UHI_SYSCALLS),1)
+  #Use UHI to handle syscalls
+  export LINKFLAGS += -luhi -Tuhi32.ld
+  export USEMODULE += newlib_syscalls_mips_uhi
+else
+  #Use RIOT to handle syscalls (default)
+  export LINKFLAGS += -Tuhi32.ld
+  export USEMODULE += newlib_syscalls_default
+endif

--- a/cpu/mips32r2_generic/Makefile.include
+++ b/cpu/mips32r2_generic/Makefile.include
@@ -3,19 +3,9 @@ export MEMORY_SIZE=1M
 export APP_START=0x80000000
 
 include $(RIOTMAKE)/arch/mips.inc.mk
+include $(RIOTCPU)/mips32r2_common/Makefile.include
 
-export USEMODULE += periph
-export USEMODULE += periph_common
-export USEMODULE += newlib
-
+# mips32 needs periph_timer for its gettimeofday() implementation
 export USEMODULE += periph_timer
 
-ifeq ($(USE_UHI_SYSCALLS),1)
-  #Use UHI to handle syscalls
-  export LINKFLAGS += -luhi -Tuhi32.ld
-  export USEMODULE += newlib_syscalls_mips_uhi
-else
-  #Use RIOT to handle syscalls (default)
-  export LINKFLAGS += -Tuhi32.ld
-  export USEMODULE += newlib_syscalls_default
-endif
+export LINKFLAGS += -Tuhi32.ld

--- a/cpu/mips32r2_generic/Makefile.include
+++ b/cpu/mips32r2_generic/Makefile.include
@@ -5,7 +5,4 @@ export APP_START=0x80000000
 include $(RIOTMAKE)/arch/mips.inc.mk
 include $(RIOTCPU)/mips32r2_common/Makefile.include
 
-# mips32 needs periph_timer for its gettimeofday() implementation
-export USEMODULE += periph_timer
-
 export LINKFLAGS += -Tuhi32.ld

--- a/cpu/mips32r2_generic/include/cpu.h
+++ b/cpu/mips32r2_generic/include/cpu.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    cpu_mips32r2_commom Imagination Technologies MIPS32R2 Common
+ * @defgroup    cpu_mips32r2_generic Imagination Technologies MIPS32R2 Common
  * @ingroup     cpu
  * @brief       Imagination Technologies MIPS32R2 common
  * @{

--- a/cpu/mips32r2_generic/include/cpu_conf.h
+++ b/cpu/mips32r2_generic/include/cpu_conf.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_mips32r2_commom
+ * @ingroup     cpu_mips32r2_generic
  * @{
  *
  * @file

--- a/cpu/mips32r2_generic/include/periph_cpu.h
+++ b/cpu/mips32r2_generic/include/periph_cpu.h
@@ -10,12 +10,6 @@
 
 /* No peripherals I/O via JTAG or Bootloader using UHI */
 
-/*
- * Note mips32r2_common can be selected in its own right as a CPU
- * for testing on PFGA systems (like BOARD=mips-malta) with limited
- * or no peripherals
- */
-
 #ifndef PERIPH_CPU_H
 #define PERIPH_CPU_H
 

--- a/cpu/mips_pic32_common/Makefile.include
+++ b/cpu/mips_pic32_common/Makefile.include
@@ -1,5 +1,4 @@
-export INCLUDES += -I$(RIOTCPU)/mips32r2_common/include \
-                   -I$(RIOTCPU)/mips_pic32_common/include
+export INCLUDES += -I$(RIOTCPU)/mips_pic32_common/include
 
 USEMODULE += periph_common
 USEMODULE += periph_hwrng

--- a/cpu/mips_pic32_common/Makefile.include
+++ b/cpu/mips_pic32_common/Makefile.include
@@ -1,4 +1,7 @@
 export INCLUDES += -I$(RIOTCPU)/mips_pic32_common/include
 
+USEMODULE += mips_pic32_common
+USEMODULE += mips_pic32_common_periph
+
 USEMODULE += periph_common
 USEMODULE += periph_hwrng

--- a/cpu/mips_pic32_common/periph/Makefile
+++ b/cpu/mips_pic32_common/periph/Makefile
@@ -1,1 +1,3 @@
+MODULE = mips_pic32_common_periph
+
 include $(RIOTMAKE)/periph.mk

--- a/cpu/mips_pic32mx/Makefile
+++ b/cpu/mips_pic32mx/Makefile
@@ -1,8 +1,6 @@
 MODULE = cpu
 
-USEMODULE += mips_pic32_common
-USEMODULE += mips32r2_common
-
-DIRS += $(RIOTCPU)/mips_pic32_common $(RIOTCPU)/mips32r2_common
+DIRS += $(RIOTCPU)/mips_pic32_common
+DIRS += $(RIOTCPU)/mips32r2_common
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/mips_pic32mx/Makefile.features
+++ b/cpu/mips_pic32mx/Makefile.features
@@ -1,1 +1,2 @@
 -include $(RIOTCPU)/mips_pic32_common/Makefile.features
+-include $(RIOTCPU)/mips32r2_common/Makefile.features

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -7,8 +7,6 @@ include $(RIOTCPU)/mips32r2_common/Makefile.include
 # define build specific options
 export CFLAGS += -march=m4k -DSKIP_COPY_TO_RAM
 
-export USEMODULE += mips_pic32_common
-
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
 export LINKFLAGS += -Tpic32mx512_12_128_uhi.ld
 

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -2,23 +2,12 @@ export ROMABLE = 1
 
 include $(RIOTMAKE)/arch/mips.inc.mk
 include $(RIOTCPU)/mips_pic32_common/Makefile.include
+include $(RIOTCPU)/mips32r2_common/Makefile.include
 
 # define build specific options
 export CFLAGS += -march=m4k -DSKIP_COPY_TO_RAM
 
 export USEMODULE += mips_pic32_common
-export USEMODULE += periph
-export USEMODULE += periph_common
-export USEMODULE += newlib
-
-ifeq ($(USE_UHI_SYSCALLS),1)
-  #Use UHI to handle syscalls
-  export LINKFLAGS += -luhi
-  export USEMODULE += newlib_syscalls_mips_uhi
-else
-  #Use RIOT to handle syscalls (default)
-  export USEMODULE += newlib_syscalls_default
-endif
 
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
 export LINKFLAGS += -Tpic32mx512_12_128_uhi.ld

--- a/cpu/mips_pic32mx/eic_pic32mx.c
+++ b/cpu/mips_pic32mx/eic_pic32mx.c
@@ -10,7 +10,7 @@
 #include <assert.h>
 
 #include "board.h"
-#include "../mips32r2_common/include/eic_irq.h"
+#include "eic_irq.h"
 
 void eic_irq_configure(int irq_num)
 {

--- a/cpu/mips_pic32mz/Makefile
+++ b/cpu/mips_pic32mz/Makefile
@@ -1,8 +1,6 @@
 MODULE = cpu
 
-USEMODULE += mips_pic32_common
-USEMODULE += mips32r2_common
-
-DIRS += $(RIOTCPU)/mips_pic32_common $(RIOTCPU)/mips32r2_common
+DIRS += $(RIOTCPU)/mips_pic32_common
+DIRS += $(RIOTCPU)/mips32r2_common
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/mips_pic32mz/Makefile.features
+++ b/cpu/mips_pic32mz/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += periph_hwrng
 
 -include $(RIOTCPU)/mips_pic32_common/Makefile.features
+-include $(RIOTCPU)/mips32r2_common/Makefile.features

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -2,25 +2,13 @@ export ROMABLE = 1
 
 include $(RIOTMAKE)/arch/mips.inc.mk
 include $(RIOTCPU)/mips_pic32_common/Makefile.include
+include $(RIOTCPU)/mips32r2_common/Makefile.include
 
 # define build specific options
 export CFLAGS += -march=m5101 -mmicromips -DSKIP_COPY_TO_RAM
 export CFLAGS += -DMIPS_MICROMIPS
 
 export USEMODULE += mips_pic32_common
-export USEMODULE += periph
-export USEMODULE += periph_common
-export USEMODULE += newlib
-
-ifeq ($(USE_UHI_SYSCALLS),1)
-  #Use UHI to handle syscalls
-  export LINKFLAGS += -luhi
-  export USEMODULE += newlib_syscalls_mips_uhi
-else
-  #Use RIOT to handle syscalls (default)
-  export USEMODULE += newlib_syscalls_default
-endif
-
 
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
 export LINKFLAGS += -Tpic32mz2048_uhi.ld

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -8,8 +8,6 @@ include $(RIOTCPU)/mips32r2_common/Makefile.include
 export CFLAGS += -march=m5101 -mmicromips -DSKIP_COPY_TO_RAM
 export CFLAGS += -DMIPS_MICROMIPS
 
-export USEMODULE += mips_pic32_common
-
 export LINKFLAGS += -Wl,--defsym,__use_excpt_boot=0 $(CFLAGS)
 export LINKFLAGS += -Tpic32mz2048_uhi.ld
 

--- a/cpu/mips_pic32mz/eic_pic32mz.c
+++ b/cpu/mips_pic32mz/eic_pic32mz.c
@@ -10,7 +10,7 @@
 #include <assert.h>
 
 #include "board.h"
-#include "../mips32r2_common/include/eic_irq.h"
+#include "eic_irq.h"
 
 void eic_irq_configure(int irq_num)
 {


### PR DESCRIPTION
This fixes https://github.com/RIOT-OS/RIOT/issues/8019

`mips32r2_common` is both a standalone cpu and a common cpu used by `mips_pic32mx/mz`.
This makes that `mips_pic32mx` and `mips_pic32mz` compile both the `cpu` and `periph` module from `mips_pic32mx/z` and `mips32r2_common`

To make `mips32r2_common` a real common cpu with different cpu/periph module names, I added `mips32r2_generic` to separate the standalone cpu part from the common part and namespaced the common one.

Now `mips_pic32mx` and `mips_pic32mz` correctly depends on `mip32r2_common` namespaced `cpu` and `periph` module.


Steps:

* Add a `mips32r2_generic`  cpu using `mips32r2_common`
* Cleanup `mips32r2_common`
* Namespace `mips32r2_common` and `mips_pic32_common` to remove conflicting module names.

Needs additional review for fixes of things that were here before.
I could do different PRs if needed.

* Add `periph_timer` as a dependency of `mips32r2_common`. This adds it to `mips_pic32mx/mz`.
  I am not sure, but if `mips32r2_common/periph` needs it, it may have been required before too.
* Include `mips32r2_common/Makefile.features` in `mips_pic32mx/mz`, as they are using the sames `periph` it makes sense to me.


Going further:

* Update the CPUs documentation, I patched a bit `mips32r2_generic` headers but it may not be enough or wrong.
* Add some documentation on what are these different CPUs directories and why not only one.
* Is `mips32r2_common` a dependency of `mips_pic32_common`? Because right now `mips_pic32mx/mz` depend on two `common` cpus.


