### PR TITLE
gnrc_netif: Fix out-of-bounds buffer access in ieee802154 netif

### DIFF
--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -46,6 +46,8 @@ extern "C" {
  * @{
  */
 #define IEEE802154_MAX_HDR_LEN              (23U)
+#define IEEE802154_MIN_FRAME_LEN            (IEEE802154_FCF_LEN + sizeof(uint8_t))
+
 #define IEEE802154_FCF_LEN                  (2U)
 #define IEEE802154_FCS_LEN                  (2U)
 

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -82,7 +82,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
-    if (bytes_expected > 0) {
+    if (bytes_expected >= (int)IEEE802154_MIN_FRAME_LEN) {
         int nread;
 
         pkt = gnrc_pktbuf_add(NULL, NULL, bytes_expected, GNRC_NETTYPE_UNDEF);
@@ -155,6 +155,9 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 
         DEBUG("_recv_ieee802154: reallocating.\n");
         gnrc_pktbuf_realloc_data(pkt, nread);
+    } else if (bytes_expected > 0) {
+        DEBUG("_recv_ieee802154: received frame is too short\n");
+        dev->driver->recv(dev, NULL, bytes_expected, NULL);
     }
 
     return pkt;


### PR DESCRIPTION
### Contribution description

**I believe** I found an out-of-bounds buffer access in the GNRC netif receive function for IEEE 802.15.4. The problem seems to be the following: The `ieee802154_get_frame_hdr_len` used to calculate the header length in the `_recv` function gets passed a buffer without any length information and access the first and second byte of that buffer. Therefore all buffers passed to that function must at least contain 2 bytes. In `gnrc_netif_ieee802154.c` the function is called without checking if that's the case before hand. Therefore an IEEE 802.15.4 frame containing only one byte will cause an out-of-bounds buffer access in `ieee802154_get_frame_hdr_len`.

Depending on the module used for allocating `pktbufs` with `gnrc_pktbuf_add` this results in different behavior. With `gnrc_pktbuf_malloc` uninitialized memory is accessed which causes valgrind to emit the following warning on native:

```
==5871== Invalid read of size 1                                                                                                                                          
==5871==    at 0x11C98E: ieee802154_get_frame_hdr_len (sys/net/link_layer/ieee802154/ieee802154.c:136)                                                                   
==5871==    by 0x11A9CF: _recv (sys/net/gnrc/netif/gnrc_netif_ieee802154.c:135)                                                                                          
==5871==    by 0x119B7A: _event_cb (sys/net/gnrc/netif/gnrc_netif.c:1322)                                                                                                
==5871==    by 0x111BA4: _netdev_isr (tests/gnrc_netif/common.c:111)                                                                                                     
==5871==    by 0x11DC75: _isr (sys/net/netdev_test/netdev_test.c:110)                                                                                                    
==5871==    by 0x1199B6: _gnrc_netif_thread (sys/net/gnrc/netif/gnrc_netif.c:1239)                                                                                       
==5871==    by 0x49873AA: makecontext (/build/glibc-lBD5b4/glibc-2.26/stdlib/../sysdeps/unix/sysv/linux/i386/makecontext.S:91)                                           
==5871==  Address 0x4b20349 is 0 bytes after a block of size 1 alloc'd                                                                                                   
==5871==    at 0x482F25B: malloc (coregrind/m_replacemalloc/vg_replace_malloc.c:299)                                                                                     
==5871==    by 0x11B784: _malloc (sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:47)                                                                                    
==5871==    by 0x11C018: _create_snip (sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:284)                                                                              
==5871==    by 0x11B918: gnrc_pktbuf_add (sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:97)                                                                            
==5871==    by 0x11A940: _recv (sys/net/gnrc/netif/gnrc_netif_ieee802154.c:104)                                                                                          
==5871==    by 0x119B7A: _event_cb (sys/net/gnrc/netif/gnrc_netif.c:1322)                                                                                                
==5871==    by 0x111BA4: _netdev_isr (tests/gnrc_netif/common.c:111)                                                                                                     
==5871==    by 0x11DC75: _isr (sys/net/netdev_test/netdev_test.c:110)                                                                                                    
==5871==    by 0x1199B6: _gnrc_netif_thread (sys/net/gnrc/netif/gnrc_netif.c:1239)                                                                                       
==5871==    by 0x49873AA: makecontext (/build/glibc-lBD5b4/glibc-2.26/stdlib/../sysdeps/unix/sysv/linux/i386/makecontext.S:91)                                         
```

With `gnrc_pktbuf_static` no warning is emitted by valgrind. Briefly looking at the code of `gnrc_pktbuf_static` this might be the case because memory of the next packet in `_pktbuf` is accessed (thereby causing no access to uninitialized memory).

I hope my observations are correct. In any case it is worth pointing out that it would be a good idea to pass buffer length information to the functions from `ieee802154.c` (e.g. `ieee802154_get_frame_hdr_len`). That would make it easier to prevent such errors in the future because you don't have to rely on the caller to provide a large enough buffer.

### Issues/PRs references

None.