### PR TITLE
tools: edbg: use for resetting

### DIFF
--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -16,3 +16,5 @@ FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -e -v -p -f $(HEXFILE)
 ifeq ($(RIOT_EDBG),$(FLASHER))
   FLASHDEPS += $(RIOT_EDBG)
 endif
+RESET ?= $(EDBG)
+RESET_FLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE)

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -1,7 +1,7 @@
 export FLASHER ?= $(RIOTBASE)/dist/tools/openocd/openocd.sh
 export DEBUGGER = $(RIOTBASE)/dist/tools/openocd/openocd.sh
 export DEBUGSERVER = $(RIOTBASE)/dist/tools/openocd/openocd.sh
-export RESET = $(RIOTBASE)/dist/tools/openocd/openocd.sh
+export RESET ?= $(RIOTBASE)/dist/tools/openocd/openocd.sh
 
 export OFLAGS ?= -O ihex
 export FFLAGS ?= flash


### PR DESCRIPTION
### Contribution description

Some boards use edbg for programming, but openocd for reset & debug.
This PR makes those boards also use edbg for resetting, as it is much more lightweight.