### PR TITLE
cpu/kinetis: Refactor LPTMR timer implementation

### DIFF
--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -80,11 +80,13 @@ static const clock_config_t clock_config = {
     },                           \
 }
 #define LPTMR_NUMOF             (1U)
-#define LPTMR_CONFIG {           \
-    {                            \
-        .dev = LPTMR0,           \
-        .irqn = LPTMR0_IRQn,     \
-    }                            \
+#define LPTMR_CONFIG {          \
+    {                           \
+        .dev = LPTMR0,          \
+        .irqn = LPTMR0_IRQn,    \
+        .src = 2,               \
+        .base_freq = 32768u,    \
+    },                          \
 }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -88,6 +88,8 @@ static const clock_config_t clock_config = {
         { \
             .dev = LPTMR0, \
             .irqn = LPTMR0_IRQn, \
+            .src = 2, \
+            .base_freq = 32768u, \
         } \
     }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -107,6 +107,8 @@ static const clock_config_t clock_config = {
         { \
             .dev = LPTMR0, \
             .irqn = LPTMR0_IRQn, \
+            .src = 2, \
+            .base_freq = 32768u, \
         } \
     }
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))

--- a/cpu/kinetis/Makefile.dep
+++ b/cpu/kinetis/Makefile.dep
@@ -1,8 +1,3 @@
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
   USEMODULE += periph_rtt
 endif
