### PR TITLE
tests: fix python E127 'continuation line over/under-indented for visual indent'

### DIFF
--- a/tests/gnrc_netif/tests/01-run.py
+++ b/tests/gnrc_netif/tests/01-run.py
@@ -20,49 +20,39 @@ def testfunc(child):
     # output cross-checked hex data with WireShark -> "Import from Hex Dump..."
     # test_netapi_send__raw_unicast_ethernet_packet
     child.expect("Sending data from Ethernet device:")
-    child.expect("00000000  3E  E6  B5  0F  19  23  3E  E6  B5  22  FD  0A  " +
-                           "FF  FF  41  42")
+    child.expect("00000000  3E  E6  B5  0F  19  23  3E  E6  B5  22  FD  0A  FF  FF  41  42")
     child.expect("00000010  43  44  45  46  47  00")
     # test_netapi_send__raw_broadcast_ethernet_packet
     child.expect("Sending data from Ethernet device:")
-    child.expect("00000000  FF  FF  FF  FF  FF  FF  3E  E6  B5  22  FD  0A  " +
-                           "FF  FF  41  42")
+    child.expect("00000000  FF  FF  FF  FF  FF  FF  3E  E6  B5  22  FD  0A  FF  FF  41  42")
     child.expect("00000010  43  44  45  46  47  00")
     # test_netapi_send__raw_unicast_ieee802154_long_long_packet
     child.expect(r"Sending data from IEEE 802\.15\.4 device:")
-    child.expect("00000000  41  DC  00  00  00  0B  FD  22  19  0F  B5  E6  " +
-                           "3E  0A  FD  22")
-    child.expect("00000010  19  0F  B5  E6  3E  31  32  33  41  42  43  44  " +
-                           "45  46  47  00")
+    child.expect("00000000  41  DC  00  00  00  0B  FD  22  19  0F  B5  E6  3E  0A  FD  22")
+    child.expect("00000010  19  0F  B5  E6  3E  31  32  33  41  42  43  44  45  46  47  00")
     # test_netapi_send__raw_unicast_ieee802154_long_short_packet
     child.expect(r"Sending data from IEEE 802\.15\.4 device:")
-    child.expect("00000000  41  D8  01  00  00  0B  FD  0A  FD  22  19  0F  " +
-                           "B5  E6  3E  31")
+    child.expect("00000000  41  D8  01  00  00  0B  FD  0A  FD  22  19  0F  B5  E6  3E  31")
     child.expect("00000010  32  33  41  42  43  44  45  46  47  00")
     # test_netapi_send__raw_unicast_ieee802154_short_long_packet1
     child.expect(r"Sending data from IEEE 802\.15\.4 device:")
-    child.expect("00000000  41  9C  02  00  00  0B  FD  22  19  0F  B5  E6  " +
-                           "3E  0A  FD  31")
+    child.expect("00000000  41  9C  02  00  00  0B  FD  22  19  0F  B5  E6  3E  0A  FD  31")
     child.expect("00000010  32  33  41  42  43  44  45  46  47  00")
     # test_netapi_send__raw_unicast_ieee802154_short_long_packet2
     child.expect(r"Sending data from IEEE 802\.15\.4 device:")
-    child.expect("00000000  41  9C  03  00  00  0B  FD  22  19  0F  B5  E6  " +
-                           "3E  0A  FD  31")
+    child.expect("00000000  41  9C  03  00  00  0B  FD  22  19  0F  B5  E6  3E  0A  FD  31")
     child.expect("00000010  32  33  41  42  43  44  45  46  47  00")
     # test_netapi_send__raw_unicast_ieee802154_short_short_packet
     child.expect(r"Sending data from IEEE 802\.15\.4 device:")
-    child.expect("00000000  41  98  04  00  00  0B  FD  0A  FD  31  32  33  " +
-                           "41  42  43  44")
+    child.expect("00000000  41  98  04  00  00  0B  FD  0A  FD  31  32  33  41  42  43  44")
     child.expect("00000010  45  46  47  00")
     # test_netapi_send__raw_broadcast_ieee802154_long_packet
     child.expect(r"Sending data from IEEE 802\.15\.4 device:")
-    child.expect("00000000  41  D8  05  00  00  FF  FF  0A  FD  22  19  0F  " +
-                              "B5  E6  3E  31")
+    child.expect("00000000  41  D8  05  00  00  FF  FF  0A  FD  22  19  0F  B5  E6  3E  31")
     child.expect("00000010  32  33  41  42  43  44  45  46  47  00")
     # test_netapi_send__raw_broadcast_ieee802154_short_packet
     child.expect(r"Sending data from IEEE 802\.15\.4 device:")
