### PR TITLE
gnrc_ipv6_nib: only discard RAs without ABROs on 6LR

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -177,7 +177,7 @@ extern "C" {
  * @see [RFC 6775, section 8.1](https://tools.ietf.org/html/rfc6775#section-8.1)
  */
 #ifndef GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
-#if GNRC_IPV6_NIB_CONF_6LN
+#if GNRC_IPV6_NIB_CONF_6LR
 #define GNRC_IPV6_NIB_CONF_MULTIHOP_P6C (1)
 #else
 #define GNRC_IPV6_NIB_CONF_MULTIHOP_P6C (0)

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -594,8 +594,8 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                             MS_PER_SEC);
     }
 #if !GNRC_IPV6_NIB_CONF_6LBR
-    else {
-        DEBUG("nib: multihop prefix and context dissemination activated,\n"
+    else if (gnrc_netif_is_6lr(netif)) {
+        DEBUG("nib: multihop prefix and context dissemination on router activated,\n"
               "     but no ABRO found. Discarding router advertisement silently\n");
         return;
     }


### PR DESCRIPTION
### Contribution description
[RFC6775] only talks of *routers* processing router advertisements,
with regards of discarding them if they do not contain an ABRO.

Additionally, this change makes configuration of tests setups a lot
easier, where one note is a router distributing a prefix and the other
is a host to be configured with the RA. Just do the following on the
router:

```
> ifconfig <if> add <GUA>
> ifconfig <if> rtr_adv
```

e voilà! In current master both nodes would have needed to be compiled
with `GNRC_IPV6_NIB_CONF_MULTIHOP_P6C=0`.

[RFC6775]: https://tools.ietf.org/html/rfc6775#section-8.1.3

### Issues/PRs references
None