### PR TITLE
gnrc_uhcpc: update compression context with new prefix

### DIFF
--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -13,6 +13,9 @@
 #ifdef MODULE_GNRC_RPL
 #include "net/gnrc/rpl.h"
 #endif
+#ifdef MODULE_GNRC_SIXLOWPAN_CTX
+#include "net/gnrc/sixlowpan/ctx.h"
+#endif
 #include "net/ipv6/addr.h"
 #include "net/netdev.h"
 #include "net/netopt.h"
@@ -54,6 +57,48 @@ static void set_interface_roles(void)
 
 static ipv6_addr_t _prefix;
 
+#ifdef MODULE_GNRC_SIXLOWPAN_CTX
+#define SIXLO_CTX_LTIME_MIN (60U)   /**< context lifetime in minutes */
+
+static bool _ctx_match(const gnrc_sixlowpan_ctx_t *ctx,
+                       const ipv6_addr_t *prefix, uint8_t prefix_len)
+{
+    return (ctx->prefix_len == prefix_len) &&
+           (ipv6_addr_match_prefix(&ctx->prefix, prefix) >= prefix_len);
+}
+
+static void _update_6ctx(const ipv6_addr_t *prefix, uint8_t prefix_len)
+{
+    gnrc_sixlowpan_ctx_t *ctx = gnrc_sixlowpan_ctx_lookup_addr(prefix);
+    uint8_t cid = 0;
+
+    if (!_ctx_match(ctx, prefix, prefix_len)) {
+        /* While the context is a prefix match, the defined prefix within the
+         * context does not match => use new context */
+        ctx = NULL;
+    }
+    else {
+        cid = ctx->flags_id & GNRC_SIXLOWPAN_CTX_FLAGS_CID_MASK;
+    }
+    /* find first free context ID */
+    if (ctx == NULL) {
+        while (((ctx = gnrc_sixlowpan_ctx_lookup_id(cid)) != NULL) &&
+               !_ctx_match(ctx, prefix, prefix_len)) {
+            cid++;
+        }
+    }
+    if (cid < GNRC_SIXLOWPAN_CTX_SIZE) {
+        static ipv6_addr_t addr_str[IPV6_ADDR_MAX_STR_LEN];
+        LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): add compression context "
+                 "%u for prefix %s/%u\n", cid,
+                 ipv6_addr_to_str(addr_str, prefix, sizeof(addr_str)),
+                 prefix_len);
+        gnrc_sixlowpan_ctx_update(cid, (ipv6_addr_t *)prefix, prefix_len,
+                                  SIXLO_CTX_LTIME_MIN, true);
+    }
+}
+#endif
+
 void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, uint8_t *src, uhcp_iface_t iface)
 {
     (void)prefix_len;
@@ -82,10 +127,17 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
 
     if (ipv6_addr_equal(&_prefix, (ipv6_addr_t*)prefix)) {
         LOG_WARNING("gnrc_uhcpc: uhcp_handle_prefix(): got same prefix again\n");
+#ifdef MODULE_GNRC_SIXLOWPAN_CTX
+        /* always update 6LoWPAN compression context so it does not time out, we
+         * can't just remove it anyway according to the RFC */
+        _update_6ctx((ipv6_addr_t *)prefix, 64);
+#endif
         return;
     }
 
     gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR, (64 << 8),
+        /* always update 6LoWPAN compression context so it does not time out, we
+         * can't just remove it anyway according to the RFC */
                     prefix, sizeof(ipv6_addr_t));
 #if defined(MODULE_GNRC_IPV6_NIB) && GNRC_IPV6_NIB_CONF_6LBR && \
     GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
@@ -117,6 +169,11 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
         puts("/64");
     }
 
+#ifdef MODULE_GNRC_SIXLOWPAN_CTX
+    /* update compression context last in case previous context was removed by
+     * gnrc_ipv6_nib_abr_del() above */
+    _update_6ctx((ipv6_addr_t *)prefix, 64);
+#endif
     memcpy(&_prefix, prefix, 16);
 }
 

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -24,6 +24,7 @@
 #include "log.h"
 #include "fmt.h"
 
