### PR TITLE
pkg/openwsn: re-integrate the network stack as a package

### DIFF
--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -135,8 +135,8 @@ static const uart_conf_t uart_config[] = {
 #define RTT_IRQ             RTC_IRQn
 #define RTT_ISR             isr_rtc
 #define RTT_MAX_VALUE       (0xffffffff)
-#define RTT_FREQUENCY       (1)             /* in Hz */
-#define RTT_PRESCALER       (0x7fff)        /* run with 1 Hz */
+#define RTT_FREQUENCY       (16384U)     /* in Hz */
+#define RTT_PRESCALER       (0x1)        /* run with ~16 kHz */
 /** @} */
 
 /**

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -147,6 +147,9 @@ void at86rf2xx_tx_prepare(at86rf2xx_t *dev)
     if (state != AT86RF2XX_STATE_TX_ARET_ON) {
         dev->idle_state = state;
     }
+
+    at86rf2xx_set_state(dev, AT86RF2XX_STATE_PLL_ON);
+
     dev->tx_frame_len = IEEE802154_FCS_LEN;
 }
 

--- a/pkg/openwsn/Makefile
+++ b/pkg/openwsn/Makefile
@@ -1,0 +1,12 @@
+PKG_NAME=openwsn-fw
+PKG_URL=https://github.com/openwsn-berkeley/openwsn-fw.git
+PKG_VERSION=dcf26e99b65ace4b1d8551a9962ee976fe7f0359
+PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+PKG_LICENSE=BSD-3-Clause
+
+.PHONY: all
+
+all: git-download
+	"$(MAKE)" -C $(PKG_BUILDDIR)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/openwsn/Makefile.dep
+++ b/pkg/openwsn/Makefile.dep
@@ -1,0 +1,19 @@
+ifneq (,$(filter openwsn,$(USEPKG)))
+  USEMODULE += openwsn_openstack
+  USEMODULE += openwsn_drivers
+  USEMODULE += openwsn_scheduler
+  USEMODULE += openwsn_mac_low
+  USEMODULE += openwsn_mac_high
+  USEMODULE += openwsn_iphc
+  USEMODULE += openwsn_ipv6
+  USEMODULE += openwsn_transport
+  USEMODULE += openwsn_crosslayers
+
+  USEMODULE += luid
+  USEMODULE += netdev_default
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_rtt
+  FEATURES_REQUIRED += periph_spi
+  FEATURES_REQUIRED += periph_timer
+  FEATURES_REQUIRED += periph_uart
+endif

--- a/pkg/openwsn/Makefile.include
+++ b/pkg/openwsn/Makefile.include
@@ -1,0 +1,19 @@
+OPENWSN_DIR = $(RIOTBASE)/pkg/openwsn
+
+INCLUDES += -I$(PKGDIRBASE)/openwsn-fw \
+            -I$(PKGDIRBASE)/openwsn-fw/kernel \
+            -I$(PKGDIRBASE)/openwsn-fw/inc \
+            -I$(PKGDIRBASE)/openwsn-fw/drivers/common \
+            -I$(PKGDIRBASE)/openwsn-fw/bsp/boards/ \
+            -I$(PKGDIRBASE)/openwsn-fw/openstack/ \
+            -I$(PKGDIRBASE)/openwsn-fw/openstack/02a-MAClow \
+            -I$(PKGDIRBASE)/openwsn-fw/openstack/02b-MAChigh \
+            -I$(PKGDIRBASE)/openwsn-fw/openstack/03a-IPHC \
+            -I$(PKGDIRBASE)/openwsn-fw/openstack/03b-IPv6 \
+            -I$(PKGDIRBASE)/openwsn-fw/openstack/04-TRAN \
+            -I$(PKGDIRBASE)/openwsn-fw/openstack/cross-layers \
+            -I$(OPENWSN_DIR)/include \
+
+DIRS += $(OPENWSN_DIR)/contrib
+
+CFLAGS += -DISR_STACKSIZE=1024

--- a/pkg/openwsn/contrib/Makefile
+++ b/pkg/openwsn/contrib/Makefile
@@ -1,0 +1,3 @@
+MODULE = openwsn
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/openwsn/contrib/board_ow.c
+++ b/pkg/openwsn/contrib/board_ow.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ * @brief       RIOT adaption definition of the "board" bsp module
+ *
+ * @author      Thomas Watteyne <watteyne@eecs.berkeley.edu>, February 2012
+ * @author      Tengfei Chang <tengfei.chang@gmail.com>, July 2012
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>, July 2017
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "sctimer.h"
+#include "radio.h"
+#include "uart_ow.h"
+#include "board_ow.h"
+#include "debugpins_riot.h"
+#include "ledpins_riot.h"
+#include "thread.h"
+#include "periph/pm.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+void board_init_ow(void)
+{
+    DEBUG("OpenWSN board_init\n");
+
+    DEBUG("pins & leds init\n");
+#if defined (BOARD_NUCLEO_F103) || defined (BOARD_SAMR21_XPRO)
+    ledpins_riot_init(openwsn_ledpins_params);
+#else
+    ledpins_riot_init(NULL);
+#endif
+#if defined (BOARD_NUCLEO_F103)
+    debugpins_riot_init(openwsn_debugpins_params);
+#else
+    debugpins_riot_init(NULL);
+#endif
+
+    DEBUG("sctimer_init\n");
+    sctimer_init();
+
+    DEBUG("uart_ow init\n");
+    uart_init_ow();
+
+    DEBUG("Finished board_init\n");
+}
+
+void board_sleep(void)
+{
+}
+
+void board_reset(void)
+{
+    puts("OpenWSN board_reset");
+    pm_reboot();
+}

--- a/pkg/openwsn/contrib/debugpins.c
+++ b/pkg/openwsn/contrib/debugpins.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2017 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ *
+ * @author      Michael Frey <michael.frey@msasafety.com>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "debugpins.h"
+#include "debugpins_riot.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/** holds the internal configuration for debug pins */
+static debugpins_config_t configuration = {
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    GPIO_UNDEF
+};
+
+/**
+ * Sets the debug pins for a specific board for OpenWSN
+ *
+ * @param[in] user_config A configuration of GPIO pins used for debugging. Unused pins need to be defined as GPIO_UNDEF
+ */
+void debugpins_riot_init(const debugpins_config_t *user_config)
+{
+    memset(&configuration, GPIO_UNDEF, sizeof(debugpins_config_t));
+
+    if (user_config != NULL) {
+        memcpy(&configuration, user_config, sizeof(debugpins_config_t));
+        debugpins_init();
+    }
+}
+
+void debugpins_init(void)
+{
+    gpio_init(configuration.frame, GPIO_OUT);
+    gpio_init(configuration.slot, GPIO_OUT);
+    gpio_init(configuration.fsm, GPIO_OUT);
+    gpio_init(configuration.task, GPIO_OUT);
+    gpio_init(configuration.isr, GPIO_OUT);
+    gpio_init(configuration.radio, GPIO_OUT);
+
+    debugpins_frame_clr();
+    debugpins_slot_clr();
+    debugpins_fsm_clr();
+    debugpins_task_clr();
+    debugpins_isr_clr();
+    debugpins_radio_clr();
+}
+
+void debugpins_frame_toggle(void)
+{
+    if (configuration.frame != GPIO_UNDEF) {
+        gpio_toggle(configuration.frame);
+    }
+}
+
+void debugpins_frame_clr(void)
+{
+    if (configuration.frame != GPIO_UNDEF) {
+        gpio_clear(configuration.frame);
+    }
+}
+
+void debugpins_frame_set(void)
+{
+    if (configuration.frame != GPIO_UNDEF) {
+        gpio_set(configuration.frame);
+    }
+}
+
+void debugpins_slot_toggle(void)
+{
+    if (configuration.slot != GPIO_UNDEF) {
+        gpio_toggle(configuration.slot);
+    }
+}
+
+void debugpins_slot_clr(void)
+{
+    if (configuration.slot != GPIO_UNDEF) {
+        gpio_clear(configuration.slot);
+    }
+}
+
+void debugpins_slot_set(void)
+{
+    if (configuration.slot != GPIO_UNDEF) {
+        gpio_set(configuration.slot);
+    }
+}
+
+void debugpins_fsm_toggle(void)
+{
+    if (configuration.fsm != GPIO_UNDEF) {
+        gpio_toggle(configuration.fsm);
+    }
+}
+
+void debugpins_fsm_clr(void)
+{
+    if (configuration.fsm != GPIO_UNDEF) {
+        gpio_clear(configuration.fsm);
+    }
+}
+
+void debugpins_fsm_set(void)
+{
+    if (configuration.fsm != GPIO_UNDEF) {
+        gpio_set(configuration.fsm);
+    }
+}
+
+void debugpins_task_toggle(void)
+{
+    if (configuration.task != GPIO_UNDEF) {
+        gpio_toggle(configuration.task);
+    }
+}
+
+void debugpins_task_clr(void)
+{
+    if (configuration.task != GPIO_UNDEF) {
+        gpio_clear(configuration.task);
+    }
+}
+
+void debugpins_task_set(void)
+{
+    if (configuration.task != GPIO_UNDEF) {
+        gpio_set(configuration.task);
+    }
+}
+
+void debugpins_isr_toggle(void)
+{
+    if (configuration.isr != GPIO_UNDEF) {
+        gpio_toggle(configuration.isr);
+    }
+}
+
+void debugpins_isr_clr(void)
+{
+    if (configuration.isr != GPIO_UNDEF) {
+        gpio_clear(configuration.isr);
+    }
+}
+
+void debugpins_isr_set(void)
+{
+    if (configuration.isr != GPIO_UNDEF) {
+        gpio_set(configuration.isr);
+    }
+}
+
+void debugpins_radio_toggle(void)
+{
+    if (configuration.radio != GPIO_UNDEF) {
+        gpio_toggle(configuration.radio);
+    }
+}
+
+void debugpins_radio_clr(void)
+{
+    if (configuration.radio != GPIO_UNDEF) {
+        gpio_clear(configuration.radio);
+    }
+}
+
+void debugpins_radio_set(void)
+{
+    if (configuration.radio != GPIO_UNDEF) {
+        gpio_set(configuration.radio);
+    }
+}

--- a/pkg/openwsn/contrib/eui64.c
+++ b/pkg/openwsn/contrib/eui64.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ * @brief       RIOT adaption definition of the "eui64" bsp module
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "string.h"
+#include "eui64.h"
+
+#include "luid.h"
+#include "net/ieee802154.h"
+
+void eui64_get(uint8_t *addressToWrite)
+{
+    luid_get((void *)addressToWrite, IEEE802154_LONG_ADDRESS_LEN);
+}

--- a/pkg/openwsn/contrib/leds.c
+++ b/pkg/openwsn/contrib/leds.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2017 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ *
+ * @author      Michael Frey <michael.frey@msasafety.com>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "leds.h"
+#include "ledpins_riot.h"
+
+#include "board.h"
+#include "periph/gpio.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/** holds the internal configuration for debug pins */
+static ledpins_config_t configuration = {
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+    GPIO_UNDEF,
+};
+
+
+/**
+ * Provides a simple delay by means of iterating over a 32-bit variable
+ */
+static void leds_delay(void);
+
+/**
+ * Sets the led pins for a specific board for OpenWSN
+ *
+ * @param[in] user_config A configuration of GPIO pins used for debugging. Unused pins need to be defined as GPIO_UNDEF
+ */
+void ledpins_riot_init(const ledpins_config_t *user_config)
+{
+    if (user_config != NULL) {
+        memcpy(&configuration, user_config, sizeof(ledpins_config_t));
+        leds_init();
+    }
+}
+
+/**
+ * Configure four leds as output which provide error, sync, debug, and
+ * radio status information.
+ */
+void leds_init(void)
+{
+    if (configuration.error != GPIO_UNDEF) {
+        gpio_init(configuration.error, GPIO_OUT);
+    }
+    else if (configuration.sync != GPIO_UNDEF) {
+        gpio_init(configuration.sync, GPIO_OUT);
+    }
+    else if (configuration.radio != GPIO_UNDEF) {
+        gpio_init(configuration.radio, GPIO_OUT);
+    }
+    else if (configuration.user != GPIO_UNDEF) {
+        gpio_init(configuration.user, GPIO_OUT);
+    }
+    leds_all_off();
+}
+
+void leds_error_on(void)
+{
+    if (configuration.error != GPIO_UNDEF) {
+        gpio_set(configuration.error);
+    }
+}
+
+void leds_error_off(void)
+{
+    if (configuration.error != GPIO_UNDEF) {
+        gpio_clear(configuration.error);
+    }
+}
+
+void leds_error_toggle(void)
+{
+    if (configuration.error != GPIO_UNDEF) {
+        gpio_toggle(configuration.error);
+    }
+}
+
+uint8_t leds_error_isOn(void)
+{
+    uint8_t ret = 0;
+
+    if (configuration.error != GPIO_UNDEF) {
+        ret = gpio_read(configuration.error);
+    }
+    return ret;
+}
+
+/**
+ * Let the error led blink for "10 seconds".
+ */
+void leds_error_blink(void)
+{
+    for (uint8_t i = 0; i < 16; i++) {
+        leds_error_toggle();
+        leds_delay();
+    }
+}
+
+void leds_radio_on(void)
+{
+    if (configuration.radio != GPIO_UNDEF) {
+        gpio_set(configuration.radio);
+    }
+}
+
+void leds_radio_off(void)
+{
+    if (configuration.radio != GPIO_UNDEF) {
+        gpio_clear(configuration.radio);
+    }
+}
+
+void leds_radio_toggle(void)
+{
+    if (configuration.radio != GPIO_UNDEF) {
+        gpio_toggle(configuration.radio);
+    }
+}
+
+uint8_t leds_radio_isOn(void)
+{
+    uint8_t ret = 0;
+
+    if (configuration.radio != GPIO_UNDEF) {
+        ret = gpio_read(configuration.radio);
+    }
+    return ret;
+}
+
+void leds_sync_on(void)
+{
+    if (configuration.sync != GPIO_UNDEF) {
+        gpio_set(configuration.sync);
+    }
+}
+
+void leds_sync_off(void)
+{
+    if (configuration.sync != GPIO_UNDEF) {
+        gpio_clear(configuration.sync);
+    }
+}
+
+void leds_sync_toggle(void)
+{
+    if (configuration.sync != GPIO_UNDEF) {
+        gpio_toggle(configuration.sync);
+    }
+}
+
+uint8_t leds_sync_isOn(void)
+{
+    uint8_t ret = 0;
+
+    if (configuration.sync != GPIO_UNDEF) {
+        ret = gpio_read(configuration.sync);
+    }
+    return ret;
+}
+
+void leds_debug_on(void)
+{
+    if (configuration.user != GPIO_UNDEF) {
+        gpio_set(configuration.user);
+    }
+}
+
+void leds_debug_off(void)
+{
+    if (configuration.user != GPIO_UNDEF) {
+        gpio_clear(configuration.user);
+    }
+}
+
+void leds_debug_toggle(void)
+{
+    if (configuration.user != GPIO_UNDEF) {
+        gpio_toggle(configuration.user);
+    }
+}
+
+uint8_t leds_debug_isOn(void)
+{
+    uint8_t ret = 0;
+
+    if (configuration.user != GPIO_UNDEF) {
+        ret = gpio_read(configuration.user);
+    }
+    return ret;
+}
+
+void leds_all_on(void)
+{
+    leds_error_on();
+    leds_radio_on();
+    leds_sync_on();
+    leds_debug_on();
+}
+
+void leds_all_off(void)
+{
+    leds_error_off();
+    leds_radio_off();
+    leds_sync_off();
+    leds_debug_off();
+}
+
+void leds_all_toggle(void)
+{
+    leds_error_toggle();
+    leds_radio_toggle();
+    leds_sync_toggle();
+    leds_debug_toggle();
+}
+
+void leds_circular_shift(void)
+{
+    leds_error_on();
+    leds_delay();
+    leds_error_off();
+    leds_delay();
+    leds_radio_on();
+    leds_delay();
+    leds_radio_off();
+    leds_delay();
+    leds_sync_on();
+    leds_delay();
+    leds_sync_off();
+    leds_delay();
+    leds_debug_on();
+    leds_delay();
+    leds_debug_off();
+}
+
+/**
+ * Turns on and off the leds as a binary counter.
+ */
+void leds_increment(void)
+{
+    /** not implemented */
+    return;
+}
+
+static void leds_delay(void)
+{
+    for (uint32_t i = 0; i < 0x7FFF8; i++) ;
+}

--- a/pkg/openwsn/contrib/openwsn.c
+++ b/pkg/openwsn/contrib/openwsn.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ */
+
+#include "scheduler.h"
+#include "openstack.h"
+#include "board_ow.h"
+#include "radio.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define OW_SCHED_NAME            "ow_network"
+#define OW_SCHED_PRIO            (THREAD_PRIORITY_MAIN - 1)
+#define OW_SCHED_STACKSIZE       (THREAD_STACKSIZE_DEFAULT)
+
+static kernel_pid_t _pid = KERNEL_PID_UNDEF;
+static char _stack[OW_SCHED_STACKSIZE];
+
+static void *_event_loop(void *arg);
+
+void openwsn_bootstrap(void)
+{
+    DEBUG("[openwsn_bootstrap]: init RIOT board\n");
+    board_init_ow();
+
+    DEBUG("[openwsn_bootstrap]: radio_init\n");
+    /* initializes an own thread for the radio driver */
+    radio_init();
+
+    DEBUG("[openwsn_bootstrap]: network thread\n");
+    if (_pid <= KERNEL_PID_UNDEF) {
+        _pid = thread_create(_stack, OW_SCHED_STACKSIZE, OW_SCHED_PRIO,
+                             THREAD_CREATE_STACKTEST, _event_loop, NULL,
+                             OW_SCHED_NAME);
+        if (_pid <= 0) {
+            DEBUG("[openwsn_bootstrap]: couldn't create thread\n");
+        }
+    }
+}
+
+static void *_event_loop(void *arg)
+{
+    DEBUG("[openwsn_bootstrap]: init openstack\n");
+    openstack_init();
+
+    DEBUG("[openwsn_bootstrap]: init scheduler\n");
+    scheduler_init();
+
+    DEBUG("[openwsn_bootstrap]: start scheduler");
+    /* starts the OpenWSN scheduler which contains a loop */
+    scheduler_start();
+    return NULL;
+}
+

--- a/pkg/openwsn/contrib/radio.c
+++ b/pkg/openwsn/contrib/radio.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2018 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ *
+ * @author  Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @author  Oliver Hahm <oliver.hahm@inria.fr>
+ * @}
+ */
+#include <sys/uio.h>
+
+#include "radio.h"
+#include "leds.h"
+#include "debugpins.h"
+#include "sctimer.h"
+
+#include "openwsn.h"
+#include "net/netdev.h"
+#include "net/netopt.h"
+#include "net/ieee802154.h"
+#include "net/netdev/ieee802154.h"
+
+#define ENABLE_DEBUG                (0)
+#include "debug.h"
+
+#ifdef MODULE_AT86RF2XX
+#include "at86rf2xx.h"
+#include "at86rf2xx_params.h"
+static at86rf2xx_t at86rf2xx_dev;
+#endif
+
+typedef struct {
+    radio_capture_cbt startFrame_cb;
+    radio_capture_cbt endFrame_cb;
+    radio_state_t state;
+    netdev_t                 *dev;
+} radio_vars_t;
+
+radio_vars_t radio_vars;
+
+static void _event_cb(netdev_t *dev, netdev_event_t event);
+
+void radio_init(void)
+{
+
+    DEBUG("OW initialize riot-adaptation\n");
+
+    uint16_t dev_type;
+    memset(&radio_vars, 0, sizeof(radio_vars_t));
+    radio_vars.state = RADIOSTATE_STOPPED;
+
+#ifdef MODULE_AT86RF2XX
+    radio_vars.dev = (netdev_t *)&at86rf2xx_dev.netdev.netdev;
+    at86rf2xx_setup(&at86rf2xx_dev, &at86rf2xx_params[0]);
+#endif
+
+    DEBUG("OW initialize RIOT radio (netdev)\n");
+    radio_vars.dev->driver->init(radio_vars.dev);
+    radio_vars.dev->event_callback = _event_cb;
+    if (radio_vars.dev->driver->get(radio_vars.dev, NETOPT_DEVICE_TYPE, &dev_type,
+                                    sizeof(dev_type)) < 0) {
+        DEBUG("OW couldn't get device type\n");
+    }
+
+    netopt_state_t state = NETOPT_STATE_STANDBY;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_STATE, &(state), sizeof(netopt_state_t));
+
+    DEBUG("OW RIOT radio (netdev) set default options\n");
+    netopt_enable_t enable;
+    /* Enable needed IRQs */
+    enable = NETOPT_ENABLE;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_RX_START_IRQ, &(enable), sizeof(netopt_enable_t));
+    enable = NETOPT_ENABLE;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_RX_END_IRQ, &(enable), sizeof(netopt_enable_t));
+    enable = NETOPT_ENABLE;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_TX_END_IRQ, &(enable), sizeof(netopt_enable_t));
+    enable = NETOPT_DISABLE;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_AUTOACK, &(enable), sizeof(netopt_enable_t));
+    enable = NETOPT_DISABLE;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_CSMA, &(enable), sizeof(netopt_enable_t));
+    /* Enable TX with preloading */
+    enable = NETOPT_ENABLE;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_PRELOADING, &(enable), sizeof(netopt_enable_t));
+    enable = NETOPT_ENABLE;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_RAWMODE, &(enable), sizeof(netopt_enable_t));
+    uint8_t retrans = 0;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_RETRANS, &(retrans), sizeof(uint8_t));
+#ifdef PANID_DEFINED
+    uint16_t pan_default = PANID_DEFINED;
+#else
+    uint16_t pan_default = 0xcafe;
+#endif
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_NID, &(pan_default), sizeof(uint16_t));
+
+    radio_vars.state = RADIOSTATE_RFOFF;
+}
+
+void radio_setStartFrameCb(radio_capture_cbt cb)
+{
+    radio_vars.startFrame_cb = cb;
+}
+
+void radio_setEndFrameCb(radio_capture_cbt cb)
+{
+    radio_vars.endFrame_cb = cb;
+}
+
+void radio_reset(void)
+{
+    netopt_state_t state = NETOPT_STATE_RESET;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_STATE, &(state), sizeof(netopt_state_t));
+
+    state = NETOPT_STATE_STANDBY;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_STATE, &(state), sizeof(netopt_state_t));
+}
+
+void radio_setFrequency(uint8_t frequency)
+{
+    radio_vars.state = RADIOSTATE_SETTING_FREQUENCY;
+
+    uint16_t chan = frequency;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_CHANNEL, &(chan), sizeof(chan));
+
+    radio_vars.state = RADIOSTATE_FREQUENCY_SET;
+}
+
+void radio_rfOn(void)
+{
+    netopt_state_t state = NETOPT_STATE_STANDBY;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_STATE, &(state), sizeof(netopt_state_t));
+}
+
+void radio_rfOff(void)
+{
+    netopt_state_t state = NETOPT_STATE_STANDBY;
+
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_STATE, &(state), sizeof(netopt_state_t));
+    leds_radio_off();
+
+    radio_vars.state = RADIOSTATE_RFOFF;
+}
+
+void radio_loadPacket(uint8_t *packet, uint16_t len)
+{
+    DEBUG("OW radio_loadPacket\n");
+    /* NETOPT_PRELOADING w as enabled in the init function so this
+       simply loads data to the device buffer */
+    iolist_t pkt = {
+        .iol_base = (void *)packet,
+        .iol_len  = (size_t)(len - 2),   /* FCS is written by driver */
+    };
+    if (radio_vars.dev->driver->send(radio_vars.dev, &pkt) < 0) {
+        DEBUG("OW couldn't load pkt\n");
+    }
+
+    radio_vars.state = RADIOSTATE_PACKET_LOADED;
+}
+
+void radio_txEnable(void)
+{
+    DEBUG("radio_txEnable\n");
+
+    radio_vars.state = RADIOSTATE_ENABLING_TX;
+
+    leds_radio_on();
+
+    radio_vars.state = RADIOSTATE_TX_ENABLED;
+}
+void radio_txNow(void)
+{
+
+    PORT_TIMER_WIDTH val;
+
+    netopt_state_t state = NETOPT_STATE_TX;
+
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_STATE, &state, sizeof(netopt_state_t));
+
+    if (radio_vars.startFrame_cb != NULL) {
+        val = sctimer_readCounter();
+        radio_vars.startFrame_cb(val);
+    }
+}
+
+void radio_rxEnable(void)
+{
+    DEBUG("radio_rxEnable\n");
+
+    radio_vars.state = RADIOSTATE_ENABLING_RX;
+
+    leds_radio_on();
+
+    netopt_state_t state = NETOPT_STATE_IDLE;
+    radio_vars.dev->driver->set(radio_vars.dev, NETOPT_STATE, &(state), sizeof(netopt_state_t));
+
+    radio_vars.state = RADIOSTATE_LISTENING;
+}
+void radio_rxNow(void)
+{
+    /* nothing to do */
+}
+void radio_getReceivedFrame(uint8_t *bufRead,
+                            uint8_t *lenRead,
+                            uint8_t maxBufLen,
+                            int8_t *rssi,
+                            uint8_t *lqi,
+                            bool *crc)
+{
+    netdev_ieee802154_rx_info_t rx_info;
+
+    int bytes_expected = radio_vars.dev->driver->recv(radio_vars.dev, bufRead, maxBufLen, &rx_info);
+
+    if (bytes_expected) {
+        netdev_ieee802154_rx_info_t rx_info;
+        DEBUG("ow_netdev: received frame of size %i\n", bytes_expected);
+        int nread = radio_vars.dev->driver->recv(radio_vars.dev, bufRead, bytes_expected, &rx_info);
+        *crc = true;
+        if (nread <= 2) {
+            *crc = false;
+            return;
+        }
+        *lenRead = nread + 2;
+
+        *lqi = 0;
+        *rssi = 0;
+
+        /* TODO: check CRC */
+        *crc = true;
+    }
+    else {
+        *crc = false;
+    }
+}
+
+PORT_TIMER_WIDTH capturedTime = 0u;
+static void _event_cb(netdev_t *dev, netdev_event_t event)
+{
+    if (event == NETDEV_EVENT_ISR) {
+        /* capture the time */
+        debugpins_isr_set();
+        capturedTime = sctimer_readCounter();
+        radio_vars.dev->driver->isr(radio_vars.dev);
+        debugpins_isr_clr();
+    }
+    else {
+        DEBUG("ow_netdev: event triggered -> %i\n", event);
+        assert( capturedTime != 0u);
+        switch (event) {
+            case NETDEV_EVENT_RX_STARTED:
+                radio_vars.startFrame_cb(capturedTime);
+                DEBUG("NETDEV_EVENT_RX_STARTED\n");
+                break;
+            case NETDEV_EVENT_RX_COMPLETE:
+                radio_vars.endFrame_cb(capturedTime);
+                DEBUG("NETDEV_EVENT_RX_COMPLETE\n");
+                break;
+            case NETDEV_EVENT_TX_COMPLETE:
+                radio_vars.endFrame_cb(capturedTime);
+                DEBUG("NETDEV_EVENT_TX_COMPLETE\n");
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/pkg/openwsn/contrib/sctimer.c
+++ b/pkg/openwsn/contrib/sctimer.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2017 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ *
+ * @author      Tengfei Chang <tengfei.chang@gmail.com>, July 2012
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>, July 2017
+ *
+ * @}
+ */
+
+#include "board_info.h"
+#include "sctimer.h"
+
+#include "periph/rtt.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+// TODO this is toooo hardware dependant
+// ========================== define ==========================================
+// 511 seconds @ 32768Hz clock
+#define TIMERLOOP_THRESHOLD          0xffffff
+// as 16kHz is used, the upper timer overflows when timer research to 0x7fffffff
+#define OVERFLOW_THRESHOLD           0x7fffffff
+#define MINIMUM_COMPAREVALE_ADVANCE  10
+
+// ========================== variable ========================================
+
+typedef struct {
+    sctimer_cbt sctimer_cb;
+    bool convert;
+    bool convertUnlock;
+} sctimer_vars_t;
+
+sctimer_vars_t sctimer_vars;
+
+static void sctimer_isr_internal(void *arg);
+
+
+/**
+   \brief Initialization sctimer.
+ */
+void sctimer_init(void)
+{
+    DEBUG("sctimer_init\n");
+    memset(&sctimer_vars, 0, sizeof(sctimer_vars_t));
+    rtt_init();
+}
+
+void sctimer_set_callback(sctimer_cbt cb)
+{
+    DEBUG("sctimer_set_callback\n");
+    sctimer_vars.sctimer_cb = cb;
+}
+
+/**
+   \brief set compare interrupt
+ */
+void sctimer_setCompare(uint32_t val)
+{
+    DEBUG("sctimer_setCompare\n");
+    // enable the compare interrupt
+    /*
+       if (current Timer counter - val < TIMERLOOP_THRESHOLD){
+        // the timer is already late, schedule the ISR right now manually.
+        triggerTimerInterrupt();
+       } else {
+        if (val - current Timer counter < MINIMUM_COMPAREVALE_ADVANCE){}
+            // there is hardware limitation to schedule the timer within TIMERTHRESHOLD ticks
+            // schedule ISR right now manually
+            triggerTimerInterrupt();
+        } else {
+            // schedule the timer at val
+            setCompareValue(val);
+        }
+       }
+     */
+    // make sure convert flag conly toggle once within one overflow period
+    if (val > OVERFLOW_THRESHOLD && sctimer_vars.convertUnlock) {
+        // toggle convert
+        if (sctimer_vars.convert) {
+            sctimer_vars.convert = true;
+        }
+        else {
+            sctimer_vars.convert = false;
+        }
+        sctimer_vars.convertUnlock = false;
+    }
+
+    // un lock the changes of convert flag
+    if (val > TIMERLOOP_THRESHOLD && val < 2 * TIMERLOOP_THRESHOLD) {
+        sctimer_vars.convertUnlock = true;
+    }
+
+    // update value to be compared according to timer condition
+    if (val <= OVERFLOW_THRESHOLD) {
+        if (sctimer_vars.convert) {
+            val = val >> 1;
+            val |= 0x80000000;
+        }
+        else {
+            val = val >> 1;
+        }
+    }
+    else {
+        if (sctimer_vars.convert) {
+            val = val >> 1;
+        }
+        else {
+            val = val >> 1;
+            val |= 0x80000000;
+        }
+    }
+    DISABLE_INTERRUPTS();
+    if (rtt_get_counter() - val < TIMERLOOP_THRESHOLD) {
+        // the timer is already late, schedule the ISR cb function manually
+        // It is not executed in interrupt context but won't be
+        // interrupted as interrupts were disabled
+        rtt_set_alarm(rtt_get_counter() + 2, sctimer_isr_internal, NULL);
+    }
+    else {
+        if (val - rtt_get_counter() < MINIMUM_COMPAREVALE_ADVANCE) {
+            //sctimer_isr_internal(NULL);
+            rtt_set_alarm(rtt_get_counter() + 2, sctimer_isr_internal, NULL);
+        }
+        else {
+            // schedule the timer at val
+            rtt_set_alarm(val, sctimer_isr_internal, NULL);
+        }
+    }
+
+    ENABLE_INTERRUPTS();
+}
+
+uint32_t sctimer_readCounter(void)
+{
+    uint32_t counter;
+
+    counter = rtt_get_counter();
+    counter = counter & OVERFLOW_THRESHOLD;
+    counter = counter << 1;
+    DEBUG("sctimer_readCounter:%" PRIu32 "\n", counter);
+    return counter;
+}
+
+void sctimer_enable(void)
+{
+    DEBUG("sctimer_enable\n");
+    rtt_poweron();
+}
+
+void sctimer_disable(void)
+{
+    DEBUG("sctimer_disable\n");
+    rtt_poweroff();
+}
+
+void sctimer_isr_internal(void *arg)
+{
+    (void)arg;
+    DEBUG("sctimer_isr_internal\n");
+    // debugpins_isr_set();
+    if (sctimer_vars.sctimer_cb != NULL) {
+        sctimer_vars.sctimer_cb();
+    }
+}

--- a/pkg/openwsn/contrib/uart_ow.c
+++ b/pkg/openwsn/contrib/uart_ow.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2018 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ * @brief       RIOT adaption-specific definition of the "uart" bsp module
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "uart_ow.h"
+#include "board_ow.h"
+#include "periph/uart.h"
+#include "periph/timer.h"
+
+/**
+ * @brief   We use a periph timer to generate an interrupt after one byte has
+ *          been transmitted, as OpenWSN's openserial tool requires this. Be aware
+ *          that some platforms might use Timer_DEV(1) for xtimer
+ */
+#ifndef RIOT_PERIPH_TIMER
+#define RIOT_PERIPH_TIMER TIMER_DEV(1)
+#endif
+
+typedef struct {
+    uart_tx_cbt txCb;
+    uart_rx_cbt rxCb;
+} uart_vars_t;
+
+uart_vars_t uart_vars;
+
+
+volatile uint8_t uart_rx_byte;
+
+static void _riot_rx_cb(void *arg, uint8_t data)
+{
+    (void)arg;
+    uart_rx_byte = data;
+    uart_vars.rxCb();
+}
+
+static void _riot_tx_cb(void *arg, int count)
+{
+    (void)arg;
+    (void)count;
+    uart_vars.txCb();
+}
+
+void uart_init_ow(void)
+{
+
+    uart_init(UART_DEV(1), 115200, (uart_rx_cb_t) _riot_rx_cb, NULL);
+    timer_init(RIOT_PERIPH_TIMER, 1000000, _riot_tx_cb, NULL); /* TODO make timer speed generic*/
+}
+
+void uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb)
+{
+    uart_vars.txCb = txCb;
+    uart_vars.rxCb = rxCb;
+}
+
+void uart_enableInterrupts(void)
+{
+
+}
+
+void uart_disableInterrupts(void)
+{
+
+}
+
+void uart_clearRxInterrupts(void)
+{
+
+}
+
+void uart_clearTxInterrupts(void)
+{
+
+}
+
+void uart_writeByte(uint8_t byteToWrite)
+{
+    uart_write(UART_DEV(1), &byteToWrite, 1);
+    timer_set(RIOT_PERIPH_TIMER, 0, 10); /* TODO check offset */
+    timer_start(RIOT_PERIPH_TIMER);
+}
+
+uint8_t uart_readByte(void)
+{
+    return uart_rx_byte;
+}

--- a/pkg/openwsn/doc.txt
+++ b/pkg/openwsn/doc.txt
@@ -1,0 +1,114 @@
+/**
+ * @defgroup pkg_openwsn   OpenWSN network stack
+ * @ingroup  pkg
+ * @ingroup  net
+ * @brief    Provides a RIOT adaption of the OpenWSN network stack
+ * @see      https://github.com/openwsn-berkeley/openwsn-fw
+ *
+ *
+ * # OpenWSN RIOT Port
+ * This implementation integrates the [OpenWSN](https://github.com/openwsn-berkeley/openwsn-fw)
+ * full stack (UDP, IPv6, RPL, 6TiSCH) into RIOT. Basically, we provide a new RIOT "board" to the
+ * OpenWSN software. In this way we connect RIOT's hardware abstraction to OpenWSN's interfaces.
+ * Furthermore, we make use of the simple scheduling mechanism in OpenWSN which we run in a RIOT
+ * thread with second highest priority after the radio thread.
+ *
+ * ## Hardware abstraction implementation
+ * Following, we share some insights about the implementation of selected hardware modules.
+ *
+ * ### sctimer
+ * The `sctimer` ("single compare timer") in OpenWSN is the lowest timer abstraction which is used
+ * by the higher layer timer module `opentimers`. In the end, it is responsible for scheduling on
+ * the MAC layer. To enable low power energy modes, this timer usually incorporates the RTC (real
+ * time clock) module of micro controllers. That's why we adapt it to RIOT's `periph_rtt` module.
+ * Upper layers assume the sctimer to run at a frequency of 32768 Hz.
+ *
+ * The `sctimer` is responsible to set the next interrupt. Under circumstances, it may happen, that
+ * the next interrupt to schedule is already late, compared to the current time. In this case,
+ * timer implementations in OpenWSN directly trigger a hardware interrupt. For a generic solution
+ * in the RIOT adaptation, we set it to `now + 2`. This might not work so well on different platforms!
+ *
+ * ### radio
+ * The radio adaptation runs in an own thread with the highest priority (`THREAD_PRIORITY_MAIN - 4`).
+ * It maps to RIOT's `netdev` API. It is worth noting that hardware MAC layer features such as CSMA/
+ * CA, ACK handling and retransmissions are handled by OpenWSN which is why we disabled these
+ * parameters during driver initialization. As we use radio devices in Extended Operation Mode in RIOT (if
+ * applicable), this mode needs to be disabled. Furthermore, this might require slight adaptions to
+ * state handling of the driver which we provide for the Atmel AT86RF2XX in form of a patch file.
+ * The PAN ID used is `0xcafe` by default. This can be overwritten with a variable `PANID_DEFINED`.
+ *
+ * ### uart
+ * In RIOT, the first configured UART device is mapped to STDIO in most cases. In OpenWSN however,
+ * the `openserial` tool uses UART to feed external software running on a host computer [compare
+ * here](https://github.com/openwsn-berkeley/openwsn-sw) such as the `Openvisualizer` for example.
+ * To enable use of these tools, we also provide a UART adaptation which we map to the second UART
+ * device in RIOT. In this way we provide STDIO and `openserial` in parallel. Please note that it is
+ * not intended to provide official support for `openserial` here. It is just meant as experimental support.
+ *
+ * The UART abstraction differs from that in RIOT. More specifically, it makes use of hardware
+ * interrupts after one byte was written to the bus, to call previously registered callback
+ * functions. As we don't have a parameter to enable these interrupts in RIOT's generic hardware
+ * abstraction, we initialize a `periph_timer` which fires shortly after a byte was written. Please
+ * note that this **may** collide with the peripheral configuration for `xtimer` in RIOT. Also,
+ * timing behavior hasn't really been tested. The parameter `RIOT_PERIPH_TIMER` can be used to
+ * change the peripheral timer to use here.
+ *
+ * ## Tested Platforms and Pin configurations
+ * So far, the only tested platforms are the `iotlab-m3` and `nucleo-f103` nodes which are both
+ * equipped with an STM32F1 MCU. Currently, the `sctimer` implementation is in really hacky state
+ * and will probably not work with other MCUs.
+ *
+ * ### radio
+ * If you're using a platform that has a radio on board, the pin configuration is provided by that
+ * board. This is the default procedure. STM Nucleo boards for example, they don't provide on board
+ * radios. Here we made use of an external Atmel AT86RF233
+ * [Openlabs](http://openlabs.co/OSHW/Raspberry-Pi-802.15.4-radio) radio which we connected via jumper cables.
+ * One working configuration can be found in the Makefile of the test application. In addition to that, the
+ * Makefile needs to include that module by `USEMODULE += at86rf233`.
+ *
+ * ### ledpins & debugpins
+ * The OpenWSN software provides different hooks all over the stack to toggle different LEDs as
+ * well as debug pins to examine state and scheduling of a node. We added default configuration
+ * files for both. The LED configuration maps to RIOTs `LEDX_PIN` definitions, if available. Be
+ * aware that Nucleo boards share the LED line with SPI, which is why it shouldn't be applied here.
+ * The default configuration can be overwritten by setting `OPENWSN_LEDPINS_DEFAULT` in
+ * the form of `ledpins_config_t`. The debugpins work similarly by setting
+ * `OPENWSN_DEBUGPINS_BOARD` in the form of `debugpins_config_t`. However, the default setup is
+ * somehow practical for Nuleo pinouts.
+ *
+ *
+ * ## Testing and debugging
+ * Here, we simply list some items which are helpful to explore the functionality of OpenWSN:
+ * - LED pins and debug pins as mentioned above in combination with a logic analyzer. The expected
+ * behavior is described in the [OpenWSN wiki](https://openwsn.atlassian.net/wiki/spaces/OW/pages/688257/Schedules).
+ * - The provided test application provides a UDP client and server. If the UDP server is able to
+ * receive packets, we consider the mechanism working correctly.
+ * - With disabled channel hopping (`CFLAGS=-DOW_RIOT_SINGLE_CHANNEL=26`) it is rather simple to
+ * sniff transmitted packets by using a single channel sniffer. Either use a 802.15.4 capable
+ * board with RIOT support and follow
+ * [these instructions](https://github.com/RIOT-OS/applications/blob/master/sniffer/tools/README.md).
+ * Alternatively use a Raspberry Pi with an external radio
+ * such as Openlabs and incorporate Linux WPAN tools. In addition to that, there's also other
+ * hardware such as the ATUSB IEEE 802.15.4 USB Adapter which can directly be used on your Linux
+ * computer with WPAN tools installed. If you conduct your experiments on the IoT-LAB testbed you
+ * might want to use a [sniffer profile](https://www.iot-lab.info/tutorials/radio-sniffer).
+ * - To explore the channel hopping mechanism there are rather expensive multi-channel sniffers
+ * such as the BeamLogic 802.15.4 Site Analyzer that can sniff all channels simultaneously.
+ * Alternatively you can set up multiple separate sniffer devices locally or make use of the
+ * `sniffer_aggregator` on the IoT-LAB testbed.
+ * - There is a collection of external tools to interact with the IoT nodes from a host computer
+ * via `openserial`. Please refer to the
+ * [OpenWSN software](https://github.com/openwsn-berkeley/openwsn-sw) repository for further information.
+ *
+ * ## Open issues and ToDos
+ * - `sctimer` is a dirty hack and won't work for other platforms right now. Clean up and find a
+ * generic adaption for different MCUs with different speeds and timer widths. This goes along
+ * with cleaning the "board_ow.h" file which partly contains relevant definitions. Is it possible
+ * to find a better way to directly trigger an interrupt, rather than using the timer to fire in
+ * `now+2` ticks?
+ * - The UART wrapper uses a peripheral timer to fake an interrupt after one byte has been sent.
+ * Find another way to do this **or** find a better location for applying a RIOT timer device to
+ * it.
+ * - Modularize the build. Make `ledpins`, `debugpins` and `uart` optional.
+ * - Remove `WERROR = 0` from the application Makefile once all warnings in OpenWSN have been fixed.
+ * /

--- a/pkg/openwsn/include/board_info.h
+++ b/pkg/openwsn/include/board_info.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2017 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ *
+ * @author      Thomas Watteyne <watteyne@eecs.berkeley.edu>, February 2012
+ * @author      Tengfei Chang <tengfei.chang@gmail.com>, July 2012
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>, July 2017
+ *
+ * @}
+ */
+
+#ifndef __BOARD_INFO_H
+#define __BOARD_INFO_H
+
+#include "stdint.h"
+#include "string.h"
+#include "cpu.h"
+
+//=========================== defines =========================================
+
+#define INTERRUPT_DECLARATION(); //no declaration
+#define DISABLE_INTERRUPTS()    irq_disable();
+#define ENABLE_INTERRUPTS()     irq_enable();
+
+//===== timer
+
+#define PORT_TIMER_WIDTH                    uint32_t
+#define PORT_RADIOTIMER_WIDTH               uint32_t
+
+#define PORT_SIGNED_INT_WIDTH               int32_t
+#define PORT_TICS_PER_MS                    32
+#define SCHEDULER_WAKEUP()                  //EXTI->SWIER |= EXTI_Line1;
+#define SCHEDULER_ENABLE_INTERRUPT()        //enable in board use EXTI_Line1
+
+//===== pinout
+
+// [PA.2] radio SLP_TR_CNTL
+#define PORT_PIN_RADIO_SLP_TR_CNTL_HIGH()       //GPIOA->ODR |= (1<<2);
+#define PORT_PIN_RADIO_SLP_TR_CNTL_LOW()        //GPIOA->ODR &= ~(1<<2);
+// radio reset line
+// radio /RST
+#define PORT_PIN_RADIO_RESET_HIGH()         //GPIOC->ODR |= 0X0040;// nothing
+#define PORT_PIN_RADIO_RESET_LOW()          //GPIOC->ODR &= ~0X0040;// nothing
+//#define PORT_PIN_RADIO_RESET_LOW()            GPIOC->ODR &= ~(1<<1);
+
+// TODO: CHECK TIMINGS!
+//===== IEEE802154E timing
+// time-slot related
+#define PORT_TsSlotDuration                 491     // counter counts one extra count, see datasheet
+// execution speed related
+#define PORT_maxTxDataPrepare               66      // 2014us (measured 746us)
+#define PORT_maxRxAckPrepare                20      //  305us (measured  83us)
+#define PORT_maxRxDataPrepare               33      // 1007us (measured  84us)
+#define PORT_maxTxAckPrepare                30      //  305us (measured 219us)
+// radio speed related
+#define PORT_delayTx                        10      //  214us (measured 219us)
+#define PORT_delayRx                        0       //    0us (can not measure)
+// radio watchdog
+
+//===== adaptive_sync accuracy
+
+#define SYNC_ACCURACY                       2     // ticks
+
+//=========================== variables =======================================
+
+static const uint8_t rreg_uriquery[] = "h=ucb";
+static const uint8_t infoBoardname[] = "riot-os";
+static const uint8_t infouCName[] = "various";
+static const uint8_t infoRadioName[] = "riot-netdev";
+
+//=========================== prototypes ======================================
+
+//=========================== public ==========================================
+
+//=========================== private =========================================
+
+#endif

--- a/pkg/openwsn/include/board_ow.h
+++ b/pkg/openwsn/include/board_ow.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2017 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ *
+ * @author      Thomas Watteyne <watteyne@eecs.berkeley.edu>, February 2012
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>, July 2017
+ *
+ * @}
+ */
+
+#ifndef __BOARD_OW_H
+#define __BOARD_OW_H
+
+#include "board_info.h"
+#include "toolchain_defs.h"
+
+typedef enum {
+    DO_NOT_KICK_SCHEDULER,
+    KICK_SCHEDULER,
+} kick_scheduler_t;
+
+void board_init_ow(void);
+void board_sleep(void);
+void board_reset(void);
+
+#endif

