### PR TITLE
drivers/mpl3115a2: apply unified params definition scheme

### DIFF
--- a/drivers/mpl3115a2/include/mpl3115a2_params.h
+++ b/drivers/mpl3115a2/include/mpl3115a2_params.h
@@ -44,10 +44,13 @@ extern "C" {
 #define MPL3115A2_PARAM_RATIO       MPL3115A2_OS_RATIO_DEFAULT
 #endif
 
-#ifndef MPL3115A2_PARAMS_DEFAULT
-#define MPL3115A2_PARAMS_DEFAULT    { .i2c   = MPL3115A2_PARAM_I2C, \
+#ifndef MPL3115A2_PARAMS
+#define MPL3115A2_PARAMS            { .i2c   = MPL3115A2_PARAM_I2C,  \
                                       .addr  = MPL3115A2_PARAM_ADDR, \
                                       .ratio = MPL3115A2_PARAM_RATIO }
+#endif
+#ifndef MPL3115A2_SAUL_INFO
+#define MPL3115A2_SAUL_INFO         { .name = "mpl3115a2" }
 #endif
 /**@}*/
 
@@ -56,12 +59,7 @@ extern "C" {
  */
 static const mpl3115a2_params_t mpl3115a2_params[] =
 {
-
-#ifdef MPL3115A2_PARAMS_CUSTOM
-    MPL3115A2_PARAMS_CUSTOM
-#else
-    MPL3115A2_PARAMS_DEFAULT
-#endif
+    MPL3115A2_PARAMS
 };
 
 /**
@@ -69,7 +67,7 @@ static const mpl3115a2_params_t mpl3115a2_params[] =
  */
 static const saul_reg_info_t mpl3115a2_saul_info[] =
 {
-    { .name = "mpl3115a2" },
+    MPL3115A2_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_mpl3115a2.c
+++ b/sys/auto_init/saul/auto_init_mpl3115a2.c
@@ -43,6 +43,11 @@ static mpl3115a2_t mpl3115a2_devs[MPL3115A2_NUM];
 static saul_reg_t saul_entries[MPL3115A2_NUM * 2];
 
 /**
+ * @brief   Define the number of saul info
+ */
+#define MPL3115A2_INFO_NUM    (sizeof(mpl3115a2_saul_info) / sizeof(mpl3115a2_saul_info[0]))
+
+/**
  * @name    Reference the driver struct
  * @{
  */
@@ -52,6 +57,8 @@ extern const saul_driver_t mpl3115a2_temperature_saul_driver;
 
 void auto_init_mpl3115a2(void)
 {
+    assert(MPL3115A2_NUM == MPL3115A2_INFO_NUM);
+
     for (unsigned i = 0; i < MPL3115A2_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing mpl3115a2 #%u\n", i);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the mpl3115a2 device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->