### PR TITLE
puts => LOG_INFO for the MSP430 startup message

### DIFF
--- a/cpu/msp430_common/startup.c
+++ b/cpu/msp430_common/startup.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include "kernel_init.h"
 #include "irq.h"
+#include "log.h"
 
 extern void board_init(void);
 
@@ -32,7 +33,7 @@ __attribute__((constructor)) static void startup(void)
 
     board_init();
 
-    puts("RIOT MSP430 hardware initialization complete.\n");
+    LOG_INFO("RIOT MSP430 hardware initialization complete.\n");
 
     kernel_init();
 }


### PR DESCRIPTION
see issue #8340, small change to make the startup message for MSP430 be a LOG_INFO instead of a puts