### PR TITLE
boards/common/nucleo: use inverted gpio for user button

### DIFF
--- a/boards/common/nucleo/include/gpio_params.h
+++ b/boards/common/nucleo/include/gpio_params.h
@@ -42,7 +42,8 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     {
         .name = "Button(B1 User)",
         .pin  = BTN0_PIN,
-        .mode = BTN0_MODE
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
     },
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

According to the [datasheet](www.st.com/resource/en/user_manual/dm00105823.pdf), the user button ,on PC13, is inverted. See the electrical schematics on page 64.

This PR add the SAUL_GPIO_INVERTED flags in the common board gpio parameters.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6629 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->