### PR TITLE
Fix/ftdi/usb hardware add

### DIFF
--- a/boards/common/iotlab/Makefile.include
+++ b/boards/common/iotlab/Makefile.include
@@ -11,6 +11,7 @@ export BAUD = 500000
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # this board uses openocd
+export DEBUG_ADAPTER ?= ftdi
 include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # add the common header files to the include path

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -32,6 +32,31 @@ ifeq ($(PORT),)
   ifeq ($(OS),Linux)
     ifneq ($(DEBUG_ADAPTER_ID),)
       PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh '^$(DEBUG_ADAPTER_ID)$$'))
+
+      # OpenOCD settings for Mulle programmer board.
+      # Try to determine which OpenOCD config file we should use based on the
+      # programmer board serial number.
+
+      # Makefile-way of comparing numbers, using lexicographical sorting since we
+      # don't have any arithmetic comparisons.
+      # Programmers with serial 100 -- 148 are version 0.60
+      # Programmers with serial 301 -- 330 are version 0.70
+      ifeq "100" "$(word 1, $(sort 100 $(DEBUG_ADAPTER_ID)))"
+        # >= 100
+        ifneq "149" "$(word 1, $(sort 149 $(DEBUG_ADAPTER_ID)))"
+          # < 149
+          PROGRAMMER_VERSION = 0.60
+        else
+          # >= 149
+          PROGRAMMER_VERSION = 0.70
+        endif
+      endif
+
+      # Default to version 0.70 programmer
+      # NOTE: Some boards (e.g. mulle) could define their own version.
+      PROGRAMMER_VERSION ?= 0.70
+      OPENOCD_ADAPTER_INIT ?= -f '$(RIOTBASE)/boards/mulle/dist/openocd/mulle-programmer-$(PROGRAMMER_VERSION).cfg'
+
     else
       # find-tty.sh will return the first USB tty if no serial is given.
       PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh))

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -25,7 +25,6 @@ export DEBUG_ADAPTER ?= ftdi
 OS := $(shell uname)
 
 # Fall back to PROGRAMMER_SERIAL for backwards compatibility
-export DEBUG_ADAPTER_ID ?= $(PROGRAMMER_SERIAL)
 
 ifeq ($(PORT),)
   # try to find tty name by serial number, only works on Linux currently.
@@ -51,12 +50,6 @@ ifeq ($(PORT),)
           PROGRAMMER_VERSION = 0.70
         endif
       endif
-
-      # Default to version 0.70 programmer
-      # NOTE: Some boards (e.g. mulle) could define their own version.
-      PROGRAMMER_VERSION ?= 0.70
-      OPENOCD_ADAPTER_INIT ?= -f '$(RIOTBASE)/boards/mulle/dist/openocd/mulle-programmer-$(PROGRAMMER_VERSION).cfg'
-
     else
       # find-tty.sh will return the first USB tty if no serial is given.
       PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh))
@@ -73,6 +66,12 @@ ifeq ($(PORT),)
   # fall back to a sensible default
   PORT := /dev/ttyUSB0
 endif
+
+# Default to version 0.70 programmer
+# NOTE: Some boards (e.g. mulle) could define their own version.
+PROGRAMMER_VERSION ?= 0.70
+OPENOCD_ADAPTER_INIT ?= -f '$(RIOTBASE)/boards/mulle/dist/openocd/mulle-programmer-$(PROGRAMMER_VERSION).cfg'
+
 
 # We need special handling of the watchdog if we want to speed up the flash
 # verification by using the MCU to compute the image checksum after flashing.

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -20,7 +20,7 @@ endif
 export CPU_MODEL
 
 # Default debug adapter choice is to use the Mulle programmer board
-export DEBUG_ADAPTER ?= mulle
+export DEBUG_ADAPTER ?= ftdi
 # Host OS name
 OS := $(shell uname)
 

--- a/dist/tools/usb-serial/find-usb.sh
+++ b/dist/tools/usb-serial/find-usb.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (C) 2018 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser General
+# Public License v2.1. See the file LICENSE in the top level directory for more
+# details.
+#
+
+# Find the USB hardware address linked to logical address (dev/ttyusb*)
+
+# default error status code
+status=1
+
+# iterate over usb-tty devices:
+for basedev in $(find /sys/bus/usb/devices/ -regex "/sys/bus/usb/devices/[0-9]+[^:/]*" -maxdepth 2 -follow 2>/dev/null); do
+    ttydirs=$(find ${basedev} -regex "${basedev}/[^/]*:.*" -mindepth 2 -maxdepth 3 -name tty -follow 2>/dev/null)
+    if [ -z "${ttydirs}" ]; then
+        continue
+    fi
+    # See if the device has any tty devices assigned to it
+    for tty in $(find ${ttydirs} -maxdepth 1 -mindepth 1 -printf '%f\n' 2>/dev/null); do
+        parent=$(echo ${basedev} | sed -e 's%\(/sys/bus/usb/devices/[^/]*\)/.*%\1%')
+        # split results into array
+
+        if [ $# -lt 1 ]; then
+            # No arguments given, return all usb hardware addresses
+            uper=$(echo ${parent} | tr -d '/sys/bus/usb/devices/' | \
+                   tr '.' ',' | tr '-' ':')
+            echo "${uper}"
+            status=0
+            continue
+        fi
+        # else: Match any of the given tty
+        for s in "${@}"; do
+            echo "/dev/${tty}" | egrep -e "${s}" -q
+            if [ $? -eq 0 ]; then
+                # return usb hardware address
+                # echo "${parent}"
+                uper=$(echo ${parent} | tr -d '/sys/bus/usb/devices/' | \
+                       tr '.' ',' | tr '-' ':')
+                echo "${uper}"
+                # convert_syntax "${parent}"
+                status=0
+            fi
+        done
+    done
+done
+
+exit $status;

--- a/makefiles/tools/openocd-adapters/ftdi.inc.mk
+++ b/makefiles/tools/openocd-adapters/ftdi.inc.mk
@@ -2,7 +2,7 @@
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
-else ifeq (,$(DEBUG_ADAPTER_LOCATION))
+else ifeq (Linux,$(OS))
   # Some boards don't have serial at all (eg. itolab-m3)
   # find-usb.sh will return the USB hardware address for PORT (/dev/ttyUSB*)
   DEBUG_ADAPTER_ID := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-usb.sh '$(PORT)'))

