### PR TITLE
periph: hwcrypto: initial draft for hardware crypto support (version 2)

### DIFF
--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -56,6 +56,20 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Hardware crypto configuration
+ * @{
+ */
+static const hwcrypto_conf_t hwcrypto_config[] = {
+    {
+        .dev = CRYPTO,
+        .cmu = cmuClock_CRYPTO
+    }
+};
+
+#define HWCRYPTO_NUMOF      PERIPH_NUMOF(hwcrypto_config)
+/** @} */
+
+/**
  * @brief   RTC configuration
  */
 #define RTC_NUMOF           (1U)

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -19,3 +19,5 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   USEMODULE += checksum
   USEMODULE += random
 endif
+
+-include $(RIOTCPU)/native/Makefile.dep

--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -15,8 +15,7 @@
  */
 #include <stdio.h>
 #include "board.h"
-#include "periph/rtc.h"
-#include "periph/hwrng.h"
+#include "periph/init.h"
 
 #include "board_internal.h"
 
@@ -32,12 +31,10 @@ void board_init(void)
 {
     LED0_OFF;
     LED1_ON;
-#ifdef MODULE_PERIPH_RTC
-    rtc_init();
-#endif
-#ifdef MODULE_PERIPH_HWRNG
-    hwrng_init();
-#endif
+
+    /* trigger static peripheral initialization */
+    periph_init();
+
     puts("RIOT native board initialized.");
 }
 

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -87,6 +87,20 @@ static const adc_chan_conf_t adc_channel_config[] = {
 /** @} */
 
 /**
+ * @brief   Hardware crypto configuration
+ * @{
+ */
+static const hwcrypto_conf_t hwcrypto_config[] = {
+    {
+        .dev = CRYPTO,
+        .cmu = cmuClock_CRYPTO
+    }
+};
+
+#define HWCRYPTO_NUMOF      PERIPH_NUMOF(hwcrypto_config)
+/** @} */
+
+/**
  * @name    I2C configuration
  * @{
  */

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -107,6 +107,11 @@ static const dac_chan_conf_t dac_channel_config[] = {
 /** @} */
 
 /**
+ * @brief   Hardware crypto configuration
+ */
+#define HWCRYPTO_NUMOF      (1)
+
+/**
  * @name    I2C configuration
  * @{
  */

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -107,6 +107,11 @@ static const dac_chan_conf_t dac_channel_config[] = {
 /** @} */
 
 /**
+ * @brief   Hardware crypto configuration
+ */
+#define HWCRYPTO_NUMOF      (1)
+
+/**
  * @name    I2C configuration
  * @{
  */

--- a/cpu/efm32/Makefile.dep
+++ b/cpu/efm32/Makefile.dep
@@ -1,3 +1,7 @@
+ifneq (,$(filter periph_hwcrypto,$(USEMODULE)))
+  USEMODULE += periph_hwcrypto_series$(EFM32_SERIES)
+endif
+
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
   USEMODULE += periph_rtc_series$(EFM32_SERIES)
 endif

--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -1,5 +1,6 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_hwcrypto
 FEATURES_PROVIDED += periph_pm
 
 ifeq (1,$(EFM32_TNRG))

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -213,16 +213,28 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 
 /**
- * @brief   Override hardware crypto supported methods.
+ * @brief   Hardware crypto configuration.
  * @{
  */
+#ifdef _SILICON_LABS_32B_SERIES_0
 #define HAVE_HWCRYPTO_AES128
 #ifdef AES_CTRL_AES256
 #define HAVE_HWCRYPTO_AES256
 #endif
+#endif
+
 #ifdef _SILICON_LABS_32B_SERIES_1
+#define HAVE_HWCRYPTO_AES128
+#define HAVE_HWCRYPTO_AES256
 #define HAVE_HWCRYPTO_SHA1
 #define HAVE_HWCRYPTO_SHA256
+#endif
+
+#ifdef _SILICON_LABS_32B_SERIES_1
+typedef struct {
+    CRYPTO_TypeDef *dev;    /**< crypto device used */
+    CMU_Clock_TypeDef cmu;  /**< the device CMU channel */
+} hwcrypto_conf_t;
 #endif
 /** @} */
 

--- a/cpu/efm32/periph/hwcrypto_series0.c
+++ b/cpu/efm32/periph/hwcrypto_series0.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_efm32
+ * @ingroup     drivers_periph_hwcrypto
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level hardware crypto driver implementation
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "mutex.h"
+#include "assert.h"
+
+#include "periph/hwcrypto.h"
+
+#include "em_cmu.h"
+#include "em_aes.h"
+
+/**
+ * @brief   Type definition of the hardware crypto device state.
+ */
+typedef struct {
+    hwcrypto_cipher_t cipher;
+    hwcrypto_mode_t mode;
+    uint8_t key[32] __attribute__((aligned));
+    union {
+        uint8_t iv[16] __attribute__((aligned));
+        uint8_t counter[16] __attribute__((aligned));
+    } opts;
+} state_t;
+
+/**
+ * @brief   Type of a 128-bit counter.
+ */
+typedef struct {
+    uint64_t hi;
+    uint64_t lo;
+} counter128_t;
+
+/**
+ * @brief   Global lock to ensure mutual exclusive access to hardware crypto
+ *          device.
+ */
+static mutex_t hwcrypto_lock = MUTEX_INIT;
+
+/**
+ * @brief   Hardware crypto device state.
+ */
+static state_t state;
+
+/**
+ * @brief   Helper for incrementing a 128-bit counter.
+ */
+static void hwcrypto_cipher_increment(uint8_t *ctr)
+{
+    counter128_t *counter = (counter128_t *)ctr;
+
+    /* on overflow of low, increment high */
+    if (counter->lo == 0) {
+        counter->hi++;
+    }
+}
+
+int hwcrypto_init(hwcrypto_t dev)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+
+    /* enable clocks */
+    CMU_ClockEnable(cmuClock_HFPER, true);
+    CMU_ClockEnable(cmuClock_AES, true);
+
+    return 0;
+}
+
+int hwcrypto_cipher_init(hwcrypto_t dev, hwcrypto_cipher_t cipher, hwcrypto_mode_t mode)
+{
+    (void) dev;
+
+    /* check if cipher is supported */
+    if (!hwcrypto_cipher_supported(dev, cipher)) {
+        return -1;
+    }
+
+    /* initialize state */
+    state.cipher = cipher;
+    state.mode = mode;
+
+    return 0;
+}
+
+int hwcrypto_cipher_set(hwcrypto_t dev, hwcrypto_opt_t option, const void *value, uint32_t size)
+{
+    (void) dev;
+
+    switch (option) {
+        case HWCRYPTO_OPT_KEY:
+            if (state.cipher == HWCRYPTO_AES128 && size == 16) {
+                memcpy(state.key, value, 16);
+            }
+            else if (state.cipher == HWCRYPTO_AES256 && size == 32) {
+                memcpy(state.key, value, 32);
+            }
+            else {
+                /* incorrect size */
+                return -2;
+            }
+
+            break;
+        case HWCRYPTO_OPT_IV:
+            if (state.mode != HWCRYPTO_MODE_CBC &&
+                state.mode != HWCRYPTO_MODE_OFB &&
+                state.mode != HWCRYPTO_MODE_CFB
+                ) {
+                /* other modes don't use iv */
+                return -1;
+            }
+
+            if (size != 16) {
+                /* incorrect iv size */
+                return -2;
+            }
+
+            memcpy(state.opts.iv, value, 16);
+            break;
+        case HWCRYPTO_OPT_COUNTER:
+            if (state.mode != HWCRYPTO_MODE_CTR) {
+                /* other modes don't use counter */
+                return -1;
+            }
+
+            if (size != 16) {
+                /* incorrect counter size */
+                return -2;
+            }
+
+            memcpy(state.opts.counter, value, 16);
+            break;
+        default:
+            /* option not supported */
+            return -1;
+    }
+
+    return 0;
+}
+
+static int hwcrypto_cipher_encrypt_decrypt(const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size, bool encrypt)
+{
+    /* blocks must be aligned */
+    assert(!((intptr_t) plain_block & 0x03));
+    assert(!((intptr_t) cipher_block & 0x03));
+
+    /* block size must be multiple of 16 */
+    if ((block_size % 16) != 0) {
+        return -2;
+    }
+
+    switch (state.cipher) {
+        case HWCRYPTO_AES128:
+            switch (state.mode) {
+                case HWCRYPTO_MODE_ECB:
+                    AES_ECB128(cipher_block, plain_block, block_size, state.key, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CBC:
+                    AES_CBC128(cipher_block, plain_block, block_size, state.key, state.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CFB:
+                    AES_CFB128(cipher_block, plain_block, block_size, state.key, state.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_OFB:
+                    AES_OFB128(cipher_block, plain_block, block_size, state.key, state.opts.iv);
+                    break;
+                case HWCRYPTO_MODE_CTR:
+                    AES_CTR128(cipher_block, plain_block, block_size, state.key, state.opts.counter, hwcrypto_cipher_increment);
+                    break;
+                default:
+                    return -1;
+            }
+
+            break;
+        case HWCRYPTO_AES256:
+            switch (state.mode) {
+                case HWCRYPTO_MODE_ECB:
+                    AES_ECB256(cipher_block, plain_block, block_size, state.key, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CBC:
+                    AES_CBC256(cipher_block, plain_block, block_size, state.key, state.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CFB:
+                    AES_CFB256(cipher_block, plain_block, block_size, state.key, state.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_OFB:
+                    AES_OFB256(cipher_block, plain_block, block_size, state.key, state.opts.iv);
+                    break;
+                case HWCRYPTO_MODE_CTR:
+                    AES_CTR256(cipher_block, plain_block, block_size, state.key, state.opts.counter, hwcrypto_cipher_increment);
+                    break;
+                default:
+                    return -1;
+            }
+
+            break;
+        default:
+            return -1;
+    }
+
+    return block_size;
+}
+
+int hwcrypto_cipher_encrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size)
+{
+    (void) dev;
+
+    return hwcrypto_cipher_encrypt_decrypt(plain_block, cipher_block, block_size, true);
+}
+
+int hwcrypto_cipher_decrypt(hwcrypto_t dev, const uint8_t *cipher_block, uint8_t *plain_block, uint32_t block_size)
+{
+    (void) dev;
+
+    return hwcrypto_cipher_encrypt_decrypt(cipher_block, plain_block, block_size, false);
+}
+
+int hwcrypto_hash_init(hwcrypto_t dev, hwcrypto_hash_t hash)
+{
+    (void) dev;
+    (void) hash;
+
+    /* not supported */
+    return -1;
+}
+
+int hwcrypto_hash_update(hwcrypto_t dev, const uint8_t *block, uint32_t block_size)
+{
+    (void) dev;
+    (void) block;
+    (void) block_size;
+
+    /* not supported */
+    return -1;
+}
+
+int hwcrypto_hash_final(hwcrypto_t dev, uint8_t *result, uint32_t result_size)
+{
+    (void) dev;
+    (void) result;
+    (void) result_size;
+
+    /* not supported */
+    return -1;
+}
+
+int hwcrypto_acquire(hwcrypto_t dev)
+{
+    (void) dev;
+
+    mutex_lock(&hwcrypto_lock);
+
+    return 0;
+}
+
+int hwcrypto_release(hwcrypto_t dev)
+{
+    (void) dev;
+
+    mutex_unlock(&hwcrypto_lock);
+
+    return 0;
+}
+
+void hwcrypto_poweron(hwcrypto_t dev)
+{
+    (void) dev;
+
+    CMU_ClockEnable(cmuClock_AES, true);
+}
+
+void hwcrypto_poweroff(hwcrypto_t dev)
+{
+    (void) dev;
+
+    CMU_ClockEnable(cmuClock_AES, false);
+}

--- a/cpu/efm32/periph/hwcrypto_series1.c
+++ b/cpu/efm32/periph/hwcrypto_series1.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_efm32
+ * @ingroup     drivers_periph_hwcrypto
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level hardware crypto driver implementation for EFM32
+ *              Series 1 MCUs
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "mutex.h"
+#include "assert.h"
+
+#include "periph/hwcrypto.h"
+
+#include "em_cmu.h"
+#include "em_crypto.h"
+
+/**
+ * @brief   Type definition of the hardware crypto device state.
+ */
+typedef union {
+    struct {
+        hwcrypto_cipher_t cipher;
+        hwcrypto_mode_t mode;
+        uint8_t key[32] __attribute__((aligned));
+        union {
+            uint8_t iv[16] __attribute__((aligned));
+            uint8_t counter[16] __attribute__((aligned));
+        } opts;
+    } cipher;
+    struct {
+        hwcrypto_hash_t hash;
+        uint8_t digest[32] __attribute__((aligned));
+    } hash;
+} state_t;
+
+/**
+ * @brief   Global lock to ensure mutual exclusive access to crypto hardware.
+ */
+static mutex_t hwcrypto_lock[HWCRYPTO_NUMOF];
+
+/**
+ * @brief   Hardware crypto device state.
+ */
+static state_t state[HWCRYPTO_NUMOF];
+
+int hwcrypto_init(hwcrypto_t dev)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+
+    /* enable clocks */
+    CMU_ClockEnable(cmuClock_HFPER, true);
+    CMU_ClockEnable(hwcrypto_config[dev].cmu, true);
+
+    /* initialize lock */
+    mutex_init(&hwcrypto_lock[dev]);
+
+    return 0;
+}
+
+int hwcrypto_cipher_init(hwcrypto_t dev, hwcrypto_cipher_t cipher, hwcrypto_mode_t mode)
+{
+    /* check if cipher is supported */
+    if (!hwcrypto_cipher_supported(dev, cipher)) {
+        return -1;
+    }
+
+    /* initialize state */
+    state[dev].cipher.cipher = cipher;
+    state[dev].cipher.mode = mode;
+
+    return 0;
+}
+
+int hwcrypto_cipher_set(hwcrypto_t dev, hwcrypto_opt_t option, const void *value, uint32_t size)
+{
+    switch (option) {
+        case HWCRYPTO_OPT_KEY:
+            if (state[dev].cipher.cipher == HWCRYPTO_AES128) {
+                memcpy(state[dev].cipher.key, value, 16);
+            }
+            else if (state[dev].cipher.cipher == HWCRYPTO_AES256) {
+                memcpy(state[dev].cipher.key, value, 32);
+            }
+            else {
+                /* incorrect size */
+                return -2;
+            }
+
+            break;
+        case HWCRYPTO_OPT_IV:
+            if (state[dev].cipher.mode != HWCRYPTO_MODE_CBC &&
+                state[dev].cipher.mode != HWCRYPTO_MODE_OFB &&
+                state[dev].cipher.mode != HWCRYPTO_MODE_CFB
+                ) {
+                /* other modes don't use iv */
+                return -1;
+            }
+
+            if (size != 16) {
+                /* incorrect iv size */
+                return -2;
+            }
+
+            memcpy(state[dev].cipher.opts.iv, value, 16);
+            break;
+        case HWCRYPTO_OPT_COUNTER:
+            if (state[dev].cipher.mode != HWCRYPTO_MODE_CTR) {
+                /* other modes don't use counter */
+                return -1;
+            }
+
+            if (size != 16) {
+                /* incorrect counter size */
+                return -2;
+            }
+
+            memcpy(state[dev].cipher.opts.counter, value, 16);
+            break;
+        default:
+            /* option not supported */
+            return -1;
+    }
+
+    return 0;
+}
+
+static int hwcrypto_cipher_encrypt_decrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size, bool encrypt)
+{
+    /* blocks must be aligned */
+    assert(!((intptr_t) plain_block & 0x03));
+    assert(!((intptr_t) cipher_block & 0x03));
+
+    if ((block_size % 16) != 0) {
+        /* invalid block size */
+        return -2;
+    }
+
+    switch (state[dev].cipher.cipher) {
+        case HWCRYPTO_AES128:
+            switch (state[dev].cipher.mode) {
+                case HWCRYPTO_MODE_ECB:
+                    CRYPTO_AES_ECB128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CBC:
+                    CRYPTO_AES_CBC128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CFB:
+                    CRYPTO_AES_CFB128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_OFB:
+                    CRYPTO_AES_OFB128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv);
+                    break;
+                case HWCRYPTO_MODE_CTR:
+                    CRYPTO_AES_CTR128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.counter, NULL);
+                    break;
+                default:
+                    return -1;
+            }
+
+            break;
+        case HWCRYPTO_AES256:
+            switch (state[dev].cipher.mode) {
+                case HWCRYPTO_MODE_ECB:
+                    CRYPTO_AES_ECB256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CBC:
+                    CRYPTO_AES_CBC256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CFB:
+                    CRYPTO_AES_CFB256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_OFB:
+                    CRYPTO_AES_OFB256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv);
+                    break;
+                case HWCRYPTO_MODE_CTR:
+                    CRYPTO_AES_CTR256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.counter, NULL);
+                    break;
+                default:
+                    return -1;
+            }
+
+            break;
+        default:
+            return -1;
+    }
+
+    return block_size;
+}
+
+int hwcrypto_cipher_encrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, plain_block, cipher_block, block_size, true);
+}
+
+int hwcrypto_cipher_decrypt(hwcrypto_t dev, const uint8_t *cipher_block, uint8_t *plain_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, cipher_block, plain_block, block_size, false);
+}
+
+int hwcrypto_hash_init(hwcrypto_t dev, hwcrypto_hash_t hash)
+{
+    /* check if hash is supported */
+    if (!hwcrypto_hash_supported(dev, hash)) {
+        return -1;
+    }
+
+    /* initialie state */
+    state[dev].hash.hash = hash;
+
+    return 0;
+}
+
+int hwcrypto_hash_update(hwcrypto_t dev, const uint8_t *block, uint32_t block_size)
+{
+    switch (state[dev].hash.hash) {
+        case HWCRYPTO_SHA1:
+            CRYPTO_SHA_1(hwcrypto_config[dev].dev, block, block_size, state[dev].hash.digest);
+            break;
+        case HWCRYPTO_SHA256:
+            CRYPTO_SHA_256(hwcrypto_config[dev].dev, block, block_size, state[dev].hash.digest);
+            break;
+        default:
+            /* hash not supported */
+            return -1;
+    }
+
+    return block_size;
+}
+
+int hwcrypto_hash_final(hwcrypto_t dev, uint8_t *result, uint32_t result_size)
+{
+    switch (state[dev].hash.hash) {
+        case HWCRYPTO_SHA1:
+            if (result_size > sizeof(CRYPTO_SHA1_Digest_TypeDef)) {
+                /* result size larger than digest size */
+                return -2;
+            }
+
+            memcpy(result, state[dev].hash.digest, result_size);
+            break;
+        case HWCRYPTO_SHA256:
+            if (result_size > sizeof(CRYPTO_SHA256_Digest_TypeDef)) {
+                /* result size larger than digest size */
+                return -2;
+            }
+
+            memcpy(result, state[dev].hash.digest, result_size);
+            break;
+        default:
+            /* hash not supported */
+            return -1;
+    }
+
+    return result_size;
+}
+
+int hwcrypto_acquire(hwcrypto_t dev)
+{
+    mutex_lock(&hwcrypto_lock[dev]);
+
+    return 0;
+}
+
+int hwcrypto_release(hwcrypto_t dev)
+{
+    mutex_unlock(&hwcrypto_lock[dev]);
+
+    return 0;
+}
+
+void hwcrypto_poweron(hwcrypto_t dev)
+{
+    CMU_ClockEnable(hwcrypto_config[dev].cmu, true);
+}
+
+void hwcrypto_poweroff(hwcrypto_t dev)
+{
+    CMU_ClockEnable(hwcrypto_config[dev].cmu, false);
+}

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -1,0 +1,5 @@
+# Link OpenSSL for hardware crypto emulation
+ifneq (,$(filter periph_hwcrypto,$(USEMODULE)))
+    LINKFLAGS += `pkg-config --libs openssl`
+    CFLAGS += `pkg-config --cflags openssl`
+endif

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_hwcrypto
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -5,5 +5,8 @@ ifeq ($(BUILDOSXNATIVE),1)
     export NATIVEINCLUDES += -I$(RIOTCPU)/native/osx-libc-extra
 endif
 
