### PR TITLE
gnrc_lwmac: revise LWMAC's doc naming.

### DIFF
--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -8,10 +8,10 @@
  */
 
 /**
- * @defgroup    net_gnrc_lwmac Simplest possible MAC layer
+ * @defgroup    net_gnrc_lwmac LWMAC
  * @ingroup     net_gnrc
- * @brief       Lightweight MAC protocol that allows for duty cycling to save
- *              energy.
+ * @brief       LWMAC is a Lightweight 802.15.4 MAC protocol that allows for duty cycling
+ *              to save energy.
  *
  * ## LWMAC implementation
  *


### PR DESCRIPTION
### Contribution description

This PR simply revises LWMAC's documentation naming, from `Simplest possible MAC layer` to `LWMAC`. :-)
