### PR TITLE
pkg/semtech-loramac: fix tx_power get/set functions

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -190,8 +190,8 @@ void semtech_loramac_set_tx_power(uint8_t power)
 {
     DEBUG("[semtech-loramac] set TX power %d\n", power);
     MibRequestConfirm_t mibReq;
-    mibReq.Type = MIB_CHANNELS_TX_POWER;
-    mibReq.Param.ChannelsTxPower = power;
+    mibReq.Type = MIB_CHANNELS_DEFAULT_TX_POWER;
+    mibReq.Param.ChannelsDefaultTxPower = power;
     LoRaMacMibSetRequestConfirm(&mibReq);
 }
 
@@ -199,9 +199,9 @@ uint8_t semtech_loramac_get_tx_power(void)
 {
     DEBUG("[semtech-loramac] get TX power\n");
     MibRequestConfirm_t mibReq;
-    mibReq.Type = MIB_CHANNELS_TX_POWER;
+    mibReq.Type = MIB_CHANNELS_DEFAULT_TX_POWER;
     LoRaMacMibGetRequestConfirm(&mibReq);
-    return (uint8_t)mibReq.Param.ChannelsTxPower;
+    return (uint8_t)mibReq.Param.ChannelsDefaultTxPower;
 }
 
 void semtech_loramac_set_rx2_freq(uint8_t freq)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the issue reported in this [comment](https://github.com/RIOT-OS/RIOT/pull/8798#issuecomment-376111162)

Using `MIB_CHANNELS_TX_POWER` has no effect on the MAC. The fix simply consists in using `MIB_CHANNELS_DEFAULT_TX_POWER` instead.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

comment raised while reviewing #8798 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->