### PR TITLE
shell/nib: fix minor inconsistency

### DIFF
--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -63,7 +63,7 @@ static void _usage_nib_neigh(char **argv)
 static void _usage_nib_prefix(char **argv)
 {
     printf("usage: %s %s [show|add|del|help]\n", argv[0], argv[1]);
-    printf("       %s %s add <iface> <prefix>[/<prefix_len>] [<valid in ms>] [<pref in ms>]\n",
+    printf("       %s %s add <iface> <prefix>[/<prefix_len>] [<valid in sec>] [<pref in sec>]\n",
            argv[0], argv[1]);
     printf("       %s %s del <iface> <prefix>[/<prefix_len>]\n", argv[0], argv[1]);
     printf("       %s %s show [iface]\n", argv[0], argv[1]);
@@ -156,10 +156,16 @@ static int _nib_prefix(int argc, char **argv)
             return 1;
         }
         if (argc > 5) {
-            valid_ltime = atoi(argv[5]);
+            uint32_t ltime_ms = atoi(argv[5]);
+            valid_ltime = (ltime_ms > UINT32_MAX / MS_PER_SEC) ?
+                          UINT32_MAX - 1 :
+                          ltime_ms * MS_PER_SEC;
         }
         if (argc > 6) {
-            pref_ltime = atoi(argv[6]);
+            uint32_t ltime_ms = atoi(argv[6]);
+            pref_ltime = (ltime_ms > UINT32_MAX / MS_PER_SEC) ?
+                         UINT32_MAX - 1 :
+                         ltime_ms * MS_PER_SEC;
         }
         gnrc_ipv6_nib_pl_set(iface, &pfx, pfx_len, valid_ltime, pref_ltime);
     }

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -57,7 +57,7 @@ static void _usage_nib_neigh(char **argv)
     printf("usage: %s %s [show|add|del|help]\n", argv[0], argv[1]);
     printf("       %s %s add <iface> <ipv6 addr> [<l2 addr>]\n", argv[0], argv[1]);
     printf("       %s %s del <ipv6 addr>\n", argv[0], argv[1]);
-    printf("       %s %s show <ipv6 addr>\n", argv[0], argv[1]);
+    printf("       %s %s show [iface]\n", argv[0], argv[1]);
 }
 
 static void _usage_nib_prefix(char **argv)
@@ -66,7 +66,7 @@ static void _usage_nib_prefix(char **argv)
     printf("       %s %s add <iface> <prefix>[/<prefix_len>] [<valid in ms>] [<pref in ms>]\n",
            argv[0], argv[1]);
     printf("       %s %s del <iface> <prefix>[/<prefix_len>]\n", argv[0], argv[1]);
-    printf("       %s %s show <iface>\n", argv[0], argv[1]);
+    printf("       %s %s show [iface]\n", argv[0], argv[1]);
 }
 
 static void _usage_nib_route(char **argv)
@@ -75,7 +75,7 @@ static void _usage_nib_route(char **argv)
     printf("       %s %s add <iface> <prefix>[/<prefix_len>] <next_hop> [<ltime in sec>]\n",
            argv[0], argv[1]);
     printf("       %s %s del <iface> <prefix>[/<prefix_len>]\n", argv[0], argv[1]);
-    printf("       %s %s show <iface>\n", argv[0], argv[1]);
+    printf("       %s %s show [iface]\n", argv[0], argv[1]);
 }
 
 static int _nib_neigh(int argc, char **argv)


### PR DESCRIPTION
2 small inconsistencies in the `nib` command. First one is the help output where the optional argument of the show subcommands was displayed as mandatory. Second one is that the `nib prefix add` command takes milliseconds for the lifetimes, while the output of the prefix command displays seconds. This changes the input argument to seconds instead of milliseconds. This way it is also consistent with the `nib route add` subcommand