### PR TITLE
tests/netstats_l2: migrate to testrunner

### DIFF
--- a/tests/netstats_l2/Makefile
+++ b/tests/netstats_l2/Makefile
@@ -17,3 +17,6 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += netstats_l2
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/netstats_l2/tests/01-run.py
+++ b/tests/netstats_l2/tests/01-run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Alexandre Abadie <alexandre.abadie@inria.fr>
+#               2017 Martine Lenders <m.lenders@fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.sendline('ifconfig')
+    child.expect(r'       Statistics for Layer 2')
+    child.expect(r'        RX packets \d+  bytes \d+')
+    child.expect(r'        TX packets \d+ \(Multicast: \d+\)  bytes \d+')
+    child.expect(r'        TX succeeded \d+ errors \d+')
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
Partially addresses #7871

The script just checks the basic output of the ifconfig shell command but it can pushed further if requested (test output of setting/getting value).

I only tested on native and maybe the regexp won't work on a board with 802.15.4 radio.