### PR TITLE
netdev: Add Netdev to Doxygen page title

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -10,7 +10,7 @@
  */
 
 /**
- * @defgroup    drivers_netdev_api Network Device Driver API
+ * @defgroup    drivers_netdev_api Netdev - Network Device Driver API
  * @ingroup     drivers_netdev
  * @brief       This is a generic low-level network driver interface
  * @{


### PR DESCRIPTION

### Contribution description

Add the word netdev to the Doxygen page title to make it easier to find in the table of contents when browsing the documentation.

### Issues/PRs references

none