### PR TITLE
gnrc_netapi: make doc a little more consistent

### DIFF
--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -117,7 +117,7 @@ int gnrc_netapi_send(kernel_pid_t pid, gnrc_pktsnip_t *pkt);
 /**
  * @brief   Sends @p cmd to all subscribers to (@p type, @p demux_ctx).
  *
- * @param[in] type      type of the targeted network module.
+ * @param[in] type      protocol type of the targeted network module.
  * @param[in] demux_ctx demultiplexing context for @p type.
  * @param[in] cmd       command for all subscribers
  * @param[in] pkt       pointer into the packet buffer holding the data to send
@@ -131,7 +131,7 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx, uint16_t cmd,
  * @brief   Sends a @ref GNRC_NETAPI_MSG_TYPE_SND command to all subscribers to
  *          (@p type, @p demux_ctx).
  *
- * @param[in] type      type of the targeted network module.
+ * @param[in] type      protocol type of the targeted network module.
  * @param[in] demux_ctx demultiplexing context for @p type.
  * @param[in] pkt       pointer into the packet buffer holding the data to send
  *
@@ -158,7 +158,7 @@ int gnrc_netapi_receive(kernel_pid_t pid, gnrc_pktsnip_t *pkt);
  * @brief   Sends a @ref GNRC_NETAPI_MSG_TYPE_RCV command to all subscribers to
  *          (@p type, @p demux_ctx).
  *
- * @param[in] type      type of the targeted network module.
+ * @param[in] type      protocol type of the targeted network module.
  * @param[in] demux_ctx demultiplexing context for @p type.
  * @param[in] pkt       pointer into the packet buffer holding the data to send
  *


### PR DESCRIPTION
Throughout the documentation `gnrc_nettype_t` is referred to as a
"protocol type". The documentation for the functions
`gnrc_netapi_dispatch_*()` that were added later only refer to it as
"type".

This fix changes those to "protocol type" to make this clearer in the
context of these functions and unify it with the rest of the
documentation.