### PR TITLE
tests/bench_timers: A comprehensive benchmark for periph_timer

### DIFF
--- a/tests/bench_timers/Makefile
+++ b/tests/bench_timers/Makefile
@@ -1,0 +1,54 @@
+include ../Makefile.tests_common
+
+# These boards only have a single timer in their periph_conf.h, needs special
+# CFLAGS configuration to build properly
+SINGLE_TIMER_BOARDS = \
+  native \
+  nucleo-f031k6 \
+  nucleo-f042k6 \
+  #
+
+# These boards have too little RAM to support collecting detailed statistics
+# with the default settings of TEST_MIN and TEST_MAX, so DETAILED_STATS will be
+# disabled by default for these boards unless explicitly enabled
+SMALL_RAM_BOARDS = \
+  nucleo-f031k6 \
+  #
+
+FEATURES_REQUIRED = periph_timer
+
+# Use RTT as a wall clock reference, if available
+FEATURES_OPTIONAL = periph_rtt
+
+USEMODULE += random
+USEMODULE += fmt
+USEMODULE += matstat
+USEMODULE += xtimer
+
+ifeq (,$(findstring TIM_TEST_DEV,$(CFLAGS)))
+  ifneq (,$(filter $(BOARD),$(SINGLE_TIMER_BOARDS)))
+    CFLAGS += -DTIM_TEST_DEV=TIMER_DEV\(0\) -DTIM_REF_DEV=TIMER_DEV\(0\)
+  endif
+endif
+
+ifeq (,$(findstring DETAILED_STATS,$(CFLAGS)))
+  ifneq (,$(filter $(BOARD),$(SMALL_RAM_BOARDS)))
+    CFLAGS += -DDETAILED_STATS=0
+  endif
+endif
+
+# Shortcut to configure the build for testing xtimer against a periph_timer reference
+.PHONY: test-xtimer
+test-xtimer: CFLAGS+=-DTEST_XTIMER -DTIM_TEST_FREQ=XTIMER_HZ -DTIM_TEST_DEV=XTIMER_DEV
+test-xtimer: all
+
+# Shortcut to configure the build for testing Kinetis LPTMR against a PIT reference
+# Usage: make BOARD=frdm-k22f test-kinetis-lptmr flash
+.PHONY: test-kinetis-lptmr
+test-kinetis-lptmr: CFLAGS+=-DTIM_TEST_DEV=TIMER_LPTMR_DEV\(0\) -DTIM_TEST_FREQ=32768 -DTIM_REF_DEV=TIMER_PIT_DEV\(0\)
+test-kinetis-lptmr: all
+
+# Reset the default goal.
+.DEFAULT_GOAL :=
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/bench_timers/README.md
+++ b/tests/bench_timers/README.md
@@ -1,0 +1,341 @@
+# Benchmark test for RIOT timers
+
+This test is intended to collect statistics about the runtime delays in the
+periph_timer implementation. This tool is mainly intended to detect problems in
+the low level driver implementation which can be difficult to detect from
+higher level systems such as xtimer.
+
+## Testing periph/timer
+
+The basic idea of the test is to generate a wide variety of calls to the
+periph/timer API, in order to detect problems with the software implementation.
+The test consists of a single thread of execution which will set random
+timeouts on a periph_timer device. A reference timer is used to measure the
+time it takes until the callback is called. The difference between the expected
+time and the measured time is computed, and the mean and variance of the
+recorded values are calculated. The results are printed as a table on stdout
+every 30 seconds. All of the test scenarios used in this application are
+based on experience from real world bugs encountered during the development of
+RIOT and other systems.
+
+### periph/timer functions tested
+
+Both timer_set and timer_set_absolute calls are mixed in a random order, to
+ensure that both functions are working correctly.
+
+### Rescheduling
+
+Some bugs may occur only when the application attempts to replace an already
+set timer by calling timer_set again while the timer is running. This is dubbed
+"resched" in this application. The application will issue rescheduling timer
+calls in the normal operation of the test to catch this class of problems.
+
+### Setting stopped timers
+
+Another class of bugs is the kind where a timer is not behaving correctly if it
+was stopped before setting a timer target. The timer should set the new target,
+but not begin counting towards the target until timer_start is called. This is
+covered by this application under the "stopped" category of test inputs.
+
+## General benchmark behaviour
+
+The benchmark application uses some techniques to improve the quality of the
+tests.
+
+### Avoiding phase lock
+
+The CPU time used for generation and setting of the next timer target in
+software is approximately constant across iterations. When the application flow
+is driven by the timer under test, via a mutex which is unlocked from the timer
+callback, the application will be "phase locked" to the timer under test. This
+peculiarity may hide certain implementation race conditions which only occur at
+specific phases of the timer ticks. In the test application, this problem is
+avoided by inserting random CPU delay loops at key locations:
+
+ - After timer_stop
+ - Before timer_set/timer_set_absolute
+ - Before timer_start
+
+### Estimating benchmark CPU overhead
+
+An estimation of the overhead resulting from the CPU processing delays inside
+the benchmarking code is performed during benchmark initialization. The
+estimation algorithm attempts to perform the exact same actions that the real
+benchmark will perform, but without setting any timers. The measured delay is
+assumed to originate in the benchmark code and will be subtracted when
+computing the difference between expected and actual values. A warning is
+printed when the variance of the estimated CPU overhead is too high, this can
+be a sign that some other process is running on the CPU and disrupting the
+estimation, or a sign of serious problems inside the timer_read function.
+
+## Testing xtimer
+
+The benchmark application can be reconfigured for using xtimer instead of the
+low level periph/timer interface. Use the Makefile target test-xtimer to build
+a test for xtimer.
+
+### xtimer functions tested
+
+The application will mix calls to the following xtimer functions:
+
+ - `_xtimer_set`
+ - `_xtimer_set_absolute`
+ - `_xtimer_periodic_wakeup`
+ - `_xtimer_spin`
+
+These functions cover almost all uses of xtimer. The higher level functions
+such as `xtimer_usleep` and `xtimer_set_msg` all use these functions internally
+in the implementations.
+
+## Results
+
+When the test has run for a certain amount of time, the current results will be
+presented as a table on stdout. To assist with finding the source of any
+discrepancies, the results are split according to three parameters:
+
+ - Function used: timer_set, timer_set_absolute
+ - Rescheduled: yes/no
+ - Stopped: yes/no
+
+### Expected results
+
+It is difficult to set a general expected result which applies to all
+platforms. However, the mean and variance of the differences should be small,
+in relation to the tick duration of the timer under test. What is "small" also
+depends the CPU core frequency, because of CPU processing time spent in the
+driver code and in the test code. For example, when testing a 1 MHz timer and
+comparing with another 1 MHz timer, the mean difference should likely be in
+single digits on a Cortex-M CPU. Testing a 32768 Hz timer and referencing a 1
+MHz timer on the other hand should have a mean difference in double digits, the
+variance will also be greater because of the quantization errors and rounding
+in the tick conversion routine. If the mean or variance of the difference is
+exceptionally large, the row will be marked with "SIC!" to draw attention to
+the fact.
+
+### Interpreting timer_set_xxx statistics
+
+The first part of the results compares the reference time elapsed against the
+expected time. A negative value means that the timer alarm is triggered too
+soon, compared to the expected time. A positive value means that the timer
+alarm is triggered late, compared to the expected time.
+
+#### Expected variance
+
+The variance of the results should generally be as small as possible, except
+for the case where the reference timer is running at a higher frequency than
+the timer under test. There will always be a truncation error when setting a
+timer target because of the discrete timer counts that can be set. The
+benchmark will compute limits for the expected variance and show a message if
+the variance is less than or greater than the expected variance.
+
+##### Variance too low
+
+A variance lower than expected indicates that there is a phase correlation
+between the reference timer and the timer under test. This can only be
+explained by a software bug or a hardware failure. The primary suspect will be
+the reference timer.
+
+##### Variance too high
+
+A variance greater than expected indicates that there is some extra randomness
+in the timeout length, which can be caused by other processes interfering with
+the test, a software bug in the timer under test, or hardware failure.
+
+##### Mathematical explanation
+
+Let `X0` be the exact time that a timer_set call occurs, `X0` is a real number.
+Let `T` be the desired timeout, `T` is a positive integer because the timer can
+only count integer number of ticks. Let `x0 = floor(X0)` be the count that the
+timer is currently on when the timer is set, `x0` is an integer. If `X0` is
+uniformly random, then the truncation error `X0' = (X0 - x0)` will be a sample
+from a continuous uniform distribution in the interval `[0,1)` ticks. The timer
+target, `x1`, in the timer under test can be expressed as `x1 = x0 + T`. Let
+`k` be a real number that satisfies `Y = kx`, where `x` is an interval in the
+unit used by the timer under test, and `Y` is an interval in the unit used by
+the reference timer, `Y` is a real number. The time measured by the reference
+timer can be expressed as
+`Y = k(x1 - X0) = k(x0 + T - X0) = k(X0 - X0' + T - X0) = k(T - X0')`.
+`Y` will be a sample from a uniform random distribution in the interval
+`[kT, k(T + 1)]`. The variance of `Y` is defined as
+`Var(Y) = (k(T + 1) - kT)^2 / 12`.
+
+### Interpreting timer_read statistics
+
+A separate table is displayed for statistics on timer_read. This table compares
+the expected timer under test time after a timer has triggered, against the
+actual reported value from `timer_read(TIM_TEST_DEV)`. A positive value means
+that the TUT time has passed the timer target time. A negative value means
+that, according to the timer under test, the alarm target time has not yet been
+reached, even though the timer callback has been executed.
+
+### A note on BOARD=native
+
+When running on native, the application will be running as a normal process in
+a multi process system which means that most results will have a much greater
+variance than expected and the resulting differences will also be much larger
+than on a bare metal system. Be careful when drawing conclusions on results
+from native.
+
+## Configuration
+
+The timer under test and the reference timer can be chosen at compile time by
+defining TIM_TEST_DEV and TIM_REF_DEV, respectively. The frequencies for
+these timers can be configured through TIM_DEV_FREQ and TIM_REF_FREQ. For
+example, to compare timer device 2 running at 32768 Hz against a reference timer
+on timer device 0 (default) running at 1 MHz (default) on Mulle:
+
+    CFLAGS='-DTIM_TEST_DEV=TIMER_DEV\(2\) -DTIM_TEST_FREQ=32768' BOARD=mulle make flash
+
+### Default configuration
+
+reference timer: TIMER_DEV(0)
+timer under test: TIMER_DEV(1)
+timer frequency: 1 MHz
+
+Define USE_REFERENCE=0 to compare a timer against itself. Be aware that this
+may hide a class of errors where the timer is losing ticks in certain
+situations, which a separate reference timer would be able to detect.
+
+### Example output
+
+Below is a short sample of a test of a 32768 Hz timer with a 1 MHz reference:
+
+    ------------- BEGIN STATISTICS --------------
+    Limits: mean: [-10, 41], variance: [58, 99]
+    Target error (actual trigger time - expected trigger time), in reference timer ticks
+    positive: timer is late, negative: timer is early
+    === timer_set running ===
+       interval    count       sum       sum_sq    min   max  mean  variance
+       1 -    2:   25705    455646      2002373      2    35    17     77
+       3 -    4:   25533    457326      1973191      2    35    17     77
+       5 -    8:   25412    451046      1970014      2    35    17     77
+       9 -   16:   25699    458563      2017198      2    36    17     78
+      17 -   32:   25832    457768      2018909      1    35    17     78
+      33 -   64:   25758    440454      1978830      1    35    17     76
+      65 -  128:   25335    414320      1942196      0    34    16     76
+     129 -  256:   25254    367689      1979616     -3    32    14     78
+     257 -  512:   25677    285822      2020736     -7    31    11     78
+          TOTAL   230205   3788634     18459378     -7    36    16     80
+...
+
+The statistics above show that the timer implementation introduces a small
+delay on short timers. Note however that it is not clear whether this delay is
+in timer_set, or timer_read, but the combined effect of all error sources make
+the timer overshoot its target by on average 17 microseconds. The difference
+between min and max is close to the expected difference of approximately
+1/32768 s = 30.51 µs. The lower min and mean for the longer timer intervals are
+most likely caused by a drift between the 1 MHz clock and the 32.768 kHz clocks
+inside the CPU, and is expected when using two separate clock sources for the
+timers being compared.
+
+Below is a short sample of a test where there is something wrong with the timer
+implementation, again a 32768 Hz timer tested with a 1 MHz reference:
+
+    === timer_set_absolute resched ===
+       interval    count       sum       sum_sq    min   max  mean  variance
+       1 -    2:  152217  82324291  13339518497     38  1071   540  87635  <=== SIC!
+       3 -    4:  152199  82254909  13301794832     38  1071   540  87397  <=== SIC!
+       5 -    8:  152023  82085454  13264873203     38  1071   539  87256  <=== SIC!
+       9 -   16:  152156  82236539  13265351119     38  1071   540  87183  <=== SIC!
+      17 -   32:  152639  82606815  13267666812     38  1071   541  86922  <=== SIC!
+      33 -   64:  151883  81836155  13268661551     37  1070   538  87361  <=== SIC!
+      65 -  128:  152114  82151495  13228100922     36  1070   540  86962  <=== SIC!
+     129 -  256:  152363  81806042  13278055359     34  1069   536  87148  <=== SIC!
+     257 -  512:  152360  81235185  13303811951     29  1066   533  87318  <=== SIC!
+          TOTAL  1369954 738536885 119197349719     29  1071   539  87008  <=== SIC!
+
+We can see that the variance, the maximum error, and the mean are very large.
+This particular timer implementation needs some work on its timer_set_absolute
+implementation.
+
+## Configuration details
+
+Configuration macros used by the application are described below
+
+### Settings related to timer hardware
+
+#### TIM_TEST_DEV
+
+Timer under test. Default: `TIMER_DEV(1)`
+
+#### TIM_REF_DEV
+
+Reference timer used for measuring the callback time error. Default: `TIMER_DEV(0)`
+
+#### TIM_TEST_FREQ
+
+Frequency of the timer under test, used when calling timer_init during the
+application startup. Default: `1000000`, 1 MHz
+
+#### TIM_REF_FREQ
+
+Frequency of the reference timer, used when calling timer_init during the
+application startup. Default: `1000000`, 1 MHz
+
+#### TIM_TEST_CHAN
+
+Timer channel used on the timer under test. Default: `0`
+
+#### USE_REFERENCE
+
+Shorthand for setting the reference timer to the same as the timer under test.
+Default: `0`
+
+### Settings related to result processing
+
+
+#### DETAILED_STATS
+
+Keep statistics per timer target offset value if set to 1, otherwise keep
+statistics only per scenario. Default: `1`
+
+#### LOG2_STATS
+
+Only used when `DETAILED_STATS == 1`. Statistics are grouped according to
+2-logarithms of the timer offset value, e.g. 1-2, 3-4, 5-8, 9-16 etc. This
+reduces memory consumption and creates a shorter result table for easier
+overview. Default: `1`
+
+#### TEST_PRINT_INTERVAL_TICKS
+
+The result table will be printed to standard output when this many reference
+timer ticks have passed since the last printout. Default: `((TIM_REF_FREQ) * 30)`
+
+### Settings related to timer input generation
+
+#### TEST_MIN
+
+Minimum timer offset tested for `timer_set_absolute`, in timer under test
+ticks. Default: `1` for timers < 1 MHz, `16` otherwise, to prevent setting a
+timer target in the past
+
+#### TEST_MIN_REL
+
+Minimum timer offset tested for `timer_set`, in timer under test ticks.
+Default: `0`
+
+#### TEST_MAX
+
+Maximum timer offset tested, in timer under test ticks. Default: `128`
+
+#### SPIN_MAX_TARGET
+
+The CPU busy wait loop will be calibrated during application start up so that
+the maximum random spin length is approximately equal to this many timer under
+test ticks. Default: `16`
+
+#### TEST_UNEXPECTED_STDDEV
+
+Mark the output row if the computed variance implies a standard deviation which
+is greater than this value. This value will be automatically recomputed to
+compensate for the variance resulting from the truncation in the tick
+conversion if the reference timer is running at a higher frequency than the
+timer under test. Default: `4`
+
+#### TEST_UNEXPECTED_MEAN
+
+Mark the output row if the computed mean absolute difference is greater than this
+number of timer under test ticks. This value will be automatically recomputed
+to compensate for the error resulting from the truncation in the tick
+conversion if the reference timer is running at a higher frequency than the
+timer under test. Default: `2`

