### PR TITLE
samd21/cpu DFLL lock loop error

### DIFF
--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -161,11 +161,10 @@ static void clk_init(void)
     }
 
     SYSCTRL->DFLLCTRL.bit.ENABLE = 1;
-    while ((SYSCTRL->PCLKSR.reg & (SYSCTRL_PCLKSR_DFLLRDY |
-                                   SYSCTRL_PCLKSR_DFLLLCKF |
-                                   SYSCTRL_PCLKSR_DFLLLCKC)) == 0) {
-        /* Wait for DFLLLXXX sync */
-    }
+    uint32_t mask = SYSCTRL_PCLKSR_DFLLRDY |
+                    SYSCTRL_PCLKSR_DFLLLCKF |
+                    SYSCTRL_PCLKSR_DFLLLCKC;
+    while ((SYSCTRL->PCLKSR.reg & mask) != mask) { } /* Wait for DFLL lock */
 
     /* select the DFLL as source for clock generator 0 (CPU core clock) */
     GCLK->GENDIV.reg =  (GCLK_GENDIV_DIV(1U) | GCLK_GENDIV_ID(0));


### PR DESCRIPTION
The DFLL locks need to wait until they are set to 1, currently it doesn't wait because of the comparison to 0 and the result is an incorrect frequency.