### PR TITLE
[RFC-WIP] docs: move wiki's Board documentation to Doxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ Makefile.local
 
 # scan-build artifacts
 scan-build/
+
+# Ignore auto-generated supported boards doxygen md file
+doc/doxygen/src/autogen/*

--- a/boards/doc/arm.md
+++ b/boards/doc/arm.md
@@ -1,0 +1,3 @@
+ARM
+===
+Blah Blah Blah

--- a/boards/iotlab-m3/doc/board.md
+++ b/boards/iotlab-m3/doc/board.md
@@ -1,0 +1,4 @@
+<!--arm-->
+IOTLAB M3
+===========
+Hello world from IoTLAB M3

--- a/boards/samr21-xpro/doc/board.md
+++ b/boards/samr21-xpro/doc/board.md
@@ -1,0 +1,4 @@
+<!--arm-->
+SAMR21-xpro
+===========
+Hello world

--- a/dist/tools/docgen/gen-board-docs.sh
+++ b/dist/tools/docgen/gen-board-docs.sh
@@ -1,0 +1,9 @@
+RIOTBASE=$(git rev-parse --show-toplevel)
+
+for DOCFILE in $(ls $RIOTBASE/boards/*/doc/board.md)
+do
+	HUMAN_NAME=$(sed -n "2 p" $DOCFILE)
+	CV=$(echo $DOCFILE | awk -F / '{ print $(NF-2) }')
+	echo "@page board-$CV $HUMAN_NAME"
+	cat $DOCFILE
+done

--- a/dist/tools/docgen/gen-family-docs.sh
+++ b/dist/tools/docgen/gen-family-docs.sh
@@ -1,0 +1,14 @@
+RIOTBASE=$(git rev-parse --show-toplevel)
+BOARD_FAMILIES_DOC=$(ls $RIOTBASE/boards/doc/*.md)
+
+for FILE in $BOARD_FAMILIES_DOC
+do
+	CV=$(basename --suffix .md $FILE)
+	HUMAN_NAME=$(head -n 1 $FILE)
+	echo "@page board-family-$CV $HUMAN_NAME"
+	cat $FILE
+	#cat $FILE | awk "{if(NR==1){printf \"%s %s\n\", \$0, \"        {#board-family-$CV}\"}else{print}}"
+	echo "Available boards"
+	echo "================"
+	sh $RIOTBASE/dist/tools/docgen/get-by-family.sh $CV | awk '$1="* @subpage board-"$1 {print $1}'
+done

--- a/dist/tools/docgen/gen-supported-boards.sh
+++ b/dist/tools/docgen/gen-supported-boards.sh
@@ -1,0 +1,13 @@
+RIOTBASE=$(git rev-parse --show-toplevel)
+DOC_FILES=$(ls -a $RIOTBASE/boards/doc/*.md)
+
+echo "Supported Boards                                                  {#boards-wiki}"
+echo "================"
+echo ""
+
+for FILE in $DOC_FILES
+do
+	CV=$(basename --suffix .md $FILE)
+	echo "* Family: @subpage board-family-$CV"
+	sh $RIOTBASE/dist/tools/docgen/get-by-family.sh $CV | awk '$1="    * @ref board-"$1 {print $1}'
+done

--- a/dist/tools/docgen/get-by-family.sh
+++ b/dist/tools/docgen/get-by-family.sh
@@ -1,0 +1,9 @@
+RIOTBASE=$(git rev-parse --show-toplevel)
+
+for DOCFILE in $(ls $RIOTBASE/boards/*/doc/board.md)
+do
+	FAMILY_NAME=$(head -n 1 $DOCFILE | sed -e "s/<!--//" -e "s/-->//")
+	if [ "$FAMILY_NAME" = "$1" ]; then
+		echo $DOCFILE | awk -F / '{ print $(NF-2) }'
+	fi
+done

--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -1,4 +1,11 @@
 RIOTBASE=$(shell git rev-parse --show-toplevel)
