### PR TITLE
gnrc_ipv6_nib: add timeouts to routes

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -192,6 +192,16 @@ extern "C" {
  * @note    Only handled with @ref GNRC_IPV6_NIB_CONF_6LN != 0
  */
 #define GNRC_IPV6_NIB_REREG_ADDRESS         (0x4fcfU)
+
+/**
+ * @brief   Route timeout event.
+ *
+ * This message type is for the event of a route timeout. The expected message
+ * context is a valid off-link entry representing the route.
+ *
+ * @note    Only handled with @ref GNRC_IPV6_NIB_CONF_ROUTER != 0
+ */
+#define GNRC_IPV6_NIB_ROUTE_TIMEOUT         (0x4fd0U)
 /** @} */
 
 /**

--- a/sys/include/net/gnrc/ipv6/nib/ft.h
+++ b/sys/include/net/gnrc/ipv6/nib/ft.h
@@ -69,13 +69,16 @@ int gnrc_ipv6_nib_ft_get(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt,
  * @param[in] next_hop  The next hop to @p dst/@p dst_len. May be NULL, if
  *                      @p dst/@p dst_len is no the default route.
  * @param[in] iface     The interface to @p next_hop. May not be 0.
+ * @param[in] lifetime  Lifetime of the route in seconds. 0 for infinite
+ *                      lifetime.
  *
  * @return  0, on success.
  * @return  -EINVAL, if a parameter was of invalid value.
  * @return  -ENOMEM, if there was no space left in forwarding table.
  */
 int gnrc_ipv6_nib_ft_add(const ipv6_addr_t *dst, unsigned dst_len,
-                         const ipv6_addr_t *next_hop, unsigned iface);
+                         const ipv6_addr_t *next_hop, unsigned iface,
+                         uint16_t lifetime);
 
 /**
  * @brief   Deletes a route from forwarding table.

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -35,7 +35,7 @@ static void set_interface_roles(void)
             ipv6_addr_from_str(&addr, "fe80::2");
             gnrc_netapi_set(dev, NETOPT_IPV6_ADDR, 64 << 8, &addr, sizeof(addr));
             ipv6_addr_from_str(&addr, "fe80::1");
-            gnrc_ipv6_nib_ft_add(&defroute, IPV6_ADDR_BIT_LEN, &addr, dev);
+            gnrc_ipv6_nib_ft_add(&defroute, IPV6_ADDR_BIT_LEN, &addr, dev, 0);
         }
         else if ((!gnrc_wireless_interface) && (is_wired != 1)) {
             gnrc_wireless_interface = dev;

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -298,6 +298,7 @@ static void *_event_loop(void *args)
             case GNRC_IPV6_NIB_RTR_TIMEOUT:
             case GNRC_IPV6_NIB_RECALC_REACH_TIME:
             case GNRC_IPV6_NIB_REREG_ADDRESS:
+            case GNRC_IPV6_NIB_ROUTE_TIMEOUT:
                 DEBUG("ipv6: NIB timer event received\n");
                 gnrc_ipv6_nib_handle_timer_event(msg.content.ptr, msg.type);
                 break;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -196,14 +196,20 @@ typedef struct {
 typedef struct {
     _nib_onl_entry_t *next_hop; /**< next hop to destination */
     ipv6_addr_t pfx;            /**< prefix to the destination */
-    unsigned pfx_len;           /**< prefix-length in bits of
-                                 *   _nib_onl_entry_t::pfx */
     /**
      * @brief   Event for @ref GNRC_IPV6_NIB_PFX_TIMEOUT
      */
     evtimer_msg_event_t pfx_timeout;
+#ifdef GNRC_IPV6_NIB_CONF_ROUTER
+    /**
+     * @brief   Event for @ref GNRC_IPV6_NIB_ROUTE_TIMEOUT
+     */
+    evtimer_msg_event_t route_timeout;
+#endif
     uint8_t mode;               /**< [mode](@ref net_gnrc_ipv6_nib_mode) of the
                                  *   off-link entry */
