### PR TITLE
examples: move gnrc_border_router from UHCP to DHCPv6 setup

### DIFF
--- a/dist/tools/Makefile
+++ b/dist/tools/Makefile
@@ -1,4 +1,4 @@
-HOST_TOOLS=ethos uhcpd
+HOST_TOOLS=ethos
 
 .PHONY: all $(HOST_TOOLS)
 

--- a/dist/tools/ethos/start_network.sh
+++ b/dist/tools/ethos/start_network.sh
@@ -20,20 +20,13 @@ cleanup() {
     echo "Cleaning up..."
     remove_tap
     ip a d fd00:dead:beef::1/128 dev lo
-    kill ${UHCPD_PID}
     trap "" INT QUIT TERM EXIT
-}
-
-start_uhcpd() {
-    ${UHCPD} ${TAP} ${PREFIX} > /dev/null &
-    UHCPD_PID=$!
 }
 
 PORT=$1
 TAP=$2
 PREFIX=$3
 BAUDRATE=115200
-UHCPD="$(readlink -f "${ETHOS_DIR}/../uhcpd/bin")/uhcpd"
 
 [ -z "${PORT}" -o -z "${TAP}" -o -z "${PREFIX}" ] && {
     echo "usage: $0 <serial-port> <tap-device> <prefix> [baudrate]"
@@ -47,4 +40,4 @@ UHCPD="$(readlink -f "${ETHOS_DIR}/../uhcpd/bin")/uhcpd"
 trap "cleanup" INT QUIT TERM EXIT
 
 
-create_tap && start_uhcpd && "${ETHOS_DIR}/ethos" ${TAP} ${PORT} ${BAUDRATE}
+create_tap && "${ETHOS_DIR}/ethos" ${TAP} ${PORT} ${BAUDRATE}

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -7,6 +7,8 @@ BOARD ?= samr21-xpro
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
+CFLAGS=-DGNRC_NETIF_IPV6_GROUPS_NUMOF=5
+
 # use ethos (ethernet over serial) for network communication and stdio over
 # UART, but not on native, as native has a tap interface towards the host.
 ifeq (,$(filter native,$(BOARD)))
@@ -52,11 +54,12 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
-# include UHCP client
-USEMODULE += gnrc_uhcpc
+# include DHCPv6 client
+USEMODULE += gnrc_dhcpv6_client
 
-# Optionally include RPL as a routing protocol. When includede gnrc_uhcpc will
-# configure the node as a RPL DODAG root when receiving a prefix.
+# Optionally include RPL as a routing protocol. When including
+# gnrc_dhcpv6_client will configure the node as a RPL DODAG root when receiving
+# a prefix.
 #USEMODULE += gnrc_rpl
 
 # Comment this out to disable code in RIOT that does safety checking
@@ -67,16 +70,9 @@ DEVELHELP ?= 1
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 TAP ?= tap0
-IPV6_PREFIX ?= 2001:db8::/64
+IPV6_PREFIX ?= 2001:db8::/32
 
-ifeq (native,$(BOARD))
-TERMDEPS += uhcpd-daemon
-
-.PHONY: uhcpd-daemon
-
-uhcpd-daemon: host-tools
-	$(RIOTTOOLS)/uhcpd/bin/uhcpd $(TAP) $(IPV6_PREFIX) &
-else
+ifneq (native,$(BOARD))
 # We override the `make term` command to use ethos
 TERMPROG ?= sudo sh $(RIOTTOOLS)/ethos/start_network.sh
 TERMFLAGS ?= $(PORT) $(TAP) $(IPV6_PREFIX)

--- a/examples/gnrc_border_router/main.c
+++ b/examples/gnrc_border_router/main.c
@@ -18,13 +18,72 @@
  * @}
  */
 
+#include <assert.h>
 #include <stdio.h>
 
+#include "event.h"
+#include "net/dhcpv6/client.h"
+#include "net/ipv6/addr.h"
+#include "net/gnrc.h"
+#include "net/gnrc/ipv6/nib/ft.h"
 #include "shell.h"
 #include "msg.h"
 
 #define MAIN_QUEUE_SIZE     (8)
+static char _dhcpv6_client_stack[DHCPV6_CLIENT_STACK_SIZE];
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+void *_dhcpv6_client_thread(void *args)
+{
+    ipv6_addr_t addr = {
+            .u8 = { 0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }
+        };
+
+    event_queue_t event_queue;
+    gnrc_netif_t *border_interface = NULL;
+    gnrc_netif_t *wpan_interface = NULL;
+    gnrc_netif_t *netif = NULL;
+
+    (void)args;
+    /* iterate over all interfaces */
+    while ((netif = gnrc_netif_iter(netif))) {
+        /* check if interface is wired */
+        int is_wired = gnrc_netapi_get(netif->pid, NETOPT_IS_WIRED, 0, NULL, 0);
+
+        /* use wired interface as "border" interface (facing to an upstream
+         * router) */
+        if ((border_interface == NULL) && (is_wired == 1)) {
+            border_interface = netif;
+        }
+        /* use wireless interface as WPAN interface (facing to the WPAN) */
+        else if ((wpan_interface == NULL) && (is_wired != 1)) {
+            wpan_interface = netif;
+        }
+        /* we found two interfaces => stop searching */
+        if ((border_interface != NULL) && (wpan_interface != NULL)) {
+            break;
+        }
+    }
+    /* the border router application assumes both interfaces have been found */
+    assert((border_interface != NULL) && (wpan_interface != NULL));
+    /* set default route to host machine (as set-up in setup_network.sh) */
+    gnrc_ipv6_nib_ft_add(NULL, 0, &addr, border_interface->pid, 0);
+    /* set additional link-local address to allow for easy static route
+     * configuration */
+    addr.u8[15] = 2;
+    gnrc_netif_ipv6_addr_add(border_interface, &addr, 64, 0);
+    /* initialize client event queue */
+    event_queue_init(&event_queue);
+    /* initialize DHCPv6 client on border interface */
+    dhcpv6_client_init(&event_queue, border_interface->pid);
+    /* configure client to request prefix delegation for WPAN interface */
+    dhcpv6_client_req_ia_pd(wpan_interface->pid, 64U);
+    /* start DHCPv6 client */
+    dhcpv6_client_start();
+    /* start event loop of DHCPv6 client */
+    event_loop(&event_queue);   /* never returns */
+    return NULL;
+}
 
 int main(void)
 {
@@ -33,6 +92,11 @@ int main(void)
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
     puts("RIOT border router example application");
 
+    /* start DHCPv6 client thread to request prefix for WPAN */
+    thread_create(_dhcpv6_client_stack, DHCPV6_CLIENT_STACK_SIZE,
+                  DHCPV6_CLIENT_PRIORITY,
+                  THREAD_CREATE_STACKTEST,
+                  _dhcpv6_client_thread, NULL, "dhcpv6-client");
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];


### PR DESCRIPTION
### Contribution description
Now that we have DHCPv6 support (see #8796) we can move our border router implementation from the proprietary UHCP to DHCPv6 configuration.

### Issues/PRs references
Depends on #8796.