### PR TITLE
cpu/mips32r2_common: use `periph_common` timer_set

### DIFF
--- a/cpu/mips32r2_common/periph/timer.c
+++ b/cpu/mips32r2_common/periph/timer.c
@@ -121,23 +121,6 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
     return 0;
 }
 
-int timer_set(tim_t dev, int channel, unsigned int timeout)
-{
-    assert(dev == 0);
-    assert(channel < CHANNELS);
-
-    (void)dev;
-
-    timeout >>= TIMER_ACCURACY_SHIFT;
-    timeout <<= TIMER_ACCURACY_SHIFT;
-
-    uint32_t status = irq_disable();
-    compares[channel] = counter + timeout;
-    irq_restore(status);
-
-    return channel;
-}
-
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
     assert(dev == 0);

--- a/cpu/mips32r2_common/periph/timer.c
+++ b/cpu/mips32r2_common/periph/timer.c
@@ -135,7 +135,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
     compares[channel] = value;
     irq_restore(status);
 
-    return channel;
+    return 1;
 }
 
 int timer_clear(tim_t dev, int channel)
@@ -149,7 +149,7 @@ int timer_clear(tim_t dev, int channel)
     compares[channel] = 0;
     irq_restore(status);
 
-    return channel;
+    return 1;
 }
 
 unsigned int timer_read(tim_t dev)

--- a/cpu/mips_pic32_common/include/periph_cpu_common.h
+++ b/cpu/mips_pic32_common/include/periph_cpu_common.h
@@ -56,11 +56,6 @@ enum {
     PORT_G = 6,             /**< port G */
 };
 
-/**
- * @brief   Prevent shared timer functions from being used
- */
-#define PERIPH_TIMER_PROVIDES_SET
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Use 'timer_set' provided by 'periph_common' instead of re-implementing it.

It also fixes 'mips32r2_generic' that should have been defining
'PERIPH_TIMER_PROVIDES_SET' as 'mips32r2_common' uses 'periph_common' but is not
necessary if removing the function.

### Issues/PRs references

Its required for #8711

It was also disabled by #5757 in periph_conf.h but the function can be removed as it has the same behavior as periph_common https://github.com/RIOT-OS/RIOT/blob/2018.01/drivers/periph_common/timer.c#L24.