### PR TITLE
stm32_common/uart: add baudrate recalculation based on clk settings

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -307,6 +307,23 @@ uint32_t periph_apb_clk(uint8_t bus);
 uint32_t periph_timer_clk(uint8_t bus);
 
 /**
+ * @brief   Recalculate Baudrate for UART device
+ *
+ * The UART device will be initialized with the following configuration:
+ * - 8 data bits
+ * - no parity
+ * - 1 stop bit
+ * - baudrate as given
+ *
+ * @param[in] uart          UART device to initialize
+ * @param[in] baudrate      desired baudrate in baud/s
+ *
+ * @return                  UART_OK on success
+ * @return                  UART_NOBAUD on inapplicable baudrate
+ */
+int uart_set_baudrate(unsigned int uart, uint32_t baudrate);
+
+/**
  * @brief   Enable the given peripheral clock
  *
  * @param[in] bus       bus the peripheral is connected to

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -321,7 +321,7 @@ uint32_t periph_timer_clk(uint8_t bus);
  * @return                  UART_OK on success
  * @return                  UART_NOBAUD on inapplicable baudrate
  */
-int uart_set_baudrate(unsigned int uart, uint32_t baudrate);
+int periph_uart_set_baudrate(unsigned int uart, uint32_t baudrate);
 
 /**
  * @brief   Enable the given peripheral clock

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -45,7 +45,7 @@ static inline USART_TypeDef *dev(uart_t uart)
     return uart_config[uart].dev;
 }
 
-int uart_set_baudrate(uart_t uart, uint32_t baudrate) {
+int periph_uart_set_baudrate(uart_t uart, uint32_t baudrate) {
     uint16_t mantissa;
     uint8_t fraction;
     uint32_t uart_clk;

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -31,8 +31,10 @@
 #include "periph/uart.h"
 #include "periph/gpio.h"
 
-#define RXENABLE            (USART_CR1_RE | USART_CR1_RXNEIE)
+#define RXENABLE                (USART_CR1_RE | USART_CR1_RXNEIE)
 
+#define UART_8X_OVERSAMPLING    8
+#define UART_16X_OVERSAMPLING   16
 /**
  * @brief   Allocate memory to store the callback functions
  */
@@ -63,18 +65,18 @@ int uart_set_baudrate(uart_t uart, uint32_t baudrate) {
 #ifdef USART_CR1_OVER8
         if (uart_clk < 16) {
             dev(uart)->CR1 |= USART_CR1_OVER8;
-            mantissa = (uint16_t)(uart_clk / 8);
-            fraction = (uint8_t)(uart_clk - (mantissa * 8));
+            mantissa = (uint16_t)(uart_clk / UART_8X_OVERSAMPLING);
+            fraction = (uint8_t)(uart_clk - (mantissa * UART_8X_OVERSAMPLING));
             dev(uart)->BRR = ((mantissa & 0x0fff) << 4) | (fraction & 0x07);
         } else {
             dev(uart)->CR1 &= ~USART_CR1_OVER8;
-            mantissa = (uint16_t)(uart_clk / 16);
-            fraction = (uint8_t)(uart_clk - (mantissa * 16));
+            mantissa = (uint16_t)(uart_clk / UART_16X_OVERSAMPLING);
+            fraction = (uint8_t)(uart_clk - (mantissa * UART_16X_OVERSAMPLING));
             dev(uart)->BRR = ((mantissa & 0x0fff) << 4) | (fraction & 0x0f);
         }
 #else
-        mantissa = (uint16_t)(uart_clk / 16);
-        fraction = (uint8_t)(uart_clk - (mantissa * 16));
+        mantissa = (uint16_t)(uart_clk / UART_16X_OVERSAMPLING);
+        fraction = (uint8_t)(uart_clk - (mantissa * UART_16X_OVERSAMPLING));
         dev(uart)->BRR = ((mantissa & 0x0fff) << 4) | (fraction & 0x0f);
 #endif
 

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -135,23 +135,6 @@ enum {
 int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg);
 
 /**
- * @brief   Recalculate Baudrate for UART device
- *
- * The UART device will be initialized with the following configuration:
- * - 8 data bits
- * - no parity
- * - 1 stop bit
- * - baudrate as given
- *
- * @param[in] uart          UART device to initialize
- * @param[in] baudrate      desired baudrate in baud/s
- *
- * @return                  UART_OK on success
- * @return                  UART_NOBAUD on inapplicable baudrate
- */
-int uart_set_baudrate(uart_t uart, uint32_t baudrate);
-
-/**
  * @brief   Write data from the given buffer to the specified UART device
  *
  * This function is blocking, as it will only return after @p len bytes from the

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -135,6 +135,23 @@ enum {
 int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg);
 
 /**
+ * @brief   Recalculate Baudrate for UART device
+ *
+ * The UART device will be initialized with the following configuration:
+ * - 8 data bits
+ * - no parity
+ * - 1 stop bit
+ * - baudrate as given
+ *
+ * @param[in] uart          UART device to initialize
+ * @param[in] baudrate      desired baudrate in baud/s
+ *
+ * @return                  UART_OK on success
+ * @return                  UART_NOBAUD on inapplicable baudrate
+ */
+int uart_set_baudrate(uart_t uart, uint32_t baudrate);
+
+/**
  * @brief   Write data from the given buffer to the specified UART device
  *
  * This function is blocking, as it will only return after @p len bytes from the


### PR DESCRIPTION
### Contribution description

This PR is based on work by @olegart, it adds the possibility to recalculate baud rate based on clock frequency, needed for proper re-initialization on devices after entering low power modes. 

### Issues/PRs references

#8403 depends on this PR