### PR TITLE
gnrc_netreg: fix static PID initialize for gnrc_netapi_callbacks

### DIFF
--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -93,7 +93,7 @@ typedef enum {
  *
  * @return  An initialized netreg entry
  */
-#ifdef MODULE_GNRC_NETAPI_MBOX
+#if defined(MODULE_GNRC_NETAPI_MBOX) || defined(MODULE_GNRC_NETAPI_CALLBACKS)
 #define GNRC_NETREG_ENTRY_INIT_PID(demux_ctx, pid)  { NULL, demux_ctx, \
                                                       GNRC_NETREG_TYPE_DEFAULT, \
                                                       { pid } }


### PR DESCRIPTION
### Contribution description
Without this fix any GNRC application does not compile when including the (pseudo-)module `gnrc_netapi_callbacks`. Discovered by @man0lis.

### Issues/PRs references
None