### PR TITLE
tests/pkg_semtech-loramac: fix loramac set devaddr

### DIFF
--- a/tests/pkg_semtech-loramac/main.c
+++ b/tests/pkg_semtech-loramac/main.c
@@ -205,7 +205,7 @@ static int _cmd_loramac(int argc, char **argv)
             fmt_hex_bytes(nwkskey, argv[3]);
             semtech_loramac_set_nwkskey(nwkskey);
         }
-        else if (strcmp("devaddr", argv[3]) == 0) {
+        else if (strcmp("devaddr", argv[2]) == 0) {
             if ((argc < 4) || (strlen(argv[3]) != LORAMAC_DEVADDR_LEN * 2)) {
                 puts("Usage: loramac set devaddr <8 hex chars>");
                 return 1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the `loramac set devaddr` command as reported in #8633 by @jia200x 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#8633 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->