### PR TITLE
tests: fix python style E305

### DIFF
--- a/tests/bitarithm_timings/tests/01-run.py
+++ b/tests/bitarithm_timings/tests/01-run.py
@@ -20,5 +20,6 @@ def testfunc(child):
     child.expect('\+ bitarithm_bits_set: \d+ iterations per second')
     child.expect_exact("Done.")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=30))

--- a/tests/bloom_bytes/tests/01-run.py
+++ b/tests/bloom_bytes/tests/01-run.py
@@ -23,5 +23,6 @@ def testfunc(child):
     child.expect(".+ false positive rate.")
     child.expect_exact("All done!")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/buttons/tests/01-run.py
+++ b/tests/buttons/tests/01-run.py
@@ -23,5 +23,6 @@ def testfunc(child):
     if index == 1:
         child.expect_exact("[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/cbor/tests/01-run.py
+++ b/tests/cbor/tests/01-run.py
@@ -51,5 +51,6 @@ def testfunc(child):
 
     print("All tests successful")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, echo=False))

--- a/tests/cpp11_condition_variable/tests/01-run.py
+++ b/tests/cpp11_condition_variable/tests/01-run.py
@@ -27,5 +27,6 @@ def testfunc(child):
     child.expect_exact("Bye, bye.")
     child.expect_exact("******************************************************")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/cpp11_mutex/tests/01-run.py
+++ b/tests/cpp11_mutex/tests/01-run.py
@@ -23,5 +23,6 @@ def testfunc(child):
     child.expect_exact("Bye, bye.")
     child.expect_exact("*****************************************")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/cpp11_thread/tests/01-run.py
+++ b/tests/cpp11_thread/tests/01-run.py
@@ -35,5 +35,6 @@ def testfunc(child):
     child.expect_exact("Bye, bye.")
     child.expect_exact("******************************************")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/driver_ds1307/tests/01-run.py
+++ b/tests/driver_ds1307/tests/01-run.py
@@ -17,5 +17,6 @@ def testfunc(child):
     child.expect([r"OK \([0-9]+ tests\)",
                   r"error: unable to initialize RTC \[I2C initialization error\]"])
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/driver_grove_ledbar/tests/01-run.py
+++ b/tests/driver_grove_ledbar/tests/01-run.py
@@ -17,5 +17,6 @@ import testrunner
 def testfunc(child):
     child.expect_exact(u"[SUCCESS]", timeout=60)
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/driver_hd44780/tests/01-run.py
+++ b/tests/driver_hd44780/tests/01-run.py
@@ -18,5 +18,6 @@ def testfunc(child):
     child.expect_exact("[START]")
     child.expect_exact("[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/driver_my9221/tests/01-run.py
+++ b/tests/driver_my9221/tests/01-run.py
@@ -17,5 +17,6 @@ import testrunner
 def testfunc(child):
     child.expect_exact("[SUCCESS]", timeout=60)
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/events/tests/01-run.py
+++ b/tests/events/tests/01-run.py
@@ -17,5 +17,6 @@ import testrunner
 def testfunc(child):
     child.expect_exact(u"[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/evtimer_msg/tests/01-run.py
+++ b/tests/evtimer_msg/tests/01-run.py
@@ -31,5 +31,6 @@ def testfunc(child):
     print("")
     print("All tests successful")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, echo=False))

--- a/tests/evtimer_underflow/tests/01-run.py
+++ b/tests/evtimer_underflow/tests/01-run.py
@@ -25,5 +25,6 @@ def testfunc(child):
     print("Stopped after %i iterations, but should run forever." % how_many)
     print("=> All tests successful")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, echo=False))

