### PR TITLE
Makefiles: add support to generate both `.hex` and `.bin` file and add FLASHFILE variable

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -430,7 +430,8 @@ binfile: $(BINFILE)
 # # # Not all boards use this file for the moment
 #
 # FLASHFILE is the file used by the flasher
-# (can be overwritten to $(HEXFILE), $(BINFILE))
+# Usually set to $(ELFFILE), $(HEXFILE) or $(BINFILE) in the board/flasher
+# or application specific files
 flashfile: $(FLASHFILE)
 
 # variables used to compile and link c++

--- a/Makefile.include
+++ b/Makefile.include
@@ -426,13 +426,14 @@ include $(RIOTMAKE)/boot/riotboot.mk
 elffile: $(ELFFILE)
 hexfile: $(HEXFILE)
 binfile: $(BINFILE)
-# # # FLASHFILE Being introduced, only supported if bsp define FLASHFILE # # #
-# # # Not all boards use this file for the moment
-#
 # FLASHFILE is the file used by the flasher
 # Usually set to $(ELFFILE), $(HEXFILE) or $(BINFILE) in the board/flasher
 # or application specific files
 flashfile: $(FLASHFILE)
+
+ifeq (,$(FLASHFILE))
+  $(error FLASHFILE is not defined for this board: $(FLASHFILE))
+endif
 
 # variables used to compile and link c++
 CPPMIX ?= $(if $(wildcard *.cpp),1,)

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -78,7 +78,7 @@ export PORT                  # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The 'intel hex' stripped result of the compilation.
 # BINFILE                    # The 'binary' stripped result of the compilation.
-# FLASHFILE                  # The output file used for flashing (transition phase: only if defined)
+# FLASHFILE                  # The output file used for flashing
 # DEBUGGER                   # The command to call on "make debug", usually a script starting the GDB front-end.
 # DEBUGGER_FLAGS             # The parameters to supply to DEBUGGER.
 # DEBUGSERVER                # The command to call on "make debug-server", usually a script starting the GDB server.


### PR DESCRIPTION
### Contribution description

I need to be able to generate a `.bin` file to flash nucleo boards by drag-and-dropping the firmware.
The main goal of this PR main is to add a target for the bin file. This would allow asking for building the bin file from the command line but not creating it for every build.

* Remove the `HEXFILE = $(ELFFILE:.elf=.bin)` hack
* Add a `FLASHFILE` variable which fixes the hack in https://github.com/RIOT-OS/RIOT/pull/8801
* Change flasher script that where getting the flashfile from environment variable.

#### Integrated in sub PRs:

While looking into this I tried fixing other problems to not propagate hack somewhere else:
* [x] Put `ELFFILE` in its own target and generally break link in sub file targets
    * [x] ~~https://github.com/RIOT-OS/RIOT/pull/8844~~ separate target
    * [x] ~~https://github.com/RIOT-OS/RIOT/pull/8845~~ .hex and .bin targets
