### PR TITLE
tests: fix python style 'E302 expected 2 blank lines, found 1'

### DIFF
--- a/tests/bitarithm_timings/tests/01-run.py
+++ b/tests/bitarithm_timings/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("Start.")
     child.expect('\+ bitarithm_msb: \d+ iterations per second')

--- a/tests/bloom_bytes/tests/01-run.py
+++ b/tests/bloom_bytes/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("Testing Bloom filter.")
     child.expect_exact("m: 4096 k: 8")

--- a/tests/buttons/tests/01-run.py
+++ b/tests/buttons/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("On-board button test")
     index = child.expect([

--- a/tests/cbor/tests/01-run.py
+++ b/tests/cbor/tests/01-run.py
@@ -14,6 +14,7 @@ import testrunner
 
 ACCEPTED_ERROR = 20
 
+
 def testfunc(child):
     child.expect_exact('Data:')
     child.expect_exact('(uint64_t, 1)')

--- a/tests/cpp11_condition_variable/tests/01-run.py
+++ b/tests/cpp11_condition_variable/tests/01-run.py
@@ -13,8 +13,8 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-def testfunc(child):
 
+def testfunc(child):
     child.expect_exact("************ C++ condition_variable test ***********")
     child.expect_exact("Wait with predicate and notify one ...")
     child.expect_exact("Done")

--- a/tests/cpp11_mutex/tests/01-run.py
+++ b/tests/cpp11_mutex/tests/01-run.py
@@ -13,8 +13,8 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-def testfunc(child):
 
+def testfunc(child):
     child.expect_exact("************ C++ mutex test ***********")
     child.expect_exact("Lock and unlock ...")
     child.expect_exact("Done")

--- a/tests/cpp11_thread/tests/01-run.py
+++ b/tests/cpp11_thread/tests/01-run.py
@@ -13,8 +13,8 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-def testfunc(child):
 
+def testfunc(child):
     child.expect_exact("************ C++ thread test ***********")
     child.expect_exact("Creating one thread and passing an argument ...")
     child.expect_exact("Done")

--- a/tests/driver_ds1307/tests/01-run.py
+++ b/tests/driver_ds1307/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect([r"OK \([0-9]+ tests\)",
                   r"error: unable to initialize RTC \[I2C initialization error\]"])

--- a/tests/driver_grove_ledbar/tests/01-run.py
+++ b/tests/driver_grove_ledbar/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact(u"[SUCCESS]", timeout=60)
 

--- a/tests/driver_hd44780/tests/01-run.py
+++ b/tests/driver_hd44780/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("[START]")
     child.expect_exact("[SUCCESS]")

--- a/tests/driver_my9221/tests/01-run.py
+++ b/tests/driver_my9221/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("[SUCCESS]", timeout=60)
 

--- a/tests/events/tests/01-run.py
+++ b/tests/events/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact(u"[SUCCESS]")
 

--- a/tests/evtimer_msg/tests/01-run.py
+++ b/tests/evtimer_msg/tests/01-run.py
@@ -15,6 +15,7 @@ import testrunner
 
 ACCEPTED_ERROR = 20
 
+
 def testfunc(child):
     child.expect(r"Testing generic evtimer \(start time = (\d+) ms\)")
     timer_offset = int(child.match.group(1))

--- a/tests/evtimer_underflow/tests/01-run.py
+++ b/tests/evtimer_underflow/tests/01-run.py
@@ -15,6 +15,7 @@ import testrunner
 
 how_many = 100
 
+
 def testfunc(child):
     for i in range(how_many):
         for j in range(8):

--- a/tests/float/tests/01-run.py
+++ b/tests/float/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("Testing floating point arithmetics...")
     child.expect_exact("[SUCCESS]")

--- a/tests/gnrc_ipv6_ext/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     index = child.expect_exact([
         "ipv6: Received (src = fd01::1, dst = fd01::2, next header = 0, length = 42)",

--- a/tests/gnrc_ipv6_nib/tests/01-run.py
+++ b/tests/gnrc_ipv6_nib/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect(r"OK \(\d+ tests\)")
 

--- a/tests/gnrc_ipv6_nib_6ln/tests/01-run.py
+++ b/tests/gnrc_ipv6_nib_6ln/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect(r"OK \(\d+ tests\)")
 

--- a/tests/gnrc_ndp/tests/01-run.py
+++ b/tests/gnrc_ndp/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     # 1st 6LoWPAN fragment
     child.expect(r"OK \(\d+ tests\)")

--- a/tests/gnrc_netif/tests/01-run.py
+++ b/tests/gnrc_netif/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     # embUnit tests
     child.expect(r"OK \(\d+ tests\)")

--- a/tests/gnrc_sixlowpan/tests/01-run.py
+++ b/tests/gnrc_sixlowpan/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     # 1st 6LoWPAN fragment
     child.expect_exact("PKTDUMP: data received:")

--- a/tests/gnrc_sock_ip/tests/01-run.py
+++ b/tests/gnrc_sock_ip/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact(u"Calling test_sock_ip_create__EAFNOSUPPORT()")
     child.expect_exact(u"Calling test_sock_ip_create__EINVAL_addr()")

--- a/tests/gnrc_sock_udp/tests/01-run.py
+++ b/tests/gnrc_sock_udp/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact(u"Calling test_sock_udp_create__EADDRINUSE()")
     child.expect_exact(u"Calling test_sock_udp_create__EAFNOSUPPORT()")

--- a/tests/libfixmath/do-test.py
+++ b/tests/libfixmath/do-test.py
@@ -47,6 +47,7 @@ FUNS = {
 
 ABS_ERROR_LIMIT = 0.011
 
+
 def main():
     total = 0
     errors = 0

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -17,6 +17,7 @@ import pexpect
 
 DEFAULT_TIMEOUT = 5
 
+
 class Strategy(object):
     def __init__(self, func=None):
         if func != None:
@@ -28,10 +29,12 @@ class Strategy(object):
     def execute(self, *args, **kwargs):
         raise NotImplementedError()
 
+
 class ApplicationStrategy(Strategy):
     def __init__(self, app_dir=os.getcwd(), func=None):
         super(ApplicationStrategy, self).__init__(func)
         self.app_dir = app_dir
+
 
 class BoardStrategy(Strategy):
     def __init__(self, board, func=None):
@@ -50,21 +53,26 @@ class BoardStrategy(Strategy):
     def execute(self, application):
         super(BoardStrategy, self).execute(application)
 
+
 class CleanStrategy(BoardStrategy):
     def execute(self, application, env=None):
         super(CleanStrategy, self).__run_make(application, ("-B", "clean"), env)
+
 
 class BuildStrategy(BoardStrategy):
     def execute(self, application, env=None):
         super(BuildStrategy, self).__run_make(application, ("all",), env)
 
+
 class FlashStrategy(BoardStrategy):
     def execute(self, application, env=None):
         super(FlashStrategy, self).__run_make(application, ("all",), env)
 
+
 class ResetStrategy(BoardStrategy):
     def execute(self, application, env=None):
         super(ResetStrategy, self).__run_make(application, ("reset",), env)
+
 
 class Board(object):
     def __init__(self, name, port=None, serial=None, clean=None,
@@ -119,6 +127,7 @@ class Board(object):
     def reset(self, application=os.getcwd(), env=None):
         self.reset_strategy.execute(application, env)
 
+
 class BoardGroup(object):
     def __init__(self, boards):
         self.boards = boards
@@ -148,6 +157,7 @@ class BoardGroup(object):
         for board in self.boards:
             board.reset(application, env)
 
+
 def default_test_case(board_group, application, env=None):
     for board in board_group:
         env = os.environ.copy()
@@ -158,6 +168,7 @@ def default_test_case(board_group, application, env=None):
                             timeout=DEFAULT_TIMEOUT,
                            logfile=sys.stdout) as spawn:
             spawn.expect("TEST: SUCCESS")
+
 
 class TestStrategy(ApplicationStrategy):
     def execute(self, board_groups, test_cases=[default_test_case],
@@ -171,10 +182,12 @@ class TestStrategy(ApplicationStrategy):
                 sys.stdout.flush()
             print()
 
+
 def get_ipv6_address(spawn):
     spawn.sendline(u"ifconfig")
     spawn.expect(u"[A-Za-z0-9]{2}_[0-9]+:  inet6 (fe80::[0-9a-f:]+)")
     return spawn.match.group(1)
+
 
 def test_ipv6_send(board_group, application, env=None):
     env_sender = os.environ.copy()
@@ -199,6 +212,7 @@ def test_ipv6_send(board_group, application, env=None):
                             (receiver_ip, ipprot))
         receiver.expect(u"00000000  01  23  45  67  89  AB  CD  EF")
 
+
 def test_udpv6_send(board_group, application, env=None):
     env_sender = os.environ.copy()
     if env != None:
@@ -222,6 +236,7 @@ def test_udpv6_send(board_group, application, env=None):
         sender.expect_exact(u"Success: send 3 byte over UDP to [%s]:%d" %
                             (receiver_ip, port))
         receiver.expect(u"00000000  AB  CD  EF")
+
 
 def test_tcpv6_send(board_group, application, env=None):
     env_client = os.environ.copy()
@@ -251,6 +266,7 @@ def test_tcpv6_send(board_group, application, env=None):
         client.sendline(u"tcp disconnect")
         client.sendline(u"tcp send affe:abe")
         client.expect_exact(u"could not send")
+
 
 def test_triple_send(board_group, application, env=None):
     env_sender = os.environ.copy()

--- a/tests/lwip_sock_ip/tests/01-run.py
+++ b/tests/lwip_sock_ip/tests/01-run.py
@@ -12,11 +12,14 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def _ipv6_tests(code):
     return code & (1 << 6)
 
+
 def _ipv4_tests(code):
     return code & (1 << 4)
+
 
 def testfunc(child):
     child.expect(u"code (0x[0-9a-f]{2})")

--- a/tests/lwip_sock_tcp/tests/01-run.py
+++ b/tests/lwip_sock_tcp/tests/01-run.py
@@ -12,14 +12,18 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def _reuse_tests(code):
     return code & 1
+
 
 def _ipv6_tests(code):
     return code & (1 << 6)
 
+
 def _ipv4_tests(code):
     return code & (1 << 4)
+
 
 def testfunc(child):
     child.expect(u"code (0x[0-9a-f]{2})")

--- a/tests/lwip_sock_udp/tests/01-run.py
+++ b/tests/lwip_sock_udp/tests/01-run.py
@@ -12,14 +12,18 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def _reuse_tests(code):
     return code & 1
+
 
 def _ipv6_tests(code):
     return code & (1 << 6)
 
+
 def _ipv4_tests(code):
     return code & (1 << 4)
+
 
 def testfunc(child):
     child.expect(u"code (0x[0-9a-f]{2})")

--- a/tests/msg_avail/tests/01-run.py
+++ b/tests/msg_avail/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact(u"[SUCCESS]")
 

--- a/tests/msg_send_receive/tests/01-run.py
+++ b/tests/msg_send_receive/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect(u"Test successful.")
 

--- a/tests/mutex_order/tests/01-run.py
+++ b/tests/mutex_order/tests/01-run.py
@@ -21,6 +21,7 @@ thread_prio = {
         7:  1
         }
 
+
 def testfunc(child):
     for k in thread_prio.keys():
         child.expect(u"T%i \(prio %i\): trying to lock mutex now" % (k, thread_prio[k]))

--- a/tests/od/tests/01-run.py
+++ b/tests/od/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("od_hex_dump(short_str, sizeof(short_str), OD_WIDTH_DEFAULT)")
     child.expect_exact("00000000  41  42  00")

--- a/tests/od/tests/02-run.py
+++ b/tests/od/tests/02-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("od_hex_dump(short_str, sizeof(short_str), OD_WIDTH_DEFAULT)")
     child.expect_exact("00000000  41  42  00                                                      AB.")

--- a/tests/pkg_tiny-asn1/tests/01-run.py
+++ b/tests/pkg_tiny-asn1/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect('Decoding finished succesfully')
 

--- a/tests/pkg_umorse/tests/01-run.py
+++ b/tests/pkg_umorse/tests/01-run.py
@@ -12,8 +12,8 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-def testfunc(child):
 
+def testfunc(child):
     child.expect(u".... . ._.. ._.. ___ / ._. .. ___ _ ___ ...", timeout=30)
     child.expect(u"_ .... .. ... / .. ... / .._ __ ___ ._. ... .", timeout=30)
 

--- a/tests/posix_semaphore/tests/01-run.py
+++ b/tests/posix_semaphore/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def test1(term):
     term.expect_exact("######################### TEST1:")
     term.expect_exact("first: sem_init")
@@ -33,6 +34,7 @@ def test1(term):
     term.expect_exact("first: sem_post done")
     term.expect_exact("first: sem_destroy")
     term.expect_exact("first: end")
+
 
 def test2(term):
     term.expect_exact("######################### TEST2:")
@@ -64,6 +66,7 @@ def test2(term):
     term.expect_exact("Thread 'priority 5' woke up.")
     term.expect_exact("Back in main thread.")
 
+
 def test3(term):
     term.expect_exact("######################### TEST3:")
     term.expect_exact("first: sem_init s1")
@@ -80,12 +83,14 @@ def test3(term):
     term.expect_exact("post s1")
     term.expect_exact("Thread 2 woke up after waiting for s1.")
 
+
 def test4(term):
     term.expect_exact("######################### TEST4:")
     term.expect_exact("first: sem_init s1")
     term.expect_exact("first: wait 1 sec for s1")
     term.expect_exact("first: timed out")
     term.expect(r"first: waited 1\d{6} usec")
+
 
 def testfunc(child):
     test1(child)

--- a/tests/posix_time/tests/01-run.py
+++ b/tests/posix_time/tests/01-run.py
@@ -18,8 +18,10 @@ import testrunner
 US_PER_SEC = 1000000
 EXTERNAL_JITTER = 0.15
 
+
 class InvalidTimeout(Exception):
     pass
+
 
 def testfunc(child):
     try:

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -35,6 +35,7 @@ PS_EXPECTED = (
     ('\t    | SUM                  |            |     | \d+  (\d+)')
 )
 
+
 def _check_startup(child):
     for i in range(5):
         child.expect_exact('Creating thread #{}, next={}'

--- a/tests/rmutex/tests/01-run.py
+++ b/tests/rmutex/tests/01-run.py
@@ -30,8 +30,10 @@ lock_depth = {
         7:  5
         }
 
+
 def thread_prio_sort(x):
     return thread_prio.get(x)*1000 + x
+
 
 def testfunc(child):
     for k in thread_prio.keys():

--- a/tests/thread_cooperation/tests/01-run.py
+++ b/tests/thread_cooperation/tests/01-run.py
@@ -13,6 +13,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect(r"MAIN: reply from T-\d+")
     child.expect(r"MAIN: \d+! = \d+")

--- a/tests/thread_msg_block_w_queue/tests/01-run.py
+++ b/tests/thread_msg_block_w_queue/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect('sender_thread start\r\n')
     child.expect('main thread alive\r\n')

--- a/tests/thread_msg_block_wo_queue/tests/01-run.py
+++ b/tests/thread_msg_block_wo_queue/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect('sender_thread start\r\n')
     child.expect('main thread alive\r\n')

--- a/tests/trickle/tests/01-run.py
+++ b/tests/trickle/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("[START]")
 

--- a/tests/unittests/tests/01-run.py
+++ b/tests/unittests/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect(u"OK \\([0-9]+ tests\\)")
 

--- a/tests/xtimer_hang/tests/01-run.py
+++ b/tests/xtimer_hang/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("[START]")
 

--- a/tests/xtimer_msg_receive_timeout/tests/01-run.py
+++ b/tests/xtimer_msg_receive_timeout/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect("[START]")
     for i in range(5):

--- a/tests/xtimer_now64_continuity/tests/01-run.py
+++ b/tests/xtimer_now64_continuity/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("[START]")
     child.expect(u"\[RESULTS\] min=\d+, avg=\d+, max=\d+")

--- a/tests/xtimer_periodic_wakeup/tests/01-run.py
+++ b/tests/xtimer_periodic_wakeup/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("xtimer_periodic_wakeup test application.")
 

--- a/tests/xtimer_remove/tests/01-run.py
+++ b/tests/xtimer_remove/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("xtimer_remove test application.")
     child.expect_exact("Setting 3 timers, removing timer 0/3")

--- a/tests/xtimer_reset/tests/01-run.py
+++ b/tests/xtimer_reset/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
+
 def testfunc(child):
     child.expect_exact("This test tests re-setting of an already active timer.")
     child.expect_exact("It should print three times \"now=<value>\", with "

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -20,8 +20,10 @@ US_PER_SEC = 1000000
 INTERNAL_JITTER = 0.05
 EXTERNAL_JITTER = 0.15
 
+
 class InvalidTimeout(Exception):
     pass
+
 
 def testfunc(child):
     child.expect(u"Running test (\\d+) times with (\\d+) distinct sleep times")

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -13,8 +13,8 @@ import pexpect
 sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
 import testrunner
 
-def testfunc(child):
 
+def testfunc(child):
     child.expect(u"This test will call xtimer_usleep for values from \\d+ down to \\d+\r\n")
 
     i = 500


### PR DESCRIPTION
Partially addresses #8141.

Fixes E302 issue `expected 2 blank lines, found 1`.