### PR TITLE
net: Introduce iolists

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -110,6 +110,7 @@ endif
 ifneq (,$(filter netdev_tap,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += netdev_eth
+  USEMODULE += iolist
 endif
 
 ifneq (,$(filter gnrc_tftp,$(USEMODULE)))

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -14,6 +14,7 @@ ifneq (,$(filter can,$(USEMODULE)))
 endif
 
 ifneq (,$(filter socket_zep,$(USEMODULE)))
+  USEMODULE += iolist
   USEMODULE += netdev_ieee802154
   USEMODULE += checksum
   USEMODULE += random

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -79,9 +79,6 @@ static int hdr_netif_to_nrfmin(nrfmin_hdr_t *nrfmin, gnrc_pktsnip_t *pkt)
 static int gnrc_nrfmin_send(gnrc_netif_t *dev, gnrc_pktsnip_t *pkt)
 {
     int res;
-    struct iovec *vec;
-    size_t vec_len;
-    gnrc_pktsnip_t *vec_snip;
     nrfmin_hdr_t nrfmin_hdr;
 
     assert(pkt);
@@ -95,26 +92,21 @@ static int gnrc_nrfmin_send(gnrc_netif_t *dev, gnrc_pktsnip_t *pkt)
     res = hdr_netif_to_nrfmin(&nrfmin_hdr, pkt);
     if (res < 0) {
         DEBUG("[nrfmin_gnrc] send: failed to build nrfmin header\n");
-        gnrc_pktbuf_release(pkt);
-        return res;
+        goto out;
     }
 
-    /* create iovec of data */
-    vec_snip = gnrc_pktbuf_get_iovec(pkt, &vec_len);
-    if (vec_snip == NULL) {
-        DEBUG("[nrfmin_gnrc] send: failed to create IO vector\n");
-        gnrc_pktbuf_release(pkt);
-        return -ENOBUFS;
-    }
-
-    /* link first entry of the vector to the nrfmin header */
-    vec = (struct iovec *)vec_snip->data;
-    vec[0].iov_base = &nrfmin_hdr;
-    vec[0].iov_len = NRFMIN_HDR_LEN;
+    /* link first entry after netif hdr of the pkt to the nrfmin header */
+    iolist_t iolist = {
+        .iol_next = (iolist_t *)pkt->next,
+        .iol_base = &nrfmin_hdr,
+        .iol_len = NRFMIN_HDR_LEN
+    };
 
     /* and finally send out the data and release the packet */
-    res = dev->dev->driver->send(dev->dev, vec, vec_len);
-    gnrc_pktbuf_release(vec_snip);
+    res = dev->dev->driver->send(dev->dev, &iolist);
+
+out:
+    gnrc_pktbuf_release(pkt);
 
     return res;
 }

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -112,6 +112,7 @@ ifneq (,$(filter encx24j600,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ethos,$(USEMODULE)))
+  USEMODULE += iolist
   USEMODULE += netdev_eth
   USEMODULE += random
   USEMODULE += tsrb
@@ -306,6 +307,7 @@ endif
 ifneq (,$(filter sx127%,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_spi
+  USEMODULE += iolist
   USEMODULE += xtimer
   USEMODULE += sx127x
   USEMODULE += netif

--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -37,14 +37,12 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static int _send(netdev_t *dev, const struct iovec *vector, unsigned count)
+static int _send(netdev_t *dev, const iolist_t *iolist)
 {
     DEBUG("%s:%u\n", __func__, __LINE__);
 
-    (void)count;
-
-    netdev_cc110x_t *netdev_cc110x = (netdev_cc110x_t*) dev;
-    cc110x_pkt_t *cc110x_pkt = vector[0].iov_base;
+    netdev_cc110x_t *netdev_cc110x = (netdev_cc110x_t *)dev;
+    cc110x_pkt_t *cc110x_pkt = iolist->iol_base;
 
     return cc110x_send(&netdev_cc110x->cc110x, cc110x_pkt);
 }

--- a/drivers/cc110x/gnrc_cc110x/gnrc_cc110x.c
+++ b/drivers/cc110x/gnrc_cc110x/gnrc_cc110x.c
@@ -71,9 +71,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
             cc110x_pkt.flags = 0;
     }
 
-    struct iovec vector;
-    vector.iov_base = (char*)&cc110x_pkt;
-    vector.iov_len = sizeof(cc110x_pkt_t);
+    iolist_t iolist = {
+        .iol_base = (char *)&cc110x_pkt,
+        .iol_len = sizeof(cc110x_pkt_t)
+    };
 
     unsigned payload_len = 0;
     uint8_t *pos = cc110x_pkt.data;
@@ -93,7 +94,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         payload = payload->next;
     }
 
-    /* pkt has been copied into iovec, we're done with it. */
+    /* pkt has been copied into cc110x_pkt, we're done with it. */
     gnrc_pktbuf_release(pkt);
 
     cc110x_pkt.length = (uint8_t) payload_len + CC110X_HEADER_LENGTH;
@@ -104,7 +105,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
             (unsigned)cc110x_pkt.address,
             (unsigned)cc110x_pkt.length);
 
-    return dev->driver->send(dev, &vector, 1);
+    return dev->driver->send(dev, &iolist);
 }
 
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -39,7 +39,7 @@
 #include "debug.h"
 
 