+    uint8_t pfx_len;            /**< prefix-length in bits of
+                                 *   _nib_onl_entry_t::pfx */
     uint16_t flags;             /**< [flags](@ref net_gnrc_ipv6_nib_offl_flags */
     uint32_t valid_until;       /**< timestamp (in ms) until which the prefix
                                      valid (UINT32_MAX means forever) */

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -324,6 +324,9 @@ void gnrc_ipv6_nib_handle_timer_event(void *ctx, uint16_t type)
         case GNRC_IPV6_NIB_SND_MC_RA:
             _handle_snd_mc_ra(ctx);
             break;
+        case GNRC_IPV6_NIB_ROUTE_TIMEOUT:
+            _nib_ft_remove(ctx);
+            break;
 #endif  /* GNRC_IPV6_NIB_CONF_ROUTER */
 #if GNRC_IPV6_NIB_CONF_6LR
         case GNRC_IPV6_NIB_ADDR_REG_TIMEOUT:

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -72,7 +72,7 @@ static void _usage_nib_prefix(char **argv)
 static void _usage_nib_route(char **argv)
 {
     printf("usage: %s %s [show|add|del|help]\n", argv[0], argv[1]);
-    printf("       %s %s add <iface> <prefix>[/<prefix_len>] <next_hop>\n",
+    printf("       %s %s add <iface> <prefix>[/<prefix_len>] <next_hop> [<ltime in sec>]\n",
            argv[0], argv[1]);
     printf("       %s %s del <iface> <prefix>[/<prefix_len>]\n", argv[0], argv[1]);
     printf("       %s %s show <iface>\n", argv[0], argv[1]);
@@ -202,6 +202,7 @@ static int _nib_route(int argc, char **argv)
         ipv6_addr_t pfx = IPV6_ADDR_UNSPECIFIED, next_hop;
         unsigned iface = atoi(argv[3]);
         unsigned pfx_len = ipv6_addr_split_prefix(argv[4]);
+        uint16_t ltime = 0;
 
         if (ipv6_addr_from_str(&pfx, argv[4]) == NULL) {
             /* check if string equals "default"
@@ -215,7 +216,10 @@ static int _nib_route(int argc, char **argv)
             _usage_nib_route(argv);
             return 1;
         }
-        gnrc_ipv6_nib_ft_add(&pfx, pfx_len, &next_hop, iface);
+        if (argc > 6) {
+            ltime = (uint16_t)atoi(argv[6]);
+        }
+        gnrc_ipv6_nib_ft_add(&pfx, pfx_len, &next_hop, iface, ltime);
     }
     else if ((argc > 4) && (strcmp(argv[2], "del") == 0)) {
         ipv6_addr_t pfx;

--- a/tests/gnrc_ipv6_nib/main.c
+++ b/tests/gnrc_ipv6_nib/main.c
@@ -113,7 +113,7 @@ static void test_get_next_hop_l2addr__EHOSTUNREACH(const ipv6_addr_t *dst,
     }
     else {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(NULL, 0, &_rem_ll,
-                                                      _mock_netif->pid));
+                                                      _mock_netif->pid, 0));
     }
     TEST_ASSERT_EQUAL_INT(-EHOSTUNREACH,
                           gnrc_ipv6_nib_get_next_hop_l2addr(dst, netif,

--- a/tests/gnrc_ipv6_nib_6ln/main.c
+++ b/tests/gnrc_ipv6_nib_6ln/main.c
@@ -176,7 +176,7 @@ static void test_get_next_hop_l2addr__global_with_default_route(void)
 
     /* add _rem_ll as default router */
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(NULL, 0, &_rem_ll,
-                                                  _mock_netif->pid));
+                                                  _mock_netif->pid, 0));
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_get_next_hop_l2addr(&_rem_gb,
                                                                NULL, NULL,
                                                                &nce));

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-ft.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-ft.c
@@ -70,7 +70,7 @@ static void test_nib_ft_get__ENETUNREACH_no_def_route(void)
     ipv6_addr_t dst = { .u64 = { { .u8 = GLOBAL_PREFIX } } };
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     dst.u16[0].u16--;
     TEST_ASSERT_EQUAL_INT(-ENETUNREACH, gnrc_ipv6_nib_ft_get(&dst, NULL, &fte));
 }
