### PR TITLE
vfs: add format in vfs API

### DIFF
--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -120,17 +120,14 @@ void spiffs_unlock(struct spiffs_t *fs)
     mutex_unlock(&fs_desc->lock);
 }
 
-static int _mount(vfs_mount_t *mountp)
+static int prepare(spiffs_desc_t *fs_desc)
 {
-    spiffs_desc_t *fs_desc = mountp->private_data;
 #if SPIFFS_HAL_CALLBACK_EXTRA == 1
     mtd_dev_t *dev = fs_desc->dev;
     fs_desc->fs.user_data = dev;
 #else
     mtd_dev_t *dev = SPIFFS_MTD_DEV;
 #endif
-
-    DEBUG("spiffs: mount: private_data = %p\n", mountp->private_data);
 
     fs_desc->config.hal_read_f = _dev_read;
     fs_desc->config.hal_write_f = _dev_write;
@@ -146,7 +143,17 @@ static int _mount(vfs_mount_t *mountp)
     fs_desc->config.phys_erase_block = dev->page_size * dev->pages_per_sector;
 #endif
 
-    mtd_init(dev);
+    return mtd_init(dev);
+}
+
+static int _format(vfs_mount_t *mountp)
+{
+    spiffs_desc_t *fs_desc = mountp->private_data;
+    DEBUG("spiffs: format: private_data = %p\n", mountp->private_data);
+    int res = prepare(fs_desc);
+    if (res) {
+        return -ENODEV;
+    }
 
     s32_t ret = SPIFFS_mount(&fs_desc->fs,
                              &fs_desc->config,
@@ -162,33 +169,38 @@ static int _mount(vfs_mount_t *mountp)
 #endif
                              NULL);
 
-    if (ret != 0) {
-        DEBUG("spiffs: mount: ret %" PRId32 "\n", ret);
-        switch (ret) {
-        case SPIFFS_ERR_NOT_A_FS:
-            DEBUG("spiffs: mount: formatting fs\n");
-            ret = SPIFFS_format(&fs_desc->fs);
-            DEBUG("spiffs: mount: format ret %" PRId32 "\n", ret);
-            if (ret < 0) {
-                return spiffs_err_to_errno(ret);
-            }
-            ret = SPIFFS_mount(&fs_desc->fs,
-                               &fs_desc->config,
-                               fs_desc->work,
-                               fs_desc->fd_space,
-                               SPIFFS_FS_FD_SPACE_SIZE,
-#if SPIFFS_CACHE == 1
-                               fs_desc->cache,
-                               SPIFFS_FS_CACHE_SIZE,
-#else
-                               NULL,
-                               0,
-#endif
-                               NULL);
-            DEBUG("spiffs: mount: ret %" PRId32 "\n", ret);
-            break;
-        }
+    if (ret == 0) {
+        DEBUG("spiffs: format: unmount fs\n");
+        SPIFFS_unmount(&fs_desc->fs);
     }
+    DEBUG("spiffs: format: formatting fs\n");
+    ret = SPIFFS_format(&fs_desc->fs);
+    DEBUG("spiffs: mount: format ret %" PRId32 "\n", ret);
+    return spiffs_err_to_errno(ret);
+}
+
+static int _mount(vfs_mount_t *mountp)
+{
+    spiffs_desc_t *fs_desc = mountp->private_data;
+    DEBUG("spiffs: mount: private_data = %p\n", mountp->private_data);
+    int res = prepare(fs_desc);
+    if (res) {
+        return -ENODEV;
+    }
+
+    s32_t ret = SPIFFS_mount(&fs_desc->fs,
+                             &fs_desc->config,
+                             fs_desc->work,
+                             fs_desc->fd_space,
+                             SPIFFS_FS_FD_SPACE_SIZE,
+#if SPIFFS_CACHE == 1
+                             fs_desc->cache,
+                             SPIFFS_FS_CACHE_SIZE,
+#else
+                             NULL,
+                             0,
+#endif
+                             NULL);
 
     return spiffs_err_to_errno(ret);
 }
@@ -488,6 +500,7 @@ static int spiffs_err_to_errno (s32_t err)
 }
 
 static const vfs_file_system_ops_t spiffs_fs_ops = {
+    .format = _format,
     .mount = _mount,
     .umount = _umount,
     .unlink = _unlink,

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -427,6 +427,16 @@ struct vfs_dir_ops {
  */
 struct vfs_file_system_ops {
     /**
+     * @brief Format the file system on the given mount point
+     *
+     * @param[in]   mountp  file system to format
+     *
+     * @return 0 on success
+     * @return <0 on error
+     */
+    int (*format) (vfs_mount_t *mountp);
+
+    /**
      * @brief Perform any extra processing needed after mounting a file system
      *
      * If this call returns an error, the whole vfs_mount call will signal a
@@ -694,6 +704,21 @@ int vfs_readdir(vfs_DIR *dirp, vfs_dirent_t *entry);
  * @return <0 on error, the directory stream dirp should be considered invalid
  */
 int vfs_closedir(vfs_DIR *dirp);
+
+/**
+ * @brief Format a file system
+ *
+ * @p mountp should have been populated in advance with a file system driver,
+ * a mount point, and private_data (if the file system driver uses one).
+ *
+ * @pre @p mountp must not be mounted
+ *
+ * @param[in]  mountp   pointer to the mount structure of the filesystem to format
+ *
+ * @return 0 on success
+ * @return <0 on error
+ */
+int vfs_format(vfs_mount_t *mountp);
 
 /**
  * @brief Mount a file system

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -425,7 +425,7 @@ static int check_mount(vfs_mount_t *mountp)
     DEBUG("vfs_mount: -> \"%s\" (%p), %p\n",
           mountp->mount_point, (void *)mountp->mount_point, mountp->private_data);
     if (mountp->mount_point[0] != '/') {
-        DEBUG("vfs_mount: not absolute mount_point path\n");
+        DEBUG("vfs: check_mount: not absolute mount_point path\n");
         return -EINVAL;
     }
     mountp->mount_point_len = strlen(mountp->mount_point);
@@ -435,7 +435,7 @@ static int check_mount(vfs_mount_t *mountp)
     if (found != NULL) {
         /* Same mount is already mounted */
         mutex_unlock(&_mount_mutex);
-        DEBUG("vfs_mount: Already mounted\n");
+        DEBUG("vfs: check_mount: Already mounted\n");
         return -EBUSY;
     }
 
@@ -491,10 +491,19 @@ int vfs_mount(vfs_mount_t *mountp)
 int vfs_umount(vfs_mount_t *mountp)
 {
     DEBUG("vfs_umount: %p\n", (void *)mountp);
-    if ((mountp == NULL) || (mountp->mount_point == NULL)) {
+    int ret = check_mount(mountp);
+    switch (ret) {
+    case 0:
+        DEBUG("vfs_umount: not mounted\n");
+        mutex_unlock(&_mount_mutex);
+        return -EINVAL;
+    case -EBUSY:
+        /* -EBUSY returned when fs is mounted, just continue */
+        break;
+    default:
+        DEBUG("vfs_umount: invalid fs\n");
         return -EINVAL;
     }
-    mutex_lock(&_mount_mutex);
     DEBUG("vfs_umount: -> \"%s\" open=%d\n", mountp->mount_point, atomic_load(&mountp->open_files));
     if (atomic_load(&mountp->open_files) > 0) {
         mutex_unlock(&_mount_mutex);

--- a/tests/unittests/tests-littlefs/tests-littlefs.c
+++ b/tests/unittests/tests-littlefs/tests-littlefs.c
@@ -144,6 +144,31 @@ static void test_littlefs_teardown(void)
     vfs_umount(&_test_littlefs_mount);
 }
 
+static void tests_littlefs_format(void)
+{
+    int res;
+    vfs_umount(&_test_littlefs_mount);
+    res = mtd_erase(_dev, 0, _dev->page_size * _dev->pages_per_sector * _dev->sector_count);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_mount(&_test_littlefs_mount);
+    TEST_ASSERT(res < 0);
+
+    /* 1. format an invalid file system (failed mount) */
+    res = vfs_format(&_test_littlefs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_mount(&_test_littlefs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_umount(&_test_littlefs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    /* 2. format a valid file system */
+    res = vfs_format(&_test_littlefs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
 static void tests_littlefs_mount_umount(void)
 {
     int res;
@@ -383,6 +408,7 @@ static void tests_littlefs_statvfs(void)
 Test *tests_littlefs_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(tests_littlefs_format),
         new_TestFixture(tests_littlefs_mount_umount),
         new_TestFixture(tests_littlefs_open_close),
         new_TestFixture(tests_littlefs_write),

--- a/tests/unittests/tests-spiffs/tests-spiffs.c
+++ b/tests/unittests/tests-spiffs/tests-spiffs.c
@@ -145,6 +145,31 @@ static void test_spiffs_teardown(void)
     vfs_umount(&_test_spiffs_mount);
 }
 
+static void tests_spiffs_format(void)
+{
+    int res;
+    vfs_umount(&_test_spiffs_mount);
+    res = mtd_erase(_dev, 0, _dev->page_size * _dev->pages_per_sector * _dev->sector_count);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_mount(&_test_spiffs_mount);
+    TEST_ASSERT(res < 0);
+
+    /* 1. format an invalid file system (failed mount) */
+    res = vfs_format(&_test_spiffs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_mount(&_test_spiffs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_umount(&_test_spiffs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    /* 2. format a valid file system */
+    res = vfs_format(&_test_spiffs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
 static void tests_spiffs_mount_umount(void)
 {
     int res;
@@ -360,6 +385,7 @@ static void tests_spiffs_statvfs(void)
 Test *tests_spiffs_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(tests_spiffs_format),
         new_TestFixture(tests_spiffs_mount_umount),
         new_TestFixture(tests_spiffs_open_close),
         new_TestFixture(tests_spiffs_write),


### PR DESCRIPTION
### Contribution description

There was no generic way to format a file system so far. This PR add a `vfs_format` function in vfs API and implements it for spiffs.

### Issues/PRs references

Fixes #8314 