### PR TITLE
sys/auto_init: cleanup in mpu9150 auto_init

### DIFF
--- a/sys/auto_init/saul/auto_init_mpu9150.c
+++ b/sys/auto_init/saul/auto_init_mpu9150.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define MPU9150_NUM         (sizeof(mpu9150_params)/sizeof(mpu9150_params[0]))
+#define MPU9150_NUM         (sizeof(mpu9150_params) / sizeof(mpu9150_params[0]))
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -44,10 +44,10 @@ static saul_reg_t saul_entries[MPU9150_NUM * 3];
 /**
  * @brief   Define the number of saul info
  */
-#define MPU9150_INFO_NUM    (sizeof(mpu9150_saul_info)/sizeof(mpu9150_saul_info[0]))
+#define MPU9150_INFO_NUM    (sizeof(mpu9150_saul_info) / sizeof(mpu9150_saul_info[0]))
 
 /**
- * @brief   Reference the driver structs
+ * @name    Reference the driver structs
  * @{
  */
 extern saul_driver_t mpu9150_saul_acc_driver;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Small cleanup in mpu9150 auto_init code.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->