### PR TITLE
drivers/saul: add UV and distance sense options

### DIFF
--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -93,6 +93,7 @@ enum {
     SAUL_SENSE_UV       = 0x8b,     /**< sensor: UV index */
     SAUL_SENSE_OBJTEMP  = 0x8c,     /**< sensor: object temperature */
     SAUL_SENSE_COUNT    = 0x8d,     /**< sensor: pulse counter */
+    SAUL_SENSE_DISTANCE = 0x8e,     /**< sensor: distance */
     SAUL_CLASS_ANY      = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -29,27 +29,29 @@
 const char *saul_class_to_str(const uint8_t class_id)
 {
     switch (class_id) {
-        case SAUL_CLASS_UNDEF:  return "CLASS_UNDEF";
-        case SAUL_ACT_ANY:      return "ACT_ANY";
-        case SAUL_ACT_LED_RGB:  return "ACT_LED_RGB";
-        case SAUL_ACT_SERVO:    return "ACT_SERVO";
-        case SAUL_ACT_MOTOR:    return "ACT_MOTOR";
-        case SAUL_ACT_SWITCH:   return "ACT_SWITCH";
-        case SAUL_ACT_DIMMER:   return "ACT_DIMMER";
-        case SAUL_SENSE_ANY:    return "SENSE_ANY";
-        case SAUL_SENSE_BTN:    return "SENSE_BTN";
-        case SAUL_SENSE_TEMP:   return "SENSE_TEMP";
-        case SAUL_SENSE_HUM:    return "SENSE_HUM";
-        case SAUL_SENSE_LIGHT:  return "SENSE_LIGHT";
-        case SAUL_SENSE_ACCEL:  return "SENSE_ACCEL";
-        case SAUL_SENSE_MAG:    return "SENSE_MAG";
-        case SAUL_SENSE_GYRO:   return "SENSE_GYRO";
-        case SAUL_SENSE_COLOR:  return "SENSE_COLOR";
-        case SAUL_SENSE_PRESS:  return "SENSE_PRESS";
-        case SAUL_SENSE_ANALOG: return "SENSE_ANALOG";
-        case SAUL_SENSE_OBJTEMP:return "SENSE_OBJTEMP";
-        case SAUL_SENSE_COUNT:  return "SENSE_PULSE_COUNT";
-        case SAUL_CLASS_ANY:    return "CLASS_ANY";
-        default:                return "CLASS_UNKNOWN";
+        case SAUL_CLASS_UNDEF:     return "CLASS_UNDEF";
+        case SAUL_ACT_ANY:         return "ACT_ANY";
+        case SAUL_ACT_LED_RGB:     return "ACT_LED_RGB";
+        case SAUL_ACT_SERVO:       return "ACT_SERVO";
+        case SAUL_ACT_MOTOR:       return "ACT_MOTOR";
+        case SAUL_ACT_SWITCH:      return "ACT_SWITCH";
+        case SAUL_ACT_DIMMER:      return "ACT_DIMMER";
+        case SAUL_SENSE_ANY:       return "SENSE_ANY";
+        case SAUL_SENSE_BTN:       return "SENSE_BTN";
+        case SAUL_SENSE_TEMP:      return "SENSE_TEMP";
+        case SAUL_SENSE_HUM:       return "SENSE_HUM";
+        case SAUL_SENSE_LIGHT:     return "SENSE_LIGHT";
+        case SAUL_SENSE_ACCEL:     return "SENSE_ACCEL";
+        case SAUL_SENSE_MAG:       return "SENSE_MAG";
+        case SAUL_SENSE_GYRO:      return "SENSE_GYRO";
+        case SAUL_SENSE_COLOR:     return "SENSE_COLOR";
+        case SAUL_SENSE_PRESS:     return "SENSE_PRESS";
+        case SAUL_SENSE_ANALOG:    return "SENSE_ANALOG";
+        case SAUL_SENSE_UV:        return "SENSE_UV";
+        case SAUL_SENSE_OBJTEMP:   return "SENSE_OBJTEMP";
+        case SAUL_SENSE_COUNT:     return "SENSE_PULSE_COUNT";
+        case SAUL_SENSE_DISTANCE:  return "SENSE_DISTANCE";
+        case SAUL_CLASS_ANY:       return "CLASS_ANY";
+        default:                   return "CLASS_UNKNOWN";
     }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While re-working  #5667, I realized 2 things:
* there is no string defined for the SAUL_SENSE_UV
* SAUL_SENSE_DISTANCE is missing

This PR adds these missing enums/values.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

required for #5667 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->