### PR TITLE
sntp.h: document sntp_sync timeout unit

### DIFF
--- a/sys/include/net/sntp.h
+++ b/sys/include/net/sntp.h
@@ -38,7 +38,7 @@ extern "C" {
  * @brief Synchronize with time server
  *
  * @param[in] server    The time server
- * @param[in] timeout   Timeout for the server response
+ * @param[in] timeout   Timeout for the server response in microseconds
  *
  * @return 0 on success
  * @return Negative number on error


### PR DESCRIPTION
Document the sntp_sync timeout unit in the header.

I wanted the information when reviewing https://github.com/RIOT-OS/RIOT/pull/8478

### Issues/PRs references

Follow up to https://github.com/RIOT-OS/RIOT/pull/8478