### PR TITLE
nanocoap: fix doxygen grouping

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    sys_net_nanocoap nanocoap small CoAP library
- * @ingroup     sys_net
+ * @defgroup    net_nanocoap nanocoap small CoAP library
+ * @ingroup     net
  * @brief       Provides CoAP functionality optimized for minimal resource usage
  *
  * @{


### PR DESCRIPTION
The doxygen group for the networking module is `net`, not `sys_net`. By using `sys_net` nanocoap appears in the [module root](https://doc.riot-os.org/modules.html) of the documentation.