### PR TITLE
gnrc_ipv6_nib: ignore corner case when adding to PL

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -764,12 +764,17 @@ _nib_offl_entry_t *_nib_pl_add(unsigned iface,
         if (pref_ltime != UINT32_MAX) {
             _evtimer_add(dst, GNRC_IPV6_NIB_PFX_TIMEOUT, &dst->pfx_timeout,
                          pref_ltime);
-            if (((pref_ltime + now) == UINT32_MAX) && (now != 0)) {
-                pref_ltime++;
+            /* ignore capped of preferred lifetimes from sec to ms conversion */
+            if (pref_ltime < (UINT32_MAX - 1)) {
+                /* prevent pref_ltime from becoming UINT32_MAX */
+                if (((pref_ltime + now) == UINT32_MAX) && (now != 0)) {
+                    pref_ltime++;
+                }
+                pref_ltime += now;
             }
-            pref_ltime += now;
         }
-        if (valid_ltime != UINT32_MAX) {
+        /* ignore capped of valid lifetimes from sec to ms conversion */
+        if (valid_ltime < (UINT32_MAX - 1)) {
             /* prevent valid_ltime from becoming UINT32_MAX */
             if ((valid_ltime + now) == UINT32_MAX) {
                 valid_ltime++;

--- a/tests/gnrc_ipv6_nib/main.c
+++ b/tests/gnrc_ipv6_nib/main.c
@@ -1114,8 +1114,8 @@ static void test_handle_pkt__rtr_adv__success(uint8_t rtr_adv_flags,
                                 "Unexpected prefix configured");
             TEST_ASSERT_EQUAL_INT(_LOC_GB_PFX_LEN, prefix.pfx_len);
             TEST_ASSERT_EQUAL_INT(_mock_netif->pid, prefix.iface);
-            TEST_ASSERT(_PIO_PFX_LTIME < prefix.valid_until);
-            TEST_ASSERT(_PIO_PFX_LTIME < prefix.pref_until);
+            TEST_ASSERT((_PIO_PFX_LTIME / MS_PER_SEC) < prefix.valid_until);
+            TEST_ASSERT((_PIO_PFX_LTIME / MS_PER_SEC) < prefix.pref_until);
         }
     }
     if (!pio || !(pio_flags & NDP_OPT_PI_FLAGS_L)) {

--- a/tests/gnrc_ipv6_nib_6ln/main.c
+++ b/tests/gnrc_ipv6_nib_6ln/main.c
@@ -1072,8 +1072,8 @@ static void test_handle_pkt__rtr_adv__success(uint8_t rtr_adv_flags,
                                 "Unexpected prefix configured");
             TEST_ASSERT_EQUAL_INT(_LOC_GB_PFX_LEN, prefix.pfx_len);
             TEST_ASSERT_EQUAL_INT(_mock_netif->pid, prefix.iface);
-            TEST_ASSERT(_PIO_PFX_LTIME < prefix.valid_until);
-            TEST_ASSERT(_PIO_PFX_LTIME < prefix.pref_until);
+            TEST_ASSERT((_PIO_PFX_LTIME / MS_PER_SEC) < prefix.valid_until);
+            TEST_ASSERT((_PIO_PFX_LTIME / MS_PER_SEC) < prefix.pref_until);
         }
     }
     if (!pio) {


### PR DESCRIPTION
### Contribution description
In #8135 the handling of corner cases for the conversion of
milliseconds to seconds, but the internal handling was not adapted.

This fixes that and also the tests for the NIB.

### Issues/PRs references
Fixes #8477