### PR TITLE
tests: rng: add test tools for RNG sources

### DIFF
--- a/tests/rng/Makefile
+++ b/tests/rng/Makefile
@@ -1,0 +1,22 @@
+APPLICATION = rng
+include ../Makefile.tests_common
+
+# some boards have not enough rom and/or ram
+BOARD_BLACKLIST += nucleo32-f031 nucleo32-f042 nucleo32-l031 pic32-clicker
+BOARD_INSUFFICIENT_MEMORY += arduino-duemilanove arduino-uno
+
+# override PRNG if desired (see sys/random for alternatives)
+# USEMODULE += prng_minstd
+
+USEMODULE += fmt
+USEMODULE += printf_float
+USEMODULE += random
+USEMODULE += shell
+USEMODULE += xtimer
+
+FEATURES_OPTIONAL += periph_hwrng
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/rng/README.md
+++ b/tests/rng/README.md
@@ -1,0 +1,25 @@
+# RNG
+Test application for the RNG sourcs.
+
+## Supported commands
+* distributions [N] — Take N samples and print a bit distribution graph on the terminal.
+* dump [N] — Take N samples and print them on the terminal.
+* fips — Run the FIPS 140-2 random number tests.
+* entropy [N] — Calculate Shannon's entropy from N samples.
+* seed [N] — Set the random seed to use.
+* source [N] — Select the RNG source, or list them all.
+* speed [N] — Run a PRNG for N seconds and print the number of KiB/sec afterwards.
+
+## Sources
+The following sources are supported:
+
+* PRNG
+* HW RNG (if available)
+* Constant number (uses the seed)
+
+The PRNG is re-initialized before every test, using the given seed (default is 0).
+
+A constant number source is useful to see if the test itself work, e.g. indicate failures.
+
+## Warning
+The tools available in this test do not garruantee that a given RNG source is secure. It should, however, rule out basic failures using statistical tests.

