### PR TITLE
tests: set APPLICATION from folder name

### DIFF
--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -1,7 +1,7 @@
-ifneq (,$(filter driver_%,$(APPLICATION)))
+APPLICATION ?= tests_$(notdir $(patsubst %/,%,$(CURDIR)))
+ifneq (,$(filter tests_driver_%,$(APPLICATION)))
     BOARD ?= samr21-xpro
 endif
 BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 QUIET ?= 1
-APPLICATION := tests_$(APPLICATION)

--- a/tests/bitarithm_timings/Makefile
+++ b/tests/bitarithm_timings/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = bitarithm_timings
 include ../Makefile.tests_common
 
 USEMODULE += xtimer

--- a/tests/bloom_bytes/Makefile
+++ b/tests/bloom_bytes/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = bloom_bytes
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h telosb wsn430-v1_3b \

--- a/tests/board_calliope-mini/Makefile
+++ b/tests/board_calliope-mini/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = board_calliope-mini
 BOARD ?= calliope-mini
 include ../Makefile.tests_common
 

--- a/tests/board_microbit/Makefile
+++ b/tests/board_microbit/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = board_microbit
 include ../Makefile.tests_common
 
 BOARD = microbit

--- a/tests/buttons/Makefile
+++ b/tests/buttons/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = buttons
 include ../Makefile.tests_common
 
 USEMODULE += xtimer

--- a/tests/cbor/Makefile
+++ b/tests/cbor/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = cbor
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno

--- a/tests/conn_can/Makefile
+++ b/tests/conn_can/Makefile
@@ -1,4 +1,3 @@
-export APPLICATION = can
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f042 \

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = cpp11_condition_variable
 include ../Makefile.tests_common
 
 # ROM is overflowing for these boards when using

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = cpp11_mutex
 include ../Makefile.tests_common
 
 # ROM is overflowing for these boards when using

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = cpp11_thread
 include ../Makefile.tests_common
 
 # ROM is overflowing for these boards when using

--- a/tests/driver_adcxx1c/Makefile
+++ b/tests/driver_adcxx1c/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_adcxx1c
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_adt7310/Makefile
+++ b/tests/driver_adt7310/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_adt7310
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-mega2560 waspmote-pro

--- a/tests/driver_adxl345/Makefile
+++ b/tests/driver_adxl345/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_adxl345
 include ../Makefile.tests_common
 
 USEMODULE += xtimer

--- a/tests/driver_apa102/Makefile
+++ b/tests/driver_apa102/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_apa102
 include ../Makefile.tests_common
 
 USEMODULE += apa102

--- a/tests/driver_at30tse75x/Makefile
+++ b/tests/driver_at30tse75x/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_at30tse75x
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_at86rf2xx
 include ../Makefile.tests_common
 
 # exclude boards with insufficient memory

--- a/tests/driver_bh1750/Makefile
+++ b/tests/driver_bh1750/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_bh1750
 include ../Makefile.tests_common
 
 USEMODULE += xtimer

--- a/tests/driver_bmp180/Makefile
+++ b/tests/driver_bmp180/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_bmp180
 include ../Makefile.tests_common
 
 USEMODULE += bmp180

--- a/tests/driver_bmx280/Makefile
+++ b/tests/driver_bmx280/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_bmx280
 include ../Makefile.tests_common
 
 DRIVER ?= bme280

--- a/tests/driver_dht/Makefile
+++ b/tests/driver_dht/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_dht
 include ../Makefile.tests_common
 
 USEMODULE += dht

--- a/tests/driver_ds1307/Makefile
+++ b/tests/driver_ds1307/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_ds1307
 include ../Makefile.tests_common
 
 USEMODULE += ds1307

--- a/tests/driver_dsp0401/Makefile
+++ b/tests/driver_dsp0401/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_dsp0401
 include ../Makefile.tests_common
 
 USEMODULE += dsp0401

--- a/tests/driver_dynamixel/Makefile
+++ b/tests/driver_dynamixel/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_dynamixel
 include ../Makefile.tests_common
 
 # chronos : USART_1 undeclared

--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_enc28j60
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_encx24j600
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio

