### PR TITLE
gnrc_rpl: fix abandoned packet bug in transit option build

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -746,11 +746,10 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
     while(gnrc_ipv6_nib_ft_iter(NULL, dodag->iface, &ft_state, &fte)) {
         DEBUG("RPL: Send DAO - building transit option\n");
 
-        if ((pkt = _dao_transit_build(NULL, lifetime, false)) == NULL) {
+        if ((pkt = _dao_transit_build(pkt, lifetime, false)) == NULL) {
             DEBUG("RPL: Send DAO - no space left in packet buffer\n");
             return;
         }
-
         if (ipv6_addr_is_global(&fte.dst)) {
             DEBUG("RPL: Send DAO - building target %s/%d\n",
                   ipv6_addr_to_str(addr_str, &fte.dst, sizeof(addr_str)), fte.dst_len);
@@ -759,7 +758,6 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
                 DEBUG("RPL: Send DAO - no space left in packet buffer\n");
                 return;
             }
-
         }
     }
 


### PR DESCRIPTION
First and most important fix in ~~a string~~ (managed to fit it into two PRs) of RPL fixes towards #7925 

Due to the transit option build function being passed a NULL pointer,
the previous transit and target options are dropped (and never freed).

This fixes #8098 and #8126.