### PR TITLE
boards: some doxygen cleanup

### DIFF
--- a/boards/acd52832/include/board.h
+++ b/boards/acd52832/include/board.h
@@ -9,10 +9,14 @@
 /**
  * @defgroup    boards_acd52832 ACD52832
  * @ingroup     boards
+ * @brief       Support for the aconno™ ACD52832
+ *
+ * For more information: http://aconno.de/acd52832/
+ *
  * @{
  *
  * @file
- * @brief       Board specific configuaration for the ACD52832
+ * @brief       Board specific configuration for the ACD52832
  *
  * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
  */

--- a/boards/airfy-beacon/include/board.h
+++ b/boards/airfy-beacon/include/board.h
@@ -9,11 +9,11 @@
 /**
  * @defgroup    boards_airfy-beacon Airfy Beacon
  * @ingroup     boards
- * @brief       Board specific files for the Arify Beacon board
+ * @brief       Board specific files for the Airfy Beacon board
  * @{
  *
  * @file
- * @brief       Board specific definitions for the Arify Beacon board
+ * @brief       Board specific definitions for the Airfy Beacon board
  *
  * @author      Christian Mehlis <mehlis@inf.fu-berlin.de>
  */

--- a/boards/common/nucleo/include/board_common.h
+++ b/boards/common/nucleo/include/board_common.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    boards_nucleo STM Nucleo Boards
  * @ingroup     boards
+ * @brief       Support for STM Nucleo boards
  *
  * @defgroup    boards_common_nucleo STM Nucleo common
  * @ingroup     boards_common

--- a/boards/common/nucleo144/include/board_common.h
+++ b/boards/common/nucleo144/include/board_common.h
@@ -10,6 +10,7 @@
 /**
  * @defgroup    boards_nucleo144 STM Nucleo144 Boards
  * @ingroup     boards
+ * @brief       Support for STM Nucleo 144 boards
  *
  * @defgroup    boards_common_nucleo144 STM Nucleo144 common
  * @ingroup     boards_common

--- a/boards/common/nucleo32/include/board_common.h
+++ b/boards/common/nucleo32/include/board_common.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    boards_nucleo32 STM Nucleo32 Boards
  * @ingroup     boards
+ * @brief       Support for STM Nucleo 32 boards
  *
  * @defgroup    boards_common_nucleo32 STM Nucleo32 common
  * @ingroup     boards_common


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR makes a small cleanup of the doxygen boards module:
* it adds a brief description for the ACD52832 and nucleo boards group
* it fixes a typo in the airfy-beacon description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->