### PR TITLE
at86rf2xx: Fix wrong state transition when leaving sleep state

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -433,11 +433,13 @@ uint8_t at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
     }
     else if (state != old_state) {
         /* we need to go via PLL_ON if we are moving between RX_AACK_ON <-> TX_ARET_ON */
-        if ((old_state | state) == (AT86RF2XX_STATE_RX_AACK_ON | AT86RF2XX_STATE_TX_ARET_ON)) {
+        if (((old_state == AT86RF2XX_STATE_RX_AACK_ON) && (state == AT86RF2XX_STATE_TX_ARET_ON)) ||
+            ((state == AT86RF2XX_STATE_RX_AACK_ON) && (old_state == AT86RF2XX_STATE_TX_ARET_ON))) {
             _set_state(dev, AT86RF2XX_STATE_PLL_ON, AT86RF2XX_STATE_PLL_ON);
         }
-        /* check if we need to wake up from sleep mode */
         if (state == AT86RF2XX_STATE_SLEEP) {
+            /* Putting the transceiver to sleep requires first going to TRX_OFF,
+             * then driving the SLP_TR pin high */
             /* First go to TRX_OFF */
             _set_state(dev, AT86RF2XX_STATE_TRX_OFF,
                             AT86RF2XX_STATE_FORCE_TRX_OFF);


### PR DESCRIPTION
SLEEP is 0xf, the bitwise OR of
(AT86RF2XX_STATE_RX_AACK_ON | AT86RF2XX_STATE_TX_ARET_ON) equals 0x1f,
so this state transition to PLL_ON was wrongly triggered when leaving
sleep for any mode which has 0x1X as its state code. The symptom is a
hang in the transceiver driver thread because the transceiver is not
listening to state transition commands while in sleep mode.

I hit this bug when using ifconfig to set some options while the transceiver was sleeping.