### PR TITLE
pkg/libcoap: update patches for git >=2.15.x

### DIFF
--- a/pkg/libcoap/patches/0001-Add-RIOT-Makefile.patch
+++ b/pkg/libcoap/patches/0001-Add-RIOT-Makefile.patch
@@ -1,4 +1,4 @@
-From bc86f013bbfc1eca7151d4faa2bb9ca33987115c Mon Sep 17 00:00:00 2001
+From e25f8860e73f9097ba613268644382d95902850c Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mlenders@inf.fu-berlin.de>
 Date: Thu, 31 Oct 2013 13:36:10 +0100
 Subject: [PATCH 1/9] Add RIOT Makefile
@@ -10,7 +10,7 @@ Subject: [PATCH 1/9] Add RIOT Makefile
 
 diff --git a/Makefile b/Makefile
 new file mode 100644
-index 0000000..7f37ccc
+index 0000000..f424cf1
 --- /dev/null
 +++ b/Makefile
 @@ -0,0 +1,4 @@
@@ -18,5 +18,6 @@ index 0000000..7f37ccc
 +CFLAGS += -DWITH_POSIX -D_GNU_SOURCE=1
 +
 +include $(RIOTBASE)/Makefile.base
---
-1.9.1
+-- 
+2.15.1
+

--- a/pkg/libcoap/patches/0002-Add-config.h.patch
+++ b/pkg/libcoap/patches/0002-Add-config.h.patch
@@ -1,4 +1,4 @@
-From 8be22676f13bd7d254378e2c04119e1632ed55d7 Mon Sep 17 00:00:00 2001
+From 64fc056031b36a6799c8f1fe28c16b2ef6bdde1b Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mlenders@inf.fu-berlin.de>
 Date: Thu, 31 Oct 2013 14:02:07 +0100
 Subject: [PATCH 2/9] Add config.h
@@ -145,6 +145,6 @@ index 0000000..8915dd3
 +/* #undef ssize_t */
 +
 +#define WITH_POSIX 1
---
-1.8.3.2
+-- 
+2.15.1
 

--- a/pkg/libcoap/patches/0003-Remove-two-example-programs-in-root.patch
+++ b/pkg/libcoap/patches/0003-Remove-two-example-programs-in-root.patch
@@ -1,5 +1,5 @@
-From e53472f0a5f15d2459bf9a9ef40d2b302bb80f8b Mon Sep 17 00:00:00 2001
-From: Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+From b6db366147714482c03753aacc522090a0f7b2bf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ludwig=20Kn=C3=BCpfer?= <ludwig.knuepfer@fu-berlin.de>
 Date: Tue, 15 Jul 2014 16:57:07 +0200
 Subject: [PATCH 3/9] Remove two example programs in root
 
@@ -428,5 +428,5 @@ index 5dcdfcd..0000000
 -}
 -/*---------------------------------------------------------------------------*/
 -- 
-2.0.1
+2.15.1
 

--- a/pkg/libcoap/patches/0004-Eliminate-some-compiler-warnings-and-errors.patch
+++ b/pkg/libcoap/patches/0004-Eliminate-some-compiler-warnings-and-errors.patch
@@ -1,4 +1,4 @@
-From 48906fde395dc05c18606ddf3abce5947ab6a1c6 Mon Sep 17 00:00:00 2001
+From be9ee2b0b8da10c8fb5eb67a6b3bdf1efe62cb84 Mon Sep 17 00:00:00 2001
 From: Martine Lenders <mlenders@inf.fu-berlin.de>
 Date: Wed, 19 Feb 2014 02:24:50 +0100
 Subject: [PATCH 4/9] Eliminate some compiler warnings and errors
@@ -16,7 +16,7 @@ index 403240e..0e715f1 100644
 @@ -106,6 +106,10 @@ _coap_address_equals_impl(const coap_address_t *a,
   return 0;
  }
-
+ 
 +#ifndef IN_MULTICAST
 +#define IN_MULTICAST(a) (1)
 +#endif
@@ -31,13 +31,13 @@ index e90d49a..83097d1 100644
 @@ -45,6 +45,10 @@
  #include "block.h"
  #include "net.h"
