### PR TITLE
sys/spin_random: CPU delay library

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -569,6 +569,11 @@ ifneq (,$(filter saul,$(USEMODULE)))
   USEMODULE += phydat
 endif
 
+ifneq (,$(filter spin_random,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_timer
+  USEMODULE += random
+endif
+
 ifneq (,$(filter phydat,$(USEMODULE)))
   USEMODULE += fmt
 endif

--- a/sys/include/spin_random.h
+++ b/sys/include/spin_random.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_spin_random Spin_random - random CPU delays
+ * @ingroup     sys
+ * @brief       CPU spinning routines for random runtime delays
+ *
+ * @{
+ * @file
+ * @brief       spin_random declarations
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef SPIN_RANDOM_H
+#define SPIN_RANDOM_H
+
+#include <stdint.h>
+#include "periph/timer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Spin for a short random delay to increase fuzziness of a test
+ *
+ * The amount of time spent in this function will be between 0 and up to at
+ * least the amount of time that the spin_random_calibrate function was called
+ * with.
+ * The spin duration is < 2 * spin_max_target, in timer ticks of the timer that
+ * was used by spin_random_calibrate.
+ *
+ * @pre spin_random_calibrate must have been run beforehand to calibrate the
+ * maximum spin count
+ */
+void spin_random_delay(void);
+
+/**
+ * @brief   Calibrate the maximum spin count
+ *
+ * The calibration function will ensure that @ref spin_random_delay will give a
+ * random delay up to at least @p spin_max_target counts on the timer device
+ * given by @p timer_dev.
+ *
+ * The new maximum spin count will ensure that the maximum random spin in
+ * @ref spin_random_delay will be at least @p spin_max_target ticks long, and
+ * no more than 2 * @p spin_max_target ticks.
+ *
+ * @pre The periph_timer @p timer_dev must be initialized and running (counting).
+ *
+ * @param[in]   timer_dev   Timer device to use as reference
+ * @param[in]   spin_max_target Spin duration target time in @p timer_dev ticks.
+ *
+ * @return the new maximum spin count
+ */
+uint32_t spin_random_calibrate(tim_t timer_dev, uint32_t spin_max_target);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPIN_RANDOM_H */
+/** @} */

--- a/sys/spin_random/Makefile
+++ b/sys/spin_random/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/spin_random/spin_random.c
+++ b/sys/spin_random/spin_random.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_spin_random
+ *
+ * @{
+ * @file
+ * @brief       spin_random implementation
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <limits.h>
+
+#include "spin_random.h"
+#include "random.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/* Default is whatever, just some small delay if the user forgets to initialize */
+static uint32_t spin_max = 64;
+
+/**
+ * @brief   Busy wait (spin) for the given number of loop iterations
+ */
+static void spin(uint32_t limit)
+{
+    /* Platform independent busy wait loop, should never be optimized out
+     * because of the volatile asm statement */
+    while (limit--) {
+        __asm__ volatile ("");
+    }
+}
+
+void spin_random_delay(void)
+{
+    uint32_t limit = random_uint32_range(0, spin_max);
+    spin(limit);
+}
+
+uint32_t spin_random_calibrate(tim_t timer_dev, uint32_t spin_max_target)
+{
+    spin_max = 16;
+    uint32_t t1;
+    uint32_t t2;
+    DEBUG("spin_random_calibrate: Begin calibration with timer %u against "
+          "target %" PRIu32 "\n", (unsigned) timer_dev, spin_max_target);
+    do {
+        spin_max = (spin_max * 5) / 4;
+        t1 = timer_read(timer_dev);
+        spin(spin_max);
+        t2 = timer_read(timer_dev);
+    } while ((t2 - t1) < spin_max_target && (spin_max < (UINT32_MAX / 5)));
+    DEBUG("spin_max = %" PRIu32 "\n", spin_max);
+    return spin_max;
+}


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Provides random CPU runtime delays.
Useful to artificially add fuzziness to hardware timings in tests.

### Issues/PRs references

Used by #8531 for avoiding phase lock between timer under test and test driver