### PR TITLE
crypto/ccm: fix auth_data_len check

### DIFF
--- a/sys/crypto/modes/ccm.c
+++ b/sys/crypto/modes/ccm.c
@@ -167,7 +167,10 @@ int cipher_encrypt_ccm(cipher_t* cipher, uint8_t* auth_data, uint32_t auth_data_
     }
 
     /* MAC calulation (T) with additional data and plaintext */
-    ccm_compute_adata_mac(cipher, auth_data, auth_data_len, mac_iv);
+    len = ccm_compute_adata_mac(cipher, auth_data, auth_data_len, mac_iv);
+    if (len < 0) {
+        return len;
+    }
     len = ccm_compute_cbc_mac(cipher, mac_iv, input, input_len, mac);
     if (len < 0) {
         return len;
@@ -245,7 +248,10 @@ int cipher_decrypt_ccm(cipher_t* cipher, uint8_t* auth_data,
     }
 
     /* MAC calulation (T) with additional data and plaintext */
-    ccm_compute_adata_mac(cipher, auth_data, auth_data_len, mac_iv);
+    len = ccm_compute_adata_mac(cipher, auth_data, auth_data_len, mac_iv);
+    if (len < 0) {
+        return len;
+    }
     len = ccm_compute_cbc_mac(cipher, mac_iv, plain, plain_len, mac);
     if (len < 0) {
         return len;

--- a/sys/crypto/modes/ccm.c
+++ b/sys/crypto/modes/ccm.c
@@ -108,13 +108,17 @@ int ccm_compute_adata_mac(cipher_t* cipher, uint8_t* auth_data,
         /* 16 octet block size + max. 10 len encoding  */
         uint8_t auth_data_encoded[26], len_encoding = 0;
 
-        if ( auth_data_len < (((uint32_t) 2) << 16)) {       /* length (0x0001 ... 0xFEFF)  */
+        /* If 0 < l(a) < (2^16 - 2^8), then the length field is encoded as two
+         * octets. (RFC3610 page 2)
+         */
+        if (auth_data_len <= 0xFEFF) {
+            /* length (0x0001 ... 0xFEFF)  */
             len_encoding = 2;
 
             auth_data_encoded[1] = auth_data_len & 0xFF;
             auth_data_encoded[0] = (auth_data_len >> 8) & 0xFF;
         } else {
-            DEBUG("UNSUPPORTED Adata length\n");
+            DEBUG("UNSUPPORTED Adata length: %" PRIu32 "\n", auth_data_len);
             return -1;
         }
 

--- a/tests/unittests/tests-crypto/tests-crypto-modes-ccm.c
+++ b/tests/unittests/tests-crypto/tests-crypto-modes-ccm.c
@@ -246,6 +246,10 @@ static void test_crypto_modes_ccm_check_len(void)
 
     ret = _test_ccm_len(cipher_decrypt_ccm, 8, einput, 16, 0);
     TEST_ASSERT_MESSAGE(ret > 0, "Decryption : failed with valid input_len");
+
+    /* ccm library does not support auth_data_len > 0xFEFF */
+    ret = _test_ccm_len(cipher_encrypt_ccm, 2, NULL, 0, 0xFEFF + 1);
+    TEST_ASSERT_EQUAL_INT(-1, ret);
 }
 
 


### PR DESCRIPTION
This PR fixes crypto/ccm checking `auth_data_len` against wrong value and add a test to it.

> RFC3610 page 2
> If 0 < l(a) < (2^16 - 2^8), then the length field is encoded as two octets.

To allow testing, I also needed to make `cipher_encrypt_ccm` and `cipher_decrypt_ccm` check for `ccm_compute_adata_mac` return value which was ignored.
I only added a test for encrypt not decrypt.

It is part of solving issue #8107 and includes/replaces a part of #6706

It depends on pull request ~~#8109~~ and ~~#8112~~ (to fix input_len check for len_encoding)

