### PR TITLE
tests/driver_bmx280: fix displayed temperature when negative

### DIFF
--- a/tests/driver_bmx280/main.c
+++ b/tests/driver_bmx280/main.c
@@ -83,6 +83,10 @@ int main(void)
 
         /* Get temperature in centi degrees Celsius */
         temperature = bmx280_read_temperature(&dev);
+        bool negative = (temperature < 0);
+        if (negative) {
+            temperature = -temperature;
+        }
 
         /* Get pressure in Pa */
         pressure = bmx280_read_pressure(&dev);
@@ -92,12 +96,13 @@ int main(void)
         humidity = bme280_read_humidity(&dev);
 #endif
 
-        printf("Temperature [°C]: %d.%d\n"
+        printf("Temperature [°C]:%c%d.%d\n"
                "Pressure [Pa]: %lu\n"
 #if defined(MODULE_BME280)
                "Humidity [%%rH]: %u.%02u\n"
 #endif
                "\n+-------------------------------------+\n",
+               (negative) ? '-' : ' ',
                temperature / 100, (temperature % 100) / 10,
 #if defined(MODULE_BME280)
                (unsigned long)pressure,


### PR DESCRIPTION
While reviewing #7280 (and with [this issue opened in another project](https://github.com/pyaiot/riot-firmwares/issues/4)), I realized that negative temperature values were incorrectly displayed by the bmx280 driver test application.

This PR fixes this.