### PR TITLE
gnrc_ipv6_nib: reduce backoff if neighbor UNREACHABLE and trying reach to it

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1072,6 +1072,12 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
             reset = true;
 #endif  /* GNRC_IPV6_NIB_CONF_ARSM */
         }
+#if GNRC_IPV6_NIB_CONF_ARSM
+        else if (_get_nud_state(entry) == GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE) {
+            /* reduce back-off to possibly resolve neighbor sooner again */
+            entry->ns_sent = 3;
+        }
+#endif  /* GNRC_IPV6_NIB_CONF_ARSM */
         if (pkt != NULL) {
 #if GNRC_IPV6_NIB_CONF_QUEUE_PKT
             if (_get_nud_state(entry) == GNRC_IPV6_NIB_NC_INFO_NUD_STATE_INCOMPLETE) {


### PR DESCRIPTION
When a neighbor becomes UNREACHABLE it causes neighbor solicitations
to be send only up to every minute. If the medium is very busy this can
easily get lost, basically causing the neighbor never to be reachable
again from the perspective of the sending node. To fix this the backoff
is reduced to its start value, every time a packet is sent to that
neighbor.

RFC 7048 doesn't say anything specific to this situation but is also not stating (apart from an example), how the backoff should be handled, so I think it is okay to assume that if the neighbor is important to a node (i.e. it wants to send to it) it is okay to reduce the backoff again.