### PR TITLE
drivers/tmp006: apply unified params definition scheme

### DIFF
--- a/drivers/tmp006/include/tmp006_params.h
+++ b/drivers/tmp006/include/tmp006_params.h
@@ -41,9 +41,14 @@ extern "C" {
 #define TMP006_PARAM_RATE           TMP006_CONFIG_CR_DEF
 #endif
 
-#define TMP006_PARAMS_DEFAULT    {  .i2c  = TMP006_PARAM_I2C, \
-                                    .addr = TMP006_PARAM_ADDR, \
-                                    .rate = TMP006_PARAM_RATE }
+#ifndef TMP006_PARAMS
+#define TMP006_PARAMS              { .i2c  = TMP006_PARAM_I2C,  \
+                                     .addr = TMP006_PARAM_ADDR, \
+                                     .rate = TMP006_PARAM_RATE }
+#endif
+#ifndef TMP006_SAUL_INFO
+#define TMP006_SAUL_INFO           { .name = "tmp006" }
+#endif
 /**@}*/
 
 /**
@@ -51,11 +56,7 @@ extern "C" {
  */
 static const tmp006_params_t tmp006_params[] =
 {
-#ifdef TMP006_PARAMS_BOARD
-    TMP006_PARAMS_BOARD,
-#else
-    TMP006_PARAMS_DEFAULT,
-#endif
+    TMP006_PARAMS
 };
 
 /**
@@ -63,7 +64,7 @@ static const tmp006_params_t tmp006_params[] =
  */
 static const saul_reg_info_t tmp006_saul_info[] =
 {
-    { .name = "tmp006" }
+    TMP006_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_tmp006.c
+++ b/sys/auto_init/saul/auto_init_tmp006.c
@@ -43,12 +43,19 @@ static tmp006_t tmp006_devs[TMP006_NUM];
 static saul_reg_t saul_entries[TMP006_NUM];
 
 /**
+ * @brief   Define the number of saul info
+ */
+#define TMP006_INFO_NUM    (sizeof(tmp006_saul_info) / sizeof(tmp006_saul_info[0]))
+
+/**
  * @brief   Reference the driver struct
  */
 extern const saul_driver_t tmp006_saul_driver;
 
 void auto_init_tmp006(void)
 {
+    assert(TMP006_NUM == TMP006_INFO_NUM);
+
     for (unsigned i = 0; i < TMP006_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing tmp006 #%u\n", i);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description


This PR update the params definitions scheme for the tmp006 device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->