### PR TITLE
sys/auto_init: fix crash with io1_xplained driver

### DIFF
--- a/sys/auto_init/saul/auto_init_io1_xplained.c
+++ b/sys/auto_init/saul/auto_init_io1_xplained.c
@@ -49,14 +49,14 @@ static saul_reg_t saul_entries[IO1_XPLAINED_NUM * 4];
  * @name    Reference the driver structs.
  * @{
  */
-extern const saul_driver_t _saul_driver;
+extern const saul_driver_t gpio_out_saul_driver;
 extern const saul_driver_t io1_xplained_temperature_saul_driver;
 /** @} */
 
 void auto_init_io1_xplained(void)
 {
     /* There are 4 saul reg info for each configured device */
-    assert(IO1_XPLAINED_NUM == (IO1_XPLAINED_INFO_NUM >> 2));
+    assert(IO1_XPLAINED_NUM == IO1_XPLAINED_INFO_NUM);
 
     for (unsigned i = 0; i < IO1_XPLAINED_NUM; i++) {
         if (io1_xplained_init(&io1_xplained_devs[i],
@@ -73,8 +73,9 @@ void auto_init_io1_xplained(void)
 
         /* GPIOs */
         for (unsigned j = 1; j < 4; j++) {
-            saul_entries[i * 4 + j].dev = &(io1_xplained_saul_gpios[j - 1]);
-            saul_entries[i * 4 + j].name = io1_xplained_saul_info[i][j - 1].name;
+            saul_entries[i * 4 + j].dev = &(io1_xplained_saul_gpios[j]);
+            saul_entries[i * 4 + j].name = io1_xplained_saul_info[i][j].name;
+            saul_entries[i * 4 + j].driver = &gpio_out_saul_driver;
             saul_reg_add(&(saul_entries[i * 4 + j]));
         }
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the saul auto initialization of the Atmel IO1 Xplained extension driver.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Fixes #8761

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->