### PR TITLE
sys/fmt: fix overflow in fmt_u32_dec()

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -164,8 +164,14 @@ size_t fmt_u32_dec(char *out, uint32_t val)
     size_t len = 1;
 
     /* count needed characters */
-    for (uint32_t tmp = 10; tmp <= val; len++) {
-        tmp *= 10;
+    /* avoid multiply overflow: uint32_t max len = 10 digits */
+    if (val >= 1000000000ul) {
+        len = 10;
+    }
+    else {
+        for (uint32_t tmp = 10; tmp <= val; len++) {
+            tmp *= 10;
+        }
     }
 
     if (out) {

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -81,7 +81,7 @@ static void test_fmt_u64_hex(void)
 
 static void test_fmt_u32_dec(void)
 {
-    char out[9] = "--------";
+    char out[11] = "----------";
     uint32_t val = 12345678;
     uint8_t chars = 0;
 
@@ -89,6 +89,13 @@ static void test_fmt_u32_dec(void)
     TEST_ASSERT_EQUAL_INT(8, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("12345678", (char *) out);
+
+    memset(out, '-', sizeof(out));
+    val = 1234567890;
+    chars = fmt_u32_dec(out, val);
+    TEST_ASSERT_EQUAL_INT(10, chars);
+    out[chars] = '\0';
+    TEST_ASSERT_EQUAL_STRING("1234567890", (char *) out);
 }
 
 static void test_fmt_u16_dec(void)


### PR DESCRIPTION
If the value was 10 digits long it caused an overflow in the multiply loop.
The case is now tested before looping over.