### PR TITLE
gnrc_rpl: allow for non-router operation (as leaf)

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -123,6 +123,7 @@ endif
 
 ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
   USEMODULE += gnrc_icmpv6
+  USEMODULE += gnrc_ipv6_nib
   USEMODULE += trickle
   USEMODULE += xtimer
 endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -122,7 +122,7 @@ ifneq (,$(filter gnrc_rpl_p2p,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6_router_default
+  USEMODULE += gnrc_icmpv6
   USEMODULE += trickle
   USEMODULE += xtimer
 endif

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -132,6 +132,7 @@ bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, k
     assert(instance && (instance->state > 0));
 
     gnrc_rpl_dodag_t *dodag = &instance->dodag;
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
 
     dodag->dodag_id = *dodag_id;
     dodag->my_rank = GNRC_RPL_INFINITE_RANK;
@@ -150,6 +151,9 @@ bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, ipv6_addr_t *dodag_id, k
     dodag->instance = instance;
     dodag->iface = iface;
 
+    if ((netif != NULL) && !(netif->flags & GNRC_NETIF_FLAGS_IPV6_FORWARDING)) {
+        gnrc_rpl_leaf_operation(dodag);
+    }
 #ifdef MODULE_GNRC_RPL_P2P
     if ((instance->mop == GNRC_RPL_P2P_MOP) && (gnrc_rpl_p2p_ext_new(dodag) == NULL)) {
         DEBUG("RPL: could not allocate new P2P-RPL DODAG extension. Remove DODAG\n");


### PR DESCRIPTION
### Contribution description
Turns out RPL *can* run on a non-routing host, but it has to be configured as a leaf [see also this discussion in the IETF 6lo group](https://mailarchive.ietf.org/arch/msg/6lo/oygvVcXwkRuv72eYnM9UOjUejEw).

This PR removes the `gnrc_ipv6_router_default` dependency of `gnrc_rpl` and replaces it just with `gnrc_icmpv6` (since that protocol is used as transport for RPL messages). Additionally, if an interfaces is non-forwarding, a RPL DODAG instance initialized for that interface will be set to leaf operation.

### Issues/PRs references
None