### PR TITLE
 gnrc_ipv6_nib_6ln: do not mark non-link-local addresses directly VALID

### DIFF
--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -119,12 +119,6 @@ enum {
 #define GNRC_NETIF_FLAGS_6LO_BACKBONE              (0x00000800U)
 
 /**
- * @brief   Marks if the addresses of the interface were already registered
- *          to an interface or not
- */
-#define GNRC_NETIF_FLAGS_6LO_ADDRS_REG             (0x00001000U)
-
-/**
  * @brief   Mask for @ref gnrc_mac_tx_feedback_t
  */
 #define GNRC_NETIF_FLAGS_MAC_TX_FEEDBACK_MASK      (0x00006000U)

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -647,15 +647,14 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     }
 #if GNRC_IPV6_NIB_CONF_6LN
     if ((dr != NULL) && gnrc_netif_is_6ln(netif) &&
-        !gnrc_netif_is_6lbr(netif) &&
-        !(netif->flags & GNRC_NETIF_FLAGS_6LO_ADDRS_REG)) {
-        /* (register addresses already assigned)*/
+        !gnrc_netif_is_6lbr(netif)) {
+        /* (register addresses already assigned but not valid yet)*/
         for (int i = 0; i < GNRC_NETIF_IPV6_ADDRS_NUMOF; i++) {
-            if ((netif->ipv6.addrs_flags[i] != 0)) {
+            if ((netif->ipv6.addrs_flags[i] != 0) &&
+                (netif->ipv6.addrs_flags[i] != GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID)) {
                 _handle_rereg_address(&netif->ipv6.addrs[i]);
             }
         }
-        netif->flags |= GNRC_NETIF_FLAGS_6LO_ADDRS_REG;
     }
 #endif  /* GNRC_IPV6_NIB_CONF_6LN */
     tmp_len = icmpv6_len - sizeof(ndp_rtr_adv_t);
@@ -1322,7 +1321,7 @@ static void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #endif  /* GNRC_IPV6_NIB_CONF_6LN */
     }
 
-if GNRC_IPV6_NIB_CONF_6LN
+#if GNRC_IPV6_NIB_CONF_6LN
     /* mark link-local addresses as valid on 6LN */
     if (gnrc_netif_is_6ln(netif) && ipv6_addr_is_link_local(pfx)) {
         /* don't do this beforehand or risk a deadlock:

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1322,8 +1322,9 @@ static void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #endif  /* GNRC_IPV6_NIB_CONF_6LN */
     }
 
-#if GNRC_IPV6_NIB_CONF_6LN
-    if (gnrc_netif_is_6ln(netif)) {
+if GNRC_IPV6_NIB_CONF_6LN
+    /* mark link-local addresses as valid on 6LN */
+    if (gnrc_netif_is_6ln(netif) && ipv6_addr_is_link_local(pfx)) {
         /* don't do this beforehand or risk a deadlock:
          *  * gnrc_netif_ipv6_addr_add_internal() adds VALID (i.e. manually configured
          *    addresses to the prefix list locking the NIB's mutex which is already
@@ -1332,7 +1333,6 @@ static void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
         netif->ipv6.addrs_flags[idx] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID;
     }
 #endif  /* GNRC_IPV6_NIB_CONF_6LN */
-    (void)idx;
     /* TODO: make this line conditional on 6LN when there is a SLAAC
      * implementation */
 #if GNRC_IPV6_NIB_CONF_6LN
@@ -1340,6 +1340,8 @@ static void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
         !gnrc_netif_is_6lbr(netif)) {
         _handle_rereg_address(&netif->ipv6.addrs[idx]);
     }
+#else   /* GNRC_IPV6_NIB_CONF_6LN */
+    (void)idx;
 #endif  /* GNRC_IPV6_NIB_CONF_6LN */
 #if GNRC_IPV6_NIB_CONF_SLAAC
     /* TODO send NS to solicited nodes and wait netif->ipv6.retrans_time to

--- a/tests/gnrc_ipv6_nib_6ln/main.c
+++ b/tests/gnrc_ipv6_nib_6ln/main.c
@@ -89,7 +89,6 @@ static void _set_up(void)
     _mock_netif->ipv6.mtu = IPV6_MIN_MTU;
     _mock_netif->cur_hl = GNRC_NETIF_DEFAULT_HL;
     gnrc_netif_ipv6_addr_remove_internal(_mock_netif, &_loc_gb);
-    _mock_netif->flags &= ~GNRC_NETIF_FLAGS_6LO_ADDRS_REG;
     gnrc_netif_release(_mock_netif);
     memset(_buffer, 0, sizeof(_buffer));
     gnrc_pktbuf_init();
@@ -1084,7 +1083,9 @@ static void test_handle_pkt__rtr_adv__success(uint8_t rtr_adv_flags,
         TEST_ASSERT_MESSAGE(!gnrc_ipv6_nib_pl_iter(0, &state, &prefix),
                             "There is an unexpected prefix list entry");
     }
-    if (set_rtr_adv_fields) {
+    /* neighbor solicitation is only sent when router lifetime is non-zero and
+     * when PIO configures GUA */
+    if (set_rtr_adv_fields && pio && (pio_flags & NDP_OPT_PI_FLAGS_A)) {
         TEST_ASSERT(msg_avail() > 0);
         while (msg_avail()) {
             gnrc_netif_hdr_t *netif_hdr;


### PR DESCRIPTION
### Contribution description
The whole address registration looses its point if all addresses are marked valid from the get-go. With this fix addresses are first marked TENTATIVE and only after successful registration marked as VALID.

Additionally because of that, we only have to register addresses that are not VALID yet on reception of router advertisements. This removes the need for the hacky `GNRC_NETIF_FLAGS_6LO_ADDRS_REG` flag that was only introduced to prevent unnecessary re-registration.

Finally, I also piggy-backed a fix for the `ifconfig` shell command, to show TENTATIVE addresses as such. They were not shown as such since sometime during the development of `gnrc_netif` TENTATIVE moved from just being a single flag to being a bit field (to count retries during duplicate address detection). The `ifconfig` command wasn't adapted for that.

### Issues/PRs references
None