### PR TITLE
drivers/periph: add basic API to read/write data to EEPROM

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -698,6 +698,10 @@ ifneq (,$(filter benchmark,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$filter periph_eeprom,$(FEATURES_REQUIRED))
+  FEATURES_REQUIRED += periph_flashpage
+endif
+
 # always select gpio (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio
 

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -58,6 +58,11 @@ static void _unlock(void)
         KEY_REG = FLASH_KEY1;
         KEY_REG = FLASH_KEY2;
     }
+}
+
+static void _unlock_flash(void)
+{
+    _unlock();
 
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1)
     DEBUG("[flashpage] unlocking the flash program memory\n");
@@ -90,7 +95,7 @@ static void _erase_page(void *page_addr)
 #endif
 
    /* unlock the flash module */
-    _unlock();
+    _unlock_flash();
 
     /* make sure no flash operation is ongoing */
     DEBUG("[flashpage] erase: waiting for any operation to finish\n");
@@ -153,7 +158,7 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 #endif
 
     DEBUG("[flashpage_raw] unlocking the flash module\n");
-    _unlock();
+    _unlock_flash();
 
     DEBUG("[flashpage] write: now writing the data\n");
 #if !(defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1))
@@ -201,3 +206,19 @@ void flashpage_write(int page, const void *data)
         flashpage_write_raw(page_addr, data, FLASHPAGE_SIZE);
     }
 }
+
+#ifdef MODULE_PERIPH_EEPROM
+uint8_t eeprom_read_byte(uint32_t pos)
+{
+    DEBUG("Reading data from EEPROM at pos %lu\n", pos);
+    return *(uint8_t *)(EEPROM_START_ADDR + pos);
+}
+
+void eeprom_write_byte(uint32_t pos, uint8_t data)
+{
+    DEBUG("Writing data '%c' to EEPROM at pos %lu\n", data, pos);
+    _unlock();
+    *(uint8_t *)(EEPROM_START_ADDR + pos) = data;
+    _lock();
+}
+#endif

--- a/cpu/stm32l0/Makefile.features
+++ b/cpu/stm32l0/Makefile.features
@@ -1,5 +1,6 @@
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
+FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_hwrng
 
 BOARDS_WITHOUT_HWRNG += nucleo32-l031

