### PR TITLE
tests: deactivate DEVELHELP for unittests

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,3 +1,4 @@
+DEVELHELP ?= 0
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon \


### PR DESCRIPTION
### Contribution description
In my opinion it doesn't make sense to activate DEVELHELP for unittests because it also causes the evaluation of `assert()`. This causes the tests to crash for values the tests test intentionally (because it is
the point of the unittests to test also some unexpected values and how this influences the behavior).

And from a purely release procedural point of view this makes sense: in 2017.10 the unittests were still working, now they don't, only because `DEVELHELP` was activated. *[edit]TL;DR Unittests are there to test if a piece of software *still* works after a change, so if a change breaks the unittests it should be reverted ;-)[/edit]* So even if you don't agree with my opinion stated above it makes sense to merge this at least for 2018.01 as a quick fix to keep the release train rolling.

### Issues/PRs references
Related to https://github.com/RIOT-OS/Release-Specs/issues/55#issuecomment-358957220 and picks up discussion from https://github.com/RIOT-OS/RIOT/pull/8439