### PR TITLE
gnrc_ipv6: fix possible NULL pointer dereference

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -197,7 +197,7 @@ ipv6_hdr_t *gnrc_ipv6_get_header(gnrc_pktsnip_t *pkt)
 {
     ipv6_hdr_t *hdr = NULL;
     gnrc_pktsnip_t *tmp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
-    if ((tmp) && ipv6_hdr_is(tmp->data)) {
+    if ((tmp != NULL) && (tmp->data != NULL) && ipv6_hdr_is(tmp->data)) {
         hdr = ((ipv6_hdr_t*) tmp->data);
     }
 
@@ -715,7 +715,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
     for (ipv6 = pkt; ipv6 != NULL; ipv6 = ipv6->next) { /* find IPv6 header if already marked */
         if ((ipv6->type == GNRC_NETTYPE_IPV6) && (ipv6->size == sizeof(ipv6_hdr_t)) &&
-            (ipv6_hdr_is(ipv6->data))) {
+            (ipv6->data != NULL) && (ipv6_hdr_is(ipv6->data))) {
             break;
         }
 
@@ -723,7 +723,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
     }
 
     if (ipv6 == NULL) {
-        if (!ipv6_hdr_is(pkt->data)) {
+        if ((pkt->data == NULL) || !ipv6_hdr_is(pkt->data)) {
             DEBUG("ipv6: Received packet was not IPv6, dropping packet\n");
             gnrc_pktbuf_release(pkt);
             return;


### PR DESCRIPTION
### Contribution description
When the payload length of an encapsulated IPv6 packet is 0, the `_receive` function of IPv6 can be given a NULL pointer, causing the IPv6 header checker to crash because of a NULL pointer dereference.

This bug can also possibly be caused if the link layer detemines the IPv6 datagram is of length zero, however we did not observe this behavior (yet).

This bug was discovered by @man0lis, this is why I credited commit authorship to him ;-).

### Issues/PRs references
None