### PR TITLE
make: add and export RIOTTOOLS directory

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -59,7 +59,7 @@ _JLINK_SERVER=JLinkGDBServer
 _JLINK_IF=SWD
 _JLINK_SPEED=2000
 # default terminal frontend
-_JLINK_TERMPROG=${RIOTBASE}/dist/tools/pyterm/pyterm
+_JLINK_TERMPROG=${RIOTTOOLS}/pyterm/pyterm
 _JLINK_TERMFLAGS="-ts 19021"
 
 #
@@ -164,7 +164,7 @@ do_flash() {
     if [ ! -z "${JLINK_POST_FLASH}" ]; then
         printf "${JLINK_POST_FLASH}\n" >> ${BINDIR}/burn.seg
     fi
-    cat ${RIOTBASE}/dist/tools/jlink/reset.seg >> ${BINDIR}/burn.seg
+    cat ${RIOTTOOLS}/jlink/reset.seg >> ${BINDIR}/burn.seg
     # flash device
     sh -c "${JLINK} ${JLINK_SERIAL} \
                     -device '${JLINK_DEVICE}' \
@@ -218,7 +218,7 @@ do_reset() {
                     -speed '${JLINK_SPEED}' \
                     -if '${JLINK_IF}' \
                     -jtagconf -1,-1 \
-                    -commandfile '${RIOTBASE}/dist/tools/jlink/reset.seg'"
+                    -commandfile '${RIOTTOOLS}/jlink/reset.seg'"
 }
 
 do_term() {
@@ -245,7 +245,7 @@ do_term() {
             -speed '${JLINK_SPEED}' \
             -if '${JLINK_IF}' \
             -jtagconf -1,-1 \
-            -commandfile '${RIOTBASE}/dist/tools/jlink/term.seg' & \
+            -commandfile '${RIOTTOOLS}/jlink/term.seg' & \
             echo  \$! > $JLINK_PIDFILE" &
 
     sh -c "${JLINK_TERMPROG} ${JLINK_TERMFLAGS}"

--- a/dist/tools/usb-serial/README.md
+++ b/dist/tools/usb-serial/README.md
@@ -45,7 +45,7 @@ solution):
       ifeq ($(PORT),)
         # try to find tty name by serial number, only works on Linux currently.
         ifeq ($(OS),Linux)
-          PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh "^$(PROGRAMMER_SERIAL)$$"))
+          PORT := $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh "^$(PROGRAMMER_SERIAL)$$"))
         endif
       endif
     endif
@@ -53,7 +53,7 @@ solution):
     # Fallback PORT if no serial was specified or if the specified serial was not found
     ifeq ($(PORT),)
         ifeq ($(OS),Linux)
-          PORT := $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh))
+          PORT := $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh))
         else ifeq ($(OS),Darwin)
           PORT := $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
         endif

--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -8,7 +8,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # settings.
 ifneq (,$(SERIAL))
   EDBG_ARGS += --serial $(SERIAL)
-  SERIAL_TTY = $(firstword $(shell $(RIOTBASE)/dist/tools/usb-serial/find-tty.sh $(SERIAL)))
+  SERIAL_TTY = $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh $(SERIAL)))
   ifeq (,$(SERIAL_TTY))
     $(error Did not find a device with serial $(SERIAL))
   endif

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -20,7 +20,7 @@ $(PKG_BUILDDIR)/Makefile: $(TOOLCHAIN_FILE)
 		  -DCHECK=off -DTESTS=0 -DBENCH=0 -DSHLIB=off -Wno-dev $(RELIC_CONFIG_FLAGS) .
 
 $(TOOLCHAIN_FILE): git-download
-	$(RIOTBASE)/dist/tools/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
+	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
 
 clean::
 	@rm -rf $(BINDIR)/$(PKG_NAME).a

