### PR TITLE
cflags: Set -gz -gsplit-dwarf by default if supported by the compiler

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -68,9 +68,11 @@ $(BINDIR)/$(MODULE)/:
 $(BINDIR)/$(MODULE).a $(OBJ): | $(BINDIR)/$(MODULE)/
 
 $(BINDIR)/$(MODULE).a: $(OBJ) | ${DIRS:%=ALL--%}
-	@# Recreate archive to cleanup deleted/non selected source files objects
+# Recreate archive to cleanup deleted/non selected source files objects
 	$(Q)$(RM) $@
-	$(Q)$(AR) $(ARFLAGS) $@ $^
+# Add split debug information as well (objfile.dwo), if found, without adding it
+# as a dependency for the recipe
+	$(Q)$(AR) $(ARFLAGS) $@ $^ $(wildcard $(patsubst %.o,%.dwo,$^))
 
 CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
 CCASFLAGS = $(filter-out $(CCASUWFLAGS), $(CFLAGS)) $(CCASEXFLAGS)

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -33,6 +33,22 @@ ifeq ($(CC_NOCOLOR),0)
   endif
 endif
 
+# Place DWARF debugging sections in separate .dwo files instead of in the object
+# .o files, if the compiler supports this and if this is not disabled by the user
+ifneq ($(NOSPLITDEBUG),1)
+  ifeq ($(shell $(CC) -gsplit-dwarf -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+    CFLAGS += -gsplit-dwarf
+  endif
+endif
+
+# use compression on debugging information if supported by the compiler and not
+# disabled by the user
+ifneq ($(NOCOMPRESSDEBUG),1)
+  ifeq ($(shell $(CC) -gz -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+    CFLAGS += -gz
+  endif
+endif
+
 # Fast-out on old style function definitions.
 # They cause unreadable error compiler errors on missing semicolons.
 # Worse yet they hide errors by accepting wildcard argument types.


### PR DESCRIPTION
### Background

There are recurring questions on the mailing lists and on Github regarding the size of object files when compiled with debugging information, which is enabled by default in the RIOT build system. The answer is that the debugging sections do not use any ROM or RAM on the actual target device, but the ELF and object files become larger, so it may seem like there is a lot of bloat in the build. The `size` command shows what the real memory usage will be, but inexperienced users may not know how to interpret the numbers.

### Contribution description

By setting `-gz -gsplit-dwarf` in CFLAGS, the debugging information will be compressed and placed in a separate file with the extension .dwo, one for each object .o file.

Using this feature requires some tool versions:
 - GCC 4.8+ (released 22 March 2013) or Clang more recent than 2013
 - binutils 2.23+ (released 26 March 2013)
 - GDB 7.6+ (released 26 April 2013)

The build system will test if the compiler supports the option and only add it if it does not cause a syntax error in the command line.

### Issues/PRs references

Only remotely related: #8408 