### PR TITLE
pkg/semtech-loramac: small enhancements in package Makefile

### DIFF
--- a/pkg/semtech-loramac/Makefile
+++ b/pkg/semtech-loramac/Makefile
@@ -1,16 +1,16 @@
 PKG_NAME=semtech-loramac
-PKG_URL=git://github.com/Lora-net/LoRaMac-node.git
+PKG_URL=https://github.com/Lora-net/LoRaMac-node.git
 PKG_VERSION=f42be67be402a40b3586724800771bfe13fb18e6
 PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all
 
 all: git-download
-	cp Makefile.loramac $(PKG_BUILDDIR)/Makefile
-	cp Makefile.loramac_mac $(PKG_BUILDDIR)/src/mac/Makefile
-	cp Makefile.loramac_region $(PKG_BUILDDIR)/src/mac/region/Makefile
-	cp Makefile.loramac_crypto $(PKG_BUILDDIR)/src/system/crypto/Makefile
-	cp Makefile.loramac_arch $(PKG_BUILDDIR)/src/boards/mcu/stm32/Makefile
+	@cp Makefile.loramac $(PKG_BUILDDIR)/Makefile
+	@cp Makefile.loramac_mac $(PKG_BUILDDIR)/src/mac/Makefile
+	@cp Makefile.loramac_region $(PKG_BUILDDIR)/src/mac/region/Makefile
+	@cp Makefile.loramac_crypto $(PKG_BUILDDIR)/src/system/crypto/Makefile
+	@cp Makefile.loramac_arch $(PKG_BUILDDIR)/src/boards/mcu/stm32/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds small enhancements to the Semtech Loramac package Makefile:
- use https protocol in source url instead of git:// : this morning during a practical course, some people had a problem with a staled download. Using https fixed the problem. Since it's used in most of the other packages, I think this is safe
- hide cp commands used with package Makefiles : this is a purely cosmetic change

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->