### PR TITLE
boards/remote*: fix doxygen grouping

### DIFF
--- a/boards/remote-pa/include/adc_params.h
+++ b/boards/remote-pa/include/adc_params.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup   boards_remote
+ * @ingroup   boards_remote-pa
  * @{
  *
  * @file

--- a/boards/remote-reva/board.c
+++ b/boards/remote-reva/board.c
@@ -8,8 +8,7 @@
  */
 
 /**
- * @defgroup    boards_remote
- * @ingroup     boards
+ * @ingroup     boards_remote-reva
  * @{
  *
  * @file

--- a/boards/remote-reva/include/adc_params.h
+++ b/boards/remote-reva/include/adc_params.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup   boards_remote
+ * @ingroup   boards_remote-reva
  * @{
  *
  * @file

--- a/boards/remote-reva/include/board.h
+++ b/boards/remote-reva/include/board.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @defgroup    boards_reva RE-Mote Revision A
+ * @defgroup    boards_remote-reva RE-Mote Revision A
  * @ingroup     boards
  * @brief       Support for the RE-Mote board Revision A
  * @{

--- a/boards/remote-revb/board.c
+++ b/boards/remote-revb/board.c
@@ -8,8 +8,7 @@
  */
 
 /**
- * @defgroup    boards_remote
- * @ingroup     boards
+ * @ingroup     boards_remote-revb
  * @{
  *
  * @file

--- a/boards/remote-revb/include/adc_params.h
+++ b/boards/remote-revb/include/adc_params.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup   boards_remote
+ * @ingroup   boards_remote-revb
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up the doxygen board groups of the Zolertia Remote boards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

I noticed that while reviewing #8516 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->