### PR TITLE
socket_zep: remove unnecessary include

### DIFF
--- a/cpu/native/include/socket_zep.h
+++ b/cpu/native/include/socket_zep.h
@@ -20,7 +20,6 @@
 #ifndef SOCKET_ZEP_H
 #define SOCKET_ZEP_H
 
-#include <netdb.h>
 #include "net/netdev.h"
 #include "net/netdev/ieee802154.h"
 #include "net/zep.h"


### PR DESCRIPTION
### Contribution description

Remove superfluous include in socker_zep, which causes following error on macOS:

```
/RIOT/cpu/native/include/socket_zep.h:23:
In file included from /usr/include/netdb.h:91:
In file included from /RIOT/sys/posix/include/netinet/in.h:27:
In file included from /RIOT/sys/posix/include/sys/socket.h:47:
/RIOT/sys/posix/include/sys/bytes.h:31:16: error: typedef redefinition
      with different types ('size_t' (aka 'unsigned long') vs '__darwin_socklen_t'
      (aka 'unsigned int'))
typedef size_t socklen_t;           /**< socket address length */
               ^
/usr/include/sys/_types/_socklen_t.h:31:28: note: previous definition is here
typedef __darwin_socklen_t      socklen_t;
                                ^
1 error generated.

```

### Issues/PRs references

None