### PR TITLE
cpu/native/socket_zep: fix doxygen grouping

### DIFF
--- a/cpu/native/include/socket_zep.h
+++ b/cpu/native/include/socket_zep.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    netdev_socket_zep  Socket-based ZEP
- * @ingroup     netdev
+ * @defgroup    drivers_socket_zep  Socket-based ZEP
+ * @ingroup     drivers_netdev
  * @brief       UDP socket-based IEEE 802.15.4 device over ZEP
  * @{
  *

--- a/cpu/native/include/socket_zep_params.h
+++ b/cpu/native/include/socket_zep_params.h
@@ -7,11 +7,11 @@
  */
 
 /**
- * @ingroup netdev_socket_zep
+ * @ingroup drivers_socket_zep
  * @{
  *
  * @file
- * @brief   Configuration parameters for the @ref netdev_socket_zep driver
+ * @brief   Configuration parameters for the @ref drivers_socket_zep driver
  *
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The socket ZEP module is appearing at the top-level module level (see [here](http://doc.riot-os.org/group__netdev__socket__zep.html)).

This PR moves it to the `drivers_netdev` module and rename the group name to `drivers_socket_zep`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->