### PR TITLE
mips: Correct usage of USEMODULE

### DIFF
--- a/boards/pic32-clicker/clicker.c
+++ b/boards/pic32-clicker/clicker.c
@@ -13,6 +13,7 @@
 #include "periph/uart.h"
 #include "bitarithm.h"
 #include "board.h"
+#include "cpu.h"
 
 extern void dummy(void);
 
@@ -35,6 +36,9 @@ void board_init(void)
     gpio_init(LED2_PIN, GPIO_OUT);
     LED1_OFF;
     LED2_OFF;
+
+    /* initialize the CPU */
+    cpu_init();
 
     /* Stop the linker from throwing away the PIC32 config register settings */
     dummy();

--- a/boards/pic32-wifire/wifire.c
+++ b/boards/pic32-wifire/wifire.c
@@ -15,6 +15,7 @@
 #include "periph/uart.h"
 #include "bitarithm.h"
 #include "board.h"
+#include "cpu.h"
 
 extern void dummy(void);
 
@@ -32,8 +33,6 @@ void board_init(void)
     uart_init(DEBUG_VIA_UART, DEBUG_UART_BAUD, NULL, 0);
 #endif
 
-    hwrng_init();
-
     /* Turn off all LED's */
     gpio_init(LED1_PIN, GPIO_OUT);
     gpio_init(LED2_PIN, GPIO_OUT);
@@ -43,6 +42,9 @@ void board_init(void)
     LED2_OFF;
     LED3_OFF;
     LED4_OFF;
+
+    /* initialize the CPU */
+    cpu_init();
 
     /* Stop the linker from throwing away the PIC32 config register settings */
     dummy();

--- a/cpu/mips32r2_common/cpu.c
+++ b/cpu/mips32r2_common/cpu.c
@@ -15,10 +15,12 @@
 
 #include "periph/uart.h"
 #include "periph/timer.h"
+#include "periph/init.h"
 #include "panic.h"
 #include "kernel_init.h"
 #include "cpu.h"
 #include "board.h"
+
 
 void mips_start(void);
 
@@ -70,4 +72,10 @@ void panic_arch(void)
     assert(0);
     while (1) {
     }
+}
+
+void cpu_init(void)
+{
+    /* trigger static peripheral initialization */
+    periph_init();
 }

--- a/cpu/mips_pic32_common/Makefile.include
+++ b/cpu/mips_pic32_common/Makefile.include
@@ -6,4 +6,3 @@ USEMODULE += mips_pic32_common
 USEMODULE += mips_pic32_common_periph
 
 USEMODULE += periph_common
-USEMODULE += periph_hwrng

--- a/cpu/mips_pic32mx/include/cpu.h
+++ b/cpu/mips_pic32mx/include/cpu.h
@@ -47,6 +47,11 @@ static inline void cpu_print_last_instruction(void)
     /* This function must exist else RIOT won't compile */
 }
 
+/**
+ * @brief Initialize the CPU, set IRQ priorities
+ */
+void cpu_init(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/mips_pic32mz/include/cpu.h
+++ b/cpu/mips_pic32mz/include/cpu.h
@@ -47,6 +47,11 @@ static inline void cpu_print_last_instruction(void)
     /* This function must exist else RIOT won't compile */
 }
 
+/**
+ * @brief Initialize the CPU, set IRQ priorities
+ */
+void cpu_init(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
In CPU definitions we should not be explicitly naming peripheral modules to use
via USEMODULE (one should use FEATURES_PROVIDED instead).
Plus add missing cpu_init() and periph_init() methods.

This addresses some issues in #8052