-static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count);
+static int _send(netdev_t *netdev, const iolist_t *iolist);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
@@ -150,10 +150,10 @@ static void _isr(netdev_t *netdev)
     netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
 }
 
-static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
+static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
     cc2420_t *dev = (cc2420_t *)netdev;
-    return (int)cc2420_send(dev, vector, count);
+    return (int)cc2420_send(dev, iolist);
 }
 
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -240,7 +240,7 @@ static void on_int(void *arg)
     netdev->event_callback(arg, NETDEV_EVENT_ISR);
 }
 
-static int nd_send(netdev_t *netdev, const struct iovec *data, unsigned count)
+static int nd_send(netdev_t *netdev, const iolist_t *iolist)
 {
     enc28j60_t *dev = (enc28j60_t *)netdev;
     uint8_t ctrl = 0;
@@ -256,9 +256,9 @@ static int nd_send(netdev_t *netdev, const struct iovec *data, unsigned count)
     cmd_w_addr(dev, ADDR_WRITE_PTR, BUF_TX_START);
     /* write control byte and the actual data into the buffer */
     cmd_wbm(dev, &ctrl, 1);
-    for (unsigned i = 0; i < count; i++) {
-        c += data[i].iov_len;
-        cmd_wbm(dev, (uint8_t *)data[i].iov_base, data[i].iov_len);
+    for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+        c += iol->iol_len;
+        cmd_wbm(dev, iol->iol_base, iol->iol_len);
     }
     /* set TX end pointer */
     cmd_w_addr(dev, ADDR_TX_END, cmd_r_addr(dev, ADDR_WRITE_PTR) - 1);

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -64,7 +64,7 @@ static inline int _packets_available(encx24j600_t *dev);
 static void _get_mac_addr(netdev_t *dev, uint8_t* buf);
 
 /* netdev interface */
-static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count);
+static int _send(netdev_t *netdev, const iolist_t *iolist);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *dev);
 static void _isr(netdev_t *dev);
@@ -291,7 +291,7 @@ static int _init(netdev_t *encdev)
     return 0;
 }
 
