### PR TITLE
newlib: add thread safe implementation

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -119,6 +119,10 @@
 #ifndef THREAD_H
 #define THREAD_H
 
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+#include <sys/reent.h>
+#endif
+
 #include "clist.h"
 #include "cib.h"
 #include "msg.h"
@@ -167,6 +171,9 @@ struct _thread {
                                          (thread_t::msg_array), if any  */
     msg_t *msg_array;               /**< memory holding messages sent
                                          to this thread's message queue */
+#endif
+#if defined(MODULE_NEWLIB_THREAD_SAFE) || defined(DOXYGEN)
+    struct _reent newlib_reent;     /**< thread's re-entrent object     */
 #endif
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
     || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -173,7 +173,7 @@ struct _thread {
                                          to this thread's message queue */
 #endif
 #if defined(MODULE_NEWLIB_THREAD_SAFE) || defined(DOXYGEN)
-    struct _reent newlib_reent;     /**< thread's re-entrent object     */
+    struct _reent newlib_reent;     /**< thread's re-entrant object     */
 #endif
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
     || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)

--- a/core/sched.c
+++ b/core/sched.c
@@ -146,6 +146,10 @@ int __attribute__((used)) sched_run(void)
     mpu_enable();
 #endif
 
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+    _impure_ptr = &(next_thread->newlib_reent);
+#endif
+
     DEBUG("sched_run: done, changed sched_active_thread.\n");
 
     return 1;

--- a/core/thread.c
+++ b/core/thread.c
@@ -20,6 +20,9 @@
 
 #include <errno.h>
 #include <stdio.h>
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+#include <string.h>
+#endif
 
 #include "assert.h"
 #include "thread.h"

--- a/core/thread.c
+++ b/core/thread.c
@@ -235,6 +235,11 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
     thread->msg_array = NULL;
 #endif
 
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+    /* initialize the reent context */
+    _REENT_INIT_PTR(&(cb->newlib_reent));
+#endif
+
     sched_num_threads++;
 
     DEBUG("Created thread %s. PID: %" PRIkernel_pid ". Priority: %u.\n", name, thread->pid, priority);

--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -41,10 +41,18 @@ extern "C" {
 #define THREAD_EXTRA_STACKSIZE_PRINTF   (512)
 #endif
 #ifndef THREAD_STACKSIZE_DEFAULT
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+#define THREAD_STACKSIZE_DEFAULT        (1152)
+#else
 #define THREAD_STACKSIZE_DEFAULT        (1024)
 #endif
+#endif
 #ifndef THREAD_STACKSIZE_IDLE
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+#define THREAD_STACKSIZE_IDLE           (384)
+#else
 #define THREAD_STACKSIZE_IDLE           (256)
+#endif
 #endif
 /** @} */
 

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -144,6 +144,9 @@ include $(RIOTCPU)/cortexm_common/Makefile.include
 
 # use the nano-specs of Newlib when available
 USEMODULE += newlib_nano
+# use thread-safe features
+USEMODULE += newlib_thread_safe
+
 # Avoid overriding the default rule:
 all:
 

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -67,6 +67,10 @@ ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
   include $(RIOTBASE)/sys/newlib_syscalls_default/Makefile.include
 endif
 
+ifneq (,$(filter newlib_thread_safe,$(USEMODULE)))
+  include $(RIOTBASE)/sys/newlib_thread_safe/Makefile.include
+endif
+
 ifneq (,$(filter arduino,$(USEMODULE)))
   include $(RIOTBASE)/sys/arduino/Makefile.include
 endif

--- a/sys/newlib_thread_safe/Makefile
+++ b/sys/newlib_thread_safe/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/newlib_thread_safe/Makefile.include
+++ b/sys/newlib_thread_safe/Makefile.include
@@ -1,0 +1,1 @@
+UNDEF += $(BINDIR)/newlib_thread_safe/syscalls.o

--- a/sys/newlib_thread_safe/Makefile.include
+++ b/sys/newlib_thread_safe/Makefile.include
@@ -1,1 +1,26 @@
 UNDEF += $(BINDIR)/newlib_thread_safe/syscalls.o
+
+# define the compile test files
+define __has_reent_test
+#include <sys/reent.h>\n
+endef
+
+define __has_reent_small_test
+#include <sys/reent.h>\n
+#ifndef _REENT_SMALL\n
+#error wasting 1KB\n
+#endif\n
+endef
+
+# compile the tests
+__has_reent := $(shell printf "$(__has_reent_test)" | $(CC) -E $(CFLAGS) $(INCLUDES) - > /dev/null 2>&1 ; echo $$?)
+__has_reent_small := $(shell printf "$(__has_reent_small_test)" | $(CC) -E $(CFLAGS) $(INCLUDES) - > /dev/null 2>&1 ; echo $$?)
+
+# check if we use REENT_SMALL
+ifeq (0, $(__has_reent))
+  ifneq (0, $(__has_reent_small))
+    $(error "MODULE_NEWLIB_THREAD_SAFE defined but _REENT_SMALL not defined")
+  endif
+else
+  $(error "MODULE_NEWLIB_THREAD_SAFE defined but <sys/reent.h> not found in toolchain path")
+endif

--- a/sys/newlib_thread_safe/Makefile.include
+++ b/sys/newlib_thread_safe/Makefile.include
@@ -13,8 +13,8 @@ define __has_reent_small_test
 endef
 
 # compile the tests
-__has_reent := $(shell printf "$(__has_reent_test)" | $(CC) -E $(CFLAGS) $(INCLUDES) - > /dev/null 2>&1 ; echo $$?)
-__has_reent_small := $(shell printf "$(__has_reent_small_test)" | $(CC) -E $(CFLAGS) $(INCLUDES) - > /dev/null 2>&1 ; echo $$?)
+__has_reent = $(shell printf "$(__has_reent_test)" | $(CC) -E $(CFLAGS) $(INCLUDES) -Wno-missing-include-dirs - > /dev/null 2>&1 ; echo $$?)
+__has_reent_small = $(shell printf "$(__has_reent_small_test)" | $(CC) -E $(CFLAGS) $(INCLUDES) -Wno-missing-include-dirs - > /dev/null 2>&1 ; echo $$?)
 
 # check if we use REENT_SMALL
 ifeq (0, $(__has_reent))

--- a/sys/newlib_thread_safe/syscalls.c
+++ b/sys/newlib_thread_safe/syscalls.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_newlib
+ * @{
+ *
+ * @file
+ * @brief       Newlib system calls for thread safety
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include <sys/reent.h>
+
+#include "rmutex.h"
+
+static rmutex_t _env = RMUTEX_INIT;
+static rmutex_t _malloc = RMUTEX_INIT;
+
+void __env_lock(struct _reent *_r)
+{
+    (void)_r;
+
+    rmutex_lock(&_env);
+}
+
+void __env_unlock(struct _reent *_r)
+{
+    (void)_r;
+
+    rmutex_unlock(&_env);
+}
+
+void __malloc_lock(struct _reent *_r)
+{
+    (void)_r;
+
+    rmutex_lock(&_malloc);
+}
+
+void __malloc_unlock(struct _reent *_r)
+{
+    (void)_r;
+
+    rmutex_unlock(&_malloc);
+}


### PR DESCRIPTION
### Contribution description

Inspired by #4529, but using `rmutex`, this implements `__malloc_lock`/`__malloc_unlock` and `__env_lock`/`__env_unlock` syscalls to make newlib trhead-safe.

I guess it should be improved to check whether `_REENT_SMALL` is defined, and maybe disabled by default...

### Issues/PRs references

#4529, fixes #4488