### PR TITLE
boards/nucleo*: fix doxygen grouping

### DIFF
--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_common_nucleo STM Nucleo Common
+ * @defgroup    boards_common_nucleo STM32 Nucleo Common
  * @ingroup     boards_common
- * @brief       Common files and configuration for all STM Nucleo boards
+ * @brief       Common support for all STM32 Nucleo boards
  * @{
  *
  * @file

--- a/boards/common/nucleo144/include/board.h
+++ b/boards/common/nucleo144/include/board.h
@@ -9,9 +9,9 @@
  */
 
 /**
- * @defgroup    boards_common_nucleo144 STM Nucleo144 common
- * @ingroup     boards_common
- * @brief       Common files and configuration for STM Nucleo144 boards
+ * @defgroup    boards_common_nucleo144 STM32 Nucleo-144
+ * @ingroup     boards
+ * @brief       Support for STM32 Nucleo-144 boards
  * @{
  *
  * @file

--- a/boards/common/nucleo32/include/board.h
+++ b/boards/common/nucleo32/include/board.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_common_nucleo32 STM Nucleo32 Common
- * @ingroup     boards_common
- * @brief       Common files and configuration for STM Nucleo32 boards
+ * @defgroup    boards_common_nucleo32 STM32 Nucleo-32
+ * @ingroup     boards
+ * @brief       Support for STM32 Nucleo-32 boards
  * @{
  *
  * @file

--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_common_nucleo64 STM Nucleo64 Common
- * @ingroup     boards_common
- * @brief       Common files and configuration for STM Nucleo64 boards
+ * @defgroup    boards_common_nucleo64 STM32 Nucleo-64
+ * @ingroup     boards
+ * @brief       Support for STM32 Nucleo-64 boards
  * @{
  *
  * @file

--- a/boards/nucleo-f030/include/periph_conf.h
+++ b/boards/nucleo-f030/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f030 STM Nucleo-F030
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F030
+ * @defgroup    boards_nucleo-f030 STM32 Nucleo-F030
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F030
  * @{
  *
  * @file

--- a/boards/nucleo-f070/include/periph_conf.h
+++ b/boards/nucleo-f070/include/periph_conf.h
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f070 STM Nucleo-F070
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F070
+ * @defgroup    boards_nucleo-f070 STM32 Nucleo-F070
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F070
  * @{
  *
  * @file

--- a/boards/nucleo-f072/include/periph_conf.h
+++ b/boards/nucleo-f072/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f072 STM Nucleo-F072
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F072
+ * @defgroup    boards_nucleo-f072 STM32 Nucleo-F072
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F072
  * @{
  *
  * @file

--- a/boards/nucleo-f091/include/periph_conf.h
+++ b/boards/nucleo-f091/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f091 STM Nucleo-F091
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F091
+ * @defgroup    boards_nucleo-f091 STM32 Nucleo-F091
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F091
  * @{
  *
  * @file

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f103 STM Nucleo-F103
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F103
+ * @defgroup    boards_nucleo-f103 STM32 Nucleo-F103
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F103
  * @{
  *
  * @file

--- a/boards/nucleo-f302/include/periph_conf.h
+++ b/boards/nucleo-f302/include/periph_conf.h
@@ -9,9 +9,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f302 STM Nucleo-F302
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F302
+ * @defgroup    boards_nucleo-f302 STM32 Nucleo-F302
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F302
  * @{
  *
  * @file

--- a/boards/nucleo-f303/include/periph_conf.h
+++ b/boards/nucleo-f303/include/periph_conf.h
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f303 STM Nucleo-F303
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F303
+ * @defgroup    boards_nucleo-f303 STM32 Nucleo-F303
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F303
  * @{
  *
  * @file

--- a/boards/nucleo-f334/include/periph_conf.h
+++ b/boards/nucleo-f334/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f334 STM Nucleo-F334
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F334
+ * @defgroup    boards_nucleo-f334 STM32 Nucleo-F334
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F334
  * @{
  *
  * @file

--- a/boards/nucleo-f401/include/periph_conf.h
+++ b/boards/nucleo-f401/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f401 STM Nucleo-F401
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F401
+ * @defgroup    boards_nucleo-f401 STM32 Nucleo-F401
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F401
  * @{
  *
  * @file

--- a/boards/nucleo-f410/include/periph_conf.h
+++ b/boards/nucleo-f410/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f410 STM Nucleo-F410
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F410
+ * @defgroup    boards_nucleo-f410 STM32 Nucleo-F410
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F410
  * @{
  *
  * @file

--- a/boards/nucleo-f411/include/periph_conf.h
+++ b/boards/nucleo-f411/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f411 STM Nucleo-F411
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F411
+ * @defgroup    boards_nucleo-f411 STM32 Nucleo-F411
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F411
  * @{
  *
  * @file

--- a/boards/nucleo-f446/include/periph_conf.h
+++ b/boards/nucleo-f446/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-f446 STM Nucleo-F446
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-F446
+ * @defgroup    boards_nucleo-f446 STM32 Nucleo-F446
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F446
  * @{
  *
  * @file

--- a/boards/nucleo-l053/include/periph_conf.h
+++ b/boards/nucleo-l053/include/periph_conf.h
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l053 STM Nucleo-L053
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-L053
+ * @defgroup    boards_nucleo-l053 STM32 Nucleo-L053
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-L053
  * @{
  *
  * @file

--- a/boards/nucleo-l073/include/periph_conf.h
+++ b/boards/nucleo-l073/include/periph_conf.h
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l073 STM Nucleo-L073
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-L073
+ * @defgroup    boards_nucleo-l073 STM32 Nucleo-L073
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-L073
  * @{
  *
  * @file

--- a/boards/nucleo-l152/include/periph_conf.h
+++ b/boards/nucleo-l152/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l152 STM Nucleo-L152
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-L152
+ * @defgroup    boards_nucleo-l152 STM32 Nucleo-L152
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-L152
  * @{
  *
  * @file

--- a/boards/nucleo-l476/include/periph_conf.h
+++ b/boards/nucleo-l476/include/periph_conf.h
@@ -9,9 +9,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo-l476 STM Nucleo-L476
- * @ingroup     boards_nucleo64
- * @brief       Support for the STM Nucleo-L476
+ * @defgroup    boards_nucleo-l476 STM32 Nucleo-L476
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-L476
  * @{
  *
  * @file

--- a/boards/nucleo144-f207/include/periph_conf.h
+++ b/boards/nucleo144-f207/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo144-f207 STM Nucleo144-F207
- * @ingroup     boards_nucleo144
- * @brief       Support for the STM Nucleo144-F207
+ * @defgroup    boards_nucleo144-f207 STM32 Nucleo144-F207
+ * @ingroup     boards_common_nucleo144
+ * @brief       Support for the STM32 Nucleo144-F207
  * @{
  *
  * @file

--- a/boards/nucleo144-f303/include/periph_conf.h
+++ b/boards/nucleo144-f303/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo144-f303 STM Nucleo144-F303
- * @ingroup     boards_nucleo144
- * @brief       Support for the STM Nucleo144-F303
+ * @defgroup    boards_nucleo144-f303 STM32 Nucleo144-F303
+ * @ingroup     boards_common_nucleo144
+ * @brief       Support for the STM32 Nucleo144-F303
  * @{
  *
  * @file

--- a/boards/nucleo144-f412/include/periph_conf.h
+++ b/boards/nucleo144-f412/include/periph_conf.h
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo144-f412 STM Nucleo144-F412
- * @ingroup     boards_nucleo144
- * @brief       Support for the STM Nucleo144-F412
+ * @defgroup    boards_nucleo144-f412 STM32 Nucleo144-F412
+ * @ingroup     boards_common_nucleo144
+ * @brief       Support for the STM32 Nucleo144-F412
  * @{
  *
  * @file

--- a/boards/nucleo144-f413/include/periph_conf.h
+++ b/boards/nucleo144-f413/include/periph_conf.h
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo144-f413 STM Nucleo144-F413
- * @ingroup     boards_nucleo144
- * @brief       Support for the STM Nucleo144-F413
+ * @defgroup    boards_nucleo144-f413 STM32 Nucleo144-F413
+ * @ingroup     boards_common_nucleo144
+ * @brief       Support for the STM32 Nucleo144-F413
  * @{
  *
  * @file

--- a/boards/nucleo144-f429/include/periph_conf.h
+++ b/boards/nucleo144-f429/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo144-f429 STM Nucleo144-F429
- * @ingroup     boards_nucleo144
- * @brief       Support for the STM Nucleo144-F429
+ * @defgroup    boards_nucleo144-f429 STM32 Nucleo144-F429
+ * @ingroup     boards_common_nucleo144
+ * @brief       Support for the STM32 Nucleo144-F429
  * @{
  *
  * @file

--- a/boards/nucleo144-f446/include/periph_conf.h
+++ b/boards/nucleo144-f446/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo144-f446 STM Nucleo144-F446
- * @ingroup     boards_nucleo144
- * @brief       Support for the STM Nucleo144-F446
+ * @defgroup    boards_nucleo144-f446 STM32 Nucleo144-F446
+ * @ingroup     boards_common_nucleo144
+ * @brief       Support for the STM32 Nucleo144-F446
  * @{
  *
  * @file

--- a/boards/nucleo144-f722/include/periph_conf.h
+++ b/boards/nucleo144-f722/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo144-f722 STM Nucleo144-F722
- * @ingroup     boards_nucleo144
- * @brief       Support for the STM Nucleo144-F722
+ * @defgroup    boards_nucleo144-f722 STM32 Nucleo144-F722
+ * @ingroup     boards_common_nucleo144
+ * @brief       Support for the STM32 Nucleo144-F722
  * @{
  *
  * @file

--- a/boards/nucleo144-f746/include/periph_conf.h
+++ b/boards/nucleo144-f746/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo144-f746 STM Nucleo144-F746
- * @ingroup     boards_nucleo144
- * @brief       Support for the STM Nucleo144-F746
+ * @defgroup    boards_nucleo144-f746 STM32 Nucleo144-F746
+ * @ingroup     boards_common_nucleo144
+ * @brief       Support for the STM32 Nucleo144-F746
  * @{
  *
  * @file

--- a/boards/nucleo144-f767/include/periph_conf.h
+++ b/boards/nucleo144-f767/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo144-f767 STM Nucleo144-F767
- * @ingroup     boards_nucleo144
- * @brief       Support for the STM Nucleo144-F767
+ * @defgroup    boards_nucleo144-f767 STM32 Nucleo144-F767
+ * @ingroup     boards_common_nucleo144
+ * @brief       Support for the STM32 Nucleo144-F767
  * @{
  *
  * @file

--- a/boards/nucleo32-f031/include/periph_conf.h
+++ b/boards/nucleo32-f031/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo32-f031 STM Nucleo32-F031
- * @ingroup     boards_nucleo32
- * @brief       Support for the STM Nucleo32-F031
+ * @defgroup    boards_nucleo32-f031 STM32 Nucleo32-F031
+ * @ingroup     boards_common_nucleo32
+ * @brief       Support for the STM32 Nucleo32-F031
  * @{
  *
  * @file

--- a/boards/nucleo32-f042/include/periph_conf.h
+++ b/boards/nucleo32-f042/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo32-f042 STM Nucleo32-F042
- * @ingroup     boards_nucleo32
- * @brief       Support for the STM Nucleo32-F042
+ * @defgroup    boards_nucleo32-f042 STM32 Nucleo32-F042
+ * @ingroup     boards_common_nucleo32
+ * @brief       Support for the STM32 Nucleo32-F042
  * @{
  *
  * @file

--- a/boards/nucleo32-f303/include/periph_conf.h
+++ b/boards/nucleo32-f303/include/periph_conf.h
@@ -7,9 +7,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo32-f303 STM Nucleo32-F303
- * @ingroup     boards_nucleo32
- * @brief       Support for the STM Nucleo32-F303
+ * @defgroup    boards_nucleo32-f303 STM32 Nucleo32-F303
+ * @ingroup     boards_common_nucleo32
+ * @brief       Support for the STM32 Nucleo32-F303
  * @{
  *
  * @file

--- a/boards/nucleo32-l031/include/periph_conf.h
+++ b/boards/nucleo32-l031/include/periph_conf.h
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo32-l031 STM Nucleo32-L031
- * @ingroup     boards_nucleo32
- * @brief       Support for the STM Nucleo32-L031
+ * @defgroup    boards_nucleo32-l031 STM32 Nucleo32-L031
+ * @ingroup     boards_common_nucleo32
+ * @brief       Support for the STM32 Nucleo32-L031
  * @{
  *
  * @file

--- a/boards/nucleo32-l432/include/periph_conf.h
+++ b/boards/nucleo32-l432/include/periph_conf.h
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_nucleo32-l432 STM Nucleo32-L432
- * @ingroup     boards_nucleo32
- * @brief       Support for the STM Nucleo32-L432
+ * @defgroup    boards_nucleo32-l432 STM32 Nucleo32-L432
+ * @ingroup     boards_common_nucleo32
+ * @brief       Support for the STM32 Nucleo32-L432
  * @{
  *
  * @file

--- a/drivers/sx127x/include/sx127x_params.h
+++ b/drivers/sx127x/include/sx127x_params.h
@@ -29,7 +29,7 @@ extern "C" {
 
 /**
  * @name    Set default configuration parameters for the SX127X driver
- *          Pins are adapted to ST Nucleo boards.
+ *          Pins are adapted to STM32 Nucleo-64 boards.
  * @{
  */
 #ifndef SX127X_PARAM_SPI

--- a/tests/driver_dsp0401/README.md
+++ b/tests/driver_dsp0401/README.md
@@ -12,7 +12,7 @@ The display can be controlled from the JP1 connection jumper as follows:
 * Connect `PWM` to the board `DSP0401_PARAM_PWM_DEV` pwm device. See the board periph_conf.h
 to find a valid pin and configuration.
 * Connect `VCC` to one of the board VCC pin (3.3V or 5V depending on your board.
-  Example: use 3.3V with ST Nucleo)
+  Example: use 3.3V with STM32 Nucleo-64)
 * Connect `GND` to one of the board GND.
 
 Since there are potentially a lot of LEDs to poweron, it's preferable to use an

