### PR TITLE
drivers: add mtd wrapper for periph_flashpage

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -342,14 +342,21 @@ ifneq (,$(filter mrf24j40,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
 endif
 
-ifneq (,$(filter mtd_sdcard,$(USEMODULE)))
+ifneq (,$(filter mtd_%,$(USEMODULE)))
   USEMODULE += mtd
-  USEMODULE += sdcard_spi
-endif
 
-ifneq (,$(filter mtd_spi_nor,$(USEMODULE)))
-  USEMODULE += mtd
-  FEATURES_REQUIRED += periph_spi
+  ifneq (,$(filter mtd_sdcard,$(USEMODULE)))
+    USEMODULE += sdcard_spi
+  endif
+
+  ifneq (,$(filter mtd_spi_nor,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_spi
+  endif
+
+  ifneq (,$(filter mtd_flashpage,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_flashpage
+    FEATURES_REQUIRED += periph_flashpage_raw
+  endif
 endif
 
 ifneq (,$(filter my9221,$(USEMODULE)))

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -158,7 +158,7 @@ struct mtd_desc {
 int mtd_init(mtd_dev_t *mtd);
 
 /**
- * @brief   mtd_read Read data from a MTD device
+ * @brief   Read data from a MTD device
  *
  * No alignment is required on @p addr and @p count.
  *
@@ -177,10 +177,11 @@ int mtd_init(mtd_dev_t *mtd);
 int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count);
 
 /**
- * @brief   mtd_read write data to a MTD device
+ * @brief   Write data to a MTD device
  *
  * @p addr + @p count must be inside a page boundary. @p addr can be anywhere
- * but the buffer cannot overlap two pages.
+ * but the buffer cannot overlap two pages. Though some devices might enforce alignement
+ * on both @p addr and @p buf.
  *
  * @param      mtd   the device to write to
  * @param[in]  src   the buffer to write
@@ -194,11 +195,12 @@ int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count);
  * @return -EOVERFLOW if @p addr or @p count are not valid, i.e. outside memory,
  * or overlapping two pages
  * @return -EIO if I/O error occured
+ * @return -EINVAL if parameters are invalid (invalid alignment for instance)
  */
 int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
 
 /**
- * @brief   mtd_erase Erase sectors of a MTD device
+ * @brief   Erase sectors of a MTD device
  *
  * @p addr must be aligned on a sector boundary. @p count must be a multiple of a sector size.
  *
@@ -216,7 +218,7 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
 int mtd_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count);
 
 /**
- * @brief   mtd_power Set power mode on a MTD device
+ * @brief   Set power mode on a MTD device
  *
  * @param      mtd   the device to access
  * @param[in]  power the power mode to set

--- a/drivers/include/mtd_flashpage.h
+++ b/drivers/include/mtd_flashpage.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mtd_flashpage   Flashpage MTD
+ * @ingroup     drivers_storage
+ * @brief       Driver for internal flash devices implementing flashpage interface
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the flashpage memory driver
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ */
+
+#ifndef MTD_FLASHPAGE_H
+#define MTD_FLASHPAGE_H
+
+#include "mtd.h"
+#include "periph/flashpage.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief   Macro helper to initialize a mtd_t with flash-age driver
+ */
+#define MTD_FLASHPAGE_INIT_VAL(_pages_per_sector) { \
+    .driver = &mtd_flashpage_driver, \
+    .sector_count = FLASHPAGE_NUMOF, \
+    .pages_per_sector = _pages_per_sector,\
+    .page_size = FLASHPAGE_SIZE / _pages_per_sector,\
+}
+
+/**
+ * @brief   Flashpage MTD device operations table
+ */
+extern const mtd_desc_t mtd_flashpage_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_FLASHPAGE_H */
+/** @} */

--- a/drivers/mtd_flashpage/Makefile
+++ b/drivers/mtd_flashpage/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mtd_flashpage
+ * @brief       Driver for internal flash devices implementing flashpage interface
+ *
+ * @{
+ *
+ * @file
+ * @brief       Implementation for the flashpage memory driver
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ * @}
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "cpu_conf.h"
+#include "mtd_flashpage.h"
+#include "periph/flashpage.h"
+
+#define MTD_FLASHPAGE_END_ADDR     CPU_FLASH_BASE + (FLASHPAGE_NUMOF * FLASHPAGE_SIZE)
+
+static int _init(mtd_dev_t *dev)
+{
+    (void)dev;
+    assert(dev->pages_per_sector * dev->page_size == FLASHPAGE_SIZE);
+    return 0;
+}
+
+static int _read(mtd_dev_t *dev, void *buf, uint32_t addr, uint32_t size)
+{
+    assert(addr < MTD_FLASHPAGE_END_ADDR);
+    (void)dev;
+
+    if (addr % FLASHPAGE_RAW_ALIGNMENT) {
+        return -EINVAL;
+    }
+
+    memcpy(buf, (void*)addr, size);
+
+    return size;
+}
+
+static int _write(mtd_dev_t *dev, const void *buf, uint32_t addr, uint32_t size)
+{
+    (void)dev;
+    if (addr % FLASHPAGE_RAW_ALIGNMENT) {
+        return -EINVAL;
+    }
+    if ((uintptr_t)buf % FLASHPAGE_RAW_ALIGNMENT) {
+        return -EINVAL;
+    }
+    if (size % FLASHPAGE_RAW_BLOCKSIZE) {
+        return -EOVERFLOW;
+    }
+    if (addr + size > MTD_FLASHPAGE_END_ADDR) {
+        return -EOVERFLOW;
+    }
+    flashpage_write_raw((void *)addr, buf, size);
+
+    return size;
+}
+
+int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
+{
+    size_t sector_size = dev->page_size * dev->pages_per_sector;
+
+    if (size % sector_size) {
+        return -EOVERFLOW;
+    }
+    if (addr + size > MTD_FLASHPAGE_END_ADDR) {
+        return - EOVERFLOW;
+    }
+    if (addr % sector_size) {
+        return - EOVERFLOW;
+    }
+    for (size_t i = 0; i < size; i += sector_size) {
+        flashpage_write(flashpage_page((void *)addr), NULL);
+    }
+
+    return 0;
+}
+
+
+const mtd_desc_t mtd_flashpage_driver = {
+    .init = _init,
+    .read = _read,
+    .write = _write,
+    .erase = _erase,
+};

--- a/tests/mtd_flashpage/Makefile
+++ b/tests/mtd_flashpage/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += mtd_flashpage
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/mtd_flashpage/tests/01-run.py
+++ b/tests/mtd_flashpage/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'OK \(\d+ tests\)')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This adds a basic mtd wrapper around perip_flashpage interface. periph_flashpage_raw is needed to write.

### Issues/PRs references

Based on #8773 