### PR TITLE
unittests: Fix printf float test BUFSIZE

### DIFF
--- a/tests/unittests/tests-printf_float/tests-printf_float.c
+++ b/tests/unittests/tests-printf_float/tests-printf_float.c
@@ -25,7 +25,7 @@
 
 #include "tests-printf_float.h"
 
-#define BUFSIZE             (10)
+#define BUFSIZE             (12)
 
 static const double in0 = 2016.0349;
 static const double in1 = 123.4567;
@@ -37,7 +37,7 @@ static void sfprintf_float(void)
     char *str = tmp;
 
     snprintf(str, BUFSIZE, "%f", in0);
-    TEST_ASSERT_EQUAL_STRING("2016.0349", str);
+    TEST_ASSERT_EQUAL_STRING("2016.034900", str);
 
     snprintf(str, BUFSIZE, "%.2f", in0);
     TEST_ASSERT_EQUAL_STRING("2016.03", str);


### PR DESCRIPTION
### Contribution description

Fixes the following error from GCC 7.2.0 with a recent newlib

```
In file included from /usr/arm-none-eabi/include/stdio.h:800:0,
                 from /home/jgn/work/src/riot/tests/unittests/tests-printf_float/tests-printf_float.c:21:
/home/jgn/work/src/riot/tests/unittests/tests-printf_float/tests-printf_float.c: In function ‘sfprintf_float’:
/home/jgn/work/src/riot/tests/unittests/tests-printf_float/tests-printf_float.c:39:28: error: ‘%f’ directive output truncated writing 11 bytes into a region of size 10 [-Werror=format-truncation=]
     snprintf(str, BUFSIZE, "%f", in0);
                            ^
/home/jgn/work/src/riot/tests/unittests/tests-printf_float/tests-printf_float.c:39:5: note: ‘__builtin_snprintf’ output 12 bytes into a destination of size 10
     snprintf(str, BUFSIZE, "%f", in0);
     ^
cc1: all warnings being treated as errors
```

The expected test output had to be updated as well, so it might be a good idea to re-run this on some other newlib versions. Tests pass on native and mulle.

### Issues/PRs references

#8265 