### PR TITLE
drivers/at: at out-of-band data support for at commands parser

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -1,3 +1,4 @@
+PSEUDOMODULES += at_urc
 PSEUDOMODULES += auto_init_gnrc_rpl
 PSEUDOMODULES += can_mbox
 PSEUDOMODULES += can_pm

--- a/tests/driver_at/Makefile
+++ b/tests/driver_at/Makefile
@@ -4,5 +4,6 @@ BOARD_INSUFFICIENT_MEMORY += nucleo-f031k6
 
 USEMODULE += shell
 USEMODULE += at
+USEMODULE += at_urc
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

This adds a trick to support asynchronous AT command parsing.

The function `at_process_oob` can be called asynchronously to handle what has been received.
User code must register callbacks with `at_add_oob`. Internally it uses a `clist`

### Issues/PRs references

Based on #7084 