### PR TITLE
sys/vfs: Exclude stdio file numbers from auto allocation

### DIFF
--- a/tests/unittests/tests-vfs/tests-vfs-bind.c
+++ b/tests/unittests/tests-vfs/tests-vfs-bind.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include "embUnit/embUnit.h"
 
@@ -71,6 +72,9 @@ static void test_vfs_bind(void)
     uint8_t buf[_VFS_TEST_BIND_BUFSIZE];
     fd = vfs_bind(VFS_ANY_FD, O_RDWR, &_test_bind_ops, &buf[0]);
     TEST_ASSERT(fd >= 0);
+    TEST_ASSERT(fd != STDIN_FILENO);
+    TEST_ASSERT(fd != STDOUT_FILENO);
+    TEST_ASSERT(fd != STDERR_FILENO);
     if (fd < 0) {
         return;
     }


### PR DESCRIPTION
### Contribution description

Do not auto-allocate the stdio file descriptor numbers to avoid conflicts between normal file system users and stdio drivers such as uart_stdio, rtt_stdio which need to be able to bind to these specific file descriptor numbers.
Adds a regression test for vfs_bind to check that it never returns stdio file descriptors (which fails without the other commit)

Tested on native and mulle.

### Issues/PRs references

Fixes #8309 
An alternative to #8310 