### PR TITLE
examples/gnrc_tftp: fix implicit fallthrough error

### DIFF
--- a/examples/gnrc_tftp/tftp_server.c
+++ b/examples/gnrc_tftp/tftp_server.c
@@ -180,12 +180,12 @@ int tftp_server_cmd(int argc, char * *argv)
                 tftp_server_stop();
                 return 0;
             }
-        /* no break */
+        /* falls through */
 
         default:
             printf("usage: %s [start|stop]\n", argv[0]);
-            return 0;
+            break;
     }
 
-    return 0;
+    return 1;
 }


### PR DESCRIPTION
### Contribution description

fixes comment for intentional fall through to prevent compile error with GCC 7.x.
Also fixes return code in case of error.

### Issues/PRs references

#8265 