### PR TITLE
pkg_littlefs: call mtd_write with size == prog_size

### DIFF
--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -85,12 +85,20 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_write: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    int ret = mtd_write(mtd, buffer, ((fs->base_addr + block) * c->block_size) + off, size);
-    if (ret >= 0) {
-        return 0;
+    const uint8_t *buf = buffer;
+    uint32_t addr = ((fs->base_addr + block) * c->block_size) + off;
+    for (const uint8_t *part = buf; part < buf + size; part += c->prog_size,
+         addr += c->prog_size) {
+        int ret = mtd_write(mtd, part, addr, c->prog_size);
+        if (ret < 0) {
+            return ret;
+        }
+        else if ((unsigned)ret != c->prog_size) {
+            return -EIO;
+        }
     }
 
-    return ret;
+    return 0;
 }
 
 static int _dev_erase(const struct lfs_config *c, lfs_block_t block)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
mtd_write can only be called with a [size <= PAGE_SIZE](https://github.com/RIOT-OS/RIOT/blob/master/tests/unittests/tests-mtd/tests-mtd.c#L72). Right now littlefs calls it with a multiple  of PAGE_SIZE. This fix will call mtd_write multiple times until everything is written.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references