### PR TITLE
cpu: efm32: implement pwm modes.

### DIFF
--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -28,6 +28,7 @@
 #include "em_cmu.h"
 #include "em_device.h"
 #include "em_gpio.h"
+#include "em_timer.h"
 #include "em_usart.h"
 #ifdef _SILICON_LABS_32B_SERIES_0
 #include "em_dac.h"
@@ -252,6 +253,20 @@ typedef struct {
     CMU_Clock_TypeDef cmu;  /**< the device CMU channel */
     IRQn_Type irq;          /**< the devices base IRQ channel */
 } i2c_conf_t;
+
+#ifndef DOXYGEN
+/**
+ * @brief   Override PWM mode values.
+ * @{
+ */
+#define HAVE_PWM_MODE_T
+typedef enum {
+    PWM_LEFT = timerModeUp,           /*< use left aligned PWM */
+    PWM_RIGHT = timerModeDown,        /*< use right aligned PWM */
+    PWM_CENTER = timerModeUp          /*< not supported, use left aligned */
+} pwm_mode_t;
+/** @} */
+#endif /* ndef DOXYGEN */
 
 /**
  * @brief   PWM channel configuration.

--- a/cpu/efm32/periph/pwm.c
+++ b/cpu/efm32/periph/pwm.c
@@ -52,6 +52,7 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
     init.enable = false;
     init.prescale = prescaler;
+    init.mode = (TIMER_Mode_TypeDef) mode;
 
     TIMER_Reset(pwm_config[dev].dev);
     TIMER_Init(pwm_config[dev].dev, &init);


### PR DESCRIPTION
### Contribution description

This PR implements `pwm_mode_t` for the EFM32 and therefore fixes the unused variable `mode`. Although the only EFM32 boards supported in `master` don't use the PWM driver, I have tested this locally with a STK3600.

I need this fix for my upcoming PR to support the development boards that have PWM support.

### Issues/PRs references

This is the cause of the failed builds of (the closed) PRs #8296, #8297 and #8298.