### PR TITLE
EFM32: fix flashpage_erase

### DIFF
--- a/cpu/efm32/periph/flashpage.c
+++ b/cpu/efm32/periph/flashpage.c
@@ -35,6 +35,10 @@ void flashpage_write(int page, void *data)
 
     MSC_Init();
     MSC_ErasePage(page_addr);
-    MSC_WriteWord(page_addr, data_addr, FLASHPAGE_SIZE);
+
+    if (data != NULL) {
+        MSC_WriteWord(page_addr, data_addr, FLASHPAGE_SIZE);
+    }
+
     MSC_Deinit();
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While testing periph_flashpage I noticed that the erase was not working properly, due to a simple check of NULL data. This PR fixes it.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->