### PR TITLE
makefiles: always link with GCC even if TOOLCHAIN is set to LLVM

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -310,7 +310,7 @@ LINKFLAGPREFIX ?= -Wl,
 
 DIRS += $(EXTERNAL_MODULE_DIRS)
 
-_LINK = $(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group  $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map $(LINKFLAGS)
+_LINK = $(if $(CPPMIX),$(LINKXX),$(LINK)) $(UNDEF) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group  $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map $(LINKFLAGS)
 
 ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container
@@ -320,7 +320,7 @@ link: ..compiler-check ..build-message $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=$
 	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
 ifeq (,$(RIOTNOLINK))
 ifeq ($(BUILDOSXNATIVE),1)
-	$(Q)$(if $(CPPMIX),$(CXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $$(find $(BASELIBS) -size +8c) $(LINKFLAGS) $(LINKFLAGPREFIX)-no_pie
+	$(Q)$(if $(CPPMIX),$(LINKXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $$(find $(BASELIBS) -size +8c) $(LINKFLAGS) $(LINKFLAGPREFIX)-no_pie
 else
 	$(Q)$(_LINK) -o $(ELFFILE)
 endif

--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -8,6 +8,7 @@ export AR         = $(PREFIX)ar
 endif
 export AS         = $(PREFIX)as
 export LINK       = $(PREFIX)gcc
+export LINKXX     = $(PREFIX)g++
 export SIZE       = $(PREFIX)size
 export OBJCOPY   ?= $(shell command -v $(PREFIX)objcopy gobjcopy objcopy | head -n 1)
 ifeq ($(OBJCOPY),)

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -9,12 +9,14 @@ endif
 export CC          = clang
 export CXX         = clang++
 export CCAS       ?= $(CC)
-export LINK        = $(CC)
 export AS          = $(LLVMPREFIX)as
 export AR          = $(LLVMPREFIX)ar
 export NM          = $(LLVMPREFIX)nm
-# There is no LLVM linker yet, use GNU binutils.
-#export LINKER      = $(LLVMPREFIX)ld
+# LLVM does have a linker, however, it is not entirely
+# compatible with GCC. For instance spec files as used in
+# `makefiles/libc/newlib.mk` are not supported. Therefore
+# we just use GCC for now.
+export LINK        = $(PREFIX)gcc
 # objcopy does not have a clear substitute in LLVM, use GNU binutils
 #export OBJCOPY     = $(LLVMPREFIX)objcopy
 export OBJCOPY    ?= $(shell command -v $(PREFIX)objcopy gobjcopy objcopy | head -n 1)
@@ -52,7 +54,8 @@ ifneq (,$(TARGET_ARCH))
   # Tell clang to cross compile
   export CFLAGS     += -target $(TARGET_ARCH)
   export CXXFLAGS   += -target $(TARGET_ARCH)
-  export LINKFLAGS  += -target $(TARGET_ARCH)
+  # We currently don't use LLVM for linking (see comment above).
+  #export LINKFLAGS  += -target $(TARGET_ARCH)
 
   # Use the wildcard Makefile function to search for existing directories matching
   # the patterns above. We use the -isystem gcc/clang argument to add the include

--- a/makefiles/toolchain/llvm.inc.mk
+++ b/makefiles/toolchain/llvm.inc.mk
@@ -17,6 +17,7 @@ export NM          = $(LLVMPREFIX)nm
 # `makefiles/libc/newlib.mk` are not supported. Therefore
 # we just use GCC for now.
 export LINK        = $(PREFIX)gcc
+export LINKXX      = $(PREFIX)g++
 # objcopy does not have a clear substitute in LLVM, use GNU binutils
 #export OBJCOPY     = $(LLVMPREFIX)objcopy
 export OBJCOPY    ?= $(shell command -v $(PREFIX)objcopy gobjcopy objcopy | head -n 1)


### PR DESCRIPTION
## Contribution description

Cross-compiling RIOT applications with `TOOLCHAIN=llvm` currently doesn't work with clang-5.0 (see #8356). The reason for this being that clang-5.0 seems to try using the LLVM linker (LLD) instead of GCC for linking cross compiled object files. I don't know though why LLVM changed this behavior in clang-5.0.

A simple workaround for this was proposed in #8356 by myself. The workround is to set the `LINK` variable to GCC. After some considerations I honestly believe that this is the easiest and best solution for now. After all clang-4.0 just calls GCC for linking as well. This approach (of cause) has various disadvantage including the fact that LTO doesn't work, however, using LLD to link the binaries would probably require a substantial amount of work. For instance LLD doesn't support spec files as used in `makefiles/libc/newlib.mk`.

### Issues/PRs references

Fixes #8356