### PR TITLE
unittests: improve tests-fmt, add buffer overflow checks

### DIFF
--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -22,8 +22,9 @@
 
 static void test_fmt_byte_hex(void)
 {
-    char out[3] = "--";
+    char out[8] = "zzzzzzz";
 
+    out[2] = '\0';
     TEST_ASSERT_EQUAL_INT(2, fmt_byte_hex(out, 0));
     TEST_ASSERT_EQUAL_STRING("00", (char *) out);
 
@@ -32,11 +33,14 @@ static void test_fmt_byte_hex(void)
 
     TEST_ASSERT_EQUAL_INT(2, fmt_byte_hex(out, 255));
     TEST_ASSERT_EQUAL_STRING("FF", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zzzz", &out[3]);
 }
 
 static void test_fmt_bytes_hex(void)
 {
-    char out[15] = "--------------";
+    char out[20] = "zzzzzzzzzzzzzzzzzzz";
     uint8_t val[7] = { 0xAA, 9, 8, 7, 6, 0xA8, 0xEF};
     uint8_t bytes = 0;
 
@@ -79,11 +83,14 @@ static void test_fmt_bytes_hex(void)
     out[bytes] = '\0';
     TEST_ASSERT_EQUAL_INT(14, bytes);
     TEST_ASSERT_EQUAL_STRING("AA09080706A8EF", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zzzz", &out[15]);
 }
 
 static void test_fmt_bytes_hex_reverse(void)
 {
-    char out[9] = "--------";
+    char out[12] = "zzzzzzzzzzz";
     uint8_t val[4] = { 9, 8, 7, 6 };
     uint8_t bytes = 0;
 
@@ -106,6 +113,9 @@ static void test_fmt_bytes_hex_reverse(void)
     out[bytes] = '\0';
     TEST_ASSERT_EQUAL_INT(8, bytes);
     TEST_ASSERT_EQUAL_STRING("06070809", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zz", &out[9]);
 }
 
 static void test_fmt_hex_bytes(void)
@@ -157,25 +167,33 @@ static void test_fmt_hex_bytes(void)
 
 static void test_fmt_u32_hex(void)
 {
-    char out[9] = "--------";
+    char out[12] = "zzzzzzzzzzz";
     uint32_t val = 3735928559;
 
+    out[8] = '\0';
     TEST_ASSERT_EQUAL_INT(8, fmt_u32_hex(out, val));
     TEST_ASSERT_EQUAL_STRING("DEADBEEF", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zz", &out[9]);
 }
 
 static void test_fmt_u64_hex(void)
 {
-    char out[17] = "----------------";
+    char out[20] = "zzzzzzzzzzzzzzzzzzz";
     uint64_t val = 1002843385516306400;
 
+    out[16] = '\0';
     TEST_ASSERT_EQUAL_INT(16, fmt_u64_hex(out, val));
     TEST_ASSERT_EQUAL_STRING("0DEAD0BEEF0CAFE0", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zz", &out[17]);
 }
 
 static void test_fmt_u32_dec(void)
 {
-    char out[11] = "----------";
+    char out[16] = "zzzzzzzzzzzzzzz";
     uint32_t val = 12345678;
     uint8_t chars = 0;
 
@@ -184,12 +202,14 @@ static void test_fmt_u32_dec(void)
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("12345678", (char *) out);
 
-    memset(out, '-', sizeof(out));
     val = 1234567890;
     chars = fmt_u32_dec(out, val);
     TEST_ASSERT_EQUAL_INT(10, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("1234567890", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zzzz", &out[11]);
 }
 
 static void test_fmt_u16_dec(void)
@@ -208,6 +228,9 @@ static void test_fmt_u16_dec(void)
     TEST_ASSERT_EQUAL_INT(5, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("65535", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("z", &out[6]);
 }
 
 static void test_fmt_s32_dec_a(void)
@@ -226,6 +249,9 @@ static void test_fmt_s32_dec_a(void)
     TEST_ASSERT_EQUAL_INT(5, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("-9876", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zzzzzzzzz", &out[6]);
 }
 
 static void test_fmt_s32_dec_b(void)
@@ -244,11 +270,14 @@ static void test_fmt_s32_dec_b(void)
     TEST_ASSERT_EQUAL_INT(11, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("-2147483648", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zzz", &out[12]);
 }
 
 static void test_fmt_u64_dec_a(void)
 {
-    char out[21] = "--------------------";
+    char out[24] = "zzzzzzzzzzzzzzzzzzzzzzz";
     uint64_t val = 0;
     uint8_t chars = 0;
 
@@ -256,11 +285,14 @@ static void test_fmt_u64_dec_a(void)
     TEST_ASSERT_EQUAL_INT(1, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("0", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zzzzzzzzzzzzzzzzzzzzz", &out[2]);
 }
 
 static void test_fmt_u64_dec_b(void)
 {
-    char out[21] = "--------------------";
+    char out[24] = "zzzzzzzzzzzzzzzzzzzzzzz";
     uint64_t val = 18446744073709551615LLU;
     uint8_t chars = 0;
 
@@ -268,11 +300,14 @@ static void test_fmt_u64_dec_b(void)
     TEST_ASSERT_EQUAL_INT(20, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("18446744073709551615", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zz", &out[21]);
 }
 
 static void test_fmt_u64_dec_c(void)
 {
-    char out[21] = "--------------------";
+    char out[24] = "zzzzzzzzzzzzzzzzzzzzzzz";
     uint64_t val = 1234567890123456789LLU;
     uint8_t chars = 0;
 
@@ -280,11 +315,14 @@ static void test_fmt_u64_dec_c(void)
     TEST_ASSERT_EQUAL_INT(19, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("1234567890123456789", (char *) out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zzz", &out[20]);
 }
 
 static void test_fmt_s16_dec(void)
 {
-    char out[7] = "------";
+    char out[10] = "zzzzzzzzz";
     int16_t val;
     size_t len;
 
@@ -305,11 +343,14 @@ static void test_fmt_s16_dec(void)
     out[len] = '\0';
     TEST_ASSERT_EQUAL_INT(5, len);
     TEST_ASSERT_EQUAL_STRING("12345", (char *)out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zz", &out[7]);
 }
 
 static void test_fmt_s16_dfp(void)
 {
-    char out[9] = "--------";
+    char out[12] = "zzzzzzzzzzz";
     int16_t val;
     unsigned fpp;
     size_t len;
@@ -369,11 +410,14 @@ static void test_fmt_s16_dfp(void)
     out[len] = '\0';
     TEST_ASSERT_EQUAL_INT(8, len);
     TEST_ASSERT_EQUAL_STRING("0.031987", (char *)out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zz", &out[9]);
 }
 
 static void test_fmt_s32_dfp(void)
 {
-    char out[13] = "-------------";
+    char out[16] = "zzzzzzzzzzzzzzz";
     int32_t val;
     unsigned fpp;
     size_t len;
@@ -426,6 +470,9 @@ static void test_fmt_s32_dfp(void)
     out[len] = '\0';
     TEST_ASSERT_EQUAL_INT(10, len);
     TEST_ASSERT_EQUAL_STRING("-123456789", (char *)out);
+
+    /* check that the buffer was not overflowed */
+    TEST_ASSERT_EQUAL_STRING("zzzz", &out[11]);
 }
 
 static void test_fmt_strlen(void)

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -194,7 +194,7 @@ static void test_fmt_u32_dec(void)
 
 static void test_fmt_u16_dec(void)
 {
-    char out[5] = "----";
+    char out[8] = "zzzzzzz";
     uint16_t val = 6556;
     uint8_t chars = 0;
 
@@ -202,6 +202,12 @@ static void test_fmt_u16_dec(void)
     TEST_ASSERT_EQUAL_INT(4, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("6556", (char *) out);
+
+    val = 65535;
+    chars = fmt_u16_dec(out, val);
+    TEST_ASSERT_EQUAL_INT(5, chars);
+    out[chars] = '\0';
+    TEST_ASSERT_EQUAL_STRING("65535", (char *) out);
 }
 
 static void test_fmt_s32_dec_a(void)

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -204,9 +204,9 @@ static void test_fmt_u16_dec(void)
     TEST_ASSERT_EQUAL_STRING("6556", (char *) out);
 }
 
-static void test_fmt_s32_dec(void)
+static void test_fmt_s32_dec_a(void)
 {
-    char out[6] = "-----";
+    char out[16] = "zzzzzzzzzzzzzzz";
     int32_t val = 9876;
     uint8_t chars = 0;
 
@@ -220,6 +220,24 @@ static void test_fmt_s32_dec(void)
     TEST_ASSERT_EQUAL_INT(5, chars);
     out[chars] = '\0';
     TEST_ASSERT_EQUAL_STRING("-9876", (char *) out);
+}
+
+static void test_fmt_s32_dec_b(void)
+{
+    char out[16] = "zzzzzzzzzzzzzzz";
+    int32_t val = 2147483647;
+    uint8_t chars = 0;
+
+    chars = fmt_s32_dec(out, val);
+    TEST_ASSERT_EQUAL_INT(10, chars);
+    out[chars] = '\0';
+    TEST_ASSERT_EQUAL_STRING("2147483647", (char *) out);
+
+    val = -2147483648;
+    chars = fmt_s32_dec(out, val);
+    TEST_ASSERT_EQUAL_INT(11, chars);
+    out[chars] = '\0';
+    TEST_ASSERT_EQUAL_STRING("-2147483648", (char *) out);
 }
 
 static void test_fmt_u64_dec_a(void)
@@ -480,7 +498,8 @@ Test *tests_fmt_tests(void)
         new_TestFixture(test_fmt_u64_dec_b),
         new_TestFixture(test_fmt_u64_dec_c),
         new_TestFixture(test_fmt_u16_dec),
-        new_TestFixture(test_fmt_s32_dec),
+        new_TestFixture(test_fmt_s32_dec_a),
+        new_TestFixture(test_fmt_s32_dec_b),
         new_TestFixture(test_fmt_s16_dec),
         new_TestFixture(test_fmt_s16_dfp),
         new_TestFixture(test_fmt_s32_dfp),


### PR DESCRIPTION
### Contribution description

Add some check for formatting min/max values to the fmt tests and add basic checks for buffer overflows in all fmt tests which modify a buffer.

### Issues/PRs references

none