--- a/tests/rng/main.c
+++ b/tests/rng/main.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief RNG testing tools.
+ *
+ * @author Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+
+#include "test.h"
+
+/*
+ * Foward declarations
+ */
+static int cmd_distributions(int argc, char **argv);
+static int cmd_dump(int argc, char **argv);
+static int cmd_entropy(int argc, char **argv);
+static int cmd_fips(int argc, char **argv);
+static int cmd_seed(int argc, char **argv);
+static int cmd_source(int argc, char **argv);
+static int cmd_speed(int argc, char **argv);
+
+/**
+ * @brief   List of command for this application.
+ */
+static const shell_command_t shell_commands[] = {
+    { "distributions", "run distributions test", cmd_distributions },
+    { "dump", "dump random numbers", cmd_dump },
+    { "fips", "run FIPS 140-2 tests", cmd_fips },
+    { "entropy", "calculate entropy test", cmd_entropy },
+    { "seed", "set random seed", cmd_seed },
+    { "source", "set randomness source", cmd_source },
+    { "speed", "run speed test", cmd_speed },
+    { NULL, NULL, NULL }
+};
+
+/**
+ * @brief   Distributions command, which accepts one argument (samples).
+ *
+ * If no arguments are given, a default is used.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0 on success
+ */
+static int cmd_distributions(int argc, char **argv)
+{
+    uint32_t samples = 10000;
+
+    if (argc > 1) {
+        samples = strtoul(argv[1], NULL, 0);
+    }
+
+    /* run the test */
+    test_distributions(samples);
+
+    return 0;
+}
+
+/**
+ * @brief   Dump command, which accepts one argument (samples).
+ *
+ * If no arguments are given, a default is used.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0 on success
+ */
+static int cmd_dump(int argc, char **argv)
+{
+    uint32_t samples = 100;
+
+    if (argc > 1) {
+        samples = strtoul(argv[1], NULL, 0);
+    }
+
+    /* run the test */
+    test_dump(samples);
+
+    return 0;
+}
+
+/**
+ * @brief   Calculate Shannon's entropy (bits), which accepts one argument
+ *          (samples).
+ *
+ * If no arguments are given, a default is used.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0 on success
+ */
+static int cmd_entropy(int argc, char **argv)
+{
+    uint32_t samples = 10000;
+
+    if (argc > 1) {
+        samples = strtoul(argv[1], NULL, 0);
+    }
+
+    /* run the test */
+    test_entropy(samples);
+
+    return 0;
+}
+
+/**
+ * @brief   Run the FIPS 140-2 tests.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0 on success
+ */
+static int cmd_fips(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    test_fips();
+
+    return 0;
+}
+
+/**
+ * @brief   Set the random seed.
+ *
+ * If no argument is given, the current seed is printed.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0 on success
+ */
+static int cmd_seed(int argc, char **argv)
+{
+    if (argc > 1) {
+        seed = strtoul(argv[1], NULL, 0);
+        printf("Seed set to %" PRIu32 "\n", seed);
+    }
+    else {
+        printf("Seed is %" PRIu32 "\n", seed);
+    }
+
+    return 0;
+}
+
+/**
+ * @brief   Helper for setting the RNG source.
+ *
+ * If no argument is given, the list of RNG sources is printed.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0 on success
+ */
+static int cmd_source(int argc, char **argv)
+{
+    if (argc > 1) {
+        uint8_t raw_source = strtoul(argv[1], NULL, 0);
+
+        if (raw_source >= RNG_NUMOF) {
+            printf("Error: source must be 0-%d.\n", RNG_NUMOF - 1);
+            return 1;
+        }
+
+        source = raw_source;
+    }
+    else {
+        printf("Available sources:\n\n");
+
+        for (int i = 0; i < RNG_NUMOF; i++) {
+            printf("%d: %s", i, sources[i]);
+
+            if ((int) source == i) {
+                puts(" (selected)");
+            }
+            else {
+                puts("");
+            }
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * @brief   Speed command, which accepts one argument (duration).
+ *
+ * If no argument is chosen, a default is chosen.
+ *
+ * @param[in] argc  Number of arguments
+ * @param[in] argv  Array of arguments
+ *
+ * @return  0 on success
+ */
+static int cmd_speed(int argc, char **argv)
+{
+    uint32_t duration = 10;
+
+    if (argc > 1) {
+        duration = strtoul(argv[1], NULL, 0);
+    }
+
+    /* run the test */
+    test_speed(duration);
+
+    return 0;
+}
+
+int main(void)
+{
+    puts("Starting shell...");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/rng/test.c
+++ b/tests/rng/test.c
@@ -1,0 +1,364 @@
+/*
+ * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "test.h"
+
+/**
+ * @brief   Seed for initializing random module.
+ */
+uint32_t seed = 0;
+
+/**
+ * @brief   Source of randomness.
+ */
+rng_source_t source = 0;
+
+/**
+ * @brief   Initialize the RNG, is needed.
+ *
+ * @param[in] name  The test name.
+ */
+static void test_init(char *name)
+{
+    /* prepare RNG source */
+    if (source == RNG_PRNG) {
+        random_init(seed);
+    }
+#ifdef MODULE_PERIPH_HWRNG
+    else if (source == RNG_HWRNG) {
+        hwrng_init();
+    }
+#endif
+
+    /* print test overview */
+    printf("Running %s test, with seed %" PRIu32 " using ", name, seed);
+
+    if (source == RNG_PRNG) {
+#if MODULE_PRNG_MERSENNE
+        puts("Mersenne Twister PRNG.\n");
+#elif MODULE_PRNG_MINSTD
+        puts("Park & Miller Minimal Standard PRNG.\n");
+#elif MODULE_PRNG_MUSL_LCG
+        puts("Musl C PRNG.\n");
+#elif MODULE_PRNG_TINYMT32
+        puts("Tiny Mersenne Twister PRNG.\n");
+#elif MODULE_PRNG_XORSHIFT
+        puts("XOR Shift PRNG.\n");
+#else
+        puts("unknown PRNG.\n");
+#endif
+    }
+#ifdef MODULE_PERIPH_HWRNG
+    else if (source == RNG_HWRNG) {
+        puts("HW RNG.\n");
+    }
+#endif
+    else if (source == RNG_CONSTANT) {
+        puts("constant value.\n");
+    }
+}
+
+/**
+ * @brief   Retrieve a 32-bit number of the source RNG.
+ */
+static inline uint32_t test_get_uint32(void)
+{
+    if (source == RNG_PRNG) {
+        return random_uint32();
+    }
+#ifdef MODULE_PERIPH_HWRNG
+    else if (source == RNG_HWRNG) {
+        uint32_t result;
+        hwrng_read(&result, 4);
+
+        return result;
+    }
+#endif
+    else if (source == RNG_CONSTANT) {
+        /* use the seed as the constant value */
+        return seed;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief   Helper for printing `passed` or `failed` depending on condition
+ *
+ * @param[in] condition     The test condition.
+ */
+void test_pass_fail(bool condition)
+{
+    if (condition) {
+        puts("passed");
+    }
+    else {
+        puts("failed");
+    }
+}
+
+void test_distributions(uint32_t samples)
+{
+    char tmp[16] = { 0 };
+
+    uint32_t distributions[32] = { 0 };
+
+    /* initialize test */
+    test_init("distributions");
+
+    /* take random samples */
+    while (samples--) {
+        uint32_t value = test_get_uint32();
+
+        /* count bits */
+        for (int i = 0; i < 32; i++) {
+            if (value & (1 << i)) {
+                distributions[i]++;
+            }
+        }
+    }
+
+    /* sum the total number of ones */
+    uint64_t total = 0;
+    uint32_t min = UINT32_MAX;
+    uint32_t max = 0;
+
+    for (int i = 0; i < 32; i++) {
+        total += distributions[i];
+
+        if (distributions[i] < min) {
+            min = distributions[i];
+        }
+
+        if (distributions[i] > max) {
+            max = distributions[i];
+        }
+    }
+
+    /* if total is zero, it would yield a division by zero */
+    if ((total / 100) == 0) {
+        puts("Total ones is zero.\n");
+        return;
+    }
+
+    /* print the distribution to screen */
+    fmt_u64_dec(tmp, total / 32);
+    printf("For 32-bit samples (min = %" PRIu32 ", max = %" PRIu32 ", avg = %s):\n", min, max, tmp);
+
+    /* print a bar for each bin, scaling max to 100% */
+    for (int i = 0; i < 32; i++) {
+        printf("%02d: ", i);
+
+        /* calculate the width of the bar (max 4 + 75 chars) */
+        uint8_t bars = (distributions[i] / (max / 75));
+
+        for (unsigned int j = 0; j < bars; j++) {
+            printf("#");
+        }
+
+        puts("");
+    }
+
+    puts("");
+}
+
+void test_dump(uint32_t samples)
+{
+    test_init("dump");
+
+    while (samples--) {
+        printf("%" PRIu32 "\n", test_get_uint32());
+    }
+}
+
+void test_fips(void)
+{
+    uint8_t last_bit = UINT8_MAX;
+
+    uint32_t ones = 0;
+    uint32_t poker[16] = { 0 };
+
+    uint32_t runs = 1;
+    uint32_t runs_ones[6] = { 0 };
+    uint32_t runs_zeroes[6] = { 0 };
+
+    uint32_t longruns = 1;
+    uint32_t longruns_max = 0;
+
+    /* initialize test */
+    test_init("FIPS 140-2");
+
+    /* FIPS 140-2 needs 20.000 bits, which are 625 32-bit random numbers */
+    for (int i = 0; i < 625; i++) {
+        uint32_t value = test_get_uint32();
+
+        for (int j = 0; j < 4; j++) {
+            uint8_t byte = ((uint8_t *) &value)[j];
+
+            /* poker */
+            poker[byte >> 4]++;
+            poker[byte & 0x0f]++;
+
+            for (int k = 0; k < 8; k++) {
+                uint8_t bit = (byte >> k) & 0x01;
+
+                /* monobit */
+                if (bit) {
+                    ones++;
+                }
+
+                /* run length */
+                if (bit == last_bit) {
+                    runs++;
+                }
+                else {
+                    if (runs > 6) {
+                        runs = 6;
+                    }
+
+                    if (last_bit) {
+                        runs_ones[runs - 1]++;
+                    }
+                    else {
+                        runs_zeroes[runs - 1]++;
+                    }
+
+                    runs = 1;
+                }
+
+                /* longruns */
+                if (bit == last_bit) {
+                    longruns++;
+                }
+                else {
+                    if (longruns > longruns_max) {
+                        longruns_max = longruns;
+                    }
+
+                    longruns = 1;
+                }
+
+                last_bit = bit;
+            }
+        }
+    }
+
+    /* for a constant stream of bits, the last (long)run must be added */
+    if (runs > 6) {
+        runs = 6;
+    }
+
+    if (last_bit) {
+        runs_ones[runs - 1]++;
+    }
+    else {
+        runs_zeroes[runs - 1]++;
+    }
+
+    if (longruns > longruns_max) {
+        longruns_max = longruns;
+    }
+
+    /* monobit test result */
+    printf("- Monobit test: ");
+
+    test_pass_fail(!((ones >= 10275) || (ones <= 9725)));
+
+    /* poker test result */
+    uint32_t result = 0;
+
+    for (int i = 0; i < 16; i++) {
+        result += poker[i] * poker[i];
+    }
+
+    printf("- Poker test: ");
+
+    test_pass_fail(!((result > 1576928) || (result < 1563176)));
+
+    /* runs test result */
+    bool passed = true;
+    uint32_t min[6] = { 2343, 1135, 542, 251, 111, 111 };
+    uint32_t max[6] = { 2657, 1365, 708, 373, 201, 201 };
+
+    for (int i = 0; i < 6; i++) {
+        if (runs_ones[i] < min[i] || runs_ones[i] > max[i]) {
+            passed = false;
+        }
+
+        if (runs_zeroes[i] < min[i] || runs_zeroes[i] > max[i]) {
+            passed = false;
+        }
+    }
+
+    printf("- Run test: ");
+
+    test_pass_fail(passed);
+
+    /* longruns test result */
+    printf("- Longrun test: ");
+
+    test_pass_fail(longruns_max < 26);
+}
+
+void test_entropy(uint32_t samples)
+{
+    uint8_t buffer[256] = { 0 };
+    uint32_t length = 0;
+
+    /* initialize test */
+    test_init("entropy");
+
+    /* take samples */
+    for (uint32_t i = 0; i < samples; i++) {
+        uint32_t value = test_get_uint32();
+
+        buffer[((uint8_t *) &value)[0]]++;
+        buffer[((uint8_t *) &value)[1]]++;
+        buffer[((uint8_t *) &value)[2]]++;
+        buffer[((uint8_t *) &value)[3]]++;
+
+        length += 4;
+    }
+
+    /* calculate entropy */
+    float entropy = 0.0;
+
+    for (int i = 0; i < 256; i++) {
+        if (buffer[i] != 0) {
+            float count = (float) buffer[i] / (float) length;
+            entropy += (-count * log2f(count));
+        }
+    }
+
+    /* print results */
+    printf("Calculated %02f bits of entropy from %" PRIu32 " samples.\n", (double) entropy, samples);
+}
+
+void test_speed(uint32_t duration)
+{
+    char tmp1[16] = { 0 }, tmp2[16] = { 0 };
+
+    uint64_t timeout = 0;
+    uint64_t samples = 0;
+
+    /* initialize test */
+    test_init("speed");
+
+    /* collect samples as long as timer has not expired */
+    timeout = xtimer_now_usec64() + (duration * US_PER_SEC);
+
+    while (xtimer_now_usec64() < timeout) {
+        test_get_uint32();
+        samples++;
+    }
+
+    /* print results */
+    fmt_u64_dec(tmp1, samples);
+    fmt_u64_dec(tmp2, (samples * 4 / 1024) / duration);
+    printf("Collected %s samples in %" PRIu32 " seconds (%s KiB/s).\n", tmp1, duration, tmp2);
+}

--- a/tests/rng/test.h
+++ b/tests/rng/test.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef TEST_H
+#define TEST_H
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "fmt.h"
+#include "random.h"
+#include "xtimer.h"
+
+#ifdef MODULE_PERIPH_HWRNG
+#include "periph/hwrng.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Define log2f for AVR-based targets.
+ */
+#ifdef __AVR__
+#define log2f(x) (logf (x) / (float) 0.693147180559945309417)
+#endif
+
+/**
+ * @brief   Enum of possible RNG sources.
+ */
+typedef enum {
+    RNG_PRNG,
+    RNG_CONSTANT,
+#ifdef MODULE_PERIPH_HWRNG
+    RNG_HWRNG,
+#endif
+    RNG_NUMOF
+} rng_source_t;
+
+/**
+ * @brief   Names of the RNG sources.
+ */
+static const char sources[][12] = {
+    [RNG_PRNG] = "PRNG",
+    [RNG_CONSTANT] = "Constant",
+#ifdef MODULE_PERIPH_HWRNG
+    [RNG_HWRNG] = "HWRNG",
+#endif
+};
+
+/**
+ * @brief   Seed for initializing random module.
+ */
+extern uint32_t seed;
+
+/**
+ * @brief   Source of randomness.
+ */
+extern rng_source_t source;
+
+/**
+ * @brief   Helper for running the bit distribution test.
+ *
+ * For each sample, the individual bits are counted. After all samples are
+ * collected, a graph is printed to visualize the distribution of bits.
+ *
+ * @param[in] samples   Number of samples.
+ */
+void test_distributions(uint32_t samples);
+
+/**
+ * @brief   Test for number dumping (e.g. for offline testing). Each number
+ *          is printed on a separate line as an unsigned 32-bit number.
+ *
+ * @param[in] samples   Number of samples to print.
+ */
+void test_dump(uint32_t samples);
+
+/**
+ * @brief   Run the FIPS 140-2 battery of test.
+ *
+ * The FIPS 140-2 tests are four statistical tests that will test 20000 bits
+ * of generated random numbers:
+ *   - monobit
+ *   - poker test
+ *   - runs
+ *   - longruns
+ *
+ * Check the following URl for more information:
+ * https://crypto.stackexchange.com/q/15052
+ */
+void test_fips(void);
+
+/**
+ * @brief   Run the entropy test. It collects N samples, then calculates
+ *          Shannon's entropy.
+ *
+ * @param[in] samples   Number of samples to take.
+ */
+void test_entropy(uint32_t samples);
+
+/**
+ * @brief   Run the speed test for a given duration. It utillizes xtimer for
+ *          setting an alarm.
+ *
+ * @param[in] duration  Test duration (in seconds)
+ */
+void test_speed(uint32_t duration);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TEST_H */
+/** @} */

--- a/tests/rng/tests/01-run.py
+++ b/tests/rng/tests/01-run.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import pexpect
+import sys
+import os
+import re
+
+
+def testfunc(child):
+    # RNG source
+    child.sendline("source 0")
+    child.sendline("seed 1337")
+
+    child.sendline("fips")
+    child.expect("Running FIPS 140-2 test, with seed 1337 using Tiny Mersenne Twister PRNG.")
+    child.expect("Monobit test: passed")
+    child.expect("Poker test: passed")
+    child.expect("Run test: passed")
+    child.expect("Longrun test: passed")
+
+    child.sendline("dump 10")
+    child.expect("1555530734")
+    child.expect("2178333451")
+    child.expect("2272913641")
+    child.expect("3790481823")
+    child.expect("3190025502")
+    child.expect("798555366")
+    child.expect("1918982324")
+    child.expect("1550167154")
+    child.expect("3454972398")
+    child.expect("1034066532")
+
+    child.sendline("entropy")
+    child.expect(re.compile(r"Calculated 7\.994\d{3} bits of entropy from 10000 samples\."))
+
+    # Constant source
+    child.sendline("source 1")
+    child.sendline("seed 1337")
+
+    child.sendline("fips")
+    child.expect("Running FIPS 140-2 test, with seed 1337 using constant value.")
+    child.expect("- Monobit test: failed")
+    child.expect("- Poker test: failed")
+    child.expect("- Run test: failed")
+    child.expect("- Longrun test: passed")
+
+    child.sendline("dump 10")
+    child.expect("1337")
+    child.expect("1337")
+    child.expect("1337")
+    child.expect("1337")
+    child.expect("1337")
+    child.expect("1337")
+    child.expect("1337")
+    child.expect("1337")
+    child.expect("1337")
+    child.expect("1337")
+
+    child.sendline("entropy")
+    child.expect(re.compile(r"Calculated 0\.017\d{3} bits of entropy from 10000 samples\."))
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ["RIOTBASE"], "dist/tools/testrunner"))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
This PR adds {HW, P}RNG test tools. It was part of #5675. Current tests include:

* Distributions
* Speed
* Entropy
* FIPS 140-2

It should (partially) fix #4882 and check-off a box in #7886.

I've included pexpect test that uses the default PRNG and a constant source (for testing failures).

This test tools doesn't guarantee that a PRNG is safe/secure/good to use, but it should validate its response and provide you the tools to play with your PRNG. For improved statistical tests, you can use the `dump` command to dump numbers and use offline tests such as DIEHARDER or TestU01.

The binary is a bit on the heavy side, but its because of math.h/floating points. We'll have to see which boards to blacklist.

I've tested this on `native` and on `sltb001a`. 