### PR TITLE
sys/auto_init: initialize app code from auto_init [RFC]

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -388,4 +388,9 @@ auto_init_mpu9150();
     auto_init_candev();
 
 #endif /* MODULE_AUTO_INIT_CAN */
+
+    extern void auto_init_app(void);
+    auto_init_app();
 }
+
+void __attribute__((weak)) auto_init_app(void) {}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A new weak function auto_init_app is called at the end of the auto_init
function to let the app initializing its own modules before main is
called.

This is a RFC. My main goal is to make the initialization of our different app and modules more generic and transparent.
So far we call our own 'auto_init' from the beginning of main, but it would be more transparent to use this hook.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->