### PR TITLE
sys/netif: add missig pkt release in gnrc_netif_raw

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -110,6 +110,8 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #endif
         res = dev->driver->send(dev, v, n);
     }
+    /* release old data */
+    gnrc_pktbuf_release(pkt);
     return res;
 }
 


### PR DESCRIPTION
### Contribution description

Release the `pkt` after calling the drivers send function in the gnrc_netif_raw adaptation layer.