### PR TITLE
efm32: Use different values for each unsupported ADC res

### DIFF
--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -56,7 +56,7 @@ extern "C" {
 /**
  * @brief   Internal define to note that resolution is not supported.
  */
-#define ADC_MODE_UNDEF      (0xff)
+#define ADC_MODE_UNDEF(x)   (ADC_MODE(x, 15))
 
 #ifndef DOXYGEN
 /**
@@ -65,12 +65,12 @@ extern "C" {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT = ADC_MODE(adcRes6Bit, 0),     /**< ADC resolution: 6 bit */
-    ADC_RES_8BIT = ADC_MODE(adcRes8Bit, 0),     /**< ADC resolution: 8 bit */
+    ADC_RES_6BIT  = ADC_MODE(adcRes6Bit, 0),    /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = ADC_MODE(adcRes8Bit, 0),    /**< ADC resolution: 8 bit */
     ADC_RES_10BIT = ADC_MODE(adcRes12Bit, 2),   /**< ADC resolution: 10 bit (shifted from 12 bit) */
     ADC_RES_12BIT = ADC_MODE(adcRes12Bit, 0),   /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = ADC_MODE_UNDEF,             /**< ADC resolution: 14 bit (unsupported) */
-    ADC_RES_16BIT = ADC_MODE_UNDEF,             /**< ADC resolution: 16 bit (unsupported) */
+    ADC_RES_14BIT = ADC_MODE_UNDEF(0),          /**< ADC resolution: 14 bit (unsupported) */
+    ADC_RES_16BIT = ADC_MODE_UNDEF(1),          /**< ADC resolution: 16 bit (unsupported) */
 } adc_res_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/efm32/periph/adc.c
+++ b/cpu/efm32/periph/adc.c
@@ -62,7 +62,7 @@ int adc_init(adc_t line)
 int adc_sample(adc_t line, adc_res_t res)
 {
     /* resolutions larger than 12 bits are not supported */
-    if (res == ADC_MODE_UNDEF) {
+    if (res >= ADC_MODE_UNDEF(0)) {
         return -1;
     }
 


### PR DESCRIPTION
### Contribution description

This PR changes the adc_res_t enums to use separate values for each unsupported resolution.
When using the ADC resolution values in a switch case section in #8577 I ran into a problem where I get the error 
```
riot/sys/analog_util/adc_util.c: In function ‘_adc_res_bits’:
riot/sys/analog_util/adc_util.c:48:9: error: duplicate case value
         case ADC_RES_16BIT:
         ^~~~
riot/sys/analog_util/adc_util.c:46:9: note: previously used here
         case ADC_RES_14BIT:
         ^~~~
```

### Issues/PRs references

discovered when testing #8577 
Required for building #8577 on efm32