### PR TITLE
pkg: heatshrink: don't copy Makefile.heatshrink, use directly

### DIFF
--- a/pkg/heatshrink/Makefile
+++ b/pkg/heatshrink/Makefile
@@ -5,7 +5,6 @@ PKG_VERSION=7d419e1fa4830d0b919b9b6a91fe2fb786cf3280
 .PHONY: all
 
 all: git-download
-	cp Makefile.heatshrink $(PKG_BUILDDIR)/Makefile
-	"$(MAKE)" -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.heatshrink
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description

Most packages either copy or patch a RIOT specific Makefile into the package's source folder.
Both seem hacky.
This PR changes the heatshrink package to use ```pkg/heatshrink/Makefile.heatshrink``` using ```make -f``` instead of copying.