### PR TITLE
 sys/phydat: Add phydat_fit to rescale values for phydat_t

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -543,6 +543,10 @@ ifneq (,$(filter xtimer,$(USEMODULE)))
   USEMODULE += div
 endif
 
+ifneq (,$(filter saul,$(USEMODULE)))
+  USEMODULE += phydat
+endif
+
 ifneq (,$(filter saul_reg,$(USEMODULE)))
   USEMODULE += saul
 endif

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -178,6 +178,40 @@ const char *phydat_unit_to_str(uint8_t unit);
  */
 char phydat_prefix_from_scale(int8_t scale);
 
+/**
+ * @brief   Scale an integer value to fit into a @ref phydat_t
+ *
+ * Insert @p value at position @p index in the given @p dat while rescaling all
+ * numbers in @p dat->val so that @p value fits inside the limits of the data
+ * type, [@ref PHYDAT_MIN, @ref PHYDAT_MAX], and update the stored scale factor.
+ * The result will be rounded towards zero (the standard C99 integer division
+ * behaviour).
+ * The final parameter @p prescale can be used to chain multiple calls to
+ * this function in order to fit multidimensional values into the same phydat_t.
+ *
+ * The code example below shows how to chain multiple calls via the @p prescale parameter
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
+ * long val0 = 100000;
+ * long val1 = 2000000;
+ * long val2 = 30000000;
+ * phydat_t dat;
+ * dat.scale = 0;
+ * phydat_fit(&dat, val0, 0, phydat_fit(&dat, val1, 1, phydat_fit(&dat, val2, 2, 0)));
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * The prescale scaling is only applied to @p value, the existing values in
+ * @p dat are only scaled if the prescaled @p value does not fit in phydat_t::val
+ *
+ * @param[in, out]  dat         the value will be written into this data array
+ * @param[in]       value       value to rescale
+ * @param[in]       index       place the value at this position in the phydat_t::val array
+ * @param[in]       prescale    start by scaling the value by this exponent
+ *
+ * @return  scaling offset that was applied
+ */
+uint8_t phydat_fit(phydat_t *dat, long value, unsigned int index, uint8_t prescale);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/phydat/phydat.c
+++ b/sys/phydat/phydat.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_phydat
+ * @{
+ *
+ * @file
+ * @brief       Generic sensor/actuator data handling
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include "phydat.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+uint8_t phydat_fit(phydat_t *dat, long value, unsigned int index, uint8_t prescale)
+{
+    assert(index < (sizeof(dat->val) / sizeof(dat->val[0])));
+    uint8_t ret = prescale;
+    while (prescale > 0) {
+        value /= 10;
+        --prescale;
+    }
+    int8_t scale_offset = 0;
+    while ((value > PHYDAT_MAX) || (value < PHYDAT_MIN)) {
+        value /= 10;
+        for (unsigned int k = 0; k < (sizeof(dat->val) / sizeof(dat->val[0])); ++k) {
+            dat->val[k] /= 10;
+        }
+        ++scale_offset;
+    }
+    dat->val[index] = value;
+    dat->scale += scale_offset;
+    ret += scale_offset;
+    return ret;
+}

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     driver_sensif
+ * @ingroup     sys_phydat
  * @{
  *
  * @file

--- a/tests/unittests/tests-phydat/Makefile
+++ b/tests/unittests/tests-phydat/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-phydat/Makefile.include
+++ b/tests/unittests/tests-phydat/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += phydat

--- a/tests/unittests/tests-phydat/tests-phydat.c
+++ b/tests/unittests/tests-phydat/tests-phydat.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "embUnit.h"
+#include "tests-phydat.h"
+
+#include "phydat.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static void test_phydat_fit(void)
+{
+    /* verify that these big numbers are scaled to fit in phydat_t::val which is int16_t */
+    long val0 =   100445;
+    long val1 =  2000954;
+    long val2 = 30000455;
+    long val4 =  1234567;
+    phydat_t dat;
+    dat.scale = -6;
+    dat.unit = UNIT_V;
+    uint8_t res = phydat_fit(&dat, val0, 0, 0);
+    /* Check that the result was rescaled to 10044e-5 */
+    /* The scaled number is rounded toward zero */
+    TEST_ASSERT_EQUAL_INT(1, res);
+    TEST_ASSERT_EQUAL_INT(UNIT_V, dat.unit);
+    TEST_ASSERT_EQUAL_INT(-5, dat.scale);
+    TEST_ASSERT_EQUAL_INT( 10044, dat.val[0]);
+    /* Fit the next value in the phydat vector */
+    res = phydat_fit(&dat, val1, 1, res);
+    TEST_ASSERT_EQUAL_INT(2, res);
+    TEST_ASSERT_EQUAL_INT(UNIT_V, dat.unit);
+    TEST_ASSERT_EQUAL_INT(-4, dat.scale);
+    TEST_ASSERT_EQUAL_INT(  1004, dat.val[0]);
+    TEST_ASSERT_EQUAL_INT( 20009, dat.val[1]);
+    /* Fit the third value in the phydat vector */
+    res = phydat_fit(&dat, val2, 2, res);
+    TEST_ASSERT_EQUAL_INT(3, res);
+    TEST_ASSERT_EQUAL_INT(UNIT_V, dat.unit);
+    TEST_ASSERT_EQUAL_INT(-3, dat.scale);
+    TEST_ASSERT_EQUAL_INT(   100, dat.val[0]);
+    TEST_ASSERT_EQUAL_INT(  2000, dat.val[1]);
+    TEST_ASSERT_EQUAL_INT( 30000, dat.val[2]);
+    /* Overwrite the second value in the phydat vector */
+    res = phydat_fit(&dat, val4, 1, res);
+    TEST_ASSERT_EQUAL_INT(3, res);
+    TEST_ASSERT_EQUAL_INT(UNIT_V, dat.unit);
+    TEST_ASSERT_EQUAL_INT(-3, dat.scale);
+    TEST_ASSERT_EQUAL_INT(   100, dat.val[0]);
+    TEST_ASSERT_EQUAL_INT(  1234, dat.val[1]);
+    TEST_ASSERT_EQUAL_INT( 30000, dat.val[2]);
+}
+
+Test *tests_phydat_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_phydat_fit),
+    };
+
+    EMB_UNIT_TESTCALLER(phydat_tests, NULL, NULL, fixtures);
+
+    return (Test *)&phydat_tests;
+}
+
+void tests_phydat(void)
+{
+    TESTS_RUN(tests_phydat_tests());
+}

--- a/tests/unittests/tests-phydat/tests-phydat.h
+++ b/tests/unittests/tests-phydat/tests-phydat.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the phydat module
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+#ifndef TESTS_PHYDAT_H
+#define TESTS_PHYDAT_H
+#include "embUnit/embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+*  @brief   The entry point of this test suite.
+*/
+void tests_phydat(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_PHYDAT_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

Fits larger values into the 16 bit integers used by phydat_t and update scale accordingly.
Including a minimal unit test.

### Issues/PRs references

Depends on ~~#8587~~ ~~#8586~~ (merged) 