### PR TITLE
tests/shell: disable DEVELHELP

### DIFF
--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -1,3 +1,4 @@
+DEVELHELP=0
 include ../Makefile.tests_common
 
 USEMODULE += shell


### PR DESCRIPTION
### Contribution description

This PR disables DEVELHELP for tests/shell.
Fixes tests assuming non-DEVELHELP ps output.

To test, try "make test" with and without this PR.
