### PR TITLE
stm32/common : add STM32_PM_SLEEP define

### DIFF
--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -85,6 +85,7 @@ extern "C" {
  * @name    Power modes
  * @{
  */
+#define STM32_PM_SLEEP        (2U)
 #define STM32_PM_STOP         (1U)
 #define STM32_PM_STANDBY      (0U)
 /** @} */


### PR DESCRIPTION
The STM32_PM_SLEEP has been added to be used with
pm_unblock function.

Signed-off-by: Aurelien Fillau <aurelien.fillau@gmail.com>

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->