### PR TITLE
boards/arduino-mkrwan1300: add initial support (without LoRa)

### DIFF
--- a/boards/arduino-mkr1000/include/board.h
+++ b/boards/arduino-mkr1000/include/board.h
@@ -46,6 +46,8 @@ extern "C" {
 #define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)
 #define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)
 #define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+
+#define LED0_NAME           "LED(Green)"
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/arduino-mkrfox1200/include/board.h
+++ b/boards/arduino-mkrfox1200/include/board.h
@@ -57,6 +57,8 @@ extern "C" {
 #define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)
 #define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)
 #define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+
+#define LED0_NAME           "LED(Green)"
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/arduino-mkrwan1300/Makefile
+++ b/boards/arduino-mkrwan1300/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/arduino-mkr
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-mkrwan1300/Makefile.dep
+++ b/boards/arduino-mkrwan1300/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/arduino-mkr/Makefile.dep

--- a/boards/arduino-mkrwan1300/Makefile.features
+++ b/boards/arduino-mkrwan1300/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/arduino-mkr/Makefile.features

--- a/boards/arduino-mkrwan1300/Makefile.include
+++ b/boards/arduino-mkrwan1300/Makefile.include
@@ -1,0 +1,10 @@
+USEMODULE += boards_common_arduino-mkr
+
+ifeq ($(PROGRAMMER),jlink)
+  export MKR_JLINK_DEVICE = atsamd21
+endif
+
+include $(RIOTBOARD)/common/arduino-mkr/Makefile.include
+
+# add arduino-mkrwan1300 include path
+INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/arduino-mkrwan1300/doc.txt
+++ b/boards/arduino-mkrwan1300/doc.txt
@@ -1,0 +1,37 @@
+/**
+ * @defgroup    boards_arduino-mkrwan1300 Arduino MKR WAN 1300
+ * @ingroup     boards
+ * @brief       Support for the Arduino MKR WAN 1300 board.
+ *
+ * ### General information
+ *
+ * The [Arduino MKR WAN 1300](https://store.arduino.cc/mkr-wan-1300) board is
+ * a learning and development board that provides LoRa connectivity and is
+ * powered by an Atmel SAMD21 microcontroller.
+ *
+ * ### Pinout
+ *
+ * <img src="https://www.arduino.cc/en/uploads/Main/MKR1000_pinout.png"
+ *      alt="Arduino MKR WAN 1300 pinout" style="height:800px;"/>
+ *
+ * ### Flash the board
+ *
+ * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
+ *    When the board is in bootloader mode, the user led (amber) oscillates
+ *    smoothly.
+ *
+ *
+ * 2. Use `BOARD=arduino-mkrwan1300` with the `make` command.<br/>
+ *    Example with `hello-world` application:
+ * ```
+ *      make BOARD=arduino-mkrwan1300 -C examples/hello-world flash
+ * ```
+ *
+ * @warning Unplug the board from the anti-static protective foam before
+ *          starting to use it otherwise it may not work as expected.
+ *
+ * ### Accessing STDIO via UART
+ *
+ * To access the STDIO of RIOT, a FTDI to USB converted needs to be plugged to
+ * the RX/TX pins on the board.
+ */

--- a/boards/arduino-mkrwan1300/include/board.h
+++ b/boards/arduino-mkrwan1300/include/board.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-mkrwan1300
+ * @brief       Support for the Arduino MKRWAN1300 board.
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Arduino MKRWAN1300
+ *              board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "board_common.h"
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to pin 6 on this board
+ */
+#define ARDUINO_LED         (6U)
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 20)
+
+#define LED_PORT            PORT->Group[PA]
+#define LED0_MASK           (1 << 20)
+
+#define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+
+#define LED0_NAME           "LED(Amber)"
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/arduino-mkrwan1300/include/periph_conf.h
+++ b/boards/arduino-mkrwan1300/include/periph_conf.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016-2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-mkrwan1300
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for Arduino MKRWAN1300 board
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Bumsik kim <kbumsik@gmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "periph_conf_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = &SERCOM5->USART,
+        .rx_pin   = GPIO_PIN(PB,23),  /* ARDUINO_PIN_13, RX Pin */
+        .tx_pin   = GPIO_PIN(PB,22),  /* ARDUINO_PIN_14, TX Pin */
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_3,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+    },
+    { /* LoRa module */
+        .dev      = &SERCOM4->USART,
+        .rx_pin   = GPIO_PIN(PA,15),
+        .tx_pin   = GPIO_PIN(PA,12),
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_3,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom5
+#define UART_1_ISR          isr_sercom4
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &SERCOM1->SPI,
+        .miso_pin = GPIO_PIN(PA, 19),   /* ARDUINO_PIN_8, SERCOM1-MISO */
+        .mosi_pin = GPIO_PIN(PA, 16),   /* ARDUINO_PIN_10, SERCOM1-MOSI */
+        .clk_pin  = GPIO_PIN(PA, 17),   /* ARDUINO_PIN_9, SERCOM1-SCK */
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_3,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/arduino-mkrzero/include/board.h
+++ b/boards/arduino-mkrzero/include/board.h
@@ -60,6 +60,8 @@ extern "C" {
 #define LED0_ON                      (LED_PORT.OUTSET.reg = LED0_MASK)
 #define LED0_OFF                     (LED_PORT.OUTCLR.reg = LED0_MASK)
 #define LED0_TOGGLE                  (LED_PORT.OUTTGL.reg = LED0_MASK)
+
+#define LED0_NAME                    "LED(Green)"
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/arduino-mkr/include/gpio_params.h
+++ b/boards/common/arduino-mkr/include/gpio_params.h
@@ -34,7 +34,7 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(Green)",
+        .name = LED0_NAME,
         .pin = LED0_PIN,
         .mode = GPIO_OUT
     },

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -25,101 +25,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "periph_conf_common.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    External oscillator and clock configuration
- *
- * For selection of the used CORECLOCK, we have implemented two choices:
- *
- * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
- * - usage of the internal 8MHz oscillator directly, divided by N if needed
- *
- *
- * The PLL option allows for the usage of a wider frequency range and a more
- * stable clock with less jitter. This is why we use this option as default.
- *
- * The target frequency is computed from the PLL multiplier and the PLL divisor.
- * Use the following formula to compute your values:
- *
- * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
- *
- * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
- *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
- *
- *
- * The internal Oscillator used directly can lead to a slightly better power
- * efficiency to the cost of a less stable clock. Use this option when you know
- * what you are doing! The actual core frequency is adjusted as follows:
- *
- * CORECLOCK = 8MHz / DIV
- *
- * NOTE: A core clock frequency below 1MHz is not recommended
- *
- * @{
- */
-#define CLOCK_USE_PLL       (1)
-
-#if CLOCK_USE_PLL
-/* edit these values to adjust the PLL output frequency */
-#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
-#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
-/* generate the actual used core clock frequency */
-#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
-#else
-/* edit this value to your needs */
-#define CLOCK_DIV           (1U)
-/* generate the actual core clock frequency */
-#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
-#endif
-/** @} */
-
-/**
- * @name Timer peripheral configuration
- * @{
- */
-static const tc32_conf_t timer_config[] = {
-    {   /* Timer 0 - System Clock */
-        .dev            = TC3,
-        .irq            = TC3_IRQn,
-        .pm_mask        = PM_APBCMASK_TC3,
-        .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
-#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
-#else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
-#endif
-        .flags          = TC_CTRLA_MODE_COUNT16,
-    },
-    {   /* Timer 1 */
-        .dev            = TC4,
-        .irq            = TC4_IRQn,
-        .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
-        .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
-#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
-        .gclk_src       = GCLK_CLKCTRL_GEN(1),
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
-#else
-        .gclk_src       = GCLK_CLKCTRL_GEN(0),
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
-#endif
-        .flags          = TC_CTRLA_MODE_COUNT32,
-    }
-};
-
-#define TIMER_0_MAX_VALUE   0xffff
-
-/* interrupt function name mapping */
-#define TIMER_0_ISR         isr_tc3
-#define TIMER_1_ISR         isr_tc4
-
-#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
-/** @} */
 
 /**
  * @name UART configuration
@@ -142,63 +52,6 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          isr_sercom5
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
-/** @} */
-
-/**
- * @name PWM configuration
- * @{
- */
-#define PWM_0_EN            1
-#define PWM_MAX_CHANNELS    (2U)
-/* for compatibility with test application */
-#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
-
-/* PWM device configuration */
-static const pwm_conf_t pwm_config[] = {
-#if PWM_0_EN
-    {TCC0, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 10), GPIO_MUX_F, 2 },    /* ~2 */
-        { GPIO_PIN(PA, 11), GPIO_MUX_F, 3 },    /* ~3 */
-    }}
-#endif
-};
-
-/* number of devices that are actually defined */
-#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
-/** @} */
-
-/**
- * @name ADC configuration
- * @{
- */
-#define ADC_0_EN                           1
-#define ADC_MAX_CHANNELS                   14
-/* ADC 0 device configuration */
-#define ADC_0_DEV                          ADC
-#define ADC_0_IRQ                          ADC_IRQn
-
-/* ADC 0 Default values */
-#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
-#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
-
-#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
-#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
-
-static const adc_conf_chan_t adc_channels[] = {
-    /* port, pin, muxpos */
-    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* A0 */
-    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A1 */
-    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A2 */
-    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},     /* A3 */
-    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* A4 */
-    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},     /* A5 */
-    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},     /* A6 */
-};
-
-#define ADC_0_CHANNELS                     (7U)
-#define ADC_NUMOF                          ADC_0_CHANNELS
 /** @} */
 
 /**
@@ -231,60 +84,6 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
-/** @} */
-
-/**
- * @name I2C configuration
- * @{
- */
-static const i2c_conf_t i2c_config[] = {
-    {
-        .dev      = &(SERCOM0->I2CM),
-        .speed    = I2C_SPEED_NORMAL,
-        .scl_pin  = GPIO_PIN(PA, 9),
-        .sda_pin  = GPIO_PIN(PA, 8),
-        .mux      = GPIO_MUX_C,
-        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
-        .flags    = I2C_FLAG_NONE
-     }
-};
-#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
-/** @} */
-
-/**
- * @name USB peripheral configuration
- * @{
- */
-static const sam0_common_usb_config_t sam_usbdev_config[] = {
-    {
-        .dm     = GPIO_PIN(PA, 24),
-        .dp     = GPIO_PIN(PA, 25),
-        .d_mux  = GPIO_MUX_G,
-        .device = &USB->DEVICE,
-    }
-};
-/** @} */
-
-/**
- * @name RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-#define RTC_DEV             RTC->MODE2
-/** @} */
-
-/**
- * @name RTT configuration
- * @{
- */
-#define RTT_NUMOF           (1U)
-#define RTT_DEV             RTC->MODE0
-#define RTT_IRQ             RTC_IRQn
-#define RTT_IRQ_PRIO        10
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
-#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
-#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016-2017 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_arduino-mkr
+ * @{
+ *
+ * @file
+ * @brief       Common configuration for clock, timer, pwm, adc, rtc and rtt
+ *              peripherals for Arduino MKR boards
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Bumsik kim <kbumsik@gmail.com>
+ */
+
+#ifndef PERIPH_CONF_COMMON_H
+#define PERIPH_CONF_COMMON_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @name    External oscillator and clock configuration
+ *
+ * For selection of the used CORECLOCK, we have implemented two choices:
+ *
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why we use this option as default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL       (1)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+/* generate the actual used core clock frequency */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TC3,
+        .irq            = TC3_IRQn,
+        .pm_mask        = PM_APBCMASK_TC3,
+        .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
+#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
+        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
+#else
+        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
+#endif
+        .flags          = TC_CTRLA_MODE_COUNT16,
+    },
+    {   /* Timer 1 */
+        .dev            = TC4,
+        .irq            = TC4_IRQn,
+        .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
+        .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
+#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
+        .gclk_src       = GCLK_CLKCTRL_GEN(1),
+        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
+#else
+        .gclk_src       = GCLK_CLKCTRL_GEN(0),
+        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
+#endif
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+#define TIMER_0_MAX_VALUE   0xffff
+
+/* interrupt function name mapping */
+#define TIMER_0_ISR         isr_tc3
+#define TIMER_1_ISR         isr_tc4
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_0_EN            1
+#define PWM_MAX_CHANNELS    (2U)
+/* for compatibility with test application */
+#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
+
+/* PWM device configuration */
+static const pwm_conf_t pwm_config[] = {
+#if PWM_0_EN
+    {TCC0, {
+        /* GPIO pin, MUX value, TCC channel */
+        { GPIO_PIN(PA, 10), GPIO_MUX_F, 2 },    /* ~2 */
+        { GPIO_PIN(PA, 11), GPIO_MUX_F, 3 },    /* ~3 */
+    }}
+#endif
+};
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_0_EN                           1
+#define ADC_MAX_CHANNELS                   14
+/* ADC 0 device configuration */
+#define ADC_0_DEV                          ADC
+#define ADC_0_IRQ                          ADC_IRQn
+
+/* ADC 0 Default values */
+#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
+#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+
+#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
+#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* A0 */
+    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A1 */
+    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A2 */
+    {GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4},     /* A3 */
+    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5},     /* A4 */
+    {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},     /* A5 */
+    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},     /* A6 */
+};
+
+#define ADC_0_CHANNELS                     (7U)
+#define ADC_NUMOF                          ADC_0_CHANNELS
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM0->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+     }
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1U)
+#define RTC_DEV             RTC->MODE2
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             RTC->MODE0
+#define RTT_IRQ             RTC_IRQn
+#define RTT_IRQ_PRIO        10
+#define RTT_ISR             isr_rtc
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
+#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+/** @} */
+
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_G,
+        .device = &USB->DEVICE,
+    }
+};
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_COMMON_H */
+/** @} */

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -15,7 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := blackpill blackpill-128kib bluepill \
                              nucleo-f302r8 nucleo-f303k8 nucleo-f334r8 \
                              nucleo-f410rb nucleo-l031k6 nucleo-l053r8 \
                              opencm904 spark-core stm32f0discovery \
