### PR TITLE
gnrc_ipv6_nib: make user added default route the primary one

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/ft.h
+++ b/sys/include/net/gnrc/ipv6/nib/ft.h
@@ -62,6 +62,9 @@ int gnrc_ipv6_nib_ft_get(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt,
 /**
  * @brief   Adds a new route to the forwarding table
  *
+ * If @p dst is the default route, the route will be configured to be the
+ * default route.
+ *
  * @param[in] dst       The destination to the route. May be NULL or `::` for
  *                      default route.
  * @param[in] dst_len   The prefix length of @p dst in bits. May be 0 for
@@ -82,6 +85,9 @@ int gnrc_ipv6_nib_ft_add(const ipv6_addr_t *dst, unsigned dst_len,
 
 /**
  * @brief   Deletes a route from forwarding table.
+ *
+ * If @p dst is the default route, the function assures, that the current
+ * primary default route is removed first.
  *
  * @param[in] dst       The destination of the route. May be NULL or `::` for
  *                      default route.

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -31,7 +31,7 @@
 #include "debug.h"
 
 /* pointers for default router selection */
-static _nib_dr_entry_t *_prime_def_router = NULL;
+_nib_dr_entry_t *_prime_def_router = NULL;
 static clist_node_t _next_removable = { NULL };
 
 static _nib_onl_entry_t _nodes[GNRC_IPV6_NIB_NUMOF];

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -251,6 +251,16 @@ extern mutex_t _nib_mutex;
 extern evtimer_msg_t _nib_evtimer;
 
 /**
+ * @brief   Primary default router.
+ *
+ * This value is returned by @ref @_nib_drl_get_dr() when it is not NULL and it
+ * is reachable. Otherwise it is selected with the [default router selection
+ * algoritm](https://tools.ietf.org/html/rfc4861#section-6.3.6) by that function.
+ * Exposed to be settable by @ref net_gnrc_ipv6_nib_ft.
+ */
+extern _nib_dr_entry_t *_prime_def_router;
+
+/**
  * @brief   Initializes NIB internally
  */
 void _nib_init(void);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
@@ -51,9 +51,12 @@ int gnrc_ipv6_nib_ft_add(const ipv6_addr_t *dst, unsigned dst_len,
         if (ptr == NULL) {
             res = -ENOMEM;
         }
-        else if (ltime > 0) {
-            _evtimer_add(ptr, GNRC_IPV6_NIB_RTR_TIMEOUT,
-                         &ptr->rtr_timeout, ltime * MS_PER_SEC);
+        else {
+            _prime_def_router = ptr;
+            if (ltime > 0) {
+                _evtimer_add(ptr, GNRC_IPV6_NIB_RTR_TIMEOUT,
+                             &ptr->rtr_timeout, ltime * MS_PER_SEC);
+            }
         }
     }
 #if GNRC_IPV6_NIB_CONF_ROUTER


### PR DESCRIPTION
This PR ensures that the (last) default route added with `gnrc_ipv6_nib_ft_add()` is the primary default route. This way the user (or the routing protocol) has full control over which route is the primary one without changing the API syntax (just the semantics).