### PR TITLE
boards/b-l072z-lrwan1: fix openocd configuration and 'make debug'

### DIFF
--- a/boards/b-l072z-lrwan1/dist/openocd.cfg
+++ b/boards/b-l072z-lrwan1/dist/openocd.cfg
@@ -1,3 +1,5 @@
 source [find target/stm32l0.cfg]
 
 reset_config srst_only
+
+$_TARGETNAME configure -rtos auto

--- a/boards/b-l072z-lrwan1/dist/openocd.cfg
+++ b/boards/b-l072z-lrwan1/dist/openocd.cfg
@@ -1,5 +1,5 @@
 source [find target/stm32l0.cfg]
 
-reset_config srst_only
+reset_config srst_only connect_assert_srst
 
 $_TARGETNAME configure -rtos auto

--- a/boards/b-l072z-lrwan1/dist/openocd.cfg
+++ b/boards/b-l072z-lrwan1/dist/openocd.cfg
@@ -1,3 +1,3 @@
 source [find target/stm32l0.cfg]
 
-reset_config trst_and_srst srst_nogate connect_assert_srst
+reset_config srst_only


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix the make `flash` and `debug` targets with the b-l072z-lrwan1 board. The current state in master prevents the `debug` from being used with it.

#8500 initially tried to provide a solution for flashing the board when the MCU is in low-power mode. Digging a little more in OpenOCD documentation, it appears that just the `connect_assert_srst` reset option was required: this option forces a wake up of the MCU before flashing (e.g ensure 'SRST is asserted'). So the first part of this PR is to restore the initial config (`srst_only`) and add `connect_assert_srst` because only this new option was required.
But the problem now is that when one adds this new option, it breaks the `make debug` command for this board (and maybe others).

So the second part of this PR tries to fix the `make debug` by forcing a reset in the openocd debug command.

It works for this board, now I can flash, even if the MCU is in low-power mode, and debug the board. But I'm not sure if the change in openocd.sh is valid.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->