### PR TITLE
boards/nucleo-l152: increase xtimer backoff

### DIFF
--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -48,7 +48,7 @@ extern "C" {
 #endif
 
 #if defined(CPU_FAM_STM32L1)
-#define XTIMER_BACKOFF              (3)
+#define XTIMER_BACKOFF              (11)
 #define XTIMER_OVERHEAD             (6)
 #endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR just increases the xtimer backoff value for the STM32L1 based boards. It has been tested on nucleo-l152re board and fixes 2 stucked xtimer based test applications: `xtimer_usleep_short` and `xtimer_periodic_wakeup`.

Other xtimer test applications are still passing.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Issues/PRs references

Fixes #7347

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->