### PR TITLE
saml21: Update FEATURE_PERIPH_PM -> MODULE_PERIPH_PM

### DIFF
--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -68,7 +68,7 @@ void cpu_init(void)
     _gclk_setup(0, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSC16M);
     _gclk_setup(1, GCLK_GENCTRL_GENEN | GCLK_GENCTRL_SRC_OSCULP32K);
 
-#ifdef FEATURE_PERIPH_PM
+#ifdef MODULE_PERIPH_PM
     /* enable power managemet module */
     MCLK->APBAMASK.reg |= MCLK_APBAMASK_PM;
     PM->CTRLA.reg = PM_CTRLA_MASK & (~PM_CTRLA_IORET);


### PR DESCRIPTION
The saml21 contained a preprocessor check for the deprecated FEATURE_PERIPH_PM define.