### PR TITLE
boards: ikea-tradfri: add support

### DIFF
--- a/boards/ikea-tradfri/Makefile
+++ b/boards/ikea-tradfri/Makefile
@@ -1,0 +1,4 @@
+# tell the Makefile.base which module to build
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/ikea-tradfri/Makefile.dep
+++ b/boards/ikea-tradfri/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+    USEMODULE += saul_gpio
+endif
+
+include $(RIOTCPU)/efr32mg1p/Makefile.dep

--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -1,0 +1,12 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m4_2
+
+include $(RIOTCPU)/efr32mg1p/Makefile.features

--- a/boards/ikea-tradfri/Makefile.include
+++ b/boards/ikea-tradfri/Makefile.include
@@ -1,0 +1,14 @@
+# define the cpu used by ikea-tradfri
+export CPU = efr32mg1p
+export CPU_MODEL = efr32mg1p132f256gm32
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup JLink for flashing
+export JLINK_DEVICE := EFR32MG1PxxxF256
+include $(RIOTMAKE)/tools/jlink.inc.mk
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/ikea-tradfri/board.c
+++ b/boards/ikea-tradfri/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_ikea-tradfri
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations IKEA TRÅDFRI modules
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+}

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_ikea-tradfri IKEA TRÅDFRI modules
+ * @ingroup     boards
+ * @brief       Support for the IKEA TRÅDFRI modules
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the IKEA TRÅDFRI modules
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#include "periph_conf.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Xtimer configuration
+ *
+ * The timer runs at 250 KHz to increase accuracy.
+ * @{
+ */
+#define XTIMER_HZ           (250000UL)
+#define XTIMER_WIDTH        (16)
+/** @} */
+
+/**
+ * @name    LED pin definitions
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 1)
+#define LED1_PIN            GPIO_PIN(PB, 13)
+/** @} */
+
+/**
+ * @name    Macros for controlling the on-board LEDs
+ * @{
+ */
+#define LED0_ON             gpio_set(LED0_PIN)
+#define LED0_OFF            gpio_clear(LED0_PIN)
+#define LED0_TOGGLE         gpio_toggle(LED0_PIN)
+#define LED1_ON             gpio_set(LED1_PIN)
+#define LED1_OFF            gpio_clear(LED1_PIN)
+#define LED1_TOGGLE         gpio_toggle(LED1_PIN)
+/** @} */
+
+/**
+ * @brief   Initialize the board (GPIO, sensors, clocks).
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/ikea-tradfri/include/gpio_params.h
+++ b/boards/ikea-tradfri/include/gpio_params.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_ikea-tradfri
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED 0",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED 1",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_ikea-tradfri
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the IKEA TRÅDFRI modules
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "cpu.h"
+
+#include "periph_cpu.h"
+
+#include "em_cmu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Internal macro to calculate *_NUMOF based on config.
+ */
+#define PERIPH_NUMOF(config)    (sizeof(config) / sizeof(config[0]))
+
+/**
+ * @name    Clock configuration
+ * @{
+ */
+#ifndef CLOCK_HF
+#define CLOCK_HF            cmuSelect_HFRCO
+#endif
+#ifndef CLOCK_CORE_DIV
+#define CLOCK_CORE_DIV      cmuClkDiv_1
+#endif
+#ifndef CLOCK_LFA
+#define CLOCK_LFA           cmuSelect_LFRCO
+#endif
+#ifndef CLOCK_LFB
+#define CLOCK_LFB           cmuSelect_LFRCO
+#endif
+#ifndef CLOCK_LFE
+#define CLOCK_LFE           cmuSelect_LFRCO
+#endif
+/** @} */
+
+/**
+ * @brief   RTC configuration
+ */
+#define RTC_NUMOF           (1U)
+
+/**
+ * @name    RTT configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+
+#define RTT_MAX_VALUE       (0xFFFFFFFF)
+#define RTT_FREQUENCY       (1U)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_dev_t spi_config[] = {
+    {
+        .dev = USART1,
+        .mosi_pin = GPIO_PIN(PD, 15),
+        .miso_pin = GPIO_PIN(PD, 14),
+        .clk_pin = GPIO_PIN(PD, 13),
+        .loc = USART_ROUTELOC0_RXLOC_LOC21 |
+               USART_ROUTELOC0_TXLOC_LOC23 |
+               USART_ROUTELOC0_CLKLOC_LOC19,
+        .cmu = cmuClock_USART1,
+        .irq = USART1_RX_IRQn
+    }
+};
+
+#define SPI_NUMOF           PERIPH_NUMOF(spi_config)
+/** @} */
+
+/**
+ * @name    Timer configuration
+ *
+ * The implementation uses two timers in cascade mode.
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        {
+            .dev = TIMER0,
+            .cmu = cmuClock_TIMER0
+        },
+        {
+            .dev = TIMER1,
+            .cmu = cmuClock_TIMER1
+        },
+        .irq = TIMER1_IRQn
+    }
+};
+
+#define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
+#define TIMER_0_ISR         isr_timer1
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev = USART0,
+        .rx_pin = GPIO_PIN(PB, 15),
+        .tx_pin = GPIO_PIN(PB, 14),
+        .loc = USART_ROUTELOC0_RXLOC_LOC9 |
+               USART_ROUTELOC0_TXLOC_LOC9,
+        .cmu = cmuClock_USART0,
+        .irq = USART0_RX_IRQn
+    }
+};
+
+#define UART_NUMOF          PERIPH_NUMOF(uart_config)
+#define UART_0_ISR_RX       isr_usart0_rx
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/efr32mg1p/include/vendor/efr32mg1p132f256gm32.h
+++ b/cpu/efr32mg1p/include/vendor/efr32mg1p132f256gm32.h
@@ -1,0 +1,439 @@
+/**************************************************************************//**
+ * @file efr32mg1p132f256gm32.h
+ * @brief CMSIS Cortex-M Peripheral Access Layer Header File
+ *        for EFR32MG1P132F256GM32
+ * @version 5.3.3
+ ******************************************************************************
+ * # License
+ * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ ******************************************************************************
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software.@n
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.@n
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * DISCLAIMER OF WARRANTY/LIMITATION OF REMEDIES: Silicon Laboratories, Inc.
+ * has no obligation to support this Software. Silicon Laboratories, Inc. is
+ * providing the Software "AS IS", with no express or implied warranties of any
+ * kind, including, but not limited to, any implied warranties of
+ * merchantability or fitness for any particular purpose or warranties against
+ * infringement of any proprietary rights of a third party.
+ *
+ * Silicon Laboratories, Inc. will not be liable for any consequential,
+ * incidental, or special damages, or any other relief, or for any claim by
+ * any third party, arising from your use of this Software.
+ *
+ *****************************************************************************/
+
+#if defined(__ICCARM__)
+#pragma system_include       /* Treat file as system include file. */
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang system_header  /* Treat file as system include file. */
+#endif
+
+#ifndef EFR32MG1P132F256GM32_H
+#define EFR32MG1P132F256GM32_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**************************************************************************//**
+ * @addtogroup Parts
+ * @{
+ *****************************************************************************/
+
+/**************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM32 EFR32MG1P132F256GM32
+ * @{
+ *****************************************************************************/
+
+/** Interrupt Number Definition */
+typedef enum IRQn{
+/******  Cortex-M4 Processor Exceptions Numbers ********************************************/
+  NonMaskableInt_IRQn   = -14,              /*!< 2  Cortex-M4 Non Maskable Interrupt      */
+  HardFault_IRQn        = -13,              /*!< 3  Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn = -12,              /*!< 4  Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn         = -11,              /*!< 5  Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10,              /*!< 6  Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,               /*!< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,               /*!< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,               /*!< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,               /*!< 15 Cortex-M4 System Tick Interrupt       */
+
+/******  EFR32MG1P Peripheral Interrupt Numbers ********************************************/
+
+  EMU_IRQn              = 0,  /*!< 16+0 EFR32 EMU Interrupt */
+  WDOG0_IRQn            = 2,  /*!< 16+2 EFR32 WDOG0 Interrupt */
+  LDMA_IRQn             = 8,  /*!< 16+8 EFR32 LDMA Interrupt */
+  GPIO_EVEN_IRQn        = 9,  /*!< 16+9 EFR32 GPIO_EVEN Interrupt */
+  TIMER0_IRQn           = 10, /*!< 16+10 EFR32 TIMER0 Interrupt */
+  USART0_RX_IRQn        = 11, /*!< 16+11 EFR32 USART0_RX Interrupt */
+  USART0_TX_IRQn        = 12, /*!< 16+12 EFR32 USART0_TX Interrupt */
+  ACMP0_IRQn            = 13, /*!< 16+13 EFR32 ACMP0 Interrupt */
+  ADC0_IRQn             = 14, /*!< 16+14 EFR32 ADC0 Interrupt */
+  IDAC0_IRQn            = 15, /*!< 16+15 EFR32 IDAC0 Interrupt */
+  I2C0_IRQn             = 16, /*!< 16+16 EFR32 I2C0 Interrupt */
+  GPIO_ODD_IRQn         = 17, /*!< 16+17 EFR32 GPIO_ODD Interrupt */
+  TIMER1_IRQn           = 18, /*!< 16+18 EFR32 TIMER1 Interrupt */
+  USART1_RX_IRQn        = 19, /*!< 16+19 EFR32 USART1_RX Interrupt */
+  USART1_TX_IRQn        = 20, /*!< 16+20 EFR32 USART1_TX Interrupt */
+  LEUART0_IRQn          = 21, /*!< 16+21 EFR32 LEUART0 Interrupt */
+  PCNT0_IRQn            = 22, /*!< 16+22 EFR32 PCNT0 Interrupt */
+  CMU_IRQn              = 23, /*!< 16+23 EFR32 CMU Interrupt */
+  MSC_IRQn              = 24, /*!< 16+24 EFR32 MSC Interrupt */
+  CRYPTO_IRQn           = 25, /*!< 16+25 EFR32 CRYPTO Interrupt */
+  LETIMER0_IRQn         = 26, /*!< 16+26 EFR32 LETIMER0 Interrupt */
+  RTCC_IRQn             = 29, /*!< 16+29 EFR32 RTCC Interrupt */
+  CRYOTIMER_IRQn        = 31, /*!< 16+31 EFR32 CRYOTIMER Interrupt */
+  FPUEH_IRQn            = 33, /*!< 16+33 EFR32 FPUEH Interrupt */
+} IRQn_Type;
+
+/**************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM32_Core Core
+ * @{
+ * @brief Processor and Core Peripheral Section
+ *****************************************************************************/
+#define __MPU_PRESENT             1 /**< Presence of MPU  */
+#define __FPU_PRESENT             1 /**< Presence of FPU  */
+#define __VTOR_PRESENT            1 /**< Presence of VTOR register in SCB */
+#define __NVIC_PRIO_BITS          3 /**< NVIC interrupt priority bits */
+#define __Vendor_SysTickConfig    0 /**< Is 1 if different SysTick counter is used */
+
+/** @} End of group EFR32MG1P132F256GM32_Core */
+
+/**************************************************************************//**
+* @defgroup EFR32MG1P132F256GM32_Part Part
+* @{
+******************************************************************************/
+
+/** Part family */
+#define _EFR32_MIGHTY_FAMILY                    1                               /**< MIGHTY Gecko RF SoC Family  */
+#define _EFR_DEVICE                                                             /**< Silicon Labs EFR-type RF SoC */
+#define _SILICON_LABS_32B_SERIES_1                                              /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES                1                               /**< Silicon Labs series number */
+#define _SILICON_LABS_32B_SERIES_1_CONFIG_1                                     /**< Series 1, Configuration 1 */
+#define _SILICON_LABS_32B_SERIES_1_CONFIG       1                               /**< Series 1, Configuration 1 */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID       80                              /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_GECKO_INTERNAL_SDID_80                                    /**< Silicon Labs internal use only, may change any time */
+#define _SILICON_LABS_EFR32_RADIO_SUBGHZ        1                               /**< Radio supports Sub-GHz */
+#define _SILICON_LABS_EFR32_RADIO_2G4HZ         2                               /**< Radio supports 2.4 GHz */
+#define _SILICON_LABS_EFR32_RADIO_DUALBAND      3                               /**< Radio supports dual band */
+#define _SILICON_LABS_EFR32_RADIO_TYPE          _SILICON_LABS_EFR32_RADIO_2G4HZ /**< Radio type */
+#define _SILICON_LABS_32B_PLATFORM_2                                            /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM              2                               /**< @deprecated Silicon Labs platform name */
+#define _SILICON_LABS_32B_PLATFORM_2_GEN_1                                      /**< @deprecated Platform 2, generation 1 */
+#define _SILICON_LABS_32B_PLATFORM_2_GEN        1                               /**< @deprecated Platform 2, generation 1 */
+
+/* If part number is not defined as compiler option, define it */
+#if !defined(EFR32MG1P132F256GM32)
+#define EFR32MG1P132F256GM32    1 /**< MIGHTY Gecko Part */
+#endif
+
+/** Configure part number */
+#define PART_NUMBER               "EFR32MG1P132F256GM32" /**< Part Number */
+
+/** Memory Base addresses and limits */
+#define FLASH_MEM_BASE            ((uint32_t) 0x00000000UL) /**< FLASH base address  */
+#define FLASH_MEM_SIZE            ((uint32_t) 0x10000000UL) /**< FLASH available address space  */
+#define FLASH_MEM_END             ((uint32_t) 0x0FFFFFFFUL) /**< FLASH end address  */
+#define FLASH_MEM_BITS            ((uint32_t) 0x0000001CUL) /**< FLASH used bits  */
+#define RAM_CODE_MEM_BASE         ((uint32_t) 0x10000000UL) /**< RAM_CODE base address  */
+#define RAM_CODE_MEM_SIZE         ((uint32_t) 0x7C00UL)     /**< RAM_CODE available address space  */
+#define RAM_CODE_MEM_END          ((uint32_t) 0x10007BFFUL) /**< RAM_CODE end address  */
+#define RAM_CODE_MEM_BITS         ((uint32_t) 0x0000000FUL) /**< RAM_CODE used bits  */
+#define PER_BITCLR_MEM_BASE       ((uint32_t) 0x44000000UL) /**< PER_BITCLR base address  */
+#define PER_BITCLR_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITCLR available address space  */
+#define PER_BITCLR_MEM_END        ((uint32_t) 0x440E7FFFUL) /**< PER_BITCLR end address  */
+#define PER_BITCLR_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITCLR used bits  */
+#define CRYPTO_BITSET_MEM_BASE    ((uint32_t) 0x460F0000UL) /**< CRYPTO_BITSET base address  */
+#define CRYPTO_BITSET_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITSET available address space  */
+#define CRYPTO_BITSET_MEM_END     ((uint32_t) 0x460F03FFUL) /**< CRYPTO_BITSET end address  */
+#define CRYPTO_BITSET_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITSET used bits  */
+#define CRYPTO_MEM_BASE           ((uint32_t) 0x400F0000UL) /**< CRYPTO base address  */
+#define CRYPTO_MEM_SIZE           ((uint32_t) 0x400UL)      /**< CRYPTO available address space  */
+#define CRYPTO_MEM_END            ((uint32_t) 0x400F03FFUL) /**< CRYPTO end address  */
+#define CRYPTO_MEM_BITS           ((uint32_t) 0x0000000AUL) /**< CRYPTO used bits  */
+#define CRYPTO_BITCLR_MEM_BASE    ((uint32_t) 0x440F0000UL) /**< CRYPTO_BITCLR base address  */
+#define CRYPTO_BITCLR_MEM_SIZE    ((uint32_t) 0x400UL)      /**< CRYPTO_BITCLR available address space  */
+#define CRYPTO_BITCLR_MEM_END     ((uint32_t) 0x440F03FFUL) /**< CRYPTO_BITCLR end address  */
+#define CRYPTO_BITCLR_MEM_BITS    ((uint32_t) 0x0000000AUL) /**< CRYPTO_BITCLR used bits  */
+#define PER_BITSET_MEM_BASE       ((uint32_t) 0x46000000UL) /**< PER_BITSET base address  */
+#define PER_BITSET_MEM_SIZE       ((uint32_t) 0xE8000UL)    /**< PER_BITSET available address space  */
+#define PER_BITSET_MEM_END        ((uint32_t) 0x460E7FFFUL) /**< PER_BITSET end address  */
+#define PER_BITSET_MEM_BITS       ((uint32_t) 0x00000014UL) /**< PER_BITSET used bits  */
+#define PER_MEM_BASE              ((uint32_t) 0x40000000UL) /**< PER base address  */
+#define PER_MEM_SIZE              ((uint32_t) 0xE8000UL)    /**< PER available address space  */
+#define PER_MEM_END               ((uint32_t) 0x400E7FFFUL) /**< PER end address  */
+#define PER_MEM_BITS              ((uint32_t) 0x00000014UL) /**< PER used bits  */
+#define RAM_MEM_BASE              ((uint32_t) 0x20000000UL) /**< RAM base address  */
+#define RAM_MEM_SIZE              ((uint32_t) 0x7C00UL)     /**< RAM available address space  */
+#define RAM_MEM_END               ((uint32_t) 0x20007BFFUL) /**< RAM end address  */
+#define RAM_MEM_BITS              ((uint32_t) 0x0000000FUL) /**< RAM used bits  */
+
+/** Bit banding area */
+#define BITBAND_PER_BASE          ((uint32_t) 0x42000000UL) /**< Peripheral Address Space bit-band area */
+#define BITBAND_RAM_BASE          ((uint32_t) 0x22000000UL) /**< SRAM Address Space bit-band area */
+
+/** Flash and SRAM limits for EFR32MG1P132F256GM32 */
+#define FLASH_BASE                (0x00000000UL) /**< Flash Base Address */
+#define FLASH_SIZE                (0x00040000UL) /**< Available Flash Memory */
+#define FLASH_PAGE_SIZE           2048U          /**< Flash Memory page size */
+#define SRAM_BASE                 (0x20000000UL) /**< SRAM Base Address */
+#define SRAM_SIZE                 (0x00007C00UL) /**< Available SRAM Memory */
+#define __CM4_REV                 0x001          /**< Cortex-M4 Core revision r0p1 */
+#define PRS_CHAN_COUNT            12             /**< Number of PRS channels */
+#define DMA_CHAN_COUNT            8              /**< Number of DMA channels */
+#define EXT_IRQ_COUNT             34             /**< Number of External (NVIC) interrupts */
+
+/** AF channels connect the different on-chip peripherals with the af-mux */
+#define AFCHAN_MAX                72
+/** AF channel maximum location number */
+#define AFCHANLOC_MAX             32
+/** Analog AF channels */
+#define AFACHAN_MAX               61
+
+/* Part number capabilities */
+
+#define TIMER_PRESENT           /**< TIMER is available in this part */
+#define TIMER_COUNT           2 /**< 2 TIMERs available  */
+#define USART_PRESENT           /**< USART is available in this part */
+#define USART_COUNT           2 /**< 2 USARTs available  */
+#define LEUART_PRESENT          /**< LEUART is available in this part */
+#define LEUART_COUNT          1 /**< 1 LEUARTs available  */
+#define LETIMER_PRESENT         /**< LETIMER is available in this part */
+#define LETIMER_COUNT         1 /**< 1 LETIMERs available  */
+#define PCNT_PRESENT            /**< PCNT is available in this part */
+#define PCNT_COUNT            1 /**< 1 PCNTs available  */
+#define I2C_PRESENT             /**< I2C is available in this part */
+#define I2C_COUNT             1 /**< 1 I2Cs available  */
+#define ADC_PRESENT             /**< ADC is available in this part */
+#define ADC_COUNT             1 /**< 1 ADCs available  */
+#define ACMP_PRESENT            /**< ACMP is available in this part */
+#define ACMP_COUNT            2 /**< 2 ACMPs available  */
+#define IDAC_PRESENT            /**< IDAC is available in this part */
+#define IDAC_COUNT            1 /**< 1 IDACs available  */
+#define WDOG_PRESENT            /**< WDOG is available in this part */
+#define WDOG_COUNT            1 /**< 1 WDOGs available  */
+#define MSC_PRESENT             /**< MSC is available in this part */
+#define MSC_COUNT             1 /**< 1 MSC available */
+#define EMU_PRESENT             /**< EMU is available in this part */
+#define EMU_COUNT             1 /**< 1 EMU available */
+#define RMU_PRESENT             /**< RMU is available in this part */
+#define RMU_COUNT             1 /**< 1 RMU available */
+#define CMU_PRESENT             /**< CMU is available in this part */
+#define CMU_COUNT             1 /**< 1 CMU available */
+#define CRYPTO_PRESENT          /**< CRYPTO is available in this part */
+#define CRYPTO_COUNT          1 /**< 1 CRYPTO available */
+#define GPIO_PRESENT            /**< GPIO is available in this part */
+#define GPIO_COUNT            1 /**< 1 GPIO available */
+#define PRS_PRESENT             /**< PRS is available in this part */
+#define PRS_COUNT             1 /**< 1 PRS available */
+#define LDMA_PRESENT            /**< LDMA is available in this part */
+#define LDMA_COUNT            1 /**< 1 LDMA available */
+#define FPUEH_PRESENT           /**< FPUEH is available in this part */
+#define FPUEH_COUNT           1 /**< 1 FPUEH available */
+#define GPCRC_PRESENT           /**< GPCRC is available in this part */
+#define GPCRC_COUNT           1 /**< 1 GPCRC available */
+#define CRYOTIMER_PRESENT       /**< CRYOTIMER is available in this part */
+#define CRYOTIMER_COUNT       1 /**< 1 CRYOTIMER available */
+#define RTCC_PRESENT            /**< RTCC is available in this part */
+#define RTCC_COUNT            1 /**< 1 RTCC available */
+#define BOOTLOADER_PRESENT      /**< BOOTLOADER is available in this part */
+#define BOOTLOADER_COUNT      1 /**< 1 BOOTLOADER available */
+#define DCDC_PRESENT            /**< DCDC is available in this part */
+#define DCDC_COUNT            1 /**< 1 DCDC available */
+
+#include "core_cm4.h"           /* Cortex-M4 processor and core peripherals */
+#include "system_efr32mg1p.h"   /* System Header File */
+
+/** @} End of group EFR32MG1P132F256GM32_Part */
+
+/**************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM32_Peripheral_TypeDefs Peripheral TypeDefs
+ * @{
+ * @brief Device Specific Peripheral Register Structures
+ *****************************************************************************/
+
+#include "efr32mg1p_msc.h"
+#include "efr32mg1p_emu.h"
+#include "efr32mg1p_rmu.h"
+#include "efr32mg1p_cmu.h"
+#include "efr32mg1p_crypto.h"
+#include "efr32mg1p_gpio_p.h"
+#include "efr32mg1p_gpio.h"
+#include "efr32mg1p_prs_ch.h"
+#include "efr32mg1p_prs.h"
+#include "efr32mg1p_ldma_ch.h"
+#include "efr32mg1p_ldma.h"
+#include "efr32mg1p_fpueh.h"
+#include "efr32mg1p_gpcrc.h"
+#include "efr32mg1p_timer_cc.h"
+#include "efr32mg1p_timer.h"
+#include "efr32mg1p_usart.h"
+#include "efr32mg1p_leuart.h"
+#include "efr32mg1p_letimer.h"
+#include "efr32mg1p_cryotimer.h"
+#include "efr32mg1p_pcnt.h"
+#include "efr32mg1p_i2c.h"
+#include "efr32mg1p_adc.h"
+#include "efr32mg1p_acmp.h"
+#include "efr32mg1p_idac.h"
+#include "efr32mg1p_rtcc_cc.h"
+#include "efr32mg1p_rtcc_ret.h"
+#include "efr32mg1p_rtcc.h"
+#include "efr32mg1p_wdog_pch.h"
+#include "efr32mg1p_wdog.h"
+#include "efr32mg1p_dma_descriptor.h"
+#include "efr32mg1p_devinfo.h"
+#include "efr32mg1p_romtable.h"
+
+/** @} End of group EFR32MG1P132F256GM32_Peripheral_TypeDefs  */
+
+/**************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM32_Peripheral_Base Peripheral Memory Map
+ * @{
+ *****************************************************************************/
+
+#define MSC_BASE          (0x400E0000UL) /**< MSC base address  */
+#define EMU_BASE          (0x400E3000UL) /**< EMU base address  */
+#define RMU_BASE          (0x400E5000UL) /**< RMU base address  */
+#define CMU_BASE          (0x400E4000UL) /**< CMU base address  */
+#define CRYPTO_BASE       (0x400F0000UL) /**< CRYPTO base address  */
+#define GPIO_BASE         (0x4000A000UL) /**< GPIO base address  */
+#define PRS_BASE          (0x400E6000UL) /**< PRS base address  */
+#define LDMA_BASE         (0x400E2000UL) /**< LDMA base address  */
+#define FPUEH_BASE        (0x400E1000UL) /**< FPUEH base address  */
+#define GPCRC_BASE        (0x4001C000UL) /**< GPCRC base address  */
+#define TIMER0_BASE       (0x40018000UL) /**< TIMER0 base address  */
+#define TIMER1_BASE       (0x40018400UL) /**< TIMER1 base address  */
+#define USART0_BASE       (0x40010000UL) /**< USART0 base address  */
+#define USART1_BASE       (0x40010400UL) /**< USART1 base address  */
+#define LEUART0_BASE      (0x4004A000UL) /**< LEUART0 base address  */
+#define LETIMER0_BASE     (0x40046000UL) /**< LETIMER0 base address  */
+#define CRYOTIMER_BASE    (0x4001E000UL) /**< CRYOTIMER base address  */
+#define PCNT0_BASE        (0x4004E000UL) /**< PCNT0 base address  */
+#define I2C0_BASE         (0x4000C000UL) /**< I2C0 base address  */
+#define ADC0_BASE         (0x40002000UL) /**< ADC0 base address  */
+#define ACMP0_BASE        (0x40000000UL) /**< ACMP0 base address  */
+#define ACMP1_BASE        (0x40000400UL) /**< ACMP1 base address  */
+#define IDAC0_BASE        (0x40006000UL) /**< IDAC0 base address  */
+#define RTCC_BASE         (0x40042000UL) /**< RTCC base address  */
+#define WDOG0_BASE        (0x40052000UL) /**< WDOG0 base address  */
+#define DEVINFO_BASE      (0x0FE081B0UL) /**< DEVINFO base address */
+#define ROMTABLE_BASE     (0xE00FFFD0UL) /**< ROMTABLE base address */
+#define LOCKBITS_BASE     (0x0FE04000UL) /**< Lock-bits page base address */
+#define USERDATA_BASE     (0x0FE00000UL) /**< User data page base address */
+
+/** @} End of group EFR32MG1P132F256GM32_Peripheral_Base */
+
+/**************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM32_Peripheral_Declaration Peripheral Declarations
+ * @{
+ *****************************************************************************/
+
+#define MSC          ((MSC_TypeDef *) MSC_BASE)             /**< MSC base pointer */
+#define EMU          ((EMU_TypeDef *) EMU_BASE)             /**< EMU base pointer */
+#define RMU          ((RMU_TypeDef *) RMU_BASE)             /**< RMU base pointer */
+#define CMU          ((CMU_TypeDef *) CMU_BASE)             /**< CMU base pointer */
+#define CRYPTO       ((CRYPTO_TypeDef *) CRYPTO_BASE)       /**< CRYPTO base pointer */
+#define GPIO         ((GPIO_TypeDef *) GPIO_BASE)           /**< GPIO base pointer */
+#define PRS          ((PRS_TypeDef *) PRS_BASE)             /**< PRS base pointer */
+#define LDMA         ((LDMA_TypeDef *) LDMA_BASE)           /**< LDMA base pointer */
+#define FPUEH        ((FPUEH_TypeDef *) FPUEH_BASE)         /**< FPUEH base pointer */
+#define GPCRC        ((GPCRC_TypeDef *) GPCRC_BASE)         /**< GPCRC base pointer */
+#define TIMER0       ((TIMER_TypeDef *) TIMER0_BASE)        /**< TIMER0 base pointer */
+#define TIMER1       ((TIMER_TypeDef *) TIMER1_BASE)        /**< TIMER1 base pointer */
+#define USART0       ((USART_TypeDef *) USART0_BASE)        /**< USART0 base pointer */
+#define USART1       ((USART_TypeDef *) USART1_BASE)        /**< USART1 base pointer */
+#define LEUART0      ((LEUART_TypeDef *) LEUART0_BASE)      /**< LEUART0 base pointer */
+#define LETIMER0     ((LETIMER_TypeDef *) LETIMER0_BASE)    /**< LETIMER0 base pointer */
+#define CRYOTIMER    ((CRYOTIMER_TypeDef *) CRYOTIMER_BASE) /**< CRYOTIMER base pointer */
+#define PCNT0        ((PCNT_TypeDef *) PCNT0_BASE)          /**< PCNT0 base pointer */
+#define I2C0         ((I2C_TypeDef *) I2C0_BASE)            /**< I2C0 base pointer */
+#define ADC0         ((ADC_TypeDef *) ADC0_BASE)            /**< ADC0 base pointer */
+#define ACMP0        ((ACMP_TypeDef *) ACMP0_BASE)          /**< ACMP0 base pointer */
+#define ACMP1        ((ACMP_TypeDef *) ACMP1_BASE)          /**< ACMP1 base pointer */
+#define IDAC0        ((IDAC_TypeDef *) IDAC0_BASE)          /**< IDAC0 base pointer */
+#define RTCC         ((RTCC_TypeDef *) RTCC_BASE)           /**< RTCC base pointer */
+#define WDOG0        ((WDOG_TypeDef *) WDOG0_BASE)          /**< WDOG0 base pointer */
+#define DEVINFO      ((DEVINFO_TypeDef *) DEVINFO_BASE)     /**< DEVINFO base pointer */
+#define ROMTABLE     ((ROMTABLE_TypeDef *) ROMTABLE_BASE)   /**< ROMTABLE base pointer */
+
+/** @} End of group EFR32MG1P132F256GM32_Peripheral_Declaration */
+
+/**************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM32_Peripheral_Offsets Peripheral Offsets
+ * @{
+ *****************************************************************************/
+
+#define TIMER_OFFSET      0x400 /**< Offset in bytes between TIMER instances */
+#define USART_OFFSET      0x400 /**< Offset in bytes between USART instances */
+#define LEUART_OFFSET     0x400 /**< Offset in bytes between LEUART instances */
+#define LETIMER_OFFSET    0x400 /**< Offset in bytes between LETIMER instances */
+#define PCNT_OFFSET       0x400 /**< Offset in bytes between PCNT instances */
+#define I2C_OFFSET        0x400 /**< Offset in bytes between I2C instances */
+#define ADC_OFFSET        0x400 /**< Offset in bytes between ADC instances */
+#define ACMP_OFFSET       0x400 /**< Offset in bytes between ACMP instances */
+#define IDAC_OFFSET       0x400 /**< Offset in bytes between IDAC instances */
+#define WDOG_OFFSET       0x400 /**< Offset in bytes between WDOG instances */
+
+/** @} End of group EFR32MG1P132F256GM32_Peripheral_Offsets */
+
+/**************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM32_BitFields Bit Fields
+ * @{
+ *****************************************************************************/
+
+#include "efr32mg1p_prs_signals.h"
+#include "efr32mg1p_dmareq.h"
+
+/**************************************************************************//**
+ * @defgroup EFR32MG1P132F256GM32_UNLOCK Unlock Codes
+ * @{
+ *****************************************************************************/
+#define MSC_UNLOCK_CODE      0x1B71 /**< MSC unlock code */
+#define EMU_UNLOCK_CODE      0xADE8 /**< EMU unlock code */
+#define RMU_UNLOCK_CODE      0xE084 /**< RMU unlock code */
+#define CMU_UNLOCK_CODE      0x580E /**< CMU unlock code */
+#define GPIO_UNLOCK_CODE     0xA534 /**< GPIO unlock code */
+#define TIMER_UNLOCK_CODE    0xCE80 /**< TIMER unlock code */
+#define RTCC_UNLOCK_CODE     0xAEE8 /**< RTCC unlock code */
+
+/** @} End of group EFR32MG1P132F256GM32_UNLOCK */
+
+/** @} End of group EFR32MG1P132F256GM32_BitFields */
+
+#include "efr32mg1p_af_ports.h"
+#include "efr32mg1p_af_pins.h"
+
+/**************************************************************************//**
+ *  @brief Set the value of a bit field within a register.
+ *
+ *  @param REG
+ *       The register to update
+ *  @param MASK
+ *       The mask for the bit field to update
+ *  @param VALUE
+ *       The value to write to the bit field
+ *  @param OFFSET
+ *       The number of bits that the field is offset within the register.
+ *       0 (zero) means LSB.
+ *****************************************************************************/
+#define SET_BIT_FIELD(REG, MASK, VALUE, OFFSET) \
+  REG = ((REG) &~(MASK)) | (((VALUE) << (OFFSET)) & (MASK));
+
+/** @} End of group EFR32MG1P132F256GM32 */
+
+/** @} End of group Parts */
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* EFR32MG1P132F256GM32_H */

--- a/cpu/efr32mg1p/include/vendor/em_device.h
+++ b/cpu/efr32mg1p/include/vendor/em_device.h
@@ -52,6 +52,9 @@ extern "C" {
 #if defined(EFR32MG1P132F256GM48)
 #include "efr32mg1p132f256gm48.h"
 
+#elif defined(EFR32MG1P132F256GM32)
+#include "efr32mg1p132f256gm32.h"
+
 #else
 #error "em_device.h: PART NUMBER undefined"
 #endif

--- a/cpu/efr32mg1p/ldscripts/efr32mg1p132f256gm32.ld
+++ b/cpu/efr32mg1p/ldscripts/efr32mg1p132f256gm32.ld
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015-2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup      cpu_efr32mg1p
+ * @{
+ *
+ * @file
+ * @brief           Memory definitions for the EFR32MG1P132F256GM32 CPU
+ *
+ * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author          Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+MEMORY
+{
+    rom (rx)    : ORIGIN = 0x00000000, LENGTH = 262144
+    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 31744
+}
+
+INCLUDE cortexm_base.ld


### PR DESCRIPTION
Last week I found out that the [IKEA TRÅDFRI](http://www.ikea.com/us/en/catalog/categories/departments/lighting/36812/) lighting products and accessories use the Silicon Labs EZR32MG1P microcontroller. Let it be a coincidence that the Thunderboard Sense (#7929) which was merged this week, uses the same CPU!

Now if we look into their line of products, it happens that they use the same CPU module in all(?) of their products: [here](https://www.heise.de/make/artikel/Ikea-Tradfri-Anleitung-fuer-ein-ESP8266-Lampen-Gateway-3598411.html), [here](http://tradfri.blogspot.nl/2017/04/teardown-of-ikea-tradfri-bulb-led1623g12.html) and [here](https://github.com/basilfx/TRADFRI-Hacking). Nonetheless, you can isolate them from the product, and use them for your own ideas, or leave them in and flash a custom firmware. 

The MCU is a ARM Cortex M4 with 256 kB of flash. It's quite packed (including hardware crypto), flexible pin mapping and has an integrated radio which supports Thread, ZigBee Light Link and more. 

It won't surprise me if people buy the cheapest light available (the GU-10 I used costed me 6,99 euro) and upgrade, hack or repurpose them. Let RIOT-OS be one of the first to support them :-)

This PR is a quick port to this new platform. I have more information on the module over [here](https://github.com/basilfx/TRADFRI-Hacking) and a demonstration video [here](https://www.youtube.com/watch?v=yi_Z2WtmdDU). For flashing you need to connect a JTAG/SWD compatible debugger, but I can flash it the exact same way as the Thunderboard Sense when I use SEGGER JLink. You do not even have to remove the module.