### PR TITLE
drivers: Initial import of low-level QDEC driver interface

### DIFF
--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -3,6 +3,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_qdec
 
 # Various other features (if any)
 FEATURES_PROVIDED += ethernet

--- a/boards/nucleo-f401/Makefile.features
+++ b/boards/nucleo-f401/Makefile.features
@@ -7,6 +7,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_qdec
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/nucleo-f401/include/periph_conf.h
+++ b/boards/nucleo-f401/include/periph_conf.h
@@ -135,19 +135,42 @@ static const pwm_conf_t pwm_config[] = {
         .af       = GPIO_AF1,
         .bus      = APB1
     },
-    {
-        .dev      = TIM3,
-        .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_B, 4) /* D5 */, .cc_chan = 0 },
-                      { .pin = GPIO_PIN(PORT_C, 7) /* D9 */, .cc_chan = 1 },
-                      { .pin = GPIO_PIN(PORT_C, 8),          .cc_chan = 2 },
-                      { .pin = GPIO_PIN(PORT_C, 9),          .cc_chan = 3 } },
-        .af       = GPIO_AF2,
-        .bus      = APB1
-    },
 };
 
 #define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+/** @} */
+
+/**
+ * @name    QDEC configuration
+ * @{
+ */
+static const qdec_conf_t qdec_config[] = {
+    {
+        .dev      = TIM3,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 6),             .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_A, 7),             .cc_chan = 1 } },
+        .af       = GPIO_AF2,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    },
+    {
+        .dev      = TIM4,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 6),             .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_B, 7),             .cc_chan = 1 } },
+        .af       = GPIO_AF2,
+        .bus      = APB1,
+        .irqn     = TIM4_IRQn
+    },
+};
+
+#define QDEC_0_ISR         isr_tim3
+#define QDEC_1_ISR         isr_tim4
+
+#define QDEC_NUMOF           (sizeof(qdec_config) / sizeof(qdec_config[0]))
 /** @} */
 
 /**

--- a/boards/nucleo-f446/Makefile.features
+++ b/boards/nucleo-f446/Makefile.features
@@ -7,6 +7,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_qdec
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/nucleo-f446/include/periph_conf.h
+++ b/boards/nucleo-f446/include/periph_conf.h
@@ -162,16 +162,6 @@ static const pwm_conf_t pwm_config[] = {
         .bus      = APB1
     },
     {
-        .dev      = TIM3,
-        .rcc_mask = RCC_APB1ENR_TIM3EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_B, 4), .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 },
-                      { .pin = GPIO_UNDEF, .cc_chan = 0 } },
-        .af       = GPIO_AF2,
-        .bus      = APB1
-    },
-    {
         .dev      = TIM8,
         .rcc_mask = RCC_APB2ENR_TIM8EN,
         .chan     = { { .pin = GPIO_PIN(PORT_C, 6), .cc_chan = 0},
@@ -184,6 +174,39 @@ static const pwm_conf_t pwm_config[] = {
 };
 
 #define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
+/** @} */
+
+/**
+ * @name    QDEC configuration
+ * @{
+ */
+static const qdec_conf_t qdec_config[] = {
+    {
+        .dev      = TIM3,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 6), .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_A, 7), .cc_chan = 1 } },
+        .af       = GPIO_AF2,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    },
+    {
+        .dev      = TIM4,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 6), .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_B, 7), .cc_chan = 1 } },
+        .af       = GPIO_AF2,
+        .bus      = APB1,
+        .irqn     = TIM4_IRQn
+    },
+};
+
+#define QDEC_0_ISR         isr_tim3
+#define QDEC_1_ISR         isr_tim4
+
+#define QDEC_NUMOF           (sizeof(qdec_config) / sizeof(qdec_config[0]))
 /** @} */
 
 /**

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -72,6 +72,13 @@
 #endif
 /** @} */
 
