### PR TITLE
cc2538dk: add renode emulator as a provided feature

### DIFF
--- a/boards/cc2538dk/Makefile.features
+++ b/boards/cc2538dk/Makefile.features
@@ -6,6 +6,9 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_adc
 
+# Various other features (if any)
+FEATURES_PROVIDED += emulator_renode
+
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 


### PR DESCRIPTION
As per @kaspar030's request in https://github.com/RIOT-OS/RIOT/pull/7959#issuecomment-346003320: the renode feature as a `FEATURES_PROVIDED` member for the `cc2538dk` board as a follow-up to #7959.