### PR TITLE
 Makefile.include: separate `link` in subtargets

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -305,7 +305,12 @@ BASELIBS += $(BINDIR)/$(APPLICATION_MODULE).a
 BASELIBS += $(APPDEPS)
 
 .PHONY: all link clean flash flash-only term doc debug debug-server reset objdump help info-modules
+.PHONY: print-size
 .PHONY: ..in-docker-container
+# Target can depend on FORCE to force running build command every time
+# and still let make use file modification timestamp (contrary to .PHONY)
+# Useful for commands that may keep files unchanged when executed.
+.PHONY: FORCE
 
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
@@ -319,6 +324,7 @@ LINKFLAGPREFIX ?= -Wl,
 DIRS += $(EXTERNAL_MODULE_DIRS)
 
 # Linker rule
+$(ELFFILE): FORCE  # Force rebuilding in case _LINK changes
 ifeq ($(BUILDOSXNATIVE),1)
   _LINK = $(if $(CPPMIX),$(LINKXX),$(LINK)) $(UNDEF) $$(find $(BASELIBS) -size +8c) $(LINKFLAGS) $(LINKFLAGPREFIX)-no_pie
 else
@@ -329,13 +335,26 @@ ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container
 else
 ## make script for your application. Build RIOT-base here!
-link: ..compiler-check ..build-message $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS)
-	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
 ifeq (,$(RIOTNOLINK))
-	$(Q)$(_LINK) -o $(ELFFILE)
-	$(Q)$(SIZE) $(ELFFILE)
-	$(Q)$(OBJCOPY) $(OFLAGS) $(ELFFILE) $(HEXFILE)
-endif
+link: ..compiler-check ..build-message $(ELFFILE) $(HEXFILE) print-size
+else
+link: ..compiler-check ..build-message $(BASELIBS)
+endif # RIOTNOLINK
+
+$(ELFFILE): $(BASELIBS)
+	$(Q)$(_LINK) -o $@
+
+# All modules are built by application.inc.mk makefile
+$(BINDIR)/$(APPLICATION_MODULE).a: $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS)
+	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
+$(BINDIR)/$(APPLICATION_MODULE).a: FORCE  # we do not know here if it needs to be updated
+
+print-size: $(ELFFILE)
+	$(Q)$(SIZE) $<
+
+$(HEXFILE): $(ELFFILE)
+	$(Q)$(OBJCOPY) $(OFLAGS) $< $@
+
 endif # BUILD_IN_DOCKER
 
 # Check given command is available in the path

--- a/Makefile.include
+++ b/Makefile.include
@@ -318,7 +318,12 @@ LINKFLAGPREFIX ?= -Wl,
 
 DIRS += $(EXTERNAL_MODULE_DIRS)
 
-_LINK = $(if $(CPPMIX),$(LINKXX),$(LINK)) $(UNDEF) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group  $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map $(LINKFLAGS)
+# Linker rule
+ifeq ($(BUILDOSXNATIVE),1)
+  _LINK = $(if $(CPPMIX),$(LINKXX),$(LINK)) $(UNDEF) $$(find $(BASELIBS) -size +8c) $(LINKFLAGS) $(LINKFLAGPREFIX)-no_pie
+else
+  _LINK = $(if $(CPPMIX),$(LINKXX),$(LINK)) $(UNDEF) $(LINKFLAGPREFIX)--start-group $(BASELIBS) -lm $(LINKFLAGPREFIX)--end-group $(LINKFLAGS) $(LINKFLAGPREFIX)-Map=$(BINDIR)/$(APPLICATION).map
+endif # BUILDOSXNATIVE
 
 ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container
@@ -327,11 +332,7 @@ else
 link: ..compiler-check ..build-message $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS)
 	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
 ifeq (,$(RIOTNOLINK))
-ifeq ($(BUILDOSXNATIVE),1)
-	$(Q)$(if $(CPPMIX),$(LINKXX),$(LINK)) $(UNDEF) -o $(ELFFILE) $$(find $(BASELIBS) -size +8c) $(LINKFLAGS) $(LINKFLAGPREFIX)-no_pie
-else
 	$(Q)$(_LINK) -o $(ELFFILE)
-endif
 	$(Q)$(SIZE) $(ELFFILE)
 	$(Q)$(OBJCOPY) $(OFLAGS) $(ELFFILE) $(HEXFILE)
 endif


### PR DESCRIPTION
### Contribution description

* Add ELFFILE, HEXFILE, print-size targets

It re-introduces https://github.com/RIOT-OS/RIOT/pull/1098 which was removed by https://github.com/RIOT-OS/RIOT/pull/1198

I removed the rebuilding issue by making ELFFILE and $(APPLICATION_MODULE).a depend on a `FORCE` .PHONY target. I did not use `.PHONY` because it disables using the file timestamp.
Calling make a second time shows that we are indeed re-going in RIOT directories and re-calling the link command.

For BUILDOSXNATIVE, I also re-used `_LINK` variable to harmonize things.
I tested it before but would like another run on a mac.

### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/8838