### PR TITLE
boards: seeeduino_arch-pro: use hex file.

### DIFF
--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -11,6 +11,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 DEBUG_ADAPTER ?= dap
 
 # this board uses openocd
+export IMAGE_FILE = $(HEXFILE)
 include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # generate image checksum from hex file


### PR DESCRIPTION
### Contribution description

LPC1768 needs a checksum inserted, which is not performed by OpenOCD. I use `lpc_checksum` for that, which requires a HEX file instead of an ELF or BIN file.

This was working before, but somewhere it broke. This PR ensures that the HEX file is used when inserting the checksum.

### Issues/PRs references

#6472