### PR TITLE
pkg: fix compile errors in gecko_sdk and umorse

### DIFF
--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -7,6 +7,8 @@ ifneq ($(CPU),efm32)
   $(error This package can only be used with EFM32 CPUs)
 endif
 
+CFLAGS += -Wno-int-in-bool-context
+
 .PHONY: all
 
 all: git-download

--- a/pkg/umorse/Makefile
+++ b/pkg/umorse/Makefile
@@ -3,6 +3,8 @@ PKG_URL=https://github.com/smlng/uMorse
 PKG_VERSION=1dc14abdba22cca2f7efc053b2bce327bc7db97e
 PKG_LICENSE=MIT
 
+CFLAGS += -D_XOPEN_SOURCE=600
+
 .PHONY: all
 
 all: git-download


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Currently all builds for boards with CPU emf32 fail with compiler error when using GCC 7.x.

This Pr disables the responsible Werror flag for the gecko sdk package.

### Issues/PRs references

see Murdock Log, e.g. [here](https://ci.riot-os.org/RIOT-OS/RIOT/8607/1fa97f0998b064e8ffcd11a7f442db67faecdbad/output/compile/tests/minimal/ikea-tradfri.txt)