### PR TITLE
ethos: add periph_uart as dependency

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -112,6 +112,7 @@ ifneq (,$(filter encx24j600,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ethos,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_uart
   USEMODULE += iolist
   USEMODULE += netdev_eth
   USEMODULE += random

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -28,7 +28,6 @@ ifeq (,$(filter native,$(BOARD)))
   # ethos baudrate can be configured from make command
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE) -DUSE_ETHOS_FOR_STDIO
-  FEATURES_REQUIRED += periph_uart
 else
   GNRC_NETIF_NUMOF := 2
   TERMFLAGS += -z [::1]:17754


### PR DESCRIPTION
`ethos` should have `periph_uart` as a dependency.

@kaspar030 could you maybe review?