### PR TITLE
add board/nucleo32-l031 adc configuration

### DIFF
--- a/boards/nucleo32-l031/Makefile.features
+++ b/boards/nucleo32-l031/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo32-l031/include/periph_conf.h
+++ b/boards/nucleo32-l031/include/periph_conf.h
@@ -153,7 +153,16 @@ static const spi_conf_t spi_config[] = {
  * @name    ADC configuration
  * @{
  */
-#define ADC_NUMOF           (0)
+#define ADC_CONFIG {                           \
+    { GPIO_PIN(PORT_A, 0), 0 },  /* Pin A0 */  \
+    { GPIO_PIN(PORT_A, 1), 1 },  /* Pin A1 */  \
+    { GPIO_PIN(PORT_A, 3), 3 },  /* Pin A2 */  \
+    { GPIO_PIN(PORT_A, 4), 4 },  /* Pin A3 */  \
+    { GPIO_PIN(PORT_A, 5), 5 },  /* Pin A4 */  \
+    { GPIO_PIN(PORT_A, 6), 6 },  /* Pin A5 */  \
+    { GPIO_PIN(PORT_A, 7), 7 },  /* Pin A6 */  \
+}
+#define ADC_NUMOF           (7U)
 /** @} */
 
 /**


### PR DESCRIPTION
Add adc configuration for the nucleo32-l031, it has been tested on nucleo32-L031K6