### PR TITLE
slipdev: simplify and solidify byte-unstuffing

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -246,6 +246,7 @@ ifneq (,$(filter si70%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter slipdev,$(USEMODULE)))
+  USEMODULE += tsrb
   FEATURES_REQUIRED += periph_uart
 endif
 

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -26,7 +26,7 @@
 #include "cib.h"
 #include "net/netdev.h"
 #include "periph/uart.h"
-#include "ringbuffer.h"
+#include "tsrb.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,20 +36,12 @@ extern "C" {
  * @brief   UART buffer size used for TX and RX buffers
  *
  * Reduce this value if your expected traffic does not include full IPv6 MTU
- * sized packets
+ * sized packets.
+ *
+ * @pre Needs to be power of two and `<= INT_MAX`
  */
 #ifndef SLIPDEV_BUFSIZE
-#define SLIPDEV_BUFSIZE (1500U)
-#endif
-
-/**
- * @brief   Packet FIFO size
- *
- * @note    For GNRC it is recommended to have it the same size as the link-layer
- *          thread's message queue, but it MUST be of power of 2
- */
-#ifndef SLIPDEV_PKTFIFO_SIZE
-#define SLIPDEV_PKTFIFO_SIZE    (8U)
+#define SLIPDEV_BUFSIZE (2048U)
 #endif
 
 /**
@@ -68,13 +60,8 @@ typedef struct {
 typedef struct {
     netdev_t netdev;                        /**< parent class */
     slipdev_params_t config;                /**< configuration parameters */
-    ringbuffer_t inbuf;                     /**< RX buffer */
+    tsrb_t inbuf;                           /**< RX buffer */
     char rxmem[SLIPDEV_BUFSIZE];            /**< memory used by RX buffer */
-    uint16_t pktfifo[SLIPDEV_PKTFIFO_SIZE]; /**< FIFO of sizes of fully received
-                                             *   packets */
-    cib_t pktfifo_idx;                      /**< CIB for slipdev_t::pktfifo */
-    uint16_t inbytes;                       /**< the number of bytes received of
-                                             *   a currently incoming packet */
     uint16_t inesc;                         /**< device previously received an escape
                                              *   byte */
 } slipdev_t;


### PR DESCRIPTION
### Contribution description

This simplifies and solidifies the reversal of SLIP's byte-stuffing
(aka byte-unstuffing ;-)) by

1. Using `tsrb` instead of `ringbuffer`: there are two actors. The ISR
   and the device's event handler.
2. Moving the byte-unstuffing from the UART RX-handler (i.e. the ISR)
   to the device's receive function (potentially not the ISR)
3. Removing the `pktfifo` member. The current number of bytes in the
   ringbuffer is returned for `recv(data = NULL, len = 0)`. If that is
   more than the packet contains (due to the byte stuffing it most
   likely will be) the packet is reallocated in GNRC anyway.

### Issues/PRs references

Alternative to #8258, fixes #8003.