### PR TITLE
boards/b-l072z-lrwan1: fix on boards LEDs

### DIFF
--- a/boards/b-l072z-lrwan1/board.c
+++ b/boards/b-l072z-lrwan1/board.c
@@ -38,4 +38,8 @@ void board_init(void)
        only if explicitly wanted by the user */
     gpio_init(LED0_PIN, GPIO_OUT);
 #endif
+
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_init(LED3_PIN, GPIO_OUT);
 }

--- a/boards/b-l072z-lrwan1/include/board.h
+++ b/boards/b-l072z-lrwan1/include/board.h
@@ -66,23 +66,23 @@ extern "C" {
 #define LED1_PIN            GPIO_PIN(PORT_B, 5)
 #define LED1_MASK           (1 << 5)
 
-#define LED1_ON             (GPIOB->BSRR = LED0_MASK)
-#define LED1_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
-#define LED1_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
+#define LED1_ON             (GPIOB->BSRR = LED1_MASK)
+#define LED1_OFF            (GPIOB->BSRR = (LED1_MASK << 16))
+#define LED1_TOGGLE         (GPIOB->ODR  ^= LED1_MASK)
 
 #define LED2_PIN            GPIO_PIN(PORT_B, 6)
 #define LED2_MASK           (1 << 6)
 
-#define LED2_ON             (GPIOB->BSRR = LED0_MASK)
-#define LED2_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
-#define LED2_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
+#define LED2_ON             (GPIOB->BSRR = LED2_MASK)
+#define LED2_OFF            (GPIOB->BSRR = (LED2_MASK << 16))
+#define LED2_TOGGLE         (GPIOB->ODR  ^= LED2_MASK)
 
 #define LED3_PIN            GPIO_PIN(PORT_B, 7)
 #define LED3_MASK           (1 << 7)
 
-#define LED3_ON             (GPIOB->BSRR = LED0_MASK)
-#define LED3_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
-#define LED3_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
+#define LED3_ON             (GPIOB->BSRR = LED3_MASK)
+#define LED3_OFF            (GPIOB->BSRR = (LED3_MASK << 16))
+#define LED3_TOGGLE         (GPIOB->ODR  ^= LED3_MASK)
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes 2 problems with the on-board LEDs of the ST B-L072Z-LRWAN1 discovery board :
- LED1/2/3 macros were referring to LED0, so they were not working
- LED1/2/3 pins are not initialized in board init

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->