### PR TITLE
boards/thingy52: use Segger RTT for STDIO

### DIFF
--- a/boards/thingy52/Makefile.include
+++ b/boards/thingy52/Makefile.include
@@ -1,9 +1,10 @@
 # CPU configuration for the Thingy:52
 CPU_MODEL = nrf52832xxaa
 
-# override default PORT
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+# for this board, we are using Segger's RTT as default terminal interface
+USEMODULE += rtt_stdio
+TERMPROG = $(RIOTBASE)/dist/tools/jlink/jlink.sh
+TERMFLAGS = term_rtt
 
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.include

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -17,7 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini 
                              wsn430-v1_4 yunjia-nrf51822 z1
 
 # The following boards do not have an available UART
-BOARD_BLACKLIST += mips-malta pic32-wifire pic32-clicker ruuvitag
+BOARD_BLACKLIST += mips-malta pic32-wifire pic32-clicker ruuvitag thingy52
 
 # use ethos (ethernet over serial) for network communication and stdio over
 # UART, but not on native, as native has a tap interface towards the host.


### PR DESCRIPTION
### Contribution description
The `thingy52` does not have any on-board UART-to-USB, nor is the optional pin header populated per default, which would be needed for connecting an external UART-to-USB converter. By using the Segger RTT interface per default, this board becomes much easier to interface/debug. This has proven to be quite reliable for the `ruuvitag` lately.

### Issues/PRs references
none