### PR TITLE
pkg/fatfs: Refactor path handling, minor fixes

### DIFF
--- a/sys/include/fs/fatfs.h
+++ b/sys/include/fs/fatfs.h
@@ -35,15 +35,6 @@ extern "C" {
 /** The epoch offset is used to convert between FatFs and time_t timestamps */
 #define EPOCH_YEAR_OFFSET (1970)
 
-/** Size of the buffer needed for a directory entry -> @attention this should be: sizeof(DIR).
-    sizeof(DIR) currently isn't used directly because it's not possible to use that within
-    preprocessor-if (see below) */
-#define FATFS_DIR_SIZE (44)
-
-/** Size of the buffer needed for directory
-    -> should be: sizeof(fatfs_file_desc_t) */
-#define FATFS_FILE_SIZE (72)
-
 /** size needed for volume strings like "n:/" where n is the volume id */
 #define FATFS_MAX_VOL_STR_LEN (4)
 
@@ -53,14 +44,6 @@ extern "C" {
 /** most FatFs file operations need an absolute path. This defines the size of the
     needed buffer to circumvent stack allocation within vfs-wrappers */
 #define FATFS_MAX_ABS_PATH_SIZE (FATFS_MAX_VOL_STR_LEN + VFS_NAME_MAX + 1)
-
-#if (VFS_DIR_BUFFER_SIZE < FATFS_DIR_SIZE)
-#error "VFS_DIR_BUFFER_SIZE too small"
-#endif
-
-#if (VFS_FILE_BUFFER_SIZE < FATFS_FILE_SIZE)
-#error "VFS_FILE_BUFFER_SIZE too small"
-#endif
 
 /**
  * needed info to run a FatFs instance

--- a/sys/include/fs/fatfs.h
+++ b/sys/include/fs/fatfs.h
@@ -36,7 +36,7 @@ extern "C" {
 #define EPOCH_YEAR_OFFSET (1970)
 
 /** size needed for volume strings like "n:/" where n is the volume id */
-#define FATFS_MAX_VOL_STR_LEN (4)
+#define FATFS_MAX_VOL_STR_LEN (6)
 
 /** 0:mount on first file access, 1 mount in f_mount() call */
 #define FATFS_MOUNT_OPT       (1)

--- a/sys/include/fs/fatfs.h
+++ b/sys/include/fs/fatfs.h
@@ -41,12 +41,16 @@ extern "C" {
 /** 0:mount on first file access, 1 mount in f_mount() call */
 #define FATFS_MOUNT_OPT       (1)
 
-/** most FatFs file operations need an absolute path. This defines the size of the
-    needed buffer to circumvent stack allocation within vfs-wrappers */
+/**
+ * @brief Size of path buffer for absolute paths
+ *
+ * Most FatFs file operations need an absolute path. This defines the size of
+ * the needed buffer to circumvent stack allocation within vfs-wrappers
+ */
 #define FATFS_MAX_ABS_PATH_SIZE (FATFS_MAX_VOL_STR_LEN + VFS_NAME_MAX + 1)
 
 /**
- * needed info to run a FatFs instance
+ * @brief FatFs instance descriptor
  */
 typedef struct fatfs_desc {
     FATFS fat_fs;       /**< FatFs work area needed for each volume */
@@ -58,7 +62,7 @@ typedef struct fatfs_desc {
 } fatfs_desc_t;
 
 /**
- * info of a single opened file
+ * @brief FatFs file instance descriptor
  */
 typedef struct fatfs_file_desc {
     FIL file;                     /**< FatFs work area for a single file */

--- a/tests/pkg_fatfs/README.md
+++ b/tests/pkg_fatfs/README.md
@@ -3,15 +3,25 @@ Using FatFs on RIOT
 
 # native
 
-To use this test on native you can either use a FAT-formatted image file or directly use the mkfs command from the RIOT shell.
-Use `make image` to extract a prepared image file that already contains a simple test.txt file.
-This is only a convinience function to allow testing against a "default linux" formatted fat volume without the need to call mount or other stuff that may require super user privileges.
-Optionally `make compressed-image` can be used to generate the compressed image that is in turn used by `make image`.
+To use this test on native you can either use a FAT-formatted image file or
+directly use the mkfs command from the RIOT shell. Use `make image` to extract
+a prepared image file that already contains a simple test.txt file. This is
+only a convinience function to allow testing against a "default linux"
+formatted fat volume without the need to call mount or other stuff that may
+require super user privileges. Optionally `make compressed-image` can be used
+to generate the compressed image that is in turn used by `make image`.
 
-To tell RIOT where your image file is located you can use the define `MTD_NATIVE_FILENAME`.
+To tell RIOT where your image file is located you can use the define
+`MTD_NATIVE_FILENAME`.
 
-	NOTE: You shouldn't leave the image mounted while you use it in RIOT, the abstraction layer between FatFs and the image file mimics a dumb block device (i.e. behaves much like the devices that are actually meant to be used with FAT) That implies it doesn't show any modifications in RIOT that you perform on your OS and the other way round. So always remember to mount/unmount correctly or your FS will probably get damaged.
+NOTE: You shouldn't leave the image mounted while you use it in RIOT, the
+abstraction layer between FatFs and the image file mimics a dumb block device
+(i.e. behaves much like the devices that are actually meant to be used with
+FAT) That implies it doesn't show any modifications in RIOT that you perform on
+your OS and the other way round. So always remember to mount/unmount correctly
+or your FS will probably get damaged.
 
 # Real Hardware
 
-Currently the test defaults to sdcard_spi on real hardware. But generally any device that supports the mtd-interface can be used with FatFs.
+Currently the test defaults to sdcard_spi on real hardware. But generally any
+device that supports the mtd-interface can be used with FatFs.

--- a/tests/pkg_fatfs_vfs/README.md
+++ b/tests/pkg_fatfs_vfs/README.md
@@ -3,18 +3,30 @@ Using FatFs (with VFS) on RIOT
 
 # native
 
-To use this test on native you can either use a FAT-formatted image file or directly use the mkfs command from the RIOT shell.
-Use `make image` to extract a prepared image file that already contains a simple test.txt file.
-This is only a convinience function to allow testing against a "default linux" formatted fat volume without the need to call mount or other stuff that may require super user privileges.
-Optionally `make compressed-image` can be used to generate the compressed image that is in turn used by `make image`.
+To use this test on native you can either use a FAT-formatted image file or
+directly use the mkfs command from the RIOT shell. Use `make image` to extract
+a prepared image file that already contains a simple test.txt file. This is
+only a convinience function to allow testing against a "default linux"
+formatted fat volume without the need to call mount or other stuff that may
+require super user privileges. Optionally `make compressed-image` can be used
+to generate the compressed image that is in turn used by `make image`.
 
-To tell RIOT where your image file is located you can use the define `MTD_NATIVE_FILENAME`.
+To tell RIOT where your image file is located you can use the define
+`MTD_NATIVE_FILENAME`.
 
-	NOTE: You shouldn't leave the image mounted while you use it in RIOT, the abstraction layer between FatFs and the image file mimics a dumb block device (i.e. behaves much like the devices that are actually meant to be used with FAT) That implies it doesn't show any modifications in RIOT that you perform on your OS and the other way round. So always remember to mount/unmount correctly or your FS will probably get damaged.
+NOTE: You shouldn't leave the image mounted while you use it in RIOT, the
+abstraction layer between FatFs and the image file mimics a dumb block device
+(i.e. behaves much like the devices that are actually meant to be used with
+FAT) That implies it doesn't show any modifications in RIOT that you perform on
+your OS and the other way round. So always remember to mount/unmount correctly
+or your FS will probably get damaged.
 
 # Real Hardware
 
-Currently the test defaults to sdcard_spi on real hardware. But generally any device that supports the mtd-interface can be used with FatFs.
-To use the automated test in pkg_fatfs_vfs you need to copy the generated image to your storage device (e.g. your SD-card).
-To copy the image onto the card you can use something like `make image && dd if=bin/riot_fatfs_disk.img of=/dev/<your_sdcard>`.
-After that you can connect the card to your RIOT device and check the test output via terminal.
+Currently the test defaults to sdcard_spi on real hardware. But generally any
+device that supports the mtd-interface can be used with FatFs. To use the
+automated test in pkg_fatfs_vfs you need to copy the generated image to your
+storage device (e.g. your SD-card). To copy the image onto the card you can use
+something like `make image && dd if=bin/riot_fatfs_disk.img
+of=/dev/<your_sdcard>`. After that you can connect the card to your RIOT device
+and check the test output via terminal.


### PR DESCRIPTION
### Contribution description

 - Move multiple identical/similar calls to snprintf to a separate internal function `_build_abs_path` for better maintainability
 - Remove stale defines `FATFS_DIR_SIZE`, `FATFS_FILE_SIZE`
 - Increase `FATFS_MAX_VOL_STR_LEN` a tiny bit to avoid any possible overflows, fixes a compilation warning/error in GCC 7 about a truncated format string (`-Wformat-truncation`)
 - Minor editorial changes in Doxygen
 - Word wrap README files for readability in terminal editors

### Issues/PRs references

depends on #8614 
contains fix for #8265 