### PR TITLE
tests: fix some makefiles

### DIFF
--- a/tests/rng/Makefile
+++ b/tests/rng/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = rng
 include ../Makefile.tests_common
 
 # some boards have not enough rom and/or ram

--- a/tests/thread_priority_inversion/Makefile
+++ b/tests/thread_priority_inversion/Makefile
@@ -1,21 +1,5 @@
-# name of your application
-APPLICATION = thread_priority_inversion
+include ../Makefile.tests_common
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= native
-
-# This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../../
-
-# Comment this out to disable code in RIOT that does safety checking
-# which is not needed in a production environment but helps in the
-# development process:
-CFLAGS += -DDEVELHELP
-
-# Change this to 0 show compiler invocation lines by default:
-QUIET ?= 1
-
-# Modules to include:
 USEMODULE += xtimer
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031

--- a/tests/xtimer_usleep_short/Makefile
+++ b/tests/xtimer_usleep_short/Makefile
@@ -1,4 +1,3 @@
-APPLICATION = xtimer_usleep_short
 include ../Makefile.tests_common
 
 USEMODULE += xtimer


### PR DESCRIPTION
### Contribution description

- rng, xtimer_usleep_short: APPLICATION not needed anymore
- thread_priority_inversion: was not using tests/Makefile.tests