### PR TITLE
kinetis: Fix shiftTooManyBitsSigned warning in GPIO driver

### DIFF
--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -290,8 +290,8 @@ static inline void irq_handler(PORT_Type *port, int port_num)
     uint32_t status = port->ISFR;
 
     for (int i = 0; i < 32; i++) {
-        if ((status & (1 << i)) && (port->PCR[i] & PORT_PCR_IRQC_MASK)) {
-            port->ISFR = (1 << i);
+        if ((status & (1u << i)) && (port->PCR[i] & PORT_PCR_IRQC_MASK)) {
+            port->ISFR = (1u << i);
             int ctx = get_ctx(port_num, i);
             isr_ctx[ctx].cb(isr_ctx[ctx].arg);
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fix a cppcheck warning in kinetis gpio periph driver. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Split from #6995 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->