### PR TITLE
boards/nucleo-f103: add rtt configuration

### DIFF
--- a/boards/nucleo-f103/Makefile.features
+++ b/boards/nucleo-f103/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f103/include/periph_conf.h
+++ b/boards/nucleo-f103/include/periph_conf.h
@@ -129,6 +129,21 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_IRQ_PRIO        1
+
+#define RTT_DEV             RTC
+#define RTT_IRQ             RTC_IRQn
+#define RTT_ISR             isr_rtc
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_FREQUENCY       (16384)      /* in Hz */
+#define RTT_PRESCALER       (0x1)        /* run with ~16 kHz Hz */
+/** @} */
+
+/**
  * @name I2C configuration
  * @{
  */


### PR DESCRIPTION
### Contribution description

This PR adds a configuration for the real time counter in order to use RIOTs RTT module with the nucleo-f103 board.

### Issues/PRs references
none