### PR TITLE
doc: added link to the tutorial in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ but not limited to:
 
 
 ## GETTING STARTED
-* You want to start the RIOT? Just follow our [quickstart guide](http://doc.riot-os.org/index.html#the-quickest-start) or the [getting started documentation](http://doc.riot-os.org/getting-started.html).
+* You want to start the RIOT? Just follow our [quickstart guide](http://doc.riot-os.org/index.html#the-quickest-start) or try this [tutorial](https://github.com/RIOT-OS/Tutorials/blob/master/README.md). For specific toolchain installation, follow instructions in the [getting started](http://doc.riot-os.org/getting-started.html) page.
 * The RIOT API itself can be built from the code using doxygen. The latest
-  version is uploaded daily to http://riot-os.org/api.
+  version of the documentation is uploaded daily to [riot-os.org/api](http://riot-os.org/api).
 
 ### USING THE NATIVE PORT WITH NETWORKING
 If you compile RIOT for the native cpu and include the `netdev_tap` module,


### PR DESCRIPTION
The main README does not link to the tutorials.
This PR fixes this.