--- a/tests/driver_sx127x/README.md
+++ b/tests/driver_sx127x/README.md
@@ -3,7 +3,7 @@
 This is a manual test application for the SX127X radio driver.
 
 This test application uses the default pin configuration provided by the
-driver implementation and that matches the ST Nucleo 64 pins layout.
+driver implementation and that matches the STM32 Nucleo-64 layout.
 It is best to use [SX1272](https://developer.mbed.org/components/SX1272MB2xAS/)
 or [SX1276](https://developer.mbed.org/components/SX1276MB1xAS/) mbed modules
 with nucleo boards or the all-in-one

--- a/tests/pkg_semtech-loramac/README.md
+++ b/tests/pkg_semtech-loramac/README.md
@@ -40,7 +40,7 @@ use the `set`/`get` commands in test application shell.
 ### Building the application
 
 The default parameters for the Semtech SX1272/SX1276 radios works as-is with
-ST Nucleo 64 boards and MBED LoRa shields
+STM32 Nucleo-64 boards and MBED LoRa shields
 ([SX1276](https://os.mbed.com/components/SX1276MB1xAS/) or
 [SX1272](https://os.mbed.com/components/SX1272MB2xAS/)). You can also use the
 ST [b-l072z-lrwan1](http://www.st.com/en/evaluation-tools/b-l072z-lrwan1.html)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the wrong doxygen parent grouping of nucleo boards introduced by #8065. Otherwise all nucleo boards group are now displayed at the root of Modules in the online documentation:
* fix correct parent group for common nucleo group, e.g use `boards`: this way the nucleo32/64/144 common groups are displayed at board level
* fix each boards parent group, e.g use `boards_common_nucleo32/64/144`: this way, all nucleo boards are displayed in 32/64/144 groups
* rename STM to ST because I think that the company name is ST, and STMicroelectronics a sub departement of ST. This is debatable, I can change that if requested.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#8065

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->