### PR TITLE
tests: fix some minor issues with auto tests scripts

### DIFF
--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 #

--- a/tests/thread_msg_block_w_queue/Makefile
+++ b/tests/thread_msg_block_w_queue/Makefile
@@ -7,6 +7,4 @@ DISABLE_MODULE += auto_init
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/thread_msg_block_wo_queue/Makefile
+++ b/tests/thread_msg_block_wo_queue/Makefile
@@ -7,6 +7,4 @@ DISABLE_MODULE += auto_init
 include $(RIOTBASE)/Makefile.include
 
 test:
-# `testrunner` calls `make term` recursively, results in duplicated `TERMFLAGS`.
-# So clears `TERMFLAGS` before run.
-	TERMFLAGS= tests/01-run.py
+	tests/01-run.py

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2017 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
 #


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes two minor issues I found when running some automated tests for the release.
First, 3 tests used `python` instead of explicitly `python3` which caused some weird encoding errors.
Second, two tests cleared TERMFLAGS before running the test script which also cleared the PORT environment and hence terminal connection failed.


### Issues/PRs references
 
None