### PR TITLE
gnrc/netif: fix source address selection for non-matching prefixes

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -874,7 +874,7 @@ static unsigned _match(const gnrc_netif_t *netif, const ipv6_addr_t *addr,
         }
         match = ipv6_addr_match_prefix(&(netif->ipv6.addrs[i]), addr);
         if (((match > 64U) || !ipv6_addr_is_link_local(&(netif->ipv6.addrs[i]))) &&
-            (match > best_match)) {
+            (match >= best_match)) {
             if (idx != NULL) {
                 *idx = i;
             }


### PR DESCRIPTION
### Contribution description

According to RFC 6724 ch. 5 rule 8, the source address candidate with the longest matching prefix has to be selected. The current implementation discards source addresses that have no matching prefix (`match = 0`) which is perfectly fine for any global destination address.

### Problem solved

It wasn't possible for a node to communicate via `gnrc_border_router` to the outside world, the node would send packets erroneously with its local address as source address. The BR would then discard the packets because it isn't supposed to forward such packets. 