### PR TITLE
boards/stm32-based: use shared configuration snippets

### DIFF
--- a/boards/common/nucleo/Makefile.include
+++ b/boards/common/nucleo/Makefile.include
@@ -2,6 +2,9 @@
 USEMODULE += boards_common_nucleo
 INCLUDES  += -I$(RIOTBOARD)/common/nucleo/include
 
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # configure the serial terminal
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/common/stm32/doc.txt
+++ b/boards/common/stm32/doc.txt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_common_stm32 STM32 Configuration Snippets
+ * @ingroup     boards_common
+ * @brief       Board configuration snippets for STM32-based boards
+ *
+ * All boards using a CPU from the STM32 family share certain parts of their
+ * configuration. This module provides a collection of fine grained
+ * configuration snippets that can be reused for different boards.
+ */

--- a/boards/common/stm32/include/cfg_spi_divtable.h
+++ b/boards/common/stm32/include/cfg_spi_divtable.h
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Collection of pre-computed bus pre-scalers for SPI configuration
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef CFG_SPI_DIVTABLE_H
+#define CFG_SPI_DIVTABLE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    SPI bus divider values for pre-defined peripheral bus clock speeds
+ *
+ * @note    These spi_divtables are generated using
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+#define CFG_SPIDIV_20               \
+    {       /* for 20000000Hz */    \
+        7,  /* -> 78125Hz */        \
+        5,  /* -> 312500Hz */       \
+        3,  /* -> 1250000Hz */      \
+        1,  /* -> 5000000Hz */      \
+        0   /* -> 10000000Hz */     \
+    },
+
+#define CFG_SPIDIV_30               \
+    {       /* for 30000000Hz */    \
+        7,  /* -> 117187Hz */       \
+        5,  /* -> 468750Hz */       \
+        4,  /* -> 937500Hz */       \
+        2,  /* -> 3750000Hz */      \
+        1   /* -> 7500000Hz */      \
+    },
+
+#define CFG_SPIDIV_32               \
+    {       /* for 32000000Hz */    \
+        7,  /* -> 125000Hz */       \
+        5,  /* -> 500000Hz */       \
+        4,  /* -> 1000000Hz */      \
+        2,  /* -> 4000000Hz */      \
+        1   /* -> 8000000Hz */      \
+    },
+
+#define CFG_SPIDIV_36               \
+    {       /* for 36000000Hz */    \
+        7,  /* -> 140625Hz */       \
+        6,  /* -> 281250Hz */       \
+        4,  /* -> 1125000Hz */      \
+        2,  /* -> 4500000Hz */      \
+        1   /* -> 9000000Hz */      \
+    },
+
+#define CFG_SPIDIV_40               \
+    {       /* for 40000000Hz */    \
+        7,  /* -> 156250Hz */       \
+        6,  /* -> 312500Hz */       \
+        4,  /* -> 1250000Hz */      \
+        2,  /* -> 5000000Hz */      \
+        1   /* -> 10000000Hz */     \
+    },
+
+#define CFG_SPIDIV_42               \
+    {       /* for 42000000Hz */    \
+        7,  /* -> 164062Hz */       \
+        6,  /* -> 328125Hz */       \
+        4,  /* -> 1312500Hz */      \
+        2,  /* -> 5250000Hz */      \
+        1   /* -> 10500000Hz */     \
+    },
+
+#define CFG_SPIDIV_45               \
+    {       /* for 45000000Hz */    \
+        7,  /* -> 175781Hz */       \
+        6,  /* -> 351562Hz */       \
+        5,  /* -> 703125Hz */       \
+        2,  /* -> 5625000Hz */      \
+        1   /* -> 11250000Hz */     \
+    },
+
+#define CFG_SPIDIV_48               \
+    {       /* for 48000000Hz */    \
+        7,  /* -> 187500Hz */       \
+        6,  /* -> 375000Hz */       \
+        5,  /* -> 750000Hz */       \
+        2,  /* -> 6000000Hz */      \
+        1   /* -> 12000000Hz */     \
+    },
+
+#define CFG_SPIDIV_50               \
+    {       /* for 50000000Hz */    \
+        7,  /* -> 195312Hz */       \
+        6,  /* -> 390625Hz */       \
+        5,  /* -> 781250Hz */       \
+        2,  /* -> 6250000Hz */      \
+        1   /* -> 12500000Hz */     \
+    },
+
+#define CFG_SPIDIV_60               \
+    {       /* for 60000000Hz */    \
+        7,  /* -> 234375Hz */       \
+        6,  /* -> 468750Hz */       \
+        5,  /* -> 937500Hz */       \
+        3,  /* -> 3750000Hz */      \
+        2   /* -> 7500000Hz */      \
+    },
+
+#define CFG_SPIDIV_64               \
+    {       /* for 64000000Hz */    \
+        7,  /* -> 250000Hz */       \
+        6,  /* -> 500000Hz */       \
+        5,  /* -> 1000000Hz */      \
+        3,  /* -> 4000000Hz */      \
+        2   /* -> 8000000Hz */      \
+    },
+
+#define CFG_SPIDIV_72               \
+    {       /* for 72000000Hz */    \
+        7,  /* -> 281250Hz */       \
+        7,  /* -> 281250Hz */       \
+        5,  /* -> 1125000Hz */      \
+        3,  /* -> 4500000Hz */      \
+        2   /* -> 9000000Hz */      \
+    },
+
+#define CFG_SPIDIV_84               \
+    {       /* for 84000000Hz */    \
+        7,  /* -> 328125Hz */       \
+        7,  /* -> 328125Hz */       \
+        5,  /* -> 1312500Hz */      \
+        3,  /* -> 5250000Hz */      \
+        2   /* -> 10500000Hz */     \
+    },
+
+#define CFG_SPIDIV_90               \
+    {       /* for 90000000Hz */    \
+        7,  /* -> 351562Hz */       \
+        7,  /* -> 351562Hz */       \
+        6,  /* -> 703125Hz */       \
+        3,  /* -> 5625000Hz */      \
+        2   /* -> 11250000Hz */     \
+    },
+
+#define CFG_SPIDIV_96               \
+    {       /* for 96000000Hz */    \
+        7,  /* -> 375000Hz */       \
+        7,  /* -> 375000Hz */       \
+        6,  /* -> 750000Hz */       \
+        3,  /* -> 6000000Hz */      \
+        2   /* -> 12000000Hz */     \
+    },
+
+#define CFG_SPIDIV_100              \
+    {       /* for 100000000Hz */   \
+        7,  /* -> 390625Hz */       \
+        7,  /* -> 390625Hz */       \
+        6,  /* -> 781250Hz */       \
+        3,  /* -> 6250000Hz */      \
+        2   /* -> 12500000Hz */     \
+    },
+/** @} */
+
+
+/**
+ * @name    SPI clock divisors
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ *
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+#if (CLOCK_APB1 == 20000000)
+    CFG_SPIDIV_20
+#elif (CLOCK_APB1 == 30000000)
+    CFG_SPIDIV_30
+#elif (CLOCK_APB1 == 32000000)
+    CFG_SPIDIV_32
+#elif (CLOCK_APB1 == 36000000)
+    CFG_SPIDIV_36
+#elif (CLOCK_APB1 == 40000000)
+    CFG_SPIDIV_40
+#elif (CLOCK_APB1 == 42000000)
+    CFG_SPIDIV_42
+#elif (CLOCK_APB1 == 45000000)
+    CFG_SPIDIV_45
+#elif (CLOCK_APB1 == 48000000)
+    CFG_SPIDIV_48
+#elif (CLOCK_APB1 == 50000000)
+    CFG_SPIDIV_50
+#elif (CLOCK_APB1 == 72000000)
+    CFG_SPIDIV_72
+#elif (CLOCK_APB1 == 60000000)
+    CFG_SPIDIV_60
+#elif (CLOCK_APB1 == 64000000)
+    CFG_SPIDIV_64
+#elif (CLOCK_APB1 == 84000000)
+    CFG_SPIDIV_84
+#elif (CLOCK_APB1 == 90000000)
+    CFG_SPIDIV_90
+#elif (CLOCK_APB1 == 96000000)
+    CFG_SPIDIV_96
+#elif (CLOCK_APB1 == 100000000)
+    CFG_SPIDIV_100
+#else
+#error "CFG_SPI_DIVTABLE: no prescalers for selected APB1 bus clock defined"
+#endif
+
+#if (CLOCK_APB2 == 20000000)
+    CFG_SPIDIV_20
+#elif (CLOCK_APB2 == 30000000)
+    CFG_SPIDIV_30
+#elif (CLOCK_APB2 == 32000000)
+    CFG_SPIDIV_32
+#elif (CLOCK_APB2 == 36000000)
+    CFG_SPIDIV_36
+#elif (CLOCK_APB2 == 40000000)
+    CFG_SPIDIV_40
+#elif (CLOCK_APB2 == 42000000)
+    CFG_SPIDIV_42
+#elif (CLOCK_APB2 == 45000000)
+    CFG_SPIDIV_45
+#elif (CLOCK_APB2 == 48000000)
+    CFG_SPIDIV_48
+#elif (CLOCK_APB2 == 50000000)
+    CFG_SPIDIV_50
+#elif (CLOCK_APB2 == 72000000)
+    CFG_SPIDIV_72
+#elif (CLOCK_APB2 == 60000000)
+    CFG_SPIDIV_60
+#elif (CLOCK_APB2 == 64000000)
+    CFG_SPIDIV_64
+#elif (CLOCK_APB2 == 84000000)
+    CFG_SPIDIV_84
+#elif (CLOCK_APB2 == 90000000)
+    CFG_SPIDIV_90
+#elif (CLOCK_APB2 == 96000000)
+    CFG_SPIDIV_96
+#elif (CLOCK_APB2 == 100000000)
+    CFG_SPIDIV_100
+#else
+#error "CFG_SPI_DIVTABLE: no prescalers for selected APB2 bus clock defined"
+#endif
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CFG_SPI_DIVTABLE_H */
+/** @} */

