### PR TITLE
tests: fix python style E402

### DIFF
--- a/tests/bitarithm_timings/tests/01-run.py
+++ b/tests/bitarithm_timings/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("Start.")
@@ -21,4 +18,6 @@ def testfunc(child):
     child.expect_exact("Done.")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=30))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=30))

--- a/tests/bloom_bytes/tests/01-run.py
+++ b/tests/bloom_bytes/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("Testing Bloom filter.")
@@ -24,4 +21,6 @@ def testfunc(child):
     child.expect_exact("All done!")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/buttons/tests/01-run.py
+++ b/tests/buttons/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("On-board button test")
@@ -24,4 +21,6 @@ def testfunc(child):
         child.expect_exact("[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/cbor/tests/01-run.py
+++ b/tests/cbor/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 ACCEPTED_ERROR = 20
 
 
@@ -52,4 +49,6 @@ def testfunc(child):
     print("All tests successful")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, echo=False))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, echo=False))

--- a/tests/cpp11_condition_variable/tests/01-run.py
+++ b/tests/cpp11_condition_variable/tests/01-run.py
@@ -10,9 +10,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("************ C++ condition_variable test ***********")
@@ -28,4 +25,6 @@ def testfunc(child):
     child.expect_exact("******************************************************")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/cpp11_mutex/tests/01-run.py
+++ b/tests/cpp11_mutex/tests/01-run.py
@@ -10,9 +10,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("************ C++ mutex test ***********")
@@ -24,4 +21,6 @@ def testfunc(child):
     child.expect_exact("*****************************************")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/cpp11_thread/tests/01-run.py
+++ b/tests/cpp11_thread/tests/01-run.py
@@ -10,9 +10,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("************ C++ thread test ***********")
@@ -36,4 +33,6 @@ def testfunc(child):
     child.expect_exact("******************************************")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/driver_ds1307/tests/01-run.py
+++ b/tests/driver_ds1307/tests/01-run.py
@@ -9,13 +9,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect([r"OK \([0-9]+ tests\)",
                   r"error: unable to initialize RTC \[I2C initialization error\]"])
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/driver_grove_ledbar/tests/01-run.py
+++ b/tests/driver_grove_ledbar/tests/01-run.py
@@ -10,12 +10,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact(u"[SUCCESS]", timeout=60)
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/driver_hd44780/tests/01-run.py
+++ b/tests/driver_hd44780/tests/01-run.py
@@ -10,13 +10,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("[START]")
     child.expect_exact("[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/driver_my9221/tests/01-run.py
+++ b/tests/driver_my9221/tests/01-run.py
@@ -10,12 +10,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("[SUCCESS]", timeout=60)
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/events/tests/01-run.py
+++ b/tests/events/tests/01-run.py
@@ -10,12 +10,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact(u"[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/evtimer_msg/tests/01-run.py
+++ b/tests/evtimer_msg/tests/01-run.py
@@ -10,9 +10,6 @@ from __future__ import print_function
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 ACCEPTED_ERROR = 20
 
 
@@ -32,4 +29,6 @@ def testfunc(child):
     print("All tests successful")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, echo=False))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, echo=False))

--- a/tests/evtimer_underflow/tests/01-run.py
+++ b/tests/evtimer_underflow/tests/01-run.py
@@ -10,9 +10,6 @@ from __future__ import print_function
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 how_many = 100
 
 
@@ -26,4 +23,6 @@ def testfunc(child):
     print("=> All tests successful")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, echo=False))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, echo=False))

