### PR TITLE
tests/xtimer_usleep: improved test, added pin toggle

### DIFF
--- a/tests/xtimer_usleep/Makefile
+++ b/tests/xtimer_usleep/Makefile
@@ -4,6 +4,12 @@ USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+# Port and pin configuration for probing with oscilloscope
+# Port number should be found in port enum e.g in cpu/include/periph_cpu.h
+#FEATURES_REQUIRED += periph_gpio
+#CFLAGS += -DSLEEP_PIN=7
+#CFLAGS += -DSLEEP_PORT=PORT_F
+
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/xtimer_usleep/README.md
+++ b/tests/xtimer_usleep/README.md
@@ -1,10 +1,86 @@
 # xtimer_usleep test application
 
-This test tests `xtimer_usleep()` both against the timings of
-`xtimer_now_usec()` and by providing capabilities to compare against an external
-timer.
+This test tests `xtimer_usleep()` against the timings of `xtimer_now_usec()`
+and by comparing the incoming values with the test hosts time.
+
+The sleep times can be probed with a oscilloscope at a pin if `SLEEP_PIN` is set
+and the respective gpio `SLEEP_PORT` is defined in the makefile, the port
+information can be found in the enum in `cpu/include/periph_cpu.h`.
+
+```
+FEATURES_REQUIRED += periph_gpio
+CFLAGS += -DSLEEP_PIN=7
+CFLAGS += -DSLEEP_PORT=PORT_F
+```
 
 ## Usage
+Executed from the project directory
 ```
-make flash test
+make BOARD=<Board Name> flash test
+```
+
+### Expected result running
+```
+XXX-XX-XX XX:XX:XX,XXX - INFO # Connect to serial port /dev/ttyACM0
+Welcome to pyterm!
+Type '/exit' to exit.
+XXXX-XX-XX XX:XX:XX,XXX - INFO # main(): This is RIOT! (Version: XXX )
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Running test 5 times with 7 distinct sleep times
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Please hit any key and then ENTER to continue
+a
+a
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10464 us (expected: 10234 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75232 us (expected: 75000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50224 us (expected: 50000 us) Offset: 224 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10464 us (expected: 10234 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75232 us (expected: 75000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10456 us (expected: 10234 us) Offset: 222 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75232 us (expected: 75000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10456 us (expected: 10234 us) Offset: 222 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75232 us (expected: 75000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10464 us (expected: 10234 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75224 us (expected: 75000 us) Offset: 224 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Test ran for 2056976 us
+```
+
+### On Error with pyterm
+```
+XXX-XX-XX XX:XX:XX,XXX - INFO # Connect to serial port /dev/ttyACM0
+Welcome to pyterm!
+Type '/exit' to exit.
+XXXX-XX-XX XX:XX:XX,XXX - INFO # main(): This is RIOT! (XXX)
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Running test 5 times with 7 distinct sleep times
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Please hit any key and then ENTER to continue
+a
+a
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10224 us (expected: 10000 us) Offset: 224 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 1464 us (expected: 1234 us) Offset: 230 us
+Invalid timeout 1464 ,expected 1172 < 1234 < 1295
+Host max error  61
+error           291
 ```

--- a/tests/xtimer_usleep/main.c
+++ b/tests/xtimer_usleep/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Inria
  *               2017 Freie Universität Berlin
+ *               2018 Josua Arndt
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,11 +17,13 @@
  *
  * @author      Francisco Acosta <francisco.acosta@inria.fr>
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  * @}
  */
 
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "xtimer.h"
 #include "timex.h"
@@ -28,11 +31,33 @@
 #define RUNS                (5U)
 #define SLEEP_TIMES_NUMOF   (sizeof(sleep_times) / sizeof(sleep_times[0]))
 
