### PR TITLE
pkg/spiffs: add multi-partitions support

### DIFF
--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -136,10 +136,16 @@ static int prepare(spiffs_desc_t *fs_desc)
 #if SPIFFS_SINGLETON == 0
     DEBUG("spiffs: mount: mtd page_size=%" PRIu32 ", pages_per_sector=%" PRIu32
           ", sector_count=%" PRIu32 "\n", dev->page_size, dev->pages_per_sector, dev->sector_count);
-    fs_desc->config.phys_size = dev->page_size * dev->pages_per_sector * dev->sector_count;
+    uint32_t sector_count = (fs_desc->block_count == 0) ? dev->sector_count : fs_desc->block_count;
+    /* inside memory area */
+    assert(((fs_desc->base_addr / (dev->page_size * dev->pages_per_sector)) + sector_count)
+           <= dev->sector_count);
+    /* base addr is aligned on a sector */
+    assert(fs_desc->base_addr % (dev->pages_per_sector * dev->page_size) == 0);
+    fs_desc->config.phys_size = dev->page_size * dev->pages_per_sector * sector_count;
     fs_desc->config.log_block_size = dev->page_size * dev->pages_per_sector;
     fs_desc->config.log_page_size = dev->page_size;
-    fs_desc->config.phys_addr = 0;
+    fs_desc->config.phys_addr = fs_desc->base_addr;
     fs_desc->config.phys_erase_block = dev->page_size * dev->pages_per_sector;
 #endif
 

--- a/sys/include/fs/spiffs_fs.h
+++ b/sys/include/fs/spiffs_fs.h
@@ -116,6 +116,11 @@ typedef struct spiffs_desc {
 #if (SPIFFS_HAL_CALLBACK_EXTRA == 1) || defined(DOXYGEN)
     mtd_dev_t *dev;                             /**< The underlying mtd device, must be set by user */
 #endif
+#if (SPIFFS_SINGLETON == 0) || defined(DOXYGEN)
+    uint32_t base_addr;                         /**< Base address of partition */
+    uint32_t block_count;                       /**< Number of blocks in current partition,
+                                                 *  if 0, the mtd number of sector is used */
+#endif
 } spiffs_desc_t;
 
 /** The SPIFFS vfs driver, a pointer to a spiffs_desc_t must be provided as vfs_mountp::private_data */

--- a/tests/unittests/tests-spiffs/tests-spiffs.c
+++ b/tests/unittests/tests-spiffs/tests-spiffs.c
@@ -143,6 +143,9 @@ static void test_spiffs_teardown(void)
     vfs_unlink("/test-spiffs/test1.txt");
     vfs_unlink("/test-spiffs/a/test2.txt");
     vfs_umount(&_test_spiffs_mount);
+
+    spiffs_desc.base_addr = 0;
+    spiffs_desc.block_count = 0;
 }
 
 static void tests_spiffs_format(void)
@@ -382,6 +385,58 @@ static void tests_spiffs_statvfs(void)
     TEST_ASSERT(sizeof(buf) <= (stat1.f_bavail - stat2.f_bavail));
 }
 
+static void tests_spiffs_partition(void)
+{
+    vfs_umount(&_test_spiffs_mount);
+
+    spiffs_desc.base_addr = _dev->page_size * _dev->pages_per_sector;
+    spiffs_desc.block_count = 2;
+    mtd_erase(_dev, 0, _dev->page_size * _dev->pages_per_sector * _dev->sector_count);
+
+    int res = vfs_format(&_test_spiffs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_mount(&_test_spiffs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+#if SPIFFS_USE_MAGIC
+    /* if SPIFFS_USE_MAGIC is used, a magic word is written in each sector */
+    uint8_t buf[4];
+    const uint8_t buf_erased[4] = {0xff, 0xff, 0xff, 0xff};
+    int nread;
+    res = 0;
+    for (size_t i = 0; i < _dev->page_size * _dev->pages_per_sector; i += sizeof(buf)) {
+        nread = mtd_read(_dev, buf, _dev->page_size * _dev->pages_per_sector + i, sizeof(buf));
+        TEST_ASSERT_EQUAL_INT(sizeof(buf), nread);
+        res |= memcmp(buf, buf_erased, sizeof(buf));
+    }
+    TEST_ASSERT(res != 0);
+    res = 0;
+    for (size_t i = 0; i < _dev->page_size * _dev->pages_per_sector; i += sizeof(buf)) {
+        nread = mtd_read(_dev, buf, (2 * _dev->page_size * _dev->pages_per_sector) + i, sizeof(buf));
+        TEST_ASSERT_EQUAL_INT(sizeof(buf), nread);
+        res |= memcmp(buf, buf_erased, sizeof(buf));
+    }
+    TEST_ASSERT(res != 0);
+    /* Check previous sector (must be erased) */
+    res = 0;
+    for (size_t i = 0; i < _dev->page_size * _dev->pages_per_sector; i += sizeof(buf)) {
+        nread = mtd_read(_dev, buf, i, sizeof(buf));
+        TEST_ASSERT_EQUAL_INT(sizeof(buf), nread);
+        res |= memcmp(buf, buf_erased, sizeof(buf));
+    }
+    TEST_ASSERT(res == 0);
+    /* Check next sector (must be erased) */
+    res = 0;
+    for (size_t i = 0; i < _dev->page_size * _dev->pages_per_sector; i += sizeof(buf)) {
+        nread = mtd_read(_dev, buf, (3 * _dev->page_size * _dev->pages_per_sector) + i, sizeof(buf));
+        TEST_ASSERT_EQUAL_INT(sizeof(buf), nread);
+        res |= memcmp(buf, buf_erased, sizeof(buf));
+    }
+    TEST_ASSERT(res == 0);
+#endif
+}
+
 Test *tests_spiffs_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -393,6 +448,7 @@ Test *tests_spiffs_tests(void)
         new_TestFixture(tests_spiffs_readdir),
         new_TestFixture(tests_spiffs_rename),
         new_TestFixture(tests_spiffs_statvfs),
+        new_TestFixture(tests_spiffs_partition),
     };
 
     EMB_UNIT_TESTCALLER(spiffs_tests, test_spiffs_setup, test_spiffs_teardown, fixtures);


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add the possibility of using multiple partitions (i.e. not use the whole memory for a spiffs partition).
Two new fileds added in spiffs descriptor:
 - base_addr: base address of the partition
 - part_block_count: number of sectors in the partition
If part_block_count is 0, the whole underlying MTD is used

### Issues/PRs references

None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->