### PR TITLE
tests: add bluepill to gnrc_netif's insufficient memory list

### DIFF
--- a/tests/gnrc_netif/Makefile
+++ b/tests/gnrc_netif/Makefile
@@ -2,7 +2,7 @@
 APPLICATION = gnrc_ipv6_nib
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk chronos maple-mini \
                              microbit msb-430 msb-430h nrf51dongle nrf6310 \
                              nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 \

--- a/tests/gnrc_netif2/Makefile
+++ b/tests/gnrc_netif2/Makefile
@@ -2,7 +2,7 @@
 APPLICATION = gnrc_ipv6_nib
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 calliope-mini \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk chronos maple-mini \
                              microbit msb-430 msb-430h nrf51dongle nrf6310 \
                              nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 \


### PR DESCRIPTION
Now that the `gnrc_netif`(2) tests were moved to a new location, the bluepill board needs to be added to the list of boards with insufficient memory for that application (as it is also the case in master already, but due to #8075 Git is unable to keep track of that).