### PR TITLE
ci: murdock: print worker information for static tests

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -65,6 +65,11 @@ get_compile_jobs() {
         | xargs '-d\n' -n 1 echo $0 compile
 }
 
+print_worker() {
+    [ -n "$DWQ_WORKER" ] && \
+        echo "-- running on worker ${DWQ_WORKER} thread ${DWQ_WORKER_THREAD}, build number $DWQ_WORKER_BUILDNUM."
+}
+
 # compile one app for one board. delete intermediates.
 compile() {
     local appdir=$1
@@ -79,8 +84,7 @@ compile() {
     # Pre-build cleanup
     rm -rf ${BINDIR}
 
-    [ -n "$DWQ_WORKER" ] && \
-        echo "-- running on worker ${DWQ_WORKER} thread ${DWQ_WORKER_THREAD}, build number $DWQ_WORKER_BUILDNUM."
+    print_worker
 
     # sanity checks
     [ $# -ne 2 ] && error "$0: compile: invalid parameters (expected \$appdir \$board)"
@@ -113,6 +117,8 @@ compile() {
 static_tests() {
     local repo=${CI_BASE_REPO:-https://github.com/RIOT-OS/RIOT}
     local branch=${CI_BASE_BRANCH:-master}
+
+    print_worker
 
     OUT="$(git remote add upstream $repo 2>&1 && git fetch upstream ${branch}:${branch} 2>&1)"
     RES=$?


### PR DESCRIPTION
### Contribution description

Currently, when murdock executes a compile job, it prints on which worker that job was executed. Not so for static-tests. This PR factors out the worker printing into a function and calls it from both compile and static-tests jobs.

### Issues/PRs references

here, "flake8" is declared missing, with no way to find out on which worker:

https://ci.riot-os.org/RIOT-OS/RIOT/6164/f45295a3e048541f6597a5b2c917de39188df0ba/output/static_tests.txt