### PR TITLE
gnrc_sixlowpan: Introduce 6Lo GNRC dispatch sub-layer

### DIFF
--- a/sys/include/net/gnrc/sixlowpan.h
+++ b/sys/include/net/gnrc/sixlowpan.h
@@ -104,6 +104,7 @@
 #include "kernel_types.h"
 
 #include "net/gnrc/sixlowpan/frag.h"
+#include "net/gnrc/sixlowpan/internal.h"
 #include "net/gnrc/sixlowpan/iphc.h"
 #include "net/sixlowpan.h"
 

--- a/sys/include/net/gnrc/sixlowpan/internal.h
+++ b/sys/include/net/gnrc/sixlowpan/internal.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup net_gnrc_sixlowpan
+ * @{
+ *
+ * @file
+ * @brief   6LoWPAN internal functions
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NET_GNRC_SIXLOWPAN_INTERNAL_H
+#define NET_GNRC_SIXLOWPAN_INTERNAL_H
+
+#include "net/gnrc/pkt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Delegates a packet to the network layer
+ *
+ * @param[in] pkt       A packet
+ * @param[in] context   Context for the packet. May be NULL.
+ * @param[in] page      Current 6Lo dispatch parsing page
+ */
+void gnrc_sixlowpan_dispatch_recv(gnrc_pktsnip_t *pkt, void *context,
+                                  unsigned page);
+
+/**
+ * @brief   Delegates a packet to the network interface
+ *
+ * @param[in] pkt       A packet
+ * @param[in] context   Context for the packet. May be NULL.
+ * @param[in] page      Current 6Lo dispatch parsing page
+ */
+void gnrc_sixlowpan_dispatch_send(gnrc_pktsnip_t *pkt, void *context,
+                                  unsigned page);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_GNRC_SIXLOWPAN_INTERNAL_H */
+/** @} */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -21,6 +21,7 @@
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/sixlowpan/frag.h"
+#include "net/gnrc/sixlowpan/internal.h"
 #include "net/gnrc/netif.h"
 #include "net/sixlowpan.h"
 #include "utlist.h"
@@ -130,11 +131,7 @@ static uint16_t _send_1st_fragment(gnrc_netif_t *iface, gnrc_pktsnip_t *pkt,
     DEBUG("6lo frag: send first fragment (datagram size: %u, "
           "datagram tag: %" PRIu16 ", fragment size: %" PRIu16 ")\n",
           (unsigned int)datagram_size, _tag, local_offset);
-    if (gnrc_netapi_send(iface->pid, frag) < 1) {
-        DEBUG("6lo frag: unable to send first fragment\n");
-        gnrc_pktbuf_release(frag);
-    }
-
+    gnrc_sixlowpan_dispatch_send(frag, NULL, 0);
     return local_offset;
 }
 
@@ -208,11 +205,7 @@ static uint16_t _send_nth_fragment(gnrc_netif_t *iface, gnrc_pktsnip_t *pkt,
           "fragment size: %" PRIu16 ")\n",
           (unsigned int)datagram_size, _tag, hdr->offset, hdr->offset << 3,
           local_offset);
-    if (gnrc_netapi_send(iface->pid, frag) < 1) {
-        DEBUG("6lo frag: unable to send subsequent fragment\n");
-        gnrc_pktbuf_release(frag);
-    }
-
+    gnrc_sixlowpan_dispatch_send(frag, NULL, 0);
     return local_offset;
 }
 

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -176,13 +176,7 @@ void rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
         new_netif_hdr->lqi = netif_hdr->lqi;
         new_netif_hdr->rssi = netif_hdr->rssi;
         LL_APPEND(entry->pkt, netif);
-
-        if (!gnrc_netapi_dispatch_receive(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL,
-                                          entry->pkt)) {
-            DEBUG("6lo rbuf: No receivers for this packet found\n");
-            gnrc_pktbuf_release(entry->pkt);
-        }
-
+        gnrc_sixlowpan_dispatch_recv(entry->pkt, NULL, 0);
         _rbuf_rem(entry);
     }
 }

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -64,6 +64,47 @@ kernel_pid_t gnrc_sixlowpan_init(void)
     return _pid;
 }
 
+void gnrc_sixlowpan_dispatch_recv(gnrc_pktsnip_t *pkt, void *context,
+                                  unsigned page)
+{
+    gnrc_nettype_t type;
+
+    (void)context;
+    (void)page;
+#ifdef MODULE_CCNLITE
+    type = GNRC_NETTYPE_UNDEF;
+    for (gnrc_pktsnip_t *ptr = pkt; (ptr || (type == GNRC_NETTYPE_UNDEF));
+         ptr = ptr->next) {
+        if ((ptr->next) && (ptr->next->type == GNRC_NETTYPE_NETIF)) {
+            type = ptr->type;
+        }
+    }
+    assert(network_snip);
+#else   /* MODULE_CCNLITE */
+    /* just assume normal IPv6 traffic */
+    type = GNRC_NETTYPE_IPV6;
+#endif  /* MODULE_CCNLITE */
+    if (!gnrc_netapi_dispatch_receive(type,
+                                      GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {
+        DEBUG("6lo: No receivers for this packet found\n");
+        gnrc_pktbuf_release(pkt);
+    }
+}
+
+void gnrc_sixlowpan_dispatch_send(gnrc_pktsnip_t *pkt, void *context,
+                                  unsigned page)
+{
+    (void)context;
+    (void)page;
+    assert(pkt->type == GNRC_NETTYPE_NETIF);
+    gnrc_netif_hdr_t *hdr = pkt->data;
+    if (gnrc_netapi_send(hdr->if_pid, pkt) < 1) {
+        DEBUG("6lo: unable to send %p over interface %u\n", (void *)pkt,
+              hdr->if_pid);
+        gnrc_pktbuf_release(pkt);
+    }
+}
+
 static void _receive(gnrc_pktsnip_t *pkt)
 {
     gnrc_pktsnip_t *payload;
@@ -163,10 +204,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
         gnrc_pktbuf_release(pkt);
         return;
     }
-    if (!gnrc_netapi_dispatch_receive(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {
-        DEBUG("6lo: No receivers for this packet found\n");
-        gnrc_pktbuf_release(pkt);
-    }
+    gnrc_sixlowpan_dispatch_recv(pkt, NULL, 0);
 }
 
 static inline bool _add_uncompr_disp(gnrc_pktsnip_t *pkt)
@@ -264,11 +302,7 @@ static void _send(gnrc_pktsnip_t *pkt)
     if (gnrc_pkt_len(pkt2->next) <= iface->sixlo.max_frag_size) {
         DEBUG("6lo: Send SND command for %p to %" PRIu16 "\n",
               (void *)pkt2, hdr->if_pid);
-        if (gnrc_netapi_send(hdr->if_pid, pkt2) < 1) {
-            DEBUG("6lo: unable to send %p over %" PRIu16 "\n", (void *)pkt, hdr->if_pid);
-            gnrc_pktbuf_release(pkt2);
-        }
-
+        gnrc_sixlowpan_dispatch_send(pkt2, NULL, 0);
         return;
     }
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG


### PR DESCRIPTION
### Contribution description
This abstracts the sending and receiving of 6Lo packets to the new
6Lo sub-layer model introduced in #8511 and exemplifies it as well.

### Issues/PRs references
Addresses parts of #8511