### PR TITLE
tests: remove unnecessary gnrc_netdev_default include

### DIFF
--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -3,11 +3,10 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
-                             nucleo32-l031 nucleo-f334 nucleo-l053 \
-                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-f334 nucleo-l053 \
+                             nucleo32-f031 nucleo32-f042 nucleo32-l031 \
+                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4
 
-USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += enc28j60
 USEMODULE += gnrc_ipv6_router_default

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -3,11 +3,10 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio
 
-BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo32-f031 nucleo32-f042 \
-                             nucleo32-l031 nucleo-l053 stm32f0discovery telosb \
-                             wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := nucleo-l053 nucleo32-f031 nucleo32-f042 \
+                             nucleo32-l031 stm32f0discovery telosb \
+                             wsn430-v1_3b wsn430-v1_4
 
-USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += encx24j600
 USEMODULE += gnrc_ipv6_router_default


### PR DESCRIPTION
The `driver_enc28j60` and `driver_encx24j600` applications exist to
test the network device drivers of this type. Including the *default*
driver of the board is thus non-sensical and might even be harmful for
the success of this test (if default device in initialized before the
device that is tested).

Additionally, does the removal of this module allow for some boards to
fit this into their memory (at least in my linker configuration), so I
removed them from the `BOARD_INSUFFICIENT_MEMORY` list.