### PR TITLE
bluepill: add i2c support

### DIFF
--- a/boards/bluepill/Makefile.features
+++ b/boards/bluepill/Makefile.features
@@ -1,10 +1,10 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_adc
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2

--- a/boards/bluepill/Makefile.features
+++ b/boards/bluepill/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/bluepill/include/periph_conf.h
+++ b/boards/bluepill/include/periph_conf.h
@@ -153,6 +153,41 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_NUMOF           (2U)
+#define I2C_0_EN            1
+#define I2C_1_EN            0 /* Disabled by default since pins collide with USART3. */
+#define I2C_IRQ_PRIO        1
+#define I2C_APBCLK          (CLOCK_APB1)
+
+/* I2C 0 device configuration */
+#define I2C_0_DEV           I2C1
+#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
+#define I2C_0_EVT_IRQ       I2C1_EV_IRQn
+#define I2C_0_EVT_ISR       isr_i2c1_ev
+#define I2C_0_ERR_IRQ       I2C1_ER_IRQn
+#define I2C_0_ERR_ISR       isr_i2c1_er
+/* I2C 0 pin configuration */
+#define I2C_0_SCL_PIN       GPIO_PIN(PORT_B, 6)
+#define I2C_0_SDA_PIN       GPIO_PIN(PORT_B, 7)
+
+/* I2C 1 device configuration */
+#define I2C_1_DEV           I2C2
+#define I2C_1_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C2EN))
+#define I2C_1_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C2EN))
+#define I2C_1_EVT_IRQ       I2C2_EV_IRQn
+#define I2C_1_EVT_ISR       isr_i2c2_ev
+#define I2C_1_ERR_IRQ       I2C2_ER_IRQn
+#define I2C_1_ERR_ISR       isr_i2c2_er
+/* I2C 1 pin configuration */
+#define I2C_1_SCL_PIN       GPIO_PIN(PORT_B, 10)
+#define I2C_1_SDA_PIN       GPIO_PIN(PORT_B, 11)
+/** @} */
+
+/**
  * @name   PWM configuration
  * @{
  */


### PR DESCRIPTION
This PR adds support for I2C on the bluepill board. It was tested today on the Hack'n'Ack using the `driver_bmx280` test. The configuration is basically copied from the `nucleon-f103` but we changed the PINs for `I2C_0`.