### PR TITLE
cortexm_common: don't try to set MEMFAULTENA on ARMv6-M

### DIFF
--- a/cpu/cortexm_common/mpu.c
+++ b/cpu/cortexm_common/mpu.c
@@ -36,8 +36,13 @@ int mpu_enable(void) {
 #if __MPU_PRESENT
     MPU->CTRL |= MPU_CTRL_PRIVDEFENA_Msk | MPU_CTRL_ENABLE_Msk;
 
-    /* Enable the memory fault exception */
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+    /* Enable the memory fault exception if SCB SHCSR (System Handler Control
+     * and State Register) has a separate bit for mem faults. That is the case
+     * on ARMv7-M. ARMv6-M does not support separate exception enable for mem
+     * faults and all fault conditions cause a HardFault. */
     SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
 
     return 0;
 #else


### PR DESCRIPTION
Before this change, if one tried to build a Cortex-M0+ target that had
an MPU, compilation would fail due to missing
`SCB_SHCSR_MEMFAULTENA_Msk` in SCB structure. Cortex-M0+ is a ARMv6-M
arch (unlike most other targets that have MPU support). ARMv6-M has more
limited support for fault conditions, see ARMv6-M Architecture Reference
Manual, D3.6.2.