### PR TITLE
sys/netif: include release of iovec in gnrc_netif_raw

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -100,8 +100,11 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         /* we don't need the netif snip: remove it */
         pkt = gnrc_pktbuf_remove_snip(pkt, pkt);
     }
+    /* prepare packet for sending */
     vector = gnrc_pktbuf_get_iovec(pkt, &n);
     if (vector != NULL) {
+        /* reassign for later release; vector is prepended to pkt */
+        pkt = vector;
         struct iovec *v = (struct iovec *)vector->data;
         netdev_t *dev = netif->dev;
 


### PR DESCRIPTION
### Contribution description
`gnrc_pktbuf_get_iovec` prepends a snip to a given packet. This also needs to be released after sending the packet. Without this fix the packet buffer will fill up after some time


### Issues/PRs references
Related to #8256