### PR TITLE
boards/*:  minor doxygen fixes

### DIFF
--- a/boards/b-l072z-lrwan1/board.c
+++ b/boards/b-l072z-lrwan1/board.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Board specific implementations for the ST b-l072z-lrwan1 discovery board
+ * @brief       Board specific implementations for the ST B-L072Z-LRWAN1 board
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  *

--- a/boards/b-l072z-lrwan1/include/board.h
+++ b/boards/b-l072z-lrwan1/include/board.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @defgroup    boards_b-l072z-lrwan1 ST b-l072z-lrwan1 discovery
+ * @defgroup    boards_b-l072z-lrwan1 ST B-L072Z-LRWAN1 LoRa discovery
  * @ingroup     boards
- * @brief       Support for the ST b-l072z-lrwan1 board
+ * @brief       Support for the ST B-L072Z-LRWAN1 board
  * @{
  *
  * @file
- * @brief       Board specific definitions for the ST b-l072z-lrwan1 board
+ * @brief       Board specific definitions for the ST B-L072Z-LRWAN1 board
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */

--- a/boards/b-l072z-lrwan1/include/gpio_params.h
+++ b/boards/b-l072z-lrwan1/include/gpio_params.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup   boards_nucleo-common
+ * @ingroup   boards_b-l072z-lrwan1
  * @{
  *
  * @file

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Peripheral MCU configuration for the ST b-l072z-lrwan1 board
+ * @brief       Peripheral MCU configuration for the ST B-L072Z-LRWAN1 board
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */

--- a/boards/b-l475e-iot01a/board.c
+++ b/boards/b-l475e-iot01a/board.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Board specific implementations for the b-l475e-iot01a board
+ * @brief       Board specific implementations for the ST B-L475E-IOT01A board
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  *

--- a/boards/b-l475e-iot01a/include/board.h
+++ b/boards/b-l475e-iot01a/include/board.h
@@ -9,11 +9,11 @@
 /**
  * @defgroup    boards_b-l475e-iot01a ST B-L475E-IOT01A
  * @ingroup     boards
- * @brief       Support for the ST b-l475e-iot01a board
+ * @brief       Support for the ST B-L475E-IOT01A board
  * @{
  *
  * @file
- * @brief       Board specific definitions for the ST b-l475e-iot01a board
+ * @brief       Board specific definitions for the ST B-L475E-IOT01A board
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */

--- a/boards/b-l475e-iot01a/include/gpio_params.h
+++ b/boards/b-l475e-iot01a/include/gpio_params.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup   boards_b-l475e-iot01a-common
+ * @ingroup   boards_b-l475e-iot01a
  * @{
  *
  * @file

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Peripheral MCU configuration for the b-l475e-iot01a board
+ * @brief       Peripheral MCU configuration for the B-L475E-IOT01A board
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */

--- a/boards/stm32f7discovery/board.c
+++ b/boards/stm32f7discovery/board.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Board specific implementations for the STM32F7Discovery evaluation board
+ * @brief       Board specific implementations for the STM32F769 Discovery board
  *
  * @author      Vincent Dupont <vincent@otakeys.com>
  *

--- a/boards/stm32f7discovery/include/board.h
+++ b/boards/stm32f7discovery/include/board.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @defgroup    boards_stm32f7discovery stm32f769 Discovery board
+ * @defgroup    boards_stm32f7discovery STM32F769 Discovery board
  * @ingroup     boards
- * @brief       Support for the stm32f769 Discovery board
+ * @brief       Support for the STM32F769 Discovery board
  * @{
  *
  * @file
- * @brief       Board specific definitions for the stm32f769 Discovery board
+ * @brief       Board specific definitions for the STM32F769 Discovery board
  *
  * @author      Vincent Dupont <vincent@otakeys.com>
  * @author      Sebastian Meiling <s@mlng.net>

--- a/boards/stm32f7discovery/include/periph_conf.h
+++ b/boards/stm32f7discovery/include/periph_conf.h
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Peripheral MCU configuration for the stm32f769discovery6 board
+ * @brief       Peripheral MCU configuration for the STM32F769 Discovery board
  *
  * @author      Vincent Dupont <vincent@otakeys.com>
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates doxygen for some ST boards:
* use consistent names for B-072Z-LRWAN1 and B-L475E-IOT01A: these names are used on ST web page
* use consistent name for STM32F769 Discovery board. This also moves it close to other STM32 boards in generated doxygen
* fix one wrong group name for B-L475E-IOT01A

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->