### PR TITLE
nanocoap: use __attribute__((packed)) for coap_hdr_t

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -209,7 +209,7 @@ extern "C" {
 /**
  * @brief   Raw CoAP PDU header structure
  */
-typedef struct {
+typedef struct __attribute__((packed)) {
     uint8_t ver_t_tkl;          /**< version, token, token length           */
     uint8_t code;               /**< CoAP code (e.g.m 205)                  */
     uint16_t id;                /**< Req/resp ID                            */


### PR DESCRIPTION
### Contribution description

Since `coap_hdr_t` is used to parse the CoAP header by casting a buffer to a `coap_hdr_t` we need to make sure that the compiler doesn't insert any padding for the `coap_hdr_t` struct.

This attribute is also used elsewhere, e.g. for the `struct udp_hdr_t` from `sys/include/net/udp.h`.

### Issues/PRs references

None.