### PR TITLE
cpu: stm32_common: always do gpio_read() from input register

### DIFF
--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -203,12 +203,7 @@ void gpio_irq_disable(gpio_t pin)
 
 int gpio_read(gpio_t pin)
 {
-    if (_port(pin)->MODER & (0x3 << (_pin_num(pin) * 2))) {
-        return _port(pin)->ODR & (1 << _pin_num(pin));
-    }
-    else {
-        return _port(pin)->IDR & (1 << _pin_num(pin));
-    }
+    return (_port(pin)->IDR & (1 << _pin_num(pin)));
 }
 
 void gpio_set(gpio_t pin)


### PR DESCRIPTION
### Contribution description

Current stm32 ```gpio_read()``` returns the value of the output register (ODR), if the pin is configured as output.

According to the datasheet (of stm32f401):
```
When the I/O port is programmed as Input:
• The data present on the I/O pin are sampled into the input data register every AHB
clock cycle
• A read access to the input data register provides the I/O State

When the I/O port is programmed as output:
• The data present on the I/O pin are sampled into the input data register every AHB
clock cycle
• A read access to the input data register gets the I/O state
• A read access to the output data register gets the last written value

When the I/O port is programmed as alternate function:
• The data present on the I/O pin are sampled into the input data register every AHB
clock cycle
• A read access to the input data register gets the I/O state
```

Thus the input register always contains the actual pin state. The output register only what was last set, which for alternate functions (PWM) is always 0.

This PR changes the read to always return the pins IDR.