### PR TITLE
tests/pkg_semtech_loramac: fix get command with EUI values

### DIFF
--- a/tests/pkg_semtech-loramac/main.c
+++ b/tests/pkg_semtech-loramac/main.c
@@ -30,7 +30,9 @@
 #include "sx127x_params.h"
 
 sx127x_t sx127x;
-static char print_buf[48];
+/* Application key is 16 bytes long (e.g. 32 hex chars), and thus the longest
+   possible size (with application session and network session keys) */
+static char print_buf[LORAMAC_APPKEY_LEN * 2 + 1];
 
 static void _loramac_usage(void)
 {
@@ -76,36 +78,42 @@ static int _cmd_loramac(int argc, char **argv)
             uint8_t deveui[LORAMAC_DEVEUI_LEN];
             semtech_loramac_get_deveui(deveui);
             fmt_bytes_hex(print_buf, deveui, LORAMAC_DEVEUI_LEN);
+            print_buf[LORAMAC_DEVEUI_LEN * 2] = '\0';
             printf("DEVEUI: %s\n", print_buf);
         }
         else if (strcmp("appeui", argv[2]) == 0) {
             uint8_t appeui[LORAMAC_APPEUI_LEN];
             semtech_loramac_get_appeui(appeui);
             fmt_bytes_hex(print_buf, appeui, LORAMAC_APPEUI_LEN);
+            print_buf[LORAMAC_APPEUI_LEN * 2] = '\0';
             printf("APPEUI: %s\n", print_buf);
         }
         else if (strcmp("appkey", argv[2]) == 0) {
             uint8_t appkey[LORAMAC_APPKEY_LEN];
             semtech_loramac_get_appkey(appkey);
             fmt_bytes_hex(print_buf, appkey, LORAMAC_APPKEY_LEN);
+            print_buf[LORAMAC_APPKEY_LEN * 2] = '\0';
             printf("APPKEY: %s\n", print_buf);
         }
         else if (strcmp("appskey", argv[2]) == 0) {
             uint8_t appskey[LORAMAC_APPSKEY_LEN];
             semtech_loramac_get_appskey(appskey);
             fmt_bytes_hex(print_buf, appskey, LORAMAC_APPSKEY_LEN);
+            print_buf[LORAMAC_APPSKEY_LEN * 2] = '\0';
             printf("APPSKEY: %s\n", print_buf);
         }
         else if (strcmp("nwkskey", argv[2]) == 0) {
             uint8_t nwkskey[LORAMAC_NWKSKEY_LEN];
             semtech_loramac_get_nwkskey(nwkskey);
             fmt_bytes_hex(print_buf, nwkskey, LORAMAC_NWKSKEY_LEN);
+            print_buf[LORAMAC_NWKSKEY_LEN * 2] = '\0';
             printf("NWKSKEY: %s\n", print_buf);
         }
         else if (strcmp("devaddr", argv[2]) == 0) {
             uint8_t devaddr[LORAMAC_DEVADDR_LEN];
             semtech_loramac_get_devaddr(devaddr);
             fmt_bytes_hex(print_buf, devaddr, LORAMAC_DEVADDR_LEN);
+            print_buf[LORAMAC_DEVADDR_LEN * 2] = '\0';
             printf("DEVADDR: %s\n", print_buf);
         }
         else if (strcmp("class", argv[2]) == 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the output of the `loramac set` command in the `pkg_semtech-loramac` test application. I
just realized that no string terminating character is added to the buffer used to store the string of hex chars. And thus, calling the `get` command with `appkey` (16 bytes, 32 hex chars) before `deveui` (8 bytes, 16 hex chars) was working for the former but not for the latter: chars from the previous command still being in the converted chars buffer.

This PR also set the maximum size of the print buffer to the maximum number of characters expected: the keys (application, application session and network session keys) are 16 bytes long (32 hex chars) so now it's 33 bytes long.

Tested and works now.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->