### PR TITLE
cpu/atmega_common: RTT and RTC support

### DIFF
--- a/boards/jiminy-mega256rfr2/Makefile.dep
+++ b/boards/jiminy-mega256rfr2/Makefile.dep
@@ -1,1 +1,3 @@
 USEMODULE += boards_common_atmega
+
+include $(RIOTCPU)/atmega_common/Makefile.dep

--- a/boards/jiminy-mega256rfr2/Makefile.features
+++ b/boards/jiminy-mega256rfr2/Makefile.features
@@ -4,5 +4,7 @@ include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
 # Put defined MCU peripherals here (in alphabetical order)
 # Peripherals are defined in common/arduino-atmega/Makefile.features
 # Add only additional Peripherals
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
 
 -include $(RIOTCPU)/atmega256rfr2/Makefile.features

--- a/boards/jiminy-mega256rfr2/include/periph_conf.h
+++ b/boards/jiminy-mega256rfr2/include/periph_conf.h
@@ -33,6 +33,22 @@ extern "C" {
 #define CLOCK_CORECLOCK     (8000000UL)
 /** @} */
 
+/**
+ * @name RTC configuration
+ * @{
+ */
+#define RTC_NUMOF    (1U)
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#define RTT_NUMOF        (1U)
+#define RTT_MAX_VALUE    (0x00FFFFFF)    /* 24-bit timer */
+#define RTT_FREQUENCY    (32U)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/mega-xplained/Makefile.dep
+++ b/boards/mega-xplained/Makefile.dep
@@ -4,3 +4,5 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_adc
   USEMODULE += saul_gpio
 endif
+
+include $(RIOTCPU)/atmega_common/Makefile.dep

--- a/boards/mega-xplained/Makefile.features
+++ b/boards/mega-xplained/Makefile.features
@@ -2,6 +2,8 @@
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/mega-xplained/include/periph_conf.h
+++ b/boards/mega-xplained/include/periph_conf.h
@@ -42,6 +42,22 @@ extern "C" {
 #define CLOCK_CORECLOCK     (8000000UL)
 /** @} */
 
+/**
+ * @name RTC configuration
+ * @{
+ */
+#define RTC_NUMOF    (1U)
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#define RTT_NUMOF        (1U)
+#define RTT_MAX_VALUE    (0x00FFFFFF)    /* 24-bit timer */
+#define RTT_FREQUENCY    (32U)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega_common/Makefile.dep
+++ b/cpu/atmega_common/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter periph_rtc,$(USEMODULE)))
+    USEMODULE += periph_rtt
+endif

