### PR TITLE
periph_rtt: remove RTT_NUMOF guard and init from periph_common

### DIFF
--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -29,9 +29,6 @@
 extern "C" {
 #endif
 
-/* guard file in case no RTT device was specified */
-#if RTT_NUMOF
-
 #ifndef RTT_FREQUENCY
 #warning "RTT_FREQUENCY undefined. Set RTT_FREQUENCY to the number of ticks" \
          "per second for the current architecture."
@@ -165,8 +162,6 @@ void rtt_poweron(void);
  * @brief Turn the RTT hardware module off
  */
 void rtt_poweroff(void);
-
-#endif /* RTT_NUMOF */
 
 #ifdef __cplusplus
 }

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -26,6 +26,9 @@
 #ifdef MODULE_PERIPH_RTC
 #include "periph/rtc.h"
 #endif
+#ifdef MODULE_PERIPH_RTT
+#include "periph/rtt.h"
+#endif
 #ifdef MODULE_PERIPH_HWRNG
 #include "periph/hwrng.h"
 #endif
@@ -42,6 +45,11 @@ void periph_init(void)
     /* Initialize RTC */
 #ifdef MODULE_PERIPH_RTC
     rtc_init();
+#endif
+
+    /* Initialize RTT */
+#ifdef MODULE_PERIPH_RTT
+    rtt_init();
 #endif
 
 #ifdef MODULE_PERIPH_HWRNG


### PR DESCRIPTION
### Contribution description

This align header with other periph (i.e. removes `RTT_NUMOF` guard which is not needed anymore).

I also added a call to `rtt_init()` from `periph_init()` but I'm not sure if it will work on every platform correctly. For instance, mulle seems to need to call `rtt_init()` earlier in the boot process.
So I can still remove the second commit if we don't agree on it.

### Issues/PRs references

None