### PR TITLE
gnrc_ipv6_nib: fix final RA behavior [2018.01 backport]

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -52,10 +52,13 @@ void _handle_snd_mc_ra(gnrc_netif_t *netif)
         bool final_ra = (netif->ipv6.ra_sent > (UINT8_MAX - NDP_MAX_FIN_RA_NUMOF));
         uint32_t next_ra_time = random_uint32_range(NDP_MIN_RA_INTERVAL_MS,
                                                     NDP_MAX_RA_INTERVAL_MS);
+        uint32_t next_scheduled = _evtimer_lookup(netif, GNRC_IPV6_NIB_SND_MC_RA);
 
         /* router has router advertising interface or the RA is one of the
-         * (now deactivated) routers final one */
-        if (final_ra || gnrc_netif_is_rtr_adv(netif)) {
+         * (now deactivated) routers final one (and there is no next
+         * scheduled within the possible time for next_ra_time) */
+        if ((final_ra && (next_scheduled > NDP_MAX_RA_INTERVAL_MS)) ||
+            gnrc_netif_is_rtr_adv(netif)) {
             _snd_rtr_advs(netif, NULL, final_ra);
             netif->ipv6.last_ra = (xtimer_now_usec64() / US_PER_MS) & UINT32_MAX;
             if ((netif->ipv6.ra_sent < NDP_MAX_INIT_RA_NUMOF) || final_ra) {
@@ -190,7 +193,11 @@ void _set_rtr_adv(gnrc_netif_t *netif)
 static void _snd_ra(gnrc_netif_t *netif, const ipv6_addr_t *dst,
                     bool final, _nib_abr_entry_t *abr)
 {
-    gnrc_pktsnip_t *ext_opts = _build_ext_opts(netif, abr);
+    gnrc_pktsnip_t *ext_opts = NULL;
+
+    if (!final) {
+        ext_opts = _build_ext_opts(netif, abr);
+    }
 
     gnrc_ndp_rtr_adv_send(netif, NULL, dst, final, ext_opts);
 }


### PR DESCRIPTION
### Contribution description
This fix

* assures that the periodicity of the final router advertisements is
  kept (so that no administrative change e.g. adding prefixes to the
  prefix list causes additional RAs outside the rate limitation)
* removes all administrative options (PIO, ABRO, 6CO) from final router
  advertisements (with router lifetime == 0)

### Issues/PRs references
Backports https://github.com/RIOT-OS/RIOT/pull/8393