-
+ 
 +#ifndef UINT_MAX
 +#define UINT_MAX    ((unsigned) -1ul)
 +#endif
 +
  #if defined(WITH_POSIX)
-
+ 
  time_t clock_offset;
 diff --git a/net.h b/net.h
 index f9afd48..59c7d59 100644
@@ -46,14 +46,14 @@ index f9afd48..59c7d59 100644
 @@ -132,7 +132,7 @@ typedef struct coap_context_t {
     * random value. A new message id can be created with
     * coap_new_message_id().
-    */
+    */ 
 -  unsigned short message_id;
 +  uint16_t message_id;
-
+ 
    /**
     * The next value to be used for Observe. This field is global for
 @@ -196,9 +196,11 @@ coap_context_t *coap_new_context(const coap_address_t *listen_addr);
- static inline unsigned short
+ static inline unsigned short 
  coap_new_message_id(coap_context_t *context) {
  #ifndef WITH_CONTIKI
 -  return htons(++(context->message_id));
@@ -65,7 +65,7 @@ index f9afd48..59c7d59 100644
 +    return uip_htons(context->message_id);
  #endif
  }
-
---
-1.8.3.2
+ 
+-- 
+2.15.1
 

--- a/pkg/libcoap/patches/0005-fix-old-style-function-declarations.patch
+++ b/pkg/libcoap/patches/0005-fix-old-style-function-declarations.patch
@@ -1,5 +1,5 @@
-From e6d36f466b2c1568cb4cfc3a3f1f9348e71db037 Mon Sep 17 00:00:00 2001
-From: Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+From 1fcbd0139432691f7cf1b2c26e543323097d14ca Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ludwig=20Kn=C3=BCpfer?= <ludwig.knuepfer@fu-berlin.de>
 Date: Tue, 15 Jul 2014 17:06:51 +0200
 Subject: [PATCH 5/9] fix old-style function declarations
 
@@ -112,5 +112,5 @@ index a891086..5bf2164 100644
  void coap_delete_pdu(coap_pdu_t *);
  
 -- 
-2.0.1
+2.15.1
 

--- a/pkg/libcoap/patches/0006-debug-do-not-misuse-NDEBUG.patch
+++ b/pkg/libcoap/patches/0006-debug-do-not-misuse-NDEBUG.patch
@@ -1,4 +1,4 @@
-From ca876797dbe6ba05f75a451e8724495a0770fe86 Mon Sep 17 00:00:00 2001
+From 50a9c4a0b04a556eddc58e94967453ed87811f7a Mon Sep 17 00:00:00 2001
 From: Oleg Hahm <oleg@hobbykeller.org>
 Date: Thu, 23 Jul 2015 10:20:38 +0200
 Subject: [PATCH 6/9] debug: do not misuse NDEBUG
@@ -30,38 +30,38 @@ index e93003c..95da094 100644
  #endif
      return NULL;
 diff --git a/debug.c b/debug.c
-index adff3c2..e043225 100644
+index 241a803..399b6ac 100644
 --- a/debug.c
 +++ b/debug.c
-@@ -86,7 +86,7 @@ print_timestamp(char *s, size_t len, coap_tick_t t) {
-
+@@ -78,7 +78,7 @@ print_timestamp(char *s, size_t len, coap_tick_t t) {
+ 
  #endif /* HAVE_TIME_H */
-
+ 
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
-
+ 
  #ifndef HAVE_STRNLEN
- /**
-@@ -326,7 +326,7 @@ coap_show_pdu(const coap_pdu_t *pdu) {
+ /** 
+@@ -318,7 +318,7 @@ coap_show_pdu(const coap_pdu_t *pdu) {
  }
  #endif /* WITH_CONTIKI */
-
+ 
 -#endif /* NDEBUG */
 +#endif /* DEBUG_ENABLED */
-
+ 
  #ifndef WITH_CONTIKI
- void
+ void 
 diff --git a/debug.h b/debug.h
-index d18558f..edf4b86 100644
+index b4dae5d..5226eb5 100644
 --- a/debug.h
 +++ b/debug.h
-@@ -54,7 +54,10 @@ void coap_log_impl(coap_log_t level, const char *format, ...);
+@@ -48,7 +48,10 @@ void coap_log_impl(coap_log_t level, const char *format, ...);
  #endif
-
+ 
  #ifndef NDEBUG
 +#define DEBUG_ENABLED
 +#endif
-
+ 
 +#ifdef DEBUG_ENABLED
  /* A set of convenience macros for common log levels. */
  #define info(...) coap_log(LOG_INFO, __VA_ARGS__)
@@ -71,43 +71,43 @@ index b034b6b..cdd9a20 100644
 --- a/encode.c
 +++ b/encode.c
 @@ -6,7 +6,7 @@
-  * README for terms of use.
+  * README for terms of use. 
   */
-
+ 
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
  #  include <stdio.h>
  #endif
-
+ 
 diff --git a/examples/client.c b/examples/client.c
-index bd75deb..7872c35 100644
+index 903685e..98f4aa9 100644
 --- a/examples/client.c
 +++ b/examples/client.c
-@@ -282,7 +282,7 @@ message_handler(struct coap_context_t  *ctx,
+@@ -287,7 +287,7 @@ message_handler(struct coap_context_t  *ctx,
    unsigned char *databuf;
    coap_tid_t tid;
-
+ 
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
    if (LOG_DEBUG <= coap_get_log_level()) {
      debug("** process incoming %d.%02d response:\n",
-     (received->hdr->code >> 5), received->hdr->code & 0x1F);
-@@ -1075,7 +1075,7 @@ main(int argc, char **argv) {
+ 	  (received->hdr->code >> 5), received->hdr->code & 0x1F);
+@@ -1087,7 +1087,7 @@ main(int argc, char **argv) {
    if (! (pdu = coap_new_request(ctx, method, optlist)))
      return -1;
-
+ 
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
    if (LOG_DEBUG <= coap_get_log_level()) {
      debug("sending CoAP request:\n");
      coap_show_pdu(pdu);
 diff --git a/net.c b/net.c
-index 7338802..9372570 100644
+index 035619c..8fe08b4 100644
 --- a/net.c
 +++ b/net.c
-@@ -243,7 +243,7 @@ coap_new_node() {
+@@ -243,7 +243,7 @@ coap_new_node(void) {
    node = coap_malloc_node();
-
+ 
    if ( ! node ) {
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
@@ -115,7 +115,7 @@ index 7338802..9372570 100644
  #endif
      return NULL;
 @@ -327,7 +327,7 @@ coap_new_context(
-
+ 
  #ifndef WITH_CONTIKI
    if ( !c ) {
 -#ifndef NDEBUG
@@ -133,14 +133,14 @@ index 7338802..9372570 100644
  #endif /* WITH_POSIX */
      goto onerror;
    }
-
+ 
    if ( setsockopt( c->sockfd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse) ) < 0 ) {
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
      coap_log(LOG_WARNING, "setsockopt SO_REUSEADDR\n");
  #endif
    }
-
+ 
    if (bind(c->sockfd, &listen_addr->addr.sa, listen_addr->size) < 0) {
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
@@ -150,33 +150,36 @@ index 7338802..9372570 100644
 @@ -923,7 +923,7 @@ if (!coap_pdu_parse((unsigned char *)buf, bytes_read, node->pdu)) {
    coap_transaction_id(&node->remote, node->pdu, &node->id);
    coap_insert_node(&ctx->recvqueue, node);
-
+ 
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
    if (LOG_DEBUG <= coap_get_log_level()) {
  #ifndef INET6_ADDRSTRLEN
  #define INET6_ADDRSTRLEN 40
 diff --git a/pdu.c b/pdu.c
-index 04ef9c6..05d8537 100644
+index e3c9720..c55823b 100644
 --- a/pdu.c
 +++ b/pdu.c
-@@ -132,7 +132,7 @@ coap_new_pdu() {
+@@ -132,7 +132,7 @@ coap_new_pdu(void) {
    pdu = coap_pdu_init(0, 0, uip_ntohs(COAP_INVALID_TID), COAP_MAX_PDU_SIZE);
  #endif /* WITH_CONTIKI */
-
+ 
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
    if (!pdu)
      coap_log(LOG_CRIT, "coap_new_pdu: cannot allocate memory for new PDU\n");
  #endif
 diff --git a/resource.c b/resource.c
-index 1d9cf34..101ea4d 100644
+index 1b2657f..5b9e90f 100644
 --- a/resource.c
 +++ b/resource.c
-@@ -821,4 +821,4 @@ coap_remove_failed_observers(coap_context_t *context,
+@@ -816,7 +816,7 @@ coap_remove_failed_observers(coap_context_t *context,
+ 	list_remove(resource->subscribers, obs);
+ 	obs->fail_cnt = 0;
+ 	
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
-   if (LOG_DEBUG <= coap_get_log_level()) {
+ 	if (LOG_DEBUG <= coap_get_log_level()) {
  #ifndef INET6_ADDRSTRLEN
  #define INET6_ADDRSTRLEN 40
 diff --git a/str.c b/str.c
@@ -204,19 +207,19 @@ index d683419..37d4e20 100644
 +#ifdef DEBUG_ENABLED
    char addr[INET6_ADDRSTRLEN];
  #endif
-
+ 
 @@ -90,7 +90,7 @@ notify(coap_context_t *context, coap_resource_t *res,
      /* TODO: add mediatype */
    }
-
+ 
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
-   if ( inet_ntop(sub->subscriber.addr.sa.sa_family,
-     &sub->subscriber.addr, addr, sizeof(addr)) ) {
+   if ( inet_ntop(sub->subscriber.addr.sa.sa_family, 
+ 		 &sub->subscriber.addr, addr, sizeof(addr)) ) {
      debug("*** notify for %s to [%s]\n", res->uri->path.s, addr);
 @@ -100,7 +100,7 @@ notify(coap_context_t *context, coap_resource_t *res,
-       &sub->subscriber.addr.sa,
-       sub->subscriber.size, pdu)
+ 				 &sub->subscriber.addr.sa,
+ 				 sub->subscriber.size, pdu) 
        == COAP_INVALID_TID) {
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
@@ -224,7 +227,7 @@ index d683419..37d4e20 100644
  #endif
      coap_delete_pdu(pdu);
 @@ -164,7 +164,7 @@ coap_get_resource_from_key(coap_context_t *ctx, coap_key_t key) {
-
+ 
  coap_resource_t *
  coap_get_resource(coap_context_t *ctx, coap_uri_t *uri) {
 -#ifndef NDEBUG
@@ -240,16 +243,16 @@ index d683419..37d4e20 100644
 +#ifdef DEBUG_ENABLED
    char addr[INET6_ADDRSTRLEN];
  #endif
-
+ 
 @@ -191,7 +191,7 @@ coap_check_subscriptions(coap_context_t *context) {
-
+ 
    node = context->subscriptions;
    while ( node && COAP_SUBSCRIPTION(node)->expires < now ) {
 -#ifndef NDEBUG
 +#ifdef DEBUG_ENABLED
      if (inet_ntop(COAP_SUBSCRIPTION(node)->subscriber.addr.sa.sa_family,
-      &COAP_SUBSCRIPTION(node)->subscriber.addr,
-      addr, sizeof(addr))) {
+ 		  &COAP_SUBSCRIPTION(node)->subscriber.addr,
+ 		  addr, sizeof(addr))) {
 @@ -236,7 +236,7 @@ coap_delete_resource(coap_context_t *context, coap_key_t key) {
    for (prev = NULL, node = context->resources; node;
         prev = node, node = node->next) {
@@ -259,5 +262,6 @@ index d683419..37d4e20 100644
        debug("removed key %lu (%s)\n",key,COAP_RESOURCE(node)->uri->path.s);
  #endif
        if (!prev)
---
-2.5.0
+-- 
+2.15.1
+

--- a/pkg/libcoap/patches/0007-fix-option-parsing-with-debug-enabled.patch
+++ b/pkg/libcoap/patches/0007-fix-option-parsing-with-debug-enabled.patch
@@ -1,4 +1,4 @@
-From e5adb25f18ff979b2777f7161b1038611c84a450 Mon Sep 17 00:00:00 2001
+From 398ee4df737c7eb21feb8ce3996096e014d974aa Mon Sep 17 00:00:00 2001
 From: Oleg Hahm <oleg@hobbykeller.org>
 Date: Tue, 4 Aug 2015 23:07:24 +0200
 Subject: [PATCH 7/9] fix option parsing with debug enabled
@@ -12,7 +12,7 @@ index a03fc9e..b825eac 100644
 --- a/option.c
 +++ b/option.c
 @@ -57,8 +57,9 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
-
+ 
    switch(result->delta) {
    case 15:
 -    if (*opt != COAP_PAYLOAD_START)
@@ -22,5 +22,6 @@ index a03fc9e..b825eac 100644
      return 0;
    case 14:
      /* Handle two-byte value: First, the MSB + 269 is stored as delta value.
---
-2.5.0
+-- 
+2.15.1
+

--- a/pkg/libcoap/patches/0008-fix-debug-out-in-PDU-parsing.patch
+++ b/pkg/libcoap/patches/0008-fix-debug-out-in-PDU-parsing.patch
@@ -1,4 +1,4 @@
-From 3409c3834022c9e7cd73ac69e34dfaa101947cf0 Mon Sep 17 00:00:00 2001
+From 2e896e0e744102502f8243c83d4cc13a4cdfce20 Mon Sep 17 00:00:00 2001
 From: Oleg Hahm <oleg@hobbykeller.org>
 Date: Tue, 4 Aug 2015 23:09:27 +0200
 Subject: [PATCH 8/9] fix debug out in PDU parsing
@@ -8,20 +8,21 @@ Subject: [PATCH 8/9] fix debug out in PDU parsing
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/net.c b/net.c
-index 9372570..86c7793 100644
+index 8fe08b4..0b8c99e 100644
 --- a/net.c
 +++ b/net.c
 @@ -930,9 +930,10 @@ if (!coap_pdu_parse((unsigned char *)buf, bytes_read, node->pdu)) {
  #endif
      unsigned char addr[INET6_ADDRSTRLEN+8];
-
+ 
 -    if (coap_print_addr(&src, addr, INET6_ADDRSTRLEN+8))
 +    if (coap_print_addr(&src, addr, INET6_ADDRSTRLEN+8)) {
        debug("** received %d bytes from %s:\n", (int)bytes_read, addr);
-
+ 
 +    }
      coap_show_pdu( node->pdu );
    }
  #endif
---
-2.5.0
+-- 
+2.15.1
+

--- a/pkg/libcoap/patches/0009-delete-unused-function-check_opt_size.patch
+++ b/pkg/libcoap/patches/0009-delete-unused-function-check_opt_size.patch
@@ -1,4 +1,4 @@
-From 4e065c420056a5416d9d4b00439042d7adcefddb Mon Sep 17 00:00:00 2001
+From d44530b311ff5bd9529f000c2a1781630f6ae576 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Cenk=20G=C3=BCndo=C4=9Fan?= <cnkgndgn@gmail.com>
 Date: Wed, 16 Sep 2015 19:02:09 +0200
 Subject: [PATCH 9/9] delete unused function check_opt_size
@@ -14,8 +14,8 @@ index 0b8c99e..18f39a7 100644
 @@ -817,20 +817,6 @@ coap_retransmit( coap_context_t *context, coap_queue_t *node ) {
    return COAP_INVALID_TID;
  }
-
--/**
+ 
+-/** 
 - * Checks if @p opt fits into the message that ends with @p maxpos.
 - * This function returns @c 1 on success, or @c 0 if the option @p opt
 - * would exceed @p maxpos.
@@ -32,5 +32,6 @@ index 0b8c99e..18f39a7 100644
  int
  coap_read( coap_context_t *ctx ) {
  #ifdef WITH_POSIX
---
-2.5.2
+-- 
+2.15.1
+


### PR DESCRIPTION
### Contribution description

Update patch files to fixes patching of libcoap package with GIT version >= 2.15.x, like the following error:

```
Applying: Add RIOT Makefile
Applying: Add config.h
Applying: Remove two example programs in root
Applying: Eliminate some compiler warnings and errors
error: patch failed: net.h:132
error: net.h: patch does not apply
Patch failed at 0004 Eliminate some compiler warnings and errors
```

### Issues/PRs references

#8289