### PR TITLE
cpu/sam3: fix build failure with TOOLCHAIN=llvm

### DIFF
--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -53,7 +53,7 @@
 /**
  * @brief Allocation of memory for 7 independent interrupt slots
  */
-static gpio_isr_ctx_t exti_ctx[CTX_NUMOF] = {{0}};
+static gpio_isr_ctx_t exti_ctx[CTX_NUMOF];
 
 /**
  * @brief Allocation of 4 bit per pin to map a pin to an interrupt context


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While testing #8365 I noticed that `examples/arduino_hello-world/` doesn't build with `TOOLCHAIN=llvm BOARD=arduino-due`, the following error is reported:

```
$ clang --version
clang version 5.0.1-2 (tags/RELEASE_501/final)                                                                                                                                                                                                
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
$ make TOOLCHAIN=llvm BOARD=arduino-due -C examples/arduino_hello-world/
make: Entering directory '/home/nmeum/RIOT/examples/arduino_hello-world'                                                                                                                                                                      
Building application "arduino_hello-world" for "arduino-due" with MCU "sam3".                                                                                                                                                                 
                                                                                                                                                                                                                                              
"make" -C /home/nmeum/RIOT/boards/arduino-due                                                                                                                                                                                                 
"make" -C /home/nmeum/RIOT/boards/common/arduino-due                                                                                                                                                                                          
"make" -C /home/nmeum/RIOT/core                                                                                                                                                                                                               
"make" -C /home/nmeum/RIOT/cpu/sam3                                                                                                                                                                                                           
"make" -C /home/nmeum/RIOT/cpu/cortexm_common                                                                                                                                                                                                 
"make" -C /home/nmeum/RIOT/cpu/cortexm_common/periph                                                                                                                                                                                          
"make" -C /home/nmeum/RIOT/cpu/sam3/periph                                                                                                                                                                                                    
/home/nmeum/RIOT/cpu/sam3/periph/gpio.c:56:48: error: missing field 'arg' initializer [-Werror,-Wmissing-field-initializers]                                                                                                                  
static gpio_isr_ctx_t exti_ctx[CTX_NUMOF] = {{0}};
                                               ^
1 error generated.                                                                                                                                                                                                                            
/home/nmeum/RIOT/Makefile.base:81: recipe for target '/root/RIOT/examples/arduino_hello-world/bin/arduino-due/periph/gpio.o' failed                                                                                                           
make[3]: *** [/home/nmeum/RIOT/examples/arduino_hello-world/bin/arduino-due/periph/gpio.o] Error 1
/home/nmeum/RIOT/Makefile.base:20: recipe for target 'ALL--/root/RIOT/cpu/sam3/periph' failed
make[2]: *** [ALL--/home/nmeum/RIOT/cpu/sam3/periph] Error 2
/home/nmeum/RIOT/Makefile.base:20: recipe for target 'ALL--/root/RIOT/cpu/sam3' failed
make[1]: *** [ALL--/home/nmeum/RIOT/cpu/sam3] Error 2
/home/nmeum/RIOT/examples/arduino_hello-world/../../Makefile.include:323: recipe for target 'link' failed
make: *** [link] Error 2
make: Leaving directory '/home/nmeum/RIOT/examples/arduino_hello-world'                                                                                                                                                                       
```

I don't see any reason why that array needs to be explicitly initialized, if you don't initialize it the build success. An alternative fix, if the explicit initialization is necessary, would be:

```patch
diff --git a/cpu/sam3/periph/gpio.c b/cpu/sam3/periph/gpio.c
index ebe7d73a2..3b8c4c580 100644
--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -53,7 +53,7 @@
 /**
  * @brief Allocation of memory for 7 independent interrupt slots
  */
-static gpio_isr_ctx_t exti_ctx[CTX_NUMOF];
+static gpio_isr_ctx_t exti_ctx[CTX_NUMOF] = {{0, 0}};
 
 /**
  * @brief Allocation of 4 bit per pin to map a pin to an interrupt context
```

### Issues/PRs references

None.