--- a/tests/cb_mux/tests/01-run.py
+++ b/tests/cb_mux/tests/01-run.py
@@ -39,6 +39,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
     sys.exit(run(testfunc))

--- a/tests/cb_mux_bench/tests/01-run.py
+++ b/tests/cb_mux_bench/tests/01-run.py
@@ -20,6 +20,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
     sys.exit(run(testfunc))

--- a/tests/pkg_tinycbor/tests/01-run.py
+++ b/tests/pkg_tinycbor/tests/01-run.py
@@ -16,7 +16,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTBASE'],
-                                 'dist/tools/testrunner'))
+    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
     sys.exit(run(testfunc))

--- a/tests/thread_race/tests/01-run.py
+++ b/tests/thread_race/tests/01-run.py
@@ -21,6 +21,6 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
     sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

Add a `RIOTTOOLS` variable to cleanup build scripts.

This PR will also patch makefiles and scripts to use it.

I started splitting this PR to simplify testing and review.
Also maintaining it is also hard.

* [x] #9067 First PR that justs defines the variable
* [x] #9069 tests: use RIOTTOOLS variable
* [x] #9070 tools/check: use RIOTTOOLS variable
* [x] #9071 sys/arduino: use RIOTTOOLS variable
* [x] #9072 pkg: use RIOTTOOLS variable
* [x] #9102 main Makefile.include related
* [x] #9133 boards
* [x] #9134 flashing
* [x] #9110 examples/gnrc_border_router

The current lines using `dist/tools` on purpose:

```
git grep 'dist/tools' | grep -v -e README.md  -e doc.txt -e '\.md:' -e  static-tests.sh -e 'build_and_test.sh' -e 'changed_files.sh' -e vagrant/bootstrap.sh  -e ':#'
Makefile.include:RIOTTOOLS      ?= $(RIOTBASE)/dist/tools
dist/tools/coccinelle/check.sh:: ${RIOTTOOLS:-./dist/tools}
dist/tools/cppcheck/check.sh:: ${RIOTTOOLS:-./dist/tools}
dist/tools/externc/check.sh:: ${RIOTTOOLS:-./dist/tools}
dist/tools/flake8/check.sh:: ${RIOTTOOLS:-./dist/tools}
dist/tools/headerguards/check.sh:: ${RIOTTOOLS:-./dist/tools}
dist/tools/licenses/check.sh:: ${RIOTTOOLS:-./dist/tools}
dist/tools/pr_check/pr_check.sh:: ${RIOTTOOLS:-./dist/tools}
```

Other usages that I think do not need to be patched
```
git grep -l 'dist/tools' | grep -v -e Makefile.include -e 'check.sh'                                                                                               .drone.yml
.github/ISSUE_TEMPLATE.md
.murdock
README.md
Vagrantfile
cpu/kinetis/dist/check-fcfield-elf.sh
cpu/kinetis/dist/check-fcfield-hex.sh
cpu/native/README.md
dist/tools/ci/build_and_test.sh
dist/tools/ci/changed_files.sh
dist/tools/coccinelle/README.md
dist/tools/cppcheck/README.md
dist/tools/desvirt/README.desvirt.md
dist/tools/git/README.md
dist/tools/packer/README.md
dist/tools/pr_check/check_labels.sh
dist/tools/static-tests.sh
dist/tools/vagrant/README.md
dist/tools/vagrant/bootstrap.sh
doc/doxygen/src/getting-started.md
doc/doxygen/src/mainpage.md
examples/ccn-lite-relay/README.md
examples/dtls-echo/README.md
examples/emcute/README.md
examples/gcoap/README-slip.md
examples/gnrc_border_router/README.md
examples/gnrc_networking/README.md
examples/gnrc_tftp/README.md
makefiles/tests.inc.mk
makefiles/tools/edbg.inc.mk
sys/arduino/doc.txt
```


### Issues/PRs references

First commit was taken from https://github.com/RIOT-OS/RIOT/pull/8509