### PR TITLE
gnrc_icmpv6_echo: fix ping for loopback [2018.01 backport]

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -93,7 +93,13 @@ void gnrc_icmpv6_echo_req_handle(gnrc_netif_t *netif, ipv6_hdr_t *ipv6_hdr,
     pkt = hdr;
     hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
-    ((gnrc_netif_hdr_t *)hdr->data)->if_pid = netif->pid;
+    if (netif != NULL) {
+        ((gnrc_netif_hdr_t *)hdr->data)->if_pid = netif->pid;
+    }
+    else {
+        /* ipv6_hdr->dst is loopback address */
+        ((gnrc_netif_hdr_t *)hdr->data)->if_pid = KERNEL_PID_UNDEF;
+    }
 
     LL_PREPEND(pkt, hdr);
 


### PR DESCRIPTION
Backport to #8499.