### PR TITLE
stm32f1: fix gpio mode GPIO_IN_PU

### DIFF
--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -90,6 +90,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
     port->CR[pin_num >> 3] |=  ((mode & MODE_MASK) << ((pin_num & 0x7) * 4));
 
+    /* set ODR */
+    if (mode == GPIO_IN_PU)
+        port->ODR |= 1 << pin_num;
+    else
+        port->ODR &= ~(1 << pin_num);
+
     return 0; /* all OK */
 }
 


### PR DESCRIPTION
### Contribution description

The GPIO mode `GPIO_IN_PU` requires a bit to be set in a `ODR` register. This was apparently forgotten while writing `gpio_init` for STM32F1.

### Issues/PRs references

There were no issues submitted in this regard.