### PR TITLE
drivers/soft_spi: fix doxygen group name

### DIFF
--- a/drivers/include/soft_spi.h
+++ b/drivers/include/soft_spi.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    driver_soft_spi Soft SPI
+ * @defgroup    drivers_soft_spi Soft SPI
  * @ingroup     drivers
  * @brief       Software implemented Serial Peripheral Interface bus
  * This module provides a software implemented Serial Peripheral Interface bus.

--- a/drivers/soft_spi/include/soft_spi_params.h
+++ b/drivers/soft_spi/include/soft_spi_params.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_soft_spi
+ * @ingroup     drivers_soft_spi
  * @{
  *
  * @file

--- a/drivers/soft_spi/soft_spi.c
+++ b/drivers/soft_spi/soft_spi.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_soft_spi
+ * @ingroup     drivers_soft_spi
  * @{
  *
  * @file


### PR DESCRIPTION
It was inconsistent with other drivers group names

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a minor issue with the soft_spi doxygen group name. Other drivers use the following pattern `drivers_<driver name>` and this one was `driver_soft_spi`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->