### PR TITLE
kinetis: Allow per-board config of ADC ref

### DIFF
--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -132,6 +132,13 @@ static const adc_conf_t adc_config[] = {
 };
 
 #define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+/*
+ * K22F ADC reference settings:
+ * 0: VREFH/VREFL external pin pair
+ * 1: VREF_OUT internal 1.2 V reference (VREF module must be enabled)
+ * 2-3: reserved
+ */
+#define ADC_REF_SETTING     0
 /** @} */
 
 /**

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -126,6 +126,13 @@ static const adc_conf_t adc_config[] = {
 };
 
 #define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+/*
+ * K64F ADC reference settings:
+ * 0: VREFH/VREFL external pin pair
+ * 1: VREF_OUT internal 1.2 V reference (VREF module must be enabled)
+ * 2-3: reserved
+ */
+#define ADC_REF_SETTING     0
 /** @} */
 
 /**

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -183,6 +183,13 @@ static const adc_conf_t adc_config[] = {
 };
 
 #define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+/*
+ * K60D ADC reference settings:
+ * 0: VREFH/VREFL external pin pair
+ * 1: VREF_OUT internal 1.2 V reference (VREF module must be enabled)
+ * 2-3: reserved
+ */
+#define ADC_REF_SETTING     0
 /** @} */
 
 /**

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -141,6 +141,12 @@ static const adc_conf_t adc_config[] = {
 };
 
 #define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
+/*
+ * KW2xD ADC reference settings:
+ * 0: VREFH/VREFL external pin pair
+ * 1-3: reserved
+ */
+#define ADC_REF_SETTING     0
 /** @} */
 
 /**

--- a/cpu/kinetis/periph/adc.c
+++ b/cpu/kinetis/periph/adc.c
@@ -196,7 +196,7 @@ int adc_init(adc_t line)
     /* select ADxxb channels, longest sample time (20 extra ADC cycles) */
     dev(line)->CFG2 = ADC_CFG2_MUXSEL_MASK | ADC_CFG2_ADLSTS(0);
     /* select software trigger, external ref pins */
-    dev(line)->SC2 = ADC_SC2_REFSEL(0);
+    dev(line)->SC2 = ADC_SC2_REFSEL(ADC_REF_SETTING);
     /* select hardware average over 32 samples */
     dev(line)->SC3 = ADC_SC3_AVGE_MASK | ADC_SC3_AVGS(3);
     /* set an (arbitrary) input channel, single-ended mode */


### PR DESCRIPTION
### Contribution description

ADC reference can be external pin or internal VREF module on most Kinetis CPUs. The CPU reference manual has a description of the valid values for each CPU, but I have added a short summary of the options in each of the existing periph_conf.h headers for reference.
This was previously hard-coded to always use reference setting 0, but for the FRDM-KW41Z board we need to use setting 1 to get valid ADC readings without always having VREF enabled (which would increase power consumption)

### Issues/PRs references

Required by #6995 