### PR TITLE
Makefile.include: add %.hex and %.bin rules

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -308,7 +308,7 @@ BASELIBS += $(BINDIR)/$(APPLICATION_MODULE).a
 BASELIBS += $(APPDEPS)
 
 .PHONY: all link clean flash flash-only term doc debug debug-server reset objdump help info-modules
-.PHONY: print-size
+.PHONY: print-size elffile binfile hexfile
 .PHONY: ..in-docker-container
 # Target can depend on FORCE to always rebuild but still let make use file
 # modification timestamp (contrary to .PHONY).
@@ -318,6 +318,11 @@ BASELIBS += $(APPDEPS)
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
 BINFILE ?= $(ELFFILE:.elf=.bin)
+
+# Targets to get given file
+elffile: $(ELFFILE)
+hexfile: $(HEXFILE)
+binfile: $(BINFILE)
 
 # variables used to compile and link c++
 CPPMIX ?= $(if $(wildcard *.cpp),1,)

--- a/Makefile.include
+++ b/Makefile.include
@@ -317,6 +317,7 @@ BASELIBS += $(APPDEPS)
 
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf
 HEXFILE ?= $(ELFFILE:.elf=.hex)
+BINFILE ?= $(ELFFILE:.elf=.bin)
 
 # variables used to compile and link c++
 CPPMIX ?= $(if $(wildcard *.cpp),1,)
@@ -355,8 +356,11 @@ $(BINDIR)/$(APPLICATION_MODULE).a: FORCE
 print-size: $(ELFFILE)
 	$(Q)$(SIZE) $<
 
-$(HEXFILE): $(ELFFILE)
-	$(Q)$(OBJCOPY) $(OFLAGS) $< $@
+%.hex: %.elf
+	$(Q)$(OBJCOPY) $(OFLAGS) -Oihex $< $@
+
+%.bin: %.elf
+	$(Q)$(OBJCOPY) $(OFLAGS) -Obinary $< $@
 
 endif # BUILD_IN_DOCKER
 

--- a/boards/bluepill/Makefile.include
+++ b/boards/bluepill/Makefile.include
@@ -20,8 +20,7 @@ ifeq ($(PROGRAMMER),dfu-util)
   export DEBUGGER = # no debugger
   export RESET = # dfu-util has no support for resetting the device
 
-  export OFLAGS = -O binary
-  HEXFILE = $(ELFFILE:.elf=.bin)
+  HEXFILE = $(BINFILE)
   export FFLAGS = -d 1d50:6017 -s 0x08002000:leave -D "$(HEXFILE)"
 else
 

--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -12,7 +12,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # we support flashing through plain fscopy or using JLink
 PROGRAMMER ?= fscopy
 ifeq (fscopy,$(PROGRAMMER))
-  export OFLAGS = -O ihex
   export FFLAGS =
   export DEBUGGER_FLAGS =
 

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -30,8 +30,8 @@ else ifeq ($(PROGRAMMER),jlink)
   export FFLAGS  = $(BINDIR) $(HEXFILE)
 endif
 
-export OFLAGS    = -O binary --gap-fill 0xff
-export HEXFILE = $(ELFFILE:.elf=.bin)
+OFLAGS = --gap-fill 0xff
+HEXFILE = $(BINFILE)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)
 

--- a/boards/chronos/Makefile.include
+++ b/boards/chronos/Makefile.include
@@ -3,7 +3,6 @@ export CPU = cc430
 export CPU_MODEL = cc430f6137
 
 # flasher configuration
-export OFLAGS = -O ihex
 export FLASHER = mspdebug
 export FFLAGS = rf2500 "prog $(HEXFILE)"
 

