### PR TITLE
sys/phydat: Introduce PHYDAT_MIN, PHYDAT_MAX

### DIFF
--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -138,6 +138,16 @@ typedef struct {
 } phydat_t;
 
 /**
+ * @brief   Minimum value for phydat_t::val
+ */
+#define PHYDAT_MIN  (INT16_MIN)
+
+/**
+ * @brief   Maximum value for phydat_t::val
+ */
+#define PHYDAT_MAX  (INT16_MAX)
+
+/**
  * @brief   Dump the given data container to STDIO
  *
  * @param[in] data      data container to dump


### PR DESCRIPTION
### Contribution description

Introduce macros for getting the min and max value of `phydat_t::val`. Having a separate macro instead of using `INT16_MAX` will make it easier to modify the phydat_t definition if an application requires more than 16 bits of resolution.

### Issues/PRs references

none