### PR TITLE
gnrc_netreg: some optimisations

### DIFF
--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -334,19 +334,6 @@ void gnrc_netreg_unregister(gnrc_nettype_t type, gnrc_netreg_entry_t *entry);
 gnrc_netreg_entry_t *gnrc_netreg_lookup(gnrc_nettype_t type, uint32_t demux_ctx);
 
 /**
- * @brief   Returns number of entries with the same gnrc_netreg_entry_t::type and
- *          gnrc_netreg_entry_t::demux_ctx.
- *
- * @param[in] type      Type of the protocol.
- * @param[in] demux_ctx The demultiplexing context for the registered thread.
- *                      See gnrc_netreg_entry_t::demux_ctx.
- *
- * @return  Number of entries with the same gnrc_netreg_entry_t::type and
- *          gnrc_netreg_entry_t::demux_ctx as the given parameters.
- */
-int gnrc_netreg_num(gnrc_nettype_t type, uint32_t demux_ctx);
-
-/**
  * @brief   Returns the next entry after @p entry with the same
  *          gnrc_netreg_entry_t::type and gnrc_netreg_entry_t::demux_ctx as the
  *          given entry.

--- a/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
+++ b/sys/net/gnrc/application_layer/tftp/gnrc_tftp.c
@@ -367,7 +367,7 @@ int _tftp_init_ctxt(ipv6_addr_t *addr, const char *file_name,
     /* generate a random source UDP source port */
     do {
         ctxt->src_port = (random_uint32() & 0xff) + GNRC_TFTP_DEFAULT_SRC_PORT;
-    } while (gnrc_netreg_num(GNRC_NETTYPE_UDP, ctxt->src_port));
+    } while (gnrc_netreg_lookup(GNRC_NETTYPE_UDP, ctxt->src_port));
 
     return TS_FINISHED;
 }

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -96,28 +96,6 @@ gnrc_netreg_entry_t *gnrc_netreg_lookup(gnrc_nettype_t type, uint32_t demux_ctx)
     return _netreg_lookup(NULL, type, demux_ctx);
 }
 
-int gnrc_netreg_num(gnrc_nettype_t type, uint32_t demux_ctx)
-{
-    int num = 0;
-    gnrc_netreg_entry_t *entry;
-
-    if (_INVALID_TYPE(type)) {
-        return 0;
-    }
-
-    entry = netreg[type];
-
-    while (entry != NULL) {
-        if (entry->demux_ctx == demux_ctx) {
-            num++;
-        }
-
-        entry = entry->next;
-    }
-
-    return num;
-}
-
 gnrc_netreg_entry_t *gnrc_netreg_getnext(gnrc_netreg_entry_t *entry)
 {
     return (entry ? _netreg_lookup(entry, 0, entry->demux_ctx) : NULL);

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -65,17 +65,35 @@ void gnrc_netreg_unregister(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
     LL_DELETE(netreg[type], entry);
 }
 
-gnrc_netreg_entry_t *gnrc_netreg_lookup(gnrc_nettype_t type, uint32_t demux_ctx)
+/**
+ * @brief   Searches the next entry in the registry that matches given
+ *          parameters, start lookup from beginning or given entry.
+ *
+ * @param[in] from      A registry entry to lookup from or NULL to start fresh
+ * @param[in] type      Type of the protocol.
+ * @param[in] demux_ctx The demultiplexing context for the registered thread.
+ *                      See gnrc_netreg_entry_t::demux_ctx.
+ *
+ * @return  The first entry fitting the given parameters on success
+ * @return  NULL if no entry can be found.
+ */
+static gnrc_netreg_entry_t *_netreg_lookup(gnrc_netreg_entry_t *from,
+                                           gnrc_nettype_t type,
+                                           uint32_t demux_ctx)
 {
-    gnrc_netreg_entry_t *res;
+    gnrc_netreg_entry_t *res = NULL;
 
-    if (_INVALID_TYPE(type)) {
-        return NULL;
+    if (from || !_INVALID_TYPE(type)) {
+        gnrc_netreg_entry_t *head = (from) ? from->next : netreg[type];
+        LL_SEARCH_SCALAR(head, res, demux_ctx, demux_ctx);
     }
 
-    LL_SEARCH_SCALAR(netreg[type], res, demux_ctx, demux_ctx);
-
     return res;
+}
+
+gnrc_netreg_entry_t *gnrc_netreg_lookup(gnrc_nettype_t type, uint32_t demux_ctx)
+{
+    return _netreg_lookup(NULL, type, demux_ctx);
 }
 
 int gnrc_netreg_num(gnrc_nettype_t type, uint32_t demux_ctx)
@@ -102,17 +120,7 @@ int gnrc_netreg_num(gnrc_nettype_t type, uint32_t demux_ctx)
 
 gnrc_netreg_entry_t *gnrc_netreg_getnext(gnrc_netreg_entry_t *entry)
 {
-    uint32_t demux_ctx;
-
-    if (entry == NULL) {
-        return NULL;
-    }
-
-    demux_ctx = entry->demux_ctx;
-
-    LL_SEARCH_SCALAR(entry->next, entry, demux_ctx, demux_ctx);
-
-    return entry;
+    return (entry ? _netreg_lookup(entry, 0, entry->demux_ctx) : NULL);
 }
 
 int gnrc_netreg_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr)

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -219,7 +219,7 @@ static void _dispatch_next_header(gnrc_pktsnip_t *current, gnrc_pktsnip_t *pkt,
 
     /* dispatch IPv6 extension header only once */
     if (should_dispatch_current_type) {
-        bool should_release = (gnrc_netreg_num(GNRC_NETTYPE_IPV6, nh) == 0) &&
+        bool should_release = (!gnrc_netreg_lookup(GNRC_NETTYPE_IPV6, nh)) &&
                               (!interested);
 
         if (!should_release) {

--- a/tests/unittests/tests-netreg/tests-netreg.c
+++ b/tests/unittests/tests-netreg/tests-netreg.c
@@ -85,6 +85,13 @@ void test_netreg_unregister__success3(void)
     TEST_ASSERT_NULL(gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16));
 }
 
+void test_netreg_lookup__empty(void)
+{
+    TEST_ASSERT_NULL(gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16));
+    TEST_ASSERT_NULL(gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16 + 1));
+    TEST_ASSERT_NULL(gnrc_netreg_lookup(GNRC_NETTYPE_TEST, GNRC_NETREG_DEMUX_CTX_ALL));
+}
+
 void test_netreg_lookup__wrong_type_undef(void)
 {
     TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_register(GNRC_NETTYPE_TEST, &entries[0]));
