### PR TITLE
Makefile.include: made configured baudrate available to programm

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -292,6 +292,11 @@ ifeq ($(origin RIOT_VERSION), undefined)
   endif
 endif
 
+# make the configured baudrate available to the programm 
+ifdef BAUD
+  CFLAGS += -DUART_STDIO_BAUDRATE=$(BAUD)
+endif
+
 # the binaries to link
 BASELIBS += $(BINDIR)/${APPLICATION}.a
 BASELIBS += $(APPDEPS)

--- a/Makefile.include
+++ b/Makefile.include
@@ -292,7 +292,7 @@ ifeq ($(origin RIOT_VERSION), undefined)
   endif
 endif
 
-# make the configured baudrate available to the programm 
+# make the configured baudrate available to the programm
 ifdef BAUD
   CFLAGS += -DUART_STDIO_BAUDRATE=$(BAUD)
 endif

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -1,6 +1,10 @@
 export DOCKER_IMAGE ?= riot/riotbuild:latest
 export DOCKER_BUILD_ROOT ?= /data/riotbuild
 export DOCKER_FLAGS ?= --rm
+ifdef BAUD
+export DOCKER_FLAGS += -e BAUD=$(BAUD)
+endif
+
 # List of Docker-enabled make goals
 export DOCKER_MAKECMDGOALS_POSSIBLE = \
   all \


### PR DESCRIPTION
"make BAUD=x" defines UART_STDIO_BAUDRATE to x
Now "make BAUD=x flash term" works consistently