--- a/tests/float/tests/01-run.py
+++ b/tests/float/tests/01-run.py
@@ -9,13 +9,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("Testing floating point arithmetics...")
     child.expect_exact("[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/fmt_print/tests/01-run.py
+++ b/tests/fmt_print/tests/01-run.py
@@ -3,13 +3,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('If you can read this:')
     child.expect_exact('Test successful.')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/gnrc_ipv6_ext/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext/tests/01-run.py
@@ -10,9 +10,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     index = child.expect_exact([
@@ -41,4 +38,6 @@ def testfunc(child):
     child.expect_exact("pkt->users: 0")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/gnrc_ipv6_nib/tests/01-run.py
+++ b/tests/gnrc_ipv6_nib/tests/01-run.py
@@ -10,12 +10,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect(r"OK \(\d+ tests\)")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=1))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/gnrc_ipv6_nib_6ln/tests/01-run.py
+++ b/tests/gnrc_ipv6_nib_6ln/tests/01-run.py
@@ -10,12 +10,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect(r"OK \(\d+ tests\)")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=1))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/gnrc_ndp/tests/01-run.py
+++ b/tests/gnrc_ndp/tests/01-run.py
@@ -10,13 +10,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     # 1st 6LoWPAN fragment
     child.expect(r"OK \(\d+ tests\)")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/gnrc_netif/tests/01-run.py
+++ b/tests/gnrc_netif/tests/01-run.py
@@ -10,9 +10,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     # embUnit tests
@@ -140,4 +137,6 @@ def testfunc(child):
     child.expect("~~ PKT    -  2 snips, total size:  61 byte")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=1, traceback=True))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=1, traceback=True))

--- a/tests/gnrc_sixlowpan/tests/01-run.py
+++ b/tests/gnrc_sixlowpan/tests/01-run.py
@@ -10,9 +10,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     # 1st 6LoWPAN fragment
@@ -78,4 +75,6 @@ def testfunc(child):
     child.expect_exact("destination address: fd01::1")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/gnrc_sock_ip/tests/01-run.py
+++ b/tests/gnrc_sock_ip/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact(u"Calling test_sock_ip_create__EAFNOSUPPORT()")
@@ -51,4 +48,6 @@ def testfunc(child):
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/gnrc_sock_udp/tests/01-run.py
+++ b/tests/gnrc_sock_udp/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact(u"Calling test_sock_udp_create__EADDRINUSE()")
@@ -55,4 +52,6 @@ def testfunc(child):
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/irq/tests/01-run.py
+++ b/tests/irq/tests/01-run.py
@@ -3,13 +3,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('START')
     child.expect('SUCCESS')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/libfixmath/tests/01-run.py
+++ b/tests/libfixmath/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def expect_unary(child):
     for _ in range(20):
@@ -41,4 +38,6 @@ def testfunc(child):
     child.expect_exact('SUCCESS')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/libfixmath_unittests/tests/01-run.py
+++ b/tests/libfixmath_unittests/tests/01-run.py
@@ -9,12 +9,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('SUCCESS')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/lwip_sock_ip/tests/01-run.py
+++ b/tests/lwip_sock_ip/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def _ipv6_tests(code):
     return code & (1 << 6)
@@ -99,4 +96,6 @@ def testfunc(child):
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/lwip_sock_tcp/tests/01-run.py
+++ b/tests/lwip_sock_tcp/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def _reuse_tests(code):
     return code & 1
@@ -93,4 +90,6 @@ def testfunc(child):
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=60))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=60))

--- a/tests/lwip_sock_udp/tests/01-run.py
+++ b/tests/lwip_sock_udp/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def _reuse_tests(code):
     return code & 1
