### PR TITLE
lostandfound: fix typo on qemu-i386

### DIFF
--- a/LOSTANDFOUND.md
+++ b/LOSTANDFOUND.md
@@ -60,7 +60,7 @@ Reason for removal:
 - this was an early development board by Nordic which was discontinued (successor: `nrf51dk`)
 - no hardware available anymore for testing
 
-### boards/qemu-i368 [99009af25e201bbc182d376e99df34133417be6c]
+### boards/qemu-i386 [99009af25e201bbc182d376e99df34133417be6c]
 Author(s):
 - René Kijewski <rene.kijewski@fu-berlin.de>
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a minor typo in the lost and found readme file.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->