### PR TITLE
dist/tools/pyterm: exit without traceback on keyboard interrupt

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -675,10 +675,6 @@ class PytermClientFactory(ReconnectingClientFactory):
                                                          reason)
 
 
-def __stop_reactor(signum, stackframe):
-    sys.stderr.write("Ctrl-C is disabled, type '/exit' instead\n")
-
-
 class fdsocket(socket.socket):
     def read(self, bufsize):
         return self.recv(bufsize)
@@ -758,13 +754,15 @@ if __name__ == "__main__":
                      args.log_dir_name, args.newline, args.format, args.prompt)
     myshell.prompt = ''
 
-    if args.server and args.tcp_port:
-        myfactory = PytermClientFactory(myshell)
-        reactor.connectTCP(args.server, args.tcp_port, myfactory)
-        myshell.factory = myfactory
-        reactor.callInThread(myshell.cmdloop, "Welcome to pyterm!\n"
-                                              "Type '/exit' to exit.")
-        signal.signal(signal.SIGINT, __stop_reactor)
-        reactor.run()
-    else:
-        myshell.cmdloop("Welcome to pyterm!\nType '/exit' to exit.")
+    try:
+        if args.server and args.tcp_port:
+            myfactory = PytermClientFactory(myshell)
+            reactor.connectTCP(args.server, args.tcp_port, myfactory)
+            myshell.factory = myfactory
+            reactor.callInThread(myshell.cmdloop, "Welcome to pyterm!\n"
+                                                  "Type '/exit' to exit.")
+            reactor.run()
+        else:
+            myshell.cmdloop("Welcome to pyterm!\nType '/exit' to exit.")
+    except KeyboardInterrupt:
+        myshell.do_PYTERM_exit(None)


### PR DESCRIPTION
Pyterm is exiting with a traceback when hitting Ctrl+C on the keyboard and this is not what the code is supposed to do ([l679](https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/pyterm/pyterm#L679)):
```python
sys.stderr.write("Ctrl-C is disabled, type '/exit' instead\n")
```

Here is the error that I get (with an iotlab-m3):
```
2017-11-27 13:19:57,033 - INFO # Connect to serial port /dev/ttyUSB1
^CTraceback (most recent call last):
  File "/home/aabadie/softs/src/riot/RIOT/dist/tools/pyterm/pyterm", line 770, in <module>
    myshell.cmdloop("Welcome to pyterm!\nType '/exit' to exit.")
  File "/home/aabadie/anaconda3/lib/python3.5/cmd.py", line 105, in cmdloop
    self.preloop()
  File "/home/aabadie/softs/src/riot/RIOT/dist/tools/pyterm/pyterm", line 231, in preloop
    time.sleep(1)
KeyboardInterrupt
/home/aabadie/RIOT/examples/default/../../Makefile.include:394: recipe for target 'term' failed
make: *** [term] Interrupt
```

This PR is not a fix for this exact behaviour but instead it slightly changes it by trapping the KeyboardInterrupt Exception and return without a traceback. Now I have this after hitting Ctrl+C:
```
2017-11-27 13:25:19,653 - INFO # Connect to serial port /dev/ttyUSB1
^C2017-11-27 13:25:20,486 - INFO # Exiting Pyterm
/home/aabadie/RIOT/examples/default/../../Makefile.include:394: recipe for target 'term' failed
make: *** [term] Interrupt
```

