### PR TITLE
boards/samr21-xpro: fix driver params usage

### DIFF
--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -44,12 +44,10 @@ extern "C" {
  *
  * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}
  */
-#define AT86RF2XX_PARAMS_BOARD      {.spi = SPI_DEV(0), \
-                                     .spi_clk = SPI_CLK_5MHZ, \
-                                     .cs_pin = GPIO_PIN(PB, 31), \
-                                     .int_pin = GPIO_PIN(PB, 0), \
-                                     .sleep_pin = GPIO_PIN(PA, 20), \
-                                     .reset_pin = GPIO_PIN(PB, 15)}
+#define AT86RF2XX_PARAM_CS         GPIO_PIN(PB, 31)
+#define AT86RF2XX_PARAM_INT        GPIO_PIN(PB, 0)
+#define AT86RF2XX_PARAM_SLEEP      GPIO_PIN(PA, 20)
+#define AT86RF2XX_PARAM_RESET      GPIO_PIN(PB, 15)
 
 /**
  * @name    LED pin definitions and handlers


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the radio driver params definitions in samr21-xpro.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937, related to #7519 and should be based on #8700 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->