### PR TITLE
gnrc_icmpv6_error: fix and use where appropriate

### DIFF
--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -20,6 +20,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
+# Activate ICMPv6 error messages
+USEMODULE += gnrc_icmpv6_error
 # Specify the mandatory networking modules for IPv6 and UDP
 USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_udp

--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -85,19 +85,7 @@ gnrc_pktsnip_t *gnrc_icmpv6_error_param_prob_build(uint8_t code, void *ptr,
  * @param[in] code      The code for the message @see net/icmpv6.h.
  * @param[in] orig_pkt  The invoking packet.
  */
-static inline void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
-{
-    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_dst_unr_build(code, orig_pkt);
-
-    if (pkt != NULL) {
-        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
-    }
-#ifdef MODULE_GNRC_PKTBUF
-    gnrc_pktbuf_release_error(orig_pkt, EHOSTUNREACH);
-#else
-    (void)orig_pkt;
-#endif
-}
+void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt);
 
 /**
  * @brief   Sends an ICMPv6 packet too big message for sending.
@@ -105,19 +93,7 @@ static inline void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *
  * @param[in] mtu       The maximum transission unit of the next-hop link.
  * @param[in] orig_pkt  The invoking packet.
  */
-static inline void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
-{
-    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_pkt_too_big_build(mtu, orig_pkt);
-
-    if (pkt != NULL) {
-        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
-    }
-#ifdef MODULE_GNRC_PKTBUF
-    gnrc_pktbuf_release_error(orig_pkt, EMSGSIZE);
-#else
-    (void)orig_pkt;
-#endif
-}
+void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt);
 
 /**
  * @brief   Sends an ICMPv6 time exceeded message for sending.
@@ -125,19 +101,7 @@ static inline void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip
  * @param[in] code      The code for the message @see net/icmpv6.h.
  * @param[in] orig_pkt  The invoking packet.
  */
-static inline void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
-{
-    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_time_exc_build(code, orig_pkt);
-
-    if (pkt != NULL) {
-        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
-    }
-#ifdef MODULE_GNRC_PKTBUF
-    gnrc_pktbuf_release_error(orig_pkt, ETIMEDOUT);
-#else
-    (void)orig_pkt;
-#endif
-}
+void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt);
 
 /**
  * @brief   Sends an ICMPv6 parameter problem message for sending.
@@ -146,20 +110,8 @@ static inline void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t 
  * @param[in] ptr       Pointer to the errorneous octet in @p orig_pkt.
  * @param[in] orig_pkt  The invoking packet.
  */
-static inline void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
-                                                     gnrc_pktsnip_t *orig_pkt)
-{
-    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_param_prob_build(code, ptr, orig_pkt);
-
-    if (pkt != NULL) {
-        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
-    }
-#ifdef MODULE_GNRC_PKTBUF
-    gnrc_pktbuf_release_error(orig_pkt, EINVAL);
-#else
-    (void)orig_pkt;
-#endif
-}
+void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
+                                       gnrc_pktsnip_t *orig_pkt);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -38,7 +38,7 @@ extern "C" {
  *
  * @pre @p orig_pkt contains a packet snip of type @ref GNRC_NETTYPE_IPV6
  *
- * @param[in] code      The code for the message @see net/icmpv6.h.
+ * @param[in] code      The [code for the message](@ref net_icmpv6_error_dst_unr_codes).
  * @param[in] orig_pkt  The invoking packet.
  */
 void gnrc_icmpv6_error_dst_unr_send(uint8_t code, const gnrc_pktsnip_t *orig_pkt);
@@ -59,7 +59,7 @@ void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu,
  *
  * @pre @p orig_pkt contains a packet snip of type @ref GNRC_NETTYPE_IPV6
  *
- * @param[in] code      The code for the message @see net/icmpv6.h.
+ * @param[in] code      The [code for the message](@ref net_icmpv6_error_time_exc_codes).
  * @param[in] orig_pkt  The invoking packet.
  */
 void gnrc_icmpv6_error_time_exc_send(uint8_t code,
@@ -71,7 +71,8 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code,
  * @pre @p orig_pkt is in receive order.
  * @pre @p orig_pkt contains a packet snip of type @ref GNRC_NETTYPE_IPV6
  *
- * @param[in] code      The code for the message @see net/icmpv6.h.
+ *
+ * @param[in] code      The [code for the message](@ref net_icmpv6_error_param_prob_codes).
  * @param[in] ptr       Pointer to the errorneous octet in @p orig_pkt.
  * @param[in] orig_pkt  The invoking packet.
  */

--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -39,7 +39,7 @@ extern "C" {
  * @param[in] code      The code for the message @see net/icmpv6.h.
  * @param[in] orig_pkt  The invoking packet.
  */
-void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt);
+void gnrc_icmpv6_error_dst_unr_send(uint8_t code, const gnrc_pktsnip_t *orig_pkt);
 
 /**
  * @brief   Sends an ICMPv6 packet too big message for sending.
@@ -47,7 +47,8 @@ void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt);
  * @param[in] mtu       The maximum transission unit of the next-hop link.
  * @param[in] orig_pkt  The invoking packet.
  */
-void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt);
+void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu,
+                                        const gnrc_pktsnip_t *orig_pkt);
 
 /**
  * @brief   Sends an ICMPv6 time exceeded message for sending.
@@ -55,7 +56,8 @@ void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt);
  * @param[in] code      The code for the message @see net/icmpv6.h.
  * @param[in] orig_pkt  The invoking packet.
  */
