### PR TITLE
gnrc_rpl: Exclude routes without next hop from DAO packets

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -750,7 +750,8 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
             DEBUG("RPL: Send DAO - no space left in packet buffer\n");
             return;
         }
-        if (ipv6_addr_is_global(&fte.dst)) {
+        if (ipv6_addr_is_global(&fte.dst) &&
+            !ipv6_addr_is_unspecified(&fte.next_hop)) {
             DEBUG("RPL: Send DAO - building target %s/%d\n",
                   ipv6_addr_to_str(addr_str, &fte.dst, sizeof(addr_str)), fte.dst_len);
 


### PR DESCRIPTION
The DAO packets contain RPL target options which don't have a next hop on the sender. This causes routes for the prefix to be propagated up the tree. This PR prevents addition of routes with an unspecified next hop to be added to the target options.

Fixes #8129 