### PR TITLE
boards/*: make doxygen brief description consistent

### DIFF
--- a/boards/airfy-beacon/include/board.h
+++ b/boards/airfy-beacon/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_airfy-beacon Airfy Beacon
  * @ingroup     boards
- * @brief       Board specific files for the Airfy Beacon board
+ * @brief       Support for the Airfy Beacon board
  * @{
  *
  * @file

--- a/boards/b-l072z-lrwan1/include/board.h
+++ b/boards/b-l072z-lrwan1/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_b-l072z-lrwan1 ST b-l072z-lrwan1 discovery
  * @ingroup     boards
- * @brief       Board specific files for the ST b-l072z-lrwan1 board
+ * @brief       Support for the ST b-l072z-lrwan1 board
  * @{
  *
  * @file

--- a/boards/b-l475e-iot01a/include/board.h
+++ b/boards/b-l475e-iot01a/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_b-l475e-iot01a ST B-L475E-IOT01A
  * @ingroup     boards
- * @brief       Board specific files for the ST b-l475e-iot01a board
+ * @brief       Support for the ST b-l475e-iot01a board
  * @{
  *
  * @file

--- a/boards/calliope-mini/include/board.h
+++ b/boards/calliope-mini/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_calliope-mini Calliope mini
  * @ingroup     boards
- * @brief       Board specific files for the Calliope mini
+ * @brief       Support for the Calliope mini
  *
  * This board is for calliope-mini revision 1.0.
  * @{

--- a/boards/cc2650stk/include/board.h
+++ b/boards/cc2650stk/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_cc2650stk CC2650STK
  * @ingroup     boards
- * @brief       SimpleLink™ CC2650 sensor tag
+ * @brief       Support for the SimpleLink™ CC2650 sensor tag
  * @{
  *
  * @file

--- a/boards/ek-lm4f120xl/include/board.h
+++ b/boards/ek-lm4f120xl/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_ek-lm4f120xl EK-LM4F120XL
  * @ingroup     boards
- * @brief       Board specific files for the Stellaris Launchpad LM4F120 board
+ * @brief       Support for the Stellaris Launchpad LM4F120 board
  * @{
  *
  * @file

--- a/boards/f4vi1/include/board.h
+++ b/boards/f4vi1/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_f4vi1  F4VI1
  * @ingroup     boards
- * @brief       Board specific files for the F4VI1 board
+ * @brief       Support for the F4VI1 board
  * @{
  *
  * @file

--- a/boards/feather-m0/include/board.h
+++ b/boards/feather-m0/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @ingroup     boards_feather-m0
- * @brief       Board specific configuration of the Adafruit Feather M0.
+ * @brief       Support for the Adafruit Feather M0
  *
  * @{
  *

--- a/boards/fox/include/board.h
+++ b/boards/fox/include/board.h
@@ -9,11 +9,11 @@
 /**
  * @defgroup    boards_fox fox
  * @ingroup     boards
- * @brief       Board specific files for the fox board.
+ * @brief       Support for the fox board
  * @{
  *
  * @file
- * @brief       Board specific definitions for the fox board.
+ * @brief       Board specific definitions for the fox board
  *
  * @author      Alaeddine Weslati <alaeddine.weslati@inria.fr>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/boards/frdm-k22f/include/board.h
+++ b/boards/frdm-k22f/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_frdm-k22f NXP FRDM-K22F Board
  * @ingroup     boards
- * @brief       Board specific implementations for the FRDM-K22F
+ * @brief       Support for the NXP FRDM-K22F
  * @{
  *
  * @file

--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_frdm-k64f Freescale FRDM-K64F Board
+ * @defgroup    boards_frdm-k64f NXP FRDM-K64F Board
  * @ingroup     boards
- * @brief       Board specific implementations for the FRDM-K64F
+ * @brief       Support for the NXP FRDM-K64F
  * @{
  *
  * @file

--- a/boards/iotlab-a8-m3/include/board.h
+++ b/boards/iotlab-a8-m3/include/board.h
@@ -9,11 +9,11 @@
 /**
  * @defgroup    boards_iotlab-m3 IoT-LAB M3 open node
  * @ingroup     boards
- * @brief       Board specific files for the iotlab-m3 board.
+ * @brief       Support for the iotlab-m3 board
  * @{
  *
  * @file
- * @brief       Board specific definitions for the iotlab-m3 board.
+ * @brief       Board specific definitions for the iotlab-m3 board
  *
  */
 

