### PR TITLE
emb6: API updates in hal_getrand()

### DIFF
--- a/pkg/emb6/contrib/target.c
+++ b/pkg/emb6/contrib/target.c
@@ -20,6 +20,9 @@
 #include "mutex.h"
 #include "periph/gpio.h"
 #include "periph/hwrng.h"
+#ifdef MODULE_RANDOM
+#include "random.h"
+#endif
 #include "xtimer.h"
 
 #include "target.h"
@@ -50,7 +53,7 @@ uint8_t hal_getrand(void)
     hwnrg_read((char *)&res, sizeof(res));
     return res;
 #elif defined(MODULE_RANDOM)
-    return (uint8_t)(genrand_uint32() % UINT8_MAX);
+    return (uint8_t)(random_uint32() % UINT8_MAX);
 #else
     return 4;   /* keeping the meme alive ;-) */
 #endif

--- a/pkg/emb6/contrib/target.c
+++ b/pkg/emb6/contrib/target.c
@@ -48,7 +48,7 @@ int8_t hal_init(void)
 
 uint8_t hal_getrand(void)
 {
-#if RANDOM_NUMOF
+#if defined(MODULE_PERIPH_HWRNG)
     uint8_t res;
     hwnrg_read((char *)&res, sizeof(res));
     return res;


### PR DESCRIPTION
This this build branch doesn't seem to be build, this slipped through
back, when the PNRG functions were renamed.