### PR TITLE
sock: extend API for asynchronous event management

### DIFF
--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -103,6 +103,11 @@
 
 #include <stdint.h>
 
+#ifdef MODULE_SOCK_ASYNC && !defined(DOXYGEN)
+#define SOCK_HAS_ASYNC      /**< allow sock_async to be defined as a provided
+                             *   feature of a stack */
+#endif
+
 #if defined(SOCK_HAS_ASYNC) && defined(RIOT_VERSION)
 #include "event.h"
 #endif

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -103,7 +103,7 @@
 
 #include <stdint.h>
 
-#ifdef MODULE_SOCK_ASYNC && !defined(DOXYGEN)
+#if defined(MODULE_SOCK_ASYNC) && !defined(DOXYGEN)
 #define SOCK_HAS_ASYNC      /**< allow sock_async to be defined as a provided
                              *   feature of a stack */
 #endif
@@ -179,7 +179,7 @@ typedef struct {
     event_t super;          /**< event_callback_t structure that gets extended */
     void *sock;             /**< sock that emitted the event */
     uint32_t type;          /**< [Event type](@ref net_sock_event_type) flags */
-} sock_event_t
+} sock_event_t;
 #endif
 
 /**

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -103,6 +103,10 @@
 
 #include <stdint.h>
 
+#if defined(SOCK_HAS_ASYNC) && defined(RIOT_VERSION)
+#include "event.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -114,6 +118,7 @@ extern "C" {
  * @{
  */
 #define SOCK_HAS_IPV6       /**< activate IPv6 support */
+#define SOCK_HAS_ASYNC      /**< activate asynchronous event functionality */
 /** @} */
 #endif
 
