### PR TITLE
gnrc_netif: assume flag settings on compile time

### DIFF
--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -23,6 +23,10 @@
 
 #include "net/gnrc/netif.h"
 
+#ifdef MODULE_GNRC_IPV6_NIB
+#include "net/gnrc/ipv6/nib/conf.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -292,6 +296,8 @@ int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64);
  * @brief   Checks if the interface represents a router according to RFC 4861
  *
  * @attention   Requires prior locking
+ * @note        Assumed to be false, when `gnrc_ipv6_router` module is not
+ *              included.
  *
  * @param[in] netif the network interface
  *
@@ -300,15 +306,21 @@ int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64);
  * @return  true, if the interface represents a router
  * @return  false, if the interface does not represent a router
  */
+#if defined(MODULE_GNRC_IPV6_ROUTER) || defined(DOXYGEN)
 static inline bool gnrc_netif_is_rtr(const gnrc_netif_t *netif)
 {
     return (netif->flags & GNRC_NETIF_FLAGS_IPV6_FORWARDING);
 }
+#else
+#define gnrc_netif_is_rtr(netif)                (false)
+#endif
 
 /**
  * @brief   Checks if the interface is allowed to send out router advertisements
  *
  * @attention   Requires prior locking
+ * @note        Assumed to be false, when `gnrc_ipv6_router` module is not
+ *              included.
  *
  * @param[in] netif the network interface
  *
@@ -316,16 +328,24 @@ static inline bool gnrc_netif_is_rtr(const gnrc_netif_t *netif)
  * @return  false, if the interface is not allowed to send out router
  *          advertisements
  */
+#if defined(MODULE_GNRC_IPV6_ROUTER) || defined(DOXYGEN)
 static inline bool gnrc_netif_is_rtr_adv(const gnrc_netif_t *netif)
 {
     return (netif->flags & GNRC_NETIF_FLAGS_IPV6_RTR_ADV);
 }
+#else
+#define gnrc_netif_is_rtr_adv(netif)            (false)
+#endif
 
 /**
  * @brief   Checks if the interface represents a 6Lo node (6LN) according to
  *          RFC 6775
  *
  * @attention   Requires prior locking
+ * @note        Assumed to be true, when @ref GNRC_NETIF_NUMOF == 1 and
+ *              @ref net_gnrc_sixlowpan module is included (and
+ *              @ref GNRC_IPV6_NIB_CONF_6LN is not 0, otherwise assumed to be
+ *              false).
  *
  * @param[in] netif the network interface
  *
@@ -334,13 +354,20 @@ static inline bool gnrc_netif_is_rtr_adv(const gnrc_netif_t *netif)
  * @return  true, if the interface represents a 6LN
  * @return  false, if the interface does not represent a 6LN
  */
+#if (GNRC_NETIF_NUMOF > 1) || !defined(MODULE_GNRC_SIXLOWPAN) || defined(DOXYGEN)
 bool gnrc_netif_is_6ln(const gnrc_netif_t *netif);
+#elif GNRC_IPV6_NIB_CONF_6LN
+#define gnrc_netif_is_6ln(netif)                (true)
+#else
+#define gnrc_netif_is_6ln(netif)                (false)
+#endif
 
 /**
  * @brief   Checks if the interface represents a 6Lo router (6LR) according to
  *          RFC 6775
  *
  * @attention   Requires prior locking
+ * @note        Assumed to be false, when @ref GNRC_IPV6_NIB_CONF_6LR == 0
  *
  * @param[in] netif the network interface
  *
@@ -349,16 +376,25 @@ bool gnrc_netif_is_6ln(const gnrc_netif_t *netif);
  * @return  true, if the interface represents a 6LR
  * @return  false, if the interface does not represent a 6LR
  */
+#if (GNRC_IPV6_NIB_CONF_6LR && \
+     /* if flag checkers even evaluate, otherwise just assume their result */ \
+     (defined(MODULE_GNRC_IPV6_ROUTER) || \
+      (GNRC_NETIF_NUMOF > 1) || !defined(MODULE_GNRC_SIXLOWPAN))) || \
+    defined(DOXYGEN)
 static inline bool gnrc_netif_is_6lr(const gnrc_netif_t *netif)
 {
     return gnrc_netif_is_rtr(netif) && gnrc_netif_is_6ln(netif);
 }
