### PR TITLE
gnrc_netif2: make more complexer functions not inline

### DIFF
--- a/sys/include/net/gnrc/netif2/internal.h
+++ b/sys/include/net/gnrc/netif2/internal.h
@@ -39,12 +39,7 @@ extern "C" {
  *
  * @internal
  */
-static inline void gnrc_netif2_acquire(gnrc_netif2_t *netif)
-{
-    if (netif && (netif->ops)) {
-        rmutex_lock(&netif->mutex);
-    }
-}
+void gnrc_netif2_acquire(gnrc_netif2_t *netif);
 
 /**
  * @brief   Releases exclusive access to the interface
@@ -53,12 +48,7 @@ static inline void gnrc_netif2_acquire(gnrc_netif2_t *netif)
  *
  * @internal
  */
-static inline void gnrc_netif2_release(gnrc_netif2_t *netif)
-{
-    if (netif && (netif->ops)) {
-        rmutex_unlock(&netif->mutex);
-    }
-}
+void gnrc_netif2_release(gnrc_netif2_t *netif);
 
 #if defined(MODULE_GNRC_IPV6) || DOXYGEN
 /**
@@ -344,17 +334,7 @@ static inline bool gnrc_netif2_is_rtr_adv(const gnrc_netif2_t *netif)
  * @return  true, if the interface represents a 6LN
  * @return  false, if the interface does not represent a 6LN
  */
-static inline bool gnrc_netif2_is_6ln(const gnrc_netif2_t *netif)
-{
-    switch (netif->device_type) {
-        case NETDEV_TYPE_IEEE802154:
-        case NETDEV_TYPE_CC110X:
-        case NETDEV_TYPE_NRFMIN:
-            return true;
-        default:
-            return false;
-    }
-}
+bool gnrc_netif2_is_6ln(const gnrc_netif2_t *netif);
 
 /**
  * @brief   Checks if the interface represents a 6Lo router (6LR) according to

--- a/sys/net/gnrc/netif2/gnrc_netif2.c
+++ b/sys/net/gnrc/netif2/gnrc_netif2.c
@@ -428,6 +428,20 @@ size_t gnrc_netif2_addr_from_str(const char *str, uint8_t *out)
     return count;
 }
 
+void gnrc_netif2_acquire(gnrc_netif2_t *netif)
+{
+    if (netif && (netif->ops)) {
+        rmutex_lock(&netif->mutex);
+    }
+}
+
+void gnrc_netif2_release(gnrc_netif2_t *netif)
+{
+    if (netif && (netif->ops)) {
+        rmutex_unlock(&netif->mutex);
+    }
+}
+
 #ifdef MODULE_GNRC_IPV6
 static inline bool _addr_anycast(const gnrc_netif2_t *netif, unsigned idx);
 static int _addr_idx(const gnrc_netif2_t *netif, const ipv6_addr_t *addr);
@@ -1028,8 +1042,19 @@ static int _group_idx(const gnrc_netif2_t *netif, const ipv6_addr_t *addr)
     }
     return -1;
 }
-
 #endif  /* MODULE_GNRC_IPV6 */
+
+bool gnrc_netif2_is_6ln(const gnrc_netif2_t *netif)
+{
+    switch (netif->device_type) {
+        case NETDEV_TYPE_IEEE802154:
+        case NETDEV_TYPE_CC110X:
+        case NETDEV_TYPE_NRFMIN:
+            return true;
+        default:
+            return false;
+    }
+}
 
 static void _update_l2addr_from_dev(gnrc_netif2_t *netif)
 {


### PR DESCRIPTION
With this optimization I get about

* 150-200 B less on Cortex-M platforms
* 200 B less on MSP430 platforms
* 300-350 B less on AVR, ARM-7, and MIPS platforms

when I merge this one into #7479.