### PR TITLE
nucleo-f4xx: increase xtimer backoff to 7 for F4 family

### DIFF
--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -53,7 +53,7 @@ extern "C" {
 #endif
 
 #if defined(CPU_FAM_STM32F4) || defined(CPU_MODEL_STM32F303ZE)
-#define XTIMER_BACKOFF              (5)
+#define XTIMER_BACKOFF              (8)
 #define XTIMER_OVERHEAD             (6)
 #endif
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`XTIMER_BACKOFF` is defined with a very low value which fails at 7us for xtimer_sleep on the F4 nucleo family.

This PR increases it to 7 which makes all tests pass.

Tested on:
- [ ] f4vi1
- [ ] msbiot
- [x] nucleo-f401
- [x] nucleo-f446
- [x] nucleo-f303ze
- [x] nucleo-f410
- [ ] nucleo-f411
- [x] nucleo144-f412
- [ ] nucleo144-f413
- [x] nucleo144-f429
- [x] nucleo144-f446
- [x] stm32f4discovery

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#7347 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->