### PR TITLE
make: always set -Wno-implicit-fallthrough

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -132,6 +132,9 @@ ifeq ($(WPEDANTIC),1)
     CFLAGS += -Wpedantic -pedantic-errors
 endif
 
+# remove this once codebase is adapted
+CFLAGS += -Wno-implicit-fallthrough
+
 ifneq (10,$(if ${RIOT_VERSION},1,0)$(if ${__RIOTBUILD_FLAG},1,0))
 
 # Provide a shallow sanity check. You cannot call `make` in a module directory.


### PR DESCRIPTION
### Contribution description

gcc 7 introduced a new warning for uncommented implicit switch/case fallthroughs. As we enable all plus extra warnings, gcc 7 stumbles over a couple of those in our codebase.

There have been numerous PR's fixing remaining fallthrough warnings, mostly in packages. Still, many are left.

Ideally we'd fix them all before CI is switching to gcc 7. Unfortunately, somehow the ppa's used within the RIOT Dockerfile now default to a newer gcc7 arm toolchain, thus forcing our hand...

I propose just disabling the warning for now, globally, as this PR does.