### PR TITLE
cpu/efm32/periph/timer: remove timer_set duplicate

### DIFF
--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -98,11 +98,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t callback, void *arg)
     return 0;
 }
 
-int timer_set(tim_t dev, int channel, unsigned int timeout)
-{
-    return timer_set_absolute(dev, channel, timer_read(dev) + timeout);
-}
-
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
     TIMER_TypeDef *tim;


### PR DESCRIPTION
timer_set is already provided by 'periph_common' so does not need to be
provided by cpu/periph.

The build system currently silently ignores this.

### Issues/PRs references

Its required for https://github.com/RIOT-OS/RIOT/pull/8711

It was also disabled by https://github.com/RIOT-OS/RIOT/pull/5757 in `periph_conf.h` but the function can be removed as its identical to `periph_common` https://github.com/RIOT-OS/RIOT/blob/2018.01/drivers/periph_common/timer.c#L24.