### PR TITLE
boards/mulle: fix doxygen invalid use of '@brief'

### DIFF
--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -40,7 +40,7 @@
 #define UART_STDIO_DEV      UART_DEV(1)
 
 /**
- * @brief   xtimer configuration
+ * @name    xtimer configuration
  * @{
  */
 #if 0
@@ -64,7 +64,7 @@
 /** @} */
 
 /**
- * @brief   LED pin definitions and handlers
+ * @name    LED pin definitions and handlers
  * @{
  */
 #define LED_PORT            PTC


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a doxygen inconsistency discovered while reviewing #8210. Use of `@brief` while it should be `@name`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#8210 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->