### PR TITLE
drivers/lpd8808: use new driver params scheme

### DIFF
--- a/drivers/lpd8808/include/lpd8808_params.h
+++ b/drivers/lpd8808/include/lpd8808_params.h
@@ -39,9 +39,11 @@ extern "C" {
 #define LPD8808_PARAM_PIN_DAT       (GPIO_PIN(0, 1))
 #endif
 
-#define LPD8808_PARAMS_DEFAULT      {.led_cnt = LPD8808_PARAM_LED_CNT, \
-                                     .pin_clk = LPD8808_PARAM_PIN_CLK, \
-                                     .pin_dat = LPD8808_PARAM_PIN_DAT }
+#ifndef LPD8808_PARAMS
+#define LPD8808_PARAMS              { .led_cnt = LPD8808_PARAM_LED_CNT, \
+                                      .pin_clk = LPD8808_PARAM_PIN_CLK, \
+                                      .pin_dat = LPD8808_PARAM_PIN_DAT }
+#endif
 /**@}*/
 
 /**
@@ -49,11 +51,7 @@ extern "C" {
  */
 static const lpd8808_params_t lpd8808_params[] =
 {
-#ifdef LPD8808_PARAMS_BOARD
-    LPD8808_PARAMS_BOARD,
-#else
-    LPD8808_PARAMS_DEFAULT,
-#endif
+    LPD8808_PARAMS
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the lpd8808 device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->