### PR TITLE
sys/net/loramac: rename network session key

### DIFF
--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -82,8 +82,8 @@ extern "C" {
  *
  *          16 bytes key, only required for ABP join procedure type.
  */
-#ifndef LORAMAC_NWKS_KEY_DEFAULT
-#define LORAMAC_NWKS_KEY_DEFAULT       { 0x00, 0x00, 0x00, 0x00, \
+#ifndef LORAMAC_NWK_SKEY_DEFAULT
+#define LORAMAC_NWK_SKEY_DEFAULT       { 0x00, 0x00, 0x00, 0x00, \
                                          0x00, 0x00, 0x00, 0x00, \
                                          0x00, 0x00, 0x00, 0x00, \
                                          0x00, 0x00, 0x00, 0x00 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a small improvement of one definition provided in `loramac.h`. It basically renames `LORAMAC_NWKS_KEY_DEFAULT` to `LORAMAC_NWK_SKEY_DEFAULT` (loramac network session key) in order to use the same naming scheme that is used for the `LORAMAC_APP_SKEY_DEFAULT`.

Semtech LoRaMAC names the corresponding variables in their implementation like this. 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->