### PR TITLE
cpu/stm32l1/vectors.c: fix model stm32l152ret6 -> stm32l152re

### DIFF
--- a/cpu/stm32l1/vectors.c
+++ b/cpu/stm32l1/vectors.c
@@ -141,7 +141,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_dma2_ch5,           /* [54] DMA2 Channel 5 global Interrupt */
     isr_aes,                /* [55] AES global Interrupt */
     isr_comp_acq            /* [56] Comparator Channel Acquisition global Interrupt */
-#elif defined(CPU_MODEL_STM32L152RET6)
+#elif defined(CPU_MODEL_STM32L152RE)
     (0UL),                  /* [45] Reserved */
     isr_tim5,               /* [46] TIM5 global Interrupt */
     isr_spi3,               /* [47] SPI3 global Interrupt */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While working on #7799 I changed the model name from stm32l152ret6 to stm32l152re,
which has some impact, until today, not harmful on vectors.c

This PR fixes that. I tested it on nucleo-l152.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#7799 is where the change was made.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->