--- a/tests/float/tests/01-run.py
+++ b/tests/float/tests/01-run.py
@@ -17,5 +17,6 @@ def testfunc(child):
     child.expect_exact("Testing floating point arithmetics...")
     child.expect_exact("[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/fmt_print/tests/01-run.py
+++ b/tests/fmt_print/tests/01-run.py
@@ -11,5 +11,6 @@ def testfunc(child):
     child.expect_exact('If you can read this:')
     child.expect_exact('Test successful.')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/gnrc_ipv6_ext/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext/tests/01-run.py
@@ -40,5 +40,6 @@ def testfunc(child):
     child.expect_exact("ipv6: forward nh = 17 to other threads")
     child.expect_exact("pkt->users: 0")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/gnrc_ipv6_nib/tests/01-run.py
+++ b/tests/gnrc_ipv6_nib/tests/01-run.py
@@ -17,5 +17,6 @@ import testrunner
 def testfunc(child):
     child.expect(r"OK \(\d+ tests\)")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=1))

--- a/tests/gnrc_ipv6_nib_6ln/tests/01-run.py
+++ b/tests/gnrc_ipv6_nib_6ln/tests/01-run.py
@@ -17,5 +17,6 @@ import testrunner
 def testfunc(child):
     child.expect(r"OK \(\d+ tests\)")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=1))

--- a/tests/gnrc_ndp/tests/01-run.py
+++ b/tests/gnrc_ndp/tests/01-run.py
@@ -18,5 +18,6 @@ def testfunc(child):
     # 1st 6LoWPAN fragment
     child.expect(r"OK \(\d+ tests\)")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/gnrc_netif/tests/01-run.py
+++ b/tests/gnrc_netif/tests/01-run.py
@@ -139,5 +139,6 @@ def testfunc(child):
     child.expect("dst_l2addr: 3e:e6:b5:22:fd:0a")
     child.expect("~~ PKT    -  2 snips, total size:  61 byte")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=1, traceback=True))

--- a/tests/gnrc_sixlowpan/tests/01-run.py
+++ b/tests/gnrc_sixlowpan/tests/01-run.py
@@ -77,5 +77,6 @@ def testfunc(child):
     child.expect_exact("source address: fe80::ff:fe00:2")
     child.expect_exact("destination address: fd01::1")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/gnrc_sock_ip/tests/01-run.py
+++ b/tests/gnrc_sock_ip/tests/01-run.py
@@ -50,5 +50,6 @@ def testfunc(child):
     child.expect_exact(u"Calling test_sock_ip_send__no_sock()")
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/gnrc_sock_udp/tests/01-run.py
+++ b/tests/gnrc_sock_udp/tests/01-run.py
@@ -54,5 +54,6 @@ def testfunc(child):
     child.expect_exact(u"Calling test_sock_udp_send__no_sock()")
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/irq/tests/01-run.py
+++ b/tests/irq/tests/01-run.py
@@ -11,5 +11,6 @@ def testfunc(child):
     child.expect('START')
     child.expect('SUCCESS')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/libfixmath/tests/01-run.py
+++ b/tests/libfixmath/tests/01-run.py
@@ -40,5 +40,6 @@ def testfunc(child):
     expect_binary(child)
     child.expect_exact('SUCCESS')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/libfixmath_unittests/tests/01-run.py
+++ b/tests/libfixmath_unittests/tests/01-run.py
@@ -16,5 +16,6 @@ import testrunner
 def testfunc(child):
     child.expect('SUCCESS')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -307,6 +307,7 @@ def test_triple_send(board_group, application, env=None):
         sender.expect_exact(u"Success: send 4 byte over TCP to server")
         receiver.expect(u"00000000  DE  AD  BE  EF")
 
+
 if __name__ == "__main__":
     TestStrategy().execute([BoardGroup((Board("native", "tap0"), \
                             Board("native", "tap1")))], \

--- a/tests/lwip_sock_ip/tests/01-run.py
+++ b/tests/lwip_sock_ip/tests/01-run.py
@@ -98,5 +98,6 @@ def testfunc(child):
         child.expect_exact(u"Calling test_sock_ip_send6__no_sock()")
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/lwip_sock_tcp/tests/01-run.py
+++ b/tests/lwip_sock_tcp/tests/01-run.py
@@ -92,5 +92,6 @@ def testfunc(child):
         child.expect_exact("Calling test_tcp_write6__success()")
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=60))

