### PR TITLE
pkg/gecko_sdk: fix #8266

### DIFF
--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -7,6 +7,8 @@ ifneq ($(CPU),efm32)
   $(error This package can only be used with EFM32 CPUs)
 endif
 
+CFLAGS += -Wno-error=implicit-fallthrough
+
 .PHONY: all
 
 all: git-download


### PR DESCRIPTION
### Contribution description

Fix fallthrough errors for GCC 7.x (#8265).

### Issues/PRs references

Fixes #8266 