@@ -97,31 +104,17 @@ void test_netreg_lookup__wrong_type_numof(void)
     TEST_ASSERT_NULL(gnrc_netreg_lookup(GNRC_NETTYPE_NUMOF, TEST_UINT16));
 }
 
-void test_netreg_num__empty(void)
+void test_netreg_lookup__2_entries(void)
 {
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_num(GNRC_NETTYPE_TEST, TEST_UINT16));
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_num(GNRC_NETTYPE_TEST, TEST_UINT16 + 1));
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_num(GNRC_NETTYPE_TEST, GNRC_NETREG_DEMUX_CTX_ALL));
-}
-
-void test_netreg_num__wrong_type_undef(void)
-{
+    gnrc_netreg_entry_t *res = NULL;
+    /* add first entry, first lookup != NULL; second == NULL */
     TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_register(GNRC_NETTYPE_TEST, &entries[0]));
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_num(GNRC_NETTYPE_UNDEF, TEST_UINT16));
-}
-
-void test_netreg_num__wrong_type_numof(void)
-{
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_register(GNRC_NETTYPE_TEST, &entries[0]));
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_num(GNRC_NETTYPE_NUMOF, TEST_UINT16));
-}
-
-void test_netreg_num__2_entries(void)
-{
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_register(GNRC_NETTYPE_TEST, &entries[0]));
-    TEST_ASSERT_EQUAL_INT(1, gnrc_netreg_num(GNRC_NETTYPE_TEST, TEST_UINT16));
+    TEST_ASSERT_NOT_NULL((res = gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16)));
+    TEST_ASSERT_NULL((res = gnrc_netreg_getnext(res)));
+    /* add second entry, both lookups != NULL */
     TEST_ASSERT_EQUAL_INT(0, gnrc_netreg_register(GNRC_NETTYPE_TEST, &entries[1]));
-    TEST_ASSERT_EQUAL_INT(2, gnrc_netreg_num(GNRC_NETTYPE_TEST, TEST_UINT16));
+    TEST_ASSERT_NOT_NULL((res = gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16)));
+    TEST_ASSERT_NOT_NULL((res = gnrc_netreg_getnext(res)));
 }
 
 void test_netreg_getnext__NULL(void)
@@ -134,7 +127,7 @@ void test_netreg_getnext__2_entries(void)
 {
     gnrc_netreg_entry_t *res = NULL;
 
-    test_netreg_num__2_entries();
+    test_netreg_lookup__2_entries();
     TEST_ASSERT_NOT_NULL((res = gnrc_netreg_lookup(GNRC_NETTYPE_TEST, TEST_UINT16)));
     TEST_ASSERT_NOT_NULL(gnrc_netreg_getnext(res));
 }
@@ -147,12 +140,10 @@ Test *tests_netreg_tests(void)
         new_TestFixture(test_netreg_unregister__success),
         new_TestFixture(test_netreg_unregister__success2),
         new_TestFixture(test_netreg_unregister__success3),
+        new_TestFixture(test_netreg_lookup__empty),
         new_TestFixture(test_netreg_lookup__wrong_type_undef),
         new_TestFixture(test_netreg_lookup__wrong_type_numof),
-        new_TestFixture(test_netreg_num__empty),
-        new_TestFixture(test_netreg_num__wrong_type_undef),
-        new_TestFixture(test_netreg_num__wrong_type_numof),
-        new_TestFixture(test_netreg_num__2_entries),
+        new_TestFixture(test_netreg_lookup__2_entries),
         new_TestFixture(test_netreg_getnext__NULL),
         new_TestFixture(test_netreg_getnext__2_entries),
     };


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Some optimisation on gnrc_netreg functions, i.e. removes `gnrc_netreg_num` which isn't used (anymore) - or was only in tests. Thereby, also omitting a (redundant) loop in `gnrc_netapi_dispatch`, which should reduce runtime overhead, too. However, this (definitely) saves 64B ROM for all examples and tests that use gnrc_netreg functionality, e.g., `examples/gnrc_networking` or `tests/gnrc_sock_udp`.


### Issues/PRs references

None