--- a/tests/lwip_sock_udp/tests/01-run.py
+++ b/tests/lwip_sock_udp/tests/01-run.py
@@ -110,5 +110,6 @@ def testfunc(child):
         child.expect_exact(u"Calling test_sock_udp_send6__no_sock()")
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/msg_avail/tests/01-run.py
+++ b/tests/msg_avail/tests/01-run.py
@@ -17,5 +17,6 @@ import testrunner
 def testfunc(child):
     child.expect_exact(u"[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/msg_send_receive/tests/01-run.py
+++ b/tests/msg_send_receive/tests/01-run.py
@@ -16,5 +16,6 @@ import testrunner
 def testfunc(child):
     child.expect(u"Test successful.")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/msg_try_receive/tests/01-run.py
+++ b/tests/msg_try_receive/tests/01-run.py
@@ -11,5 +11,6 @@ def testfunc(child):
     child.expect('main starting')
     child.expect('msg available: 1 \(should be 1\!\)')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/mutex_order/tests/01-run.py
+++ b/tests/mutex_order/tests/01-run.py
@@ -32,5 +32,6 @@ def testfunc(child):
         assert(int(child.match.group(1)) > last)
         last = int(child.match.group(1))
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/mutex_unlock_and_sleep/tests/01-run.py
+++ b/tests/mutex_unlock_and_sleep/tests/01-run.py
@@ -17,5 +17,6 @@ def testfunc(child):
     for i in range(20):
         child.expect(r"\[ALIVE\] alternated \d+k times.")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/netdev_test/tests/01-run.py
+++ b/tests/netdev_test/tests/01-run.py
@@ -24,5 +24,6 @@ def testfunc(child):
     child.expect_exact(' + succeeded.')
     child.expect_exact('ALL TESTS SUCCESSFUL')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/netstats_l2/tests/01-run.py
+++ b/tests/netstats_l2/tests/01-run.py
@@ -18,6 +18,7 @@ def testfunc(child):
     child.expect(r'        TX packets \d+ \(Multicast: \d+\)  bytes \d+')
     child.expect(r'        TX succeeded \d+ errors \d+')
 
+
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
     from testrunner import run

--- a/tests/nhdp/tests/01-run.py
+++ b/tests/nhdp/tests/01-run.py
@@ -16,5 +16,6 @@ import testrunner
 def testfunc(child):
     child.expect_exact('SUCCESS: NHDP compiled!')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/od/tests/01-run.py
+++ b/tests/od/tests/01-run.py
@@ -41,5 +41,6 @@ def testfunc(child):
 
     print("All tests successful")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=1, echo=False))

--- a/tests/od/tests/02-run.py
+++ b/tests/od/tests/02-run.py
@@ -41,5 +41,6 @@ def testfunc(child):
 
     print("All tests successful")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=1, echo=False))

--- a/tests/periph_timer/tests/01-run.py
+++ b/tests/periph_timer/tests/01-run.py
@@ -23,5 +23,6 @@ def testfunc(child):
         child.expect_exact('TIMER_{}: starting'.format(timer))
     child.expect('TEST SUCCEEDED')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/pipe/tests/01-run.py
+++ b/tests/pipe/tests/01-run.py
@@ -31,5 +31,6 @@ def testfunc(child):
     child.expect_exact('End read: <YZ> [24:26]')
     child.expect_exact('End done.')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/pkg_jsmn/tests/01-run.py
+++ b/tests/pkg_jsmn/tests/01-run.py
@@ -17,5 +17,6 @@ def testfunc(child):
     child.expect_exact('  * audio')
     child.expect_exact('  * video')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/pkg_libcoap/tests/01-run.py
+++ b/tests/pkg_libcoap/tests/01-run.py
@@ -10,5 +10,6 @@ import testrunner
 def testfunc(child):
     child.expect_exact('SUCCESS: Libcoap compiled!')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/pkg_micro-ecc-with-hwrng/tests/01-run.py
