### PR TITLE
boards/remote: invert button logic in SAUL

### DIFF
--- a/boards/remote-pa/include/gpio_params.h
+++ b/boards/remote-pa/include/gpio_params.h
@@ -32,24 +32,28 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
-        .pin = LED0_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(red)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
     },
     {
-        .name = "LED(green)",
-        .pin = LED1_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(green)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
     },
     {
-        .name = "LED(blue)",
-        .pin = LED2_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(blue)",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
     },
     {
-        .name = "Button(User)",
-        .pin  = BTN0_PIN,
-        .mode = BTN0_MODE
+        .name  = "Button(User)",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
     },
 };
 

--- a/boards/remote-reva/include/gpio_params.h
+++ b/boards/remote-reva/include/gpio_params.h
@@ -32,24 +32,28 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
-        .pin = LED0_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(red)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
     },
     {
-        .name = "LED(green)",
-        .pin = LED1_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(green)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
     },
     {
-        .name = "LED(blue)",
-        .pin = LED2_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(blue)",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
     },
     {
-        .name = "Button(User)",
-        .pin  = BTN0_PIN,
-        .mode = BTN0_MODE
+        .name  = "Button(User)",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
     },
 };
 

--- a/boards/remote-revb/include/gpio_params.h
+++ b/boards/remote-revb/include/gpio_params.h
@@ -32,24 +32,28 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "LED(red)",
-        .pin = LED0_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(red)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
     },
     {
-        .name = "LED(green)",
-        .pin = LED1_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(green)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
     },
     {
-        .name = "LED(blue)",
-        .pin = LED2_PIN,
-        .mode = GPIO_OUT
+        .name  = "LED(blue)",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
     },
     {
-        .name = "Button(User)",
-        .pin  = BTN0_PIN,
-        .mode = BTN0_MODE
+        .name  = "Button(User)",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
     },
 };
 


### PR DESCRIPTION
### Contribution description

The button on the Zolertia remotes reads `1` (high) if not pressed and `0` if pressed. This PR fixes the logic in SAUL by inverting the value via config.

### Issues/PRs references

none