### PR TITLE
tests: deactivate assert() for netdev_test [2018.01 backport]

### DIFF
--- a/tests/netdev_test/Makefile
+++ b/tests/netdev_test/Makefile
@@ -1,3 +1,7 @@
+# These tests hit an assert when used with gnrc_netif, but they exactly for
+# testing this netdev simulating framework, so I it's better if the assert is
+# ignored.
+CFLAGS += -DNDEBUG
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031


### PR DESCRIPTION
Backport of #8485 (commit message changed during discussion, but PR title did not this is why this PR has a different title than #8485).