### PR TITLE
drivers/enc28j60: Add feature deps to makefile

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -86,6 +86,8 @@ ifneq (,$(filter dsp0401,$(USEMODULE)))
 endif
 
 ifneq (,$(filter enc28j60,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
   USEMODULE += netdev_eth
   USEMODULE += xtimer
   USEMODULE += luid

--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_spi periph_gpio
-
 BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-f334 nucleo-l053 \
                              nucleo32-f031 nucleo32-f042 nucleo32-l031 \
                              stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4


### PR DESCRIPTION
And remove them from the test

### Contribution description

As stated in the title, this adds the feature requirements of the enc28j60 ethernet chip to the dependency makefile and removes the feature requirements from the makefile of the test application.

### Issues/PRs references

Similar to #8387 and #8390