### PR TITLE
gnrc_netif: set-up 6Lo for NRFmin

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -123,7 +123,7 @@ ifneq (,$(filter trickle,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter ieee802154,$(USEMODULE)))
+ifneq (,$(filter ieee802154 nrfmin,$(USEMODULE)))
   ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan
   endif

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -31,6 +31,10 @@
 #include "nrfmin.h"
 #include "net/netdev.h"
 
+#ifdef MODULE_GNRC_SIXLOWPAN
+#include "net/gnrc/nettype.h"
+#endif
+
 #define ENABLE_DEBUG            (0)
 #include "debug.h"
 
@@ -495,9 +499,12 @@ static int nrfmin_get(netdev_t *dev, netopt_t opt, void *val, size_t max_len)
             assert(max_len >= sizeof(uint16_t));
             *((uint16_t*)val) = CONF_PSEUDO_NID;
             return sizeof(uint16_t);
+#ifdef MODULE_GNRC_SIXLOWPAN
         case NETOPT_PROTO:
-            *((uint16_t *)val) = 809; /* TODO */
-            return 2;
+            assert(max_len >= sizeof(uint16_t));
+            *((uint16_t *)val) = GNRC_NETTYPE_SIXLOWPAN;
+            return sizeof(uint16_t);
+#endif
         case NETOPT_DEVICE_TYPE:
             assert(max_len >= sizeof(uint16_t));
             *((uint16_t *)val) = NETDEV_TYPE_NRFMIN;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1157,8 +1157,9 @@ static void _init_from_device(gnrc_netif_t *netif)
     assert(res == sizeof(tmp));
     netif->device_type = (uint8_t)tmp;
     switch (netif->device_type) {
-#ifdef MODULE_NETDEV_IEEE802154
+#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_NRFMIN)
         case NETDEV_TYPE_IEEE802154:
+        case NETDEV_TYPE_NRFMIN:
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
             netif->flags |= GNRC_NETIF_FLAGS_6LO_HC;
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -58,6 +58,12 @@ static inline uint8_t _reverse_iid(const ipv6_addr_t *dst,
             l2addr[0] ^= 0x02;
             return sizeof(dst->u64[1]);
 #endif  /* MODULE_NETDEV_IEEE802154 */
+#ifdef MODULE_NRFMIN
+        case NETDEV_TYPE_NRFMIN:
+            l2addr[0] = dst->u8[14];
+            l2addr[1] = dst->u8[15];
+            return sizeof(uint16_t);
+#endif  /* MODULE_NETDEV_IEEE802154 */
 #ifdef MODULE_CC110X
         case NETDEV_TYPE_CC110X:
             l2addr[0] = dst->u8[15];


### PR DESCRIPTION
### Contribution description
Currently nrfmin doesn't pull in 6Lo as a dependency and doesn't set-up the interface to allow for fragmentation. This fixes that.

### Issues/PRs references
None