### PR TITLE
drivers/rn2xx3: add netdev adaption + auto_init

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -488,6 +488,7 @@ ifneq (,$(filter rn2%3,$(USEMODULE)))
   USEMODULE += xtimer
   USEMODULE += rn2xx3
   USEMODULE += fmt
+  USEMODULE += netif
 endif
 
 ifneq (,$(filter sdcard_spi,$(USEMODULE)))

--- a/drivers/rn2xx3/rn2xx3_netdev.c
+++ b/drivers/rn2xx3/rn2xx3_netdev.c
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2017
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_rn2xx3
+ * @{
+ * @file
+ * @brief       Netdev adaption for the rn2xx3 driver
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @}
+ */
+
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
+
+#include "net/netopt.h"
+#include "net/netdev.h"
+#include "net/loramac.h"
+
+#include "rn2xx3_internal.h"
+#include "rn2xx3.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/* Internal helper functions */
+static int _set_state(rn2xx3_t *dev, netopt_state_t state)
+{
+    switch (state) {
+        case NETOPT_STATE_SLEEP:
+            rn2xx3_sys_sleep(dev);
+            break;
+
+        case NETOPT_STATE_RESET:
+            rn2xx3_sys_reset(dev);
+            break;
+
+        default:
+            return -ENOTSUP;
+    }
+
+    return sizeof(netopt_state_t);
+}
+
+static int _get_state(rn2xx3_t *dev, void *val)
+{
+    netopt_state_t state;
+    switch(dev->int_state) {
+        case RN2XX3_INT_STATE_SLEEP:
+            state = NETOPT_STATE_SLEEP;
+            break;
+
+        case RN2XX3_INT_STATE_CMD:
+        case RN2XX3_INT_STATE_MAC_JOIN:
+        case RN2XX3_INT_STATE_IDLE:
+            state = NETOPT_STATE_STANDBY;
+            break;
+
+        case RN2XX3_INT_STATE_MAC_TX:
+            state = NETOPT_STATE_TX;
+            break;
+
+        case RN2XX3_INT_STATE_MAC_RX_PORT:
+        case RN2XX3_INT_STATE_MAC_RX_MESSAGE:
+            state = NETOPT_STATE_RX;
+            break;
+
+        default:
+            break;
+    }
+    memcpy(val, &state, sizeof(netopt_state_t));
+    return sizeof(netopt_state_t);
+}
+
+static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
+{
+    rn2xx3_t *dev = (rn2xx3_t *) netdev;
+
+    if (dev->int_state != RN2XX3_INT_STATE_IDLE) {
+        DEBUG("[WARNING] Cannot send packet: module is not ready .\n");
+        return -ENOTSUP;
+    }
+
+    /* Start send command */
+    rn2xx3_mac_tx_start(dev);
+
+    /* Write payload buffer */
+    for (size_t i = 0; i < count; i++) {
+        rn2xx3_cmd_append(dev, vector[i].iov_base, vector[i].iov_len);
+    }
+
+    /* Finalize the transmission */
+    rn2xx3_mac_tx_finalize(dev);
+
+    return 0;
+}
+
+static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
+{
+    (void) info;
+    rn2xx3_t *dev = (rn2xx3_t *) netdev;
+
+    uint8_t size = strlen((char *)dev->rx_buf);
+
+    if (buf == NULL) {
+        return size;
+    }
+
+    if (size > len) {
+        return -ENOBUFS;
+    }
+
+    memcpy(buf, dev->rx_buf, size);
+
+    return size;
+}
+
+static int _init(netdev_t *netdev)
+{
+    rn2xx3_t *dev = (rn2xx3_t *) netdev;
+
+    DEBUG("[rn2xx3] netdev: initializing device\n");
+    if (rn2xx3_init(dev) != RN2XX3_OK) {
+        DEBUG("[rn2xx3] netdev: device initialization failed\n");
+        return -1;
+    }
+
+    DEBUG("[rn2xx3] netdev: initializing mac layer\n");
+    if (rn2xx3_mac_init(dev) != RN2XX3_OK) {
+        DEBUG("[rn2xx3] netdev: mac initialization failed\n");
+        return -1;
+    }
+
+    DEBUG("[rn2xx3] netdev: initialization succeeded\n");
+
+    return 0;
+}
+
+static void _isr(netdev_t *netdev)
+{
+    rn2xx3_t *dev = (rn2xx3_t *)netdev;
+
+    switch (dev->int_state) {
+        case RN2XX3_INT_STATE_MAC_RX_MESSAGE:
+            DEBUG("[rn2xx3] isr: data available, waiting for read\n");
+            netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
+            break;
+
+        case RN2XX3_INT_STATE_MAC_TX:
+        case RN2XX3_INT_STATE_MAC_RX_PORT:
+            DEBUG("[rn2xx3] isr: data sent\n");
+            netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
+            break;
+    }
+}
+
+static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
+{
+    rn2xx3_t *dev = (rn2xx3_t *) netdev;
+
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+
+    switch(opt) {
+        case NETOPT_STATE:
+            assert(max_len >= sizeof(netopt_state_t));
+            return _get_state(dev, val);
+
+        case NETOPT_TX_POWER:
+            assert(max_len >= sizeof(uint8_t));
+            *((uint8_t *) val) = rn2xx3_mac_get_tx_power(dev);
+            return sizeof(uint8_t);
+
+        case NETOPT_LORAWAN_DR:
+            assert(max_len >= sizeof(uint8_t));
+            *((uint8_t *) val) = rn2xx3_mac_get_dr(dev);
+            return sizeof(uint8_t);
+
+        case NETOPT_LORAWAN_ADR:
+            assert(max_len >= sizeof(netopt_enable_t));
+            *((netopt_enable_t *) val) = rn2xx3_mac_get_adr(dev) ? NETOPT_ENABLE : NETOPT_DISABLE;
+            break;
+
+        case NETOPT_RETRANS:
+            assert(max_len >= sizeof(uint8_t));
+            *((uint8_t *) val) = rn2xx3_mac_get_retx(dev);
+            return sizeof(uint8_t);
+
+        case NETOPT_LORAWAN_RX2_DR:
+            assert(max_len >= sizeof(uint8_t));
+            *((uint8_t *) val) = rn2xx3_mac_get_rx2_dr(dev);
+            return sizeof(uint8_t);
+
+        case NETOPT_LORAWAN_RX2_FREQ:
+            assert(max_len >= sizeof(uint32_t));
+            *((uint32_t *) val) = rn2xx3_mac_get_rx2_freq(dev);
+            return sizeof(uint32_t);
+
+        case NETOPT_LORAWAN_TX_PORT:
+            assert(max_len >= sizeof(uint8_t));
+            *((uint8_t *) val) = rn2xx3_mac_get_tx_port(dev);
+            return sizeof(uint8_t);
+
+        case NETOPT_ACK_REQ:
+            assert(max_len >= sizeof(netopt_enable_t));
+            *((netopt_enable_t*) val) = (rn2xx3_mac_get_tx_mode(dev) == LORAMAC_TX_CNF) ? NETOPT_ENABLE : NETOPT_DISABLE;
+            break;
+
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
+{
+    rn2xx3_t *dev = (rn2xx3_t *) netdev;
+    int res = -ENOTSUP;
+
+    if (dev == NULL) {
+        return -ENODEV;
+    }
+
+    switch(opt) {
+        case NETOPT_STATE:
+            assert(len <= sizeof(netopt_state_t));
+            return _set_state(dev, *((const netopt_state_t *) val));
+
+        case NETOPT_TX_POWER:
+            assert(len <= sizeof(uint8_t));
+            uint8_t poweridx = *((const uint8_t *)val);
+            if (poweridx > LORAMAC_TX_PWR_15) {
+                res = -EINVAL;
+                break;
+            }
+            rn2xx3_mac_set_tx_power(dev, poweridx);
+            return sizeof(uint8_t);
+
+        case NETOPT_LORAWAN_DR:
+            assert(len <= sizeof(uint8_t));
+            uint8_t dr = *((const uint8_t *)val);
+            if (dr > LORAMAC_DR_15) {
+                res = -EINVAL;
+                break;
+            }
+            rn2xx3_mac_set_dr(dev, dr);
+            return sizeof(uint8_t);
+
+        case NETOPT_LORAWAN_ADR:
+            assert(len <= sizeof(netopt_enable_t));
+            rn2xx3_mac_set_adr(dev, *((const netopt_enable_t *) val) ? true : false);
+            return sizeof(netopt_enable_t);
+
+        case NETOPT_LORAWAN_RX2_DR:
+            assert(len <= sizeof(uint8_t));
+            uint8_t rx2_dr = *((const uint8_t *)val);
+            if (rx2_dr > LORAMAC_DR_15) {
+                res = -EINVAL;
+                break;
+            }
+            rn2xx3_mac_set_rx2_dr(dev, rx2_dr);
+            return sizeof(uint8_t);
+
+        case NETOPT_LORAWAN_RX2_FREQ:
+            assert(len <= sizeof(uint32_t));
+            rn2xx3_mac_set_rx2_freq(dev, *((const uint32_t *) val));
+            return sizeof(uint32_t);
+
+        case NETOPT_LORAWAN_TX_PORT:
+            assert(len <= sizeof(uint8_t));
+            uint8_t port = *((const uint8_t *)val);
+            if (port < LORAMAC_PORT_MIN ||
+                port > LORAMAC_PORT_MAX) {
+                res = -EINVAL;
+                break;
+            }
+            rn2xx3_mac_set_tx_port(dev, port);
+            return sizeof(uint8_t);
+
+        case NETOPT_ACK_REQ:
+            assert(len <= sizeof(netopt_enable_t));
+            rn2xx3_mac_set_tx_mode(dev, *((const netopt_enable_t *) val) ? LORAMAC_TX_CNF : LORAMAC_TX_UNCNF);
+            return sizeof(netopt_enable_t);
+
+        default:
+            break;
+
+    }
+
+    return res;
+}
+
+const netdev_driver_t rn2xx3_driver = {
+    .send = _send,
+    .recv = _recv,
+    .init = _init,
+    .isr = _isr,
+    .get = _get,
+    .set = _set,
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -331,6 +331,11 @@ void auto_init(void)
     auto_init_nrf802154();
 #endif
 
+#ifdef MODULE_RN2XX3
+    extern void auto_init_rn2xx3(void);
+    auto_init_rn2xx3();
+#endif
+
 #endif /* MODULE_AUTO_INIT_GNRC_NETIF */
 
 #ifdef MODULE_GNRC_UHCPC

--- a/sys/auto_init/netif/auto_init_rn2xx3.c
+++ b/sys/auto_init/netif/auto_init_rn2xx3.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     auto_init_gnrc_netif
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for RN2483 and RN2903 devices (LoRaMAC only)
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifdef MODULE_RN2XX3
+
+#include "log.h"
+#include "board.h"
+#include "net/gnrc/netif/raw.h"
+#include "net/gnrc.h"
+
+#include "rn2xx3.h"
+#include "rn2xx3_params.h"
+
+/**
+ * @brief   Calculate the number of configured RN2XX3 devices
+ */
+#define RN2XX3_NUMOF        (sizeof(rn2xx3_params) / sizeof(rn2xx3_params[0]))
+
+/**
+ * @brief   Define stack parameters for the MAC layer thread
+ */
+#define RN2XX3_STACKSIZE           (THREAD_STACKSIZE_DEFAULT)
+#ifndef RN2XX3_PRIO
+#define RN2XX3_PRIO                (GNRC_NETIF_PRIO)
+#endif
+
+/**
+ * @brief   Allocate memory for device descriptors, stacks, and GNRC adaption
+ */
+static rn2xx3_t rn2xx3_devs[RN2XX3_NUMOF];
+static char rn2xx3_stacks[RN2XX3_NUMOF][RN2XX3_STACKSIZE];
+
+void auto_init_rn2xx3(void)
+{
+    for (unsigned i = 0; i < RN2XX3_NUMOF; ++i) {
+#if defined(MODULE_RN2483)
+        LOG_DEBUG("[auto_init_netif] initializing rn2483 #%u\n", i);
+#else /* MODULE_RN2903 */
+        LOG_DEBUG("[auto_init_netif] initializing rn2903 #%u\n", i);
+#endif
+
+        rn2xx3_setup(&rn2xx3_devs[i], &rn2xx3_params[i]);
+        gnrc_netif_raw_create(rn2xx3_stacks[i], RN2XX3_STACKSIZE, RN2XX3_PRIO,
+                              "rn2xx3", (netdev_t *)&rn2xx3_devs[i]);
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_RN2XX3 */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a follow-up of #7505:
* it introduces new netopts for loramac
* it implement the netdev adaption of the microchip rn2xx3 driver
* it add `auto_init` for the rn2xx3 devices

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Depends on ~#7505~ #9022

Related to #7331

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->