### PR TITLE
murdock: initial hardware-in-the-loop support

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -1,13 +1,40 @@
 #!/bin/sh
 
+export TEST_BOARDS_AVAILABLE=${TEST_BOARDS_AVAILABLE:-"samr21-xpro"}
 export RIOT_CI_BUILD=1
 export STATIC_TESTS=${STATIC_TESTS:-1}
 export CFLAGS_DBG=""
 export DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
 
+NIGHTLY=${NIGHTLY:-0}
+RUN_TESTS=${RUN_TESTS:-${NIGHTLY}}
+
+check_label() {
+    local label="${1}"
+    [ -z "${CI_PULL_LABELS}" ] && return 1
+    echo "${CI_PULL_LABELS}" | grep -q "${label}"
+    return $?
+}
+
+[ "$RUN_TESTS" != "1" ] && {
+    check_label "CI: run tests" && RUN_TESTS=1
+}
+
 error() {
     echo "$@"
     exit 1
+}
+
+# true if word "$1" is in list of words "$2", false otherwise
+# uses grep -w, thus only alphanum and "_" count as word bounderies
+# (word "def" matches "abc-def")
+is_in_list() {
+    [ $# -ne 2 ] && return 1
+
+    local needle="$1"
+    local haystack="$2"
+
+    echo "$haystack" | grep -q -w "$needle"
 }
 
 _greplist() {
@@ -91,14 +118,23 @@ compile() {
     [ ! -d "$appdir" ] && error "$0: compile: error: application directory \"$appdir\" doesn't exist"
     [ ! -d "boards/$board" ] && error "$0: compile: error: board directory \"boards/$board\" doesn't exist"
 
+    # compile
     CCACHE_BASEDIR="$(pwd)" BOARD=$board RIOT_CI_BUILD=1 \
         make -C${appdir} clean all -j${JOBS:-4}
     RES=$?
 
+    # run tests
     if [ $RES -eq 0 ]; then
-        if [ "$board" = "native" -a "$appdir" = "tests/unittests" ]; then
-            make -C${appdir} test
-            RES=$?
+        if [ $RUN_TESTS -eq 1 -o "$board" = "native" ]; then
+            if [ -f "${BINDIR}/.test" ]; then
+                if [ "$board" = "native" ]; then
+                    BOARD=$board make -C${appdir} test
+                    RES=$?
+                elif is_in_list "$board" "$TEST_BOARDS_AVAILABLE"; then
+                    BOARD=$board make -C${appdir} test-murdock
+                    RES=$?
+                fi
+            fi
         fi
     fi
 
@@ -111,6 +147,32 @@ compile() {
     fi
 
     return $RES
+}
+
+test_job() {
+    local appdir=$1
+    local board=$2
+    local flashfile="$3"
+
+    [ ! -f "$flashfile" ] && {
+        echo "$0: _test(): flashfile \"$flashfile\" doesn't exist!"
+        return 1
+    }
+
+    dwqc \
+        ${DWQ_JOBID:+--subjob} \
+        --file $flashfile:$appdir/bin/${board}/$(basename $flashfile) \
+        --queue ${TEST_QUEUE:-$board} \
+        --maxfail 1 \
+        "./.murdock run_test $appdir $board"
+}
+
+run_test() {
+    local appdir=$1
+    local board=$2
+    print_worker
+    echo "-- executing tests for $appdir on $board:"
+    BOARD=$board make -C$appdir flash-only test
 }
 
 # execute static tests

--- a/Makefile.include
+++ b/Makefile.include
@@ -593,8 +593,12 @@ CFLAGS += -include '$(RIOTBUILD_CONFIG_HEADER_C)'
 # include mcuboot support
 include $(RIOTMAKE)/mcuboot.mk
 
+# include Murdock helpers
+include $(RIOTMAKE)/murdock.inc.mk
+
 # Sanity check, 'all' should be the default goal
 ifneq (all, $(.DEFAULT_GOAL))
   $(error .DEFAULT_GOAL := $(.DEFAULT_GOAL))
 endif
+
 endif # BOARD=none

--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -1,0 +1,6 @@
+test-murdock: link
+	cd $(RIOTBASE) && \
+		./.murdock make_test_job \
+		$$(realpath --relative-to $(RIOTBASE) $(APPDIR)) \
+		$(BOARD) \
+		$(HEXFILE)

--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -1,6 +1,36 @@
-test-murdock: link
+#
+# This file contains helper targets used by the CI.
+#
+
+# (HACK) get actual flash binary from FFLAGS.
+FLASHFILE:=$(filter $(HEXFILE) $(ELFFILE:.elf=.bin) $(ELFFILE),$(FFLAGS))
+
+#
+# This target will run "make test" on the CI cluster.
+#
+# In order to work, these requirements must be fulfilled:
+# - DWQ_REPO and DWQ_COMMIT are set correctly
+# - the user has set up autossh & proper authentication for connecting to the CI
+# (intended to be used by CI only for now)
+test-murdock:
 	cd $(RIOTBASE) && \
-		./.murdock make_test_job \
+		./.murdock test_job \
 		$$(realpath --relative-to $(RIOTBASE) $(APPDIR)) \
 		$(BOARD) \
-		$(HEXFILE)
+		$(FLASHFILE)
+
+# don't whitelist tests if there's no binary
+ifeq (1,$(RIOTNOLINK))
+  TEST_ON_CI_WHITELIST:=
+endif
+
+# create $(BINDIR)/.test file only if BOARD is in $(TEST_ON_CI_WHITELIST)
+.PHONY: $(BINDIR)/.test
+link: $(BINDIR)/.test
+$(BINDIR)/.test: $(filter clean, $(MAKECMDGOALS))
+ifneq (,$(filter $(BOARD) all, $(TEST_ON_CI_WHITELIST)))
+	$(Q)mkdir -p $(BINDIR)
+	$(Q)touch $@
+else
+	$(Q)rm -f $@
+endif

--- a/tests/bitarithm_timings/Makefile
+++ b/tests/bitarithm_timings/Makefile
@@ -2,6 +2,8 @@ include ../Makefile.tests_common
 
 USEMODULE += xtimer
 
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/bloom_bytes/Makefile
+++ b/tests/bloom_bytes/Makefile
@@ -10,6 +10,8 @@ USEMODULE += xtimer
 
 DISABLE_MODULE += auto_init
 
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/evtimer_msg/Makefile
+++ b/tests/evtimer_msg/Makefile
@@ -4,6 +4,8 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
 
 USEMODULE += evtimer
 
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/fmt_print/Makefile
+++ b/tests/fmt_print/Makefile
@@ -2,6 +2,8 @@ include ../Makefile.tests_common
 
 USEMODULE += fmt
 
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/mutex_order/Makefile
+++ b/tests/mutex_order/Makefile
@@ -3,6 +3,9 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f030 \
                              nucleo-l053 stm32f0discovery
 
+# list of boards to run CI tests on
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -227,11 +227,17 @@ BASELIBS += $(UNIT_TESTS:%=$(BINDIR)/%.a)
 
 INCLUDES += -I$(RIOTBASE)/tests/unittests/common
 
+# list of boards to run CI tests on
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 .PHONY: $(UNIT_TESTS)
 
 all:
+
+info-unittests:
+	@echo $(UNIT_TESTS)
 
 $(UNIT_TESTS): all
 


### PR DESCRIPTION
### Contribution description

This PR adds:

- the make target "test-murdock", which will run "make test" for the given board on murdock. (needs authentication to be set up)

- a per-application variable "TEST_WHITELIST", which is supposed to contain a list of boards on which CI should execute "make test".

- some code in ```.murdock``` that executes "make test" after successful compilation, on nightly builds or if the label "CI: run tests" is set.

Don't merge (yet), this needs a worker for every board in "TEST_WHITELIST", otherwise CI builds stall forever.