### PR TITLE
tests: revert removal of pca1000x in gnrc_netif2

### DIFF
--- a/tests/gnrc_netif2/Makefile
+++ b/tests/gnrc_netif2/Makefile
@@ -8,7 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini 
                              nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 \
                              nucleo-f302 nucleo-f334 nucleo-l053 nucleo-l073 \
                              nucleo32-f031 nucleo32-f042 nucleo32-f303 \
-                             nucleo32-l031 opencm904 \
+                             nucleo32-l031 opencm904 pca10000 pca10005 \
                              spark-core stm32f0discovery telosb wsn430-v1_3b \
                              wsn430-v1_4 yunjia-nrf51822 z1 \
 


### PR DESCRIPTION
As in #7986 this application (obviously) causes a conflict in #7925 since #7979. This PR fixes that.