@@ -111,4 +108,6 @@ def testfunc(child):
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/msg_avail/tests/01-run.py
+++ b/tests/msg_avail/tests/01-run.py
@@ -10,12 +10,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact(u"[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/msg_send_receive/tests/01-run.py
+++ b/tests/msg_send_receive/tests/01-run.py
@@ -9,12 +9,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect(u"Test successful.")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/msg_try_receive/tests/01-run.py
+++ b/tests/msg_try_receive/tests/01-run.py
@@ -3,13 +3,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('main starting')
     child.expect('msg available: 1 \(should be 1\!\)')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/mutex_order/tests/01-run.py
+++ b/tests/mutex_order/tests/01-run.py
@@ -10,9 +10,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 thread_prio = {
         3:  6,
         4:  4,
@@ -33,4 +30,6 @@ def testfunc(child):
         last = int(child.match.group(1))
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/mutex_unlock_and_sleep/tests/01-run.py
+++ b/tests/mutex_unlock_and_sleep/tests/01-run.py
@@ -9,13 +9,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     for i in range(20):
         child.expect(r"\[ALIVE\] alternated \d+k times.")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/netdev_test/tests/01-run.py
+++ b/tests/netdev_test/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('Executing test_get_addr()')
@@ -25,4 +22,6 @@ def testfunc(child):
     child.expect_exact('ALL TESTS SUCCESSFUL')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/nhdp/tests/01-run.py
+++ b/tests/nhdp/tests/01-run.py
@@ -9,12 +9,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('SUCCESS: NHDP compiled!')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/od/tests/01-run.py
+++ b/tests/od/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("od_hex_dump(short_str, sizeof(short_str), OD_WIDTH_DEFAULT)")
@@ -42,4 +39,6 @@ def testfunc(child):
     print("All tests successful")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=1, echo=False))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=1, echo=False))

--- a/tests/od/tests/02-run.py
+++ b/tests/od/tests/02-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("od_hex_dump(short_str, sizeof(short_str), OD_WIDTH_DEFAULT)")
@@ -42,4 +39,6 @@ def testfunc(child):
     print("All tests successful")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=1, echo=False))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=1, echo=False))

--- a/tests/periph_timer/tests/01-run.py
+++ b/tests/periph_timer/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('Available timers: (\d+)')
@@ -24,4 +21,6 @@ def testfunc(child):
     child.expect('TEST SUCCEEDED')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pipe/tests/01-run.py
+++ b/tests/pipe/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('Start.')
@@ -32,4 +29,6 @@ def testfunc(child):
     child.expect_exact('End done.')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pkg_jsmn/tests/01-run.py
+++ b/tests/pkg_jsmn/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('- User: johndoe')
@@ -18,4 +15,6 @@ def testfunc(child):
     child.expect_exact('  * video')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pkg_libcoap/tests/01-run.py
+++ b/tests/pkg_libcoap/tests/01-run.py
@@ -3,12 +3,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('SUCCESS: Libcoap compiled!')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pkg_micro-ecc-with-hwrng/tests/01-run.py
+++ b/tests/pkg_micro-ecc-with-hwrng/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('micro-ecc compiled!')
@@ -15,4 +12,6 @@ def testfunc(child):
     child.expect_exact('SUCCESS')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=60))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=60))

--- a/tests/pkg_micro-ecc/tests/01-run.py
+++ b/tests/pkg_micro-ecc/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('micro-ecc compiled!')
@@ -15,4 +12,6 @@ def testfunc(child):
     child.expect_exact('SUCCESS')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=60))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=60))

--- a/tests/pkg_minmea/tests/01-run.py
+++ b/tests/pkg_minmea/tests/01-run.py
@@ -3,13 +3,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('START')
     child.expect_exact('SUCCESS')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pkg_tiny-asn1/tests/01-run.py
+++ b/tests/pkg_tiny-asn1/tests/01-run.py
@@ -10,12 +10,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('Decoding finished succesfully')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pkg_umorse/tests/01-run.py
+++ b/tests/pkg_umorse/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect(u".... . ._.. ._.. ___ / ._. .. ___ _ ___ ...", timeout=30)
@@ -23,4 +20,6 @@ def testfunc(child):
     child.expect_exact("[SUCCESS]", timeout=120)
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/posix_semaphore/tests/01-run.py
+++ b/tests/posix_semaphore/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def test1(term):
     term.expect_exact("######################### TEST1:")
@@ -100,4 +97,6 @@ def testfunc(child):
     child.expect("######################### DONE")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/posix_time/tests/01-run.py
+++ b/tests/posix_time/tests/01-run.py
@@ -12,9 +12,6 @@ import os
 import sys
 import time
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 US_PER_SEC = 1000000
 EXTERNAL_JITTER = 0.15
 
