### PR TITLE
cpu/cortexm: add __NOP(); after __WFI(); for stm32l152 to avoid hardfault

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -107,6 +107,10 @@ static inline void cortexm_sleep(int deep)
     unsigned state = irq_disable();
     __DSB();
     __WFI();
+#if defined(CPU_MODEL_STM32L152RE)
+    /* STM32L152RE crashes without this __NOP(). See #8518. */
+    __NOP();
+#endif
     irq_restore(state);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Currently, the stm32l1x hardfaults due to the irq state being stored in r0, which for some reason is lost after wake-up.
~~This PR fixes that by ensuring that the state is being stored in RAM.~~
The actual, less intrusive, fix is to add a `__NOP();` just after wake up, which also solves the problem.

~~It additionally allows to choose a different Low Speed clock source, since by default LSE (external) is hardcoded. Although this might be in another PR, users of an old revision of nucleo boards cannot test (so far one of the two stm32l1x based supported boards).~~

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
Refs #8024

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->