### PR TITLE
drivers/periph: Add adc_conv voltage conversion helpers

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -283,6 +283,10 @@ ifneq (,$(filter pcd8544,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter periph_common,$(USEMODULE)))
+  USEMODULE += analog_util
+endif
+
 ifneq (,$(filter pir,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += xtimer

--- a/drivers/include/periph/adc_conv.h
+++ b/drivers/include/periph/adc_conv.h
@@ -83,6 +83,8 @@ void adc_conv_set_vrefl(int new_vrefl);
  * This is the 10 exponent for the value in vrefh/vrefl, i.e.
  * Real Vrefh = vrefh * 10^(scale)
  * For example, scale = -3 means that vrefh, vrefl are given in millivolts.
+ *
+ * @param[in]   new_scale   Vref unit scale exponent
  */
 void adc_conv_set_scale(int new_scale);
 

--- a/drivers/include/periph/adc_conv.h
+++ b/drivers/include/periph/adc_conv.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_periph_adc
+ * @{
+ *
+ * @file
+ * @brief       Conversion routines for CPU ADC samples
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include "periph/adc.h"
+#if MODULE_SAUL_ADC
+#include "saul/periph.h"
+#endif
+
+#ifndef BOARD_ADC_VREFH_DEFAULT
+/**
+ * @brief Boot default for vrefh
+ */
+/* 3300 mV is as good as any other guess */
+#define BOARD_ADC_VREFH_DEFAULT 3300
+#endif
+
+#ifndef BOARD_ADC_VREFL_DEFAULT
+/**
+ * @brief Boot default for vrefl
+ */
+/* 0 mV is as good as any other guess */
+#define BOARD_ADC_VREFL_DEFAULT 0
+#endif
+
+#ifndef BOARD_ADC_VREF_SCALE_DEFAULT
+/**
+ * @brief Boot default for vref scale
+ */
+/* millivolts by default */
+#define BOARD_ADC_VREF_SCALE_DEFAULT -3
+#endif
+
+/**
+ * @brief Convert ADC sample to actual voltage
+ *
+ * This function uses the stored ADC reference voltage for the conversion
+ *
+ * @param[in] sample  an ADC reading
+ * @param[in] res     ADC resolution setting
+ */
+int adc_conv_volts(int sample, adc_res_t res);
+
+/**
+ * @brief Update the internal upper voltage reference value
+ *
+ * This should be called if the software knows that the reference voltage for
+ * the ADC has changed since last update.
+ *
+ * @param[in] new_vrefh  new reference voltage
+ */
+void adc_conv_set_vrefh(int new_vrefh);
+
+/**
+ * @brief Update the internal lower voltage reference value
+ *
+ * This should be called if the software knows that the reference voltage for
+ * the ADC has changed since last update.
+ *
+ * @param[in] new_vrefl  new reference voltage
+ */
+void adc_conv_set_vrefl(int new_vrefl);
+
+/**
+ * @brief Set the ADC VREF unit scale exponent
+ *
+ * This is the 10 exponent for the value in vrefh/vrefl, i.e.
+ * Real Vrefh = vrefh * 10^(scale)
+ * For example, scale = -3 means that vrefh, vrefl are given in millivolts.
+ */
+void adc_conv_set_scale(int new_scale);
+
+#if MODULE_SAUL_ADC || DOXYGEN
+/**
+ * @brief SAUL ADC compatible conversion wrapper function
+ *
+ * @param[in] params  SAUL ADC params pointer
+ * @param[in] res     ADC sample
+ *
+ * @return 1
+ */
+int adc_conv_saul_adc_volts(const saul_adc_params_t *params, phydat_t *res);
+#endif

--- a/drivers/include/periph/adc_conv.h
+++ b/drivers/include/periph/adc_conv.h
@@ -28,7 +28,7 @@
  * @brief Boot default for vrefh
  */
 /* 3300 mV is as good as any other guess */
-#define BOARD_ADC_VREFH_DEFAULT 3300
+#define BOARD_ADC_VREFH_DEFAULT         (3300)
 #endif
 
 #ifndef BOARD_ADC_VREFL_DEFAULT
@@ -36,7 +36,7 @@
  * @brief Boot default for vrefl
  */
 /* 0 mV is as good as any other guess */
-#define BOARD_ADC_VREFL_DEFAULT 0
+#define BOARD_ADC_VREFL_DEFAULT         (0)
 #endif
 
 #ifndef BOARD_ADC_VREF_SCALE_DEFAULT
@@ -44,7 +44,7 @@
  * @brief Boot default for vref scale
  */
 /* millivolts by default */
-#define BOARD_ADC_VREF_SCALE_DEFAULT -3
+#define BOARD_ADC_VREF_SCALE_DEFAULT    (-3)
 #endif
 
 /**

--- a/drivers/periph_common/adc_conv.c
+++ b/drivers/periph_common/adc_conv.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_periph_adc
+ * @{
+ *
+ * @file
+ * @brief       Implementations of conversion routines for CPU internal analog signals
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+
+#include "board.h"
+#include "phydat.h"
+#include "periph/adc.h"
+#include "periph/adc_conv.h"
+#include "analog_util.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/**
+ * @brief ADC low side potential
+ *
+ * An ADC reading of zero means that the sampled voltage is close to or less than this value.
+ */
+static int vrefl = BOARD_ADC_VREFL_DEFAULT;
+
+/**
+ * @brief ADC reference voltage high potential
+ *
+ * An ADC reading of max means that the sampled voltage is close to or greater than this value
+ */
+static int vrefh = BOARD_ADC_VREFH_DEFAULT;
+
+/**
+ * @brief ADC unit scale exponent
+ *
+ * e.g. -3 for millivolts
+ */
+static int vref_scale = BOARD_ADC_VREF_SCALE_DEFAULT;
+
+int adc_conv_volts(int sample, adc_res_t res)
+{
+    /* Convert to voltage */
+    /* sample is in the range 0..max, where 0 means the sampled voltage was in
+     * the range [vrefl, vrefl + LSB), and max means the sampled voltage was in
+     * the range [vrefh - LSB, vrefh) */
+    return adc_util_map(sample, res, vrefl, vrefh);
+}
+
+void adc_conv_set_vrefh(int new_vrefh)
+{
+    vrefh = new_vrefh;
+}
+
+void adc_conv_set_vrefl(int new_vrefl)
+{
+    vrefl = new_vrefl;
+}
+
+void adc_conv_set_scale(int new_scale)
+{
+    vref_scale = new_scale;
+}
+
+#if MODULE_SAUL_ADC
+int adc_conv_saul_adc_volts(const saul_adc_params_t *params, phydat_t *res)
+{
+    int sample = res->val[0];
+    if (params->res == ADC_RES_16BIT) {
+        /* Assume single-ended reading for now, clear sign bits */
+        sample &= 0xffff;
+    }
+    int converted = adc_conv_volts(sample, params->res);
+    DEBUG("vref: %de%d\n", vrefh, vref_scale);
+    DEBUG("conv: %d\n", converted);
+    res->unit = UNIT_V;
+    res->scale = vref_scale;
+    phydat_fit(res, converted, 0, 0);
+    DEBUG("res: %d\n", res->val[0]);
+    return 1;
+}
+#endif


### PR DESCRIPTION
### Contribution description

The adc_conv module contains helper functions to convert CPU ADC readings into physical voltage.

### Issues/PRs references

Depends on #8577 ~~#8587~~ #8592 