### PR TITLE
cc2420/gnrc_netif: Adds crc_valid to netif

### DIFF
--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -206,13 +206,13 @@ int cc2420_rx(cc2420_t *dev, uint8_t *buf, size_t max_len, void *info)
 
         /* fetch and check if CRC_OK bit (MSB) is set */
         cc2420_fifo_read(dev, &crc_corr, 1);
-        if (!(crc_corr & 0x80)) {
-            DEBUG("cc2420: recv: CRC_OK bit not set, dropping packet\n");
-            /* drop the corrupted frame from the RXFIFO */
-            len = 0;
+        if (!(crc_corr & 0x80) && (len > CC2420_PKT_MAXLEN)) {
+            len = CC2420_PKT_MAXLEN;
         }
+
         if (info != NULL) {
             netdev_ieee802154_rx_info_t *radio_info = info;
+            radio_info->crc_valid = (crc_corr & 0x80);
             radio_info->rssi = CC2420_RSSI_OFFSET + rssi;
             radio_info->lqi = crc_corr & CC2420_CRCCOR_COR_MASK;
         }

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -249,6 +249,7 @@ typedef enum {
 struct netdev_radio_rx_info {
     int16_t rssi;       /**< RSSI of a received packet in dBm */
     uint8_t lqi;        /**< LQI of a received packet */
+    uint8_t crc_valid;  /**< CRC was valid (when != 0) */
 };
 
 /**

--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -88,6 +88,11 @@ extern "C" {
  *          @ref IEEE802154_FCF_FRAME_PEND
  */
 #define GNRC_NETIF_HDR_FLAGS_MORE_DATA  (0x10)
+
+/**
+ * @brief   Link-layer checksum was valid on receive
+ */
+#define GNRC_NETIF_HDR_FLAGS_CRC_VALID  (0x01)
 /**
  * @}
  */

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -90,7 +90,7 @@ static inline bool _already_received(gnrc_netif_t *netif,
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
-    netdev_ieee802154_rx_info_t rx_info;
+    netdev_ieee802154_rx_info_t rx_info = { .crc_valid = 0 };
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
@@ -184,6 +184,9 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 
             hdr->lqi = rx_info.lqi;
             hdr->rssi = rx_info.rssi;
+            if (rx_info.crc_valid) {
+                hdr->flags |= GNRC_NETIF_HDR_FLAGS_CRC_VALID;
+            }
             hdr->if_pid = thread_getpid();
             dev->driver->get(dev, NETOPT_PROTO, &pkt->type, sizeof(pkt->type));
 #if ENABLE_DEBUG


### PR DESCRIPTION
Provides a way to check CRC inside the application, by adding a crc_valid field to the netif hdr.