### PR TITLE
pkg: disable implicit fallthroughs errors in tinydtls

### DIFF
--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -4,6 +4,8 @@ PKG_URL=https://github.com/rfuentess/TinyDTLS.git
 PKG_VERSION=eb6f017ab451bb6cc4428b3e449955a76aeeba19
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
+CFLAGS += -Wno-implicit-fallthrough
+
 .PHONY: all
 
 all: git-download


### PR DESCRIPTION
### Contribution description

Disable `implicit-fallthrough` checks for external package tinydtls, this error is raised with gcc 7.x versions on any platform. Sample error:

```
dtls.c:244:1601: error: this statement may fall through [-Werror=implicit-fallthrough=]
   FIND_PEER(ctx->peers, session, p);
```

### Issues/PRs references

#8265