### PR TITLE
sys/phydat: align numbers, remove index if dim == 1

### DIFF
--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -49,13 +49,18 @@ void phydat_dump(phydat_t *data, uint8_t dim)
                 scale_prefix = phydat_prefix_from_scale(data->scale);
         }
 
-        printf("\t[%i] ", (int)i);
-
+        printf("\t");
+        if (dim > 1) {
+            printf("[%u] ", (unsigned int)i);
+        }
+        else {
+            printf("     ");
+        }
         if (scale_prefix) {
-            printf("%i %c", (int)data->val[i], scale_prefix);
+            printf("%6d %c", (int)data->val[i], scale_prefix);
         }
         else if (data->scale == 0) {
-            printf("%i", (int)data->val[i]);
+            printf("%6d", (int)data->val[i]);
         }
         else if ((data->scale > -5) && (data->scale < 0)) {
             char num[8];


### PR DESCRIPTION
### Contribution description

Align the printed numbers and only print array index if there is more than one value to print.

Future work: Use fmt instead

### Issues/PRs references

Depends on #8582 