### PR TITLE
boards/telosb: fix driver params usage

### DIFF
--- a/boards/telosb/include/board.h
+++ b/boards/telosb/include/board.h
@@ -97,17 +97,18 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Definition of the interface to the CC2420 radio
+ * @name    Definition of the interface to the CC2420 radio
+ * @{
  */
-#define CC2420_PARAMS_BOARD   {.spi        = SPI_DEV(0), \
-                               .spi_clk    = SPI_CLK_1MHZ , \
-                               .pin_cs     = GPIO_PIN(P4, 2), \
-                               .pin_fifo   = GPIO_PIN(P1, 3), \
-                               .pin_fifop  = GPIO_PIN(P1, 0), \
-                               .pin_cca    = GPIO_PIN(P1, 4), \
-                               .pin_sfd    = GPIO_PIN(P4, 1), \
-                               .pin_vrefen = GPIO_PIN(P4, 5), \
-                               .pin_reset  = GPIO_PIN(P4, 6)}
+#define CC2420_PARAM_SPI_CLK        (SPI_CLK_1MHZ)
+#define CC2420_PARAM_CS             GPIO_PIN(P4, 2)
+#define CC2420_PARAM_FIFO           GPIO_PIN(P1, 3)
+#define CC2420_PARAM_FIFOP          GPIO_PIN(P1, 0)
+#define CC2420_PARAM_CCA            GPIO_PIN(P1, 4)
+#define CC2420_PARAM_SFD            GPIO_PIN(P4, 1)
+#define CC2420_PARAM_VREFEN         GPIO_PIN(P4, 5)
+#define CC2420_PARAM_RESET          GPIO_PIN(P4, 6)
+/** @} */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates the way on-board cc2420 driver params are configured on the telosb board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519. ~Ideally, it should be merged with #8701 and maybe #8706~ 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->