### PR TITLE
drivers/enc28j60: use new driver params scheme

### DIFF
--- a/drivers/enc28j60/include/enc28j60_params.h
+++ b/drivers/enc28j60/include/enc28j60_params.h
@@ -41,18 +41,20 @@ extern "C" {
 #ifndef ENC28J60_PARAM_RESET
 #define ENC28J60_PARAM_RESET    (GPIO_PIN(0, 2))
 #endif
+
+#ifndef ENC28J60_PARAMS
+#define ENC28J60_PARAMS         { .spi = ENC28J60_PARAM_SPI,     \
+                                  .cs_pin = ENC28J60_PARAM_CS,   \
+                                  .int_pin = ENC28J60_PARAM_INT, \
+                                  .reset_pin = ENC28J60_PARAM_RESET }
+#endif
 /** @} */
 
 /**
  * @brief   ENC28J60 configuration
  */
 static const  enc28j60_params_t enc28j60_params[] = {
-    {
-        .spi = ENC28J60_PARAM_SPI,
-        .cs_pin = ENC28J60_PARAM_CS,
-        .int_pin = ENC28J60_PARAM_INT,
-        .reset_pin = ENC28J60_PARAM_RESET,
-    },
+    ENC28J60_PARAMS
 };
 /** @} */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the enc28j60 device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->