### PR TITLE
gnrc_gomach: add flexible number limit for allocating slots.

### DIFF
--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -266,17 +266,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Maximum number of slots allowed to be allocated in one cycle.
- *
- * GoMacH dynamically allocates transmission slots to senders that have
- * pending packets.This macro defines the maximum number of slots allowed
- * to be allocated in one cycle.
- */
-#ifndef GNRC_GOMACH_MAX_ALLOC_SLOTS_NUM
-#define GNRC_GOMACH_MAX_ALLOC_SLOTS_NUM           (25U)
-#endif
-
-/**
  * @brief Maximum number of senders allowed to be allocated slots in one cycle.
  *
  * Exclude the static GoMacH MAC header payload in the beacon, which is 20 bytes,

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -467,6 +467,10 @@ int gnrc_gomach_send_beacon(gnrc_netif_t *netif)
     gnrc_gomach_l2_id_t id_list[GNRC_GOMACH_SLOSCH_UNIT_COUNT];
     uint8_t slots_list[GNRC_GOMACH_SLOSCH_UNIT_COUNT];
 
+    /* Calculate how many slots left can be allocated to senders. */
+    uint16_t max_slot_num = (GNRC_GOMACH_SUPERFRAME_DURATION_US - gnrc_gomach_phase_now(netif)) /
+                            GNRC_GOMACH_VTDMA_SLOT_SIZE_US;
+
     for (i = 0; i < GNRC_GOMACH_SLOSCH_UNIT_COUNT; i++) {
         if (netif->mac.rx.slosch_list[i].queue_indicator > 0) {
             /* Record the device's (that will be allocated slots) address to the ID list. */
@@ -481,9 +485,9 @@ int gnrc_gomach_send_beacon(gnrc_netif_t *netif)
             total_tdma_slot_num += slots_list[j];
 
             /* If there is no room for allocating more slots, stop. */
-            if (total_tdma_slot_num >= GNRC_GOMACH_MAX_ALLOC_SLOTS_NUM) {
+            if (total_tdma_slot_num >= max_slot_num) {
                 uint8_t redueced_slots_num;
-                redueced_slots_num = total_tdma_slot_num - GNRC_GOMACH_MAX_ALLOC_SLOTS_NUM;
+                redueced_slots_num = total_tdma_slot_num - max_slot_num;
                 slots_list[j] -= redueced_slots_num;
                 total_tdma_slot_num -= redueced_slots_num;
                 break;

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -467,7 +467,7 @@ int gnrc_gomach_send_beacon(gnrc_netif_t *netif)
     gnrc_gomach_l2_id_t id_list[GNRC_GOMACH_SLOSCH_UNIT_COUNT];
     uint8_t slots_list[GNRC_GOMACH_SLOSCH_UNIT_COUNT];
 
-    /* Calculate how many slots left can be allocated to senders. */
+    /* Check the maximum number of slots that can be allocated to senders. */
     uint16_t max_slot_num = (GNRC_GOMACH_SUPERFRAME_DURATION_US - gnrc_gomach_phase_now(netif)) /
                             GNRC_GOMACH_VTDMA_SLOT_SIZE_US;
 


### PR DESCRIPTION
### Contribution description

Adds a **flexible** number limit of allocated slots for the receiver that is about to allocate transmission slots to the senders. 
In other words, with the left time in the current cycle (superframe), the receiver calculates the maximum number of slots left that can be allocated. This removes the rely on a fixed slots number limit that used to be defined in `GNRC_GOMACH_MAX_ALLOC_SLOTS_NUM`.
