### PR TITLE
[rfc] file system benchmark

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -44,10 +44,6 @@
 #define TRACE(...)
 #endif
 
-#ifndef MTD_SPI_NOR_WRITE_WAIT_US
-#define MTD_SPI_NOR_WRITE_WAIT_US (50 * US_PER_MS)
-#endif
-
 #define MTD_32K             (32768ul)
 #define MTD_32K_ADDR_MASK   (0x7FFF)
 #define MTD_4K              (4096ul)
@@ -266,11 +262,7 @@ static inline void wait_for_write_complete(const mtd_spi_nor_t *dev)
         if ((status & 1) == 0) { /* TODO magic number */
             break;
         }
-#if MODULE_XTIMER
-        xtimer_usleep(MTD_SPI_NOR_WRITE_WAIT_US);
-#else
         thread_yield();
-#endif
     } while (1);
 }
 

--- a/tests/bench_vfs/Makefile
+++ b/tests/bench_vfs/Makefile
@@ -1,0 +1,17 @@
+include ../Makefile.tests_common
+
+USEMODULE += vfs
+USEMODULE += xtimer
+
+FS ?= spiffs
+
+USEMODULE += $(FS)
+
+ifeq ($(FS),littlefs)
+    # Set vfs file and dir buffer sizes
+    CFLAGS += -DVFS_FILE_BUFFER_SIZE=52 -DVFS_DIR_BUFFER_SIZE=44
+    # Reduce LFS_NAME_MAX to 31 (as VFS_NAME_MAX default)
+    CFLAGS += -DLFS_NAME_MAX=31
+endif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/bench_vfs/Makefile
+++ b/tests/bench_vfs/Makefile
@@ -2,8 +2,9 @@ include ../Makefile.tests_common
 
 USEMODULE += vfs
 USEMODULE += xtimer
+USEMODULE += printf_float
 
-FS ?= spiffs
+FS ?= littlefs
 
 USEMODULE += $(FS)
 

--- a/tests/bench_vfs/main.c
+++ b/tests/bench_vfs/main.c
@@ -121,7 +121,7 @@ static mtd_dev_t dev = {
 static mtd_dev_t *_dev = (mtd_dev_t*) &dev;
 #endif /* MTD_0 */
 
-#ifdef MODULE_SPIFFS
+#if defined(MODULE_SPIFFS)
 #include "fs/spiffs_fs.h"
 static char fs_name[] = "spiffs";
 
@@ -143,9 +143,7 @@ static void init_fs(void)
     mtd_init(_dev);
     mtd_erase(_dev, 0, _dev->page_size * _dev->pages_per_sector * _dev->sector_count);
 }
-#endif
-
-#ifdef MODULE_LITTLEFS
+#elif defined(MODULE_LITTLEFS)
 #include "fs/littlefs_fs.h"
 static char fs_name[] = "littlefs";
 
@@ -163,6 +161,8 @@ static void init_fs(void)
     mtd_init(_dev);
     mtd_erase(_dev, 0, _dev->page_size * _dev->pages_per_sector * _dev->sector_count);
 }
+#else
+#define "No or unsupported file system module used"
 #endif
 
 #define FILE_LOOP_SIZE  (20)