-void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt);
+void gnrc_icmpv6_error_time_exc_send(uint8_t code,
+                                     const gnrc_pktsnip_t *orig_pkt);
 
 /**
  * @brief   Sends an ICMPv6 parameter problem message for sending.
@@ -65,7 +67,7 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt);
  * @param[in] orig_pkt  The invoking packet.
  */
 void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
-                                       gnrc_pktsnip_t *orig_pkt);
+                                       const gnrc_pktsnip_t *orig_pkt);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -36,6 +36,8 @@ extern "C" {
 /**
  * @brief   Sends an ICMPv6 destination unreachable message for sending.
  *
+ * @pre @p orig_pkt contains a packet snip of type @ref GNRC_NETTYPE_IPV6
+ *
  * @param[in] code      The code for the message @see net/icmpv6.h.
  * @param[in] orig_pkt  The invoking packet.
  */
@@ -43,6 +45,8 @@ void gnrc_icmpv6_error_dst_unr_send(uint8_t code, const gnrc_pktsnip_t *orig_pkt
 
 /**
  * @brief   Sends an ICMPv6 packet too big message for sending.
+ *
+ * @pre @p orig_pkt contains a packet snip of type @ref GNRC_NETTYPE_IPV6
  *
  * @param[in] mtu       The maximum transission unit of the next-hop link.
  * @param[in] orig_pkt  The invoking packet.
@@ -52,6 +56,8 @@ void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu,
 
 /**
  * @brief   Sends an ICMPv6 time exceeded message for sending.
+ *
+ * @pre @p orig_pkt contains a packet snip of type @ref GNRC_NETTYPE_IPV6
  *
  * @param[in] code      The code for the message @see net/icmpv6.h.
  * @param[in] orig_pkt  The invoking packet.
@@ -63,6 +69,7 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code,
  * @brief   Sends an ICMPv6 parameter problem message for sending.
  *
  * @pre @p orig_pkt is in receive order.
+ * @pre @p orig_pkt contains a packet snip of type @ref GNRC_NETTYPE_IPV6
  *
  * @param[in] code      The code for the message @see net/icmpv6.h.
  * @param[in] ptr       Pointer to the errorneous octet in @p orig_pkt.

--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -34,52 +34,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Builds an ICMPv6 destination unreachable message for sending.
- *
- * @param[in] code      The code for the message @see net/icmpv6.h.
- * @param[in] orig_pkt  The invoking packet.
- *
- * @return  The destination unreachable message on success.
- * @return  NULL, on failure.
- */
-gnrc_pktsnip_t *gnrc_icmpv6_error_dst_unr_build(uint8_t code, gnrc_pktsnip_t *orig_pkt);
-
-/**
- * @brief   Builds an ICMPv6 packet too big message for sending.
- *
- * @param[in] mtu       The maximum transission unit of the next-hop link.
- * @param[in] orig_pkt  The invoking packet.
- *
- * @return  The packet too big message on success.
- * @return  NULL, on failure.
- */
-gnrc_pktsnip_t *gnrc_icmpv6_error_pkt_too_big_build(uint32_t mtu, gnrc_pktsnip_t *orig_pkt);
-
-/**
- * @brief   Builds an ICMPv6 time exceeded message for sending.
- *
- * @param[in] code      The code for the message @see net/icmpv6.h.
- * @param[in] orig_pkt  The invoking packet.
- *
- * @return  The time exceeded message on success.
- * @return  NULL, on failure.
- */
-gnrc_pktsnip_t *gnrc_icmpv6_error_time_exc_build(uint8_t code, gnrc_pktsnip_t *orig_pkt);
-
-/**
- * @brief   Builds an ICMPv6 parameter problem message for sending.
- *
- * @param[in] code      The code for the message @see net/icmpv6.h.
- * @param[in] ptr       Pointer to the errorneous octet in @p orig_pkt.
- * @param[in] orig_pkt  The invoking packet.
- *
- * @return  The parameter problem message on success.
- * @return  NULL, on failure.
- */
-gnrc_pktsnip_t *gnrc_icmpv6_error_param_prob_build(uint8_t code, void *ptr,
-                                                   gnrc_pktsnip_t *orig_pkt);
-
-/**
  * @brief   Sends an ICMPv6 destination unreachable message for sending.
  *
  * @param[in] code      The code for the message @see net/icmpv6.h.

--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -62,6 +62,8 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code,
 /**
  * @brief   Sends an ICMPv6 parameter problem message for sending.
  *
+ * @pre @p orig_pkt is in receive order.
+ *
  * @param[in] code      The code for the message @see net/icmpv6.h.
  * @param[in] ptr       Pointer to the errorneous octet in @p orig_pkt.
  * @param[in] orig_pkt  The invoking packet.

--- a/sys/include/net/gnrc/icmpv6/error.h
+++ b/sys/include/net/gnrc/icmpv6/error.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+#if defined(MODULE_GNRC_ICMPV6_ERROR) || defined(DOXYGEN)
 /**
  * @brief   Sends an ICMPv6 destination unreachable message for sending.
  *
@@ -78,6 +79,17 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code,
  */
 void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
                                        const gnrc_pktsnip_t *orig_pkt);
+#else   /* defined(MODULE_GNRC_ICMPV6_ERROR) || defined(DOXYGEN) */
+/* NOPs to make the usage code more readable */
+#define gnrc_icmpv6_error_dst_unr_send(code, orig_pkt) \
+        (void)code; (void)orig_pkt
+#define gnrc_icmpv6_error_pkt_too_big_send(mtu, orig_pkt) \
+        (void)mtu; (void)orig_pkt
+#define gnrc_icmpv6_error_time_exc_send(code, orig_pkt) \
+        (void)code; (void)orig_pkt
+#define gnrc_icmpv6_error_param_prob_send(code, ptr, orig_pkt) \
+        (void)code; (void)ptr, (void)orig_pkt
+#endif  /* defined(MODULE_GNRC_ICMPV6_ERROR) || defined(DOXYGEN) */
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/icmpv6.h
+++ b/sys/include/net/icmpv6.h
@@ -75,6 +75,7 @@ extern "C" {
  * @{
  * @name Codes for destination unreachable messages
  *
+ * @anchor net_icmpv6_error_dst_unr_codes
  * @see <a href="https://tools.ietf.org/html/rfc4443#section-3.1">
  *          RFC 4443, section 3.1
  *      </a>
@@ -97,6 +98,7 @@ extern "C" {
  * @{
  * @name Codes for time exceeded messages
  *
+ * @anchor net_icmpv6_error_time_exc_codes
  * @see <a href="https://tools.ietf.org/html/rfc4443#section-3.3">
  *          RFC 4443, section 3.3
  *      </a>
@@ -111,6 +113,7 @@ extern "C" {
  * @{
  * @name Codes for parameter problem messages
  *
+ * @anchor net_icmpv6_error_param_prob_codes
  * @see <a href="https://tools.ietf.org/html/rfc4443#section-3.4">
  *          RFC 4443, section 3.4
  *      </a>

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -54,17 +54,20 @@ static gnrc_pktsnip_t *_icmpv6_error_build(uint8_t type, uint8_t code,
     return pkt;
 }
 
-gnrc_pktsnip_t *gnrc_icmpv6_error_dst_unr_build(uint8_t code, gnrc_pktsnip_t *orig_pkt)
+static inline gnrc_pktsnip_t *_dst_unr_build(uint8_t code,
+                                             gnrc_pktsnip_t *orig_pkt)
 {
     return _icmpv6_error_build(ICMPV6_DST_UNR, code, orig_pkt, 0);
 }
 
-gnrc_pktsnip_t *gnrc_icmpv6_error_pkt_too_big_build(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
+static inline gnrc_pktsnip_t *_pkt_too_big_build(uint32_t mtu,
+                                                 gnrc_pktsnip_t *orig_pkt)
 {
     return _icmpv6_error_build(ICMPV6_PKT_TOO_BIG, 0, orig_pkt, mtu);
 }
 
-gnrc_pktsnip_t *gnrc_icmpv6_error_time_exc_build(uint8_t code, gnrc_pktsnip_t *orig_pkt)
+static inline gnrc_pktsnip_t *_time_exc_build(uint8_t code,
+                                              gnrc_pktsnip_t *orig_pkt)
 {
     return _icmpv6_error_build(ICMPV6_TIME_EXC, code, orig_pkt, 0);
 }
@@ -74,8 +77,8 @@ static inline bool _in_range(uint8_t *ptr, uint8_t *start, size_t sz)
     return (ptr >= start) && (ptr < (start + sz));
 }
 
-gnrc_pktsnip_t *gnrc_icmpv6_error_param_prob_build(uint8_t code, void *ptr,
-                                                   gnrc_pktsnip_t *orig_pkt)
+static gnrc_pktsnip_t *_param_prob_build(uint8_t code, void *ptr,
+                                         gnrc_pktsnip_t *orig_pkt)
 {
     gnrc_pktsnip_t *pkt = gnrc_icmpv6_build(NULL, ICMPV6_PARAM_PROB, code,
                                             _fit(orig_pkt));
@@ -120,7 +123,7 @@ gnrc_pktsnip_t *gnrc_icmpv6_error_param_prob_build(uint8_t code, void *ptr,
 
 void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
 {
-    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_dst_unr_build(code, orig_pkt);
+    gnrc_pktsnip_t *pkt = _dst_unr_build(code, orig_pkt);
 
     if (pkt != NULL) {
         gnrc_netapi_send(gnrc_ipv6_pid, pkt);
@@ -134,7 +137,7 @@ void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
 
 void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
 {
-    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_pkt_too_big_build(mtu, orig_pkt);
+    gnrc_pktsnip_t *pkt = _pkt_too_big_build(mtu, orig_pkt);
 
     if (pkt != NULL) {
         gnrc_netapi_send(gnrc_ipv6_pid, pkt);
@@ -148,7 +151,7 @@ void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
 
 void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
 {
-    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_time_exc_build(code, orig_pkt);
+    gnrc_pktsnip_t *pkt = _time_exc_build(code, orig_pkt);
 
     if (pkt != NULL) {
         gnrc_netapi_send(gnrc_ipv6_pid, pkt);
@@ -163,7 +166,7 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
 void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
                                        gnrc_pktsnip_t *orig_pkt)
 {
-    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_param_prob_build(code, ptr, orig_pkt);
+    gnrc_pktsnip_t *pkt = _param_prob_build(code, ptr, orig_pkt);
 
     if (pkt != NULL) {
         gnrc_netapi_send(gnrc_ipv6_pid, pkt);

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -118,4 +118,61 @@ gnrc_pktsnip_t *gnrc_icmpv6_error_param_prob_build(uint8_t code, void *ptr,
     return pkt;
 }
 
+void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
+{
+    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_dst_unr_build(code, orig_pkt);
+
+    if (pkt != NULL) {
+        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+    }
+#ifdef MODULE_GNRC_PKTBUF
+    gnrc_pktbuf_release_error(orig_pkt, EHOSTUNREACH);
+#else
+    (void)orig_pkt;
+#endif
+}
+
+void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
+{
+    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_pkt_too_big_build(mtu, orig_pkt);
+
+    if (pkt != NULL) {
+        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+    }
+#ifdef MODULE_GNRC_PKTBUF
+    gnrc_pktbuf_release_error(orig_pkt, EMSGSIZE);
+#else
+    (void)orig_pkt;
+#endif
+}
+
+void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
+{
+    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_time_exc_build(code, orig_pkt);
+
+    if (pkt != NULL) {
+        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+    }
+#ifdef MODULE_GNRC_PKTBUF
+    gnrc_pktbuf_release_error(orig_pkt, ETIMEDOUT);
+#else
+    (void)orig_pkt;
+#endif
+}
+
+void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
+                                       gnrc_pktsnip_t *orig_pkt)
+{
+    gnrc_pktsnip_t *pkt = gnrc_icmpv6_error_param_prob_build(code, ptr, orig_pkt);
+
+    if (pkt != NULL) {
+        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+    }
+#ifdef MODULE_GNRC_PKTBUF
+    gnrc_pktbuf_release_error(orig_pkt, EINVAL);
+#else
+    (void)orig_pkt;
+#endif
+}
+
 /** @} */

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -128,11 +128,6 @@ void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
     if (pkt != NULL) {
         gnrc_netapi_send(gnrc_ipv6_pid, pkt);
     }
-#ifdef MODULE_GNRC_PKTBUF
-    gnrc_pktbuf_release_error(orig_pkt, EHOSTUNREACH);
-#else
-    (void)orig_pkt;
-#endif
 }
 
 void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
@@ -142,11 +137,6 @@ void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
     if (pkt != NULL) {
         gnrc_netapi_send(gnrc_ipv6_pid, pkt);
     }
-#ifdef MODULE_GNRC_PKTBUF
-    gnrc_pktbuf_release_error(orig_pkt, EMSGSIZE);
-#else
-    (void)orig_pkt;
-#endif
 }
 
 void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
@@ -156,11 +146,6 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
     if (pkt != NULL) {
         gnrc_netapi_send(gnrc_ipv6_pid, pkt);
     }
-#ifdef MODULE_GNRC_PKTBUF
-    gnrc_pktbuf_release_error(orig_pkt, ETIMEDOUT);
-#else
-    (void)orig_pkt;
-#endif
 }
 
 void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
@@ -171,11 +156,6 @@ void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
     if (pkt != NULL) {
         gnrc_netapi_send(gnrc_ipv6_pid, pkt);
     }
-#ifdef MODULE_GNRC_PKTBUF
-    gnrc_pktbuf_release_error(orig_pkt, EINVAL);
-#else
-    (void)orig_pkt;
-#endif
 }
 
 /** @} */

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -12,11 +12,11 @@
  * @file
  */
 
+#include "net/ipv6.h"
+#include "net/gnrc/icmpv6.h"
 #include "net/gnrc/pktbuf.h"
 
-#include "net/ipv6.h"
 #include "net/gnrc/icmpv6/error.h"
-#include "net/gnrc/icmpv6.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -128,7 +128,12 @@ static gnrc_pktsnip_t *_param_prob_build(uint8_t code, void *ptr,
 static void _send(gnrc_pktsnip_t *pkt)
 {
     if (pkt != NULL) {
-        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+        if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6,
+                                       GNRC_NETREG_DEMUX_CTX_ALL,
+                                       pkt)) {
+            DEBUG("gnrc_icmpv6_error: No send handler found.\n");
+            gnrc_pktbuf_release(pkt);
+        }
     }
     else {
         DEBUG("gnrc_icmpv6_error: No space in packet buffer left\n");

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -51,6 +51,7 @@ static size_t _fit(const gnrc_pktsnip_t *orig_pkt)
         gnrc_netif_hdr_t *data = netif_hdr->data;
         gnrc_netif_t *netif = gnrc_netif_get_by_pid(data->if_pid);
 
+        pkt_len -= netif_hdr->size;
         DEBUG("gnrc_icmpv6_error: fitting to MTU of iface %u (%u)\n",
               netif->pid, netif->ipv6.mtu);
         return MIN(pkt_len, netif->ipv6.mtu - sizeof(ipv6_hdr_t));

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -18,6 +18,9 @@
 #include "net/gnrc/icmpv6/error.h"
 #include "net/gnrc/icmpv6.h"
 
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
 /* all error messages are basically the same size and format */
 #define ICMPV6_ERROR_SZ (sizeof(icmpv6_error_dst_unr_t))
 #define ICMPV6_ERROR_SET_VALUE(data, value) \
@@ -127,12 +130,16 @@ static void _send(gnrc_pktsnip_t *pkt)
     if (pkt != NULL) {
         gnrc_netapi_send(gnrc_ipv6_pid, pkt);
     }
+    else {
+        DEBUG("gnrc_icmpv6_error: No space in packet buffer left\n");
+    }
 }
 
 void gnrc_icmpv6_error_dst_unr_send(uint8_t code, const gnrc_pktsnip_t *orig_pkt)
 {
     gnrc_pktsnip_t *pkt = _dst_unr_build(code, orig_pkt);
 
+    DEBUG("gnrc_icmpv6_error: trying to send destination unreachable error\n");
     _send(pkt);
 }
 
@@ -141,6 +148,7 @@ void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu,
 {
     gnrc_pktsnip_t *pkt = _pkt_too_big_build(mtu, orig_pkt);
 
+    DEBUG("gnrc_icmpv6_error: trying to send packet too big error\n");
     _send(pkt);
 }
 
@@ -149,6 +157,7 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code,
 {
     gnrc_pktsnip_t *pkt = _time_exc_build(code, orig_pkt);
 
+    DEBUG("gnrc_icmpv6_error: trying to send time exceeded error\n");
     _send(pkt);
 }
 
@@ -157,6 +166,7 @@ void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
 {
     gnrc_pktsnip_t *pkt = _param_prob_build(code, ptr, orig_pkt);
 
+    DEBUG("gnrc_icmpv6_error: trying to send parameter problem error\n");
     _send(pkt);
 }
 

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -26,7 +26,7 @@
 /* TODO: generalize and centralize (see https://github.com/RIOT-OS/RIOT/pull/3184) */
 #define MIN(a, b)   ((a) < (b)) ? (a) : (b)
 
-static inline size_t _fit(gnrc_pktsnip_t *pkt)
+static inline size_t _fit(const gnrc_pktsnip_t *pkt)
 {
     /* TODO: replace IPV6_MIN_MTU with known path MTU? */
     return MIN((gnrc_pkt_len(pkt) + ICMPV6_ERROR_SZ), IPV6_MIN_MTU);
@@ -34,7 +34,8 @@ static inline size_t _fit(gnrc_pktsnip_t *pkt)
 
 /* Build a generic error message */
 static gnrc_pktsnip_t *_icmpv6_error_build(uint8_t type, uint8_t code,
-                                           gnrc_pktsnip_t *orig_pkt, uint32_t value)
+                                           const gnrc_pktsnip_t *orig_pkt,
+                                           uint32_t value)
 {
     gnrc_pktsnip_t *pkt = gnrc_icmpv6_build(NULL, type, code, _fit(orig_pkt));
 
@@ -55,19 +56,19 @@ static gnrc_pktsnip_t *_icmpv6_error_build(uint8_t type, uint8_t code,
 }
 
 static inline gnrc_pktsnip_t *_dst_unr_build(uint8_t code,
-                                             gnrc_pktsnip_t *orig_pkt)
+                                             const gnrc_pktsnip_t *orig_pkt)
 {
     return _icmpv6_error_build(ICMPV6_DST_UNR, code, orig_pkt, 0);
 }
 
 static inline gnrc_pktsnip_t *_pkt_too_big_build(uint32_t mtu,
-                                                 gnrc_pktsnip_t *orig_pkt)
+                                                 const gnrc_pktsnip_t *orig_pkt)
 {
     return _icmpv6_error_build(ICMPV6_PKT_TOO_BIG, 0, orig_pkt, mtu);
 }
 
 static inline gnrc_pktsnip_t *_time_exc_build(uint8_t code,
-                                              gnrc_pktsnip_t *orig_pkt)
+                                              const gnrc_pktsnip_t *orig_pkt)
 {
     return _icmpv6_error_build(ICMPV6_TIME_EXC, code, orig_pkt, 0);
 }
@@ -78,7 +79,7 @@ static inline bool _in_range(uint8_t *ptr, uint8_t *start, size_t sz)
 }
 
 static gnrc_pktsnip_t *_param_prob_build(uint8_t code, void *ptr,
-                                         gnrc_pktsnip_t *orig_pkt)
+                                         const gnrc_pktsnip_t *orig_pkt)
 {
     gnrc_pktsnip_t *pkt = gnrc_icmpv6_build(NULL, ICMPV6_PARAM_PROB, code,
                                             _fit(orig_pkt));
@@ -121,7 +122,7 @@ static gnrc_pktsnip_t *_param_prob_build(uint8_t code, void *ptr,
     return pkt;
 }
 
-void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
+void gnrc_icmpv6_error_dst_unr_send(uint8_t code, const gnrc_pktsnip_t *orig_pkt)
 {
     gnrc_pktsnip_t *pkt = _dst_unr_build(code, orig_pkt);
 
@@ -130,7 +131,8 @@ void gnrc_icmpv6_error_dst_unr_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
     }
 }
 
-void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
+void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu,
+                                        const gnrc_pktsnip_t *orig_pkt)
 {
     gnrc_pktsnip_t *pkt = _pkt_too_big_build(mtu, orig_pkt);
 
@@ -139,7 +141,8 @@ void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu, gnrc_pktsnip_t *orig_pkt)
     }
 }
 
-void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
+void gnrc_icmpv6_error_time_exc_send(uint8_t code,
+                                     const gnrc_pktsnip_t *orig_pkt)
 {
     gnrc_pktsnip_t *pkt = _time_exc_build(code, orig_pkt);
 
@@ -149,7 +152,7 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code, gnrc_pktsnip_t *orig_pkt)
 }
 
 void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
-                                       gnrc_pktsnip_t *orig_pkt)
+                                       const gnrc_pktsnip_t *orig_pkt)
 {
     gnrc_pktsnip_t *pkt = _param_prob_build(code, ptr, orig_pkt);
 

--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -122,13 +122,18 @@ static gnrc_pktsnip_t *_param_prob_build(uint8_t code, void *ptr,
     return pkt;
 }
 
+static void _send(gnrc_pktsnip_t *pkt)
+{
+    if (pkt != NULL) {
+        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
+    }
+}
+
 void gnrc_icmpv6_error_dst_unr_send(uint8_t code, const gnrc_pktsnip_t *orig_pkt)
 {
     gnrc_pktsnip_t *pkt = _dst_unr_build(code, orig_pkt);
 
-    if (pkt != NULL) {
-        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
-    }
+    _send(pkt);
 }
 
 void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu,
@@ -136,9 +141,7 @@ void gnrc_icmpv6_error_pkt_too_big_send(uint32_t mtu,
 {
     gnrc_pktsnip_t *pkt = _pkt_too_big_build(mtu, orig_pkt);
 
-    if (pkt != NULL) {
-        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
-    }
+    _send(pkt);
 }
 
 void gnrc_icmpv6_error_time_exc_send(uint8_t code,
@@ -146,9 +149,7 @@ void gnrc_icmpv6_error_time_exc_send(uint8_t code,
 {
     gnrc_pktsnip_t *pkt = _time_exc_build(code, orig_pkt);
 
-    if (pkt != NULL) {
-        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
-    }
+    _send(pkt);
 }
 
 void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
@@ -156,9 +157,7 @@ void gnrc_icmpv6_error_param_prob_send(uint8_t code, void *ptr,
 {
     gnrc_pktsnip_t *pkt = _param_prob_build(code, ptr, orig_pkt);
 
-    if (pkt != NULL) {
-        gnrc_netapi_send(gnrc_ipv6_pid, pkt);
-    }
+    _send(pkt);
 }
 
 /** @} */

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "net/gnrc/icmpv6/error.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/ipv6/nib/conf.h"
 #include "net/gnrc/ipv6/nib/nc.h"
@@ -265,6 +266,8 @@ void _nib_nc_remove(_nib_onl_entry_t *node)
          (ptr != NULL) && (tmp = (ptr->next), 1);
          ptr = tmp) {
         gnrc_pktqueue_t *entry = gnrc_pktqueue_remove(&node->pktqueue, ptr);
+        gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_ADDR,
+                                       entry->pkt);
         gnrc_pktbuf_release_error(entry->pkt, EHOSTUNREACH);
         entry->pkt = NULL;
     }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -18,6 +18,7 @@
 
 #include "log.h"
 #include "net/ipv6/addr.h"
+#include "net/gnrc/icmpv6/error.h"
 #include "net/gnrc/nettype.h"
 #include "net/gnrc/netif/internal.h"
 #include "net/gnrc/ipv6/nib.h"
@@ -203,6 +204,8 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
                  * we also shouldn't release), but if netif is not defined we
                  * should release in any case. */
                 if (netif == NULL) {
+                    gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_ADDR,
+                                                   pkt);
                     gnrc_pktbuf_release_error(pkt, EHOSTUNREACH);
                 }
                 res = -EHOSTUNREACH;
@@ -225,6 +228,8 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
                     memcpy(&route.next_hop, dst, sizeof(route.next_hop));
                 }
                 else {
+                    gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_NO_ROUTE,
+                                                   pkt);
                     res = -ENETUNREACH;
                     gnrc_pktbuf_release_error(pkt, ENETUNREACH);
                     break;
@@ -1168,9 +1173,13 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
                 }
             }
             else {
+                gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_ADDR,
+                                               pkt);
                 gnrc_pktbuf_release_error(pkt, EHOSTUNREACH);
             }
 #else   /* GNRC_IPV6_NIB_CONF_QUEUE_PKT */
