### PR TITLE
shell: adapt 6ctx command for NIB

### DIFF
--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -44,7 +44,7 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
     SRC += sc_gnrc_rpl.c
 endif
 ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))
-ifneq (,$(filter gnrc_sixlowpan_nd_border_router,$(USEMODULE)))
+ifneq (,$(filter gnrc_ipv6_nib_6lbr,$(USEMODULE)))
     SRC += sc_gnrc_6ctx.c
 endif
 endif

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -113,7 +113,7 @@ extern int _gnrc_rpl(int argc, char **argv);
 #endif
 
 #ifdef MODULE_GNRC_SIXLOWPAN_CTX
-#ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER
+#ifdef MODULE_GNRC_IPV6_NIB_6LBR
 extern int _gnrc_6ctx(int argc, char **argv);
 #endif
 #endif
@@ -203,7 +203,7 @@ const shell_command_t _shell_command_list[] = {
     {"rpl", "rpl configuration tool ('rpl help' for more information)", _gnrc_rpl },
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN_CTX
-#ifdef MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER
+#ifdef MODULE_GNRC_IPV6_NIB_6LBR
     {"6ctx", "6LoWPAN context configuration tool", _gnrc_6ctx },
 #endif
 #endif


### PR DESCRIPTION
This somehow was left by the wayside when we moved from the old ND to
the NIB. Also piggybacks some fixes to the output (which was broken).