### PR TITLE
tests: periph_i2c: map speed to i2c_speed_t

### DIFF
--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -29,6 +29,14 @@
 
 static int i2c_dev = -1;
 
+static i2c_speed_t map_speed[] = {
+    I2C_SPEED_LOW,
+    I2C_SPEED_NORMAL,
+    I2C_SPEED_FAST,
+    I2C_SPEED_FAST_PLUS,
+    I2C_SPEED_HIGH
+};
+
 int cmd_init_master(int argc, char **argv)
 {
     int dev, speed, res;
@@ -52,7 +60,12 @@ int cmd_init_master(int argc, char **argv)
     dev = atoi(argv[1]);
     speed = atoi(argv[2]);
 
-    res = i2c_init_master(dev, speed);
+    if (speed < 0 || speed > 4) {
+        puts("Error: Speed value not in range (0 - 4)");
+        return 1;
+    }
+
+    res = i2c_init_master(dev, map_speed[speed]);
     if (res == -1) {
         puts("Error: Init: Given device not available");
         return 1;


### PR DESCRIPTION
### Contribution description

This PR maps the given speed value to `i2c_speed_t`, so it initializes I2C master with a proper value, since the specs allows one to [override](https://github.com/RIOT-OS/RIOT/blob/master/drivers/include/periph/i2c.h#L114) `i2c_speed_t`.

Tested on SLSTK3401A.

### Issues/PRs references

Should fix #8851 for NRF52 and EFM32 (they override `i2c_speed_t`).