--- a/pkg/openwsn/include/debugpins_riot.h
+++ b/pkg/openwsn/include/debugpins_riot.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ * @brief       Provides an adaption of OpenWSN debug pin handling
+ *              to RIOTs handling of GPIOs.
+ *
+ * @author      Michael Frey <michael.frey@msasafety.com>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#ifndef __DEBUGPINS_RIOT_H
+#define __DEBUGPINS_RIOT_H
+
+#include "periph/gpio.h"
+
+/**
+ * Holds a configuration of debug pins for debugging OpenWSN
+ */
+typedef struct debugpins_config {
+    gpio_t frame;       /**< debug pin for frames */
+    gpio_t slot;        /**< debug pin for slots  */
+    gpio_t fsm;         /**< debug pin for fsm */
+    gpio_t task;        /**< debug pin for tasks */
+    gpio_t isr;         /**< debug pin for interrupt service routines */
+    gpio_t radio;       /**< debug pin for the radio */
+} debugpins_config_t;
+
+
+/*
+ * Set default configuration parameters for debugpins (tested on Nucleo-F103)
+ */
+#ifndef OPENWSN_DEBUGPIN_FRAME
+#define OPENWSN_DEBUGPIN_FRAME          (GPIO_PIN(0, 0))
+#endif
+#ifndef OPENWSN_DEBUGPIN_SLOT
+#define OPENWSN_DEBUGPIN_SLOT           (GPIO_PIN(0, 1))
+#endif
+#ifndef OPENWSN_DEBUGPIN_FSM
+#define OPENWSN_DEBUGPIN_FSM            (GPIO_PIN(0, 4))
+#endif
+#ifndef OPENWSN_DEBUGPIN_TASK
+#define OPENWSN_DEBUGPIN_TASK           (GPIO_PIN(1, 0))
+#endif
+#ifndef OPENWSN_DEBUGPIN_ISR
+#define OPENWSN_DEBUGPIN_ISR            (GPIO_PIN(2, 1))
+#endif
+#ifndef OPENWSN_DEBUGPIN_RADIO
+#define OPENWSN_DEBUGPIN_RADIO          (GPIO_PIN(2, 0))
+#endif
+
+#define OPENWSN_DEBUGPINS_DEFAULT    { .frame = OPENWSN_DEBUGPIN_FRAME, \
+                                       .slot = OPENWSN_DEBUGPIN_SLOT, \
+                                       .fsm = OPENWSN_DEBUGPIN_FSM,  \
+                                       .task = OPENWSN_DEBUGPIN_TASK, \
+                                       .isr = OPENWSN_DEBUGPIN_ISR,  \
+                                       .radio = OPENWSN_DEBUGPIN_RADIO }
+
+
+static const debugpins_config_t openwsn_debugpins_params[] =
+{
+#ifdef OPENWSN_DEBUGPINS_BOARD
+    OPENWSN_DEBUGPINS_BOARD,
+#else
+    OPENWSN_DEBUGPINS_DEFAULT,
+#endif
+};
+
+void debugpins_riot_init(const debugpins_config_t *user_config);
+
+#endif /* __DEBUGPINS_RIOT_H */

