### PR TITLE
boards: add UART1 config for Zolertia Remotes

### DIFF
--- a/boards/common/remote/include/periph_common.h
+++ b/boards/common/remote/include/periph_common.h
@@ -84,11 +84,19 @@ static const uart_conf_t uart_config[] = {
         .tx_pin   = GPIO_PIN(0, 1),
         .cts_pin  = GPIO_UNDEF,
         .rts_pin  = GPIO_UNDEF
+    },
+    {
+        .dev      = UART1_BASEADDR,
+        .rx_pin   = GPIO_PIN(2, 1),
+        .tx_pin   = GPIO_PIN(2, 0),
+        .cts_pin  = GPIO_UNDEF,
+        .rts_pin  = GPIO_UNDEF
     }
 };
 
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_uart0
+#define UART_1_ISR          isr_uart1
 
 /* macros common across all UARTs */
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))

--- a/boards/common/remote/include/periph_common.h
+++ b/boards/common/remote/include/periph_common.h
@@ -78,17 +78,18 @@ static const timer_conf_t timer_config[] = {
  * @{
  */
 static const uart_conf_t uart_config[] = {
+    /* UART0 is mapped to debug usb */
     {
         .dev      = UART0_BASEADDR,
-        .rx_pin   = GPIO_PIN(0, 0),
-        .tx_pin   = GPIO_PIN(0, 1),
+        .rx_pin   = GPIO_PIN(PORT_A, 0),
+        .tx_pin   = GPIO_PIN(PORT_A, 1),
         .cts_pin  = GPIO_UNDEF,
         .rts_pin  = GPIO_UNDEF
     },
     {
         .dev      = UART1_BASEADDR,
-        .rx_pin   = GPIO_PIN(2, 1),
-        .tx_pin   = GPIO_PIN(2, 0),
+        .rx_pin   = GPIO_PIN(PORT_C, 1),
+        .tx_pin   = GPIO_PIN(PORT_C, 0),
         .cts_pin  = GPIO_UNDEF,
         .rts_pin  = GPIO_UNDEF
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds UART1 to periph conf for all Zolertia remotes, see pinout in docu [here](https://github.com/Zolertia/Resources/wiki/RE-Mote#re-mote-revision-a-pin-out). It also adapts UART config to use port names instead of "meaningless" numbers.


### Issues/PRs references

#8345 

