### PR TITLE
tests/xtimer_usleep_short: fix non set APPLICATION variable

### DIFF
--- a/tests/xtimer_usleep_short/Makefile
+++ b/tests/xtimer_usleep_short/Makefile
@@ -1,3 +1,4 @@
+APPLICATION = xtimer_usleep_short
 include ../Makefile.tests_common
 
 USEMODULE += xtimer


### PR DESCRIPTION
test/xtimer_usleep_short does not set APPLICATION in the Makefile. This results in binaries named test_.elf
This patch sets APPLICATION appropriately.