### PR TITLE
core/mutex: fix -fpermissive warning in C++ mode

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -58,7 +58,7 @@ typedef struct {
  * @brief This is the value of the mutex when locked and no threads are waiting
  *        for it
  */
-#define MUTEX_LOCKED ((void *)-1)
+#define MUTEX_LOCKED ((list_node_t *)-1)
 /**
  * @endcond
  */


### PR DESCRIPTION

### Contribution description

g++ gives the error message `error: invalid conversion from ‘void*’ to ‘list_node*’ [-fpermissive]`
when using MUTEX_INIT_LOCKED from C++ files.

### Issues/PRs references

Used in a refactoring of #8531 