### PR TITLE
drivers/lps331ap: apply unified params definition scheme

### DIFF
--- a/drivers/include/lps331ap.h
+++ b/drivers/include/lps331ap.h
@@ -36,14 +36,6 @@ extern "C" {
 #define LPS331AP_DEFAULT_ADDRESS        (0x5c)
 
 /**
- * @brief   Device descriptor for LPS331AP sensors
- */
-typedef struct {
-    i2c_t i2c;                  /**< I2C device the sensor is connected to */
-    uint8_t address;            /**< I2C bus address of the sensor */
-} lps331ap_t;
-
-/**
  * @brief   Possible sampling rates for LPS331AP sensors
  */
 typedef enum {
@@ -63,17 +55,22 @@ typedef struct {
 } lps331ap_params_t;
 
 /**
+ * @brief   Device descriptor for LPS331AP sensors
+ */
+typedef struct {
+    lps331ap_params_t params;   /**< device initialization parameters */
+} lps331ap_t;
+
+/**
  * @brief   Initialize a given LPS331AP pressure sensor
  *
  * @param[out] dev      device descriptor of the sensor
- * @param[in]  i2c      I2C bus the sensor is connected to
- * @param[in]  address  the sensor's address on the I2C bus
- * @param[in]  rate     internal sampling rate of the sensor
+ * @param[in]  params   initialization parameters
  *
  * @return              0 on success
  * @return              -1 on error
  */
-int lps331ap_init(lps331ap_t *dev, i2c_t i2c, uint8_t address, lps331ap_rate_t rate);
+int lps331ap_init(lps331ap_t *dev, const lps331ap_params_t * params);
 
 /**
  * @brief   Read a temperature value from the given sensor, returned in m°C

--- a/drivers/lps331ap/include/lps331ap_params.h
+++ b/drivers/lps331ap/include/lps331ap_params.h
@@ -41,9 +41,14 @@ extern "C" {
 #define LPS331AP_PARAM_RATE             (LPS331AP_RATE_7HZ)
 #endif
 
-#define LPS331AP_PARAMS_DEFAULT         { .i2c  = LPS331AP_PARAM_I2C,  \
+#ifndef LPS331AP_PARAMS
+#define LPS331AP_PARAMS                 { .i2c  = LPS331AP_PARAM_I2C,  \
                                           .addr = LPS331AP_PARAM_ADDR, \
                                           .rate = LPS331AP_PARAM_RATE }
+#endif
+#ifndef LPS331AP_SAUL_INFO
+#define LPS331AP_SAUL_INFO              { .name = "lps331ap" }
+#endif
 /**@}*/
 
 /**
@@ -51,11 +56,7 @@ extern "C" {
  */
 static const lps331ap_params_t lps331ap_params[] =
 {
-#ifdef LPS331AP_PARAMS_CUSTOM
-    LPS331AP_PARAMS_CUSTOM,
-#else
-    LPS331AP_PARAMS_DEFAULT,
-#endif
+    LPS331AP_PARAMS
 };
 
 /**
@@ -63,7 +64,7 @@ static const lps331ap_params_t lps331ap_params[] =
  */
 static const saul_reg_info_t lps331ap_saul_info[] =
 {
-    { .name = "lps331ap" }
+    LPS331AP_SAUL_INFO
 };
 
 #ifdef __cplusplus

--- a/sys/auto_init/saul/auto_init_lps331ap.c
+++ b/sys/auto_init/saul/auto_init_lps331ap.c
@@ -29,7 +29,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define LPS331AP_NUM    (sizeof(lps331ap_params)/sizeof(lps331ap_params[0]))
+#define LPS331AP_NUM    (sizeof(lps331ap_params) / sizeof(lps331ap_params[0]))
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -42,6 +42,11 @@ static lps331ap_t lps331ap_devs[LPS331AP_NUM];
 static saul_reg_t saul_entries[LPS331AP_NUM * 2];
 
 /**
+ * @brief   Define the number of saul info
+ */
+#define LPS331AP_INFO_NUM    (sizeof(lps331ap_saul_info) / sizeof(lps331ap_saul_info[0]))
+
+/**
  * @brief   Reference the driver struct
  */
 extern saul_driver_t lps331ap_saul_pres_driver;
@@ -50,13 +55,12 @@ extern saul_driver_t lps331ap_saul_temp_driver;
 
 void auto_init_lps331ap(void)
 {
-    for (unsigned int i = 0; i < LPS331AP_NUM; i++) {
-        const lps331ap_params_t *p = &lps331ap_params[i];
+    assert(LPS331AP_NUM == LPS331AP_INFO_NUM);
 
+    for (unsigned int i = 0; i < LPS331AP_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing lps331ap #%u\n", i);
 
-        int res = lps331ap_init(&lps331ap_devs[i], p->i2c, p->addr, p->rate);
-        if (res < 0) {
+        if (lps331ap_init(&lps331ap_devs[i], &lps331ap_params[i]) < 0) {
             LOG_ERROR("[auto_init_saul] error initializing lps331ap #%u\n", i);
             continue;
         }

--- a/tests/driver_lps331ap/Makefile
+++ b/tests/driver_lps331ap/Makefile
@@ -5,12 +5,4 @@ FEATURES_REQUIRED = periph_i2c
 USEMODULE += lps331ap
 USEMODULE += xtimer
 
-# set default device parameters in case they are undefined
-TEST_LPS331AP_I2C  ?= I2C_DEV\(0\)
-TEST_LPS331AP_ADDR ?= 92
-
-# export parameters
-CFLAGS += -DTEST_LPS331AP_I2C=$(TEST_LPS331AP_I2C)
-CFLAGS += -DTEST_LPS331AP_ADDR=$(TEST_LPS331AP_ADDR)
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lps331ap/main.c
+++ b/tests/driver_lps331ap/main.c
@@ -18,30 +18,21 @@
  * @}
  */
 
-#ifndef TEST_LPS331AP_I2C
-#error "TEST_LPS331AP_I2C not defined"
-#endif
-#ifndef TEST_LPS331AP_ADDR
-#error "TEST_LPS331AP_ADDR not defined"
-#endif
-
 #include <stdio.h>
 
 #include "xtimer.h"
 #include "lps331ap.h"
+#include "lps331ap_params.h"
 
-#define RATE        LPS331AP_RATE_7HZ
 #define SLEEP       (250 * 1000U)
 
 int main(void)
 {
     lps331ap_t dev;
-    int temp, pres;
-    int temp_abs, pres_abs;
 
     puts("LPS331AP pressure sensor test application\n");
-    printf("Initializing LPS331AP sensor at I2C_%i... ", TEST_LPS331AP_I2C);
-    if (lps331ap_init(&dev, TEST_LPS331AP_I2C, TEST_LPS331AP_ADDR, RATE) == 0) {
+    puts("Initializing LPS331AP sensor");
+    if (lps331ap_init(&dev, &lps331ap_params[0]) == 0) {
         puts("[OK]\n");
     }
     else {
@@ -50,12 +41,12 @@ int main(void)
     }
 
     while (1) {
-        pres = lps331ap_read_pres(&dev);
-        temp = lps331ap_read_temp(&dev);
+        int pres = lps331ap_read_pres(&dev);
+        int temp = lps331ap_read_temp(&dev);
 
-        pres_abs = pres / 1000;
+        int pres_abs = pres / 1000;
         pres -= pres_abs * 1000;
-        temp_abs = temp / 1000;
+        int temp_abs = temp / 1000;
         temp -= temp_abs * 1000;
 
         printf("Pressure value: %2i.%03i bar - Temperature: %2i.%03i °C\n",


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR update the params definitions scheme for this device driver and does some cleanup in the internal implementation.

Also forgot this one last week.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->