### PR TITLE
boards/make: use shared makefiles for serial port selection

### DIFF
--- a/boards/airfy-beacon/Makefile.include
+++ b/boards/airfy-beacon/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxaa
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2

--- a/boards/b-l072z-lrwan1/Makefile.include
+++ b/boards/b-l072z-lrwan1/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = stm32l0
 export CPU_MODEL = stm32l072cz
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2-1

--- a/boards/b-l475e-iot01a/Makefile.include
+++ b/boards/b-l475e-iot01a/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = stm32l4
 export CPU_MODEL = stm32l475vg
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2-1

--- a/boards/bluepill/Makefile.include
+++ b/boards/bluepill/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = stm32f1
 export CPU_MODEL = stm32f103c8
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 # optionally, use dfu-util to flash via usb
 # note: needs a bootloader flashed before, config below is compatible

--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxab
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # we support flashing through plain fscopy or using JLink
 PROGRAMMER ?= fscopy

--- a/boards/cc2650-launchpad/Makefile.include
+++ b/boards/cc2650-launchpad/Makefile.include
@@ -2,12 +2,8 @@ export CPU       = cc26x0
 export CPU_MODEL = cc26x0f128
 export XDEBUGGER = XDS110
 
-# set default port depending on operating system
-PORT_LINUX  ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # configure the flash tool
 export UNIFLASH_PATH ?= "UNIFLASH_PATH unconfigured"

--- a/boards/common/arduino-due/Makefile.include
+++ b/boards/common/arduino-due/Makefile.include
@@ -6,12 +6,8 @@ export CPU_MODEL = sam3x8e
 USEMODULE += boards_common_arduino_due
 INCLUDES  += -I$(RIOTBOARD)/common/arduino-due/include
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # setup flasher (using BOSSA)
 export BOSSA_ARDUINO_PREFLASH = yes

--- a/boards/common/arduino-mkr/Makefile.include
+++ b/boards/common/arduino-mkr/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = samd21
 export CPU_MODEL = samd21g18a
 
-#export needed for flash rule
-export PORT_LINUX ?= /dev/ttyACM0
-export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # setup the flash tool used
 ifeq ($(PROGRAMMER),jlink)

--- a/boards/common/frdm/Makefile.include
+++ b/boards/common/frdm/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # Use the shared OpenOCD configuration
 # Using dap or jlink depends on which firmware the OpenSDA debugger is running
 export DEBUG_ADAPTER ?= dap
@@ -39,7 +35,7 @@ export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/frdm/dist/openocd-$(CPU_FAMILY).cfg
 export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/$(CPU)/dist/check-fcfield-elf.sh
 
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -2,11 +2,8 @@
 export CPU = msp430fxyz
 export CPU_MODEL = msp430f1612
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 # setup flash tool
 export OFLAGS = -O ihex

--- a/boards/common/nrf52xxxdk/Makefile.include
+++ b/boards/common/nrf52xxxdk/Makefile.include
@@ -8,9 +8,7 @@ ifeq (,$(filter thingy52 acd52832,$(BOARD)))
 endif
 
 # set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # setup JLink for flashing
 export JLINK_DEVICE := nrf52

--- a/boards/common/nucleo/Makefile.include
+++ b/boards/common/nucleo/Makefile.include
@@ -3,9 +3,7 @@ USEMODULE += boards_common_nucleo
 INCLUDES  += -I$(RIOTBOARD)/common/nucleo/include
 
 # configure the serial terminal
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # all Nucleo boards have an on-board ST-link v2-1 adapter
 export DEBUG_ADAPTER ?= stlink

--- a/boards/common/wsn430/Makefile.include
+++ b/boards/common/wsn430/Makefile.include
@@ -8,9 +8,7 @@ USEMODULE += boards_common_wsn430
 export INCLUDES += -I$(RIOTBOARD)/common/wsn430/include
 
 # configure the serial interface
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 # configure the flash tool
 export OFLAGS = -O ihex

--- a/boards/ek-lm4f120xl/Makefile.include
+++ b/boards/ek-lm4f120xl/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = lm4f120
 export CPU_MODEL = LM4F120H5QR
 
-#define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = stm32f4
 export CPU_MODEL = stm32f415rg
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 # st-flash
 export FLASHER = st-flash

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = samd21
 export CPU_MODEL = samd21g18a
 
-#export needed for flash rule
-export PORT_LINUX ?= /dev/ttyACM0
-export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # setup the flash tool used
 ifeq ($(PROGRAMMER),jlink)

--- a/boards/ikea-tradfri/Makefile.include
+++ b/boards/ikea-tradfri/Makefile.include
@@ -2,13 +2,9 @@
 export CPU = efm32
 export CPU_MODEL = efr32mg1p132f256gm32
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 export JLINK_DEVICE := EFR32MG1PxxxF256
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk

--- a/boards/limifrog-v1/Makefile.include
+++ b/boards/limifrog-v1/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = stm32l1
 export CPU_MODEL = stm32l151rc
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2

--- a/boards/msbiot/Makefile.include
+++ b/boards/msbiot/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = stm32f4
 export CPU_MODEL = stm32f415rg
 
