### PR TITLE
drivers/adxl345: apply unified params definition scheme

### DIFF
--- a/drivers/adxl345/include/adxl345_params.h
+++ b/drivers/adxl345/include/adxl345_params.h
@@ -62,6 +62,9 @@ extern "C" {
                                       .rate   = ADXL345_PARAM_RATE,      \
                                       .full_res = ADXL345_PARAM_FULL_RES }
 #endif
+#ifndef ADXL345_SAUL_INFO
+#define ADXL345_SAUL_INFO           { .name = "adxl345" }
+#endif
 /**@}*/
 
 /**
@@ -77,9 +80,7 @@ static const adxl345_params_t adxl345_params[] =
  */
 static const saul_reg_info_t adxl345_saul_info[] =
 {
-    {
-        .name = "adxl345"
-    }
+    ADXL345_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_adxl345.c
+++ b/sys/auto_init/saul/auto_init_adxl345.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define ADXL345_NUM    (sizeof(adxl345_params)/sizeof(adxl345_params[0]))
+#define ADXL345_NUM    (sizeof(adxl345_params) / sizeof(adxl345_params[0]))
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -42,14 +42,19 @@ static adxl345_t adxl345_devs[ADXL345_NUM];
 static saul_reg_t saul_entries[ADXL345_NUM];
 
 /**
+ * @brief   Define the number of saul info
+ */
+#define ADXL345_INFO_NUM (sizeof(adxl345_saul_info) / sizeof(adxl345_saul_info[0]))
+
+/**
  * @brief   Reference the driver structs
- * @{
  */
 extern saul_driver_t adxl345_saul_driver;
-/** @} */
 
 void auto_init_adxl345(void)
 {
+    assert(ADXL345_INFO_NUM == ADXL345_NUM);
+
     for (unsigned i = 0; i < ADXL345_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing adxl345 #%u\n", i);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the adxl345 device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->