### PR TITLE
fs: add tmpfs, a RAM file system

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -655,6 +655,7 @@ endif
 
 ifneq (,$(filter tmpfs,$(USEMODULE)))
   USEMODULE += vfs
+  USEMODULE += memarray
 endif
 
 ifneq (,$(filter vfs,$(USEMODULE)))

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -653,6 +653,10 @@ ifneq (,$(filter devfs,$(USEMODULE)))
   USEMODULE += vfs
 endif
 
+ifneq (,$(filter tmpfs,$(USEMODULE)))
+  USEMODULE += vfs
+endif
+
 ifneq (,$(filter vfs,$(USEMODULE)))
   ifeq (native, $(BOARD))
     USEMODULE += native_vfs

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -118,6 +118,9 @@ endif
 ifneq (,$(filter devfs,$(USEMODULE)))
   DIRS += fs/devfs
 endif
+ifneq (,$(filter tmpfs,$(USEMODULE)))
+  DIRS += fs/tmpfs
+endif
 ifneq (,$(filter l2filter,$(USEMODULE)))
   DIRS += net/link_layer/l2filter
 endif

--- a/sys/fs/tmpfs/Makefile
+++ b/sys/fs/tmpfs/Makefile
@@ -1,0 +1,3 @@
+MODULE = tmpfs
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/fs/tmpfs/tmpfs.c
+++ b/sys/fs/tmpfs/tmpfs.c
@@ -269,9 +269,12 @@ static tmpfs_file_buf_t *find_buf_index(tmpfs_file_t *file, off_t pos, size_t *i
 static tmpfs_file_buf_t *alloc_buf(tmpfs_file_t *file, size_t nbytes)
 {
     tmpfs_file_buf_t *buf = TMPFS_MALLOC(sizeof(*buf));
-    void *data_buf = TMPFS_MALLOC(nbytes);
-    if (!buf || !data_buf) {
+    if (!buf) {
         return NULL;
+    }
+    void *data_buf = TMPFS_MALLOC(nbytes);
+    if (!data_buf) {
+        TMPFS_FREE(buf);
     }
     clist_rpush(&file->buf, &buf->next);
     buf->buf = data_buf;

--- a/sys/fs/tmpfs/tmpfs.c
+++ b/sys/fs/tmpfs/tmpfs.c
@@ -1,0 +1,387 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_fs_tmpfs
+ * @{
+ *
+ * @file
+ * @brief       TempFS implementation
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fs/tmpfs.h"
+#include "vfs.h"
+#include "mutex.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifndef TMPFS_MALLOC
+#define TMPFS_MALLOC malloc
+#endif
+
+#ifndef TMPFS_FREE
+#define TMPFS_FREE free
+#endif
+
+/**
+ * @brief   tmpfs file buffer element
+ */
+typedef struct {
+    clist_node_t next;  /**< next buffer in list */
+    void *buf;          /**< data buffer */
+    size_t size;        /**< data buffer size */
+} tmpfs_file_buf_t;
+
+/**
+ *  @brief  tmpfs file descriptor
+ */
+typedef struct {
+    clist_node_t next;              /**< next file in the list */
+    clist_node_t buf;               /**< buffer list of this file */
+    char name[VFS_NAME_MAX + 1];    /**< file name */
+    size_t size;                    /**< total file size */
+} tmpfs_file_t;
+
+static void free_file(tmpfs_file_t *file)
+{
+    clist_node_t *node;
+
+    while ((node = clist_lpop(&file->buf)) != NULL) {
+        tmpfs_file_buf_t *buf = container_of(node, tmpfs_file_buf_t, next);
+        TMPFS_FREE(buf->buf);
+        TMPFS_FREE(buf);
+    }
+    TMPFS_FREE(file);
+}
+
+static int _mount(vfs_mount_t *mountp)
+{
+    tmpfs_t *tmpfs = mountp->private_data;
+
+    mutex_init(&tmpfs->lock);
+
+    return 0;
+}
+
+static int _umount(vfs_mount_t *mountp)
+{
+    tmpfs_t *tmpfs = mountp->private_data;
+    clist_node_t *node;
+
+    mutex_lock(&tmpfs->lock);
+
+    while ((node = clist_lpop(&tmpfs->files)) != NULL) {
+        tmpfs_file_t *file = container_of(node, tmpfs_file_t, next);
+        free_file(file);
+    }
+
+    mutex_unlock(&tmpfs->lock);
+
+    return 0;
+}
+
+static tmpfs_file_t *find_file(tmpfs_t *tmpfs, const char *name)
+{
+    clist_node_t *node = tmpfs->files.next;
+
+    if (node) {
+        do {
+            node = node->next;
+            tmpfs_file_t *file = container_of(node, tmpfs_file_t, next);
+            if (strcmp(file->name, name) == 0) {
+                return file;
+            }
+        } while (node != tmpfs->files.next);
+    }
+
+    return NULL;
+}
+
+static int _unlink(vfs_mount_t *mountp, const char *name)
+{
+    tmpfs_t *tmpfs = mountp->private_data;
+
+    mutex_lock(&tmpfs->lock);
+
+    tmpfs_file_t *file = find_file(tmpfs, name);
+    if (!file) {
+        mutex_unlock(&tmpfs->lock);
+        return -ENOENT;
+    }
+
+    clist_remove(&tmpfs->files, &file->next);
+    free_file(file);
+
+    mutex_unlock(&tmpfs->lock);
+
+    return 0;
+}
+
+static int _rename(vfs_mount_t *mountp, const char *from_path, const char *to_path)
+{
+    tmpfs_t *tmpfs = mountp->private_data;
+
+    mutex_lock(&tmpfs->lock);
+
+    tmpfs_file_t *file = find_file(tmpfs, from_path);
+    if (!file) {
+        mutex_unlock(&tmpfs->lock);
+        return -ENOENT;
+    }
+
+    strncpy(file->name, to_path, VFS_NAME_MAX);
+
+    mutex_unlock(&tmpfs->lock);
+
+    return 0;
+}
+
+static int _stat(vfs_mount_t *mountp, const char *restrict path, struct stat *restrict buf)
+{
+    tmpfs_t *tmpfs = mountp->private_data;
+
+    mutex_lock(&tmpfs->lock);
+    tmpfs_file_t *file = find_file(tmpfs, path);
+    mutex_unlock(&tmpfs->lock);
+    if (!file) {
+        return -ENOENT;
+    }
+
+    buf->st_size = file->size;
+
+    return 0;
+}
+
+static int count_file_size(clist_node_t *node, void *arg)
+{
+    size_t *total_size = arg;
+    tmpfs_file_t *file = container_of(node, tmpfs_file_t, next);
+    *total_size += file->size;
+
+    return 0;
+}
+
+static int _statvfs(vfs_mount_t *mountp, const char *restrict path, struct statvfs *restrict buf)
+{
+    (void)path;
+    tmpfs_t *tmpfs = mountp->private_data;
+    size_t total_size = 0;
+
+    mutex_lock(&tmpfs->lock);
+    clist_foreach(&tmpfs->files, count_file_size, &total_size);
+    mutex_unlock(&tmpfs->lock);
+
+    buf->f_bsize = 1;           /* block size */
+    buf->f_frsize = 1;          /* fundamental block size */
+    buf->f_blocks = total_size; /* Blocks total */
+    buf->f_bfree = 0;           /* Blocks free */
+    buf->f_bavail = 0;          /* Blocks available to non-privileged processes */
+    buf->f_flag = ST_NOSUID;
+    buf->f_namemax = VFS_NAME_MAX;
+
+    return 0;
+}
+
+static tmpfs_file_t *add_file(tmpfs_t *tmpfs, const char *name)
+{
+    tmpfs_file_t *file = TMPFS_MALLOC(sizeof(tmpfs_file_t));
+    if (!file) {
+        return NULL;
+    }
+
+    memset(file, 0, sizeof(*file));
+    strncpy(file->name, name, sizeof(file->name) - 1);
+    clist_rpush(&tmpfs->files, &file->next);
+
+    return file;
+}
+
+static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path)
+{
+    (void)mode;
+    (void)abs_path;
+    tmpfs_t *tmpfs = filp->mp->private_data;
+    int ret = 0;
+
+    mutex_lock(&tmpfs->lock);
+
+    tmpfs_file_t *file = find_file(tmpfs, name);
+    if (!file) {
+        if ((flags & O_CREAT) && ((flags & O_ACCMODE) != O_RDONLY)) {
+            file = add_file(tmpfs, name);
+            if (!file) {
+                ret = -ENOMEM;
+            }
+        }
+        else {
+            ret = -EINVAL;
+        }
+    }
+    if (!ret) {
+        filp->private_data.ptr = file;
+        if (flags & O_APPEND) {
+            filp->pos = ((tmpfs_file_t *)filp->private_data.ptr)->size;
+        }
+    }
+
+    mutex_unlock(&tmpfs->lock);
+    return ret;
+}
+
+static tmpfs_file_buf_t *find_buf_index(tmpfs_file_t *file, off_t pos, size_t *index)
+{
+    assert(index);
+    size_t cur = 0;
+
+    clist_node_t *node = file->buf.next;
+    if (!node) {
+        return NULL;
+    }
+    do {
+        node = node->next;
+        tmpfs_file_buf_t *buf = container_of(node, tmpfs_file_buf_t, next);
+        if ((size_t)pos < cur + buf->size) {
+            *index = pos - cur;
+            return buf;
+        }
+        cur += buf->size;
+    } while (node != file->buf.next);
+
+    return NULL;
+}
+
+static tmpfs_file_buf_t *alloc_buf(tmpfs_file_t *file, size_t nbytes)
+{
+    tmpfs_file_buf_t *buf = TMPFS_MALLOC(sizeof(*buf));
+    void *data_buf = TMPFS_MALLOC(nbytes);
+    if (!buf || !data_buf) {
+        return NULL;
+    }
+    clist_rpush(&file->buf, &buf->next);
+    buf->buf = data_buf;
+    buf->size = nbytes;
+    file->size += nbytes;
+
+    return buf;
+}
+
+static ssize_t _write(vfs_file_t *filp, const void *src, size_t nbytes)
+{
+    tmpfs_file_t *file = filp->private_data.ptr;
+    tmpfs_file_buf_t *buf = NULL;
+    size_t index;
+    size_t written = 0;
+
+    if ((size_t)filp->pos < file->size) {
+        buf = find_buf_index(file, filp->pos, &index);
+    }
+    if (!buf) {
+        buf = alloc_buf(file, nbytes);
+        if (!buf) {
+            return -ENOMEM;
+        }
+        index = 0;
+    }
+
+    while (nbytes) {
+        if (nbytes <= buf->size - index) {
+            memcpy((char *)buf->buf + index, src, nbytes);
+            written += nbytes;
+            nbytes = 0;
+        }
+        else {
+            memcpy((char *)buf->buf + index, src, buf->size - index);
+            nbytes -= buf->size - index;
+            written += buf->size - index;
+            src = (char *)src + buf->size - index;
+            clist_node_t *node = &buf->next;
+            if (node != file->buf.next) {
+                buf = container_of(node->next, tmpfs_file_buf_t, next);
+            }
+            else {
+                buf = alloc_buf(file, nbytes);
+                if (!buf) {
+                    return -ENOMEM;
+                }
+            }
+            index = 0;
+        }
+    }
+
+    filp->pos += written;
+
+    return written;
+}
+
+static ssize_t _read(vfs_file_t *filp, void *dest, size_t nbytes)
+{
+    tmpfs_file_t *file = filp->private_data.ptr;
+    size_t index;
+    tmpfs_file_buf_t *buf = find_buf_index(file, filp->pos, &index);
+    size_t read = 0;
+
+    if (!buf) {
+        return -EOVERFLOW;
+    }
+
+    while (nbytes) {
+        if (nbytes <= buf->size - index) {
+            memcpy(dest, (char *)buf->buf + index, nbytes);
+            read += nbytes;
+            dest = (char *)dest + nbytes;
+            nbytes = 0;
+        }
+        else {
+            memcpy(dest, (char *)buf->buf + index, buf->size - index);
+            read += buf->size - index;
+            nbytes -= buf->size - index;
+            dest = (char *)dest + buf->size - index;
+            clist_node_t *node = &buf->next;
+            if (node != file->buf.next) {
+                buf = container_of(node->next, tmpfs_file_buf_t, next);
+                index = 0;
+            }
+            else {
+                return read;
+            }
+        }
+    }
+
+    return read;
+}
+
+static const vfs_file_system_ops_t fs_ops = {
+    .umount = _umount,
+    .mount = _mount,
+    .rename = _rename,
+    .unlink = _unlink,
+    .stat = _stat,
+    .statvfs = _statvfs,
+};
+
+static const vfs_file_ops_t f_ops = {
+    .open = _open,
+    .write = _write,
+    .read = _read,
+};
+
+const vfs_file_system_t tmpfs_file_system = {
+    .f_op = &f_ops,
+    .fs_op = &fs_ops,
+};

--- a/sys/fs/tmpfs/tmpfs.c
+++ b/sys/fs/tmpfs/tmpfs.c
@@ -29,7 +29,7 @@
 #include "mutex.h"
 #include "memarray.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 /**

--- a/sys/include/fs/tmpfs.h
+++ b/sys/include/fs/tmpfs.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup  sys_fs_tmpfs TempFS file system
+ * @ingroup   sys_fs
+ * @brief     Temporary file system
+ *
+ * This file system implementation allows implement a RAM only file system with
+ * dynamic memory allocation.
+ *
+ * This file system can be used for temporary file-like storage, everything is
+ * removed when unmounting. This uses dynamic memory allocation and default
+ * @p malloc and @p free functions can be overwritten with @p TMPFS_MALLOC and
+ * @p TMPFS_FREE defines.
+ *
+ * The file system is composed of a chained list of files. Each file is a chained
+ * list of file buffer.
+ *
+ * @{
+ * @file
+ * @brief   TempFS public API
+ * @author  Vincent Dupont <vincent@otakeys.com>
+ */
+
+#ifndef FS_TMPFS_H
+#define FS_TMPFS_H
+
+#include "clist.h"
+#include "vfs.h"
+#include "mutex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   tmpfs file system superblock
+ */
+typedef struct {
+    clist_node_t files; /**< list of files */
+    mutex_t lock;       /**< lock */
+} tmpfs_t;
+
+/**
+ * @brief   TempFS file system driver
+ *
+ * For use with vfs_mount
+ */
+extern const vfs_file_system_t tmpfs_file_system;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FS_TMPFS_H */
+
+/** @} */

--- a/sys/include/fs/tmpfs.h
+++ b/sys/include/fs/tmpfs.h
@@ -39,6 +39,18 @@
 extern "C" {
 #endif
 
+#ifndef TMPFS_MAX_FILES
+#define TMPFS_MAX_FILES     (16)
+#endif
+
+#ifndef TMPFS_BUF_SIZE
+#define TMPFS_BUF_SIZE      (128)
+#endif
+
+#ifndef TMPFS_MAX_BUF
+#define TMPFS_MAX_BUF       (128)
+#endif
+
 /**
  * @brief   tmpfs file system superblock
  */

--- a/sys/include/fs/tmpfs.h
+++ b/sys/include/fs/tmpfs.h
@@ -15,9 +15,7 @@
  * dynamic memory allocation.
  *
  * This file system can be used for temporary file-like storage, everything is
- * removed when unmounting. This uses dynamic memory allocation and default
- * @p malloc and @p free functions can be overwritten with @p TMPFS_MALLOC and
- * @p TMPFS_FREE defines.
+ * removed when unmounting. This uses dynamic pool memory allocation with memarray.
  *
  * The file system is composed of a chained list of files. Each file is a chained
  * list of file buffer.
@@ -40,14 +38,23 @@ extern "C" {
 #endif
 
 #ifndef TMPFS_MAX_FILES
+/**
+ * @brief   Maximum number of files that can be allocated on the tmpfs
+ */
 #define TMPFS_MAX_FILES     (16)
 #endif
 
 #ifndef TMPFS_BUF_SIZE
+/**
+ * @brief   Size of a file chunk that is allocated
+ */
 #define TMPFS_BUF_SIZE      (128)
 #endif
 
 #ifndef TMPFS_MAX_BUF
+/**
+ * @brief   Maximum number of chunks that can be allocated
+ */
 #define TMPFS_MAX_BUF       (128)
 #endif
 

--- a/tests/unittests/tests-tmpfs/Makefile
+++ b/tests/unittests/tests-tmpfs/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-tmpfs/Makefile.include
+++ b/tests/unittests/tests-tmpfs/Makefile.include
@@ -1,0 +1,3 @@
+USEMODULE += tmpfs
+
+CFLAGS += -g

--- a/tests/unittests/tests-tmpfs/tests-tmpfs.c
+++ b/tests/unittests/tests-tmpfs/tests-tmpfs.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+#include "fs/tmpfs.h"
+#include "vfs.h"
+
+#include <fcntl.h>
+#include <errno.h>
+
+#include "embUnit/embUnit.h"
+
+#include "tests-tmpfs.h"
+
+static tmpfs_t tmpfs_desc = {
+    .lock = MUTEX_INIT,
+};
+
+static vfs_mount_t _test_tmpfs_mount = {
+    .fs = &tmpfs_file_system,
+    .mount_point = "/tmp",
+    .private_data = &tmpfs_desc,
+};
+
+static void tests_tmpfs_mount_umount(void)
+{
+    int res;
+    res = vfs_mount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_umount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+static void test_tmpfs_open_close(void)
+{
+    int res;
+    int fd;
+    res = vfs_mount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test", O_RDONLY, 0);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, fd);
+
+    fd = vfs_open("/tmp/test", O_RDWR, 0);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, fd);
+
+    fd = vfs_open("/tmp/test", O_RDWR | O_CREAT, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test", O_RDONLY, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_umount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+static void test_tmpfs_write_read(void)
+{
+    const char w_buf[] = "ABCDEFG01234567890";
+    char r_buf[2 * sizeof(w_buf) + 4];
+    int res;
+    int fd;
+    res = vfs_mount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test", O_RDWR | O_CREAT, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_write(fd, w_buf, sizeof(w_buf));
+    TEST_ASSERT_EQUAL_INT(sizeof(w_buf), res);
+
+    res = vfs_write(fd, w_buf, sizeof(w_buf));
+    TEST_ASSERT_EQUAL_INT(sizeof(w_buf), res);
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test", O_RDONLY, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_read(fd, r_buf, sizeof(r_buf));
+    TEST_ASSERT_EQUAL_INT(2 * sizeof(w_buf), res);
+    for (size_t i = 0; i < sizeof(w_buf); i++) {
+        TEST_ASSERT_EQUAL_INT(w_buf[i], r_buf[i]);
+        TEST_ASSERT_EQUAL_INT(w_buf[i], r_buf[i + sizeof(w_buf)]);
+    }
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test", O_RDWR, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_lseek(fd, 5, SEEK_SET);
+    TEST_ASSERT_EQUAL_INT(5, res);
+
+    res = vfs_write(fd, w_buf, sizeof(w_buf));
+    TEST_ASSERT_EQUAL_INT(sizeof(w_buf), res);
+
+    res = vfs_lseek(fd, 0, SEEK_SET);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_read(fd, r_buf, sizeof(r_buf));
+    TEST_ASSERT_EQUAL_INT(2 * sizeof(w_buf), res);
+    for (size_t i = 0; i < 5; i++) {
+        TEST_ASSERT_EQUAL_INT(w_buf[i], r_buf[i]);
+    }
+    for (size_t i = 5; i < 5 + sizeof(w_buf); i++) {
+        TEST_ASSERT_EQUAL_INT(w_buf[i - 5], r_buf[i]);
+    }
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_umount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+static void tests_tmpfs_umount_open(void)
+{
+    const char w_buf[] = "ABCDEFG01234567890";
+    char r_buf[2 * sizeof(w_buf) + 4];
+    int fd;
+    int res;
+    res = vfs_mount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test", O_RDWR | O_CREAT, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_write(fd, w_buf, sizeof(w_buf));
+    TEST_ASSERT_EQUAL_INT(sizeof(w_buf), res);
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test", O_RDONLY, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_read(fd, r_buf, sizeof(r_buf));
+    TEST_ASSERT_EQUAL_INT(sizeof(w_buf), res);
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_umount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_mount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test", O_RDONLY, 0);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, fd);
+
+    res = vfs_umount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+static void tests_tmpfs_unlink(void)
+{
+    const char buf[] = "TESTSTRING";
+    int res;
+    int fd;
+
+    res = vfs_mount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test.txt", O_CREAT | O_RDWR, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_write(fd, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(sizeof(buf), res);
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_unlink("/tmp/test.txt");
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test.txt", O_RDONLY, 0);
+    TEST_ASSERT_EQUAL_INT(-EINVAL, fd);
+
+    res = vfs_umount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+static void tests_tmpfs_statvfs(void)
+{
+    const char buf[] = "TESTSTRING";
+    struct statvfs stat1;
+    struct statvfs stat2;
+
+    int res = vfs_mount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_statvfs("/tmp/", &stat1);
+    TEST_ASSERT_EQUAL_INT(0, res);
+    TEST_ASSERT_EQUAL_INT(1, stat1.f_bsize);
+    TEST_ASSERT_EQUAL_INT(1, stat1.f_frsize);
+    TEST_ASSERT_EQUAL_INT(0, stat1.f_bfree);
+    TEST_ASSERT_EQUAL_INT(0, stat1.f_blocks);
+
+    int fd = vfs_open("/tmp/test.txt", O_CREAT | O_RDWR, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_write(fd, buf, sizeof(buf));
+    TEST_ASSERT(res == sizeof(buf));
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_statvfs("/tmp/", &stat2);
+    TEST_ASSERT_EQUAL_INT(0, res);
+    TEST_ASSERT_EQUAL_INT(1, stat2.f_bsize);
+    TEST_ASSERT_EQUAL_INT(1, stat2.f_frsize);
+    TEST_ASSERT_EQUAL_INT(0, stat2.f_bfree);
+    TEST_ASSERT_EQUAL_INT(sizeof(buf), stat2.f_blocks);
+
+    res = vfs_umount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+static void tests_tmpfs_rename(void)
+{
+    const char buf[] = "TESTSTRING";
+
+    int res = vfs_mount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    int fd = vfs_open("/tmp/test.txt", O_CREAT | O_RDWR, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_write(fd, buf, sizeof(buf));
+    TEST_ASSERT(res == sizeof(buf));
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test2.txt", O_RDONLY, 0);
+    TEST_ASSERT(fd < 0);
+
+    res = vfs_rename("/tmp/test.txt", "/tmp/test2.txt");
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    fd = vfs_open("/tmp/test2.txt", O_RDONLY, 0);
+    TEST_ASSERT(fd >= 0);
+
+    res = vfs_close(fd);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    res = vfs_rename("/tmp/test.txt", "/tmp/test2.txt");
+    TEST_ASSERT_EQUAL_INT(-ENOENT, res);
+
+    res = vfs_umount(&_test_tmpfs_mount);
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+Test *tests_tmpfs_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(tests_tmpfs_mount_umount),
+        new_TestFixture(test_tmpfs_open_close),
+        new_TestFixture(test_tmpfs_write_read),
+        new_TestFixture(tests_tmpfs_umount_open),
+        new_TestFixture(tests_tmpfs_unlink),
+        new_TestFixture(tests_tmpfs_statvfs),
+        new_TestFixture(tests_tmpfs_rename),
+    };
+
+    EMB_UNIT_TESTCALLER(tmpfs_tests, NULL, NULL, fixtures);
+
+    return (Test *)&tmpfs_tests;
+}
+
+void tests_tmpfs(void)
+{
+    TESTS_RUN(tests_tmpfs_tests());
+}
+/** @} */

--- a/tests/unittests/tests-tmpfs/tests-tmpfs.h
+++ b/tests/unittests/tests-tmpfs/tests-tmpfs.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for TempFS
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ */
+#ifndef TESTS_TMPFS_H
+#define TESTS_TMPFS_H
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_tmpfs(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_TMPFS_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR adds a temporary RAM file system. It uses dynamic memory allocation (malloc/free, but this can be overwritten with defines and could be improved later on) to allocate RAM files.

The file system is based on a chained list of files, each file containing a chained list of buffers.
There is no support for directories.

### Issues/PRs references

None