### PR TITLE
gnrc_ipv6_nib: Remove stray assert() in _handle_aro()

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -175,7 +175,6 @@ uint8_t _handle_aro(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
 #if GNRC_IPV6_NIB_CONF_6LR
         else if (gnrc_netif_is_6lr(netif) &&
                  (icmpv6->type == ICMPV6_NBR_SOL)) {
-            assert(nce != NULL);
             return _reg_addr_upstream(netif, ipv6, icmpv6, aro, sl2ao, nce);
         }
 #else   /* GNRC_IPV6_NIB_CONF_6LR */


### PR DESCRIPTION
Fixes a bug reported by @cgundogan and @bergzand in IRC.

This assertion doesn't make any sense. The function is called by
_copy_and_handle_aro() on a router which causes `nce` to be NULL
(because there is no NCE known yet) and then the function called
directly after (_reg_addr_upstream()) checks if `nce` might be NULL and
creates an NCE if necessary.