-static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count) {
+static int _send(netdev_t *netdev, const iolist_t *iolist) {
     encx24j600_t * dev = (encx24j600_t *) netdev;
     lock(dev);
 
@@ -301,9 +301,9 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count) {
     /* copy packet to SRAM */
     size_t len = 0;
 
-    for (unsigned i = 0; i < count; i++) {
-        sram_op(dev, ENC_WGPDATA, (i ? 0xFFFF : TX_BUFFER_START), vector[i].iov_base, vector[i].iov_len);
-        len += vector[i].iov_len;
+    for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+        sram_op(dev, ENC_WGPDATA, ((iol == iolist) ? TX_BUFFER_START : 0xFFFF), iol->iol_base, iol->iol_len);
+        len += iol->iol_len;
     }
 
     /* set start of TX packet and length */

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -263,13 +263,12 @@ netopt_state_t cc2420_get_state(cc2420_t *dev);
  * @note This function ignores the PRELOADING option
  *
  * @param[in] dev           device to use for sending
- * @param[in] data          data to send (must include IEEE802.15.4 header)
- * @param[in] count         length of @p data
+ * @param[in] iolist        data to send (must include IEEE802.15.4 header)
  *
  * @return                  number of bytes that were actually send
  * @return                  0 on error
  */
-size_t cc2420_send(cc2420_t *dev, const struct iovec *data, unsigned count);
+size_t cc2420_send(cc2420_t *dev, const iolist_t *iolist);
 
 /**
  * @brief   Prepare for sending of data
@@ -278,10 +277,9 @@ size_t cc2420_send(cc2420_t *dev, const struct iovec *data, unsigned count);
  * data is possible after it was called.
  *
  * @param[in] dev           device to prepare for sending
- * @param[in] data          data to prepare (must include IEEE802.15.4 header)
- * @param[in] count         length of @p data
+ * @param[in] iolist        data to prepare (must include IEEE802.15.4 header)
  */
-size_t cc2420_tx_prepare(cc2420_t *dev, const struct iovec *data, unsigned count);
+size_t cc2420_tx_prepare(cc2420_t *dev, const iolist_t *iolist);
 
 /**
  * @brief   Trigger sending of data previously loaded into transmit buffer

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -195,8 +195,8 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include <sys/uio.h>
 
+#include "iolist.h"
 #include "net/netopt.h"
 
 #ifdef MODULE_NETSTATS_L2
@@ -294,17 +294,14 @@ typedef struct netdev_driver {
     /**
      * @brief Send frame
      *
-     * @pre `(dev != NULL)`
-     * @pre `(count == 0) || (vector != NULL)`
-     *      (`(count != 0) => (vector != NULL)`)
+     * @pre `(dev != NULL) && (iolist != NULL`
      *
      * @param[in] dev       network device descriptor
-     * @param[in] vector    io vector array to send
-     * @param[in] count     nr of entries in vector
+     * @param[in] iolist    io vector list to send
      *
      * @return number of bytes sent, or `< 0` on error
      */
-    int (*send)(netdev_t *dev, const struct iovec *vector, unsigned count);
+    int (*send)(netdev_t *dev, const iolist_t *iolist);
 
     /**
      * @brief Get a received frame

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -27,31 +27,6 @@
 #define SLIP_END_ESC           (0xdcU)
 #define SLIP_ESC_ESC           (0xddU)
 
-static int _send(netdev_t *dev, const struct iovec *vector, unsigned count);
-static int _recv(netdev_t *dev, void *buf, size_t len, void *info);
-static int _init(netdev_t *dev);
-static void _isr(netdev_t *dev);
-static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
-static int _set(netdev_t *dev, netopt_t opt, const void *value,
-                size_t value_len);
-
-static const netdev_driver_t slip_driver = {
-    .send = _send,
-    .recv = _recv,
-    .init = _init,
-    .isr = _isr,
-    .get = _get,
-    .set = _set,
-};
-
-void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params)
-{
-    /* set device descriptor fields */
-    memcpy(&dev->config, params, sizeof(dev->config));
-    dev->inesc = 0U;
-    dev->netdev.driver = &slip_driver;
-}
-
 static void _slip_rx_cb(void *arg, uint8_t byte)
 {
     slipdev_t *dev = arg;
@@ -84,16 +59,16 @@ static inline void _write_byte(slipdev_t *dev, uint8_t byte)
     uart_write(dev->config.uart, &byte, 1);
 }
 
-static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
+static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
     slipdev_t *dev = (slipdev_t *)netdev;
     int bytes = 0;
 
-    DEBUG("slipdev: sending vector of length %u\n", count);
-    for (unsigned i = 0; i < count; i++) {
-        uint8_t *data = vector[i].iov_base;
+    DEBUG("slipdev: sending iolist\n");
+    for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+        uint8_t *data = iol->iol_base;
 
-        for (unsigned j = 0; j < vector[i].iov_len; j++, data++) {
+        for (unsigned j = 0; j < iol->iol_len; j++, data++) {
             switch(*data) {
                 case SLIP_END:
                     /* escaping END byte*/
@@ -221,6 +196,23 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
     (void)value;
     (void)value_len;
     return -ENOTSUP;
+}
+
+static const netdev_driver_t slip_driver = {
+    .send = _send,
+    .recv = _recv,
+    .init = _init,
+    .isr = _isr,
+    .get = _get,
+    .set = _set,
+};
+
+void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params)
+{
+    /* set device descriptor fields */
+    memcpy(&dev->config, params, sizeof(dev->config));
+    dev->inesc = 0U;
+    dev->netdev.driver = &slip_driver;
 }
 
 /** @} */

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -34,7 +34,6 @@
 #include "debug.h"
 
 /* Internal helper functions */
-static uint8_t _get_tx_len(const struct iovec *vector, unsigned count);
 static int _set_state(sx127x_t *dev, netopt_state_t state);
 static int _get_state(sx127x_t *dev, void *val);
 void _on_dio0_irq(void *arg);
@@ -42,24 +41,7 @@ void _on_dio1_irq(void *arg);
 void _on_dio2_irq(void *arg);
 void _on_dio3_irq(void *arg);
 
-/* Netdev driver api functions */
-static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count);
-static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
-static int _init(netdev_t *netdev);
-static void _isr(netdev_t *netdev);
-static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len);
-static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len);
-
-const netdev_driver_t sx127x_driver = {
-    .send = _send,
-    .recv = _recv,
-    .init = _init,
-    .isr = _isr,
-    .get = _get,
-    .set = _set,
-};
-
-static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
+static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
     sx127x_t *dev = (sx127x_t*) netdev;
 
@@ -69,8 +51,8 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
         return -ENOTSUP;
     }
 
-    uint8_t size;
-    size = _get_tx_len(vector, count);
+    uint8_t size = iolist_size(iolist);
+
     switch (dev->settings.modem) {
         case SX127X_MODEM_FSK:
             /* todo */
@@ -91,8 +73,8 @@ static int _send(netdev_t *netdev, const struct iovec *vector, unsigned count)
             }
 
             /* Write payload buffer */
-            for (size_t i = 0; i < count; i++) {
-                sx127x_write_fifo(dev, vector[i].iov_base, vector[i].iov_len);
+            for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+                sx127x_write_fifo(dev, iol->iol_base, iol->iol_len);
             }
             break;
         default:
@@ -489,17 +471,6 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     return res;
 }
 
-static uint8_t _get_tx_len(const struct iovec *vector, unsigned count)
-{
-    uint8_t len = 0;
-
-    for (unsigned i = 0 ; i < count ; i++) {
-        len += vector[i].iov_len;
-    }
-
-    return len;
-}
-
 static int _set_state(sx127x_t *dev, netopt_state_t state)
 {
     switch (state) {
@@ -717,3 +688,12 @@ void _on_dio3_irq(void *arg)
             break;
     }
 }
+
+const netdev_driver_t sx127x_driver = {
+    .send = _send,
+    .recv = _recv,
+    .init = _init,
+    .isr = _isr,
+    .get = _get,
+    .set = _set,
+};

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -194,7 +194,7 @@ static uint16_t tx_upload(w5100_t *dev, uint16_t start, void *data, size_t len)
     }
 }
 