-ifneq (,$(filter periph_timer,$(USEMODULE)))
-  # RTT is used as the time base for the LPTMR driver.
-  # TODO: Remove when LPTMR is refactored.
-  FEATURES_OPTIONAL += periph_rtt
-endif

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -293,6 +293,10 @@ typedef struct {
 typedef struct {
     /** LPTMR device base pointer */
     LPTMR_Type *dev;
+    /** Input clock frequency */
+    uint32_t base_freq;
+    /** Clock source setting */
+    uint8_t src;
     /** IRQn interrupt number */
     uint8_t irqn;
 } lptmr_conf_t;


### PR DESCRIPTION
### Contribution description

Refactor Kinetis LPTMR driver to use freerunning counter mode (TFC flag) and get rid of the RTT subtick counter dependency in the implementation.

Comparison between the bench_periph_timer results before and after reveal that the problem reported in #8532 is fixed, and the new implementation provides results which are close to optimal for a 32768 Hz timer.

### Issues/PRs references

Fixes #8532 
Uses #8531 for benchmarking
Depends on #8928 

### Result comparison

#### Good results with this PR

```
------------- BEGIN STATISTICS --------------
Limits: mean: [-41, 41], variance: [58, 99]
Target error (actual trigger time - expected trigger time), in reference timer ticks
positive: timer is late, negative: timer is early
=== timer_set running ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:   25705    455646      2002373      2    35    17     77
   3 -    4:   25533    457326      1973191      2    35    17     77
   5 -    8:   25412    451046      1970014      2    35    17     77
   9 -   16:   25699    458563      2017198      2    36    17     78
  17 -   32:   25832    457768      2018909      1    35    17     78
  33 -   64:   25758    440454      1978830      1    35    17     76
  65 -  128:   25335    414320      1942196      0    34    16     76
 129 -  256:   25254    367689      1979616     -3    32    14     78
 257 -  512:   25677    285822      2020736     -7    31    11     78
      TOTAL   230205   3788634     18459378     -7    36    16     80
=== timer_set resched ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:   25369    484188      2000763      2    38    19     78
   3 -    4:   25188    509764      1958162      4    36    20     77
   5 -    8:   25546    513382      1994162      4    36    20     78
   9 -   16:   25491    515802      1980773      4    36    20     77
  17 -   32:   25565    513309      1976695      4    36    20     77
  33 -   64:   25536    497785      1975338      3    36    19     77
  65 -  128:   25226    469163      1978715      2    35    18     78
 129 -  256:   25580    433869      1984646      0    34    16     77
 257 -  512:   25562    344196      2051719     -5    32    13     80
      TOTAL   229063   4281458     20398742     -5    38    18     89
=== timer_set stopped ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:   25358    414569      1978321      0    32    16     78
   3 -    4:   25425    417915      1985722      0    32    16     78
   5 -    8:   25528    419527      1979459      0    32    16     77
   9 -   16:   25654    420564      1991475      0    32    16     77
  17 -   32:   25704    416362      2005219      0    32    16     78
  33 -   64:   25373    399093      1984943     -1    32    15     78
  65 -  128:   25514    380799      2005983     -2    31    14     78
 129 -  256:   25707    340960      2017901     -4    30    13     78
 257 -  512:   25464    248312      2017071     -9    28     9     79
      TOTAL   229727   3458101     17502440     -9    32    15     76
=== timer_set resched, stopped ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:   25383    414739      1975450      0    32    16     77
   3 -    4:   25207    414519      1952349      0    33    16     77
   5 -    8:   25480    417808      1971313      0    32    16     77
   9 -   16:   25624    423082      1986321      0    33    16     77
  17 -   32:   25686    414774      1995632      0    33    16     77
  33 -   64:   25432    399469      1976666     -1    32    15     77
  65 -  128:   25601    379594      1986523     -1    31    14     77
 129 -  256:   25608    336491      2015353     -4    30    13     78
 257 -  512:   25649    246195      2060183     -9    28     9     80
      TOTAL   229670   3446671     17474966     -9    33    15     76
=== timer_set_absolute running ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:   25776    373865      1991879     -2    36    14     77
   3 -    4:   25642    373980      1988302     -1    36    14     77
   5 -    8:   25357    370226      1974292     -2    36    14     77
   9 -   16:   25407    371825      1992329     -2    36    14     78
  17 -   32:   25362    366265      1979713     -2    37    14     78
  33 -   64:   25119    351246      1967622     -3    35    13     78
  65 -  128:   25569    334769      1990278     -4    35    13     77
 129 -  256:   25669    292687      2005469     -6    33    11     78
 257 -  512:   25236    198456      2032245    -10    31     7     80
      TOTAL   229137   3033319     18002180    -10    37    13     78
=== timer_set_absolute resched ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:   25799    424871      2414532     -2    40    16     93
   3 -    4:   25479    447482      2483982     -1    37    17     97
   5 -    8:   25534    449205      2467643     -2    37    17     96
   9 -   16:   25323    446661      2460755     -1    37    17     97
  17 -   32:   25471    440200      2464165     -2    37    17     96
  33 -   64:   25444    426795      2472679     -3    36    16     97
  65 -  128:   25568    410044      2484737     -4    36    16     97
 129 -  256:   25349    362396      2517640     -6    35    14     99
 257 -  512:   25559    278883      2547384    -10    32    10     99
      TOTAL   229526   3686537     21698975    -10    40    16     94
=== timer_set_absolute stopped ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:   25394    415090      1992582      0    32    16     78
   3 -    4:   25510    422025      1982785      0    33    16     77
   5 -    8:   25503    417777      1987370      0    32    16     77
   9 -   16:   25561    420641      1994500      0    33    16     78
  17 -   32:   25464    415338      1999564      0    32    16     78
  33 -   64:   25421    400033      1972944     -1    32    15     77
  65 -  128:   25365    379725      1983130     -1    31    14     78
 129 -  256:   25430    336270      1976137     -4    30    13     77
 257 -  512:   25603    247256      2058653     -9    28     9     80
      TOTAL   229251   3454155     17502735     -9    33    15     76
=== timer_set_absolute resched, stopped ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:   25389    413249      1967576      0    32    16     77
   3 -    4:   25448    419741      2000263      1    33    16     78
   5 -    8:   25537    417992      1988075      0    33    16     77
   9 -   16:   25345    416417      1998092      0    33    16     78
  17 -   32:   25264    410541      1982664      0    32    16     78
  33 -   64:   25554    402257      1993152     -1    32    15     78
  65 -  128:   25597    379344      2036834     -2    32    14     79
 129 -  256:   25714    338831      2036091     -4    30    13     79
 257 -  512:   25532    247781      2057582     -9    28     9     80
      TOTAL   229380   3446153     17594577     -9    33    15     76
=== timer_read statistics ===
Limits: mean: [-10, 10], variance: [0, 16]
timer_read error (TUT time elapsed - expected TUT interval), in timer under test ticks
positive: timer target handling is slow, negative: timer_read is dropping ticks
function              count       sum       sum_sq    min   max  mean  variance
 timer_set           917489     55527        55527      0     1     0      0
  running            229922     24323        24323      0     1     0      0
  resched            228769     31204        31204      0     1     0      0
  stopped            229430         0            0      0     0     0      0
  resched, stopped   229368         0            0      0     0     0      0

 timer_set_absolute  916098     11371        11371      0     1     0      0
  running            228833       174          174      0     1     0      0
  resched            229218     11197        11197      0     1     0      0
  stopped            228979         0            0      0     0     0      0
  resched, stopped   229068         0            0      0     0     0      0
-------------- END STATISTICS ---------------
```

#### Bad results from current master
```
------------- BEGIN STATISTICS --------------
Limits: mean: [-41, 41], variance: [58, 99]
Target error (actual trigger time - expected trigger time), in reference timer ticks
positive: timer is late, negative: timer is early
=== timer_set running ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:  151759   8169157     12000186     38    70    53     79  <=== SIC!
   3 -    4:  152055   8188904     11862848     38    70    53     78  <=== SIC!
   5 -    8:  152649   8220089     11964135     38    70    53     78  <=== SIC!
   9 -   16:  152496   8206005     11959285     38    70    53     78  <=== SIC!
  17 -   32:  152474   8190871     11969389     37    70    53     78  <=== SIC!
  33 -   64:  152804   8122016     11896317     37    70    53     77  <=== SIC!
  65 -  128:  152317   7964069     11850482     35    69    52     77  <=== SIC!
 129 -  256:  151744   7682948     11946216     33    68    50     78  <=== SIC!
 257 -  512:  151983   7160562     12116871     28    66    47     79  <=== SIC!
      TOTAL  1370281  71904621    105494065     28    70    52     76  <=== SIC!
=== timer_set resched ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:  152263   8206204     12010296     38    70    53     78  <=== SIC!
   3 -    4:  152116   8204391     11931688     38    70    53     78  <=== SIC!
   5 -    8:  152067   8198164     11950671     38    70    53     78  <=== SIC!
   9 -   16:  151560   8167391     11919235     38    70    53     78  <=== SIC!
  17 -   32:  152329   8185912     11909493     37    70    53     78  <=== SIC!
  33 -   64:  151503   8062216     11803110     37    70    53     77  <=== SIC!
  65 -  128:  152167   7970259     11895465     36    69    52     78  <=== SIC!
 129 -  256:  152349   7724101     11986967     33    68    50     78  <=== SIC!
 257 -  512:  152399   7191203     12110072     29    65    47     79  <=== SIC!
      TOTAL  1368753  71909841    105137058     29    70    52     76  <=== SIC!
=== timer_set stopped ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:  152436   7912342     12041099     36    68    51     78  <=== SIC!
   3 -    4:  151847   7889039     11893236     36    68    51     78  <=== SIC!
   5 -    8:  152534   7913327     11961832     36    68    51     78  <=== SIC!
   9 -   16:  152352   7908221     11996378     36    68    51     78  <=== SIC!
  17 -   32:  152812   7905451     11944996     35    68    51     78  <=== SIC!
  33 -   64:  152378   7807559     11859982     35    68    51     77  <=== SIC!
  65 -  128:  151639   7642262     11814410     33    67    50     77  <=== SIC!
 129 -  256:  152308   7414758     11989057     31    66    48     78  <=== SIC!
 257 -  512:  152385   6884889     12119216     26    64    45     79  <=== SIC!
      TOTAL  1370691  69277848    105702184     26    68    50     77  <=== SIC!
=== timer_set resched, stopped ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:  152208   7904077     12032672     36    68    51     79  <=== SIC!
   3 -    4:  151731   7879622     11898309     36    68    51     78  <=== SIC!
   5 -    8:  152203   7891337     11922765     36    68    51     78  <=== SIC!
   9 -   16:  152467   7911684     11929837     36    68    51     78  <=== SIC!
  17 -   32:  152308   7877985     11948695     35    68    51     78  <=== SIC!
  33 -   64:  152108   7796425     11837918     34    68    51     77  <=== SIC!
  65 -  128:  152676   7691983     11944369     33    67    50     78  <=== SIC!
 129 -  256:  152726   7436216     12081218     31    66    48     79  <=== SIC!
 257 -  512:  152747   6903408     12155173     26    64    45     79  <=== SIC!
      TOTAL  1371174  69292737    105622614     26    68    50     77  <=== SIC!
=== timer_set_absolute running ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:  152169 100035262  13265840288     38 769948   657  87178  <=== SIC!
   3 -    4:  152310 104565512  16674414583     38 770314   686 109477  <=== SIC!
   5 -    8:  152079 100886958  14712273714     38 770159   663  96741  <=== SIC!
   9 -   16:  151633  96223372  18396187268     38 771686   634 121321  <=== SIC!
  17 -   32:  152117 104125759  17832726202     37 769975   684 117231  <=== SIC!
  33 -   64:  152298  97972418  13799844569     37 764547   643  90611  <=== SIC!
  65 -  128:  152301 103208853  13581175382     36 767945   677  89173  <=== SIC!
 129 -  256:  152145  99984338  15878683026     33 770257   657 104366  <=== SIC!
 257 -  512:  152115 103898360  20273313407     29 770751   683 133277  <=== SIC!
      TOTAL  1369167 910900832 144757151884     29 771686   665 105726  <=== SIC!
=== timer_set_absolute resched ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:  152217  82324291  13339518497     38  1071   540  87635  <=== SIC!
   3 -    4:  152199  82254909  13301794832     38  1071   540  87397  <=== SIC!
   5 -    8:  152023  82085454  13264873203     38  1071   539  87256  <=== SIC!
   9 -   16:  152156  82236539  13265351119     38  1071   540  87183  <=== SIC!
  17 -   32:  152639  82606815  13267666812     38  1071   541  86922  <=== SIC!
  33 -   64:  151883  81836155  13268661551     37  1070   538  87361  <=== SIC!
  65 -  128:  152114  82151495  13228100922     36  1070   540  86962  <=== SIC!
 129 -  256:  152363  81806042  13278055359     34  1069   536  87148  <=== SIC!
 257 -  512:  152360  81235185  13303811951     29  1066   533  87318  <=== SIC!
      TOTAL  1369954 738536885 119197349719     29  1071   539  87008  <=== SIC!
=== timer_set_absolute stopped ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:  151970   7886761     11976801     36    68    51     78  <=== SIC!
   3 -    4:  152623   7927814     11957032     36    68    51     78  <=== SIC!
   5 -    8:  152094   7893198     11954578     36    68    51     78  <=== SIC!
   9 -   16:  152332   7901961     11912402     36    68    51     78  <=== SIC!
  17 -   32:  152049   7872382     11920405     35    68    51     78  <=== SIC!
  33 -   64:  152091   7793251     11879647     35    68    51     78  <=== SIC!
  65 -  128:  151448   7632631     11788810     33    67    50     77  <=== SIC!
 129 -  256:  151484   7372482     11974362     31    66    48     79  <=== SIC!
 257 -  512:  152537   6894721     12136568     27    64    45     79  <=== SIC!
      TOTAL  1368628  69175201    105557403     27    68    50     77  <=== SIC!
=== timer_set_absolute resched, stopped ===
   interval    count       sum       sum_sq    min   max  mean  variance
   1 -    2:  151667   7869652     11991800     36    68    51     79  <=== SIC!
   3 -    4:  152199   7904472     11890810     36    68    51     78  <=== SIC!
   5 -    8:  151810   7875692     11913674     36    68    51     78  <=== SIC!
   9 -   16:  152234   7900578     11901225     36    68    51     78  <=== SIC!
  17 -   32:  152066   7867827     11935234     35    68    51     78  <=== SIC!
  33 -   64:  152339   7802074     11834613     35    68    51     77  <=== SIC!
  65 -  128:  152770   7707041     11946908     33    67    50     78  <=== SIC!
 129 -  256:  152918   7446933     12037469     31    66    48     78  <=== SIC!
 257 -  512:  152815   6904741     12163831     27    63    45     79  <=== SIC!
      TOTAL  1370818  69279010    105418288     27    68    50     76  <=== SIC!
=== timer_read statistics ===
Limits: mean: [-10, 10], variance: [0, 16]
timer_read error (TUT time elapsed - expected TUT interval), in timer under test ticks
positive: timer target handling is slow, negative: timer_read is dropping ticks
function              count       sum       sum_sq    min   max  mean  variance
 timer_set          5472033 102022565   2050417904      1    69    18    374  <=== SIC!
  running           1368442   2984851       247967      2     3     2      0
  resched           1366940   3052688       362365      1     4     2      0
  stopped           1368087  47995591    257083445      1    69    35    187  <=== SIC!
  resched, stopped  1368564  47989435    257579309      1    69    35    188  <=== SIC!

 timer_set_absolute 5469149 149465780  76733027671      1 25302    27  14030  <=== SIC!
  running           1366875  28677763  75747486848      2 25302    20  55416  <=== SIC!
  resched           1367833  24874644    128667739      1    35    18     94  <=== SIC!
  stopped           1366172  47919701    256908110      1    69    35    188  <=== SIC!
  resched, stopped  1368269  47993672    257274127      1    69    35    188  <=== SIC!
-------------- END STATISTICS ---------------
```