### PR TITLE
posix: fix pthread and socket example

### DIFF
--- a/examples/posix_sockets/udp.c
+++ b/examples/posix_sockets/udp.c
@@ -18,6 +18,11 @@
  * @}
  */
 
+/* needed for posix usleep */
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif
+
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -237,7 +237,7 @@ int pthread_join(pthread_t th, void **thread_return)
             other->joining_thread = sched_active_pid;
             /* go blocked, I'm waking up if other thread exits */
             thread_sleep();
-            /* no break */
+            /* falls through */
         case (PTS_ZOMBIE):
             if (thread_return) {
                 *thread_return = other->returnval;

--- a/tests/posix_time/main.c
+++ b/tests/posix_time/main.c
@@ -19,6 +19,11 @@
  * @}
  */
 
+/* needed for posix usleep */
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 600
+#endif
+
 #include <stdio.h>
 #include <unistd.h>
 


### PR DESCRIPTION
### Contribution description

Started with fixing an intentional fall through reported as error by newer GCC (>7.x) versions. But also found an issue with the usage of `usleep`, apparently POSIX deprecated it and suggests to use `nanosleep` instead? See here https://stackoverflow.com/questions/10053788/implicit-declaration-of-function-usleep

### Issues/PRs references

#8265