### PR TITLE
shell_commands: sntp: increase default timeout

### DIFF
--- a/sys/shell/commands/sc_sntp.c
+++ b/sys/shell/commands/sc_sntp.c
@@ -27,12 +27,12 @@
 #include "net/ipv6/addr.h"
 #include "timex.h"
 
-#define _DEFAULT_TIMEOUT (5000U);
+#define _DEFAULT_TIMEOUT (500000LU)
 
 static void _usage(char *cmd)
 {
     printf("Usage: %s <server addr>[%%<interface>] [<timeout in us>]\n", cmd);
-    puts("default: timeout = 5000");
+    printf("default: timeout = %lu\n", _DEFAULT_TIMEOUT);
 }
 
 int _ntpdate(int argc, char **argv)

--- a/sys/shell/commands/sc_sntp.c
+++ b/sys/shell/commands/sc_sntp.c
@@ -31,7 +31,7 @@
 
 static void _usage(char *cmd)
 {
-    printf("Usage: %s <server addr>[%%<interface>] [<timeout>]\n", cmd);
+    printf("Usage: %s <server addr>[%%<interface>] [<timeout in us>]\n", cmd);
     puts("default: timeout = 5000");
 }
 


### PR DESCRIPTION
### Contribution description
This PR

* specifies the time unit used for the timeout with the `ntpdate` command
* increases the default timeout as 5000μs is far to small

### Issues/PRs references
Fixes #8473