### PR TITLE
drivers/ata8520e: internal improvements

### DIFF
--- a/drivers/ata8520e/include/ata8520e_internals.h
+++ b/drivers/ata8520e/include/ata8520e_internals.h
@@ -60,6 +60,26 @@ extern "C" {
 #define ATA8520E_ATMEL_PA_MASK               (0x01)
 /** @} */
 
+/**
+ * @name Sigfox errors codes
+ * @{
+ */
+#define ATA8520E_SIGFOX_NO_ERROR             (0x00)
+#define ATA8520E_SIGFOX_TX_LEN_TOO_LONG      (0x30)
+#define ATA8520E_SIGFOX_RX_TIMEOUT           (0x3E)
+#define ATA8520E_SIGFOX_RX_BIT_TIMEOUT       (0x4E)
+/** @} */
+
+/**
+ * @name Sigfox2 errors codes
+ * @{
+ */
+#define ATA8520E_SIGFOX2_INIT_ERROR          (0x10)
+#define ATA8520E_SIGFOX2_TX_ERROR            (0x18)
+#define ATA8520E_SIGFOX2_RF_ERROR            (0x40)
+#define ATA8520E_SIGFOX2_DF_WAIT_ERROR       (0x68)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/ata8520e.h
+++ b/drivers/include/ata8520e.h
@@ -196,15 +196,6 @@ void ata8520e_read_pac(const ata8520e_t *dev, char *pac);
 void ata8520e_read_id(const ata8520e_t *dev, char *id);
 
 /**
- * @brief Check the current status of the device
- *
- * Calling this function clears the system event line.
- *
- * @param[in] dev                 Pointer to device descriptor
- */
-void ata8520e_status(const ata8520e_t *dev);
-
-/**
  * @brief Send a frame
  *
  * @param[in] dev                 Pointer to device descriptor


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

After the comments received in #7087 but after it was merged, I decided to look again at this driver implementation and found that there were effectively things that could be changed, or rewritten. So this PR:
- moves public function `ata8520e_status` to the private implementation because it makes no sense to leave this public
- rewrite the print status helper functions (only used with ENABLE_DEBUG). The status codes have changed but this is because the datasheet of the ATA8520E doesn't mention them. This is because I initially wrote this driver for the [ata8520](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-9372-Smart-RF-ATA8520_Datasheet.pdf) (no *e* at the end) by mistake where they were defined.
- add helpful references to the datasheet in comments

This PR has been tested with success on the Arduino MKRFOX1200.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#7087 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->