@@ -88,7 +88,7 @@ static void test_nib_ft_get__success1(void)
     static const ipv6_addr_t next_hop = { .u64 = { { .u8 = LINK_LOCAL_PREFIX },
                                                  { .u64 = TEST_UINT64 } } };
 
-    TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(NULL, 0, &next_hop, IFACE));
+    TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(NULL, 0, &next_hop, IFACE, 0));
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_get(&dst, NULL, &fte));
     TEST_ASSERT(ipv6_addr_is_unspecified(&fte.dst));
     TEST_ASSERT(ipv6_addr_equal(&next_hop, &fte.next_hop));
@@ -111,7 +111,7 @@ static void test_nib_ft_get__success2(void)
                                                  { .u64 = TEST_UINT64 } } };
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_get(&dst, NULL, &fte));
     TEST_ASSERT(ipv6_addr_match_prefix(&dst, &fte.dst) >= GLOBAL_PREFIX_LEN);
     TEST_ASSERT(ipv6_addr_equal(&next_hop, &fte.next_hop));
@@ -139,9 +139,9 @@ static void test_nib_ft_get__success3(void)
 
     bf_toggle(dst2.u8, GLOBAL_PREFIX_LEN);
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst1, GLOBAL_PREFIX_LEN,
-                                                  &next_hop1, IFACE));
+                                                  &next_hop1, IFACE, 0));
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst2, GLOBAL_PREFIX_LEN,
-                                                  &next_hop2, IFACE));
+                                                  &next_hop2, IFACE, 0));
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_get(&dst1, NULL, &fte));
     TEST_ASSERT(ipv6_addr_match_prefix(&dst1, &fte.dst) >= GLOBAL_PREFIX_LEN);
     TEST_ASSERT(ipv6_addr_equal(&next_hop1, &fte.next_hop));
@@ -167,9 +167,9 @@ static void test_nib_ft_get__success4(void)
                                                   { .u64 = TEST_UINT64 + 1 } } };
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                  &next_hop1, IFACE));
+                                                  &next_hop1, IFACE, 0));
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN - 1,
-                                                  &next_hop2, IFACE));
+                                                  &next_hop2, IFACE, 0));
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_get(&dst, NULL, &fte));
     TEST_ASSERT(ipv6_addr_match_prefix(&dst, &fte.dst) >= GLOBAL_PREFIX_LEN);
     TEST_ASSERT(ipv6_addr_equal(&next_hop1, &fte.next_hop));
