### PR TITLE
drivers: MH-Z19: initial support

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -204,6 +204,11 @@ ifneq (,$(filter mag3110,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter mhz19,$(USEMODULE)))
+  USEMODULE += xtimer
+  FEATURES_REQUIRED += periph_uart
+endif
+
 ifneq (,$(filter mma8x5x,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -150,6 +150,10 @@ ifneq (,$(filter mag3110,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mag3110/include
 endif
 
+ifneq (,$(filter mhz19,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mhz19/include
+endif
+
 ifneq (,$(filter mma8x5x,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mma8x5x/include
 endif

--- a/drivers/include/mhz19.h
+++ b/drivers/include/mhz19.h
@@ -48,7 +48,7 @@ enum {
     MHZ19_OK            =  0,       /**< everything was fine */
     MHZ19_ERR_UART      = -1,       /**< error initializing the UART bus */
     MHZ19_ERR_TIMEOUT   = -2,       /**< UART timeout on retrieving sensor data */
-    MHZ19_ERR_CHECKSUM  = -3,       /**< Checksum failure on received data */
+    MHZ19_ERR_CHECKSUM  = -3,       /**< checksum failure on received data */
 };
 
 /**
@@ -62,9 +62,9 @@ typedef struct {
  * @brief   Device descriptor for a MH-Z19 device
  */
 typedef struct {
-    const mhz19_params_t *params;   /**< Device parameters */
+    const mhz19_params_t *params;   /**< device parameters */
     mutex_t mutex;                  /**< protect against simulaneous access */
-    mutex_t sync;                   /**< Transfer complete or timeout sync */
+    mutex_t sync;                   /**< transfer complete or timeout sync */
     uint8_t idx;                    /**< rx buffer index */
     uint8_t rxmem[MHZ19_BUF_SIZE];  /**< rx buffer */
 } mhz19_t;

--- a/drivers/include/mhz19.h
+++ b/drivers/include/mhz19.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mhz19 MH-Z19 CO2 sensor
+ * @ingroup     drivers_sensors
+ *
+ * @brief       MH-Z19 CO2 sensor driver
+ *
+ * ## Description
+ *
+ * The MH-Z19 is a C02 sensor. Measurements are provided in ppm over UART and
+ * PWM. Only the UART interface is implemented in this driver. PPM range from
+ * 0 (theoretically) to 2000 or 5000 depending on the sensor settings.
+ *
+ * @note The sensor requires considerable time before accurate measurements are
+ * provided
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the mh-z19 CO2 sensor driver.
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef MHZ19_H
+#define MHZ19_H
+
+#include "periph/uart.h"
+#include "saul.h"
+#include "mhz19_internals.h"
+#include "mutex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Status and error return codes
+ */
+enum {
+    MHZ19_OK            =  0,       /**< everything was fine */
+    MHZ19_ERR_UART      = -1,       /**< error initializing the UART bus */
+    MHZ19_ERR_TIMEOUT   = -2,       /**< UART timeout on retrieving sensor data */
+    MHZ19_ERR_CHECKSUM  = -3,       /**< Checksum failure on received data */
+};
+
+/**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    uart_t uart;        /**< UART device that sensor is connected to */
+} mhz19_params_t;
+
+/**
+ * @brief   Device descriptor for a MH-Z19 device
+ */
+typedef struct {
+    const mhz19_params_t *params;   /**< Device parameters */
+    mutex_t mutex;                  /**< protect against simulaneous access */
+    mutex_t sync;                   /**< Transfer complete or timeout sync */
+    uint8_t idx;                    /**< rx buffer index */
+    uint8_t rxmem[MHZ19_BUF_SIZE];  /**< rx buffer */
+} mhz19_t;
+
+/**
+ * @brief   Export SAUL endpoint
+ */
+extern const saul_driver_t mhz19_ppm_saul_driver;
+
+/**
+ * @brief   Initialize a MH-Z19 device
+ *
+ * @param[out] dev          device descriptor
+ * @param[in]  params       MH-Z19 initialization struct
+ *
+ * @return                  MHZ19_OK
+ * @return                  MHZ19_ERR_UART
+ */
+int mhz19_init(mhz19_t *dev, const mhz19_params_t *params);
+
+/**
+ * @brief   Get measured CO2 ppm value
+ *
+ * @param[in] dev           device descriptor
+ * @param[out] ppm          int16_t buffer where CO2 measurement will be written to in ppm
+ *
+ * @return                  MHZ19_OK
+ * @return                  MHZ19_ERR_TIMEOUT
+ * @return                  MHZ19_ERR_CHECKSUM
+ */
+int mhz19_get_ppm(mhz19_t *dev, int16_t *ppm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MHZ19_H */
+/** @} */

--- a/drivers/mhz19/Makefile
+++ b/drivers/mhz19/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mhz19/include/mhz19_internals.h
+++ b/drivers/mhz19/include/mhz19_internals.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mhz19
+ * @{
+ * @file
+ * @brief       Internal addresses, registers, constants for the MH-Z19 CO2 sensor
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef MHZ19_INTERNALS_H
+#define MHZ19_INTERNALS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    MH-Z19 Baud rate
+ *
+ * Fixed at 9600 by design.
+ */
+#define MHZ19_UART_BAUDRATE             9600
+
+/**
+ * @name    MH-Z19 Buffer size
+ *
+ * A transmission from the MH-Z19 is 9 bytes long:
+ * 1 Start byte
+ * 1 Sensor number
+ * 2 bytes data
+ * 4 bytes padding
+ * 1 byte checksum
+ *
+ * The start byte is not stored because it is not used in the checksum
+ * calculation.
+ */
+#define MHZ19_BUF_SIZE                  8
+
+
+/**
+ * @name    MH-Z19 Timeout in milliseconds
+ *
+ * 20 ms gives a decent margin on top of the UART transmission time. The
+ * datasheet does not specify any timings beside the UART baud rate.
+ *
+ * A single byte takes 10 bits effectively: a start bit, 8 bits data
+ * and stop bit. 9 bytes are transmitted, thus 10 bits * 9 / 9600bps = 9.3 ms.
+ */
+#define MHZ19_READ_TIMEOUT              20
+
+/**
+ * @name    MH-Z19 transmission constants
+ * @{
+ */
+#define MHZ19_READ_START                0xff    /**< Start bytes */
+#define MHZ19_READ_SENSOR_NUM           0x01    /**< Sensor number */
+#define MHZ19_READ_GAS_CHECKSUM         0x79    /**< Checksum */
+/** @} */
+
+/**
+ * @name    MH-Z19 registers
+ * @{
+ */
+#define MHZ19_REG_GAS_CONCENTRATION     0x86    /**< Gas concentration command */
+#define MHZ19_REG_CALIBRATE_ZERO        0x87    /**< Zero callibration command */
+#define MHZ19_REG_CALIBRATE_SPAN        0x88    /**< Span callibration command */
+/** @} */
+
+/**
+ * @name    MH-Z19 transmission data positions
+ * @{
+ */
+#define MHZ19_RX_POS_PPM_HIGH           1   /**< Measurement high byte */
+#define MHZ19_RX_POS_PPM_LOW            2   /**< Measurement low byte */
+#define MHZ19_RX_POS_CHECKSUM           7   /**< Checksum position */
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MHZ19_INTERNALS_H */
+/** @} */

--- a/drivers/mhz19/include/mhz19_internals.h
+++ b/drivers/mhz19/include/mhz19_internals.h
@@ -27,7 +27,7 @@ extern "C" {
  *
  * Fixed at 9600 by design.
  */
-#define MHZ19_UART_BAUDRATE             9600
+#define MHZ19_UART_BAUDRATE 9600
 
 /**
  * @name    MH-Z19 Buffer size
@@ -42,7 +42,7 @@ extern "C" {
  * The start byte is not stored because it is not used in the checksum
  * calculation.
  */
-#define MHZ19_BUF_SIZE                  8
+#define MHZ19_BUF_SIZE      8
 
 
 /**
@@ -54,7 +54,7 @@ extern "C" {
  * A single byte takes 10 bits effectively: a start bit, 8 bits data
  * and stop bit. 9 bytes are transmitted, thus 10 bits * 9 / 9600bps = 9.3 ms.
  */
-#define MHZ19_READ_TIMEOUT              20
+#define MHZ19_READ_TIMEOUT  20
 
 /**
  * @name    MH-Z19 transmission constants

--- a/drivers/mhz19/include/mhz19_params.h
+++ b/drivers/mhz19/include/mhz19_params.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mh-z19
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for MH-Z19
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef MHZ19_PARAMS_H
+#define MHZ19_PARAMS_H
+
+#include "board.h"
+#include "mhz19.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the MH-Z19
+ * @{
+ */
+#ifndef MHZ19_PARAM_UART_DEV
+#define MHZ19_PARAM_UART_DEV        UART_DEV(1)
+#endif
+#ifndef MHZ19_PARAM_UART_BAUD
+#define MHZ19_PARAM_UART_BAUDRATE   9600
+#endif
+
+#define MHZ19_PARAMS_DEFAULT    { .uart = MHZ19_PARAM_UART_DEV }
+
+/**
+ * @brief   Configure MHZ19
+ */
+static const mhz19_params_t mhz19_params[] =
+{
+#ifdef MHZ19_PARAMS_BOARD
+    MHZ19_PARAMS_BOARD,
+#else
+    MHZ19_PARAMS_DEFAULT
+#endif
+};
+
+/**
+ * @brief   The number of configured sensors
+ */
+#define MHZ19_NUMOF    (sizeof(mhz19_params) / sizeof(mhz19_params[0]))
+
+/**
+ * @brief   Configuration details of SAUL registry entries
+ *
+ * This two dimensional array contains static details of the sensors
+ * for each device. Please be awar that the indexes are used in
+ * auto_init_mhz280, so make sure the indexes match.
+ */
+static const saul_reg_info_t mhz19_saul_reg_info[MHZ19_NUMOF] =
+{
+    { .name = "mh-z19" }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MHZ19_PARAMS_H */
+/** @} */

--- a/drivers/mhz19/include/mhz19_params.h
+++ b/drivers/mhz19/include/mhz19_params.h
@@ -57,7 +57,7 @@ static const mhz19_params_t mhz19_params[] =
  * for each device. Please be awar that the indexes are used in
  * auto_init_mhz280, so make sure the indexes match.
  */
-static const saul_reg_info_t mhz19_saul_reg_info[] =
+static const saul_reg_info_t mhz19_saul_info[] =
 {
     MHZ19_SAUL_INFO
 };

--- a/drivers/mhz19/include/mhz19_params.h
+++ b/drivers/mhz19/include/mhz19_params.h
@@ -34,28 +34,21 @@ extern "C" {
 #ifndef MHZ19_PARAM_UART_DEV
 #define MHZ19_PARAM_UART_DEV        UART_DEV(1)
 #endif
-#ifndef MHZ19_PARAM_UART_BAUD
-#define MHZ19_PARAM_UART_BAUDRATE   9600
+
+#ifndef MHZ19_PARAMS
+#define MHZ19_PARAMS    { .uart = MHZ19_PARAM_UART_DEV }
 #endif
 
-#define MHZ19_PARAMS_DEFAULT    { .uart = MHZ19_PARAM_UART_DEV }
-
+#ifndef MHZ19_SAUL_INFO
+#define MHZ19_SAUL_INFO { .name = "mh-z19" }
+#endif
 /**
  * @brief   Configure MHZ19
  */
 static const mhz19_params_t mhz19_params[] =
 {
-#ifdef MHZ19_PARAMS_BOARD
-    MHZ19_PARAMS_BOARD,
-#else
-    MHZ19_PARAMS_DEFAULT
-#endif
+    MHZ19_PARAMS
 };
-
-/**
- * @brief   The number of configured sensors
- */
-#define MHZ19_NUMOF    (sizeof(mhz19_params) / sizeof(mhz19_params[0]))
 
 /**
  * @brief   Configuration details of SAUL registry entries
@@ -64,9 +57,9 @@ static const mhz19_params_t mhz19_params[] =
  * for each device. Please be awar that the indexes are used in
  * auto_init_mhz280, so make sure the indexes match.
  */
-static const saul_reg_info_t mhz19_saul_reg_info[MHZ19_NUMOF] =
+static const saul_reg_info_t mhz19_saul_reg_info[] =
 {
-    { .name = "mh-z19" }
+    MHZ19_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/drivers/mhz19/mhz19.c
+++ b/drivers/mhz19/mhz19.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mhz19
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for MH-Z19 CO2 sensor.
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include "mhz19.h"
+#include "mhz19_internals.h"
+#include "mhz19_params.h"
+#include "periph/uart.h"
+#include "xtimer.h"
+#include "mutex.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+/* Precalculated command sequence */
+static const uint8_t value_read[] = {
+    MHZ19_READ_START,
+    MHZ19_READ_SENSOR_NUM,
+    MHZ19_REG_GAS_CONCENTRATION,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    MHZ19_READ_GAS_CHECKSUM
+};
+
+static void _mhz19_timeout(void *arg)
+{
+    mhz19_t *dev = arg;
+
+    mutex_unlock(&(dev->sync));
+}
+
+static void _mhz19_rx_cb(void *arg, uint8_t byte)
+{
+    mhz19_t *dev = arg;
+
+    /* Skip start byte and skip out of array bounds writes */
+    if ((dev->idx == 0 && byte == 0xff) || dev->idx >= MHZ19_BUF_SIZE) {
+        return;
+    }
+    /* Store byte and increment idx */
+    dev->rxmem[dev->idx++] = byte;
+    if (dev->idx == MHZ19_BUF_SIZE) {
+        mutex_unlock(&dev->sync);
+    }
+}
+
+int mhz19_init(mhz19_t *dev, const mhz19_params_t *params)
+{
+    dev->params = params;
+
+    DEBUG("mhz19: initializing device %p on UART %i\n",
+          (void *)dev, dev->params->uart);
+    mutex_init(&dev->mutex);
+    mutex_init(&dev->sync);
+    dev->idx = 0;
+    /* Initialize UART interface */
+    if (uart_init(params->uart, MHZ19_UART_BAUDRATE, _mhz19_rx_cb, dev)) {
+        DEBUG("[Error] UART device not enabled\n");
+        return MHZ19_ERR_UART;
+    }
+    DEBUG("mhz19: Initialization complete\n");
+    return MHZ19_OK;
+}
+
+int mhz19_get_ppm(mhz19_t *dev, int16_t *ppm)
+{
+    xtimer_t timer; /* MH-Z19 timout timer, in case it doesn't respond */
+    int res = MHZ19_OK;
+
+    timer.callback = _mhz19_timeout;
+    timer.arg = dev;
+    timer.target = 0;
+    timer.long_target = 0;
+    DEBUG("mhz19: Starting measurement\n");
+    /* Lock concurrent access guard mutex */
+    mutex_lock(&dev->mutex);
+    /* Reset the buffer */
+    dev->idx = 0;
+    /* Send read command */
+    uart_write(dev->params->uart, value_read, sizeof(value_read));
+
+    /* Lock synchronisation mutex */
+    mutex_lock(&dev->sync);
+    /* Schedule timeout wakeup callback */
+    xtimer_set(&timer, MHZ19_READ_TIMEOUT * US_PER_MS);
+
+    /* Wait until the timeout or the UART ISR unlocks the mutex */
+    mutex_lock(&dev->sync);
+
+    /* Unlock mutex again to reset it */
+    mutex_unlock(&dev->sync);
+    /* Clean up timer */
+    xtimer_remove(&timer);
+    DEBUG("mhz19: Checking buffer: %d\n", dev->idx);
+    /* MHZ19_BUF_SIZE indicates completely filled buffer */
+    if (dev->idx == MHZ19_BUF_SIZE) {
+        uint8_t checksum = 0;
+        /* MHZ19_BUF_SIZE - 1 to exclude the received checksum */
+        for (unsigned i = 0; i < MHZ19_BUF_SIZE - 1; i++) {
+            checksum -= dev->rxmem[i];
+        }
+        if (checksum == dev->rxmem[MHZ19_RX_POS_CHECKSUM]) {
+            *ppm = dev->rxmem[MHZ19_RX_POS_PPM_HIGH] << 8;
+            *ppm += dev->rxmem[MHZ19_RX_POS_PPM_LOW];
+            res = MHZ19_OK;
+        }
+        else {
+            /* Checksum mismatch */
+            DEBUG("mhz19: Checksum failed, calculated 0x%x != 0x%x\n", checksum, dev->rxmem[MHZ19_RX_POS_CHECKSUM]);
+            res = MHZ19_ERR_CHECKSUM;
+        }
+    }
+    else {
+        DEBUG("mhz19: Timeout trying to retrieve measurement\n");
+        res = MHZ19_ERR_TIMEOUT;
+    }
+    /* Unlock guard mutex */
+    mutex_unlock(&dev->mutex);
+
+    return res;
+}

--- a/drivers/mhz19/mhz19_saul.c
+++ b/drivers/mhz19/mhz19_saul.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mhz19
+ * @{
+ *
+ * @file
+ * @brief       SAUL adaption for MH-Z19 CO2 sensor device
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include "saul.h"
+#include "mhz19.h"
+
+static int read_ppm(const void *dev, phydat_t *res)
+{
+    int16_t ppm;
+
+    /* Drops the const keyword, otherwise the mutex can't be locked */
+    mhz19_get_ppm((mhz19_t *)dev, &ppm);
+    res->val[0] = ppm;
+    res->unit = UNIT_PPM;
+    res->scale = 0;
+    return 1;
+}
+
+const saul_driver_t mhz19_ppm_saul_driver = {
+    .read = read_ppm,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_CO2
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -283,6 +283,10 @@ void auto_init(void)
 extern void auto_init_lis3mdl(void);
 auto_init_lis3mdl();
 #endif
+#ifdef MODULE_MHZ19
+    extern void auto_init_mhz19(void);
+    auto_init_mhz19();
+#endif
 #ifdef MODULE_MAG3110
     extern void auto_init_mag3110(void);
     auto_init_mag3110();

--- a/sys/auto_init/saul/auto_init_mhz19.c
+++ b/sys/auto_init/saul/auto_init_mhz19.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2017 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of MH-Z19 C02 sensor device.
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#ifdef MODULE_MHZ19
+
+#include "log.h"
+#include "saul_reg.h"
+#include "mhz19.h"
+#include "mhz19_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define MHZ19_NUMOF    (sizeof(mhz19_params) / sizeof(mhz19_params[0]))
+
+/**
+ * @brief   Allocation of memory for device descriptors
+ */
+static mhz19_t mhz19_devs[MHZ19_NUMOF];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[MHZ19_NUMOF];
+
+/**
+ * @brief   Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t mhz19_ppm_saul_driver;
+/** @} */
+
+void auto_init_mhz19(void)
+{
+    for (unsigned i = 0; i < MHZ19_NUMOF; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing mhz19 #%u\n", i);
+
+        if (mhz19_init(&mhz19_devs[i], &mhz19_params[i]) < 0) {
+            LOG_ERROR("[auto_init_saul] error initializing mhz19 #%u\n", i);
+            continue;
+        }
+
+        /* temperature */
+        saul_entries[i].dev = &(mhz19_devs[i]);
+        saul_entries[i].name = mhz19_saul_reg_info[i].name;
+        saul_entries[i].driver = &mhz19_ppm_saul_driver;
+
+        /* register to saul */
+        saul_reg_add(&(saul_entries[i]));
+    }
+}
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_MHZ19 */

--- a/sys/auto_init/saul/auto_init_mhz19.c
+++ b/sys/auto_init/saul/auto_init_mhz19.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Koen Zandberg
+ * Copyright (C) 2018 Koen Zandberg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -57,7 +57,6 @@ void auto_init_mhz19(void)
             continue;
         }
 
-        /* temperature */
         saul_entries[i].dev = &(mhz19_devs[i]);
         saul_entries[i].name = mhz19_saul_reg_info[i].name;
         saul_entries[i].driver = &mhz19_ppm_saul_driver;

--- a/sys/auto_init/saul/auto_init_mhz19.c
+++ b/sys/auto_init/saul/auto_init_mhz19.c
@@ -41,14 +41,19 @@ static mhz19_t mhz19_devs[MHZ19_NUMOF];
 static saul_reg_t saul_entries[MHZ19_NUMOF];
 
 /**
+ * @brief   Define the number of saul info
+ */
+#define MHZ19_INFO_NUM    (sizeof(mhz19_saul_info) / sizeof(mhz19_saul_info[0]))
+
+/**
  * @brief   Reference the driver structs.
- * @{
  */
 extern const saul_driver_t mhz19_ppm_saul_driver;
-/** @} */
 
 void auto_init_mhz19(void)
 {
+    assert(MHZ19_NUM == MHZ19_INFO_NUM);
+
     for (unsigned i = 0; i < MHZ19_NUMOF; i++) {
         LOG_DEBUG("[auto_init_saul] initializing mhz19 #%u\n", i);
 

--- a/sys/auto_init/saul/auto_init_mhz19.c
+++ b/sys/auto_init/saul/auto_init_mhz19.c
@@ -28,17 +28,17 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define MHZ19_NUMOF    (sizeof(mhz19_params) / sizeof(mhz19_params[0]))
+#define MHZ19_NUM   (sizeof(mhz19_params) / sizeof(mhz19_params[0]))
 
 /**
  * @brief   Allocation of memory for device descriptors
  */
-static mhz19_t mhz19_devs[MHZ19_NUMOF];
+static mhz19_t mhz19_devs[MHZ19_NUM];
 
 /**
  * @brief   Memory for the SAUL registry entries
  */
-static saul_reg_t saul_entries[MHZ19_NUMOF];
+static saul_reg_t saul_entries[MHZ19_NUM];
 
 /**
  * @brief   Define the number of saul info
@@ -54,7 +54,7 @@ void auto_init_mhz19(void)
 {
     assert(MHZ19_NUM == MHZ19_INFO_NUM);
 
-    for (unsigned i = 0; i < MHZ19_NUMOF; i++) {
+    for (unsigned i = 0; i < MHZ19_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing mhz19 #%u\n", i);
 
         if (mhz19_init(&mhz19_devs[i], &mhz19_params[i]) < 0) {
@@ -63,7 +63,7 @@ void auto_init_mhz19(void)
         }
 
         saul_entries[i].dev = &(mhz19_devs[i]);
-        saul_entries[i].name = mhz19_saul_reg_info[i].name;
+        saul_entries[i].name = mhz19_saul_info[i].name;
         saul_entries[i].driver = &mhz19_ppm_saul_driver;
 
         /* register to saul */

--- a/tests/driver_mhz19/Makefile
+++ b/tests/driver_mhz19/Makefile
@@ -1,0 +1,12 @@
+include ../Makefile.tests_common
+
+USEMODULE += mhz19
+USEMODULE += xtimer
+
+# set default device parameters in case they are undefined
+TEST_UART ?= 1
+
+# export parameters
+CFLAGS += -DTEST_UART=$(TEST_UART)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mhz19/README.md
+++ b/tests/driver_mhz19/README.md
@@ -1,0 +1,12 @@
+# MH-Z19 Driver Test
+
+## Introduction
+This test will test if the MH-Z19 C02 gas sensor is working.
+
+## Configuration
+
+* `TEST_UART` &mdash; UART interface to use
+
+## Expected result
+The sensor should continuously (every 1 sec) output the CO2 ppm level. When the
+sensor is disconnected, it should display a failure message every second.

--- a/tests/driver_mhz19/README.md
+++ b/tests/driver_mhz19/README.md
@@ -1,7 +1,8 @@
-# MH-Z19 Driver Test
+# MH-Z19/MH-Z19B Driver Test
 
 ## Introduction
-This test will test if the MH-Z19 C02 gas sensor is working.
+This test will test if the MH-Z19 C02 gas sensor is working. The MH-Z19B seems
+to be newer design which also works with this driver.
 
 ## Configuration
 

--- a/tests/driver_mhz19/main.c
+++ b/tests/driver_mhz19/main.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the MH-Z19 sensor driver
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#ifndef TEST_UART
+#error "TEST_UART not defined"
+#endif
+
+#include <stdio.h>
+
+#include "xtimer.h"
+
+#include "periph/uart.h"
+
+#include "mhz19.h"
+
+int main(void)
+{
+    mhz19_t dev;
+    mhz19_params_t params = {
+        .uart = TEST_UART,
+    };
+
+    puts("MH-Z19 CO2 sensor test application\n");
+
+    /* initialize the sensor */
+    printf("Initializing sensor...");
+
+    if (mhz19_init(&dev, &params) == 0) {
+        puts("[OK]");
+    }
+    else {
+        puts("[Failed]");
+        return 1;
+    }
+
+    /* read CO2 level every 1 seconds */
+    int16_t ppm;
+    while (1) {
+        printf("Testing sensor communication...");
+        int res = mhz19_get_ppm(&dev, &ppm);
+        if (res == 0) {
+            puts("[OK]");
+        }
+        else {
+            printf("[Failed]: %d\n", res);
+        }
+
+        /* display results */
+        printf("CO2: %d ppm\n", ppm);
+
+        /* sleep between measurements */
+        xtimer_usleep(1000 * US_PER_MS);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

The MH-Z19 is a relative cheap (15 euro) CO2 ppm sensor. This PR adds basic support for reading the CO2 measurement over the UART interface. Saul integration is provided with this PR.

As UART is asynchronous, I had to implement a bit of synchronisation and timeout support in the driver itself. This is the reason two mutexes are used and the reason the const keyword had to be dropped in the saul interface.

### Issues/PRs references

None