--- a/tests/driver_feetech/Makefile
+++ b/tests/driver_feetech/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_feetech
 include ../Makefile.tests_common
 
 # chronos : USART_1 undeclared

--- a/tests/driver_grove_ledbar/Makefile
+++ b/tests/driver_grove_ledbar/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_grove_ledbar
 include ../Makefile.tests_common
 
 USEMODULE += grove_ledbar

--- a/tests/driver_hd44780/Makefile
+++ b/tests/driver_hd44780/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_hd44780
 include ../Makefile.tests_common
 
 # the stm32f4discovery does not have the arduino pinout

--- a/tests/driver_hdc1000/Makefile
+++ b/tests/driver_hdc1000/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_hdc1000
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_hih6130/Makefile
+++ b/tests/driver_hih6130/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_hih6130
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_hts221/Makefile
+++ b/tests/driver_hts221/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_hts221
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_ina220/Makefile
+++ b/tests/driver_ina220/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_ina220
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_io1_xplained/Makefile
+++ b/tests/driver_io1_xplained/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_io1_xplained
 include ../Makefile.tests_common
 
 USEMODULE += io1_xplained

--- a/tests/driver_isl29020/Makefile
+++ b/tests/driver_isl29020/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_isl29020
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_isl29125/Makefile
+++ b/tests/driver_isl29125/Makefile
@@ -1,5 +1,3 @@
-APPLICATION = driver_isl29125
-
 # If no BOARD is found in the environment, use this default:
 BOARD ?= samr21-xpro
 

--- a/tests/driver_jc42/Makefile
+++ b/tests/driver_jc42/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_jc42
 include ../Makefile.tests_common
 
 USEMODULE += jc42

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_kw2xrf
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio

--- a/tests/driver_l3g4200d/Makefile
+++ b/tests/driver_l3g4200d/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_l3g4200d
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c periph_gpio

--- a/tests/driver_lis3dh/Makefile
+++ b/tests/driver_lis3dh/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_lis3dh
 include ../Makefile.tests_common
 
 USEMODULE += lis3dh

--- a/tests/driver_lis3mdl/Makefile
+++ b/tests/driver_lis3mdl/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_lis3mdl
 BOARD ?= limifrog-v1
 include ../Makefile.tests_common
 

--- a/tests/driver_lpd8808/Makefile
+++ b/tests/driver_lpd8808/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_lpd8808
 include ../Makefile.tests_common
 
 USEMODULE += lpd8808

--- a/tests/driver_lps331ap/Makefile
+++ b/tests/driver_lps331ap/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_lps331ap
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_lsm303dlhc/Makefile
+++ b/tests/driver_lsm303dlhc/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_lsm303dlhc
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_lsm6dsl/Makefile
+++ b/tests/driver_lsm6dsl/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_lsm6dsl
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_mag3110/Makefile
+++ b/tests/driver_mag3110/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_mag3110
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_mma8x5x/Makefile
+++ b/tests/driver_mma8x5x/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_mma8x5x
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_mpl3115a2/Makefile
+++ b/tests/driver_mpl3115a2/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_mpl3115a2
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_mpu9150/Makefile
+++ b/tests/driver_mpu9150/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_mpu9150
 include ../Makefile.tests_common
 
 USEMODULE += mpu9150

--- a/tests/driver_mq3/Makefile
+++ b/tests/driver_mq3/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_mq3
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_adc

--- a/tests/driver_my9221/Makefile
+++ b/tests/driver_my9221/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_my9221
 include ../Makefile.tests_common
 
 USEMODULE += my9221

--- a/tests/driver_nrf24l01p_lowlevel/Makefile
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_nrf24l01p_lowlevel
 include ../Makefile.tests_common
 
 # exclude boards with insufficient memory

--- a/tests/driver_nvram_spi/Makefile
+++ b/tests/driver_nvram_spi/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_nvram_spi
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_spi periph_gpio

--- a/tests/driver_pcd8544/Makefile
+++ b/tests/driver_pcd8544/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_pdc8544
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_gpio periph_spi

--- a/tests/driver_pir/Makefile
+++ b/tests/driver_pir/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_pir
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/driver_pn532/Makefile
+++ b/tests/driver_pn532/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_pn532
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c periph_gpio

