### PR TITLE
 tests/fmt_print: improved

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -221,6 +221,7 @@ size_t fmt_u32_dec(char *out, uint32_t val)
 
     if (out) {
         char *ptr = out + len;
+        *ptr = '\0';
         do {
             *--ptr = (val % 10) + '0';
         } while ((val /= 10));

--- a/tests/fmt_print/README.md
+++ b/tests/fmt_print/README.md
@@ -1,0 +1,32 @@
+Expected result
+===============
+This application Test the formatter.
+
+Example:
+
+```
+RIOT native interrupts/signals initialized.
+LED_RED_OFF
+LED_GREEN_ON
+RIOT native board initialized.
+RIOT native hardware initialization complete.
+
+main(): This is RIOT! (Version: 2018.04-devel-796-g49347-josua-VBox-fmt)
+Testing 'print_str' if you can read this it works.
+
+Testing 16 bit to char conversion:
+1 = 1
+65 535 = 65535
+
+Testing 32 bit to char conversion:
+1 000 000 = 65536
+4 294 967 295 = 4294967295
+
+Testing 64 bit to char conversion:
+Error length 1 != 10
+4 294 967 296 = 0
+Error length 10 != 19
+18 446 744 073 709 551 615 = 4294967295
+
+More testing has to be implemented jet.
+```

--- a/tests/fmt_print/main.c
+++ b/tests/fmt_print/main.c
@@ -20,12 +20,72 @@
  * @}
  */
 
+
+
 #include "fmt.h"
+#include "stdio.h"
 
 int main(void)
 {
-    print_str("If you can read this:\n");
-    print_str("Test successful.\n");
+    char str[22]; // UINT64_MAX 18446744073709551615
+    uint16_t temp16;
+    uint32_t temp32;
+    uint64_t temp64;
+    size_t len;
+
+    print_str("Testing 'print_str' if you can read this it works.\n");
+
+    /* 16 bit conversion */
+    printf("\nTesting 16 bit to char conversion:\n");
+
+    temp16 = 1;
+    len = fmt_u16_dec( str, temp16);
+    if(len != 1){
+        printf("\tError length %i != 1\n", len);
+    }
+    printf("1 = %s\n", str);
+
+    temp16 = UINT16_MAX;
+    len = fmt_u16_dec( str, temp16);
+    if(len != 5){
+        printf("\tError length %i != 5\n", len);
+    }
+    printf("65 535 = %s\n", str);
+
+    /* 32 bit conversion */
+    printf("\nTesting 32 bit to char conversion:\n");
+
+    temp32 = UINT16_MAX +1;
+    len = fmt_u32_dec( str, temp32);
+    if(len != 5){
+        printf("Error length %i != 7\n", len);
+    }
+    printf("1 000 000 = %s\n", str);
+
+    temp32 = UINT32_MAX;
+    len = fmt_u32_dec( str, temp32);
+    if(len != 10){
+        printf("Error length %i != 10\n", len);
+    }
+    printf("4 294 967 295 = %s\n", str);
+
+    /* 64 bit conversion */
+    printf("\nTesting 64 bit to char conversion:\n");
+    temp64 = UINT32_MAX+1;
+    len = fmt_u64_dec( str, temp64);
+    if(len != 10){
+        printf("Error length %i != 10\n", len);
+    }
+    printf("4 294 967 296 = %s\n", str);
+
+    temp64 = UINT64_MAX;
+    len = fmt_u32_dec( str, temp32);
+    if(len != 19){
+        printf("Error length %i != 19\n", len);
+    }
+    printf("18 446 744 073 709 551 615 = %s\n", str);
+
+    printf("\nMore testing has to be implemented jet.\n");
 
     return 0;
 }


### PR DESCRIPTION
tests/fmt_print: improved

Added test for unsigned int 16/32/64 to decimal string conversion.

Besides that the 64bit conversion seems to make problems on Native.
See the README.
