### PR TITLE
tools/pyterm: Notify user if wrong serial package is installed

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -24,9 +24,19 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
-
 import cmd, serial, socket, sys, threading, readline, time, logging, \
     os, argparse, re, codecs, signal
+
+try:
+    serial.Serial
+except AttributeError:
+    print("\033[1;37;41m\n")
+    print("Something went terribly wrong when loading the pyserial package.")
+    print("There is a good chance that you installed the 'serial' package instead")
+    print("of 'pyserial'. Try running 'pip uninstall serial && pip install pyserial'")
+    print("\033[0m")
+    sys.exit(1)
+
 
 # import twisted if available, define dummy classes otherwise
 try:


### PR DESCRIPTION
When installing the `serial` package (in contrast to `pyserial`)
the pyterm script will print a cryptic error message and fail.
This is because both packages, though unrelated, expose a `serial`
package (whereas pyserial should expose `pyserial`).

This change catches the error and might save some precious lifetime
of unsuspecting RIOT users, such as myself.