+/**
+ * @brief QDEC configuration
+ */
+#ifndef QDEC_NUMOF
+#define QDEC_NUMOF (8U)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/native/periph/qdec.c
+++ b/cpu/native/periph/qdec.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2017 Gilles DOFFE <gdoffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     native_cpu
+ * @ingroup     drivers_periph_qdec
+ * @{
+ *
+ * @file
+ * @brief       Low-level QDEC driver implementation
+ *
+ * @author      Gilles DOFFE <gilles.doffe@gmail.com>
+ *
+ * @}
+ */
+
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach_init.h>
+#include <mach/mach_port.h>
+#include <mach/mach_host.h>
+/* Both OS X and RIOT typedef thread_t. timer.c does not use either thread_t. */
+#define thread_t riot_thread_t
+#endif
+
+#include <time.h>
+#include <sys/time.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <err.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "cpu.h"
+#include "cpu_conf.h"
+#include "native_internal.h"
+#include "periph/qdec.h"
+#include "periph/gpio.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifdef QDEC_NUMOF
+
+#define NATIVE_QDEC_MAX     (0x7FFFFFFFL)
+
+/* QDEC devices */
+uint32_t qdecs[QDEC_NUMOF];
+/* QDEC values for each device, should be set externally */
+int32_t  qdecs_value[QDEC_NUMOF];
+
+int32_t qdec_init(qdec_t qdec, qdec_mode_t mode, qdec_cb_t cb, void *arg)
+{
+    /* no interrupt needed since it is externally incremented */
+    (void)cb;
+    (void)arg;
+
+    /* Verify parameters */
+    assert((qdec < QDEC_NUMOF));
+
+    /* Count on A (TI1) signal edges, B (TI2) signal edges or both,
+     * default to EINVAL (Invalid argument).
+     */
+    switch (mode) {
+        /* X1 mode */
+        case QDEC_X1:
+            break;
+        case QDEC_X2:
+        case QDEC_X4:
+        default:
+            errno = EINVAL;
+            goto err_invalid_mode;
+    }
+
+    /* Initialize qdec channels */
+    for (uint8_t i = 0; i < QDEC_NUMOF; i++) {
+        qdecs[qdec] = 0;
+    }
+
+    /* Reset counter and start qdec */
+    qdec_start(qdec);
+
+    return 0;
+
+/* Error management */
+err_invalid_mode:
+    return errno;
+}
+
+/* Return QDEC value */
+inline int32_t qdec_read_and_reset(qdec_t qdec)
+{
+    int32_t count = 0;
+
+    count = qdecs_value[qdec];
+    qdecs_value[qdec] = 0;
+
+    return count;
+}
+
+/* Return QDEC value */
+inline int32_t qdec_read(qdec_t qdec)
+{
+    return qdecs_value[qdec];
+}
+
+/* Empty functions to keep API */
+void qdec_start(qdec_t qdec)
+{
+    (void)qdec;
+}
+
+void qdec_stop(qdec_t qdec)
+{
+    (void)qdec;
+}
+
+#endif /* QDEC_NUMOF */

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -61,6 +61,11 @@ extern "C" {
 #define TIMER_CHAN          (4U)
 
 /**
+ * @brief   All STM QDEC timers have 2 capture channels
+ */
+#define QDEC_CHAN           (2U)
+
+/**
  * @brief   Use the shared SPI functions
  * @{
  */
@@ -243,6 +248,28 @@ typedef struct {
     gpio_af_t af;                   /**< alternate function used */
     uint8_t bus;                    /**< APB bus */
 } pwm_conf_t;
+
+/**
+ * @brief   QDEC channel
+ */
+typedef struct {
+    gpio_t pin;             /**< GPIO pin mapped to this channel */
+    uint8_t cc_chan;        /**< capture compare channel used */
+} qdec_chan_t;
+
+/**
+ * @brief   QDEC configuration
+ */
+typedef struct {
+    TIM_TypeDef *dev;               /**< Timer used */
+    uint32_t max;                   /**< Maximum counter value */
+    uint32_t rcc_mask;              /**< bit in clock enable register */
+    qdec_chan_t chan[QDEC_CHAN];    /**< channel mapping, set to {GPIO_UNDEF, 0}
+                                     *   if not used */
+    gpio_af_t af;                   /**< alternate function used */
+    uint8_t bus;                    /**< APB bus */
+    uint8_t irqn;                   /**< global IRQ channel */
+} qdec_conf_t;
 
 /**
  * @brief   Structure for UART configuration data

--- a/cpu/stm32_common/periph/qdec.c
+++ b/cpu/stm32_common/periph/qdec.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2017 Gilles DOFFE <gdoffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph_qdec
+ * @{
+ *
+ * @file
+ * @brief       Low-level QDEC driver implementation
+ *
+ * @author      Gilles DOFFE <gilles.doffe@gmail.com>
+ *
+ * @}
+ */
+
+#include <errno.h>
+
+#include "cpu.h"
+#include "assert.h"
+#include "periph/qdec.h"
+#include "periph/gpio.h"
+
+#ifdef QDEC_NUMOF
+
+/**
+ * @brief   Interrupt context for each configured qdec
+ */
+static qdec_isr_ctx_t isr_ctx[QDEC_NUMOF];
+
+/**
+ * @brief Read the current value of the given qdec device. Internal use.
+ *
+ * @param[in] dev           the qdec to read the current value from
+ * @param[in] dev           perform a reset of qdec counter if not 0
+ *
+ * @return                  the qdecs current value
+ */
+static int32_t _qdec_read(qdec_t qdec, uint8_t reset);
+
+static inline TIM_TypeDef *dev(qdec_t qdec)
+{
+    return qdec_config[qdec].dev;
+}
+
+int32_t qdec_init(qdec_t qdec, qdec_mode_t mode, qdec_cb_t cb, void *arg)
+{
+    /* Control variables */
+    uint8_t i = 0;
+
+    /* Verify parameters */
+    assert((qdec < QDEC_NUMOF));
+
+    /* Power on the used timer */
+    periph_clk_en(qdec_config[qdec].bus, qdec_config[qdec].rcc_mask);
+
+    /* Reset configuration and CC channels */
+    dev(qdec)->CR1 = 0;
+    dev(qdec)->CR2 = 0;
+    dev(qdec)->SMCR = 0;
+    dev(qdec)->CCER = 0;
+    for (i = 0; i < QDEC_CHAN; i++) {
+        dev(qdec)->CCR[i] = 0;
+    }
+
+    /* Count on A (TI1) signal edges, B (TI2) signal edges or both,
+     * default to EINVAL (Invalide argument).
+     */
+    switch (mode) {
+        /* X2 mode */
+        case QDEC_X2:
+            dev(qdec)->SMCR |= (0x02 << TIM_SMCR_SMS_Pos);
+            break;
+        /* X4 mode */
+        case QDEC_X4:
+            dev(qdec)->SMCR |= (0x03 << TIM_SMCR_SMS_Pos);
+            break;
+        /* X1 mode does not exist on STM32 as STM32 always counts
+         * on both rising and falling edges from encoder
+         */
+        case QDEC_X1:
+        default:
+            errno = EINVAL;
+            goto err_invalid_mode;
+    }
+
+    /* Reset configuration and CC channels */
+    for (i = 0; i < QDEC_CHAN; i++) {
+        dev(qdec)->CCR[i] = 0;
+    }
+
+    /* Configure the used pins */
+    i = 0;
+    while ((i < QDEC_CHAN) && (qdec_config[qdec].chan[i].pin != GPIO_UNDEF)) {
+        gpio_init(qdec_config[qdec].chan[i].pin, GPIO_IN);
+        gpio_init_af(qdec_config[qdec].chan[i].pin, qdec_config[qdec].af);
+        i++;
+    }
+
+    /* Set counting max value */
+    dev(qdec)->ARR = qdec_config[qdec].max;
+
+    /* Set TIMx_CNT value to half of of TIMx_ARR to permit countdown */
+    dev(qdec)->CNT = dev(qdec)->ARR / 2;
+
+    /* Remember the interrupt context */
+    isr_ctx[qdec].cb = cb;
+    isr_ctx[qdec].arg = arg;
+
+    /* Enable the qdec's interrupt */
+    NVIC_EnableIRQ(qdec_config[qdec].irqn);
+    dev(qdec)->DIER |= TIM_DIER_UIE;
+
+    /* Reset counter and start qdec */
+    qdec_start(qdec);
+
+    return 0;
+
+/* Error management */
+err_invalid_mode:
+    return errno;
+}
+
+inline int32_t qdec_read(qdec_t qdec)
+{
+    return _qdec_read(qdec, false);
+}
+
+inline int32_t qdec_read_and_reset(qdec_t qdec)
+{
+    return _qdec_read(qdec, true);
+}
+
+static int32_t _qdec_read(qdec_t qdec, uint8_t reset)
+{
+    int32_t count = 0;
+    uint32_t irq_save = 0;
+
+    /* Protect critical section */
+    irq_save = irq_disable();
+
+    /* Get counter value */
+    count = dev(qdec)->CNT;
+
+    /* Reset counter if asked */
+    if (reset)
+    {
+        dev(qdec)->CNT = dev(qdec)->ARR / 2;
+    }
+
+    /* Restore IRQ */
+    irq_restore(irq_save);
+
+    /* Substract offset before return */
+    count -= dev(qdec)->ARR / 2;
+
+    /* Return count minus offset */
+    return count;
+}
+
+void qdec_start(qdec_t qdec)
+{
+    dev(qdec)->CR1 |= TIM_CR1_CEN;
+}
+
+void qdec_stop(qdec_t qdec)
+{
+    dev(qdec)->CR1 &= ~TIM_CR1_CEN;
+}
+
+static inline void irq_handler(qdec_t qdec)
+{
+    uint32_t status = (dev(qdec)->SR & dev(qdec)->DIER);
+
+    if (status & (TIM_SR_UIF)) {
+        dev(qdec)->SR &= ~(TIM_SR_UIF);
+        isr_ctx[qdec].cb(isr_ctx[qdec].arg);
+    }
+    cortexm_isr_end();
+}
+
+
+#ifdef QDEC_0_ISR
+void QDEC_0_ISR(void)
+{
+    irq_handler(0);
+}
+#endif
+
+#ifdef QDEC_1_ISR
+void QDEC_1_ISR(void)
+{
+    irq_handler(1);
+}
+#endif
+
+#ifdef QDEC_2_ISR
+void QDEC_2_ISR(void)
+{
+    irq_handler(2);
+}
+#endif
+
+#ifdef QDEC_3_ISR
+void QDEC_3_ISR(void)
+{
+    irq_handler(3);
+}
+#endif
+
+#ifdef QDEC_4_ISR
+void QDEC_4_ISR(void)
+{
+    irq_handler(4);
+}
+#endif
+
+#endif /* QDEC_NUMOF */

--- a/drivers/include/periph/qdec.h
+++ b/drivers/include/periph/qdec.h
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2017 Gilles DOFFE <gdoffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_qdec Quadrature Decoder (QDEC)
+ * @ingroup     drivers_periph
+ * @brief       Low-level QDEC peripheral driver
+ *
+ * This file was inspired by pwm.h written by :
+ *  Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * QDEC interface enables access to CPU peripherals acquiring quadrature
+ * signals. On most platforms, this interface will be implemented based
+ * on hardware timers.
+ *
+ * A quadrature encoder outputs two wave forms that are 90 degrees
+ * out of phase.
+ *
+ * Clockwise (C) :              Counter-clockwise (CC) :
+ *  ___________________          ___________________
+ * | Phase |  A  |  B  |        | Phase |  A  |  B  |
+ * |-------------------|        |-------------------|
+ * |   1   |  0  |  0  |        |   1   |  0  |  0  |
+ * |-------------------|        |-------------------|
+ * |   2   |  0  |  1  |        |   2   |  1  |  0  |
+ * |-------------------|        |-------------------|
+ * |   3   |  1  |  1  |        |   3   |  1  |  1  |
+ * |-------------------|        |-------------------|
+ * |   4   |  1  |  0  |        |   4   |  0  |  1  |
+ *  -------------------          -------------------
+ *         __    __                   __    __
+ *      __|  |__|  |_               _|  |__|  |__
+ *        __    __                     __    __
+ *      _|  |__|  |__               __|  |__|  |_
+ *
+ * These signals are decoded to produce a count up or a count down.
+ * On rising or falling edge of one signal, other signal state is checked to
+ * determine direction.
+ *
+ *  1. Rising edge on A and signal B is up       => (C)  => increment counter
+ *  2. Rising edge on A and signal B is down     => (CC) => decrement counter
+ *  3. Falling edge on A and signal B is up      => (C)  => decrement counter
+ *  4. Falling edge on A and signal B is down    => (CC) => increment counter
+ *  5. Rising edge on B and signal A is up       => (C)  => decrement counter
+ *  6. Rising edge on B and signal A is down     => (CC) => increment counter
+ *  7. Falling edge on B and signal A is up      => (C)  => increment counter
+ *  8. Falling edge on B and signal A is down    => (CC) => decrement counter
+ *
+ * According to these cases, three modes are available :
+ *  X1 mode : signal A, rising edges (cases 1 and 2)
+ *  X2 mode : signal A, rising and falling edges (cases 1, 2, 3 and 4)
+ *  X4 mode : signals A and B, rising and falling edges (all cases)
+ *
+ * The mapping/configuration of QDEC devices (timers) and the used pins has to be
+ * done in the board configuration (the board's `periph_conf.h).
+ *
+ * When using the QDEC interface, first thing you have to do is initialize the
+ * QDEC device with the targeted mode. Once the device is initialized,
+ * it will start counting quadrature signals on all configured pins
+ * immediately.
+ *
+ * @{
+ * @file
+ * @brief       Low-level QDEC peripheral driver interface definitions
+ *
+ * @author      Gilles DOFFE <gdoffe@gmail.com>
+ */
+
+#ifndef PERIPH_QDEC_H
+#define PERIPH_QDEC_H
+
+#include <stdint.h>
+#include <limits.h>
+
+#include "periph_cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default QDEC access macro
+ */
+#ifndef QDEC_DEV
+#define QDEC_DEV(x)          (x)
+#endif
+
+/**
+ * @brief  Default QDEC undefined value
+ */
+#ifndef QDEC_UNDEF
+#define QDEC_UNDEF           (UINT_MAX)
+#endif
+
+/**
+ * @brief   Default QDEC type definition
+ */
+#ifndef HAVE_QDEC_T
+typedef unsigned int qdec_t;
+#endif
+
+/**
+ * @brief   Default QDEC mode definition
+ */
+#ifndef HAVE_QDEC_MODE_T
+typedef enum {
+    QDEC_X1,    /* X1 mode */
+    QDEC_X2,    /* X2 mode */
+    QDEC_X4,    /* X4 mode */
+} qdec_mode_t;
+#endif
+
+/**
+ * @brief   Signature of event callback functions triggered from interrupts
+ *
+ * @param[in] arg       optional context for the callback
+ */
+typedef void (*qdec_cb_t)(void *arg);
+
+/**
+ * @brief   Default interrupt context entry holding callback and argument
+ */
+#ifndef HAVE_TIMER_ISR_CTX_T
+typedef struct {
+    qdec_cb_t cb;           /**< callback executed from qdec interrupt */
+    void *arg;              /**< optional argument given to that callback */
+} qdec_isr_ctx_t;
+#endif
+
+/**
+ * @brief   Initialize a QDEC device
+ *
+ * The QDEC module is based on virtual QDEC devices.
+ * The QDEC devices can be configured to run in three modes :
+ *      - X1
+ *      - X2
+ *      - X4
+ * See description above for more details about modes.
+ *
+ * On QDEC counter overflow, an interrupt is triggered.
+ * The interruption calls the callback defined.
+ *
+ * @param[in] dev           QDEC device to initialize
+ * @param[in] mode          QDEC mode : X1, X2 or X4
+ * @param[in] cb            Callback on QDEC timer overflow
+ * @param[in] arg           Callback arguments
+ *
+ * @return                  error code on error
+ * @return                  0 on success
+ */
+int32_t qdec_init(qdec_t dev, qdec_mode_t mode, qdec_cb_t cb, void *arg);
+
+/**
+ * @brief Read the current value of the given qdec device
+ *
+ * @param[in] dev           the qdec to read the current value from
+ *
+ * @return                  the qdecs current value
+ */
+int32_t qdec_read(qdec_t dev);
+
+/**
+ * @brief Read the current value of the given qdec device and reset it
+ *
+ * @param[in] dev           the qdec to read the current value from
+ *
+ * @return                  the qdecs current value
+ */
+int32_t qdec_read_and_reset(qdec_t dev);
+
+/**
+ * @brief Start the given qdec timer
+ *
+ * This function is only needed if the qdec timer was stopped manually before.
+ *
+ * @param[in] qdec          the qdec device to start
+ */
+void qdec_start(qdec_t qdec);
+
+/**
+ * @brief Stop the given qdec timer
+ *
+ * This will effect all of the timer's channels.
+ *
+ * @param[in] qdec          the qdec device to stop
+ */
+void qdec_stop(qdec_t qdec);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_QDEC_H */
+/** @} */

--- a/tests/periph_qdec/Makefile
+++ b/tests/periph_qdec/Makefile
@@ -1,0 +1,8 @@
+BOARD ?= nucleo-f401
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_qdec
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_qdec/README.md
+++ b/tests/periph_qdec/README.md
@@ -1,0 +1,7 @@
+Expected result
+===============
+If everything is running as supposed to, you should see a X4 mode quadrature decoding on each qdec configured.
+
+Background
+==========
+Test for the low-level QDEC driver.

--- a/tests/periph_qdec/main.c
+++ b/tests/periph_qdec/main.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017 Gilles DOFFE <gdoffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test for low-level QDEC drivers
+ *
+ * This test initializes all declared QDEC devices.
+ * It displays QDEC counters value each second.
+ *
+ * @author      Gilles DOFFE <gdoffe@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "periph/qdec.h"
+#include "xtimer.h"
+
+void handler(void *arg)
+{
+    qdec_t qdec = (qdec_t)arg;
+    printf("QDEC %u counter overflow : reset counter\n", qdec);
+    qdec_read_and_reset(QDEC_DEV(qdec));
+}
+
+int main(void)
+{
+    uint32_t i = 0;
+    int32_t value = 0;
+    puts("Welcome into Quadrature Decoder (QDEC) test program.");
+    puts("This program will count pulses on all available QDEC channels");
+    puts("Written for nucleo-f401, you have to plug signals A and B as follow :");
+    puts("  QDEC0 : signal A on PA6 and signal B on PA7");
+    puts("  QDEC1 : signal A on PB6 and signal B on PB7");
+    puts("Quadrature decoding mode is set to X4 : counting on all edges on both signals");
+
+    for (i = 0; i < QDEC_NUMOF; i++) {
+        int32_t error = qdec_init(QDEC_DEV(i), QDEC_X4, handler, (void *)i);
+        if (error) {
+            fprintf(stderr,"Not supported mode !\n");
+            return error;
+        }
+    }
+
+    while (1) {
+        for (i = 0; i < QDEC_NUMOF; i++) {
+            value = qdec_read_and_reset(QDEC_DEV(i));
+            printf("QDEC %lu = %ld\n", (unsigned long int)i, (long int)value);
+        }
+        xtimer_sleep(1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Hello,

I am a member of an amateur association of robotics named COGIP :
[https://github.com/cogip](https://github.com/cogip)

### Contribution description

On several arch (STM32, atxmega, ...), you can use a quadrature decoder interface.
It is useful in motion control like in robotics. For example we must compute a PID for robot (with 2 wheels) speed and position control.
It increments/decrements a counter based on edges of a quadrature signal (signal A and B dephased of pi/2).
It is often a feature of an hardware timer.

As we need it I developped the driver for qdec peripheral driver considering 3 simple modes:
*  X1 mode : signal A, rising edges
*  X2 mode : signal A, rising and falling edges
*  X4 mode : signals A and B, rising and falling edges

I hope it will be useful to others.

**EDIT**

I forgot to mention that the driver is implemented for STM32 and native architecture.