### PR TITLE
drivers/adcxx1c: apply unified params definition scheme

### DIFF
--- a/drivers/adcxx1c/include/adcxx1c_params.h
+++ b/drivers/adcxx1c/include/adcxx1c_params.h
@@ -56,14 +56,19 @@ extern "C" {
 #define ADCXX1C_PARAM_HYSTERESIS (0)
 #endif
 
-#define ADCXX1C_PARAMS_DEFAULT  { .i2c        = ADCXX1C_PARAM_I2C, \
-                                  .addr       = ADCXX1C_PARAM_ADDR, \
-                                  .bits       = ADCXX1C_PARAM_BITS, \
-                                  .cycle      = ADCXX1C_PARAM_CYCLE, \
-                                  .alert_pin  = ADCXX1C_PARAM_ALERT_PIN, \
-                                  .low_limit  = ADCXX1C_PARAM_LOW_LIMIT, \
+#ifndef ADCXX1C_PARAMS
+#define ADCXX1C_PARAMS          { .i2c        = ADCXX1C_PARAM_I2C,        \
+                                  .addr       = ADCXX1C_PARAM_ADDR,       \
+                                  .bits       = ADCXX1C_PARAM_BITS,       \
+                                  .cycle      = ADCXX1C_PARAM_CYCLE,      \
+                                  .alert_pin  = ADCXX1C_PARAM_ALERT_PIN,  \
+                                  .low_limit  = ADCXX1C_PARAM_LOW_LIMIT,  \
                                   .high_limit = ADCXX1C_PARAM_HIGH_LIMIT, \
                                   .hysteresis = ADCXX1C_PARAM_HYSTERESIS }
+#endif
+#ifndef ADCXX1C_SAUL_INFO
+#define ADCXX1C_SAUL_INFO       { .name = "adcxx1c" }
+#endif
 /** @} */
 
 /**
@@ -71,11 +76,7 @@ extern "C" {
  */
 static const adcxx1c_params_t adcxx1c_params[] =
 {
-#ifdef ADCXX1C_PARAMS_BOARD
-    ADCXX1C_PARAMS_BOARD,
-#else
-    ADCXX1C_PARAMS_DEFAULT,
-#endif
+    ADCXX1C_PARAMS
 };
 
 
@@ -84,9 +85,7 @@ static const adcxx1c_params_t adcxx1c_params[] =
  */
 static const saul_reg_info_t adcxx1c_saul_info[] =
 {
-    {
-        .name = "adcxx1c",
-    },
+    ADCXX1C_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_adcxx1c.c
+++ b/sys/auto_init/saul/auto_init_adcxx1c.c
@@ -30,7 +30,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define ADCXX1C_NUM    (sizeof(adcxx1c_params)/sizeof(adcxx1c_params[0]))
+#define ADCXX1C_NUM   (sizeof(adcxx1c_params) / sizeof(adcxx1c_params[0]))
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -43,18 +43,22 @@ static adcxx1c_t adcxx1c_devs[ADCXX1C_NUM];
 static saul_reg_t saul_entries[ADCXX1C_NUM];
 
 /**
+ * @brief   Define the number of saul info
+ */
+#define ADCXX1C_INFO_NUM (sizeof(adcxx1c_saul_info) / sizeof(adcxx1c_saul_info[0]))
+
+/**
  * @brief   Reference the driver struct
  */
 extern saul_driver_t adcxx1c_saul_driver;
 
-
 void auto_init_adcxx1c(void)
 {
-    for (unsigned i = 0; i < ADCXX1C_NUM; i++) {
-        const adcxx1c_params_t *p = &adcxx1c_params[i];
+    assert(ADCXX1C_INFO_NUM == ADCXX1C_NUM);
 
+    for (unsigned i = 0; i < ADCXX1C_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing adcxx1c #%d\n", i);
-        if (adcxx1c_init(&adcxx1c_devs[i], p) < 0) {
+        if (adcxx1c_init(&adcxx1c_devs[i], &adcxx1c_params[i]) < 0) {
             LOG_ERROR("[auto_init_saul] error initializing adcxx1c #%d\n", i);
             continue;
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the adcxx1c device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937  and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->