### PR TITLE
sys/event/timeout: add timeout_clear() function

### DIFF
--- a/sys/event/timeout.c
+++ b/sys/event/timeout.c
@@ -26,3 +26,8 @@ void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout)
 {
     xtimer_set(&event_timeout->timer, timeout);
 }
+
+void event_timeout_clear(event_timeout_t *event_timeout)
+{
+    xtimer_remove(&event_timeout->timer);
+}

--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -54,11 +54,12 @@ typedef struct {
 /**
  * @brief   Initialize timeout event object
  *
- * @param[in]   event_timeout   event_timeout object to initilalize
+ * @param[in]   event_timeout   event_timeout object to initialize
  * @param[in]   queue           queue that the timed-out event will be added to
  * @param[in]   event           event to add to queue after timeout
  */
-void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue, event_t *event);
+void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue,
+                        event_t *event);
 
 /**
  * @brief   Set a timeout
@@ -69,7 +70,7 @@ void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue, ev
  * @note: the used event_timeout struct must stay valid until after the timeout
  *        event has been processed!
  *
- * @param[in]   event_timeout   event_timout context onject to use
+ * @param[in]   event_timeout   event_timout context object to use
  * @param[in]   timeout         timeout in miliseconds
  */
 void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout);

--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -74,6 +74,18 @@ void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue, ev
  */
 void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout);
 
+/**
+ * @brief   Clear a timeout event
+ *
+ * Calling this function will cancel the timeout by removing its underlying
+ * timer. If the timer has already fired before calling this function, the
+ * connected event will be put already into the given event queue and this
+ * function does not have any effect.
+ *
+ * @param[in]   event_timeout   event_timeout context object to use
+ */
+void event_timeout_clear(event_timeout_t *event_timeout);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/events/main.c
+++ b/tests/events/main.c
@@ -71,7 +71,7 @@ static void timed_callback(void *arg)
     uint32_t now = xtimer_now_usec();
     assert((now - before >= 100000LU));
     printf("triggered timed callback with arg 0x%08x after %" PRIu32 "us\n", (unsigned)arg, now - before);
-    printf("[SUCCESS]\n");
+    puts("[SUCCESS]");
 }
 
 static void forbidden_callback(void *arg)
@@ -98,12 +98,12 @@ int main(void)
     printf("canceling 0x%08x\n", (unsigned)&event2);
     event_cancel(&queue, &event2);
 
-    printf("posting custom event\n");
+    puts("posting custom event");
     event_post(&queue, (event_t *)&custom_event);
 
     event_timeout_t event_timeout;
 
-    printf("posting timed callback with timeout 1sec\n");
+    puts("posting timed callback with timeout 1sec");
     event_timeout_init(&event_timeout, &queue, (event_t *)&event_callback);
     before = xtimer_now_usec();
     event_timeout_set(&event_timeout, 100000LU);
@@ -116,7 +116,7 @@ int main(void)
     event_timeout_set(&event_timeout_canceled, 500 * US_PER_MS);
     event_timeout_clear(&event_timeout_canceled);
 
-    printf("launching event queue\n");
+    puts("launching event queue");
     event_loop(&queue);
 
     return 0;

--- a/tests/events/main.c
+++ b/tests/events/main.c
@@ -31,6 +31,7 @@ static uint32_t before;
 static void callback(event_t *arg);
 static void custom_callback(event_t *event);
 static void timed_callback(void *arg);
+static void forbidden_callback(void *arg);
 
 
 static event_t event = { .handler = callback };
@@ -51,6 +52,7 @@ typedef struct {
 
 static custom_event_t custom_event = { .super.handler = custom_callback, .text = "CUSTOM CALLBACK" };
 static event_callback_t event_callback = EVENT_CALLBACK_INIT(timed_callback, 0x12345678);
+static event_callback_t noevent_callback = EVENT_CALLBACK_INIT(forbidden_callback, 0);
 
 static void custom_callback(event_t *event)
 {
@@ -70,6 +72,17 @@ static void timed_callback(void *arg)
     assert((now - before >= 100000LU));
     printf("triggered timed callback with arg 0x%08x after %" PRIu32 "us\n", (unsigned)arg, now - before);
     printf("[SUCCESS]\n");
+}
+
+static void forbidden_callback(void *arg)
+{
+    (void)arg;
+    /* this callback should never be triggered! */
+    puts("call to forbidden callback");
+    puts("[FAILED]");
+    while (1) {
+        assert(false);
+    }
 }
 
 int main(void)
@@ -94,6 +107,14 @@ int main(void)
     event_timeout_init(&event_timeout, &queue, (event_t *)&event_callback);
     before = xtimer_now_usec();
     event_timeout_set(&event_timeout, 100000LU);
+
+    event_timeout_t event_timeout_canceled;
+
+    puts("posting timed callback with timeout 0.5sec and canceling it again");
+    event_timeout_init(&event_timeout_canceled, &queue,
+                       (event_t *)&noevent_callback);
+    event_timeout_set(&event_timeout_canceled, 500 * US_PER_MS);
+    event_timeout_clear(&event_timeout_canceled);
 
     printf("launching event queue\n");
     event_loop(&queue);

--- a/tests/events/main.c
+++ b/tests/events/main.c
@@ -106,7 +106,7 @@ int main(void)
     puts("posting timed callback with timeout 1sec");
     event_timeout_init(&event_timeout, &queue, (event_t *)&event_callback);
     before = xtimer_now_usec();
-    event_timeout_set(&event_timeout, 100000LU);
+    event_timeout_set(&event_timeout, (1 * US_PER_SEC));
 
     event_timeout_t event_timeout_canceled;
 


### PR DESCRIPTION
### Contribution description
For some use-cases, it is required to cancel scheduled events (e.g. to model timeouts). This PR adds a `event_timeout_clear()` function to the `event/timout` submodule to enable this.

### Issues/PRs references
none