### PR TITLE
 gnrc_ipv6_nib: add interface parameter to nc_del function

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/nc.h
+++ b/sys/include/net/gnrc/ipv6/nib/nc.h
@@ -235,11 +235,12 @@ int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
  *
  * @pre `ipv6 != NULL`
  *
- * @param[in] ipv6 The neighbor's IPv6 address.
+ * @param[in] ipv6  The neighbor's IPv6 address.
+ * @param[in] iface The interface to the neighbor.
  *
  * If the @p ipv6 can't be found for a neighbor in the NIB nothing happens.
  */
-void gnrc_ipv6_nib_nc_del(const ipv6_addr_t *ipv6);
+void gnrc_ipv6_nib_nc_del(const ipv6_addr_t *ipv6, unsigned iface);
 
 /**
  * @brief   Mark neighbor with address @p ipv6 as reachable

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
@@ -53,13 +53,14 @@ int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
     return 0;
 }
 
-void gnrc_ipv6_nib_nc_del(const ipv6_addr_t *ipv6)
+void gnrc_ipv6_nib_nc_del(const ipv6_addr_t *ipv6, unsigned iface)
 {
     _nib_onl_entry_t *node = NULL;
 
     mutex_lock(&_nib_mutex);
     while ((node = _nib_onl_iter(node)) != NULL) {
-        if (ipv6_addr_equal(ipv6, &node->ipv6)) {
+        if ((_nib_onl_get_if(node) == iface) &&
+            ipv6_addr_equal(ipv6, &node->ipv6)) {
             _nib_nc_remove(node);
             break;
         }

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -56,7 +56,7 @@ static void _usage_nib_neigh(char **argv)
 {
     printf("usage: %s %s [show|add|del|help]\n", argv[0], argv[1]);
     printf("       %s %s add <iface> <ipv6 addr> [<l2 addr>]\n", argv[0], argv[1]);
-    printf("       %s %s del <ipv6 addr>\n", argv[0], argv[1]);
+    printf("       %s %s del <iface> <ipv6 addr>\n", argv[0], argv[1]);
     printf("       %s %s show [iface]\n", argv[0], argv[1]);
 }
 
@@ -114,11 +114,13 @@ static int _nib_neigh(int argc, char **argv)
     }
     else if ((argc > 3) && (strcmp(argv[2], "del") == 0)) {
         ipv6_addr_t ipv6_addr;
+        unsigned iface = atoi(argv[3]);
 
-        if (ipv6_addr_from_str(&ipv6_addr, argv[3]) == NULL) {
+        if (ipv6_addr_from_str(&ipv6_addr, argv[4]) == NULL) {
             _usage_nib_neigh(argv);
             return 1;
         }
+        (void)iface;
         gnrc_ipv6_nib_nc_del(&ipv6_addr);
     }
     else {

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -120,8 +120,7 @@ static int _nib_neigh(int argc, char **argv)
             _usage_nib_neigh(argv);
             return 1;
         }
-        (void)iface;
-        gnrc_ipv6_nib_nc_del(&ipv6_addr);
+        gnrc_ipv6_nib_nc_del(&ipv6_addr, iface);
     }
     else {
         _usage_nib_neigh(argv);

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-nc.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-nc.c
@@ -172,7 +172,7 @@ static void test_nib_nc_del__unknown(void)
         iface++;
         l2addr[7]++;
     }
-    gnrc_ipv6_nib_nc_del(&addr);
+    gnrc_ipv6_nib_nc_del(&addr, iface);
     while (gnrc_ipv6_nib_nc_iter(0, &iter_state, &nce)) {
         count++;
     }
@@ -193,7 +193,7 @@ static void test_nib_nc_del__success(void)
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_nc_set(&addr, IFACE, l2addr,
                                                   sizeof(l2addr)));
-    gnrc_ipv6_nib_nc_del(&addr);
+    gnrc_ipv6_nib_nc_del(&addr, IFACE);
     TEST_ASSERT(!gnrc_ipv6_nib_nc_iter(0, &iter_state, &nce));
 }
 


### PR DESCRIPTION
As suggested in https://github.com/RIOT-OS/RIOT/issues/7713#issuecomment-347145964, this introduces an interface parameter to the `gnrc_ipv6_nib_nc_del()` function, to pick the correct entry in case two neighbors on different networks have the same IPv6 address.