### PR TITLE
mips32r2_common: timer fixes

### DIFF
--- a/cpu/mips32r2_common/periph/timer.c
+++ b/cpu/mips32r2_common/periph/timer.c
@@ -135,7 +135,7 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
     compares[channel] = counter + timeout;
     irq_restore(status);
 
-    return channel;
+    return 1;
 }
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
@@ -152,7 +152,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
     compares[channel] = value;
     irq_restore(status);
 
-    return channel;
+    return 1;
 }
 
 int timer_clear(tim_t dev, int channel)
@@ -166,7 +166,7 @@ int timer_clear(tim_t dev, int channel)
     compares[channel] = 0;
     irq_restore(status);
 
-    return channel;
+    return 1;
 }
 
 unsigned int timer_read(tim_t dev)

--- a/cpu/mips32r2_generic/include/periph_cpu.h
+++ b/cpu/mips32r2_generic/include/periph_cpu.h
@@ -24,6 +24,11 @@ extern "C" {
 #define PROVIDES_PM_SET_LOWEST
 /** @} */
 
+/**
+ * @brief   Prevent shared timer functions from being used
+ */
+#define PERIPH_TIMER_PROVIDES_SET   1
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

Fix return value for `timer_` function that should return 1 on success.

mips32r2_common already implements timer_set so it should not be provided by
periph_common/timer to avoid multiple definition errors hidden by the linker.

The firmware was using the one from `mips32r2_common` before (binary checked).
So the final linked version is the same.

This PR is using a commit from https://github.com/RIOT-OS/RIOT/pull/8711 with added info in the commit message.

### Verification

I checked what was built with:

```
mips-mti-elf-objdump -d bin/mips-malta/mips32r2_common_periph/timer.o bin/mips-malta/periph_common/timer.o bin/
mips-malta/*.elf | grep -A 30 '<timer_set>:'
```

And the timer_set implementation is the same before and after the fix.

### Issues/PRs references

It is required for https://github.com/RIOT-OS/RIOT/pull/8711 and replaces https://github.com/RIOT-OS/RIOT/pull/8720 which raised other problems.