### PR TITLE
pkg: add local.mk, allow source folder override for git packages

### DIFF
--- a/pkg/local.mk
+++ b/pkg/local.mk
@@ -1,0 +1,24 @@
+#
+# This file allows specifying a local folder using PKG_SOURCE_LOCAL.
+#
+# Every clean or prepare will remove $(PKG_BUILDDIR) and copy over
+# $(PKG_SOURCE_LOCAL).  This is intended to be used during package development.
+#
+# WARNING: any local changes made to $(PKG_BUILDDIR) *will* get lost!
+
+.PHONY: prepare git-download clean
+
+git-download:
+	@true
+
+prepare: $(PKG_BUILDDIR)/.prepared
+	@true
+
+$(PKG_BUILDDIR)/.prepared:
+	rm -Rf $(PKG_BUILDDIR)
+	mkdir -p $$(dirname $(PKG_BUILDDIR))
+	cp -a $(PKG_SOURCE_LOCAL) $(PKG_BUILDDIR)
+	touch $@
+
+clean::
+	@rm -f $(PKG_BUILDDIR)/.prepared

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -4,6 +4,11 @@
 PKG_DIR?=$(CURDIR)
 PKG_BUILDDIR?=$(PKGDIRBASE)/$(PKG_NAME)
 
+# allow overriding package source with local folder (useful during development)
+ifneq (,$(PKG_SOURCE_LOCAL))
+  include $(RIOTBASE)/pkg/local.mk
+else
+
 .PHONY: prepare git-download clean
 
 prepare: git-download
@@ -39,3 +44,5 @@ clean::
 
 distclean::
 	rm -rf "$(PKG_BUILDDIR)"
+
+endif


### PR DESCRIPTION
### Contribution description

Previously, fixing package code / adaption was a tedious task, as it either required (risky) editing within ```$(BINDIR)/pkg/$(BOARD)/$(PKG_NAME)```, or pushing to a repo, updating the commit hash in package makefile and then ```make clean``` so the package folder gets re-checked-out.

This PR allows specifying ```PKG_SOURCE_LOCAL``` in a package makefile.
If set, git source data is ignored, and the folder pointed to by ```$(PKG_SOURCE_LOCAL)``` will be copied to ```$(BINDIR)/pkg/$(BOARD)/$(PKG_NAME)```.
This allows safely editing a local version of the source code until everything works fine.