### PR TITLE
Makefile.include: FIX .DEFAULT_GOAL not being all

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -593,4 +593,9 @@ CFLAGS += -include '$(RIOTBUILD_CONFIG_HEADER_C)'
 
 # include mcuboot support
 include $(RIOTMAKE)/mcuboot.mk
+
+# Sanity check, 'all' should be the default goal
+ifneq (all, $(.DEFAULT_GOAL))
+  $(error .DEFAULT_GOAL := $(.DEFAULT_GOAL))
+endif
 endif # BOARD=none

--- a/Makefile.include
+++ b/Makefile.include
@@ -1,3 +1,6 @@
+# Globally set default goal to `all`
+.DEFAULT_GOAL := all
+
 # include Makefile.local if it exists
 -include Makefile.local
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -463,8 +463,7 @@ $(CURDIR)/eclipsesym.xml:
 # Export variables used throughout the whole make system:
 include $(RIOTMAKE)/vars.inc.mk
 
-# Include build targets for selected tools after the default RIOT targets have
-# been defined (-> so the `all` will be always the first target)
+# Include build targets for selected tools
 include $(RIOTMAKE)/tools/targets.inc.mk
 
 # Warn if the selected board and drivers don't provide all needed features:

--- a/boards/common/frdm/Makefile.include
+++ b/boards/common/frdm/Makefile.include
@@ -26,9 +26,6 @@ export OPENOCD_EXTRA_INIT
 .PHONY: flash
 flash: $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
 
-# Reset the default goal.
-.DEFAULT_GOAL :=
-
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/frdm/dist/old-openocd-$(CPU_FAMILY).cfg
 endif
 

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -61,9 +61,6 @@ export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/$(CPU)/dist/check-fcfield-elf.sh
 .PHONY: flash
 flash: $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
 
-# Reset the default goal.
-.DEFAULT_GOAL :=
-
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk
 

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -15,9 +15,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 .PHONY: flash
 flash: $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
 
-# Reset the default goal.
-.DEFAULT_GOAL :=
-
 # We need special handling of the watchdog if we want to speed up the flash
 # verification by using the MCU to compute the image checksum after flashing.
 # wdog-disable.bin is a precompiled binary which will disable the watchdog and

--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -44,7 +44,4 @@ USEMODULE += periph_wdog
 $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin: $(RIOTCPU)/$(CPU)/dist/wdog-disable.s
 	$(Q)$(MAKE) -C $(RIOTCPU)/$(CPU)/dist/ $(notdir $@)
 
-# Reset the default goal to not make wdog-disable.bin the default target.
-.DEFAULT_GOAL :=
-
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/makefiles/scan-build.inc.mk
+++ b/makefiles/scan-build.inc.mk
@@ -87,6 +87,3 @@ else
 	    echo "No report found"; \
 	  fi
 endif
-
-# Reset the default goal.
-.DEFAULT_GOAL :=


### PR DESCRIPTION
### Contribution description

.DEFAULT_GOAL is reset many times which removed 'all' from being the default goal.
By chance it was then set to `link` so was working by luck.

When I added an `elffile` goal in https://github.com/RIOT-OS/RIOT/pull/8845 the default changed for it which is more problematic.

Output with buildtest error shown with only the `assert` commit.

```
make -C examples/hello-world/  buildtest | grep -v success
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for arduino-duemilanove ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for arduino-mega2560 ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for arduino-uno ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for avsextrem ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for chronos ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for jiminy-mega256rfr2 ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for mega-xplained ... failed!
There are unsatisfied feature requirements: periph_uart


EXPECT ERRORS!


/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for mips-malta ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for msb-430 ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for msb-430h ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for msba2 ... failed!
e/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for pic32-clicker ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for pic32-wifire ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for telosb ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for waspmote-pro ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for wsn430-v1_3b ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for wsn430-v1_4 ... failed!
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:595: *** .DEFAULT_GOAL := link.  Stop.
Building for z1 ... failed!
make: *** [buildtest] Error 1
/home/harter/work/git/RIOT/makefiles/buildtests.inc.mk:7: recipe for target 'buildtest' failed
make: Leaving directory '/home/harter/work/git/RIOT/examples/hello-world'
```

### Issues/PRs references

Required for https://github.com/RIOT-OS/RIOT/pull/8845