### PR TITLE
examples: gnrc_tftp: add bluepill board to insufficient memory list

### DIFF
--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -7,8 +7,8 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon calliope-mini chronos microbit msb-430 \
-                             msb-430h nrf51dongle nrf6310 nucleo32-f031 \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon bluepill calliope-mini chronos \
+                             microbit msb-430 msb-430h nrf51dongle nrf6310 nucleo32-f031 \
                              nucleo32-f042 nucleo32-f303 nucleo32-l031 nucleo-f030 \
                              nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f302 nucleo-f334 \
                              nucleo-l053 pca10000 pca10005 spark-core stm32f0discovery \


### PR DESCRIPTION
The NIB makes this application (for now) to big for this board. So put it into the list of boards with insufficient memory for now.