### PR TITLE
sys/can: fix compiler warning due to usage of potentially uninitialized variables

### DIFF
--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -473,11 +473,10 @@ int can_device_calc_bittiming(uint32_t clock, const struct can_bittiming_const *
     uint32_t spt_error;
     uint32_t min_spt_error = UINT32_MAX;
     uint32_t best_brp = 0;
-    uint32_t tseg;
-    uint32_t tseg1;
-    uint32_t tseg2;
+    uint32_t tseg = 0;
+    uint32_t tseg1 = 0;
+    uint32_t tseg2 = 0;
     uint32_t best_tseg = 0;
-    uint32_t rate;        /* current bitrate */
     uint32_t rate_error;
     uint32_t min_rate_error;
 

--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -514,8 +514,8 @@ int can_device_calc_bittiming(uint32_t clock, const struct can_bittiming_const *
             DEBUG("invalid brp\n");
             continue;
         }
-
-        rate = clock / (brp * nbt);
+        /* current bitrate */
+        uint32_t rate = clock / (brp * nbt);
         rate_error = max(timing->bitrate, rate) - min(timing->bitrate, rate);
         if (rate_error > min_rate_error) {
             DEBUG("timing->rate=%" PRIu32 ", rate=%" PRIu32 ", rate_error=%" PRIu32 " > min_rate_error=%" PRIu32 ", continuing\n",


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes an issue with potential usage of uninitiated variables in can. Also reduces the scope of variable `rate`. This fixes build issues with AVR-GCC version 5.4.x as reported by Murdock, see link below.

### Issues/PRs references

see [Murdock log](https://ci.riot-os.org/RIOT-OS/RIOT/8618/11638eb1d6ed9e374f65ef1c1580a1229c7b3609/output/compile/tests/conn_can/arduino-uno.txt)