### PR TITLE
cpu/stm32_common: add RTT support for stm32f4

### DIFF
--- a/boards/nucleo144-f413/Makefile.features
+++ b/boards/nucleo144-f413/Makefile.features
@@ -4,6 +4,7 @@ FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo144-f413/include/periph_conf.h
+++ b/boards/nucleo144-f413/include/periph_conf.h
@@ -275,6 +275,15 @@ static const spi_conf_t spi_config[] = {
 #define RTC_NUMOF           (1)
 /** @} */
 
+/**
+ * @name    RTT configuration
+ * @{
+ */
+#define RTT_NUMOF           (1)
+#define RTT_FREQUENCY       (4096)
+#define RTT_MAX_VALUE       (0xffff)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

RTT periph needed some changes to support stm32f4 cpus having a LPTIM.
Added support and tested with nucleo144-f413.

### Issues/PRs references

This might fix #8539 as LSE was not enable by `rtt_init()`, but I don't have any L4 to test.