### PR TITLE
drivers/sx127x: cleanup RX/TX timers

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -176,7 +176,6 @@ typedef struct {
  */
 typedef struct {
     uint32_t channel;                  /**< Radio channel */
-    uint32_t window_timeout;           /**< Timeout window */
     uint8_t state;                     /**< Radio state */
     uint8_t modem;                     /**< Driver model (FSK or LoRa) */
     sx127x_lora_settings_t lora;       /**< LoRa settings */

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -309,9 +309,8 @@ void sx127x_set_rx(sx127x_t *dev)
     }
 
     sx127x_set_state(dev, SX127X_RF_RX_RUNNING);
-    if (dev->settings.window_timeout != 0) {
-        xtimer_set(&(dev->_internal.rx_timeout_timer),
-                   dev->settings.window_timeout);
+    if (dev->settings.lora.rx_timeout != 0) {
+        xtimer_set(&(dev->_internal.rx_timeout_timer), dev->settings.lora.rx_timeout);
     }
 
     if (dev->settings.lora.flags & SX127X_RX_CONTINUOUS_FLAG) {
@@ -372,9 +371,8 @@ void sx127x_set_tx(sx127x_t *dev)
     }
 
     sx127x_set_state(dev, SX127X_RF_RX_RUNNING);
-    if (dev->settings.window_timeout != 0) {
-        xtimer_set(&(dev->_internal.tx_timeout_timer),
-                   dev->settings.window_timeout);
+    if (dev->settings.lora.tx_timeout != 0) {
+        xtimer_set(&(dev->_internal.tx_timeout_timer), dev->settings.lora.tx_timeout);
     }
     sx127x_set_op_mode(dev, SX127X_RF_OPMODE_TRANSMITTER );
 }

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -500,8 +500,8 @@ static int _set_state(sx127x_t *dev, netopt_state_t state)
             break;
 
         case NETOPT_STATE_IDLE:
-            dev->settings.window_timeout = 0;
             /* set permanent listening */
+            sx127x_set_rx_timeout(dev, 0);
             sx127x_set_rx(dev);
             break;
 

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -241,6 +241,7 @@ int listen_cmd(int argc, char **argv)
 
     /* Switch to continuous listen mode */
     netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, false, sizeof(uint8_t));
+    netdev->driver->set(netdev, NETOPT_RX_TIMEOUT, 0, sizeof(uint8_t));
 
     /* Switch to RX state */
     uint8_t state = NETOPT_STATE_RX;


### PR DESCRIPTION
This PR is a small cleanup of a SX127x drivers. It basically removes the useless window timeout param (not used in the original semtech drivers).

This PR doesn't have any effect with the current behaviour of the test application but it does when working with LoRaMAC.

Maybe @dylad is interested in having a look.