+++ b/tests/pkg_micro-ecc-with-hwrng/tests/01-run.py
@@ -14,5 +14,6 @@ def testfunc(child):
     child.expect_exact('................ done with 0 error(s)')
     child.expect_exact('SUCCESS')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=60))

--- a/tests/pkg_micro-ecc/tests/01-run.py
+++ b/tests/pkg_micro-ecc/tests/01-run.py
@@ -14,5 +14,6 @@ def testfunc(child):
     child.expect_exact('................ done with 0 error(s)')
     child.expect_exact('SUCCESS')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=60))

--- a/tests/pkg_minmea/tests/01-run.py
+++ b/tests/pkg_minmea/tests/01-run.py
@@ -11,5 +11,6 @@ def testfunc(child):
     child.expect_exact('START')
     child.expect_exact('SUCCESS')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/pkg_tiny-asn1/tests/01-run.py
+++ b/tests/pkg_tiny-asn1/tests/01-run.py
@@ -17,5 +17,6 @@ import testrunner
 def testfunc(child):
     child.expect('Decoding finished succesfully')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/pkg_u8g2/tests/01-run.py
+++ b/tests/pkg_u8g2/tests/01-run.py
@@ -69,6 +69,7 @@ def testfunc(child):
     for line in EXPECTED_STDOUT:
         child.expect_exact(line)
 
+
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
     from testrunner import run

--- a/tests/pkg_umorse/tests/01-run.py
+++ b/tests/pkg_umorse/tests/01-run.py
@@ -22,5 +22,6 @@ def testfunc(child):
 
     child.expect_exact("[SUCCESS]", timeout=120)
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/posix_semaphore/tests/01-run.py
+++ b/tests/posix_semaphore/tests/01-run.py
@@ -99,5 +99,6 @@ def testfunc(child):
     test4(child)
     child.expect("######################### DONE")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/posix_time/tests/01-run.py
+++ b/tests/posix_time/tests/01-run.py
@@ -47,5 +47,6 @@ def testfunc(child):
         print(e)
         sys.exit(1)
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, echo=True))

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -62,5 +62,6 @@ def testfunc(child):
     _check_help(child)
     _check_ps(child)
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/pthread_tls/tests/01-run.py
+++ b/tests/pthread_tls/tests/01-run.py
@@ -37,5 +37,6 @@ def testfunc(child):
     child.expect('tls tests finished.')
     child.expect('SUCCESS')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/rmutex/tests/01-run.py
+++ b/tests/rmutex/tests/01-run.py
@@ -46,5 +46,6 @@ def testfunc(child):
             child.expect(u"T%i \(prio %i, depth %i\): locked rmutex now" %
                          (T, thread_prio[T], depth))
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/sched_testing/tests/01-run.py
+++ b/tests/sched_testing/tests/01-run.py
@@ -17,5 +17,6 @@ def testfunc(child):
     child.expect_exact('yield 2')
     child.expect_exact('done')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -57,5 +57,6 @@ def testfunc(child):
     for cmd, expected in CMDS.items():
         check_cmd(child, cmd, expected)
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/sizeof_tcb/tests/01-run.py
+++ b/tests/sizeof_tcb/tests/01-run.py
@@ -27,5 +27,6 @@ def testfunc(child):
     child.expect_exact('\tmsg_array     4  32')
     child.expect_exact('SUCCESS')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/ssp/tests/01-run.py
+++ b/tests/ssp/tests/01-run.py
@@ -17,5 +17,6 @@ def testfunc(child):
     child.expect_exact('calling stack corruption function')
     child.expect('.*stack smashing detected.*')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/struct_tm_utility/tests/01-run.py
+++ b/tests/struct_tm_utility/tests/01-run.py
@@ -115,5 +115,6 @@ def testfunc(child):
     _check_doomsday(child)
     _check_day(child)
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/thread_basic/tests/01-run.py
+++ b/tests/thread_basic/tests/01-run.py
@@ -17,5 +17,6 @@ def testfunc(child):
     child.expect('first thread\r\n')
     child.expect('second thread\r\n')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/thread_cooperation/tests/01-run.py
