### PR TITLE
sys/auto_init: cleanup si70xx auto_init

### DIFF
--- a/drivers/si70xx/include/si70xx_params.h
+++ b/drivers/si70xx/include/si70xx_params.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 #ifndef SI70XX_PARAMS
-#define SI70XX_PARAMS                { .i2c_dev = SI70XX_PARAM_I2C_DEV,  \
+#define SI70XX_PARAMS                { .i2c_dev = SI70XX_PARAM_I2C_DEV, \
                                        .address = SI70XX_PARAM_ADDR }
 #endif
 #ifndef SI70XX_SAUL_INFO
@@ -61,7 +61,7 @@ static const si70xx_params_t si70xx_params[] =
 /**
  * @brief   Configure SAUL registry entries
  */
-static const saul_reg_info_t si70xx_saul_reg_info[] =
+static const saul_reg_info_t si70xx_saul_info[] =
 {
     SI70XX_SAUL_INFO
 };

--- a/sys/auto_init/saul/auto_init_si70xx.c
+++ b/sys/auto_init/saul/auto_init_si70xx.c
@@ -28,25 +28,25 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define SI70XX_NUMOF    (sizeof(si70xx_params) / sizeof(si70xx_params[0]))
+#define SI70XX_NUM    (sizeof(si70xx_params) / sizeof(si70xx_params[0]))
 
 /**
  * @brief   Allocation of memory for device descriptors
  */
-static si70xx_t si70xx_devs[SI70XX_NUMOF];
+static si70xx_t si70xx_devs[SI70XX_NUM];
 
 /**
  * @brief   Memory for the SAUL registry entries
  */
-static saul_reg_t saul_entries[SI70XX_NUMOF * 2];
+static saul_reg_t saul_entries[SI70XX_NUM * 2];
 
 /**
  * @brief   Define the number of saul info
  */
-#define SI70XX_INFO_NUMOF    (sizeof(si70xx_saul_reg_info) / sizeof(si70xx_saul_reg_info[0]))
+#define SI70XX_INFO_NUM    (sizeof(si70xx_saul_info) / sizeof(si70xx_saul_info[0]))
 
 /**
- * @brief   Reference the driver structs.
+ * @name    Reference the driver structs.
  * @{
  */
 extern const saul_driver_t si70xx_temperature_saul_driver;
@@ -55,9 +55,9 @@ extern const saul_driver_t si70xx_relative_humidity_saul_driver;
 
 void auto_init_si70xx(void)
 {
-    assert(SI70XX_INFO_NUMOF == SI70XX_NUMOF);
+    assert(SI70XX_INFO_NUM == SI70XX_NUM);
 
-    for (unsigned i = 0; i < SI70XX_NUMOF; i++) {
+    for (unsigned i = 0; i < SI70XX_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing SI70xx #%u\n", i);
 
         if (si70xx_init(&si70xx_devs[i], &si70xx_params[i]) != SI70XX_OK) {
@@ -67,12 +67,12 @@ void auto_init_si70xx(void)
 
         /* temperature */
         saul_entries[i * 2].dev = &si70xx_devs[i];
-        saul_entries[i * 2].name = si70xx_saul_reg_info[i].name;
+        saul_entries[i * 2].name = si70xx_saul_info[i].name;
         saul_entries[i * 2].driver = &si70xx_temperature_saul_driver;
 
         /* relative humidity */
         saul_entries[(i * 2) + 1].dev = &si70xx_devs[i];
-        saul_entries[(i * 2) + 1].name = si70xx_saul_reg_info[i].name;
+        saul_entries[(i * 2) + 1].name = si70xx_saul_info[i].name;
         saul_entries[(i * 2) + 1].driver = \
                 &si70xx_relative_humidity_saul_driver;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A straight forward cleanup in the auto_init implementation of the Si70xx driver. The idead is to have it consistent with other drivers.

Also forgot this one last week.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Initially done in #7937 and related to #7519

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->