--- a/cpu/stm32l0/include/cpu_conf.h
+++ b/cpu/stm32l0/include/cpu_conf.h
@@ -79,6 +79,20 @@ extern "C" {
 #define FLASHPAGE_RAW_ALIGNMENT    (4U)
 /** @} */
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#define EEPROM_START_ADDR          (0x08080000)
+#if defined(CPU_MODEL_STM32L073RZ) || defined(CPU_MODEL_STM32L072CZ)
+#define EEPROM_SIZE                (6144U)  /* 6kB */
+#elif defined(CPU_MODEL_STM32L053R8)
+#define EEPROM_SIZE                (2048U)  /* 2kB */
+#elif defined(CPU_MODEL_STM32L031K6)
+#define EEPROM_SIZE                (1024U)  /* 1kB */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32l1/Makefile.features
+++ b/cpu/stm32l1/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
+FEATURES_PROVIDED += periph_eeprom
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -93,6 +93,18 @@ extern "C" {
 #define FLASHPAGE_RAW_ALIGNMENT    (4U)
 /** @} */
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#define EEPROM_START_ADDR          (0x08080000)
+#if defined(CPU_MODEL_STM32L152RE)
+#define EEPROM_SIZE                (16384UL)  /* 16kB */
+#elif defined(CPU_MODEL_STM32L151RC)
+#define EEPROM_SIZE                (8192U)    /* 8kB */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/eeprom.h
+++ b/drivers/include/periph/eeprom.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_eeprom EEPROM driver
+ * @ingroup     drivers_periph
+ * @brief       Low-level EEPROM interface
+ *
+ * @{
+ * @file
+ * @brief       Low-level eeprom driver interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_EEPROM_H
+#define PERIPH_EEPROM_H
+
+#include <stdint.h>
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef EEPROM_SIZE
+#error "periph/eeprom: EEPROM_SIZE is not defined"
+#endif
+
+#ifndef EEPROM_START_ADDR
+#error "periph/eeprom: EEPROM_START_ADDR is not defined"
+#endif
+
+/**
+ * @brief   Read a byte at the given position in eeprom
+ *
+ * @param[in]  pos      position to read
+ *
+ * @return the read byte
+ */
+uint8_t eeprom_read_byte(uint32_t pos);
+
+/**
+ * @brief   Read @p len bytes from the given position
+ *
+ * @param[in]  addr     start position in eeprom
+ * @param[out] data     byte address to write to
+ * @param[in]  len      the number of bytes to read
+ */
+void eeprom_read(uint32_t pos, void *data, uint8_t len);
+
+/**
+ * @brief   Write a byte at the given position
+ *
+ * @param[in] pos       position to write
+ * @param[in] data      byte address to write to
+ */
+void eeprom_write_byte(uint32_t pos, uint8_t data);
+
+/**
+ * @brief   Write @p len bytes at the given position
+ *
+ * @param[in] pos       start position in eeprom
+ * @param[in] data      byte address to write to
+ * @param[in] len       the number of bytes to read
+ */
+void eeprom_write(uint32_t pos, const void *data, uint8_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_EEPROM_H */
+/** @} */

--- a/drivers/periph_common/eeprom.c
+++ b/drivers/periph_common/eeprom.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers
+ * @{
+ *
+ * @file
+ * @brief       Common eeprom functions implmentation
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include "cpu.h"
+#include "assert.h"
+
+/* guard this file, must be done before including periph/eeprom.h */
+#if defined(EEPROM_SIZE) && defined(EEPROM_START_ADDR)
+
+#include "periph/eeprom.h"
+
+void eeprom_read(uint32_t pos, void *data, uint8_t len)
+{
+    assert(pos + len < EEPROM_SIZE);
+
+    while(len--) {
+        *(uint8_t *)data++ = eeprom_read_byte(pos++);
+    }
+}
+
+void eeprom_write(uint32_t pos, const void *data, uint8_t len)
+{
+    assert(pos + len < EEPROM_SIZE);
+
+    while(len--) {
+        eeprom_write_byte(pos++, *(uint8_t *)data++);
+    }
+}
+
+#endif

--- a/tests/periph_eeprom/Makefile
+++ b/tests/periph_eeprom/Makefile
@@ -1,0 +1,8 @@
+BOARD ?= b-l072z-lrwan1
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED += periph_eeprom
+
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_eeprom/README.md
+++ b/tests/periph_eeprom/README.md
@@ -1,0 +1,17 @@
+Expected result
+===============
+
+Use the provided shell commands to read and write bytes from/to the MCU's
+internal EEPROM memory.
+
+    # Read 10 bytes from the beginning of the eeprom
+    > read 0 10
+
+    # Write HelloWorld starting from the 10th position in the eeprom
+    > write 10 HelloWorld
+
+Background
+==========
+
+This test application provides shell commands to verify the implementations of
+the `eeprom` peripheral driver interface.

--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Manual test application for the EEPROM peripheral drivers
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "shell.h"
+
+#include "periph/eeprom.h"
+
+static char buffer[42];
+
+static int cmd_info(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    printf("EEPROM start addr:\t0x%08x\n", (int)EEPROM_START_ADDR);
+    printf("EEPROM size:\t\t%i\n", (int)EEPROM_SIZE);
+
+    return 0;
+}
+
+static int cmd_read(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <pos> <count>\n", argv[0]);
+        return 1;
+    }
+
+    uint32_t pos = atoi(argv[1]);
+    uint8_t count = atoi(argv[2]);
+
+    if (!count) {
+        puts("Count should be greater than 0");
+        return 1;
+    }
+
+    if (pos + count >= EEPROM_SIZE) {
+        puts("Failed: cannot read out of eeprom bounds");
+        return 1;
+    }
+
+    eeprom_read(pos, buffer, count);
+    buffer[count] = '\0';
+
+    printf("Data read from EEPROM: %s\n", buffer);
+
+    return 0;
+}
+
+static int cmd_write(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <pos> <data>\n", argv[0]);
+        return 1;
+    }
+
+    uint32_t pos = atoi(argv[1]);
+
+    if (pos + strlen(argv[2]) >= EEPROM_SIZE) {
+        puts("Failed: cannot write out of eeprom bounds");
+        return 1;
+    }
+
+    eeprom_write(pos, argv[2], strlen(argv[2]));
+    printf("Data writen to EEPROM\n");
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "info", "Print information about eeprom", cmd_info },
+    { "read", "Read bytes from eeprom", cmd_read },
+    { "write", "Write bytes to eeprom", cmd_write},
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("EEPROM read write test\n");
+    puts("Please refer to the README.md for further information\n");
+
+    cmd_info(0, NULL);
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds:
- a basic API for reading/writing data to the internal EEPROM present on certain CPUs
- support for this to the stm32l0 and stm32l1 CPU families
- a basic test application with a shell

The test application has been tested on b-l072z-lrwan1 and nucleo-l152 boards.

Since reading and writing data to EEPROM has a very similar workflow than the flashpage implementation, the base eeprom functions are implemented in the same `flashpage.c` file. This allows for example to reuse the lock/unlock functions.
The problem is that it makes this feature dependent from the flashpage feature. Any advice on a better approach will be welcome.

Maybe this PR will interest @kYc0o, @vincent-d or @haukepetersen 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

none

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->