### PR TITLE
at86rf2xx: Use AWAKE_END IRQ to detect exit from SLEEP mode

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -27,6 +27,7 @@
 
 #include "luid.h"
 #include "byteorder.h"
+#include "mutex.h"
 #include "net/ieee802154.h"
 #include "net/gnrc.h"
 #include "at86rf2xx_registers.h"
@@ -48,6 +49,8 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params)
     /* radio state is P_ON when first powered-on */
     dev->state = AT86RF2XX_STATE_P_ON;
     dev->pending_tx = 0;
+    mutex_init(&dev->mutex_sleep);
+    mutex_lock(&dev->mutex_sleep);
 }
 
 void at86rf2xx_reset(at86rf2xx_t *dev)

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -57,7 +57,7 @@ extern "C" {
  * @brief   Transition time from SLEEP to TRX_OFF in us, refer figure 7-4, p.42.
  *          For different environments refer figure 13-13, p.201
  */
-#define AT86RF2XX_WAKEUP_DELAY          (306U)
+#define AT86RF2XX_WAKEUP_DELAY          (1000U)
 
 /**
  * @brief   Minimum reset pulse width, refer p.190. We use 62us so

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "mutex.h"
 #include "board.h"
 #include "periph/spi.h"
 #include "periph/gpio.h"
@@ -168,22 +169,24 @@ typedef struct at86rf2xx_params {
  * @extends netdev_ieee802154_t
  */
 typedef struct {
-    netdev_ieee802154_t netdev;             /**< netdev parent struct */
+    netdev_ieee802154_t netdev;  /**< netdev parent struct */
     /* device specific fields */
-    at86rf2xx_params_t params;              /**< parameters for initialization */
-    uint8_t state;                          /**< current state of the radio */
-    uint8_t tx_frame_len;                   /**< length of the current TX frame */
+    at86rf2xx_params_t params;   /**< parameters for initialization */
+    mutex_t mutex_sleep;         /**< used when waiting for the AWAKE_END IRQ */
+    uint8_t irq_mask;            /**< IRQ_MASK register backup during sleep */
+    uint8_t state;               /**< current state of the radio */
+    uint8_t tx_frame_len;        /**< length of the current TX frame */
 #ifdef MODULE_AT86RF212B
     /* Only AT86RF212B supports multiple pages (PHY modes) */
-    uint8_t page;                       /**< currently used channel page */
+    uint8_t page;                /**< currently used channel page */
 #endif
-    uint8_t idle_state;                 /**< state to return to after sending */
-    uint8_t pending_tx;                 /**< keep track of pending TX calls
-                                             this is required to know when to
-                                             return to @ref at86rf2xx_t::idle_state */
+    uint8_t idle_state;          /**< state to return to after sending */
+    uint8_t pending_tx;          /**< keep track of pending TX calls
+                                      this is required to know when to
+                                      return to @ref at86rf2xx_t::idle_state */
 #if AT86RF2XX_HAVE_RETRIES
     /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
-    uint8_t tx_retries;                 /**< Number of NOACK retransmissions */
+    uint8_t tx_retries;          /**< Number of NOACK retransmissions */
 #endif
     /** @} */
 } at86rf2xx_t;


### PR DESCRIPTION
Alternative to #7865.

All IRQs are masked upon entry into SLEEP mode, and the AWAKE_END IRQ is enabled. Upon exit from sleep, the netdev thread is waiting for a mutex which will be unlocked from the at86rf2xx IRQ pin ISR (no other IRQs can occur while the transceiver is sleeping so there is no need to read any registers to check the IRQ status flags etc.)

If IRQs are disabled in the system when the software wants to exit sleep mode, then the behaviour is the same as the master version where the thread will sleep for a predefined time before checking the transceiver state.

Only very briefly tested on actual hardware, needs more testing in real applications.