--- a/pkg/openwsn/include/ledpins_riot.h
+++ b/pkg/openwsn/include/ledpins_riot.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2017 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ * @brief       Provides an adaption of OpenWSN led handling
+ *              to RIOTs handling of LEDs and/or GPIOs
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+#ifndef __LEDPINS_RIOT_H
+#define __LEDPINS_RIOT_H
+
+
+#include "board.h"
+#include "periph/gpio.h"
+
+/**
+ * Holds a configuration of LED pins for debugging OpenWSN
+ */
+typedef struct ledpins_config {
+    gpio_t error;
+    gpio_t sync;
+    gpio_t radio;
+    gpio_t user;
+} ledpins_config_t;
+
+
+/*
+ * Set default configuration parameters for debugpins (tested on Nucleo-F103)
+ * On Nucleo boards the LED pin is shared with SPI -> don't use it!
+ */
+#if defined (LED0_PIN) && !defined(BOARD_NUCLEO_F103)
+#define OPENWSN_LEDPIN_ERROR            LED0_PIN
+#else
+#define OPENWSN_LEDPIN_ERROR            (GPIO_PIN(2, 8))
+#endif
+
+#ifdef LED1_PIN
+#define OPENWSN_LEDPIN_SYNC             LED1_PIN
+#else
+#define OPENWSN_LEDPIN_SYNC             (GPIO_PIN(2, 6))
+#endif
+
+#ifdef LED2_PIN
+#define OPENWSN_LEDPIN_RADIO            LED2_PIN
+#else
+#define OPENWSN_LEDPIN_RADIO            (GPIO_PIN(2, 5))
+#endif
+
+#ifdef LED3_PIN
+#define OPENWSN_LEDPIN_USER             LED3_PIN
+#else
+#define OPENWSN_LEDPIN_USER             (GPIO_PIN(0, 12))
+#endif
+
+
+
+#define OPENWSN_LEDPINS_DEFAULT    { .error = OPENWSN_LEDPIN_ERROR, \
+                                     .sync = OPENWSN_LEDPIN_SYNC, \
+                                     .radio = OPENWSN_LEDPIN_RADIO, \
+                                     .user = OPENWSN_LEDPIN_USER  }
+
+
+static const ledpins_config_t openwsn_ledpins_params[] =
+{
+#ifdef OPENWSN_DEBUGPINS_BOARD
+    OPENWSN_LEDPINS_BOARD,
+#else
+    OPENWSN_LEDPINS_DEFAULT,
+#endif
+};
+
+void ledpins_riot_init(const ledpins_config_t *user_config);
+
+#endif /* __LEDPINS_RIOT_H */

