### PR TITLE
boards/samr21: added function to configure antenna switch

### DIFF
--- a/boards/samr21-xpro/board.c
+++ b/boards/samr21-xpro/board.c
@@ -23,10 +23,32 @@
 #include "board.h"
 #include "periph/gpio.h"
 
+int board_choose_antenna(uint8_t antenna)
+{
+	if (antenna == 2){
+		gpio_clear(RFCTL2_PIN);
+		gpio_set(RFCTL1_PIN);
+		return antenna;
+  	}
+	else if (antenna == 1){
+		gpio_clear(RFCTL1_PIN);
+		gpio_set(RFCTL2_PIN);
+		return antenna;
+  	}
+	else{
+		return -1;
+	}
+}
+
 void board_init(void)
 {
     /* initialize the on-board LED */
     gpio_init(LED0_PIN, GPIO_OUT);
+    /* initialize the on-board antenna switch */
+    gpio_init(RFCTL1_PIN, GPIO_OUT);
+    gpio_init(RFCTL2_PIN, GPIO_OUT);
+    /* choose antenna 1 (chip antenna) as default */
+    board_choose_antenna(1);
 
     /* initialize the CPU */
     cpu_init();

--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -73,12 +73,34 @@ extern "C" {
 #define BTN0_PIN            GPIO_PIN(0, 28)
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */
+/**
+ * @name    RFCTL pin definitions and handlers
+ * @{
+ */
+#define RFCTL1_PIN            GPIO_PIN(0, 9)
+#define RFCTL2_PIN            GPIO_PIN(0, 12)
+
+#define RFCTL_PORT            PORT->Group[0]
+#define RFCTL1_MASK           (1 << 9)
+#define RFCTL2_MASK           (1 << 12)
+
+#define RFCTL1_ON             (RFCTL_PORT.OUTCLR.reg = RFCTL1_MASK)
+#define RFCTL1_OFF            (RFCTL_PORT.OUTSET.reg = RFCTL1_MASK)
+#define RFCTL1_TOGGLE         (RFCTL_PORT.OUTTGL.reg = RFCTL1_MASK)
+#define RFCTL2_ON             (RFCTL_PORT.OUTCLR.reg = RFCTL2_MASK)
+#define RFCTL2_OFF            (RFCTL_PORT.OUTSET.reg = RFCTL2_MASK)
+#define RFCTL2_TOGGLE         (RFCTL_PORT.OUTTGL.reg = RFCTL2_MASK)
+/** @} */
 
 /**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);
 
+/**
+ * @brief  controls whether antenna 1 or 2 is used
+ */
+int board_choose_antenna(uint8_t antenna);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
this is needed to bring the antenna switch(AS222-92) into a defined
state, ref. datasheet page 3.

Without this the antenna switch is in an undefined state and there is no way to tell which -- if any -- antenna is used at a time.