--- a/tests/bench_timers/bench_timers_config.h
+++ b/tests/bench_timers/bench_timers_config.h
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Configuration definitions for bench_periph_timer
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+#ifndef BENCH_TIMERS_CONFIG_H
+#define BENCH_TIMERS_CONFIG_H
+
+#include <stdint.h>
+
+#include "periph/timer.h"
+#include "cpu.h"
+#if TEST_XTIMER
+#include "xtimer.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef TIMER_NUMOF
+#error "TIMER_NUMOF not defined!"
+#endif
+
+/**
+ * @brief Timer under test (TUT)
+ */
+#ifndef TIM_TEST_DEV
+#define TIM_TEST_DEV (TIMER_DEV(0))
+#endif
+#ifndef TIM_TEST_FREQ
+#define TIM_TEST_FREQ 1000000ul
+#endif
+#ifndef TIM_TEST_CHAN
+#define TIM_TEST_CHAN 0
+#endif
+
+/* Use separate reference timer to compare against */
+#ifndef USE_REFERENCE
+#define USE_REFERENCE 1
+#endif
+
+/* Whether to keep statistics per timer target value, or only totals */
+#ifndef DETAILED_STATS
+#define DETAILED_STATS 1
+#endif
+
+/* Group statistics into log2 size buckets, instead of one record per timer target
+ * i.e. 1, 2, 3-4, 5-8, 9-16, 17-32 etc. */
+/* Only used if DETAILED_STATS is 1 */
+#ifndef LOG2_STATS
+#define LOG2_STATS 1
+#endif
+
+/* Margin to ensure that the rescheduling timer never is hit */
+#ifndef RESCHEDULE_MARGIN
+#define RESCHEDULE_MARGIN (SPIN_MAX_TARGET * 16)
+#endif
+
+/**
+ * @brief Reference timer to compare against
+ */
+#ifndef TIM_REF_DEV
+/* Avoid using the timer under test as reference */
+#if ((TIM_TEST_DEV) == (TIMER_DEV(0)))
+#define TIM_REF_DEV (TIMER_DEV(1))
+#else
+#define TIM_REF_DEV (TIMER_DEV(0))
+#endif
+#endif
+#ifndef TIM_REF_FREQ
+#define TIM_REF_FREQ 1000000ul
+#endif
+
+#if !USE_REFERENCE
+#undef TIM_REF_DEV
+#undef TIM_REF_FREQ
+#undef TIM_TEST_TO_REF
+#define TIM_REF_DEV TIM_TEST_DEV
+#define TIM_REF_FREQ TIM_TEST_FREQ
+#define TIM_TEST_TO_REF(x) (x)
+#endif
+
+/* Longest timer timeout tested (TUT ticks)*/
+/* Reduce this if RAM usage is too high */
+#ifndef TEST_MAX
+#define TEST_MAX 128
+#endif
+/* Shortest timer timeout tested (TUT ticks) */
+#ifndef TEST_MIN
+#if TEST_XTIMER
+/* Default minimum delay for xtimer */
+#define TEST_MIN (XTIMER_ISR_BACKOFF)
+#elif TIM_TEST_FREQ < 100000
+/* this usually works for slow timers */
+#define TEST_MIN 1
+#else
+/* avoid problems with timer_set_absolute setting a time in the past because of
+ * processing delays */
+#define TEST_MIN 16
+#endif
+#endif
+/* Minimum delay for relative timers, should usually work with any value */
+#ifndef TEST_MIN_REL
+#if TEST_XTIMER
+#define TEST_MIN_REL (TEST_MIN)
+#else
+#define TEST_MIN_REL (0)
+#endif
+#endif
+/* Number of test values */
+#define TEST_NUM ((TEST_MAX) - (TEST_MIN) + 1)
+/* 2-logarithm of TEST_NUM, not possible to compute automatically by the
+ * preprocessor unless comparing values like this */
+#if TEST_NUM <=     (1 <<  2)
+#define TEST_LOG2NUM       2
+#elif TEST_NUM <=   (1 <<  3)
+#define TEST_LOG2NUM       3
+#elif TEST_NUM <=   (1 <<  4)
+#define TEST_LOG2NUM       4
+#elif TEST_NUM <=   (1 <<  5)
+#define TEST_LOG2NUM       5
+#elif TEST_NUM <=   (1 <<  6)
+#define TEST_LOG2NUM       6
+#elif TEST_NUM <=   (1 <<  7)
+#define TEST_LOG2NUM       7
+#elif TEST_NUM <=   (1 <<  8)
+#define TEST_LOG2NUM       8
+#elif TEST_NUM <=   (1 <<  9)
+#define TEST_LOG2NUM       9
+#elif TEST_NUM <=   (1 << 10)
+#define TEST_LOG2NUM      10
+#elif TEST_NUM <=   (1 << 11)
+#define TEST_LOG2NUM      11
+#elif TEST_NUM <=   (1 << 12)
+#define TEST_LOG2NUM      12
+#elif TEST_NUM <=   (1 << 13)
+#define TEST_LOG2NUM      13
+#elif TEST_NUM <=   (1 << 14)
+#define TEST_LOG2NUM      14
+#elif TEST_NUM <=   (1 << 15)
+#define TEST_LOG2NUM      15
+#elif TEST_NUM <=   (1 << 16)
+#define TEST_LOG2NUM      16
+#elif TEST_NUM <=   (1 << 20)
+#define TEST_LOG2NUM      20
+#elif TEST_NUM <=   (1 << 24)
+#define TEST_LOG2NUM      24
+#else
+#define TEST_LOG2NUM      32
+#endif
+
+/* convert TUT ticks to reference ticks */
+/* x is expected to be < 2**16 */
+#ifndef TIM_TEST_TO_REF
+#if (TIM_TEST_FREQ == TIM_REF_FREQ)
+#define TIM_TEST_TO_REF(x) (x)
+#elif (TIM_TEST_FREQ == 32768ul) && (TIM_REF_FREQ == 1000000ul)
+#define TIM_TEST_TO_REF(x) (((uint32_t)(x) * 15625ul) >> 9)
+#elif (TIM_TEST_FREQ == 1000000ul) && (TIM_REF_FREQ == 32768ul)
+#define TIM_TEST_TO_REF(x) (div_u32_by_15625div512(x))
+/* General conversion for Timer with 2^x factor */
+#elif (TIM_TEST_FREQ < TIM_REF_FREQ ) && ((TIM_REF_FREQ % TIM_TEST_FREQ) == 0)
+#ifndef TIM_TEST_TO_REF_SHIFT
+#if ((TIM_REF_FREQ >> 1) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   1
+#elif ((TIM_REF_FREQ >> 2) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   2
+#elif ((TIM_REF_FREQ >> 3) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   3
+#elif ((TIM_REF_FREQ >> 4) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   4
+#elif ((TIM_REF_FREQ >> 5) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   5
+#elif ((TIM_REF_FREQ >> 6) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   6
+#elif ((TIM_REF_FREQ >> 7) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   7
+#elif ((TIM_REF_FREQ >> 8) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   8
+#elif ((TIM_REF_FREQ >> 9) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   9
+#elif ((TIM_REF_FREQ >> 10) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   10
+#elif ((TIM_REF_FREQ >> 11) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   11
+#elif ((TIM_REF_FREQ >> 12) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   12
+#elif ((TIM_REF_FREQ >> 13) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   13
+#elif ((TIM_REF_FREQ >> 14) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   14
+#elif ((TIM_REF_FREQ >> 15) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   15
+#elif ((TIM_REF_FREQ >> 16) == TIM_TEST_FREQ)
+#define TIM_TEST_TO_REF_SHIFT   16
+#else
+#error define TIM_TEST_TO_REF_SHIFT so that TIM_REF_FREQ == (TIM_TEST_FREQ << TIM_TEST_FREQ_SHIFT)
+#endif
+#endif
+#define TIM_TEST_TO_REF(x) ((uint32_t)(x) << (TIM_TEST_TO_REF_SHIFT))
+#else
+#error define TIM_TEST_TO_REF so that TIM_REF_FREQ == TIM_TEST_TO_REF(TIM_TEST_FREQ)
+#endif
+#endif
+
+/* Print results every X reference ticks */
+#ifndef TEST_PRINT_INTERVAL_TICKS
+#define TEST_PRINT_INTERVAL_TICKS ((TIM_REF_FREQ) * 30)
+#endif
+
+/* If variance or mean exceeds these values the row will be marked with a "SIC!"
+ * in the table output */
+#ifndef TEST_UNEXPECTED_STDDEV
+#define TEST_UNEXPECTED_STDDEV 4
+#endif
+#ifndef TEST_UNEXPECTED_MEAN
+#define TEST_UNEXPECTED_MEAN 10
+#endif
+
+/* The spin calibration will try to set spin_limit to a number of loop
+ * iterations which correspond to this many TUT ticks */
+#ifndef SPIN_MAX_TARGET
+#define SPIN_MAX_TARGET 16
+#endif
+
+/* estimate_cpu_overhead will loop for this many iterations to get a proper estimate */
+#define ESTIMATE_CPU_ITERATIONS 2048
+
+#if TEST_XTIMER
+#define READ_TUT() _xtimer_now()
+#else
+#define READ_TUT() timer_read(TIM_TEST_DEV)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BENCH_TIMERS_CONFIG_H */

