### PR TITLE
gnrc_ipv6_nib: Add capability to handle and send RDNSS option

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -305,6 +305,10 @@ ifneq (,$(filter gnrc_ipv6_nib_6ln,$(USEMODULE)))
   USEMODULE += gnrc_sixlowpan_nd
 endif
 
+ifneq (,$(filter gnrc_ipv6_nib_dns,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6_nib
+endif
+
 ifneq (,$(filter gnrc_ipv6_nib_router,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_nib
 endif
@@ -315,6 +319,9 @@ ifneq (,$(filter gnrc_ipv6_nib,$(USEMODULE)))
   USEMODULE += gnrc_netif
   USEMODULE += ipv6_addr
   USEMODULE += random
+  ifneq (,$(filter sock_dns,$(USEMODULE)))
+    USEMODULE += gnrc_ipv6_nib_dns
+  endif
 endif
 
 ifneq (,$(filter gnrc_udp,$(USEMODULE)))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -17,6 +17,7 @@ PSEUDOMODULES += gnrc_ipv6_router_default
 PSEUDOMODULES += gnrc_ipv6_nib_6lbr
 PSEUDOMODULES += gnrc_ipv6_nib_6ln
 PSEUDOMODULES += gnrc_ipv6_nib_6lr
+PSEUDOMODULES += gnrc_ipv6_nib_dns
 PSEUDOMODULES += gnrc_ipv6_nib_router
 PSEUDOMODULES += gnrc_netdev_default
 PSEUDOMODULES += gnrc_neterr

--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -222,6 +222,17 @@ extern "C" {
  * @note    Only handled with @ref GNRC_IPV6_NIB_CONF_SLAAC != 0
  */
 #define GNRC_IPV6_NIB_VALID_ADDR            (0x4fd2U)
+
+/**
+ * @brief   Recursive DNS server timeout
+ *
+ * This message type is for the event of a recursive DNS server timeout.
+ * The expected message context is the [UDP end point](@ref sock_udp_ep_t)
+ * representing the DNS server.
+ *
+ * @note    Only handled with @ref GNRC_IPV6_NIB_CONF_DNS != 0
+ */
+#define GNRC_IPV6_NIB_RDNSS_TIMEOUT         (0x4fd3U)
 /** @} */
 
 /**

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -68,6 +68,10 @@ extern "C" {
 #define GNRC_IPV6_NIB_CONF_ROUTER       (1)
 #endif
 
+#ifdef MODULE_GNRC_IPV6_NIB_DNS
+#define GNRC_IPV6_NIB_CONF_DNS          (1)
+#endif
+
 /**
  * @name    Compile flags
  * @brief   Compile flags to (de-)activate certain features for NIB
@@ -169,6 +173,15 @@ extern "C" {
 #else
 #define GNRC_IPV6_NIB_CONF_DC           (0)
 #endif
+#endif
+
+/**
+ * @brief   Support for DNS configuration options
+ *
+ * @see [RFC 8106](https://tools.ietf.org/html/rfc8106)
+ */
+#ifndef GNRC_IPV6_NIB_CONF_DNS
+#define GNRC_IPV6_NIB_CONF_DNS          (0)
 #endif
 
 /**

--- a/sys/include/net/gnrc/ndp.h
+++ b/sys/include/net/gnrc/ndp.h
@@ -251,6 +251,29 @@ gnrc_pktsnip_t *gnrc_ndp_opt_pi_build(const ipv6_addr_t *prefix,
 gnrc_pktsnip_t *gnrc_ndp_opt_mtu_build(uint32_t mtu, gnrc_pktsnip_t *next);
 
 /**
+ * @brief   Builts the recursive DNS server option
+ *
+ * @see [RFC 8106, section 5.1](https://tools.ietf.org/html/rfc8106#section-5.1)
+ * @pre `addrs != NULL`
+ * @pre `addrs_num > 0`
+ *
+ * @note    Should only be used with router advertisemnents. This is not checked
+ *          however, since nodes should silently ignore it in other NDP messages.
+ *
+ * @param[in] lifetime      The lifetime of the recursive DNS servers
+ * @param[in] addrs         The addresses of the recursive DNS servers
+ * @param[in] addrs_num     The number of addresses in @p addrs
+ * @param[in] next          More options in the packet. NULL, if there are none.
+ *
+ * @return  The packet snip list of options, on success
+ * @return  @p next, if RDNSS is not supported
+ * @return  NULL, if packet buffer is full
+ */
+gnrc_pktsnip_t *gnrc_ndp_opt_rdnss_build(uint32_t lifetime, ipv6_addr_t *addrs,
+                                         unsigned addrs_num,
+                                         gnrc_pktsnip_t *next);
+
+/**
  * @brief   Send pre-compiled neighbor solicitation depending on a given network
  *          interface.
  *

--- a/sys/include/net/ndp.h
+++ b/sys/include/net/ndp.h
@@ -88,6 +88,7 @@ extern "C" {
 #define NDP_OPT_PI                  (3)     /**< prefix information option */
 #define NDP_OPT_RH                  (4)     /**< redirected option */
 #define NDP_OPT_MTU                 (5)     /**< MTU option */
+#define NDP_OPT_RDNSS               (25)    /**< recursive DNS server option */
 #define NDP_OPT_AR                  (33)    /**< address registration option */
 #define NDP_OPT_6CTX                (34)    /**< 6LoWPAN context option */
 #define NDP_OPT_ABR                 (35)    /**< authoritative border router option */
@@ -119,6 +120,12 @@ extern "C" {
 #define NDP_OPT_PI_LEN              (4U)
 #define NDP_OPT_MTU_LEN             (1U)
 /** @} */
+
+/**
+ * @brief   Minimum length of a recursive DNS server option (in units of 8 bytes)
+ * @see     [RFC 8106, section 5.1](https://tools.ietf.org/html/rfc8106#section-5.1)
+ */
+#define NDP_OPT_RDNSS_MIN_LEN       (3U)
 
 /**
  * @{
@@ -314,6 +321,19 @@ typedef struct __attribute__((packed)) {
     network_uint32_t mtu;   /**< MTU */
 } ndp_opt_mtu_t;
 
+/**
+ * @brief   Recursive DNS server option format
+ * @extends ndp_opt_t
+ *
+ * @see     [RFC 8106, section 5.1](https://tools.ietf.org/html/rfc8106#section-5.1)
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t type;           /**< option type */
+    uint8_t len;            /**< length in units of 8 octets */
+    network_uint16_t resv;  /**< reserved field */
+    network_uint32_t ltime; /**< lifetime in seconds */
+    ipv6_addr_t addrs[];    /**< addresses of IPv6 recursive DNS servers */
+} ndp_opt_rdnss_t;
 
 #ifdef __cplusplus
 }

--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -135,6 +135,10 @@ int sock_dns_query(const char *domain_name, void *addr_out, int family)
     uint8_t buf[SOCK_DNS_QUERYBUF_LEN];
     uint8_t reply_buf[512];
 
+    if (sock_dns_server.port == 0) {
+        return -ECONNREFUSED;
+    }
+
     if (strlen(domain_name) > SOCK_DNS_MAX_NAME_LEN) {
         return -ENOSPC;
     }

--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -28,6 +28,9 @@
 /* min domain name length is 1, so minimum record length is 7 */
 #define DNS_MIN_REPLY_LEN   (unsigned)(sizeof(sock_dns_hdr_t ) + 7)
 
+/* global DNS server UDP endpoint */
+sock_udp_ep_t sock_dns_server;
+
 static ssize_t _enc_domain_name(uint8_t *out, const char *domain_name)
 {
     /*

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -222,6 +222,27 @@ gnrc_pktsnip_t *gnrc_ndp_opt_mtu_build(uint32_t mtu, gnrc_pktsnip_t *next)
     return pkt;
 }
 
+gnrc_pktsnip_t *gnrc_ndp_opt_rdnss_build(uint32_t ltime, ipv6_addr_t *addrs,
+                                         unsigned addrs_num,
+                                         gnrc_pktsnip_t *next)
+{
+    assert(addrs != NULL);
+    assert(addrs_num > 0);
+    size_t opt_size = sizeof(ndp_opt_t) + (sizeof(ipv6_addr_t) * addrs_num);
+    gnrc_pktsnip_t *pkt = gnrc_ndp_opt_build(NDP_OPT_RDNSS, opt_size, next);
+
+    if (pkt != NULL) {
+        ndp_opt_rdnss_t *rdnss_opt = pkt->data;
+        rdnss_opt->resv.u16 = 0;
+        rdnss_opt->ltime = byteorder_htonl(ltime);
+        for (unsigned i = 0; i < addrs_num; i++) {
+            memcpy(&rdnss_opt->addrs[i], &addrs[i],
+                   sizeof(rdnss_opt->addrs[i]));
+        }
+    }
+    return pkt;
+}
+
 static gnrc_pktsnip_t *_build_headers(gnrc_netif_t *netif,
                                       const ipv6_addr_t *src,
                                       const ipv6_addr_t *dst,

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -9,6 +9,7 @@ BOARD_INSUFFICIENT_MEMORY := chronos telosb nucleo-f042k6 nucleo-f031k6 \
 USEMODULE += sock_dns
 USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6_default
+USEMODULE += gnrc_ipv6_nib_dns
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 

--- a/tests/gnrc_sock_dns/main.c
+++ b/tests/gnrc_sock_dns/main.c
@@ -31,10 +31,6 @@
 #define TEST_NAME   "example.org"
 #endif
 
-#ifndef DNS_SERVER
-#define DNS_SERVER  "[2001:db8::1]:53"
-#endif
-
 /* import "ifconfig" shell command, used for printing addresses */
 
 extern int _gnrc_netif_config(int argc, char **argv);
@@ -42,8 +38,6 @@ extern int _gnrc_netif_config(int argc, char **argv);
 int main(void)
 {
     uint8_t addr[16] = {0};
-
-    sock_udp_str2ep(&sock_dns_server, DNS_SERVER);
 
     puts("waiting for router advertisement...");
     xtimer_usleep(1U*1000000);

--- a/tests/gnrc_sock_dns/main.c
+++ b/tests/gnrc_sock_dns/main.c
@@ -35,9 +35,6 @@
 #define DNS_SERVER  "[2001:db8::1]:53"
 #endif
 
-/* global DNS server UDP endpoint */
-sock_udp_ep_t sock_dns_server;
-
 /* import "ifconfig" shell command, used for printing addresses */
 
 extern int _gnrc_netif_config(int argc, char **argv);


### PR DESCRIPTION
### Contribution description
With the RDNSS option `sock_dns` can be auto-configured by the administrative router (either the border router or the upstream router configuring the border router).

Also some fixes/convenience enhancements to `sock_dns` and `sock_util` piggy-backed.

### Issues/PRs references
None