### PR TITLE
mtd: refactor mtd struct for better erase support

### DIFF
--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -52,8 +52,9 @@ static mtd_spi_nor_t mulle_nor_dev = {
     .base = {
         .driver = &mtd_spi_nor_driver,
         .page_size = 256,
-        .pages_per_sector = 256,
+        .sector_size = 65536,
         .sector_count = 32,
+        .min_erase_size = 65536,
     },
     .opcode = &mtd_spi_nor_opcode_default,
     .spi = MULLE_NOR_SPI_DEV,

--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -55,7 +55,8 @@ static mtd_native_dev_t mtd0_dev = {
     .dev = {
         .driver = &native_flash_driver,
         .sector_count = MTD_NATIVE_SECTOR_NUM,
-        .pages_per_sector = MTD_NATIVE_SECTOR_SIZE / MTD_NATIVE_PAGE_SIZE,
+        .sector_size = MTD_NATIVE_SECTOR_SIZE,
+        .min_erase_size = MTD_NATIVE_SECTOR_SIZE,
         .page_size = MTD_NATIVE_PAGE_SIZE,
     },
     .fname = MTD_NATIVE_FILENAME,

--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -42,8 +42,8 @@ static int _init(mtd_dev_t *dev)
         if (!f) {
             return -EIO;
         }
-        size_t size = dev->sector_count * dev->pages_per_sector * dev->page_size;
-        for (size_t i = 0; i < size; i++) {
+        size_t mtd_size = dev->sector_count * dev->sector_size;
+        for (size_t i = 0; i < mtd_size; i++) {
             real_fputc(0xff, f);
         }
     }
@@ -56,7 +56,7 @@ static int _init(mtd_dev_t *dev)
 static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
 {
     mtd_native_dev_t *_dev = (mtd_native_dev_t*) dev;
-    size_t mtd_size = dev->sector_count * dev->pages_per_sector * dev->page_size;
+    size_t mtd_size = dev->sector_count * dev->sector_size;
 
     DEBUG("mtd_native: read from page %" PRIu32 " count %" PRIu32 "\n", addr, size);
 
@@ -78,7 +78,7 @@ static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
 static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
 {
     mtd_native_dev_t *_dev = (mtd_native_dev_t*) dev;
-    size_t mtd_size = dev->sector_count * dev->pages_per_sector * dev->page_size;
+    size_t mtd_size = dev->sector_count * dev->sector_size;
 
     DEBUG("mtd_native: write from 0x%" PRIx32 " count %" PRIu32 "\n", addr, size);
 
@@ -110,15 +110,14 @@ static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size
 static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
 {
     mtd_native_dev_t *_dev = (mtd_native_dev_t*) dev;
-    size_t mtd_size = dev->sector_count * dev->pages_per_sector * dev->page_size;
-    size_t sector_size = dev->pages_per_sector * dev->page_size;
+    size_t mtd_size = dev->sector_count * dev->sector_size;
 
     DEBUG("mtd_native: erase from sector %" PRIu32 " count %" PRIu32 "\n", addr, size);
 
     if (addr + size > mtd_size) {
         return -EOVERFLOW;
     }
-    if (((addr % sector_size) != 0) || ((size % sector_size) != 0)) {
+    if (((addr % dev->min_erase_size) != 0) || ((size % dev->min_erase_size) != 0)) {
         return -EOVERFLOW;
     }
 

--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -79,14 +79,16 @@ static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size
 {
     mtd_native_dev_t *_dev = (mtd_native_dev_t*) dev;
     size_t mtd_size = dev->sector_count * dev->pages_per_sector * dev->page_size;
-    size_t sector_size = dev->pages_per_sector * dev->page_size;
 
-    DEBUG("mtd_native: write from page %" PRIu32 " count %" PRIu32 "\n", addr, size);
+    DEBUG("mtd_native: write from 0x%" PRIx32 " count %" PRIu32 "\n", addr, size);
 
+    if (size > dev->page_size) {
+        return -EOVERFLOW;
+    }
     if (addr + size > mtd_size) {
         return -EOVERFLOW;
     }
-    if (((addr % sector_size) + size) > sector_size) {
+    if (((addr % dev->page_size) + size) > dev->page_size) {
         return -EOVERFLOW;
     }
 

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -58,7 +58,8 @@ typedef struct mtd_desc mtd_desc_t;
 typedef struct {
     const mtd_desc_t *driver;  /**< MTD driver */
     uint32_t sector_count;     /**< Number of sector in the MTD */
-    uint32_t pages_per_sector; /**< Number of pages by sector in the MTD */
+    uint32_t sector_size;      /**< Size of the sectors in the MTD */
+    uint32_t min_erase_size;   /**< Minimum size which can be erased */
     uint32_t page_size;        /**< Size of the pages in the MTD */
 } mtd_dev_t;
 

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -42,6 +42,7 @@ extern "C"
 typedef struct {
     uint8_t rdid;            /**< Read identification (JEDEC ID) */
     uint8_t wren;            /**< Write enable */
+    uint8_t wrdi;            /**< Write disable */
     uint8_t rdsr;            /**< Read status register */
     uint8_t wrsr;            /**< Write status register */
     uint8_t read;            /**< Read data bytes, 3 byte address */
@@ -109,6 +110,12 @@ typedef struct {
      * Computed by mtd_spi_nor_init, no need to touch outside the driver.
      */
     uint32_t sec_addr_mask;
+    /**
+     * @brief   bitmask corresponding to the minimum erasable sector address
+     *
+     * Computed by mtd_spi_nor_init, no need to touch outside the driver.
+     */
+    uint32_t min_erase_addr_mask;
     uint8_t addr_width;      /**< Number of bytes in addresses, usually 3 for small devices */
     /**
      * @brief   number of right shifts to get the address to the start of the page
@@ -122,6 +129,12 @@ typedef struct {
      * Computed by mtd_spi_nor_init, no need to touch outside the driver.
      */
     uint8_t sec_addr_shift;
+    /**
+     * @brief   number of right shifts to get the address to the start of the erasable sector
+     *
+     * Computed by mtd_spi_nor_init, no need to touch outside the driver.
+     */
+    uint8_t min_erase_addr_shift;
 } mtd_spi_nor_t;
 
 /**

--- a/drivers/mtd/mtd-vfs.c
+++ b/drivers/mtd/mtd-vfs.c
@@ -54,7 +54,7 @@ static int mtd_vfs_fstat(vfs_file_t *filp, struct stat *buf)
         return -EFAULT;
     }
     buf->st_nlink = 1;
-    buf->st_size = mtd->page_size * mtd->sector_count * mtd->pages_per_sector;
+    buf->st_size = mtd->sector_count * mtd->sector_size;
     return 0;
 }
 
@@ -71,7 +71,7 @@ static off_t mtd_vfs_lseek(vfs_file_t *filp, off_t off, int whence)
             off += filp->pos;
             break;
         case SEEK_END:
-            off += mtd->page_size * mtd->sector_count * mtd->pages_per_sector;
+            off += mtd->sector_count * mtd->sector_size;
             break;
         default:
             return -EINVAL;
@@ -91,7 +91,7 @@ static ssize_t mtd_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
     if (mtd == NULL) {
         return -EFAULT;
     }
-    uint32_t size = mtd->page_size * mtd->sector_count * mtd->pages_per_sector;
+    uint32_t size = mtd->sector_count * mtd->sector_size;
     uint32_t src = filp->pos;
     if (src >= size) {
         return 0;
@@ -114,7 +114,7 @@ static ssize_t mtd_vfs_write(vfs_file_t *filp, const void *src, size_t nbytes)
     if (mtd == NULL) {
         return -EFAULT;
     }
-    uint32_t size = mtd->page_size * mtd->sector_count * mtd->pages_per_sector;
+    uint32_t size = mtd->sector_count * mtd->sector_size;
     uint32_t dest = filp->pos;
     if (dest >= size) {
         /* attempt to write outside the device memory */

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -311,12 +311,13 @@ static int mtd_spi_nor_init(mtd_dev_t *mtd)
 
     DEBUG("mtd_spi_nor_init: %" PRIu32 " bytes "
         "(%" PRIu32 " sectors, %" PRIu32 " bytes/sector, "
-        "%" PRIu32 " pages, "
-        "%" PRIu32 " pages/sector, %" PRIu32 " bytes/page)\n",
-        mtd->pages_per_sector * mtd->sector_count * mtd->page_size,
-        mtd->sector_count, mtd->pages_per_sector * mtd->page_size,
-        mtd->pages_per_sector * mtd->sector_count,
-        mtd->pages_per_sector, mtd->page_size);
+        "%" PRIu32 " pages, %" PRIu32 " bytes/page,"
+        "Min erase size %" PRIu32 ")\n",
+        mtd->sector_count * mtd->sector_size,
+        mtd->sector_count, mtd->sector_size,
+        (mtd->sector_count * mtd->sector_size) / mtd->page_size,
+        mtd->page_size,
+        mtd->min_erase_size);
     DEBUG("mtd_spi_nor_init: Using %u byte addresses\n", dev->addr_width);
 
     if (dev->addr_width == 0) {
@@ -357,7 +358,7 @@ static int mtd_spi_nor_init(mtd_dev_t *mtd)
 
     mask = 0;
     shift = 0;
-    uint32_t sector_size = mtd->page_size * mtd->pages_per_sector;
+    uint32_t sector_size = mtd->sector_size;
     if ((sector_size & (sector_size - 1)) == 0) {
         while ((sector_size >> shift) > 1) {
             ++shift;
@@ -366,6 +367,19 @@ static int mtd_spi_nor_init(mtd_dev_t *mtd)
     }
     dev->sec_addr_mask = mask;
     dev->sec_addr_shift = shift;
+
+    if (dev->flag & SPI_NOR_F_SECT_4K) {
+        dev->min_erase_addr_mask = UINT32_MAX << 12;
+        dev->min_erase_addr_shift = 12;
+    }
+    else if (dev->flag & SPI_NOR_F_SECT_32K) {
+        dev->min_erase_addr_mask = UINT32_MAX << 15;
+        dev->min_erase_addr_shift = 15;
+    }
+    else {
+        dev->min_erase_addr_mask = dev->sec_addr_mask;
+        dev->min_erase_addr_shift = dev->sec_addr_shift;
+    }
 
     DEBUG("mtd_spi_nor_init: sec_addr_mask = 0x%08" PRIx32 ", sec_addr_shift = %u\n",
         mask, (unsigned int)shift);
@@ -378,8 +392,9 @@ static int mtd_spi_nor_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t 
     DEBUG("mtd_spi_nor_read: %p, %p, 0x%" PRIx32 ", 0x%" PRIx32 "\n",
         (void *)mtd, dest, addr, size);
     const mtd_spi_nor_t *dev = (mtd_spi_nor_t *)mtd;
-    size_t chipsize = mtd->page_size * mtd->pages_per_sector * mtd->sector_count;
+    size_t chipsize = mtd->sector_size * mtd->sector_count;
     if (addr > chipsize) {
+        DEBUG("mtd_spi_nor_read: ERR: reading outside memory!\n");
         return -EOVERFLOW;
     }
     if (size > mtd->page_size) {
@@ -404,7 +419,7 @@ static int mtd_spi_nor_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t 
 
 static int mtd_spi_nor_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t size)
 {
-    uint32_t total_size = mtd->page_size * mtd->pages_per_sector * mtd->sector_count;
+    uint32_t total_size = mtd->sector_size * mtd->sector_count;
     DEBUG("mtd_spi_nor_write: %p, %p, 0x%" PRIx32 ", 0x%" PRIx32 "\n",
         (void *)mtd, src, addr, size);
     if (size == 0) {
@@ -421,6 +436,7 @@ static int mtd_spi_nor_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uin
         return -EOVERFLOW;
     }
     if (addr + size > total_size) {
+        DEBUG("mtd_spi_nor_write: ERR: writing outside memory!\n");
         return -EOVERFLOW;
     }
     be_uint32_t addr_be = byteorder_htonl(addr);
@@ -438,25 +454,29 @@ static int mtd_spi_nor_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uin
 
 static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
 {
+    int res = 0;
     DEBUG("mtd_spi_nor_erase: %p, 0x%" PRIx32 ", 0x%" PRIx32 "\n",
         (void *)mtd, addr, size);
     mtd_spi_nor_t *dev = (mtd_spi_nor_t *)mtd;
-    uint32_t sector_size = mtd->page_size * mtd->pages_per_sector;
-    uint32_t total_size = sector_size * mtd->sector_count;
+    uint32_t total_size = mtd->sector_size * mtd->sector_count;
 
-    if (dev->sec_addr_mask &&
-        ((addr & ~dev->sec_addr_mask) != 0)) {
+    if (dev->min_erase_addr_mask &&
+        ((addr & ~dev->min_erase_addr_mask) != 0)) {
         /* This is not a requirement in hardware, but it helps in catching
          * software bugs (the erase-all-your-files kind) */
-        DEBUG("addr = %" PRIx32 " ~dev->erase_addr_mask = %" PRIx32 "", addr, ~dev->sec_addr_mask);
+        DEBUG("addr = %" PRIx32 " ~dev->min_erase_addr_mask = %" PRIx32 "",
+              addr, ~dev->min_erase_addr_mask);
         DEBUG("mtd_spi_nor_erase: ERR: erase addr not aligned on %" PRIu32 " byte boundary.\n",
-            sector_size);
+              mtd->min_erase_size);
         return -EOVERFLOW;
     }
     if (addr + size > total_size) {
+        DEBUG("mtd_spi_nor_erase: ERR: erasing outside memory!\n");
         return -EOVERFLOW;
     }
-    if (size % sector_size != 0) {
+    if (size % mtd->min_erase_size != 0) {
+        DEBUG("mtd_spi_nor_erase: ERR: size is not aligned on %" PRIu32 " byte boundary\n",
+              mtd->min_erase_size);
         return -EOVERFLOW;
     }
 
@@ -469,7 +489,12 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
             mtd_spi_cmd(dev, dev->opcode->chip_erase);
             size -= total_size;
         }
-        else if ((dev->flag & SPI_NOR_F_SECT_32K) && (size >= 32768) && ((addr & 0x7FFF) == 0)) {
+        else if ((size >= mtd->sector_size) && ((addr & ~dev->sec_addr_mask) == 0)){
+            mtd_spi_cmd_addr_write(dev, dev->opcode->block_erase, addr_be, NULL, 0);
+            addr += mtd->sector_size;
+            size -= mtd->sector_size;
+        }
+        else if ((dev->flag & SPI_NOR_F_SECT_32K) && (size >= 32768ul) && ((addr & 0x7FFF) == 0)) {
             /* 32 KiO sectors can be erased with sector erase command */
             mtd_spi_cmd_addr_write(dev, dev->opcode->block_erase_32k, addr_be, NULL, 0);
             addr += 32768ul;
@@ -482,16 +507,18 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
             size -= 4096ul;
         }
         else {
-            mtd_spi_cmd_addr_write(dev, dev->opcode->block_erase, addr_be, NULL, 0);
-            addr += sector_size;
-            size -= sector_size;
+            DEBUG("mtd_spi_nor_erase: ERR: remaining size is not aligned on %" PRIu32 " byte boundary\n",
+                  mtd->min_erase_size);
+            mtd_spi_cmd(dev, dev->opcode->wrdi);
+            res = -EOVERFLOW;
+            break;
         }
 
         /* waiting for the command to complete before continuing */
         wait_for_write_complete(dev);
     }
 
-    return 0;
+    return res;
 }
 
 static int mtd_spi_nor_power(mtd_dev_t *mtd, enum mtd_power_state power)

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -456,35 +456,41 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
     if (addr + size > total_size) {
         return -EOVERFLOW;
     }
-    be_uint32_t addr_be = byteorder_htonl(addr);
-
-    /* write enable */
-    mtd_spi_cmd(dev, dev->opcode->wren);
-
-    if (size == total_size) {
-        mtd_spi_cmd(dev, dev->opcode->chip_erase);
-    }
-    else if ((dev->flag & SPI_NOR_F_SECT_4K) && size == 4096) {
-        /* 4 KiO sectors can be erased with sector erase command */
-        mtd_spi_cmd_addr_write(dev, dev->opcode->sector_erase, addr_be, NULL, 0);
-    }
-    else if ((dev->flag & SPI_NOR_F_SECT_32K) && size == 32768) {
-        /* 32 KiO sectors can be erased with sector erase command */
-        mtd_spi_cmd_addr_write(dev, dev->opcode->block_erase_32k, addr_be, NULL, 0);
-    }
-    else if (size % sector_size != 0) {
+    if (size % sector_size != 0) {
         return -EOVERFLOW;
     }
-    else {
-        for (size_t i = 0; i < size / sector_size; i++) {
+
+    while (size) {
+        be_uint32_t addr_be = byteorder_htonl(addr);
+        /* write enable */
+        mtd_spi_cmd(dev, dev->opcode->wren);
+
+        if (size == total_size) {
+            mtd_spi_cmd(dev, dev->opcode->chip_erase);
+            size -= total_size;
+        }
+        else if ((dev->flag & SPI_NOR_F_SECT_32K) && (size >= 32768) && ((addr & 0x7FFF) == 0)) {
+            /* 32 KiO sectors can be erased with sector erase command */
+            mtd_spi_cmd_addr_write(dev, dev->opcode->block_erase_32k, addr_be, NULL, 0);
+            addr += 32768ul;
+            size -= 32768ul;
+        }
+        else if ((dev->flag & SPI_NOR_F_SECT_4K) && (size >= 4096ul) && ((addr & 0xFFF) == 0)) {
+            /* 4 KiO sectors can be erased with sector erase command */
+            mtd_spi_cmd_addr_write(dev, dev->opcode->sector_erase, addr_be, NULL, 0);
+            addr += 4096ul;
+            size -= 4096ul;
+        }
+        else {
             mtd_spi_cmd_addr_write(dev, dev->opcode->block_erase, addr_be, NULL, 0);
             addr += sector_size;
-            addr_be = byteorder_htonl(addr);
+            size -= sector_size;
         }
+
+        /* waiting for the command to complete before continuing */
+        wait_for_write_complete(dev);
     }
 
-    /* waiting for the command to complete before returning */
-    wait_for_write_complete(dev);
     return 0;
 }
 

--- a/drivers/mtd_spi_nor/mtd_spi_nor_configs.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor_configs.c
@@ -29,6 +29,7 @@
 const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default = {
     .rdid            = 0x9f,
     .wren            = 0x06,
+    .wrdi            = 0x04,
     .rdsr            = 0x05,
     .wrsr            = 0x01,
     .read            = 0x03,

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -125,10 +125,11 @@ static int _mount(vfs_mount_t *mountp)
     DEBUG("littlefs: mount: mountp=%p\n", (void *)mountp);
 
     if (!fs->config.block_count) {
-        fs->config.block_count = fs->dev->sector_count - fs->base_addr;
+        fs->config.block_count = ((fs->dev->sector_count * fs->dev->sector_size) /
+                                  fs->dev->min_erase_size) - fs->base_addr;
     }
     if (!fs->config.block_size) {
-        fs->config.block_size = fs->dev->page_size * fs->dev->pages_per_sector;
+        fs->config.block_size = fs->dev->min_erase_size;
     }
     if (!fs->config.prog_size) {
         fs->config.prog_size = fs->dev->page_size;

--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -137,13 +137,13 @@ static int _mount(vfs_mount_t *mountp)
     fs_desc->config.hal_erase_f = _dev_erase;
 
 #if SPIFFS_SINGLETON == 0
-    DEBUG("spiffs: mount: mtd page_size=%" PRIu32 ", pages_per_sector=%" PRIu32
-          ", sector_count=%" PRIu32 "\n", dev->page_size, dev->pages_per_sector, dev->sector_count);
-    fs_desc->config.phys_size = dev->page_size * dev->pages_per_sector * dev->sector_count;
-    fs_desc->config.log_block_size = dev->page_size * dev->pages_per_sector;
+    DEBUG("spiffs: mount: mtd page_size=%" PRIu32 ", sector_size=%" PRIu32
+          ", sector_count=%" PRIu32 "\n", dev->page_size, dev->sector_size, dev->sector_count);
+    fs_desc->config.phys_size = dev->sector_size * dev->sector_count;
+    fs_desc->config.log_block_size = dev->min_erase_size;
     fs_desc->config.log_page_size = dev->page_size;
     fs_desc->config.phys_addr = 0;
-    fs_desc->config.phys_erase_block = dev->page_size * dev->pages_per_sector;
+    fs_desc->config.phys_erase_block = dev->min_erase_size;
 #endif
 
     mtd_init(dev);

--- a/tests/unittests/tests-littlefs/tests-littlefs.c
+++ b/tests/unittests/tests-littlefs/tests-littlefs.c
@@ -357,10 +357,9 @@ static void tests_littlefs_statvfs(void)
 
     int res = vfs_statvfs("/test-littlefs/", &stat1);
     TEST_ASSERT_EQUAL_INT(0, res);
-    TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat1.f_bsize);
-    TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat1.f_frsize);
-    TEST_ASSERT((_dev->pages_per_sector * _dev->page_size * _dev->sector_count) >=
-                          stat1.f_blocks);
+    TEST_ASSERT_EQUAL_INT(_dev->min_erase_size, stat1.f_bsize);
+    TEST_ASSERT_EQUAL_INT(_dev->min_erase_size, stat1.f_frsize);
+    TEST_ASSERT((_dev->sector_size * _dev->sector_count) >= stat1.f_blocks);
 
     int fd = vfs_open("/test-littlefs/test.txt", O_CREAT | O_RDWR, 0);
     TEST_ASSERT(fd >= 0);
@@ -374,8 +373,8 @@ static void tests_littlefs_statvfs(void)
     res = vfs_statvfs("/test-littlefs/", &stat2);
     TEST_ASSERT_EQUAL_INT(0, res);
 
-    TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat2.f_bsize);
-    TEST_ASSERT_EQUAL_INT(_dev->page_size * _dev->pages_per_sector, stat2.f_frsize);
+    TEST_ASSERT_EQUAL_INT(_dev->min_erase_size, stat2.f_bsize);
+    TEST_ASSERT_EQUAL_INT(_dev->min_erase_size, stat2.f_frsize);
     TEST_ASSERT(stat1.f_bfree > stat2.f_bfree);
     TEST_ASSERT(stat1.f_bavail > stat2.f_bavail);
 }

--- a/tests/unittests/tests-mtd/tests-mtd.c
+++ b/tests/unittests/tests-mtd/tests-mtd.c
@@ -72,6 +72,9 @@ static int write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
     if (size > PAGE_SIZE) {
         return -EOVERFLOW;
     }
+    if (((addr % PAGE_SIZE) + size) > PAGE_SIZE) {
+        return -EOVERFLOW;
+    }
     memcpy(dummy_memory + addr, buff, size);
 
     return size;
@@ -211,6 +214,18 @@ static void test_mtd_write_read(void)
     /* out of bounds write (addr + count) */
     ret = mtd_write(dev, buf, (dev->pages_per_sector * dev->page_size * dev->sector_count)
                     - (sizeof(buf) / 2), sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+
+    /* out of bounds write (more than page size) */
+    const size_t page_size = dev->page_size;
+    const uint8_t buf_page[page_size + 1];
+    ret = mtd_write(dev, buf_page, 0, sizeof(buf_page));
+    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+
+    /* pages overlap write */
+    ret = mtd_write(dev, buf, dev->page_size - (sizeof(buf) / 2), sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+    ret = mtd_write(dev, buf_page, 1, sizeof(buf_page) - 1);
     TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
 }
 

--- a/tests/unittests/tests-mtd/tests-mtd.c
+++ b/tests/unittests/tests-mtd/tests-mtd.c
@@ -31,16 +31,19 @@
 #else
 /* Test mock object implementing a simple RAM-based mtd */
 #ifndef SECTOR_COUNT
-#define SECTOR_COUNT 4
+#define SECTOR_COUNT    4
 #endif
-#ifndef PAGE_PER_SECTOR
-#define PAGE_PER_SECTOR 4
+#ifndef SECTOR_SIZE
+#define SECTOR_SIZE     512
+#endif
+#ifndef MIN_ERASE_SIZE
+#define MIN_ERASE_SIZE  256
 #endif
 #ifndef PAGE_SIZE
-#define PAGE_SIZE 128
+#define PAGE_SIZE       128
 #endif
 
-static uint8_t dummy_memory[PAGE_PER_SECTOR * PAGE_SIZE * SECTOR_COUNT];
+static uint8_t dummy_memory[SECTOR_SIZE * SECTOR_COUNT];
 
 static int init(mtd_dev_t *dev)
 {
@@ -75,7 +78,10 @@ static int write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
     if (((addr % PAGE_SIZE) + size) > PAGE_SIZE) {
         return -EOVERFLOW;
     }
-    memcpy(dummy_memory + addr, buff, size);
+    const uint8_t *p = buff;
+    for (size_t i = 0; i < size; i++) {
+        dummy_memory[addr + i] &= p[i];
+    }
 
     return size;
 }
@@ -84,10 +90,10 @@ static int erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
 {
     (void)dev;
 
-    if (size % (PAGE_PER_SECTOR * PAGE_SIZE) != 0) {
+    if (size % (MIN_ERASE_SIZE) != 0) {
         return -EOVERFLOW;
     }
-    if (addr % (PAGE_PER_SECTOR * PAGE_SIZE) != 0) {
+    if (addr % (MIN_ERASE_SIZE) != 0) {
         return -EOVERFLOW;
     }
     if (addr + size > sizeof(dummy_memory)) {
@@ -116,7 +122,8 @@ static const mtd_desc_t driver = {
 static mtd_dev_t _dev = {
     .driver = &driver,
     .sector_count = SECTOR_COUNT,
-    .pages_per_sector = PAGE_PER_SECTOR,
+    .sector_size = SECTOR_SIZE,
+    .min_erase_size = MIN_ERASE_SIZE,
     .page_size = PAGE_SIZE,
 };
 
@@ -124,9 +131,9 @@ static mtd_dev_t *dev = (mtd_dev_t*) &_dev;
 
 #endif /* MTD_0 */
 
-static void setup_teardown(void)
+static void teardown(void)
 {
-    mtd_erase(dev, 0, dev->pages_per_sector * dev->page_size);
+    mtd_erase(dev, 0, dev->sector_count * dev->sector_size);
 }
 
 static void test_mtd_init(void)
@@ -138,7 +145,10 @@ static void test_mtd_init(void)
 static void test_mtd_erase(void)
 {
     /* Erase first sector */
-    int ret = mtd_erase(dev, 0, dev->pages_per_sector * dev->page_size);
+    int ret = mtd_erase(dev, 0, dev->sector_size);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    ret = mtd_erase(dev, 0, dev->min_erase_size);
     TEST_ASSERT_EQUAL_INT(0, ret);
 
     /* Erase with wrong size (les than sector size) */
@@ -150,14 +160,47 @@ static void test_mtd_erase(void)
     TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
 
     /* Erase 2nd - 3rd sector */
-    ret = mtd_erase(dev, dev->pages_per_sector * dev->page_size,
-                    dev->pages_per_sector * dev->page_size * 2);
+    ret = mtd_erase(dev, dev->min_erase_size,
+                    dev->min_erase_size * 2);
     TEST_ASSERT_EQUAL_INT(0, ret);
 
     /* Erase out of memory area */
-    ret = mtd_erase(dev, dev->pages_per_sector * dev->page_size * dev->sector_count,
-                    dev->pages_per_sector * dev->page_size);
+    ret = mtd_erase(dev, dev->sector_count * dev->sector_size,
+                    dev->min_erase_size);
     TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
+}
+
+static void test_mtd_erase_read(void)
+{
+    int ret;
+    uint8_t buf[32];
+    memset(buf, 0x55, sizeof(buf));
+
+    /* Fill in 4 sectors */
+    size_t i = 0;
+    while (i < 4 * dev->sector_size) {
+        ret = mtd_write(dev, buf, i, sizeof(buf));
+        i += sizeof(buf);
+        TEST_ASSERT_EQUAL_INT(sizeof(buf), ret);
+    }
+
+    /* Erase 2 sectors, starting from second erasable unit */
+    ret = mtd_erase(dev, dev->min_erase_size, 2 * dev->sector_size);
+    TEST_ASSERT_EQUAL_INT(0, ret);
+
+    /* First erasable unit is not erased */
+    memset(buf, 0, sizeof(buf));
+    ret = mtd_read(dev, buf, dev->min_erase_size - sizeof(buf), sizeof(buf));
+    for (unsigned j = 0; j < sizeof(buf); j++) {
+        TEST_ASSERT_EQUAL_INT(0x55, buf[j]);
+    }
+
+    /* Second erasable unit of third sector is not erased */
+    memset(buf, 0, sizeof(buf));
+    ret = mtd_read(dev, buf, 2 * dev->sector_size + dev->min_erase_size, sizeof(buf));
+    for (unsigned j = 0; j < sizeof(buf); j++) {
+        TEST_ASSERT_EQUAL_INT(0x55, buf[j]);
+    }
 }
 
 static void test_mtd_write_erase(void)
@@ -170,7 +213,7 @@ static void test_mtd_write_erase(void)
     int ret = mtd_write(dev, buf, sizeof(buf_empty), sizeof(buf));
     TEST_ASSERT_EQUAL_INT(sizeof(buf), ret);
 
-    ret = mtd_erase(dev, 0, dev->pages_per_sector * dev->page_size);
+    ret = mtd_erase(dev, 0, dev->min_erase_size);
     TEST_ASSERT_EQUAL_INT(0, ret);
 
     uint8_t expected[sizeof(buf_read)];
@@ -207,12 +250,12 @@ static void test_mtd_write_read(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf, buf_read + sizeof(buf_empty), sizeof(buf)));
 
     /* out of bounds write (addr) */
-    ret = mtd_write(dev, buf, dev->pages_per_sector * dev->page_size * dev->sector_count,
+    ret = mtd_write(dev, buf, dev->sector_count * dev->sector_size,
                     sizeof(buf));
     TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
 
     /* out of bounds write (addr + count) */
-    ret = mtd_write(dev, buf, (dev->pages_per_sector * dev->page_size * dev->sector_count)
+    ret = mtd_write(dev, buf, (dev->sector_count * dev->sector_size)
                     - (sizeof(buf) / 2), sizeof(buf));
     TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
 
@@ -229,7 +272,6 @@ static void test_mtd_write_read(void)
     TEST_ASSERT_EQUAL_INT(-EOVERFLOW, ret);
 }
 
-#ifdef MTD_0
 static void test_mtd_write_read_flash(void)
 {
     const uint8_t buf1[] = {0xee, 0xdd, 0xcc};
@@ -252,7 +294,6 @@ static void test_mtd_write_read_flash(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_expected, buf_read, sizeof(buf_expected)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_empty, buf_read + sizeof(buf_expected), sizeof(buf_empty)));
 }
-#endif
 
 #if MODULE_VFS
 static void test_mtd_vfs(void)
@@ -288,17 +329,16 @@ Test *tests_mtd_tests(void)
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_mtd_init),
         new_TestFixture(test_mtd_erase),
+        new_TestFixture(test_mtd_erase_read),
         new_TestFixture(test_mtd_write_erase),
         new_TestFixture(test_mtd_write_read),
-#ifdef MTD_0
         new_TestFixture(test_mtd_write_read_flash),
-#endif
 #if MODULE_VFS
         new_TestFixture(test_mtd_vfs),
 #endif
     };
 
-    EMB_UNIT_TESTCALLER(mtd_tests, setup_teardown, setup_teardown, fixtures);
+    EMB_UNIT_TESTCALLER(mtd_tests, NULL, teardown, fixtures);
 
     return (Test *)&mtd_tests;
 }

--- a/tests/unittests/tests-spiffs/tests-spiffs.c
+++ b/tests/unittests/tests-spiffs/tests-spiffs.c
@@ -336,8 +336,7 @@ static void tests_spiffs_statvfs(void)
     TEST_ASSERT_EQUAL_INT(0, res);
     TEST_ASSERT_EQUAL_INT(1, stat1.f_bsize);
     TEST_ASSERT_EQUAL_INT(1, stat1.f_frsize);
-    TEST_ASSERT((_dev->pages_per_sector * _dev->page_size * _dev->sector_count) >=
-                          stat1.f_blocks);
+    TEST_ASSERT((_dev->sector_size * _dev->sector_count) >= stat1.f_blocks);
 
     int fd = vfs_open("/test-spiffs/test.txt", O_CREAT | O_RDWR, 0);
     TEST_ASSERT(fd >= 0);


### PR DESCRIPTION

### Contribution description

As said in #8400, erase in mtd spi nor is not working correctly as on some flash, the erase size might be smaller than the sector size.

Thie PR adds `min_erase_size`  and  `sector_size` fields in the `mtd_dev_t` to fix that. 

On spi flashes supporting different erase size, the config can be (for instance a flash with 64KB blocks and 4KB erasable sectors):
`sector_size = 65536`
`min_erase_size = 4096`


### Issues/PRs references

This is based on #8399 and #8400 