--- a/boards/common/stm32/include/f4/cfg_clock_168_16_0.h
+++ b/boards/common/stm32/include/f4/cfg_clock_168_16_0.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Configure STM32F4 clock to 168MHz using PLL
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef F4_CFG_CLOCK_168_16_0_H
+#define F4_CFG_CLOCK_168_16_0_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 168MHz */
+#define CLOCK_CORECLOCK     (168000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (16000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (0)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 42MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 84MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
+
+/* Main PLL factors */
+#define CLOCK_PLL_M          (8)
+#define CLOCK_PLL_N          (168)
+#define CLOCK_PLL_P          (2)
+#define CLOCK_PLL_Q          (7)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F4_CFG_CLOCK_168_16_0_H */
+/** @} */

--- a/boards/common/stm32/include/f4/cfg_clock_168_8_1.h
+++ b/boards/common/stm32/include/f4/cfg_clock_168_8_1.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Configure STM32F4 clock to 168MHz using PLL
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef F4_CFG_CLOCK_168_8_1_H
+#define F4_CFG_CLOCK_168_8_1_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 168MHz */
+#define CLOCK_CORECLOCK     (168000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (1)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 42MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 84MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
+
+/* Main PLL factors */
+#define CLOCK_PLL_M          (4)
+#define CLOCK_PLL_N          (168)
+#define CLOCK_PLL_P          (2)
+#define CLOCK_PLL_Q          (7)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F4_CFG_CLOCK_168_8_1_H */
+/** @} */