-    child.expect("00000000  41  98  06  00  00  FF  FF  0A  FD  31  32  33  " +
-                           "41  42  43  44")
+    child.expect("00000000  41  98  06  00  00  FF  FF  0A  FD  31  32  33  41  42  43  44")
     child.expect("00000010  45  46  47  00")
     # test_netapi_send__ipv6_unicast_ethernet_packet
     child.expect("Sending data from Ethernet device:")

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -166,7 +166,7 @@ def default_test_case(board_group, application, env=None):
         env.update(board.to_env())
         with pexpect.spawnu("make", ["-C", application, "term"], env=env,
                             timeout=DEFAULT_TIMEOUT,
-                           logfile=sys.stdout) as spawn:
+                            logfile=sys.stdout) as spawn:
             spawn.expect("TEST: SUCCESS")
 
 
@@ -200,8 +200,8 @@ def test_ipv6_send(board_group, application, env=None):
     env_receiver.update(board_group.boards[1].to_env())
     with pexpect.spawnu("make", ["-C", application, "term"], env=env_sender,
                         timeout=DEFAULT_TIMEOUT) as sender, \
-         pexpect.spawnu("make", ["-C", application, "term"], env=env_receiver,
-                        timeout=DEFAULT_TIMEOUT) as receiver:
+        pexpect.spawnu("make", ["-C", application, "term"], env=env_receiver,
+                       timeout=DEFAULT_TIMEOUT) as receiver:
         ipprot = random.randint(0x00, 0xff)
         receiver_ip = get_ipv6_address(receiver)
         receiver.sendline(u"ip server start %d" % ipprot)
@@ -224,8 +224,8 @@ def test_udpv6_send(board_group, application, env=None):
     env_receiver.update(board_group.boards[1].to_env())
     with pexpect.spawnu("make", ["-C", application, "term"], env=env_sender,
                         timeout=DEFAULT_TIMEOUT) as sender, \
-         pexpect.spawnu("make", ["-C", application, "term"], env=env_receiver,
-                        timeout=DEFAULT_TIMEOUT) as receiver:
+        pexpect.spawnu("make", ["-C", application, "term"], env=env_receiver,
+                       timeout=DEFAULT_TIMEOUT) as receiver:
         port = random.randint(0x0000, 0xffff)
         receiver_ip = get_ipv6_address(receiver)
 
@@ -249,8 +249,8 @@ def test_tcpv6_send(board_group, application, env=None):
     env_server.update(board_group.boards[1].to_env())
     with pexpect.spawnu("make", ["-C", application, "term"], env=env_client,
                         timeout=DEFAULT_TIMEOUT) as client, \
-         pexpect.spawnu("make", ["-C", application, "term"], env=env_server,
-                        timeout=DEFAULT_TIMEOUT) as server:
+        pexpect.spawnu("make", ["-C", application, "term"], env=env_server,
+                       timeout=DEFAULT_TIMEOUT) as server:
         port = random.randint(0x0000, 0xffff)
         server_ip = get_ipv6_address(server)
         client_ip = get_ipv6_address(client)
@@ -279,8 +279,8 @@ def test_triple_send(board_group, application, env=None):
     env_receiver.update(board_group.boards[1].to_env())
     with pexpect.spawnu("make", ["-C", application, "term"], env=env_sender,
                         timeout=DEFAULT_TIMEOUT) as sender, \
-         pexpect.spawnu("make", ["-C", application, "term"], env=env_receiver,
-                        timeout=DEFAULT_TIMEOUT) as receiver:
+        pexpect.spawnu("make", ["-C", application, "term"], env=env_receiver,
+                       timeout=DEFAULT_TIMEOUT) as receiver:
         udp_port = random.randint(0x0000, 0xffff)
         tcp_port = random.randint(0x0000, 0xffff)
         ipprot = random.randint(0x00, 0xff)

--- a/tests/posix_time/tests/01-run.py
+++ b/tests/posix_time/tests/01-run.py
@@ -37,7 +37,7 @@ def testfunc(child):
         child.expect_exact("DONE")
         testtime = (time.time() - start_test) * US_PER_SEC
         exp = sum(i * 500000 for i in range(5)) + \
-              sum(i * US_PER_SEC for i in range(5))
+            sum(i * US_PER_SEC for i in range(5))
         lower_bound = exp - (exp * EXTERNAL_JITTER)
         upper_bound = exp + (exp * EXTERNAL_JITTER)
         if not (lower_bound < testtime < upper_bound):


### PR DESCRIPTION
Another one that partially addressed #8141.