### PR TITLE
netopt/drivers: Add phy link status output

### DIFF
--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -454,6 +454,14 @@ static int nd_get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             assert(max_len >= ETHERNET_ADDR_LEN);
             mac_get(dev, (uint8_t *)value);
             return ETHERNET_ADDR_LEN;
+        case NETOPT_LINK_CONNECTED:
+            if (cmd_r_phy(dev, REG_PHY_PHSTAT2) & PHSTAT2_LSTAT) {
+                *((netopt_enable_t *)value) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)value) = NETOPT_DISABLE;
+            }
+            return sizeof(netopt_enable_t);
         default:
             return netdev_eth_get(netdev, opt, value, max_len);
     }

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -401,6 +401,14 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
                 res = ETHERNET_ADDR_LEN;
             }
             break;
+        case NETOPT_LINK_CONNECTED:
+            if (reg_get((encx24j600_t *)dev, ENC_ESTAT) & ENC_PHYLNK) {
+                *((netopt_enable_t *)value) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)value) = NETOPT_DISABLE;
+            }
+            return sizeof(netopt_enable_t);
         default:
             res = netdev_eth_get(dev, opt, value, max_len);
             break;

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -271,6 +271,18 @@ typedef enum {
     NETOPT_IS_WIRED,
 
     /**
+     * @brief (@ref netopt_enable_t) Phy link status.
+     *
+     * Returns NETOPT_ENABLE when the the link of the interface is up,
+     * NETOPT_DISABLE when the link is down. If the interface is wireless or
+     * doesn't support link status detection this function will return
+     * -ENOTSUP.
+     *
+     * @note Setting this option will always return -ENOTSUP.
+     */
+    NETOPT_LINK_CONNECTED,
+
+    /**
      * @brief get a device's "type", e.g., ethernet, 802.15.4, ...
      */
     NETOPT_DEVICE_TYPE,

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -61,6 +61,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_CSMA_MINBE]            = "NETOPT_CSMA_MINBE",
     [NETOPT_MAC_NO_SLEEP]          = "NETOPT_MAC_NO_SLEEP",
     [NETOPT_IS_WIRED]              = "NETOPT_IS_WIRED",
+    [NETOPT_LINK_CONNECTED]        = "NETOPT_LINK_CONNECTED",
     [NETOPT_DEVICE_TYPE]           = "NETOPT_DEVICE_TYPE",
     [NETOPT_CHANNEL_PAGE]          = "NETOPT_CHANNEL_PAGE",
     [NETOPT_CCA_THRESHOLD]         = "NETOPT_CCA_THRESHOLD",

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -426,6 +426,10 @@ static void _netif_list(kernel_pid_t iface)
     if (res >= 0) {
         printf(" CR: %s ", _netopt_coding_rate_str[u8]);
     }
+    res = gnrc_netapi_get(iface, NETOPT_LINK_CONNECTED, 0, &u8, sizeof(u8));
+    if (res >= 0) {
+        printf(" Link: %s ", (netopt_enable_t)u8 ? "up" : "down" );
+    }
     line_thresh = _newline(0U, line_thresh);
     res = gnrc_netapi_get(iface, NETOPT_ADDRESS_LONG, 0, hwaddr, sizeof(hwaddr));
     if (res >= 0) {


### PR DESCRIPTION
### Contribution description

This PR adds netopt support to query the status of the phy link of a network driver, whether a cable is attached and the link is functional. Output for the ifconfig command to report this status is added.

### Issues/PRs references

None

### Todo

Other drivers beside the enc28j60:

- [ ] netdev_tap
- [x] encx24j600
~~w5100~~