### PR TITLE
gnrc_netif: rename IPv6 address "setters"

### DIFF
--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -85,8 +85,9 @@ void gnrc_netif_release(gnrc_netif_t *netif);
  * @return  >= 0, on success
  * @return  -ENOMEM, when no space for new addresses is left on the interface
  */
-int gnrc_netif_ipv6_addr_add(gnrc_netif_t *netif, const ipv6_addr_t *addr,
-                             unsigned pfx_len, uint8_t flags);
+int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
+                                      const ipv6_addr_t *addr,
+                                      unsigned pfx_len, uint8_t flags);
 
 /**
  * @brief   Removes an IPv6 address from the interface
@@ -98,8 +99,8 @@ int gnrc_netif_ipv6_addr_add(gnrc_netif_t *netif, const ipv6_addr_t *addr,
  *
  * @note    Only available with @ref net_gnrc_ipv6 "gnrc_ipv6".
  */
-void gnrc_netif_ipv6_addr_remove(gnrc_netif_t *netif,
-                                 const ipv6_addr_t *addr);
+void gnrc_netif_ipv6_addr_remove_internal(gnrc_netif_t *netif,
+                                          const ipv6_addr_t *addr);
 
 
 /**
@@ -240,8 +241,8 @@ gnrc_netif_t *gnrc_netif_get_by_prefix(const ipv6_addr_t *prefix);
  * @return  0, on success
  * @return  -ENOMEM, when no space for new addresses is left on the interface
  */
-int gnrc_netif_ipv6_group_join(gnrc_netif_t *netif,
-                               const ipv6_addr_t *addr);
+int gnrc_netif_ipv6_group_join_internal(gnrc_netif_t *netif,
+                                        const ipv6_addr_t *addr);
 
 /**
  * @brief   Let interface leave from an IPv6 multicast group
@@ -253,8 +254,8 @@ int gnrc_netif_ipv6_group_join(gnrc_netif_t *netif,
  *
  * @note    Only available with @ref net_gnrc_ipv6 "gnrc_ipv6".
  */
-void gnrc_netif_ipv6_group_leave(gnrc_netif_t *netif,
-                                 const ipv6_addr_t *addr);
+void gnrc_netif_ipv6_group_leave_internal(gnrc_netif_t *netif,
+                                          const ipv6_addr_t *addr);
 
 /**
  * @brief   Returns the index of @p addr in gnrc_netif_t::ipv6_groups of @p

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -243,7 +243,7 @@ int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
                 uint8_t pfx_len = (uint8_t)(opt->context >> 8U);
                 /* acquire locks a recursive mutex so we are safe calling this
                  * public function */
-                gnrc_netif_ipv6_addr_add(netif, opt->data, pfx_len, flags);
+                gnrc_netif_ipv6_addr_add_internal(netif, opt->data, pfx_len, flags);
                 res = sizeof(ipv6_addr_t);
             }
             break;
@@ -251,21 +251,21 @@ int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
             assert(opt->data_len == sizeof(ipv6_addr_t));
             /* acquire locks a recursive mutex so we are safe calling this
              * public function */
-            gnrc_netif_ipv6_addr_remove(netif, opt->data);
+            gnrc_netif_ipv6_addr_remove_internal(netif, opt->data);
             res = sizeof(ipv6_addr_t);
             break;
         case NETOPT_IPV6_GROUP:
             assert(opt->data_len == sizeof(ipv6_addr_t));
             /* acquire locks a recursive mutex so we are safe calling this
              * public function */
-            gnrc_netif_ipv6_group_join(netif, opt->data);
+            gnrc_netif_ipv6_group_join_internal(netif, opt->data);
             res = sizeof(ipv6_addr_t);
             break;
         case NETOPT_IPV6_GROUP_LEAVE:
             assert(opt->data_len == sizeof(ipv6_addr_t));
             /* acquire locks a recursive mutex so we are safe calling this
              * public function */
