### PR TITLE
dist/tools/testrunner: Make started wait time configurable

### DIFF
--- a/dist/tools/testrunner/testrunner.py
+++ b/dist/tools/testrunner/testrunner.py
@@ -19,6 +19,11 @@ PEXPECT_PATH = os.path.dirname(pexpect.__file__)
 RIOTBASE = os.environ['RIOTBASE'] or \
            os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
+# Setting an empty 'TESTRUNNER_START_DELAY' environment variable use the
+# default value (3)
+MAKE_TERM_STARTED_DELAY = int(os.environ.get('TESTRUNNER_START_DELAY') or 3)
+
+
 def list_until(l, cond):
     return l[:([i for i, e in enumerate(l) if cond(e)][0])]
 
@@ -33,7 +38,7 @@ def run(testfunc, timeout=10, echo=True, traceback=False):
     child = pexpect.spawnu("make term", env=env, timeout=timeout)
 
     # on many platforms, the termprog needs a short while to be ready...
-    time.sleep(3)
+    time.sleep(MAKE_TERM_STARTED_DELAY)
 
     if echo:
         child.logfile = sys.stdout


### PR DESCRIPTION
The wait before board is started is 3 by default but can be overwritten by
setting 'TESTRUNNER_START_WAIT' environment variable.

This could help when the default 3 seconds does not fit like https://github.com/RIOT-OS/RIOT/pull/7992#issuecomment-344884708