### PR TITLE
gnrc_gomach: add duty-cycle display shell command.

### DIFF
--- a/examples/gnrc_networking_mac/mac.c
+++ b/examples/gnrc_networking_mac/mac.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 Shuguo Zhuo
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       MAC shell commands
+ *
+ * @author      Shuguo Zhuo <zhuosgzju@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "net/gnrc.h"
+#include "net/gnrc/mac/types.h"
+
+int mac_cmd(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("usage: %s duty\n", argv[0]);
+        return 1;
+    }
+
+    if (strcmp(argv[1], "duty") == 0) {
+#if (GNRC_MAC_ENABLE_DUTYCYCLE_RECORD == 1)
+        gnrc_netif_t *netif = NULL;
+        netif = gnrc_netif_iter(netif);
+
+        msg_t msg;
+        msg.type = GNRC_MAC_TYPE_GET_DUTYCYCLE;
+        msg_send(&msg, netif->pid);
+#else
+        puts("MAC: radio duty-cycle unavailable.");
+#endif
+    }
+    else {
+        puts("error: invalid command");
+    }
+    return 0;
+}

--- a/examples/gnrc_networking_mac/main.c
+++ b/examples/gnrc_networking_mac/main.c
@@ -29,9 +29,11 @@
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 extern int udp_cmd(int argc, char **argv);
+extern int mac_cmd(int argc, char **argv);
 
 static const shell_command_t shell_commands[] = {
     { "udp", "send data over UDP and listen on UDP ports", udp_cmd },
+    { "mac", "get MAC protocol's internal information", mac_cmd },
     { NULL, NULL, NULL }
 };
 

--- a/sys/include/net/gnrc/gomach/types.h
+++ b/sys/include/net/gnrc/gomach/types.h
@@ -85,15 +85,6 @@ extern "C" {
 #define GNRC_GOMACH_TYPE_KNOWN             (1U)
 
 /**
- * @brief Enable/disable duty-cycle record and print out.
- *
- * Set "1" to enable, set "0" to disable.
- */
-#ifndef GNRC_GOMACH_ENABLE_DUTYCYLE_RECORD
-#define GNRC_GOMACH_ENABLE_DUTYCYLE_RECORD    (0U)
-#endif
-
-/**
  * @brief   State-machine states of Broadcast procedure of GoMacH.
  */
 typedef enum {
@@ -304,8 +295,7 @@ typedef struct gomach {
     uint8_t rx_pkt_lqi;                                         /**< LQI of latest received
                                                                      packet */
 
-
-#if (GNRC_GOMACH_ENABLE_DUTYCYLE_RECORD == 1)
+#if (GNRC_MAC_ENABLE_DUTYCYCLE_RECORD == 1)
     /* Parameters for recording duty-cycle */
     uint64_t last_radio_on_time_ticks;                          /**< The last time in ticks
                                                                      when radio is on */

--- a/sys/include/net/gnrc/mac/mac.h
+++ b/sys/include/net/gnrc/mac/mac.h
@@ -56,6 +56,15 @@ extern "C" {
 #define GNRC_MAC_TX_QUEUE_SIZE             (8U)
 #endif
 
+/**
+ * @brief Enable/disable MAC radio duty-cycle recording and displaying.
+ *
+ * Set "1" to enable, set "0" to disable.
+ */
+#ifndef GNRC_MAC_ENABLE_DUTYCYCLE_RECORD
+#define GNRC_MAC_ENABLE_DUTYCYCLE_RECORD    (1U)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -41,6 +41,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   MAC message type for getting radio's duty-cycle.
+ */
+#ifndef GNRC_MAC_TYPE_GET_DUTYCYCLE
+#define GNRC_MAC_TYPE_GET_DUTYCYCLE      (0x4401)
+#endif
+
+/**
  * @brief definition for device transmission feedback types
  */
 typedef enum {

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -2194,7 +2194,7 @@ static void _gomach_init(gnrc_netif_t *netif)
 
     netif->mac.tx.t2u_fail_count = 0;
 
-#if (GNRC_GOMACH_ENABLE_DUTYCYLE_RECORD == 1)
+#if (GNRC_MAC_ENABLE_DUTYCYCLE_RECORD == 1)
     /* Start duty cycle recording */
     netif->mac.prot.gomach.system_start_time_ticks = xtimer_now_usec64();
     netif->mac.prot.gomach.last_radio_on_time_ticks =

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -949,15 +949,6 @@ static void gomach_t2k_end(gnrc_netif_t *netif)
     netif->mac.rx.listen_state = GNRC_GOMACH_LISTEN_SLEEP;
     gnrc_gomach_set_enter_new_cycle(netif, false);
     gnrc_gomach_set_update(netif, true);
-
-#if (GNRC_GOMACH_ENABLE_DUTYCYLE_RECORD == 1)
-    /* Output duty-cycle ratio */
-    uint64_t duty;
-    duty = xtimer_now_usec64();
-    duty = (netif->mac.prot.gomach.awake_duration_sum_ticks) * 100 /
-           (duty - netif->mac.prot.gomach.system_start_time_ticks);
-    printf("[GoMacH]: achieved radio duty-cycle: %lu %% \n", (uint32_t)duty);
-#endif
 }
 
 static void gomach_t2k_update(gnrc_netif_t *netif)
@@ -1406,15 +1397,6 @@ static void gomach_t2u_end(gnrc_netif_t *netif)
     netif->mac.rx.listen_state = GNRC_GOMACH_LISTEN_SLEEP;
     gnrc_gomach_set_enter_new_cycle(netif, false);
     gnrc_gomach_set_update(netif, true);
-
-#if (GNRC_GOMACH_ENABLE_DUTYCYLE_RECORD == 1)
-    /* Output duty-cycle ratio */
-    uint64_t duty;
-    duty = xtimer_now_usec64();
-    duty = (netif->mac.prot.gomach.awake_duration_sum_ticks) * 100 /
-           (duty - netif->mac.prot.gomach.system_start_time_ticks);
-    printf("[GoMacH]: achieved radio duty-cycle: %lu %% \n", (uint32_t)duty);
-#endif
 }
 
 static void gomach_t2u_update(gnrc_netif_t *netif)
@@ -2004,6 +1986,17 @@ static void _gomach_msg_handler(gnrc_netif_t *netif, msg_t *msg)
             gnrc_gomach_set_update(netif, true);
             break;
         }
+#if (GNRC_MAC_ENABLE_DUTYCYCLE_RECORD == 1)
+        case GNRC_MAC_TYPE_GET_DUTYCYCLE: {
+            /* Output GoMacH's current radio duty-cycle. */
+            uint64_t duty;
+            duty = xtimer_now_usec64();
+            duty = (netif->mac.prot.gomach.awake_duration_sum_ticks) * 100 /
+                   (duty - netif->mac.prot.gomach.system_start_time_ticks);
+            printf("[GoMacH]: achieved radio duty-cycle: %lu %% \n", (uint32_t)duty);
+            break;
+        }
+#endif
         default: {
             DEBUG("[GoMacH]: Unknown command %" PRIu16 "\n", msg->type);
             break;


### PR DESCRIPTION
### Contribution description
Add a shell command to display GoMacH's current, achieved radio duty-cycle.

### Issues/PRs references

See also #8178.