+static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 static kernel_pid_t gnrc_border_interface;
 static kernel_pid_t gnrc_wireless_interface;
 
@@ -88,7 +89,6 @@ static void _update_6ctx(const ipv6_addr_t *prefix, uint8_t prefix_len)
         }
     }
     if (cid < GNRC_SIXLOWPAN_CTX_SIZE) {
-        static ipv6_addr_t addr_str[IPV6_ADDR_MAX_STR_LEN];
         LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): add compression context "
                  "%u for prefix %s/%u\n", cid,
                  ipv6_addr_to_str(addr_str, prefix, sizeof(addr_str)),
@@ -153,9 +153,8 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
 #endif
     gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR_REMOVE, 0,
                     &_prefix, sizeof(_prefix));
-    print_str("gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix ");
-    ipv6_addr_print((ipv6_addr_t*)prefix);
-    puts("/64");
+    LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix %s/64\n",
+             ipv6_addr_to_str(addr_str, (ipv6_addr_t *)prefix, sizeof(addr_str)));
 
     if (!ipv6_addr_is_unspecified(&_prefix)) {
         gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR_REMOVE, 0,
@@ -164,9 +163,8 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
     GNRC_IPV6_NIB_CONF_MULTIHOP_P6C
         gnrc_ipv6_nib_abr_del(&_prefix);
 #endif
-        print_str("gnrc_uhcpc: uhcp_handle_prefix(): removed old prefix ");
-        ipv6_addr_print(&_prefix);
-        puts("/64");
+        LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): removed old prefix %s/64\n",
+                 ipv6_addr_to_str(addr_str, &_prefix, sizeof(addr_str)));
     }
 
 #ifdef MODULE_GNRC_SIXLOWPAN_CTX


### PR DESCRIPTION
### Contribution description
This updates (or adds) a compression context whenever a new prefix
arrives at the border router. This allows 6LoWPAN to compress said
prefix in the network.

Sadly, there is now way to just remove the context when the prefix is
overwritten, so I do not do it. If an administrator chooses to reset the
prefix they can use `6ctx del` which timeouts the prefix appropriately,
but IMHO it doesn't hurt to keep the old contexts.

@kaspar030 any idea why this wasn't done in the first place?

### Testing procedure
Flash and run `examples/gnrc_border_router` with `uhcpc` on a 6LoWPAN-enabled board of your choice (e.g. `samr21-xpro`). When the prefix is configured, check `6ctx`: The prefix should show up as compression context 0 with a lifetime of 60 minutes:

```sh
make -C examples/gnrc_border_router/ flash test
```

```
uhcp_client(): sending REQ...
got packet from fe80::f401:35ff:feed:abbb port 50383
uhcp: push from fe80::f401:35ff:feed:abbb:50383 prefix=2001:db8::/64
gnrc_uhcpc: uhcp_handle_prefix(): add compression context 0 for prefix 2001:db8::589d:9386:2208:6578/64
gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix 2001:db8::589d:9386:2208:6578/64

ifconfig
Iface  7  HWaddr: 02:79:27:EA:94:E7 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          RTR_ADV  Source address length: 6
          Link type: wired
          inet6 addr: fe80::79:27ff:feea:94e7  scope: link  VAL
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffea:94e7
          inet6 group: ff02::1:ff00:2
          
Iface  6  HWaddr: 2D:4B  Channel: 26  Page: 0  NID: 0x23
          Long HWaddr: 5A:9D:93:86:22:08:65:78 
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::589d:9386:2208:6578  scope: link  VAL
          inet6 addr: 2001:db8::589d:9386:2208:6578  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff08:6578
          
> 6ctx
6ctx
cid|prefix                                     |C|ltime
-----------------------------------------------------------
  0|                             2001:db8::/64 |1|   60min
```

### Issues/PRs references
#8575 for the `6ctx` command to work again (which isn't required but helps with debugging/testing ;-))