### PR TITLE
dist/tools: jlink: use GDB as default for DBG

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -32,6 +32,7 @@
 #               options:
 #               GDB_PORT:       port opened for GDB connections
 #               TELNET_PORT:    port opened for telnet connections
+#               DBG:            debugger client command, default: 'gdb -q'
 #               TUI:            if TUI!=null, the -tui option will be used
 #               ELFFILE:        path to the ELF file to debug
 #
@@ -133,8 +134,7 @@ test_serial() {
 
 test_dbg() {
     if [ -z "${DBG}" ]; then
-        echo "Error: No debugger defined in DBG env var"
-        exit 1
+        DBG="${GDB}"
     fi
 }
 


### PR DESCRIPTION
### Contribution description

I'm not sure when exactly, but suddenly `make debug` didn't work for JLink-based targets, unless you specify `DBG`. I therefore created #7904.

Today, I compared `jlink.sh` with `openocd.sh`, and I noticed that OpenOCD defaults to the `GDB` variable if `DBG` is undefined. This PR will now do the same for JLink. I'm not a shell-script expert, so I have no intentions to rewrite/refactor the script, but this easy fix does it. 

### Issues/PRs references

[This comment](https://github.com/RIOT-OS/RIOT/pull/8824#discussion_r176777646)