### PR TITLE
sys/vfs: reserve file descriptors for stdin, stdout, and stderr

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -80,6 +80,10 @@
 #include "net/gnrc/ipv6/nib.h"
 #endif
 
+#ifdef MODULE_VFS
+#include "vfs.h"
+#endif
+
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -93,6 +97,10 @@ void auto_init(void)
 #ifdef MODULE_XTIMER
     DEBUG("Auto init xtimer module.\n");
     xtimer_init();
+#endif
+#ifdef MODULE_VFS
+    DEBUG("Auto init VFS module.\n")
+    vfs_init();
 #endif
 #ifdef MODULE_SHT11
     DEBUG("Auto init SHT11 module.\n");

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -528,6 +528,11 @@ struct vfs_file_system_ops {
 };
 
 /**
+ * @brief Initialize the VFS module
+ */
+void vfs_init(void);
+
+/**
  * @brief Close an open file
  *
  * @param[in]  fd    fd number to close

--- a/sys/uart_stdio/uart_stdio.c
+++ b/sys/uart_stdio/uart_stdio.c
@@ -26,11 +26,6 @@
  */
 
 #include <stdio.h>
-#if MODULE_VFS
-#include <unistd.h>
-#include <errno.h>
-#include <fcntl.h>
-#endif
 #include "uart_stdio.h"
 
 #include "board.h"
@@ -42,46 +37,11 @@
 extern ethos_t ethos;
 #endif
 
-#if MODULE_VFS
-#include "vfs.h"
-#endif
-
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
 static char _rx_buf_mem[UART_STDIO_RX_BUFSIZE];
 isrpipe_t uart_stdio_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
-
-#if MODULE_VFS
-static ssize_t uart_stdio_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes);
-static ssize_t uart_stdio_vfs_write(vfs_file_t *filp, const void *src, size_t nbytes);
-
-/**
- * @brief VFS file operation table for stdin/stdout/stderr
- */
-static vfs_file_ops_t uart_stdio_vfs_ops = {
-    .read = uart_stdio_vfs_read,
-    .write = uart_stdio_vfs_write,
-};
-
-static ssize_t uart_stdio_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
-{
-    int fd = filp->private_data.value;
-    if (fd != STDIN_FILENO) {
-        return -EBADF;
-    }
-    return uart_stdio_read(dest, nbytes);
-}
-
-static ssize_t uart_stdio_vfs_write(vfs_file_t *filp, const void *src, size_t nbytes)
-{
-    int fd = filp->private_data.value;
-    if (fd == STDIN_FILENO) {
-        return -EBADF;
-    }
-    return uart_stdio_write(src, nbytes);
-}
-#endif
 
 void uart_stdio_init(void)
 {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Previously, the code to reserve file descriptors 0, 1, and 2 for stdin, stdout, and stderr was in the uart_stdio code. However, this is insufficient for platforms that use the rtt_stdio module to write to the screen. Therefore, I moved the code to the VFS code, where it will get executed no matter what mechanism is needed to write characters to the screen.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Fixes #8309.