-                             airfy-beacon  arduino-mkr1000 \
+                             airfy-beacon arduino-mkr1000 arduino-mkrwan1300 \
                              arduino-mkrfox1200 arduino-mkrzero arduino-zero \
                              b-l072z-lrwan1  cc2538dk ek-lm4f120xl  feather-m0 \
                              ikea-tradfri limifrog-v1 lobaro-lorabox \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -25,6 +25,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-mega2560 \
                              arduino-mkr1000 \
                              arduino-mkrfox1200 \
+                             arduino-mkrwan1300 \
                              arduino-mkrzero \
                              arduino-nano \
                              arduino-uno \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the [Arduino MKR WAN 1300](https://store.arduino.cc/mkr-wan-1300) board that was released at the end of last year.

The LoRa module is a [Murata](https://wireless.murata.com/RFM/data/type_abz.pdf) chip. This is the same one that is on the [ST b-l072z-lrwan1](http://www.st.com/en/evaluation-tools/b-l072z-lrwan1.html) but on the Arduino board, it's controlled using AT commands on one of the MCU UART.

For better integration with other MKR boards and to avoid too much code duplication (because there one more UART and one SPI less than others) I had to slightly refactor the periph configuration header.

I also started to write a driver for the LoRa module but it doesn't work yet. I'm trying to base it on #7084.

I'm also planning to add the support for the [Arduino MKR GSM 1400](https://store.arduino.cc/mkr-gsm-1400), will PR this soon.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->