### PR TITLE
gnrc_rpl: gnrc_ipv6_nib: Fix second to millisecond conversion corner cases

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -100,9 +100,9 @@ static gnrc_pktsnip_t *_offl_to_pio(_nib_offl_entry_t *offl,
     gnrc_pktsnip_t *pio;
     uint8_t flags = 0;
     uint32_t valid_ltime = (offl->valid_until == UINT32_MAX) ? UINT32_MAX :
-                           (offl->valid_until - now);
+                           ((offl->valid_until - now) / MS_PER_SEC);
     uint32_t pref_ltime = (offl->pref_until == UINT32_MAX) ? UINT32_MAX :
-                          (offl->pref_until - now);
+                          ((offl->pref_until - now) / MS_PER_SEC);
 
     DEBUG("nib: Build PIO for %s/%u\n",
           ipv6_addr_to_str(addr_str, &offl->pfx, sizeof(addr_str)),

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1258,15 +1258,15 @@ static uint32_t _handle_pio(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
         if (valid_ltime < UINT32_MAX) { /* UINT32_MAX means infinite lifetime */
             /* the valid lifetime is given in seconds, but our timers work in
              * microseconds, so we have to scale down to the smallest possible
-             * value (UINT32_MAX). This is however alright since we ask for a
-             * new router advertisement before this timeout expires */
+             * value (UINT32_MAX - 1). This is however alright since we ask for
+             * a new router advertisement before this timeout expires */
             valid_ltime = (valid_ltime > (UINT32_MAX / MS_PER_SEC)) ?
-                          UINT32_MAX : valid_ltime * MS_PER_SEC;
+                          (UINT32_MAX - 1) : valid_ltime * MS_PER_SEC;
         }
         if (pref_ltime < UINT32_MAX) { /* UINT32_MAX means infinite lifetime */
             /* same treatment for pref_ltime */
             pref_ltime = (pref_ltime > (UINT32_MAX / MS_PER_SEC)) ?
-                         UINT32_MAX : pref_ltime * MS_PER_SEC;
+                         (UINT32_MAX - 1) : pref_ltime * MS_PER_SEC;
         }
         if ((pfx = _nib_pl_add(netif->pid, &pio->prefix, pio->prefix_len,
                                valid_ltime, pref_ltime))) {


### PR DESCRIPTION
Fixes the corner cases for the second to millisecond conversion for prefix lifetimes described in #8133.

It fixes this by way of the described methods in #8133.