### PR TITLE
net: fix output in gnrc_pktdump for ccnl

### DIFF
--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -91,7 +91,7 @@ static void _dump_snip(gnrc_pktsnip_t *pkt)
 #ifdef MODULE_CCN_LITE_UTILS
         case GNRC_NETTYPE_CCN_CHUNK:
             printf("GNRC_NETTYPE_CCN_CHUNK (%i)\n", pkt->type);
-            printf("Content is: %.*s\n", pkt->size, (char*)pkt->data);
+            printf("Content is: %.*s\n", (int)pkt->size, (char*)pkt->data);
             break;
 #endif
 #ifdef TEST_SUITES


### PR DESCRIPTION
### Contribution description

Fixes the following compile error on macOS

```
/RIOT/sys/net/gnrc/pktdump/gnrc_pktdump.c:94:35: error: field precision should have type 'int', but argument has type 'size_t' (aka 'unsigned long') [-Werror,-Wformat]
            printf("Content is: %.*s\n", pkt->size, (char*)pkt->data);
                                ~~^~     ~~~~~~~~~
1 error generated.
```

### Issues/PRs references

None