### PR TITLE
ci: murdock: Replace hardcoded path by bindir variable

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -73,9 +73,11 @@ compile() {
     [ "$board" = "makefile_broken" ] && error "$0: Makefile in \"$appdir\" seems to be broken!"
 
     # set build directory. CI ensures only one build at a time in $(pwd).
-    rm -rf build
     export BINDIR="$(pwd)/build"
     export PKGDIRBASE="${BINDIR}/pkg"
+
+    # Pre-build cleanup
+    rm -rf ${BINDIR}
 
     [ -n "$DWQ_WORKER" ] && \
         echo "-- running on worker ${DWQ_WORKER} thread ${DWQ_WORKER_THREAD}, build number $DWQ_WORKER_BUILDNUM."
@@ -96,10 +98,13 @@ compile() {
         fi
     fi
 
-    test -d ${BINDIR} && echo "-- build directory size: $(du -sh ${BINDIR} | cut -f1)"
+    if [ -d ${BINDIR} ]
+    then
+        echo "-- build directory size: $(du -sh ${BINDIR} | cut -f1)"
 
-    # cleanup
-    rm -Rf build
+        # cleanup
+        rm -rf ${BINDIR}
+    fi
 
     return $RES
 }


### PR DESCRIPTION
Replaces the two `rm -rf build` to use the `BINDIR` variable.