### PR TITLE
sys/crypto/ccm: fix docstring value for 'nonce_len'

### DIFF
--- a/sys/include/crypto/modes/ccm.h
+++ b/sys/include/crypto/modes/ccm.h
@@ -44,7 +44,7 @@ extern "C" {
  *                         (2^(8*length_enc)).
  * @param nonce            Nounce for ctr mode encryption
  * @param nonce_len        Length of the nonce in octets
- *                         (maximum: 16-length_encoding)
+ *                         (maximum: 15-length_encoding)
  * @param input            pointer to input data to encrypt
  * @param input_len        length of the input data
  * @param output           pointer to allocated memory for encrypted data. It
@@ -69,7 +69,7 @@ int cipher_encrypt_ccm(cipher_t* cipher, uint8_t* auth_data,
  *                         (2^(8*length_enc)).
  * @param nonce            Nounce for ctr mode encryption
  * @param nonce_len        Length of the nonce in octets
- *                         (maximum: 16-length_encoding)
+ *                         (maximum: 15-length_encoding)
  * @param input            pointer to input data to decrypt
  * @param input_len        length of the input data
  * @param output           pointer to allocated memory for decrypted data. It


### PR DESCRIPTION
From RFC3610 - 2.1.2:

    A nonce N of 15-L octets
    (where L: Number of octets in length field)

The RFC link: https://tools.ietf.org/html/rfc3610#section-2.1