### PR TITLE
gnrc_ipv6: gnrc_icmpv6: simplify access to network interfaces

### DIFF
--- a/sys/include/net/gnrc/icmpv6.h
+++ b/sys/include/net/gnrc/icmpv6.h
@@ -27,8 +27,8 @@
 #ifndef NET_GNRC_ICMPV6_H
 #define NET_GNRC_ICMPV6_H
 
-#include "kernel_types.h"
 #include "net/icmpv6.h"
+#include "net/gnrc/netif.h"
 #include "net/gnrc/pkt.h"
 
 #include "net/gnrc/icmpv6/echo.h"
@@ -41,10 +41,10 @@ extern "C" {
 /**
  * @brief   Demultiplexes a received ICMPv6 packet according to its type field.
  *
- * @param[in] iface     The receiving interface
+ * @param[in] netif     The receiving interface
  * @param[in] pkt       The packet to demultiplex.
  */
-void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt);
+void gnrc_icmpv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 
 /**
  * @brief   Builds an ICMPv6 message for sending.

--- a/sys/include/net/gnrc/icmpv6/echo.h
+++ b/sys/include/net/gnrc/icmpv6/echo.h
@@ -23,7 +23,7 @@
 #include <inttypes.h>
 
 #include "byteorder.h"
-#include "kernel_types.h"
+#include "net/gnrc/netif.h"
 #include "net/ipv6/hdr.h"
 
 #ifdef __cplusplus
@@ -49,13 +49,13 @@ gnrc_pktsnip_t *gnrc_icmpv6_echo_build(uint8_t type, uint16_t id, uint16_t seq,
 /**
  * @brief   ICMPv6 echo request handler
  *
- * @param[in] iface     The interface the echo requuest was received on.
+ * @param[in] netif     The interface the echo request was received on.
  * @param[in] ipv6_hdr  The IPv6 header of the echo request.
  * @param[in] echo      The Echo Request message.
  * @param[in] len       Length of the echo request message (ipv6_hdr_t::len
  *                      of @p ipv6_hdr minus length of extension headers).
  */
-void gnrc_icmpv6_echo_req_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6_hdr,
+void gnrc_icmpv6_echo_req_handle(gnrc_netif_t *netif, ipv6_hdr_t *ipv6_hdr,
                                  icmpv6_echo_t *echo, uint16_t len);
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -145,12 +145,13 @@ kernel_pid_t gnrc_ipv6_init(void);
  * This situation may happen when the packet has a source routing extension
  * header (RFC 6554), and the packet is forwarded from an interface to another.
  *
- * @param[in] iface     The receiving interface.
+ * @param[in] netif     The receiving interface.
  * @param[in] current   A snip to process.
  * @param[in] pkt       A packet.
  * @param[in] nh        A protocol number (see @ref net_protnum) of the current snip.
  */
-void gnrc_ipv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *current, gnrc_pktsnip_t *pkt, uint8_t nh);
+void gnrc_ipv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *current,
+                     gnrc_pktsnip_t *pkt, uint8_t nh);
 
 /**
  * @brief   Get the IPv6 header from a given list of @ref gnrc_pktsnip_t

--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "kernel_types.h"
+#include "net/gnrc/netif.h"
 #include "net/gnrc/pkt.h"
 #include "net/ipv6/ext.h"
 
@@ -52,12 +52,12 @@ extern "C" {
  *
  * @internal
  *
- * @param[in] iface     The receiving interface.
+ * @param[in] netif     The receiving interface.
  * @param[in] current   A snip to process.
  * @param[in] pkt       A packet.
  * @param[in] nh        A protocol number (see @ref net_protnum) of the current snip.
  */
