### PR TITLE
make: ignore fallthroughs errors with GCC 7.x

### DIFF
--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -159,7 +159,8 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
                         dev->inesc = 0;
                         break;
                     }
-                    /* falls through intentionally to default when !dev->inesc */
+                    /* Intentionally falls through */
+                    /* to default when !dev->inesc */
                 case SLIP_ESC_ESC:
                     if (dev->inesc) {
                         *(ptr++) = SLIP_ESC;
@@ -167,7 +168,8 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
                         dev->inesc = 0;
                         break;
                     }
-                    /* falls through intentionally to default when !dev->inesc */
+                    /* Intentionally falls through */
+                    /* to default when !dev->inesc */
                 default:
                     *(ptr++) = (uint8_t)byte;
                     res++;

--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -3,6 +3,9 @@ PKG_URL=https://github.com/obgm/libcoap
 PKG_VERSION=ef41ce5d02d64cec0751882ae8fd95f6c32bc018
 PKG_LICENSE=BSD-2-Clause
 
+# GCC 7.x fails on (intentional) fallthrough, thus disable implicit-fallthrough.
+CFLAGS += -Wno-implicit-fallthrough
+
 .PHONY: all
 
 all: git-download

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -5,6 +5,9 @@ PKG_LICENSE=BSD-3-Clause
 
 MODULE:=$(PKG_NAME)
 
+# GCC 7.x fails on (intentional) fallthrough, thus disable implicit-fallthrough.
+CFLAGS += -Wno-implicit-fallthrough
+
 .PHONY: all
 
 all: git-download

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -689,6 +689,7 @@ static void gomach_t2k_wait_cp_txfeedback(gnrc_netif_t *netif)
                 if (!_cp_tx_busy(netif)) {
                     return;
                 }
+                /* Intentionally falls through */
             case TX_FEEDBACK_NOACK:
             default: {
                 _cp_tx_default(netif);

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -572,26 +572,25 @@ static void _tx_management(gnrc_netif_t *netif)
     gnrc_lwmac_tx_state_t state_tx = netif->mac.tx.state;
 
     switch (state_tx) {
-        case GNRC_LWMAC_TX_STATE_STOPPED: {
+        case GNRC_LWMAC_TX_STATE_STOPPED:
             _tx_management_stopped(netif);
             break;
-        }
-        case GNRC_LWMAC_TX_STATE_FAILED: {
+
+        case GNRC_LWMAC_TX_STATE_FAILED:
             /* If transmission failure, do not try burst transmissions and quit other
              * transmission attempts in this cycle for collision avoidance */
             gnrc_lwmac_set_tx_continue(netif, false);
             gnrc_lwmac_set_quit_tx(netif, true);
-            /* falls through */
-            /* TX packet will therefore be dropped. No automatic resending here,
-             * we did our best.
-             */
-        }
-        case GNRC_LWMAC_TX_STATE_SUCCESSFUL: {
+            /* TX packet will be dropped, no automatic resending here. */
+            /* Intentionally falls through */
+
+        case GNRC_LWMAC_TX_STATE_SUCCESSFUL:
             _tx_management_success(netif);
             break;
-        }
+
         default:
             gnrc_lwmac_tx_update(netif);
+            break;
     }
 
     /* If state has changed, reschedule main state machine */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes several implicit-fallthrough errors when using GCC 7.x. That is, for libcoap and oonf_api package the errors are ignored, and this PR also relaxes `-Werror=implicit-fallthrough=2` to allow more descriptive comments. See also [here](https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/)

### Issues/PRs references

#8265 