### PR TITLE
drivers/sx127x: add static keyword to inline

### DIFF
--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -446,7 +446,7 @@ uint8_t sx127x_get_bandwidth(const sx127x_t *dev)
     return dev->settings.lora.bandwidth;
 }
 
-inline void _low_datarate_optimize(sx127x_t *dev)
+static void _low_datarate_optimize(sx127x_t *dev)
 {
     if ( ((dev->settings.lora.bandwidth == LORA_BW_125_KHZ) &&
           ((dev->settings.lora.datarate == LORA_SF11) ||
@@ -471,7 +471,7 @@ inline void _low_datarate_optimize(sx127x_t *dev)
 #endif
 }
 
-inline void _update_bandwidth(const sx127x_t *dev)
+static void _update_bandwidth(const sx127x_t *dev)
 {
     uint8_t config1_reg = sx127x_reg_read(dev, SX127X_REG_LR_MODEMCONFIG1);
 #if defined(MODULE_SX1272)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR replaces inline keyword with static to a couple of functions in sx127x driver. This makes it C99 compliant, since (non static) inline functions expect the definition to be in a separate translation unit. Arm gcc v7.2.1 fails to link if these functions in the current state.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
  