### PR TITLE
 tests-gcoap: Fix resources order which should be sorted.

### DIFF
--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -25,7 +25,7 @@
 /*
  * A test set of dummy resources. The resource handlers are set to NULL.
  */
-static const coap_resource_t ressources[] = {
+static const coap_resource_t resources[] = {
     { "/test/info/all", (COAP_GET), NULL },
     { "/sensor/temp", (COAP_GET), NULL },
     { "/act/switch", (COAP_GET | COAP_POST), NULL }
@@ -36,8 +36,8 @@ static const coap_resource_t resources_second[] = {
 };
 
 static gcoap_listener_t listener = {
-    .resources     = (coap_resource_t *)&ressources[0],
-    .resources_len = (sizeof(ressources) / sizeof(ressources[0])),
+    .resources     = (coap_resource_t *)&resources[0],
+    .resources_len = (sizeof(resources) / sizeof(resources[0])),
     .next          = NULL
 };
 

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -26,9 +26,9 @@
  * A test set of dummy resources. The resource handlers are set to NULL.
  */
 static const coap_resource_t resources[] = {
-    { "/test/info/all", (COAP_GET), NULL },
+    { "/act/switch", (COAP_GET | COAP_POST), NULL },
     { "/sensor/temp", (COAP_GET), NULL },
-    { "/act/switch", (COAP_GET | COAP_POST), NULL }
+    { "/test/info/all", (COAP_GET), NULL },
 };
 
 static const coap_resource_t resources_second[] = {
@@ -47,7 +47,7 @@ static gcoap_listener_t listener_second = {
     .next          = NULL
 };
 
-static const char *resource_list_str = "</test/info/all>,</sensor/temp>,</act/switch>,</second/part>";
+static const char *resource_list_str = "</act/switch>,</sensor/temp>,</test/info/all>,</second/part>";
 
 /*
  * Client GET request success case. Test request generation.


### PR DESCRIPTION
gcoap documentation says for `resources`:

    First element in the array of resources; must order alphabetically

So change the tests to respect the API.

https://github.com/RIOT-OS/RIOT/blob/2017.10-branch/sys/include/net/gcoap.h#L412

Also a typo fix 'ressources -> resources' in a separate commit.

This PR replaces https://github.com/RIOT-OS/RIOT/pull/7580