### PR TITLE
gnrc_ipv6_nib: fix retransmission timeout unit for address re-registration

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -230,7 +230,7 @@ void _handle_rereg_address(const ipv6_addr_t *addr)
             uint32_t retrans_time;
 
             if (_is_valid(netif, idx)) {
-                retrans_time = SIXLOWPAN_ND_MAX_RS_SEC_INTERVAL;
+                retrans_time = SIXLOWPAN_ND_MAX_RS_SEC_INTERVAL * MS_PER_SEC;
             }
             else {
                 retrans_time = netif->ipv6.retrans_time;


### PR DESCRIPTION
Fixes #8088 by fixing the retransmission time from 60 milliseconds to 60 seconds ;-).