### PR TITLE
tests/core: add overflow test for cib

### DIFF
--- a/tests/unittests/tests-core/tests-core-cib.c
+++ b/tests/unittests/tests-core/tests-core-cib.c
@@ -77,6 +77,16 @@ static void test_empty_cib(void)
     TEST_ASSERT_EQUAL_INT(-1, cib_put(&cib));
 }
 
+static void test_overflow_cib(void)
+{
+    cib_init(&cib, 4);
+    cib.read_count = 0xffffffff;
+    cib.write_count = 0xffffffff;
+    TEST_ASSERT_EQUAL_INT(0, cib_avail(&cib));
+    TEST_ASSERT_EQUAL_INT(3, cib_put(&cib));
+    TEST_ASSERT_EQUAL_INT(3, cib_get(&cib));
+}
+
 static void test_singleton_cib(void)
 {
     cib_init(&cib, 1);
@@ -96,6 +106,7 @@ Test *tests_core_cib_tests(void)
         new_TestFixture(test_cib_avail),
         new_TestFixture(test_cib_put_and_get),
         new_TestFixture(test_empty_cib),
+        new_TestFixture(test_overflow_cib),
         new_TestFixture(test_singleton_cib),
         new_TestFixture(test_cib_peek),
     };


### PR DESCRIPTION
Unittest for overflow of the cib, demo of problem described by #8117, should fail without #8119