### PR TITLE
gnrc_netif: fix GNRC_NETAPI_GET of arrays

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -133,10 +133,11 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
                 res = 0;
                 for (unsigned i = 0;
                      (res < opt->data_len) && (i < GNRC_NETIF_IPV6_ADDRS_NUMOF);
-                     i++, tgt++) {
+                     i++) {
                     if (netif->ipv6.addrs_flags[i] != 0) {
                         memcpy(tgt, &netif->ipv6.addrs[i], sizeof(ipv6_addr_t));
                         res += sizeof(ipv6_addr_t);
+                        tgt++;
                     }
                 }
             }
@@ -148,10 +149,11 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
                 res = 0;
                 for (unsigned i = 0;
                      (res < opt->data_len) && (i < GNRC_NETIF_IPV6_ADDRS_NUMOF);
-                     i++, tgt++) {
+                     i++) {
                     if (netif->ipv6.addrs_flags[i] != 0) {
                         *tgt = netif->ipv6.addrs_flags[i];
                         res += sizeof(uint8_t);
+                        tgt++;
                     }
                 }
             }
@@ -163,10 +165,11 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
                 res = 0;
                 for (unsigned i = 0;
                      (res < opt->data_len) && (i < GNRC_NETIF_IPV6_GROUPS_NUMOF);
-                     i++, tgt++) {
+                     i++) {
                     if (!ipv6_addr_is_unspecified(&netif->ipv6.groups[i])) {
                         memcpy(tgt, &netif->ipv6.groups[i], sizeof(ipv6_addr_t));
                         res += sizeof(ipv6_addr_t);
+                        tgt++;
                     }
                 }
             }


### PR DESCRIPTION
Fixes #8090. The target array currently moves with the loop instead of with the results.