### PR TITLE
ci: use circleci to get a preview of the generated documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+# CircleCI configuration file used to build and get a preview of the generated
+# Doxygen documentation.
+# Note that the job on CircleCI takes around 30 minutes to complete because
+# copying +19k individual files to their cloud storage is very slow.
+
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: riot/riotbuild
+    steps:
+      - checkout
+      - run: make doc
+      - run:
+          command: |
+            cp -R doc/doxygen/html /doc
+      - store_artifacts:
+          path: /doc


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to move the static-test from travis to [circleci](https://circleci.com/). The main ideas behind are:
- use the riotbuild docker image to run the static-test and  be consistent with workers of Murdock
- have a per PR and online access to the generated documentation (this was my initial goal in fact) using the [build artifacts](https://circleci.com/docs/2.0/artifacts/) feature provided by circleci.

I tested the solution on my own fork and it works. One can see the results here: https://circleci.com/gh/aabadie/RIOT/8 and the generated documentation here: https://8-44016379-gh.circle-artifacts.com/0/tmp/doc/html/index.html

The main problem I see is the time it takes to upload the artifacts to the final report. The total build time is 9 minutes and the upload takes a bit more than 7 minutes.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->