### PR TITLE
tests/rng: Clean up includes

### DIFF
--- a/tests/rng/main.c
+++ b/tests/rng/main.c
@@ -19,6 +19,9 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <inttypes.h>
 
 #include "shell.h"
 

--- a/tests/rng/test.c
+++ b/tests/rng/test.c
@@ -6,7 +6,19 @@
  * directory for more details.
  */
 
+#include <stdint.h>
+#include <math.h>
+#include <stdio.h>
+
 #include "test.h"
+
+#include "fmt.h"
+#include "random.h"
+#include "xtimer.h"
+
+#ifdef MODULE_PERIPH_HWRNG
+#include "periph/hwrng.h"
+#endif
 
 /**
  * @brief   Seed for initializing random module.

--- a/tests/rng/test.h
+++ b/tests/rng/test.h
@@ -9,17 +9,7 @@
 #ifndef TEST_H
 #define TEST_H
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-
-#include "fmt.h"
-#include "random.h"
-#include "xtimer.h"
-
-#ifdef MODULE_PERIPH_HWRNG
-#include "periph/hwrng.h"
-#endif
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Contribution description

I realized there were a lot of includes in the test.h file in the rng test application, which were not used. This PR only rearranges the include directives to the files where they are actually used.

### Issues/PRs references

none