### PR TITLE
ci: murdock: fix output error on missing builddir after failed build

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -96,7 +96,7 @@ compile() {
         fi
     fi
 
-    echo "-- build directory size: $(du -sh ${BINDIR} | cut -f1)"
+    test -d ${BINDIR} && echo "-- build directory size: $(du -sh ${BINDIR} | cut -f1)"
 
     # cleanup
     rm -Rf build


### PR DESCRIPTION
Small check prevents "du" error like [here](https://ci.riot-os.org/RIOT-OS/RIOT/8190/d07db6f04e77ad1ad037bbc185b6d25b56fc9cfb/output/compile/tests/openthread/fox.txt).