+
+SUPPORTED_BOARD_MD=supported-boards.md
+BOARDS_MD=boards.md
+FAMILIES_MD=families.md
+AUTOGEN_DIR=src/autogen
+
+#
 # Generate list of quoted absolute include paths. Evaluated in riot.doxyfile.
 export STRIP_FROM_INC_PATH_LIST=$(shell \
     git ls-tree -dr --full-tree --name-only HEAD core drivers sys |\
@@ -18,13 +25,21 @@ endif
 .PHONY: doc
 doc: html
 
+$(AUTOGEN_DIR):
+	mkdir -p $(AUTOGEN_DIR)
+
+bootstrap:
+	sh $(RIOTBASE)/dist/tools/docgen/gen-board-docs.sh > $(AUTOGEN_DIR)/${BOARDS_MD}
+	sh $(RIOTBASE)/dist/tools/docgen/gen-family-docs.sh > $(AUTOGEN_DIR)/${FAMILIES_MD}
+	sh $(RIOTBASE)/dist/tools/docgen/gen-supported-boards.sh > $(AUTOGEN_DIR)/${SUPPORTED_BOARD_MD}
+
 # by marking html as phony we force make to re-run Doxygen even if the directory exists.
 .PHONY: html
-html: src/css/riot.css src/changelog.md
+html: $(AUTOGEN_DIR) bootstrap src/css/riot.css src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
 
 .PHONY: man
-man: src/changelog.md
+man: $(AUTOGEN_DIR) bootstrap src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
 
 ifneq (,$(LESSC))
@@ -40,8 +55,8 @@ src/changelog.md: src/changelog.md.tmp ../../release-notes.txt
 	@./generate-changelog.py $+ $@
 
 .PHONY:
-latex: src/changelog.md
+latex: $(AUTOGEN_DIR) bootstrap src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_LATEX= yes" ) | doxygen -
 
 clean:
-	-@rm -rf latex man html doxygen_objdb_*.tmp doxygen_entrydb_*.tmp src/changelog.md
+	-@rm -rf latex man html doxygen_objdb_*.tmp doxygen_entrydb_*.tmp src/changelog.md $(AUTOGEN_DIR)

--- a/doc/doxygen/RIOTDoxygenLayout.xml
+++ b/doc/doxygen/RIOTDoxygenLayout.xml
@@ -3,6 +3,7 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
+    <tab type="user" url="@ref boards-wiki" title="Boards"/>
     <tab type="pages" visible="yes" title="" intro=""/>
     <tab type="modules" visible="yes" title="" intro=""/>
     <tab type="namespaces" visible="yes" title="">

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -762,6 +762,9 @@ INPUT                  = ../../doc.txt \
                          ../../sys \
                          src/ \
                          src/mainpage.md \
+                         src/autogen/supported-boards.md \
+                         src/autogen/boards.md \
+                         src/autogen/families.md \
                          src/creating-modules.md \
                          src/creating-an-application.md \
                          src/getting-started.md \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This ~~PR~~ WIP RFC is an initial approach to move the [Board Wiki documentation](https://github.com/RIOT-OS/RIOT/wiki/RIOT-Platforms) to the Doxygen documentation. The motivation is to help developers keeping an up-to-date End User documentation for each board without adding too much overhead, and help the End User to find all the documentation in the same place. With this implementation, it's possible to add a new board with documentation without touching any doc file besides the ones in the `boards` folder.

Help from Bash/Doxygen experts will be appreciated as always.

I provide here the initial implementation with all the tools for generating the Board documentation, and some dummy md files for SamR21 and IotLAB-M3.

## How it works
* For a given board, a `doc/board.md` file is placed inside the <board_name> folder. E.g:
`boards/samr21-xpro/doc/board.md`
For samr21, this md file would be a copy of [this entry](https://github.com/RIOT-OS/RIOT/wiki/Board%3A-SAMR21-xpro)
* The first line of this file should indicate the family of the board with an HTML comment (ARM, MSP430).E.g (`boards/samr21-xpro/doc/board.md`):
```
<!--arm-->
SAMR21-xpro
===========
Hello world
```
* There is a `boards/doc` folder with multiple Markdown files, one for each family. These files provide all information about the CPU family (like [the ARM entry in RIOT wiki](https://github.com/RIOT-OS/RIOT/wiki/Family%3A-ARM)). The board specific HTML comment (`<!--arm-->`) must match the name of the file with the family file (I provide here a `boards/doc/arm.md`).
* `make doc`
* The content of the wiki will be available from a Boards entry in the top Navbar.


## Technical details
* There is a list of tools in dist/tools/docgen to generate md files for the Board documentation. These files are not being tracked by git.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

## RFC/Ideas
- [ ] Less BASH/Doxygen magic? (Help needed here!)
- [ ] Where to store images?
- [ ] HTML comments for family matching? Any ideas?

### Issues/PRs references
References #8479
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->