### PR TITLE
tests: deactivate DEVELHELP for unittests [2018.01 backport]

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,3 +1,4 @@
+DEVELHELP ?= 0
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon \


### PR DESCRIPTION
Backport of #8440.