### PR TITLE
tests/thread_flags: fix error condition and return value

### DIFF
--- a/tests/thread_flags/main.c
+++ b/tests/thread_flags/main.c
@@ -27,7 +27,8 @@ static char stack[THREAD_STACKSIZE_MAIN];
 
 volatile unsigned done;
 
-#define TIMEOUT   (100UL * US_PER_MS)
+#define TIMEOUT     (100UL * US_PER_MS)
+#define THRESHOLD   (500U)
 
 static void *_thread(void *arg)
 {
@@ -97,12 +98,11 @@ int main(void)
     uint32_t diff = xtimer_now_usec() - before;
     printf("main: timeout triggered. time passed: %uus\n", (unsigned)diff);
 
-    if (abs(diff - TIMEOUT) < 500) {
+    if (diff < (TIMEOUT + THRESHOLD)) {
         puts("SUCCESS");
+        return 0;
     }
-    else {
-        puts("FAILURE");
-    }
+    puts("FAILURE");
 
-    return 0;
+    return 1;
 }


### PR DESCRIPTION
### Contribution description

Fix following compile issue found with clang on macOS

```
/RIOT/tests/thread_flags/main.c:100:9: error: taking the absolute value of unsigned type 'unsigned long' has no effect [-Werror,-Wabsolute-value]
    if (abs(diff - TIMEOUT) < 500) {
        ^
/RIOT/tests/thread_flags/main.c:100:9: note: remove the call to 'abs' since unsigned values cannot be negative
    if (abs(diff - TIMEOUT) < 500) {
        ^~~
1 error generated.
```

and also fix the return value of the test in case of error and success, currently it always returns `0`.

Btw. this tests fails very often on macOS native, but that's a more general timing issue not related to the flags stuff.

### Issues/PRs references

related to #6473 