### PR TITLE
sntp: set netif when using link local address

### DIFF
--- a/sys/shell/commands/sc_sntp.c
+++ b/sys/shell/commands/sc_sntp.c
@@ -45,6 +45,13 @@ int _ntpdate(int argc, char **argv)
     }
     sock_udp_ep_t server = { .port = NTP_PORT, .family = AF_INET6 };
     ipv6_addr_from_str((ipv6_addr_t *)&server.addr, argv[1]);
+
+    if (ipv6_addr_is_link_local((ipv6_addr_t *)&server.addr)) {
+        /* choose first interface when address is link local */
+        gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+        server.netif = (uint16_t)netif->pid;
+    }
+
     if (argc > 2) {
         timeout = atoi(argv[2]);
     }

--- a/sys/shell/commands/sc_sntp.c
+++ b/sys/shell/commands/sc_sntp.c
@@ -31,7 +31,7 @@
 
 static void _usage(char *cmd)
 {
-    printf("Usage: %s <server addr> [<timeout>]\n", cmd);
+    printf("Usage: %s <server addr>[%%<interface>] [<timeout>]\n", cmd);
     puts("default: timeout = 5000");
 }
 
@@ -44,12 +44,37 @@ int _ntpdate(int argc, char **argv)
         return 1;
     }
     sock_udp_ep_t server = { .port = NTP_PORT, .family = AF_INET6 };
-    ipv6_addr_from_str((ipv6_addr_t *)&server.addr, argv[1]);
+    ipv6_addr_t *addr = (ipv6_addr_t *)&server.addr;
 
-    if (ipv6_addr_is_link_local((ipv6_addr_t *)&server.addr)) {
-        /* choose first interface when address is link local */
-        gnrc_netif_t *netif = gnrc_netif_iter(NULL);
-        server.netif = (uint16_t)netif->pid;
+    int src_iface = ipv6_addr_split_iface(argv[1]);
+    if (src_iface == -1) {
+        src_iface = KERNEL_PID_UNDEF;
+    }
+
+    if (ipv6_addr_from_str(addr, argv[1]) == NULL) {
+        puts("error: malformed address");
+        return 1;
+    }
+
+    if (ipv6_addr_is_link_local(addr) || (src_iface != KERNEL_PID_UNDEF)) {
+        size_t ifnum = gnrc_netif_numof();
+
+        if (src_iface == KERNEL_PID_UNDEF) {
+            if (ifnum == 1) {
+                src_iface = gnrc_netif_iter(NULL)->pid;
+            }
+            else {
+                puts("error: link local target needs interface parameter (use \"<address>%<ifnum>\")\n");
+                return 1;
+            }
+        }
+        else {
+            if (gnrc_netif_get_by_pid(src_iface) == NULL) {
+                printf("error: %"PRIkernel_pid" is not a valid interface.\n", src_iface);
+                return 1;
+            }
+        }
+        server.netif = src_iface;
     }
 
     if (argc > 2) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Currently the `ntpdate` shell command  doesn't work when using a link local address for the timeserver. This PR fixes the issue by explicitly setting the netif property of the udp endpoint.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
Credit goes to @miri64 (see [this commit](https://github.com/RIOT-OS/Tutorials/pull/40/commits/166d2a0d4c9a7e3156f06058ea857212966c7fdb) of RIOT-OS/Tutorials/[#40](https://github.com/RIOT-OS/Tutorials/pull/40)).
Thanks for the pointer @cgundogan!
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->