### PR TITLE
docheck: make doccheck executable from any directory

### DIFF
--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -8,7 +8,9 @@
 
 RIOTBASE=$(readlink -f "$(dirname $(realpath $0))/../../..")
 
-ERRORS=$(make doc 2>&1 | grep '.*warning' | sed "s#${PWD}/\([^:]*\)#\1#g")
+ERRORS=$(make -C "${RIOTBASE}" doc 2>&1 | \
+            grep '.*warning' | \
+            sed "s#${PWD}/\([^:]*\)#\1#g")
 
 if [ -n "${ERRORS}" ]
 then


### PR DESCRIPTION
The doccheck script reports reports a false positive when executed from
any directory but `RIOTBASE`. With this fix, `make doc` changes into
the currently unused `RIOTBASE` variable.

This is an alternative approach to #7217, which removes this variable,
but keeps the false positive aspect of the script untouched.