### PR TITLE
openthread: remove GNRC header include

### DIFF
--- a/pkg/openthread/contrib/platform_functions_wrapper.c
+++ b/pkg/openthread/contrib/platform_functions_wrapper.c
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include "thread.h"
 #include "openthread/ip6.h"
 #include "openthread/thread.h"

--- a/pkg/openthread/include/ot.h
+++ b/pkg/openthread/include/ot.h
@@ -30,7 +30,7 @@ extern "C" {
 #include "net/netopt.h"
 #include "net/ieee802154.h"
 #include "net/ethernet.h"
-#include "net/gnrc/netdev.h"
+#include "net/netdev.h"
 #include "thread.h"
 #include "openthread/types.h"
 


### PR DESCRIPTION
Including a GNRC header into OpenThread doesn't make sense, since it is
a different network stack.