--- a/tests/bench_vfs/main.c
+++ b/tests/bench_vfs/main.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Benchmark application for file systems
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ * @}
+ */
+
+#include <stdio.h>
+#include <fcntl.h>
+
+#include "board.h"
+#include "xtimer.h"
+#include "timex.h"
+#include "mtd.h"
+#include "vfs.h"
+
+/* Define MTD_0 in board.h to use the board mtd if any */
+#ifdef MTD_0
+#define _dev (MTD_0)
+#else
+/* Test mock object implementing a simple RAM-based mtd */
+#ifndef SECTOR_COUNT
+#define SECTOR_COUNT 4
+#endif
+#ifndef PAGE_PER_SECTOR
+#define PAGE_PER_SECTOR 8
+#endif
+#ifndef PAGE_SIZE
+#define PAGE_SIZE 128
+#endif
+
+static uint8_t dummy_memory[PAGE_PER_SECTOR * PAGE_SIZE * SECTOR_COUNT];
+
+static int _init(mtd_dev_t *dev)
+{
+    (void)dev;
+
+    memset(dummy_memory, 0xff, sizeof(dummy_memory));
+    return 0;
+}
+
+static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
+{
+    (void)dev;
+
+    if (addr + size > sizeof(dummy_memory)) {
+        return -EOVERFLOW;
+    }
+    memcpy(buff, dummy_memory + addr, size);
+
+    return size;
+}
+
+static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
+{
+    (void)dev;
+
+    if (addr + size > sizeof(dummy_memory)) {
+        return -EOVERFLOW;
+    }
+    if (size > PAGE_SIZE) {
+        return -EOVERFLOW;
+    }
+    memcpy(dummy_memory + addr, buff, size);
+
+    return size;
+}
+
+static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
+{
+    (void)dev;
+
+    if (size % (PAGE_PER_SECTOR * PAGE_SIZE) != 0) {
+        return -EOVERFLOW;
+    }
+    if (addr % (PAGE_PER_SECTOR * PAGE_SIZE) != 0) {
+        return -EOVERFLOW;
+    }
+    if (addr + size > sizeof(dummy_memory)) {
+        return -EOVERFLOW;
+    }
+    memset(dummy_memory + addr, 0xff, size);
+
+    return 0;
+}
+
+static int _power(mtd_dev_t *dev, enum mtd_power_state power)
+{
+    (void)dev;
+    (void)power;
+    return 0;
+}
+
+static const mtd_desc_t driver = {
+    .init = _init,
+    .read = _read,
+    .write = _write,
+    .erase = _erase,
+    .power = _power,
+};
+
+static mtd_dev_t dev = {
+    .driver = &driver,
+    .sector_count = SECTOR_COUNT,
+    .pages_per_sector = PAGE_PER_SECTOR,
+    .page_size = PAGE_SIZE,
+};
+
+static mtd_dev_t *_dev = (mtd_dev_t*) &dev;
+#endif /* MTD_0 */
+
+#ifdef MODULE_SPIFFS
+#include "fs/spiffs_fs.h"
+static char fs_name[] = "spiffs";
+
+static struct spiffs_desc spiffs_desc = {
+    .lock = MUTEX_INIT,
+};
+
+static vfs_mount_t _bench_mount = {
+    .fs = &spiffs_file_system,
+    .mount_point = "/bench",
+    .private_data = &spiffs_desc,
+};
+
+static void init_fs(void)
+{
+#if SPIFFS_HAL_CALLBACK_EXTRA == 1
+    spiffs_desc.dev = _dev;
+#endif
+    mtd_init(_dev);
+    mtd_erase(_dev, 0, _dev->page_size * _dev->pages_per_sector * _dev->sector_count);
+}
+#endif
+
+#ifdef MODULE_LITTLEFS
+#include "fs/littlefs_fs.h"
+static char fs_name[] = "littlefs";
+
+static littlefs_desc_t littlefs_desc;
+
+static vfs_mount_t _bench_mount = {
+    .fs = &littlefs_file_system,
+    .mount_point = "/bench",
+    .private_data = &littlefs_desc,
+};
+
+static void init_fs(void)
+{
+    littlefs_desc.dev = _dev;
+    mtd_init(_dev);
+    mtd_erase(_dev, 0, _dev->page_size * _dev->pages_per_sector * _dev->sector_count);
+}
+#endif
+
+#define FILE_LOOP_SIZE  (20)
+#define LOOP_SIZE       (100)
+#define BASE_NAME       "/bench/test"
+
+int main(void)
+{
+    printf("benchmarking file system: %s\n", fs_name);
+    init_fs();
+
+    xtimer_ticks32_t begin;
+    xtimer_ticks32_t end;
+    xtimer_ticks32_t diff;
+
+    puts("[BEGIN] Format test...");
+    begin = xtimer_now();
+    vfs_format(&_bench_mount);
+    end = xtimer_now();
+    diff = xtimer_diff(end, begin);
+    printf("Test time: %" PRIu32 "us\n", xtimer_usec_from_ticks(diff));
+    puts("[END] Format test");
+
+    puts("[BEGIN] Mount test...");
+    begin = xtimer_now();
+    vfs_mount(&_bench_mount);
+    end = xtimer_now();
+    diff = xtimer_diff(end, begin);
+    printf("Test time: %" PRIu32 "us\n", xtimer_usec_from_ticks(diff));
+    puts("[END] Mount test");
+
+    int fd;
+    char buf[] = "1234567890123456789012345678901234567890";
+    uint32_t total_time = 0;
+
+    puts("[BEGIN] Write test...");
+    for (int f = 0; f < FILE_LOOP_SIZE; f++) {
+        char name[20];
+        sprintf(name, BASE_NAME"%d", f);
+        begin = xtimer_now();
+        fd = vfs_open(name, O_CREAT | O_RDWR, 0);
+        for (int i = 0; i < LOOP_SIZE; i++) {
+            vfs_write(fd, buf, sizeof(buf) - 1);
+        }
+        vfs_close(fd);
+        end = xtimer_now();
+        diff = xtimer_diff(end, begin);
+        printf("File #%d, %d bytes written in: %" PRIu32 "us\n", f,
+               LOOP_SIZE * sizeof(buf - 1), xtimer_usec_from_ticks(diff));
+        total_time += xtimer_usec_from_ticks(diff);
+    }
+    printf("Mean time: %" PRIu32 "us\n", total_time / (uint32_t)FILE_LOOP_SIZE);
+    puts("[END] Write test");
+
+    total_time = 0;
+    puts("[BEGIN] Read test...");
+    for (int f = 0; f < FILE_LOOP_SIZE; f++) {
+        char name[20];
+        sprintf(name, BASE_NAME"%d", f);
+        begin = xtimer_now();
+        fd = vfs_open(name, O_RDONLY, 0);
+        int total = 0;
+        int ret;
+        while ((ret = vfs_read(fd, buf, sizeof(buf))) > 0) {
+            total += ret;
+        }
+        vfs_close(fd);
+        end = xtimer_now();
+        diff = xtimer_diff(end, begin);
+        printf("File #%d, %d bytes read in: %" PRIu32 "us\n", f,
+               total, xtimer_usec_from_ticks(diff));
+        total_time += xtimer_usec_from_ticks(diff);
+    }
+    printf("Mean time: %" PRIu32 "us\n", total_time / (uint32_t)FILE_LOOP_SIZE);
+    puts("[END] Read test");
+
+    total_time = 0;
+    puts("[BEGIN] Remove test...");
+    for (int f = 0; f < FILE_LOOP_SIZE; f++) {
+        char name[20];
+        sprintf(name, BASE_NAME"%d", f);
+        begin = xtimer_now();
+        vfs_unlink(name);
+        end = xtimer_now();
+        diff = xtimer_diff(end, begin);
+        printf("File #%d, test time: %" PRIu32 "us\n", f, xtimer_usec_from_ticks(diff));
+        total_time += xtimer_usec_from_ticks(diff);
+    }
+    printf("Mean time: %" PRIu32 "us\n", total_time / (uint32_t)FILE_LOOP_SIZE);
+    puts("[END] Remove test");
+
+    puts("[BEGIN] Unmount test...");
+    begin = xtimer_now();
+    vfs_umount(&_bench_mount);
+    end = xtimer_now();
+    diff = xtimer_diff(end, begin);
+    printf("Test time: %" PRIu32 "us\n", xtimer_usec_from_ticks(diff));
+    puts("[END] Unmount test");
+
+    return 0;
+}

