### PR TITLE
tests: fix python style 'E401 multiple imports on one line'

### DIFF
--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -7,13 +7,13 @@
 # Distributed under terms of the MIT license.
 
 from __future__ import print_function
-import argparse
-import os, sys
+import os
+import sys
 import random
-import pexpect
 import subprocess
 import time
 import types
+import pexpect
 
 DEFAULT_TIMEOUT = 5
 

--- a/tests/warn_conflict/test.py
+++ b/tests/warn_conflict/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-import subprocess, os
+import subprocess
+import os
 
 cross_gcc = "arm-none-eabi-gcc"
 


### PR DESCRIPTION
Partially addresses #8141 by covering the `E401 multiple imports on one line` issue.