### PR TITLE
board/native: add periph_hwrng and init

### DIFF
--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include "board.h"
 #include "periph/rtc.h"
+#include "periph/hwrng.h"
 
 #include "board_internal.h"
 
@@ -33,6 +34,9 @@ void board_init(void)
     LED1_ON;
 #ifdef MODULE_PERIPH_RTC
     rtc_init();
+#endif
+#ifdef MODULE_PERIPH_HWRNG
+    hwrng_init();
 #endif
     puts("RIOT native board initialized.");
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Though native CPU provides the hwrng feature its never initialised when needed.


### Issues/PRs references

fixes #8464 