### PR TITLE
gnrc_ipv6_nib: fix gnrc_netif dependency

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -280,6 +280,7 @@ endif
 ifneq (,$(filter gnrc_ipv6_nib,$(USEMODULE)))
   USEMODULE += evtimer
   USEMODULE += gnrc_ndp
+  USEMODULE += gnrc_netif
   USEMODULE += ipv6_addr
   USEMODULE += random
 endif


### PR DESCRIPTION
GNRC includes this dependency implicitly, but if the NIB is used
isolated (as e.g. in its unittest suite) this dependency is missing.