### PR TITLE
drivers/adcxx1c: apply unified params definition scheme

### DIFF
--- a/drivers/veml6070/include/veml6070_params.h
+++ b/drivers/veml6070/include/veml6070_params.h
@@ -38,8 +38,13 @@ extern "C" {
 #define VEML6070_PARAM_ITIME            VEML6070_1_T
 #endif
 
-#define VEML6070_PARAMS_DEFAULT        { .i2c_dev = VEML6070_PARAM_I2C_DEV,  \
+#ifndef VEML6070_PARAMS
+#define VEML6070_PARAMS                { .i2c_dev = VEML6070_PARAM_I2C_DEV, \
                                          .itime   = VEML6070_PARAM_ITIME }
+#endif
+#ifndef VEML6070_SAUL_INFO
+#define VEML6070_SAUL_INFO             { .name = "veml6070" }
+#endif
 /**@}*/
 
 /**
@@ -47,19 +52,15 @@ extern "C" {
  */
 static const veml6070_params_t veml6070_params[] =
 {
-#ifdef VEML6070_PARAMS_BOARD
-    VEML6070_PARAMS_BOARD,
-#else
-    VEML6070_PARAMS_DEFAULT,
-#endif
+    VEML6070_PARAMS
 };
 
 /**
  * @brief   Configure SAUL registry entries
  */
-static const saul_reg_info_t veml6070_saul_reg_info[] =
+static const saul_reg_info_t veml6070_saul_info[] =
 {
-    { .name = "veml6070" }
+    VEML6070_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_veml6070.c
+++ b/sys/auto_init/saul/auto_init_veml6070.c
@@ -41,14 +41,19 @@ static veml6070_t veml6070_devs[VEML6070_NUMOF];
 static saul_reg_t saul_entries[VEML6070_NUMOF];
 
 /**
+ * @brief   Define the number of saul info
+ */
+#define VEML6070_INFO_NUM    (sizeof(veml6070_saul_info) / sizeof(veml6070_saul_info[0]))
+
+/**
  * @brief   Reference the driver structs.
- * @{
  */
 extern const saul_driver_t veml6070_uv_saul_driver;
-/** @} */
 
 void auto_init_veml6070(void)
 {
+    assert(VEML6070_NUM == VEML6070_INFO_NUM);
+
     for (unsigned i = 0; i < VEML6070_NUMOF; i++) {
         LOG_DEBUG("[auto_init_saul] initializing veml6070 #%u\n", i);
 
@@ -59,7 +64,7 @@ void auto_init_veml6070(void)
         }
 
         saul_entries[(i)].dev = &(veml6070_devs[i]);
-        saul_entries[(i)].name = veml6070_saul_reg_info[i].name;
+        saul_entries[(i)].name = veml6070_saul_info[i].name;
         saul_entries[(i)].driver = &veml6070_uv_saul_driver;
 
         /* register to saul */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the veml6070 device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->