### PR TITLE
pkg/openthread: cleanup makefile + fix implicit-fallthrough warning

### DIFF
--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -10,7 +10,9 @@ $(info $$OPENTHREAD_ARGS is [${OPENTHREAD_ARGS}])
 
 .PHONY: all
 
-OPENTHREAD_COMMON_FLAGS=-fdata-sections -ffunction-sections -Os
+OPENTHREAD_COMMON_FLAGS = -fdata-sections -ffunction-sections -Os
+OPENTHREAD_COMMON_FLAGS += -Wno-implicit-fallthrough
+
 all: git-download
 	cd $(PKG_BUILDDIR) && PREFIX="/" ./bootstrap
 	cd $(PKG_BUILDDIR) && CPP="$(CPP)" CC="$(CC)" CXX="$(CXX)"\
@@ -29,4 +31,5 @@ all: git-download
 	cp $(PKG_BUILDDIR)/output/lib/libopenthread-ftd.a ${BINDIR}/libopenthread.a
 	cp $(PKG_BUILDDIR)/output/lib/libopenthread-cli-ftd.a ${BINDIR}/libopenthread-cli.a
 	sed -ie 's/BASE/_BASE/g' $(PKG_BUILDDIR)/output/include/openthread/types.h
+
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the openthread build failure because of an implicit-fallthrough warning.

Murdock is complaining about it in #8604 and maybe in other places.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#8604 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->