### PR TITLE
dist/tools: add Python style check in static tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 
 before_install:
-  - sudo apt-get install coreutils realpath doxygen graphviz python-lesscpy cppcheck coccinelle pcregrep
+  - sudo apt-get install coreutils realpath doxygen graphviz python-lesscpy cppcheck coccinelle pcregrep python3-flake8
 
 script:
   - make static-test

--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -91,6 +91,7 @@ then
         run ./dist/tools/cppcheck/check.sh
         run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/coccinelle/check.sh
+        run ./dist/tools/flake8/check.sh
         QUIET=1 run ./dist/tools/headerguards/check.sh
         exit $RESULT
     fi

--- a/dist/tools/flake8/check.sh
+++ b/dist/tools/flake8/check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 Alexandre Abadie <alexandre.abadie@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+if tput colors &> /dev/null && [ $(tput colors) -ge 8 ]; then
+    CERROR="\e[1;31m"
+    CRESET="\e[0m"
+else
+    CERROR=
+    CRESET=
+fi
+
+DIST_TOOLS=${RIOTBASE:-.}/dist/tools
+
+. ${DIST_TOOLS}/ci/changed_files.sh
+
+FILES=$(FILEREGEX='*.py$' changed_files)
+
+if [ -z "${FILES}" ]
+then
+    exit 0
+fi
+
+ERRORS=$(flake8 --config=${DIST_TOOLS}/flake8/flake8.cfg ${FILES})
+
+if [ -n "${ERRORS}" ]
+then
+    printf "${CERROR}There are style issues in the following Python scripts:${CRESET}\n\n"
+    printf "${ERRORS}\n"
+    exit 1
+else
+    exit 0
+fi

--- a/dist/tools/flake8/flake8.cfg
+++ b/dist/tools/flake8/flake8.cfg
@@ -1,0 +1,3 @@
+[flake8]
+# Allow 119 characters width per line to simplify test output parsing
+max-line-length = 119


### PR DESCRIPTION
As required in #8036 (see [comment](https://github.com/RIOT-OS/RIOT/pull/8036#issuecomment-344560286)), I'm trying to split the PR in smaller pieces.

This PR is about adding a new checker in the static-test for common Python style issues. I think it's important to keep the automatic test scripts consistent and Python provide very well described rules for that (see [PEP8](https://www.python.org/dev/peps/pep-0008/) for instance).

The style checks are performed using [Flake8](http://flake8.pycqa.org/en/latest/). I also integrated this into Travis (~that will obviously fail~).

The static-test target doesn't fail for now but just displays the errors found.

We could also go further with linter (using pylint) but I'm still not convinced for the moment.