### PR TITLE
drivers/lis2dh12: add I2C mode

### DIFF
--- a/boards/thingy52/Makefile.dep
+++ b/boards/thingy52/Makefile.dep
@@ -1,3 +1,7 @@
 ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
   USEMODULE += nrfmin
 endif
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += lis2dh12
+endif

--- a/boards/thingy52/Makefile.features
+++ b/boards/thingy52/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/thingy52/include/board.h
+++ b/boards/thingy52/include/board.h
@@ -36,6 +36,14 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    LIS2DH12 low power accelerometer configuration
+ * @{
+ */
+#define LIS2DH12_PARAM_I2C  I2C_DEV(1)
+/** @} */
+
+
+/**
  * @brief   Initialize board specific hardware
  */
 void board_init(void);

--- a/boards/thingy52/include/periph_conf.h
+++ b/boards/thingy52/include/periph_conf.h
@@ -77,6 +77,28 @@ static const timer_conf_t timer_config[] = {
 #define UART_PIN_TX         GPIO_PIN(0, 3)
 /** @} */
 
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        /* main I2C bus */
+        .dev = NRF_TWIM0,
+        .sda = 7,
+        .scl = 8,
+    },
+    {
+        /* EXT I2C bus */
+        .dev = NRF_TWIM1,
+        .sda = 14,
+        .scl = 15,
+    },
+};
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/lis2dh12.h
+++ b/drivers/include/lis2dh12.h
@@ -33,17 +33,26 @@
 #ifndef LIS2DH12_H
 #define LIS2DH12_H
 
+#include <stdint.h>
+
 #include "saul.h"
+
+#ifdef MODULE_LIS2DH12_SPI
 #include "periph/spi.h"
 #include "periph/gpio.h"
+#else
+#include "periph/i2c.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* I2C support is not implemented (yet), so throw an error when selected */
-#ifndef MODULE_LIS2DH12_SPI
-#error "LIS2DH12 error: I2C mode is not supported, yet. Use module li2dh12_spi"
+#if defined(MODULE_LIS2DH12) || defined(DOXYGEN)
+/**
+ * @brief   Default I2C slave address for LIS2DH12 devices
+ */
+#define LIS2DH12_ADDR_DEFAULT       (0x19)
 #endif
 
 /**
@@ -76,8 +85,13 @@ typedef enum {
  * @brief   LIS2DH12 configuration parameters
  */
 typedef struct {
+#ifdef MODULE_LIS2DH12_SPI
     spi_t spi;                      /**< SPI bus the device is connected to */
     gpio_t cs;                      /**< connected chip select pin */
+#else
+    i2c_t i2c;                      /**< I2C bus the device is connected to */
+    uint8_t addr;                   /**< device address on the I2C bus */
+#endif
     lis2dh12_scale_t scale;         /**< sampling sensitivity used */
     lis2dh12_rate_t rate;           /**< sampling rate used */
 } lis2dh12_params_t;

--- a/drivers/lis2dh12/include/lis2dh12_params.h
+++ b/drivers/lis2dh12/include/lis2dh12_params.h
@@ -31,12 +31,28 @@ extern "C" {
  * @name    Set default configuration parameters for LIS2DH12 devices
  * @{
  */
+#ifdef MODULE_LIS2DH12_SPI          /* default configuration for SPI mode */
 #ifndef LIS2DH12_PARAM_SPI
 #define LIS2DH12_PARAM_SPI          SPI_DEV(0)
 #endif
 #ifndef LIS2DH12_PARAM_CS
 #define LIS2DH12_PARAM_CS           GPIO_PIN(0, 0)
 #endif
+#define LIS2DH12_PARAMS_BUSCFG      .spi = LIS2DH12_PARAM_SPI, \
+                                    .cs  = LIS2DH12_PARAM_CS
+
+#else                               /* default configuration for I2C mode */
+#ifndef LIS2DH12_PARAM_I2C
+#define LIS2DH12_PARAM_I2C          I2C_DEV(0)
+#endif
+#ifndef LIS2DH12_PARAM_ADDR
+#define LIS2DH12_PARAM_ADDR         LIS2DH12_ADDR_DEFAULT
+#endif
+#define LIS2DH12_PARAMS_BUSCFG      .i2c  = LIS2DH12_PARAM_I2C, \
+                                    .addr = LIS2DH12_PARAM_ADDR
+
+#endif
+
 #ifndef LIS2DH12_PARAM_SCALE
 #define LIS2DH12_PARAM_SCALE        LIS2DH12_SCALE_2G
 #endif
@@ -45,10 +61,9 @@ extern "C" {
 #endif
 
 #ifndef LIS2DH12_PARAMS
-#define LIS2DH12_PARAMS             { .spi = LIS2DH12_PARAM_SPI,     \
-                                      .cs = LIS2DH12_PARAM_CS,       \
+#define LIS2DH12_PARAMS             { LIS2DH12_PARAMS_BUSCFG,        \
                                       .scale = LIS2DH12_PARAM_SCALE, \
-                                      .rate  = LIS2DH12_PARAM_RATE }
+                                      .rate  = LIS2DH12_PARAM_RATE, }
 #endif
 
 #ifndef LIS2DH12_SAULINFO

--- a/drivers/lis2dh12/lis2dh12.c
+++ b/drivers/lis2dh12/lis2dh12.c
@@ -137,26 +137,25 @@ int lis2dh12_init(lis2dh12_t *dev, const lis2dh12_params_t *params)
     dev->comp = (1000UL * (0x02 << (dev->p->scale >> 4)));
 
 #ifdef MODULE_LIS2DH12_SPI
-    /* initialize the bus */
+    /* initialize the chip select line */
     if (_init_bus(dev) != LIS2DH12_OK) {
-        DEBUG("[lis2dh12] error: unable to initialize bus\n");
+        DEBUG("[lis2dh12] error: unable to initialize the CS pin\n");
         return LIS2DH12_NOBUS;
     }
+#endif
+
     /* acquire the bus and verify that our parameters are valid */
     if (_acquire(dev) != BUS_OK) {
-        DEBUG("[lis2dh12] error: unable to acquire SPI bus\n");
+        DEBUG("[lis2dh12] error: unable to acquire the bus\n");
         return LIS2DH12_NOBUS;
     }
-#else
+
+#ifndef MODULE_LIS2DH12_SPI
     /* in the current state, the I2C driver expects the bus to be acquired
      * before the init function is called, so we have to switch order */
-    if (_acquire(dev) != BUS_OK) {
-        DEBUG("[lis2dh12] error: unable to acquire SPI bus\n");
-        return LIS2DH12_NOBUS;
-    }
     if (_init_bus(dev) != LIS2DH12_OK) {
         _release(dev);
-        DEBUG("[lis2dh12] error: unable to initialize bus\n");
+        DEBUG("[lis2dh12] error: unable to initialize the I2C bus\n");
         return LIS2DH12_NOBUS;
     }
 #endif


### PR DESCRIPTION
### Contribution description
The PR adapts the `lis2dh12` driver to work also in I2C mode, which is the used configuration on the `thingy52`. 


### Issues/PRs references
- ~~rebased on #8385~~
- adaption of #8381 to make the driver work also with the `thingy52`