### PR TITLE
drivers/ina220: fix bus voltage range bitmask

### DIFF
--- a/drivers/include/ina220.h
+++ b/drivers/include/ina220.h
@@ -69,7 +69,7 @@ typedef enum ina220_range {
  */
 typedef enum ina220_brng {
     INA220_BRNG_16V_FSR = 0x0000, /**< 16 V bus voltage full scale range */
-    INA220_BRNG_32V_FSR = 0x0200, /**< 32 V bus voltage full scale range, default. */
+    INA220_BRNG_32V_FSR = 0x2000, /**< 32 V bus voltage full scale range, default. */
 } ina220_brng_t;
 
 /**

--- a/drivers/include/ina220.h
+++ b/drivers/include/ina220.h
@@ -75,7 +75,7 @@ typedef enum ina220_brng {
 /**
  * @brief   Shunt ADC settings
  *
- * @see Table 5 in INA220 data sheet
+ * @see Table 4 in INA220 data sheet
  */
 typedef enum ina220_sadc {
     /** 9 bit resolution, 84 us conversion time */
@@ -107,7 +107,7 @@ typedef enum ina220_sadc {
 /**
  * @brief   Bus ADC settings
  *
- * @see Table 5 in INA220 data sheet
+ * @see Table 4 in INA220 data sheet
  */
 typedef enum ina220_badc {
     /** 9 bit resolution, 84 us conversion time */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes wrong Bus Range bitmask in INA220 driver (see [datasheet, P19](http://www.ti.com/lit/ds/symlink/ina220.pdf)). Also, fixes a wrong Doxygen reference to the ADC settings Table.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
Fixes #8262 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->