### PR TITLE
cpu/stm32f4: fix periph/adc resolution check

### DIFF
--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -99,7 +99,7 @@ int adc_sample(adc_t line, adc_res_t res)
     int sample;
 
     /* check if resolution is applicable */
-    if (res < 0xff) {
+    if (res & 0xff) {
         return -1;
     }
 


### PR DESCRIPTION
### Contribution description

stm32f4 defines the possible resolutions like this:

```
typedef enum {
    ADC_RES_6BIT  = 0x03000000,     /**< ADC resolution: 6 bit */
    ADC_RES_8BIT  = 0x02000000,     /**< ADC resolution: 8 bit */
    ADC_RES_10BIT = 0x01000000,     /**< ADC resolution: 10 bit */
    ADC_RES_12BIT = 0x00000000,     /**< ADC resolution: 12 bit */
    ADC_RES_14BIT = 1,              /**< ADC resolution: 14 bit (not supported) */
    ADC_RES_16BIT = 2               /**< ADC resolution: 16 bit (not supported)*/
} adc_res_t;
```

Thus ADC_RES_12BIT is a valid value. Current adc_sample() checks for ``` 0xff```, which hits for 12bit.
This PR fixes the check.
