### PR TITLE
pkg/semtech-loramac: add link check support

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -241,6 +241,15 @@ static void mlme_confirm(MlmeConfirm_t *confirm)
             }
             break;
 
+        case MLME_LINK_CHECK:
+            if (confirm->Status == LORAMAC_EVENT_INFO_STATUS_OK) {
+                DEBUG("[semtech-loramac] link check received\n");
+                msg_t msg;
+                msg.type = MSG_TYPE_LORAMAC_LINK_CHECK;
+                msg.content.ptr = confirm;
+                msg_send(&msg, semtech_loramac_pid);
+            }
+
         default:
             break;
     }
@@ -313,6 +322,7 @@ void _init_loramac(semtech_loramac_t *mac,
     semtech_loramac_set_class(mac, LORAMAC_DEFAULT_DEVICE_CLASS);
     semtech_loramac_set_tx_port(mac, LORAMAC_DEFAULT_TX_PORT);
     semtech_loramac_set_tx_mode(mac, LORAMAC_DEFAULT_TX_MODE);
+    mac->link_chk.available = false;
 }
 
 static void _join_otaa(semtech_loramac_t *mac)
@@ -522,6 +532,19 @@ void *_semtech_loramac_event_loop(void *arg)
                     mac->state = SEMTECH_LORAMAC_STATE_IDLE;
                     break;
                 }
+                case MSG_TYPE_LORAMAC_LINK_CHECK:
+                {
+                    MlmeConfirm_t *confirm = (MlmeConfirm_t *)msg.content.ptr;
+                    mac->link_chk.demod_margin = confirm->DemodMargin;
+                    mac->link_chk.nb_gateways = confirm->NbGateways;
+                    mac->link_chk.available = true;
+                    DEBUG("[semtech-loramac] link check info received:\n"
+                          "  - Demodulation marging: %d\n"
+                          "  - Number of gateways: %d\n",
+                          mac->link_chk.demod_margin,
+                          mac->link_chk.nb_gateways);
+                    break;
+                }
                 case MSG_TYPE_LORAMAC_TX_DONE:
                 {
                     DEBUG("[semtech-loramac] loramac TX done\n");
@@ -609,6 +632,16 @@ uint8_t semtech_loramac_join(semtech_loramac_t *mac, uint8_t type)
     return SEMTECH_LORAMAC_JOIN_SUCCEEDED;
 }
 
