### PR TITLE
drivers/at86rf2xx: apply unified driver params scheme

### DIFF
--- a/drivers/at86rf2xx/include/at86rf2xx_params.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_params.h
@@ -49,12 +49,14 @@ extern "C" {
 #define AT86RF2XX_PARAM_RESET       (GPIO_PIN(0, 3))
 #endif
 
-#define AT86RF2XX_PARAMS_DEFAULT    {.spi = AT86RF2XX_PARAM_SPI, \
-                                     .spi_clk = AT86RF2XX_PARAM_SPI_CLK, \
-                                     .cs_pin = AT86RF2XX_PARAM_CS, \
-                                     .int_pin = AT86RF2XX_PARAM_INT, \
-                                     .sleep_pin = AT86RF2XX_PARAM_SLEEP, \
-                                     .reset_pin = AT86RF2XX_PARAM_RESET}
+#ifndef AT86RF2XX_PARAMS
+#define AT86RF2XX_PARAMS            { .spi = AT86RF2XX_PARAM_SPI,         \
+                                      .spi_clk = AT86RF2XX_PARAM_SPI_CLK, \
+                                      .cs_pin = AT86RF2XX_PARAM_CS,       \
+                                      .int_pin = AT86RF2XX_PARAM_INT,     \
+                                      .sleep_pin = AT86RF2XX_PARAM_SLEEP, \
+                                      .reset_pin = AT86RF2XX_PARAM_RESET }
+#endif
 /**@}*/
 
 /**
@@ -62,11 +64,7 @@ extern "C" {
  */
 static const at86rf2xx_params_t at86rf2xx_params[] =
 {
-#ifdef AT86RF2XX_PARAMS_BOARD
-    AT86RF2XX_PARAMS_BOARD,
-#else
-    AT86RF2XX_PARAMS_DEFAULT,
-#endif
+    AT86RF2XX_PARAMS
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates the params definitions scheme of this device driver

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->