### PR TITLE
drivers/bmp180: apply unified params definition scheme 

### DIFF
--- a/drivers/bmp180/include/bmp180_params.h
+++ b/drivers/bmp180/include/bmp180_params.h
@@ -44,9 +44,14 @@ extern "C" {
 #define BMP180_PARAM_OVERSAMPLING    BMP180_ULTRALOWPOWER
 #endif
 
-#define BMP180_PARAMS_DEFAULT        { .i2c_dev      = BMP180_PARAM_I2C_DEV,  \
+#ifndef BMP180_PARAMS
+#define BMP180_PARAMS                { .i2c_dev      = BMP180_PARAM_I2C_DEV,  \
                                        .i2c_addr     = BMP180_PARAM_I2C_ADDR, \
                                        .oversampling = BMP180_PARAM_OVERSAMPLING }
+#endif
+#ifndef BMP180_SAUL_INFO
+#define BMP180_SAUL_INFO             { .name = "bmp180" }
+#endif
 /**@}*/
 
 /**
@@ -54,19 +59,15 @@ extern "C" {
  */
 static const bmp180_params_t bmp180_params[] =
 {
-#ifdef BMP180_PARAMS_BOARD
-    BMP180_PARAMS_BOARD,
-#else
-    BMP180_PARAMS_DEFAULT,
-#endif
+    BMP180_PARAMS
 };
 
 /**
  * @brief   Configure SAUL registry entries
  */
-static const saul_reg_info_t bmp180_saul_reg_info[] =
+static const saul_reg_info_t bmp180_saul_info[] =
 {
-    { .name = "bmp180" }
+    BMP180_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_bmp180.c
+++ b/sys/auto_init/saul/auto_init_bmp180.c
@@ -28,20 +28,25 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define BMP180_NUMOF    (sizeof(bmp180_params) / sizeof(bmp180_params[0]))
+#define BMP180_NUM      (sizeof(bmp180_params) / sizeof(bmp180_params[0]))
 
 /**
  * @brief   Allocation of memory for device descriptors
  */
-static bmp180_t bmp180_devs[BMP180_NUMOF];
+static bmp180_t bmp180_devs[BMP180_NUM];
 
 /**
  * @brief   Memory for the SAUL registry entries
  */
-static saul_reg_t saul_entries[BMP180_NUMOF * 2];
+static saul_reg_t saul_entries[BMP180_NUM * 2];
 
 /**
- * @brief   Reference the driver structs.
+ * @brief   Define the number of saul info
+ */
+#define BMP180_INFO_NUM (sizeof(bmp180_saul_info) / sizeof(bmp180_saul_info[0]))
+
+/**
+ * @name    Reference the driver structs.
  * @{
  */
 extern const saul_driver_t bmp180_temperature_saul_driver;
@@ -50,7 +55,9 @@ extern const saul_driver_t bmp180_pressure_saul_driver;
 
 void auto_init_bmp180(void)
 {
-    for (unsigned i = 0; i < BMP180_NUMOF; i++) {
+    assert(BMP180_INFO_NUM == BMP180_NUM);
+
+    for (unsigned i = 0; i < BMP180_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing bmp180 #%u\n", i);
 
         if (bmp180_init(&bmp180_devs[i],
@@ -61,12 +68,12 @@ void auto_init_bmp180(void)
 
         /* temperature */
         saul_entries[(i * 2)].dev = &(bmp180_devs[i]);
-        saul_entries[(i * 2)].name = bmp180_saul_reg_info[i].name;
+        saul_entries[(i * 2)].name = bmp180_saul_info[i].name;
         saul_entries[(i * 2)].driver = &bmp180_temperature_saul_driver;
 
         /* atmospheric pressure */
         saul_entries[(i * 2) + 1].dev = &(bmp180_devs[i]);
-        saul_entries[(i * 2) + 1].name = bmp180_saul_reg_info[i].name;
+        saul_entries[(i * 2) + 1].name = bmp180_saul_info[i].name;
         saul_entries[(i * 2) + 1].driver = &bmp180_pressure_saul_driver;
 
         /* register to saul */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the bmp180 device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->