### PR TITLE
evtimer: Add function to retrieve the current remaining time of an evtimer event

### DIFF
--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -153,6 +153,25 @@ void evtimer_del(evtimer_t *evtimer, evtimer_event_t *event)
     irq_restore(state);
 }
 
+uint32_t evtimer_get_offset(evtimer_t *evtimer, evtimer_event_t *event)
+{
+    uint32_t offset = 0;
+    unsigned state = irq_disable();
+    if (evtimer->events) {
+        evtimer_event_t *list = evtimer->events;
+        /* Get current offset to first event */
+        offset = _get_offset(&evtimer->timer);
+        while ((list = list->next)) {
+            offset += list->offset;
+            if (list == event) {
+                break;
+            }
+        }
+    }
+    irq_restore(state);
+    return offset;
+}
+
 static evtimer_event_t *_get_next(evtimer_t *evtimer)
 {
     evtimer_event_t *event = evtimer->events;

--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include <stdbool.h>
 #include "div.h"
 #include "irq.h"
 #include "xtimer.h"
@@ -156,20 +157,21 @@ void evtimer_del(evtimer_t *evtimer, evtimer_event_t *event)
 uint32_t evtimer_get_offset(evtimer_t *evtimer, evtimer_event_t *event)
 {
     uint32_t offset = 0;
+    bool res = false;
+
     unsigned state = irq_disable();
-    if (evtimer->events) {
-        evtimer_event_t *list = evtimer->events;
-        /* Get current offset to first event */
-        offset = _get_offset(&evtimer->timer);
-        while ((list = list->next)) {
-            offset += list->offset;
-            if (list == event) {
-                break;
-            }
+
+    evtimer_event_t *list = (evtimer_event_t *)&evtimer->events;
+    _update_head_offset(evtimer);
+    while ((list = list->next)) {
+        offset += list->offset;
+        if (list == event) {
+            res = true;
+            break;
         }
     }
     irq_restore(state);
-    return offset;
+    return (res) ? offset : 0;
 }
 
 static evtimer_event_t *_get_next(evtimer_t *evtimer)

--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -99,6 +99,20 @@ void evtimer_add(evtimer_t *evtimer, evtimer_event_t *event);
 void evtimer_del(evtimer_t *evtimer, evtimer_event_t *event);
 
 /**
+ * @brief   Retrieves the time remaining for an event
+ * @warning Retrieval of evtimer event offsets disables interrupts and has
+ *          O(n) complexity with (n) being the number of active
+ *          @ref evtimer_event_t for an @ref evtimer_t
+ *
+ * @param[in] evtimer       The event timer the event belongs to
+ * @param[in] event         An event
+ *
+ * @return  The offset of the event
+ * @return  Zero when the event is not in the list
+ */
+uint32_t evtimer_get_offset(evtimer_t *evtimer, evtimer_event_t *event);
+
+/**
  * @brief   Print overview of current state of an event timer
  *
  * @param[in] evtimer   An event timer

--- a/tests/evtimer_msg/main.c
+++ b/tests/evtimer_msg/main.c
@@ -46,11 +46,13 @@ void *worker_thread(void *arg)
         char *ctx;
         msg_t m;
         uint32_t now;
+        uint32_t remaining;
 
         msg_receive(&m);
         now = xtimer_now_usec() / US_PER_MS;
         ctx = m.content.ptr;
-        printf("At %6" PRIu32 " ms received msg %i: \"%s\"\n", now, count++, ctx);
+        remaining = evtimer_get_offset(&evtimer,(evtimer_event_t*)&events[NEVENTS - 1]);
+        printf("At %6" PRIu32 " ms received msg %i: \"%s\", time until last event: %" PRIu32 " ms\n", now, count++, ctx, remaining);
     }
 }
 
@@ -66,6 +68,8 @@ int main(void)
                                      THREAD_CREATE_STACKTEST,
                                      worker_thread, NULL, "worker");
     printf("Testing generic evtimer (start time = %" PRIu32 " ms)\n", now);
+    uint32_t last_event = events[NEVENTS - 1].event.offset;
+    printf("Last evtimer event expected at %" PRIu32 " ms\n", last_event);
     for (unsigned i = 0; i < NEVENTS; i++) {
         evtimer_add_msg(&evtimer, &events[i], pid);
     }

--- a/tests/evtimer_msg/tests/01-run.py
+++ b/tests/evtimer_msg/tests/01-run.py
@@ -19,14 +19,22 @@ ACCEPTED_ERROR = 20
 def testfunc(child):
     child.expect(r"Testing generic evtimer \(start time = (\d+) ms\)")
     timer_offset = int(child.match.group(1))
+    child.expect(r"Last evtimer event expected at (\d+) ms")
+    remaining = int(child.match.group(1))
     child.expect(r"Are the reception times of all (\d+) msgs close to the supposed values?")
     numof = int(child.match.group(1))
 
     for i in range(numof):
-        child.expect(r'At \s*(\d+) ms received msg %i: "supposed to be (\d+)"' % i)
+        child.expect(r'At \s*(\d+) ms received msg %i: "supposed to be (\d+)",'
+                     r' time until last event: (\d+) ms' % i)
         # check if output is correct
+        cur_time = int(child.match.group(1))
         exp = int(child.match.group(2)) + timer_offset
-        assert(int(child.match.group(1)) in range(exp - ACCEPTED_ERROR, exp + ACCEPTED_ERROR + 1))
+        recv_rem = int(child.match.group(3))
+        exp_rem = remaining - cur_time
+        assert(cur_time in range(exp - ACCEPTED_ERROR, exp + ACCEPTED_ERROR + 1))
+        assert(recv_rem in range(exp_rem - ACCEPTED_ERROR,
+                                 exp_rem + ACCEPTED_ERROR + 1))
         print(".", end="", flush=True)
     print("")
     print("All tests successful")


### PR DESCRIPTION
As the title states, this PR adds a function to evtimer to retrieve the time remaining for an evtimer_event_t.

Expected use: Display of collections/objects with a timeout based on an event. For example `_nib_offl_entry_t` (currently route lifetime isn't displayed with `nib route`).