### PR TITLE
kinetis: Add dependency on rtt for LPTMR time base

### DIFF
--- a/cpu/kinetis/Makefile.dep
+++ b/cpu/kinetis/Makefile.dep
@@ -1,3 +1,8 @@
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
   USEMODULE += periph_rtt
 endif
+ifneq (,$(filter periph_timer,$(USEMODULE)))
+  # RTT is used as the time base for the LPTMR driver.
+  # TODO: Remove when LPTMR is refactored.
+  FEATURES_OPTIONAL += periph_rtt
+endif


### PR DESCRIPTION
### Contribution description

The current implementation of the periph timer driver on Kinetis uses the RTT as a time reference for the low power timer hardware, so the RTT needs to be included if using the LPTMR device in periph timer.

This PR adds FEATURES_OPTIONAL on kinetis because the RTT is not configured for all boards, so USEMODULE += periph_rtt will fail on boards without RTT e.g. teensy31.

### Issues/PRs references

split from #6995