### PR TITLE
pkg*: replace curly braces by parenthesis in makefiles

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -5,10 +5,10 @@ PKG_LICENSE=ISC
 
 .PHONY: all
 
-export RIOT_CFLAGS = ${CFLAGS} ${INCLUDES}
+export RIOT_CFLAGS = $(CFLAGS) $(INCLUDES)
 
 all: git-download
-	cd $(PKG_BUILDDIR)/src && cmake -DCCNL_RIOT=1 -DRIOT_CFLAGS="${RIOT_CFLAGS}" -DBUILD_TESTING=OFF . && make
-	cp $(PKG_BUILDDIR)/src/lib/libccnl-riot.a ${BINDIR}/ccn-lite.a
+	cd $(PKG_BUILDDIR)/src && cmake -DCCNL_RIOT=1 -DRIOT_CFLAGS="$(RIOT_CFLAGS)" -DBUILD_TESTING=OFF . && make
+	cp $(PKG_BUILDDIR)/src/lib/libccnl-riot.a $(BINDIR)/ccn-lite.a
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/minmea/Makefile
+++ b/pkg/minmea/Makefile
@@ -6,7 +6,7 @@ PKG_LICENSE=WTFPL
 .PHONY: all
 
 all: git-download
-	@cp Makefile.${PKG_NAME} $(PKG_BUILDDIR)/Makefile
+	@cp Makefile.$(PKG_NAME) $(PKG_BUILDDIR)/Makefile
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -6,7 +6,7 @@ PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
 $(info Compile OpenThread for FTD device)
 OPENTHREAD_ARGS+= --enable-cli-app=ftd --enable-application-coap
 
-$(info $$OPENTHREAD_ARGS is [${OPENTHREAD_ARGS}])
+$(info $$OPENTHREAD_ARGS is [$(OPENTHREAD_ARGS)])
 
 .PHONY: all
 
@@ -24,12 +24,12 @@ all: git-download
 		LDFLAGS="$(OPENTHREAD_COMMON_FLAGS) $(CFLAGS_CPU) -nostartfiles -specs=nano.specs \
 		-specs=nosys.specs -Wl,--gc-sections -Wl,-Map=map.map " \
 		./configure --disable-docs --host=$(TARGET_ARCH) --target=$(TARGET_ARCH) \
-		--prefix=/ --enable-default-logging ${OPENTHREAD_ARGS}
+		--prefix=/ --enable-default-logging $(OPENTHREAD_ARGS)
 	cd $(PKG_BUILDDIR) &&  DESTDIR=$(PKG_BUILDDIR)/output PREFIX=/ make -j4 --no-print-directory install
 
-	cp $(PKG_BUILDDIR)/output/lib/libmbedcrypto.a ${BINDIR}/libmbedcrypto.a
-	cp $(PKG_BUILDDIR)/output/lib/libopenthread-ftd.a ${BINDIR}/libopenthread.a
-	cp $(PKG_BUILDDIR)/output/lib/libopenthread-cli-ftd.a ${BINDIR}/libopenthread-cli.a
+	cp $(PKG_BUILDDIR)/output/lib/libmbedcrypto.a $(BINDIR)/libmbedcrypto.a
+	cp $(PKG_BUILDDIR)/output/lib/libopenthread-ftd.a $(BINDIR)/libopenthread.a
+	cp $(PKG_BUILDDIR)/output/lib/libopenthread-cli-ftd.a $(BINDIR)/libopenthread-cli.a
 	sed -ie 's/BASE/_BASE/g' $(PKG_BUILDDIR)/output/include/openthread/types.h
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR simply use the right way of accessing variables in makefiles, as suggested in [this comment](https://github.com/RIOT-OS/RIOT/pull/8809#discussion_r176113445).

This PR only addresses the packages makefiles, but using git grep, there are other places in the code that need to be addressed as well.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->