--- a/tests/driver_sdcard_spi/Makefile
+++ b/tests/driver_sdcard_spi/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_sdcard_spi
 include ../Makefile.tests_common
 
 # exclude boards with insufficient memory

--- a/tests/driver_servo/Makefile
+++ b/tests/driver_servo/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_servo
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_pwm

--- a/tests/driver_si70xx/Makefile
+++ b/tests/driver_si70xx/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_si70xx
 include ../Makefile.tests_common
 
 # This test should also work with Si7006, Si7013 and Si7020 variants.

--- a/tests/driver_soft_spi/Makefile
+++ b/tests/driver_soft_spi/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_soft_spi
 include ../Makefile.tests_common
 
 BOARD ?= native

--- a/tests/driver_srf02/Makefile
+++ b/tests/driver_srf02/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_srf02
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_srf08/Makefile
+++ b/tests/driver_srf08/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_srf08
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_sx127x/Makefile
+++ b/tests/driver_sx127x/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_sx127x
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/driver_tcs37727/Makefile
+++ b/tests/driver_tcs37727/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_tcs37727
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_tmp006/Makefile
+++ b/tests/driver_tmp006/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_tmp006
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_tsl2561/Makefile
+++ b/tests/driver_tsl2561/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_tsl2561
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_i2c

--- a/tests/driver_veml6070/Makefile
+++ b/tests/driver_veml6070/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_veml6070
 include ../Makefile.tests_common
 
 USEMODULE += veml6070

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_xbee
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_uart periph_gpio

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = emb6
 # overwrite board, do not set native as default
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common

--- a/tests/events/Makefile
+++ b/tests/events/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = event
 include ../Makefile.tests_common
 
 FORCE_ASSERTS = 1

--- a/tests/evtimer_msg/Makefile
+++ b/tests/evtimer_msg/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = evtimer_msg
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042

--- a/tests/evtimer_underflow/Makefile
+++ b/tests/evtimer_underflow/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = evtimer_msg
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042

--- a/tests/fault_handler/Makefile
+++ b/tests/fault_handler/Makefile
@@ -1,5 +1,4 @@
 # name of your application
-APPLICATION = fault_handler
 include ../Makefile.tests_common
 
 CFLAGS += -DDEVELHELP=1

--- a/tests/float/Makefile
+++ b/tests/float/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = float
 include ../Makefile.tests_common
 
 DISABLE_MODULE += auto_init

--- a/tests/fmt_print/Makefile
+++ b/tests/fmt_print/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = fmt_print
 include ../Makefile.tests_common
 
 USEMODULE += fmt

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -1,5 +1,4 @@
 # name of your application
-APPLICATION = gnrc_ipv6_ext
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \

--- a/tests/gnrc_ipv6_nib/Makefile
+++ b/tests/gnrc_ipv6_nib/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = gnrc_ipv6_nib
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos nucleo32-f031 nucleo32-f042 nucleo32-l031 \

--- a/tests/gnrc_ipv6_nib_6ln/Makefile
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = gnrc_ipv6_nib_6ln
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos nucleo-f030 nucleo-l053 nucleo32-f031 \

--- a/tests/gnrc_ndp/Makefile
+++ b/tests/gnrc_ndp/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = gnrc_ndp
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos nucleo32-f031 nucleo32-f042 nucleo32-l031 \

--- a/tests/gnrc_netif/Makefile
+++ b/tests/gnrc_netif/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = gnrc_ipv6_nib
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -1,5 +1,4 @@
 # name of your application
-APPLICATION = gnrc_sixlowpan
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = gnrc_sock_dns
 include ../Makefile.tests_common
 
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = gnrc_sock_ip
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos nucleo32-f031 nucleo32-f042 nucleo32-l031

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = gnrc_sock_udp
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos nucleo32-f031 nucleo32-f042 nucleo32-l031

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = gnrc_tcp_client
 include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = gnrc_tcp_server
 include ../Makefile.tests_common
 
 # If no BOARD is found in the environment, use this default:

--- a/tests/gnrc_udp/Makefile
+++ b/tests/gnrc_udp/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = gnrc_udp
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := calliope-mini chronos microbit msb-430 msb-430h \