+++ b/tests/thread_cooperation/tests/01-run.py
@@ -19,5 +19,6 @@ def testfunc(child):
     child.expect(r"MAIN: \d+! = \d+")
     child.expect_exact("[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/thread_flood/tests/01-run.py
+++ b/tests/thread_flood/tests/01-run.py
@@ -12,5 +12,6 @@ def testfunc(child):
     child.expect(r'\.+')
     child.expect(r'\[SUCCESS\] created \d+')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/thread_msg/tests/01-run.py
+++ b/tests/thread_msg/tests/01-run.py
@@ -15,5 +15,6 @@ def testfunc(child):
     child.expect_exact('THREAD 1 end')
     child.expect_exact('SUCCESS')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/thread_msg_block_w_queue/tests/01-run.py
+++ b/tests/thread_msg_block_w_queue/tests/01-run.py
@@ -17,5 +17,6 @@ def testfunc(child):
     child.expect('sender_thread start\r\n')
     child.expect('main thread alive\r\n')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/thread_msg_block_wo_queue/tests/01-run.py
+++ b/tests/thread_msg_block_wo_queue/tests/01-run.py
@@ -17,5 +17,6 @@ def testfunc(child):
     child.expect('sender_thread start\r\n')
     child.expect('main thread alive\r\n')
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/trickle/tests/01-run.py
+++ b/tests/trickle/tests/01-run.py
@@ -26,5 +26,6 @@ def testfunc(child):
 
     child.expect_exact("[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/unittests/tests/01-run.py
+++ b/tests/unittests/tests/01-run.py
@@ -16,5 +16,6 @@ import testrunner
 def testfunc(child):
     child.expect(u"OK \\([0-9]+ tests\\)")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, timeout=60))

--- a/tests/warn_conflict/tests/01-make.py
+++ b/tests/warn_conflict/tests/01-make.py
@@ -45,5 +45,6 @@ def testfunc():
         finally:
             child.close()
 
+
 if __name__ == '__main__':
     testfunc()

--- a/tests/xtimer_hang/tests/01-run.py
+++ b/tests/xtimer_hang/tests/01-run.py
@@ -23,5 +23,6 @@ def testfunc(child):
 
     child.expect_exact("[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_msg_receive_timeout/tests/01-run.py
+++ b/tests/xtimer_msg_receive_timeout/tests/01-run.py
@@ -20,5 +20,6 @@ def testfunc(child):
         child.expect("Timeout!")
     child.expect("[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_now64_continuity/tests/01-run.py
+++ b/tests/xtimer_now64_continuity/tests/01-run.py
@@ -18,5 +18,6 @@ def testfunc(child):
     child.expect(u"\[RESULTS\] min=\d+, avg=\d+, max=\d+")
     child.expect_exact("[SUCCESS]")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_periodic_wakeup/tests/01-run.py
+++ b/tests/xtimer_periodic_wakeup/tests/01-run.py
@@ -24,5 +24,6 @@ def testfunc(child):
     child.expect(u"Min/max error: \d+/\d+")
     child.expect_exact("Test complete.")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_remove/tests/01-run.py
+++ b/tests/xtimer_remove/tests/01-run.py
@@ -26,5 +26,6 @@ def testfunc(child):
     child.expect_exact("timer 1 triggered.")
     child.expect_exact("test successful.")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_reset/tests/01-run.py
+++ b/tests/xtimer_reset/tests/01-run.py
@@ -22,5 +22,6 @@ def testfunc(child):
     child.expect(u"now=\d+")
     child.expect_exact("Test completed!")
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -54,5 +54,6 @@ def testfunc(child):
         print(e)
         sys.exit(1)
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc, echo=True))

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -30,5 +30,6 @@ def testfunc(child):
 
     child.expect(u"[SUCCESS]", timeout=3)
 
+
 if __name__ == "__main__":
     sys.exit(testrunner.run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR partially addresses #8141 by fixing the E305 style error 'expected 2 blank lines after class or function definition, found 1' in python tests scripts.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

refs #8141 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->