### PR TITLE
core: add DEFAULT_APP_ENTRY to select main() function

### DIFF
--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -40,7 +40,16 @@
 #include <auto_init.h>
 #endif
 
-extern int main(void);
+#ifndef DEFAULT_APP_ENTRY
+#define DEFAULT_APP_ENTRY main
+#endif
+
+#define QUOTE(s) #s
+#define RESOLVE_NAME(name) QUOTE(name)
+#define DEFAULT_APP_ENTRY_NAME RESOLVE_NAME(DEFAULT_APP_ENTRY)
+
+extern int DEFAULT_APP_ENTRY(void);
+
 static void *main_trampoline(void *arg)
 {
     (void) arg;
@@ -54,9 +63,9 @@ static void *main_trampoline(void *arg)
     stat->laststart = 0;
 #endif
 
-    LOG_INFO("main(): This is RIOT! (Version: " RIOT_VERSION ")\n");
+    LOG_INFO(DEFAULT_APP_ENTRY_NAME "(): This is RIOT! (Version: " RIOT_VERSION ")\n");
 
-    main();
+    DEFAULT_APP_ENTRY();
     return NULL;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR/RFC adds a mechanism to change the default entry point to the user main function.
To change main entry point simply define DEFAULT_APP_ENTRY to a different function (by default, will call main() ).

### Why?
I found this use cases:
* For JavaScript apps (#7796), the main() function is (somehow) just an event_loop() call and could be a common js_main() inside sys/js folder.
* For Arduino support, we could have an arduino_main() that handles setup() and loop() functions
* If at some point we add an App framework (provide custom setup, loop, handlers, whatever), we won't need to touch core files.

I also added a mechanism to print the name of the function, which I'm still not 100% sure if it's the way to go (message should still be there?, etc).

All feedback will be really appreciated!

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->