### PR TITLE
mips: clean up pic32 makefiles

### DIFF
--- a/cpu/mips_pic32_common/Makefile.include
+++ b/cpu/mips_pic32_common/Makefile.include
@@ -1,3 +1,5 @@
+include $(RIOTCPU)/mips32r2_common/Makefile.include
+
 export INCLUDES += -I$(RIOTCPU)/mips_pic32_common/include
 
 USEMODULE += mips_pic32_common

--- a/cpu/mips_pic32mx/Makefile.features
+++ b/cpu/mips_pic32mx/Makefile.features
@@ -1,2 +1,1 @@
 -include $(RIOTCPU)/mips_pic32_common/Makefile.features
--include $(RIOTCPU)/mips32r2_common/Makefile.features

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -1,8 +1,7 @@
 export ROMABLE = 1
 
-include $(RIOTMAKE)/arch/mips.inc.mk
 include $(RIOTCPU)/mips_pic32_common/Makefile.include
-include $(RIOTCPU)/mips32r2_common/Makefile.include
+include $(RIOTMAKE)/arch/mips.inc.mk
 
 # define build specific options
 export CFLAGS += -march=m4k -DSKIP_COPY_TO_RAM

--- a/cpu/mips_pic32mz/Makefile.features
+++ b/cpu/mips_pic32mz/Makefile.features
@@ -1,4 +1,3 @@
 FEATURES_PROVIDED += periph_hwrng
 
 -include $(RIOTCPU)/mips_pic32_common/Makefile.features
--include $(RIOTCPU)/mips32r2_common/Makefile.features

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -1,8 +1,7 @@
 export ROMABLE = 1
 
-include $(RIOTMAKE)/arch/mips.inc.mk
 include $(RIOTCPU)/mips_pic32_common/Makefile.include
-include $(RIOTCPU)/mips32r2_common/Makefile.include
+include $(RIOTMAKE)/arch/mips.inc.mk
 
 # define build specific options
 export CFLAGS += -march=m5101 -mmicromips -DSKIP_COPY_TO_RAM


### PR DESCRIPTION
Make pic32m* depend on pic32_common which depends on mips32r2_common.
Remove some duplication.

This addresses some issues in #8052.
