### PR TITLE
dist/tools/openocd: add the possibility to do a reset before halt in openocd debug command

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.include
+++ b/boards/b-l072z-lrwan1/Makefile.include
@@ -12,5 +12,8 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 export DEBUG_ADAPTER ?= stlink
 export STLINK_VERSION ?= 2-1
 
+# call a 'reset halt' command before starting the debugger
+export OPENOCD_DBG_START_CMD = -c 'reset halt'
+
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -83,6 +83,10 @@
 # Debugger flags, will be passed to sh -c, remember to escape any quotation signs.
 # Use ${DBG_DEFAULT_FLAGS} to insert the default flags anywhere in the string
 : ${DBG_FLAGS:=${DBG_DEFAULT_FLAGS} ${DBG_EXTRA_FLAGS}}
+# Initial target state when using debug, by default a 'halt' request is sent to
+# the target when starting a debug session. 'reset halt' can also be used
+# depending on the type of target.
+: ${OPENOCD_DBG_START_CMD:=-c 'halt'}
 # This is an optional offset to the base address that can be used to flash an
 # image in a different location than it is linked at. This feature can be useful
 # when flashing images for firmware swapping/remapping boot loaders.
@@ -201,7 +205,7 @@ do_debug() {
             -c 'gdb_port ${GDB_PORT}' \
             -c 'init' \
             -c 'targets' \
-            -c 'halt' \
+            ${OPENOCD_DBG_START_CMD} \
             -l /dev/null & \
             echo \$! > $OCD_PIDFILE" &
     # Export to be able to access these from the sh -c command lines, may be


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR tries to address this [comment](https://github.com/RIOT-OS/RIOT/pull/8790#discussion_r177503888) by using an environment variable to trigger a reset before halt in the openocd debug command.

It's required for the b-l072z-lrwan1 board (at least), so the config of this board is updated accordingly.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Addresses the same issue than #8790 but in a cleaner way.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->