### PR TITLE
gnrc_lwmac: include lwmac headers upon lwmac defined.

### DIFF
--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -22,7 +22,9 @@
 #include "log.h"
 #include "board.h"
 #include "net/gnrc/netif/ieee802154.h"
+#ifdef MODULE_GNRC_LWMAC
 #include "net/gnrc/lwmac/lwmac.h"
+#endif
 #include "net/gnrc.h"
 
 #include "at86rf2xx.h"

--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -29,7 +29,9 @@
 #include "net/gnrc/priority_pktqueue.h"
 #include "net/ieee802154.h"
 #include "net/gnrc/mac/mac.h"
+#ifdef MODULE_GNRC_LWMAC
 #include "net/gnrc/lwmac/types.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
+++ b/sys/net/gnrc/link_layer/lwmac/tx_state_machine.c
@@ -74,7 +74,7 @@ static uint8_t _send_bcast(gnrc_netif_t *netif)
         gnrc_pktsnip_t *pkt_payload;
 
         /* Prepare packet with LWMAC header*/
-        gnrc_lwmac_frame_broadcast_t hdr = {};
+        gnrc_lwmac_frame_broadcast_t hdr;
         hdr.header.type = GNRC_LWMAC_FRAMETYPE_BROADCAST;
         hdr.seq_nr = netif->mac.tx.bcast_seqnr++;
 
@@ -165,7 +165,7 @@ static uint8_t _send_wr(gnrc_netif_t *netif)
     }
 
     /* Assemble WR */
-    gnrc_lwmac_frame_wr_t wr_hdr = {};
+    gnrc_lwmac_frame_wr_t wr_hdr;
     wr_hdr.header.type = GNRC_LWMAC_FRAMETYPE_WR;
     memcpy(&(wr_hdr.dst_addr.addr), netif->mac.tx.current_neighbor->l2_addr,
            netif->mac.tx.current_neighbor->l2_addr_len);

--- a/tests/lwmac/README.md
+++ b/tests/lwmac/README.md
@@ -1,5 +1,5 @@
-examples/default
-================
+LWMAC test application
+======================
 This application is a showcase for testing LWMAC communications. Using it
 for your board, you should be able to interactively use any hardware
 that is supported for communications among devices based on LWMAC.
@@ -22,7 +22,7 @@ that is `/dev/ttyUSB0`. If your port is named differently, the
 
 
 Example output
-==========
+==============
 
 The `ifconfig` command will help you to configure all available network
 interfaces. On an samr21 board it will print something like:

--- a/tests/lwmac/main.c
+++ b/tests/lwmac/main.c
@@ -18,6 +18,7 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * @author      Shuguo Zhuo <shuguo.zhuo@inria.fr>
  *
  * @}
  */


### PR DESCRIPTION
This PR introduces the limit that `gnrc_lwmac`'s header files will only be included when `gnrc_lwmac` is defined, it also removes some useless initializations and revises some error texts.