### PR TITLE
 gnrc_netif: add nrfmin IID support

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -775,6 +775,19 @@ int gnrc_netif_ipv6_group_idx(gnrc_netif_t *netif, const ipv6_addr_t *addr)
     return idx;
 }
 
+#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_CC110X)
+static void _create_iid_from_short(const gnrc_netif_t *netif, eui64_t *eui64)
+{
+    const unsigned offset = sizeof(eui64_t) - netif->l2addr_len;
+
+    assert(netif->l2addr_len <= 3);
+    memset(eui64->uint8, 0, sizeof(eui64->uint8));
+    eui64->uint8[3] = 0xff;
+    eui64->uint8[4] = 0xfe;
+    memcpy(&eui64->uint8[offset], netif->l2addr, netif->l2addr_len);
+}
+#endif /* define(MODULE_NETDEV_IEEE802154) || defined(MODULE_CC110X) */
+
 int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
 {
 #if GNRC_NETIF_L2ADDR_MAXLEN > 0
@@ -797,14 +810,7 @@ int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
             case NETDEV_TYPE_IEEE802154:
                 switch (netif->l2addr_len) {
                     case IEEE802154_SHORT_ADDRESS_LEN:
-                        eui64->uint8[0] = 0x0;
-                        eui64->uint8[1] = 0x0;
-                        eui64->uint8[2] = 0x0;
-                        eui64->uint8[3] = 0xff;
-                        eui64->uint8[4] = 0xfe;
-                        eui64->uint8[5] = 0x0;
-                        eui64->uint8[6] = netif->l2addr[0];
-                        eui64->uint8[7] = netif->l2addr[1];
+                        _create_iid_from_short(netif, eui64);
                         return 0;
                     case IEEE802154_LONG_ADDRESS_LEN:
                         memcpy(eui64, netif->l2addr, sizeof(eui64_t));
@@ -819,15 +825,7 @@ int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
 #endif
 #ifdef MODULE_CC110X
             case NETDEV_TYPE_CC110X:
-                assert(netif->l2addr_len == 1U);
-                eui64->uint8[0] = 0x0;
-                eui64->uint8[1] = 0x0;
-                eui64->uint8[2] = 0x0;
-                eui64->uint8[3] = 0xff;
-                eui64->uint8[4] = 0xfe;
-                eui64->uint8[5] = 0x0;
-                eui64->uint8[6] = 0x0;
-                eui64->uint8[7] = netif->l2addr[0];
+                _create_iid_from_short(netif, eui64);
                 return 0;
 #endif
             default:

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -775,7 +775,8 @@ int gnrc_netif_ipv6_group_idx(gnrc_netif_t *netif, const ipv6_addr_t *addr)
     return idx;
 }
 
-#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_CC110X)
+#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_CC110X) || \
+    defined(MODULE_NRFMIN)
 static void _create_iid_from_short(const gnrc_netif_t *netif, eui64_t *eui64)
 {
     const unsigned offset = sizeof(eui64_t) - netif->l2addr_len;
@@ -786,7 +787,8 @@ static void _create_iid_from_short(const gnrc_netif_t *netif, eui64_t *eui64)
     eui64->uint8[4] = 0xfe;
     memcpy(&eui64->uint8[offset], netif->l2addr, netif->l2addr_len);
 }
-#endif /* define(MODULE_NETDEV_IEEE802154) || defined(MODULE_CC110X) */
+#endif /* defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_CC110X) ||
+        * defined(MODULE_NRFMIN) */
 
 int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
 {
@@ -823,8 +825,9 @@ int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
                 }
                 break;
 #endif
-#ifdef MODULE_CC110X
+#if defined(MODULE_CC110X) || defined(MODULE_NRFMIN)
             case NETDEV_TYPE_CC110X:
+            case NETDEV_TYPE_NRFMIN:
                 _create_iid_from_short(netif, eui64);
                 return 0;
 #endif


### PR DESCRIPTION
### Contribution description

There are two contributions in this PR. One generalizing step to simplify the `nrfmin` integration and the `nrfmin` integration itself:

* Moves setting of addresses of length lesser than 3 to a function that initializes the first 5 byte of the IID with `00:00:00:ff:fe` and then fills up the rest with zeroes and the given short address.
* Adds a `nrfmin` case to IID generation, so an IID can be generated from a `nrfmin` device's (short) address (the long address is just 4-time repetition of the short address).

### Issues/PRs references
None