### PR TITLE
unittests: update boards lists

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -74,7 +74,9 @@ else
   UNIT_TESTS := $(filter tests-%, $(MAKECMDGOALS))
 endif
 
-ARM7_BOARDS := msba2 avrextrem
+ARM7_BOARDS := avsextrem \
+               msba2 \
+               #
 DISABLE_TEST_FOR_ARM7 := tests-relic tests-cpp_%
 
 ARM_CORTEX_M_BOARDS := airfy-beacon \
@@ -83,25 +85,40 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        arduino-mkrzero \
                        arduino-zero \
                        b-l072z-lrwan1 \
+                       bluepill \
+                       calliope-mini \
                        cc2538dk \
+                       cc2650-launchpad \
+                       cc2650stk \
                        ek-lm4f120xl \
                        f4vi1 \
                        feather-m0 \
                        fox \
+                       frdm-k22f \
                        frdm-k64f \
+                       iotlab-a8-m3 \
                        iotlab-m3 \
                        limifrog-v1 \
+                       maple-mini \
                        mbed_lpc1768 \
+                       microbit \
                        msbiot \
                        mulle \
                        nrf51dongle \
                        nrf52840dk \
+                       nrf52dk \
                        nrf6310 \
+                       nucleo144-f207 \
                        nucleo144-f303 \
                        nucleo144-f412 \
+                       nucleo144-f413 \
                        nucleo144-f429 \
                        nucleo144-f446 \
+                       nucleo144-f722 \
+                       nucleo144-f746 \
+                       nucleo144-f767 \
                        nucleo32-f031 \
+                       nucleo32-f042 \
                        nucleo32-f303 \
                        nucleo32-l031 \
                        nucleo32-l432 \
@@ -109,12 +126,14 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        nucleo-f070 \
                        nucleo-f072 \
                        nucleo-f091 \
+                       nucleo-f103 \
                        nucleo-f302 \
                        nucleo-f303 \
                        nucleo-f334 \
                        nucleo-f401 \
                        nucleo-f410 \
                        nucleo-f411 \
+                       nucleo-f446 \
                        nucleo-l053 \
                        nucleo-l073 \
                        nucleo-l152 \
@@ -123,10 +142,14 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        opencm904 \
                        openmote-cc2538 \
                        pba-d-01-kw2x \
-                       remote \
+                       remote-pa \
+                       remote-reva \
+                       remote-revb \
                        samd21-xpro \
                        saml21-xpro \
                        samr21-xpro \
+                       seeeduino_arch-pro \
+                       sltb001a \
                        slwstk6220a \
                        sodaq-autonomo \
                        sodaq-explorer \
@@ -134,15 +157,28 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        stm32f0discovery \
                        stm32f3discovery \
                        stm32f4discovery \
+                       stm32f7discovery \
                        udoo \
-                       yunjia-nrf51822
-
+                       yunjia-nrf51822 \
+                       #
 DISABLE_TEST_FOR_ARM_CORTEX_M := tests-relic
 
-AVR_BOARDS := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove
+AVR_BOARDS := arduino-duemilanove \
+              arduino-mega2560 \
+              arduino-uno \
+              waspmote-pro \
+              #
 DISABLE_TEST_FOR_AVR := tests-relic tests-cpp_%
 
-MSP430_BOARDS :=  chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+MSP430_BOARDS := chronos \
+                 msb-430 \
+                 msb-430-common \
+                 msb-430h \
+                 telosb \
+                 wsn430-v1_3b \
+                 wsn430-v1_4 \
+                 z1 \
+                 #
 DISABLE_TEST_FOR_MSP430 := tests-relic tests-spiffs tests-cpp_%
 
 ifneq (, $(filter $(ARM7_BOARDS), $(BOARD)))


### PR DESCRIPTION
I discovered that the `ARM_CORTEX_M_BOARDS` list from unittests' Makefile was not up to date.
I fixed it and cleaned up list for all architecture.