### PR TITLE
sys/phydat: rename phydat_scale_to_str -> phydat_prefix_from_scale

### DIFF
--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -36,7 +36,6 @@
 #define PHYDAT_H
 
 #include <stdint.h>
-#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -157,15 +156,17 @@ void phydat_dump(phydat_t *data, uint8_t dim);
 const char *phydat_unit_to_str(uint8_t unit);
 
 /**
- * @brief   Convert the given scale factor to a NULL terminated string
+ * @brief   Convert the given scale factor to an SI prefix
  *
- * The given scaling factor will be given as SI unit (e.g. M for Mega, u for
- * micro, etc) for obvious cases or in scientific notation (e.g. 2E11, 1E-22,
- * etc) otherwise.
+ * The given scaling factor is returned as a SI unit prefix (e.g. M for Mega, u
+ * for micro, etc), or `\0` otherwise.
  *
  * @param[in] scale     scale factor to convert
+ *
+ * @return  SI prefix if applicable
+ * @return  `\0` if no SI prefix was found
  */
-char phydat_scale_to_str(int8_t scale);
+char phydat_prefix_from_scale(int8_t scale);
 
 #ifdef __cplusplus
 }

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -32,7 +32,7 @@ void phydat_dump(phydat_t *data, uint8_t dim)
     }
     printf("Data:");
     for (uint8_t i = 0; i < dim; i++) {
-        char scale_str;
+        char scale_prefix;
 
         switch (data->unit) {
             case UNIT_UNDEF:
@@ -43,16 +43,16 @@ void phydat_dump(phydat_t *data, uint8_t dim)
             case UNIT_TEMP_C:
             case UNIT_TEMP_F:
                 /* no string conversion */
-                scale_str = '\0';
+                scale_prefix = '\0';
                 break;
             default:
-                scale_str = phydat_scale_to_str(data->scale);
+                scale_prefix = phydat_prefix_from_scale(data->scale);
         }
 
         printf("\t[%i] ", (int)i);
 
-        if (scale_str) {
-            printf("%i%c", (int)data->val[i], scale_str);
+        if (scale_prefix) {
+            printf("%i%c", (int)data->val[i], scale_prefix);
         }
         else if (data->scale == 0) {
             printf("%i", (int)data->val[i]);
@@ -95,7 +95,7 @@ const char *phydat_unit_to_str(uint8_t unit)
     }
 }
 
-char phydat_scale_to_str(int8_t scale)
+char phydat_prefix_from_scale(int8_t scale)
 {
     switch (scale) {
         case -3:    return 'm';


### PR DESCRIPTION
### Contribution description

Correct some outdated documentation and make the name represent what the
function does today.

### Issues/PRs references

in #4668, `phydat_scale_to_str` was modified from its original form but the documentation was not updated