### PR TITLE
sys/random/tinymt32: remove unused static function

### DIFF
--- a/sys/random/tinymt32.c
+++ b/sys/random/tinymt32.c
@@ -24,14 +24,6 @@
 
 #include "tinymt32/tinymt32.h"
 
-#define _ALIGNMENT_MASK (sizeof(uint32_t) - 1)
-
-/* fits size to byte alignment */
-static inline uint8_t *_align(uint8_t *buf)
-{
-    return (uint8_t *)(((size_t) buf + _ALIGNMENT_MASK) & ~(_ALIGNMENT_MASK));
-}
-
 static tinymt32_t _random;
 
 void random_init(uint32_t seed)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While testing some POSIX stuff I realised that there was an unused static function on tinymt32, which throws an error on OS X clang for native.

This PR removes it to fix the error.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
The function was unused after #8782.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->