+            gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_ADDR,
+                                           pkt);
             gnrc_pktbuf_release_error(pkt, EHOSTUNREACH);
 #endif  /* GNRC_IPV6_NIB_CONF_QUEUE_PKT */
         }

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -27,6 +27,7 @@
 #include "net/ipv6/hdr.h"
 #include "net/gnrc/udp.h"
 #include "net/gnrc.h"
+#include "net/gnrc/icmpv6/error.h"
 #include "net/inet_csum.h"
 
 
@@ -157,6 +158,8 @@ static void _receive(gnrc_pktsnip_t *pkt)
     /* send payload to receivers */
     if (!gnrc_netapi_dispatch_receive(GNRC_NETTYPE_UDP, port, pkt)) {
         DEBUG("udp: unable to forward packet as no one is interested in it\n");
+        /* TODO determine if IPv6 packet, when IPv4 is implemented */
+        gnrc_icmpv6_error_dst_unr_send(ICMPV6_ERROR_DST_UNR_PORT, pkt);
         gnrc_pktbuf_release(pkt);
     }
 }


### PR DESCRIPTION
### Contribution description
When implementing ICMPv6 for GNRC I also added build and send functions for ICMPv6 error messages, but I never actually used them while implementing IPv6. Reviewing that sub-module I found it quite buggy:

