### PR TITLE
drivers/grove_ledbar: apply unified params definition scheme

### DIFF
--- a/drivers/grove_ledbar/include/grove_ledbar_params.h
+++ b/drivers/grove_ledbar/include/grove_ledbar_params.h
@@ -54,23 +54,24 @@ extern "C"
 /**
  * @brief   Default parameter settings
  */
-#define GROVE_LEDBAR_PARAMS {       \
-    .leds       = 10,               \
-    .dir        = GROVE_LEDBAR_DIR, \
-    .clk        = GROVE_LEDBAR_CLK, \
-    .dat        = GROVE_LEDBAR_DAT, \
-}
+#ifndef GROVE_LEDBAR_PARAMS
+#define GROVE_LEDBAR_PARAMS     { .leds = 10,               \
+                                  .dir  = GROVE_LEDBAR_DIR, \
+                                  .clk  = GROVE_LEDBAR_CLK, \
+                                  .dat  = GROVE_LEDBAR_DAT }
+#endif
+
+/**
+ * @brief   SAUL info
+ */
+#define GROVE_LEDBAR_SAUL_INFO  { .name = "Grove LED bar" }
 
 /**
  * @brief   Grove LED bar configuration
  */
 static const grove_ledbar_params_t grove_ledbar_params[] =
 {
-#ifdef GROVE_LEDBAR_CUSTOM
-    GROVE_LEDBAR_CUSTOM,
-#else
     GROVE_LEDBAR_PARAMS,
-#endif
 };
 
 /**
@@ -78,9 +79,7 @@ static const grove_ledbar_params_t grove_ledbar_params[] =
  */
 static const saul_reg_info_t grove_ledbar_saul_info[] =
 {
-    {
-        .name = "Grove LED bar"
-    }
+    GROVE_LEDBAR_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_grove_ledbar.c
+++ b/sys/auto_init/saul/auto_init_grove_ledbar.c
@@ -43,12 +43,19 @@ static grove_ledbar_t grove_ledbar_devs[GROVE_LEDBAR_NUM];
 static saul_reg_t saul_entries[GROVE_LEDBAR_NUM];
 
 /**
+ * @brief   Define the number of saul info
+ */
+#define GROVE_LEDBAR_INFO_NUM (sizeof(grove_ledbar_saul_info) / sizeof(grove_ledbar_saul_info[0]))
+
+/**
  * @brief   Reference the driver struct
  */
 extern const saul_driver_t grove_ledbar_saul_driver;
 
 void auto_init_grove_ledbar(void)
 {
+    assert(GROVE_LEDBAR_NUM == GROVE_LEDBAR_INFO_NUM);
+
     for (unsigned i = 0; i < GROVE_LEDBAR_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing Grove LED bar #%u: ", i);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the grove_ledbar device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->