### PR TITLE
make: add flag for no-implicit-fallthrough in CXXFLAGS

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -134,6 +134,7 @@ endif
 
 # remove this once codebase is adapted
 CFLAGS += -Wno-implicit-fallthrough
+CXXFLAGS += -Wno-implicit-fallthrough
 
 ifneq (10,$(if ${RIOT_VERSION},1,0)$(if ${__RIOTBUILD_FLAG},1,0))
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
### Contribution description
This PR adds -Wno-implicit-fallthrough to CXXFLAGS, with the same purposes as #8603
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#8603, #8616 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->