--- a/boards/common/arduino-atmega/Makefile.include
+++ b/boards/common/arduino-atmega/Makefile.include
@@ -17,5 +17,5 @@ export DEBUGGER = $(DIST_PATH)/debug.sh $(DEBUGSERVER_FLAGS) $(DIST_PATH) $(DEBU
 
 export PROGRAMMER_FLAGS = -P $(PORT) -b $(PROGRAMMER_SPEED)
 
-export OFLAGS += -j .text -j .data -O ihex
+OFLAGS += -j .text -j .data
 export FFLAGS += -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -D -U flash:w:$(HEXFILE)

--- a/boards/common/msb-430/Makefile.include
+++ b/boards/common/msb-430/Makefile.include
@@ -9,7 +9,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup flash tool
-export OFLAGS = -O ihex
 export PROGRAMMER ?= olimex
 export MSPDEBUGFLAGS += -j $(PROGRAMMER)
 ifeq ($(strip $(PROGRAMMER)),uif)

--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -29,8 +29,6 @@ export FFLAGS = $(PORT) $(HEXFILE)
 INCLUDES += -I$(RIOTBOARD)/common/msba2/include
 INCLUDES += -I$(RIOTBOARD)/common/msba2/drivers/include
 
-export OFLAGS = -O ihex
-
 export UNDEF += $(BINDIR)/cpu/startup.o
 
 USEMODULE += boards_common_msba2-drivers

--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -22,8 +22,8 @@ else ifeq ($(PROGRAMMER),jlink)
   export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 endif
 
-export OFLAGS    = -O binary --gap-fill 0xff
-export HEXFILE = $(ELFFILE:.elf=.bin)
+OFLAGS = --gap-fill 0xff
+HEXFILE = $(BINFILE)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb

--- a/boards/common/wsn430/Makefile.include
+++ b/boards/common/wsn430/Makefile.include
@@ -13,6 +13,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # configure the flash tool
-export OFLAGS = -O ihex
 export FLASHER = mspdebug
 export FFLAGS = -d $(PORT) -j uif "prog $(HEXFILE)"

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -15,7 +15,6 @@ export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
 export DEBUGSERVER = st-util
 
 # define st-flash parameters
-export OFLAGS = -O binary
-HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)
 export FFLAGS = write $(HEXFILE) 0x8000000
 export DEBUGGER_FLAGS = $(RIOTBOARD)/$(BOARD)/dist/gdb.conf $(ELFFILE)

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -5,8 +5,7 @@ export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
 export DEBUGGER =
 export DEBUGSERVER =
 
-export OFLAGS = -O binary
-export HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)
 export FFLAGS =
 export DEBUGGER_FLAGS =
 

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -20,5 +20,5 @@ export PROGRAMMER ?= buspirate
 
 export PROGRAMMER_FLAGS = -P /dev/ttyUSB0
 
-export OFLAGS += -j .text -j .data -O ihex
+OFLAGS += -j .text -j .data
 export FFLAGS += -p m1284p -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:$(HEXFILE)

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -12,7 +12,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # we support flashing through plain fscopy or using JLink
 PROGRAMMER ?= fscopy
 ifeq (fscopy,$(PROGRAMMER))
-  export OFLAGS = -O ihex
   export FFLAGS =
   export DEBUGGER_FLAGS =
 

--- a/boards/mips-malta/Makefile.include
+++ b/boards/mips-malta/Makefile.include
@@ -3,3 +3,6 @@ export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 #export USE_HARD_FLOAT = 1
 export USE_DSP = 1
 export USE_UHI_SYSCALLS = 1
+
+OFLAGS = -Obinary
+HEXFILE = $(ELFFILE:.elf=.bin)

--- a/boards/mips-malta/Makefile.include
+++ b/boards/mips-malta/Makefile.include
@@ -4,5 +4,4 @@ export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 export USE_DSP = 1
 export USE_UHI_SYSCALLS = 1
 
-OFLAGS = -Obinary
-HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -27,9 +27,9 @@ else
     export OBJCOPY ?= gobjcopy
     export OFLAGS ?= -O ihex
   else
-    # If gobjcopy is not available, just create an empty file. The hexfile
+    # If gobjcopy is not available, just do nothing. The hexfile
     # is not used for native anyways.
-    export OBJCOPY ?= touch
+    export OBJCOPY ?= true
     export OFLAGS =
   endif
 endif

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -25,12 +25,10 @@ ifneq ($(shell uname -s),Darwin)
 else
   ifeq (0,$(shell which gobjcopy 2>&1 > /dev/null ; echo $$?))
     export OBJCOPY ?= gobjcopy
-    export OFLAGS ?= -O ihex
   else
     # If gobjcopy is not available, just do nothing. The hexfile
     # is not used for native anyways.
     export OBJCOPY ?= true
-    export OFLAGS =
   endif
 endif
 

--- a/boards/nrf6310/Makefile.include
+++ b/boards/nrf6310/Makefile.include
@@ -12,8 +12,7 @@ export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
 export DEBUGSERVER = JLinkGDBServer -device nrf51822 -if SWD
 export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 
-export OFLAGS = -O binary
-export HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)
 export FFLAGS = $(BINDIR) $(HEXFILE)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
 export RESET_FLAGS = $(BINDIR)

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -13,8 +13,7 @@ export FLASHER = dfu-util
 export DEBUGGER = # dfu-util has no debugger
 export RESET = # dfu-util has no support for resetting the device
 
-export OFLAGS = -O binary
-HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)
 export FFLAGS = -d $(ID) -a 0 -s 0x08000000:leave -D "$(HEXFILE)"
 export TERMFLAGS = -p $(PORT)
 

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -7,8 +7,7 @@ export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/robotis-loader.py
 export DEBUGGER =
 export DEBUGSERVER =
 
