### PR TITLE
sys/saul_reg: Fix saul_reg_rm return value when removing first element

### DIFF
--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -62,6 +62,7 @@ int saul_reg_rm(saul_reg_t *dev)
     }
     if (saul_reg == dev) {
         saul_reg = dev->next;
+        return 0;
     }
     while (tmp->next && (tmp->next != dev)) {
         tmp = tmp->next;

--- a/tests/unittests/tests-saul_reg/tests-saul_reg.c
+++ b/tests/unittests/tests-saul_reg/tests-saul_reg.c
@@ -171,6 +171,17 @@ static void test_reg_rm(void)
     TEST_ASSERT_EQUAL_INT(-ENODEV, res);
 
     TEST_ASSERT_EQUAL_INT(2, count());
+
+    res = saul_reg_rm(&s0);
+    TEST_ASSERT_EQUAL_INT(0, res);
+    TEST_ASSERT_EQUAL_INT(1, count());
+    TEST_ASSERT_EQUAL_STRING("S2", saul_reg->name);
+    TEST_ASSERT_EQUAL_STRING("S2", last()->name);
+
+    res = saul_reg_rm(&s2);
+    TEST_ASSERT_EQUAL_INT(0, res);
+    TEST_ASSERT_EQUAL_INT(0, count());
+    TEST_ASSERT_NULL(saul_reg);
 }
 
 Test *tests_saul_reg_tests(void)


### PR DESCRIPTION
Currently when calling saul_reg_rm() for the first element an error is returned even though the delete works. This PR fixes that by adding the success return at the proper place.