### PR TITLE
gnrc_sock: make sock compilable with gnrc_neterr

### DIFF
--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -185,9 +185,9 @@ ssize_t gnrc_sock_send(gnrc_pktsnip_t *payload, sock_ip_ep_t *local,
     err_report.type = 0;
 
     while (err_report.type != GNRC_NETERR_MSG_TYPE) {
-        msg_try_receive(err_report);
+        msg_try_receive(&err_report);
         if (err_report.type != GNRC_NETERR_MSG_TYPE) {
-            msg_try_send(err_report, sched_active_pid);
+            msg_try_send(&err_report, sched_active_pid);
         }
     }
     if (err_report.content.value != GNRC_NETERR_SUCCESS) {


### PR DESCRIPTION
gnrc_sock currently does not compile with `gnrc_neterr` included, since
both `msg_try_receive()` and `msg_try_send()` expect a *pointer* to a
`msg_t`, not a `msg_t`.

To test, just compile an application using `gnrc_sock` (e.g.
`examples/gcoap`) with `USEMODULE+=gnrc_neterr`.