### PR TITLE
unittests/tests-spiffs: fix dummy mtd (as in #8607)

### DIFF
--- a/tests/unittests/tests-spiffs/tests-spiffs.c
+++ b/tests/unittests/tests-spiffs/tests-spiffs.c
@@ -43,8 +43,6 @@ static uint8_t dummy_memory[PAGE_PER_SECTOR * PAGE_SIZE * SECTOR_COUNT];
 static int _init(mtd_dev_t *dev)
 {
     (void)dev;
-
-    memset(dummy_memory, 0xff, sizeof(dummy_memory));
     return 0;
 }
 
@@ -439,6 +437,9 @@ static void tests_spiffs_partition(void)
 
 Test *tests_spiffs_tests(void)
 {
+#ifndef MTD_0
+    memset(dummy_memory, 0xff, sizeof(dummy_memory));
+#endif
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(tests_spiffs_format),
         new_TestFixture(tests_spiffs_mount_umount),


### PR DESCRIPTION
### Contribution description

This is the same fix as #8607 for spiffs.

### Issues/PRs references

Fixes #8730, see also #8607