### PR TITLE
drivers/tja1042: move to drivers_can group

### DIFF
--- a/drivers/include/tja1042.h
+++ b/drivers/include/tja1042.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    drivers_tja1042 TJA1042
- * @ingroup     drivers
+ * @ingroup     drivers_can
  * @ingroup     trx_can
  * @brief       tja1042 High Speed CAN transceiver driver
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR moves the tja1042 doxygen group to the `drivers_can` group instead of the toplevel `drivers`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->