### PR TITLE
bindist: remove APPLICATION_MODULE duplicate

### DIFF
--- a/makefiles/bindist.inc.mk
+++ b/makefiles/bindist.inc.mk
@@ -1,4 +1,5 @@
-USEMODULE += $(BIN_USEMODULE)
+# Avoid including APPLICATION_MODULE twice to prevent multiple definition errors
+USEMODULE += $(filter-out $(APPLICATION_MODULE),$(BIN_USEMODULE))
 
 DIST_FILES += $(BIN_USEMODULE:%=bin/$(BOARD)/%.a)
 


### PR DESCRIPTION
### Contribution description

Fix APPLICATION_MODULE being duplicated in the command line during link.

This error is currently silently ignored by the linker.

### Issues/PRs references

This is a preliminary fix required for https://github.com/RIOT-OS/RIOT/pull/8711