### PR TITLE
makefiles: FIX boards generating a binary '.hex' file

### DIFF
--- a/boards/bluepill/Makefile.include
+++ b/boards/bluepill/Makefile.include
@@ -21,6 +21,7 @@ ifeq ($(PROGRAMMER),dfu-util)
   export RESET = # dfu-util has no support for resetting the device
 
   export OFLAGS = -O binary
+  HEXFILE = $(ELFFILE:.elf=.bin)
   export FFLAGS = -d 1d50:6017 -s 0x08002000:leave -D "$(HEXFILE)"
 else
 

--- a/boards/bluepill/Makefile.include
+++ b/boards/bluepill/Makefile.include
@@ -16,7 +16,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # (ground) GPIO B1.
 ifeq ($(PROGRAMMER),dfu-util)
   export ROM_OFFSET ?= 0x2000 # Skip the space needed by the embedded bootloader
-  export BINFILE = $(patsubst %.elf,%.bin,$(ELFFILE))
   export FLASHER = dfu-util
   export DEBUGGER = # no debugger
   export RESET = # dfu-util has no support for resetting the device

--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -13,7 +13,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 PROGRAMMER ?= fscopy
 ifeq (fscopy,$(PROGRAMMER))
   export OFLAGS = -O ihex
-  export HEXFILE = $(ELFFILE:.elf=.hex)
   export FFLAGS =
   export DEBUGGER_FLAGS =
 

--- a/boards/common/arduino-atmega/Makefile.include
+++ b/boards/common/arduino-atmega/Makefile.include
@@ -18,4 +18,4 @@ export DEBUGGER = $(DIST_PATH)/debug.sh $(DEBUGSERVER_FLAGS) $(DIST_PATH) $(DEBU
 export PROGRAMMER_FLAGS = -P $(PORT) -b $(PROGRAMMER_SPEED)
 
 export OFLAGS += -j .text -j .data -O ihex
-export FFLAGS += -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -D -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex
+export FFLAGS += -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -D -U flash:w:$(HEXFILE)

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -16,5 +16,5 @@ export DEBUGSERVER = st-util
 
 # define st-flash parameters
 export OFLAGS = -O binary
-export FFLAGS = write bin/$(BOARD)/$(APPLICATION).hex 0x8000000
-export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(BINDIR)/$(APPLICATION).elf
+export FFLAGS = write $(HEXFILE) 0x8000000
+export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(ELFFILE)

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -16,5 +16,6 @@ export DEBUGSERVER = st-util
 
 # define st-flash parameters
 export OFLAGS = -O binary
+HEXFILE = $(ELFFILE:.elf=.bin)
 export FFLAGS = write $(HEXFILE) 0x8000000
 export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(ELFFILE)

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -21,4 +21,4 @@ export PROGRAMMER ?= buspirate
 export PROGRAMMER_FLAGS = -P /dev/ttyUSB0
 
 export OFLAGS += -j .text -j .data -O ihex
-export FFLAGS += -p m1284p -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex
+export FFLAGS += -p m1284p -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:$(HEXFILE)

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -13,7 +13,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 PROGRAMMER ?= fscopy
 ifeq (fscopy,$(PROGRAMMER))
   export OFLAGS = -O ihex
-  export HEXFILE = $(ELFFILE:.elf=.hex)
   export FFLAGS =
   export DEBUGGER_FLAGS =
 

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -14,6 +14,7 @@ export DEBUGGER = # dfu-util has no debugger
 export RESET = # dfu-util has no support for resetting the device
 
 export OFLAGS = -O binary
+HEXFILE = $(ELFFILE:.elf=.bin)
 export FFLAGS = -d $(ID) -a 0 -s 0x08000000:leave -D "$(HEXFILE)"
 export TERMFLAGS = -p $(PORT)
 

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -9,8 +9,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 # set the default id
 export ID ?= 0483:df11
 
-export BINFILE = $(patsubst %.elf,%.bin,$(ELFFILE))
-
 export FLASHER = dfu-util
 export DEBUGGER = # dfu-util has no debugger
 export RESET = # dfu-util has no support for resetting the device

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -7,8 +7,6 @@ PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-export BINFILE = $(patsubst %.elf,%.bin,$(ELFFILE))
-
 export FLASHER = dfu-util
 export DEBUGGER = # spark core has no debugger
 export RESET = # dfu-util has no support for resetting the device

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -12,6 +12,7 @@ export DEBUGGER = # spark core has no debugger
 export RESET = # dfu-util has no support for resetting the device
 
 export OFLAGS = -O binary
+HEXFILE = $(ELFFILE:.elf=.bin)
 export FFLAGS = -d 1d50:607f -a 0 -s 0x08005000:leave -D "$(HEXFILE)"
 
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include/

--- a/boards/teensy31/Makefile.include
+++ b/boards/teensy31/Makefile.include
@@ -7,7 +7,6 @@ TEENSY_LOADER = $(RIOTBASE)/dist/tools/teensy-loader-cli/teensy_loader
 FLASHER = $(TEENSY_LOADER)
 
 OFLAGS = -O ihex
-HEXFILE = $(ELFFILE:.elf=.hex)
 
 FFLAGS ?= --mcu=mk20dx256 $(HEXFILE)
 

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -34,4 +34,4 @@ ifeq ($(PROGRAMMER), stk500v1)
 endif
 
 export OFLAGS += -j .text -j .data -O ihex
-export FFLAGS += -p m1281 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:bin/$(BOARD)/$(PROJECT)$(APPLICATION).hex
+export FFLAGS += -p m1281 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:$(HEXFILE)

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -18,7 +18,7 @@ info-objsize:
 	  sort -rnk$${SORTROW}
 
 info-buildsize:
-	@$(SIZE) -d -B $(BINDIR)/$(APPLICATION).elf || echo ''
+	@$(SIZE) -d -B $(ELFFILE) || echo ''
 
 info-build:
 	@echo 'APPLICATION: $(APPLICATION)'


### PR DESCRIPTION
### Contribution description

Some boards generate a '.hex' file that is a created with '-Obinary' which is wrong and is problematic to create rules by extension used in https://github.com/RIOT-OS/RIOT/pull/8838

I also include some cleanup for HEXFILE/ELFFILE/BINFILE variables in the boards Makefile. To use them and remove unused BINFILE.

### Issues/PRs references

Used in https://github.com/RIOT-OS/RIOT/pull/8838