-void gnrc_ipv6_ext_demux(kernel_pid_t iface,
+void gnrc_ipv6_ext_demux(gnrc_netif_t *netif,
                          gnrc_pktsnip_t *current,
                          gnrc_pktsnip_t *pkt,
                          uint8_t nh);

--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -56,7 +56,7 @@ gnrc_pktsnip_t *gnrc_icmpv6_echo_build(uint8_t type, uint16_t id, uint16_t seq,
     return pkt;
 }
 
-void gnrc_icmpv6_echo_req_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6_hdr,
+void gnrc_icmpv6_echo_req_handle(gnrc_netif_t *netif, ipv6_hdr_t *ipv6_hdr,
                                  icmpv6_echo_t *echo, uint16_t len)
 {
     uint8_t *payload = ((uint8_t *)echo) + sizeof(icmpv6_echo_t);
@@ -93,7 +93,7 @@ void gnrc_icmpv6_echo_req_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6_hdr,
     pkt = hdr;
     hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
-    ((gnrc_netif_hdr_t *)hdr->data)->if_pid = iface;
+    ((gnrc_netif_hdr_t *)hdr->data)->if_pid = netif->pid;
 
     LL_PREPEND(pkt, hdr);
 

--- a/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
+++ b/sys/net/gnrc/network_layer/icmpv6/gnrc_icmpv6.c
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 
 #include "byteorder.h"
-#include "kernel_types.h"
 #include "net/ipv6/hdr.h"
 #include "net/gnrc.h"
 #include "net/gnrc/ipv6/nib.h"
@@ -53,7 +52,7 @@ static inline uint16_t _calc_csum(gnrc_pktsnip_t *hdr,
     return ~csum;
 }
 
-void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
+void gnrc_icmpv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     gnrc_pktsnip_t *icmpv6, *ipv6;
     icmpv6_hdr_t *hdr;
@@ -88,7 +87,7 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
 #ifdef MODULE_GNRC_ICMPV6_ECHO
         case ICMPV6_ECHO_REQ:
             DEBUG("icmpv6: handle echo request.\n");
-            gnrc_icmpv6_echo_req_handle(iface, (ipv6_hdr_t *)ipv6->data,
+            gnrc_icmpv6_echo_req_handle(netif, (ipv6_hdr_t *)ipv6->data,
                                         (icmpv6_echo_t *)hdr, icmpv6->size);
             break;
 #endif
@@ -101,13 +100,12 @@ void gnrc_icmpv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *pkt)
         case ICMPV6_DAR:
         case ICMPV6_DAC:
             DEBUG("icmpv6: NDP message received. Handle with gnrc_ipv6_nib\n");
-            gnrc_ipv6_nib_handle_pkt(gnrc_netif_get_by_pid(iface),
-                                     ipv6->data, hdr, icmpv6->size);
+            gnrc_ipv6_nib_handle_pkt(netif, ipv6->data, hdr, icmpv6->size);
             break;
 
         default:
             DEBUG("icmpv6: unknown type field %u\n", hdr->type);
-            (void)iface;
+            (void)netif;
             break;
     }
 

--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 
 #include "utlist.h"
+#include "net/gnrc/netif.h"
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/ipv6.h"
 
@@ -170,7 +171,7 @@ static inline bool _has_valid_size(gnrc_pktsnip_t *pkt, uint8_t nh)
  *         v                       v
  * IPv6 <- IPv6_EXT <- IPv6_EXT <- UNDEF
  */
-void gnrc_ipv6_ext_demux(kernel_pid_t iface,
+void gnrc_ipv6_ext_demux(gnrc_netif_t *netif,
                          gnrc_pktsnip_t *current,
                          gnrc_pktsnip_t *pkt,
                          uint8_t nh)
@@ -200,7 +201,7 @@ void gnrc_ipv6_ext_demux(kernel_pid_t iface,
                             return;
                         }
 
-                        gnrc_ipv6_demux(iface, current, pkt, nh); /* demultiplex next header */
+                        gnrc_ipv6_demux(netif, current, pkt, nh); /* demultiplex next header */
 
                         return;
 
@@ -246,7 +247,7 @@ void gnrc_ipv6_ext_demux(kernel_pid_t iface,
                 break;
 
             default:
-                gnrc_ipv6_demux(iface, current, pkt, nh); /* demultiplex next header */
+                gnrc_ipv6_demux(netif, current, pkt, nh); /* demultiplex next header */
                 return;
         }
     }

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -104,7 +104,8 @@ static void _dispatch_next_header(gnrc_pktsnip_t *current, gnrc_pktsnip_t *pkt,
  *         v                       v
  * IPv6 <- IPv6_EXT <- IPv6_EXT <- UNDEF
  */
-void gnrc_ipv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *current, gnrc_pktsnip_t *pkt, uint8_t nh)
+void gnrc_ipv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *current,
+                     gnrc_pktsnip_t *pkt, uint8_t nh)
 {
     bool interested = false;
 
@@ -135,7 +136,7 @@ void gnrc_ipv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *current, gnrc_pktsnip_t
 
             break;
         default:
-            (void)iface;
+            (void)netif;
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC_NHC
             /* second statement is true for small 6LoWPAN NHC decompressed frames
              * since in this case it looks like
@@ -165,7 +166,7 @@ void gnrc_ipv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *current, gnrc_pktsnip_t
 #ifdef MODULE_GNRC_ICMPV6
         case PROTNUM_ICMPV6:
             DEBUG("ipv6: handle ICMPv6 packet (nh = %u)\n", nh);
-            gnrc_icmpv6_demux(iface, pkt);
+            gnrc_icmpv6_demux(netif, pkt);
             return;
 #endif
 #ifdef MODULE_GNRC_IPV6_EXT
@@ -178,7 +179,7 @@ void gnrc_ipv6_demux(kernel_pid_t iface, gnrc_pktsnip_t *current, gnrc_pktsnip_t
         case PROTNUM_IPV6_EXT_MOB:
             DEBUG("ipv6: handle extension header (nh = %u)\n", nh);
 
-            gnrc_ipv6_ext_demux(iface, current, pkt, nh);
+            gnrc_ipv6_ext_demux(netif, current, pkt, nh);
 
             return;
 #endif
@@ -564,14 +565,14 @@ static void _send_multicast(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt,
 
 static void _send(gnrc_pktsnip_t *pkt, bool prep_hdr)
 {
-    kernel_pid_t iface = KERNEL_PID_UNDEF;
+    gnrc_netif_t *netif = NULL;
     gnrc_pktsnip_t *ipv6, *payload;
     ipv6_hdr_t *hdr;
     /* get IPv6 snip and (if present) generic interface header */
     if (pkt->type == GNRC_NETTYPE_NETIF) {
         /* If there is already a netif header (routing protocols and
          * neighbor discovery might add them to preset sending interface) */
-        iface = ((gnrc_netif_hdr_t *)pkt->data)->if_pid;
+        netif = gnrc_netif_get_by_pid(((gnrc_netif_hdr_t *)pkt->data)->if_pid);
         /* seize payload as temporary variable */
         ipv6 = gnrc_pktbuf_start_write(pkt); /* write protect for later removal
                                               * in _send_unicast() */
@@ -605,94 +606,87 @@ static void _send(gnrc_pktsnip_t *pkt, bool prep_hdr)
     hdr = ipv6->data;
     payload = ipv6->next;
 
-    gnrc_netif_t *netif = (iface == KERNEL_PID_UNDEF) ?
-                            NULL :
-                            gnrc_netif_get_by_pid(iface);
     if (ipv6_addr_is_multicast(&hdr->dst)) {
         _send_multicast(netif, pkt, ipv6, payload, prep_hdr);
     }
-    else if ((ipv6_addr_is_loopback(&hdr->dst)) ||      /* dst is loopback address */
-             ((iface == KERNEL_PID_UNDEF) && /* or dst registered to any local interface */
-              ((netif = gnrc_netif_get_by_ipv6_addr(&hdr->dst)) != NULL)
-             ) || ((iface != KERNEL_PID_UNDEF) && /* or dst registered to given interface */
-              (gnrc_netif_ipv6_addr_idx(netif, &hdr->dst) > 0)
-             )) {
-        uint8_t *rcv_data;
-        gnrc_pktsnip_t *ptr = ipv6, *rcv_pkt;
-
-        if (prep_hdr) {
-            if (_fill_ipv6_hdr(netif, ipv6, payload) < 0) {
-                /* error on filling up header */
-                gnrc_pktbuf_release(pkt);
-                return;
-            }
-        }
-
-        rcv_pkt = gnrc_pktbuf_add(NULL, NULL, gnrc_pkt_len(ipv6), GNRC_NETTYPE_IPV6);
-
-        if (rcv_pkt == NULL) {
-            DEBUG("ipv6: error on generating loopback packet\n");
-            gnrc_pktbuf_release(pkt);
-            return;
-        }
-
-        rcv_data = rcv_pkt->data;
-
-        /* "reverse" packet (by making it one snip as if received from NIC) */
-        while (ptr != NULL) {
-            memcpy(rcv_data, ptr->data, ptr->size);
-            rcv_data += ptr->size;
-            ptr = ptr->next;
-        }
-
-        gnrc_pktbuf_release(pkt);
-
-        DEBUG("ipv6: packet is addressed to myself => loopback\n");
-
-        if (gnrc_netapi_receive(gnrc_ipv6_pid, rcv_pkt) < 1) {
-            DEBUG("ipv6: unable to deliver packet\n");
-            gnrc_pktbuf_release(rcv_pkt);
-        }
-    }
     else {
-        gnrc_ipv6_nib_nc_t nce;
-        gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+        gnrc_netif_t *tmp_netif = gnrc_netif_get_by_ipv6_addr(&hdr->dst);
 
-        if (gnrc_ipv6_nib_get_next_hop_l2addr(&hdr->dst, netif, pkt,
-                                              &nce) < 0) {
-            /* packet is released by NIB */
-            return;
-        }
-        iface = gnrc_ipv6_nib_nc_get_iface(&nce);
-        netif = gnrc_netif_get_by_pid(iface);
-        assert(netif != NULL);
-        if (prep_hdr) {
-            if (_fill_ipv6_hdr(netif, ipv6, payload) < 0) {
-                /* error on filling up header */
+        if (ipv6_addr_is_loopback(&hdr->dst) ||    /* dst is loopback address */
+                /* or dst registered to a local interface */
+                (tmp_netif != NULL)) {
+            uint8_t *rcv_data;
+            gnrc_pktsnip_t *ptr = ipv6, *rcv_pkt;
+
+            if (prep_hdr) {
+                if (_fill_ipv6_hdr(tmp_netif, ipv6, payload) < 0) {
+                    /* error on filling up header */
+                    gnrc_pktbuf_release(pkt);
+                    return;
+                }
+            }
+
+            rcv_pkt = gnrc_pktbuf_add(NULL, NULL, gnrc_pkt_len(ipv6),
+                                      GNRC_NETTYPE_IPV6);
+
+            if (rcv_pkt == NULL) {
+                DEBUG("ipv6: error on generating loopback packet\n");
                 gnrc_pktbuf_release(pkt);
                 return;
             }
-        }
 
-        _send_unicast(netif, nce.l2addr,
-                      nce.l2addr_len, pkt);
+            rcv_data = rcv_pkt->data;
+
+            /* "reverse" packet (by making it one snip as if received from NIC) */
+            while (ptr != NULL) {
+                memcpy(rcv_data, ptr->data, ptr->size);
+                rcv_data += ptr->size;
+                ptr = ptr->next;
+            }
+
+            gnrc_pktbuf_release(pkt);
+
+            DEBUG("ipv6: packet is addressed to myself => loopback\n");
+
+            if (gnrc_netapi_receive(gnrc_ipv6_pid, rcv_pkt) < 1) {
+                DEBUG("ipv6: unable to deliver packet\n");
+                gnrc_pktbuf_release(rcv_pkt);
+            }
+        }
+        else {
+            gnrc_ipv6_nib_nc_t nce;
+
+            if (gnrc_ipv6_nib_get_next_hop_l2addr(&hdr->dst, netif, pkt,
+                                                  &nce) < 0) {
+                /* packet is released by NIB */
+                return;
+            }
+            netif = gnrc_netif_get_by_pid(gnrc_ipv6_nib_nc_get_iface(&nce));
+            assert(netif != NULL);
+            if (prep_hdr) {
+                if (_fill_ipv6_hdr(netif, ipv6, payload) < 0) {
+                    /* error on filling up header */
+                    gnrc_pktbuf_release(pkt);
+                    return;
+                }
+            }
+
+            _send_unicast(netif, nce.l2addr,
+                          nce.l2addr_len, pkt);
+        }
     }
 }
 
 /* functions for receiving */
-static inline bool _pkt_not_for_me(kernel_pid_t *iface, ipv6_hdr_t *hdr)
+static inline bool _pkt_not_for_me(gnrc_netif_t **netif, ipv6_hdr_t *hdr)
 {
     if (ipv6_addr_is_loopback(&hdr->dst)) {
         return false;
     }
     else if ((!ipv6_addr_is_link_local(&hdr->dst)) ||
-             (*iface == KERNEL_PID_UNDEF)) {
-        gnrc_netif_t *netif = gnrc_netif_get_by_ipv6_addr(&hdr->dst);
-        if (*iface == KERNEL_PID_UNDEF) {
-            /* Use original interface for reply if existent */
-            *iface = (netif != NULL) ? netif->pid : KERNEL_PID_UNDEF;
-        }
-        return (netif == NULL);
+             (*netif == NULL)) {
+        *netif = gnrc_netif_get_by_ipv6_addr(&hdr->dst);
+        return (*netif == NULL);
     }
     else {
         return (gnrc_netif_get_by_ipv6_addr(&hdr->dst) == NULL);
@@ -701,22 +695,21 @@ static inline bool _pkt_not_for_me(kernel_pid_t *iface, ipv6_hdr_t *hdr)
 
 static void _receive(gnrc_pktsnip_t *pkt)
 {
-    kernel_pid_t iface = KERNEL_PID_UNDEF;
-    gnrc_pktsnip_t *ipv6, *netif, *first_ext;
+    gnrc_netif_t *netif = NULL;
+    gnrc_pktsnip_t *ipv6, *netif_hdr, *first_ext;
     ipv6_hdr_t *hdr;
 
     assert(pkt != NULL);
 
-    netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
+    netif_hdr = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
 
-    if (netif != NULL) {
-        iface = ((gnrc_netif_hdr_t *)netif->data)->if_pid;
-
+    if (netif_hdr != NULL) {
+        netif = gnrc_netif_get_by_pid(((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid);
 #ifdef MODULE_NETSTATS_IPV6
-        assert(iface);
-        netstats_t *stats = &(gnrc_netif_get_by_pid(iface)->ipv6.stats);
+        assert(netif != NULL);
+        netstats_t *stats = &netif->ipv6.stats;
         stats->rx_count++;
-        stats->rx_bytes += (gnrc_pkt_len(pkt) - netif->size);
+        stats->rx_bytes += (gnrc_pkt_len(pkt) - netif_hdr->size);
 #endif
     }
 
@@ -813,7 +806,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
           ipv6_addr_to_str(addr_str, &(hdr->dst), sizeof(addr_str)),
           hdr->nh, byteorder_ntohs(hdr->len));
 
-    if (_pkt_not_for_me(&iface, hdr)) { /* if packet is not for me */
+    if (_pkt_not_for_me(&netif, hdr)) { /* if packet is not for me */
         DEBUG("ipv6: packet destination not this host\n");
 
 #ifdef MODULE_GNRC_IPV6_ROUTER    /* only routers redirect */
@@ -845,9 +838,9 @@ static void _receive(gnrc_pktsnip_t *pkt)
             }
 
             /* remove L2 headers around IPV6 */
-            netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
-            if (netif != NULL) {
-                gnrc_pktbuf_remove_snip(pkt, netif);
+            netif_hdr = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
+            if (netif_hdr != NULL) {
+                gnrc_pktbuf_remove_snip(pkt, netif_hdr);
             }
 
             /* reverse packet snip list order */
@@ -883,7 +876,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
     }
 
     /* IPv6 internal demuxing (ICMPv6, Extension headers etc.) */
-    gnrc_ipv6_demux(iface, first_ext, pkt, hdr->nh);
+    gnrc_ipv6_demux(netif, first_ext, pkt, hdr->nh);
 }
 
 static void _decapsulate(gnrc_pktsnip_t *pkt)


### PR DESCRIPTION
Replaces most occurrences of `kernel_pid_t` where it makes sense with `gnrc_netif_t *` in the IPv6 (and related) code. This way repeated calls to `gnrc_netif_get_by_pid()` are not necessary anymore.