### PR TITLE
boards/nz32-sc151: fix ingroup directive in periph_conf

### DIFF
--- a/boards/nz32-sc151/include/periph_conf.h
+++ b/boards/nz32-sc151/include/periph_conf.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     nz32-sc151
+ * @ingroup     boards_nz32-sc151
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes wrong `@ingroup` directive in NZ32-SC151's periph_conf.h. With this change, doxygen now adds a reference to this periph_conf.h file.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->