### PR TITLE
boards/iotlab-a8-m3: fix doxygen grouping

### DIFF
--- a/boards/iotlab-a8-m3/include/board.h
+++ b/boards/iotlab-a8-m3/include/board.h
@@ -7,13 +7,13 @@
  */
 
 /**
- * @defgroup    boards_iotlab-m3 IoT-LAB M3 open node
+ * @defgroup    boards_iotlab-a8-m3 IoT-LAB A8 M3 open node
  * @ingroup     boards
- * @brief       Support for the iotlab-m3 board
+ * @brief       Support for the iotlab-a8-m3 board
  * @{
  *
  * @file
- * @brief       Board specific definitions for the iotlab-m3 board
+ * @brief       Board specific definitions for the iotlab-a8-m3 board
  *
  */
 

--- a/boards/iotlab-a8-m3/include/periph_conf.h
+++ b/boards/iotlab-a8-m3/include/periph_conf.h
@@ -7,11 +7,11 @@
  */
 
 /**
- * @ingroup     boards_iotlab-m3
+ * @ingroup     boards_iotlab-a8-m3
  * @{
  *
  * @file
- * @brief       Peripheral MCU configuration for the iotlab-m3 board
+ * @brief       Peripheral MCU configuration for the iotlab-a8-m3 board
  *
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the doxygen group of the iotlab-a8-m3 board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Found while reviewing #8516 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->