--- a/boards/common/stm32/include/f4/cfg_clock_180_8_1.h
+++ b/boards/common/stm32/include/f4/cfg_clock_180_8_1.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Configure STM32F4 clock to 180MHz using PLL
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef F4_CFG_CLOCK_180_8_1_H
+#define F4_CFG_CLOCK_180_8_1_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ *
+ * @note    This is auto-generated from
+ *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 180MHz */
+#define CLOCK_CORECLOCK     (180000000U)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (8000000U)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (1)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 45MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 90MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
+
+/* Main PLL factors */
+#define CLOCK_PLL_M          (4)
+#define CLOCK_PLL_N          (180)
+#define CLOCK_PLL_P          (2)
+#define CLOCK_PLL_Q          (0)
+
+/* PLL SAI configuration */
+#define CLOCK_ENABLE_PLL_SAI (1)
+#define CLOCK_PLL_SAI_M      (4)
+#define CLOCK_PLL_SAI_N      (192)
+#define CLOCK_PLL_SAI_P      (8)
+#define CLOCK_PLL_SAI_Q      (0)
+
+/* Use alternative source for 48MHz clock */
+#define CLOCK_USE_ALT_48MHZ  (1)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F4_CFG_CLOCK_180_8_1_H */
+/** @} */

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = stm32f4
 export CPU_MODEL = stm32f415rg
 
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/f4vi1/include/periph_conf.h
+++ b/boards/f4vi1/include/periph_conf.h
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @name       Peripheral MCU configuration for the F4VI1 board
+ * @name        Peripheral MCU configuration for the F4VI1 board
  *
  * @author      Stefan Pfeiffer <pfeiffer@inf.fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
