### PR TITLE
event: fix additional unit in doc for event_timeout_set()

### DIFF
--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -65,7 +65,7 @@ void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue,
  * @brief   Set a timeout
  *
  * This will make the event as configured in @p event_timeout be triggered
- * after @p timeout miliseconds.
+ * after @p timeout microseconds.
  *
  * @note: the used event_timeout struct must stay valid until after the timeout
  *        event has been processed!


### PR DESCRIPTION
### Contribution description

#8562 was merged before I could mention this additional mention of `miliseconds`.

### Issues/PRs references

#8562 