### PR TITLE
boards/b-l072z-lrwan1/dist: fix openocd reset_config options

### DIFF
--- a/boards/b-l072z-lrwan1/dist/openocd.cfg
+++ b/boards/b-l072z-lrwan1/dist/openocd.cfg
@@ -1,3 +1,3 @@
 source [find target/stm32l0.cfg]
 
-reset_config srst_only
+reset_config trst_and_srst srst_nogate connect_assert_srst


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates the openocd configuration file of the b-l073z-lrwan1 board by changing the `reset_config` options.
Using `reset_config srst_only` is not enough when flashing a new board (I mean just after taking it from the box). The board is in state that prevents openocd from correctly resetting it before flash.

I found the working solution [here](https://visualgdb.com/tutorials/stm32/sleep/) so maybe it should be applied to other L0 based boards (nucleo-l053/l073/l031).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->