### PR TITLE
uncrustify: add auto uncrustify with blacklist

### DIFF
--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -76,5 +76,6 @@ run ./dist/tools/flake8/check.sh
 run ./dist/tools/headerguards/check.sh
 run ./dist/tools/buildsystem_sanity_check/check.sh
 run ./dist/tools/codespell/check.sh
+run ./dist/tools/uncrustify/uncrustify.sh --check
 
 exit $RESULT

--- a/dist/tools/uncrustify/uncrustify.sh
+++ b/dist/tools/uncrustify/uncrustify.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+RIOTBASE=$(git rev-parse --show-toplevel)
+CURDIR=$(cd "$(dirname "$0")" && pwd)
+UNCRUSTIFY_CFG="$RIOTBASE"/uncrustify-riot.cfg
+
+WHITELIST=$CURDIR/whitelist.txt
+BLACKLIST=$CURDIR/blacklist.txt
+
+. "$RIOTBASE"/dist/tools/ci/changed_files.sh
+
+# only consider whitelisted stuff, then filter out blacklist
+# note: this also applies changed_files' default filter
+FILES=$(changed_files | grep -xf "$WHITELIST" | grep -xvf "$BLACKLIST")
+
+check () {
+    for F in $FILES
+    do
+        OUT="$(uncrustify -c "$UNCRUSTIFY_CFG" -f "$RIOTBASE/$F" --check 2> /dev/null)"
+        if [ "$OUT" ] ; then
+            echo "Please run 'dist/tools/uncrustify/uncrustify.sh'"
+            exit 1
+        fi
+    done
+    echo "All files are uncrustified!"
+}
+
+exec_uncrustify () {
+    if [ "$(git diff HEAD)" ] ; then
+        echo "Please commit all changes before running uncrustify.sh"
+        exit 1
+    fi
+    for F in $FILES
+    do
+        uncrustify -c "$UNCRUSTIFY_CFG" --no-backup "$RIOTBASE/$F"
+    done
+}
+
+if [ "$1" == "--check" ] ; then
+    check
+else
+    exec_uncrustify
+fi

--- a/dist/tools/uncrustify/whitelist.txt
+++ b/dist/tools/uncrustify/whitelist.txt
@@ -1,0 +1,2 @@
+core/.*\.c
+core/include/.*\.h


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Here is a proposal for the discussion in #4363. 
- This PR adds a tool in dist/tools that applies the current uncrustify-riot.cfg config to all tracked files that don't match an entry in a blacklist.txt file.
- It also includes a `check.sh` that could be used from CI. Checks if files in a branch have been uncrustified (close to a automatic style check).
- Last but not least, provides a blacklist.txt with core and (most) vendor files blacklisted

To use this tool, simply run either `uncrustify.sh` for applying the configuration or `check.sh` to check if files have been uncrustified.

Does it make sense? Please feel free to give feedback.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#4363