### PR TITLE
atmega: add last instruction print

### DIFF
--- a/cpu/atmega_common/include/cpu.h
+++ b/cpu/atmega_common/include/cpu.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
  *               2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -22,6 +23,8 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
+ *
  */
 
 #ifndef CPU_H
@@ -76,7 +79,22 @@ void cpu_init(void);
  */
 static inline void cpu_print_last_instruction(void)
 {
-    puts("n/a");
+    uint8_t hi;
+    uint8_t lo;
+    uint16_t ptr;
+
+    __asm__ volatile( "in r0, __SP_H__; \n\t"
+                      "mov %0, r0       \n\t"
+                             : "=g"(hi)
+                             :
+                             : "r0");
+    __asm__ volatile( "in r0, __SP_L__; \n\t"
+                      "mov %0, r0       \n\t"
+                             : "=g"(lo)
+                             :
+                             : "r0");
+    ptr = hi<<8 | lo;
+    printf("Stack Pointer: 0x%04x\n", ptr);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add stackpointer print to cpu_print_last_instruction()

Signed-off-by: Josua Arndt  <josuaarndt@live.de>