### PR TITLE
newlib: link without -lnosys

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -17,11 +17,7 @@ ifeq (1,$(USE_NEWLIB_NANO))
   export LINKFLAGS += -specs=nano.specs
 endif
 
-ifeq ($(TARGET_ARCH),mips-mti-elf)
- export LINKFLAGS += -lc
-else
- export LINKFLAGS += -lc -lnosys
-endif
+export LINKFLAGS += -lc
 
 # Search for Newlib include directories
 

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -500,11 +500,19 @@ int _kill(pid_t pid, int sig)
 #ifdef MODULE_XTIMER
 int _gettimeofday_r(struct _reent *r, struct timeval *restrict tp, void *restrict tzp)
 {
-    (void)tzp;
     (void) r;
+    (void) tzp;
     uint64_t now = xtimer_now_usec64();
     tp->tv_sec = div_u64_by_1000000(now);
     tp->tv_usec = now - (tp->tv_sec * US_PER_SEC);
     return 0;
+}
+#else
+int _gettimeofday_r(struct _reent *r, struct timeval *restrict tp, void *restrict tzp)
+{
+    (void) tp;
+    (void) tzp;
+    r->_errno = ENOSYS;
+    return -1;
 }
 #endif


### PR DESCRIPTION

### Contribution description

lnosys and nosys.specs is mainly intended to provide empty stubs for syscalls, which we do not want since we implement the syscalls ourselves.

### Issues/PRs references

none