### PR TITLE
pkg/tinydtls: fix for arm-none-eabi newlib 2.4.x

### DIFF
--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -5,6 +5,9 @@ PKG_VERSION=eb6f017ab451bb6cc4428b3e449955a76aeeba19
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
 CFLAGS += -Wno-implicit-fallthrough
+# following is require due to known issue with newlib 2.4.x, see bug report:
+# http://lists-archives.com/cygwin/97008-gettimeofday-not-defined.html
+CFLAGS += -D_XOPEN_SOURCE=600
 
 .PHONY: all
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes an issue when compiling `examples/dtls_echo` form arm cortex-m mcus, using the arm-none-eabi toolchain with newlib version 2.4.x. The latter has a known bug (which is fixed for newer version) requiring special CFLAGS to make functions like `gettimeofday` visible in system headers.

Otherwise the following error may be shown:

```
/RIOT/examples/dtls-echo/bin/pkg/samr21-xpro/tinydtls/dtls_time.c:60:3: error: implicit declaration of function 'gettimeofday' [-Werror=implicit-function-declaration]
   gettimeofday(&tv, NULL);
   ^~~~~~~~~~~~
```

This pops up on Ubuntu 17.10 (bionic) using the `gcc-arm-none-eabi` package from the default APT repository (not launchpad), which installs newlib-arm-none-eabi version 2.4.0.

### Issues/PRs references

see bug report http://lists-archives.com/cygwin/97008-gettimeofday-not-defined.html

@kaspar030 this also fixes another issue that I found when integrating new riotci workers with kubernetes. 