+void semtech_loramac_request_link_check(semtech_loramac_t *mac)
+{
+    mutex_lock(&mac->lock);
+    mac->link_chk.available = false;
+    MlmeReq_t mlmeReq;
+    mlmeReq.Type = MLME_LINK_CHECK;
+    LoRaMacMlmeRequest(&mlmeReq);
+    mutex_unlock(&mac->lock);
+}
+
 uint8_t semtech_loramac_send(semtech_loramac_t *mac, uint8_t *data, uint8_t len)
 {
     mutex_lock(&mac->lock);
@@ -616,6 +649,7 @@ uint8_t semtech_loramac_send(semtech_loramac_t *mac, uint8_t *data, uint8_t len)
     mibReq.Type = MIB_NETWORK_JOINED;
     LoRaMacMibGetRequestConfirm(&mibReq);
     bool is_joined = mibReq.Param.IsNetworkJoined;
+    mac->link_chk.available = false;
     mutex_unlock(&mac->lock);
 
     if (!is_joined) {

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -44,6 +44,7 @@ extern "C" {
 #define MSG_TYPE_LORAMAC_JOIN          (0x3461)  /**< MAC join event */
 #define MSG_TYPE_LORAMAC_TX_DONE       (0x3462)  /**< MAC TX completes */
 #define MSG_TYPE_LORAMAC_RX            (0x3463)  /**< Some data received */
+#define MSG_TYPE_LORAMAC_LINK_CHECK    (0x3464)  /**< Link check info received */
 /** @} */
 
 /**
@@ -90,6 +91,15 @@ typedef struct {
 } semtech_loramac_rx_data_t;
 
 /**
+ * @brief   LoRaMAC link check information
+ */
+typedef struct {
+    uint8_t demod_margin;                        /**< Demodulation margin */
+    uint8_t nb_gateways;                         /**< number of LoRa gateways found */
+    bool available;                              /**< new link check information avalable */
+} semtech_loramac_link_check_info_t;
+
+/**
  * @brief   Semtech LoRaMAC descriptor
  */
 typedef struct {
@@ -105,6 +115,7 @@ typedef struct {
     uint8_t nwkskey[LORAMAC_NWKSKEY_LEN];        /**< network session key */
     uint8_t devaddr[LORAMAC_DEVADDR_LEN];        /**< device address */
     semtech_loramac_rx_data_t rx_data;           /**< struct handling the RX data */
+    semtech_loramac_link_check_info_t link_chk;  /**< link check information */
 } semtech_loramac_t;
 
 /**
@@ -165,6 +176,13 @@ uint8_t semtech_loramac_send(semtech_loramac_t *mac, uint8_t *data, uint8_t len)
  * @return SEMTECH_LORAMAC_DATA_RECEIVED when TX has completed and data is received
  */
 uint8_t semtech_loramac_recv(semtech_loramac_t *mac);
+
+/**
+ * @brief   Requests a LoRaWAN link check
+ *
+ * @param[in] mac          Pointer to the mac
+ */
+void semtech_loramac_request_link_check(semtech_loramac_t *mac);
 
 /**
  * @brief   Sets the device EUI

--- a/tests/pkg_semtech-loramac/main.c
+++ b/tests/pkg_semtech-loramac/main.c
@@ -34,7 +34,7 @@ static char print_buf[LORAMAC_APPKEY_LEN * 2 + 1];
 
 static void _loramac_usage(void)
 {
-    puts("Usage: loramac <get|set|join|tx>");
+    puts("Usage: loramac <get|set|join|tx|link_check>");
 }
 
 static void _loramac_join_usage(void)
@@ -416,7 +416,24 @@ static int _cmd_loramac(int argc, char **argv)
                 break;
         }
 
+        if (loramac.link_chk.available) {
+            printf("Link check information:\n"
+                   "  - Demodulation margin: %d\n"
+                   "  - Number of gateways: %d\n",
+                   loramac.link_chk.demod_margin,
+                   loramac.link_chk.nb_gateways);
+        }
+
         return 0;
+    }
+    else if (strcmp(argv[1], "link_check") == 0) {
+        if (argc > 2) {
+            _loramac_usage();
+            return 1;
+        }
+
+        semtech_loramac_request_link_check(&loramac);
+        puts("Link check request scheduled");
     }
     else {
         _loramac_usage();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the LoRaWAN "LinkCheckReq" MAC command.

The feature adds the possibility to validate the connectivity with the network by retrieving 2 informations:
- the number of gateways reachable by the end device
- the demodulation margin indicates the link margin in dB of the last received command (from the specs:
"A value of 0 means that the frame was received at the demodulation floor (0 dB or no
margin) while a value of 20, for example, means that the frame reached the gateway 20 dB
above the demodulation floor"

The link check request will be sent with the next TX packet and the reply will be received by the nodes in the following RX window. This means that one has to schedule the request and check for the result after a TX.

This PR also adds the `link_check` subcommand to the `loramac` command of the `pkg_semtech-loramac` test application shell. Use it as follows:

```
# schedule the link check
> loramac link_check
Link check request scheduled
# then retrieve the link check information
> loramac tx test
TX done
Link check information:
- Demodulation margin: 38
- Number of gateways: 1
```

~As a side note, I'm planning to refactor the API of the semtech loramac package by introducing a structure that will handle a loramac instance. This structure will also contain usefull attributes (radio device descriptor, keys, rx_data, etc) and will simplify the netdev adaption (I think) and help fixing thread safety issues.~ see #8798 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Now based on ~#8798~

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->