### PR TITLE
boards: fix doxygen inconsistencies and typos

### DIFF
--- a/boards/arduino-zero/include/arduino_pinmap.h
+++ b/boards/arduino-zero/include/arduino_pinmap.h
@@ -58,7 +58,7 @@ extern "C" {
 /** @ */
 
 /**
- * @name    Mapping of Ardunino analog pins to RIOT ADC lines
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
  * @{
  */
 #define ARDUINO_A0              ADC_LINE(0)

--- a/boards/common/arduino-due/include/arduino_pinmap.h
+++ b/boards/common/arduino-due/include/arduino_pinmap.h
@@ -115,7 +115,7 @@ extern "C" {
 /** @ */
 
 /**
- * @name    Mapping of Ardunino analog pins to RIOT ADC lines
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
  * @{
  */
 #define ARDUINO_A0              ADC_LINE(7)

--- a/boards/common/arduino-mkr/include/arduino_pinmap.h
+++ b/boards/common/arduino-mkr/include/arduino_pinmap.h
@@ -60,7 +60,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name    Mapping of Ardunino analog pins to RIOT ADC lines
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
  * @{
  */
 #define ARDUINO_A0              ADC_LINE(0)

--- a/boards/common/nucleo/include/arduino_pinmap.h
+++ b/boards/common/nucleo/include/arduino_pinmap.h
@@ -66,7 +66,7 @@ extern "C" {
 /** @ */
 
 /**
- * @name    Mapping of Ardunino analog pins to RIOT ADC lines
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
  * @{
  */
 #define ARDUINO_A0              ADC_LINE(0)

--- a/boards/common/nucleo144/include/arduino_pinmap.h
+++ b/boards/common/nucleo144/include/arduino_pinmap.h
@@ -76,7 +76,7 @@ extern "C" {
 /** @ */
 
 /**
- * @name    Mapping of Ardunino analog pins to RIOT ADC lines
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
  * @{
  */
 #define ARDUINO_A0              ADC_LINE(0)

--- a/boards/common/nucleo144/include/arduino_pinmap.h
+++ b/boards/common/nucleo144/include/arduino_pinmap.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Mapping of MCU pins to Arduino pins
+ * @name    Mapping of MCU pins to Arduino pins
  * @{
  */
 #if defined(CPU_MODEL_STM32F303ZE)

--- a/boards/common/nucleo32/include/arduino_pinmap.h
+++ b/boards/common/nucleo32/include/arduino_pinmap.h
@@ -64,7 +64,7 @@ extern "C" {
 /** @ */
 
 /**
- * @name    Mapping of Ardunino analog pins to RIOT ADC lines
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
  * @{
  */
 #define ARDUINO_A0              ADC_LINE(0)

--- a/boards/common/nucleo32/include/arduino_pinmap.h
+++ b/boards/common/nucleo32/include/arduino_pinmap.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Mapping of MCU pins to Arduino pins
+ * @name    Mapping of MCU pins to Arduino pins
  * @{
  */
 #define ARDUINO_PIN_0           GPIO_PIN(PORT_A, 10)

--- a/boards/stm32f4discovery/include/arduino_pinmap.h
+++ b/boards/stm32f4discovery/include/arduino_pinmap.h
@@ -44,7 +44,7 @@ extern "C" {
 /** @ */
 
 /**
- * @name    Mapping of Ardunino analog pins to RIOT ADC lines
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
  * @{
  */
 #define ARDUINO_A0              ADC_LINE(0)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes 2 minor problems in some boards doxygen:
* I found several typos on ardu**n**ino instead of arduino
* there were remaining use of `@brief` instead of `@name`


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
  