### PR TITLE
gnrc_icmpv6_echo: fix ping for loopback

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -93,7 +93,13 @@ void gnrc_icmpv6_echo_req_handle(gnrc_netif_t *netif, ipv6_hdr_t *ipv6_hdr,
     pkt = hdr;
     hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
-    ((gnrc_netif_hdr_t *)hdr->data)->if_pid = netif->pid;
+    if (netif != NULL) {
+        ((gnrc_netif_hdr_t *)hdr->data)->if_pid = netif->pid;
+    }
+    else {
+        /* ipv6_hdr->dst is loopback address */
+        ((gnrc_netif_hdr_t *)hdr->data)->if_pid = KERNEL_PID_UNDEF;
+    }
 
     LL_PREPEND(pkt, hdr);
 


### PR DESCRIPTION
### Contribution description
At the moment ping is crashing if one pings the loopback address.
This was caused in #8214 when we moved interfaces from `kernel_pid_t`
ID to pointer-based handling, since loopback doesn't evaluate to such
an interface.

### Issues/PRs references
Follow-up to #8214 