--- a/tests/irq/Makefile
+++ b/tests/irq/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = irq
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/leds/Makefile
+++ b/tests/leds/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = leds
 include ../Makefile.tests_common
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/libfixmath/Makefile
+++ b/tests/libfixmath/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = libfixmath
 include ../Makefile.tests_common
 
 USEPKG += libfixmath

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = libfixmath_unittests
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = lwip
 include ../Makefile.tests_common
 
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = lwip_sock_ip
 include ../Makefile.tests_common
 
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -1,5 +1,3 @@
-APPLICATION = lwip_sock_tcp
-
 include ../Makefile.tests_common
 
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -1,5 +1,3 @@
-APPLICATION = lwip_sock_udp
-
 include ../Makefile.tests_common
 
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the

--- a/tests/malloc/Makefile
+++ b/tests/malloc/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = malloc
 include ../Makefile.tests_common
 
 # Comment this out to disable code in RIOT that does safety checking

--- a/tests/mcuboot/Makefile
+++ b/tests/mcuboot/Makefile
@@ -1,5 +1,3 @@
-APPLICATION = hello_mcuboot
-
 BOARD ?= nrf52dk
 
 include ../Makefile.tests_common

--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = minimal
 include ../Makefile.tests_common
 
 #

--- a/tests/mpu_stack_guard/Makefile
+++ b/tests/mpu_stack_guard/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = mpu_stack_guard
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 

--- a/tests/msg_avail/Makefile
+++ b/tests/msg_avail/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = msg_avail
 include ../Makefile.tests_common
 
 DISABLE_MODULE += auto_init

--- a/tests/msg_send_receive/Makefile
+++ b/tests/msg_send_receive/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = msg_send_receive
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/msg_try_receive/Makefile
+++ b/tests/msg_try_receive/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = msg_try_receive
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/mutex_order/Makefile
+++ b/tests/mutex_order/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = mutex_order
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f030 \

--- a/tests/mutex_unlock_and_sleep/Makefile
+++ b/tests/mutex_unlock_and_sleep/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = mutex_unlock_and_sleep
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/netdev_test/Makefile
+++ b/tests/netdev_test/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = netdev_test
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/netstats_l2/Makefile
+++ b/tests/netstats_l2/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = netstats
 include ../Makefile.tests_common
 
 BOARD_PROVIDES_NETIF := airfy-beacon fox iotlab-m3 mulle native nrf51dongle \

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = nhdp
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb \

--- a/tests/od/Makefile
+++ b/tests/od/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = od
 include ../Makefile.tests_common
 
 USEMODULE += od

--- a/tests/periph_adc/Makefile
+++ b/tests/periph_adc/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_adc
 BOARD ?= pba-d-01-kw2x
 include ../Makefile.tests_common
 

--- a/tests/periph_cpuid/Makefile
+++ b/tests/periph_cpuid/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_cpuid
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_cpuid

--- a/tests/periph_dac/Makefile
+++ b/tests/periph_dac/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_dac
 BOARD ?= stm32f4discovery
 include ../Makefile.tests_common
 

--- a/tests/periph_flashpage/Makefile
+++ b/tests/periph_flashpage/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_flashpage
 BOARD ?= iotlab-m3
 include ../Makefile.tests_common
 

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_gpio
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_gpio

--- a/tests/periph_hwrng/Makefile
+++ b/tests/periph_hwrng/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_hwrng
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_hwrng

--- a/tests/periph_i2c/Makefile
+++ b/tests/periph_i2c/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_i2c
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 

--- a/tests/periph_pwm/Makefile
+++ b/tests/periph_pwm/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_pwm
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 

--- a/tests/periph_rtc/Makefile
+++ b/tests/periph_rtc/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_rtc
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_rtc

--- a/tests/periph_rtt/Makefile
+++ b/tests/periph_rtt/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_rtt
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 

--- a/tests/periph_spi/Makefile
+++ b/tests/periph_spi/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_spi
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_timer
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_timer

--- a/tests/periph_uart/Makefile
+++ b/tests/periph_uart/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = periph_uart
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/pipe/Makefile
+++ b/tests/pipe/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pipe
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/pkg_cmsis-dsp/Makefile
+++ b/tests/pkg_cmsis-dsp/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = cmsis-dsp
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 