--- a/pkg/openwsn/include/openwsn.h
+++ b/pkg/openwsn/include/openwsn.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    pkg_openwsn    OpenWSN
+ * @ingroup     pkg
+ * @brief       An IoT Network Stack Umplementing 6TiSCH
+ * @see         https://github.com/openwsn-berkeley/openwsn-fw
+ *
+ *
+ * @{
+ *
+ * @file
+ * @brief   OpenWSN bootstrap definitions
+ *
+ * @author  Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ */
+#ifndef OPENWSN_H
+#define OPENWSN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OW_SCHED_MSG_TYPE_EVENT    0x667    // TODO ADAPT!!!
+#define OW_NETDEV_MSG_TYPE_EVENT   0x666    // TODO ADAPT!!!
+
+
+/**
+ * @brief   Initializes the OpenWSN stack.
+ */
+void openwsn_bootstrap(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OPENWSN_H */
+/** @} */

--- a/pkg/openwsn/include/uart_ow.h
+++ b/pkg/openwsn/include/uart_ow.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_openwsn
+ * @{
+ *
+ * @file
+ *
+ * @author      Thomas Watteyne <watteyne@eecs.berkeley.edu>, February 2012
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>, July 2018
+ *
+ * @}
+ */
+
+#ifndef __UART_OW_H
+#define __UART_OW_H
+
+#include "stdint.h"
+#include "board_ow.h"
+
+typedef enum {
+    UART_EVENT_THRES,
+    UART_EVENT_OVERFLOW,
+} uart_event_t;
+
+typedef void (*uart_tx_cbt)(void);
+typedef void (*uart_rx_cbt)(void);
+
+void    uart_init_ow(void);
+void    uart_setCallbacks(uart_tx_cbt txCb, uart_rx_cbt rxCb);
+void    uart_enableInterrupts(void);
+void    uart_disableInterrupts(void);
+void    uart_clearRxInterrupts(void);
+void    uart_clearTxInterrupts(void);
+void    uart_writeByte(uint8_t byteToWrite);
+uint8_t uart_readByte(void);
+
+#endif

--- a/pkg/openwsn/patches/0001-Add-Makefiles.patch
+++ b/pkg/openwsn/patches/0001-Add-Makefiles.patch
@@ -1,0 +1,132 @@
+From 0c967954f444044cbc5c51d25230a5ca6cfa1383 Mon Sep 17 00:00:00 2001
+From: PeterKietzmann <peter.kietzmann@haw-hamburg.de>
+Date: Thu, 8 Feb 2018 10:19:38 +0100
+Subject: [PATCH 1/6] Add Makefiles
+
+---
+ Makefile                        |  7 +++++++
+ drivers/common/Makefile         |  3 +++
+ kernel/openos/Makefile          |  3 +++
+ openstack/02a-MAClow/Makefile   |  3 +++
+ openstack/02b-MAChigh/Makefile  |  3 +++
+ openstack/03a-IPHC/Makefile     |  3 +++
+ openstack/03b-IPv6/Makefile     |  3 +++
+ openstack/04-TRAN/Makefile      |  3 +++
+ openstack/Makefile              | 10 ++++++++++
+ openstack/cross-layers/Makefile |  3 +++
+ 10 files changed, 41 insertions(+)
+ create mode 100644 Makefile
+ create mode 100644 drivers/common/Makefile
+ create mode 100644 kernel/openos/Makefile
+ create mode 100644 openstack/02a-MAClow/Makefile
+ create mode 100644 openstack/02b-MAChigh/Makefile
+ create mode 100644 openstack/03a-IPHC/Makefile
+ create mode 100644 openstack/03b-IPv6/Makefile
+ create mode 100644 openstack/04-TRAN/Makefile
+ create mode 100644 openstack/Makefile
+ create mode 100644 openstack/cross-layers/Makefile
+
+diff --git a/Makefile b/Makefile
+new file mode 100644
+index 00000000..fb6d84f4
+--- /dev/null
++++ b/Makefile
+@@ -0,0 +1,7 @@
++MODULE := openwsn
++
++DIRS += $(CURDIR)/openstack \
++	$(CURDIR)/drivers/common \
++	$(CURDIR)/kernel/openos \
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/drivers/common/Makefile b/drivers/common/Makefile
+new file mode 100644
+index 00000000..1b7154c5
+--- /dev/null
++++ b/drivers/common/Makefile
+@@ -0,0 +1,3 @@
++MODULE := openwsn_drivers
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/kernel/openos/Makefile b/kernel/openos/Makefile
+new file mode 100644
+index 00000000..01719b0c
+--- /dev/null
++++ b/kernel/openos/Makefile
+@@ -0,0 +1,3 @@
++MODULE := openwsn_scheduler
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/openstack/02a-MAClow/Makefile b/openstack/02a-MAClow/Makefile
+new file mode 100644
+index 00000000..9f8053e5
+--- /dev/null
++++ b/openstack/02a-MAClow/Makefile
+@@ -0,0 +1,3 @@
++MODULE := openwsn_mac_low
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/openstack/02b-MAChigh/Makefile b/openstack/02b-MAChigh/Makefile
+new file mode 100644
+index 00000000..8bfc2e79
+--- /dev/null
++++ b/openstack/02b-MAChigh/Makefile
+@@ -0,0 +1,3 @@
++MODULE := openwsn_mac_high
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/openstack/03a-IPHC/Makefile b/openstack/03a-IPHC/Makefile
+new file mode 100644
+index 00000000..13cd664c
+--- /dev/null
++++ b/openstack/03a-IPHC/Makefile
+@@ -0,0 +1,3 @@
++MODULE := openwsn_iphc
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/openstack/03b-IPv6/Makefile b/openstack/03b-IPv6/Makefile
+new file mode 100644
+index 00000000..ee7d6368
+--- /dev/null
++++ b/openstack/03b-IPv6/Makefile
+@@ -0,0 +1,3 @@
++MODULE := openwsn_ipv6
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/openstack/04-TRAN/Makefile b/openstack/04-TRAN/Makefile
+new file mode 100644
+index 00000000..336010cb
+--- /dev/null
++++ b/openstack/04-TRAN/Makefile
+@@ -0,0 +1,3 @@
++MODULE := openwsn_transport
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/openstack/Makefile b/openstack/Makefile
+new file mode 100644
+index 00000000..aac34170
+--- /dev/null
++++ b/openstack/Makefile
+@@ -0,0 +1,10 @@
++MODULE := openwsn_openstack
++
++DIRS +=02a-MAClow
++DIRS +=02b-MAChigh
++DIRS +=03a-IPHC
++DIRS +=03b-IPv6
++DIRS +=04-TRAN
++DIRS +=cross-layers
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/openstack/cross-layers/Makefile b/openstack/cross-layers/Makefile
+new file mode 100644
+index 00000000..21a9f4ed
+--- /dev/null
++++ b/openstack/cross-layers/Makefile
+@@ -0,0 +1,3 @@
++MODULE := openwsn_crosslayers
++
++include $(RIOTBASE)/Makefile.base
+-- 
+2.14.1
+

--- a/pkg/openwsn/patches/0002-Rename-includes-for-RIOT-OpenWSN-board.patch
+++ b/pkg/openwsn/patches/0002-Rename-includes-for-RIOT-OpenWSN-board.patch
@@ -1,0 +1,53 @@
+From d5af70bd8dbf392907410dcca17a84ae9e4f4380 Mon Sep 17 00:00:00 2001
+From: PeterKietzmann <peter.kietzmann@haw-hamburg.de>
+Date: Thu, 8 Feb 2018 10:23:00 +0100
+Subject: [PATCH 2/6] Rename includes for RIOT-OpenWSN board
+
+---
+ bsp/boards/radio.h        | 2 +-
+ bsp/boards/sctimer.h      | 2 +-
+ kernel/openos/scheduler.c | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/bsp/boards/radio.h b/bsp/boards/radio.h
+index 93cd0d99..495284e3 100644
+--- a/bsp/boards/radio.h
++++ b/bsp/boards/radio.h
+@@ -12,7 +12,7 @@
+ \author Thomas Watteyne <watteyne@eecs.berkeley.edu>, February 2012.
+ */
+ 
+-#include "board.h"
++#include "board_ow.h"
+ 
+ //=========================== define ==========================================
+ 
+diff --git a/bsp/boards/sctimer.h b/bsp/boards/sctimer.h
+index 668496cb..979a13d3 100644
+--- a/bsp/boards/sctimer.h
++++ b/bsp/boards/sctimer.h
+@@ -13,7 +13,7 @@
+ */
+ 
+ #include "stdint.h"
+-#include "board.h"
++#include "board_ow.h"
+ 
+ //=========================== typedef =========================================
+ 
+diff --git a/kernel/openos/scheduler.c b/kernel/openos/scheduler.c
+index dabea8bd..34ce8ca3 100644
+--- a/kernel/openos/scheduler.c
++++ b/kernel/openos/scheduler.c
+@@ -6,7 +6,7 @@
+ 
+ #include "opendefs.h"
+ #include "scheduler.h"
+-#include "board.h"
++#include "board_ow.h"
+ #include "debugpins.h"
+ #include "leds.h"
+ 
+-- 
+2.14.1
+

--- a/pkg/openwsn/patches/0003-Comment-out-problematic-includes.patch
+++ b/pkg/openwsn/patches/0003-Comment-out-problematic-includes.patch
@@ -1,0 +1,72 @@
+From 587609720250906a6ae5b6d5bd5c1daca2dd3349 Mon Sep 17 00:00:00 2001
+From: PeterKietzmann <peter.kietzmann@haw-hamburg.de>
+Date: Thu, 8 Feb 2018 11:25:18 +0100
+Subject: [PATCH 3/6] Comment out problematic includes
+
+---
+ openstack/02b-MAChigh/msf.c |  2 +-
+ openstack/04-TRAN/openudp.c | 10 +++++-----
+ openstack/openstack.c       |  6 +++---
+ 3 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/openstack/02b-MAChigh/msf.c b/openstack/02b-MAChigh/msf.c
+index 1b2db4f1..001ec3c9 100644
+--- a/openstack/02b-MAChigh/msf.c
++++ b/openstack/02b-MAChigh/msf.c
+@@ -4,7 +4,7 @@
+ #include "sixtop.h"
+ #include "scheduler.h"
+ #include "schedule.h"
+-#include "openapps.h"
++//#include "openapps.h"
+ #include "openrandom.h"
+ #include "idmanager.h"
+ #include "icmpv6rpl.h"
+diff --git a/openstack/04-TRAN/openudp.c b/openstack/04-TRAN/openudp.c
+index 07b1a309..db262078 100644
+--- a/openstack/04-TRAN/openudp.c
++++ b/openstack/04-TRAN/openudp.c
+@@ -5,11 +5,11 @@
+ #include "forwarding.h"
+ #include "openqueue.h"
+ // applications
+-#include "opencoap.h"
+-#include "uecho.h"
+-#include "uinject.h"
+-#include "userialbridge.h"
+-#include "rrt.h"
++// #include "opencoap.h"
++// #include "uecho.h"
++// #include "uinject.h"
++// #include "userialbridge.h"
++// #include "rrt.h"
+ 
+ //=========================== variables =======================================
+ 
+diff --git a/openstack/openstack.c b/openstack/openstack.c
+index f5656f77..edeaf28c 100644
+--- a/openstack/openstack.c
++++ b/openstack/openstack.c
+@@ -34,7 +34,7 @@
+ //-- 04-TRAN
+ #include "openudp.h"
+ //===== applications
+-#include "openapps.h"
++//#include "openapps.h"
+ 
+ //=========================== variables =======================================
+ 
+@@ -75,8 +75,8 @@ void openstack_init(void) {
+    openudp_init();
+    
+    //===== applications
+-   openapps_init();
+-   
++   //openapps_init();
++   
+    openserial_printInfo(
+       COMPONENT_OPENWSN,ERR_BOOTED,
+       (errorparameter_t)0,
+-- 
+2.14.1
+

--- a/pkg/openwsn/patches/0004-Fix-unrelated-warning.patch
+++ b/pkg/openwsn/patches/0004-Fix-unrelated-warning.patch
@@ -1,0 +1,38 @@
+From f434eb788b91eb247354e95ea2ba096d290fac3e Mon Sep 17 00:00:00 2001
+From: PeterKietzmann <peter.kietzmann@haw-hamburg.de>
+Date: Thu, 8 Feb 2018 12:19:15 +0100
+Subject: [PATCH 4/6] Fix unrelated warning
+
+---
+ drivers/common/openserial.c          | 2 ++
+ openstack/02a-MAClow/adaptive_sync.c | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/drivers/common/openserial.c b/drivers/common/openserial.c
+index ccf0cf2c..ac225455 100644
+--- a/drivers/common/openserial.c
++++ b/drivers/common/openserial.c
+@@ -39,6 +39,8 @@ enum{
+ };
+ //=========================== prototypes ======================================
+ 
++void sniffer_setListeningChannel(uint8_t channel){return;}
++
+ // printing
+ owerror_t openserial_printInfoErrorCritical(
+     char             severity,
+diff --git a/openstack/02a-MAClow/adaptive_sync.c b/openstack/02a-MAClow/adaptive_sync.c
+index 8f772377..7a876e31 100644
+--- a/openstack/02a-MAClow/adaptive_sync.c
++++ b/openstack/02a-MAClow/adaptive_sync.c
+@@ -170,6 +170,7 @@ void adaptive_sync_calculateCompensatedSlots(int16_t timeCorrection) {
+ 
+ Once compensationTimeout == 0, extend or shorten current slot length for one tick.
+ */
++void radiotimer_setPeriod(PORT_RADIOTIMER_WIDTH period);
+ void adaptive_sync_countCompensationTimeout(void) {
+    uint16_t newSlotDuration;
+    
+-- 
+2.14.1
+

--- a/pkg/openwsn/patches/0005-Add-messaging-to-scheduler.patch
+++ b/pkg/openwsn/patches/0005-Add-messaging-to-scheduler.patch
@@ -1,0 +1,109 @@
+From b68ce568ac0d90730c97f375c0ee461855c378b7 Mon Sep 17 00:00:00 2001
+From: PeterKietzmann <peter.kietzmann@haw-hamburg.de>
+Date: Wed, 14 Feb 2018 16:02:25 +0100
+Subject: [PATCH 5/6] Add messaging to scheduler
+
+---
+ kernel/openos/scheduler.c | 62 ++++++++++++++++++++++++++++++-----------------
+ 1 file changed, 40 insertions(+), 22 deletions(-)
+
+diff --git a/kernel/openos/scheduler.c b/kernel/openos/scheduler.c
+index 34ce8ca3..ed30afae 100644
+--- a/kernel/openos/scheduler.c
++++ b/kernel/openos/scheduler.c
+@@ -9,12 +9,15 @@
+ #include "board_ow.h"
+ #include "debugpins.h"
+ #include "leds.h"
++#include "openwsn.h"
+ 
+ //=========================== variables =======================================
+ 
+ scheduler_vars_t scheduler_vars;
+ scheduler_dbg_t  scheduler_dbg;
+ 
++static kernel_pid_t openwsn_sched_pid = KERNEL_PID_UNDEF;
++
+ //=========================== prototypes ======================================
+ 
+ void consumeTask(uint8_t taskId);
+@@ -33,32 +36,43 @@ void scheduler_init(void) {
+ 
+ void scheduler_start(void) {
+    taskList_item_t* pThisTask;
++
++   msg_t msg;
++   msg_t msg_queue[8];
++   /* initialize message queue */
++   msg_init_queue(msg_queue, 8);
++
++   openwsn_sched_pid = thread_getpid();
++
+    while (1) {
+-      while(scheduler_vars.task_list!=NULL) {
+-         // there is still at least one task in the linked-list of tasks
+-         
+-    	 INTERRUPT_DECLARATION();
+-    	 DISABLE_INTERRUPTS();
+-
+-         // the task to execute is the one at the head of the queue
+-         pThisTask                = scheduler_vars.task_list;
+-         
+-         // shift the queue by one task
+-         scheduler_vars.task_list = pThisTask->next;
+-         
+-         ENABLE_INTERRUPTS();
+-
+-         // execute the current task
+-         pThisTask->cb();
+-         
+-         // free up this task container
+-         pThisTask->cb            = NULL;
+-         pThisTask->prio          = TASKPRIO_NONE;
+-         pThisTask->next          = NULL;
+-         scheduler_dbg.numTasksCur--;
++      if(msg.type == OW_SCHED_MSG_TYPE_EVENT) {
++         while(scheduler_vars.task_list!=NULL) {
++            // there is still at least one task in the linked-list of tasks
++
++            INTERRUPT_DECLARATION();
++            DISABLE_INTERRUPTS();
++
++            // the task to execute is the one at the head of the queue
++            pThisTask                = scheduler_vars.task_list;
++
++            // shift the queue by one task
++            scheduler_vars.task_list = pThisTask->next;
++
++            ENABLE_INTERRUPTS();
++
++            // execute the current task
++            pThisTask->cb();
++
++            // free up this task container
++            pThisTask->cb            = NULL;
++            pThisTask->prio          = TASKPRIO_NONE;
++            pThisTask->next          = NULL;
++            scheduler_dbg.numTasksCur--;
++         }
+       }
+       debugpins_task_clr();
+       board_sleep();
++      msg_receive(&msg);
+       debugpins_task_set();                      // IAR should halt here if nothing to do
+    }
+ }
+@@ -105,6 +119,10 @@ void scheduler_start(void) {
+    }
+    
+    ENABLE_INTERRUPTS();
++
++   msg_t msg;
++   msg.type = OW_SCHED_MSG_TYPE_EVENT;
++   msg_send(&msg, openwsn_sched_pid);
+ }
+ 
+ //=========================== private =========================================
+-- 
+2.14.1
+

--- a/pkg/openwsn/patches/0006-Enable-mode-to-disable-channel-hopping.patch
+++ b/pkg/openwsn/patches/0006-Enable-mode-to-disable-channel-hopping.patch
@@ -1,0 +1,57 @@
+From 3923023a6bd724a2481abb9d49beb59a45da29c4 Mon Sep 17 00:00:00 2001
+From: PeterKietzmann <peter.kietzmann@haw-hamburg.de>
+Date: Thu, 15 Feb 2018 15:11:05 +0100
+Subject: [PATCH 6/6] Enable mode to disable channel hopping
+
+---
+ openstack/02a-MAClow/IEEE802154E.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/openstack/02a-MAClow/IEEE802154E.c b/openstack/02a-MAClow/IEEE802154E.c
+index e9efce0f..6c4bcf96 100644
+--- a/openstack/02a-MAClow/IEEE802154E.c
++++ b/openstack/02a-MAClow/IEEE802154E.c
+@@ -115,7 +115,11 @@ void ieee154e_init(void) {
+     memset(&ieee154e_dbg,0,sizeof(ieee154e_dbg_t));
+     
+     // set singleChannel to 0 to enable channel hopping.
+-    ieee154e_vars.singleChannel     = 0;
++#if OW_RIOT_SINGLE_CHANNEL
++    ieee154e_vars.singleChannel     = OW_RIOT_SINGLE_CHANNEL;
++#else
++    ieee154e_vars.singleChannel     = 0; // 0 means channel hopping
++#endif
+     ieee154e_vars.isAckEnabled      = TRUE;
+     ieee154e_vars.isSecurityEnabled = FALSE;
+     ieee154e_vars.slotDuration      = TsSlotDuration;
+@@ -237,13 +241,13 @@ void ieee154e_calculateExpTime(uint16_t max_delay, uint8_t* et_asn) {
+    uint8_t delay_array[5];
+    uint8_t i =0, carry = 0,slot_time = 0;
+    uint16_t sum = 0, delay_in_asn =0;
+-	
++  
+    memset(&delay_array[0],0,5);
+    
+    //Slot time = (Duration in ticks * Time equivalent ticks w.r.t 32kHz) in ms
+    slot_time = (ieee154e_getSlotDuration()*305)/10000;  
+    delay_in_asn = max_delay / slot_time; 
+-		
++    
+    delay_array[0]         = (delay_in_asn     & 0xff);
+    delay_array[1]         = (delay_in_asn/256 & 0xff);
+    
+@@ -540,7 +544,11 @@ port_INLINE void activity_synchronize_newSlot(void) {
+         radio_rfOff();
+         
+         // update record of current channel
++#if OW_RIOT_SINGLE_CHANNEL
++        ieee154e_vars.freq = OW_RIOT_SINGLE_CHANNEL;
++#else
+         ieee154e_vars.freq = (openrandom_get16b()&0x0F) + 11;
++#endif
+         
+         // configure the radio to listen to the default synchronizing channel
+         radio_setFrequency(ieee154e_vars.freq);
+-- 
+2.14.1
+

--- a/tests/openwsn/Makefile
+++ b/tests/openwsn/Makefile
@@ -1,0 +1,30 @@
+APPLICATION = openwsn_test
+include ../Makefile.tests_common
+
+BOARD ?= iotlab-m3
+
+USEPKG += openwsn
+USEMODULE += ipv6_addr
+USEMODULE += ps
+USEMODULE += od_string
+USEMODULE += shell
+USEMODULE += shell_commands
+
+# Enable this to use single channel debugging mode
+#CFLAGS=-DOW_RIOT_SINGLE_CHANNEL=26
+
+CFLAGS += -DDEVELHELP
+WERROR = 0
+
+ifneq (,$(filter nucleo-f103,$(BOARD)))
+    USEMODULE += at86rf233
+
+    CFLAGS += -DAT86RF2XX_PARAM_SPI=SPI_DEV\(0\)
+    CFLAGS += -DAT86RF2XX_PARAM_SPI_CLK=SPI_CLK_5MHZ
+    CFLAGS += -DAT86RF2XX_PARAM_CS=GPIO_PIN\(1,1\)
+    CFLAGS += -DAT86RF2XX_PARAM_INT=GPIO_PIN\(2,4\)
+    CFLAGS += -DAT86RF2XX_PARAM_SLEEP=GPIO_PIN\(1,15\)
+    CFLAGS += -DAT86RF2XX_PARAM_RESET=GPIO_PIN\(1,14\)
+endif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/openwsn/README.md
+++ b/tests/openwsn/README.md
@@ -1,0 +1,44 @@
+# OpenWSN on RIOT
+This test demonstrates the [OpenWSN](https://github.com/openwsn-berkeley/openwsn-fw) full
+stack (UDP, IPv6, RPL, 6TiSCH) running on RIOT. When flashed, it will initialize the stack
+and provide the user with some minimal shell commands to:
+
+- print the own IPv6 address `ifconfig`
+- start a RPL root node `rplroot`
+- change the UDP destination port `udp server start <port>`
+- send a UDP packet `udp send <addr> <port> <data>`
+
+Please note that this port is still in experimental status. For further information about the port,
+currently supported platforms as well as issues, TODOs and debugging mechanisms, please refer to
+the documentation](../../pkg/openwsn/doc.txt).
+
+## Experimental setups
+The following experiments act as a starting point for testing and debugging. Either
+build and flash local nodes or incorporate the [FIT IoT-LAB](https://www.iot-lab.info/)
+Testbed. Please check the ports [documentation](../../pkg/openwsn/doc.txt) for information
+about supported hardware platforms.
+
+### Single-hop w/o channel hopping
+Build this application with `CFLAGS=-DOW_RIOT_SINGLE_CHANNEL=26` to disable channel hopping
+and simply using radio channel 26. Flash it to two boards. Type `ifconfig` to explore the
+link local IPv6 addresses. Then, on one node, enable the RPL DODAG root by `rplroot`.
+After short time, check the IPv6 addresses again with `ifconfig`. You should see that both
+have a global unicast address now.
+
+### Single-hop w/ channel hopping
+Do the same as above but **without** setting the `OW_RIOT_SINGLE_CHANNEL` flag.
+
+### Multi-hop w/o channel hopping
+Build this application with `CFLAGS=-DOW_RIOT_SINGLE_CHANNEL=26` to disable channel hopping.
+Flash it to three boards. On one node, enable the RPL DODAG root by `rplroot`. After
+short time you should see all three nodes are equipped with global unicast addresses.
+
+The default UDP server port in this application is set to `61617`. You can change it with the
+above mentioned command. Determine one of the **non**- DAGAG root nodes as UDP server and one
+as client. Send a UDP packet from the client to the server (don't forget to look up the IPv6
+address!) by the above mentioned `udp send` command. On the sender you will get a notification
+once the packet has actually been sent by the link layer. On the receiver it will print
+information about the received packet.
+
+### Multi-hop w/ channel hopping
+Do the same as above but **without** setting the `OW_RIOT_SINGLE_CHANNEL` flag.

--- a/tests/openwsn/main.c
+++ b/tests/openwsn/main.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2017 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       OpenWSN test application
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "od.h"
+#include "shell.h"
+#include "openwsn.h"
+#include "net/ipv6/addr.h"
+
+#include "opendefs.h"
+#include "02a-MAClow/IEEE802154E.h"
+#include "03b-IPv6/icmpv6rpl.h"
+#include "04-TRAN/openudp.h"
+#include "cross-layers/openqueue.h"
+#include "cross-layers/idmanager.h"
+#include "cross-layers/packetfunctions.h"
+
+extern idmanager_vars_t idmanager_vars;
+extern icmpv6rpl_vars_t icmpv6rpl_vars;
+
+udp_resource_desc_t uinject_vars;
+
+void uinject_sendDone(OpenQueueEntry_t *msg, owerror_t error)
+{
+    openqueue_freePacketBuffer(msg);
+    puts("Send success");
+}
+
+void uinject_receive(OpenQueueEntry_t *pkt)
+{
+    printf("Received %i bytes on port %i\n", (int)pkt->length, pkt->l4_destination_port);
+    od_hex_dump(pkt->payload, pkt->length, OD_WIDTH_DEFAULT);
+    openqueue_freePacketBuffer(pkt);
+}
+
+void uinject_init(void)
+{
+    uinject_vars.port = WKP_UDP_INJECT;
+    uinject_vars.callbackReceive = &uinject_receive;
+    uinject_vars.callbackSendDone = &uinject_sendDone;
+    openudp_register(&uinject_vars);
+}
+
+static int ifconfig_cmd(int argc, char **argv)
+{
+    if (idmanager_vars.isDAGroot) {
+        puts("Node is DAG root");
+    }
+    open_addr_t temp_my128bID;
+    char addr_str[IPV6_ADDR_MAX_STR_LEN];
+    memcpy(&temp_my128bID.addr_128b[0], &idmanager_vars.myPrefix.prefix, 8);
+    memcpy(&temp_my128bID.addr_128b[8], &idmanager_vars.my64bID.addr_64b, 8);
+    ipv6_addr_to_str(addr_str, (ipv6_addr_t *)temp_my128bID.addr_128b, sizeof(addr_str));
+    printf("inet6 %s\n", addr_str);
+    printf("RPL rank: %i\n", icmpv6rpl_vars.myDAGrank);
+    return 0;
+}
+
+static int rpl_cmd(int argc, char **argv)
+{
+    /* TODO allow other prefixes via shell ?!? */
+    uint8_t temp[8] = { 0xbb, 0xbb, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x00 };
+    open_addr_t myPrefix;
+
+    myPrefix.type = ADDR_PREFIX;
+    memcpy(myPrefix.prefix, &temp, sizeof(myPrefix.prefix));
+    idmanager_setMyID(&myPrefix);
+    icmpv6rpl_init();
+    idmanager_setIsDAGroot(TRUE);
+
+    return 0;
+}
+
+extern int udp_cmd(int argc, char **argv);
+
+static const shell_command_t shell_commands[] = {
+    { "ifconfig", "Shows assigned IPv6 addresses", ifconfig_cmd },
+    { "udp", "Send UDP messages and listen for messages on UDP port", udp_cmd },
+    { "rplroot", "Set node as RPL DODAG root node", rpl_cmd },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("OpenWSN UDP test");
+
+    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
+    printf("This board features a(n) %s MCU.\n", RIOT_MCU);
+
+    openwsn_bootstrap();
+
+    uinject_init();
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+}

--- a/tests/openwsn/udp.c
+++ b/tests/openwsn/udp.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ * Copyright (C) 2018 Hamburg University of Applied Sciences
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @}
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "xtimer.h"
+#include "net/ipv6.h"
+
+#include "opendefs.h"
+#include "scheduler.h"
+#include "02a-MAClow/IEEE802154E.h"
+#include "03b-IPv6/icmpv6rpl.h"
+#include "04-TRAN/openudp.h"
+#include "cross-layers/openqueue.h"
+#include "cross-layers/idmanager.h"
+#include "cross-layers/packetfunctions.h"
+
+extern udp_resource_desc_t uinject_vars;
+extern idmanager_vars_t idmanager_vars;
+
+static uint16_t counter = 0;
+
+OpenQueueEntry_t *pkt;
+
+void push_pkt_cb(void){
+    owerror_t ret = openudp_send(pkt);
+    if (ret == E_FAIL) {
+        puts("could not send");
+    }
+}
+
+static int udp_send(char *addr_str, char *port_str, char *data, unsigned int num,
+                    unsigned int delay)
+{
+    size_t data_len;
+    ipv6_addr_t addr;
+
+    /* don't run if not in synch */
+    if (ieee154e_isSynch() == FALSE) {
+        puts("Error: Node not in synch, exit");
+        return 1;
+    }
+
+    /* parse destination address */
+    if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
+        puts("Error: unable to parse destination address");
+        return 1;
+    }
+
+    data_len = strlen(data);
+    uint8_t asnArray[data_len];
+
+    /* get a free packet buffer */
+    pkt = openqueue_getFreePacketBuffer(COMPONENT_UINJECT);
+    if (pkt == NULL) {
+        puts("Erro: could not create packet buffer");
+        return 1;
+    }
+
+    /* change resource port so "send done" callback can be triggered;
+     * this is dangerous because it's the destination port */
+    uinject_vars.port = atoi(port_str);
+
+    pkt->owner = COMPONENT_UINJECT;
+    pkt->creator = COMPONENT_UINJECT;
+    pkt->l4_protocol = IANA_UDP;
+    pkt->l4_destination_port = atoi(port_str);
+    pkt->l4_sourcePortORicmpv6Type = atoi(port_str);     // TODO
+    pkt->l3_destinationAdd.type = ADDR_128B;
+    memcpy(&pkt->l3_destinationAdd.addr_128b[0], (void *)&addr, 16);
+    /* add payload */
+    packetfunctions_reserveHeaderSize(pkt, data_len);
+    memcpy(&pkt->payload[0], data, data_len);
+
+    packetfunctions_reserveHeaderSize(pkt, sizeof(uint16_t));
+    pkt->payload[1] = (uint8_t)((counter & 0xff00) >> 8);
+    pkt->payload[0] = (uint8_t)(counter & 0x00ff);
+    counter++;
+
+    packetfunctions_reserveHeaderSize(pkt, sizeof(asn_t));
+    ieee154e_getAsn(asnArray);
+    pkt->payload[0] = asnArray[0];
+    pkt->payload[1] = asnArray[1];
+    pkt->payload[2] = asnArray[2];
+    pkt->payload[3] = asnArray[3];
+    pkt->payload[4] = asnArray[4];
+
+    for (unsigned int i = 0; i < num; i++) {
+        printf("Send %u byte over UDP to [%s]:%s\n",
+                (unsigned)data_len, addr_str, port_str);
+        scheduler_push_task(push_pkt_cb, TASKPRIO_COAP);
+        xtimer_usleep(delay);
+    }
+    return 0;
+}
+
+int udp_cmd(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("usage: %s [send|server]\n", argv[0]);
+        return 1;
+    }
+
+    if (strcmp(argv[1], "send") == 0) {
+        uint32_t num = 1;
+        uint32_t delay = 1000000;
+        /* don't send as root */
+        if (idmanager_vars.isDAGroot) {
+            puts("Error: Node is root, exit");
+            return 1;
+        }
+        if (argc < 5) {
+            printf("usage: %s send <addr> <port> <hex data> [<num> [<delay in us>]]\n",
+                   argv[0]);
+            return 1;
+        }
+        if (argc > 5) {
+            num = atoi(argv[5]);
+        }
+        if (argc > 6) {
+            delay = atoi(argv[6]);
+        }
+        return udp_send(argv[2], argv[3], argv[4], num, delay);
+    }
+    else if (strcmp(argv[1], "server") == 0) {
+        if (argc < 3) {
+            printf("usage: %s server [start|stop]\n", argv[0]);
+            return 1;
+        }
+        if (strcmp(argv[2], "start") == 0) {
+            if (argc < 4) {
+                printf("usage %s server start <port>\n", argv[0]);
+                return 1;
+            }
+            uint16_t port = atoi(argv[3]);
+            uinject_vars.port = port;
+            printf("Set UDP server port to %" PRIu16 "\n", port);
+            return 0;
+        }
+        else {
+            puts("error: invalid command");
+            return 1;
+        }
+    }
+    else {
+        puts("error: invalid command");
+        return 1;
+    }
+}
+/** @} */


### PR DESCRIPTION
### Contribution description
This PR re-integrates the OpenWSN network stack as a pkg to RIOT. It is marked as WIP because it does not yet work stable and I'm asking for your help in terms of debugging, testing and review.

An example application is provided, including documentation in the [README](https://github.com/RIOT-OS/RIOT/pull/8570/files#diff-af628c95ba6f73b8a95c7f7993036f63) next to it. Furthermore, I added [documentation](https://github.com/RIOT-OS/RIOT/pull/8570/files#diff-71c35b7e125127740270b42094c8dd75) about the port in general, the status of this implementation as well as additional information about debugging capabilities and currently open issues/TODOs. The two commits covering Atmel radio driver changes and iotlab-m3 timer configuration are not intended to be merged but rather to be included as a patch later.

I have a collection of additional test applications for different wrappers lying around, which I would provide in a separate PR if we agree on how to integrate them into the repository.

### Implementation Issues 
~~- Nodes reset after some time ([here?](https://github.com/PeterKietzmann/openwsn-fw/blob/RIOT_port/kernel/openos/scheduler.c#L98)). **Without** channel hopping this effect does not show up that often. **With** channel hopping it gets worse~~
~~- After a node restarts, it won't join the topology any time soon, even though neighbored nodes still send DIOs~~

### People that might be interested and in charge to support
(alphabetical order of last name)
@emmanuelsearch, @kb2ma, @changtengfei, @OlegHahm, @sieben, @fjmolinas, @Lotterleben, @twatteyne

### Issues/PRs references
Relates to #3039 and #7893