@@ -190,11 +190,11 @@ static void test_nib_ft_add__EINVAL_def_route_next_hop_NULL(void)
 
     TEST_ASSERT_EQUAL_INT(-EINVAL, gnrc_ipv6_nib_ft_add(&ipv6_addr_unspecified,
                                                         GLOBAL_PREFIX_LEN,
-                                                        NULL, IFACE));
+                                                        NULL, IFACE, 0));
     TEST_ASSERT_EQUAL_INT(-EINVAL, gnrc_ipv6_nib_ft_add(NULL, GLOBAL_PREFIX_LEN,
-                                                        NULL, IFACE));
-    TEST_ASSERT_EQUAL_INT(-EINVAL, gnrc_ipv6_nib_ft_add(&dst, 0, NULL, IFACE));
-    TEST_ASSERT_EQUAL_INT(-EINVAL, gnrc_ipv6_nib_ft_add(NULL, 0, NULL, IFACE));
+                                                        NULL, IFACE, 0));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, gnrc_ipv6_nib_ft_add(&dst, 0, NULL, IFACE, 0));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, gnrc_ipv6_nib_ft_add(NULL, 0, NULL, IFACE, 0));
 }
 
 /*
@@ -209,7 +209,7 @@ static void test_nib_ft_add__EINVAL_iface0(void)
                                                  { .u64 = TEST_UINT64 } } };
 
     TEST_ASSERT_EQUAL_INT(-EINVAL, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                        &next_hop, 0));
+                                                        &next_hop, 0, 0));
 }
 
 #if GNRC_IPV6_NIB_NUMOF < GNRC_IPV6_NIB_OFFL_NUMOF
@@ -230,11 +230,11 @@ static void test_nib_ft_add__ENOMEM_diff_def_router(void)
 
     for (unsigned i = 0; i < GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(NULL, 0, &next_hop,
-                                                      IFACE));
+                                                      IFACE, 0));
         next_hop.u64[1].u64++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(NULL, GLOBAL_PREFIX_LEN,
-                                                        &next_hop, IFACE));
+                                                        &next_hop, IFACE, 0));
 }
 
 /*
@@ -248,11 +248,11 @@ static void test_nib_ft_add__ENOMEM_diff_dst(void)
 
     for (unsigned i = 0; i < GNRC_IPV6_NIB_OFFL_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                      NULL, IFACE));
+                                                      NULL, IFACE, 0));
         dst.u16[0].u16--;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                        NULL, IFACE));
+                                                        NULL, IFACE, 0));
 }
 
 /*
@@ -267,11 +267,11 @@ static void test_nib_ft_add__ENOMEM_diff_dst_len(void)
 
     for (unsigned i = 0; i < GNRC_IPV6_NIB_OFFL_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                      NULL, IFACE));
+                                                      NULL, IFACE, 0));
         dst_len--;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                        NULL, IFACE));
+                                                        NULL, IFACE, 0));
 }
 
 /*
@@ -287,12 +287,12 @@ static void test_nib_ft_add__ENOMEM_diff_dst_dst_len(void)
 
     for (unsigned i = 0; i < GNRC_IPV6_NIB_OFFL_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                      NULL, IFACE));
+                                                      NULL, IFACE, 0));
         dst.u16[0].u16--;
         dst_len--;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                        NULL, IFACE));
+                                                        NULL, IFACE, 0));
 }
 
 /*
@@ -308,11 +308,11 @@ static void test_nib_ft_add__ENOMEM_diff_next_hop(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                      &next_hop, IFACE));
+                                                      &next_hop, IFACE, 0));
         next_hop.u64[1].u64++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                        &next_hop, IFACE));
+                                                        &next_hop, IFACE, 0));
 }
 
 /*
@@ -328,12 +328,12 @@ static void test_nib_ft_add__ENOMEM_diff_dst_next_hop(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                      &next_hop, IFACE));
+                                                      &next_hop, IFACE, 0));
         dst.u16[0].u16--;
         next_hop.u64[1].u64++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                        &next_hop, IFACE));
+                                                        &next_hop, IFACE, 0));
 }
 
 /*
@@ -350,13 +350,13 @@ static void test_nib_ft_add__ENOMEM_diff_dst_dst_len_next_hop(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, dst_len, &next_hop,
-                                                      IFACE));
+                                                      IFACE, 0));
         dst.u16[0].u16--;
         dst_len--;
         next_hop.u64[1].u64++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                        &next_hop, IFACE));
+                                                        &next_hop, IFACE, 0));
 }
 
 /*
@@ -372,12 +372,12 @@ static void test_nib_ft_add__ENOMEM_diff_dst_iface(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                      NULL, iface));
+                                                      NULL, iface, 0));
         dst.u16[0].u16--;
         iface++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                        NULL, iface));
+                                                        NULL, iface, 0));
 }
 
 /*
@@ -394,12 +394,12 @@ static void test_nib_ft_add__ENOMEM_diff_dst_len_iface(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                      NULL, iface));
+                                                      NULL, iface, 0));
         dst_len--;
         iface++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                        NULL, iface));
+                                                        NULL, iface, 0));
 }
 
 /*
@@ -416,13 +416,13 @@ static void test_nib_ft_add__ENOMEM_diff_dst_dst_len_iface(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                      NULL, iface));
+                                                      NULL, iface, 0));
         dst.u16[0].u16--;
         dst_len--;
         iface++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                        NULL, iface));
+                                                        NULL, iface, 0));
 }
 
 /*
@@ -439,12 +439,12 @@ static void test_nib_ft_add__ENOMEM_diff_next_hop_iface(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                      &next_hop, iface));
+                                                      &next_hop, iface, 0));
         next_hop.u64[1].u64++;
         iface++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                        &next_hop, iface));
+                                                        &next_hop, iface, 0));
 }
 
 /*
@@ -461,13 +461,13 @@ static void test_nib_ft_add__ENOMEM_diff_dst_next_hop_iface(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                      &next_hop, iface));
+                                                      &next_hop, iface, 0));
         dst.u16[0].u16--;
         next_hop.u64[1].u64++;
         iface++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                        &next_hop, iface));
+                                                        &next_hop, iface, 0));
 }
 
 /*
@@ -486,14 +486,14 @@ static void test_nib_ft_add__ENOMEM_diff_dst_dst_len_next_hop_iface(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, dst_len, &next_hop,
-                                                      iface));
+                                                      iface, 0));
         dst.u16[0].u16--;
         dst_len--;
         next_hop.u64[1].u64++;
         iface++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                        &next_hop, iface));
+                                                        &next_hop, iface, 0));
 }
 
 /*
@@ -515,10 +515,10 @@ static void test_nib_ft_add__success_duplicate(void)
         next_hop.u64[1].u64++;
         iface++;
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, dst_len, &next_hop,
-                                                      iface));
+                                                      iface, 0));
     }
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, dst_len,
-                                                  &next_hop, iface));
+                                                  &next_hop, iface, 0));
 }
 
 /*
@@ -536,9 +536,9 @@ static void test_nib_ft_add__success_overwrite_unspecified(void)
                                                  { .u64 = TEST_UINT64 } } };
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN, NULL,
-                                                  IFACE));
+                                                  IFACE, 0));
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     TEST_ASSERT(gnrc_ipv6_nib_ft_iter(NULL, 0, &iter_state, &fte));
     TEST_ASSERT(ipv6_addr_equal(&fte.next_hop, &next_hop));
     TEST_ASSERT(!gnrc_ipv6_nib_ft_iter(NULL, 0, &iter_state, &fte));
@@ -558,7 +558,7 @@ static void test_nib_ft_add__success(void)
                                                  { .u64 = TEST_UINT64 } } };
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     TEST_ASSERT(gnrc_ipv6_nib_ft_iter(NULL, 0, &iter_state, &fte));
     TEST_ASSERT(ipv6_addr_match_prefix(&fte.dst, &dst) >= GLOBAL_PREFIX_LEN);
     TEST_ASSERT_EQUAL_INT(GLOBAL_PREFIX_LEN, fte.dst_len);
@@ -586,7 +586,7 @@ static void test_nib_ft_del__unknown(void)
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, dst_len, &next_hop,
-                                                      iface));
+                                                      iface, 0));
         dst.u16[0].u16--;
         dst_len--;
         next_hop.u64[1].u64++;
@@ -612,7 +612,7 @@ static void test_nib_ft_del__success(void)
     gnrc_ipv6_nib_ft_t fte;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&dst, GLOBAL_PREFIX_LEN,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     gnrc_ipv6_nib_ft_del(&dst, GLOBAL_PREFIX_LEN);
     TEST_ASSERT(!gnrc_ipv6_nib_ft_iter(NULL ,0, &iter_state, &fte));
 }
@@ -632,13 +632,13 @@ static void test_nib_ft_iter__empty_def_route_at_beginning(void)
     int count = 0;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(NULL, 0,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     next_hop.u16[0].u16++;
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(NULL, 0,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     next_hop.u16[0].u16++;
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(NULL, 0,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     gnrc_ipv6_nib_ft_del(NULL, 0);
     next_hop.u16[0].u16--;
     while (gnrc_ipv6_nib_ft_iter(NULL, 0, &iter_state, &fte)) {
@@ -669,13 +669,13 @@ static void test_nib_ft_iter__empty_pref_route_in_the_middle(void)
     int count = 0;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&route, GLOBAL_PREFIX_LEN,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     route.u16[0].u16++;
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&route, GLOBAL_PREFIX_LEN,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     route.u16[0].u16++;
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_ft_add(&route, GLOBAL_PREFIX_LEN,
-                                                  &next_hop, IFACE));
+                                                  &next_hop, IFACE, 0));
     route.u16[0].u16--;
     gnrc_ipv6_nib_ft_del(&route, GLOBAL_PREFIX_LEN);
     route.u16[0].u16--;


### PR DESCRIPTION
RPL requires route timeouts and this PR adds them. In [communication with @cgundogan](https://github.com/RIOT-OS/RIOT/pull/8010#discussion_r150406005) I only decided for a second resolution for that.