### PR TITLE
pkg/ccn-lite: bump version to fix compile error

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=ccn-lite
 PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
-PKG_VERSION=0474080335aac08d3afa44a439ac9def92b9fcf3
+PKG_VERSION=8b17f2b43f337242dce3175efd95f5439cf4a4f5
 PKG_LICENSE=ISC
 
 .PHONY: all


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

this PR updates the CCN-lite version to fix a compile issue found when using GCC 7.x and debug output, see here:

```
/RIOT/examples/ccn-lite-relay/bin/pkg/native/ccn-lite/src/ccnl-fwd/src/ccnl-dispatch.c:94:36: error: format '%zd' expects argument of type 'signed size_t', but argument 5 has type 'int' [-Werror=format=]
             DEBUGMSG_CORE(WARNING, "?unknown packet format? ccnl_core_RX ifndx=%d, %d bytes starting with 0x%02x at offset %zd\n",
                                    ^
                      ifndx, datalen, *data, data - base);
                                             ~~~~~~~~

```

I made a PR on the upstream repo of CCN-lite which is already merged, hence this PR update the package version accordingly.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

for GCC7 compatibility see #8265, fixes #8627
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->