### PR TITLE
cpu/lm4f120: Changed UART configuration format for lm4f120

### DIFF
--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -75,20 +75,18 @@ extern "C" {
  */
 static const uart_conf_t uart_config[] = {
     {
-        .uart_sysctl       = SYSCTL_PERIPH_UART0,
-        .uart_base         = UART0_BASE,
+        .dev               = 0,
         .uart_txint_mode   = UART_TXINT_MODE_EOT,
         .uart_fifo_tx      = UART_FIFO_TX4_8,
         .uart_fifo_rx      = UART_FIFO_RX4_8,
         .uart_irq_chan     = UART0_IRQn,
-        .uart_im_r         = &UART0_IM_R,
         .gpio_sysctl       = SYSCTL_PERIPH_GPIOA,
         .gpio_port         = GPIO_PORTA_BASE,
         .pins = {
-          .rx   = GPIO_PA0_U0RX,
-          .tx   = GPIO_PA1_U0TX,
-          .mask_rx = (GPIO_PIN_0),
-          .mask_tx = (GPIO_PIN_1),
+          .rx              = GPIO_PA0_U0RX,
+          .tx              = GPIO_PA1_U0TX,
+          .mask_rx         = (GPIO_PIN_0),
+          .mask_tx         = (GPIO_PIN_1),
           }
     },
 };

--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -87,14 +87,15 @@ static const uart_conf_t uart_config[] = {
             .mask_rx        = (GPIO_PIN_0),
             .mask_tx        = (GPIO_PIN_1),
         }
-    },
+    }
 };
 
 /* interrupt function name mapping */
-#define UART_0_ISR          isr_uart0
+#define UART_0_ISR          (isr_uart0)
 
 /* macros common across all UARTs */
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
 
 /**
  * @name   ADC configuration

--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -68,26 +68,25 @@ extern "C" {
 #define TIMER_1_IRQ_CHAN    Timer1A_IRQn
 /** @} */
 
-
 /**
  * @name    UART configuration
  * @{
  */
 static const uart_conf_t uart_config[] = {
     {
-        .dev               = 0,
-        .uart_txint_mode   = UART_TXINT_MODE_EOT,
-        .uart_fifo_tx      = UART_FIFO_TX4_8,
-        .uart_fifo_rx      = UART_FIFO_RX4_8,
-        .uart_irq_chan     = UART0_IRQn,
-        .gpio_sysctl       = SYSCTL_PERIPH_GPIOA,
-        .gpio_port         = GPIO_PORTA_BASE,
+        .dev = 0,
+        .uart_txint_mode = UART_TXINT_MODE_EOT,
+        .uart_fifo_tx = UART_FIFO_TX4_8,
+        .uart_fifo_rx = UART_FIFO_RX4_8,
+        .uart_irq_chan = UART0_IRQn,
+        .gpio_sysctl = SYSCTL_PERIPH_GPIOA,
+        .gpio_port = GPIO_PORTA_BASE,
         .pins = {
-          .rx              = GPIO_PA0_U0RX,
-          .tx              = GPIO_PA1_U0TX,
-          .mask_rx         = (GPIO_PIN_0),
-          .mask_tx         = (GPIO_PIN_1),
-          }
+            .rx = GPIO_PA0_U0RX,
+            .tx = GPIO_PA1_U0TX,
+            .mask_rx = (GPIO_PIN_0),
+            .mask_tx = (GPIO_PIN_1),
+        }
     },
 };
 

