### PR TITLE
cpu, native: replace timex_t in syscalls

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -424,10 +424,9 @@ int getpid(void)
 int _gettimeofday(struct timeval *tp, void *restrict tzp)
 {
     (void) tzp;
-    timex_t now;
-    xtimer_now_timex(&now);
-    tp->tv_sec = now.seconds;
-    tp->tv_usec = now.microseconds;
+    uint64_t now = xtimer_now_usec64();
+    tp->tv_sec  = now / US_PER_SEC;
+    tp->tv_usec = now - tp->tv_sec;
     return 0;
 }
 #endif


### PR DESCRIPTION
### Contribution description

Replaces usage of `timex_t` in native sys calls with alternative xtimer calls.

### Issues/PRs references

contributes to #1305