### PR TITLE
drivers/soft_spi: move to drivers_periph group

### DIFF
--- a/drivers/doc.txt
+++ b/drivers/doc.txt
@@ -43,3 +43,9 @@
  * @ingroup     drivers
  * @brief       Drivers for storage devices
  */
+
+ /**
+ * @defgroup    drivers_soft_periph Soft Peripheral Driver Interface
+ * @ingroup     drivers
+ * @brief       Software emulated peripheral driver interface for UART, SPI, etc
+ */

--- a/drivers/doc.txt
+++ b/drivers/doc.txt
@@ -47,5 +47,5 @@
  /**
  * @defgroup    drivers_soft_periph Soft Peripheral Driver Interface
  * @ingroup     drivers
- * @brief       Software emulated peripheral driver interface for UART, SPI, etc
+ * @brief       Software emulated @ref drivers_periph for UART, SPI, etc
  */

--- a/drivers/include/soft_spi.h
+++ b/drivers/include/soft_spi.h
@@ -8,8 +8,9 @@
 
 /**
  * @defgroup    drivers_soft_spi Soft SPI
- * @ingroup     drivers
+ * @ingroup     drivers_soft_periph
  * @brief       Software implemented Serial Peripheral Interface bus
+ *
  * This module provides a software implemented Serial Peripheral Interface bus.
  * It is intended to be used in situation where hardware spi is not available.
  * The signatures of the functions are similar to the functions declared in spi.h


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR moves the soft_spi driver doxygen group to the drivers_periph group otherwise it appears at the top level drivers group in the documentation, e.g at the same level as Network, Actuators, Sensors, etc.

Even if the drivers_periph is more related to MCU peripherals and soft_spi is just built on top of GPIOs, I think it makes more sense to have it here, close to the hardware SPI driver. And I didn't find a better place for it.

The added empty line fixes an issue with the brief display in the documentation: without it no newline is added to the generated html and the beginning of the detailed description is displayed with the brief description.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->