### PR TITLE
drivers/kw2xrf: fix fall through

### DIFF
--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -197,6 +197,7 @@ static int _set_state(kw2xrf_t *dev, netopt_state_t state)
         case NETOPT_STATE_OFF:
             /* TODO: Replace with powerdown (set reset input low) */
             kw2xrf_set_power_mode(dev, KW2XRF_HIBERNATE);
+            break;
         default:
             return -ENOTSUP;
     }


### PR DESCRIPTION
This was made visible by #7919. Broke build on GCC 7.2.

Probably a bug.