* Packets in receive order were assumed in send order
* Packets were sent out without an IP header attached
* Packets were just sent to the PID of the IP thread instead of searching the registry
* etc.

This PR fixes those issues. Additionally a call of the send functions is added were appropriate, so GNRC is now able to correctly (but optionally) report to a sender what went wrong. To prevent further degeneration of that module, I activated it for `gnrc_networking` (but also some tests might be nice, which is why I set the WIP label, though the tests can also come as a follow-up IMHO).

### Testing procedures

I tested this using `examples/gnrc_networking` and [scapy](https://scapy.readthedocs.io/en/latest/). If you get problems receiving you might need to merge #10356 first. The tests are required to be executed in order as commands previously executed in other tests might be a precondition:

1. Compile and start `gnrc_networking` (make sure `gnrc_icmpv6_error` is included; should be automatically as per this PR) for native
    ```sh
    make -C examples/gnrc_networking all term
    ``` 
2. Get the link-local IPv6 address and hardware address of the native instance:
    ```
    > ifconfig
   Iface  6  HWaddr: 36:54:72:4F:8B:1F 
              MTU:1500  HL:64  RTR  
              RTR_ADV  
              Source address length: 6
              Link type: wired
              inet6 addr: fe80::3454:72ff:fe4f:8b1f  scope: local  VAL
              inet6 group: ff02::2
              inet6 group: ff02::1
              inet6 group: ff02::1:ff4f:8b1f
              inet6 group: ff02::1a
              
              Statistics for Layer 2
                RX packets 32  bytes 6964
                TX packets 28 (Multicast: 6)  bytes 6980
                TX succeeded 28 errors 0
              Statistics for IPv6
                RX packets 32  bytes 6516
                TX packets 28 (Multicast: 6)  bytes 6588
                TX succeeded 28 errors 0
    ```
3. Get the link-local IPv6 address of your TAP interface/bridge
4. Start `scapy` with root privileges (required to send ethernet frames)
5. Set some variables:
   ```py
   DST_ADDR = "<native link-local IPv6 address>"
   DST_HWADDR = "<native hardware address>"
   SRC_ADDR = "<TAP interface link-local IPv6 address>"
   ```
6. Test UDP "port unreachable" error:
    1. Port not registered:
          **scapy:**
          ```py
          p = srp1(Ether(dst=DST_HWADDR) / IPv6(dst=DST_ADDR, src=SRC_ADDR) / UDP(),
                    iface="tapbr0")
          assert(ICMPv6DestUnreach in p)
          assert(p[ICMPv6DestUnreach].code == 4) # Port unreachable
          ```
    2. Port registered:
          **RIOT:**
          ```py
         udp server start 1337
          ```
          **scapy:**
          ```py
          p = srp1(Ether(dst=DST_HWADDR) / IPv6(dst=DST_ADDR, src=SRC_ADDR) / UDP(dport=1337),
                    iface="tapbr0", timeout=1)
          assert(p == None)
          ```
7. Check if large packets are carried correctly:
    ```py
    # 1452 = 1500 (Ethernet payload length) - 40 (IPv6 header size) - 8 (UDP header size)
    p = srp1(Ether(dst=DST_HWADDR) / IPv6(dst=DST_ADDR, src=SRC_ADDR) / UDP() / (1452 * "x"),
                   iface="tapbr0")
    assert(ICMPv6DestUnreach in p)
    assert(p[ICMPv6DestUnreach].code == 4) # Port unreachable
    assert(len(p[Raw]) < 1452)
    ```
8. Test "address unreachable" (local address):
    ```py
    p = srp1(Ether(dst=DST_HWADDR) / IPv6(dst="fe80::1", src=SRC_ADDR) / UDP(), iface="tapbr0", timeout=1)
    assert(ICMPv6DestUnreach in p)
    assert(p[ICMPv6DestUnreach].code == 3) # Address unreachable
    ```
9. Test "beyond scope of source address":
    ```py
   p = srp1(Ether(dst=DST_HWADDR) / IPv6(dst="affe::1", src=SRC_ADDR) / UDP(), iface="tapbr0", timeout=1)
    assert(ICMPv6DestUnreach in p)
    assert(p[ICMPv6DestUnreach].code == 2) # Beyond scope of source address
    ```
10. Test "erroneous header field encountered":
    ```py
    p = srp1(Ether(dst=DST_HWADDR) / IPv6(dst=DST_ADDR, src=SRC_ADDR, plen=20) / UDP(),
                   iface="tapbr0")
    assert(ICMPv6ParamProblem in p)
    assert(p[ICMPv6ParamProblem].code == 0) # erroneous header field encountered
    assert(p[ICMPv6ParamProblem].ptr == 4)  # IPv6 length field
    ```
11. Test "No route to destination"
    **Linux**: Configure route to native instance and set a global source address:
    ```sh
    sudo ip a a beef::1 dev tapbr0
    sudo ip r a affe::/64 via "<native link-local IPv6 address>" dev tapbr0
    ```
    **RIOT**: Configure route back to Linux:
    ```
    nib route add 6 beef::/64 "<TAP interface link-local IPv6 address>"
    ```
    **scapy**:
    ```py
    p = srp1(Ether(dst=DST_HWADDR) / IPv6(dst="affe::1", src="beef::1") / UDP(), iface="tapbr0")
    assert(ICMPv6DestUnreach in p)
    assert(p[ICMPv6DestUnreach].code == 0) # No route to destination
    ```
12. Test "Address unreachable" (neighboring node):
    **RIOT**: Configure route to bogus neighbor:
    ```
    nib route add 6 affe::/64 fe80::1
    ```
    **scapy**:
    ```py
    sendp(Ether(dst=DST_HWADDR) / IPv6(dst="affe::1", src="beef::1") / UDP(), iface="tapbr0")
    # srp1 would not return, for some reason
    # just check with wireshark or a second `scapy` instance using
    ps = sniff(iface="tapbr0", count=20)
    p = [p for p in ps if ICMPv6DestUnreach in p]
    assert(len(p) == 1)
    assert(p[0][ICMPv6DestUnreach].code == 3) # Address unreachable
    ```
13. Test "Hop limit exceeded in transit"
    ```py
    p = srp1(Ether(dst=DST_HWADDR) / IPv6(dst="affe::1", src="beef::1", hlim=1) / UDP(), iface="tapbr0")
    assert(ICMPv6TimeExceeded in p)
    assert(p[ICMPv6TimeExceeded].code == 0) # Hop limit exceeded in transit
    ```

### Issues/PRs references
None