@@ -48,4 +45,6 @@ def testfunc(child):
         sys.exit(1)
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, echo=True))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -9,10 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
-
 PS_EXPECTED = (
     ('\tpid | name                 | state    Q | pri | stack  ( used) | '
      'base addr  | current     | runtime  | switches'),
@@ -63,4 +59,6 @@ def testfunc(child):
     _check_ps(child)
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pthread/tests/01-run.py
+++ b/tests/pthread/tests/01-run.py
@@ -4,10 +4,6 @@ import os
 import sys
 import math
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
-
 FACTORIAL_PARAM = 6
 
 
@@ -22,4 +18,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pthread_barrier/tests/01-run.py
+++ b/tests/pthread_barrier/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('START')
@@ -19,4 +16,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pthread_cleanup/tests/01-run.py
+++ b/tests/pthread_cleanup/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('START')
@@ -23,4 +20,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pthread_condition_variable/tests/01-run.py
+++ b/tests/pthread_condition_variable/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('START')
@@ -16,4 +13,6 @@ def testfunc(child):
 if __name__ == "__main__":
     # This test can take some time to complete when testing on hardware (e.g
     # on samr21-xpro) and the default timeout (10s) is not enough.
-    sys.exit(testrunner.run(testfunc, timeout=60))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=60))

--- a/tests/pthread_cooperation/tests/01-run.py
+++ b/tests/pthread_cooperation/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('START')
@@ -20,4 +17,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pthread_rwlock/tests/01-run.py
+++ b/tests/pthread_rwlock/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('START')
@@ -19,4 +16,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/pthread_tls/tests/01-run.py
+++ b/tests/pthread_tls/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def _check_test_output(child):
     child.expect('show tls values:')
@@ -38,4 +35,6 @@ def testfunc(child):
     child.expect('SUCCESS')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/rmutex/tests/01-run.py
+++ b/tests/rmutex/tests/01-run.py
@@ -11,9 +11,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 thread_prio = {
         3:  6,
         4:  4,
@@ -47,4 +44,6 @@ def testfunc(child):
                          (T, thread_prio[T], depth))
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/sched_testing/tests/01-run.py
+++ b/tests/sched_testing/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('The output should be: yield 1, snd_thread running, '
@@ -18,4 +15,6 @@ def testfunc(child):
     child.expect_exact('done')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 EXPECTED_HELP = (
     'Command              Description',
     '---------------------------------------',
@@ -58,4 +55,6 @@ def testfunc(child):
         check_cmd(child, cmd, expected)
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/sizeof_tcb/tests/01-run.py
+++ b/tests/sizeof_tcb/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('\tmember, sizeof, offsetof')
@@ -28,4 +25,6 @@ def testfunc(child):
     child.expect_exact('SUCCESS')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/ssp/tests/01-run.py
+++ b/tests/ssp/tests/01-run.py
@@ -9,13 +9,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('calling stack corruption function')
     child.expect('.*stack smashing detected.*')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/struct_tm_utility/tests/01-run.py
+++ b/tests/struct_tm_utility/tests/01-run.py
@@ -11,9 +11,6 @@ import sys
 import calendar
 import datetime
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def _check_help(child):
     child.sendline('help')
@@ -116,4 +113,6 @@ def testfunc(child):
     _check_day(child)
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_basic/tests/01-run.py
+++ b/tests/thread_basic/tests/01-run.py
@@ -9,13 +9,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('first thread\r\n')
     child.expect('second thread\r\n')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_cooperation/tests/01-run.py
+++ b/tests/thread_cooperation/tests/01-run.py
@@ -10,9 +10,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect(r"MAIN: reply from T-\d+")
@@ -20,4 +17,6 @@ def testfunc(child):
     child.expect_exact("[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_exit/tests/01-run.py
+++ b/tests/thread_exit/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect("main: starting")
@@ -19,4 +16,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_flags/tests/01-run.py
+++ b/tests/thread_flags/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect("START")
@@ -31,4 +28,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_flags_xtimer/tests/01-run.py
+++ b/tests/thread_flags_xtimer/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect("START")
@@ -15,4 +12,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_flood/tests/01-run.py
+++ b/tests/thread_flood/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact(u'[START] Spawning threads')
@@ -13,4 +10,6 @@ def testfunc(child):
     child.expect(r'\[SUCCESS\] created \d+')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_msg/tests/01-run.py
+++ b/tests/thread_msg/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact('THREADS CREATED')
@@ -16,4 +13,6 @@ def testfunc(child):
     child.expect_exact('SUCCESS')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_msg_block_w_queue/tests/01-run.py
+++ b/tests/thread_msg_block_w_queue/tests/01-run.py
@@ -9,13 +9,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('sender_thread start\r\n')
     child.expect('main thread alive\r\n')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_msg_block_wo_queue/tests/01-run.py
+++ b/tests/thread_msg_block_wo_queue/tests/01-run.py
@@ -9,13 +9,12 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect('sender_thread start\r\n')
     child.expect('main thread alive\r\n')
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/thread_msg_seq/tests/01-run.py
+++ b/tests/thread_msg_seq/tests/01-run.py
@@ -3,9 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect("START")
@@ -23,4 +20,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/trickle/tests/01-run.py
+++ b/tests/trickle/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("[START]")
@@ -27,4 +24,6 @@ def testfunc(child):
     child.expect_exact("[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/unittests/tests/01-run.py
+++ b/tests/unittests/tests/01-run.py
@@ -9,12 +9,11 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect(u"OK \\([0-9]+ tests\\)")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, timeout=60))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc, timeout=60))

