### PR TITLE
sys/vfs: Check suggested fd is valid (2018.01 backport)

### DIFF
--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -821,10 +821,10 @@ static inline int _allocate_fd(int fd)
                 break;
             }
         }
-        if (fd >= VFS_MAX_OPEN_FILES) {
-            /* The _vfs_open_files array is full */
-            return -ENFILE;
-        }
+    }
+    if (fd >= VFS_MAX_OPEN_FILES) {
+        /* The _vfs_open_files array is full */
+        return -ENFILE;
     }
     else if (_vfs_open_files[fd].pid != KERNEL_PID_UNDEF) {
         /* The desired fd is already in use */


### PR DESCRIPTION
### Contribution description

Avoids out of bounds array access on _vfs_open_files if vfs_bind is called with an invalid (positive) fd number

### Issues/PRs references

backport of #8546 