### PR TITLE
tests/sx127x: adapt to driver interface change

### DIFF
--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -104,11 +104,11 @@ int lora_setup_cmd(int argc, char **argv) {
     /* Configure radio device */
     netdev_t *netdev = (netdev_t*) &sx127x;
     netdev->driver->set(netdev, NETOPT_BANDWIDTH,
-                        &lora_bw, sizeof(uint8_t));
+                        &lora_bw, sizeof(lora_bw));
     netdev->driver->set(netdev, NETOPT_SPREADING_FACTOR,
-                        &lora_sf, 1);
+                        &lora_sf, lora_sf);
     netdev->driver->set(netdev, NETOPT_CODING_RATE,
-                        &lora_cr, sizeof(uint8_t));
+                        &lora_cr, sizeof(lora_cr));
 
     puts("[Info] setup: configuration set with success");
 
@@ -247,7 +247,7 @@ int listen_cmd(int argc, char **argv)
 
     /* Switch to RX state */
     uint8_t state = NETOPT_STATE_RX;
-    netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(uint8_t));
+    netdev->driver->set(netdev, NETOPT_STATE, &state, sizeof(state));
 
     printf("Listen mode set\n");
 
@@ -263,7 +263,7 @@ int channel_cmd(int argc, char **argv)
 
     uint32_t chan;
     if (strstr(argv[1], "get") != NULL) {
-        netdev->driver->get(netdev, NETOPT_CHANNEL_FREQUENCY, &chan, sizeof(uint32_t));
+        netdev->driver->get(netdev, NETOPT_CHANNEL_FREQUENCY, &chan, sizeof(chan));
         printf("Channel: %i\n", (int) chan);
         return 0;
     }
@@ -274,7 +274,7 @@ int channel_cmd(int argc, char **argv)
             return -1;
         }
         chan = atoi(argv[2]);
-        netdev->driver->set(netdev, NETOPT_CHANNEL_FREQUENCY, &chan, sizeof(uint32_t));
+        netdev->driver->set(netdev, NETOPT_CHANNEL_FREQUENCY, &chan, sizeof(chan));
         printf("New channel set\n");
     }
     else {

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -240,8 +240,10 @@ int listen_cmd(int argc, char **argv)
     (void)argv;
 
     /* Switch to continuous listen mode */
-    netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, false, sizeof(uint8_t));
-    netdev->driver->set(netdev, NETOPT_RX_TIMEOUT, 0, sizeof(uint8_t));
+    const netopt_enable_t single = false;
+    netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
+    const uint32_t timeout = 0;
+    netdev->driver->set(netdev, NETOPT_RX_TIMEOUT, &timeout, sizeof(timeout));
 
     /* Switch to RX state */
     uint8_t state = NETOPT_STATE_RX;

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -261,7 +261,7 @@ int channel_cmd(int argc, char **argv)
 
     uint32_t chan;
     if (strstr(argv[1], "get") != NULL) {
-        netdev->driver->get(netdev, NETOPT_CHANNEL, &chan, sizeof(uint32_t));
+        netdev->driver->get(netdev, NETOPT_CHANNEL_FREQUENCY, &chan, sizeof(uint32_t));
         printf("Channel: %i\n", (int) chan);
         return 0;
     }
@@ -272,7 +272,7 @@ int channel_cmd(int argc, char **argv)
             return -1;
         }
         chan = atoi(argv[2]);
-        netdev->driver->set(netdev, NETOPT_CHANNEL, &chan, sizeof(uint32_t));
+        netdev->driver->set(netdev, NETOPT_CHANNEL_FREQUENCY, &chan, sizeof(uint32_t));
         printf("New channel set\n");
     }
     else {


### PR DESCRIPTION
Since deb88bc9723aa49a21c6863cfc6dfcdae40cee64, the `sx127x` driver uses `NETOPT_CHANNEL_FREQUENCY` instead of `NETOPT_CHANNEL`. This PR fixes the corresponding test to use that new option instead of the old one.