### PR TITLE
native: call rtc_init from board_init

### DIFF
--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -15,6 +15,7 @@
  */
 #include <stdio.h>
 #include "board.h"
+#include "periph/rtc.h"
 
 #include "board_internal.h"
 
@@ -30,6 +31,9 @@ void board_init(void)
 {
     LED0_OFF;
     LED1_ON;
+#ifdef MODULE_PERIPH_RTC
+    rtc_init();
+#endif
     puts("RIOT native board initialized.");
 }
 

--- a/tests/pkg_fatfs_vfs/main.c
+++ b/tests/pkg_fatfs_vfs/main.c
@@ -295,10 +295,6 @@ static void test_create(void)
 
 int main(void)
 {
-#if defined(BOARD_NATIVE) && (FATFS_FFCONF_OPT_FS_NORTC == 0)
-    rtc_init();
-#endif
-
 #if MODULE_MTD_SDCARD
     for(unsigned int i = 0; i < SDCARD_SPI_NUM; i++){
         mtd_sdcard_devs[i].base.driver = &mtd_sdcard_driver;


### PR DESCRIPTION
### Contribution description

When reviewing #7104 I realized that `rtc_init` was not called on native. On other platforms it should be called from `periph_init`.
This PR fixes it and call `rtc_init` from `board_init` to avoid pulling `periph_common` as a dependency.

### Issues/PRs references

#7104