--- a/tests/bench_vfs/main.c
+++ b/tests/bench_vfs/main.c
@@ -18,6 +18,8 @@
  */
 
 #include <stdio.h>
+#include <string.h>
+#include <errno.h>
 #include <fcntl.h>
 
 #include "board.h"
@@ -210,8 +212,8 @@ int main(void)
         vfs_close(fd);
         end = xtimer_now();
         diff = xtimer_diff(end, begin);
-        printf("File #%d, %d bytes written in: %" PRIu32 "us\n", f,
-               LOOP_SIZE * sizeof(buf - 1), xtimer_usec_from_ticks(diff));
+        printf("File #%d, %u bytes written in: %" PRIu32 "us\n", f,
+               (unsigned)(LOOP_SIZE * (sizeof(buf) - 1)), xtimer_usec_from_ticks(diff));
         total_time += xtimer_usec_from_ticks(diff);
     }
     printf("Mean time: %" PRIu32 "us\n", total_time / (uint32_t)FILE_LOOP_SIZE);


### PR DESCRIPTION
### Contribution description

This is based on #8315 and #8239.
This provide an app to benchmark the file systems using vfs.

### Results

I've run the test on native with the emulated mtd device for spiffs and littlefs with the following results.

#### spiffs

Binary size:
```
   text	   data	    bss	    dec	    hex
  87874	    792	  49440	 138106	  21b7a
```

