### PR TITLE
boards/b-l072z-lrwan1: make sx127x default netdev

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.dep
+++ b/boards/b-l072z-lrwan1/Makefile.dep
@@ -1,3 +1,7 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += sx1276
+endif
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -281,6 +281,7 @@ static void _isr(netdev_t *netdev)
 
 static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 {
+    (void) max_len;  /* unused when compiled without debug, assert empty */
     sx127x_t *dev = (sx127x_t*) netdev;
 
     if (dev == NULL) {

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -34,7 +34,7 @@ USEMODULE += ps
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 
-BOARD_PROVIDES_NETIF := airfy-beacon cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
+BOARD_PROVIDES_NETIF := airfy-beacon b-l072z-lrwan1 cc2538dk fox iotlab-m3 iotlab-a8-m3 mulle \
         microbit native nrf51dongle nrf52dk nrf6310 openmote-cc2538 pba-d-01-kw2x \
         remote-pa remote-reva samr21-xpro \
         spark-core telosb yunjia-nrf51822 z1

--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -7,7 +7,7 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon bluepill calliope-mini chronos \
+BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini chronos \
                              microbit msb-430 msb-430h nrf51dongle nrf6310 nucleo32-f031 \
                              nucleo32-f042 nucleo32-f303 nucleo32-l031 nucleo-f030 \
                              nucleo-f070 nucleo-f072 nucleo-f103 nucleo-f302 nucleo-f334 \


### PR DESCRIPTION
This way, one can add this board to the netif capable boards in `examples/default`.

Based on ~#8159~ and ~#8232~