### PR TITLE
doc/doxygen: enable parsing of packages docs

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -827,7 +827,11 @@ EXCLUDE_PATTERNS       = */board/*/tools/* \
                          */cpu/native/osx-libc-extra \
                          */cpu/x86/include/* \
                          */drivers/kw2xrf/include/overwrites.h \
-                         */pkg/*/*/* \
+                         */pkg/emb6/* \
+                         */pkg/lwip/* \
+                         */pkg/nordic_softdevice_ble/* \
+                         */pkg/openthread/* \
+                         */pkg/semtech-loramac/* \
                          */pkg/tlsf/patch.txt \
                          */sys/include/embUnit/* \
                          */sys/random/tinymt32/* \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR enables parsing doxygen in all packages except a few that have issues: emb6, lwip, nordic_softdevice_ble, openthread and semtech-loramac

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#8664 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->