### PR TITLE
pkg/relic: disable newline-eof compile error

### DIFF
--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -15,7 +15,7 @@ $(PKG_BUILDDIR)/comp-options.cmake: fix_source
 $(PKG_BUILDDIR)/Makefile: $(PKG_BUILDDIR)/comp-options.cmake
 	cd "$(PKG_BUILDDIR)" && COMP="$(filter-out -Werror=old-style-definition -Werror=strict-prototypes, $(CFLAGS) ) " cmake -DCMAKE_TOOLCHAIN_FILE=comp-options.cmake -DCHECK=off -DTESTS=0 -DBENCH=0 -DSHLIB=off -Wno-dev $(RELIC_CONFIG_FLAGS) .
 
-CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function
+CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function -Wno-newline-eof
 
 fix_source: git-download
 	./fix-util_print_wo_args.sh $(PKG_BUILDDIR)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Intermediate fix (package should be update anyways) for following error:

```
[ 64%] Building C object src/CMakeFiles/relic_s.dir/cp/relic_cp_ecdsa.c.obj
[ 65%] Building C object src/CMakeFiles/relic_s.dir/cp/relic_cp_ecss.c.obj
[ 66%] Building C object src/CMakeFiles/relic_s.dir/cp/relic_cp_vbnn_ibs.c.obj
/root/RIOT/tests/unittests/bin/pkg/native/relic/src/cp/relic_cp_vbnn_ibs.c:328:2: error: no newline at end of file [-Werror,-Wnewline-eof]
}
 ^
1 error generated.
src/CMakeFiles/relic_s.dir/build.make:1502: recipe for target 'src/CMakeFiles/relic_s.dir/cp/relic_cp_vbnn_ibs.c.obj' failed
```


### Issues/PRs references

package update in #6965
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->