@@ -22,41 +22,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f4/cfg_clock_168_16_0.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 168MHz */
-#define CLOCK_CORECLOCK     (168000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (16000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (0)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 42MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 84MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (8)
-#define CLOCK_PLL_N          (168)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (7)
-/** @} */
 
 /**
  * @name    Timer configuration

--- a/boards/msbiot/Makefile.include
+++ b/boards/msbiot/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = stm32f4
 export CPU_MODEL = stm32f415rg
 
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 #define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -20,41 +20,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f4/cfg_clock_168_16_0.h"
+#include "cfg_spi_divtable.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 168MHz */
-#define CLOCK_CORECLOCK     (168000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (16000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (0)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 42MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 84MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (8)
-#define CLOCK_PLL_N          (168)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (7)
-/** @} */
 
 /**
  * @name    Timer configuration
@@ -193,28 +164,8 @@ static const uart_conf_t uart_config[] = {
 
 /**
  * @name    SPI configuration
- *
- * @note    The spi_divtable is auto-generated from
- *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
  * @{
  */
-static const uint8_t spi_divtable[2][5] = {
-    {       /* for APB1 @ 42000000Hz */
-        7,  /* -> 164062Hz */
-        6,  /* -> 328125Hz */
-        4,  /* -> 1312500Hz */
-        2,  /* -> 5250000Hz */
-        1   /* -> 10500000Hz */
-    },
-    {       /* for APB2 @ 84000000Hz */
-        7,  /* -> 328125Hz */
-        7,  /* -> 328125Hz */
-        5,  /* -> 1312500Hz */
-        3,  /* -> 5250000Hz */
-        2   /* -> 10500000Hz */
-    }
-};
-
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SPI1,

--- a/boards/nucleo-f429zi/include/periph_conf.h
+++ b/boards/nucleo-f429zi/include/periph_conf.h
@@ -22,41 +22,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f4/cfg_clock_168_8_1.h"
+#include "cfg_spi_divtable.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 180MHz */
-#define CLOCK_CORECLOCK     (168000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 45MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 90MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (4)
-#define CLOCK_PLL_N          (168)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (7)
-/** @} */
 
 /**
  * @name    Timer configuration
@@ -168,28 +139,8 @@ static const pwm_conf_t pwm_config[] = {
 
 /**
  * @name    SPI configuration
- *
- * @note    The spi_divtable is auto-generated from
- *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
  * @{
  */
-static const uint8_t spi_divtable[2][5] = {
-    {       /* for APB1 @ 42000000Hz */
-        7,  /* -> 164062Hz */
-        6,  /* -> 328125Hz */
-        4,  /* -> 1312500Hz */
-        2,  /* -> 5250000Hz */
-        1   /* -> 10500000Hz */
-    },
-    {       /* for APB2 @ 84000000Hz */
-        7,  /* -> 328125Hz */
-        7,  /* -> 328125Hz */
-        5,  /* -> 1312500Hz */
-        3,  /* -> 5250000Hz */
-        2   /* -> 10500000Hz */
-    }
-};
-
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SPI1,

--- a/boards/nucleo-f446re/include/periph_conf.h
+++ b/boards/nucleo-f446re/include/periph_conf.h
@@ -22,51 +22,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f4/cfg_clock_180_8_1.h"
+#include "cfg_spi_divtable.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 180MHz */
-#define CLOCK_CORECLOCK     (180000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 45MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 90MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (4)
-#define CLOCK_PLL_N          (180)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (0)
-
-/* PLL SAI configuration */
-#define CLOCK_ENABLE_PLL_SAI (1)
-#define CLOCK_PLL_SAI_M      (4)
-#define CLOCK_PLL_SAI_N      (192)
-#define CLOCK_PLL_SAI_P      (8)
-#define CLOCK_PLL_SAI_Q      (0)
-
-/* Use alternative source for 48MHz clock */
-#define CLOCK_USE_ALT_48MHZ  (1)
-/** @} */
 
 /**
  * @name   Timer configuration
@@ -216,23 +177,6 @@ static const qdec_conf_t qdec_config[] = {
  *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
  * @{
  */