-            gnrc_netif_ipv6_group_leave(netif, opt->data);
+            gnrc_netif_ipv6_group_leave_internal(netif, opt->data);
             res = sizeof(ipv6_addr_t);
             break;
         case NETOPT_MAX_PACKET_SIZE:
@@ -522,8 +522,9 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
                                         uint8_t *candidate_set);
 static int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 
-int gnrc_netif_ipv6_addr_add(gnrc_netif_t *netif, const ipv6_addr_t *addr,
-                             unsigned pfx_len, uint8_t flags)
+int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
+                                      const ipv6_addr_t *addr,
+                                      unsigned pfx_len, uint8_t flags)
 {
     unsigned idx = UINT_MAX;
 
@@ -561,7 +562,7 @@ int gnrc_netif_ipv6_addr_add(gnrc_netif_t *netif, const ipv6_addr_t *addr,
     /* TODO: SHOULD delay join between 0 and MAX_RTR_SOLICITATION_DELAY
      * for SLAAC */
     ipv6_addr_set_solicited_nodes(&sol_nodes, addr);
-    res = gnrc_netif_ipv6_group_join(netif, &sol_nodes);
+    res = gnrc_netif_ipv6_group_join_internal(netif, &sol_nodes);
 #if ENABLE_DEBUG
     if (res < 0) {
         DEBUG("nib: Can't join solicited-nodes of %s on interface %u\n",
@@ -599,8 +600,8 @@ int gnrc_netif_ipv6_addr_add(gnrc_netif_t *netif, const ipv6_addr_t *addr,
     return idx;
 }
 
-void gnrc_netif_ipv6_addr_remove(gnrc_netif_t *netif,
-                                 const ipv6_addr_t *addr)
+void gnrc_netif_ipv6_addr_remove_internal(gnrc_netif_t *netif,
+                                          const ipv6_addr_t *addr)
 {
     bool remove_sol_nodes = true;
     ipv6_addr_t sol_nodes;
@@ -625,7 +626,7 @@ void gnrc_netif_ipv6_addr_remove(gnrc_netif_t *netif,
         }
     }
     if (remove_sol_nodes) {
-        gnrc_netif_ipv6_group_leave(netif, &sol_nodes);
+        gnrc_netif_ipv6_group_leave_internal(netif, &sol_nodes);
     }
     gnrc_netif_release(netif);
 }
@@ -715,8 +716,8 @@ gnrc_netif_t *gnrc_netif_get_by_prefix(const ipv6_addr_t *prefix)
     return best_netif;
 }
 
-int gnrc_netif_ipv6_group_join(gnrc_netif_t *netif,
-                               const ipv6_addr_t *addr)
+int gnrc_netif_ipv6_group_join_internal(gnrc_netif_t *netif,
+                                        const ipv6_addr_t *addr)
 {
     unsigned idx = UINT_MAX;
 
@@ -742,8 +743,8 @@ int gnrc_netif_ipv6_group_join(gnrc_netif_t *netif,
     return idx;
 }
 
-void gnrc_netif_ipv6_group_leave(gnrc_netif_t *netif,
-                                 const ipv6_addr_t *addr)
+void gnrc_netif_ipv6_group_leave_internal(gnrc_netif_t *netif,
+                                          const ipv6_addr_t *addr)
 {
     int idx;
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -149,7 +149,7 @@ uint8_t _handle_aro(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                           ipv6_addr_to_str(addr_str,
                                            &ipv6->dst,
                                            sizeof(addr_str)), netif->pid);
-                    gnrc_netif_ipv6_addr_remove(netif, &ipv6->dst);
+                    gnrc_netif_ipv6_addr_remove_internal(netif, &ipv6->dst);
                     /* TODO: generate new address */
                     break;
                 case SIXLOWPAN_ND_STATUS_NC_FULL: {

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.h
@@ -49,7 +49,7 @@ static inline void _init_iface_router(gnrc_netif_t *netif)
 #if GNRC_IPV6_NIB_CONF_6LBR
     netif->flags |= GNRC_NETIF_FLAGS_6LO_ABR;
 #endif  /* GNRC_IPV6_NIB_CONF_6LBR */
-    gnrc_netif_ipv6_group_join(netif, &ipv6_addr_all_routers_link_local);
+    gnrc_netif_ipv6_group_join_internal(netif, &ipv6_addr_all_routers_link_local);
 }
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -124,8 +124,8 @@ void gnrc_ipv6_nib_init_iface(gnrc_netif_t *netif)
     }
 #endif  /* GNRC_IPV6_NIB_CONF_6LN */
     netif->ipv6.na_sent = 0;
-    if (gnrc_netif_ipv6_group_join(netif,
-                                   &ipv6_addr_all_nodes_link_local) < 0) {
+    if (gnrc_netif_ipv6_group_join_internal(netif,
+                                            &ipv6_addr_all_nodes_link_local) < 0) {
         DEBUG("nib: Can't join link-local all-nodes on interface %u\n",
               netif->pid);
         gnrc_netif_release(netif);
@@ -1113,7 +1113,8 @@ static void _handle_pfx_timeout(_nib_offl_entry_t *pfx)
         for (int i = 0; i < GNRC_NETIF_IPV6_ADDRS_NUMOF; i++) {
             if (ipv6_addr_match_prefix(&netif->ipv6.addrs[i],
                                        &pfx->pfx) >= pfx->pfx_len) {
-                gnrc_netif_ipv6_addr_remove(netif, &netif->ipv6.addrs[i]);
+                gnrc_netif_ipv6_addr_remove_internal(netif,
+                                                     &netif->ipv6.addrs[i]);
             }
         }
         pfx->mode &= ~_PL;
@@ -1303,7 +1304,8 @@ static void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
     gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&addr.u64[1]);
     ipv6_addr_init_prefix(&addr, pfx, pfx_len);
     if ((idx = gnrc_netif_ipv6_addr_idx(netif, &addr)) < 0) {
-        if ((idx = gnrc_netif_ipv6_addr_add(netif, &addr, pfx_len, flags)) < 0) {
+        if ((idx = gnrc_netif_ipv6_addr_add_internal(netif, &addr, pfx_len,
+                                                     flags)) < 0) {
             DEBUG("nib: Can't add link-local address on interface %u\n",
                   netif->pid);
             return;
@@ -1316,7 +1318,7 @@ static void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #if GNRC_IPV6_NIB_CONF_6LN
     if (gnrc_netif_is_6ln(netif)) {
         /* don't do this beforehand or risk a deadlock:
-         *  * gnrc_netif_ipv6_addr_add() adds VALID (i.e. manually configured
+         *  * gnrc_netif_ipv6_addr_add_internal() adds VALID (i.e. manually configured
          *    addresses to the prefix list locking the NIB's mutex which is already
          *    locked here) */
         netif->ipv6.addrs_flags[idx] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -81,8 +81,8 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid)
     }
 
     /* register all_RPL_nodes multicast address */
-    gnrc_netif_ipv6_group_join(gnrc_netif_get_by_pid(if_pid),
-                               &ipv6_addr_all_rpl_nodes);
+    gnrc_netif_ipv6_group_join_internal(gnrc_netif_get_by_pid(if_pid),
+                                        &ipv6_addr_all_rpl_nodes);
 
     gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes);
     return gnrc_rpl_pid;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -447,8 +447,8 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
                 }
                 ipv6_addr_set_aiid(&pi->prefix, iid.uint8);
                 /* TODO: find a way to do this with DAD (i.e. state != VALID) */
-                gnrc_netif_ipv6_addr_add(netif, &pi->prefix, pi->prefix_len,
-                                         GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
+                gnrc_netif_ipv6_addr_add_internal(netif, &pi->prefix, pi->prefix_len,
+                                                  GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
                 /* set lifetimes */
                 gnrc_ipv6_nib_pl_set(netif->pid, &pi->prefix, pi->prefix_len,
                                      _sec_to_ms(byteorder_ntohl(pi->valid_lifetime)),

--- a/tests/gnrc_ipv6_nib/main.c
+++ b/tests/gnrc_ipv6_nib/main.c
@@ -79,7 +79,7 @@ static void _set_up(void)
     /* reset some fields not set by the nib interface initializer */
     _mock_netif->ipv6.mtu = ETHERNET_DATA_LEN;
     _mock_netif->cur_hl = GNRC_NETIF_DEFAULT_HL;
-    gnrc_netif_ipv6_addr_remove(_mock_netif, &_loc_gb);
+    gnrc_netif_ipv6_addr_remove_internal(_mock_netif, &_loc_gb);
     gnrc_netif_release(_mock_netif);
     memset(_buffer, 0, sizeof(_buffer));
     gnrc_pktbuf_init();
@@ -107,7 +107,7 @@ static void test_get_next_hop_l2addr__EHOSTUNREACH(const ipv6_addr_t *dst,
     }
     else if (on_link) {
         /* add _rem_gb prefix as on-link prefix */
-        TEST_ASSERT(gnrc_netif_ipv6_addr_add(_mock_netif, &addr,
+        TEST_ASSERT(gnrc_netif_ipv6_addr_add_internal(_mock_netif, &addr,
                             _REM_GB_PFX_LEN,
                             GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID) >= 0);
     }
@@ -158,7 +158,7 @@ static void test_get_next_hop_l2addr__EHOSTUNREACH(const ipv6_addr_t *dst,
         gnrc_pktbuf_release(pkt);
         TEST_ASSERT(gnrc_pktbuf_is_empty());
     }
-    gnrc_netif_ipv6_addr_remove(_mock_netif, &addr);
+    gnrc_netif_ipv6_addr_remove_internal(_mock_netif, &addr);
 }
 
 static void test_get_next_hop_l2addr__link_local_EHOSTUNREACH_no_iface(void)

--- a/tests/gnrc_ipv6_nib_6ln/main.c
+++ b/tests/gnrc_ipv6_nib_6ln/main.c
@@ -88,7 +88,7 @@ static void _set_up(void)
     /* reset some fields not set by the nib interface initializer */
     _mock_netif->ipv6.mtu = IPV6_MIN_MTU;
     _mock_netif->cur_hl = GNRC_NETIF_DEFAULT_HL;
-    gnrc_netif_ipv6_addr_remove(_mock_netif, &_loc_gb);
+    gnrc_netif_ipv6_addr_remove_internal(_mock_netif, &_loc_gb);
     _mock_netif->flags &= ~GNRC_NETIF_FLAGS_6LO_ADDRS_REG;
     gnrc_netif_release(_mock_netif);
     memset(_buffer, 0, sizeof(_buffer));
@@ -630,7 +630,7 @@ static void test_handle_pkt__nbr_adv__aro_not_my_eui64(void)
                                      SIXLOWPAN_ND_STATUS_SUCCESS);
     int idx;
 
-    idx = gnrc_netif_ipv6_addr_add(_mock_netif, &_loc_gb, _LOC_GB_PFX_LEN,
+    idx = gnrc_netif_ipv6_addr_add_internal(_mock_netif, &_loc_gb, _LOC_GB_PFX_LEN,
                                    GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE);
     TEST_ASSERT(idx >= 0);
     gnrc_ipv6_nib_handle_pkt(_mock_netif, ipv6, icmpv6, icmpv6_len);
@@ -648,7 +648,7 @@ static void test_handle_pkt__nbr_adv__aro_duplicate(void)
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_nc_set(&_rem_ll, _mock_netif->pid,
                                                   _rem_l2, sizeof(_rem_l2)));
-    idx = gnrc_netif_ipv6_addr_add(_mock_netif, &_loc_gb, _LOC_GB_PFX_LEN,
+    idx = gnrc_netif_ipv6_addr_add_internal(_mock_netif, &_loc_gb, _LOC_GB_PFX_LEN,
                                    GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE);
     TEST_ASSERT(idx >= 0);
     gnrc_ipv6_nib_handle_pkt(_mock_netif, ipv6, icmpv6, icmpv6_len);

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -239,11 +239,11 @@ static void test_ipv6_addr_add__ENOMEM(void)
 
     for (unsigned i = 0; i < GNRC_NETIF_IPV6_ADDRS_NUMOF;
          i++, addr.u16[3].u16++) {
-        TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+        TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                                   GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM,
-                          gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+                          gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                                    GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
 }
 
@@ -252,11 +252,11 @@ static void test_ipv6_addr_add__success(void)
     static const ipv6_addr_t addr = { .u8 = NETIF0_IPV6_LL };
     int idx;
 
-    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                                      GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID)));
     /* check duplicate addition */
     TEST_ASSERT_EQUAL_INT(idx,
-                          gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+                          gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                                    GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
     TEST_ASSERT_EQUAL_INT(GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID,
                           netifs[0]->ipv6.addrs_flags[idx]);
@@ -270,13 +270,13 @@ static void test_ipv6_addr_add__readd_with_free_entry(void)
     static const ipv6_addr_t addr2 = { .u8 = NETIF0_IPV6_G };
     int idx;
 
-    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add(netifs[0], &addr1, 64U,
+    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr1, 64U,
                                               GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
-    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add(netifs[0], &addr2, 64U,
+    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr2, 64U,
                                                      GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID)));
-    gnrc_netif_ipv6_addr_remove(netifs[0], &addr1);
+    gnrc_netif_ipv6_addr_remove_internal(netifs[0], &addr1);
     TEST_ASSERT_EQUAL_INT(idx,
-                          gnrc_netif_ipv6_addr_add(netifs[0], &addr2, 64U,
+                          gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr2, 64U,
                                                    GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
 }
 
@@ -287,9 +287,9 @@ static void test_ipv6_addr_remove__not_allocated(void)
 
     test_ipv6_addr_add__success();
     TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_idx(netifs[0], &addr1));
-    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add(netifs[0], &addr2, 64U,
+    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr2, 64U,
                                               GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
-    gnrc_netif_ipv6_addr_remove(netifs[0], &addr2);
+    gnrc_netif_ipv6_addr_remove_internal(netifs[0], &addr2);
     TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_idx(netifs[0], &addr1));
 }
 
@@ -298,7 +298,7 @@ static void test_ipv6_addr_remove__success(void)
     static const ipv6_addr_t addr = { .u8 = NETIF0_IPV6_LL };
 
     test_ipv6_addr_add__success();
-    gnrc_netif_ipv6_addr_remove(netifs[0], &addr);
+    gnrc_netif_ipv6_addr_remove_internal(netifs[0], &addr);
     TEST_ASSERT_EQUAL_INT(-1, gnrc_netif_ipv6_addr_idx(netifs[0], &addr));
 }
 
@@ -363,7 +363,7 @@ static void test_ipv6_addr_match__success18(void)
     static const ipv6_addr_t pfx = { .u8 = GLOBAL_PFX18 };
     int idx;
 
-    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                                      GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID)));
     TEST_ASSERT_EQUAL_INT(idx, gnrc_netif_ipv6_addr_match(netifs[0], &pfx));
     TEST_ASSERT_EQUAL_INT(18, ipv6_addr_match_prefix(&netifs[0]->ipv6.addrs[idx],
@@ -377,7 +377,7 @@ static void test_ipv6_addr_match__success23(void)
     static const ipv6_addr_t pfx = { .u8 = GLOBAL_PFX23 };
     int idx;
 
-    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                                      GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID)));
     TEST_ASSERT_EQUAL_INT(idx, gnrc_netif_ipv6_addr_match(netifs[0], &pfx));
     TEST_ASSERT_EQUAL_INT(23, ipv6_addr_match_prefix(&netifs[0]->ipv6.addrs[idx],
@@ -391,7 +391,7 @@ static void test_ipv6_addr_match__success64(void)
     static const ipv6_addr_t pfx = { .u8 = GLOBAL_PFX64 };
     int idx;
 
-    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                                      GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID)));
     TEST_ASSERT_EQUAL_INT(idx, gnrc_netif_ipv6_addr_match(netifs[0], &pfx));
     TEST_ASSERT_EQUAL_INT(64, ipv6_addr_match_prefix(&netifs[0]->ipv6.addrs[idx],
@@ -407,7 +407,7 @@ static void test_ipv6_addr_best_src__multicast_input(void)
 
     /* adds a link-local address */
     test_ipv6_addr_add__success();
-    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add(netifs[0], &addr1, 64U,
+    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr1, 64U,
                                               GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
     TEST_ASSERT_NOT_NULL((out = gnrc_netif_ipv6_addr_best_src(netifs[0],
                                                               &addr2,
@@ -458,7 +458,7 @@ static void test_get_by_prefix__success18(void)
     static const ipv6_addr_t addr = { .u8 = NETIF0_IPV6_G };
     static const ipv6_addr_t pfx = { .u8 = GLOBAL_PFX18 };
 
-    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                               GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
     TEST_ASSERT_NOT_NULL(netifs[0]);
     TEST_ASSERT(netifs[0] == gnrc_netif_get_by_prefix(&pfx));
@@ -470,7 +470,7 @@ static void test_get_by_prefix__success23(void)
     static const ipv6_addr_t addr = { .u8 = NETIF0_IPV6_G };
     static const ipv6_addr_t pfx = { .u8 = GLOBAL_PFX23 };
 
-    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                               GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
     TEST_ASSERT_NOT_NULL(netifs[0]);
     TEST_ASSERT(netifs[0] == gnrc_netif_get_by_prefix(&pfx));
@@ -482,7 +482,7 @@ static void test_get_by_prefix__success64(void)
     static const ipv6_addr_t addr = { .u8 = NETIF0_IPV6_G };
     static const ipv6_addr_t pfx = { .u8 = GLOBAL_PFX64 };
 
-    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add(netifs[0], &addr, 64U,
+    TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add_internal(netifs[0], &addr, 64U,
                                               GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
     TEST_ASSERT_NOT_NULL(netifs[0]);
     TEST_ASSERT(netifs[0] == gnrc_netif_get_by_prefix(&pfx));
@@ -495,21 +495,21 @@ static void test_ipv6_group_join__ENOMEM(void)
 
     for (unsigned i = 0; i < GNRC_NETIF_IPV6_ADDRS_NUMOF;
          i++, addr.u16[7].u16++) {
-        TEST_ASSERT(0 <= gnrc_netif_ipv6_group_join(netifs[0], &addr));
+        TEST_ASSERT(0 <= gnrc_netif_ipv6_group_join_internal(netifs[0], &addr));
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM,
-                          gnrc_netif_ipv6_group_join(netifs[0], &addr));
+                          gnrc_netif_ipv6_group_join_internal(netifs[0], &addr));
 }
 
 static void test_ipv6_group_join__success(void)
 {
     int idx;
 
-    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_group_join(netifs[0],
+    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_group_join_internal(netifs[0],
                                                        &ipv6_addr_all_nodes_link_local)));
     /* check duplicate addition */
     TEST_ASSERT_EQUAL_INT(idx,
-                          gnrc_netif_ipv6_group_join(netifs[0],
+                          gnrc_netif_ipv6_group_join_internal(netifs[0],
                                                      &ipv6_addr_all_nodes_link_local));
     TEST_ASSERT(ipv6_addr_equal(&ipv6_addr_all_nodes_link_local,
                                 &netifs[0]->ipv6.groups[idx]));
@@ -520,13 +520,13 @@ static void test_ipv6_group_join__readd_with_free_entry(void)
     /* Tests for possible duplicates (see #2965) */
     int idx;
 
-    TEST_ASSERT(0 <= gnrc_netif_ipv6_group_join(netifs[0],
+    TEST_ASSERT(0 <= gnrc_netif_ipv6_group_join_internal(netifs[0],
                                                 &ipv6_addr_all_nodes_link_local));
-    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_group_join(netifs[0],
+    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_group_join_internal(netifs[0],
                                                        &ipv6_addr_all_routers_link_local)));
-    gnrc_netif_ipv6_group_leave(netifs[0], &ipv6_addr_all_nodes_link_local);
+    gnrc_netif_ipv6_group_leave_internal(netifs[0], &ipv6_addr_all_nodes_link_local);
     TEST_ASSERT_EQUAL_INT(idx,
-                          gnrc_netif_ipv6_group_join(netifs[0],
+                          gnrc_netif_ipv6_group_join_internal(netifs[0],
                                                      &ipv6_addr_all_routers_link_local));
 }
 
@@ -535,9 +535,9 @@ static void test_ipv6_group_leave__not_allocated(void)
     test_ipv6_group_join__success();
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(netifs[0],
                                                &ipv6_addr_all_nodes_link_local));
-    TEST_ASSERT(0 <= gnrc_netif_ipv6_group_join(netifs[0],
+    TEST_ASSERT(0 <= gnrc_netif_ipv6_group_join_internal(netifs[0],
                                                 &ipv6_addr_all_routers_link_local));
-    gnrc_netif_ipv6_group_leave(netifs[0], &ipv6_addr_all_routers_link_local);
+    gnrc_netif_ipv6_group_leave_internal(netifs[0], &ipv6_addr_all_routers_link_local);
     TEST_ASSERT(0 <= gnrc_netif_ipv6_group_idx(netifs[0],
                                                &ipv6_addr_all_nodes_link_local));
 }
@@ -545,7 +545,7 @@ static void test_ipv6_group_leave__not_allocated(void)
 static void test_ipv6_group_leave__success(void)
 {
     test_ipv6_group_join__success();
-    gnrc_netif_ipv6_group_leave(netifs[0], &ipv6_addr_all_nodes_link_local);
+    gnrc_netif_ipv6_group_leave_internal(netifs[0], &ipv6_addr_all_nodes_link_local);
     TEST_ASSERT_EQUAL_INT(-1, gnrc_netif_ipv6_group_idx(netifs[0],
                                                         &ipv6_addr_all_nodes_link_local));
 }


### PR DESCRIPTION
### Contribution description

This renames the following functions

* `gnrc_netif_ipv6_addr_add()`
* `gnrc_netif_ipv6_addr_remove()`
* `gnrc_netif_ipv6_group_join()`
* `gnrc_netif_ipv6_group_leave()`

by appending the suffix `_internal`.

### Reasoning

I'd like to provide a helper function for the *public* equivalent using
`gnrc_netapi_set()`, and those names are to nice to not be taken for
those.

### Procedure
I used a combination of `git grep` and `sed` to do this and fixed the
alignment in the result of some cases by hand.

```sh
git grep --name-only "\<gnrc_netif_ipv6_\(addr\|group\)_\(add\|remove\|join\|leave\)\>" | \
        xargs sed -i 's/\<gnrc_netif_ipv6_\(addr\|group\)_\(add\|remove\|join\|leave\)/\0_internal/g'
```

### Issues/PRs references
None