### PR TITLE
gnrc_netif: remove "new" qualifier in documentation

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    net_gnrc_netif New network interface API
+ * @defgroup    net_gnrc_netif Network interface API
  * @ingroup     net_gnrc
  * @brief       Abstraction layer for GNRC's network interfaces
  *


### PR DESCRIPTION
Calling the API "new" when it is the only network interface API (that
also now is named the same as the old one) might be a little confusing.