### PR TITLE
tests/periph_uart: included power_on/off() in test

### DIFF
--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -152,6 +152,18 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     }
 }
 
+void uart_poweron(uart_t uart)
+{
+    (void)uart;
+    /* not implemented (yet) */
+}
+
+void uart_poweroff(uart_t uart)
+{
+    (void)uart;
+    /* not implemented (yet) */
+}
+
 static inline void isr_handler(int num)
 {
     isr_ctx[num].rx_cb(isr_ctx[num].arg, dev[num]->DR);

--- a/cpu/kinetis/periph/uart.c
+++ b/cpu/kinetis/periph/uart.c
@@ -122,6 +122,18 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     return UART_OK;
 }
 
+void uart_poweron(uart_t uart)
+{
+    (void)uart;
+    /* not implemented (yet) */
+}
+
+void uart_poweroff(uart_t uart)
+{
+    (void)uart;
+    /* not implemented (yet) */
+}
+
 #if KINETIS_HAVE_UART && KINETIS_HAVE_LPUART
 /* Dispatch function to pass to the proper write function depending on UART type
  * This function is only used when the CPU supports both UART and LPUART. */

--- a/cpu/lpc2387/periph/uart.c
+++ b/cpu/lpc2387/periph/uart.c
@@ -98,3 +98,15 @@ void UART0_IRQHandler(void)
 
     VICVectAddr = 0;                    /* Acknowledge Interrupt */
 }
+
+void uart_poweron(uart_t uart)
+{
+    (void)uart;
+    /* not implemented (yet) */
+}
+
+void uart_poweroff(uart_t uart)
+{
+    (void)uart;
+    /* not implemented (yet) */
+}

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -177,3 +177,15 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 
     _native_write(tty_fds[uart], data, len);
 }
+
+void uart_poweron(uart_t uart)
+{
+    (void)uart;
+    /* not implemented (yet) */
+}
+
+void uart_poweroff(uart_t uart)
+{
+    (void)uart;
+    /* not implemented (yet) */
+}

--- a/tests/periph_uart/Makefile
+++ b/tests/periph_uart/Makefile
@@ -5,5 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031
 FEATURES_REQUIRED = periph_uart
 
 USEMODULE += shell
+USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description
The `uart_poweron()` and `uart_poweroff()` functions are so far never been called in any of our test code. So this functions adds a small addition to the `tests/periph_uart` applications and will put each UART device to sleep for a short amount of time before using it. This way it should be guaranteed, that at least the `poweron()` and `poweroff()` functions don't put the device in some unusable state. This test does of course not guarantee, that the uart peripheral actually goes into power down mode, though...

### Issues/PRs references
this comment here triggered this PR: https://github.com/RIOT-OS/RIOT/pull/8345/files#r162366574