### PR TITLE
tests: fix python style 'E703 statement ends with a semicolon'

### DIFF
--- a/tests/posix_time/tests/01-run.py
+++ b/tests/posix_time/tests/01-run.py
@@ -40,7 +40,7 @@ def testfunc(child):
         upper_bound = exp + (exp * EXTERNAL_JITTER)
         if not (lower_bound < testtime < upper_bound):
             raise InvalidTimeout("Host timer measured %d us (client measured %d us)" % \
-                                 (testtime, exp));
+                                 (testtime, exp))
     except InvalidTimeout as e:
         print(e)
         sys.exit(1)

--- a/tests/rmutex/tests/01-run.py
+++ b/tests/rmutex/tests/01-run.py
@@ -38,7 +38,7 @@ def testfunc(child):
         child.expect(u"T%i \(prio %i, depth 0\): trying to lock rmutex now" %
                      (k, thread_prio[k]))
 
-    pri_sorted = sorted(thread_prio, key=thread_prio_sort);
+    pri_sorted = sorted(thread_prio, key=thread_prio_sort)
     for T in pri_sorted:
         for depth in range(lock_depth[T]):
             child.expect(u"T%i \(prio %i, depth %i\): locked rmutex now" %

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -39,7 +39,7 @@ def testfunc(child):
                 lower_bound = exp - (exp * INTERNAL_JITTER)
                 upper_bound = exp + (exp * INTERNAL_JITTER)
                 if not (lower_bound < sleep_time < upper_bound):
-                    raise InvalidTimeout("Invalid timeout %d (expected %d)" % (sleep_time, exp));
+                    raise InvalidTimeout("Invalid timeout %d (expected %d)" % (sleep_time, exp))
         testtime = (time.time() - start_test) * US_PER_SEC
         child.expect(u"Test ran for (\\d+) us")
         exp = int(child.match.group(1))
@@ -47,7 +47,7 @@ def testfunc(child):
         upper_bound = exp + (exp * EXTERNAL_JITTER)
         if not (lower_bound < testtime < upper_bound):
             raise InvalidTimeout("Host timer measured %d us (client measured %d us)" % \
-                                 (testtime, exp));
+                                 (testtime, exp))
     except InvalidTimeout as e:
         print(e)
         sys.exit(1)

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -23,9 +23,9 @@ def testfunc(child):
         try:
             child.expect(u"going to sleep \\d+ usecs...\r\n", timeout=3)
         except pexpect.TIMEOUT:
-            print("xtimer stuck when trying to sleep %d usecs" % (i+1));
+            print("xtimer stuck when trying to sleep %d usecs" % (i+1))
             print("[FAILED]")
-            break;
+            break
         i = i - 1
 
     child.expect(u"[SUCCESS]", timeout=3)


### PR DESCRIPTION
Partially addresses #8141 by fixing `E703 statement ends with a semicolon` (this is not C code :))