--- a/boards/iotlab-m3/include/board.h
+++ b/boards/iotlab-m3/include/board.h
@@ -9,11 +9,11 @@
 /**
  * @defgroup    boards_iotlab-m3 IoT-LAB M3 open node
  * @ingroup     boards
- * @brief       Board specific files for the iotlab-m3 board.
+ * @brief       Support for the iotlab-m3 board
  * @{
  *
  * @file
- * @brief       Board specific definitions for the iotlab-m3 board.
+ * @brief       Board specific definitions for the iotlab-m3 board
  *
  * @author      Alaeddine Weslati <alaeddine.weslati@inria.fr>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>

--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -9,11 +9,11 @@
 /**
  * @defgroup    boards_limifrog-v1 LimiFrog Version 1
  * @ingroup     boards
- * @brief       Board specific files for the limifrog-v1 board.
+ * @brief       Support for the limifrog-v1 board
  * @{
  *
  * @file
- * @brief       Board specific definitions for the limifrog-v1  board.
+ * @brief       Board specific definitions for the limifrog-v1 board
  *
  * @author      Katja Kirstein <katja.kirstein@haw-hamburg.de>
  */

--- a/boards/maple-mini/include/board.h
+++ b/boards/maple-mini/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_maple-mini maple-mini
  * @ingroup     boards
