### PR TITLE
doc: fix event_t attribute in documentation

### DIFF
--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -73,7 +73,7 @@
  *     printf("triggered custom event with text: \"%s\"\n", custom_event->text);
  * }
  *
- * static custom_event_t custom_event = { .super.callback = custom_handler, .text = "CUSTOM EVENT" };
+ * static custom_event_t custom_event = { .super.handler = custom_handler, .text = "CUSTOM EVENT" };
  *
  * [...] event_post(&queue, &custom_event)
  * ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR renames a wrong `event_t` attribute in the Event Queue documentation:

`sed 's/callback/handler'`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->