### PR TITLE
boards: define default radio for wsn430 boards

### DIFF
--- a/boards/common/wsn430/include/board_common.h
+++ b/boards/common/wsn430/include/board_common.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef BOARD_H
-#define BOARD_H
+#ifndef BOARD_COMMON_H
+#define BOARD_COMMON_H
 
 #include "cpu.h"
 
@@ -73,5 +73,5 @@ extern "C" {
 }
 #endif
 
-#endif /* BOARD_H */
+#endif /* BOARD_COMMON_H */
 /** @} */

--- a/boards/wsn430-v1_3b/include/board.h
+++ b/boards/wsn430-v1_3b/include/board.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_wsn430-v1_3b WSN430 v1.3b
+ * @ingroup     boards
+ * @brief       Support for the Senslab WSN430 v1.3b board
+ *
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Senslab WSN430 v1.3b board
+ *
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Define the interface to the CC1101 radio
+ * @{
+ */
+#define CC110X_PARAM_CS             (GPIO_PIN(P4, 2))
+#define CC110X_PARAM_GDO0           (GPIO_PIN(P1, 3))
+#define CC110X_PARAM_GDO1           (GPIO_PIN(P5, 2))
+#define CC110X_PARAM_GDO2           (GPIO_PIN(P1, 4))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/wsn430-v1_4/include/board.h
+++ b/boards/wsn430-v1_4/include/board.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_wsn430-v1_4 WSN430 v1.4
+ * @ingroup     boards
+ * @brief       Support for the Senslab WSN430 v1.4 board
+ *
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Senslab WSN430 v1.4 board
+ *
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Define the interface to the CC2420 radio
+ * @{
+ */
+#define CC2420_PARAMS_PIN_CS            (GPIO_PIN(P4, 2))
+#define CC2420_PARAMS_PIN_FIFO          (GPIO_PIN(P1, 3))
+#define CC2420_PARAMS_PIN_FIFOP         (GPIO_PIN(P1, 4))
+#define CC2420_PARAMS_PIN_CCA           (GPIO_PIN(P1, 6))
+#define CC2420_PARAMS_PIN_SFD           (GPIO_PIN(P1, 5))
+#define CC2420_PARAMS_PIN_VREFEN        (GPIO_PIN(P3, 0))
+#define CC2420_PARAMS_PIN_RESET         (GPIO_PIN(P1, 7))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */


### PR DESCRIPTION
### Contribution description
While testing #8061 I noticed, that the default radios for the wsn430 are not configured. Sadly it doesn't work right now but it doesn't work, but I don't know why. At least with my limited possibilities (debugging via IoT-Lab + using `printf()`) I was able to see, that

* the wsn430-v1_3b hangs after calling `cc110x_cs()` in `_reset()` of `drivers/cc110x/cc110x.c` (called from `cc110x_setup()` in `auto_init`) and
* the wsn430-v1_4 hangs after `gpio_set(dev->params.pin_reset);` in the `netdev::init()` method of the cc2420 driver.

Anyone has an idea? Maybe some from the INRIA people @kYc0o @aabadie or one of the more hardware-savvy crowy @PeterKietzmann @gebart?

### Issues/PRs references
Depends on #8437.