### PR TITLE
gnrc_ipv6_nib: fix nrfmin module check

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -190,11 +190,11 @@ static inline unsigned _get_l2addr_len(gnrc_netif_t *netif,
             (void)opt;
             return ETHERNET_ADDR_LEN;
 #endif  /* MODULE_NETDEV_ETH */
-#ifdef MODULE_NETDEV_NRFMIN
+#ifdef MODULE_NRFMIN
         case NETDEV_TYPE_NRFMIN:
             (void)opt;
             return sizeof(uint16_t);
-#endif  /* MODULE_NETDEV_NRFMIN */
+#endif  /* MODULE_NRFMIN */
 #ifdef MODULE_NETDEV_IEEE802154
         case NETDEV_TYPE_IEEE802154:
             switch (opt->len) {


### PR DESCRIPTION
### Contribution description
The module is called `nrfmin` not `netdev_nrfmin`. As such this compile path was never included, even if the `nrfmin` module was present.

This PR fixes that by removing the `NETDEV_` part in the `#ifdef` checking for the presence of that module.

### Issues/PRs references
None