### PR TITLE
tests/gnrc_ipv6_ext: Increase ipv6 addr numof

### DIFF
--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -22,6 +22,8 @@ USEMODULE += gnrc_udp
 # Add also the shell, some shell commands
 USEMODULE += ps
 
+CFLAGS += -DGNRC_NETIF_IPV6_ADDRS_NUMOF=3
+
 include $(RIOTBASE)/Makefile.include
 
 # The test can check more things with ENABLE_DEBUG set to 1 in gnrc_ipv6.c


### PR DESCRIPTION
### Contribution description

Since the new netif code, this test throws an error that it is unable to add the second IPv6 address. This due to gnrc_netif only allocating memory for 2 IPv6 addresses. The gnrc_ipv6_ext test currently fails with an assertion failure. This PR increases the number of IPv6 addresses to 3 to allow the extra address to be added.

### Issues/PRs references

None