### PR TITLE
drivers/sx127x: make paselect configurable in the driver params

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -83,16 +83,7 @@ extern "C" {
 #define SX127X_TX_TIMEOUT_DEFAULT        (1000U * 1000U * 30UL) /**< TX timeout, 30s */
 #define SX127X_RX_SINGLE                 (false)                /**< Single byte receive mode => continuous by default */
 #define SX127X_RX_BUFFER_SIZE            (256)                  /**< RX buffer size */
-
 #define SX127X_RADIO_TX_POWER            (14U)                  /**< Radio power in dBm */
-
-#ifndef SX1272_DEFAULT_PASELECT
-/** @brief   Default PA selection config (1: RFO, 0: PABOOST)
- *
- * This depends on the module configuration.
- */
-#define SX1272_DEFAULT_PASELECT          (1U)
-#endif
 
 #define SX127X_EVENT_HANDLER_STACK_SIZE  (2048U) /**< Stack size event handler */
 #define SX127X_IRQ_DIO0                  (1<<0)  /**< DIO0 IRQ */
@@ -142,6 +133,18 @@ enum {
     SX127X_RX_ERROR_CRC,               /**< Receiving CRC error */
     SX127X_FHSS_CHANGE_CHANNEL,        /**< Channel change */
     SX127X_CAD_DONE,                   /**< Channel activity detection complete */
+};
+
+/**
+ * @brief Power amplifier modes
+ *
+ * Default value is SX127X_PA_RFO.
+ *
+ * The power amplifier mode depends on the module hardware configuration.
+ */
+enum {
+    SX127X_PA_RFO = 0,                 /**< RFO HF or RFO LF */
+    SX127X_PA_BOOST,                   /**< Power amplifier boost (high power) */
 };
 
 /**
@@ -205,6 +208,7 @@ typedef struct {
     gpio_t dio3_pin;                   /**< Interrupt line DIO3 (CAD done) */
     gpio_t dio4_pin;                   /**< Interrupt line DIO4 (not used) */
     gpio_t dio5_pin;                   /**< Interrupt line DIO5 (not used) */
+    uint8_t paselect;                  /**< Power amplifier mode (RFO or PABOOST) */
 } sx127x_params_t;
 
 /**

--- a/drivers/sx127x/include/sx127x_params.h
+++ b/drivers/sx127x/include/sx127x_params.h
@@ -60,6 +60,10 @@ extern "C" {
 #define SX127X_PARAM_DIO3                   GPIO_PIN(1, 4)       /* D5 */
 #endif
 
+#ifndef SX127X_PARAM_PASELECT
+#define SX127X_PARAM_PASELECT               (SX127X_PA_RFO)
+#endif
+
 #ifndef SX127X_PARAMS
 #define SX127X_PARAMS                       { .spi       = SX127X_PARAM_SPI,     \
                                               .nss_pin   = SX127X_PARAM_SPI_NSS, \
@@ -67,7 +71,8 @@ extern "C" {
                                               .dio0_pin  = SX127X_PARAM_DIO0,    \
                                               .dio1_pin  = SX127X_PARAM_DIO1,    \
                                               .dio2_pin  = SX127X_PARAM_DIO2,    \
-                                              .dio3_pin  = SX127X_PARAM_DIO3 }
+                                              .dio3_pin  = SX127X_PARAM_DIO3,    \
+                                              .paselect  = SX127X_PARAM_PASELECT }
 #endif
 /**@}*/
 

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -707,23 +707,13 @@ void sx127x_set_payload_length(sx127x_t *dev, uint8_t len)
     sx127x_reg_write(dev, SX127X_REG_LR_PAYLOADLENGTH, len);
 }
 
-static inline uint8_t sx127x_get_pa_select(uint32_t channel)
+static inline uint8_t sx127x_get_pa_select(const sx127x_t *dev)
 {
-#if defined(MODULE_SX1272)
-    (void) channel;
-#if SX1272_DEFAULT_PASELECT
-    return SX127X_RF_PACONFIG_PASELECT_RFO;
-#else
-    return SX127X_RF_PACONFIG_PASELECT_PABOOST;
-#endif
-#else /* MODULE_SX1276 */
-    if (channel < SX127X_RF_MID_BAND_THRESH) {
+    if (dev->params.paselect == SX127X_PA_BOOST) {
         return SX127X_RF_PACONFIG_PASELECT_PABOOST;
     }
-    else {
-        return SX127X_RF_PACONFIG_PASELECT_RFO;
-    }
-#endif
+
+    return SX127X_RF_PACONFIG_PASELECT_RFO;
 }
 
 uint8_t sx127x_get_tx_power(const sx127x_t *dev)
@@ -745,7 +735,7 @@ void sx127x_set_tx_power(sx127x_t *dev, int8_t power)
 #endif
 
     pa_config = ((pa_config & SX127X_RF_PACONFIG_PASELECT_MASK) |
-                 sx127x_get_pa_select(dev->settings.channel));
+                 sx127x_get_pa_select(dev));
 
 #if defined(MODULE_SX1276)
     /* max power is 14dBm */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an extra configuration parameter for power amplifier selection to the SX127x driver. As reported in #8813, this should be made easily configurable by the user.

RFO selection mode is kept as the default since it is the one that works in EU868 with mbed shields. Apparently BOOST mode can only be used in Europe with EU433 band or in the US915 band.

cc @dylad and @ilf-S who might be interested

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Should fix #8813 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->