### PR TITLE
at86rf2xx: revert regression introduced in #7276

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -435,7 +435,10 @@ uint8_t at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
     }
     else if (state != old_state) {
         /* we need to go via PLL_ON if we are moving between RX_AACK_ON <-> TX_ARET_ON */
-        if ((old_state | state) == (AT86RF2XX_STATE_RX_AACK_ON | AT86RF2XX_STATE_TX_ARET_ON)) {
+        if ((old_state == AT86RF2XX_STATE_RX_AACK_ON &&
+             state == AT86RF2XX_STATE_TX_ARET_ON) ||
+            (old_state == AT86RF2XX_STATE_TX_ARET_ON &&
+             state == AT86RF2XX_STATE_RX_AACK_ON)) {
             _set_state(dev, AT86RF2XX_STATE_PLL_ON, AT86RF2XX_STATE_PLL_ON);
         }
         /* check if we need to wake up from sleep mode */


### PR DESCRIPTION
This fixes a regression involving setting the device's state introduced in #7276, that I discovered in https://github.com/RIOT-OS/RIOT/pull/5618#discussion_r154126971. Without this fix the applications for GoMacH block due to a state change in the initialization of that MAC protocol. The two expressions aren't also quite obviously the same, so I guess that's on me for ACKing this ;-).