### PR TITLE
tools/tapsetup: try to retrieve user name if not set

### DIFF
--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -175,8 +175,11 @@ while true ; do
 done
 
 if [ -z "${USER}" ]; then
-    echo 'need to export $USER'
-    exit 1
+    export USER=$(id -un)
+    if [ -z "${USER}" ]; then
+        echo 'need to export $USER'
+        exit 1
+    fi
 fi
 if [ -z "${COMMAND}" ]; then
     COMMAND="create"


### PR DESCRIPTION
### Contribution description

The tapsetup requires that the `USER` environment variable is set, on some systems, e.g., in a Docker container, that might not be the case. This PR adds a work around trying to set `USER` if possible, otherwise fail as before.


### Issues/PRs references

None