### PR TITLE
boards/stm32f429i-disc1: add initial support

### DIFF
--- a/boards/stm32f429i-disc1/Makefile
+++ b/boards/stm32f429i-disc1/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/stm32f429i-disc1/Makefile.dep
+++ b/boards/stm32f429i-disc1/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -1,0 +1,10 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m4_2
+
+-include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/stm32f429i-disc1/Makefile.include
+++ b/boards/stm32f429i-disc1/Makefile.include
@@ -1,0 +1,19 @@
+# define the cpu used by the stm32f4-discovery board
+export CPU = stm32f4
+export CPU_MODEL = stm32f429zi
+
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# this board has an on-board ST-link adapter
+export DEBUG_ADAPTER ?= stlink
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/stm32f429i-disc1/board.c
+++ b/boards/stm32f429i-disc1/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_stm32f429i-disc1
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the STM32F429I-DISC1 evaluation board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/stm32f429i-disc1/doc.txt
+++ b/boards/stm32f429i-disc1/doc.txt
@@ -1,0 +1,5 @@
+/**
+ * @defgroup    boards_stm32f429i-disc1 STM32F429I-DISC1
+ * @ingroup     boards
+ * @brief       Support for the STM32F429I-DISC1 board
+ */

--- a/boards/stm32f429i-disc1/include/board.h
+++ b/boards/stm32f429i-disc1/include/board.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_stm32f429i-disc1
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the STM32F429I-DISC1 evaluation board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_G, 13)
+#define LED1_PIN            GPIO_PIN(PORT_G, 14)
+
+#define LED0_MASK           (1 << 13)
+#define LED1_MASK           (1 << 14)
+
+#define LED0_ON             (GPIOG->BSRR = LED0_MASK)
+#define LED0_OFF            (GPIOG->BSRR = (LED0_MASK << 16))
+#define LED0_TOGGLE         (GPIOG->ODR  ^= LED0_MASK)
+
+#define LED1_ON             (GPIOG->BSRR = LED1_MASK)
+#define LED1_OFF            (GPIOG->BSRR = (LED1_MASK << 16))
+#define LED1_TOGGLE         (GPIOG->ODR  ^= LED1_MASK)
+/** @} */
+
+/**
+ * @brief User button
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_A, 0)
+#define BTN0_MODE           GPIO_IN
+/** @} */
+
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/stm32f429i-disc1/include/gpio_params.h
+++ b/boards/stm32f429i-disc1/include/gpio_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_stm32f429i-disc1
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LD3 (green)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LD4 (red)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "BTN USER",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/stm32f429i-disc1/include/periph_conf.h
+++ b/boards/stm32f429i-disc1/include/periph_conf.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32f429i-disc1
+ * @{
+ *
+ * @file
+ * @name        Peripheral MCU configuration for the STM32F429I-DISC1 board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "f4/cfg_clock_168_8_1.h"
+#include "cfg_spi_divtable.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM5,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR_TIM5EN,
+        .bus      = APB1,
+        .irqn     = TIM5_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim5
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+#ifdef UART_USE_DMA
+        .dma_stream = 6,
+        .dma_chan   = 4
+#endif
+    }
+};
+
+#define UART_0_ISR          (isr_usart1)
+#define UART_0_DMA_ISR      (isr_dma1_stream6)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI5,
+        .mosi_pin = GPIO_PIN(PORT_F, 9),
+        .miso_pin = GPIO_PIN(PORT_F, 8),
+        .sclk_pin = GPIO_PIN(PORT_F, 7),
+        .cs_pin   = GPIO_UNDEF,
+        .af       = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI5EN,
+        .apbbus   = APB2
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a very basic support for the STM32F429I-DISC1 board.

This boards embeds an ILI9341 display and could be used with #8623 (not tested yet though).

Only one uart, timer and spi are configured for the moment.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->