### PR TITLE
dist/tools/ci: also print doxygen and flake8 versions

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -68,7 +68,7 @@ printf "%21s: %s\n" "avr-libc" "$(avr_libc_version avr-gcc)"
 printf "\n"
 printf "%s\n" "Installed development tools"
 printf "%s\n" "---------------------------"
-for c in cmake cppcheck git; do
+for c in cmake cppcheck doxygen flake8 git; do
     printf "%21s: %s\n" "$c" "$(get_cmd_version $c)"
 done
 printf "%21s: %s\n" "coccinelle" "$(get_cmd_version spatch)"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the possibility to display the doxygen and flake8 versions in the `print_toolchain` script. I wanted to comment in #8727 about this but it was already merged.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#8727 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->