### PR TITLE
net/gcoap: Require interface for link local address in shell example

### DIFF
--- a/examples/gcoap/README.md
+++ b/examples/gcoap/README.md
@@ -58,7 +58,7 @@ Start the libcoap example server with the command below.
 
 Enter the query below in the RIOT CLI.
 
-    > coap get fe80::d8b8:65ff:feee:121b 5683 /.well-known/core
+    > coap get fe80::d8b8:65ff:feee:121b%6 5683 /.well-known/core
 
 CLI output:
 


### PR DESCRIPTION
Networking infrastructure updates require that a message to a link local address specifies the interface to use, as discussed in #8199. This PR accepts an interface ID in the gcoap shell example, and requires it for a link local address. See the example below.
```
coap get fe80::d8b8:65ff:feee:121b%6 5683 /.well-known/core
```