### PR TITLE
cpu: efm32_common: use board defined EMU/CMU settings

### DIFF
--- a/cpu/efm32_common/cpu.c
+++ b/cpu/efm32_common/cpu.c
@@ -27,13 +27,36 @@
 #include "em_cmu.h"
 #include "em_emu.h"
 
+/**
+ * @brief   Default settings for CMU initialization.
+ */
+#ifndef CMU_HFXOINIT
+#define CMU_HFXOINIT        CMU_HFXOINIT_DEFAULT
+#endif
+#ifndef CMU_LFXOINIT
+#define CMU_LFXOINIT        CMU_LFXOINIT_DEFAULT
+#endif
+
+/**
+ * @brief   Default settings for EMU initialization
+ */
+#ifndef EMU_DCDCINIT
+#define EMU_DCDCINIT        EMU_DCDCINIT_DEFAULT
+#endif
+#ifndef EMU_EM23INIT
+#define EMU_EM23INIT        EMU_EM23INIT_DEFAULT
+#endif
+#ifndef EMU_EM4INIT
+#define EMU_EM4INIT         EMU_EM4INIT_DEFAULT
+#endif
+
 #ifdef _SILICON_LABS_32B_SERIES_1
 /**
  * @brief   Initialize integrated DC-DC regulator
  */
 static void dcdc_init(void)
 {
-    EMU_DCDCInit_TypeDef init_dcdc = EMU_DCDCINIT_DEFAULT;
+    EMU_DCDCInit_TypeDef init_dcdc = EMU_DCDCINIT;
 
     EMU_DCDCInit(&init_dcdc);
 }
@@ -47,17 +70,20 @@ static void dcdc_init(void)
  * oscillator (HFRCO, enabled by default).
  *
  * The clocks for the LFA, LFB, LFE and HFPER are also configured.
+ *
+ * When selecting the HFXO, the HFRCO is disabled. The same applies for the
+ * LFA, LFB and LFE branch, in case the LFXO is selected.
  */
 static void clk_init(void)
 {
-    CMU_HFXOInit_TypeDef init_hfxo = CMU_HFXOINIT_DEFAULT;
-
     /* initialize HFXO with board-specific parameters before switching */
     if (CLOCK_HF == cmuSelect_HFXO) {
+        CMU_HFXOInit_TypeDef init_hfxo = CMU_HFXOINIT;
+
         CMU_HFXOInit(&init_hfxo);
     }
 
-    /* set the HF clock source */
+    /* set (and enable) the HF clock source */
     CMU_ClockSelectSet(cmuClock_HF, CLOCK_HF);
     CMU_ClockDivSet(cmuClock_CORE, CLOCK_CORE_DIV);
 
@@ -66,16 +92,40 @@ static void clk_init(void)
         CMU_OscillatorEnable(cmuOsc_HFRCO, false, false);
     }
 
-    /* set the LFA clock source */
+    /* initialize LFXO with board-specific parameters before switching */
+    if (CLOCK_LFA == cmuSelect_LFXO || CLOCK_LFB == cmuSelect_LFXO ||
+#ifdef _SILICON_LABS_32B_SERIES_1
+        CLOCK_LFE == cmuSelect_LFXO)
+#else
+        false)
+#endif
+    {
+        CMU_LFXOInit_TypeDef init_lfxo = CMU_LFXOINIT;
+
+        CMU_LFXOInit(&init_lfxo);
+    }
+
+    /* set (and enable) the LFA clock source */
     CMU_ClockSelectSet(cmuClock_LFA, CLOCK_LFA);
 
-    /* set the LFB clock source */
+    /* set (and enable) the LFB clock source */
     CMU_ClockSelectSet(cmuClock_LFB, CLOCK_LFB);
 
-    /* set the LFE clock source */
 #ifdef _SILICON_LABS_32B_SERIES_1
+    /* set (and enable) the LFE clock source */
     CMU_ClockSelectSet(cmuClock_LFE, CLOCK_LFE);
 #endif
+
+    /* disable the LFRCO if external crystal is used */
+    if (CLOCK_LFA == cmuSelect_LFXO && CLOCK_LFB == cmuSelect_LFXO &&
+#ifdef _SILICON_LABS_32B_SERIES_1
+        CLOCK_LFE == cmuSelect_LFXO)
+#else
+        true)
+#endif
+    {
+        CMU_OscillatorEnable(cmuOsc_LFRCO, false, false);
+    }
 }
 
 /**
@@ -87,13 +137,13 @@ static void clk_init(void)
 static void pm_init(void)
 {
     /* initialize EM2 and EM3 */
-    EMU_EM23Init_TypeDef init_em23 = EMU_EM23INIT_DEFAULT;
+    EMU_EM23Init_TypeDef init_em23 = EMU_EM23INIT;
 
     EMU_EM23Init(&init_em23);
 
 #ifdef _SILICON_LABS_32B_SERIES_1
     /* initialize EM4 */
-    EMU_EM4Init_TypeDef init_em4 = EMU_EM4INIT_DEFAULT;
+    EMU_EM4Init_TypeDef init_em4 = EMU_EM4INIT;
 
     EMU_EM4Init(&init_em4);
 #endif


### PR DESCRIPTION
This is split-off #8139.

This PR allows one to define differen Energy Management Unit (EMU) and Clock Management Unit (CMU) settings on a per-board basis.

The defaults are good enough in most cases, but you need other values for radio support.