+#else
+#define gnrc_netif_is_6lr(netif)                (false)
+#endif
 
 /**
  * @brief   Checks if the interface represents a 6Lo border router (6LBR)
  *          according to RFC 6775
  *
  * @attention   Requires prior locking
+ * @note        Assumed to be false, when @ref GNRC_IPV6_NIB_CONF_6LBR == 0.
  *
  * @param[in] netif the network interface
  *
@@ -367,11 +403,15 @@ static inline bool gnrc_netif_is_6lr(const gnrc_netif_t *netif)
  * @return  true, if the interface represents a 6LBR
  * @return  false, if the interface does not represent a 6LBR
  */
+#if GNRC_IPV6_NIB_CONF_6LBR
 static inline bool gnrc_netif_is_6lbr(const gnrc_netif_t *netif)
 {
     return (netif->flags & GNRC_NETIF_FLAGS_6LO_ABR) &&
            gnrc_netif_is_6lr(netif);
 }
+#else
+#define gnrc_netif_is_6lbr(netif)               (false)
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1100,6 +1100,7 @@ static int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr)
 }
 #endif  /* MODULE_GNRC_IPV6 */
 
+#if (GNRC_NETIF_NUMOF > 1) || !defined(MODULE_GNRC_SIXLOWPAN)
 bool gnrc_netif_is_6ln(const gnrc_netif_t *netif)
 {
     switch (netif->device_type) {
@@ -1111,6 +1112,7 @@ bool gnrc_netif_is_6ln(const gnrc_netif_t *netif)
             return false;
     }
 }
