### PR TITLE
boards: *: add support for renode

### DIFF
--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -6,6 +6,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Various other features (if any)
+FEATURES_PROVIDED += emulator_renode
+
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 

--- a/boards/ikea-tradfri/Makefile.include
+++ b/boards/ikea-tradfri/Makefile.include
@@ -6,6 +6,9 @@ export CPU_MODEL = efr32mg1p132f256gm32
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
+# setup emulator
+include $(RIOTMAKE)/tools/renode.inc.mk
+
 # setup JLink for flashing
 export JLINK_DEVICE := EFR32MG1PxxxF256
 include $(RIOTMAKE)/tools/jlink.inc.mk

--- a/boards/ikea-tradfri/dist/board.resc
+++ b/boards/ikea-tradfri/dist/board.resc
@@ -1,0 +1,22 @@
+mach create
+using sysbus
+machine LoadPlatformDescription @platforms/cpus/efr32mg.repl
+machine SetClockSource cpu
+
+# osc hack - push the initialization forward
+machine PyDevFromFile @scripts/pydev/flipflop.py 0x400E4090 4 true "CMU_STATUS"
+
+# show the UART output
+showAnalyzer usart0
+
+# generate a unique device id
+$unique_id = `next_value 1`
+
+macro reset
+"""
+    sysbus LoadELF $image_file
+    deviceInformation Unique $unique_id
+"""
+
+runMacro $reset
+start

--- a/boards/sltb001a/Makefile.features
+++ b/boards/sltb001a/Makefile.features
@@ -8,6 +8,9 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Various other features (if any)
+FEATURES_PROVIDED += emulator_renode
+
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 

--- a/boards/sltb001a/Makefile.include
+++ b/boards/sltb001a/Makefile.include
@@ -6,6 +6,9 @@ export CPU_MODEL = efr32mg1p132f256gm48
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
+# setup emulator
+include $(RIOTMAKE)/tools/renode.inc.mk
+
 # setup JLink for flashing
 export JLINK_DEVICE := EFR32MG1PxxxF256
 include $(RIOTMAKE)/tools/jlink.inc.mk

--- a/boards/sltb001a/dist/board.resc
+++ b/boards/sltb001a/dist/board.resc
@@ -1,0 +1,22 @@
+mach create
+using sysbus
+machine LoadPlatformDescription @platforms/cpus/efr32mg.repl
+machine SetClockSource cpu
+
+# osc hack - push the initialization forward
+machine PyDevFromFile @scripts/pydev/flipflop.py 0x400E4090 4 true "CMU_STATUS"
+
+# show the UART output
+showAnalyzer usart0
+
+# generate a unique device id
+$unique_id = `next_value 1`
+
+macro reset
+"""
+    sysbus LoadELF $image_file
+    deviceInformation Unique $unique_id
+"""
+
+runMacro $reset
+start

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -11,6 +11,7 @@ FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += emulator_renode
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -6,6 +6,9 @@ export CPU_MODEL = stm32f407vg
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
+# setup emulator
+include $(RIOTMAKE)/tools/renode.inc.mk
+
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/stm32f4discovery/dist/board.resc
+++ b/boards/stm32f4discovery/dist/board.resc
@@ -1,0 +1,40 @@
+mach create
+using sysbus
+machine LoadPlatformDescription @platforms/boards/stm32f4_discovery-kit.repl
+
+machine SetClockSource sysbus.cpu
+cpu PerformanceInMips 125
+
+# oscillator setup to toggle status bit based on requested clock.
+set RCC_CFGR
+"""
+if request.isWrite:
+    value = (request.value & ~(0x0C)) | ((request.value & 0x03) << 0x02)
+elif request.isRead:
+    request.value = value
+"""
+
+machine PyDevFromString $RCC_CFGR 0x40023808 0x4 false "RCC_CFGR"
+
+# show the UART output
+showAnalyzer uart2
+
+# generate a unique device id
+python "import _random"
+python "rand = _random.Random()"
+
+$id1 = `python "print rand.getrandbits(32)"`
+$id2 = `python "print rand.getrandbits(32)"`
+$id3 = `python "print rand.getrandbits(32)"`
+
+macro reset
+"""
+    sysbus LoadELF $image_file
+
+    sysbus WriteDoubleWord 0x1FFF7A10 $id1
+    sysbus WriteDoubleWord 0x1FFF7A14 $id2
+    sysbus WriteDoubleWord 0x1FFF7A18 $id3
+"""
+
+runMacro $reset
+start

--- a/boards/stm32f7discovery/Makefile.features
+++ b/boards/stm32f7discovery/Makefile.features
@@ -4,6 +4,9 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
+# Various other features (if any)
+FEATURES_PROVIDED += emulator_renode
+
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m7
 

--- a/boards/stm32f7discovery/Makefile.include
+++ b/boards/stm32f7discovery/Makefile.include
@@ -6,6 +6,9 @@ export CPU_MODEL = stm32f769ni
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
+# setup emulator
+include $(RIOTMAKE)/tools/renode.inc.mk
+
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/boards/stm32f7discovery/dist/board.resc
+++ b/boards/stm32f7discovery/dist/board.resc
@@ -1,0 +1,37 @@
+mach create
+using sysbus
+machine LoadPlatformDescription @platforms/boards/stm32f7_discovery-bb.repl
+
+# oscillator setup to toggle status bit based on requested clock.
+set RCC_CFGR
+"""
+if request.isWrite:
+    value = (request.value & ~(0x0C)) | ((request.value & 0x03) << 0x02)
+elif request.isRead:
+    request.value = value
+"""
+
+machine PyDevFromString $RCC_CFGR 0x40023808 0x4 false "RCC_CFGR"
+
+# show the UART output
+showAnalyzer usart1
+
+# generate a unique device id
+python "import _random"
+python "rand = _random.Random()"
+
+$id1 = `python "print rand.getrandbits(32)"`
+$id2 = `python "print rand.getrandbits(32)"`
+$id3 = `python "print rand.getrandbits(32)"`
+
+macro reset
+"""
+    sysbus LoadELF $image_file
+
+    sysbus WriteDoubleWord 0x1FFF7A10 $id1
+    sysbus WriteDoubleWord 0x1FFF7A14 $id2
+    sysbus WriteDoubleWord 0x1FFF7A18 $id3
+"""
+
+runMacro $reset
+start


### PR DESCRIPTION
Now that #7959 is merged, I promised to add support for more boards except `cc2538dk`.

This PR adds support for the boards that are currently supported by Renode as part of their distribution. Exact support will always depend on the hardware connected, board initialization and so on, but we'll have to start somewhere. My current reference for success is running the `hello-world` example.

* `ikea-tradfri` (EFR32MG)
* `sltb001a` (EFR32MG)
* `stm32f4discovery` (STM32F4)
* `stm32f7discovery` (STM32F7, Cortex M7!)

I propose to keep this WIP for the time being, especially since @mgielda [promised me](https://github.com/renode/renode/issues/1#issuecomment-346896303) to show me how I could add support for EFM32 in the best possible way :-)