### PR TITLE
cpu/stm32/gpio: do not change pin state when switching to output

### DIFF
--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -87,6 +87,8 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     periph_clk_en(AHB1, (RCC_AHB1ENR_GPIOAEN << _port_num(pin)));
 #endif
 
+    /* do not touch actual line state */
+    _port(pin)->ODR = _port(pin)->IDR;
     /* set mode */
     port->MODER &= ~(0x3 << (2 * pin_num));
     port->MODER |=  ((mode & 0x3) << (2 * pin_num));


### PR DESCRIPTION
### Contribution description

This PR fix issue with changing existing line state when switching GPIO from IN to OUT.
I.e.: There is shared signal between multiple MCUs. Line is with external pull-up and should be handled by open-drain output. After power up MCU sets GPIO as input. When I switched line to output open-drain, line is incorrectly drive to low state. 

