### PR TITLE
Makefile.include: Remove --cref from linking flags

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -310,7 +310,7 @@ LINKFLAGPREFIX ?= -Wl,
 
 DIRS += $(EXTERNAL_MODULE_DIRS)
 
-_LINK = $(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group  $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map $(LINKFLAGPREFIX)--cref $(LINKFLAGS)
+_LINK = $(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group  $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map $(LINKFLAGS)
 
 ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container


### PR DESCRIPTION
Seem to cause internal linker errors and linker segfaults under some circumstances when using gold as the linker.

This will reduce the verbosity of the linker map, but it can always be re-added for a specific build via the LINKFLAGS environment variable.

I can't specify more about the segfaults other than that I have seen it happen from time to time with different versions of binutils on my own machine, but only when using ld.gold instead of ld.bfd for the default linker. Both native and arm-none-eabi ld have been affected.

The error message is always something like the below:
```
/usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/../../../../x86_64-pc-linux-gnu/bin/ld: internal error in operator(), at /var/tmp/portage/sys-devel/binutils-2.29.1-r1/work/binutils-2.29.1/gold/cref.cc:242
collect2: error: ld returned 1 exit status
```