### PR TITLE
sys/benchmark: remove BENCHMARK_SETUP()

### DIFF
--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -30,34 +30,27 @@ extern "C" {
 #endif
 
 /**
- * @brief   Prepare the current scope for running BENCHMARK_x() macros
- */
-#define BENCHMARK_SETUP()                       \
-    unsigned state;                             \
-    unsigned time
-
-/**
  * @brief   Measure the runtime of a given function call
  *
  * As we are doing a time sensitive measurement here, there is no way around
  * using a preprocessor function, as going with a function pointer or similar
  * would influence the measured runtime...
  *
- * @note    BENCHMARK_SETUP() needs to be called in the same scope
- *
  * @param[in] name      name for labeling the output
  * @param[in] runs      number of times to run @p func
  * @param[in] func      function call to benchmark
  */
-#define BENCHMARK_FUNC(name, runs, func)        \
-    state = irq_disable();                      \
-    time = xtimer_now_usec();                   \
-    for (unsigned long i = 0; i < runs; i++) {  \
-        func;                                   \
-    }                                           \
-    time = (xtimer_now_usec() - time);          \
-    irq_restore(state);                         \
-    benchmark_print_time(time, runs, name)
+#define BENCHMARK_FUNC(name, runs, func)                    \
+    {                                                           \
+        unsigned _benchmark_irqstate = irq_disable();           \
+        uint32_t _benchmark_time = xtimer_now_usec();           \
+        for (unsigned long i = 0; i < runs; i++) {              \
+            func;                                               \
+        }                                                       \
+        _benchmark_time = (xtimer_now_usec() - _benchmark_time);\
+        irq_restore(_benchmark_irqstate);                       \
+        benchmark_print_time(_benchmark_time, runs, name);      \
+    }
 
 /**
  * @brief   Output the given time as well as the time per run on STDIO

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -221,7 +221,6 @@ static int bench(int argc, char **argv)
     }
 
     puts("\nGPIO driver run-time performance benchmark\n");
-    BENCHMARK_SETUP();
     BENCHMARK_FUNC("nop loop", runs, __asm__ volatile("nop"));
     BENCHMARK_FUNC("gpio_set", runs, gpio_set(pin));
     BENCHMARK_FUNC("gpio_clear", runs, gpio_clear(pin));


### PR DESCRIPTION
### Contribution description

Currently, an extra macro is needed for declaring necessary temporary variables.
This PR moves those vars into the benchmark scope, thus removing the need for the setup macro.

Code compiles to same size on samr21-xpro.