### PR TITLE
SAUL/phydat: parts per million support

### DIFF
--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -94,6 +94,7 @@ enum {
     SAUL_SENSE_OBJTEMP  = 0x8c,     /**< sensor: object temperature */
     SAUL_SENSE_COUNT    = 0x8d,     /**< sensor: pulse counter */
     SAUL_SENSE_DISTANCE = 0x8e,     /**< sensor: distance */
+    SAUL_SENSE_CO2      = 0x8f,     /**< sensor: CO2 Gas */
     SAUL_CLASS_ANY      = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -51,6 +51,7 @@ const char *saul_class_to_str(const uint8_t class_id)
         case SAUL_SENSE_OBJTEMP:   return "SENSE_OBJTEMP";
         case SAUL_SENSE_COUNT:     return "SENSE_PULSE_COUNT";
         case SAUL_SENSE_DISTANCE:  return "SENSE_DISTANCE";
+        case SAUL_SENSE_CO2:       return "SENSE_CO2";
         case SAUL_CLASS_ANY:       return "CLASS_ANY";
         default:                   return "CLASS_UNKNOWN";
     }

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -89,6 +89,7 @@ const char *phydat_unit_to_str(uint8_t unit)
         case UNIT_GS:       return "Gs";
         case UNIT_BAR:      return "Bar";
         case UNIT_PA:       return "Pa";
+        case UNIT_PPM:      return "ppm";
         case UNIT_CD:       return "cd";
         case UNIT_PERCENT:  return "%";
         default:            return "";


### PR DESCRIPTION
### Contribution description

Add ppm (parts per million) unit support to saul and phydat.

### Issues/PRs references

None, but a dependency for a follow up PR for a driver for the MH-Z19 CO2 sensor.