### PR TITLE
boards, pba-d-01-kw2x: fix saul gpio init

### DIFF
--- a/boards/pba-d-01-kw2x/include/gpio_params.h
+++ b/boards/pba-d-01-kw2x/include/gpio_params.h
@@ -32,29 +32,34 @@ extern "C" {
 static const saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
-        .pin = LED0_PIN,
-        .mode = GPIO_OUT
+        .name   = "LED(red)",
+        .pin    = LED0_PIN,
+        .mode   = GPIO_OUT,
+        .flags  = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name = "LED(green)",
-        .pin = LED1_PIN,
-        .mode = GPIO_OUT
+        .name   = "LED(green)",
+        .pin    = LED1_PIN,
+        .mode   = GPIO_OUT,
+        .flags  = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name = "LED(blue)",
-        .pin = LED2_PIN,
-        .mode = GPIO_OUT
+        .name   = "LED(blue)",
+        .pin    = LED2_PIN,
+        .mode   = GPIO_OUT,
+        .flags  = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
     },
     {
-        .name = "Button(SW0)",
-        .pin  = BTN0_PIN,
-        .mode = BTN0_MODE
+        .name   = "Button(SW0)",
+        .pin    = BTN0_PIN,
+        .mode   = BTN0_MODE,
+        .flags  = SAUL_GPIO_INVERTED
     },
     {
-        .name = "Button(CS0)",
-        .pin  = BTN1_PIN,
-        .mode = BTN1_MODE
+        .name   = "Button(CS0)",
+        .pin    = BTN1_PIN,
+        .mode   = BTN1_MODE,
+        .flags  = 0x0
     },
 };
 


### PR DESCRIPTION
followup on e.g. #7759 to invert SAUL GPIO for LEDs and button on init.

Rational: LED control is inverted, i.e., LED off is reported as `1` on read, same for the button, which is set `1` when not pressed and `0` when pressed. This PR corrects this by inverting the logic in SAUL init.