+#endif  /* (GNRC_NETIF_NUMOF > 1) || !defined(MODULE_GNRC_SIXLOWPAN) */
 
 static void _update_l2addr_from_dev(gnrc_netif_t *netif)
 {

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.h
@@ -69,6 +69,7 @@ static inline void _set_ar_state(_nib_onl_entry_t *entry, uint16_t state)
 static inline bool _rtr_sol_on_6lr(const gnrc_netif_t *netif,
                                    const icmpv6_hdr_t *icmpv6)
 {
+    (void)netif;    /* gnrc_netif_is_6lr() might just evaluate to false */
     return gnrc_netif_is_6lr(netif) && (icmpv6->type == ICMPV6_RTR_SOL);
 }
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -291,6 +291,7 @@ void _nib_nc_get(const _nib_onl_entry_t *node, gnrc_ipv6_nib_nc_t *nce)
     if (ipv6_addr_is_link_local(&nce->ipv6)) {
         gnrc_netif_t *netif = gnrc_netif_get_by_pid(_nib_onl_get_if(node));
         assert(netif != NULL);
+        (void)netif;    /* flag-checkers might evaluate just to constants */
         if (gnrc_netif_is_6ln(netif) && !gnrc_netif_is_rtr(netif)) {
             _get_l2addr_from_ipv6(nce->l2addr, &node->ipv6);
             nce->l2addr_len = sizeof(uint64_t);


### PR DESCRIPTION
This PR optimizes a lot of code out, by making the flag checker functions of `gnrc_netif` default to static values based on certain compile-time configurations. This leads to some impressive ROM changes (see table below; `✗` means the board did not compile in #7925 or is black listed, but might be with this PR, if there is no information on the board it did not build for any configuration, even with this PR).

* For host configuration I used the `gcoap` example
* For router configuration I used the `gnrc_networking` example
* For border router configuration I used the `gnrc_border_router` example.

| Board | Host | Router | Border Router |
| :---- | ---: | -----: | ------------: |
| airfy-beacon | -108 | -576 | ✗ |
| arduino-due | -60 | -404 | -1024 |
| arduino-duemilanove | -84 | -708 | -1660 |
| arduino-mega2560 | -84 | -706 | -1662 |
| arduino-mkr1000 | -64 | -484 | -1180 |
| arduino-mkrzero | -64 | -484 | -1180 |
| arduino-uno | -84 | -708 | -1660 |
| arduino-zero | -64 | -484 | -1180 |
| avsextrem | -88 | -648 | -1632 |
| b-l072z-lrwan1 | -64 | -484 | ✗ |
| calliope-mini | -64 | -484 | ✗ |
| cc2538dk | -460 | -2380 | -1024 |
| cc2650-launchpad | -60 | -404 | ✗ |
| cc2650stk | -60 | -404 | ✗ |
| ek-lm4f120xl | -48 | -400 | -1040 |
| f4vi1 | -64 | -400 | -1040 |
| fox | -460 | -2380 | -1024 |
| frdm-k22f | -64 | -416 | -1024 |
| frdm-k64f | -64 | -400 | -1040 |
| iotlab-a8-m3 | -460 | -2380 | -1024 |
| iotlab-m3 | -460 | -2380 | -1024 |
| limifrog-v1 | -60 | -404 | -1024 |
| maple-mini | -60 | -404 | ✗ |
| mbed_lpc1768 | -60 | -404 | -1024 |
| microbit | -108 | -576 | ✗ |
| mips-malta | -116 | -652 | ✗ |
| msba2 | -720 | -3976 | -1632 |
| msbiot | -64 | -400 | -1024 |
| mulle | -464 | -2384 | -1024 |
| native | -816 | -1848 | ✗ |
| nrf51dongle | -108 | -576 | ✗ |
| nrf52840dk | -112 | -496 | -1024 |
| nrf52dk | -304 | -1376 | -1024 |
| nrf6310 | -108 | -576 | ✗ |
| nucleo-f070 | -64 | -484 | ✗ |
| nucleo-f072 | -64 | -484 | ✗ |
| nucleo-f091 | -64 | -484 | -1180 |
| nucleo-f103 | -60 | -404 | ✗ |
| nucleo-f302 | -64 | -400 | ✗ |
| nucleo-f303 | -64 | -400 | -1040 |
| nucleo-f401 | -64 | -400 | -1024 |
| nucleo-f410 | -64 | -400 | -1024 |
| nucleo-f411 | -64 | -400 | -1024 |
| nucleo-f446 | -64 | -400 | -1024 |
| nucleo-l073 | -64 | -484 | ✗ |
| nucleo-l152 | -60 | -404 | -1024 |
| nucleo-l476 | -64 | -400 | -1040 |
| nucleo144-f207 | -60 | -404 | -1024 |
| nucleo144-f303 | -64 | -400 | -1024 |
| nucleo144-f412 | -48 | -416 | -1024 |
| nucleo144-f413 | -64 | -400 | -1040 |
| nucleo144-f429 | -48 | -416 | -1024 |
| nucleo144-f446 | -48 | -416 | -1024 |
| nucleo144-f722 | -64 | -400 | -1024 |
| nucleo144-f746 | -64 | -416 | -1040 |
| nucleo144-f767 | -64 | -416 | -1040 |
| nucleo32-f303 | -64 | -400 | ✗ |
| nucleo32-l432 | -48 | -400 | -1024 |
| nz32-sc151 | -60 | -404 | -1024 |
| opencm904 | -60 | -404 | ✗ |
| openmote-cc2538 | -460 | -2380 | -1024 |
| pba-d-01-kw2x | -464 | -2384 | -1024 |
| pca10000 | -108 | -576 | ✗ |
| pca10005 | -108 | -576 | ✗ |
| pic32-clicker | -112 | -656 | ✗ |
| pic32-wifire | -84 | -476 | ✗ |
| remote-pa | -460 | -2380 | -1024 |
| remote-reva | -460 | -2380 | -1024 |
| remote-revb | -460 | -2380 | -1024 |
| samd21-xpro | -64 | -484 | -1180 |
| saml21-xpro | -64 | -484 | -1180 |
| samr21-xpro | -504 | -2684 | -1184 |
| seeeduino_arch-pro | -60 | -404 | -1024 |
| slwstk6220a | -64 | -416 | -1024 |
| sodaq-autonomo | -64 | -484 | -1180 |
| sodaq-explorer | -64 | -484 | -1180 |
| spark-core | -60 | -404 | ✗ |
| stm32f3discovery | -48 | -416 | -1024 |
| stm32f4discovery | -64 | -400 | -1024 |
| stm32f7discovery | -64 | -400 | -1024 |
| udoo | -60 | -404 | -1024 |
| waspmote-pro | -84 | -708 | -1660 |
| yunjia-nrf51822 | -108 | -576 | ✗ |