### PR TITLE
driver, w5100: fix sign-compare and add spi as required feature

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -262,6 +262,7 @@ ifneq (,$(filter veml6070,$(USEMODULE)))
 endif
 
 ifneq (,$(filter w5100,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi
   USEMODULE += netdev_eth
   USEMODULE += luid
 endif

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -235,7 +235,7 @@ static int recv(netdev_t *netdev, void *buf, size_t len, void *info)
     (void)info;
     w5100_t *dev = (w5100_t *)netdev;
     uint8_t *in_buf = (uint8_t *)buf;
-    int n = 0;
+    unsigned n = 0;
 
     /* get access to the SPI bus for the duration of this function */
     spi_acquire(dev->p.spi, dev->p.cs, SPI_CONF, dev->p.clk);
@@ -255,7 +255,7 @@ static int recv(netdev_t *netdev, void *buf, size_t len, void *info)
         if (in_buf != NULL) {
             uint16_t pos = rp + 2;
             len = (n <= len) ? n : len;
-            for (int i = 0; i < (int)len; i++) {
+            for (unsigned i = 0; i < len; i++) {
                 in_buf[i] = rreg(dev, (S0_RX_BASE + ((pos++) & S0_MASK)));
             }
 
@@ -276,7 +276,7 @@ static int recv(netdev_t *netdev, void *buf, size_t len, void *info)
     /* release the SPI bus again */
     spi_release(dev->p.spi);
 
-    return n;
+    return (int)n;
 }
 
 static void isr(netdev_t *netdev)


### PR DESCRIPTION
fixes sign-compare compiler error and adds missing dependency for SPI feature, the latter caused linker errors due to missing SPI peripheral driver not included then.