-static const uint32_t sleep_times[] = { 10000, 50000, 100000 };
+static const uint32_t sleep_times[] = { 10000, 50000, 10234, 56780, 12122, 98765, 75000 };
+
+#define ERROR_US 70
+
+/*
+ * To use a pin to probe the sleep times enable the gpio module and define
+ * SLEEP_PORT and SLEEP_PIN in the makefile, the port information can be found
+ * in the enum in `cpu/include/periph_cpu.h`.
+ *
+ * FEATURES_REQUIRED += periph_gpio
+ * CFLAGS += -DSLEEP_PIN=7
+ * CFLAGS += -DSLEEP_PORT=PORT_F
+ * */
+#ifdef SLEEP_PIN
+#include "board.h"
+#include "periph/gpio.h"
+#endif
 
 int main(void)
 {
     uint32_t start_test, testtime;
+
+#ifdef SLEEP_PIN
+    printf("Debug port 0x%02x pin %d\n", SLEEP_PORT, SLEEP_PIN);
+    gpio_t sleep_pin = GPIO_PIN(SLEEP_PORT, SLEEP_PIN);
+    gpio_init(sleep_pin, GPIO_OUT);
+#endif
 
     printf("Running test %u times with %u distinct sleep times\n", RUNS,
            (unsigned)SLEEP_TIMES_NUMOF);
@@ -43,12 +68,26 @@ int main(void)
         for (unsigned n = 0;
              n < sizeof(sleep_times) / sizeof(sleep_times[0]);
              n++) {
-            uint32_t diff, start;
-            start = xtimer_now_usec();
+
+            uint32_t start_sleep, diff;
+            int32_t err;
+
+            start_sleep = xtimer_now_usec();
+
+#ifdef SLEEP_PIN
+            gpio_set(sleep_pin);
+#endif
             xtimer_usleep(sleep_times[n]);
-            diff = xtimer_now_usec() - start;
-            printf("Slept for %" PRIu32 " us (expected: %" PRIu32 " us)\n",
-                   diff, sleep_times[n]);
+#ifdef SLEEP_PIN
+            gpio_clear(sleep_pin);
+#endif
+
+            diff = xtimer_now_usec() - start_sleep;
+
+            err = diff - sleep_times[n];
+
+            printf("Slept for %" PRIu32 " us (expected: %" PRIu32 " us) "
+                   "Offset: %" PRIi32 " us\n", diff, sleep_times[n], err);
         }
     }
     testtime = xtimer_now_usec() - start_test;

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -32,13 +32,17 @@ def testfunc(child):
         start_test = time.time()
         for m in range(RUNS):
             for n in range(SLEEP_TIMES_NUMOF):
-                child.expect(u"Slept for (\\d+) us \\(expected: (\\d+) us\\)")
+                child.expect(u"Slept for (\\d+) us \\(expected: (\\d+) us\\) Offset: (\\d+) us")
                 sleep_time = int(child.match.group(1))
                 exp = int(child.match.group(2))
                 lower_bound = exp - (exp * INTERNAL_JITTER)
                 upper_bound = exp + (exp * INTERNAL_JITTER)
                 if not (lower_bound < sleep_time < upper_bound):
-                    raise InvalidTimeout("Invalid timeout %d (expected %d)" % (sleep_time, exp))
+                    delta = (upper_bound-lower_bound)/2
+                    raise InvalidTimeout("Invalid timeout %d ,expected %d < %d < %d"
+                                         "\nHost max error\t%d\nerror\t\t%d" %
+                                         (sleep_time, lower_bound, exp, upper_bound,
+                                          delta, sleep_time-lower_bound))
         testtime = (time.time() - start_test) * US_PER_SEC
         child.expect(u"Test ran for (\\d+) us")
         exp = int(child.match.group(1))


### PR DESCRIPTION
Added `ERROR_US 500` to emphasize when errors occur.
Added `SLEEP_PIN ` and to probe sleep times at `SLEEP_GPIO_PIN`.

Atmega mcu will "hang" when the main ends, which will not matter here but should be addressed, imho.