-static int send(netdev_t *netdev, const struct iovec *vector, unsigned count)
+static int send(netdev_t *netdev, const iolist_t *iolist)
 {
     w5100_t *dev = (w5100_t *)netdev;
     int sum = 0;
@@ -210,9 +210,10 @@ static int send(netdev_t *netdev, const struct iovec *vector, unsigned count)
         pos = S0_TX_BASE;
     }
 
-    for (unsigned i = 0; i < count; i++) {
-        pos = tx_upload(dev, pos, vector[i].iov_base, vector[i].iov_len);
-        sum += vector[i].iov_len;
+    for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+        size_t len = iol->iol_len;
+        pos = tx_upload(dev, pos, iol->iol_base, len);
+        sum += len;
     }
 
     waddr(dev, S0_TX_WR0, S0_TX_WR1, pos);

--- a/pkg/emb6/contrib/netdev/emb6_netdev.c
+++ b/pkg/emb6/contrib/netdev/emb6_netdev.c
@@ -138,11 +138,11 @@ static int8_t _netdev_init(s_ns_t *p_ns)
 static int8_t _netdev_send(const void *pr_payload, uint8_t c_len)
 {
     if (_dev != NULL) {
-        const struct iovec vector = {
-            .iov_base = (void *)pr_payload,
-            .iov_len = c_len
+        iolist_t iolist = {
+            .iol_base = (void *)pr_payload,
+            .iol_len = c_len,
         };
-        if (_dev->driver->send(_dev, &vector, 1) < 0) {
+        if (_dev->driver->send(_dev, &iolist) < 0) {
             DEBUG("Error on send\n");
             return RADIO_TX_ERR;
         }

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -185,15 +185,24 @@ static err_t _eth_link_output(struct netif *netif, struct pbuf *p)
     pbuf_header(p, -ETH_PAD_SIZE); /* drop the padding word */
 #endif
     LL_COUNT(p, q, count);
-    struct iovec pkt[count];
+    iolist_t iolist[count];
+
+    /* make last point to the last entry of iolist[] */
+    iolist_t *last = &iolist[count];
+    last--;
+
     for (q = p, count = 0; q != NULL; q = q->next, count++) {
-        pkt[count].iov_base = q->payload;
-        pkt[count].iov_len = (size_t)q->len;
+        iolist_t *iol = &iolist[count];
+
+        iol->iol_next = (iol == last) ? NULL : &iolist[count + 1];
+
+        iol->iol_base = q->payload;
+        iol->iol_len = (size_t)q->len;
     }
 #if ETH_PAD_SIZE
     pbuf_header(p, ETH_PAD_SIZE); /* reclaim the padding word */
 #endif
-    return (netdev->driver->send(netdev, pkt, count) > 0) ? ERR_OK : ERR_BUF;
+    return (netdev->driver->send(netdev, iolist) > 0) ? ERR_OK : ERR_BUF;
 }
 #endif
 
@@ -202,12 +211,12 @@ static err_t _ieee802154_link_output(struct netif *netif, struct pbuf *p)
 {
     LWIP_ASSERT("p->next == NULL", p->next == NULL);
     netdev_t *netdev = (netdev_t *)netif->state;
-    struct iovec pkt = {
-        .iov_base = p->payload,
-        .iov_len = (p->len - IEEE802154_FCS_LEN),   /* FCS is written by driver */
+    iolist_t pkt = {
+        .iol_base = p->payload,
+        .iol_len = (p->len - IEEE802154_FCS_LEN),   /* FCS is written by driver */
     };
 
-    return (netdev->driver->send(netdev, &pkt, 1) > 0) ? ERR_OK : ERR_BUF;
+    return (netdev->driver->send(netdev, &pkt) > 0) ? ERR_OK : ERR_BUF;
 }
 #endif
 

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -297,14 +297,15 @@ void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
 ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
 {
     (void) aInstance;
-    struct iovec pkt;
 
-    /* Populate iovec with transmit data
+    /* Populate iolist with transmit data
      * Unlike RIOT, OpenThread includes two bytes FCS (0x00 0x00) so
      * these bytes are removed
      */
-    pkt.iov_base = aPacket->mPsdu;
-    pkt.iov_len = aPacket->mLength - RADIO_IEEE802154_FCS_LEN;
+    iolist_t iolist = {
+        .iol_base = aPacket->mPsdu,
+        .iol_len = (aPacket->mLength - RADIO_IEEE802154_FCS_LEN)
+    };
 
     /*Set channel and power based on transmit frame */
     DEBUG("otPlatRadioTransmit->channel: %i, length %d\n", (int) aPacket->mChannel, (int)aPacket->mLength);
@@ -316,7 +317,7 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
     _set_power(aPacket->mPower);
 
     /* send packet though netdev */
-    _dev->driver->send(_dev, &pkt, 1);
+    _dev->driver->send(_dev, &iolist);
 
     return kThreadError_None;
 }

--- a/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
@@ -136,10 +136,11 @@ uint32_t SX127XGetTimeOnAir(RadioModems_t modem, uint8_t pktLen)
 void SX127XSend(uint8_t *buffer, uint8_t size)
 {
     netdev_t *dev = (netdev_t *)&sx127x;
-    struct iovec vec[1];
-    vec[0].iov_base = buffer;
-    vec[0].iov_len = size;
-    dev->driver->send(dev, vec, 1);
+    iolist_t iol = {
+        .iol_base = buffer,
+        .iol_len = size
+    };
+    dev->driver->send(dev, &iol);
 }
 
 void SX127XSetSleep(void)

--- a/sys/include/iolist.h
+++ b/sys/include/iolist.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_util_iolist iolist scatter / gather IO
+ * @ingroup     sys_util
+ * @brief       Provides linked-list scatter / gather IO
+ *
+ * @{
+ *
+ * @file
+ * @brief       iolist scatter / gather IO
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef IOLIST_H
+#define IOLIST_H
+
+#include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief iolist forward declaration */
+typedef struct iolist iolist_t;
+
+/**
+ * @brief   iolist structure definition
+ */
+struct iolist {
+    iolist_t *iol_next;     /**< ptr to next list entry */
+    void *iol_base;         /**< ptr to this list entries data */
+    size_t iol_len;         /**< size of data pointet to by ptr */
+};
+
+/**
+ * @brief   Count number of entries in an iolist_t
+ *
+ * @param[in]   iolist  iolist to count
+ *
+ * @returns number of entries (zero for NULL parameter)
+ */
+unsigned iolist_count(const iolist_t *iolist);
+
+/**
+ * @brief   Sum up number of bytes in iolist
+ *
+ * This function returns the summed ip lenght values of all entries in @p
+ * iolist.
+ *
+ * @param[in]   iolist  iolist to sum up
+ *
+ * @returns summed up number of bytes or zero if @p iolist == NULL
+ */
+size_t iolist_size(const iolist_t *iolist);
+
+/** @brief  struct iovec anonymous declaration */
+struct iovec;
+
+/**
+ * @brief   Create struct iovec from iolist
+ *
+ * This function fills an array of struct iovecs with the contents of @p
+ * iolist. It will write the number of used array entries into @p count.
+ *
+ * The caller *must* ensure that @p iov p points to an array of size >= count!
+ *
+ * @param[in]   iolist  iolist to read from
+ * @param[out]  iov     ptr to array of struct iovec that will be filled
+ * @param[out]  count   number of elements in @p iolist
+ *
+ * @returns iolist_size(iolist)
+ */
+size_t iolist_to_iovec(const iolist_t *iolist, struct iovec *iov, unsigned *count);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* IOLIST_H */
+/** @} */

--- a/sys/include/net/csma_sender.h
+++ b/sys/include/net/csma_sender.h
@@ -87,8 +87,7 @@ extern const csma_sender_conf_t CSMA_SENDER_CONF_DEFAULT;
  * CSMA/CA, this feature is used. Otherwise, a software procedure is used.
  *
  * @param[in] dev       netdev device, needs to be already initialized
- * @param[in] vector    pointer to the data
- * @param[in] count     number of elements in @p vector
+ * @param[in] iolist    pointer to the data
  * @param[in] conf      configuration for the backoff;
  *                      will be set to @ref CSMA_SENDER_CONF_DEFAULT if NULL.
  *
@@ -101,8 +100,8 @@ extern const csma_sender_conf_t CSMA_SENDER_CONF_DEFAULT;
  * @return              -EBUSY if radio medium never was available
  *                      to send the given data
  */
-int csma_sender_csma_ca_send(netdev_t *dev, struct iovec *vector,
-                             unsigned count, const csma_sender_conf_t *conf);
+int csma_sender_csma_ca_send(netdev_t *dev, iolist_t *iolist,
+                             const csma_sender_conf_t *conf);
 
 /**
  * @brief   Sends a 802.15.4 frame when medium is avaiable.
@@ -121,8 +120,7 @@ int csma_sender_csma_ca_send(netdev_t *dev, struct iovec *vector,
  *          @ref csma_sender_csma_ca_send().
  *
  * @param[in] dev       netdev device, needs to be already initialized
- * @param[in] vector    pointer to the data
- * @param[in] count     number of elements in @p vector
+ * @param[in] iolist    pointer to the data
  *
  * @return              number of bytes that were actually send out
  * @return              -ENODEV if @p dev is invalid
@@ -133,7 +131,7 @@ int csma_sender_csma_ca_send(netdev_t *dev, struct iovec *vector,
  * @return              -EBUSY if radio medium was not available
  *                      to send the given data
  */
-int csma_sender_cca_send(netdev_t *dev, struct iovec *vector, unsigned count);
+int csma_sender_cca_send(netdev_t *dev, iolist_t *iolist);
 
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/pkt.h
+++ b/sys/include/net/gnrc/pkt.h
@@ -96,20 +96,25 @@ extern "C" {
  *      | * L2 header 3
  *      * L2 header 4
  *
+ * The first three fields (next, data, size) match iolist_t (named iol_next,
+ * iol_base and iol_len there).  That means that any pktsnip can be casted to
+ * iolist_t for direct passing to e.g., netdev send() functions.
+ *
  * @note    This type has no initializer on purpose. Please use @ref net_gnrc_pktbuf
  *          as factory.
  */
 /* packed to be aligned correctly in the static packet buffer */
 typedef struct gnrc_pktsnip {
+    /* the first three fields *MUST* match iolist_t! */
+    struct gnrc_pktsnip *next;      /**< next snip in the packet */
+    void *data;                     /**< pointer to the data of the snip */
+    size_t size;                    /**< the length of the snip in byte */
     /**
      * @brief   Counter of threads currently having control over this packet.
      *
      * @internal
      */
     unsigned int users;
-    struct gnrc_pktsnip *next;      /**< next snip in the packet */
-    void *data;                     /**< pointer to the data of the snip */
-    size_t size;                    /**< the length of the snip in byte */
     gnrc_nettype_t type;            /**< protocol of the packet snip */
 #ifdef MODULE_GNRC_NETERR
     kernel_pid_t err_sub;           /**< subscriber to errors related to this

--- a/sys/include/net/netdev_test.h
+++ b/sys/include/net/netdev_test.h
@@ -33,11 +33,10 @@
  * static uint32_t sum = 0;
  * static mutex_t wait = MUTEX_INIT;
  *
- * int _send_timer(netdev_t *dev, const struct iovec *vector, int count)
+ * int _send_timer(netdev_t *dev, const iolist_t *iolist)
  * {
  *     (void)dev;
- *     (void)vector;
- *     (void)count;
+ *     (void)iolist;
  *
  *     sum += (xtimer_now_usec() - last_start);
  *     mutex_unlock(&wait);
@@ -95,15 +94,12 @@ extern "C" {
  * @brief   Callback type to handle send command
  *
  * @param[in] dev       network device descriptor
- * @param[in] vector    io vector array to send
- * @param[in] count     number of entries in vector
+ * @param[in] iolist    io vector list to send
  *
  * @return  number of bytes sent
  * @return  <= 0 on error
  */
-typedef int (*netdev_test_send_cb_t)(netdev_t *dev,
-                                     const struct iovec *vector,
-                                     int count);
+typedef int (*netdev_test_send_cb_t)(netdev_t *dev, const iolist_t *iolist);
 
 /**
  * @brief   Callback type to handle receive command

--- a/sys/iolist/Makefile
+++ b/sys/iolist/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/iolist/iolist.c
+++ b/sys/iolist/iolist.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_util
+ * @{
+ *
+ * @file
+ * @brief       iolist scatter / gather IO
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @}
+ */
+
+#include <sys/uio.h>
+
+#include "iolist.h"
+
+unsigned iolist_count(const iolist_t *iolist)
+{
+    unsigned count = 0;
+    while (iolist) {
+        count++;
+        iolist = iolist->iol_next;
+    }
+    return count;
+}
+
+size_t iolist_size(const iolist_t *iolist)
+{
+    size_t result = 0;
+    while (iolist) {
+        result += iolist->iol_len;
+        iolist = iolist->iol_next;
+    }
+    return result;
+}
+
+size_t iolist_to_iovec(const iolist_t *iolist, struct iovec *iov, unsigned *count)
+{
+    size_t bytes = 0;
+    unsigned _count = 0;
+
+    while (iolist) {
+        iov->iov_base = iolist->iol_base;
+        iov->iov_len = iolist->iol_len;
+        bytes += iov->iov_len;
+        _count++;
+        iolist = iolist->iol_next;
+        iov++;
+    }
+
+    *count = _count;
+
+    return bytes;
+}

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -37,10 +37,9 @@ int _gnrc_lwmac_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     netdev_t *dev = netif->dev;
     netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_netif_hdr_t *netif_hdr;
-    gnrc_pktsnip_t *vec_snip;
     const uint8_t *src, *dst = NULL;
     int res = 0;
-    size_t n, src_len, dst_len;
+    size_t src_len, dst_len;
     uint8_t mhr[IEEE802154_MAX_HDR_LEN];
     uint8_t flags = (uint8_t)(state->flags & NETDEV_IEEE802154_SEND_MASK);
     le_uint16_t dev_pan = byteorder_btols(byteorder_htons(state->pan));
@@ -80,38 +79,34 @@ int _gnrc_lwmac_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         DEBUG("_send_ieee802154: Error preperaring frame\n");
         return -EINVAL;
     }
-    /* prepare packet for sending */
-    vec_snip = gnrc_pktbuf_get_iovec(pkt, &n);
-    if (vec_snip != NULL) {
-        struct iovec *vector;
 
-        pkt = vec_snip;     /* reassign for later release; vec_snip is prepended to pkt */
-        vector = (struct iovec *)pkt->data;
-        vector[0].iov_base = mhr;
-        vector[0].iov_len = (size_t)res;
+    /* prepare packet for sending */
+    iolist_t iolist = {
+        .iol_next = (iolist_t *)pkt->next,
+        .iol_base = mhr,
+        .iol_len = (size_t)res
+    };
+
 #ifdef MODULE_NETSTATS_L2
-        if (netif_hdr->flags &
+    if (netif_hdr->flags &
             (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
-            netif->dev->stats.tx_mcast_count++;
-        }
-        else {
-            netif->dev->stats.tx_unicast_count++;
-        }
-#endif
-#ifdef MODULE_GNRC_MAC
-        if (netif->mac.mac_info & GNRC_NETIF_MAC_INFO_CSMA_ENABLED) {
-            res = csma_sender_csma_ca_send(dev, vector, n, &netif->mac.csma_conf);
-        }
-        else {
-            res = dev->driver->send(dev, vector, n);
-        }
-#else
-        res = dev->driver->send(dev, vector, n);
-#endif
+        netif->dev->stats.tx_mcast_count++;
     }
     else {
-        return -ENOBUFS;
+        netif->dev->stats.tx_unicast_count++;
     }
+#endif
+#ifdef MODULE_GNRC_MAC
+    if (netif->mac.mac_info & GNRC_NETIF_MAC_INFO_CSMA_ENABLED) {
+        res = csma_sender_csma_ca_send(dev, &iolist, &netif->mac.csma_conf);
+    }
+    else {
+        res = dev->driver->send(dev, &iolist);
+    }
+#else
+    res = dev->driver->send(dev, &iolist);
+#endif
+
     /* release old data */
     gnrc_pktbuf_release(pkt);
     return res;

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -168,10 +168,9 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     netdev_t *dev = netif->dev;
     netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_netif_hdr_t *netif_hdr;
-    gnrc_pktsnip_t *vec_snip;
     const uint8_t *src, *dst = NULL;
     int res = 0;
-    size_t n, src_len, dst_len;
+    size_t src_len, dst_len;
     uint8_t mhr[IEEE802154_MAX_HDR_LEN];
     uint8_t flags = (uint8_t)(state->flags & NETDEV_IEEE802154_SEND_MASK);
     le_uint16_t dev_pan = byteorder_btols(byteorder_htons(state->pan));
@@ -211,38 +210,34 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         DEBUG("_send_ieee802154: Error preperaring frame\n");
         return -EINVAL;
     }
-    /* prepare packet for sending */
-    vec_snip = gnrc_pktbuf_get_iovec(pkt, &n);
-    if (vec_snip != NULL) {
-        struct iovec *vector;
 
-        pkt = vec_snip;     /* reassign for later release; vec_snip is prepended to pkt */
-        vector = (struct iovec *)pkt->data;
-        vector[0].iov_base = mhr;
-        vector[0].iov_len = (size_t)res;
+    /* prepare iolist for netdev / mac layer */
+    iolist_t iolist = {
+        .iol_next = (iolist_t *)pkt->next,
+        .iol_base = mhr,
+        .iol_len = (size_t)res
+    };
+
 #ifdef MODULE_NETSTATS_L2
     if (netif_hdr->flags &
-        (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
-            netif->dev->stats.tx_mcast_count++;
-        }
-        else {
-            netif->dev->stats.tx_unicast_count++;
-        }
-#endif
-#ifdef MODULE_GNRC_MAC
-        if (netif->mac.mac_info & GNRC_NETIF_MAC_INFO_CSMA_ENABLED) {
-            res = csma_sender_csma_ca_send(dev, vector, n, &netif->mac.csma_conf);
-        }
-        else {
-            res = dev->driver->send(dev, vector, n);
-        }
-#else
-        res = dev->driver->send(dev, vector, n);
-#endif
+            (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
+        netif->dev->stats.tx_mcast_count++;
     }
     else {
-        return -ENOBUFS;
+        netif->dev->stats.tx_unicast_count++;
     }
+#endif
+#ifdef MODULE_GNRC_MAC
+    if (netif->mac.mac_info & GNRC_NETIF_MAC_INFO_CSMA_ENABLED) {
+        res = csma_sender_csma_ca_send(dev, &iolist, &netif->mac.csma_conf);
+    }
+    else {
+        res = dev->driver->send(dev, &iolist);
+    }
+#else
+    res = dev->driver->send(dev, &iolist);
+#endif
+
     /* release old data */
     gnrc_pktbuf_release(pkt);
     return res;

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -224,10 +224,12 @@ int send_cmd(int argc, char **argv)
     printf("sending \"%s\" payload (%d bytes)\n",
            argv[1], strlen(argv[1]) + 1);
 
-    struct iovec vec[1];
-    vec[0].iov_base = argv[1];
-    vec[0].iov_len = strlen(argv[1]) + 1;
-    if (netdev->driver->send(netdev, vec, 1) == -ENOTSUP) {
+    iolist_t iolist = {
+        .iol_base = argv[1],
+        .iol_len = (strlen(argv[1]) + 1)
+    };
+
+    if (netdev->driver->send(netdev, &iolist) == -ENOTSUP) {
         puts("Cannot send: radio is still transmitting");
     }
 

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -141,16 +141,16 @@ static int _netdev_recv(netdev_t *dev, char *buf, int len, void *info)
     return res;
 }
 
-static int _netdev_send(netdev_t *dev, const struct iovec *vector, int count)
+static int _netdev_send(netdev_t *dev, const iolist_t *iolist)
 {
     msg_t done = { .type = _SEND_DONE };
     unsigned offset = 0;
 
     (void)dev;
     mutex_lock(&_netdev_buffer_mutex);
-    for (int i = 0; i < count; i++) {
-        memcpy(&_netdev_buffer[offset], vector[i].iov_base, vector[i].iov_len);
-        offset += vector[i].iov_len;
+    for (; iolist; iolist = iolist->iol_next) {
+        memcpy(&_netdev_buffer[offset], iolist->iol_base, iolist->iol_len);
+        offset += iolist->iol_len;
         if (offset > sizeof(_netdev_buffer)) {
             mutex_unlock(&_netdev_buffer_mutex);
             return -ENOBUFS;

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -143,16 +143,16 @@ static int _netdev_recv(netdev_t *dev, char *buf, int len, void *info)
     return res;
 }
 
-static int _netdev_send(netdev_t *dev, const struct iovec *vector, int count)
+static int _netdev_send(netdev_t *dev, const iolist_t *iolist)
 {
     msg_t done = { .type = _SEND_DONE };
     unsigned offset = 0;
 
     (void)dev;
     mutex_lock(&_netdev_buffer_mutex);
-    for (int i = 0; i < count; i++) {
-        memcpy(&_netdev_buffer[offset], vector[i].iov_base, vector[i].iov_len);
-        offset += vector[i].iov_len;
+    for (; iolist; iolist = iolist->iol_next) {
+        memcpy(&_netdev_buffer[offset], iolist->iol_base, iolist->iol_len);
+        offset += iolist->iol_len;
         if (offset > sizeof(_netdev_buffer)) {
             mutex_unlock(&_netdev_buffer_mutex);
             return -ENOBUFS;

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -321,7 +321,7 @@ static void test_pktbuf_mark__pkt_NOT_NULL__size_greater_than_pkt_size(void)
 
 static void test_pktbuf_mark__pkt_NOT_NULL__pkt_data_NULL(void)
 {
-    gnrc_pktsnip_t pkt = { 1, NULL, NULL, sizeof(TEST_STRING16), GNRC_NETTYPE_TEST };
+    gnrc_pktsnip_t pkt = { NULL, NULL, sizeof(TEST_STRING16), 1, GNRC_NETTYPE_TEST };
 
     TEST_ASSERT_NULL(gnrc_pktbuf_mark(&pkt, sizeof(TEST_STRING16) - 1,
                                       GNRC_NETTYPE_TEST));
@@ -661,7 +661,7 @@ static void test_pktbuf_hold__pkt_null(void)
 
 static void test_pktbuf_hold__pkt_external(void)
 {
-    gnrc_pktsnip_t pkt = { 1, NULL, TEST_STRING8, sizeof(TEST_STRING8), GNRC_NETTYPE_TEST };
+    gnrc_pktsnip_t pkt = { NULL, TEST_STRING8, sizeof(TEST_STRING8), 1, GNRC_NETTYPE_TEST };
 
     gnrc_pktbuf_hold(&pkt, 1);
     TEST_ASSERT(gnrc_pktbuf_is_empty());

--- a/tests/unittests/tests-pktqueue/tests-pktqueue.c
+++ b/tests/unittests/tests-pktqueue/tests-pktqueue.c
@@ -22,7 +22,7 @@
 #include "tests-pktqueue.h"
 
 #define PKT_INIT_ELEM(len, data, next) \
-    { 1, (next), (data), (len), GNRC_NETTYPE_UNDEF }
+    { (next), (data), (len), 1, GNRC_NETTYPE_UNDEF }
 #define PKT_INIT_ELEM_STATIC_DATA(data, next) PKT_INIT_ELEM(sizeof(data), data, next)
 #define PKTQUEUE_INIT_ELEM(pkt) { NULL, pkt }
 

--- a/tests/unittests/tests-priority_pktqueue/tests-priority_pktqueue.c
+++ b/tests/unittests/tests-priority_pktqueue/tests-priority_pktqueue.c
@@ -23,7 +23,7 @@
 #include "tests-priority_pktqueue.h"
 
 #define PKT_INIT_ELEM(len, data, next) \
-    { 1, (next), (data), (len), GNRC_NETTYPE_UNDEF }
+    { (next), (data), (len), 1, GNRC_NETTYPE_UNDEF }
 #define PKT_INIT_ELEM_STATIC_DATA(data, next) PKT_INIT_ELEM(sizeof(data), data, next)
 #define PKTQUEUE_INIT_ELEM(pkt) { NULL, pkt }
 


### PR DESCRIPTION
### Contribution description

netdev used to use ```struct iovec``` for its send function. While being the standard for scatter/gather IO (well, we had to add the header as newlib doesn't support it), it is a little clumsy to use, as usually the size of the needed array is not known in stacked environments like a network stack.

This PR introduces "iolists", which are basically a linked list of IO vectors, not unlike GNRC's pktsnips.
netdev is changed to use iolists.

```gnrc_pktsnip_t``` is rearranged so its beginning matches ```iolist_t```, so pktsnips can be directly handed to netdev's send() function.

~~This is WIP, only netdev_tap and at86rf2xx has been adapted, and only gnrc_ethernet and gnrc_ieee802154.~~

### Issues/PRs references

Probably solves bullet point #2 of #6299.

### Testing checklist

- [x] cc2538_rf
- [x] netdev_tap
- [x] socket_zep
- [x] nrfmin
- [x] at86rf2xx
- [ ] cc1100
- [x] cc2420
- [x] enc28j60
- [x] encx24j600
- [x] ethos
- [x] kw2xrf
- [x] mrf24j40
- [x] slipdev
- [x] sx127x
- [ ] w5100
- [x] xbee
- [x] emb6
- [x] lwip
- [x] openthread
- [x] semtech-loramac
- [x] gomach
- [x] lwmac