### PR TITLE
gnrc_sixlowpan_nd: add missing header

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/nd.h
+++ b/sys/include/net/gnrc/sixlowpan/nd.h
@@ -26,6 +26,7 @@
 #include <stdint.h>
 
 #include "kernel_types.h"
+#include "net/gnrc/pkt.h"
 #include "net/ipv6/addr.h"
 #include "net/ndp.h"
 #include "net/sixlowpan/nd.h"


### PR DESCRIPTION
`gnrc_pktsnip_t` is used in `net/gnrc/sixlowpan/nd.h` but it is not
included. There were no compile errors yet, since this file is always
included with some other GNRC headers, but it might not in the future.