--- a/tests/bench_timers/main.c
+++ b/tests/bench_timers/main.c
@@ -1,0 +1,750 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Another peripheral timer test application
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "bitarithm.h"
+#include "fmt.h"
+#include "mutex.h"
+#include "random.h"
+#include "div.h"
+#include "matstat.h"
+#include "thread.h"
+#ifdef MODULE_PERIPH_RTT
+#include "periph/rtt.h"
+#endif
+#if TEST_XTIMER
+#include "xtimer.h"
+#endif
+
+#include "board.h"
+#include "cpu.h"
+#include "periph/timer.h"
+
+#include "print_results.h"
+#include "spin_random.h"
+#include "bench_timers_config.h"
+
+#ifndef TEST_TRACE
+#define TEST_TRACE 0
+#endif
+
+/*
+ * All different variations will be mixed to provide the most varied input
+ * vector possible for the benchmark. A more varied input should yield a more
+ * correct estimate of the mean error and variance. Random CPU processing delays
+ * will be inserted between each step to avoid phase locking the benchmark to
+ * unobservable timer internals.
+ */
+#if TEST_XTIMER
+enum test_variants {
+    TEST_XTIMER_SET             = 0,
+    TEST_PARALLEL               = 1,
+    TEST_XTIMER_SET_ABSOLUTE    = 2,
+    TEST_XTIMER_PERIODIC_WAKEUP = 4,
+    TEST_XTIMER_SPIN            = 6,
+    TEST_VARIANT_NUMOF          = 8,
+};
+#else /* TEST_XTIMER */
+/*
+ * Results will be grouped by function, rescheduling yes/no, start/stop.
+ * functions: timer_set, timer_set_absolute
+ * reschedule: yes/no, when yes: first set one target time, before that time has
+ *             passed, set the real target time
+ * start/stop: if stop: call timer_stop before setting the target time, then call timer_start
+ */
+enum test_variants {
+    TEST_RESCHEDULE         = 1,
+    TEST_STOPPED            = 2,
+    TEST_ABSOLUTE           = 4,
+    TEST_VARIANT_NUMOF      = 8,
+};
+#endif /* else TEST_XTIMER */
+
+/* Benchmark processing overhead, results will be compensated for this to make
+ * the results easier to understand */
+static int32_t overhead_target;
+static int32_t overhead_read;
+
+/* Seed for initializing the random module */
+static uint32_t seed = 123;
+
+/* Mutex used for signalling between main thread and ISR callback */
+static mutex_t mtx_cb = MUTEX_INIT_LOCKED;
+
+/* Test state element */
+typedef struct {
+    matstat_state_t *ref_state; /* timer_set error statistics state */
+    matstat_state_t *int_state; /* timer_read error statistics state */
+    unsigned int target_ref; /* Target time in reference timer */
+    unsigned int target_tut; /* Target time in timer under test */
+} test_ctx_t;
+
+static test_ctx_t test_context;
+
+#if DETAILED_STATS
+#if LOG2_STATS
+/* Group test values by 2-logarithm to reduce memory requirements */
+static matstat_state_t ref_states[TEST_VARIANT_NUMOF * TEST_LOG2NUM];
+#else
+/* State vector, first half will contain state for timer_set tests, second half
+ * will contain state for timer_set_absolute */
+static matstat_state_t ref_states[TEST_VARIANT_NUMOF * TEST_NUM];
+#endif
+#else
+/* Only keep stats per function variation */
+static matstat_state_t ref_states[TEST_VARIANT_NUMOF];
+#endif
+
+/* timer_read error statistics states */
+static matstat_state_t int_states[TEST_VARIANT_NUMOF];
+
+/* Limits for the mean and variance, to compare the results against expectation */
+static stat_limits_t ref_limits;
+static stat_limits_t int_limits;
+
+#if TEST_XTIMER
+static const result_presentation_t presentation = {
+    .groups = (const result_group_t[1]) {
+        {
+            .label = "xtimer",
+            .sub_labels = (const char *[]){
+                [TEST_XTIMER_SET] = "_xt_set",
+                [TEST_XTIMER_SET | TEST_PARALLEL] = "_xt_set race",
+                [TEST_XTIMER_SET_ABSOLUTE] = "_xt_set_abs",
+                [TEST_XTIMER_SET_ABSOLUTE | TEST_PARALLEL] = "_xt_set_abs race",
+                [TEST_XTIMER_PERIODIC_WAKEUP] = "_xt_periodic",
+                [TEST_XTIMER_PERIODIC_WAKEUP | TEST_PARALLEL] = "_xt_periodic race",
+                [TEST_XTIMER_SPIN] = "_xt_spin",
+                [TEST_XTIMER_SPIN | TEST_PARALLEL] = "_xt_spin race",
+            },
+            .num_sub_labels = TEST_VARIANT_NUMOF,
+        },
+    },
+    .num_groups = 1,
+    .ref_limits = &ref_limits,
+    .int_limits = &int_limits,
+    .offsets = (const unsigned[]) {
+        [TEST_XTIMER_SET]                               = TEST_MIN_REL,
+        [TEST_XTIMER_SET | TEST_PARALLEL]               = TEST_MIN_REL,
+        [TEST_XTIMER_SET_ABSOLUTE]                      = TEST_MIN,
+        [TEST_XTIMER_SET_ABSOLUTE | TEST_PARALLEL]      = TEST_MIN,
+        [TEST_XTIMER_PERIODIC_WAKEUP]                   = TEST_MIN_REL,
+        [TEST_XTIMER_PERIODIC_WAKEUP | TEST_PARALLEL]   = TEST_MIN_REL,
+        [TEST_XTIMER_SPIN]                              = TEST_MIN_REL,
+        [TEST_XTIMER_SPIN | TEST_PARALLEL]              = TEST_MIN_REL,
+    },
+};
+#else /* TEST_XTIMER */
+/* Number of variant groups, used when printing results */
+#define TEST_VARIANT_GROUPS 2
+
+static const result_presentation_t presentation = {
+    .groups = (const result_group_t[TEST_VARIANT_GROUPS]) {
+        {
+            .label = "timer_set",
+            .sub_labels = (const char *[]){
+                [0] = "running",
+                [TEST_RESCHEDULE] = "resched",
+                [TEST_STOPPED] = "stopped",
+                [TEST_STOPPED | TEST_RESCHEDULE] = "stopped, resched",
+            },
+            .num_sub_labels = (TEST_VARIANT_NUMOF / TEST_VARIANT_GROUPS),
+        },
+        {
+            .label = "timer_set_absolute",
+            .sub_labels = (const char *[]){
+                [0] = "running",
+                [TEST_RESCHEDULE] = "resched",
+                [TEST_STOPPED] = "stopped",
+                [TEST_STOPPED | TEST_RESCHEDULE] = "stopped, resched",
+            },
+            .num_sub_labels = (TEST_VARIANT_NUMOF / TEST_VARIANT_GROUPS),
+        },
+    },
+    .num_groups = TEST_VARIANT_GROUPS,
+    .ref_limits = &ref_limits,
+    .int_limits = &int_limits,
+    .offsets = (const unsigned[]) {
+        [0] =                                               TEST_MIN_REL,
+        [TEST_RESCHEDULE] =                                 TEST_MIN_REL,
+        [TEST_STOPPED] =                                    TEST_MIN_REL,
+        [TEST_STOPPED | TEST_RESCHEDULE] =                  TEST_MIN_REL,
+        [TEST_ABSOLUTE] =                                   TEST_MIN,
+        [TEST_ABSOLUTE | TEST_RESCHEDULE] =                 TEST_MIN,
+        [TEST_ABSOLUTE | TEST_STOPPED] =                    TEST_MIN,
+        [TEST_ABSOLUTE | TEST_STOPPED | TEST_RESCHEDULE] =  TEST_MIN,
+    },
+};
+#endif /* else TEST_XTIMER */
+
+#ifdef MODULE_PERIPH_RTT
+static uint32_t rtt_begin;
+#endif
+
+static unsigned int ref_begin;
+static unsigned int tut_begin;
+
+/**
+ * @brief   Calculate the limits for mean and variance for this test
+ */
+static void set_limits(void)
+{
+    ref_limits.mean_low = -(TEST_UNEXPECTED_MEAN);
+    ref_limits.mean_high = (TEST_UNEXPECTED_MEAN);
+    ref_limits.variance_low = 0;
+    ref_limits.variance_high = (TEST_UNEXPECTED_STDDEV) * (TEST_UNEXPECTED_STDDEV);
+
+    int_limits.mean_low = -(TEST_UNEXPECTED_MEAN);
+    int_limits.mean_high = TEST_UNEXPECTED_MEAN;
+    int_limits.variance_low = 0;
+    int_limits.variance_high = (TEST_UNEXPECTED_STDDEV) * (TEST_UNEXPECTED_STDDEV);
+
+    /* The quantization errors should be uniformly distributed within +/- 0.5
+     * test timer ticks of the reference time */
+    /* The formula for the variance of a rectangle distribution on [a, b] is
+     * Var = (b - a)^2 / 12 (taken directly from a statistics textbook)
+     * Using (b - a)^2 / 12 == (10b - 10a) * ((10b + 1) - (10a + 1)) / 1200
+     * gives a smaller truncation error when using integer operations for
+     * converting the ticks */
+    uint32_t conversion_variance = ((TIM_TEST_TO_REF(10) - TIM_TEST_TO_REF(0)) *
+        (TIM_TEST_TO_REF(11) - TIM_TEST_TO_REF(1))) / 1200;
+    if (TIM_REF_FREQ > TIM_TEST_FREQ) {
+        ref_limits.variance_low = ((TIM_TEST_TO_REF(10) - TIM_TEST_TO_REF(0) - 10 * (TEST_UNEXPECTED_STDDEV)) *
+            (TIM_TEST_TO_REF(11) - TIM_TEST_TO_REF(1) - 10 * (TEST_UNEXPECTED_STDDEV))) / 1200;
+        ref_limits.variance_high = ((TIM_TEST_TO_REF(10) - TIM_TEST_TO_REF(0) + 10 * (TEST_UNEXPECTED_STDDEV)) *
+            (TIM_TEST_TO_REF(11) - TIM_TEST_TO_REF(1) + 10 * (TEST_UNEXPECTED_STDDEV))) / 1200;
+        /* The limits of the mean should account for the conversion error as well */
+        /* rounded towards positive infinity */
+        int32_t mean_error = (TIM_TEST_TO_REF(128) - TIM_TEST_TO_REF(0) + 127) / 128;
+        ref_limits.mean_high += mean_error;
+    }
+
+    print_str("Expected error variance due to truncation in tick conversion: ");
+    print_u32_dec(conversion_variance);
+    print("\n", 1);
+}
+
+/* Callback for the timeout */
+static void cb(void *arg)
+{
+    unsigned int now_tut = READ_TUT();
+    unsigned int now_ref = timer_read(TIM_REF_DEV);
+    if (arg == NULL) {
+        print_str("cb: Warning! arg = NULL\n");
+        return;
+    }
+    test_ctx_t *ctx = arg;
+    if (ctx->ref_state == NULL) {
+        print_str("cb: Warning! ref_state = NULL\n");
+        return;
+    }
+    if (ctx->int_state == NULL) {
+        print_str("cb: Warning! int_state = NULL\n");
+        return;
+    }
+    /* Update running stats */
+    /* When setting a timer with a timeout of X ticks, we expect the
+     * duration between the set and the callback, dT, to be at least
+     * X * time_per_tick.
+     * In order to ensure that dT <= X * time_per_tick, the timer read value
+     * will actually have incremented (X + 1) times during that period,
+     * because the set can occur asynchrously anywhere between timer
+     * increments. Therefore, in this test, we consider (X + 1) to be the
+     * expected timer_read value at the point the callback is called.
+     */
+
+    /* Check that reference timer did not overflow during the test */
+    if ((now_ref + 0x4000u) >= ctx->target_ref) {
+        int32_t diff = now_ref - ctx->target_ref - 1 - overhead_target;
+        matstat_add(ctx->ref_state, diff);
+    }
+    /* Update timer_read statistics only when timer_read has not overflowed
+     * since the timer was set */
+    if ((now_tut + 0x4000u) >= ctx->target_tut) {
+        int32_t diff = now_tut - ctx->target_tut - 1 - overhead_read;
+        matstat_add(ctx->int_state, diff);
+    }
+
+    mutex_unlock(&mtx_cb);
+}
+
+/* Wrapper for periph_timer callbacks */
+static void cb_timer_periph(void *arg, int chan)
+{
+    (void)chan;
+    cb(arg);
+}
+
+/**
+ * @brief   Select the proper state for the given test number depending on the
+ *          compile time configuration
+ *
+ * Depends on DETAILED_STATS, LOG2_STATS
+ */
+static void assign_state_ptr(test_ctx_t *ctx, unsigned int variant, uint32_t interval)
+{
+    ctx->int_state = &int_states[variant];
+    if (DETAILED_STATS) {
+        if (LOG2_STATS) {
+            unsigned int log2num = bitarithm_msb(interval);
+
+            ctx->ref_state = &ref_states[variant * TEST_LOG2NUM + log2num];
+        }
+        else {
+            ctx->ref_state = &ref_states[variant * TEST_NUM + interval];
+        }
+    }
+    else {
+        ctx->ref_state = &ref_states[variant];
+    }
+}
+
+static uint32_t derive_interval(uint32_t num)
+{
+    uint32_t interval;
+    if ((DETAILED_STATS) && (LOG2_STATS)) {
+        /* Use a logarithmic method to generate geometric variates in order to
+         * populate the result table evenly across all buckets */
+
+        /* Static exponent mask, picking the mask as tightly as possible reduces the
+         * probability of discarded values, which reduces the computing overhead
+         * between test iterations */
+
+        static uint32_t exp_mask = 0;
+        if (exp_mask == 0) {
+            /* non-constant initializer */
+            exp_mask = (2 << bitarithm_msb(TEST_LOG2NUM)) - 1;
+            print_str("exp_mask = ");
+            print_u32_hex(exp_mask);
+            print("\n", 1);
+            print_str("max interval = ");
+            print_u32_dec((2 << exp_mask) - 1);
+            print("\n", 1);
+        }
+
+        /* Pick an exponent based on the top bits of the number */
+        /* exponent will be a number in the interval [0, log2(TEST_NUM) + 1] */
+        unsigned int exponent = ((num >> (32 - 8)) & exp_mask);
+        if (exponent == 0) {
+            /* Special handling to avoid the situation where we never see a zero */
+            /* We could also have used an extra right shift in the else case,
+             * but the state grouping also groups 0 and 1 in the same bucket, which means that they are twice as likely  */
+            interval = bitarithm_bits_set(num) & 1;
+        }
+        else {
+            interval = (1 << exponent);
+            interval |= (num & (interval - 1));
+        }
+    }
+    else {
+        static const uint32_t mask = (1 << TEST_LOG2NUM) - 1;
+        interval = num & mask;
+    }
+    return interval;
+}
+
+#if TEST_XTIMER
+static void nop(void *arg)
+{
+    (void)arg;
+}
+
+static void run_test(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
+{
+    interval += TEST_MIN;
+    unsigned int interval_ref = TIM_TEST_TO_REF(interval);
+    xtimer_t xt = {
+        .target = 0,
+        .long_target = 0,
+        .callback = cb,
+        .arg = ctx,
+    };
+    xtimer_t xt_parallel = {
+        .target = 0,
+        .long_target = 0,
+        .callback = nop,
+        .arg = NULL,
+    };
+    if (TEST_TRACE) {
+        switch (variant & ~TEST_PARALLEL) {
+            case TEST_XTIMER_SET:
+                print_str("rel ");
+                break;
+            case TEST_XTIMER_SET_ABSOLUTE:
+                print_str("abs ");
+                break;
+            case TEST_XTIMER_PERIODIC_WAKEUP:
+                print_str("per ");
+                break;
+            case TEST_XTIMER_SPIN:
+                print_str("spn ");
+                break;
+            default:
+                break;
+        }
+        if (variant & TEST_PARALLEL) {
+            print_str("- ");
+        }
+        else {
+            print_str("= ");
+        }
+        print_u32_dec(interval);
+        print("\n", 1);
+    }
+
+    spin_random_delay();
+    if (variant & TEST_PARALLEL) {
+        _xtimer_set(&xt_parallel, interval);
+        //~ interval += XTIMER_BACKOFF;
+        spin_random_delay();
+    }
+    ctx->target_ref = timer_read(TIM_REF_DEV) + interval_ref;
+    uint32_t now = READ_TUT();
+    ctx->target_tut = now + interval;
+    switch (variant & ~TEST_PARALLEL) {
+        case TEST_XTIMER_SET:
+            _xtimer_set(&xt, interval);
+            break;
+        case TEST_XTIMER_SET_ABSOLUTE:
+            now = READ_TUT();
+            ctx->target_tut = now + interval;
+            _xtimer_set_absolute(&xt, ctx->target_tut);
+            break;
+        case TEST_XTIMER_PERIODIC_WAKEUP:
+            _xtimer_periodic_wakeup(&now, interval);
+            /* xtimer_periodic_wakeup sleeps the thread, no automatic callback */
+            cb(xt.arg);
+            break;
+        case TEST_XTIMER_SPIN:
+            _xtimer_spin(interval);
+            /* xtimer_spin sleeps the thread, no automatic callback */
+            cb(xt.arg);
+            break;
+        default:
+            break;
+    }
+    mutex_lock(&mtx_cb);
+    xtimer_remove(&xt_parallel);
+    xtimer_remove(&xt);
+}
+#else /* TEST_XTIMER */
+static void run_test(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
+{
+    if (variant & TEST_ABSOLUTE) {
+        interval += TEST_MIN;
+    }
+    else {
+        interval += TEST_MIN_REL;
+    }
+    unsigned int interval_ref = TIM_TEST_TO_REF(interval);
+
+    if (TEST_TRACE) {
+        if (variant & TEST_ABSOLUTE) {
+            print_str("A");
+        }
+        else {
+            print_str("_");
+        }
+        if (variant & TEST_RESCHEDULE) {
+            print_str("R");
+        }
+        else {
+            print_str("_");
+        }
+        if (variant & TEST_STOPPED) {
+            print_str("S ");
+        }
+        else {
+            print_str("_ ");
+        }
+        print_u32_dec(interval);
+        print_str("   ");
+        print_u64_hex(READ_TUT());
+        print("\n", 1);
+    }
+
+    spin_random_delay();
+    if (variant & TEST_RESCHEDULE) {
+        timer_set(TIM_TEST_DEV, TIM_TEST_CHAN, interval + RESCHEDULE_MARGIN);
+        spin_random_delay();
+    }
+    if (variant & TEST_STOPPED) {
+        timer_stop(TIM_TEST_DEV);
+        spin_random_delay();
+    }
+    ctx->target_ref = timer_read(TIM_REF_DEV) + interval_ref;
+    ctx->target_tut = READ_TUT() + interval;
+    if (variant & TEST_ABSOLUTE) {
+        timer_set_absolute(TIM_TEST_DEV, TIM_TEST_CHAN, ctx->target_tut);
+    }
+    else {
+        timer_set(TIM_TEST_DEV, TIM_TEST_CHAN, interval);
+    }
+    if (variant & TEST_STOPPED) {
+        spin_random_delay();
+        /* do not update ctx->target_tut, because TUT should have been stopped
+         * and not incremented during spin_random_delay */
+        ctx->target_ref = timer_read(TIM_REF_DEV) + interval_ref;
+        timer_start(TIM_TEST_DEV);
+    }
+    mutex_lock(&mtx_cb);
+}
+#endif /* TEST_XTIMER */
+
+static int test_timer(void)
+{
+    uint32_t time_last = timer_read(TIM_REF_DEV);
+    uint32_t time_elapsed = 0;
+    do {
+        uint32_t num = random_uint32();
+
+        unsigned int variant = (num >> (32 - 3));
+        if (variant >= TEST_VARIANT_NUMOF) {
+            continue;
+        }
+        uint32_t interval = derive_interval(num);
+        if (interval >= TEST_NUM) {
+            /* Discard values outside our test range */
+            continue;
+        }
+        assign_state_ptr(&test_context, variant, interval);
+        run_test(&test_context, interval, variant);
+        uint32_t now = timer_read(TIM_REF_DEV);
+        if (now >= time_last) {
+            /* Account for reference timer possibly overflowing before 30 seconds have passed */
+            time_elapsed += now - time_last;
+        }
+        time_last = now;
+        //~ print_str("e: ");
+        //~ print_u32_dec(time_elapsed);
+        //~ print_str("\n");
+    } while(time_elapsed < TEST_PRINT_INTERVAL_TICKS);
+
+    uint32_t ref_now = timer_read(TIM_REF_DEV);
+    uint32_t tut_now = READ_TUT();
+#ifdef MODULE_PERIPH_RTT
+    uint32_t rtt_now = rtt_get_counter();
+#endif
+    print_str("Elapsed time:\n");
+    print_str("        Reference: ");
+    print_u32_dec((ref_now - ref_begin) / TIM_REF_FREQ);
+    print_str("\n");
+    print_str(" Timer under test: ");
+    print_u32_dec((tut_now - tut_begin) / TIM_TEST_FREQ);
+    print_str("\n");
+#ifdef MODULE_PERIPH_RTT
+    print_str(" Wall clock (RTT): ");
+    print_u32_dec((rtt_now - rtt_begin) / RTT_FREQUENCY);
+    print_str("\n");
+#endif
+    print_results(&presentation, &ref_states[0], &int_states[0]);
+
+    return 0;
+}
+
+static void estimate_cpu_overhead(void)
+{
+    /* Try to estimate the amount of CPU overhead between test start to test
+     * finish to get a better reading */
+    print_str("Estimating benchmark overhead...\n");
+    uint32_t interval = 0;
+    overhead_target = 0;
+    overhead_read = 0;
+    test_ctx_t context;
+    test_ctx_t *ctx = &context;
+    matstat_state_t ref_state = MATSTAT_STATE_INIT;
+    matstat_state_t int_state = MATSTAT_STATE_INIT;
+    ctx->ref_state = &ref_state;
+    ctx->int_state = &int_state;
+    for (unsigned int k = 0; k < ESTIMATE_CPU_ITERATIONS; ++k) {
+        unsigned int interval_ref = TIM_TEST_TO_REF(interval);
+        spin_random_delay();
+        ctx->target_tut = READ_TUT() + interval - 1;
+        ctx->target_ref = timer_read(TIM_REF_DEV) + interval_ref - 1;
+        /* call yield to simulate a context switch to isr and back */
+        thread_yield_higher();
+        cb_timer_periph(ctx, TIM_TEST_CHAN);
+        mutex_lock(&mtx_cb);
+    }
+    overhead_target = matstat_mean(&ref_state);
+    overhead_read = matstat_mean(&int_state);
+    print_str("overhead_target = ");
+    print_s32_dec(overhead_target);
+    print_str(" (s2 = ");
+    uint32_t var = matstat_variance(&ref_state);
+    print_u32_dec(var);
+    print_str(")\n");
+    if (var > 2) {
+        print_str("Warning: Variance in CPU estimation is too high\n");
+#ifdef CPU_NATIVE
+        print_str("This is expected on native when other processes are running\n");
+#endif
+    }
+    print_str("overhead_read = ");
+    print_s32_dec(overhead_read);
+    print_str(" (s2 = ");
+    var = matstat_variance(&int_state);
+    print_u32_dec(var);
+    print_str(")\n");
+    if (var > 2) {
+        print_str("Warning: Variance in CPU estimation is too high\n");
+#ifdef CPU_NATIVE
+        print_str("This is expected on native when other processes are running\n");
+#endif
+    }
+}
+
+int main(void)
+{
+    print_str("\nStatistical benchmark for timers\n");
+    for (unsigned int k = 0; k < (sizeof(ref_states) / sizeof(ref_states[0])); ++k) {
+        matstat_clear(&ref_states[k]);
+    }
+    for (unsigned int k = 0; k < (sizeof(int_states) / sizeof(int_states[0])); ++k) {
+        matstat_clear(&int_states[k]);
+    }
+    /* print test overview */
+    print_str("Running timer test with seed ");
+    print_u32_dec(seed);
+    print_str(" using ");
+#if MODULE_PRNG_MERSENNE
+    print_str("Mersenne Twister PRNG.\n");
+#elif MODULE_PRNG_MINSTD
+    print_str("Park & Miller Minimal Standard PRNG.\n");
+#elif MODULE_PRNG_MUSL_LCG
+    print_str("Musl C PRNG.\n");
+#elif MODULE_PRNG_TINYMT32
+    print_str("Tiny Mersenne Twister PRNG.\n");
+#elif MODULE_PRNG_XORSHIFT
+    print_str("XOR Shift PRNG.\n");
+#else
+    print_str("unknown PRNG.\n");
+#endif
+
+    print_str("TEST_MIN = ");
+    print_u32_dec(TEST_MIN);
+    print("\n", 1);
+    print_str("TEST_MAX = ");
+    print_u32_dec(TEST_MAX);
+    print("\n", 1);
+    print_str("TEST_MIN_REL = ");
+    print_u32_dec(TEST_MIN_REL);
+    print("\n", 1);
+    print_str("TEST_MAX_REL = ");
+    print_u32_dec(TEST_MIN_REL + TEST_NUM - 1);
+    print("\n", 1);
+    print_str("TEST_NUM = ");
+    print_u32_dec(TEST_NUM);
+    print("\n", 1);
+    print_str("log2(TEST_NUM - 1) = ");
+    unsigned log2test = bitarithm_msb(TEST_NUM - 1);
+    print_u32_dec(log2test);
+    print("\n", 1);
+    print_str("state vector elements per variant = ");
+    print_u32_dec(sizeof(ref_states) / sizeof(ref_states[0]) / TEST_VARIANT_NUMOF);
+    print("\n", 1);
+    print_str("number of variants = ");
+    print_u32_dec(TEST_VARIANT_NUMOF);
+    print("\n", 1);
+    print_str("sizeof(state) = ");
+    print_u32_dec(sizeof(ref_states[0]));
+    print_str(" bytes\n");
+    print_str("state vector total memory usage = ");
+    print_u32_dec(sizeof(ref_states));
+    print_str(" bytes\n");
+    assert(log2test < TEST_LOG2NUM);
+    print_str("TIM_TEST_DEV = ");
+    print_u32_dec(TIM_TEST_DEV);
+    print_str(", TIM_TEST_FREQ = ");
+    print_u32_dec(TIM_TEST_FREQ);
+    print_str(", TIM_TEST_CHAN = ");
+    print_u32_dec(TIM_TEST_CHAN);
+    print("\n", 1);
+    print_str("TIM_REF_DEV  = ");
+    print_u32_dec(TIM_REF_DEV);
+    print_str(", TIM_REF_FREQ  = ");
+    print_u32_dec(TIM_REF_FREQ);
+    print("\n", 1);
+#ifdef TIM_TEST_TO_REF_SHIFT
+    print_str("TIM_TEST_TO_REF_SHIFT = ");
+    print_u32_dec(TIM_TEST_TO_REF_SHIFT);
+    print("\n", 1);
+#endif
+    print_str("USE_REFERENCE = ");
+    print_u32_dec(USE_REFERENCE);
+    print("\n", 1);
+    print_str("TEST_PRINT_INTERVAL_TICKS = ");
+    print_u32_dec(TEST_PRINT_INTERVAL_TICKS);
+    print("\n", 1);
+
+    if (TEST_MAX > 512) { /* Arbitrarily chosen limit */
+        print_str("Warning: Using long intervals for testing makes the result "
+                  "more likely to be affected by clock drift between the "
+                  "reference timer and the timer under test. This can be "
+                  "detected as a skewness in the mean values between different "
+                  "intervals in the results table.\n");
+        if (LOG2_STATS) {
+            print_str("The variance of the larger intervals may also be greater "
+                      "than expected if there is significant clock drift across "
+                      "the bucketed time frame\n");
+        }
+
+    }
+    int res = timer_init(TIM_REF_DEV, TIM_REF_FREQ, cb_timer_periph, NULL);
+    if (res < 0) {
+        print_str("Error ");
+        print_s32_dec(res);
+        print_str(" intializing reference timer\n");
+        return res;
+    }
+    random_init(seed);
+
+#if !(TEST_XTIMER)
+    res = timer_init(TIM_TEST_DEV, TIM_TEST_FREQ, cb_timer_periph, &test_context);
+    if (res < 0) {
+        print_str("Error ");
+        print_s32_dec(res);
+        print_str(" intializing timer under test\n");
+        return res;
+    }
+#endif
+
+    set_limits();
+
+    print_str("Calibrating spin delay...\n");
+    uint32_t spin_max = spin_random_calibrate(TIM_TEST_DEV, SPIN_MAX_TARGET);
+    print_str("spin_max = ");
+    print_u32_dec(spin_max);
+    print("\n", 1);
+    estimate_cpu_overhead();
+#ifdef MODULE_PERIPH_RTT
+    rtt_begin = rtt_get_counter();
+#endif
+    ref_begin = timer_read(TIM_REF_DEV);
+    tut_begin = READ_TUT();
+    while(1) {
+        test_timer();
+    }
+
+    return 0;
+}

--- a/tests/bench_timers/print_results.c
+++ b/tests/bench_timers/print_results.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Another peripheral timer test application
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include "print_results.h"
+#include "matstat.h"
+#include "fmt.h"
+#include "bench_timers_config.h"
+
+static void print_statistics(const matstat_state_t *state, const stat_limits_t *limits)
+{
+    if (state->count == 0) {
+        print_str("no samples\n");
+        return;
+    }
+    if (state->count == 1) {
+        print_str("single sample: ");
+        print_s32_dec((int32_t)state->sum);
+        print("\n", 1);
+        return;
+    }
+    int32_t mean = matstat_mean(state);
+    uint64_t variance = matstat_variance(state);
+
+    char buf[20];
+    print(buf, fmt_lpad(buf, fmt_u32_dec(buf, state->count), 8, ' '));
+    print(" ", 1);
+    print(buf, fmt_lpad(buf, fmt_s64_dec(buf, state->sum), 9, ' '));
+    print(" ", 1);
+    print(buf, fmt_lpad(buf, fmt_u64_dec(buf, state->sum_sq), 12, ' '));
+    print(" ", 1);
+    print(buf, fmt_lpad(buf, fmt_s32_dec(buf, state->min), 6, ' '));
+    print(" ", 1);
+    print(buf, fmt_lpad(buf, fmt_s32_dec(buf, state->max), 5, ' '));
+    print(" ", 1);
+    print(buf, fmt_lpad(buf, fmt_s32_dec(buf, mean), 5, ' '));
+    print(" ", 1);
+    print(buf, fmt_lpad(buf, fmt_u64_dec(buf, variance), 6, ' '));
+    if (limits) {
+        if ((mean < limits->mean_low) || (limits->mean_high < mean) ||
+            (variance < limits->variance_low) || (limits->variance_high < variance) ) {
+            /* mean or variance is outside the expected range, alert the user */
+            print_str("  <=== SIC!");
+        }
+    }
+    print("\n", 1);
+}
+
+static void print_totals(const matstat_state_t *states, size_t nelem, const stat_limits_t *limits)
+{
+    matstat_state_t totals;
+    matstat_clear(&totals);
+    for (size_t k = 0; k < nelem; ++k) {
+        matstat_merge(&totals, &states[k]);
+    }
+    print_statistics(&totals, limits);
+}
+
+static void print_detailed(const matstat_state_t *states, size_t nelem, unsigned int test_min, const stat_limits_t *limits)
+{
+    if (LOG2_STATS) {
+        print_str("   interval     count       sum       sum_sq    min   max  mean  variance\n");
+        for (unsigned int k = 0; k < nelem; ++k) {
+            char buf[20];
+            unsigned int num = (1 << k);
+            if (num >= TEST_NUM) {
+                break;
+            }
+            unsigned int start = num + test_min;
+            if (num == 1) {
+                /* special case, bitarithm_msb will return 0 for both 0 and 1 */
+                start = test_min;
+            }
+            print(buf, fmt_lpad(buf, fmt_u32_dec(buf, start), 4, ' '));
+            print_str(" - ");
+            print(buf, fmt_lpad(buf, fmt_u32_dec(buf, test_min + (num * 2) - 1), 4, ' '));
+            print_str(": ");
+            print_statistics(&states[k], limits);
+        }
+        print_str("      TOTAL  ");
+    }
+    else {
+        print_str("interval    count       sum       sum_sq    min   max  mean  variance\n");
+        for (unsigned int k = 0; k < nelem; ++k) {
+            char buf[10];
+            print(buf, fmt_lpad(buf, fmt_u32_dec(buf, k + test_min), 7, ' '));
+            print_str(": ");
+            print_statistics(&states[k], limits);
+        }
+        print_str("  TOTAL: ");
+    }
+    print_totals(states, nelem, limits);
+}
+
+void print_results(const result_presentation_t *pres, const matstat_state_t *ref_states, const matstat_state_t *int_states)
+{
+    static char buf[48]; /* String formatting temporary buffer, not thread safe */
+    print_str("------------- BEGIN STATISTICS --------------\n");
+    print_str("===== Reference timer statistics =====\n");
+    print_str("Limits: mean: [");
+    print_s32_dec(pres->ref_limits->mean_low);
+    print_str(", ");
+    print_s32_dec(pres->ref_limits->mean_high);
+    print_str("], variance: [");
+    print_u32_dec(pres->ref_limits->variance_low);
+    print_str(", ");
+    print_u32_dec(pres->ref_limits->variance_high);
+    print_str("]\n");
+    print_str("Target error (actual trigger time - expected trigger time), in reference timer ticks\n");
+    print_str("positive: timer under test is late, negative: timer under test is early\n");
+
+    if (DETAILED_STATS) {
+        static const unsigned int count = ((LOG2_STATS) ? (TEST_LOG2NUM) : (TEST_NUM));
+        unsigned k = 0;
+        for (unsigned g = 0; g < pres->num_groups; ++g) {
+            for (unsigned c = 0; c < pres->groups[g].num_sub_labels; ++c) {
+                print_str("=== ");
+                print_str(pres->groups[g].label);
+                print(" ", 1);
+                print_str(pres->groups[g].sub_labels[c]);
+                print_str(" ===\n");
+                print_detailed(&ref_states[k * count], count, pres->offsets[k], pres->ref_limits);
+                ++k;
+            }
+        }
+    }
+    else {
+        print_str("function              count       sum       sum_sq    min   max  mean  variance\n");
+        unsigned k = 0;
+        for (unsigned g = 0; g < pres->num_groups; ++g) {
+            print("\n", 1);
+            print(buf, fmt_lpad(buf, fmt_str(buf, pres->groups[g].label), 18, ' '));
+            print(" ", 1);
+            print_totals(&ref_states[k], pres->groups[g].num_sub_labels, pres->ref_limits);
+            for (unsigned c = 0; c < pres->groups[g].num_sub_labels; ++c) {
+                print(buf, fmt_lpad(buf, fmt_str(buf, pres->groups[g].sub_labels[c]), 18, ' '));
+                print(" ", 1);
+                print_statistics(&ref_states[k], pres->ref_limits);
+                ++k;
+            }
+        }
+    }
+    print_str("===== introspective statistics =====\n");
+    print_str("Limits: mean: [");
+    print_s32_dec(pres->int_limits->mean_low);
+    print_str(", ");
+    print_s32_dec(pres->int_limits->mean_high);
+    print_str("], variance: [");
+    print_u32_dec(pres->int_limits->variance_low);
+    print_str(", ");
+    print_u32_dec(pres->int_limits->variance_high);
+    print_str("]\n");
+    print_str("self-referencing error (TUT time elapsed - expected TUT interval), in timer under test ticks\n");
+    print_str("positive: timer target handling is slow, negative: TUT is dropping ticks or triggering callback early\n");
+    print_str("function              count       sum       sum_sq    min   max  mean  variance\n");
+    for (unsigned k = 0, g = 0; g < pres->num_groups; ++g) {
+        print("\n", 1);
+        print(buf, fmt_lpad(buf, fmt_str(buf, pres->groups[g].label), 18, ' '));
+        print(" ", 1);
+        print_totals(&int_states[k], pres->groups[g].num_sub_labels, pres->int_limits);
+        for (unsigned c = 0; c < pres->groups[g].num_sub_labels; ++c) {
+            print(buf, fmt_lpad(buf, fmt_str(buf, pres->groups[g].sub_labels[c]), 18, ' '));
+            print(" ", 1);
+            print_statistics(&int_states[k], pres->int_limits);
+            ++k;
+        }
+    }
+
+    print_str("-------------- END STATISTICS ---------------\n");
+}

--- a/tests/bench_timers/print_results.h
+++ b/tests/bench_timers/print_results.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Result printing function declarations
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef PRINT_RESULTS_H
+#define PRINT_RESULTS_H
+
+#include "matstat.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Test limits */
+typedef struct {
+    int32_t mean_low;
+    int32_t mean_high;
+    uint32_t variance_low;
+    uint32_t variance_high;
+} stat_limits_t;
+
+typedef struct  {
+    const char *label;
+    const char **sub_labels;
+    unsigned num_sub_labels;
+} result_group_t;
+
+typedef struct {
+    const result_group_t *groups;
+    unsigned num_groups;
+    const stat_limits_t *ref_limits; /* Reference stats limits */
+    const stat_limits_t *int_limits; /* Introspective stats limits */
+    const unsigned *offsets; /* Pointer to array of input offsets, for correctly printing the detailed stats */
+} result_presentation_t;
+
+/**
+ * @brief   Present the results of the benchmark
+ *
+ * Depends on DETAILED_STATS, LOG2_STATS
+ * @param[in]   ref_states  State vector from reference measurements
+ * @param[in]   int_states  State vector from introspective measurements
+ */
+void print_results(const result_presentation_t *pres, const matstat_state_t *ref_states, const matstat_state_t *int_states);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PRINT_RESULTS_H */

--- a/tests/bench_timers/spin_random.c
+++ b/tests/bench_timers/spin_random.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_spin_random
+ *
+ * @{
+ * @file
+ * @brief       spin_random implementation
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <limits.h>
+
+#include "spin_random.h"
+#include "random.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/* Default is whatever, just some small delay if the user forgets to initialize */
+static uint32_t spin_max = 64;
+
+/**
+ * @brief   Busy wait (spin) for the given number of loop iterations
+ */
+static void spin(uint32_t limit)
+{
+    /* Platform independent busy wait loop, should never be optimized out
+     * because of the volatile asm statement */
+    while (limit--) {
+        __asm__ volatile ("");
+    }
+}
+
+void spin_random_delay(void)
+{
+    uint32_t limit = random_uint32_range(0, spin_max);
+    spin(limit);
+}
+
+uint32_t spin_random_calibrate(tim_t timer_dev, uint32_t spin_max_target)
+{
+    spin_max = 16;
+    uint32_t t1;
+    uint32_t t2;
+    DEBUG("spin_random_calibrate: Begin calibration with timer %u against "
+          "target %" PRIu32 "\n", (unsigned) timer_dev, spin_max_target);
+    do {
+        spin_max = (spin_max * 5) / 4;
+        t1 = timer_read(timer_dev);
+        spin(spin_max);
+        t2 = timer_read(timer_dev);
+    } while ((t2 - t1) < spin_max_target && (spin_max < (UINT32_MAX / 5)));
+    DEBUG("spin_max = %" PRIu32 "\n", spin_max);
+    return spin_max;
+}

--- a/tests/bench_timers/spin_random.h
+++ b/tests/bench_timers/spin_random.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_spin_random Spin_random - random CPU delays
+ * @ingroup     sys
+ * @brief       CPU spinning routines for random runtime delays
+ *
+ * @{
+ * @file
+ * @brief       spin_random declarations
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef SPIN_RANDOM_H
+#define SPIN_RANDOM_H
+
+#include <stdint.h>
+#include "periph/timer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Spin for a short random delay to increase fuzziness of a test
+ *
+ * The amount of time spent in this function will be between 0 and up to at
+ * least the amount of time that the spin_random_calibrate function was called
+ * with.
+ * The spin duration is < 2 * spin_max_target, in timer ticks of the timer that
+ * was used by spin_random_calibrate.
+ *
+ * @pre spin_random_calibrate must have been run beforehand to calibrate the
+ * maximum spin count
+ */
+void spin_random_delay(void);
+
+/**
+ * @brief   Calibrate the maximum spin count
+ *
+ * The calibration function will ensure that @ref spin_random_delay will give a
+ * random delay up to at least @p spin_max_target counts on the timer device
+ * given by @p timer_dev.
+ *
+ * The new maximum spin count will ensure that the maximum random spin in
+ * @ref spin_random_delay will be at least @p spin_max_target ticks long, and
+ * no more than 2 * @p spin_max_target ticks.
+ *
+ * @pre The periph_timer @p timer_dev must be initialized and running (counting).
+ *
+ * @param[in]   timer_dev   Timer device to use as reference
+ * @param[in]   spin_max_target Spin duration target time in @p timer_dev ticks.
+ *
+ * @return the new maximum spin count
+ */
+uint32_t spin_random_calibrate(tim_t timer_dev, uint32_t spin_max_target);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPIN_RANDOM_H */
+/** @} */


### PR DESCRIPTION
Depends on #8733 
(Excerpts from the [README](https://github.com/gebart/RIOT/blob/pr/periph-timer-stats/tests/bench_periph_timer/README.md))
# Benchmark test for periph_timer

This test is intended to collect statistics about the runtime delays in the
periph_timer implementation. This tool is mainly intended to detect problems in
the low level driver implementation which can be difficult to detect from
higher level systems such as xtimer.

## Test outline

The basic idea of the test is to generate a wide variety of calls to the
periph/timer API, in order to detect problems with the software implementation.
The test consists of a single thread of execution which will set random
timeouts on a periph_timer device. A reference timer is used to measure the
time it takes until the callback is called. The difference between the expected
time and the measured time is computed, and the mean and variance of the
recorded values are calculated. The results are printed as a table on stdout
every 30 seconds. All of the test scenarios used in this application are
based on experience from real world bugs encountered during the development of
RIOT and other systems.

### API functions tested

Both timer_set and timer_set_absolute calls are mixed in a random order, to
ensure that both functions are working correctly.

### Rescheduling

Some bugs may occur only when the application attempts to replace an already
set timer by calling timer_set again while the timer is running. This is dubbed
"resched" in this application. The application will issue rescheduling timer
calls in the normal operation of the test to catch this class of problems.

### Setting stopped timers

Another class of bugs is the kind where a timer is not behaving correctly if it
was stopped before setting a timer target. The timer should set the new target,
but not begin counting towards the target until timer_start is called. This is
covered by this application under the "stopped" category of test inputs.

### Avoiding phase lock

The CPU time used for generation and setting of the next timer target in
software is approximately constant across iterations. When the application flow
is driven by the timer under test, via a mutex which is unlocked from the timer
callback, the application will be "phase locked" to the timer under test. This
peculiarity may hide certain implementation race conditions which only occur at
specific phases of the timer ticks. In the test application, this problem is
avoided by inserting random CPU delay loops at key locations:

 - After timer_stop
 - Before timer_set/timer_set_absolute
 - Before timer_start

### Estimating benchmark CPU overhead

An estimation of the overhead resulting from the CPU processing delays inside
the benchmarking code is performed during benchmark initialization. The
estimation algorithm attempts to perform the exact same actions that the real
benchmark will perform, but without setting any timers. The measured delay is
assumed to originate in the benchmark code and will be subtracted when
computing the difference between expected and actual values. A warning is
printed when the variance of the estimated CPU overhead is too high, this can
be a sign that some other process is running on the CPU and disrupting the
estimation, or a sign of serious problems inside the timer_read function.

## Results

When the test has run for a certain amount of time, the current results will be
presented as a table on stdout. To assist with finding the source of any
discrepancies, the results are split according to three parameters:

 - Function used: timer_set, timer_set_absolute
 - Rescheduled: yes/no
 - Stopped: yes/no

### Interpreting timer_read statistics

A separate table is displayed for statistics on timer_read. This table compares
the expected timer under test time after a timer has triggered, against the
actual reported value from `timer_read(TIM_TEST_DEV)`. A positive value means
that the TUT time has passed the timer target time. A negative value means
that, according to the timer under test, the alarm target time has not yet been
reached, even though the timer callback has been executed.

### Example output

Below is a short sample of a test of a 32768 Hz timer with a 1 MHz reference:

    ------------- BEGIN STATISTICS --------------
    Limits: mean: [-10, 41], variance: [58, 99]
    Target error (actual trigger time - expected trigger time), in reference timer ticks
    positive: timer is late, negative: timer is early
    === timer_set running ===
       interval    count       sum       sum_sq    min   max  mean  variance
       1 -    2:   25705    455646      2002373      2    35    17     77
       3 -    4:   25533    457326      1973191      2    35    17     77
       5 -    8:   25412    451046      1970014      2    35    17     77
       9 -   16:   25699    458563      2017198      2    36    17     78
      17 -   32:   25832    457768      2018909      1    35    17     78
      33 -   64:   25758    440454      1978830      1    35    17     76
      65 -  128:   25335    414320      1942196      0    34    16     76
     129 -  256:   25254    367689      1979616     -3    32    14     78
     257 -  512:   25677    285822      2020736     -7    31    11     78
          TOTAL   230205   3788634     18459378     -7    36    16     80
...

The statistics above show that the timer implementation introduces a small
delay on short timers. Note however that it is not clear whether this delay is
in timer_set, or timer_read, but the combined effect of all error sources make
the timer overshoot its target by on average 17 microseconds. The difference
between min and max is close to the expected difference of approximately
1/32768 s = 30.51 µs. The lower min and mean for the longer timer intervals are
most likely caused by a drift between the 1 MHz clock and the 32.768 kHz clocks
inside the CPU, and is expected when using two separate clock sources for the
timers being compared.

Below is a short sample of a test where there is something wrong with the timer
implementation, again a 32768 Hz timer tested with a 1 MHz reference:

    === timer_set_absolute resched ===
       interval    count       sum       sum_sq    min   max  mean  variance
       1 -    2:  152217  82324291  13339518497     38  1071   540  87635  <=== SIC!
       3 -    4:  152199  82254909  13301794832     38  1071   540  87397  <=== SIC!
       5 -    8:  152023  82085454  13264873203     38  1071   539  87256  <=== SIC!
       9 -   16:  152156  82236539  13265351119     38  1071   540  87183  <=== SIC!
      17 -   32:  152639  82606815  13267666812     38  1071   541  86922  <=== SIC!
      33 -   64:  151883  81836155  13268661551     37  1070   538  87361  <=== SIC!
      65 -  128:  152114  82151495  13228100922     36  1070   540  86962  <=== SIC!
     129 -  256:  152363  81806042  13278055359     34  1069   536  87148  <=== SIC!
     257 -  512:  152360  81235185  13303811951     29  1066   533  87318  <=== SIC!
          TOTAL  1369954 738536885 119197349719     29  1071   539  87008  <=== SIC!

We can see that the variance, the maximum error, and the mean are very large.
This particular timer implementation needs some work on its timer_set_absolute
implementation.