### PR TITLE
makefiles/modules.inc.mk: remove setting deprecated FEATURE_PERIPH_ macros

### DIFF
--- a/makefiles/modules.inc.mk
+++ b/makefiles/modules.inc.mk
@@ -1,5 +1,4 @@
-ED = $(addprefix FEATURE_,$(sort $(filter $(FEATURES_PROVIDED), $(FEATURES_REQUIRED))))
-ED += $(addprefix MODULE_,$(sort $(USEMODULE) $(USEPKG)))
+ED = $(addprefix MODULE_,$(sort $(USEMODULE) $(USEPKG)))
 EXTDEFINES = $(addprefix -D,$(shell echo '$(ED)' | tr 'a-z-' 'A-Z_'))
 
 # filter "pseudomodules" from "real modules", but not "no_pseudomodules"


### PR DESCRIPTION
This PR removes setting the `FEATURES_PERIPH_` macros as they are completely unused and said deprecated.

There will be no reference after https://github.com/RIOT-OS/RIOT/pull/8227
Was cleaned up also by:  https://github.com/RIOT-OS/RIOT/pull/8226

TODO: Modify the commit message to add reference to when it was deprecated.