### PR TITLE
cpu/sam0_common: fix assert in periph/flashpage

### DIFF
--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -68,7 +68,7 @@ void flashpage_write_raw(void *target_addr, void *data, size_t len)
             ((unsigned)data % FLASHPAGE_RAW_ALIGNMENT)));
 
     /* ensure the length doesn't exceed the actual flash size */
-    assert(((uint8_t*)target_addr + len) <
+    assert(((unsigned)target_addr + len) <
            (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)));
 
     uint32_t *dst = (uint32_t *)target_addr;


### PR DESCRIPTION
needed for #8080, fixes an error with comparison of pointer and int.