### PR TITLE
cpu/efm32: fix 'cpu' module name conflict

### DIFF
--- a/cpu/efm32/Makefile.include
+++ b/cpu/efm32/Makefile.include
@@ -14,6 +14,12 @@ ifeq ($(CPU_ARCH),cortex-m0plus)
   USEPKG += cmsis-dsp
 endif
 
+# include CPU family module
+USEMODULE += cpu_$(EFM32_FAMILY)
+
+# vectors.o is provided by 'cpu_$(EFM32_FAMILY)' and not by 'cpu'
+VECTORS_O := $(BINDIR)/cpu_$(EFM32_FAMILY)/vectors.o
+
 # include common periph module
 USEMODULE += periph_common
 

--- a/cpu/efm32/families/efr32mg1p/Makefile
+++ b/cpu/efm32/families/efr32mg1p/Makefile
@@ -1,4 +1,4 @@
-MODULE = cpu
+MODULE = cpu_efr32mg1p
 
 # (file triggers compiler bug. see #5775)
 SRC_NOLTO += vectors.c

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -85,8 +85,9 @@ endif
 
 # Explicitly tell the linker to link the startup code.
 #   Without this the interrupt vectors will not be linked correctly!
+VECTORS_O ?= $(BINDIR)/cpu/vectors.o
 ifeq ($(COMMON_STARTUP),)
-export UNDEF += $(BINDIR)/cpu/vectors.o
+export UNDEF += $(VECTORS_O)
 endif
 
 # CPU depends on the cortex-m common module, so include it:


### PR DESCRIPTION
### Contribution description

In 'cpu/efm32' two different directories had the same module name 'cpu'.

It can lead to issues when building in parallel, when building with a non clean environment, or if the two modules start providing a file with the same name.

This required adding a configuration variable for vectors.o path in cortexm.inc.mk.

### Issues/PRs references

This is required to merge https://github.com/RIOT-OS/RIOT/pull/7952