### PR TITLE
boards: set stm32 based boards LSI by default

### DIFF
--- a/boards/nucleo-l152/include/periph_conf.h
+++ b/boards/nucleo-l152/include/periph_conf.h
@@ -34,7 +34,7 @@ extern "C" {
 #define CLOCK_CORECLOCK     (32000000U)             /* targeted core clock frequency */
 /* 0: no external low speed crystal available,
  * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
+#define CLOCK_LSE           (0)
 /* configuration of PLL prescaler and multiply values */
 /* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
 #define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -41,7 +41,7 @@ extern "C" {
 #define CLOCK_HSE           (8000000U)
 /* 0: no external low speed crystal available,
  * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
+#define CLOCK_LSE           (0)
 /* peripheral clock setup */
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
 #define CLOCK_AHB           (CLOCK_CORECLOCK / 1)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Some board configurations can vary according to the revision, especially on ST discovery and nucleo development boards.

This PR sets the default low speed clock source to LSI, which is always present regardless of the revision. While I acknowledge the preference for LSE (more accurate), for the sake of functionality, LSI should be set by default, unless we know *all* revisions have LSE. Otherwise, boards simply don't work when RTC is used, and it's used by default on all ST platforms.

According to UM1724, revision MB1136 C-01 on, as far as I can tell, all nucleo64 boards don't have neither HSE and LSE, thus risk to be broken on master.

In this PR I'm only fixing nucleo-l152 and stm32f4doscovery, but I'd advice to change all to LSI by default. Comments welcome!
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#7504 (3897d003f04a92901f46c90fd4af7670730fb2be) enabled LSE on nucleo-l152 and #7158 (b3e7dd84f9ac862e6b30aa1c8b1b15f3e2250607) for stm32f4discovery
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Fixes #8240, though is already closed.