### PR TITLE
sys/include/net/gcoap.h: improve documentation

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -44,9 +44,10 @@
  * this by uncommenting the appropriate lines in gcoap's make file.
  *
  * gcoap allows an application to specify a collection of request resource paths
- * it wants to be notified about. Create an array of resources, coap_resource_t
- * structs. Use gcoap_register_listener() at application startup to pass in
- * these resources, wrapped in a gcoap_listener_t.
+ * it wants to be notified about. Create an array of resources (coap_resource_t
+ * structs). Note that the elements must be ordered alphabetically with respect
+ * to the resource path. Use gcoap_register_listener() at application startup
+ * to pass in these resources, wrapped in a gcoap_listener_t.
  *
  * gcoap itself defines a resource for `/.well-known/core` discovery, which
  * lists all of the registered paths.


### PR DESCRIPTION
### Contribution description

This PR adds a hint to alphabetical ordering of CoAP resources to the doxygen module description, where I find it easier to find than at the definition of gcoap_listener_t.

### Issues/PRs references
none