-#define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2

--- a/boards/nrf51dongle/Makefile.include
+++ b/boards/nrf51dongle/Makefile.include
@@ -2,13 +2,9 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxab
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup JLink for flashing
 export JLINK_DEVICE := nrf51822
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk

--- a/boards/nrf6310/Makefile.include
+++ b/boards/nrf6310/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxaa
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # define flash and debugging environment
 export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
 export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
@@ -19,4 +15,4 @@ export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)
 
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = stm32l1
 export CPU_MODEL = stm32l151rc
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # set the default id
 export ID ?= 0483:df11
 
@@ -22,4 +18,4 @@ export TERMFLAGS = -p $(PORT)
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include/
 
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -12,12 +12,8 @@ export HEXFILE = $(ELFFILE:.elf=.bin)
 export FFLAGS =
 export DEBUGGER_FLAGS =
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # Skip the space needed by the embedded bootloader
 export ROM_OFFSET ?= 0x3000
 
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = cc2538
 export CPU_MODEL = cc2538sf53
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
-
 # Set default flash tool
 export PROGRAMMER ?= cc2538-bsl
 
@@ -24,4 +20,5 @@ else
 endif
 
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -8,10 +8,6 @@ export CPU_MODEL ?= mkw21d256vha5
 
 export MCPU = cortex-m4
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 .PHONY: flash
 flash: $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
 
@@ -43,7 +39,7 @@ ifneq (,$(SERIAL))
 endif
 
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -1,12 +1,8 @@
 # define the used CPU
 export CPU = lpc1768
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 DEBUG_ADAPTER ?= dap
 

--- a/boards/sltb001a/Makefile.include
+++ b/boards/sltb001a/Makefile.include
@@ -2,13 +2,10 @@
 export CPU = efm32
 export CPU_MODEL = efr32mg1p132f256gm48
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # setup JLink for flashing
 export JLINK_DEVICE := EFR32MG1PxxxF256
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/slwstk6220a/Makefile.include
+++ b/boards/slwstk6220a/Makefile.include
@@ -2,13 +2,10 @@
 export CPU = ezr32wg
 export CPU_MODEL = ezr32wg330f256r60
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # setup JLink for flashing
 export JLINK_DEVICE := ezr32wg330f256
 include $(RIOTMAKE)/tools/jlink.inc.mk
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/sodaq-explorer/Makefile.include
+++ b/boards/sodaq-explorer/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = samd21
 export CPU_MODEL = samd21j18a
 
-#export needed for flash rule
-export PORT_LINUX ?= /dev/ttyACM0
-export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyacm0.inc.mk
 
 # setup the flash tool used
 # we use BOSSA to flash this board since there's an Arduino bootloader

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -3,9 +3,7 @@ export CPU = stm32f1
 export CPU_MODEL = stm32f103cb
 
 # configure the serial interface
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 export BINFILE = $(patsubst %.elf,%.bin,$(ELFFILE))
 

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = stm32f0
 export CPU_MODEL = stm32f051r8
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = stm32f3
 export CPU_MODEL = stm32f303vc
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = stm32f4
 export CPU_MODEL = stm32f407vg
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -2,12 +2,10 @@
 export CPU = msp430fxyz
 export CPU_MODEL = msp430f1611
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-MXV*)))
 # setup serial terminal
 export BAUD ?= 9600
-include $(RIOTMAKE)/tools/serial.inc.mk
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-MXV*)))
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 # flash tool configuration
 export OFLAGS = -O ihex

--- a/boards/yunjia-nrf51822/Makefile.include
+++ b/boards/yunjia-nrf51822/Makefile.include
@@ -2,12 +2,8 @@
 export CPU = nrf51
 export CPU_MODEL = nrf51x22xxaa
 
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -2,11 +2,8 @@
 export CPU = msp430fxyz
 export CPU_MODEL = msp430f2617
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+include $(RIOTMAKE)/tools/serial.ttyusb0.inc.mk
 
 # setup flash tool
 export OFLAGS = -O ihex

--- a/makefiles/tools/serial.ttyacm0.inc.mk
+++ b/makefiles/tools/serial.ttyacm0.inc.mk
@@ -1,0 +1,6 @@
+# convenience makefile exporting the commonly used /dev/ttyACM0 based serial
+# configuration
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+include $(RIOTMAKE)/tools/serial.inc.mk

--- a/makefiles/tools/serial.ttyusb0.inc.mk
+++ b/makefiles/tools/serial.ttyusb0.inc.mk
@@ -1,0 +1,6 @@
+# convenience makefile exporting the commonly used /dev/ttyUSB0 based serial
+# configuration
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+include $(RIOTMAKE)/tools/serial.inc.mk


### PR DESCRIPTION
### Contribution description
This PR introduces two shared convenience makefiles for the most common serial configurations. Though I adapted the most obvious boards, there are others that can potentially also benefit from the new makefiles. I suggest to adapt other boards on a 'when we get to it' basis.

### Issues/PRs references
#8475 gave me the idea for this...