### PR TITLE
drivers: encx24j600: add required features to Makefile.dep

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -92,6 +92,8 @@ ifneq (,$(filter enc28j60,$(USEMODULE)))
 endif
 
 ifneq (,$(filter encx24j600,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
   USEMODULE += netdev_eth
   USEMODULE += xtimer
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes the drivers/Makefile.dep to include the required GPIO and SPI features for the encx24j600 Ethernet chip. Thus it is no longer necessary to specify the requirement of these features in the application Makefile, so that it does comply with the usage of other modules.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
The issue was discovered and fixed at the IoThon 2018, so there is no corresponding issue here on GitHub.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->