### PR TITLE
sys/net/loramac: add device class enum

### DIFF
--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -305,6 +305,15 @@ extern "C" {
  */
 
 /**
+ * @brief   Device class
+ */
+typedef enum {
+    LORAMAC_CLASS_A,                   /**< Class A device */
+    LORAMAC_CLASS_B,                   /**< Class B device */
+    LORAMAC_CLASS_C,                   /**< Class C device */
+} loramac_class_t;
+
+/**
  * @brief   LoRaMAC network join procedure type
  */
 enum {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an enum for loramac device class in the `loramac.h` file. This will be usefull for #8264 and for future LoRa driver PRs.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#7331 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->