### PR TITLE
driver/at86rf2xx: add an option for auto-ack with the pending bit

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -380,6 +380,13 @@ void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state)
                           : (tmp & ~AT86RF2XX_IRQ_STATUS_MASK__RX_START);
             at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK, tmp);
             break;
+        case AT86RF2XX_OPT_ACK_PENDING:
+            DEBUG("[at86rf2xx] opt: enabling pending ACKs\n");
+            tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__CSMA_SEED_1);
+            tmp = (state) ? (tmp |  AT86RF2XX_CSMA_SEED_1__AACK_SET_PD)
+                          : (tmp & ~AT86RF2XX_CSMA_SEED_1__AACK_SET_PD);
+            at86rf2xx_reg_write(dev, AT86RF2XX_REG__CSMA_SEED_1, tmp);
+            break;
         default:
             /* do nothing */
             break;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -486,6 +486,12 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             res = sizeof(netopt_enable_t);
             break;
 
+        case NETOPT_ACK_PENDING:
+            at86rf2xx_set_option(dev, AT86RF2XX_OPT_ACK_PENDING,
+                                 ((const bool *)val)[0]);
+            res = sizeof(netopt_enable_t);
+            break;
+
         case NETOPT_RETRANS:
             assert(len <= sizeof(uint8_t));
             at86rf2xx_set_max_retries(dev, *((const uint8_t *)val));

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -135,6 +135,7 @@ extern "C" {
 #define AT86RF2XX_OPT_SRC_ADDR_LONG  (NETDEV_IEEE802154_SRC_MODE_LONG)  /**< legacy define */
 #define AT86RF2XX_OPT_RAWDUMP        (NETDEV_IEEE802154_RAW)            /**< legacy define */
 #define AT86RF2XX_OPT_AUTOACK        (NETDEV_IEEE802154_ACK_REQ)        /**< legacy define */
+#define AT86RF2XX_OPT_ACK_PENDING    (NETDEV_IEEE802154_FRAME_PEND)     /**< legacy define */
 
 #define AT86RF2XX_OPT_CSMA           (0x0100)       /**< CSMA active */
 #define AT86RF2XX_OPT_PROMISCUOUS    (0x0200)       /**< promiscuous mode

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -53,6 +53,11 @@ extern "C" {
  * @brief   request ACK from receiver
  */
 #define NETDEV_IEEE802154_ACK_REQ           (IEEE802154_FCF_ACK_REQ)
+
+/**
+ * @brief   set frame pending bit
+ */
+#define NETDEV_IEEE802154_FRAME_PEND        (IEEE802154_FCF_FRAME_PEND)
 /**
  * @}
  */

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -147,6 +147,12 @@ typedef enum {
                                  *   the current state */
     NETOPT_AUTOACK,             /**< en/disable link layer auto ACKs or read
                                  *   the current state */
+    NETOPT_ACK_PENDING,         /**< en/disable the frame pending bit of ACKs.
+                                 *   This bit is copied into the frame pending
+                                 *   subfield of the ACK if it is the response
+                                 *   to a data request MAC command frame, which
+                                 *   lets the data request sender know if the ACK
+                                 *   sender has pending data or not. */
     NETOPT_ACK_REQ,             /**< en/disable acknowledgement requests or
                                  *   read the current state */
     NETOPT_RETRANS,             /**< get/set the maximum number of

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -45,6 +45,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_PRELOADING]            = "NETOPT_PRELOADING",
     [NETOPT_PROMISCUOUSMODE]       = "NETOPT_PROMISCUOUSMODE",
     [NETOPT_AUTOACK]               = "NETOPT_AUTOACK",
+    [NETOPT_ACK_PENDING]           = "NETOPT_ACK_PENDING",
     [NETOPT_ACK_REQ]               = "NETOPT_ACK_REQ",
     [NETOPT_RETRANS]               = "NETOPT_RETRANS",
     [NETOPT_PROTO]                 = "NETOPT_PROTO",


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

IEEE 802.15.4 provides ACK with the pending bit for data polling mechanism.
This PR adds this option to the at86rf2xx driver.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->