### PR TITLE
gnrc_uhcpc: initialize rpl root on prefix configuration

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -67,6 +67,10 @@ USEMODULE += ps
 # include UHCP client
 USEMODULE += gnrc_uhcpc
 
+# Optionally include RPL as a routing protocol. When includede gnrc_uhcpc will
+# configure the node as a RPL DODAG root when receiving a prefix.
+#USEMODULE += gnrc_rpl
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -10,6 +10,9 @@
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/netif.h"
+#ifdef MODULE_GNRC_RPL
+#include "net/gnrc/rpl.h"
+#endif
 #include "net/ipv6/addr.h"
 #include "net/netdev.h"
 #include "net/netopt.h"
@@ -87,6 +90,14 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
 #if defined(MODULE_GNRC_IPV6_NIB) && GNRC_IPV6_NIB_CONF_6LBR && \
     GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
     gnrc_ipv6_nib_abr_add((ipv6_addr_t *)prefix);
+#endif
+#ifdef MODULE_GNRC_RPL
+    gnrc_rpl_init(gnrc_wireless_interface);
+    gnrc_rpl_instance_t *inst = gnrc_rpl_instance_get(GNRC_RPL_DEFAULT_INSTANCE);
+    if (inst) {
+        gnrc_rpl_instance_remove(inst);
+    }
+    gnrc_rpl_root_init(GNRC_RPL_DEFAULT_INSTANCE, (ipv6_addr_t*)prefix, false, false);
 #endif
     gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR_REMOVE, 0,
                     &_prefix, sizeof(_prefix));


### PR DESCRIPTION
This PR adds functionality to gnrc_uhcpc to initialize a border router as RPL dodag root when the RPL module is included. When a new prefix is retrieved over uhcpc the old instance is deleted and a new dodag root with the new prefix is created.

Testing: `GNRC_NETIF_IPV6_ADDRS_NUMOF` was set to 3 as a work around for #8172.