### PR TITLE
gnrc/netreg: fix assert

### DIFF
--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -39,11 +39,9 @@ void gnrc_netreg_init(void)
 int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
 {
 #if defined(MODULE_GNRC_NETAPI_MBOX) || defined(MODULE_GNRC_NETAPI_CALLBACKS)
-#ifdef DEVELHELP
     /* only threads with a message queue are allowed to register at gnrc */
     assert((entry->type != GNRC_NETREG_TYPE_DEFAULT) ||
            sched_threads[entry->target.pid]->msg_array);
-#endif
 #else
     /* only threads with a message queue are allowed to register at gnrc */
     assert(sched_threads[entry->target.pid]->msg_array);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes wrong order in preprocessor `if-else` causing failed assertions during release testing, see [here](https://github.com/RIOT-OS/Release-Specs/issues/55#issuecomment-358957220)

### Issues/PRs references

https://github.com/RIOT-OS/Release-Specs/issues/55#issuecomment-358957220