### PR TITLE
fixed wrong makefile variable name

### DIFF
--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -12,7 +12,7 @@ export PROGRAMMER ?= cc2538-bsl
 ifeq ($(PROGRAMMER),jlink)
   # setup JLink for flashing
   export JLINK_DEVICE := cc2538sf53
-  export JLINK_FLASH_ADDR := 200000
+  export FLASH_ADDR := 200000
   export JLINK_IF := JTAG
   export TUI := 1
   include $(RIOTMAKE)/tools/jlink.inc.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Fixed makefile variable name for flash address when using JLink programmer.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #8337