### PR TITLE
tests: enhance xtimer_msg and add auto test script

### DIFF
--- a/tests/xtimer_msg/Makefile
+++ b/tests/xtimer_msg/Makefile
@@ -5,3 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/xtimer_msg/tests/01-run.py
+++ b/tests/xtimer_msg/tests/01-run.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    # 1st check for periodic 2s Hello World message, i.e., 2 output + 1 msg
+    for _ in range(7):
+        child.expect(r"sec=\d+ min=\d+ hour=\d+")
+        child.expect(r"sec=\d+ min=\d+ hour=\d+")
+        child.expect(r"now=\d+:\d+ -> every 2.0s: Hello World")
+    # 2nd check for periodic 5s test message, i.e., 5 output + 1 msg
+    for _ in range(3):
+        child.expect(r"sec=\d+ min=\d+ hour=\d+")
+        child.expect(r"sec=\d+ min=\d+ hour=\d+")
+        child.expect(r"sec=\d+ min=\d+ hour=\d+")
+        child.expect(r"sec=\d+ min=\d+ hour=\d+")
+        child.expect(r"sec=\d+ min=\d+ hour=\d+")
+        child.expect(r"now=\d+:\d+ -> every 5.0s: This is a Test")
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This PR enhances the xtimer_msg tests, by a) removing timex and use xtimer only instead, and b) reduce memory size by lowering thread stack size to an appropriate
 (and still more than enough) value. 

Further, this PR adds a test runner script for automation.


### Issues/PRs references

followup on #7871, and others