* [x] Fix boards generating a binary `.hex` file  ~~https://github.com/RIOT-OS/RIOT/pull/8840~~
* [x] Random refactoring ~~https://github.com/RIOT-OS/RIOT/pull/8839~~
* [x] Split most of the boards changes to take flashfile from command line arguments
  * [x] Use `BINFILE` instead of `HEXFILE` https://github.com/RIOT-OS/RIOT/pull/10471
    * [x] Flasher not even working for `common/remote` with PROGRAMMER=jlink https://github.com/RIOT-OS/RIOT/pull/10472
  * [x] board/*/flash.sh get flashfile from command line https://github.com/RIOT-OS/RIOT/pull/10473
  * [x] board/opencm904 https://github.com/RIOT-OS/RIOT/pull/10474
  * [x] jlink: get flash and debug files from cli https://github.com/RIOT-OS/RIOT/pull/10528
  * [x] openocd: get flash and debug files from cli https://github.com/RIOT-OS/RIOT/pull/10539
    * [x]  `hifive1` included here
  * [x] Other splits incoming out of https://github.com/RIOT-OS/RIOT/pull/9514
  * [x] ESP boards
  * [x] Other missing boards not currently migrated (see along the way)
* [x] Introduce FLASHFILE variable even if not used everywhere #11084
  * [x] Using `FLASHFILE`
    * [x] makefiles/murdock.inc.mk: do not overwrite FLASHFILE if set #11097
    * [x] tests/riotboot: use FLASHFILE for the generated file https://github.com/RIOT-OS/RIOT/pull/11089
    * [x] makefiles/mcuboot: prepare for when FLASHFILE is used #11112        
  * [x] Migrate boards by group
    * [x] makefiles/tools/jlink.inc.mk: use FLASHFILE #11130
    * [x] makefiles/edbg.inc.mk: use FLASHFILE #11172 
      * [x] makefiles/boot/riotboot.mk: fix unrelated introduced change #11284
    * [x] boards/lpc2k_pgm: use FLASHFILE for boards using lpc2k_pgm #11188
    * [x] tools/avrdude.inc.mk: use FLASHFILE variable #11190
    * [x] makefiles/tools/uniflash.inc.mk: add a common configuration for using UniFlash https://github.com/RIOT-OS/RIOT/pull/11198
    * [x] makefiles/openocd.inc.mk: use FLASHFILE #11254
    * [x] boards/cc2538: use FLASHFILE for boards using cc2538-bsl.py #11569
    * [x] boards/lobaro-lorabox: use FLASHFILE for boards using stm32loader.py #11629 
    * [x] cpu/esp*: use FLASHFILE for esp32 and esp8266 boards #11648
    * [x] makefiles/pyocd.inc.mk use FLASHFILE #11696 
    * [x] boards/pic32-xx: set FLASHFILE to HEXFILE #11699
    * [x] boards/mips-malta: set FLASHFILE #11711
    * [x] boards/mspdebug: use FLASHFILE for boards using mspdebug #11708
    * [x] makefiles/bossa.inc.mk: use FLASHFILE #11700
    * [x] boards/dfu-util: use FLASHFILE for boards using dfu-util #11709
    * [x] boards/single: use FLASHFILE #11710
    * [x] boards/native: define FLASHFILE #11752 
* [x] Cleanups
  * [x] makefiles/murdock.inc.mk: remove flashfile hack #11755
  * [x] Makefile.include: do not build HEXFILE by default anymore #11757 
  * [x]  makefiles: documentation for hexfile binfile #11845 
* [x] add a static test to verify it's done for all
* Other cleanups
  * [ ] Migrate `common/remote` and `cc2538dk` to use `jlink.inc.mk` similar to https://github.com/RIOT-OS/RIOT/pull/9851
  * [ ] tests/mcuboot: use FLASHFILE for the generated file (Waiting For Other PR #10494)
  * [ ] boards/hamilton: remove OFLAGS '-O binary' #11849
  * [ ] Remove overwriting `HEXFILE` in `docker`, it is now only handled to deduce it from `ELFFILE`
 

It has the side effect to not generate the '.hex' or '.bin' file if not required for the flasher, which I think is better

This ended up in a big PR that I will split.


#### Verifying after rebase:

Things I should look into after rebasing the PR in case new boards where added:

    git grep FFLAGS | grep -v FLASHFILE
    git grep OFLAGS |  grep -e '-O'
    git grep HEXFILE | grep -v FLASHFILE

### Issues/PRs references

* Its re-introducing https://github.com/RIOT-OS/RIOT/pull/1098 (reverted by https://github.com/RIOT-OS/RIOT/pull/1198)
* Will remove the hack for https://github.com/RIOT-OS/RIOT/pull/8801/files
* ~~It will need rebase after https://github.com/RIOT-OS/RIOT/pull/8822 is merged~~