- * @brief       Board specific files for the maple-mini board
+ * @brief       Support for the maple-mini board
  * @{
  *
  * @file

--- a/boards/microbit/include/board.h
+++ b/boards/microbit/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_microbit BBC micro:bit
  * @ingroup     boards
- * @brief       Board specific files for the BBC micro:bit
+ * @brief       Support for the BBC micro:bit
  * @{
  *
  * @file

--- a/boards/mips-malta/include/board.h
+++ b/boards/mips-malta/include/board.h
@@ -11,7 +11,7 @@
 /**
  * @defgroup    boards_mips-malta MIPS MALTA
  * @ingroup     boards
- * @brief       Board specific files for the MIPS Malta FPGA system
+ * @brief       Support for the MIPS Malta FPGA system
  * @{
  *
  * @file

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_msbiot MSB-IoT
  * @ingroup     boards
- * @brief       Board specific files for the MSB-IoT board
+ * @brief       Support for the MSB-IoT board
  * @{
  *
  * @file

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_mulle Eistec Mulle
  * @ingroup     boards
- * @brief       Board specific files for Eistec Mulle IoT boards
+ * @brief       Support for Eistec Mulle IoT boards
  * @{
  *
  * @file

--- a/boards/nrf51dongle/include/board.h
+++ b/boards/nrf51dongle/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nrf51dongle nRF51 Dongle
  * @ingroup     boards
- * @brief       Board specific files for the Nordic nRF51 Dongle
+ * @brief       Support for the Nordic nRF51 Dongle
  * @{
  *
  * @file

--- a/boards/nrf52840dk/include/board.h
+++ b/boards/nrf52840dk/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nrf52840dk nRF52840 DK
  * @ingroup     boards
- * @brief       Board specific configuration for the nRF52840 DK
+ * @brief       Support for the nRF52840 DK
  * @{
  *
  * @file

--- a/boards/nrf52dk/include/board.h
+++ b/boards/nrf52dk/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nrf52dk nRF52 DK
  * @ingroup     boards
- * @brief       Board specific configuration for the nRF52 DK
+ * @brief       Support for the nRF52 DK
  * @{
  *
  * @file

--- a/boards/nrf6310/include/board.h
+++ b/boards/nrf6310/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nrf6310 NRF6310 (Nordic NRF Hardware Development Kit)
  * @ingroup     boards
- * @brief       Board specific files for the nRF51 boards nrf6310 or MOMMOSOFT BLE DEVKIT.N
+ * @brief       Support for the nRF51 boards: nrf6310 or MOMMOSOFT BLE DEVKIT.N
  * @{
  *
  * @file

--- a/boards/nucleo-f030/include/board.h
+++ b/boards/nucleo-f030/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-f030 Nucleo-F030
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f030 board
+ * @brief       Support for the nucleo-f030 board
  * @{
  *
  * @file

--- a/boards/nucleo-f070/include/board.h
+++ b/boards/nucleo-f070/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo-f072 Nucleo-F072
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f072 board
+ * @brief       Support for the nucleo-f072 board
  * @{
  *
  * @file

--- a/boards/nucleo-f072/include/board.h
+++ b/boards/nucleo-f072/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-f072 Nucleo-F072
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f072 board
+ * @brief       Support for the nucleo-f072 board
  * @{
  *
  * @file

--- a/boards/nucleo-f091/include/board.h
+++ b/boards/nucleo-f091/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-f091 Nucleo-F091
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f091 board
+ * @brief       Support for the nucleo-f091 board
  * @{
  *
  * @file

--- a/boards/nucleo-f103/include/board.h
+++ b/boards/nucleo-f103/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-f103 Nucleo-F103
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f103 board
+ * @brief       Support for the nucleo-f103 board
  * @{
  *
  * @file

--- a/boards/nucleo-f302/include/board.h
+++ b/boards/nucleo-f302/include/board.h
@@ -11,7 +11,7 @@
 /**
  * @defgroup    boards_nucleo-f302 Nucleo-F302
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f302 board
+ * @brief       Support for the nucleo-f302 board
  * @{
  *
  * @file

--- a/boards/nucleo-f303/include/board.h
+++ b/boards/nucleo-f303/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo-f303 Nucleo-F303
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f303 board
+ * @brief       Support for the nucleo-f303 board
  * @{
  *
  * @file

--- a/boards/nucleo-f334/include/board.h
+++ b/boards/nucleo-f334/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-f334 Nucleo-F334
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f334 board
+ * @brief       Support for the nucleo-f334 board
  * @{
  *
  * @file

--- a/boards/nucleo-f401/include/board.h
+++ b/boards/nucleo-f401/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-f401 Nucleo-F401
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f401 board
+ * @brief       Support for the nucleo-f401 board
  * @{
  *
  * @file

--- a/boards/nucleo-f410/include/board.h
+++ b/boards/nucleo-f410/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-f410 Nucleo-F410
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f410 board
+ * @brief       Support for the nucleo-f410 board
  * @{
  *
  * @file

--- a/boards/nucleo-f411/include/board.h
+++ b/boards/nucleo-f411/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-f411 Nucleo-F411
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f411 board
+ * @brief       Support for the nucleo-f411 board
  * @{
  *
  * @file

--- a/boards/nucleo-f446/include/board.h
+++ b/boards/nucleo-f446/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-f446 Nucleo-F446
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-f446 board
+ * @brief       Support for the nucleo-f446 board
  * @{
  *
  * @file

--- a/boards/nucleo-l053/include/board.h
+++ b/boards/nucleo-l053/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo-l053 Nucleo-L053
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-l053 board
+ * @brief       Support for the nucleo-l053 board
  * @{
  *
  * @file

--- a/boards/nucleo-l073/include/board.h
+++ b/boards/nucleo-l073/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo-l073 Nucleo-L073
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-l073 board
+ * @brief       Support for the nucleo-l073 board
  * @{
  *
  * @file

--- a/boards/nucleo-l152/include/board.h
+++ b/boards/nucleo-l152/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo-l152 Nucleo-L152
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-l152 board.
+ * @brief       Support for the nucleo-l152 board.
  * @{
  *
  * @file

--- a/boards/nucleo-l476/include/board.h
+++ b/boards/nucleo-l476/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo-l476 Nucleo-L476
  * @ingroup     boards_nucleo
- * @brief       Board specific files for the nucleo-l476 board
+ * @brief       Support for the nucleo-l476 board
  * @{
  *
  * @file

--- a/boards/nucleo144-f207/include/board.h
+++ b/boards/nucleo144-f207/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo144-f207 Nucleo144-F207
  * @ingroup     boards_nucleo144
- * @brief       Board specific files for the nucleo144-f207 board
+ * @brief       Support for the nucleo144-f207 board
  * @{
  *
  * @file

--- a/boards/nucleo144-f303/include/board.h
+++ b/boards/nucleo144-f303/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo144-f303 Nucleo144-F303
  * @ingroup     boards_nucleo144
- * @brief       Board specific files for the nucleo144-f303 board
+ * @brief       Support for the nucleo144-f303 board
  * @{
  *
  * @file

--- a/boards/nucleo144-f412/include/board.h
+++ b/boards/nucleo144-f412/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo144-f412 Nucleo144-F412
  * @ingroup     boards_nucleo144
- * @brief       Board specific files for the STM Nucleo144-f412 board
+ * @brief       Support for the Nucleo144-f412 board
  * @{
  *
  * @file

--- a/boards/nucleo144-f413/include/board.h
+++ b/boards/nucleo144-f413/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo144-f413 Nucleo144-F413
  * @ingroup     boards_nucleo144
- * @brief       Board specific files for the STM Nucleo144-f413 board
+ * @brief       Support for the Nucleo144-f413 board
  * @{
  *
  * @file

--- a/boards/nucleo144-f429/include/board.h
+++ b/boards/nucleo144-f429/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo144-f429 Nucleo144-F429
  * @ingroup     boards_nucleo144
- * @brief       Board specific files for the nucleo144-f429 board
+ * @brief       Support for the nucleo144-f429 board
  * @{
  *
  * @file

--- a/boards/nucleo144-f446/include/board.h
+++ b/boards/nucleo144-f446/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo144-f446 Nucleo144-F446
  * @ingroup     boards_nucleo144
- * @brief       Board specific files for the nucleo144-f446 board
+ * @brief       Support for the nucleo144-f446 board
  * @{
  *
  * @file

--- a/boards/nucleo144-f722/include/board.h
+++ b/boards/nucleo144-f722/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo144-f722 Nucleo144-F722
  * @ingroup     boards_nucleo144
- * @brief       Board specific files for the nucleo144-f722 board
+ * @brief       Support for the nucleo144-f722 board
  * @{
  *
  * @file

--- a/boards/nucleo144-f746/include/board.h
+++ b/boards/nucleo144-f746/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo144-f746 Nucleo144-F746
  * @ingroup     boards_nucleo144
- * @brief       Board specific files for the nucleo144-f746 board
+ * @brief       Support for the nucleo144-f746 board
  * @{
  *
  * @file

--- a/boards/nucleo144-f767/include/board.h
+++ b/boards/nucleo144-f767/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo144-f767 Nucleo144-F767
  * @ingroup     boards_nucleo144
- * @brief       Board specific files for the nucleo144-f767 board
+ * @brief       Support for the nucleo144-f767 board
  * @{
  *
  * @file

--- a/boards/nucleo32-f031/include/board.h
+++ b/boards/nucleo32-f031/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo32-f031 Nucleo32-F031
  * @ingroup     boards_nucleo32
- * @brief       Board specific files for the nucleo32-f031 board
+ * @brief       Support for the nucleo32-f031 board
  * @{
  *
  * @file

--- a/boards/nucleo32-f042/include/board.h
+++ b/boards/nucleo32-f042/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo32-f042 Nucleo32-F042
  * @ingroup     boards_nucleo32
- * @brief       Board specific files for the STM Nucleo32-f042 board
+ * @brief       Support for the Nucleo32-f042 board
  * @{
  *
  * @file

--- a/boards/nucleo32-f303/include/board.h
+++ b/boards/nucleo32-f303/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nucleo32-f303 Nucleo32-F303
  * @ingroup     boards_nucleo32
- * @brief       Board specific files for the nucleo32-f303 board
+ * @brief       Support for the nucleo32-f303 board
  * @{
  *
  * @file

--- a/boards/nucleo32-l031/include/board.h
+++ b/boards/nucleo32-l031/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo32-l031 Nucleo32-L031
  * @ingroup     boards_nucleo32
- * @brief       Board specific files for the nucleo32-l031 board
+ * @brief       Support for the nucleo32-l031 board
  * @{
  *
  * @file

--- a/boards/nucleo32-l432/include/board.h
+++ b/boards/nucleo32-l432/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_nucleo32-l432 Nucleo32-L432
  * @ingroup     boards_nucleo32
- * @brief       Board specific files for the nucleo32-l432 board
+ * @brief       Support for the nucleo32-l432 board
  * @{
  *
  * @file

--- a/boards/nz32-sc151/include/board.h
+++ b/boards/nz32-sc151/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_nz32-sc151 NZ32-SC151
  * @ingroup     boards
- * @brief       Board specific files for the nz32-sc151 board.
+ * @brief       Support for the Modtronix nz32-sc151 board.
  * @{
  *
  * @file

--- a/boards/opencm904/include/board.h
+++ b/boards/opencm904/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_opencm904 OpenCM9.04
  * @ingroup     boards
- * @brief       Board specific files for the OpenCM9.04 board
+ * @brief       Support for the OpenCM9.04 board
  * @{
  *
  * @file

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -10,7 +10,7 @@
 /**
  * @defgroup    boards_pba-d-01-kw2x phyWAVE-KW22 Board
  * @ingroup     boards
- * @brief       Board specific implementations for the phyWAVE evaluation board
+ * @brief       Support for the phyWAVE evaluation board
  * @{
  *
  * @file

--- a/boards/pic32-clicker/include/board.h
+++ b/boards/pic32-clicker/include/board.h
@@ -11,7 +11,7 @@
 /**
  * @defgroup    boards_pic32-clicker MikroE PIC32 Clicker
  * @ingroup     boards
- * @brief       board configuration for the MikroE PIC32 Clicker
+ * @brief       Support for the MikroE PIC32 Clicker
  * @details
  * see:
  * http://www.mikroe.com/pic32/pic32mx-clicker/

--- a/boards/pic32-wifire/include/board.h
+++ b/boards/pic32-wifire/include/board.h
@@ -11,7 +11,7 @@
 /**
  * @defgroup    boards_pic32-wifire Digilent PIC32 WiFire
  * @ingroup     boards
- * @brief       board configuration for the Digilent PIC32 WiFire
+ * @brief       Support for the Digilent PIC32 WiFire
  * @details
  * See:
  * http://store.digilentinc.com/chipkit-wi-fire-wifi-enabled-mz-microcontroller-board/

--- a/boards/ruuvitag/include/board.h
+++ b/boards/ruuvitag/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_ruuvitag RuuviTag
  * @ingroup     boards
- * @brief       Board specific configuration for the RuuviTag board
+ * @brief       Support for the RuuviTag board
  * @{
  *
  * @file

--- a/boards/sodaq-explorer/include/board.h
+++ b/boards/sodaq-explorer/include/board.h
@@ -8,7 +8,7 @@
 
 /**
  * @ingroup     boards_sodaq-explorer
- * @brief       Board specific definitions for the SODAQ ExpLoRer board
+ * @brief       Support for the SODAQ ExpLoRer board
  * @{
  *
  * @file

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_spark-core Spark-Core
  * @ingroup     boards
- * @brief       Board specific files for the spark-core board.
+ * @brief       Support for the spark-core board
  * @{
  *
  * @file

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_stm32f3discovery STM32F3Discovery
  * @ingroup     boards
- * @brief       Board specific files for the STM32F3Discovery board
+ * @brief       Support for the STM32F3Discovery board
  * @{
  *
  * @file

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_stm32f4discovery STM32F4Discovery
  * @ingroup     boards
- * @brief       Board specific files for the STM32F4Discovery board
+ * @brief       Support for the STM32F4Discovery board
  * @{
  *
  * @file

--- a/boards/stm32f7discovery/include/board.h
+++ b/boards/stm32f7discovery/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_stm32f7discovery stm32f769 Discovery board
  * @ingroup     boards
- * @brief       Board specific files for the stm32f769 Discovery board
+ * @brief       Support for the stm32f769 Discovery board
  * @{
  *
  * @file

--- a/boards/teensy31/include/board.h
+++ b/boards/teensy31/include/board.h
@@ -8,7 +8,6 @@
 
 /**
  * @ingroup     boards_teensy31
- * @brief       Board specific files for Teensy3.1 & 3.2
  * @{
  *
  * @file

--- a/boards/thingy52/include/board.h
+++ b/boards/thingy52/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_thingy52 Nordic Thingy:52
  * @ingroup     boards
- * @brief       Board specific configuration for the Nordic Thingy:52 board
+ * @brief       Support for the Nordic Thingy:52 board
  * @{
  *
  * @file

--- a/boards/waspmote-pro/include/board.h
+++ b/boards/waspmote-pro/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_waspmote-pro Waspmote PRO v1.2
  * @ingroup     boards
- * @brief       Board specific files for the Waspmote PRO v1.2 board.
+ * @brief       Support for the Waspmote PRO v1.2 board.
  * @{
  *
  * @file

--- a/boards/yunjia-nrf51822/include/board.h
+++ b/boards/yunjia-nrf51822/include/board.h
@@ -9,7 +9,7 @@
 /**
  * @defgroup    boards_yunjia-nrf51822 Yunjia NRF51822
  * @ingroup     boards
- * @brief       Board specific files for the Yunjia NRF51822 board
+ * @brief       Support for the Yunjia NRF51822 board
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR makes all doxygen brief description of boards consistent. In fact, the brief statement is most of the time written in `board.h` but it refers to the board group name.

See http://doc.riot-os.org/group__boards.html
Some boards brief description is `Support for <board>` which is correct and others have `Board specific files for the <board>` which is a bit misleading.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->