--- a/tests/pkg_fatfs/Makefile
+++ b/tests/pkg_fatfs/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_fatfs
 include ../Makefile.tests_common
 
 USEMODULE += shell

--- a/tests/pkg_jsmn/Makefile
+++ b/tests/pkg_jsmn/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_jsmn
 include ../Makefile.tests_common
 
 USEPKG += jsmn

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_libcoap
 include ../Makefile.tests_common
 
 # msp430 and avr have problems with int width and libcoaps usage of :x notation in structs

--- a/tests/pkg_micro-ecc-with-hwrng/Makefile
+++ b/tests/pkg_micro-ecc-with-hwrng/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_micro-ecc-with-hwrng
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_hwrng

--- a/tests/pkg_micro-ecc/Makefile
+++ b/tests/pkg_micro-ecc/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_micro-ecc
 include ../Makefile.tests_common
 
 USEMODULE += hashes

--- a/tests/pkg_microcoap/Makefile
+++ b/tests/pkg_microcoap/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_microcoap
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 nucleo32-f042 \

--- a/tests/pkg_minmea/Makefile
+++ b/tests/pkg_minmea/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_minmea
 include ../Makefile.tests_common
 
 USEPKG += minmea

--- a/tests/pkg_oonf_api/Makefile
+++ b/tests/pkg_oonf_api/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_oonf_api
 include ../Makefile.tests_common
 
 BOARD_WHITELIST := native

--- a/tests/pkg_tiny-asn1/Makefile
+++ b/tests/pkg_tiny-asn1/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_tiny-asn1
 include ../Makefile.tests_common
 
 USEPKG += tiny-asn1

--- a/tests/pkg_u8g2/Makefile
+++ b/tests/pkg_u8g2/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_u8g2
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/pkg_umorse/Makefile
+++ b/tests/pkg_umorse/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pkg_umorse
 include ../Makefile.tests_common
 
 USEMODULE += xtimer

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = posix_semaphore
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos mbed_lpc1768 msb-430 msb-430h nrf6310 \

--- a/tests/posix_time/Makefile
+++ b/tests/posix_time/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = posix_time
 include ../Makefile.tests_common
 
 USEMODULE += posix_time

--- a/tests/ps_schedstatistics/Makefile
+++ b/tests/ps_schedstatistics/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = ps_schedstatistics
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030 nucleo-l053 \

--- a/tests/pthread/Makefile
+++ b/tests/pthread/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pthread
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove

--- a/tests/pthread_barrier/Makefile
+++ b/tests/pthread_barrier/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = pthread_barrier
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove

--- a/tests/pthread_cleanup/Makefile
+++ b/tests/pthread_cleanup/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pthread_cleanup
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove

--- a/tests/pthread_condition_variable/Makefile
+++ b/tests/pthread_condition_variable/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = condition_variable
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pthread_cooperation
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pthread_rwlock
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove

--- a/tests/pthread_tls/Makefile
+++ b/tests/pthread_tls/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = pthread_tls
 include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove

--- a/tests/rmutex/Makefile
+++ b/tests/rmutex/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = rmutex
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f030 \

--- a/tests/saul/Makefile
+++ b/tests/saul/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = saul
 include ../Makefile.tests_common
 
 # include and auto-initialize all available sensors

--- a/tests/sched_testing/Makefile
+++ b/tests/sched_testing/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = sched_testing
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = shell
 include ../Makefile.tests_common
 
 USEMODULE += shell

--- a/tests/sizeof_tcb/Makefile
+++ b/tests/sizeof_tcb/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = sizeof_tcb
 include ../Makefile.tests_common
 
 # othread_t modifying modules:

--- a/tests/slip/Makefile
+++ b/tests/slip/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = driver_slip
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo32-f031 nucleo32-f042 \

--- a/tests/sntp/Makefile
+++ b/tests/sntp/Makefile
@@ -1,5 +1,3 @@
-# name of your application
-APPLICATION = sntp
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo32-f031 \

--- a/tests/ssp/Makefile
+++ b/tests/ssp/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = ssp
 include ../Makefile.tests_common
 
 # avr8, msp430 and mips don't support ssp (yet)

