### PR TITLE
kinetis: Avoid reinitializing RTT if running

### DIFF
--- a/cpu/kinetis/periph/rtt.c
+++ b/cpu/kinetis/periph/rtt.c
@@ -53,6 +53,10 @@ void rtt_init(void)
     RTC_Type *rtt = RTT_DEV;
 
     RTT_UNLOCK();
+    if (!(rtt->SR & RTC_SR_TIF_MASK)) {
+        /* RTC is already started, let it run */
+        return;
+    }
     /* Reset RTC */
     rtt->CR = RTC_CR_SWR_MASK;
     /* cppcheck-suppress redundantAssignment


### PR DESCRIPTION


### Contribution description

The RTC hardware is only reset on power on reset, this avoids
accidentally clearing the RTC counter if rtt_init is called when the RTC
is already running.

We check the Time Invalid Flag to see if the RTC hardware needs initialization

### Issues/PRs references

none