### PR TITLE
assert: add static_assert if using c11

### DIFF
--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -109,6 +109,20 @@ NORETURN void _assert_failure(const char *file, unsigned line);
 #define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, assert_crash_message))
 #endif
 
+#if !defined __cplusplus
+#if __STDC_VERSION__ >= 201112L
+/**
+ * @brief c11 static_assert() macro
+ */
+#define static_assert(...) _Static_assert(__VA_ARGS__)
+#else
+/**
+ * @brief static_assert dummy for c-version < c11
+ */
+#define static_assert(...) struct static_assert_dummy
+#endif
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When using c11 the macro `static_assert` doesn't exist. This contribution adds the macro to RIOT's assert.h file.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->