### PR TITLE
can: fix fall through error

### DIFF
--- a/sys/can/conn/isotp.c
+++ b/sys/can/conn/isotp.c
@@ -174,7 +174,7 @@ int conn_can_isotp_send(conn_can_isotp_t *conn, const void *buf, size_t size, in
                 if (msg.content.ptr == conn) {
                     ret = -EIO;
                 }
-                /* No break */
+                /* Fall through */
             case CAN_MSG_TX_CONFIRMATION:
 #ifdef MODULE_CONN_CAN_ISOTP_MULTI
                 if (msg.content.ptr != conn) {

--- a/sys/can/isotp/isotp.c
+++ b/sys/can/isotp/isotp.c
@@ -609,6 +609,7 @@ static void _isotp_rx_timeout_task(struct isotp *isotp)
     case ISOTP_SENDING_FC:
         DEBUG("_isotp_rx_timeout_task: FC tx conf timeout\n");
         raw_can_abort(isotp->entry.ifnum, isotp->rx.tx_handle);
+        /* Fall through */
     case ISOTP_WAIT_CF:
         DEBUG("_isotp_rx_timeout_task: free rx buf\n");
         gnrc_pktbuf_release(isotp->rx.snip);


### PR DESCRIPTION
### Contribution description

When building `tests/conn_can` with gcc 7.2.0, two `implicit-fallthrough` errors are generated.
This fix them by adding a `/* Fall through */` comment.

### Issues/PRs references

None