### PR TITLE
testrunner: make traceback extraction downwards-compatible

### DIFF
--- a/dist/tools/testrunner/testrunner.py
+++ b/dist/tools/testrunner/testrunner.py
@@ -20,15 +20,15 @@ RIOTBASE = os.environ['RIOTBASE'] or \
            os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 def list_until(l, cond):
-    return l[:([i for i, e in  enumerate(l) if cond(e)][0])]
+    return l[:([i for i, e in enumerate(l) if cond(e)][0])]
 
 def find_exc_origin(exc_info):
     pos = list_until(extract_tb(exc_info),
-                     lambda frame: frame.filename.startswith(PEXPECT_PATH)
+                     lambda frame: frame[0].startswith(PEXPECT_PATH)
                     )[-1]
-    return pos.line, \
-           os.path.relpath(os.path.abspath(pos.filename), RIOTBASE), \
-           pos.lineno
+    return pos[3], \
+           os.path.relpath(os.path.abspath(pos[0]), RIOTBASE), \
+           pos[1]
 
 def run(testfunc, timeout=10, echo=True, traceback=False):
     env = os.environ.copy()


### PR DESCRIPTION
The object-like access to frame information in the traceback was only
introduced in Python 3.5. Before that version it was a 4-tuple [[1]].

The indexed way to access the frame seems to be upwards-compatible for
newer versions (tested with python 3.5, maybe some of the Arch crew can
test with even newer versions), so I used that one.

[1]: https://docs.python.org/3.4/library/traceback.html#traceback.extract_tb