### PR TITLE
gnrc_sock: set remote network interface implicitly

### DIFF
--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -24,6 +24,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 #include "mbox.h"
 #include "net/af.h"
 #include "net/gnrc.h"
@@ -94,6 +95,25 @@ static inline bool gnrc_ep_addr_any(const sock_ip_ep_t *ep)
         }
     }
     return true;
+}
+
+/**
+ * @brief   Initializes a sock end-point from a given and sets the network
+ *          interface implicitly if there is only one potential interface.
+ * @internal
+ */
+static inline void gnrc_ep_set(sock_ip_ep_t *out, const sock_ip_ep_t *in,
+                               size_t in_size)
+{
+    memcpy(out, in, in_size);
+#if GNRC_NETIF_NUMOF == 1
+    /* set interface implicitly */
+    gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+
+    if (netif != NULL) {
+        out->netif = netif->pid;
+    }
+#endif
 }
 
 /**

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -140,7 +140,8 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
         return -EINVAL;
     }
     if ((remote == NULL) &&
-        /* sock can't be NULL as per assertion above */
+        /* cppcheck-suppress nullPointerRedundantCheck
+         * (reason: sock can't be NULL as per the check above) */
         (sock->remote.family == AF_UNSPEC)) {
         return -ENOTCONN;
     }

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -51,7 +51,7 @@ int sock_ip_create(sock_ip_t *sock, const sock_ip_ep_t *local,
         if (gnrc_ep_addr_any(remote)) {
             return -EINVAL;
         }
-        memcpy(&sock->remote, remote, sizeof(sock_ip_ep_t));
+        gnrc_ep_set(&sock->remote, remote, sizeof(sock_ip_ep_t));
     }
     gnrc_sock_create(&sock->reg, GNRC_NETTYPE_IPV6,
                      proto);
@@ -165,7 +165,7 @@ ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
         memcpy(&rem, &sock->remote, sizeof(rem));
     }
     else {
-        memcpy(&rem, remote, sizeof(rem));
+        gnrc_ep_set(&rem, remote, sizeof(rem));
     }
     if ((remote != NULL) && (remote->family == AF_UNSPEC) &&
         (sock->remote.family != AF_UNSPEC)) {

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -252,6 +252,9 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
         if ((src_port = _get_dyn_port(sock)) == GNRC_SOCK_DYN_PORTRANGE_ERR) {
             return -EINVAL;
         }
+        /* cppcheck-suppress nullPointer
+         * (reason: sock *can* be NULL at this place, cppcheck is weird here as
+         * well, see above) */
         if (sock != NULL) {
             /* bind sock object implicitly */
             sock->local.port = src_port;

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -123,7 +123,8 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
         if (gnrc_ep_addr_any((const sock_ip_ep_t *)remote)) {
             return -EINVAL;
         }
-        memcpy(&sock->remote, remote, sizeof(sock_udp_ep_t));
+        gnrc_ep_set((sock_ip_ep_t *)&sock->remote,
+                    (sock_ip_ep_t *)remote, sizeof(sock_udp_ep_t));
     }
     if (local != NULL) {
         /* listen only with local given */
@@ -216,6 +217,7 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
     gnrc_pktsnip_t *payload, *pkt;
     uint16_t src_port = 0, dst_port;
     sock_ip_ep_t local;
+    sock_udp_ep_t remote_cpy;
     sock_ip_ep_t *rem;
 
     assert((sock != NULL) || (remote != NULL));
@@ -277,7 +279,8 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
         dst_port = sock->remote.port;
     }
     else {
-        rem = (sock_ip_ep_t *)remote;
+        rem = (sock_ip_ep_t *)&remote_cpy;
+        gnrc_ep_set(rem, (sock_ip_ep_t *)remote, sizeof(sock_udp_ep_t));
         dst_port = remote->port;
     }
     /* check for matching address families in local and remote */


### PR DESCRIPTION
### Contribution description
When there is only one interface we are simplifying a lot for the users
if the interface is set implicitly.

### Issues/PRs references
"Fixes" the problems encountered in #8457.