--- a/tests/struct_tm_utility/Makefile
+++ b/tests/struct_tm_utility/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = struct_tm_utility
 include ../Makefile.tests_common
 
 DISABLE_MODULE += auto_init

--- a/tests/thread_basic/Makefile
+++ b/tests/thread_basic/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_basic
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_cooperation
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY :=    chronos \

--- a/tests/thread_exit/Makefile
+++ b/tests/thread_exit/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_exit
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/thread_flags/Makefile
+++ b/tests/thread_flags/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_flags
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/thread_flags_xtimer/Makefile
+++ b/tests/thread_flags_xtimer/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_flags_xtimer
 include ../Makefile.tests_common
 
 USEMODULE += core_thread_flags

--- a/tests/thread_flood/Makefile
+++ b/tests/thread_flood/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_flood
 include ../Makefile.tests_common
 
 DISABLE_MODULE += auto_init

--- a/tests/thread_msg/Makefile
+++ b/tests/thread_msg/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_msg
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042

--- a/tests/thread_msg_block_w_queue/Makefile
+++ b/tests/thread_msg_block_w_queue/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_msg_block_w_queue
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/thread_msg_block_wo_queue/Makefile
+++ b/tests/thread_msg_block_wo_queue/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_msg_block_wo_queue
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/thread_msg_seq/Makefile
+++ b/tests/thread_msg_seq/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = thread_msg_seq
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042

--- a/tests/trickle/Makefile
+++ b/tests/trickle/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = trickle
 include ../Makefile.tests_common
 
 USEMODULE += trickle

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = unittests
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon \

--- a/tests/warn_conflict/Makefile
+++ b/tests/warn_conflict/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = warn_conflict
 BOARD ?= stm32f4discovery
 include ../Makefile.tests_common
 

--- a/tests/xtimer_drift/Makefile
+++ b/tests/xtimer_drift/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_drift
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042

--- a/tests/xtimer_hang/Makefile
+++ b/tests/xtimer_hang/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_hang
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/xtimer_longterm/Makefile
+++ b/tests/xtimer_longterm/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_longterm
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042

--- a/tests/xtimer_msg/Makefile
+++ b/tests/xtimer_msg/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_msg
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/xtimer_msg_receive_timeout/Makefile
+++ b/tests/xtimer_msg_receive_timeout/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_msg_receive_timeout
 include ../Makefile.tests_common
 
 USEMODULE += xtimer

--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_now64_continuity
 include ../Makefile.tests_common
 
 USEMODULE += fmt

--- a/tests/xtimer_periodic_wakeup/Makefile
+++ b/tests/xtimer_periodic_wakeup/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_periodic_wakeup
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos

--- a/tests/xtimer_remove/Makefile
+++ b/tests/xtimer_remove/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_remove
 include ../Makefile.tests_common
 
 USEMODULE += xtimer

--- a/tests/xtimer_reset/Makefile
+++ b/tests/xtimer_reset/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_reset
 include ../Makefile.tests_common
 
 USEMODULE += xtimer

--- a/tests/xtimer_usleep/Makefile
+++ b/tests/xtimer_usleep/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_usleep
 include ../Makefile.tests_common
 
 USEMODULE += xtimer


### PR DESCRIPTION
There where a some tests where APPLICATION did not match the folder name (plus "test_"):

```
[kaspar@booze tests (master)]$ for i in */Makefile; do test "$(dirname $i)" = "$(grep APPLICATION $i | cut -d ' ' -f 3)" || echo $i; done
conn_can/Makefile
driver_pcd8544/Makefile
events/Makefile
evtimer_underflow/Makefile
gnrc_netif/Makefile
mcuboot/Makefile
netstats_l2/Makefile
pkg_cmsis-dsp/Makefile
pthread_condition_variable/Makefile
slip/Makefile
xtimer_usleep_short/Makefile
[kaspar@booze tests (master)]$
```

Most where either c&p leftovers or typos. Some just had a different name, but using the folder name still makes sense.

This PR sets ```APPLICATION``` in ```tests/Makefile.tests_common``` to the test's folder name.
Another commit removes the now redundant name definitions from the actual tests' Makefiles.