### PR TITLE
boards: adds support for Nordic Thingy:52

### DIFF
--- a/boards/common/nrf52xxxdk/Makefile.include
+++ b/boards/common/nrf52xxxdk/Makefile.include
@@ -2,7 +2,7 @@
 export CPU = nrf52
 
 # include this module into the build
-ifeq (,$(filter acd52832,$(BOARD)))
+ifeq (,$(filter thingy52 acd52832,$(BOARD)))
   INCLUDES += -I$(RIOTBOARD)/common/nrf52xxxdk/include
   USEMODULE += boards_common_nrf52
 endif

--- a/boards/thingy52/Makefile
+++ b/boards/thingy52/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/thingy52/Makefile.dep
+++ b/boards/thingy52/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+  USEMODULE += nrfmin
+endif

--- a/boards/thingy52/Makefile.features
+++ b/boards/thingy52/Makefile.features
@@ -1,0 +1,13 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrfmin
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m4_3
+
+-include $(RIOTCPU)/nrf52/Makefile.features

--- a/boards/thingy52/Makefile.include
+++ b/boards/thingy52/Makefile.include
@@ -1,12 +1,9 @@
 # CPU configuration for the Thingy:52
-export CPU = nrf52
 CPU_MODEL = nrf52832xxaa
 
-# set default port depending on operating system
+# override default PORT
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-include $(RIOTMAKE)/tools/serial.inc.mk
 
-# setup JLink for flashing
-export JLINK_DEVICE := nrf52
-include $(RIOTMAKE)/tools/jlink.inc.mk
+# use shared Makefile.include
+include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/thingy52/Makefile.include
+++ b/boards/thingy52/Makefile.include
@@ -1,0 +1,12 @@
+# CPU configuration for the Thingy:52
+export CPU = nrf52
+CPU_MODEL = nrf52832xxaa
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# setup JLink for flashing
+export JLINK_DEVICE := nrf52
+include $(RIOTMAKE)/tools/jlink.inc.mk

--- a/boards/thingy52/board.c
+++ b/boards/thingy52/board.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_thingy52
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the Thingy:52
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/thingy52/include/board.h
+++ b/boards/thingy52/include/board.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 Feie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_thingy52 Nordic Thingy:52
+ * @ingroup     boards
+ * @brief       Board specific configuration for the Nordic Thingy:52 board
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Nordic Thingy:52 board
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 11)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/thingy52/include/periph_conf.h
+++ b/boards/thingy52/include/periph_conf.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_thingy52
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Thingy:52
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ *
+ * @note    The radio will not work with the internal RC oscillator!
+ *
+ * @{
+ */
+#define CLOCK_HFCLK         (32U)           /* set to  0: internal RC oscillator
+                                             *        32: 32MHz crystal */
+#define CLOCK_LFCLK         (1)             /* set to  0: internal RC oscillator
+                                             *         1: 32.768 kHz crystal
+                                             *         2: derived from HFCLK */
+/** @} */
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = NRF_TIMER1,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
+        .irqn     = TIMER1_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_timer1
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             (1)             /* NRF_RTC1 */
+#define RTT_MAX_VALUE       (0x00ffffff)
+#define RTT_FREQUENCY       (1024)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_PIN_RX         GPIO_PIN(0, 2)
+#define UART_PIN_TX         GPIO_PIN(0, 3)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */


### PR DESCRIPTION
This PR adds rudimentary support for the new [Nordic Thingy:52](https://www.nordicsemi.com/eng/Products/Nordic-Thingy-52). In this first step, support for the baord is very basic, only allowing for a basic shell and working timers. Additional PRs with support for the i2c-based on-board pin multiplexer (`SX1509`) and mappings for the on-board sensors (e.g. `mpu9150`) will follow.

For programming I am currently using simply a `nrf52dk` with a 10-pin flatband cable connected to the `thingy52`. But I also verified the programming working with an independent Segger Jlink adapter. In theory, programming should also be doable using e.g. an ST-Link or any other SWD capable programmer, but I have not tried this (and hence not added configuration to the port).

NOTE: to interface with the UART, one needs also to connected an external USB-to-Uart adapter to pins `P0.02 (RX)` and `P0.03 (TX)` on the `P1` pin header -> see `periph_conf.h` and the board's ref manual.