-export OFLAGS = -O binary
-export HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)
 export FFLAGS =
 export DEBUGGER_FLAGS =
 

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -17,8 +17,7 @@ ifeq ($(PROGRAMMER),jlink)
   export TUI := 1
   include $(RIOTMAKE)/tools/jlink.inc.mk
 else
-  export OFLAGS = -O binary
-  export HEXFILE = $(ELFFILE:.elf=.bin)
+  HEXFILE = $(BINFILE)
   export FLASHER = $(RIOTBASE)/dist/tools/cc2538-bsl/cc2538-bsl.py
   export FFLAGS  = -p "$(PORT)" -e -w -v -b 460800 $(HEXFILE)
 endif

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -11,8 +11,7 @@ export FLASHER = dfu-util
 export DEBUGGER = # spark core has no debugger
 export RESET = # dfu-util has no support for resetting the device
 
-export OFLAGS = -O binary
-HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)
 export FFLAGS = -d 1d50:607f -a 0 -s 0x08005000:leave -D "$(HEXFILE)"
 
 export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include/

--- a/boards/teensy31/Makefile.include
+++ b/boards/teensy31/Makefile.include
@@ -6,8 +6,6 @@ CPU_MODEL = mk20dx256vlh7
 TEENSY_LOADER = $(RIOTBASE)/dist/tools/teensy-loader-cli/teensy_loader
 FLASHER = $(TEENSY_LOADER)
 
-OFLAGS = -O ihex
-
 FFLAGS ?= --mcu=mk20dx256 $(HEXFILE)
 
 ifeq ($(TEENSY_LOADER),$(FLASHER))

--- a/boards/telosb/Makefile.include
+++ b/boards/telosb/Makefile.include
@@ -10,6 +10,5 @@ export BAUD ?= 9600
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # flash tool configuration
-export OFLAGS = -O ihex
 export FLASHER = $(RIOTBASE)/dist/tools/goodfet/goodfet.bsl
 export FFLAGS = --telosb -c $(PORT) -r -e -I -p $(HEXFILE)

--- a/boards/waspmote-pro/Makefile.include
+++ b/boards/waspmote-pro/Makefile.include
@@ -33,5 +33,5 @@ ifeq ($(PROGRAMMER), stk500v1)
   export PROGRAMMER_FLAGS = -P $(PORT) -b 115200
 endif
 
-export OFLAGS += -j .text -j .data -O ihex
+OFLAGS += -j .text -j .data
 export FFLAGS += -p m1281 -c $(PROGRAMMER) $(PROGRAMMER_FLAGS) -F -U flash:w:$(HEXFILE)

--- a/boards/z1/Makefile.include
+++ b/boards/z1/Makefile.include
@@ -9,6 +9,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup flash tool
-export OFLAGS = -O ihex
 export FLASHER = $(RIOTBASE)/dist/tools/goodfet/goodfet.bsl
 export FFLAGS = --z1 -I -c $(PORT) -r -e -p $(HEXFILE)

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -11,18 +11,18 @@ export LINKFLAGS += -Tpic32mx512_12_128_uhi.ld
 
 # the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
 export OBJCOPY = objcopy #use system objcopy as toolchain one is broken.
-export OFLAGS += -O ihex \
-				--change-section-lma .bootflash-0xA0000000 \
-				--change-section-lma .exception_vector-0x80000000 \
-				--change-section-lma .text-0x80000000 \
-				--change-section-lma .init-0x80000000 \
-				--change-section-lma .fini-0x80000000 \
-				--change-section-lma .eh_frame-0x80000000 \
-				--change-section-lma .gcc_except_table-0x80000000 \
-				--change-section-lma .jcr-0x80000000 \
-				--change-section-lma .ctors-0x80000000 \
-				--change-section-lma .dtors-0x80000000 \
-				--change-section-lma .rodata-0x80000000 \
-				--change-section-lma .data-0x80000000 \
-				--change-section-lma .bss-0x80000000 \
-				--change-section-lma .startdata-0x80000000 \
+export OFLAGS += \
+    --change-section-lma .bootflash-0xA0000000 \
+    --change-section-lma .exception_vector-0x80000000 \
+    --change-section-lma .text-0x80000000 \
+    --change-section-lma .init-0x80000000 \
+    --change-section-lma .fini-0x80000000 \
+    --change-section-lma .eh_frame-0x80000000 \
+    --change-section-lma .gcc_except_table-0x80000000 \
+    --change-section-lma .jcr-0x80000000 \
+    --change-section-lma .ctors-0x80000000 \
+    --change-section-lma .dtors-0x80000000 \
+    --change-section-lma .rodata-0x80000000 \
+    --change-section-lma .data-0x80000000 \
+    --change-section-lma .bss-0x80000000 \
+    --change-section-lma .startdata-0x80000000 \

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -12,7 +12,7 @@ export LINKFLAGS += -Tpic32mz2048_uhi.ld
 
 # the pickit programmer (MPLAB-IPE) wants physical addresses in the hex file!!
 export OBJCOPY = objcopy #use system objcopy as toolchain one is broken.
