### PR TITLE
boards/native: clean-up MTD and SPIFFS default config

### DIFF
--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -34,25 +34,12 @@ void board_init(void)
 }
 
 #ifdef MODULE_MTD
-#ifndef MTD_NATIVE_PAGE_SIZE
-#define MTD_NATIVE_PAGE_SIZE     256
-#endif
-#ifndef MTD_NATIVE_SECTOR_SIZE
-#define MTD_NATIVE_SECTOR_SIZE   4096
-#endif
-#ifndef MTD_NATIVE_SECTOR_NUM
-#define MTD_NATIVE_SECTOR_NUM    2048
-#endif
-#ifndef MTD_NATIVE_FILENAME
-#define MTD_NATIVE_FILENAME    "MEMORY.bin"
-#endif
-
 static mtd_native_dev_t mtd0_dev = {
     .dev = {
         .driver = &native_flash_driver,
-        .sector_count = MTD_NATIVE_SECTOR_NUM,
-        .pages_per_sector = MTD_NATIVE_SECTOR_SIZE / MTD_NATIVE_PAGE_SIZE,
-        .page_size = MTD_NATIVE_PAGE_SIZE,
+        .sector_count = MTD_SECTOR_NUM,
+        .pages_per_sector = MTD_SECTOR_SIZE / MTD_PAGE_SIZE,
+        .page_size = MTD_PAGE_SIZE,
     },
     .fname = MTD_NATIVE_FILENAME,
 };

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -79,29 +79,51 @@ void _native_LED_RED_TOGGLE(void);
 extern mtd_dev_t *mtd0;
 #endif
 
-#ifdef MODULE_SPIFFS
-#define SPIFFS_READ_ONLY 0
-#define SPIFFS_SINGLETON 0
-
-#define SPIFFS_HAL_CALLBACK_EXTRA 1
-
-#define SPIFFS_CACHE 1
+#if defined(MODULE_SPIFFS) || DOXYGEN
+/**
+ * @name    SPIFFS default configuration
+ * @{
+ */
+/* SPIFFS config flags */
+#ifndef SPIFFS_READ_ONLY
+#define SPIFFS_READ_ONLY                    (0)
+#endif
+#ifndef SPIFFS_SINGLETON
+#define SPIFFS_SINGLETON                    (0)
+#endif
+#ifndef SPIFFS_HAL_CALLBACK_EXTRA
+#define SPIFFS_HAL_CALLBACK_EXTRA           (1)
+#endif
+#ifndef SPIFFS_CACHE
+#define SPIFFS_CACHE                        (1)
+#endif
 
 #if SPIFFS_SINGLETON == 1
-#define SPIFFS_CFG_PHYS_SZ(ignore)        (0x800000)
-
-#define SPIFFS_CFG_PHYS_ERASE_SZ(ignore)  (4096)
-
-#define SPIFFS_CFG_PHYS_ADDR(ignore)      (0)
-
-#define SPIFFS_CFG_LOG_PAGE_SZ(ignore)    (256)
-
-#define SPIFFS_CFG_LOG_BLOCK_SZ(ignore)   (4096)
+/* MTD config if singleton is used */
+#ifndef SPIFFS_CFG_PHYS_SZ
+#define SPIFFS_CFG_PHYS_SZ(ignore)          (MTD_SECTOR_SIZE * MTD_SECTOR_NUM)
+#endif
+#ifndef SPIFFS_CFG_PHYS_ERASE_SZ
+#define SPIFFS_CFG_PHYS_ERASE_SZ(ignore)    (MTD_SECTOR_SIZE)
+#endif
+#ifndef SPIFFS_CFG_PHYS_ADDR
+#define SPIFFS_CFG_PHYS_ADDR(ignore)        (0)
+#endif
+#ifndef SPIFFS_CFG_LOG_PAGE_SZ
+#define SPIFFS_CFG_LOG_PAGE_SZ(ignore)      (MTD_PAGE_SIZE)
+#endif
+#ifndef SPIFFS_CFG_LOG_BLOCK_SZ
+#define SPIFFS_CFG_LOG_BLOCK_SZ(ignore)     (MTD_SECTOR_SIZE)
+#endif
 #endif
 
 #if SPIFFS_HAL_CALLBACK_EXTRA == 0
-#define SPIFFS_MTD_DEV (MTD_0)
+/* Default MTD device if no callback parameter */
+#ifndef SPIFFS_MTD_DEV
+#define SPIFFS_MTD_DEV                      (MTD_0)
 #endif
+#endif
+/** @} */
 #endif
 
 #ifdef __cplusplus

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -53,7 +53,26 @@ void _native_LED_RED_TOGGLE(void);
 #define LED1_TOGGLE         (_native_LED_GREEN_TOGGLE())
 /** @} */
 
-#ifdef MODULE_MTD
+#if defined(MODULE_MTD) || DOXYGEN
+/**
+ * @name    MTD emulation configuration
+ * @{
+ */
+#ifndef MTD_PAGE_SIZE
+#define MTD_PAGE_SIZE           (256)
+#endif
+#ifndef MTD_SECTOR_SIZE
+#define MTD_SECTOR_SIZE         (4096)
+#endif
+#ifndef MTD_SECTOR_NUM
+#define MTD_SECTOR_NUM          (2048)
+#endif
+#ifndef MTD_NATIVE_FILENAME
+#define MTD_NATIVE_FILENAME     "MEMORY.bin"
+#endif
+/** @} */
+
+/** Default MTD device */
 #define MTD_0 mtd0
 
 /** mtd flash emulation device */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In native board:
- Clean-up MTD default config: move defines from `board.c` to `board.h`
- Clean-up SPIFFS default config: use previously added MTD defines and clean-up doc


### Issues/PRs references

None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->