### PR TITLE
cpu/native: reduce scope of CFLAGS for OSX compatibility

### DIFF
--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -3,6 +3,10 @@ MODULE = cpu
 DIRS += periph
 DIRS += vfs
 
+ifeq ($(shell uname -s),Darwin)
+  CFLAGS += -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE
+endif
+
 ifneq (,$(filter netdev_tap,$(USEMODULE)))
   DIRS += netdev_tap
 endif

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -7,7 +7,3 @@ endif
 
 USEMODULE += periph
 USEMODULE += periph_uart
-
-ifeq ($(shell uname -s),Darwin)
-export CFLAGS += -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE
-endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

First, typically we set such additional CFLAGS in the Makefile not Makefile.include. Second, CFLAGS don't need to be exported anyway, here.

### Issues/PRs references