+# include common hardware crypto functions
+USEMODULE += periph_common
+
 USEMODULE += periph
 USEMODULE += periph_uart

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -21,6 +21,13 @@
 #endif
 
 /**
+ * @name Number of hardware crypto devices
+ * @{
+ */
+#define HWCRYPTO_NUMOF      (1U)
+/** @} */
+
+/**
  * @name hardware timer clock skew avoidance
  * @{
  */

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -33,6 +33,19 @@ extern "C" {
 #endif
 
 /**
+ * @name    Hardware crypto configuration
+ * @{
+ */
+#define HAVE_HWCRYPTO_AES128
+#define HAVE_HWCRYPTO_AES256
+#define HAVE_HWCRYPTO_SHA1
+#define HAVE_HWCRYPTO_SHA224
+#define HAVE_HWCRYPTO_SHA256
+#define HAVE_HWCRYPTO_SHA384
+#define HAVE_HWCRYPTO_SHA512
+/** @} */
+
+/**
  * @brief   Prevent shared timer functions from being used
  */
 #define PERIPH_TIMER_PROVIDES_SET

--- a/cpu/native/periph/hwcrypto.c
+++ b/cpu/native/periph/hwcrypto.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     native_cpu
+ * @ingroup     drivers_periph_hwcrypto
+ *
+ * @{
+ *
+ * @file
+ * @brief       Hardware crypto driver implementation for native
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include <openssl/sha.h>
+#include <openssl/aes.h>
+#include <openssl/rsa.h>
+
+#include "mutex.h"
+#include "assert.h"
+
+#include "periph/hwcrypto.h"
+
+/**
+ * @brief   Type definition of the hardware crypto device state.
+ */
+typedef union {
+    struct {
+        hwcrypto_cipher_t cipher;
+        hwcrypto_mode_t mode;
+        uint8_t key[32] __attribute__((aligned));
+        union {
+            uint8_t iv[16] __attribute__((aligned));
+            uint8_t counter[16] __attribute__((aligned));
+        } opts;
+    } cipher;
+    struct {
+        hwcrypto_hash_t hash;
+        union {
+            SHA_CTX sha1;
+            SHA256_CTX sha256;
+            SHA512_CTX sha512;
+        } sha;
+    } hash;
+} state_t;
+
+/**
+ * @brief   Global lock to ensure mutual exclusive access to crypto hardware.
+ */
+static mutex_t hwcrypto_lock[HWCRYPTO_NUMOF];
+
+/**
+ * @brief   Hardware crypto device state.
+ */
+static state_t state[HWCRYPTO_NUMOF];
+
+void hwcrypto_init(hwcrypto_t dev)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+
+    /* initialize lock */
+    mutex_init(&hwcrypto_lock[dev]);
+
+    /* clear the state */
+    memset(&state[dev], 0, sizeof(state_t));
+}
+
+int hwcrypto_cipher_init(hwcrypto_t dev, hwcrypto_cipher_t cipher, hwcrypto_mode_t mode)
+{
+    /* check if cipher is supported */
+    if (!hwcrypto_cipher_supported(dev, cipher)) {
+        return HWCRYPTO_NOTSUP;
+    }
+
+    /* initialize state */
+    state[dev].cipher.cipher = cipher;
+    state[dev].cipher.mode = mode;
+
+    return HWCRYPTO_OK;
+}
+
+int hwcrypto_cipher_set(hwcrypto_t dev, hwcrypto_opt_t option, const void *value, uint32_t size)
+{
+    switch (option) {
+        case HWCRYPTO_OPT_KEY:
+            if (state[dev].cipher.cipher == HWCRYPTO_AES128 && size == 16) {
+                memcpy(state[dev].cipher.key, value, 16);
+            }
+            else if (state[dev].cipher.cipher == HWCRYPTO_AES256 && size == 32) {
+                memcpy(state[dev].cipher.key, value, 32);
+            }
+            else {
+                return HWCRYPTO_INVALID;
+            }
+
+            break;
+        case HWCRYPTO_OPT_IV:
+            if (state[dev].cipher.mode != HWCRYPTO_MODE_CBC &&
+                state[dev].cipher.mode != HWCRYPTO_MODE_OFB &&
+                state[dev].cipher.mode != HWCRYPTO_MODE_CFB
+                ) {
+                return HWCRYPTO_NOTSUP;
+            }
+
+            if (size != 16) {
+                return HWCRYPTO_INVALID;
+            }
+
+            memcpy(state[dev].cipher.opts.iv, value, 16);
+            break;
+        case HWCRYPTO_OPT_COUNTER:
+            if (state[dev].cipher.mode != HWCRYPTO_MODE_CTR) {
+                return HWCRYPTO_NOTSUP;
+            }
+
+            if (size != 16) {
+                return HWCRYPTO_INVALID;
+            }
+
+            memcpy(state[dev].cipher.opts.counter, value, 16);
+            break;
+        default:
+            return HWCRYPTO_NOTSUP;
+    }
+
+    return HWCRYPTO_OK;
+}
+
+static int hwcrypto_cipher_encrypt_decrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size, bool encrypt)
+{
+    (void) dev;
+    (void) plain_block;
+    (void) cipher_block;
+    (void) block_size;
+    (void) encrypt;
+
+    return HWCRYPTO_NOTSUP;
+}
+
+int hwcrypto_cipher_encrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, plain_block, cipher_block, block_size, true);
+}
+
+int hwcrypto_cipher_decrypt(hwcrypto_t dev, const uint8_t *cipher_block, uint8_t *plain_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, cipher_block, plain_block, block_size, false);
+}
+
+int hwcrypto_hash_init(hwcrypto_t dev, hwcrypto_hash_t hash)
+{
+    /* check if hash algorithm is supported */
+    if (!hwcrypto_hash_supported(dev, hash)) {
+        return HWCRYPTO_NOTSUP;
+    }
+
+    /* initialize state */
+    state[dev].hash.hash = hash;
+
+    switch (hash) {
+        case HWCRYPTO_SHA1:
+            SHA1_Init(&state[dev].hash.sha.sha1);
+            break;
+        case HWCRYPTO_SHA224:
+            SHA224_Init(&state[dev].hash.sha.sha256);
+            break;
+        case HWCRYPTO_SHA256:
+            SHA256_Init(&state[dev].hash.sha.sha256);
+            break;
+        case HWCRYPTO_SHA384:
+            SHA384_Init(&state[dev].hash.sha.sha512);
+            break;
+        case HWCRYPTO_SHA512:
+            SHA512_Init(&state[dev].hash.sha.sha512);
+            break;
+        default:
+            return HWCRYPTO_NOTSUP;
+    }
+
+    return HWCRYPTO_OK;
+}
+
+int hwcrypto_hash_update(hwcrypto_t dev, const uint8_t *block, uint32_t block_size)
+{
+    switch (state[dev].hash.hash) {
+        case HWCRYPTO_SHA1:
+            SHA1_Update(&state[dev].hash.sha.sha1, block, block_size);
+            break;
+        case HWCRYPTO_SHA224:
+            SHA224_Update(&state[dev].hash.sha.sha256, block, block_size);
+            break;
+        case HWCRYPTO_SHA256:
+            SHA256_Update(&state[dev].hash.sha.sha256, block, block_size);
+            break;
+        case HWCRYPTO_SHA384:
+            SHA384_Update(&state[dev].hash.sha.sha512, block, block_size);
+            break;
+        case HWCRYPTO_SHA512:
+            SHA512_Update(&state[dev].hash.sha.sha512, block, block_size);
+            break;
+        default:
+            return HWCRYPTO_NOTSUP;
+    }
+
+    return block_size;
+}
+
+int hwcrypto_hash_final(hwcrypto_t dev, uint8_t *result, uint32_t result_size)
+{
+    uint8_t tmp[64];
+
+    switch (state[dev].hash.hash) {
+        case HWCRYPTO_SHA1:
+            if (result_size > 20) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA1_Final(tmp, &state[dev].hash.sha.sha1);
+            break;
+        case HWCRYPTO_SHA224:
+            if (result_size > 28) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA224_Final(tmp, &state[dev].hash.sha.sha256);
+            break;
+        case HWCRYPTO_SHA256:
+            if (result_size > 32) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA256_Final(tmp, &state[dev].hash.sha.sha256);
+            break;
+        case HWCRYPTO_SHA384:
+            if (result_size > 48) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA384_Final(tmp, &state[dev].hash.sha.sha512);
+            break;
+        case HWCRYPTO_SHA512:
+            if (result_size > 64) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA512_Final(tmp, &state[dev].hash.sha.sha512);
+            break;
+        default:
+            return HWCRYPTO_NOTSUP;
+    }
+
+    /* copy the number of bytes requested */
+    memcpy(result, tmp, result_size);
+
+    return result_size;
+}
+
+int hwcrypto_acquire(hwcrypto_t dev)
+{
+    mutex_lock(&hwcrypto_lock[dev]);
+
+    return HWCRYPTO_OK;
+}
+
+int hwcrypto_release(hwcrypto_t dev)
+{
+    mutex_unlock(&hwcrypto_lock[dev]);
+
+    return HWCRYPTO_OK;
+}

