### PR TITLE
drivers/kw2xrf: finish ongoing transmission before sending next frame

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -142,6 +142,7 @@ ifneq (,$(filter kw2xrf,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+  USEMODULE += core_thread_flags
   FEATURES_REQUIRED += periph_spi
 endif
 

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -31,6 +31,7 @@
 #include "net/netdev.h"
 #include "net/netdev/ieee802154.h"
 #include "net/gnrc/nettype.h"
+#include "thread.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -129,6 +130,7 @@ typedef struct {
      * @brief   device specific fields
      * @{
      */
+    thread_t *thread;                   /**< Network driver thread, for providing feedback from IRQ handler */
     kw2xrf_params_t params;             /**< parameters for initialization */
     uint8_t buf[KW2XRF_MAX_PKT_LENGTH]; /**< Buffer for incoming or outgoing packets */
     uint8_t state;                      /**< current state of the radio */


### PR DESCRIPTION
### Contribution description

As described in below referenced issues, the KW2XRF driver currently does not wait for ongoing transmissions to finish before sending a next frame. If the device is busy, the second frame will simply be ignored. Problems usually occur with 6LoWPAN-fragmented  IPv6 packets. This PR provides a fix. Now `ping6` between a Phytec node an Atmel node with payloads up to 900. 

@gebart I added you as author because this is actually your solution from #7107. D'accord?

### Issues/PRs references

(Partly) fixes #4822; relates to #7474; fix taken from #7107