-static const uint8_t spi_divtable[2][5] = {
-    {       /* for APB1 @ 90000000Hz */
-        7,  /* -> 351562Hz */
-        7,  /* -> 351562Hz */
-        6,  /* -> 703125Hz */
-        3,  /* -> 5625000Hz */
-        2   /* -> 11250000Hz */
-    },
-    {       /* for APB2 @ 180000000Hz */
-        7,  /* -> 703125Hz */
-        7,  /* -> 703125Hz */
-        7,  /* -> 703125Hz */
-        4,  /* -> 5625000Hz */
-        3   /* -> 11250000Hz */
-    }
-};
-
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SPI1,

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -22,51 +22,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f4/cfg_clock_180_8_1.h"
+#include "cfg_spi_divtable.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 180MHz */
-#define CLOCK_CORECLOCK     (180000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 45MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 90MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (4)
-#define CLOCK_PLL_N          (180)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (0)
-
-/* PLL SAI configuration */
-#define CLOCK_ENABLE_PLL_SAI (1)
-#define CLOCK_PLL_SAI_M      (4)
-#define CLOCK_PLL_SAI_N      (192)
-#define CLOCK_PLL_SAI_P      (8)
-#define CLOCK_PLL_SAI_Q      (0)
-
-/* Use alternative source for 48MHz clock */
-#define CLOCK_USE_ALT_48MHZ  (1)
-/** @} */
 
 /**
  * @name    Timer configuration
@@ -178,28 +139,8 @@ static const pwm_conf_t pwm_config[] = {
 
 /**
  * @name    SPI configuration
- *
- * @note    The spi_divtable is auto-generated from
- *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
  * @{
  */
-static const uint8_t spi_divtable[2][5] = {
-    {       /* for APB1 @ 90000000Hz */
-        7,  /* -> 351562Hz */
-        7,  /* -> 351562Hz */
-        6,  /* -> 703125Hz */
-        3,  /* -> 5625000Hz */
-        2   /* -> 11250000Hz */
-    },
-    {       /* for APB2 @ 180000000Hz */
-        7,  /* -> 703125Hz */
-        7,  /* -> 703125Hz */
-        7,  /* -> 703125Hz */
-        4,  /* -> 5625000Hz */
-        3   /* -> 11250000Hz */
-    }
-};
-
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SPI1,

--- a/boards/stm32f4discovery/Makefile.include
+++ b/boards/stm32f4discovery/Makefile.include
@@ -2,6 +2,9 @@
 export CPU = stm32f4
 export CPU_MODEL = stm32f407vg
 
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -21,41 +21,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f4/cfg_clock_168_8_1.h"
+#include "cfg_spi_divtable.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 168MHz */
-#define CLOCK_CORECLOCK     (168000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4     /* max 42MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2     /* max 84MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-
-/* Main PLL factors */
-#define CLOCK_PLL_M          (4)
-#define CLOCK_PLL_N          (168)
-#define CLOCK_PLL_P          (2)
-#define CLOCK_PLL_Q          (7)
-/** @} */
 
 /**
  * @name   Timer configuration
@@ -188,28 +159,8 @@ static const pwm_conf_t pwm_config[] = {
 
 /**
  * @name   SPI configuration
- *
- * @note    The spi_divtable is auto-generated from
- *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
  * @{
  */
-static const uint8_t spi_divtable[2][5] = {
-    {       /* for APB1 @ 42000000Hz */
-        7,  /* -> 164062Hz */
-        6,  /* -> 328125Hz */
-        4,  /* -> 1312500Hz */
-        2,  /* -> 5250000Hz */
-        1   /* -> 10500000Hz */
-    },
-    {       /* for APB2 @ 84000000Hz */
-        7,  /* -> 328125Hz */
-        7,  /* -> 328125Hz */
-        5,  /* -> 1312500Hz */
-        3,  /* -> 5250000Hz */
-        2   /* -> 10500000Hz */
-    }
-};
-
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SPI1,


### PR DESCRIPTION
### Contribution description
This is another change cut from #8044 to reduce the vast code duplication in the (STM32) board configurations.

Presented in this PR in my idea for using shared configuration snippets in the board's `periph_conf.h` files. This is demonstrated so far only for some selected `stm32f4`-based boards, and focused on their clock configuration only. Once we agree for this approach, we can optimize the configuration for more STM32-based boards, in small, easily revieweable steps...

### Issues/PRs references
continuation of merging #8044 in small steps...