### PR TITLE
unittests/tests-littlefs: fix dummy mtd

### DIFF
--- a/tests/unittests/tests-littlefs/tests-littlefs.c
+++ b/tests/unittests/tests-littlefs/tests-littlefs.c
@@ -46,7 +46,6 @@ static int _init(mtd_dev_t *dev)
 {
     (void)dev;
 
-    memset(dummy_memory, 0xff, sizeof(dummy_memory));
     return 0;
 }
 
@@ -407,6 +406,10 @@ static void tests_littlefs_statvfs(void)
 
 Test *tests_littlefs_tests(void)
 {
+#ifndef MTD_0
+    memset(dummy_memory, 0xff, sizeof(dummy_memory));
+#endif
+
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(tests_littlefs_format),
         new_TestFixture(tests_littlefs_mount_umount),


### PR DESCRIPTION
### Contribution description

_init function were erasing whole memory leading to losing everything
when mounting or formating the memory


### Issues/PRs references

#8600 