### PR TITLE
periph/spi: extend available clock speeds

### DIFF
--- a/drivers/include/periph/spi.h
+++ b/drivers/include/periph/spi.h
@@ -162,7 +162,10 @@ typedef enum {
     SPI_CLK_400KHZ,         /**< drive the SPI bus with 400KHz */
     SPI_CLK_1MHZ,           /**< drive the SPI bus with 1MHz */
     SPI_CLK_5MHZ,           /**< drive the SPI bus with 5MHz */
-    SPI_CLK_10MHZ           /**< drive the SPI bus with 10MHz */
+    SPI_CLK_10MHZ,          /**< drive the SPI bus with 10MHz */
+    SPI_CLK_20MHZ,          /**< drive the SPI bus with 20MHz */
+    SPI_CLK_40MHZ,          /**< drive the SPI bus with 40MHz */
+    SPI_CLK_80MHZ           /**< drive the SPI bus with 80MHz */
 } spi_clk_t;
 #endif
 


### PR DESCRIPTION
### Contribution description

So far the maximum speed available through spi interface is 10MHz.

A lot a cpu could support higher speed, that's why I propose to extend the `spi_clk_t`.

I would like feedback on this before trying to update the drivers, especially on the values. I arbitrary add 25MHz and 50MHz, but this should be discussed.

### Issues/PRs references

None