### PR TITLE
pkg/fatfs: bump version to R0.13a

### DIFF
--- a/pkg/fatfs/Makefile
+++ b/pkg/fatfs/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=fatfs
-PKG_URL=https://github.com/MichelRottleuthner/FatFs_for_RIOT.git
-PKG_VERSION=61fd6ae3815170bf7bf6121f33f1ef68c2b11599
+PKG_URL=https://github.com/RIOT-OS/FatFS
+PKG_VERSION=34f371c7735fc6fc8e714a74a7a73a61d3ed5633
 PKG_LICENSE=BSD-1-Clause
 MODULE_MAKEFILE := $(CURDIR)/Makefile.fatfs
 

--- a/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
+++ b/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
@@ -31,7 +31,7 @@
 #endif
 
 /* mtd devices for use by FatFs should be provided by the application */
-extern mtd_dev_t *fatfs_mtd_devs[_VOLUMES];
+extern mtd_dev_t *fatfs_mtd_devs[FF_VOLUMES];
 
 /**
  * @brief           returns the status of the disk
@@ -45,7 +45,7 @@ extern mtd_dev_t *fatfs_mtd_devs[_VOLUMES];
 DSTATUS disk_status(BYTE pdrv)
 {
     DEBUG("disk_status %d\n", pdrv);
-    if (pdrv >= _VOLUMES) {
+    if (pdrv >= FF_VOLUMES) {
         return STA_NODISK;
     } else if (fatfs_mtd_devs[pdrv]->driver == NULL){
         return STA_NOINIT;
@@ -66,7 +66,7 @@ DSTATUS disk_status(BYTE pdrv)
 DSTATUS disk_initialize(BYTE pdrv)
 {
     DEBUG("disk_initialize %d\n", pdrv);
-    if (pdrv >= _VOLUMES) {
+    if (pdrv >= FF_VOLUMES) {
         return STA_NODISK;
     } else if (fatfs_mtd_devs[pdrv]->driver == NULL){
         return STA_NOINIT;
@@ -91,7 +91,7 @@ DSTATUS disk_initialize(BYTE pdrv)
 DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
 {
     DEBUG("disk_read: %d, %lu, %d\n", pdrv, sector, count);
-    if ((pdrv >= _VOLUMES) || (fatfs_mtd_devs[pdrv]->driver == NULL)) {
+    if ((pdrv >= FF_VOLUMES) || (fatfs_mtd_devs[pdrv]->driver == NULL)) {
         return RES_PARERR;
     }
 
@@ -122,7 +122,7 @@ DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
 DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
 {
     DEBUG("disk_write: %d, %lu, %d\n", pdrv, sector, count);
-    if ((pdrv >= _VOLUMES) || (fatfs_mtd_devs[pdrv]->driver == NULL)) {
+    if ((pdrv >= FF_VOLUMES) || (fatfs_mtd_devs[pdrv]->driver == NULL)) {
         return RES_PARERR;
     }
 
@@ -150,7 +150,7 @@ DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
 /**
  * @brief                  perform miscellaneous low-level control functions
  *
- * @param[in]      pdrv    Physical drive nmuber (0.._VOLUMES-1)
+ * @param[in]      pdrv    Physical drive nmuber (0..FF_VOLUMES-1)
  * @param[in out]  cmd     Control code
  * @param[in]      sector  Buffer to send/receive control data
  *
@@ -160,18 +160,18 @@ DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
  */
 DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 {
-    if ((pdrv >= _VOLUMES) || (fatfs_mtd_devs[pdrv]->driver == NULL)) {
+    if ((pdrv >= FF_VOLUMES) || (fatfs_mtd_devs[pdrv]->driver == NULL)) {
         return RES_PARERR;
     }
 
     switch (cmd) {
-#if (_FS_READONLY == 0)
+#if (FF_FS_READONLY == 0)
         case CTRL_SYNC:
             /* r/w is always finished within r/w-functions of mtd */
             return RES_OK;
 #endif
 
-#if (_USE_MKFS == 1)
+#if (FF_USE_MKFS == 1)
         case GET_SECTOR_COUNT:
             *(DWORD *)buff = fatfs_mtd_devs[pdrv]->sector_count;
             return RES_OK;
@@ -183,13 +183,13 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
             return RES_OK;
 #endif
 
-#if (_MAX_SS != _MIN_SS)
+#if (FF_MAX_SS != FF_MIN_SS)
         case GET_SECTOR_SIZE:
             *(DWORD *)buff = fatfs_mtd_devs[pdrv]->page_size;
             return RES_OK;
 #endif
 
-#if (_USE_TRIM == 1)
+#if (FF_USE_TRIM == 1)
         case CTRL_TRIM:
             return RES_OK;
 #endif

--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -73,7 +73,7 @@ static int _umount(vfs_mount_t *mountp)
     snprintf(volume_str, sizeof(volume_str), "%d:/", fs_desc->vol_idx);
 
     DEBUG("unmounting file system of volume '%s'\n", volume_str);
-    FRESULT res = f_mount(NULL, volume_str, 1);
+    FRESULT res = f_unmount(volume_str);
 
     if (res == FR_OK) {
         DEBUG("[OK]");

--- a/tests/pkg_fatfs/main.c
+++ b/tests/pkg_fatfs/main.c
@@ -106,7 +106,7 @@ static int _mount(int argc, char **argv)
         }
         else {
 
-            #if _MAX_SS == _MIN_SS
+            #if FF_MAX_SS == FF_MIN_SS
             uint16_t sector_size = TEST_FATFS_FIXED_SECTOR_SIZE;
             #else
             uint16_t sector_size = fs->ssize;
@@ -349,7 +349,7 @@ static int _mkfs(int argc, char **argv)
 
     char volume_str[TEST_FATFS_MAX_VOL_STR_LEN];
     sprintf(volume_str, "%d:/", vol_idx);
-    BYTE work[_MAX_SS];
+    BYTE work[FF_MAX_SS];
 
     puts("formatting media...");
 

--- a/tests/pkg_fatfs_vfs/main.c
+++ b/tests/pkg_fatfs_vfs/main.c
@@ -62,7 +62,7 @@ static vfs_mount_t _test_vfs_mount = {
 };
 
 /* provide mtd devices for use within diskio layer of fatfs */
-mtd_dev_t *fatfs_mtd_devs[_VOLUMES];
+mtd_dev_t *fatfs_mtd_devs[FF_VOLUMES];
 
 #ifdef MODULE_MTD_NATIVE
 /* mtd device for native is provided in boards/native/board_init.c */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This updates the version for the fatfs package and switches to the git repo that is controlled by the riot community instead of my own repo.
Also included are minor necessary changes for mtd / vfs and test implementations that use fatfs.

edit: For now i only tested on native. tests/pkg_fatfs_vfs and tests/pkg_fatfs show no errors.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
none
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->