### PR TITLE
examples: superfluous extern "C" in c++ example removed

### DIFF
--- a/examples/riot_and_cpp/c_functions.h
+++ b/examples/riot_and_cpp/c_functions.h
@@ -22,6 +22,11 @@
 #ifndef C_FUNCTIONS_H
 #define C_FUNCTIONS_H
 
+
+/*
+ * all headers defining c functions must be marked as extern "C" when included
+ * into c++ sources
+ */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/examples/riot_and_cpp/main.cpp
+++ b/examples/riot_and_cpp/main.cpp
@@ -21,14 +21,9 @@
  * @author      DangNhat Pham-Huu <51002279@hcmut.edu.vn>
  */
 
-/*
- * all included headers defining c functions, i.e. all RIOT functions, must be marked as extern "C"
- */
-extern "C" {
 #include "thread.h"
 
 #include "c_functions.h"
-}
 
 #include <cstdio>
 #include <vector>


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

superfluous extern "C" in c++ example removed

### Issues/PRs references