--- a/tests/xtimer_hang/tests/01-run.py
+++ b/tests/xtimer_hang/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("[START]")
@@ -24,4 +21,6 @@ def testfunc(child):
     child.expect_exact("[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/xtimer_msg_receive_timeout/tests/01-run.py
+++ b/tests/xtimer_msg_receive_timeout/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect("[START]")
@@ -21,4 +18,6 @@ def testfunc(child):
     child.expect("[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/xtimer_now64_continuity/tests/01-run.py
+++ b/tests/xtimer_now64_continuity/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("[START]")
@@ -19,4 +16,6 @@ def testfunc(child):
     child.expect_exact("[SUCCESS]")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/xtimer_periodic_wakeup/tests/01-run.py
+++ b/tests/xtimer_periodic_wakeup/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("xtimer_periodic_wakeup test application.")
@@ -25,4 +22,6 @@ def testfunc(child):
     child.expect_exact("Test complete.")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/xtimer_remove/tests/01-run.py
+++ b/tests/xtimer_remove/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("xtimer_remove test application.")
@@ -27,4 +24,6 @@ def testfunc(child):
     child.expect_exact("test successful.")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/xtimer_reset/tests/01-run.py
+++ b/tests/xtimer_reset/tests/01-run.py
@@ -9,9 +9,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect_exact("This test tests re-setting of an already active timer.")
@@ -23,4 +20,6 @@ def testfunc(child):
     child.expect_exact("Test completed!")
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -13,9 +13,6 @@ import os
 import sys
 import time
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 US_PER_SEC = 1000000
 INTERNAL_JITTER = 0.05
 EXTERNAL_JITTER = 0.15
@@ -55,4 +52,6 @@ def testfunc(child):
         sys.exit(1)
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc, echo=True))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -10,9 +10,6 @@ import os
 import sys
 import pexpect
 
-sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
-import testrunner
-
 
 def testfunc(child):
     child.expect(u"This test will call xtimer_usleep for values from \\d+ down to \\d+\r\n")
@@ -31,4 +28,6 @@ def testfunc(child):
     child.expect(u"[SUCCESS]", timeout=3)
 
 if __name__ == "__main__":
-    sys.exit(testrunner.run(testfunc))
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR partially addresses #8141 by fixing the python style E402 error, e.g 'module level import not at top of file'.
This issue is related to the testrunner import that is called after adding the module path to the python path at the beginning of the script.

This PR solves it by importing the testrunner module in the \_\_main\_\_ block.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

refs #8141 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->