### PR TITLE
boards: stm32f4discovery: include: periph_conf.h: Change I2C_0_SDA_PIN

### DIFF
--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -259,7 +259,7 @@ static const spi_conf_t spi_config[] = {
 #define I2C_0_SCL_AF        4
 #define I2C_0_SCL_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 #define I2C_0_SDA_PORT      GPIOB
-#define I2C_0_SDA_PIN       7
+#define I2C_0_SDA_PIN       9
 #define I2C_0_SDA_AF        4
 #define I2C_0_SDA_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
 /** @} */


### PR DESCRIPTION
The STM32F4DISCOVERY on-board I2C peripheral CS43L22 is connected
to PB6 (SCL) and PB9 (SDA). Both pins have external 4.7K pull-up
resistors and are ready for I2C communication by default. The
default RIOT configuration uses PB7 as SDA pin which makes first
I2C bus bring up unnecessarily complicated.

* Change #define for I2C_0_SDA_PIN from 7 to 9

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->