### PR TITLE
sys/timex: make NS_PER_US unsigned

### DIFF
--- a/sys/include/timex.h
+++ b/sys/include/timex.h
@@ -56,7 +56,7 @@ extern "C" {
 /**
  * @brief The number of nanoseconds per microsecond
  */
-#define NS_PER_US  (1000)
+#define NS_PER_US  (1000U)
 
 /**
  * @brief The maximum length of the string representation of a timex timestamp


### PR DESCRIPTION
Seems like the missing `U` here was a mistake, right? But as the value of the `NS_IN_US` define is clearly unsigned, I guess the value should be marked as such. 