### PR TITLE
boards: fix CLOCK_PLL_PREDIV on stm32f1-based boards

### DIFF
--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -26,37 +26,32 @@ extern "C" {
 #endif
 
 /**
- * @name    Clock system configuration
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
  * @{
- **/
-/* high speed clock configuration:
- * 0 := use internal HSI oscillator (always 8MHz)
- * HSE frequency value := use external HSE oscillator with given freq [in Hz]
- *                        must be 4000000 <= value <= 16000000 */
-#define CLOCK_HSE           (16000000U)
-/* low speed clock configuration:
- * 0 := use internal LSI oscillator (~40kHz)
- * 1 := use extern LSE oscillator, always 32.768kHz */
-#define CLOCK_LSE           (1)
-/* targeted system clock speed [in Hz], must be <= 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* PLL configuration, set both values to zero to disable PLL usage. The values
- * must be set to satisfy the following equation:
- * CORECLOCK := CLOCK_SOURCE / PLL_DIV * PLL_MUL
- * with
- * 1 <= CLOCK_PLL_DIV <= 2
- * 2 <= CLOCK_PLL_MUL <= 17 */
-#define CLOCK_PLL_DIV       (2)
-#define CLOCK_PLL_MUL       (9)
-/* AHB and APBx bus clock configuration, keep in mind the following constraints:
- * ABP1 <= 36MHz
  */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 72MHz */
+#define CLOCK_CORECLOCK     (72000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (16000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (1U)
+/* peripheral clock setup */
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
 #define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
 #define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+
+/* PLL factors */
+#define CLOCK_PLL_PREDIV     (2)
+#define CLOCK_PLL_MUL        (9)
 /** @} */
 
 /**

--- a/boards/maple-mini/include/periph_conf.h
+++ b/boards/maple-mini/include/periph_conf.h
@@ -26,37 +26,32 @@ extern "C" {
 #endif
 
 /**
- * @name    Clock system configuration
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
  * @{
- **/
-/* high speed clock configuration:
- * 0 := use internal HSI oscillator (always 8MHz)
- * HSE frequency value := use external HSE oscillator with given freq [in Hz]
- *                        must be 4000000 <= value <= 16000000 */
-#define CLOCK_HSE           (8000000U)
-/* low speed clock configuration:
- * 0 := use internal LSI oscillator (~40kHz)
- * 1 := use extern LSE oscillator, always 32.768kHz */
-#define CLOCK_LSE           (0)
-/* targeted system clock speed [in Hz], must be <= 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* PLL configuration, set both values to zero to disable PLL usage. The values
- * must be set to satisfy the following equation:
- * CORECLOCK := CLOCK_SOURCE / PLL_DIV * PLL_MUL
- * with
- * 1 <= CLOCK_PLL_DIV <= 2
- * 2 <= CLOCK_PLL_MUL <= 17 */
-#define CLOCK_PLL_DIV       (1)
-#define CLOCK_PLL_MUL       (9)
-/* AHB and APBx bus clock configuration, keep in mind the following constraints:
- * ABP1 <= 36MHz
  */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 72MHz */
+#define CLOCK_CORECLOCK     (72000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (0U)
+/* peripheral clock setup */
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
 #define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
 #define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+
+/* PLL factors */
+#define CLOCK_PLL_PREDIV     (1)
+#define CLOCK_PLL_MUL        (9)
 /** @} */
 
 /**

--- a/boards/opencm904/include/periph_conf.h
+++ b/boards/opencm904/include/periph_conf.h
@@ -26,37 +26,32 @@ extern "C" {
 #endif
 
 /**
- * @name    Clock system configuration
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
  * @{
- **/
-/* high speed clock configuration:
- * 0 := use internal HSI oscillator (always 8MHz)
- * HSE frequency value := use external HSE oscillator with given freq [in Hz]
- *                        must be 4000000 <= value <= 16000000 */
-#define CLOCK_HSE           (8000000U)
-/* low speed clock configuration:
- * 0 := use internal LSI oscillator (~40kHz)
- * 1 := use extern LSE oscillator, always 32.768kHz */
-#define CLOCK_LSE           (0)
-/* targeted system clock speed [in Hz], must be <= 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* PLL configuration, set both values to zero to disable PLL usage. The values
- * must be set to satisfy the following equation:
- * CORECLOCK := CLOCK_SOURCE / PLL_DIV * PLL_MUL
- * with
- * 1 <= CLOCK_PLL_DIV <= 2
- * 2 <= CLOCK_PLL_MUL <= 17 */
-#define CLOCK_PLL_DIV       (1)
-#define CLOCK_PLL_MUL       (9)
-/* AHB and APBx bus clock configuration, keep in mind the following constraints:
- * ABP1 <= 36MHz
  */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 72MHz */
+#define CLOCK_CORECLOCK     (72000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (0U)
+/* peripheral clock setup */
 #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
 #define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
 #define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+
+/* PLL factors */
+#define CLOCK_PLL_PREDIV     (1)
+#define CLOCK_PLL_MUL        (9)
 /** @} */
 
 /**

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -25,39 +25,34 @@
 extern "C" {
 #endif
 
-/**
- * @name    Clock system configuration
- * @{
- **/
-/* high speed clock configuration:
- * 0 := use internal HSI oscillator (always 8MHz)
- * HSE frequency value := use external HSE oscillator with given freq [in Hz]
- *                        must be 4000000 <= value <= 16000000 */
-#define CLOCK_HSE           (8000000U)
-/* low speed clock configuration:
- * 0 := use internal LSI oscillator (~40kHz)
- * 1 := use extern LSE oscillator, always 32.768kHz */
-#define CLOCK_LSE           (0)
-/* targeted system clock speed [in Hz], must be <= 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* PLL configuration, set both values to zero to disable PLL usage. The values
- * must be set to satisfy the following equation:
- * CORECLOCK := CLOCK_SOURCE / PLL_DIV * PLL_MUL
- * with
- * 1 <= CLOCK_PLL_DIV <= 2
- * 2 <= CLOCK_PLL_MUL <= 17 */
-#define CLOCK_PLL_DIV       (1)
-#define CLOCK_PLL_MUL       (9)
-/* AHB and APBx bus clock configuration, keep in mind the following constraints:
- * ABP1 <= 36MHz
- */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-/** @} */
+ /**
+  * @name    Clock settings
+  *
+  * @note    This is auto-generated from
+  *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+  * @{
+  */
+ /* give the target core clock (HCLK) frequency [in Hz],
+  * maximum: 72MHz */
+ #define CLOCK_CORECLOCK     (72000000U)
+ /* 0: no external high speed crystal available
+  * else: actual crystal frequency [in Hz] */
+ #define CLOCK_HSE           (8000000U)
+ /* 0: no external low speed crystal available,
+  * 1: external crystal available (always 32.768kHz) */
+ #define CLOCK_LSE           (0U)
+ /* peripheral clock setup */
+ #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+ #define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+ #define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
+ #define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+ #define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
+ #define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+
+ /* PLL factors */
+ #define CLOCK_PLL_PREDIV     (1)
+ #define CLOCK_PLL_MUL        (9)
+ /** @} */
 
 /**
  * @name   Timer configuration

--- a/cpu/stm32_common/stmclk.c
+++ b/cpu/stm32_common/stmclk.c
@@ -225,6 +225,8 @@ void stmclk_init_sysclk(void)
     RCC->CFGR |= RCC_CFGR_PLLXTPRE; /* PREDIV == 2 */
 #elif CLOCK_PLL_PREDIV > 2
     RCC->CFGR2 = PLL_PREDIV;        /* PREDIV > 2 */
+#elif CLOCK_PLL_PREDIV == 0
+#error "CLOCK_PLL_PREDIV invalid"
 #endif
 #endif
     RCC->CR |= (RCC_CR_PLLON);


### PR DESCRIPTION
### Contribution description

I discovered by accident that some stm32f1-based boards had not been updated regarding their clock configuration. Except the fox, all other should have still worked correctly.

The `CLOCK_PLL_PREDIV` was not defined but the old  `CLOCK_PLL_DIV` was still there.
I added a check in `stmclk.c` to check it's defined correctly and updated the boards config with the right values.

### Issues/PRs references

#7500