### PR TITLE
cpu: stm32_common: always enable PWR module

### DIFF
--- a/cpu/stm32_common/cpu_init.c
+++ b/cpu/stm32_common/cpu_init.c
@@ -30,12 +30,21 @@
 
 #include "cpu.h"
 #include "stmclk.h"
+#include "periph_cpu.h"
 #include "periph/init.h"
+
+#if defined (CPU_FAM_STM32L4)
+#define BIT_APB_PWREN       RCC_APB1ENR1_PWREN
+#else
+#define BIT_APB_PWREN       RCC_APB1ENR_PWREN
+#endif
 
 void cpu_init(void)
 {
     /* initialize the Cortex-M core */
     cortexm_init();
+    /* enable PWR module */
+    periph_clk_en(APB1, BIT_APB_PWREN);
     /* initialize the system clock as configured in the periph_conf.h */
     stmclk_init_sysclk();
     /* trigger static peripheral initialization */

--- a/cpu/stm32_common/stmclk_common.c
+++ b/cpu/stm32_common/stmclk_common.c
@@ -31,12 +31,6 @@
 #define BIT_CR_DBP          PWR_CR_DBP
 #endif
 
-#if defined (CPU_FAM_STM32L4)
-#define BIT_APB_PWREN       RCC_APB1ENR1_PWREN
-#else
-#define BIT_APB_PWREN       RCC_APB1ENR_PWREN
-#endif
-
 #if defined (CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
 #define REG_LSE             CSR
 #define BIT_LSEON           RCC_CSR_LSEON
@@ -100,12 +94,10 @@ void stmclk_disable_lfclk(void)
 
 void stmclk_dbp_unlock(void)
 {
-    periph_clk_en(APB1, BIT_APB_PWREN);
     PWR->REG_PWR_CR |= BIT_CR_DBP;
 }
 
 void stmclk_dbp_lock(void)
 {
     PWR->REG_PWR_CR &= ~(BIT_CR_DBP);
-    periph_clk_dis(APB1, BIT_APB_PWREN);
 }

--- a/cpu/stm32_common/stmclk_l0l1.c
+++ b/cpu/stm32_common/stmclk_l0l1.c
@@ -92,8 +92,6 @@ void stmclk_init_sysclk(void)
     FLASH->ACR |= FLASH_ACR_PRFTEN;
     /* Flash 1 wait state */
     FLASH->ACR |= CLOCK_FLASH_LATENCY;
-    /* Power enable */
-    periph_clk_en(APB1, RCC_APB1ENR_PWREN);
     /* Select the Voltage Range 1 (1.8 V) */
     PWR->CR = PWR_CR_VOS_0;
     /* Wait Until the Voltage Regulator is ready */

--- a/cpu/stm32f1/periph/rtt.c
+++ b/cpu/stm32f1/periph/rtt.c
@@ -151,7 +151,7 @@ void rtt_clear_alarm(void)
 
 void rtt_poweron(void)
 {
-    periph_clk_en(APB1, (RCC_APB1ENR_BKPEN|RCC_APB1ENR_PWREN)); /* enable BKP and PWR, Clock */
+    periph_clk_en(APB1, RCC_APB1ENR_BKPEN);  /* enable BKP, Clock */
     /* RTC clock source configuration */
     PWR->CR |= PWR_CR_DBP;                   /* Allow access to BKP Domain */
     RCC->BDCR |= RCC_BDCR_LSEON;             /* Enable LSE OSC */
@@ -164,7 +164,7 @@ void rtt_poweroff(void)
 {
     PWR->CR |= PWR_CR_DBP;                   /* Allow access to BKP Domain */
     RCC->BDCR &= ~RCC_BDCR_RTCEN;            /* disable RTC */
-    periph_clk_dis(APB1, (RCC_APB1ENR_BKPEN|RCC_APB1ENR_PWREN)); /* disable BKP and PWR, Clock */
+    periph_clk_dis(APB1, RCC_APB1ENR_BKPEN); /* disable BKP, Clock */
 }
 
 static inline void _rtt_enter_config_mode(void)


### PR DESCRIPTION
### Contribution description

STM32F[024] don't enable the clock domain necessary to set deep sleep options, basically disabling most low-power features.

~~This PR adds an optional pm_init() call in periph_init(), and uses that facility to activate PWR's clock.~~

This PR now just enables PWR on all stm32.