### PR TITLE
sys/shell: switch stdout to unbuffered mode

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -282,6 +282,13 @@ static inline void print_prompt(void)
 
 void shell_run(const shell_command_t *shell_commands, char *line_buf, int len)
 {
+#ifndef SHELL_NO_ECHO
+    /* If echo is enabled, switch stdout to unbuffered mode. Otherwise we'll
+     * buffer output characters and only echo them back after ENTER has been
+     * pressed. */
+    setvbuf(stdout, NULL, _IONBF, 0);
+#endif
+
     print_prompt();
 
     while (1) {


### PR DESCRIPTION
Without this, if there is enough memory, newlib will enable
line-buffered mode by default and allocate 1024 byte buffer. Any
characters echoed by the shell would keep accumulating in the buffer and
only get "echoed" back when ENTER is pressed or command line overflows.

Tested: verified that behavior has not changed on a nucleo32-f031, and that echo now works properly on the board I'm working with.