### PR TITLE
toolchains: print git version

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -69,6 +69,17 @@ spatch_version() {
     printf "%s" "$ver"
 }
 
+git_version() {
+    local cmd="git"
+    if command -v "$cmd" 2>&1 >/dev/null; then
+        ver=$("$cmd" --version | head -n 1)
+    else
+        ver="missing"
+    fi
+
+    printf "%s" "$ver"
+}
+
 printf "%s\n" "Installed toolchain versions"
 printf "%s\n" "----------------------------"
 VER=$(gcc --version | head -n 1)
@@ -91,4 +102,5 @@ for p in avr; do
 done
 printf "%20s: %s\n" "cppcheck" "$(cppcheck_version)"
 printf "%20s: %s\n" "coccinelle" "$(spatch_version)"
+printf "%20s: %s\n" "git" "$(git_version)"
 exit 0


### PR DESCRIPTION
### Contribution description

Minor enhancement to print the GIT version used by the CI, recently found that pkg libcoap patching fails with newer GIT versions, so might be good to know which is used by CI and which one has on their system.

### Issues/PRs references

See also #8289