### PR TITLE
cpu: lpc1768: provide periph_pm

### DIFF
--- a/cpu/lpc1768/Makefile.features
+++ b/cpu/lpc1768/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_pm
 
 -include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/lpc1768/Makefile.include
+++ b/cpu/lpc1768/Makefile.include
@@ -1,3 +1,5 @@
 export CPU_ARCH = cortex-m3
 
+USEMODULE += pm_layered
+
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -26,7 +26,15 @@
 extern "C" {
 #endif
 
-/* nothing to do here, yet */
+/**
+ * @brief   CPU provides own pm_off() function
+ */
+#define PROVIDES_PM_LAYERED_OFF
+
+/**
+ * @brief   Power management configuration
+ */
+#define PM_NUM_MODES    (3U)
 
 #ifdef __cplusplus
 }

--- a/cpu/lpc1768/periph/pm.c
+++ b/cpu/lpc1768/periph/pm.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_lpc1768
+ * @ingroup     drivers_periph_pm
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the power management peripheral
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ * @}
+ */
+
+#include "periph/pm.h"
+
+void pm_set(unsigned mode)
+{
+    switch (mode) {
+        case 0:
+            /* enter sleep mode */
+            LPC_SC->PCON = 0x00;
+            cortexm_sleep(0);
+            break;
+        case 1:
+            /* enter deep sleep mode */
+            LPC_SC->PCON = 0x00;
+            cortexm_sleep(1);
+            break;
+        case 2:
+            /* enter power down mode */
+            LPC_SC->PCON = 0x01;
+            cortexm_sleep(1);
+            break;
+    }
+}
+
+void pm_off(void)
+{
+    /* enter deep power down mode */
+    LPC_SC->PCON = 0x03;
+    cortexm_sleep(1);
+}


### PR DESCRIPTION
### Contribution description

This provides power management for the LPC1768. It's based on [this](http://www.po-star.com/public/uploads/20120319123122_141.pdf) application note.

Tested using #8848 on the Seeeduino Arch-Pro. Although I could only measure milli-amps, I do see a difference when forcing different power modes. 

### Issues/PRs references

None