### PR TITLE
adxl345.h Name collsion INT1

### DIFF
--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -82,10 +82,10 @@ enum {
  * @brief   List fifo mode
  */
 enum {
-    BYPASS  = 0,          /**< FIFO bypass mode */
-    FIFO    = 1,          /**< FIFO mode */
-    STREAM  = 2,          /**< FIFO stream mode */
-    TRIGGER = 3           /**< FIFO trigger mode */
+    ADXL345_BYPASS  = 0,          /**< FIFO bypass mode */
+    ADXL345_FIFO    = 1,          /**< FIFO mode */
+    ADXL345_STREAM  = 2,          /**< FIFO stream mode */
+    ADXL345_TRIGGER = 3           /**< FIFO trigger mode */
 };
 
 /**

--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -92,8 +92,8 @@ enum {
  * @brief   Output Interrupt selection
  */
 enum {
-    INT1,  /**< Output interrupt on INT1 pin */
-    INT2   /**< Output interrupt on INT2 pin */
+    ADXL345_INT1,  /**< Output interrupt on INT1 pin */
+    ADXL345_INT2   /**< Output interrupt on INT2 pin */
 };
 
 /**


### PR DESCRIPTION
fixed be prepending ADXL345_INT1

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->