### PR TITLE
drivers/sx127x: Fix -Wmaybe-uninitialized warning

### DIFF
--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -539,7 +539,7 @@ static int _get_state(sx127x_t *dev, void *val)
 {
     uint8_t op_mode;
     op_mode = sx127x_get_op_mode(dev);
-    netopt_state_t state;
+    netopt_state_t state = NETOPT_STATE_OFF;
     switch(op_mode) {
         case SX127X_RF_OPMODE_SLEEP:
             state = NETOPT_STATE_SLEEP;


### PR DESCRIPTION
### Contribution description

Fix a warning in the get_state function in sx127x

### Issues/PRs references

#8265 