### PR TITLE
boards/ACD52832: add new NRF52 based development board

### DIFF
--- a/boards/acd52832/Makefile
+++ b/boards/acd52832/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/acd52832/Makefile.dep
+++ b/boards/acd52832/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep

--- a/boards/acd52832/Makefile.features
+++ b/boards/acd52832/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.features

--- a/boards/acd52832/Makefile.include
+++ b/boards/acd52832/Makefile.include
@@ -1,0 +1,7 @@
+# define the cpu used by the acd52832
+export CPU_MODEL = nrf52832xxaa
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyUSB0
+
+include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/acd52832/board.c
+++ b/boards/acd52832/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_acd52832
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the ACD52832
+ *
+ * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/acd52832/include/board.h
+++ b/boards/acd52832/include/board.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_acd52832 ACD52832
+ * @ingroup     boards
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuaration for the ACD52832
+ *
+ * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 26)
+
+#define LED_PORT            (NRF_P0)
+#define LED0_MASK           (1 << 26)
+
+#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 25)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/acd52832/include/gpio_params.h
+++ b/boards/acd52832/include/gpio_params.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_acd52832
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED 1",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+        {
+        .name = "Button 1",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    }
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/acd52832/include/periph_conf.h
+++ b/boards/acd52832/include/periph_conf.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2016-2017 Freie Universität Berlin
+ *                    2017 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_acd52832
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the ACD52832
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ *
+ * @note    The radio will not work with the internal RC oscillator!
+ *
+ * @{
+ */
+#define CLOCK_CORECLOCK     (64000000U)     /* fixed for all nRF52832 */
+#define CLOCK_HFCLK         (32U)           /* set to  0: internal RC oscillator
+                                             *        32: 32MHz crystal */
+#define CLOCK_LFCLK         (1)             /* set to  0: internal RC oscillator
+                                             *         1: 32.768 kHz crystal
+                                             *         2: derived from HFCLK */
+/** @} */
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = NRF_TIMER1,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
+        .irqn     = TIMER1_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_timer1
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             (1)             /* NRF_RTC1 */
+#define RTT_MAX_VALUE       (0x00ffffff)
+#define RTT_FREQUENCY       (1024)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_PIN_RX         GPIO_PIN(0, 30)
+#define UART_PIN_TX         GPIO_PIN(0, 31)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = 4,
+        .mosi = 3,
+        .miso = 13
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/common/nrf52xxxdk/Makefile.include
+++ b/boards/common/nrf52xxxdk/Makefile.include
@@ -2,8 +2,10 @@
 export CPU = nrf52
 
 # include this module into the build
-INCLUDES += -I$(RIOTBOARD)/common/nrf52xxxdk/include
-USEMODULE += boards_common_nrf52
+ifeq (,$(filter acd52832,$(BOARD)))
+  INCLUDES += -I$(RIOTBOARD)/common/nrf52xxxdk/include
+  USEMODULE += boards_common_nrf52
+endif
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -34,7 +34,7 @@ USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 
-BOARD_PROVIDES_NETIF := airfy-beacon b-l072z-lrwan1 cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
+BOARD_PROVIDES_NETIF := acd52832 airfy-beacon b-l072z-lrwan1 cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
         microbit native nrf51dongle nrf52dk nrf6310 openmote-cc2538 pba-d-01-kw2x \
         remote-pa remote-reva samr21-xpro \
         spark-core telosb yunjia-nrf51822 z1


### PR DESCRIPTION
This PR takes over #7501. It adds a new development board by 'aconno' which is based on a NRF52X MCU and has a bunch of nice features on top (unfortunately not all supported yet). Further information can be found [here](http://aconno.de/acd52832/).

Until know I used an external USB/UART converter for testing but we should consider the Segger RTT Client tool as default behind the make command in future.