### PR TITLE
pkg: ccn-lite: Use version that allows older CMake versions

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=ccn-lite
 PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
-PKG_VERSION=0474080335aac08d3afa44a439ac9def92b9fcf3
+PKG_VERSION=d2ea61ff450d0f3636aa29af3e448ef10ee95f9e
 PKG_LICENSE=ISC
 
 .PHONY: all


### PR DESCRIPTION
### Contribution description
The `ccn-lite` version currently used in RIOT doesn't build on Ubuntu 16.04 (current LTS version). This moves it to a version where this issue was fixed upstream.

### Issues/PRs references
Fixes #8627.