### PR TITLE
cpu: efm32_common: add support for GPIO ports A-K and I2C2.

### DIFF
--- a/cpu/efm32_common/include/periph_cpu.h
+++ b/cpu/efm32_common/include/periph_cpu.h
@@ -147,14 +147,39 @@ typedef uint32_t gpio_t;
  * @brief   Available ports on the EFM32.
  */
 enum {
+#if (_GPIO_PORT_A_PIN_COUNT > 0)
     PA = gpioPortA,         /**< port A */
+#endif
+#if (_GPIO_PORT_B_PIN_COUNT > 0)
     PB = gpioPortB,         /**< port B */
+#endif
+#if (_GPIO_PORT_C_PIN_COUNT > 0)
     PC = gpioPortC,         /**< port C */
+#endif
+#if (_GPIO_PORT_D_PIN_COUNT > 0)
     PD = gpioPortD,         /**< port D */
-#if _GPIO_PORT_E_PIN_COUNT
+#endif
+#if (_GPIO_PORT_E_PIN_COUNT > 0)
     PE = gpioPortE,         /**< port E */
 #endif
-    PF = gpioPortF          /**< port F */
+#if (_GPIO_PORT_F_PIN_COUNT > 0)
+    PF = gpioPortF,         /**< port F */
+#endif
+#if (_GPIO_PORT_G_PIN_COUNT > 0)
+    PG = gpioPortG,         /**< port G */
+#endif
+#if (_GPIO_PORT_H_PIN_COUNT > 0)
+    PH = gpioPortH,         /**< port H */
+#endif
+#if (_GPIO_PORT_I_PIN_COUNT > 0)
+    PI = gpioPortI,         /**< port I */
+#endif
+#if (_GPIO_PORT_J_PIN_COUNT > 0)
+    PJ = gpioPortJ,         /**< port J */
+#endif
+#if (_GPIO_PORT_K_PIN_COUNT > 0)
+    PK = gpioPortK          /**< port K */
+#endif
 };
 
 #ifndef DOXYGEN

--- a/cpu/efm32_common/periph/i2c.c
+++ b/cpu/efm32_common/periph/i2c.c
@@ -254,3 +254,11 @@ void I2C_1_ISR(void)
     cortexm_isr_end();
 }
 #endif
+
+#ifdef I2C_2_ISR
+void I2C_2_ISR(void)
+{
+    i2c_progress[2] = I2C_Transfer(i2c_config[2].dev);
+    cortexm_isr_end();
+}
+#endif


### PR DESCRIPTION
This is split-off #8139.

The new EFM32GG1B has support for GPIO pins up to K, and also I2C2. This PR exposes them in efm32_common.