### PR TITLE
cpu, efm32_common: fix sign-compare error in flashpage

### DIFF
--- a/cpu/efm32_common/periph/flashpage.c
+++ b/cpu/efm32_common/periph/flashpage.c
@@ -28,7 +28,7 @@
 
 void flashpage_write(int page, void *data)
 {
-    assert(page < FLASHPAGE_NUMOF);
+    assert(page < (int)FLASHPAGE_NUMOF);
 
     uint32_t *page_addr = (uint32_t *)flashpage_addr(page);
     uint32_t *data_addr = (uint32_t *)data;


### PR DESCRIPTION
don't know why or how, but this slipped through when merging #7919, but popped up in Murdock of #8080 (see [here](https://ci.riot-os.org/RIOT-OS/RIOT/8080/81728be94ab1f794a37eb46eeab0ac3410b07fca/output.html#error0))