-export OFLAGS += -O ihex \
+export OFLAGS += \
     --change-section-lma .lowerbootflashalias-0xA0000000 \
     --change-section-lma .bootflash1-0xA0000000 \
     --change-section-lma .bootflash2-0xA0000000 \

--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -6,7 +6,6 @@ override IMGTOOL := $(abspath $(IMGTOOL))
 BINFILE ?= $(BINDIR)/$(APPLICATION).bin
 SIGN_BINFILE = $(BINDIR)/signed-$(APPLICATION).bin
 MCUBOOT_KEYFILE ?= $(BINDIR)/key.pem
-OFLAGS = -O binary
 MCUBOOT_BIN ?= $(BINDIR)/mcuboot.bin
 MCUBOOT_BIN_URL ?= http://download.riot-os.org/mynewt.mcuboot.bin
 MCUBOOT_BIN_MD5 ?= 0c71a0589bd3709fc2d90f07a0035ce7
@@ -28,7 +27,7 @@ mcuboot: mcuboot-create-key link
 	$(Q)$(_LINK) $(LINKFLAGPREFIX)--defsym=offset="$$(($(MCUBOOT_SLOT0_SIZE) + $(IMAGE_HDR_SIZE)))" \
 	$(LINKFLAGPREFIX)--defsym=length="$$(($(MCUBOOT_SLOT1_SIZE) - $(IMAGE_HDR_SIZE)))" \
 	$(LINKFLAGPREFIX)--defsym=image_header="$(IMAGE_HDR_SIZE)" -o $(ELFFILE) && \
-	$(OBJCOPY) $(OFLAGS) $(ELFFILE) $(BINFILE) && \
+	$(OBJCOPY) $(OFLAGS) -Obinary $(ELFFILE) $(BINFILE) && \
 	$(IMGTOOL) sign --key $(MCUBOOT_KEYFILE) --version $(IMAGE_VERSION) --align \
 	$(MCUBOOT_IMAGE_ALIGN) -H $(IMAGE_HDR_SIZE) $(BINFILE) $(SIGN_BINFILE)
 	@$(COLOR_ECHO)

--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -1,8 +1,7 @@
 export FLASHER ?= $(RIOTBASE)/dist/tools/bossa/bossac
 export FFLAGS  ?= -p $(PORT) -e -i -w -v -b -R $(HEXFILE)
 
-export OFLAGS  = -O binary
-export HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)
 
 # some arduino boards need to toggle the serial interface a little bit to get
 # them ready for flashing...

--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -1,8 +1,7 @@
 RIOT_EDBG = $(RIOTBASE)/dist/tools/edbg/edbg
 EDBG ?= $(RIOT_EDBG)
 FLASHER ?= $(EDBG)
-OFLAGS ?= -O binary
-HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)
 # Use USB serial number to select device when more than one is connected
 # Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
 #   Usage:

--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -3,8 +3,7 @@ export DEBUGGER = $(RIOTBASE)/dist/tools/jlink/jlink.sh
 export DEBUGSERVER = $(RIOTBASE)/dist/tools/jlink/jlink.sh
 export RESET = $(RIOTBASE)/dist/tools/jlink/jlink.sh
 
-export OFLAGS = -O binary
-export HEXFILE = $(ELFFILE:.elf=.bin)
+HEXFILE = $(BINFILE)
 
 export FFLAGS ?= flash
 export DEBUGGER_FLAGS ?= debug

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -3,7 +3,6 @@ export DEBUGGER = $(RIOTBASE)/dist/tools/openocd/openocd.sh
 export DEBUGSERVER = $(RIOTBASE)/dist/tools/openocd/openocd.sh
 export RESET ?= $(RIOTBASE)/dist/tools/openocd/openocd.sh
 
-export OFLAGS ?= -O ihex
 export FFLAGS ?= flash
 export DEBUGGER_FLAGS ?= debug
 export DEBUGSERVER_FLAGS ?= debug-server


### PR DESCRIPTION
### Contribution description
    
* Replace HEXFILE rule by a rule for each type.
* Add BINFILE variable
* Add 'elffile', 'hexfile' and 'binfile' named targets
* Cleanup of OFLAGS from -Oformat

### Issues/PRs references

Depends on ~~https://github.com/RIOT-OS/RIOT/pull/8844~~ ~~https://github.com/RIOT-OS/RIOT/pull/8846~~
Part of https://github.com/RIOT-OS/RIOT/pull/8838