### PR TITLE
boards/nucleo-l152: configure LSI by default

### DIFF
--- a/boards/nucleo-l152/include/periph_conf.h
+++ b/boards/nucleo-l152/include/periph_conf.h
@@ -34,9 +34,17 @@ extern "C" {
  **/
 #define CLOCK_HSI           (16000000U)             /* frequency of internal oscillator */
 #define CLOCK_CORECLOCK     (32000000U)             /* targeted core clock frequency */
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
+/*
+ * 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz)
+ *
+ * LSE might not be available by default in early (C-01) Nucleo boards.
+ * For newer revisions, LSE crystal is present, but currently is not working.
+ * (issue at https://github.com/RIOT-OS/RIOT/pull/8545).
+ */
+#ifndef CLOCK_LSE
+#define CLOCK_LSE           (0)
+#endif
 /* configuration of PLL prescaler and multiply values */
 /* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
 #define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Some nucleo-l152 boards, namely revision C-01, don't have a LSE to rely on for low speed clocking, which is mostly used for RTC.

This PR makes it optional, and define LSI by default.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
Fixes #8024 and fixes #8240, depends on ~#8518~ to fix everything. 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->