### PR TITLE
pkg/cayenne-lpp: add support for Cayenne LPP format

### DIFF
--- a/pkg/cayenne-lpp/Makefile
+++ b/pkg/cayenne-lpp/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=cayenne-lpp
+PKG_URL=https://github.com/aabadie/cayenne-lpp
+PKG_VERSION=ad3aa26043e221eda28ac3da2484e1ef84986442
+PKG_LICENSE=LGPLv2.1
+
+.PHONY: all
+
+all: git-download
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/cayenne-lpp/Makefile.cayenne-lpp
+++ b/pkg/cayenne-lpp/Makefile.cayenne-lpp
@@ -1,0 +1,3 @@
+MODULE = cayenne-lpp
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/cayenne-lpp/Makefile.include
+++ b/pkg/cayenne-lpp/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(PKGDIRBASE)/cayenne-lpp

--- a/pkg/cayenne-lpp/doc.txt
+++ b/pkg/cayenne-lpp/doc.txt
@@ -1,0 +1,14 @@
+/**
+ * @defgroup pkg_cayenne-lpp Cayenne Low Power Payload (LPP)
+ * @ingroup  pkg
+ * @ingroup  sys
+ * @brief    Provides a RIOT support for Cayenne LPP format
+ *
+ * The Cayenne Low Power Payload (LPP) provides a convenient and easy way to
+ * send data over LPWAN networks such as LoRaWAN.
+ *
+ * For more details on the format, see
+ * https://mydevices.com/cayenne/docs_stage/lora/#lora-cayenne-low-power-payload
+ *
+ * @see      https://github.com/aabadie/cayenne-lpp
+ */

--- a/tests/pkg_cayenne-lpp/Makefile
+++ b/tests/pkg_cayenne-lpp/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+USEPKG += cayenne-lpp
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/pkg_cayenne-lpp/README.md
+++ b/tests/pkg_cayenne-lpp/README.md
@@ -1,0 +1,17 @@
+Cayenne LPP test
+================
+
+Usage
+-----
+
+Simply run the application on native using:
+
+    make all term
+
+Expected result
+---------------
+
+The application should display the following output:
+
+    Cayenne LPP test application
+    03670110056700FF

--- a/tests/pkg_cayenne-lpp/main.c
+++ b/tests/pkg_cayenne-lpp/main.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     test
+ * @{
+ *
+ * @file
+ * @brief       Cayenne Low Power Payload example application
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "cayenne_lpp.h"
+
+static cayenne_lpp_t lpp;
+
+static void _print_buffer(cayenne_lpp_t *lpp)
+{
+    for (uint8_t i = 0; i < lpp->cursor; ++i) {
+        printf("%02X", lpp->buffer[i]);
+    }
+    puts("");
+}
+
+int main(void)
+{
+    puts("Cayenne LPP test application");
+
+    /* generate payload like the one given as example at
+     * https://mydevices.com/cayenne/docs_stage/lora/#lora-cayenne-low-power-payload
+     */
+    /* Device with 2 temperature sensors */
+    cayenne_lpp_add_temperature(&lpp, 3, 27.2);
+    cayenne_lpp_add_temperature(&lpp, 5, 25.5);
+    _print_buffer(&lpp);
+
+    /* Device with temperature and acceleration sensors */
+    cayenne_lpp_reset(&lpp);
+    cayenne_lpp_add_temperature(&lpp, 1, -4.1);
+    cayenne_lpp_add_accelerometer(&lpp, 6, 1.234, -1.234, 0);
+    _print_buffer(&lpp);
+
+    /* Device with GPS */
+    cayenne_lpp_reset(&lpp);
+    cayenne_lpp_add_gps(&lpp, 1, 42.3519, -87.9094, 10);
+    _print_buffer(&lpp);
+
+    return 0;
+}

--- a/tests/pkg_cayenne-lpp/tests/01-run.py
+++ b/tests/pkg_cayenne-lpp/tests/01-run.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect_exact('03670110056700FF')
+    child.expect_exact('0167FFD8067104D1FB2F0000')
+    child.expect_exact('018806765EF2960A0003E8')
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for generating payload compatible with [Cayenne](https://mydevices.com/), a web IoT dashboard builder. 
To nicely integrate into Cayenne, the payload must be compatible with the Cayenne Low Power Payload (LPP) format. This format mainly targets LoRaWAN networks and details about the format are available online here: https://mydevices.com/cayenne/docs_stage/lora/#lora-cayenne-low-power-payload

The payload format is generated using an external library on github: https://github.com/aabadie/cayenne-lpp and this PR just imports it in RIOT as a package.

A basic test application is provided.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->