### PR TITLE
cpu/board: native: use common peripheral initialization

### DIFF
--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -15,8 +15,6 @@
  */
 #include <stdio.h>
 #include "board.h"
-#include "periph/rtc.h"
-#include "periph/hwrng.h"
 
 #include "board_internal.h"
 
@@ -32,12 +30,7 @@ void board_init(void)
 {
     LED0_OFF;
     LED1_ON;
-#ifdef MODULE_PERIPH_RTC
-    rtc_init();
-#endif
-#ifdef MODULE_PERIPH_HWRNG
-    hwrng_init();
-#endif
+
     puts("RIOT native board initialized.");
 }
 

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -7,3 +7,6 @@ endif
 
 USEMODULE += periph
 USEMODULE += periph_uart
+
+# include common peripheral initialization
+USEMODULE += periph_common

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -43,6 +43,8 @@
 #include "native_internal.h"
 #include "tty_uart.h"
 
+#include "periph/init.h"
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -536,6 +538,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
     }
 #endif
 
+    periph_init();
     board_init();
 
     puts("RIOT native hardware initialization complete.\n");


### PR DESCRIPTION
### Contribution description

While working on hardware crypto drive, I noticed that the CPU initializes `hwrng` and `rtc`, which are also initialized by the common peripheral initialization.

I moved it from `board` to `cpu`, just like other CPUs do.

### Issues/PRs references

None