### PR TITLE
tests: fix python style E502 issue

### DIFF
--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -308,7 +308,7 @@ def test_triple_send(board_group, application, env=None):
         receiver.expect(u"00000000  DE  AD  BE  EF")
 
 if __name__ == "__main__":
-    TestStrategy().execute([BoardGroup((Board("native", "tap0"), \
-                            Board("native", "tap1")))], \
+    TestStrategy().execute([BoardGroup((Board("native", "tap0"),
+                            Board("native", "tap1")))],
                            [test_ipv6_send, test_udpv6_send, test_tcpv6_send,
                             test_triple_send])

--- a/tests/posix_time/tests/01-run.py
+++ b/tests/posix_time/tests/01-run.py
@@ -41,7 +41,7 @@ def testfunc(child):
         lower_bound = exp - (exp * EXTERNAL_JITTER)
         upper_bound = exp + (exp * EXTERNAL_JITTER)
         if not (lower_bound < testtime < upper_bound):
-            raise InvalidTimeout("Host timer measured %d us (client measured %d us)" % \
+            raise InvalidTimeout("Host timer measured %d us (client measured %d us)" %
                                  (testtime, exp))
     except InvalidTimeout as e:
         print(e)

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -48,7 +48,7 @@ def testfunc(child):
         lower_bound = exp - (exp * EXTERNAL_JITTER)
         upper_bound = exp + (exp * EXTERNAL_JITTER)
         if not (lower_bound < testtime < upper_bound):
-            raise InvalidTimeout("Host timer measured %d us (client measured %d us)" % \
+            raise InvalidTimeout("Host timer measured %d us (client measured %d us)" %
                                  (testtime, exp))
     except InvalidTimeout as e:
         print(e)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR partially addresses #8141 by fixing python style error E502: 'the backslash is redundant between brackets'

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

refs #8141 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->