### PR TITLE
cpu/stm32l1: fix ADC resolution register

### DIFF
--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -64,12 +64,12 @@ typedef struct {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = (0x3 << 3),  /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT  = (0x2 << 3),  /**< ADC resolution: 8 bit */
-    ADC_RES_10BIT = (0x1 << 3),  /**< ADC resolution: 10 bit */
-    ADC_RES_12BIT = (0x0 << 3),  /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0xfe),      /**< not applicable */
-    ADC_RES_16BIT = (0xff)       /**< not applicable */
+    ADC_RES_6BIT  = (ADC_CR1_RES_0 | ADC_CR1_RES_1),    /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CR1_RES_1),                    /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CR1_RES_0),                    /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x00),                             /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0xfe),                             /**< not applicable */
+    ADC_RES_16BIT = (0xff)                              /**< not applicable */
 } adc_res_t;
 /** @} */
 


### PR DESCRIPTION
This PR is for fix resolution of cpu stm32l1. 
Before this PR all adc resolutions where in 12 bits. I used the mcu register to set the resolution in the periph_cpu file.
  