### PR TITLE
drivers: fix indentation in Makefile.include

### DIFF
--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -119,7 +119,7 @@ ifneq (,$(filter sdcard_spi,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sdcard_spi/include
 endif
 ifneq (,$(filter soft_spi,$(USEMODULE)))
-    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/soft_spi/include
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/soft_spi/include
 endif
 ifneq (,$(filter veml6070,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/veml6070/include


### PR DESCRIPTION
- soft_spi was using a 4 spaces indentation, but only 2 are required

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a minor indentation fix in `drivers/Makefile.include`. Found that while (re)working on #5667.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->