### PR TITLE
drivers/flashpage: use const pointers for write and verify

### DIFF
--- a/cpu/efm32/periph/flashpage.c
+++ b/cpu/efm32/periph/flashpage.c
@@ -26,12 +26,12 @@
 
 #include "em_msc.h"
 
-void flashpage_write(int page, void *data)
+void flashpage_write(int page, const void *data)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
 
     uint32_t *page_addr = (uint32_t *)flashpage_addr(page);
-    uint32_t *data_addr = (uint32_t *)data;
+    const uint32_t *data_addr = data;
 
     MSC_Init();
     MSC_ErasePage(page_addr);

--- a/cpu/msp430_common/periph/flashpage.c
+++ b/cpu/msp430_common/periph/flashpage.c
@@ -24,11 +24,11 @@
 #include "irq.h"
 #include "periph/flashpage.h"
 
-void flashpage_write(int page, void *data)
+void flashpage_write(int page, const void *data)
 {
     assert(page < FLASHPAGE_NUMOF);
 
-    uint8_t *src = (uint8_t *)data;
+    const uint8_t *src = data;
     uint8_t *dst = (uint8_t *)flashpage_addr(page);
     unsigned istate;
 

--- a/cpu/nrf5x_common/periph/flashpage.c
+++ b/cpu/nrf5x_common/periph/flashpage.c
@@ -23,12 +23,12 @@
 #include "assert.h"
 #include "periph/flashpage.h"
 
-void flashpage_write(int page, void *data)
+void flashpage_write(int page, const void *data)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
 
     uint32_t *page_addr = (uint32_t *)flashpage_addr(page);
-    uint32_t *data_addr = (uint32_t *)data;
+    const uint32_t *data_addr = data;
 
     /* erase given page */
     NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Een;

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -56,7 +56,7 @@ static void _lock(void)
 #endif
 }
 
-void flashpage_write_raw(void *target_addr, void *data, size_t len)
+void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 {
     /* The actual minimal block size for writing is 16B, thus we
      * assert we write on multiples and no less of that length.
@@ -72,7 +72,7 @@ void flashpage_write_raw(void *target_addr, void *data, size_t len)
            (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)));
 
     uint32_t *dst = (uint32_t *)target_addr;
-    uint32_t *data_addr = (uint32_t *)data;
+    const uint32_t *data_addr = data;
 
     /* write 4 bytes in one go */
     len /= 4;
@@ -88,7 +88,7 @@ void flashpage_write_raw(void *target_addr, void *data, size_t len)
     _lock();
 }
 
-void flashpage_write(int page, void *data)
+void flashpage_write(int page, const void *data)
 {
     assert(page < FLASHPAGE_NUMOF);
 

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -126,7 +126,7 @@ static void _erase_page(void *page_addr)
 #endif
 }
 
-void flashpage_write_raw(void *target_addr, void *data, size_t len)
+void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 {
     /* assert multiples of FLASHPAGE_RAW_BLOCKSIZE are written and no less of
        that length. */
@@ -142,10 +142,10 @@ void flashpage_write_raw(void *target_addr, void *data, size_t len)
 
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
     uint32_t *dst = target_addr;
-    uint32_t *data_addr = (uint32_t *)data;
+    const uint32_t *data_addr = data;
 #else
     uint16_t *dst = (uint16_t *)target_addr;
-    uint16_t *data_addr = (uint16_t *)data;
+    const uint16_t *data_addr = data;
 
     uint32_t hsi_state = (RCC->CR & RCC_CR_HSION);
     /* the internal RC oscillator (HSI) must be enabled */
@@ -181,7 +181,7 @@ void flashpage_write_raw(void *target_addr, void *data, size_t len)
 #endif
 }
 
-void flashpage_write(int page, void *data)
+void flashpage_write(int page, const void *data)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
 

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -130,7 +130,7 @@ static inline int flashpage_page(void *addr)
  * @param[in] data      data to write to the page, MUST be FLASHPAGE_SIZE
  *                      byte. Set to NULL for page erase only.
  */
-void flashpage_write(int page, void *data);
+void flashpage_write(int page, const void *data);
 
 /**
  * @brief   Write any number of data bytes to a given location in the
@@ -153,7 +153,7 @@ void flashpage_write(int page, void *data);
  *                          ensure it doesn't exceed the actual flash
  *                          memory size.
  */
-void flashpage_write_raw(void *target_addr, void *data, size_t len);
+void flashpage_write_raw(void *target_addr, const void *data, size_t len);
 
 /**
  * @brief   Read the given page into the given memory location
@@ -174,7 +174,7 @@ void flashpage_read(int page, void *data);
  * @return              FLASHPAGE_OK if data in the page is identical to @p data
  * @return              FLASHPAGE_NOMATCH if data and page content diverge
  */
-int flashpage_verify(int page, void *data);
+int flashpage_verify(int page, const void *data);
 
 /**
  * @brief   Write the given page and verify the results
@@ -188,7 +188,7 @@ int flashpage_verify(int page, void *data);
  * @return              FLASHPAGE_OK on success
  * @return              FLASHPAGE_NOMATCH if data and page content diverge
  */
-int flashpage_write_and_verify(int page, void *data);
+int flashpage_write_and_verify(int page, const void *data);
 
 #ifdef __cplusplus
 }

--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -35,7 +35,7 @@ void flashpage_read(int page, void *data)
     memcpy(data, flashpage_addr(page), FLASHPAGE_SIZE);
 }
 
-int flashpage_verify(int page, void *data)
+int flashpage_verify(int page, const void *data)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
 
@@ -47,7 +47,7 @@ int flashpage_verify(int page, void *data)
     }
 }
 
-int flashpage_write_and_verify(int page, void *data)
+int flashpage_write_and_verify(int page, const void *data)
 {
     flashpage_write(page, data);
     return flashpage_verify(page, data);


### PR DESCRIPTION
### Contribution description

This update the periph_flashpage interface to use const pointer for writes and verify operations.

### Issues/PRs references

Based on #8768 