### PR TITLE
sys/vfs: Check suggested fd is valid

### DIFF
--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -871,10 +871,10 @@ static inline int _allocate_fd(int fd)
                 break;
             }
         }
-        if (fd >= VFS_MAX_OPEN_FILES) {
-            /* The _vfs_open_files array is full */
-            return -ENFILE;
-        }
+    }
+    if (fd >= VFS_MAX_OPEN_FILES) {
+        /* The _vfs_open_files array is full */
+        return -ENFILE;
     }
     else if (_vfs_open_files[fd].pid != KERNEL_PID_UNDEF) {
         /* The desired fd is already in use */

--- a/tests/unittests/tests-vfs/tests-vfs-bind.c
+++ b/tests/unittests/tests-vfs/tests-vfs-bind.c
@@ -107,11 +107,25 @@ static void test_vfs_bind__leak_fds(void)
     test_vfs_bind();
 }
 
+static void test_vfs_bind__allocate_invalid_fd(void)
+{
+    /* Check that fds >= VFS_MAX_OPEN_FILES fails with -ENFILE, to avoid out of
+     * bounds array access */
+    /* This test assumes FD numbering begins at 0, update this test if
+     * VFS_MAX_OPEN_FILES is a valid fd number */
+    int fd;
+    fd = vfs_bind(VFS_MAX_OPEN_FILES, O_RDONLY, &_test_bind_ops, NULL);
+    TEST_ASSERT_EQUAL_INT(-ENFILE, fd);
+    fd = vfs_bind((VFS_MAX_OPEN_FILES + 1), O_RDONLY, &_test_bind_ops, NULL);
+    TEST_ASSERT_EQUAL_INT(-ENFILE, fd);
+}
+
 Test *tests_vfs_bind_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_vfs_bind),
         new_TestFixture(test_vfs_bind__leak_fds),
+        new_TestFixture(test_vfs_bind__allocate_invalid_fd),
     };
 
     EMB_UNIT_TESTCALLER(vfs_bind_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

Avoids out of bounds array access on _vfs_open_files if vfs_bind is called with an invalid (positive) fd number.
Added a unit test to catch future regressions.

### Issues/PRs references

Backport for 2018.01 in #8547 