### PR TITLE
boards: add support for nrf52-based RuuviTag

### DIFF
--- a/boards/common/nrf52xxxdk/board.c
+++ b/boards/common/nrf52xxxdk/board.c
@@ -7,11 +7,11 @@
  */
 
 /**
- * @ingroup     boards_common_nrf52
+ * @ingroup     boards_common_nrf52xxxdk
  * @{
  *
  * @file
- * @brief       Board initialization for the nRF52840 DK
+ * @brief       Board initialization for the nRF52xxx DK
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *

--- a/boards/common/nrf52xxxdk/board.c
+++ b/boards/common/nrf52xxxdk/board.c
@@ -24,8 +24,8 @@
 void board_init(void)
 {
     /* initialize the boards LEDs */
-    LED_PORT->DIRSET = (LED0_MASK | LED1_MASK | LED2_MASK | LED3_MASK);
-    LED_PORT->OUTSET = (LED0_MASK | LED1_MASK | LED2_MASK | LED3_MASK);
+    LED_PORT->DIRSET = (LED_MASK);
+    LED_PORT->OUTSET = (LED_MASK);
 
     /* initialize the CPU */
     cpu_init();

--- a/boards/common/nrf52xxxdk/include/gpio_params.h
+++ b/boards/common/nrf52xxxdk/include/gpio_params.h
@@ -38,48 +38,62 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
+#ifdef LED1_PIN
     {
         .name  = "LED 2",
         .pin   = LED1_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
+#endif
+#ifdef LED2_PIN
     {
         .name  = "LED 3",
         .pin   = LED2_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
+#endif
+#ifdef LED3_PIN
     {
         .name  = "LED 4",
         .pin   = LED3_PIN,
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
+#endif
+#ifdef BTN0_PIN
     {
         .name  = "Button 1",
         .pin   = BTN0_PIN,
         .mode  = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+#endif
+#ifdef BTN1_PIN
     {
         .name  = "Button 2",
         .pin   = BTN1_PIN,
         .mode  = BTN1_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+#endif
+#ifdef BTN2_PIN
     {
         .name  = "Button 3",
         .pin   = BTN2_PIN,
         .mode  = BTN2_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
+#endif
+#ifdef BTN3_PIN
     {
         .name  = "Button 4",
         .pin   = BTN3_PIN,
         .mode  = BTN3_MODE,
         .flags = SAUL_GPIO_INVERTED,
-    }
+    },
+#endif
 };
 
 

--- a/boards/nrf52840dk/include/board.h
+++ b/boards/nrf52840dk/include/board.h
@@ -42,6 +42,7 @@ extern "C" {
 #define LED1_MASK           (1 << 14)
 #define LED2_MASK           (1 << 15)
 #define LED3_MASK           (1 << 16)
+#define LED_MASK            (LED0_MASK | LED1_MASK | LED2_MASK | LED3_MASK)
 
 #define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
 #define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)

--- a/boards/nrf52dk/include/board.h
+++ b/boards/nrf52dk/include/board.h
@@ -42,6 +42,7 @@ extern "C" {
 #define LED1_MASK           (1 << 18)
 #define LED2_MASK           (1 << 19)
 #define LED3_MASK           (1 << 20)
+#define LED_MASK            (LED0_MASK | LED1_MASK | LED2_MASK | LED3_MASK)
 
 #define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
 #define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)

--- a/boards/ruuvitag/Makefile
+++ b/boards/ruuvitag/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/nrf52xxxdk
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/ruuvitag/Makefile.dep
+++ b/boards/ruuvitag/Makefile.dep
@@ -1,0 +1,11 @@
+include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  # TODO: enable drivers once their adaption/implementations are merged
+  # USEMODULE += bme280_spi
+  # USEMODULE += lis2dh12_spi
+endif
+
+ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+  USEMODULE += nrfmin
+endif

--- a/boards/ruuvitag/Makefile.features
+++ b/boards/ruuvitag/Makefile.features
@@ -1,0 +1,14 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrfmin
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m4_3
+
+-include $(RIOTCPU)/nrf52/Makefile.features

--- a/boards/ruuvitag/Makefile.include
+++ b/boards/ruuvitag/Makefile.include
@@ -1,0 +1,10 @@
+# CPU configuration
+CPU_MODEL = nrf52832xxaa
+
+# for this board, we are using Segger's RTT as default terminal interface
+USEMODULE += rtt_stdio
+TERMPROG = $(RIOTBASE)/dist/tools/jlink/jlink.sh
+TERMFLAGS = term_rtt
+
+# use shared Makefile.include
+include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/boards/ruuvitag/include/board.h
+++ b/boards/ruuvitag/include/board.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2018 Feie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_ruuvitag RuuviTag
+ * @ingroup     boards
+ * @brief       Board specific configuration for the RuuviTag board
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the RuuviTag board
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 17)
+#define LED1_PIN            GPIO_PIN(0, 19)
+
+#define LED_PORT            NRF_P0
+#define LED0_MASK           (1 << 17)
+#define LED1_MASK           (1 << 19)
+#define LED_MASK            (LED0_MASK | LED1_MASK)
+
+#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED_PORT->OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 13)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @name    Environmental sensor configuration (Bosch BMX280)
+ * @{
+ */
+#define BMX280_PARAM_CS     GPIO_PIN(0, 3)
+/** @} */
+
+/**
+ * @name    Accelerometer configuration
+ * @{
+ */
+#define LIS2DH12_PARAM_CS   GPIO_PIN(0, 8)
+#define LIS2DH12_PARAM_INT1 GPIO_PIN(0, 2)
+#define LIS2DH12_PARAM_INT2 GPIO_PIN(0, 6)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/ruuvitag/include/periph_conf.h
+++ b/boards/ruuvitag/include/periph_conf.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_ruuvitag
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the RuuviTag
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ *
+ * @note    The radio will not work with the internal RC oscillator!
+ *
+ * @{
+ */
+#define CLOCK_HFCLK         (32U)           /* set to  0: internal RC oscillator
+                                             *        32: 32MHz crystal */
+#define CLOCK_LFCLK         (1)             /* set to  0: internal RC oscillator
+                                             *         1: 32.768 kHz crystal
+                                             *         2: derived from HFCLK */
+/** @} */
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = NRF_TIMER1,
+        .channels = 3,
+        .bitmode  = TIMER_BITMODE_BITMODE_32Bit,
+        .irqn     = TIMER1_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_timer1
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             (1)             /* NRF_RTC1 */
+#define RTT_MAX_VALUE       (0x00ffffff)
+#define RTT_FREQUENCY       (1024)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = 29,
+        .mosi = 25,
+        .miso = 28,
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_PIN_RX         GPIO_PIN(0, 4)
+#define UART_PIN_TX         GPIO_PIN(0, 5)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/dist/tools/jlink/term.seg
+++ b/dist/tools/jlink/term.seg
@@ -1,0 +1,1 @@
+connect

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -16,7 +16,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini 
                              spark-core stm32f0discovery telosb weio wsn430-v1_3b \
                              wsn430-v1_4 yunjia-nrf51822 z1
 
-BOARD_BLACKLIST += mips-malta pic32-wifire pic32-clicker# No full UART available.
+# The following boards do not have an available UART
+BOARD_BLACKLIST += mips-malta pic32-wifire pic32-clicker ruuvitag
 
 # use ethos (ethernet over serial) for network communication and stdio over
 # UART, but not on native, as native has a tap interface towards the host.


### PR DESCRIPTION
### Contribution description
The main purpose of this PR is to add support for the [RuuviTag](https://tag.ruuvi.com/).

For supporting this board nicely, this PR includes also the following changes:
- some minor generalization to the `nrf52xxxdk` common code: mainly making LEDs and BTNs conditional
- adds a new `rtt_term` target to the common `jlink.sh` script, for enabling `make term` using Segger's RTT interface -> this is used per default for this board

The device drivers for the environmental sensor and the accelerometer are already done and will be PRed in separate PRs tomorrow, thats why there are already placeholders for these in the `Makefile.dep`... 

### Issues/PRs references
none