### PR TITLE
tests/driver_encx24j600: remove now unnecessary feature deps

### DIFF
--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_spi periph_gpio
-
 BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h \
                              nucleo-l053 nucleo32-f031 nucleo32-f042 \
                              nucleo32-l031 stm32f0discovery telosb \


### PR DESCRIPTION
### Contribution description

#8387 added encx24j600's feature requirements to Makefile.dep, where they belong. So they're not needed in the driver's test application anymore.

### Issues/PRs references

#8387