### PR TITLE
drivers/sx127x: add functions required for loramac

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -282,6 +282,26 @@ uint32_t sx127x_random(sx127x_t *dev);
 void sx127x_start_cad(sx127x_t *dev);
 
 /**
+ * @brief   Checks that channel is free with specified RSSI threshold.
+ *
+ * @param[in] dev                      The sx127x device structure pointer
+ * @param[in] freq                     channel RF frequency
+ * @param[in] rssi_threshold           RSSI threshold
+ *
+ * @return true if channel is free, false otherwise
+ */
+bool sx127x_is_channel_free(sx127x_t *dev, uint32_t freq, int16_t rssi_threshold);
+
+/**
+ * @brief   Reads the current RSSI value.
+ *
+ * @param[in] dev                      The sx127x device structure pointer
+ *
+ * @return the current value of RSSI (in dBm)
+ */
+int16_t sx127x_read_rssi(const sx127x_t *dev);
+
+/**
  * @brief   Gets current state of transceiver.
  *
  * @param[in] dev                      The sx127x device descriptor

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -109,7 +109,7 @@ uint8_t sx127x_get_syncword(const sx127x_t *dev)
 
 void sx127x_set_syncword(sx127x_t *dev, uint8_t syncword)
 {
-    DEBUG("[DEBUG] Set syncword: %d\n", syncword);
+    DEBUG("[DEBUG] Set syncword: %02x\n", syncword);
 
     sx127x_reg_write(dev, SX127X_REG_LR_SYNCWORD, syncword);
 }

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -224,3 +224,18 @@ void sx127x_start_cad(sx127x_t *dev)
             break;
     }
 }
+
+bool sx127x_is_channel_free(sx127x_t *dev, uint32_t freq, int16_t rssi_threshold)
+{
+    int16_t rssi = 0;
+
+    sx127x_set_channel(dev, freq);
+    sx127x_set_op_mode(dev, SX127X_RF_OPMODE_RECEIVER);
+
+    xtimer_usleep(1000); /* wait 1 millisecond */
+
+    rssi = sx127x_read_rssi(dev);
+    sx127x_set_sleep(dev);
+
+    return (rssi <= rssi_threshold);
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a missing function in the SX127x driver that is required for LoRaMAC. Plus it adds a missing definition for a function already present in the driver.

There's also a small cleanup in one debug output.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

refs #7331 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->