### PR TITLE
examples: tests: remove remaining pca1000x references

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -12,8 +12,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini 
                              microbit msb-430 msb-430h nrf51dongle nrf6310 \
                              nucleo32-f031 nucleo32-f042 nucleo32-f303 nucleo32-l031 \
                              nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f302 \
-                             nucleo-f334 nucleo-l053 nucleo-l073 opencm904 pca10000 \
-                             pca10005 spark-core stm32f0discovery telosb weio wsn430-v1_3b \
+                             nucleo-f334 nucleo-l053 nucleo-l073 opencm904 \
+                             spark-core stm32f0discovery telosb weio wsn430-v1_3b \
                              wsn430-v1_4 yunjia-nrf51822 z1
 
 BOARD_BLACKLIST += mips-malta pic32-wifire pic32-clicker# No full UART available.

--- a/tests/gnrc_netif/Makefile
+++ b/tests/gnrc_netif/Makefile
@@ -8,9 +8,9 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini 
                              nucleo-f030 nucleo-f070 nucleo-f072 nucleo-f103 \
                              nucleo-f302 nucleo-f334 nucleo-l053 nucleo-l073 \
                              nucleo32-f031 nucleo32-f042 nucleo32-f303 \
-                             nucleo32-l031 opencm904 pca10000 pca10005 \
-                             spark-core stm32f0discovery telosb wsn430-v1_3b \
-                             wsn430-v1_4 yunjia-nrf51822 z1 \
+                             nucleo32-l031 opencm904 spark-core \
+                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
+                             yunjia-nrf51822 z1
 
 USEMODULE += embunit
 USEMODULE += gnrc_netif


### PR DESCRIPTION
Reverts #7986 and #8072, now that #7925 is merged