### PR TITLE
boards/b-l072z-lrwan1: add missing rtc in features provided list

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Just realized that `periph_rtc` is missing in the list of features provided by the b-l072z-lrwan1 board, [although it's configured](https://github.com/RIOT-OS/RIOT/blob/master/boards/b-l072z-lrwan1/include/periph_conf.h#L191) (and works).

This PR fixes that omission.

Maybe @kYc0o can test.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->