### PR TITLE
boards/microbit: use gpio inverted flag for buttons

### DIFF
--- a/boards/microbit/include/gpio_params.h
+++ b/boards/microbit/include/gpio_params.h
@@ -35,12 +35,14 @@ static const saul_gpio_params_t saul_gpio_params[] =
     {
         .name = "Button A",
         .pin  = BTN0_PIN,
-        .mode = BTN0_MODE
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
     },
     {
         .name = "Button B",
         .pin  = BTN1_PIN,
-        .mode = BTN1_MODE
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
     },
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the SAUL_GPIO_INVERTED flag to the on-board buttons.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->