### PR TITLE
drivers/sdcard_spi: use of ucrc16 by default

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -271,6 +271,7 @@ endif
 ifneq (,$(filter sdcard_spi,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_spi
+  USEMODULE += checksum
   USEMODULE += xtimer
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

We probably should use checksum algorithms provided in RIOT by default. Here the standard lightweight CCITT CRC16 is used to avoid code duplication.

The CRC7 isn't implemented yet. Maybe a candidate for a future refactoring?