### PR TITLE
driver/adxl345: rename enums to avoid conflicts

### DIFF
--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -82,18 +82,18 @@ enum {
  * @brief   List fifo mode
  */
 enum {
-    BYPASS  = 0,          /**< FIFO bypass mode */
-    FIFO    = 1,          /**< FIFO mode */
-    STREAM  = 2,          /**< FIFO stream mode */
-    TRIGGER = 3           /**< FIFO trigger mode */
+    ADXL345_BYPASS  = 0,          /**< FIFO bypass mode */
+    ADXL345_FIFO    = 1,          /**< FIFO mode */
+    ADXL345_STREAM  = 2,          /**< FIFO stream mode */
+    ADXL345_TRIGGER = 3           /**< FIFO trigger mode */
 };
 
 /**
  * @brief   Output Interrupt selection
  */
 enum {
-    INT1,  /**< Output interrupt on INT1 pin */
-    INT2   /**< Output interrupt on INT2 pin */
+    ADXL345_INT1,  /**< Output interrupt on INT1 pin */
+    ADXL345_INT2   /**< Output interrupt on INT2 pin */
 };
 
 /**


### PR DESCRIPTION
driver/adxl345: rename enums to avoid conflicts