### PR TITLE
native: remove non required NATIVEINCLUDES

### DIFF
--- a/boards/native/Makefile
+++ b/boards/native/Makefile
@@ -3,5 +3,3 @@ MODULE = board
 DIRS = drivers
 
 include $(RIOTBASE)/Makefile.base
-
-INCLUDES = $(NATIVEINCLUDES)

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -1,9 +1,7 @@
-export NATIVEINCLUDES += -DNATIVE_INCLUDES
-export NATIVEINCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
-export NATIVEINCLUDES += -I$(RIOTBASE)/core/include/
-export NATIVEINCLUDES += -I$(RIOTBASE)/drivers/include/
-
 export CPU = native
+
+# Configuration for core/include/kernel_types.h
+CFLAGS += -DNATIVE_INCLUDES
 
 USEMODULE += native-drivers
 
@@ -117,7 +115,7 @@ debug-valgrind-server: export VALGRIND_FLAGS ?= --vgdb=yes --vgdb-error=0 -v \
 term-cachegrind: export CACHEGRIND_FLAGS += --tool=cachegrind
 term-gprof: export TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELFFILE)
 all-valgrind: export CFLAGS += -DHAVE_VALGRIND_H -g
-all-valgrind: export NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
+all-valgrind: export CFLAGS += $(shell pkg-config valgrind --cflags)
 all-debug: export CFLAGS += -g
 all-cachegrind: export CFLAGS += -g
 all-gprof: export CFLAGS += -pg
@@ -125,8 +123,6 @@ all-gprof: export LINKFLAGS += -pg
 all-asan: export CFLAGS += -fsanitize=address -fno-omit-frame-pointer -g
 all-asan: export CFLAGS += -DNATIVE_IN_CALLOC
 all-asan: export LINKFLAGS += -fsanitize=address -fno-omit-frame-pointer -g
-
-export INCLUDES += $(NATIVEINCLUDES)
 
 export CFLAGS += -DDEBUG_ASSERT_VERBOSE
 

--- a/boards/native/drivers/Makefile
+++ b/boards/native/drivers/Makefile
@@ -1,5 +1,3 @@
 MODULE = native-drivers
 
 include $(RIOTBASE)/Makefile.base
-
-INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/Makefile
+++ b/cpu/native/Makefile
@@ -24,5 +24,3 @@ ifneq (,$(filter can_linux,$(USEMODULE)))
 endif
 
 include $(RIOTBASE)/Makefile.base
-
-INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -1,8 +1,6 @@
-export NATIVEINCLUDES += -I$(RIOTCPU)/native/include -I$(RIOTBASE)/sys/include
-
 # Local include for OSX
 ifeq ($(BUILDOSXNATIVE),1)
-    export NATIVEINCLUDES += -I$(RIOTCPU)/native/osx-libc-extra
+    INCLUDES += -I$(RIOTCPU)/native/osx-libc-extra
 endif
 
 USEMODULE += periph

--- a/cpu/native/mtd/Makefile
+++ b/cpu/native/mtd/Makefile
@@ -1,5 +1,3 @@
 MODULE := mtd_native
 
 include $(RIOTBASE)/Makefile.base
-
-INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/netdev_tap/Makefile
+++ b/cpu/native/netdev_tap/Makefile
@@ -1,3 +1,1 @@
 include $(RIOTBASE)/Makefile.base
-
-INCLUDES = $(NATIVEINCLUDES)

--- a/cpu/native/socket_zep/Makefile
+++ b/cpu/native/socket_zep/Makefile
@@ -1,3 +1,1 @@
 include $(RIOTBASE)/Makefile.base
-
-INCLUDES = $(NATIVEINCLUDES)

--- a/sys/posix/include/sys/bytes.h
+++ b/sys/posix/include/sys/bytes.h
@@ -28,7 +28,12 @@
 extern "C" {
 #endif
 
+#ifndef __MACH__
 typedef size_t socklen_t;           /**< socket address length */
+#else
+/* Defined for OSX with a different type */
+typedef __darwin_socklen_t socklen_t;   /**< socket address length */
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -36,6 +36,9 @@
   sa_family_t sa_prefix##family
 
 #define __SOCKADDR_COMMON_SIZE  (sizeof (unsigned short int))
+#ifdef __MACH__
+#define AF_LINK (18)    /* Link layer interface */
+#endif
 #endif
 
 #include <stdlib.h>


### PR DESCRIPTION
While trying to document more what is done in boards and cpu Makefile.include files I found this native 'NATIVEINCLUDES' special case and found no current reasons to have it.
Also, not real explanation on why it is needed.

### Contribution description

Some modules used a 'NATIVEINCLUDES' with different include path and no other included directories.
It was defining basic 'include' in a different order and not using other things defined in INCLUDES.
After doing some checks with the given include path and possible conflicting files, there should be no conflict when using the default one.

* No common headers between all the NATIVEINCLUDES directories
* No common headers files between board/native/include, cpu/native/include and
  other files in the repository (except other boards/cpus of course).

### Notes

I found reference in a previous issue here https://github.com/RIOT-OS/RIOT/issues/793 but it looks like its not the case anymore.

Maybe I am missing some things and would like to ask at least if it is still necessary.
Also they may be other solutions to not need this special case.

If its still necessary, I would change the PR to only use the same include order as the one currently used in RIOT as there is no reasons to have another one.

I tried to detect problems with this script:

```
#! /bin/sh

INCLUDE_DIRS+=" boards/native/include/"
INCLUDE_DIRS+=" cpu/native/include/"
INCLUDE_DIRS+=" core/include/"
INCLUDE_DIRS+=" drivers/include/"
INCLUDE_DIRS+=" sys/include/"
INCLUDE_DIRS+=" cpu/native/osx-libc-extra/"
INCLUDE_DIRS+=" /usr/include/valgrind/"

list_headers() {
    local include_dir="$1"
    echo "Listing files in $include_dir" >&2
    find "${include_dir}" -type f | sed "s|^${include_dir}||"
}

list_all_headers() {
    for i in $@; do
        list_headers "$i"
    done
}

list_conflicting_headers() {
    local directory="$1"
    echo "Listing files with same name as in ${directory}"
    for i in $(ls "$directory"); do
        find . -name $i | grep -v -e '^./cpu' -e '^./boards' | sed 's/^/  /'
    done
}

OUTPUT=/tmp/out
list_all_headers ${INCLUDE_DIRS} | sort | uniq -c -d | sed 's/^ */  /'
echo ""

list_conflicting_headers boards/native/include
list_conflicting_headers cpu/native/include
echo ""

NI_PATTERN="NATIVE.?INCLUDES"
echo "Listing ${NI_PATTERN}"
git grep -E ${NI_PATTERN} | sed 's/^/  /'
```

### Issues/PRs references

None.