### PR TITLE
drivers/sx127x: fix iq_invert bug, build issue with SX1272 and minor enhancements

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -613,7 +613,16 @@ void sx127x_set_rx_timeout(sx127x_t *dev, uint32_t timeout);
 void sx127x_set_tx_timeout(sx127x_t *dev, uint32_t timeout);
 
 /**
- * @brief   Sets the SX127X LoRa IQ inverted mode
+ * @brief   Checks if the SX127X LoRa inverted IQ mode is enabled/disabled
+ *
+ * @param[in] dev                      The sx127x device descriptor
+ *
+ * @return the LoRa IQ inverted mode
+ */
+bool sx127x_get_iq_invert(const sx127x_t *dev);
+
+/**
+ * @brief   Enable/disable the SX127X LoRa IQ inverted mode
  *
  * @param[in] dev                      The sx127x device descriptor
  * @param[in] iq_invert                The LoRa IQ inverted mode

--- a/drivers/sx127x/include/sx127x_netdev.h
+++ b/drivers/sx127x/include/sx127x_netdev.h
@@ -38,7 +38,6 @@ typedef struct netdev_radio_lora_packet_info {
     uint8_t rssi;           /**< RSSI of a received packet */
     uint8_t lqi;            /**< LQI of a received packet */
     int8_t snr;             /**< S/N ratio */
-    uint32_t time_on_air;   /**< Time on air of a received packet (ms) */
 } netdev_sx127x_lora_packet_info_t;
 
 #ifdef __cplusplus

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -235,7 +235,7 @@ void sx127x_set_rx(sx127x_t *dev)
                              ((sx127x_reg_read(dev, SX127X_REG_LR_INVERTIQ) &
                                SX127X_RF_LORA_INVERTIQ_TX_MASK &
                                SX127X_RF_LORA_INVERTIQ_RX_MASK) |
-                              SX127X_RF_LORA_INVERTIQ_RX_ON |
+                              ((dev->settings.lora.flags & SX127X_IQ_INVERTED_FLAG) ? SX127X_RF_LORA_INVERTIQ_RX_ON :SX127X_RF_LORA_INVERTIQ_RX_OFF) |
                               SX127X_RF_LORA_INVERTIQ_TX_OFF));
             sx127x_reg_write(dev, SX127X_REG_LR_INVERTIQ2,
                              ((dev->settings.lora.flags & SX127X_IQ_INVERTED_FLAG) ? SX127X_RF_LORA_INVERTIQ2_ON : SX127X_RF_LORA_INVERTIQ2_OFF));

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -479,13 +479,13 @@ inline void _update_bandwidth(const sx127x_t *dev)
 #if defined(MODULE_SX1272)
     config1_reg &= SX1272_RF_LORA_MODEMCONFIG1_BW_MASK;
     switch (dev->settings.lora.bandwidth) {
-    case SX127X_BW_125_KHZ:
+    case LORA_BW_125_KHZ:
         config1_reg |=  SX1272_RF_LORA_MODEMCONFIG1_BW_125_KHZ;
         break;
-    case SX127X_BW_250_KHZ:
+    case LORA_BW_250_KHZ:
         config1_reg |=  SX1272_RF_LORA_MODEMCONFIG1_BW_250_KHZ;
         break;
-    case SX127X_BW_500_KHZ:
+    case LORA_BW_500_KHZ:
         config1_reg |=  SX1272_RF_LORA_MODEMCONFIG1_BW_500_KHZ;
         break;
     default:

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -850,6 +850,11 @@ void sx127x_set_symbol_timeout(sx127x_t *dev, uint16_t timeout)
     sx127x_reg_write(dev, SX127X_REG_LR_SYMBTIMEOUTLSB,timeout & 0xFF);
 }
 
+bool sx127x_get_iq_invert(const sx127x_t *dev)
+{
+    return dev->settings.lora.flags & SX127X_IQ_INVERTED_FLAG;
+}
+
 void sx127x_set_iq_invert(sx127x_t *dev, bool iq_invert)
 {
     DEBUG("[DEBUG] Set IQ invert: %d\n", iq_invert);

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -91,7 +91,7 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
             }
 
             /* Write payload buffer */
-            for (size_t i = 0;i < count ; i++) {
+            for (size_t i = 0; i < count; i++) {
                 sx127x_write_fifo(dev, vector[i].iov_base, vector[i].iov_len);
             }
             break;
@@ -196,7 +196,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
                     }
 #endif
                 }
-                packet_info->time_on_air = sx127x_get_time_on_air(dev, len);
             }
 
             size = sx127x_reg_read(dev, SX127X_REG_LR_RXNBBYTES);

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -342,6 +342,16 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             *((netopt_enable_t*) val) = sx127x_get_rx_single(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
             break;
 
+        case NETOPT_TX_POWER:
+            assert(max_len >= sizeof(int8_t));
+            *((int8_t*) val) = sx127x_get_tx_power(dev);
+            return sizeof(int8_t);
+
+        case NETOPT_IQ_INVERT:
+            assert(max_len >= sizeof(uint8_t));
+            *((netopt_enable_t*) val) = sx127x_get_iq_invert(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
+            break;
+
         default:
             break;
     }
@@ -427,7 +437,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             return sizeof(uint8_t);
 
         case NETOPT_SINGLE_RECEIVE:
-            assert(len <= sizeof(uint8_t));
+            assert(len <= sizeof(netopt_enable_t));
             sx127x_set_rx_single(dev, *((const netopt_enable_t*) val) ? true : false);
             return sizeof(netopt_enable_t);
 

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -221,7 +221,7 @@ int send_cmd(int argc, char **argv)
         return -1;
     }
 
-    printf("sending \"%s\" payload (%zd bytes)\n",
+    printf("sending \"%s\" payload (%d bytes)\n",
            argv[1], strlen(argv[1]) + 1);
 
     struct iovec vec[1];

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -241,7 +241,10 @@ int listen_cmd(int argc, char **argv)
 
     /* Switch to continuous listen mode */
     netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, false, sizeof(uint8_t));
-    sx127x_set_rx(&sx127x);
+
+    /* Switch to RX state */
+    uint8_t state = NETOPT_STATE_RX;
+    netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(uint8_t));
 
     printf("Listen mode set\n");
 
@@ -308,10 +311,10 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
             case NETDEV_EVENT_RX_COMPLETE:
                 len = dev->driver->recv(dev, NULL, 0, 0);
                 dev->driver->recv(dev, message, len, &packet_info);
-                printf("{Payload: \"%s\" (%d bytes), RSSI: %i, SNR: %i, TOA: %i}\n",
+                printf("{Payload: \"%s\" (%d bytes), RSSI: %i, SNR: %i, TOA: %lu}\n",
                        message, (int)len,
                        packet_info.rssi, (int)packet_info.snr,
-                       (int)packet_info.time_on_air);
+                       sx127x_get_time_on_air((const sx127x_t*)dev, len));
                 break;
             case NETDEV_EVENT_TX_COMPLETE:
                 sx127x_set_sleep(&sx127x);


### PR DESCRIPTION
I'm trying to split in small PRs the gnrc unrelated pieces introduced in #7950.

This one just adds new getters in the netdev interface of sx127x radio driver and does some cleanup as well.
It also drop the time_on_air attribute because I think it's useless to have it here.