### PR TITLE
tests: optimise and automate mutex_unlock_and_sleep

### DIFF
--- a/tests/mutex_unlock_and_sleep/Makefile
+++ b/tests/mutex_unlock_and_sleep/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
-
 DISABLE_MODULE += auto_init
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/mutex_unlock_and_sleep/Makefile
+++ b/tests/mutex_unlock_and_sleep/Makefile
@@ -3,3 +3,6 @@ include ../Makefile.tests_common
 DISABLE_MODULE += auto_init
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/mutex_unlock_and_sleep/tests/01-run.py
+++ b/tests/mutex_unlock_and_sleep/tests/01-run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+import testrunner
+
+
+def testfunc(child):
+    for i in range(20):
+        child.expect(r"\[ALIVE\] alternated \d+k times.")
+
+if __name__ == "__main__":
+    sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
PR enhances `tests/mutex_unlock_and_sleep` reducing memory footprint below 4K allowing to clear list of boards with insufficient memory. Further this PR adds a script for automated testing.