--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -68,31 +68,35 @@ extern "C" {
 #define TIMER_1_IRQ_CHAN    Timer1A_IRQn
 /** @} */
 
+
 /**
- * @name UART configuration
+ * @name    UART configuration
  * @{
  */
-#define UART_NUMOF          (1U)
-#define UART_0_EN           1
-#define UART_1_EN           0
-#define UART_IRQ_PRIO       1
-#define UART_CLK            ROM_SysCtlClockGet()  /* UART clock runs with 40MHz */
-/* UART 0 device configuration */
-#define UART_0_DEV          UART0_BASE
-#define UART_0_CLK          (40000000)
-#define UART_0_IRQ_CHAN     UART0_IRQn
-#define UART_0_ISR          isr_uart0
-/* UART 0 pin configuration */
-#define UART_0_PORT         GPIOA
-#define UART_0_TX_PIN       UART_PA1_U0TX
-#define UART_0_RX_PIN       UART_PA0_U0RX
+static const uart_conf_t uart_config[] = {
+    {
+        .uart_sysctl       = SYSCTL_PERIPH_UART0,
+        .uart_base         = UART0_BASE,
+        .uart_txint_mode   = UART_TXINT_MODE_EOT,
+        .uart_fifo_tx      = UART_FIFO_TX4_8,
+        .uart_fifo_rx      = UART_FIFO_RX4_8,
+        .uart_irq_chan     = UART0_IRQn,
+        .uart_im_r         = &UART0_IM_R,
+        .gpio_sysctl       = SYSCTL_PERIPH_GPIOA,
+        .gpio_port         = GPIO_PORTA_BASE,
+        .pins = {
+          .rx   = GPIO_PA0_U0RX,
+          .tx   = GPIO_PA1_U0TX,
+          .mask = (GPIO_PIN_0 | GPIO_PIN_1)
+          }
+    },
+};
 
-/* UART 1 device configuration */
-#define UART_1_DEV          UART1_BASE
-#define UART_1_CLK          (40000000)
-#define UART_1_IRQ_CHAN     UART1_IRQn
-#define UART_1_ISR          isr_uart1
-/** @} */
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_uart0
+
+/* macros common across all UARTs */
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 
 /**
  * @name   ADC configuration

--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -74,18 +74,18 @@ extern "C" {
  */
 static const uart_conf_t uart_config[] = {
     {
-        .dev = 0,
-        .uart_txint_mode = UART_TXINT_MODE_EOT,
-        .uart_fifo_tx = UART_FIFO_TX4_8,
-        .uart_fifo_rx = UART_FIFO_RX4_8,
-        .uart_irq_chan = UART0_IRQn,
-        .gpio_sysctl = SYSCTL_PERIPH_GPIOA,
-        .gpio_port = GPIO_PORTA_BASE,
+        .dev                = 0,
+        .uart_txint_mode    = UART_TXINT_MODE_EOT,
+        .uart_fifo_tx       = UART_FIFO_TX4_8,
+        .uart_fifo_rx       = UART_FIFO_RX4_8,
+        .uart_irq_chan      = UART0_IRQn,
+        .gpio_sysctl        = SYSCTL_PERIPH_GPIOA,
+        .gpio_port          = GPIO_PORTA_BASE,
         .pins = {
-            .rx = GPIO_PA0_U0RX,
-            .tx = GPIO_PA1_U0TX,
-            .mask_rx = (GPIO_PIN_0),
-            .mask_tx = (GPIO_PIN_1),
+            .rx             = GPIO_PA0_U0RX,
+            .tx             = GPIO_PA1_U0TX,
+            .mask_rx        = (GPIO_PIN_0),
+            .mask_tx        = (GPIO_PIN_1),
         }
     },
 };

--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -87,7 +87,8 @@ static const uart_conf_t uart_config[] = {
         .pins = {
           .rx   = GPIO_PA0_U0RX,
           .tx   = GPIO_PA1_U0TX,
-          .mask = (GPIO_PIN_0 | GPIO_PIN_1)
+          .mask_rx = (GPIO_PIN_0),
+          .mask_tx = (GPIO_PIN_1),
           }
     },
 };

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -111,19 +111,19 @@ typedef enum {
  * @{
  */
 typedef struct {
-    unsigned long dev;                 /**< UART device number */
-    unsigned long uart_txint_mode;     /**< UART TX interrupt mode */
-    unsigned long uart_fifo_tx;        /**< UART TX fifo select */
-    unsigned long uart_fifo_rx;        /**< UART RX fifo select */
-    IRQn_Type uart_irq_chan;           /**< UART IRQ channel */
-    unsigned long gpio_sysctl;         /**< GPIO device in sysctl */
-    unsigned long gpio_port;           /**< GPIO port */
+    unsigned int dev;              /**< UART device number */
+    unsigned long uart_txint_mode;  /**< UART TX interrupt mode */
+    unsigned long uart_fifo_tx;     /**< UART TX fifo select */
+    unsigned long uart_fifo_rx;     /**< UART RX fifo select */
+    IRQn_Type uart_irq_chan;        /**< UART IRQ channel */
+    unsigned long gpio_sysctl;      /**< GPIO device in sysctl */
+    unsigned long gpio_port;        /**< GPIO port */
     struct {
-        unsigned long rx;              /**< pin used for RX */
-        unsigned long tx;              /**< pin used for TX */
-        unsigned long mask_rx;         /**< Pin mask for RX*/
-        unsigned long mask_tx;         /**< Pin mask for TX*/
-    } pins;                            /**< Pin setting */
+        unsigned long rx;           /**< pin used for RX */
+        unsigned long tx;           /**< pin used for TX */
+        unsigned long mask_rx;      /**< Pin mask for RX*/
+        unsigned long mask_tx;      /**< Pin mask for TX*/
+    } pins;                         /**< Pin setting */
 } uart_conf_t;
 /** @} */
 

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -123,7 +123,8 @@ typedef struct {
     struct {
         unsigned long rx;              /**< pin used for RX */
         unsigned long tx;              /**< pin used for TX */
-        unsigned long mask;            /**< Pin mask */
+        unsigned long mask_rx;            /**< Pin mask for RX*/
+        unsigned long mask_tx;            /**< Pin mask for TX*/
     } pins;                            /**< Pin setting */
 } uart_conf_t;
 /** @} */

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -107,6 +107,28 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 
 /**
+ * @name   UART device configuration
+ * @{
+ */
+typedef struct {
+    unsigned long uart_sysctl;         /**< UART device in sysctl */
+    unsigned long uart_base;           /**< UART base address */
+    unsigned long uart_txint_mode;     /**< UART TX interrupt mode */
+    unsigned long uart_fifo_tx;        /**< UART TX fifo select */
+    unsigned long uart_fifo_rx;        /**< UART RX fifo select */
+    IRQn_Type uart_irq_chan;           /**< UART IRQ channel */
+    volatile unsigned long * uart_im_r;/**< UART RX Enable Register */
+    unsigned long gpio_sysctl;         /**< GPIO device in sysctl */
+    unsigned long gpio_port;           /**< GPIO port */
+    struct {
+        unsigned long rx;              /**< pin used for RX */
+        unsigned long tx;              /**< pin used for TX */
+        unsigned long mask;            /**< Pin mask */
+    } pins;                            /**< Pin setting */
+} uart_conf_t;
+/** @} */
+
+/**
  * @brief   Override SPI hardware chip select macro
  *
  * As of now, we do not support HW CS, so we always set it to a fixed value
@@ -122,6 +144,10 @@ typedef struct {
     unsigned long ssi_base;            /**< SSI base address */
     unsigned long gpio_sysctl;         /**< GPIO device in sysctl */
     unsigned long gpio_port;           /**< GPIO port */
+
+
+    volatile unsigned long * uart_im_r;        /**< UART RX fifo select */
+
     struct {
         unsigned long clk;             /**< pin used for SCK */
         unsigned long fss;             /**< pin used for FSS */

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -111,20 +111,18 @@ typedef enum {
  * @{
  */
 typedef struct {
-    unsigned long uart_sysctl;         /**< UART device in sysctl */
-    unsigned long uart_base;           /**< UART base address */
+    unsigned long dev;                 /**< UART device number */
     unsigned long uart_txint_mode;     /**< UART TX interrupt mode */
     unsigned long uart_fifo_tx;        /**< UART TX fifo select */
     unsigned long uart_fifo_rx;        /**< UART RX fifo select */
     IRQn_Type uart_irq_chan;           /**< UART IRQ channel */
-    volatile unsigned long * uart_im_r;/**< UART RX Enable Register */
     unsigned long gpio_sysctl;         /**< GPIO device in sysctl */
     unsigned long gpio_port;           /**< GPIO port */
     struct {
         unsigned long rx;              /**< pin used for RX */
         unsigned long tx;              /**< pin used for TX */
-        unsigned long mask_rx;            /**< Pin mask for RX*/
-        unsigned long mask_tx;            /**< Pin mask for TX*/
+        unsigned long mask_rx;         /**< Pin mask for RX*/
+        unsigned long mask_tx;         /**< Pin mask for TX*/
     } pins;                            /**< Pin setting */
 } uart_conf_t;
 /** @} */
@@ -145,10 +143,6 @@ typedef struct {
     unsigned long ssi_base;            /**< SSI base address */
     unsigned long gpio_sysctl;         /**< GPIO device in sysctl */
     unsigned long gpio_port;           /**< GPIO port */
-
-
-    volatile unsigned long * uart_im_r;        /**< UART RX fifo select */
-
     struct {
         unsigned long clk;             /**< pin used for SCK */
         unsigned long fss;             /**< pin used for FSS */

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -111,19 +111,19 @@ typedef enum {
  * @{
  */
 typedef struct {
-    unsigned int dev;              /**< UART device number */
-    unsigned long uart_txint_mode;  /**< UART TX interrupt mode */
-    unsigned long uart_fifo_tx;     /**< UART TX fifo select */
-    unsigned long uart_fifo_rx;     /**< UART RX fifo select */
-    IRQn_Type uart_irq_chan;        /**< UART IRQ channel */
-    unsigned long gpio_sysctl;      /**< GPIO device in sysctl */
-    unsigned long gpio_port;        /**< GPIO port */
+    unsigned int dev;                  /**< UART device number */
+    unsigned long uart_txint_mode;     /**< UART TX interrupt mode */
+    unsigned long uart_fifo_tx;        /**< UART TX fifo select */
+    unsigned long uart_fifo_rx;        /**< UART RX fifo select */
+    IRQn_Type uart_irq_chan;           /**< UART IRQ channel */
+    unsigned long gpio_sysctl;         /**< GPIO device in sysctl */
+    unsigned long gpio_port;           /**< GPIO port */
     struct {
-        unsigned long rx;           /**< pin used for RX */
-        unsigned long tx;           /**< pin used for TX */
-        unsigned long mask_rx;      /**< Pin mask for RX*/
-        unsigned long mask_tx;      /**< Pin mask for TX*/
-    } pins;                         /**< Pin setting */
+        unsigned long rx;              /**< pin used for RX */
+        unsigned long tx;              /**< pin used for TX */
+        unsigned long mask_rx;         /**< Pin mask for RX*/
+        unsigned long mask_tx;         /**< Pin mask for TX*/
+    } pins;                            /**< Pin setting */
 } uart_conf_t;
 /** @} */
 

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -31,120 +31,111 @@
  */
 static uart_isr_ctx_t config[UART_NUMOF];
 
-static int init_base(uart_t uart, uint32_t baudrate);
-
 /**
  * Configuring the UART console
  */
 int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 {
     /* Check the arguments */
-    assert(uart == 0);
+    assert(uart < UART_NUMOF);
+
+
     /* Check to make sure the UART peripheral is present */
-    if(!ROM_SysCtlPeripheralPresent(SYSCTL_PERIPH_UART0)){
+    if(!ROM_SysCtlPeripheralPresent(uart_config[uart].uart_sysctl)){
         return UART_NODEV;
     }
 
-    int res = init_base(uart, baudrate);
-    if(res != UART_OK){
-        return res;
-    }
+    ROM_SysCtlPeripheralEnable(uart_config[uart].uart_sysctl);
+    ROM_SysCtlPeripheralEnable(uart_config[uart].gpio_sysctl);
+    //no checks for rx_cb
+    ROM_GPIOPinConfigure(uart_config[uart].pins.rx);
+    ROM_GPIOPinConfigure(uart_config[uart].pins.tx);
+    //no checks for rx_cb
+    ROM_GPIOPinTypeUART(uart_config[uart].gpio_port, uart_config[uart].pins.mask);
+
+    ROM_UARTDisable(uart_config[uart].uart_base);
+    ROM_UARTConfigSetExpClk(uart_config[uart].uart_base,
+            ROM_SysCtlClockGet(), baudrate,
+            (UART_CONFIG_PAR_NONE | UART_CONFIG_STOP_ONE |
+             UART_CONFIG_WLEN_8));
+
+    ROM_UARTEnable(uart_config[uart].uart_base);
 
 /* save callbacks */
-    config[uart].rx_cb = rx_cb;
-    config[uart].arg = arg;
-
-/*  ulBase = g_ulUARTBase[uart]; */
-    switch (uart){
-#if UART_0_EN
-        case UART_0:
-            ROM_UARTTxIntModeSet(UART0_BASE, UART_TXINT_MODE_EOT);
-            ROM_UARTFIFOLevelSet(UART0_BASE, UART_FIFO_TX4_8, UART_FIFO_RX4_8);
-            ROM_UARTFIFOEnable(UART0_BASE);
-
-            /* Enable the UART interrupt */
-            NVIC_EnableIRQ(UART_0_IRQ_CHAN);
-            /* Enable RX interrupt */
-            UART0_IM_R = UART_IM_RXIM | UART_IM_RTIM;
-            break;
-#endif
-#if UART_1_EN
-        case UART_1:
-            /* Enable the UART interrupt */
-            NVIC_EnableIRQ(UART_1_IRQ_CHAN);
-            break;
-#endif
+    if (rx_cb) {
+        config[uart].rx_cb = rx_cb;
+        config[uart].arg = arg;
     }
+
+    ROM_UARTTxIntModeSet(uart_config[uart].uart_base,
+        uart_config[uart].uart_txint_mode);
+      //no checks for rx_cb
+    ROM_UARTFIFOLevelSet(uart_config[uart].uart_base,
+        uart_config[uart].uart_fifo_tx, uart_config[uart].uart_fifo_rx);
+    ROM_UARTFIFOEnable(uart_config[uart].uart_base);
+
+      //no flow control config? maybe add that in
+
+    /* Enable the UART interrupt */
+    NVIC_EnableIRQ(uart_config[uart].uart_irq_chan);
+
+    /* Enable RX interrupt */
+    (*uart_config[uart].uart_im_r) = (UART_IM_RXIM | UART_IM_RTIM);
+
     return UART_OK;
 }
 
-static int init_base(uart_t uart, uint32_t baudrate)
-{
-    switch(uart){
-#if UART_0_EN
-        case UART_0:
-            ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_UART0);
-            ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOA);
-            ROM_GPIOPinConfigure(GPIO_PA0_U0RX);
-            ROM_GPIOPinConfigure(GPIO_PA1_U0TX);
-            ROM_GPIOPinTypeUART(GPIO_PORTA_BASE, GPIO_PIN_0 | GPIO_PIN_1);
-
-            ROM_UARTDisable(UART0_BASE);
-            ROM_UARTConfigSetExpClk(UART0_BASE,ROM_SysCtlClockGet(), baudrate,
-                    (UART_CONFIG_PAR_NONE | UART_CONFIG_STOP_ONE |
-                     UART_CONFIG_WLEN_8));
-
-
-            ROM_UARTEnable(UART0_BASE);
-            break;
-#endif
-        default:
-            return UART_NODEV;
-        }
-    return UART_OK;
-}
 
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
-    (void) uart;
+    assert(uart < UART_NUMOF);
 
     for (size_t i = 0; i < len; i++) {
-        ROM_UARTCharPut(UART0_BASE, (char)data[i]);
+        ROM_UARTCharPut(uart_config[uart].uart_base, (char)data[i]);
     }
 }
 
 void uart_poweron(uart_t uart)
 {
-    (void) uart;
+    assert(uart < UART_NUMOF);
 
-    ROM_UARTEnable(UART0_BASE);
+    ROM_UARTEnable(uart_config[uart].uart_base);
 }
 
 void uart_poweroff(uart_t uart)
 {
-    (void) uart;
+    assert(uart < UART_NUMOF);
 
-    ROM_UARTDisable(UART0_BASE);
+    ROM_UARTDisable(uart_config[uart].uart_base);
 }
 
 /**
  * The UART interrupt handler.
  */
-void isr_uart0(void)
+static inline void irq_handler(uart_t uart)
 {
+    assert(uart < UART_NUMOF);
+
     unsigned long ulStatus;
 
-    ulStatus = ROM_UARTIntStatus(UART0_BASE, true);
-    ROM_UARTIntClear(UART0_BASE, ulStatus);
+    ulStatus = ROM_UARTIntStatus(uart_config[uart].uart_base, true);
+    ROM_UARTIntClear(uart_config[uart].uart_base, ulStatus);
 
     /* Are we interrupted due to a recieved character */
     if(ulStatus & (UART_INT_RX | UART_INT_RT))
     {
-        while(ROM_UARTCharsAvail(UART0_BASE))
+        while(ROM_UARTCharsAvail(uart_config[uart].uart_base))
         {
-            long lchar = ROM_UARTCharGetNonBlocking(UART0_BASE);
-            config[UART_0].rx_cb(config[UART_0].arg, (uint8_t)lchar);
+            long lchar = ROM_UARTCharGetNonBlocking(uart_config[uart].uart_base);
+            config[uart].rx_cb(config[uart].arg, (uint8_t)lchar);
         }
     }
     cortexm_isr_end();
 }
+
+#ifdef UART_0_ISR
+void UART_0_ISR(void)
+{
+    irq_handler((uart_t)0);
+}
+#endif

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -133,7 +133,7 @@ void uart_poweroff(uart_t uart)
 /**
  * The UART interrupt handler.
  */
-static inline void irq_handler(uart_t uart)
+void irq_handler(uart_t uart)
 {
     assert(uart < UART_NUMOF);
 

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -133,7 +133,7 @@ void uart_poweroff(uart_t uart)
 /**
  * The UART interrupt handler.
  */
-static inline void irq_handler(uart_t uart)
+void irq_handler(uart_t uart)
 {
     assert(uart < UART_NUMOF);
 
@@ -154,23 +154,17 @@ static inline void irq_handler(uart_t uart)
     cortexm_isr_end();
 }
 
-#ifdef UART_0_ISR
 void UART_0_ISR(void)
 {
     irq_handler((uart_t)0);
 }
-#endif
 
-#ifdef UART_1_ISR
 void UART_1_ISR(void)
 {
     irq_handler((uart_t)1);
 }
-#endif
 
-#ifdef UART_2_ISR
 void UART_2_ISR(void)
 {
     irq_handler((uart_t)2);
 }
-#endif

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -150,3 +150,10 @@ void UART_0_ISR(void)
     irq_handler((uart_t)0);
 }
 #endif
+
+#ifdef UART_1_ISR
+void UART_1_ISR(void)
+{
+    irq_handler((uart_t)1);
+}
+#endif

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -133,7 +133,7 @@ void uart_poweroff(uart_t uart)
 /**
  * The UART interrupt handler.
  */
-void irq_handler(uart_t uart)
+static inline void irq_handler(uart_t uart)
 {
     assert(uart < UART_NUMOF);
 


### PR DESCRIPTION
### Contribution description

Changed the style of the UART configuration for ek-lm4f120xl, from
a define based configuration to one based on an array of structs, one
struct for each UART, with the format of the struct defined in
lm4f120/include/periph_cpu.h.

Defined the fields of the struct in periph_cpu.h
Updated uart.c to use the new configuration type
Implemented the configuration on ek-lm4f120xl/include/periph_conf.h

Notes to reviewer:
-UART1 is not used but the cpu should be supported if the board is configured for it

### Issues/PRs references
Ticks the UART checkbox for lm4f120 in #7941.
Based off of #8345