@@ -151,6 +156,22 @@ extern "C" {
  * @brief   Special value meaning "wait forever" (don't timeout)
  */
 #define SOCK_NO_TIMEOUT     (UINT32_MAX)
+
+#if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+/**
+ * @brief   Event types for asynchronous event functionality
+ * @note    Only available with @ref SOCK_HAS_ASYNC defined.
+ */
+typedef enum {
+    SOCK_EVENT_RECEIVE = 0, /**< receive event */
+    /**
+     * @brief   number of event types (for internal arrays)
+     *
+     * @note    Please keep this last.
+     */
+    SOCK_EVENT_NUMOF,
+} sock_event_t;
+#endif
 
 /**
  * @brief   Abstract IP end point and end point for a raw IP sock object

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -166,16 +166,20 @@ extern "C" {
 /**
  * @brief   Event types for asynchronous event functionality
  * @note    Only available with @ref SOCK_HAS_ASYNC defined.
+ * @anchor  net_sock_event_type
+ * @{
  */
-typedef enum {
-    SOCK_EVENT_RECEIVE = 0, /**< receive event */
-    /**
-     * @brief   number of event types (for internal arrays)
-     *
-     * @note    Please keep this last.
-     */
-    SOCK_EVENT_NUMOF,
-} sock_event_t;
+#define SOCK_EVENT_RECV     (0x00000001)    /**< Receive event */
+/** @} */
+
+/**
+ * @brief   Sock event
+ */
+typedef struct {
+    event_t super;          /**< event_callback_t structure that gets extended */
+    void *sock;             /**< sock that emitted the event */
+    uint32_t type;          /**< [Event type](@ref net_sock_event_type) flags */
+} sock_event_t
 #endif
 
 /**

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -344,13 +344,10 @@ int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
  *          This also implies, that **only one thread can execute the event
  *          handlers** added via @ref sock_ip_set_event_handler()!
  *
- * @param[in] sock              The sock to set the event queue for. May not be `NULL`.
- * @param[in] queue             The queue to set. May be `NULL` to unset the queue.
- * @param[in] event_pool        Pool of event to allocate in case an event is fired.
- * @param[in] event_pool_size   Size of @p event_pool.
+ * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue The queue to set. May be `NULL` to unset the queue.
  */
-void sock_ip_set_event_queue(sock_ip_t *sock, event_queue_t *queue,
-                             event_t *event_pool, size_t event_pool_size);
+void sock_ip_set_event_queue(sock_ip_t *sock, event_queue_t *queue);
 
 /**
  * @brief   Sets an event handler for asynchronous events of [a certain

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -344,10 +344,13 @@ int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
  *          This also implies, that **only one thread can execute the event
  *          handlers** added via @ref sock_ip_set_event_handler()!
  *
- * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
- * @param[in] queue The queue to set. May be `NULL` to unset the queue.
+ * @param[in] sock              The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue             The queue to set. May be `NULL` to unset the queue.
+ * @param[in] event_pool        Pool of event to allocate in case an event is fired.
+ * @param[in] event_pool_size   Size of @p event_pool.
  */
-void sock_ip_set_event_queue(sock_ip_t *sock, event_queue_t *queue);
+void sock_ip_set_event_queue(sock_ip_t *sock, event_queue_t *queue,
+                             event_t *event_pool, size_t event_pool_size);
 
 /**
  * @brief   Sets an event handler for asynchronous events of [a certain

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -332,6 +332,12 @@ typedef struct sock_ip sock_ip_t;
 int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
                    const sock_ip_ep_t *remote, uint8_t proto, uint16_t flags);
 
+#if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+void sock_p_set_event_queue(sock_ip_t *sock, event_queue_t *queue);
+void sock_ip_set_event_handler(sock_ip_t *sock, sock_event_type_t *type,
+                               event_handler_t handler);
+#endif
+
 /**
  * @brief   Closes a raw IPv4/IPv6 sock object
  *

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -333,7 +333,7 @@ int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
                    const sock_ip_ep_t *remote, uint8_t proto, uint16_t flags);
 
 #if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
-void sock_p_set_event_queue(sock_ip_t *sock, event_queue_t *queue);
+void sock_ip_set_event_queue(sock_ip_t *sock, event_queue_t *queue);
 void sock_ip_set_event_handler(sock_ip_t *sock, sock_event_type_t *type,
                                event_handler_t handler);
 #endif

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -333,8 +333,37 @@ int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
                    const sock_ip_ep_t *remote, uint8_t proto, uint16_t flags);
 
 #if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+/**
+ * @brief   Set the event queue for asynchronous events for a raw IPv4/IPv6 sock
+ *          object
+ *
+ * @pre     `sock == NULL`
+ *
+ * @note    Only one event queue per sock can be set. Since
+ *          event_queue_t::waiter only allows for one thread to own the queue.
+ *          This also implies, that **only one thread can execute the event
+ *          handlers** added via @ref sock_ip_set_event_handler()!
+ *
+ * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue The queue to set. May be `NULL` to unset the queue.
+ */
 void sock_ip_set_event_queue(sock_ip_t *sock, event_queue_t *queue);
-void sock_ip_set_event_handler(sock_ip_t *sock, sock_event_type_t *type,
+
+/**
+ * @brief   Sets an event handler for asynchronous events of [a certain
+ *          type](@ref sock_event_type_t) for a raw IPv4/IPv6 sock object
+ *
+ * @pre `sock != NULL`
+ * @pre `type < SOCK_EVENT_NUMOF`
+ *
+ * @param[in] sock      The sock to set the event handler for. May not be
+ *                      `NULL`
+ * @param[in] type      The [event type](@ref sock_event_type_t), @p handler
+ *                      should handle. Must be < @ref SOCK_EVENT_NUMOF.
+ * @param[in] handler   The event handler for @p type. May be `NULL` to unset
+ *                      the event handler for @p type.
+ */
+void sock_ip_set_event_handler(sock_ip_t *sock, sock_event_type_t type,
                                event_handler_t handler);
 #endif
 

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -337,34 +337,19 @@ int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
  * @brief   Set the event queue for asynchronous events for a raw IPv4/IPv6 sock
  *          object
  *
- * @pre     `sock == NULL`
+ * @pre     `sock != NULL`
  *
  * @note    Only one event queue per sock can be set. Since
  *          event_queue_t::waiter only allows for one thread to own the queue.
- *          This also implies, that **only one thread can execute the event
- *          handlers** added via @ref sock_ip_set_event_handler()!
+ *          This also implies, that **only one thread can execute the
+ *          @p handler**!
  *
- * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
- * @param[in] queue The queue to set. May be `NULL` to unset the queue.
+ * @param[in] sock      The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue     The queue to set. May be `NULL` to unset the queue.
+ * @param[in] handler   The event handler. May be `NULL` to unset.
  */
-void sock_ip_set_event_queue(sock_ip_t *sock, event_queue_t *queue);
-
-/**
- * @brief   Sets an event handler for asynchronous events of [a certain
- *          type](@ref sock_event_type_t) for a raw IPv4/IPv6 sock object
- *
- * @pre `sock != NULL`
- * @pre `type < SOCK_EVENT_NUMOF`
- *
- * @param[in] sock      The sock to set the event handler for. May not be
- *                      `NULL`
- * @param[in] type      The [event type](@ref sock_event_type_t), @p handler
- *                      should handle. Must be < @ref SOCK_EVENT_NUMOF.
- * @param[in] handler   The event handler for @p type. May be `NULL` to unset
- *                      the event handler for @p type.
- */
-void sock_ip_set_event_handler(sock_ip_t *sock, sock_event_type_t type,
-                               event_handler_t handler);
+void sock_ip_set_event_queue(sock_ip_t *sock, event_queue_t *queue,
+                             event_handler_t handler);
 #endif
 
 /**

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -388,7 +388,36 @@ int sock_tcp_listen(sock_tcp_queue_t *queue, const sock_tcp_ep_t *local,
                     uint16_t flags);
 
 #if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+/**
+ * @brief   Set the event queue for asynchronous events for a TCP sock
+ *          object
+ *
+ * @pre     `sock == NULL`
+ *
+ * @note    Only one event queue per sock can be set. Since
+ *          event_queue_t::waiter only allows for one thread to own the queue.
+ *          This also implies, that **only one thread can execute the event
+ *          handlers** added via @ref sock_tcp_set_event_handler()!
+ *
+ * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue The queue to set. May be `NULL` to unset the queue.
+ */
 void sock_tcp_set_event_queue(sock_tcp_t *sock, event_queue_t *queue);
+
+/**
+ * @brief   Sets an event handler for asynchronous events of [a certain
+ *          type](@ref sock_event_type_t) for a raw TCP sock object
+ *
+ * @pre `sock != NULL`
+ * @pre `type < SOCK_EVENT_NUMOF`
+ *
+ * @param[in] sock      The sock to set the event handler for. May not be
+ *                      `NULL`
+ * @param[in] type      The [event type](@ref sock_event_type_t), @p handler
+ *                      should handle. Must be < @ref SOCK_EVENT_NUMOF.
+ * @param[in] handler   The event handler for @p type. May be `NULL` to unset
+ *                      the event handler for @p type.
+ */
 void sock_tcp_set_event_handler(sock_tcp_t *sock, sock_event_type_t *type,
                                 event_handler_t handler);
 #endif

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -387,6 +387,12 @@ int sock_tcp_listen(sock_tcp_queue_t *queue, const sock_tcp_ep_t *local,
                     sock_tcp_t *queue_array, unsigned queue_len,
                     uint16_t flags);
 
+#if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+void sock_tcp_set_event_queue(sock_tcp_t *sock, event_queue_t *queue);
+void sock_tcp_set_event_handler(sock_tcp_t *sock, sock_event_type_t *type,
+                                event_handler_t handler);
+#endif
+
 /**
  * @brief   Disconnects a TCP connection
  *

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -392,33 +392,18 @@ int sock_tcp_listen(sock_tcp_queue_t *queue, const sock_tcp_ep_t *local,
  * @brief   Set the event queue for asynchronous events for a TCP sock
  *          object
  *
- * @pre     `sock == NULL`
+ * @pre     `sock != NULL`
  *
  * @note    Only one event queue per sock can be set. Since
  *          event_queue_t::waiter only allows for one thread to own the queue.
- *          This also implies, that **only one thread can execute the event
- *          handlers** added via @ref sock_tcp_set_event_handler()!
+ *          This also implies, that **only one thread can execute the
+ *          @p handler**!
  *
- * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
- * @param[in] queue The queue to set. May be `NULL` to unset the queue.
+ * @param[in] sock      The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue     The queue to set. May be `NULL` to unset the queue.
+ * @param[in] handler   The event handler. May be `NULL` to unset.
  */
-void sock_tcp_set_event_queue(sock_tcp_t *sock, event_queue_t *queue);
-
-/**
- * @brief   Sets an event handler for asynchronous events of [a certain
- *          type](@ref sock_event_type_t) for a raw TCP sock object
- *
- * @pre `sock != NULL`
- * @pre `type < SOCK_EVENT_NUMOF`
- *
- * @param[in] sock      The sock to set the event handler for. May not be
- *                      `NULL`
- * @param[in] type      The [event type](@ref sock_event_type_t), @p handler
- *                      should handle. Must be < @ref SOCK_EVENT_NUMOF.
- * @param[in] handler   The event handler for @p type. May be `NULL` to unset
- *                      the event handler for @p type.
- */
-void sock_tcp_set_event_handler(sock_tcp_t *sock, sock_event_type_t *type,
+void sock_tcp_set_event_handler(sock_tcp_t *sock, event_queue_t *queue,
                                 event_handler_t handler);
 #endif
 

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -399,13 +399,10 @@ int sock_tcp_listen(sock_tcp_queue_t *queue, const sock_tcp_ep_t *local,
  *          This also implies, that **only one thread can execute the event
  *          handlers** added via @ref sock_tcp_set_event_handler()!
  *
- * @param[in] sock              The sock to set the event queue for. May not be `NULL`.
- * @param[in] queue             The queue to set. May be `NULL` to unset the queue.
- * @param[in] event_pool        Pool of event to allocate in case an event is fired.
- * @param[in] event_pool_size   Size of @p event_pool.
+ * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue The queue to set. May be `NULL` to unset the queue.
  */
-void sock_tcp_set_event_queue(sock_tcp_t *sock, event_queue_t *queuei,
-                              event_t *event_pool, size_t event_pool_size);
+void sock_tcp_set_event_queue(sock_tcp_t *sock, event_queue_t *queue);
 
 /**
  * @brief   Sets an event handler for asynchronous events of [a certain

--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -399,10 +399,13 @@ int sock_tcp_listen(sock_tcp_queue_t *queue, const sock_tcp_ep_t *local,
  *          This also implies, that **only one thread can execute the event
  *          handlers** added via @ref sock_tcp_set_event_handler()!
  *
- * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
- * @param[in] queue The queue to set. May be `NULL` to unset the queue.
+ * @param[in] sock              The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue             The queue to set. May be `NULL` to unset the queue.
+ * @param[in] event_pool        Pool of event to allocate in case an event is fired.
+ * @param[in] event_pool_size   Size of @p event_pool.
  */
-void sock_tcp_set_event_queue(sock_tcp_t *sock, event_queue_t *queue);
+void sock_tcp_set_event_queue(sock_tcp_t *sock, event_queue_t *queuei,
+                              event_t *event_pool, size_t event_pool_size);
 
 /**
  * @brief   Sets an event handler for asynchronous events of [a certain

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -333,6 +333,12 @@ typedef struct sock_udp sock_udp_t;
 int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
                     const sock_udp_ep_t *remote, uint16_t flags);
 
+#if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+void sock_udp_set_event_queue(sock_udp_t *sock, event_queue_t *queue);
+void sock_udp_set_event_handler(sock_udp_t *sock, sock_event_type_t *type,
+                                event_handler_t handler);
+#endif
+
 /**
  * @brief   Closes a UDP sock object
  *

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -344,13 +344,10 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
  *          This also implies, that **only one thread can execute the event
  *          handlers** added via @ref sock_udp_set_event_handler()!
  *
- * @param[in] sock              The sock to set the event queue for. May not be `NULL`.
- * @param[in] queue             The queue to set. May be `NULL` to unset the queue.
- * @param[in] event_pool        Pool of event to allocate in case an event is fired.
- * @param[in] event_pool_size   Size of @p event_pool.
+ * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue The queue to set. May be `NULL` to unset the queue.
  */
-void sock_udp_set_event_queue(sock_udp_t *sock, event_queue_t *queue,
-                              event_t *event_pool, size_t event_pool_size);
+void sock_udp_set_event_queue(sock_udp_t *sock, event_queue_t *queue);
 
 /**
  * @brief   Sets an event handler for asynchronous events of [a certain

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -344,10 +344,13 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
  *          This also implies, that **only one thread can execute the event
  *          handlers** added via @ref sock_udp_set_event_handler()!
  *
- * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
- * @param[in] queue The queue to set. May be `NULL` to unset the queue.
+ * @param[in] sock              The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue             The queue to set. May be `NULL` to unset the queue.
+ * @param[in] event_pool        Pool of event to allocate in case an event is fired.
+ * @param[in] event_pool_size   Size of @p event_pool.
  */
-void sock_udp_set_event_queue(sock_udp_t *sock, event_queue_t *queue);
+void sock_udp_set_event_queue(sock_udp_t *sock, event_queue_t *queue,
+                              event_t *event_pool, size_t event_pool_size);
 
 /**
  * @brief   Sets an event handler for asynchronous events of [a certain

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -334,7 +334,35 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
                     const sock_udp_ep_t *remote, uint16_t flags);
 
 #if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+/**
+ * @brief   Set the event queue for asynchronous events for a UDP sock object
+ *
+ * @pre     `sock == NULL`
+ *
+ * @note    Only one event queue per sock can be set. Since
+ *          event_queue_t::waiter only allows for one thread to own the queue.
+ *          This also implies, that **only one thread can execute the event
+ *          handlers** added via @ref sock_udp_set_event_handler()!
+ *
+ * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue The queue to set. May be `NULL` to unset the queue.
+ */
 void sock_udp_set_event_queue(sock_udp_t *sock, event_queue_t *queue);
+
+/**
+ * @brief   Sets an event handler for asynchronous events of [a certain
+ *          type](@ref sock_event_type_t) for a UDP sock object
+ *
+ * @pre `sock != NULL`
+ * @pre `type < SOCK_EVENT_NUMOF`
+ *
+ * @param[in] sock      The sock to set the event handler for. May not be
+ *                      `NULL`
+ * @param[in] type      The [event type](@ref sock_event_type_t), @p handler
+ *                      should handle. Must be < @ref SOCK_EVENT_NUMOF.
+ * @param[in] handler   The event handler for @p type. May be `NULL` to unset
+ *                      the event handler for @p type.
+ */
 void sock_udp_set_event_handler(sock_udp_t *sock, sock_event_type_t *type,
                                 event_handler_t handler);
 #endif

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -337,34 +337,19 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
 /**
  * @brief   Set the event queue for asynchronous events for a UDP sock object
  *
- * @pre     `sock == NULL`
+ * @pre     `sock != NULL`
  *
  * @note    Only one event queue per sock can be set. Since
  *          event_queue_t::waiter only allows for one thread to own the queue.
- *          This also implies, that **only one thread can execute the event
- *          handlers** added via @ref sock_udp_set_event_handler()!
+ *          This also implies, that **only one thread can execute the
+ *          @p handler**!
  *
- * @param[in] sock  The sock to set the event queue for. May not be `NULL`.
- * @param[in] queue The queue to set. May be `NULL` to unset the queue.
+ * @param[in] sock      The sock to set the event queue for. May not be `NULL`.
+ * @param[in] queue     The queue to set. May be `NULL` to unset the queue.
+ * @param[in] handler   The event handler. May be `NULL` to unset.
  */
-void sock_udp_set_event_queue(sock_udp_t *sock, event_queue_t *queue);
-
-/**
- * @brief   Sets an event handler for asynchronous events of [a certain
- *          type](@ref sock_event_type_t) for a UDP sock object
- *
- * @pre `sock != NULL`
- * @pre `type < SOCK_EVENT_NUMOF`
- *
- * @param[in] sock      The sock to set the event handler for. May not be
- *                      `NULL`
- * @param[in] type      The [event type](@ref sock_event_type_t), @p handler
- *                      should handle. Must be < @ref SOCK_EVENT_NUMOF.
- * @param[in] handler   The event handler for @p type. May be `NULL` to unset
- *                      the event handler for @p type.
- */
-void sock_udp_set_event_handler(sock_udp_t *sock, sock_event_type_t *type,
-                                event_handler_t handler);
+void sock_udp_set_event_queue(sock_udp_t *sock, event_queue_t *queue,
+                              event_handler_t handler);
 #endif
 
 /**


### PR DESCRIPTION
This is a first draft to extend the `sock` APIs for asynchronous events using the `event` module.

I kept it optionally to

1. be backwards compatible for older `sock` implementations
2. be compatible to non-RIOT implementations, like @kaspar030's [wrapper around POSIX sockets](https://github.com/kaspar030/sock/tree/master/src/posix).

Doc and implementation will come as soon as I get the go from enough people.