### PR TITLE
tests/periph_gpio: added benchmark capabilities

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -679,6 +679,10 @@ ifneq (,$(filter fatfs_vfs,$(USEMODULE)))
   USEMODULE += vfs
 endif
 
+ifneq (,$(filter benchmark,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
 # always select gpio (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio
 

--- a/sys/benchmark/Makefile
+++ b/sys/benchmark/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/benchmark/benchmark.c
+++ b/sys/benchmark/benchmark.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     sys_benchmark
+ * @{
+ *
+ * @file
+ * @brief       Utility functions for the benchmark module
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "benchmark.h"
+
+void benchmark_print_time(uint32_t time, unsigned long runs, const char *name)
+{
+    uint32_t full = (time / runs);
+    uint32_t div  = (time - (full * runs)) / (runs / 1000);
+
+    printf("%11s: %9" PRIu32 "us  ---  %2" PRIu32 ".%03" PRIu32 "us per call\n",
+           name, time, full, div);
+}

--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_benchmark Benchmark
+ * @ingroup     sys
+ * @brief       Framework for running simple runtime benchmarks
+ * @{
+ *
+ * @file
+ * @brief       Interface for running simple benchmarks
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef BENCHMARK_H
+#define BENCHMARK_H
+
+#include <stdint.h>
+
+#include "xtimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Prepare the current scope for running BENCHMARK_x() macros
+ */
+#define BENCHMARK_SETUP()                       \
+    unsigned state;                             \
+    unsigned time
+
+/**
+ * @brief   Measure the runtime of a given function call
+ *
+ * As we are doing a time sensitive measurement here, there is no way around
+ * using a preprocessor function, as going with a function pointer or similar
+ * would influence the measured runtime...
+ *
+ * @note    BENCHMARK_SETUP() needs to be called in the same scope
+ *
+ * @param[in] name      name for labeling the output
+ * @param[in] runs      number of times to run @p func
+ * @param[in] func      function call to benchmark
+ */
+#define BENCHMARK_FUNC(name, runs, func)        \
+    state = irq_disable();                      \
+    time = xtimer_now_usec();                   \
+    for (unsigned long i = 0; i < runs; i++) {  \
+        func;                                   \
+    }                                           \
+    time = (xtimer_now_usec() - time);          \
+    irq_restore(state);                         \
+    benchmark_print_time(time, runs, name)
+
+/**
+ * @brief   Output the given time as well as the time per run on STDIO
+ *
+ * @param[in] time      overall runtime in us
+ * @param[in] runs      number of runs
+ * @param[in] name      name to label the output
+ */
+void benchmark_print_time(uint32_t time, unsigned long runs, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BENCHMARK_H */
+/** @} */

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -3,5 +3,6 @@ include ../Makefile.tests_common
 FEATURES_REQUIRED = periph_gpio
 
 USEMODULE += shell
+USEMODULE += benchmark
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -6,3 +6,6 @@ USEMODULE += shell
 USEMODULE += benchmark
 
 include $(RIOTBASE)/Makefile.include
+
+bench:
+	tests/02-bench.py

--- a/tests/periph_gpio/tests/02-bench.py
+++ b/tests/periph_gpio/tests/02-bench.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect_exact("GPIO peripheral driver test")
+    child.expect_exact(">")
+
+    for pin in range(0, 8):
+        child.sendline("bench 0 {}".format(pin))
+        child.expect(r" *nop loop: +(\d+)us  --- +(\d+\.\d+)us per call")
+        child.expect(r" *gpio_set: +(\d+)us  --- +(\d+\.\d+)us per call")
+        child.expect(r" *gpio_clear: +(\d+)us  --- +(\d+\.\d+)us per call")
+        child.expect(r" *gpio_toggle: +(\d+)us  --- +(\d+\.\d+)us per call")
+        child.expect(r" *gpio_read: +(\d+)us  --- +(\d+\.\d+)us per call")
+        child.expect(r" *gpio_write: +(\d+)us  --- +(\d+\.\d+)us per call")
+        child.expect_exact(" --- DONE ---")
+        child.expect_exact(">")
+
+    # TODO do some automated verification here? E.g. all pins should have the
+    #      same timing?
+    # TODO parse output data and put in some unified format?
+
+    print("Benchmark was successful")
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=10))


### PR DESCRIPTION
alternative to #7478

Instead of adding a dedicated benchmark application this PR simply adds the same functionality as shell command to the existing `periph_gpio` test application (as done some time ago also for the `periph_spi` test). For convenience and potentially more advanced improvements I added also a `make bench` target using pexpect. This way one can (semi-) automatically run the benchmark on any platform.

I know there is a 1000 things that can be build upon this (and possible also improved), but I'd like to get this in in the current state for now and we can always improve this later. But it is quite useful already and I prefer this solution over #7478.