### PR TITLE
event: fix unit in doc for event_timeout_set()

### DIFF
--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -71,7 +71,7 @@ void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue,
  *        event has been processed!
  *
  * @param[in]   event_timeout   event_timout context object to use
- * @param[in]   timeout         timeout in miliseconds
+ * @param[in]   timeout         timeout in microseconds
  */
 void event_timeout_set(event_timeout_t *event_timeout, uint32_t timeout);
 


### PR DESCRIPTION
### Contribution description
1. It's spelled "milliseconds" not "miliseconds"
2. As far as I can see `event_timeout_set()` just calls `xtimer_set()` without any unit conversion to `timeout`. I'm assuming this is a bug in documentation, not in implementation, so I fixed the documentation accordingly. If not I can change the implementation in a follow-up.

### Issues/PRs references
None