### PR TITLE
net/gcoap: allow to not define a response handler

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -574,7 +574,7 @@ static inline ssize_t gcoap_request(coap_pkt_t *pdu, uint8_t *buf, size_t len,
  * @param[in] buf           Buffer containing the PDU
  * @param[in] len           Length of the buffer
  * @param[in] remote        Destination for the packet
- * @param[in] resp_handler  Callback when response received
+ * @param[in] resp_handler  Callback when response received, may be NULL
  *
  * @return  length of the packet
  * @return  0 if cannot send
@@ -592,7 +592,7 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
  * @param[in] len           Length of the buffer
  * @param[in] addr          Destination for the packet
  * @param[in] port          Port at the destination
- * @param[in] resp_handler  Callback when response received
+ * @param[in] resp_handler  Callback when response received, may be NULL
  *
  * @return  length of the packet
  * @return  0 if cannot send

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -200,7 +200,9 @@ static void _listen(sock_udp_t *sock)
             case COAP_TYPE_ACK:
                 xtimer_remove(&memo->response_timer);
                 memo->state = GCOAP_MEMO_RESP;
-                memo->resp_handler(memo->state, &pdu, &remote);
+                if (memo->resp_handler) {
+                    memo->resp_handler(memo->state, &pdu, &remote);
+                }
 
                 if (memo->send_limit >= 0) {        /* if confirmable */
                     *memo->msg.data.pdu_buf = 0;    /* clear resend PDU buffer */
@@ -749,7 +751,6 @@ size_t gcoap_req_send2(const uint8_t *buf, size_t len,
 {
     gcoap_request_memo_t *memo = NULL;
     assert(remote != NULL);
-    assert(resp_handler != NULL);
 
     /* Find empty slot in list of open requests. */
     mutex_lock(&_coap_state.lock);


### PR DESCRIPTION
### Contribution description
Sometimes it makes sense to send out CoAP packages without needing/wanting to act on any responses. So this PRs allows to parse a `NULL` pointer as response handler.

### Issues/PRs references
Cut out and needed for #7428 and #7406