### PR TITLE
tests: deactivate DEVELHELP for netdev_test

### DIFF
--- a/tests/netdev_test/Makefile
+++ b/tests/netdev_test/Makefile
@@ -1,3 +1,7 @@
+# These tests hit an assert when used with gnrc_netif, but they exactly for
+# testing this netdev simulating framework, so I it's better if the assert is
+# ignored.
+CFLAGS += -DNDEBUG
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031


### PR DESCRIPTION
### Contribution description
These tests hit an assert when used with `gnrc_netif`, but they exactly for testing this netdev simulating framework, so I it's better if the assert is ignored.

### Issues/PRs references
Fixes https://github.com/RIOT-OS/Release-Specs/issues/59#issuecomment-361620486