### PR TITLE
tests: minor fixes for libfixmath, sizeof_tcb and gnrc_netif

### DIFF
--- a/tests/gnrc_netif/common.c
+++ b/tests/gnrc_netif/common.c
@@ -113,8 +113,11 @@ static void _netdev_isr(netdev_t *dev)
 
 static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len)
 {
-    netdev_test_t *dev = (netdev_test_t *)netdev;
     assert(max_len == sizeof(uint16_t));
+    (void)max_len;
+
+    netdev_test_t *dev = (netdev_test_t *)netdev;
+
     if (dev->state == 0x0) {
         *((uint16_t *)value) = NETDEV_TYPE_ETHERNET;
     }
@@ -129,8 +132,11 @@ static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len
 
 static int _get_netdev_max_packet_size(netdev_t *netdev, void *value, size_t max_len)
 {
-    netdev_test_t *dev = (netdev_test_t *)netdev;
     assert(max_len == sizeof(uint16_t));
+    (void)max_len;
+
+    netdev_test_t *dev = (netdev_test_t *)netdev;
+
     if (dev->state == 0x0) {
         *((uint16_t *)value) = ETHERNET_DATA_LEN;
     }

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1452,6 +1452,8 @@ static uint16_t ieee802154_l2addr_len = 8U;
 
 static int _get_netdev_address(netdev_t *dev, void *value, size_t max_len)
 {
+    (void)max_len;
+
     if (dev == ethernet_dev) {
         assert(max_len >= sizeof(ethernet_l2addr));
         memcpy(value, ethernet_l2addr, sizeof(ethernet_l2addr));
@@ -1483,6 +1485,8 @@ static int _set_netdev_address(netdev_t *dev, const void *value,
 
 static int _get_netdev_address_long(netdev_t *dev, void *value, size_t max_len)
 {
+    (void)max_len;
+
     if (dev == ieee802154_dev) {
         assert(max_len >= sizeof(ieee802154_l2addr_long));
         memcpy(value, ieee802154_l2addr_long, sizeof(ieee802154_l2addr_long));
@@ -1504,6 +1508,8 @@ static int _set_netdev_address_long(netdev_t *dev, const void *value,
 
 static int _get_netdev_src_len(netdev_t *dev, void *value, size_t max_len)
 {
+    (void)max_len;
+
     if (dev == ieee802154_dev) {
         assert(max_len == sizeof(uint16_t));
         *((uint16_t *)value) = ieee802154_l2addr_len;
@@ -1515,6 +1521,8 @@ static int _get_netdev_src_len(netdev_t *dev, void *value, size_t max_len)
 static int _set_netdev_src_len(netdev_t *dev, const void *value,
                                size_t value_len)
 {
+    (void)value_len;
+
     if (dev == ieee802154_dev) {
         assert(value_len == sizeof(uint16_t));
         ieee802154_l2addr_len = *((uint16_t *)value);

--- a/tests/libfixmath/tests/01-run.py
+++ b/tests/libfixmath/tests/01-run.py
@@ -23,7 +23,7 @@ def expect_unary(child):
 
 
 def expect_binary(child):
-    for _ in range(20):
+    for _ in range(1500):
         for op_name in ('add', 'sub', 'mul', 'div', 'mod', 'sadd', 'ssub',
                         'smul', 'sdiv', 'min', 'max'):
             child.expect('{}\(-?\d+.\d+\, -?\d+.\d+\) = -?\d+.\d+'

--- a/tests/sizeof_tcb/tests/01-run.py
+++ b/tests/sizeof_tcb/tests/01-run.py
@@ -12,7 +12,7 @@ import sys
 
 def testfunc(child):
     child.expect_exact('\tmember, sizeof, offsetof')
-    child.expect_exact('sizeof(thread_t): 36')
+    child.expect(r'sizeof\(thread_t\): [36, 48]')
     child.expect_exact('\tsp            4   0')
     child.expect_exact('\tstatus        1   4')
     child.expect_exact('\tpriority      1   5')


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

- fixes issue with auto test script in `libfixmath`, which fails with timeout when run on real hardware
- fixes issue with auto test script in `sizeof_tcb`, which reports different sizes when compiled with DEVELHELP=0 or 1
- fixes issue with `gnrc_netif` when compiled with DEVELHELP=0


### Issues/PRs references

none