--- a/makefiles/tools/openocd-adapters/ftdi.inc.mk
+++ b/makefiles/tools/openocd-adapters/ftdi.inc.mk
@@ -1,3 +1,4 @@
+# ftdi-serial debug adapter
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'

--- a/makefiles/tools/openocd-adapters/ftdi.inc.mk
+++ b/makefiles/tools/openocd-adapters/ftdi.inc.mk
@@ -3,7 +3,7 @@
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
 else ifeq (,$(DEBUG_ADAPTER_LOCATION))
-  #Some boards doesn't have serial at all (eg. itolab-m3)
+  # Some boards don't have serial at all (eg. itolab-m3)
   # find-usb.sh will return the USB hardware address for PORT (/dev/ttyUSB*)
   DEBUG_ADAPTER_ID := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-usb.sh '$(PORT)'))
   OPENOCD_EXTRA_INIT += -c 'ftdi_location $(DEBUG_ADAPTER_ID)'

--- a/makefiles/tools/openocd-adapters/ftdi.inc.mk
+++ b/makefiles/tools/openocd-adapters/ftdi.inc.mk
@@ -2,5 +2,11 @@
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
+else ifeq (,$(DEBUG_ADAPTER_LOCATION))
+  #Some boards doesn't have serial at all (eg. itolab-m3)
+  # find-usb.sh will return the USB hardware address for PORT (/dev/ttyUSB*)
+  DEBUG_ADAPTER_ID := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-usb.sh '$(PORT)'))
+  OPENOCD_EXTRA_INIT += -c 'ftdi_location $(DEBUG_ADAPTER_ID)'
 endif
 export OPENOCD_ADAPTER_INIT
+export OPENOCD_EXTRA_INIT

--- a/makefiles/tools/openocd-adapters/mulle.inc.mk
+++ b/makefiles/tools/openocd-adapters/mulle.inc.mk
@@ -1,31 +1,3 @@
-# OpenOCD settings for Mulle programmer board.
-# Try to determine which OpenOCD config file we should use based on the
-# programmer board serial number.
-
-# Fall back to PROGRAMMER_SERIAL for backwards compatibility
-export DEBUG_ADAPTER_ID ?= $(PROGRAMMER_SERIAL)
-
-ifneq (,$(DEBUG_ADAPTER_ID))
-  # Makefile-way of comparing numbers, using lexicographical sorting since we
-  # don't have any arithmetic comparisons.
-  # Programmers with serial 100 -- 148 are version 0.60
-  # Programmers with serial 301 -- 330 are version 0.70
-  ifeq "100" "$(word 1, $(sort 100 $(DEBUG_ADAPTER_ID)))"
-    # >= 100
-    ifneq "149" "$(word 1, $(sort 149 $(DEBUG_ADAPTER_ID)))"
-      # < 149
-      PROGRAMMER_VERSION = 0.60
-    else
-      # >= 149
-      PROGRAMMER_VERSION = 0.70
-    endif
-  endif
-endif
-# Default to version 0.70 programmer
-PROGRAMMER_VERSION ?= 0.70
-
-OPENOCD_ADAPTER_INIT ?= -f '$(RIOTBASE)/boards/mulle/dist/openocd/mulle-programmer-$(PROGRAMMER_VERSION).cfg'
-
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While working with physical boards iotlab-m3 I noticed that they were burned without a serial field, restricting RIOT ability of working with multiple of them at the same time. 

This is what RIOT sees when two iotlab-m3 boards are up:

```
~/RIOT/examples/hello-world$ make list-ttys 
/sys/bus/usb/devices/4-1.7.1.6: IoT-LAB M3 serial: '', tty(s): ttyUSB2
/sys/bus/usb/devices/4-1.7.1.5.2: HiKoB FITECO M3 serial: '', tty(s): ttyUSB1
```

`make flash` will works but will be always with `ttyUSB1`. The alternative is to use the real USB hardware address which requires the use of `ftdi_location` command instead of `ftdi_serial`. 

Also, after a off-line discussion with @kYc0o , we opted to concentrate all the current work for the FTDI driver, and this addition,  in a single point. This is why the mulle board is also impacted by this commit, as was already using the FTDI driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->