### PR TITLE
cpu/saml21: fix RTC wrong condition for #if

### DIFF
--- a/cpu/saml21/periph/rtc.c
+++ b/cpu/saml21/periph/rtc.c
@@ -22,6 +22,13 @@
 #include "periph/rtc.h"
 #include "periph_conf.h"
 
+/* SAML21 rev B needs an extra bit, which in rev A defaults to 1, but isn't
+ * visible. Thus define it here. */
+#ifndef RTC_MODE2_CTRLA_CLOCKSYNC
+#define RTC_MODE2_CTRLA_CLOCKSYNC_Pos   15
+#define RTC_MODE2_CTRLA_CLOCKSYNC       (0x1ul << RTC_MODE2_CTRLA_CLOCKSYNC_Pos)
+#endif
+
 typedef struct {
     rtc_alarm_cb_t cb;        /**< callback called from RTC interrupt */
     void *arg;                /**< argument passed to the callback */
@@ -97,9 +104,7 @@ void rtc_init(void)
 
     /* RTC config with RTC_MODE2_CTRL_CLKREP = 0 (24h) */
     RTC->MODE2.CTRLA.reg = RTC_MODE2_CTRLA_PRESCALER_DIV1024 |  /* CLK_RTC_CNT = 1KHz / 1024 -> 1Hz */
-#if (SAML21XXXB) || (SAMR30)
                            RTC_MODE2_CTRLA_CLOCKSYNC         |  /* Clock Read Synchronization Enable */
-#endif
                            RTC_MODE2_CTRLA_MODE_CLOCK;          /* Mode 2: Clock/Calendar */
 
     /* Clear interrupt flags */


### PR DESCRIPTION
### Contribution description

This PR fixes a wrong #if condition for the RTC driver.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->