### PR TITLE
cpu/atmega_common: use __temp_reg__

### DIFF
--- a/cpu/atmega_common/include/cpu.h
+++ b/cpu/atmega_common/include/cpu.h
@@ -74,25 +74,20 @@ void cpu_init(void);
 
 /**
  * @brief   Print the last instruction's address
- *
- * @todo:   Not supported
  */
-static inline void cpu_print_last_instruction(void)
+__attribute__((always_inline)) static inline void cpu_print_last_instruction(void)
 {
     uint8_t hi;
     uint8_t lo;
     uint16_t ptr;
 
-    __asm__ volatile( "in r0, __SP_H__; \n\t"
-                      "mov %0, r0       \n\t"
-                             : "=g"(hi)
-                             :
-                             : "r0");
-    __asm__ volatile( "in r0, __SP_L__; \n\t"
-                      "mov %0, r0       \n\t"
-                             : "=g"(lo)
-                             :
-                             : "r0");
+    __asm__ volatile( "in __tmp_reg__, __SP_H__  \n\t"
+                      "mov %0, __tmp_reg__       \n\t"
+                      : "=g"(hi) );
+
+    __asm__ volatile( "in __tmp_reg__, __SP_L__  \n\t"
+                      "mov %0, __tmp_reg__       \n\t"
+                      : "=g"(lo) );
     ptr = hi<<8 | lo;
     printf("Stack Pointer: 0x%04x\n", ptr);
 }

--- a/cpu/atmega_common/irq_arch.c
+++ b/cpu/atmega_common/irq_arch.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * @}
  */
@@ -35,24 +37,22 @@ volatile uint8_t __in_isr = 0;
 __attribute__((always_inline)) static inline uint8_t  __get_interrupt_state(void)
 {
     uint8_t sreg;
-    __asm__ volatile("in r0, __SREG__; \n\t"
-                 "mov %0, r0       \n\t"
-                 : "=g"(sreg)
-                 :
-                 : "r0");
+    __asm__ volatile( "in __tmp_reg__, __SREG__ \n\t"
+                      "mov %0, __tmp_reg__      \n\t"
+                      : "=g"(sreg) );
     return sreg & (1 << 7);
 }
 
 __attribute__((always_inline)) inline void __set_interrupt_state(uint8_t state)
 {
-    __asm__ volatile("mov r15,%0;       \n\t"
-                 "in r16, __SREG__; \n\t"
-                 "cbr r16,7;        \n\t"
-                 "or r15,r16;       \n\t"
-                 "out __SREG__, r15 \n\t"
-                 :
-                 : "g"(state)
-                 : "r15", "r16");
+    __asm__ volatile( "mov r15,%0        \n\t"
+                      "in r16, __SREG__  \n\t"
+                      "cbr r16,7         \n\t"
+                      "or r15,r16        \n\t"
+                      "out __SREG__, r15 \n\t"
+                      :
+                      : "g"(state)
+                      : "r15", "r16");
 }
 
 /**

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Implementation of the kernel's architecture dependent thread interface
  *
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * @}
  */
@@ -261,17 +263,17 @@ ISR(AVR_CONTEXT_SWAP_INTERRUPT_VECT, ISR_NAKED) {
 __attribute__((always_inline)) static inline void __context_save(void)
 {
     __asm__ volatile(
-        "push r0                             \n\t"
-        "in   r0, __SREG__                   \n\t"
+        "push __tmp_reg__                    \n\t"
+        "in   __tmp_reg__, __SREG__          \n\t"
         "cli                                 \n\t"
-        "push r0                             \n\t"
+        "push __tmp_reg__                    \n\t"
 #if defined(RAMPZ)
-        "in     r0, __RAMPZ__                \n\t"
-        "push   r0                           \n\t"
+        "in     __tmp_reg__, __RAMPZ__       \n\t"
+        "push   __tmp_reg__                  \n\t"
 #endif
 #if defined(EIND)
-        "in     r0, 0x3c                     \n\t"
-        "push   r0                           \n\t"
+        "in     __tmp_reg__, 0x3c            \n\t"
+        "push   __tmp_reg__                  \n\t"
 #endif
         "push r1                             \n\t"
         "clr  r1                             \n\t"
@@ -307,10 +309,10 @@ __attribute__((always_inline)) static inline void __context_save(void)
         "push r31                            \n\t"
         "lds  r26, sched_active_thread       \n\t"
         "lds  r27, sched_active_thread + 1   \n\t"
-        "in   r0, __SP_L__                   \n\t"
-        "st   x+, r0                         \n\t"
-        "in   r0, __SP_H__                   \n\t"
-        "st   x+, r0                         \n\t"
+        "in   __tmp_reg__, __SP_L__          \n\t"
+        "st   x+, __tmp_reg__                \n\t"
+        "in   __tmp_reg__, __SP_H__          \n\t"
+        "st   x+, __tmp_reg__                \n\t"
     );
 
 }
@@ -356,15 +358,15 @@ __attribute__((always_inline)) static inline void __context_restore(void)
         "pop  r2                             \n\t"
         "pop  r1                             \n\t"
 #if defined(EIND)
-        "pop    r0                           \n\t"
-        "out    0x3c, r0                     \n\t"
+        "pop    __tmp_reg__                  \n\t"
+        "out    0x3c, __tmp_reg__            \n\t"
 #endif
 #if defined(RAMPZ)
-        "pop    r0                           \n\t"
-        "out    __RAMPZ__, r0                \n\t"
+        "pop    __tmp_reg__                  \n\t"
+        "out    __RAMPZ__, __tmp_reg__       \n\t"
 #endif
-        "pop  r0                             \n\t"
-        "out  __SREG__, r0                   \n\t"
-        "pop  r0                             \n\t"
+        "pop  __tmp_reg__                    \n\t"
+        "out  __SREG__, __tmp_reg__          \n\t"
+        "pop  __tmp_reg__                    \n\t"
     );
 }


### PR DESCRIPTION
Using __temp_reg__ in assebler code to ensure proper working in future.