--- a/drivers/include/periph/hwcrypto.h
+++ b/drivers/include/periph/hwcrypto.h
@@ -1,0 +1,394 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_hwcrypt Hardware Crypto
+ * @ingroup     drivers_periph
+ * @brief       Low-level hardware crypto peripheral driver
+ *
+ * Modern CPUs may be equipped with a hardware crypto peripheral to speed up
+ * cryptographical operations such as (as)symmetric ciphers and hashing
+ * algorithms. With no or little intervention, the CPU can typically execute
+ * more operations than the software alternative.
+ *
+ * This driver provides an abstract for the different ciphers and hashes that
+ * may be supported. Using HAVE_HWCRYPTO_xxx defines, software may choose to
+ * use the hardware crypto alternative, or fall back to a software variant if
+ * not defined.
+ *
+ * Current interface is optimized for (as)symmetric block ciphers and block
+ * hashes. It supports multiple hardware crypto peripherals, including limited
+ * support.
+ *
+ * All operations block until they are finished. Operations may change the
+ * internal peripheral state (e.g. load the key, keep the digest interally),
+ * therefore must be used to control mutual exclusive access.
+ *
+ * @{
+ * @file
+ * @brief       Low-level hardware crypto driver interface definitions
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#ifndef HWCRYPTO_H
+#define HWCRYPTO_H
+
+#include <stdint.h>
+
+#include "periph_cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef HAVE_HWCRYPTO_T
+/**
+ * @brief   Hardware crypto type identifier
+ */
+typedef unsigned int hwcrypto_t;
+#endif
+
+/**
+ * @brief   Supported ciphers.
+ *
+ * Define HAVE_HWCRYPTO_xxx in periph_cpu.h for each supported cipher.
+ *
+ * Extend at will, but also update drivers/periph_common/hwcrypto.c.
+ */
+typedef enum {
+    HWCRYPTO_AES128,                  /**< AES128 cipher */
+    HWCRYPTO_AES192,                  /**< AES192 cipher */
+    HWCRYPTO_AES256,                  /**< AES256 cipher */
+    HWCRYPTO_DES,                     /**< DES cipher */
+    HWCRYPTO_3DES,                    /**< 3DES cipher */
+    HWCRYPTO_TWOFISH,                 /**< Two-fish cipher */
+    HWCRYPTO_RSA512,                  /**< RSA512 cipher */
+    HWCRYPTO_RSA1024,                 /**< RSA1024 cipher */
+    HWCRYPTO_RSA2048,                 /**< RSA2048 cipher */
+    HWCRYPTO_RSA4096,                 /**< RSA4096 cipher */
+    HWCRYPTO_ECC128,                  /**< ECC128 cipher */
+    HWCRYPTO_ECC192,                  /**< ECC192 cipher */
+    HWCRYPTO_ECC256,                  /**< ECC256 cipher */
+    HWCRYPT_CIPHER_NUMOF              /**< number of ciphers available */
+} hwcrypto_cipher_t;
+
+/**
+ * @brief   Supported hashing algorithms.
+ *
+ * Define HAVE_HWCRYPTO_xxx in periph_cpu.h for each supported hashing
+ * algorithm.
+ *
+ * Extend at will, but also update drivers/periph_common/hwcrypto.c.
+ */
+typedef enum {
+    HWCRYPTO_MD4,                     /**< MD4 hashing algorithm */
+    HWCRYPTO_MD5,                     /**< MD5 hashing algorithm */
+    HWCRYPTO_SHA1,                    /**< SHA1 hashing algorithm */
+    HWCRYPTO_SHA3,                    /**< SHA3 hashing algorithm */
+    HWCRYPTO_SHA224,                  /**< SHA224 hashing algorithm */
+    HWCRYPTO_SHA256,                  /**< SHA256 hashing algorithm */
+    HWCRYPTO_SHA384,                  /**< SHA384 hashing algorithm */
+    HWCRYPTO_SHA512,                  /**< SHA512 hashing algorithm */
+    HWCRYPT_HASH_NUMOF                /**< number of hashes available */
+} hwcrypto_hash_t;
+
+/**
+ * @brief   Setup options for cipher and hash methods.
+ *
+ * Extend at will.
+ */
+typedef enum {
+    HWCRYPTO_OPT_KEY,
+    HWCRYPTO_OPT_IV,
+    HWCRYPTO_OPT_COUNTER,
+    HWCRYPTO_OPT_PADDING,
+} hwcrypto_opt_t;
+
+/**
+ * @brief   Supported cipher modes of operation, to be used with
+ *          @p HWCRYPTO_OPT_MODE.
+ *
+ * Extend at will.
+ */
+typedef enum {
+    HWCRYPTO_MODE_NONE,               /**< no mode */
+    HWCRYPTO_MODE_ECB,                /**< electronic codebook mode */
+    HWCRYPTO_MODE_CBC,                /**< cipher block chaining mode */
+    HWCRYPTO_MODE_CFB,                /**< cipher feedback mode */
+    HWCRYPTO_MODE_OFB,                /**< output feedback mode */
+    HWCRYPTO_MODE_CTR                 /**< counter mode */
+} hwcrypto_mode_t;
+
+/**
+ * @brief   Determine if the given hardware crypto peripheral supports the
+ *          given cipher.
+ *
+ * This method should not require the peripheral to be initialized. It will
+ * also not change its state.
+ *
+ * The method should return a deterministic result.
+ *
+ * @param[in] dev           the device
+ * @param[in] cipher        cipher to check
+ *
+ * @return                  nonzero value if supported
+ * @return                  0 if unsupported
+ */
+int hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher);
+
+/**
+ * @brief   Determine if the given hardware crypto peripheral supports the
+ *          given hashing algorithm.
+ *
+ * This method should not require the peripheral to be initialized. It will
+ * also not change its state.
+ *
+ * The method should return a deterministic result.
+ *
+ * @param[in] dev           the device
+ * @param[in] hash          hashing algorithm to check
+ *
+ * @return                  nonzero value if supported
+ * @return                  0 if unsupported
+ */
+int hwcrypto_hash_supported(hwcrypto_t dev, hwcrypto_hash_t hash);
+
+/**
+ * @brief   Initialize the hardware crypto peripheral.
+ *
+ * The peripheral should be turned on in this method.
+ *
+ * @param[in] dev           the device to initialize
+ *
+ * @return                  0 on success
+ * @return                  -1 if an error occurs
+ */
+int hwcrypto_init(hwcrypto_t dev);
+
+/**
+ * @brief   Initialize hardware crypto device for a given encryption or
+ *          decryption algorithm.
+ *
+ * The implementation must use a key (size) as defined by the cipher. It must
+ * not apply a different key scheduling algorithm.
+ *
+ * The mode parameter can be used to change the cipher's mode of operation. If
+ * a mode does not apply, use @p HWCRYPTO_MODE_NONE.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] cipher        cipher to initialize
+ * @param[in] mode          cipher mode of operation.
+ *
+ * @return                  0 on success
+ * @return                  -1 if cipher is not supported
+ * @return                  -2 if device could not be prepared
+ */
+int hwcrypto_cipher_init(hwcrypto_t dev,
+                         hwcrypto_cipher_t cipher,
+                         hwcrypto_mode_t mode);
+
+/**
+ * @brief   Set an option for the given hardware crypto device in cipher mode.
+ *
+ * If the given option or value is not supported by the cipher, an error code
+ * is returned.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * The peripheral's state is undefined if this method is used after one or more
+ * encryption or decryption round(s).
+ *
+ * A hardware crypto device not initialized for cipher mode may produce
+ * unexpected results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] option        option from @p hwcrypto_opt_t to initialize
+ * @param[in] value         pointer to option value
+ * @param[in] size          option size
+ *
+ * @return                  0 on success
+ * @return                  -1 if option is not supported or applicable
+ * @return                  -2 if value is not supported or applicable
+ */
+int hwcrypto_cipher_set(hwcrypto_t dev,
+                        hwcrypto_opt_t option,
+                        const void* value,
+                        uint32_t size);
+
+/**
+ * @brief   Perform a cipher encrypt operation for an initialized hardware
+ *          crypto device in cipher mode.
+ *
+ * The plain block may overlap with the cipher block, but not partially.
+ *
+ * The method must accept block sizes that are a multiple of the smallest block
+ * size. This allows for minimal CPU intervention for large blocks of data.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * A hardware crypto device not initialized for cipher mode may produce
+ * unexpected results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] plain_block   the plain input buffer
+ * @param[out] cipher_block the cipher output buffer (may overlap plain_block)
+ * @param[in] block_size    size of the plain_block and cipher_block in bytes
+ *
+ * @return                  0 on success
+ * @return                  -1 if cipher operation not supported
+ * @return                  -2 if block_size is invalid
+ */
+int hwcrypto_cipher_encrypt(hwcrypto_t dev,
+                            const uint8_t *plain_block,
+                            uint8_t *cipher_block,
+                            uint32_t block_size);
+
+/**
+ * @brief   Perform a cipher decrypt operation for an initialized hardware
+ *          crypto device in cipher mode
+ *
+ * The cipher block may overlap with the plain block, but not partially.
+ *
+ * The method must accept block sizes that are a multiple of the smallest block
+ * size. This allows for minimal CPU intervention for large blocks of data.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * A hardware crypto device not initialized for cipher mode may produce
+ * unexpected results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] cipher_block  the cipher input buffer
+ * @param[out] plain_block  the plain output buffer (may overlap cipher_block)
+ * @param[in] block_size    size of the cipher_block and plain_block in bytes
+ *
+ * @return                  0 on success
+ * @return                  -1 if cipher operation not supported
+ * @return                  -2 if block_size is invalid
+ */
+int hwcrypto_cipher_decrypt(hwcrypto_t dev,
+                            const uint8_t *cipher_block,
+                            uint8_t *plain_block,
+                            uint32_t block_size);
+
+/**
+ * @brief   Initialize hardware crypto device for a given hashing algorithm.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] hash          desired hash algorithm
+ *
+ * @return                  0 on success
+ * @return                  -1 if hash is not supported
+ * @return                  -2 if device could not be prepared
+ */
+int hwcrypto_hash_init(hwcrypto_t dev, hwcrypto_hash_t hash);
+
+/**
+ * @brief   Update the digest with a block of data.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * A hardware crypto device not initialized for hashing may produce unexpected
+ * results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] block         block of data to update digest with
+ * @param[in] block_size    number of bytes in data block
+ *
+ * @return                  number of bytes added to digest
+ * @return                  -1 if hash is not supported
+ * @return                  -2 if block_size is incorrect
+ * @return                  -3 if digest could not be updated
+ */
+int hwcrypto_hash_update(hwcrypto_t dev,
+                         const uint8_t* block,
+                         uint32_t block_size);
+
+/**
+ * @brief   Finalize the hash and copy the result to result buffer.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * A hardware crypto device not initialized for hashing may produce unexpected
+ * results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[out] cipher       result output buffer
+ * @param[in] result_size   number of bytes to copy from digest to result
+ *
+ * @return                  number of bytes copied
+ * @return                  -1 if hash is not supported
+ * @returned                -2 if @p result_size exceeds hash size
+ */
+int hwcrypto_hash_final(hwcrypto_t dev,
+                        uint8_t* result,
+                        uint32_t result_size);
+
+/**
+ * @brief   Get mutually exclusive access to the hardware crypto peripheral.
+ *
+ * In case the peripheral is busy, this function will block until the
+ * peripheral is available again.
+ *
+ * @param[in] dev           the device to initialize
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int hwcrypto_acquire(hwcrypto_t dev);
+
+/**
+ * @brief   Release the hardware crypto peripheral to be used by others.
+ *
+ * @param[in] dev           the device to initialize
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int hwcrypto_release(hwcrypto_t dev);
+
+/**
+ * @brief   Power on the hardware crypto peripheral.
+ *
+ * @param[in] dev           the device to initialize
+ */
+void hwcrypto_poweron(hwcrypto_t dev);
+
+/**
+ * @brief   Power off the hardware crypto peripheral.
+ *
+ * @param[in] dev           the device to initialize
+ */
+void hwcrypto_poweroff(hwcrypto_t dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HWCRYPTO_H */
+/** @} */

--- a/drivers/periph_common/hwcrypto.c
+++ b/drivers/periph_common/hwcrypto.c
@@ -24,7 +24,7 @@
 /**
  * @brief Bitmap of supported ciphers.
  */
-static uint32_t cipher_bitmap = (
+static const uint32_t cipher_bitmap = (
 #ifdef HAVE_HWCRYPTO_AES128
     (1 << HWCRYPTO_AES128) +
 #endif
@@ -66,7 +66,7 @@ static uint32_t cipher_bitmap = (
 #endif
     0);
 
-inline int hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher)
+inline bool hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher)
 {
     (void) dev;
 
@@ -78,7 +78,7 @@ inline int hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher)
 /**
  * @brief Bitmap of supported hashes.
  */
-static uint32_t hash_bitmap = (
+static const uint32_t hash_bitmap = (
 #ifdef HAVE_HWCRYPTO_MD4
     (1 << HWCRYPTO_MD4) +
 #endif
@@ -105,7 +105,7 @@ static uint32_t hash_bitmap = (
 #endif
     0);
 
-inline int hwcrypto_hash_supported(hwcrypto_t dev, hwcrypto_hash_t hash)
+inline bool hwcrypto_hash_supported(hwcrypto_t dev, hwcrypto_hash_t hash)
 {
     (void) dev;
 

--- a/drivers/periph_common/hwcrypto.c
+++ b/drivers/periph_common/hwcrypto.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers
+ * @{
+ *
+ * @file
+ * @brief       Shared hardware crypto code
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include "periph/hwcrypto.h"
+
+#ifndef PERIPH_HWCRYPTO_PROVIDES_CIPHER_SUPPORTED
+/**
+ * @brief Bitmap of supported ciphers.
+ */
+static uint32_t cipher_bitmap = (
+#ifdef HAVE_HWCRYPTO_AES128
+    (1 << HWCRYPTO_AES128) +
+#endif
+#ifdef HAVE_HWCRYPTO_AES192
+    (1 << HWCRYPTO_AES192) +
+#endif
+#ifdef HAVE_HWCRYPTO_AES256
+    (1 << HWCRYPTO_AES256) +
+#endif
+#ifdef HAVE_HWCRYPTO_DES
+    (1 << HWCRYPTO_DES) +
+#endif
+#ifdef HAVE_HWCRYPTO_3DES
+    (1 << HWCRYPTO_3DES) +
+#endif
+#ifdef HAVE_HWCRYPTO_TWOFISH
+    (1 << HWCRYPTO_TWOFISH) +
+#endif
+#ifdef HAVE_HWCRYPTO_RSA512
+    (1 << HWCRYPTO_RSA512) +
+#endif
+#ifdef HAVE_HWCRYPTO_RSA1024
+    (1 << HWCRYPTO_RSA1024) +
+#endif
+#ifdef HAVE_HWCRYPTO_RSA2048
+    (1 << HWCRYPTO_RSA2048) +
+#endif
+#ifdef HAVE_HWCRYPTO_RSA4096
+    (1 << HWCRYPTO_RSA4096) +
+#endif
+#ifdef HAVE_HWCRYPTO_ECC128
+    (1 << HWCRYPTO_ECC128) +
+#endif
+#ifdef HAVE_HWCRYPTO_ECC192
+    (1 << HWCRYPTO_ECC192) +
+#endif
+#ifdef HAVE_HWCRYPTO_ECC256
+    (1 << HWCRYPTO_ECC256) +
+#endif
+    0);
+
+inline int hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher)
+{
+    (void) dev;
+
+    return cipher_bitmap & (1 << cipher);
+}
+#endif /* PERIPH_HWCRYPTO_PROVIDES_CIPHER_SUPPORTED */
+
+#ifndef PERIPH_HWCRYPTO_PROVIDES_HASH_SUPPORTED
+/**
+ * @brief Bitmap of supported hashes.
+ */
+static uint32_t hash_bitmap = (
+#ifdef HAVE_HWCRYPTO_MD4
+    (1 << HWCRYPTO_MD4) +
+#endif
+#ifdef HAVE_HWCRYPTO_MD5
+    (1 << HWCRYPTO_MD5) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA1
+    (1 << HWCRYPTO_SHA1) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA3
+    (1 << HWCRYPTO_SHA3) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA224
+    (1 << HWCRYPTO_SHA224) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA256
+    (1 << HWCRYPTO_SHA256) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA384
+    (1 << HWCRYPTO_SHA384) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA512
+    (1 << HWCRYPTO_SHA512) +
+#endif
+    0);
+
+inline int hwcrypto_hash_supported(hwcrypto_t dev, hwcrypto_hash_t hash)
+{
+    (void) dev;
+
+    return hash_bitmap & (1 << hash);
+}
+#endif /* PERIPH_HWCRYPTO_PROVIDES_HASH_SUPPORTED */

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -16,6 +16,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
  *
  * @}
  */
@@ -25,6 +26,9 @@
 #endif
 #ifdef MODULE_PERIPH_RTC
 #include "periph/rtc.h"
+#endif
+#ifdef MODULE_PERIPH_HWCRYPTO
+#include "periph/hwcrypto.h"
 #endif
 #ifdef MODULE_PERIPH_HWRNG
 #include "periph/hwrng.h"
@@ -42,6 +46,13 @@ void periph_init(void)
     /* Initialize RTC */
 #ifdef MODULE_PERIPH_RTC
     rtc_init();
+#endif
+
+#ifdef MODULE_PERIPH_HWCRYPTO
+    /* initialize hardware crypto devices */
+    for (unsigned i = 0; i < HWCRYPTO_NUMOF; i++) {
+        hwcrypto_init(HWCRYPTO_DEV(i));
+    }
 #endif
 
 #ifdef MODULE_PERIPH_HWRNG

--- a/tests/periph_hwcrypto/Makefile
+++ b/tests/periph_hwcrypto/Makefile
@@ -1,5 +1,5 @@
 APPLICATION = periph_hwcrypto
-BOARD ?= stk3600
+BOARD ?= native
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_hwcrypto

--- a/tests/periph_hwcrypto/Makefile
+++ b/tests/periph_hwcrypto/Makefile
@@ -1,0 +1,7 @@
+APPLICATION = periph_hwcrypto
+BOARD ?= stk3600
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_hwcrypto
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_hwcrypto/README.md
+++ b/tests/periph_hwcrypto/README.md
@@ -1,0 +1,8 @@
+Expected result
+===============
+You should be presented with the RIOT shell, providing you with commands to initialize a board
+as master or slave, and to send and receive data via SPI.
+
+Background
+==========
+Test for the low-level SPI driver.

--- a/tests/periph_hwcrypto/README.md
+++ b/tests/periph_hwcrypto/README.md
@@ -1,8 +1,10 @@
 Expected result
 ===============
-You should be presented with the RIOT shell, providing you with commands to initialize a board
-as master or slave, and to send and receive data via SPI.
+This application will run all supported hardware accelerated ciphers and hashing algorithms.
+
+For the ones supported, no error should be raised. Note that this test only checks if the
+implementation works, and does not verify results against reference results.
 
 Background
 ==========
-Test for the low-level SPI driver.
+Test for the low-level hardware crypto driver.

--- a/tests/periph_hwcrypto/main.c
+++ b/tests/periph_hwcrypto/main.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Hardware crypto device tests.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "periph/hwcrypto.h"
+
+/**
+ * @brief   Dummy data buffer.
+ */
+static uint8_t data[32] __attribute__((aligned));
+
+/**
+ * @brief   Dummy key.
+ */
+static uint8_t key[32] __attribute__((aligned));
+
+/**
+ * @brief   Dummy initialization vector.
+ */
+static uint8_t iv[32] __attribute__((aligned));
+
+/**
+ * @brief   Dummy counter vector.
+ */
+static uint8_t counter[32] __attribute__((aligned));
+
+#if defined(HAVE_HWCRYPTO_AES128) || defined(HAVE_HWCRYPTO_AES256)
+static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hwcrypto_mode_t mode, uint8_t key_size, uint8_t block_size)
+{
+    int result;
+
+    printf("Testing %s\n", name);
+
+    /* check if hash is supported */
+    if (!hwcrypto_cipher_supported(dev, cipher)) {
+        puts("Cipher not supported.");
+        return;
+    }
+
+    /* initialize hwcrypto module */
+    result = hwcrypto_init(dev);
+
+    if (result != 0) {
+        printf("Unable to init: %d\n", result);
+        return;
+    }
+
+    /* turn it on */
+    hwcrypto_poweron(dev);
+
+    /* acquire hwcrypto module */
+    result = hwcrypto_acquire(dev);
+
+    if (result != 0) {
+        printf("Unable to acquire: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* initialize cipher */
+    result = hwcrypto_cipher_init(dev, cipher, mode);
+
+    if (result != 0) {
+        printf("Unable to init cipher: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_KEY, key, key_size);
+
+    if (result != 0) {
+        printf("Unable to set key: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    if (mode == HWCRYPTO_MODE_CBC || mode == HWCRYPTO_MODE_CFB || mode == HWCRYPTO_MODE_OFB) {
+        result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_IV, iv, 16);
+
+        if (result != 0) {
+            printf("Unable to set iv: %d\n", result);
+            hwcrypto_release(dev);
+
+            return;
+        }
+    }
+    else if (mode == HWCRYPTO_MODE_CTR) {
+        result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_COUNTER, counter, 16);
+
+        if (result != 0) {
+            printf("Unable to set counter: %d\n", result);
+            hwcrypto_release(dev);
+
+            return;
+        }
+    }
+
+    /* test encryption */
+    result = hwcrypto_cipher_encrypt(dev, data, data, block_size);
+
+    if (result != block_size) {
+        printf("Unable to encrypt: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* test decryption */
+    result = hwcrypto_cipher_decrypt(dev, data, data, block_size);
+
+    if (result != block_size) {
+        printf("Unable to decrypt: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* release it */
+    hwcrypto_release(dev);
+
+    /* power it off */
+    hwcrypto_poweroff(dev);
+}
+#endif
+
+#if defined(HAVE_HWCRYPTO_SHA1) || defined(HAVE_HWCRYPTO_SHA256)
+static void test_hash(hwcrypto_t dev, char *name, hwcrypto_hash_t hash, uint8_t block_size)
+{
+    int result;
+
+    printf("Testing %s\n", name);
+
+    /* check if hash is supported */
+    if (!hwcrypto_hash_supported(dev, hash)) {
+        puts("Hash not supported.");
+        return;
+    }
+
+    /* initialize hwcrypto module */
+    result = hwcrypto_init(dev);
+
+    if (result != 0) {
+        printf("Unable to init: %d\n", result);
+        return;
+    }
+
+    /* turn it on */
+    hwcrypto_poweron(dev);
+
+    /* acquire hwcrypto module */
+    result = hwcrypto_acquire(dev);
+
+    if (result != 0) {
+        printf("Unable to acquire: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* initialize hash */
+    result = hwcrypto_hash_init(dev, hash);
+
+    if (result != 0) {
+        printf("Unable to init hash: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* test hashing */
+    result = hwcrypto_hash_update(dev, data, block_size);
+
+    if (result != block_size) {
+        printf("Unable to hash: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    result = hwcrypto_hash_final(dev, data, block_size);
+
+    if (result != block_size) {
+        printf("Unable to finalize hash: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* release it */
+    hwcrypto_release(dev);
+
+    /* power it off */
+    hwcrypto_poweroff(dev);
+}
+#endif
+
+int main(void)
+{
+    puts("HWCRYPTO peripheral driver test\n");
+    puts("In this test, the supported cipher and hash functions will be "
+         "tested on each hardware crypto peripheral. It will test the "
+         "implementation only, not the results.\n");
+
+    /* run a test for every hardware crypto peripheral */
+    for (int i = 0; i < (int) HWCRYPTO_NUMOF; i++) {
+        hwcrypto_t dev = (hwcrypto_t) i;
+
+#ifdef HAVE_HWCRYPTO_AES128
+        /* AES-128 tests */
+        test_cipher(dev, "AES-128 ECB", HWCRYPTO_AES128, HWCRYPTO_MODE_ECB, 16, 16);
+        test_cipher(dev, "AES-128 CBC", HWCRYPTO_AES128, HWCRYPTO_MODE_CBC, 16, 16);
+        test_cipher(dev, "AES-128 CFB", HWCRYPTO_AES128, HWCRYPTO_MODE_CFB, 16, 16);
+        test_cipher(dev, "AES-128 OFB", HWCRYPTO_AES128, HWCRYPTO_MODE_OFB, 16, 16);
+        test_cipher(dev, "AES-128 CTR", HWCRYPTO_AES128, HWCRYPTO_MODE_CTR, 16, 16);
+#endif
+
+#ifdef HAVE_HWCRYPTO_AES256
+        /* AES-256 tests */
+        test_cipher(dev, "AES-256 ECB", HWCRYPTO_AES256, HWCRYPTO_MODE_ECB, 32, 16);
+        test_cipher(dev, "AES-256 CBC", HWCRYPTO_AES256, HWCRYPTO_MODE_CBC, 32, 16);
+        test_cipher(dev, "AES-256 CFB", HWCRYPTO_AES256, HWCRYPTO_MODE_CFB, 32, 16);
+        test_cipher(dev, "AES-256 OFB", HWCRYPTO_AES256, HWCRYPTO_MODE_OFB, 32, 16);
+        test_cipher(dev, "AES-256 CTR", HWCRYPTO_AES256, HWCRYPTO_MODE_CTR, 32, 16);
+#endif
+
+#ifdef HAVE_HWCRYPTO_SHA1
+        /* SHA-1 tests */
+        test_hash(dev, "SHA-1", HWCRYPTO_SHA1, 20);
+#endif
+
+#ifdef HAVE_HWCRYPTO_SHA256
+        /* SHA-256 tests */
+        test_hash(dev, "SHA-256", HWCRYPTO_SHA256, 32);
+#endif
+    }
+
+    puts("Testing done!\n");
+
+    return 0;
+}

--- a/tests/periph_hwcrypto/main.c
+++ b/tests/periph_hwcrypto/main.c
@@ -56,21 +56,10 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
         return;
     }
 
-    /* initialize hwcrypto module */
-    result = hwcrypto_init(dev);
-
-    if (result != 0) {
-        printf("Unable to init: %d\n", result);
-        return;
-    }
-
-    /* turn it on */
-    hwcrypto_poweron(dev);
-
     /* acquire hwcrypto module */
     result = hwcrypto_acquire(dev);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to acquire: %d\n", result);
         hwcrypto_release(dev);
 
@@ -80,7 +69,7 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
     /* initialize cipher */
     result = hwcrypto_cipher_init(dev, cipher, mode);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to init cipher: %d\n", result);
         hwcrypto_release(dev);
 
@@ -89,7 +78,7 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
 
     result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_KEY, key, key_size);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to set key: %d\n", result);
         hwcrypto_release(dev);
 
@@ -99,7 +88,7 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
     if (mode == HWCRYPTO_MODE_CBC || mode == HWCRYPTO_MODE_CFB || mode == HWCRYPTO_MODE_OFB) {
         result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_IV, iv, 16);
 
-        if (result != 0) {
+        if (result != HWCRYPTO_OK) {
             printf("Unable to set iv: %d\n", result);
             hwcrypto_release(dev);
 
@@ -109,7 +98,7 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
     else if (mode == HWCRYPTO_MODE_CTR) {
         result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_COUNTER, counter, 16);
 
-        if (result != 0) {
+        if (result != HWCRYPTO_OK) {
             printf("Unable to set counter: %d\n", result);
             hwcrypto_release(dev);
 
@@ -139,9 +128,6 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
 
     /* release it */
     hwcrypto_release(dev);
-
-    /* power it off */
-    hwcrypto_poweroff(dev);
 }
 #endif
 
@@ -158,21 +144,10 @@ static void test_hash(hwcrypto_t dev, char *name, hwcrypto_hash_t hash, uint8_t 
         return;
     }
 
-    /* initialize hwcrypto module */
-    result = hwcrypto_init(dev);
-
-    if (result != 0) {
-        printf("Unable to init: %d\n", result);
-        return;
-    }
-
-    /* turn it on */
-    hwcrypto_poweron(dev);
-
     /* acquire hwcrypto module */
     result = hwcrypto_acquire(dev);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to acquire: %d\n", result);
         hwcrypto_release(dev);
 
@@ -182,7 +157,7 @@ static void test_hash(hwcrypto_t dev, char *name, hwcrypto_hash_t hash, uint8_t 
     /* initialize hash */
     result = hwcrypto_hash_init(dev, hash);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to init hash: %d\n", result);
         hwcrypto_release(dev);
 
@@ -210,9 +185,6 @@ static void test_hash(hwcrypto_t dev, char *name, hwcrypto_hash_t hash, uint8_t 
 
     /* release it */
     hwcrypto_release(dev);
-
-    /* power it off */
-    hwcrypto_poweroff(dev);
 }
 #endif
 
@@ -225,7 +197,7 @@ int main(void)
 
     /* run a test for every hardware crypto peripheral */
     for (int i = 0; i < (int) HWCRYPTO_NUMOF; i++) {
-        hwcrypto_t dev = (hwcrypto_t) i;
+        hwcrypto_t dev = HWCRYPTO_DEV(i);
 
 #ifdef HAVE_HWCRYPTO_AES128
         /* AES-128 tests */

--- a/tests/periph_hwcrypto/main.c
+++ b/tests/periph_hwcrypto/main.c
@@ -26,7 +26,7 @@
 /**
  * @brief   Dummy data buffer.
  */
-static uint8_t data[32] __attribute__((aligned));
+static uint8_t data[64] __attribute__((aligned));
 
 /**
  * @brief   Dummy key.
@@ -222,9 +222,24 @@ int main(void)
         test_hash(dev, "SHA-1", HWCRYPTO_SHA1, 20);
 #endif
 
+#ifdef HAVE_HWCRYPTO_SHA224
+        /* SHA-224 tests */
+        test_hash(dev, "SHA-224", HWCRYPTO_SHA224, 28);
+#endif
+
 #ifdef HAVE_HWCRYPTO_SHA256
         /* SHA-256 tests */
         test_hash(dev, "SHA-256", HWCRYPTO_SHA256, 32);
+#endif
+
+#ifdef HAVE_HWCRYPTO_SHA384
+        /* SHA-384 tests */
+        test_hash(dev, "SHA-384", HWCRYPTO_SHA384, 48);
+#endif
+
+#ifdef HAVE_HWCRYPTO_SHA512
+        /* SHA-512 tests */
+        test_hash(dev, "SHA-512", HWCRYPTO_SHA512, 64);
 #endif
     }
 


### PR DESCRIPTION
### Contribution description

This is my second attempt to define a peripheral interface for hardware crypto devices. In this version, hardware accelerated (block) ciphers and hashing algorithms are supported.

It is a complete rewrite of #5429:

* Dropped the context parameter (peripherals should define state if needed)
* Added support for multiple hardware crypto peripherals (EFM32 has support)
* Removed long list of defines
* Removed the weird include structure

I have also added a peripheral test and a working implementation for the EFM32.

### Issues/PRs references

#5429 (first version)