### PR TITLE
drivers/lsm6dsl: apply unified params definition scheme 

### DIFF
--- a/drivers/lsm6dsl/include/lsm6dsl_params.h
+++ b/drivers/lsm6dsl/include/lsm6dsl_params.h
@@ -58,14 +58,19 @@ extern "C" {
 #define LSM6DSL_PARAM_GYRO_FIFO_DEC  (LSM6DSL_DECIMATION_NO)
 #endif
 
-#define LSM6DSL_PARAMS_DEFAULT       { .i2c             = LSM6DSL_PARAM_I2C, \
-                                       .addr            = LSM6DSL_PARAM_ADDR, \
-                                       .acc_odr         = LSM6DSL_PARAM_ACC_ODR, \
-                                       .gyro_odr        = LSM6DSL_PARAM_GYRO_ODR, \
-                                       .acc_fs          = LSM6DSL_PARAM_ACC_FS, \
-                                       .gyro_fs         = LSM6DSL_PARAM_GYRO_FS, \
+#ifndef LSM6DSL_PARAMS
+#define LSM6DSL_PARAMS               { .i2c             = LSM6DSL_PARAM_I2C,          \
+                                       .addr            = LSM6DSL_PARAM_ADDR,         \
+                                       .acc_odr         = LSM6DSL_PARAM_ACC_ODR,      \
+                                       .gyro_odr        = LSM6DSL_PARAM_GYRO_ODR,     \
+                                       .acc_fs          = LSM6DSL_PARAM_ACC_FS,       \
+                                       .gyro_fs         = LSM6DSL_PARAM_GYRO_FS,      \
                                        .acc_decimation  = LSM6DSL_PARAM_ACC_FIFO_DEC, \
                                        .gyro_decimation = LSM6DSL_PARAM_GYRO_FIFO_DEC }
+#endif
+#ifndef LSM6DSL_SAUL_INFO
+#define LSM6DSL_SAUL_INFO            { .name = "lsm6dsl" }
+#endif
 /** @} */
 
 /**
@@ -73,11 +78,7 @@ extern "C" {
  */
 static const lsm6dsl_params_t lsm6dsl_params[] =
 {
-#ifdef LSM6DSL_PARAMS_CUSTOM
-    LSM6DSL_PARAMS_CUSTOM,
-#else
-    LSM6DSL_PARAMS_DEFAULT,
-#endif
+    LSM6DSL_PARAMS
 };
 
 /**
@@ -85,7 +86,7 @@ static const lsm6dsl_params_t lsm6dsl_params[] =
  */
 static const saul_reg_info_t lsm6dsl_saul_info[] =
 {
-    { .name = "lsm6dsl" }
+    LSM6DSL_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_lsm6dsl.c
+++ b/sys/auto_init/saul/auto_init_lsm6dsl.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define LSM6DSL_NUM    (sizeof(lsm6dsl_params)/sizeof(lsm6dsl_params[0]))
+#define LSM6DSL_NUM    (sizeof(lsm6dsl_params) / sizeof(lsm6dsl_params[0]))
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -42,7 +42,12 @@ static lsm6dsl_t lsm6dsl_devs[LSM6DSL_NUM];
 static saul_reg_t saul_entries[LSM6DSL_NUM * 3];
 
 /**
- * @brief   Reference the driver structs
+ * @brief   Define the number of saul info
+ */
+#define LSM6DSL_INFO_NUM    (sizeof(lsm6dsl_saul_info) / sizeof(lsm6dsl_saul_info[0]))
+
+/**
+ * @name    Reference the driver structs
  * @{
  */
 extern saul_driver_t lsm6dsl_saul_acc_driver;
@@ -53,11 +58,12 @@ extern saul_driver_t lsm6dsl_saul_temp_driver;
 
 void auto_init_lsm6dsl(void)
 {
+    assert(LSM6DSL_NUM == LSM6DSL_INFO_NUM);
+
     for (unsigned int i = 0; i < LSM6DSL_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing lsm6dsl #%u\n", i);
 
-        int res = lsm6dsl_init(&lsm6dsl_devs[i], &lsm6dsl_params[i]);
-        if (res < 0) {
+        if (lsm6dsl_init(&lsm6dsl_devs[i], &lsm6dsl_params[i]) < 0) {
             LOG_ERROR("[auto_init_saul] error initializing lsm6dsl #%u\n", i);
             continue;
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for the lsm6dsl device driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->