### PR TITLE
gnrc_ipv6_nib: actually timeout a default router

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -184,7 +184,10 @@ typedef struct _nib_onl_entry {
  */
 typedef struct {
     _nib_onl_entry_t *next_hop; /**< next hop to destination */
-    uint16_t ltime;             /**< lifetime in seconds */
+    /**
+     * @brief   Event for @ref GNRC_IPV6_NIB_RTR_TIMEOUT
+     */
+    evtimer_msg_event_t rtr_timeout;
 } _nib_dr_entry_t;
 
 /**


### PR DESCRIPTION
While the GNRC_IPV6_NIB_RTR_TIMEOUT is properly handled, it is actually
never fired. Moreover, the router lifetime is set, but never read.

This removes the router lifetime and switches it out for an evtimer
to does the GNRC_IPV6_NIB_RTR_TIMEOUT event.