### PR TITLE
drivers/mm8x5x: apply unified params definition scheme

### DIFF
--- a/drivers/mma8x5x/include/mma8x5x_params.h
+++ b/drivers/mma8x5x/include/mma8x5x_params.h
@@ -51,12 +51,15 @@ extern "C" {
 #endif
 
 #ifndef MMA8X5X_PARAMS
-#define MMA8X5X_PARAMS          { .i2c    = MMA8X5X_PARAM_I2C, \
-                                  .addr   = MMA8X5X_PARAM_ADDR, \
-                                  .type   = MMA8X5X_PARAM_TYPE, \
-                                  .rate   = MMA8X5X_PARAM_RATE, \
+#define MMA8X5X_PARAMS          { .i2c    = MMA8X5X_PARAM_I2C,   \
+                                  .addr   = MMA8X5X_PARAM_ADDR,  \
+                                  .type   = MMA8X5X_PARAM_TYPE,  \
+                                  .rate   = MMA8X5X_PARAM_RATE,  \
                                   .range  = MMA8X5X_PARAM_RANGE, \
                                   .offset = MMA8X5X_PARAM_OFFSET }
+#endif
+#ifndef MMA8X5X_SAUL_INFO
+#define MMA8X5X_SAUL_INFO       { .name = "mma8652" }
 #endif
 /**@}*/
 
@@ -73,9 +76,7 @@ static const mma8x5x_params_t mma8x5x_params[] =
  */
 static const saul_reg_info_t mma8x5x_saul_info[] =
 {
-    {
-        .name = "mma8652"
-    }
+    MMA8X5X_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_mma8x5x.c
+++ b/sys/auto_init/saul/auto_init_mma8x5x.c
@@ -43,14 +43,19 @@ static mma8x5x_t mma8x5x_devs[MMA8X5X_NUM];
 static saul_reg_t saul_entries[MMA8X5X_NUM];
 
 /**
+ * @brief   Define the number of saul info
+ */
+#define MMA8X5X_INFO_NUM    (sizeof(mma8x5x_saul_info) / sizeof(mma8x5x_saul_info[0]))
+
+/**
  * @brief   Reference the driver struct
- * @{
  */
 extern saul_driver_t mma8x5x_saul_driver;
-/** @} */
 
 void auto_init_mma8x5x(void)
 {
+    assert(MMA8X5X_NUM == MMA8X5X_INFO_NUM);
+
     for (unsigned i = 0; i < MMA8X5X_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing mma8x5x #%u\n", i);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the mm8x5x device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->