### PR TITLE
gnrc_gomach: add sender ID number limit in beacon packet.

### DIFF
--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -277,6 +277,19 @@ extern "C" {
 #endif
 
 /**
+ * @brief Maximum number of senders allowed to be allocated slots in one cycle.
+ *
+ * Exclude the static GoMacH MAC header payload in the beacon, which is 20 bytes,
+ * we have 107 bytes left for constructing the sender-ID list and the related slots-number
+ * list. A combined slots allocation information pair (sender ID with its corresponded
+ * allocate slots number) will cost 9 (8+1) bytes, thus we can hold a maximum of 11
+ * i.e., ((127 - 20) / 9), sender IDs in the beacon.
+ */
+#ifndef GNRC_GOMACH_MAX_ALLOC_SENDER_NUM
+#define GNRC_GOMACH_MAX_ALLOC_SENDER_NUM          (11U)
+#endif
+
+/**
  * @brief Maximum t2k attempts before going to t2u in GoMacH.
  *
  * After phase-locked with the receiver, a sender runs a t2k (transmit-to-known)

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -488,7 +488,13 @@ int gnrc_gomach_send_beacon(gnrc_netif_t *netif)
                 total_tdma_slot_num -= redueced_slots_num;
                 break;
             }
+
             j++;
+
+            /* If reach the maximum sender ID number limit, stop. */
+            if (total_tdma_node_num >= GNRC_GOMACH_MAX_ALLOC_SENDER_NUM) {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
This PR is mainly about a bug-fix.

It intends to add a limit for restricting the number of senders that will be allocated slots in one cycle in GoMacH protocol.

Exclude the static GoMacH MAC header payload in the beacon, which is 20 bytes (17 bytes of 15.4 MAC header payload + 3 bytes of specific GoMacH MAC header payload), we have 107 bytes left for constructing the sender-ID list and the related slots-number list. A combined slots allocation information pair (sender ID with its corresponded allocate slots number) will cost 9 (8+1) bytes, thus we can hold a maximum of 11, i.e., ((127 - 20) / 9), sender IDs in the beacon.