### PR TITLE
shell: fix net commands

### DIFF
--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -115,7 +115,7 @@ static int _nib_neigh(int argc, char **argv)
     else if ((argc > 3) && (strcmp(argv[2], "del") == 0)) {
         ipv6_addr_t ipv6_addr;
 
-        if (ipv6_addr_from_str(&ipv6_addr, argv[4]) == NULL) {
+        if (ipv6_addr_from_str(&ipv6_addr, argv[3]) == NULL) {
             _usage_nib_neigh(argv);
             return 1;
         }

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -430,7 +430,7 @@ static void _netif_list(kernel_pid_t iface)
     }
     res = gnrc_netapi_get(iface, NETOPT_HOP_LIMIT, 0, &u8, sizeof(u8));
     if (res > 0) {
-        printf("HL:%" PRIu16 "  ", u8);
+        printf("HL:%u  ", u8);
         line_thresh++;
     }
     line_thresh = _netif_list_flag(iface, NETOPT_IPV6_FORWARDING, "RTR  ",


### PR DESCRIPTION
2 minor issues I found during testing.

- fix compile issue, found on macOS
- fix `nib neigh del <addr>` command