Timings:
```
benchmarking file system: spiffs
[BEGIN] Format test...
Test time: 69146us
[END] Format test
[BEGIN] Mount test...
Test time: 16786us
[END] Mount test
[BEGIN] Write test...
File #0, 400 bytes written in: 60569us
File #1, 400 bytes written in: 54963us
File #2, 400 bytes written in: 59451us
File #3, 400 bytes written in: 53766us
File #4, 400 bytes written in: 58093us
File #5, 400 bytes written in: 56973us
File #6, 400 bytes written in: 55487us
File #7, 400 bytes written in: 53980us
File #8, 400 bytes written in: 56722us
File #9, 400 bytes written in: 55598us
File #10, 400 bytes written in: 53592us
File #11, 400 bytes written in: 54107us
File #12, 400 bytes written in: 55462us
File #13, 400 bytes written in: 56342us
File #14, 400 bytes written in: 54442us
File #15, 400 bytes written in: 55705us
File #16, 400 bytes written in: 55280us
File #17, 400 bytes written in: 55397us
File #18, 400 bytes written in: 54621us
File #19, 400 bytes written in: 55357us
Mean time: 55795us
[END] Write test
[BEGIN] Read test...
File #0, 4000 bytes read in: 661us
File #1, 4000 bytes read in: 659us
File #2, 4000 bytes read in: 722us
File #3, 4000 bytes read in: 663us
File #4, 4000 bytes read in: 662us
File #5, 4000 bytes read in: 658us
File #6, 4000 bytes read in: 660us
File #7, 4000 bytes read in: 934us
File #8, 4000 bytes read in: 1039us
File #9, 4000 bytes read in: 1063us
File #10, 4000 bytes read in: 934us
File #11, 4000 bytes read in: 949us
File #12, 4000 bytes read in: 943us
File #13, 4000 bytes read in: 687us
File #14, 4000 bytes read in: 666us
File #15, 4000 bytes read in: 664us
File #16, 4000 bytes read in: 647us
File #17, 4000 bytes read in: 678us
File #18, 4000 bytes read in: 651us
File #19, 4000 bytes read in: 836us
Mean time: 768us
[END] Read test
[BEGIN] Remove test...
File #0, test time: 6857us
File #1, test time: 222us
File #2, test time: 220us
File #3, test time: 217us
File #4, test time: 219us
File #5, test time: 219us
File #6, test time: 219us
File #7, test time: 216us
File #8, test time: 221us
File #9, test time: 219us
File #10, test time: 225us
File #11, test time: 217us
File #12, test time: 220us
File #13, test time: 219us
File #14, test time: 217us
File #15, test time: 220us
File #16, test time: 231us
File #17, test time: 219us
File #18, test time: 216us
File #19, test time: 217us
Mean time: 551us
[END] Remove test
[BEGIN] Unmount test...
Test time: 3us
[END] Unmount test
```

