### PR TITLE
vagrant: sync with host time

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,12 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider "virtualbox" do |vb|
     vb.name = "RIOT-VM"
+
+    vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-interval", 10000]
+    vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-min-adjust", 100]
+    vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-on-restore", 1]
+    vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000]
+
     # additional USB passthrough entries
     # vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', '<custom_name>', '--vendorid', '<vID>', '--productid', '<pID>']
   end


### PR DESCRIPTION
### Contribution description
When building with `make` within vagrant, a clock skew warning is thrown.
The proposed modifications to the `Vagrant` file improves the time sync between the host and guest machines.

### Issues/PRs references