### PR TITLE
Makefile.include: fix board/cpu inconsistent include order

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -228,8 +228,6 @@ export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
 
 # Add standard include directories
 INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
-INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/$(BOARD)/include))
 
 # process provided features
 -include $(RIOTBOARD)/$(BOARD)/Makefile.features
@@ -237,7 +235,11 @@ INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/$(BOARD)/include))
 # mandatory includes!
 include $(RIOTMAKE)/pseudomodules.inc.mk
 include $(RIOTMAKE)/defaultmodules.inc.mk
+
+# Include Board and CPU configuration
+INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/$(BOARD)/include))
 include $(RIOTBOARD)/$(BOARD)/Makefile.include
+INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
 # Import all toolchain settings


### PR DESCRIPTION
### Contribution description

Re-organize headers include directories order to be consistent to include first all things related to board then all things related to CPU.

I did a check to verify there were no header names conflicts between boards and cpu so changing the order has no impact. Output and verification script below.

### Details

Include order for board and cpu was

1. cpu include
2. board include
3. board common includes
4. cpu common includes

Its now changed to:

1. board include
2. board common includes
3. cpu include
4. cpu common includes

#### Further steps

I plan to move the two lines with "INCLUDE +=" and "include ../Makefile.include" into dedicated files in boards and cpu to allow further cleanup, but it requires the include order to be solved before.

### Changes INCLUDES output

Using https://github.com/RIOT-OS/RIOT/pull/8714 with `examples/gnrc_networking` for `iotlab-m3`:

Without the PR, notice the `cpu/stm32f1` before the boards include:

```
INCLUDES: 
        -isystem  
        /usr/arm-none-eabi/include/newlib-nano  
        -I/home/harter/work/git/RIOT/core/include  
        -I/home/harter/work/git/RIOT/drivers/include  
        -I/home/harter/work/git/RIOT/sys/include  
        -I/home/harter/work/git/RIOT/cpu/stm32f1/include  
        -I/home/harter/work/git/RIOT/boards/iotlab-m3/include  
        -I/home/harter/work/git/RIOT/boards/common/iotlab/include  
        -I/home/harter/work/git/RIOT/boards/iotlab-m3/include  # This is currently re-added in the board/Makefile.include
        -I/home/harter/work/git/RIOT/cpu/stm32_common/include  
        -I/home/harter/work/git/RIOT/cpu/cortexm_common/include  
        -I/home/harter/work/git/RIOT/cpu/cortexm_common/include/vendor  
        -I/home/harter/work/git/RIOT/sys/libc/include  
        -I/home/harter/work/git/RIOT/drivers/at86rf2xx/include
```

With the PR

```
INCLUDES:                                                                                                                                                     
        -isystem  
        /usr/arm-none-eabi/include/newlib-nano  
        -I/home/harter/work/git/RIOT/core/include  
        -I/home/harter/work/git/RIOT/drivers/include  
        -I/home/harter/work/git/RIOT/sys/include  
        -I/home/harter/work/git/RIOT/boards/iotlab-m3/include  
        -I/home/harter/work/git/RIOT/boards/common/iotlab/include  
        -I/home/harter/work/git/RIOT/boards/iotlab-m3/include  # This is currently re-added in the board/Makefile.include
        -I/home/harter/work/git/RIOT/cpu/stm32f1/include  
        -I/home/harter/work/git/RIOT/cpu/stm32_common/include  
        -I/home/harter/work/git/RIOT/cpu/cortexm_common/include  
        -I/home/harter/work/git/RIOT/cpu/cortexm_common/include/vendor  
        -I/home/harter/work/git/RIOT/sys/libc/include  
        -I/home/harter/work/git/RIOT/drivers/at86rf2xx/include
```


### Verifications

There are no common headers names between boards and cpus.
Except native that has a 'periph_conf.h' in cpu instead of being in board.

```
Checking boards and cpu uniq headers names

wc -l ${BOARDS_HEADERS} 50
wc -l ${CPU_HEADERS} 630

Common headers between boards and cpu
      2 periph_conf.h

Culprit for common header
cpu/native/include/periph_conf.h

```


I used the following script to test this.
```
#! /bin/bash

find_headers_in_dir() {
    local directory="$1"
    find "${directory}" -name '*.h' -exec basename {} \;
}

BOARDS_HEADERS=$(find_headers_in_dir boards | sort -u)
CPU_HEADERS=$(find_headers_in_dir cpu | sort -u)

echo Checking boards and cpu uniq headers names
echo ""

# echo "${BOARDS_HEADERS}"
# echo "${CPU_HEADERS}"

echo -n 'wc -l ${BOARDS_HEADERS} '
echo "${BOARDS_HEADERS}" | wc -l
echo -n 'wc -l ${CPU_HEADERS} '
echo "${CPU_HEADERS}" | wc -l
echo

echo "Common headers between boards and cpu"
echo "${BOARDS_HEADERS}" "${CPU_HEADERS}" | sort | uniq -c -d
echo ""

echo "Culprit for common header"
find cpu -name periph_conf.h
```

### Issues/PRs references

Part of Issue https://github.com/RIOT-OS/RIOT/issues/8713