### PR TITLE
unittests: fix gnrc_ipv6_nib test

### DIFF
--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-internal.c
@@ -483,7 +483,7 @@ static void test_nib_nc_add__success_full_but_garbage_collectible(void)
 
     for (int i = 0; i < (3 * GNRC_IPV6_NIB_NUMOF); i++) {
         TEST_ASSERT_NOT_NULL((node = _nib_nc_add(&addr, IFACE,
-                                                 GNRC_IPV6_NIB_NC_INFO_NUD_STATE_REACHABLE)));
+                                                 GNRC_IPV6_NIB_NC_INFO_NUD_STATE_STALE)));
         TEST_ASSERT(last != node);
         TEST_ASSERT(ipv6_addr_equal(&addr, &node->ipv6));
         TEST_ASSERT_EQUAL_INT(IFACE, _nib_onl_get_if(node));
@@ -1789,7 +1789,7 @@ static void test_nib_abr_add_pfx__pfx_not_in_nib(void)
     static const ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
                                              { .u64 = TEST_UINT64 } } };
     _nib_offl_entry_t offl;
-
+    offl.mode = _PL;
     TEST_ASSERT_NOT_NULL((abr = _nib_abr_add(&addr)));
     TEST_ASSERT_NULL(_nib_abr_iter_pfx(abr, NULL));
     _nib_abr_add_pfx(abr, &offl);

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-nc.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-nc.c
@@ -107,9 +107,9 @@ static void test_nib_nc_set__ENOMEM_diff_addr_iface(void)
 static void test_nib_nc_set__success(void)
 {
     void *iter_state = NULL;
-    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                  { .u64 = TEST_UINT64 } } };
-    uint8_t l2addr[] = L2ADDR;
+    static const ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
+                                             { .u64 = TEST_UINT64 } } };
+    static const uint8_t l2addr[] = L2ADDR;
     gnrc_ipv6_nib_nc_t nce;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_nc_set(&addr, IFACE, l2addr,
@@ -188,7 +188,7 @@ static void test_nib_nc_del__success(void)
     void *iter_state = NULL;
     static const ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
                                              { .u64 = TEST_UINT64 } } };
-    uint8_t l2addr[] = L2ADDR;
+    static const uint8_t l2addr[] = L2ADDR;
     gnrc_ipv6_nib_nc_t nce;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_nc_set(&addr, IFACE, l2addr,


### PR DESCRIPTION
discovered failed assertion when enabling DEVELHELP for unit tests of gnrc_ipv6_nib, this PR fixes them (see Murdock error [here](https://ci.riot-os.org/RIOT-OS/RIOT/8080/188813461cacda64d6509d3389ef92b098ff93e3/output.html#error0) [edit]-> PR #8080).