--- a/cpu/atmega_common/periph/rtc.c
+++ b/cpu/atmega_common/periph/rtc.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_atmega_common
+ * @ingroup     drivers_periph_rtc
+ *
+ * @{
+ *
+ * @file
+ * @brief       RTC interface wrapper for use with RTT modules.
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * In order to safely sleep when using the RTT:
+ * 1. Disable interrupts
+ * 2. Write to one of the asynch registers (e.g. TCCR2A)
+ * 3. Wait for ASSR register's busy flags to clear
+ * 4. Re-enable interrupts
+ * 5. Sleep before interrupt re-enable takes effect
+ *
+ * @}
+ */
+
+#include <avr/interrupt.h>
+#include <time.h>
+
+#include "cpu.h"
+#include "irq.h"
+#include "periph/rtc.h"
+#include "periph/rtt.h"
+#include "periph_conf.h"
+#include "thread.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/* guard file in case no RTC device is defined */
+#if RTC_NUMOF
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    time_t alarm;               /* alarm_cb when time == alarm */
+    rtc_alarm_cb_t alarm_cb;    /* callback called from RTC alarm */
+    void *alarm_arg;            /* argument passed to the callback */
+} rtc_state_t;
+
+static rtc_state_t rtc_state;
+
+/* RTC second counter. This is treated as-if it is a register as it is
+ * incremented by the overflow ISR. This MUST BE marked volatile for two
+ * reasons: to guarantee ordering with other register operations, and to
+ * force redundant access to occur (in case it was changed by the ISR). */
+static volatile time_t time_cnt;
+
+static inline void _asynch_wait(void)
+{
+    /* Wait until all busy flags clear. According to the datasheet,
+     * this can take up to 2 positive edges of TOSC1 (32kHz). */
+    while (ASSR & ((1 << TCN2UB) | (1 << OCR2AUB) | (1 << OCR2BUB)
+                   | (1 << TCR2AUB) | (1 << TCR2BUB))) {}
+}
+
+/* This safely reads time_cnt and TCNT2, since an atomic read cannot be provided.
+ * Note: still requires prior synch using _asynch_wait() */
+static inline time_t _safe_time_get(void)
+{
+    time_t time_tmp;
+    uint8_t irq_flag, cnt_tmp;
+
+    do {
+        /* Operations must occur in this order: */
+        irq_flag = TIFR2 & (1 << TOV2);
+        time_tmp = time_cnt;
+        cnt_tmp = TCNT2;
+
+    /* Detect rollover after time_tmp read. If condition is met, then rollover
+     * just occured, and it is safe to read again now. */
+    } while ((time_tmp != time_cnt) || (irq_flag != (TIFR2 & (1 << TOV2))));
+
+    if (irq_flag) {
+        time_tmp += 8;
+    }
+
+    return time_tmp + (cnt_tmp >> 5);
+}
+
+void rtc_init(void)
+{
+    /* RTC depends on RTT */
+    rtt_init();
+}
+
+int rtc_set_time(struct tm *time)
+{
+    uint8_t irq_flag;
+
+    /* Make sure it is safe to read TCNT2, in case we just woke up */
+    DEBUG("RTT sleeps until safe to read TCNT2\n");
+    TCCR2A = 0;
+    _asynch_wait();
+
+    /* Convert to seconds since the epoch */
+    time_t time_secs = mk_gmtime(time);
+
+    /* Make non-atomic writes atomic */
+    unsigned state = irq_disable();
+
+    do {
+        /* Operations must occur in this order: */
+        time_cnt = time_secs - (TCNT2 >> 5);
+        irq_flag = TIFR2 & (1 << TOV2);
+
+    /* Detect rollover after time_cnt is written. If condition is met, then
+     * rollover just occured, and it is safe to write now. */
+    } while (irq_flag != (TIFR2 & (1 << TOV2)));
+
+    irq_restore(state);
+
+    DEBUG("RTC set time: %" PRIu32 " seconds\n", time_cnt);
+
+    return 0;
+}
+
+int rtc_get_time(struct tm *time)
+{
+    /* Make sure it is safe to read TCNT2, in case we just woke up */
+    DEBUG("RTT sleeps until safe to read TCNT2\n");
+    TCCR2A = 0;
+    _asynch_wait();
+
+    time_t time_secs = _safe_time_get();
+
+    /* Convert from seconds since the epoch */
+    gmtime_r(&time_secs, time);
+
+    DEBUG("RTC get time: %" PRIu32 " seconds\n", time_secs);
+
+    return 0;
+}
+
+int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
+{
+    /* Disable alarm */
+    rtc_clear_alarm();
+
+    /* Make sure it is safe to read TCNT2, in case we just woke up, and */
+    /* safe to write OCR2B (in case it was busy) */
+    DEBUG("RTC sleeps until safe read TCNT2 and to write OCR2B\n");
+    TCCR2A = 0;
+    _asynch_wait();
+
+    time_t now = _safe_time_get();
+    time_t alarm_tmp = mk_gmtime(time);
+
+    if (alarm_tmp < now) {
+        DEBUG("RTC alarm set in the past. Time: %" PRIu32 " seconds, alarm: %"
+              PRIu32 "\n", now, rtc_state.alarm);
+        cb(arg);
+        return 0;
+    }
+
+    /* Calculate time to wait, based on TCNT2 = 0 */
+    time_t diff = rtc_state.alarm - now;
+
+    /* Make non-atomic writes atomic */
+    unsigned state = irq_disable();
+
+    /* Set alarm time */
+    rtc_state.alarm = alarm_tmp;
+
+    /* Prepare the counter for sub 8-second precision */
+    OCR2B = (uint8_t)(diff << 5);
+
+    rtc_state.alarm_arg = arg;
+    rtc_state.alarm_cb = cb;
+
+    irq_restore(state);
+
+    DEBUG("RTC set alarm: %" PRIu32 " seconds, OCR2B: %" PRIu8 "\n",
+          rtc_state.alarm, OCR2B);
+
+    /* Enable irq only if alarm is in the 8s period before it overflows */
+    if (diff < 8) {
+        /* Clear interrupt flag */
+        TIFR2 = (1 << OCF2B);
+
+        /* Enable interrupt */
+        TIMSK2 |= (1 << OCIE2B);
+
+        DEBUG("RTT alarm interrupt active\n");
+    }
+    else {
+        DEBUG("RTT alarm interrupt not active\n");
+    }
+
+    return 0;
+}
+
+int rtc_get_alarm(struct tm *time)
+{
+    /* Convert from seconds since the epoch */
+    gmtime_r(&rtc_state.alarm, time);
+
+    DEBUG("RTC get alarm: %" PRIu32 " seconds\n", alarm);
+
+    return 0;
+}
+
+void rtc_clear_alarm(void)
+{
+    /* Make non-atomic writes atomic */
+    unsigned state = irq_disable();
+
+    /* Disable alarm interrupt */
+    TIMSK2 &= ~(1 << OCIE2B);
+
+    rtc_state.alarm_cb = NULL;
+    rtc_state.alarm_arg = NULL;
+
+    irq_disable(state);
+}
+
+void rtc_poweron(void)
+{
+    rtt_poweron();
+}
+
+void rtc_poweroff(void)
+{
+    rtt_poweroff();
+}
+
+void atmega_rtc_incr(void)
+{
+    time_cnt += 8;
+
+    /* If alarm not set, nothing else to do */
+    if (rtc_state.alarm_cb == NULL) {
+        return;
+    }
+
+    /* Check to see if alarm was missed */
+    if (rtc_state.alarm <= time_cnt) {
+        /* Clear callback */
+        rtc_alarm_cb_t cb = rtc_state.alarm_cb;
+        rtc_state.alarm_cb = NULL;
+
+        /* Execute callback */
+        cb(rtc_state.alarm_arg);
+
+        return;
+    }
+
+    /* Enable irq only if alarm is in the 8s period before it overflows */
+    if ((rtc_state.alarm - time_cnt) < 8) {
+        /* Clear interrupt flag */
+        TIFR2 = (1 << OCF2B);
+
+        /* Enable interrupt */
+        TIMSK2 |= (1 << OCIE2B);
+    }
+}
+
+ISR(TIMER2_COMPB_vect)
+{
+    __enter_isr();
+    /* Disable alarm interrupt */
+    TIMSK2 &= ~(1 << OCIE2B);
+
+    /* Execute callback */
+    if (rtc_state.alarm_cb != NULL) {
+        /* Clear callback */
+        rtc_alarm_cb_t cb = rtc_state.alarm_cb;
+        rtc_state.alarm_cb = NULL;
+
+        /* Execute callback */
+        cb(rtc_state.alarm_arg);
+    }
+
+    __exit_isr();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RTC_NUMOF */

--- a/cpu/atmega_common/periph/rtt.c
+++ b/cpu/atmega_common/periph/rtt.c
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/*
+ * @ingroup cpu_atmega_common
+ * @ingroup drivers_periph_rtt
+ * @{
+ *
+ * @file
+ * @brief       Low-level ATmega RTT driver implementation
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * In order to safely sleep when using the RTT:
+ * 1. Disable interrupts
+ * 2. Write to one of the asynch registers (e.g. TCCR2A)
+ * 3. Wait for ASSR register's busy flags to clear
+ * 4. Re-enable interrupts
+ * 5. Sleep before interrupt re-enable takes effect
+ *
+ * @}
+ */
+
+#include <avr/interrupt.h>
+
+#include "cpu.h"
+#include "irq.h"
+#include "periph/rtt.h"
+#include "periph_conf.h"
+#include "thread.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* guard file in case no RTT device is defined */
+#if RTT_NUMOF
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if MODULE_PERIPH_RTC
+extern void atmega_rtc_incr(void);
+#endif
+
+typedef struct {
+    uint16_t ext_comp;          /* Extend compare to 24-bits */
+    rtt_cb_t alarm_cb;          /* callback called from RTT alarm */
+    void *alarm_arg;            /* argument passed to the callback */
+    rtt_cb_t overflow_cb;       /* callback called when RTT overflows */
+    void *overflow_arg;         /* argument passed to the callback */
+} rtt_state_t;
+
+static rtt_state_t rtt_state;
+
+/* Extend TCNT2 to 24-bits. This is treated as-if it is a register as it is
+ * incremented by the overflow ISR. This MUST BE marked volatile for two
+ * reasons: to guarantee ordering with other register operations, and to
+ * force redundant access to occur (in case it was changed by the ISR). */
+static volatile uint16_t ext_cnt;
+
+static inline void _asynch_wait(void)
+{
+    /* Wait until all busy flags clear. According to the datasheet,
+     * this can take up to 2 positive edges of TOSC1 (32kHz). */
+    while (ASSR & ((1 << TCN2UB) | (1 << OCR2AUB) | (1 << OCR2BUB)
+                   | (1 << TCR2AUB) | (1 << TCR2BUB))) {}
+}
+
+/* This safely reads ext_cnt and TCNT2, since an atomic read cannot be provided.
+ * Note: still requires prior synch using _asynch_wait() */
+static inline uint32_t _safe_cnt_get(void)
+{
+    uint16_t ext_cnt_tmp;
+    uint8_t irq_flag, cnt_tmp;
+
+    do {
+        /* Operations must occur in this order: */
+        irq_flag = TIFR2 & (1 << TOV2);
+        ext_cnt_tmp = ext_cnt;
+        cnt_tmp = TCNT2;
+
+    /* Detect rollover after ext_cnt read. If condition is met, then rollover
+     * just occured, and it is safe to read again now. */
+    } while ((ext_cnt_tmp != ext_cnt) || (irq_flag != (TIFR2 & (1 << TOV2))));
+
+    if (irq_flag) {
+        ext_cnt_tmp++;
+    }
+
+    return (((uint32_t)ext_cnt_tmp << 8) | (uint32_t)cnt_tmp);
+}
+
+void rtt_init(void)
+{
+    DEBUG("Initializing RTT\n");
+
+    rtt_poweron();
+
+    /*
+     * From the datasheet section "Asynchronous Operation of Timer/Counter2"
+     * p148 for ATmega1284P.
+     * 1. Disable the Timer/Counter2 interrupts by clearing OCIE2x and TOIE2.
+     * 2. Select clock source by setting AS2 as appropriate.
+     * 3. Write new values to TCNT2, OCR2x, and TCCR2x.
+     * 4. To switch to asynchronous: Wait for TCN2UB, OCR2xUB, TCR2xUB.
+     * 5. Clear the Timer/Counter2 Interrupt Flags.
+     * 6. Enable interrupts, if needed
+     */
+
+    /* Disable all timer 2 interrupts */
+    TIMSK2 = 0;
+
+    /* Select asynchronous clock source */
+    ASSR = (1 << AS2);
+
+    /* Set counter to 0 */
+    TCNT2 = 0;
+
+    /* Reset compare values */
+    OCR2A = 0;
+    OCR2B = 0;
+
+    /* Reset timer control */
+    TCCR2A = 0;
+
+    /* 32768Hz / 1024 = 32 ticks per second */
+    TCCR2B = (1 << CS22) | (1 << CS21) | (1 << CS20);
+
+    /* Wait until not busy anymore */
+    DEBUG("RTT waits until ASSR not busy\n");
+    _asynch_wait();
+
+    /* Clear interrupt flags */
+    /* Oddly, this is done by writing ones; see datasheet */
+    TIFR2 = (1 << OCF2B) | (1 << OCF2A) | (1 << TOV2);
+
+    /* Enable 8-bit overflow interrupt */
+    TIMSK2 |= (1 << TOIE2);
+
+    DEBUG("RTT initialized\n");
+}
+
+void rtt_set_overflow_cb(rtt_cb_t cb, void *arg)
+{
+    /* Make non-atomic write to callback atomic */
+    unsigned state = irq_disable();
+
+    rtt_state.overflow_cb = cb;
+    rtt_state.overflow_arg = arg;
+
+    irq_restore(state);
+}
+
+void rtt_clear_overflow_cb(void)
+{
+    /* Make non-atomic write to callback atomic */
+    unsigned state = irq_disable();
+
+    rtt_state.overflow_cb = NULL;
+    rtt_state.overflow_arg = NULL;
+
+    irq_restore(state);
+}
+
+uint32_t rtt_get_counter(void)
+{
+    /* Make sure it is safe to read TCNT2, in case we just woke up */
+    DEBUG("RTT sleeps until safe to read TCNT2\n");
+    TCCR2A = 0;
+    _asynch_wait();
+
+    return _safe_cnt_get();
+}
+
+void rtt_set_counter(uint32_t counter)
+{
+    /* Wait until not busy anymore (should be immediate) */
+    DEBUG("RTT sleeps until safe to write TCNT2\n");
+    _asynch_wait();
+
+    /* Make non-atomic writes atomic (for concurrent access) */
+    unsigned state = irq_disable();
+
+    /* Prevent overflow flag from being set during update */
+    TCNT2 = 0;
+
+    /* Clear overflow flag */
+    /* Oddly, this is done by writing a one; see datasheet */
+    TIFR2 = 1 << TOV2;
+
+    ext_cnt = (uint16_t)(counter >> 8);
+    TCNT2 = (uint8_t)counter;
+
+    irq_restore(state);
+
+    DEBUG("RTT set counter TCNT2: %" PRIu8 ", ext_cnt: %" PRIu16 "\n",
+          TCNT2, ext_cnt);
+}
+
+void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
+{
+    /* Disable alarm */
+    rtt_clear_alarm();
+
+    /* Make sure it is safe to read TCNT2, in case we just woke up, and */
+    /* safe to write OCR2B (in case it was busy) */
+    DEBUG("RTC sleeps until safe read TCNT2 and to write OCR2B\n");
+    TCCR2A = 0;
+    _asynch_wait();
+
+    uint32_t now = _safe_cnt_get();
+
+    if (alarm < now) {
+        DEBUG("RTC alarm set in the past. Time: %" PRIu32 " seconds, alarm: %"
+              PRIu32 "\n", now, alarm);
+        cb(arg);
+        return;
+    }
+
+    /* Make non-atomic writes atomic */
+    unsigned state = irq_disable();
+
+    /* Set the alarm value. Atomic for concurrent access */
+    rtt_state.ext_comp = (uint16_t)(alarm >> 8);
+    OCR2A = (uint8_t)alarm;
+
+    rtt_state.alarm_cb = cb;
+    rtt_state.alarm_arg = arg;
+
+    irq_restore(state);
+
+    DEBUG("RTT set alarm TCNT2: %" PRIu8 ", OCR2A: %" PRIu8 "\n", TCNT2, OCR2A);
+
+    /* Enable alarm interrupt only if it will trigger before overflow */
+    if (rtt_state.ext_comp <= (uint16_t)(now >> 8)) {
+        /* Clear interrupt flag */
+        TIFR2 = (1 << OCF2A);
+
+        /* Enable interrupt */
+        TIMSK2 |= (1 << OCIE2A);
+
+        DEBUG("RTT alarm interrupt active\n");
+    }
+    else {
+        DEBUG("RTT alarm interrupt not active\n");
+    }
+}
+
+uint32_t rtt_get_alarm(void)
+{
+    return (((uint32_t)rtt_state.ext_comp << 8) | (uint32_t)OCR2A);
+}
+
+void rtt_clear_alarm(void)
+{
+    /* Make non-atomic writes atomic */
+    unsigned state = irq_disable();
+
+    /* Disable alarm interrupt */
+    TIMSK2 &= ~(1 << OCIE2A);
+
+    rtt_state.alarm_cb = NULL;
+    rtt_state.alarm_arg = NULL;
+
+    irq_restore(state);
+}
+
+void rtt_poweron(void)
+{
+    power_timer2_enable();
+}
+
+void rtt_poweroff(void)
+{
+    power_timer2_disable();
+}
+
+ISR(TIMER2_OVF_vect)
+{
+    __enter_isr();
+
+    ext_cnt++;
+
+    /* Enable RTT alarm if overflowed enough times */
+    if (rtt_state.ext_comp <= ext_cnt) {
+        /* Clear interrupt flag */
+        TIFR2 = (1 << OCF2A);
+
+        /* Enable interrupt */
+        TIMSK2 |= (1 << OCIE2A);
+    }
+
+#if MODULE_PERIPH_RTC
+    /* Increment RTC by 8 seconds */
+    atmega_rtc_incr();
+#endif
+
+    /* Virtual 24-bit timer overflowed */
+    if (ext_cnt == 0) {
+        /* Execute callback */
+        if (rtt_state.overflow_cb != NULL) {
+            rtt_state.overflow_cb(rtt_state.overflow_arg);
+        }
+    }
+    __exit_isr();
+}
+
+ISR(TIMER2_COMPA_vect)
+{
+    __enter_isr();
+    /* Disable alarm interrupt */
+    TIMSK2 &= ~(1 << OCIE2A);
+
+    if (rtt_state.alarm_cb != NULL) {
+        /* Clear callback */
+        rtt_cb_t cb = rtt_state.alarm_cb;
+        rtt_state.alarm_cb = NULL;
+
+        /* Execute callback */
+        cb(rtt_state.alarm_arg);
+    }
+
+    __exit_isr();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RTT_NUMOF */


### PR DESCRIPTION
This adds RTT and RTC support to the ATmegas. It is currently partially working on ATMega1284P using the mega-xplained board. So far as I can tell, the timer used with the real-time crystal is the same across all supported ATmegas, so if another board is added with a RTC crystal it should work right away. The crystal cannot be added to any of the Arduino boards without soldering, unfortunately.

There are a few problems with the code that I need to work out, but I need some advice on how to proceed:
- The use of RTC_NUMOF in rtt.c does not work, but I am not sure what to use to guard the RTC code.
- The use of thread_yield while waiting for busy conditions to clear lags messages in tests/periph_rtt a long time. But the wait can be up to 70ms, which seems really long to just spin if xtimer is not enabled.
- periph_rtt is required for the RTC to work, but I don't know how to add this dependency without adding it for a bunch of stuff that doesn't need it (e.g. it must be added to FEATURES_REQUIRED in tests/periph_rtc).
- ld does not seem to be able to find mktime and gmtime_r for rtc.c, leading to a 'undefined reference' error during linking.

The RTT code is based on some prior work by Robert Hartung in #7604