### PR TITLE
pkg/*: put $(MAKE) in quotes in all packages

### DIFF
--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -8,6 +8,6 @@ CFLAGS += -Wno-strict-aliasing
 .PHONY: all
 
 all: git-download
-	$(MAKE) -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -9,6 +9,6 @@ CFLAGS += -Wno-implicit-fallthrough
 
 all: git-download
 	@cp Makefile.jerryscript $(PKG_BUILDDIR)/Makefile
-	$(MAKE) -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -26,7 +26,7 @@ libjerry:
 	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP)
 
-	make -C $(BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal
+	"$(MAKE)" -C $(BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal
 	cp $(BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
 	cp $(BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
 	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a

--- a/pkg/libfixmath/Makefile
+++ b/pkg/libfixmath/Makefile
@@ -6,6 +6,6 @@ PKG_LICENSE  := MIT
 .PHONY: all
 
 all: git-download
-	$(Q)$(MAKE) -C $(PKG_BUILDDIR)
+	$(Q)"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -6,6 +6,6 @@ PKG_LICENSE=BSD-3-Clause
 .PHONY: all
 
 all: git-download
-	$(MAKE) -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/micro-ecc/Makefile
+++ b/pkg/micro-ecc/Makefile
@@ -6,6 +6,6 @@ PKG_LICENSE=BSD-2-Clause
 .PHONY: all
 
 all: git-download
-	make -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tiny-asn1/Makefile
+++ b/pkg/tiny-asn1/Makefile
@@ -9,6 +9,6 @@ INCLUDES+=-I$(TINYASN1_ROOT)/src
 .PHONY: all
 
 all: git-download
-	$(MAKE) -C $(PKG_BUILDDIR)/src
+	"$(MAKE)" -C $(PKG_BUILDDIR)/src
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -11,6 +11,6 @@ all: git-download
 	@cp $(PKG_BUILDDIR)/aes/Makefile.riot $(PKG_BUILDDIR)/aes/Makefile
 	@cp $(PKG_BUILDDIR)/ecc/Makefile.riot $(PKG_BUILDDIR)/ecc/Makefile
 	@cp $(PKG_BUILDDIR)/sha2/Makefile.riot $(PKG_BUILDDIR)/sha2/Makefile
-	$(MAKE) -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tlsf/Makefile
+++ b/pkg/tlsf/Makefile
@@ -15,7 +15,7 @@ all: $(PKG_SRCDIR)/$(PKG_NAME).a
 prepare: $(PKG_SRCDIR)/Makefile
 
 $(PKG_SRCDIR)/$(PKG_NAME).a: $(PKG_SRCDIR)/Makefile
-	$(Q)make -C $(<D)
+	$(Q)"$(MAKE)" -C $(<D)
 
 $(PKG_SRCDIR)/Makefile: $(PKG_BUILDDIR)/$(PKG_FILE) $(CURDIR)/patch.txt
 	rm -rf $(@D)

--- a/pkg/umorse/Makefile
+++ b/pkg/umorse/Makefile
@@ -7,6 +7,6 @@ PKG_LICENSE=MIT
 
 all: git-download
 	@cp Makefile.umorse $(PKG_BUILDDIR)/Makefile
-	$(MAKE) -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a cosmetic improvement of some package build output. Some `make` are not surrounded by double quotes and this shifts the corresponding build line from regular RIOT modules.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->