### PR TITLE
drivers/bh1750fvi: use new driver params scheme

### DIFF
--- a/drivers/bh1750fvi/include/bh1750fvi_params.h
+++ b/drivers/bh1750fvi/include/bh1750fvi_params.h
@@ -40,9 +40,11 @@ extern "C" {
 #define BH1750FVI_PARAM_I2C_CLK     (BH1750FVI_I2C_MAX_CLK)
 #endif
 
-#define BH1750FVI_PARAMS_DEFAULT    {.i2c = BH1750FVI_PARAM_I2C, \
-                                     .addr = BH1750FVI_PARAM_ADDR, \
-                                     .clk = BH1750FVI_PARAM_I2C_CLK}
+#ifndef BH1750FVI_PARAMS
+#define BH1750FVI_PARAMS            { .i2c = BH1750FVI_PARAM_I2C,   \
+                                      .addr = BH1750FVI_PARAM_ADDR, \
+                                      .clk = BH1750FVI_PARAM_I2C_CLK }
+#endif
 /**@}*/
 
 /**
@@ -50,11 +52,7 @@ extern "C" {
  */
 static const bh1750fvi_params_t bh1750fvi_params[] =
 {
-#ifdef BH1750FVI_PARAMS_BOARD
-    BH1750FVI_PARAMS_BOARD,
-#else
-    BH1750FVI_PARAMS_DEFAULT,
-#endif
+    BH1750FVI_PARAMS
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description



This PR update the params definitions scheme for the bh1750fvi device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->