### PR TITLE
drivers/bmx280: reworked driver and added SPI mode

### DIFF
--- a/boards/avr-rss2/Makefile.dep
+++ b/boards/avr-rss2/Makefile.dep
@@ -1,6 +1,6 @@
 USEMODULE += boards_common_atmega
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
-  USEMODULE += bme280
+  USEMODULE += bme280_i2c
   USEMODULE += saul_gpio
 endif

--- a/boards/ruuvitag/Makefile.dep
+++ b/boards/ruuvitag/Makefile.dep
@@ -1,8 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += bme280_spi
   USEMODULE += lis2dh12_spi
-  # TODO: enable drivers once their adaption/implementations are merged
-  # USEMODULE += bme280_spi
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/sltb001a/Makefile.dep
+++ b/boards/sltb001a/Makefile.dep
@@ -1,6 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
-  USEMODULE += bmp280
+  USEMODULE += bmp280_i2c
   USEMODULE += si7021
 endif
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -75,14 +75,23 @@ ifneq (,$(filter bmp180,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter bmx055,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
+ifneq (,$(filter bm%280_spi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi
+  FEATURES_REQUIRED += periph_gpio
+  USEMODULE += bmx280
 endif
 
-ifneq (,$(filter bm%280,$(USEMODULE)))
+ifneq (,$(filter bm%280_i2c,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
   USEMODULE += bmx280
+endif
+
+ifneq (,$(filter bmx280,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
+ifneq (,$(filter bmx055,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter cc110%,$(USEMODULE)))

--- a/drivers/bmx280/bmx280_saul.c
+++ b/drivers/bmx280/bmx280_saul.c
@@ -26,7 +26,7 @@
 
 static int read_temperature(const void *dev, phydat_t *res)
 {
-    res->val[0] = bmx280_read_temperature((const bmx280_t *)dev);
+    res->val[0] = bmx280_read_temperature((bmx280_t *)dev);
     res->unit = UNIT_TEMP_C;
     res->scale = -2;
 
@@ -42,7 +42,7 @@ static int read_pressure(const void *dev, phydat_t *res)
     return 1;
 }
 
-#ifdef MODULE_BME280
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
 static int read_relative_humidity(const void *dev, phydat_t *res)
 {
     res->val[0] = bme280_read_humidity((const bmx280_t *)dev);
@@ -65,7 +65,7 @@ const saul_driver_t bmx280_pressure_saul_driver = {
     .type = SAUL_SENSE_PRESS,
 };
 
-#ifdef MODULE_BME280
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
 const saul_driver_t bme280_relative_humidity_saul_driver = {
     .read = read_relative_humidity,
     .write = saul_notsup,

--- a/drivers/bmx280/include/bmx280_internals.h
+++ b/drivers/bmx280/include/bmx280_internals.h
@@ -26,60 +26,100 @@ extern "C" {
 #endif
 
 /**
+ * @name    Device specific chip ID
+ * @{
+ */
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
+#define BMX280_CHIP_ID_VAL              (0x60)
+#else
+#define BMX280_CHIP_ID_VAL              (0x58)
+#endif
+/** @} */
+
+/**
  * @name    BME280 registers
  * @{
  */
-#define BME280_CHIP_ID                          0x60    /* The identifier of the BME280 */
-#define BMP280_CHIP_ID                          0x58    /* The identifier of the BMP280 */
-#define BMX280_CHIP_ID_REG                      0xD0
-#define BMEX80_RST_REG                          0xE0 /* Softreset Reg */
+#define BMX280_CHIP_ID_REG              (0xD0)
+#define BMEX80_RST_REG                  (0xE0)      /* Softreset Reg */
 
-#define BMX280_DIG_T1_LSB_REG                   0x88
-#define BMX280_DIG_T1_MSB_REG                   0x89
-#define BMX280_DIG_T2_LSB_REG                   0x8A
-#define BMX280_DIG_T2_MSB_REG                   0x8B
-#define BMX280_DIG_T3_LSB_REG                   0x8C
-#define BMX280_DIG_T3_MSB_REG                   0x8D
-#define BMX280_DIG_P1_LSB_REG                   0x8E
-#define BMX280_DIG_P1_MSB_REG                   0x8F
-#define BMX280_DIG_P2_LSB_REG                   0x90
-#define BMX280_DIG_P2_MSB_REG                   0x91
-#define BMX280_DIG_P3_LSB_REG                   0x92
-#define BMX280_DIG_P3_MSB_REG                   0x93
-#define BMX280_DIG_P4_LSB_REG                   0x94
-#define BMX280_DIG_P4_MSB_REG                   0x95
-#define BMX280_DIG_P5_LSB_REG                   0x96
-#define BMX280_DIG_P5_MSB_REG                   0x97
-#define BMX280_DIG_P6_LSB_REG                   0x98
-#define BMX280_DIG_P6_MSB_REG                   0x99
-#define BMX280_DIG_P7_LSB_REG                   0x9A
-#define BMX280_DIG_P7_MSB_REG                   0x9B
-#define BMX280_DIG_P8_LSB_REG                   0x9C
-#define BMX280_DIG_P8_MSB_REG                   0x9D
-#define BMX280_DIG_P9_LSB_REG                   0x9E
-#define BMX280_DIG_P9_MSB_REG                   0x9F
+#define BMX280_DIG_T1_LSB_REG           (0x88)
+#define BMX280_DIG_T1_MSB_REG           (0x89)
+#define BMX280_DIG_T2_LSB_REG           (0x8A)
+#define BMX280_DIG_T2_MSB_REG           (0x8B)
+#define BMX280_DIG_T3_LSB_REG           (0x8C)
+#define BMX280_DIG_T3_MSB_REG           (0x8D)
+#define BMX280_DIG_P1_LSB_REG           (0x8E)
+#define BMX280_DIG_P1_MSB_REG           (0x8F)
+#define BMX280_DIG_P2_LSB_REG           (0x90)
+#define BMX280_DIG_P2_MSB_REG           (0x91)
+#define BMX280_DIG_P3_LSB_REG           (0x92)
+#define BMX280_DIG_P3_MSB_REG           (0x93)
+#define BMX280_DIG_P4_LSB_REG           (0x94)
+#define BMX280_DIG_P4_MSB_REG           (0x95)
+#define BMX280_DIG_P5_LSB_REG           (0x96)
+#define BMX280_DIG_P5_MSB_REG           (0x97)
+#define BMX280_DIG_P6_LSB_REG           (0x98)
+#define BMX280_DIG_P6_MSB_REG           (0x99)
+#define BMX280_DIG_P7_LSB_REG           (0x9A)
+#define BMX280_DIG_P7_MSB_REG           (0x9B)
+#define BMX280_DIG_P8_LSB_REG           (0x9C)
+#define BMX280_DIG_P8_MSB_REG           (0x9D)
+#define BMX280_DIG_P9_LSB_REG           (0x9E)
+#define BMX280_DIG_P9_MSB_REG           (0x9F)
 
-#define BME280_DIG_H1_REG                       0xA1
-#define BME280_DIG_H2_LSB_REG                   0xE1
-#define BME280_DIG_H2_MSB_REG                   0xE2
-#define BME280_DIG_H3_REG                       0xE3
-#define BME280_DIG_H4_MSB_REG                   0xE4 /* H4[11:4] */
-#define BME280_DIG_H4_H5_REG                    0xE5 /* H5[3:0]  H4[3:0] */
-#define BME280_DIG_H5_MSB_REG                   0xE6 /* H5[11:4] */
-#define BME280_DIG_H6_REG                       0xE7
+#define BME280_DIG_H1_REG               (0xA1)
+#define BME280_DIG_H2_LSB_REG           (0xE1)
+#define BME280_DIG_H2_MSB_REG           (0xE2)
+#define BME280_DIG_H3_REG               (0xE3)
+#define BME280_DIG_H4_MSB_REG           (0xE4)      /* H4[11:4] */
+#define BME280_DIG_H4_H5_REG            (0xE5)      /* H5[3:0]  H4[3:0] */
+#define BME280_DIG_H5_MSB_REG           (0xE6)      /* H5[11:4] */
+#define BME280_DIG_H6_REG               (0xE7)
 
-#define BMX280_STAT_REG                         0xF3 /* Status Reg */
-#define BMX280_CTRL_MEAS_REG                    0xF4 /* Ctrl Measure Reg */
-#define BMX280_CONFIG_REG                       0xF5 /* Configuration Reg */
-#define BMX280_PRESSURE_MSB_REG                 0xF7 /* Pressure MSB */
-#define BMX280_PRESSURE_LSB_REG                 0xF8 /* Pressure LSB */
-#define BMX280_PRESSURE_XLSB_REG                0xF9 /* Pressure XLSB */
-#define BMX280_TEMPERATURE_MSB_REG              0xFA /* Temperature MSB */
-#define BMX280_TEMPERATURE_LSB_REG              0xFB /* Temperature LSB */
-#define BMX280_TEMPERATURE_XLSB_REG             0xFC /* Temperature XLSB */
-#define BME280_CTRL_HUMIDITY_REG                0xF2 /* Ctrl Humidity Reg */
-#define BME280_HUMIDITY_MSB_REG                 0xFD /* Humidity MSB */
-#define BME280_HUMIDITY_LSB_REG                 0xFE /* Humidity LSB */
+#define BMX280_STAT_REG                 (0xF3)      /* Status Reg */
+#define BMX280_CTRL_MEAS_REG            (0xF4)      /* Ctrl Measure Reg */
+#define BMX280_CONFIG_REG               (0xF5)      /* Configuration Reg */
+#define BMX280_PRESSURE_MSB_REG         (0xF7)      /* Pressure MSB */
+#define BMX280_PRESSURE_LSB_REG         (0xF8)      /* Pressure LSB */
+#define BMX280_PRESSURE_XLSB_REG        (0xF9)      /* Pressure XLSB */
+#define BMX280_TEMPERATURE_MSB_REG      (0xFA)      /* Temperature MSB */
+#define BMX280_TEMPERATURE_LSB_REG      (0xFB)      /* Temperature LSB */
+#define BMX280_TEMPERATURE_XLSB_REG     (0xFC)      /* Temperature XLSB */
+#define BME280_CTRL_HUM_REG             (0xF2)      /* Ctrl Humidity Reg */
+#define BME280_HUMIDITY_MSB_REG         (0xFD)      /* Humidity MSB */
+#define BME280_HUMIDITY_LSB_REG         (0xFE)      /* Humidity LSB */
+/** @} */
+
+/**
+ * @name    Bitmasks for selected registers
+ * @{
+ */
+#define MEAS_OSRS_T_POS                 (5U)
+#define MEAS_OSRS_P_POS                 (2U)
+#define STAT_MEASURING                  (1 << 3)
+#define RESET_WORD                      (0xB6)
+/** @} */
+
+/**
+ * @name    The base address for the row of data registers
+ * @{
+ */
+#define DATA_BASE                       BMX280_PRESSURE_MSB_REG
+/** @} */
+
+/**
+ * @name    Calibration data base addresses, block sizes, and offsets
+ * @{
+ */
+#define CALIB_T_P_BASE                  (BMX280_DIG_T1_LSB_REG)
+#define CALIB_T_P_LEN                   (17U)
+#define OFFSET_T_P(x)                   (x - CALIB_T_P_BASE)
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
+#define CALIB_H_BASE                    (BME280_DIG_H2_LSB_REG)
+#define CALIB_H_LEN                     (7U)
+#define OFFSET_H(x)                     (x - CALIB_H_BASE)
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -25,21 +25,33 @@
  *
  * ## Usage
  *
- * Add the following to your makefile:
+ * To include this driver to your application, simply add one of the following
+ * to the application's Makefile:
  *
  * ```make
- * # For BME280
- * USEMODULE += bme280
+ * # BME280 connected via SPI
+ * USEMODULE += bme280_spi
+ * # BME280 connected via I2C
+ * USEMODULE += bme280_i2c
+ * # BMP280 via SPI
+ * USEMODULE += bmp280_spi
+ * # BMP280 via I2C
+ * USEMODULE += bmp280_i2c
  *
  * # When using I2C, specify the default I2C device to use,
  * # and the BME280's address (see datasheet).
  * # The values below are the defaults:
  * CFLAGS += -DBMX280_PARAM_I2C_DEV=I2C_DEV\(0\)
  * CFLAGS += -DBMX280_PARAM_I2C_ADDR=0x77
+ *
+ * # Using SPI, you can override the default configuration by specifying the
+ * # used SPI bus and the ship select pin:
+ * CFLAGS += -DBMX280_PARAM_SPI_DEV=SPI_DEV\(x\)
+ * CFLAGS += -DBMX280_PARAM_CS=GPIO_PIN\(y,z\)
  * ```
  *
- * This allows initialisation with the default parameters in `BMX280_PARAMS_DEFAULT`
- * from `bmx280_params.h`.
+ * This way the default parameters in `drivers/bmx280/include/bmx280_params.h`
+ * are replaced by these new values.
  *
  * @{
  * @file

--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Kees Bakker, SODAQ
  *               2017 Inria
+ *               2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -8,10 +9,10 @@
  */
 
 /**
- * @defgroup    drivers_bmx280 BMP280/BME280 temperature, pressure and humidity sensor
+ * @defgroup    drivers_bmx280 BMP280/BME280 temperature, pressure and humidity
+ *                             sensor
  * @ingroup     drivers_sensors
- * @ingroup     drivers_saul
- * @brief       Device driver interface for the Bosch BMP280 and BME280 sensors.
+ * @brief       Device driver interface for the Bosch BMP280 and BME280 sensors
  *
  * BMP280 and BME280 measure temperature in centi °C and pressure in Pa. BME280
  * can also measure relative humidity in %.
@@ -42,7 +43,7 @@
  *
  * @{
  * @file
- * @brief       Device driver interface for the BMX280 sensors (BMP280 and BME280).
+ * @brief       Device driver interface for the BMP280 and BME280 sensors
  *
  * @details     There are three sensor values that can be read: temperature,
  *              pressure and humidity.  The BME280 device usually measures them
@@ -55,17 +56,33 @@
  *
  * @author      Kees Bakker <kees@sodaq.com>
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef BMX280_H
 #define BMX280_H
 
-#include <inttypes.h>
+#include <stdint.h>
 #include "saul.h"
+
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BMP280_SPI)
+#define BMX280_USE_SPI
+#include "periph/spi.h"
+#else
 #include "periph/i2c.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/**
+ * @brief   Select the number or raw data bytes depending on the device type
+ */
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
+#define BMX280_RAW_LEN      (8U)
+#else
+#define BMX280_RAW_LEN      (6U)
 #endif
 
 /**
@@ -100,35 +117,34 @@ typedef struct {
  * @brief   Values for t_sb field of the BMX280 config register
  */
 typedef enum {
-    BMX280_SB_0_5 = 0,
-    BMX280_SB_62_5 = 1,
-    BMX280_SB_125 = 2,
-    BMX280_SB_250 = 3,
-    BMX280_SB_500 = 4,
-    BMX280_SB_1000 = 5,
-    BMX280_SB_10 = 6,
-    BMX280_SB_20 = 7
+    BMX280_SB_0_5  = 0x00,
+    BMX280_SB_62_5 = 0x20,
+    BMX280_SB_125  = 0x40,
+    BMX280_SB_250  = 0x60,
+    BMX280_SB_500  = 0x80,
+    BMX280_SB_1000 = 0xa0,
+    BMX280_SB_10   = 0xc0,
+    BMX280_SB_20   = 0xe0,
 } bmx280_t_sb_t;
 
 /**
  * @brief   Values for filter field of the BMX280 config register
  */
 typedef enum {
-    BMX280_FILTER_OFF = 0,
-    BMX280_FILTER_2 = 1,
-    BMX280_FILTER_4 = 2,
-    BMX280_FILTER_8 = 3,
-    BMX280_FILTER_16 = 4,
+    BMX280_FILTER_OFF = 0x00,
+    BMX280_FILTER_2   = 0x04,
+    BMX280_FILTER_4   = 0x08,
+    BMX280_FILTER_8   = 0x0c,
+    BMX280_FILTER_16  = 0x10,
 } bmx280_filter_t;
 
 /**
  * @brief   Values for mode field of the BMX280 ctrl_meas register
  */
 typedef enum {
-    BMX280_MODE_SLEEP = 0,
-    BMX280_MODE_FORCED = 1,
-    BMX280_MODE_FORCED2 = 2,    /* Same as FORCED */
-    BMX280_MODE_NORMAL = 3
+    BMX280_MODE_SLEEP  = 0x00,
+    BMX280_MODE_FORCED = 0x01,
+    BMX280_MODE_NORMAL = 0x03,
 } bmx280_mode_t;
 
 /**
@@ -140,12 +156,12 @@ typedef enum {
  *  - osrs_p field of the BMX280 ctrl_meas register
  */
 typedef enum {
-    BMX280_OSRS_SKIPPED = 0,
-    BMX280_OSRS_X1 = 1,
-    BMX280_OSRS_X2 = 2,
-    BMX280_OSRS_X4 = 3,
-    BMX280_OSRS_X8 = 4,
-    BMX280_OSRS_X16 = 5,
+    BMX280_OSRS_SKIPPED = 0x00,
+    BMX280_OSRS_X1      = 0x01,
+    BMX280_OSRS_X2      = 0x02,
+    BMX280_OSRS_X4      = 0x03,
+    BMX280_OSRS_X8      = 0x04,
+    BMX280_OSRS_X16     = 0x05,
 } bmx280_osrs_t;
 
 /**
@@ -154,9 +170,16 @@ typedef enum {
  * These parameters are needed to configure the device at startup.
  */
 typedef struct {
+#ifdef BMX280_USE_SPI
+    /* SPI configuration */
+    spi_t spi;                          /**< SPI bus */
+    spi_clk_t clk;                      /**< clock speed for the SPI bus */
+    gpio_t cs;                          /**< chip select pin */
+#else
     /* I2C details */
     i2c_t i2c_dev;                      /**< I2C device which is used */
     uint8_t i2c_addr;                   /**< I2C address */
+#endif
 
     /* Config Register */
     bmx280_t_sb_t t_sb;                 /**< standby */
@@ -178,6 +201,8 @@ typedef struct {
 typedef struct {
     bmx280_params_t params;             /**< Device Parameters */
     bmx280_calibration_t calibration;   /**< Calibration Data */
+    int32_t t_fine;                     /**< temperature compensation value */
+    uint8_t last_reading[BMX280_RAW_LEN];   /**< cache the RAW data */
 } bmx280_t;
 
 /**
@@ -185,55 +210,85 @@ typedef struct {
  */
 enum {
     BMX280_OK           =  0,     /**< everything was fine */
-    BMX280_ERR_NODEV    = -1,     /**< did not detect BME280 or BMP280 */
-    BMX280_ERR_NOCAL    = -2,     /**< could not read calibration data */
+    BMX280_ERR_BUS      = -1,     /**< bus error */
+    BMX280_ERR_NODEV    = -2,     /**< did not detect BME280 or BMP280 */
 };
+
+/**
+ * @brief   Export of SAUL interface for temperature sensor
+ */
+extern const saul_driver_t bmx280_temperature_saul_driver;
+
+/**
+ * @brief   Export of SAUL interface for pressure sensor
+ */
+extern const saul_driver_t bmx280_pressure_saul_driver;
+
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
+/**
+ * @brief   Export of SAUL interface for humidity sensor
+ */
+extern const saul_driver_t bme280_relative_humidity_saul_driver;
+#endif
 
 /**
  * @brief   Initialize the given BMX280 device
  *
- * @param[out] dev          Initialized device descriptor of BMX280 device
- * @param[in]  params       The parameters for the BMX280 device (sampling rate, etc)
+ * @param[out] dev      device descriptor of the given BMX280 device
+ * @param[in]  params   static configuration parameters
  *
- * @return                  BMX280_OK on success
- * @return                  BMX280_ERR_I2C
- * @return                  BMX280_ERR_NODEV
- * @return                  BMX280_ERR_NOCAL
+ * @return  BMX280_OK on success
+ * @return  BMX280_ERR_BUS on bus error
+ * @return  BMX280_ERR_NODEV if no corresponding device was found on the bus
  */
 int bmx280_init(bmx280_t* dev, const bmx280_params_t* params);
 
 /**
- * @brief   Read temperature value from the given BMX280 device, returned in centi °C
+ * @brief   Read temperature value from the given BMX280 device
  *
- * @param[in] dev           Device descriptor of BMX280 device to read from
+ * The measured temperature is returned in centi °C (x.xx°C).
  *
- * @returns                 The temperature in centi Celsius. In case of an error
- *                          it returns INT16_MIN.
+ * @param[in] dev       device to read from
+ *
+ * @return  measured temperature in centi Celsius
+ * @return  INT16_MIN on error
  */
-int16_t bmx280_read_temperature(const bmx280_t* dev);
+int16_t bmx280_read_temperature(bmx280_t* dev);
 
 /**
- * @brief   Read air pressure value from the given BMX280 device, returned in PA
+ * @brief   Read air pressure value from the given BMX280 device
  *
- * @details This function should only be called after doing bmx280_read_temperature
- *          first.
+ * The air pressure is returned in PA (Pascal).
  *
- * @param[in]  dev          Device descriptor of BMX280 device to read from
+ * This function returns the pressure data that was measured when
+ * bmx280_read_temperature() has been called last. So bmx280_read_temperature()
+ * has to be called before.
  *
- * @returns                 The air pressure in Pa
+ * If bmx280_read_temperatue() did not succeed in acquiring a new set of sensor
+ * data, the result of this function is undefined.
+ *
+ * @param[in]  dev      device to read from
+ *
+ * @return  air pressure in PA
  */
 uint32_t bmx280_read_pressure(const bmx280_t *dev);
 
-#if defined(MODULE_BME280) || defined(DOXYGEN)
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C) || defined(DOXYGEN)
 /**
- * @brief   Read humidity value from the given BME280 device, returned in centi %RH
+ * @brief   Read humidity value from the given BME280 device
  *
- * @details This function should only be called after doing bmx280_read_temperature
- *          first. It's only available with BME280 sensor.
+ * The humidity is returned in centi %RH (x.xx% relative humidity).
  *
- * @param[in]  dev          Device descriptor of BME280 device to read from
+ * This function returns the pressure data that was measured when
+ * bmx280_read_temperature() has been called last. So bmx280_read_temperature()
+ * has to be called before.
  *
- * @returns                 Humidity in centi %RH (i.e. the percentage times 100)
+ * If bmx280_read_temperatue() did not succeed in acquiring a new set of sensor
+ * data, the result of this function is undefined.
+ *
+ * @param[in]  dev      device to read from
+ *
+ * @return  humidity in centi %RH (i.e. the percentage times 100)
  */
 uint16_t bme280_read_humidity(const bmx280_t *dev);
 #endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -102,8 +102,10 @@ PSEUDOMODULES += at86rfa1
 PSEUDOMODULES += at86rfr2
 
 # include variants of the BMX280 drivers as pseudo modules
-PSEUDOMODULES += bmp280
-PSEUDOMODULES += bme280
+PSEUDOMODULES += bmp280_i2c
+PSEUDOMODULES += bmp280_spi
+PSEUDOMODULES += bme280_i2c
+PSEUDOMODULES += bme280_spi
 
 # variants of TI ADCXX1C
 PSEUDOMODULES += adc081c

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -382,7 +382,7 @@ void auto_init(void)
     extern void auto_init_bmp180(void);
     auto_init_bmp180();
 #endif
-#if defined(MODULE_BME280) || defined(MODULE_BMP280)
+#ifdef MODULE_BMX280
     extern void auto_init_bmx280(void);
     auto_init_bmx280();
 #endif

--- a/sys/auto_init/saul/auto_init_bmx280.c
+++ b/sys/auto_init/saul/auto_init_bmx280.c
@@ -20,7 +20,7 @@
  * @}
  */
 
-#if defined(MODULE_BME280) || defined(MODULE_BMP280)
+#ifdef MODULE_BMX280
 
 #include "log.h"
 #include "saul_reg.h"
@@ -34,20 +34,9 @@
 static bmx280_t bmx280_devs[BMX280_NUMOF];
 
 /**
- * @brief   Reference the driver structs.
- * @{
- */
-extern const saul_driver_t bmx280_temperature_saul_driver;
-extern const saul_driver_t bmx280_pressure_saul_driver;
-#if defined(MODULE_BME280)
-extern const saul_driver_t bme280_relative_humidity_saul_driver;
-#endif
-/** @} */
-
-/**
  * @brief   Memory for the SAUL registry entries
  */
-#if defined(MODULE_BME280)
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
 #define SENSORS_NUMOF 3
 #else
 #define SENSORS_NUMOF 2
@@ -79,7 +68,7 @@ void auto_init_bmx280(void)
         saul_reg_add(&saul_entries[se_ix]);
         se_ix++;
 
-#if defined(MODULE_BME280)
+#if defined(MODULE_BME280_SPI) || defined(MODULE_BME280_I2C)
         /* relative humidity */
         saul_entries[se_ix].dev = &bmx280_devs[i];
         saul_entries[se_ix].name = bmx280_saul_reg_info[i].name;

--- a/tests/driver_bmx280/Makefile
+++ b/tests/driver_bmx280/Makefile
@@ -1,8 +1,8 @@
 include ../Makefile.tests_common
 
-DRIVER ?= bme280
+DRIVER ?= bme280_i2c
 
+USEMODULE += fmt
 USEMODULE += $(DRIVER)
-USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bmx280/Makefile.ci
+++ b/tests/driver_bmx280/Makefile.ci
@@ -1,0 +1,6 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    #


### PR DESCRIPTION
### Issues/PRs references
For supporting  the `ruuvitag` it is needed to interface the `bmx280` sensor in SPI mode. While adding this mode, I found the driver was in a very bad state. This PR adds the possibility to use the driver in SPI mode and it significantly improves the drivers structure and style:

 bugs fixed (I wonder how these were able to go by previous reviews...):
- move global variables into device descriptor
- guard bus access (use acquire and release)

added functionality:
- enable SPI mode

structural improvements:
- reduce stack usage
- simplify the driver's structure
- centralize bus access code
- use assertions
- cleanup includes
- use shortcuts for bus access

style changes:
- fix line length
- cleanup and improve doxygen
- unify pointer notation (char *var over char* var)
- unify (error) return messages
- use `#ifdef MODULE_BME280` instead of `#if defined(BME..)`
- unify debug messages -> using `[bmx28] x: msg` scheme

This PR also adapts and improves the test application accordingly and also add the `bme280_spi` module as default SAUL module to the `ruuvitag`.

Note on commits: as it was impossible to cleanly split the rework and cleanup efforts from the SPI mode addition to the driver, I put all changes into a single commit...

### Testing:
The changes are tested and verified for the `bmx280_spi` and `bmp280_spi` on the `ruuvitag`. I don't have access to any board having these sensors connected via I2C, so the I2C mode still needs to be tested.