### PR TITLE
periph_common: Call hwrng_init when enabled

### DIFF
--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -26,6 +26,9 @@
 #ifdef MODULE_PERIPH_RTC
 #include "periph/rtc.h"
 #endif
+#ifdef MODULE_PERIPH_HWRNG
+#include "periph/hwrng.h"
+#endif
 
 void periph_init(void)
 {
@@ -39,5 +42,9 @@ void periph_init(void)
     /* Initialize RTC */
 #ifdef MODULE_PERIPH_RTC
     rtc_init();
+#endif
+
+#ifdef MODULE_PERIPH_HWRNG
+    hwrng_init();
 #endif
 }

--- a/tests/periph_hwrng/main.c
+++ b/tests/periph_hwrng/main.c
@@ -34,9 +34,6 @@ int main(void)
     printf("This test will print from 1 to %u random bytes about every "
            "second\n\n", LIMIT);
 
-    puts("Initializing the HWRNG driver.\n");
-    hwrng_init();
-
     while (1) {
         /* zero out buffer */
         memset(buf, 0, sizeof(buf));

--- a/tests/pkg_micro-ecc-with-hwrng/main.c
+++ b/tests/pkg_micro-ecc-with-hwrng/main.c
@@ -61,9 +61,6 @@ int main(void)
 
     printf("Testing %d random private key pairs and signature using HWRNG\n", TESTROUNDS);
 
-    /* initialize hardware random number generator */
-    hwrng_init();
-
     uint8_t l_private1[curve_size];
     uint8_t l_private2[curve_size];
 


### PR DESCRIPTION
This adds a call to hwrng_init from periph_init if the periph_hwrng module is enabled, to eliminate the need to explicitly call it from the application code. The tests which called hwrng_init are also updated to remove that call.