#### littlefs

Binary size:
```
   text	   data	    bss	    dec	    hex	
  69561	    796	  49024	 119381	  1d255
```

Timings:
```
benchmarking file system: littlefs
[BEGIN] Format test...
Test time: 1178us
[END] Format test
[BEGIN] Mount test...
Test time: 35us
[END] Mount test
[BEGIN] Write test...
File #0, 400 bytes written in: 6103us
File #1, 400 bytes written in: 6440us
File #2, 400 bytes written in: 7328us
File #3, 400 bytes written in: 6891us
File #4, 400 bytes written in: 6089us
File #5, 400 bytes written in: 6173us
File #6, 400 bytes written in: 6036us
File #7, 400 bytes written in: 6308us
File #8, 400 bytes written in: 6899us
File #9, 400 bytes written in: 6145us
File #10, 400 bytes written in: 6027us
File #11, 400 bytes written in: 6046us
File #12, 400 bytes written in: 6128us
File #13, 400 bytes written in: 7743us
File #14, 400 bytes written in: 7992us
File #15, 400 bytes written in: 7394us
File #16, 400 bytes written in: 6756us
File #17, 400 bytes written in: 7549us
File #18, 400 bytes written in: 8485us
File #19, 400 bytes written in: 6799us
Mean time: 6766us
[END] Write test
[BEGIN] Read test...
File #0, 4000 bytes read in: 160us
File #1, 4000 bytes read in: 157us
File #2, 4000 bytes read in: 170us
File #3, 4000 bytes read in: 158us
File #4, 4000 bytes read in: 159us
File #5, 4000 bytes read in: 157us
File #6, 4000 bytes read in: 145us
File #7, 4000 bytes read in: 127us
File #8, 4000 bytes read in: 134us
File #9, 4000 bytes read in: 128us
File #10, 4000 bytes read in: 127us
File #11, 4000 bytes read in: 129us
File #12, 4000 bytes read in: 137us
File #13, 4000 bytes read in: 142us
File #14, 4000 bytes read in: 150us
File #15, 4000 bytes read in: 143us
File #16, 4000 bytes read in: 156us
File #17, 4000 bytes read in: 134us
File #18, 4000 bytes read in: 134us
File #19, 4000 bytes read in: 134us
Mean time: 144us
[END] Read test
[BEGIN] Remove test...
File #0, test time: 734us
File #1, test time: 731us
File #2, test time: 735us
File #3, test time: 744us
File #4, test time: 728us
File #5, test time: 746us
File #6, test time: 414us
File #7, test time: 426us
File #8, test time: 419us
File #9, test time: 407us
File #10, test time: 399us
File #11, test time: 403us
File #12, test time: 394us
File #13, test time: 394us
File #14, test time: 398us
File #15, test time: 423us
File #16, test time: 399us
File #17, test time: 386us
File #18, test time: 381us
File #19, test time: 386us
Mean time: 502us
[END] Remove test
[BEGIN] Unmount test...
Test time: 2us
[END] Unmount test
```

#### Differences
- Opening/writing 4000B/closing a file is about 8 times faster with littlefs than with spiffs
- Opening/reading 4000B/closing a file is about 5 times faster with littlefs than with spiffs
- Formatting is about 500 times faster with littlefs than with spiffs
- Mounting is about 60 times faster with littlefs than with spiffs