### PR TITLE
pn532: remove redundant #ifdefs

### DIFF
--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -120,21 +120,19 @@ int pn532_init(pn532_t *dev, const pn532_params_t *params, pn532_mode_t mode)
     gpio_init(dev->conf->reset, GPIO_OUT);
     gpio_set(dev->conf->reset);
     dev->mode = mode;
-    if (mode == PN532_I2C) {
 #ifdef PN532_SUPPORT_I2C
+    if (mode == PN532_I2C) {
         if (i2c_init_master(dev->conf->i2c, I2C_SPEED_FAST) != 0) {
             DEBUG("pn532: initialization of I2C bus failed\n");
             return -1;
         }
-#endif
     }
     else {
-#ifdef PN532_SUPPORT_SPI
         /* we handle the CS line manually... */
         gpio_init(dev->conf->nss, GPIO_OUT);
         gpio_set(dev->conf->nss);
-#endif
     }
+#endif
 
     pn532_reset(dev);
 
@@ -172,15 +170,13 @@ static int _write(const pn532_t *dev, char *buff, unsigned len)
     (void)buff;
     (void)len;
 
-    if (dev->mode == PN532_I2C) {
 #ifdef PN532_SUPPORT_I2C
+    if (dev->mode == PN532_I2C) {
         i2c_acquire(dev->conf->i2c);
         ret = i2c_write_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len);
         i2c_release(dev->conf->i2c);
-#endif
     }
     else {
-#ifdef PN532_SUPPORT_SPI
         spi_acquire(dev->conf->spi, SPI_CS_UNDEF, SPI_MODE, SPI_CLK);
         gpio_clear(dev->conf->nss);
         xtimer_usleep(SPI_WRITE_DELAY_US);
@@ -190,8 +186,8 @@ static int _write(const pn532_t *dev, char *buff, unsigned len)
         gpio_set(dev->conf->nss);
         spi_release(dev->conf->spi);
         ret = (int)len;
-#endif
     }
+#endif
     DEBUG("pn532: -> ");
     PRINTBUFF(buff, len);
     return ret;
@@ -201,19 +197,18 @@ static int _read(const pn532_t *dev, char *buff, unsigned len)
 {
     int ret = -1;
 
+    (void)dev;
     (void)buff;
     (void)len;
 
-    if (dev->mode == PN532_I2C) {
 #ifdef PN532_SUPPORT_I2C
+    if (dev->mode == PN532_I2C) {
         i2c_acquire(dev->conf->i2c);
         /* len+1 for RDY after read is accepted */
         ret = i2c_read_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len + 1);
         i2c_release(dev->conf->i2c);
-#endif
     }
     else {
-#ifdef PN532_SUPPORT_SPI
         spi_acquire(dev->conf->spi, SPI_CS_UNDEF, SPI_MODE, SPI_CLK);
         gpio_clear(dev->conf->nss);
         spi_transfer_byte(dev->conf->spi, SPI_CS_UNDEF, true, SPI_DATA_READ);
@@ -224,8 +219,8 @@ static int _read(const pn532_t *dev, char *buff, unsigned len)
         buff[0] = 0x80;
         reverse(buff, len);
         ret = (int)len + 1;
-#endif
     }
+#endif
     DEBUG("pn532: <- ");
     PRINTBUFF(buff, len);
     return ret;


### PR DESCRIPTION
Some `#ifdef`s in this file are redundant and weirdly placed inside the
respective branches of an `if {  } else {  }`.

This PR puts the `#ifdef` *around* the `if {  } else {  }`, reducing the
number of `#ifdef`s in this file, and making it more readable for humans
and tools like `cppcheck` alike ;-).

This is a follow-up on https://github.com/RIOT-OS/RIOT/pull/7994#issuecomment-347495142