### PR TITLE
sys/phydat: Add space between value and unit

### DIFF
--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -52,7 +52,7 @@ void phydat_dump(phydat_t *data, uint8_t dim)
         printf("\t[%i] ", (int)i);
 
         if (scale_prefix) {
-            printf("%i%c", (int)data->val[i], scale_prefix);
+            printf("%i %c", (int)data->val[i], scale_prefix);
         }
         else if (data->scale == 0) {
             printf("%i", (int)data->val[i]);


### PR DESCRIPTION

### Contribution description

It is easier to read the output of phydat_str if there is a space between the numbers and the unit.

### Issues/PRs references

none